### PR TITLE
fix(web): bound deployment convergence polling

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -199,6 +199,8 @@ describe("deployment mutation settlement", () => {
 			["stop", "stopping"],
 			["restart", "restarting"],
 			["update", "updating"],
+			["runtime_switch", "updating"],
+			["rename", "updating"],
 			["delete", "deleting"],
 		] as const;
 
@@ -209,13 +211,10 @@ describe("deployment mutation settlement", () => {
 			const deployments = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 
 			expect(deployments?.[0]?.resource.status.summary_state).toBe(status);
+			expect(deployments?.[0]?.resource.status.failure).toBeNull();
 			expect(deployments?.[0]?.accepted_operation).toEqual(operation);
 			expect(
-				deploymentRefetchInterval(
-					deployments?.map((deployment) => ({
-						status: deployment.resource.status.summary_state,
-					})),
-				),
+				deploymentRefetchInterval(deployments, new Map(), Date.parse("2026-07-24T00:00:00Z")),
 			).toBe(DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS);
 		}
 	});

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -6,6 +6,7 @@ import { billingKeys } from "@/hosted/billing/query-keys";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+	type DeploymentOperationVerb,
 	deploymentRefetchInterval,
 } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -146,13 +147,13 @@ describe("runtime UI settling polling", () => {
 	});
 });
 
-function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
 	return {
 		name: `operations/${verb}-accepted`,
 		metadata: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
 			deploymentId: "hdep_test",
-			verb,
+			verb: verb as DeploymentOperation["metadata"]["verb"],
 			targetGeneration: 2,
 			manifestETag: "manifest-accepted",
 			createTime: "2026-07-24T00:00:00Z",
@@ -199,6 +200,7 @@ describe("deployment mutation settlement", () => {
 			["stop", "stopping"],
 			["restart", "restarting"],
 			["update", "updating"],
+			["plan_change", "updating"],
 			["runtime_switch", "updating"],
 			["rename", "updating"],
 			["delete", "deleting"],

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -22,7 +22,11 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
-import { boundedSettlingPollState, type SettlingTracker } from "@/hosted/deployment-status";
+import {
+	boundedSettlingPollState,
+	type DeploymentOperationVerb,
+	type SettlingTracker,
+} from "@/hosted/deployment-status";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 import {
 	defaultDeploymentRuntime,
@@ -41,13 +45,11 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 	stop: "stopping",
 	restart: "restarting",
 	update: "updating",
+	plan_change: "updating",
 	runtime_switch: "updating",
 	rename: "updating",
 	delete: "deleting",
-} satisfies Record<
-	AcceptedOperation["operation"]["metadata"]["verb"],
-	HostedDeploymentStatus["summary_state"]
->;
+} satisfies Record<DeploymentOperationVerb, HostedDeploymentStatus["summary_state"]>;
 
 export const RUNTIME_UI_SETTLING_POLL_INTERVAL_MS = 3_000;
 export const RUNTIME_UI_SETTLING_TIMEOUT_MS = 5 * 60_000;

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -63,8 +63,8 @@ export type RuntimeUiSettlingPollState = {
 /**
  * A4 may report compute as running just before its runtime UI endpoint is
  * published. Keep that short-lived gap on the fast deployment-query cadence,
- * but stop rapid polling after the boot window. Returning false leaves the
- * inventory event-driven unless another scoped interval applies.
+ * but stop rapid polling after the boot window. Returning false lets the
+ * shared query fall back to its modest foreground reconciliation interval.
  */
 export function runtimeUiSettlingPollState(
 	deployment: HostedDeployment | null | undefined,

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -22,6 +22,7 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
+import { boundedSettlingPollState, type SettlingTracker } from "@/hosted/deployment-status";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 import {
 	defaultDeploymentRuntime,
@@ -51,10 +52,7 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 export const RUNTIME_UI_SETTLING_POLL_INTERVAL_MS = 3_000;
 export const RUNTIME_UI_SETTLING_TIMEOUT_MS = 5 * 60_000;
 
-export type RuntimeUiSettlingTracker = {
-	key: string;
-	startedAtMs: number;
-};
+export type RuntimeUiSettlingTracker = SettlingTracker;
 
 export type RuntimeUiSettlingPollState = {
 	refetchInterval: number | false;
@@ -84,19 +82,14 @@ export function runtimeUiSettlingPollState(
 	}
 
 	const key = `${deployment.resource.id}:${deployment.resource.metadata.generation}:${runtime}`;
-	const nextTracker =
-		tracker?.key === key
-			? tracker
-			: {
-					key,
-					startedAtMs: runtimeUiSettlingStartedAtMs(deployment, nowMs),
-				};
-	const timedOut = nowMs - nextTracker.startedAtMs >= RUNTIME_UI_SETTLING_TIMEOUT_MS;
-	return {
-		refetchInterval: timedOut ? false : RUNTIME_UI_SETTLING_POLL_INTERVAL_MS,
-		timedOut,
-		tracker: nextTracker,
-	};
+	return boundedSettlingPollState({
+		key,
+		startedAtMs: runtimeUiSettlingStartedAtMs(deployment, nowMs),
+		tracker,
+		nowMs,
+		pollIntervalMs: RUNTIME_UI_SETTLING_POLL_INTERVAL_MS,
+		timeoutMs: RUNTIME_UI_SETTLING_TIMEOUT_MS,
+	});
 }
 
 function runtimeUiSettlingStartedAtMs(deployment: HostedDeployment, nowMs: number): number {
@@ -138,7 +131,11 @@ export function projectAcceptedDeploymentTransition(
 						accepted_operation: accepted.operation,
 						resource: {
 							...deployment.resource,
-							status: { ...deployment.resource.status, summary_state: status },
+							status: {
+								...deployment.resource.status,
+								summary_state: status,
+								failure: null,
+							},
 						},
 					}
 				: deployment,
@@ -217,6 +214,13 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 	);
 	const match = resolution.match;
 	const runtimeUiSettling = deriveRuntimeUiSettlingState(inventory.deployments, Date.now());
+	const deploymentId = match?.deployment.resource.id;
+	const deploymentTransition = deploymentId
+		? (inventory.deploymentTransitions.get(deploymentId) ?? null)
+		: null;
+	const deploymentFailure = deploymentId
+		? (inventory.deploymentFailures.get(deploymentId) ?? null)
+		: null;
 
 	useEffect(() => {
 		runtimeUiSettlingTrackerRef.current = runtimeUiSettling.tracker;
@@ -243,8 +247,12 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
 		isFetching: inventory.isFetching,
 		runtimeUiSettlingTimedOut: runtimeUiSettling.timedOut,
+		deploymentTransition,
+		deploymentTransitionTimedOut: deploymentTransition?.kind === "timed_out",
+		deploymentFailure,
 		error: inventory.error,
 		refetch: inventory.refetch,
+		retryDeploymentTransition: inventory.refetch,
 	};
 }
 

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -63,8 +63,8 @@ export type RuntimeUiSettlingPollState = {
 /**
  * A4 may report compute as running just before its runtime UI endpoint is
  * published. Keep that short-lived gap on the fast deployment-query cadence,
- * but stop rapid polling after the boot window. The normal inventory
- * reconciliation cadence remains active after this override returns false.
+ * but stop rapid polling after the boot window. Returning false leaves the
+ * inventory event-driven unless another scoped interval applies.
  */
 export function runtimeUiSettlingPollState(
 	deployment: HostedDeployment | null | undefined,

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -3,6 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { checkoutReturnMarker, checkoutReturnWasCanceled } from "@/hosted/billing/checkout-return";
 import type {
 	ComputeSubscriptionActionResult,
+	DeploymentOperation,
 	HostedComputeSubscription,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
@@ -10,8 +11,10 @@ import {
 	applyDeploymentSubscriptionResult,
 	billingKeys,
 	billingRecoveryRefetchIntervalFor,
+	reconcileDeploymentSnapshots,
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
+import { deploymentFailureProjection } from "@/hosted/deployment-failure";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 function deployment(
@@ -34,6 +37,23 @@ function subscriptionAction(cancelAtPeriodEnd: boolean): ComputeSubscriptionActi
 		cancel_at_period_end: cancelAtPeriodEnd,
 		current_period_end: "2026-08-01T00:00:00Z",
 		cancel_at: cancelAtPeriodEnd ? "2026-08-01T00:00:00Z" : null,
+	};
+}
+
+function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+	return {
+		name: `operations/${verb}-failure`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "hdep_failure",
+			verb,
+			targetGeneration: 2,
+			manifestETag: "manifest-failure",
+			createTime: "2026-07-25T00:00:00Z",
+			updateTime: "2026-07-25T00:01:00Z",
+		},
+		done: false,
+		response: null,
 	};
 }
 
@@ -218,6 +238,44 @@ describe("billingRecoveryRefetchIntervalFor", () => {
 			"hdep_unpaid",
 		);
 		expect(billingRecoveryRefetchIntervalFor([unpaid], unpaid.resource.id)).toBe(false);
+	});
+});
+
+describe("reconcileDeploymentSnapshots", () => {
+	test("lets a failed server snapshot override optimistic pending state and retain its verb", () => {
+		const optimistic = hostedDeploymentFixture({
+			id: "hdep_failure",
+			status: "updating",
+			acceptedOperation: acceptedOperation("update"),
+		});
+		const failure = {
+			type: "https://api.clawdi.ai/problems/deployment-update-failed",
+			title: "Agent settings could not be applied",
+			status: 409,
+			detail: "The requested settings were rejected by the runtime.",
+			instance: "hdep_failure",
+			code: "deployment_update_failed",
+			conditionReason: "DeploymentUpdateFailed",
+			conditionMessage: "The requested settings were rejected by the runtime.",
+			observedGeneration: 2,
+		};
+		const serverSnapshot = hostedDeploymentFixture({
+			id: "hdep_failure",
+			status: "failed",
+			failure,
+			acceptedOperation: null,
+		});
+
+		const [reconciled] = reconcileDeploymentSnapshots([optimistic], [serverSnapshot]);
+
+		expect(reconciled?.resource.status.summary_state).toBe("failed");
+		expect(reconciled?.resource.status.failure).toEqual(failure);
+		expect(deploymentFailureProjection(reconciled)).toEqual({
+			reason: "Agent settings could not be applied",
+			failedVerb: "update",
+			retryable: null,
+			code: "deployment_update_failed",
+		});
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -21,7 +21,10 @@ import {
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
 import { deploymentFailureProjection } from "@/hosted/deployment-failure";
-import { DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS } from "@/hosted/deployment-status";
+import {
+	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+	type DeploymentOperationVerb,
+} from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 function deployment(
@@ -47,13 +50,13 @@ function subscriptionAction(cancelAtPeriodEnd: boolean): ComputeSubscriptionActi
 	};
 }
 
-function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
 	return {
 		name: `operations/${verb}-failure`,
 		metadata: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
 			deploymentId: "hdep_failure",
-			verb,
+			verb: verb as DeploymentOperation["metadata"]["verb"],
 			targetGeneration: 2,
 			manifestETag: "manifest-failure",
 			createTime: "2026-07-25T00:00:00Z",
@@ -294,17 +297,21 @@ describe("reconcileDeploymentSnapshots", () => {
 		const optimistic = hostedDeploymentFixture({
 			id: "hdep_failure",
 			status: "updating",
-			acceptedOperation: acceptedOperation("update"),
+			acceptedOperation: acceptedOperation("plan_change"),
 		});
+		const actionableReason =
+			"Re-quote the plan change and try again. Operation ID: operations/plan_change-failure.";
 		const failure = {
-			type: "https://api.clawdi.ai/problems/deployment-update-failed",
-			title: "Agent settings could not be applied",
+			type: "https://api.clawdi.ai/problems/operation_aborted",
+			title: "Deployment operation was aborted",
 			status: 409,
-			detail: "The requested settings were rejected by the runtime.",
+			detail: actionableReason,
 			instance: "hdep_failure",
-			code: "deployment_update_failed",
-			conditionReason: "DeploymentUpdateFailed",
-			conditionMessage: "The requested settings were rejected by the runtime.",
+			code: "operation_aborted",
+			phase: "plan_change",
+			retryable: false,
+			conditionReason: "OperationAborted",
+			conditionMessage: "Deployment operation was aborted",
 			observedGeneration: 2,
 		};
 		const serverSnapshot = hostedDeploymentFixture({
@@ -319,10 +326,10 @@ describe("reconcileDeploymentSnapshots", () => {
 		expect(reconciled?.resource.status.summary_state).toBe("failed");
 		expect(reconciled?.resource.status.failure).toEqual(failure);
 		expect(deploymentFailureProjection(reconciled)).toEqual({
-			reason: "Agent settings could not be applied",
-			failedVerb: "update",
-			retryable: null,
-			code: "deployment_update_failed",
+			reason: actionableReason,
+			failedVerb: "plan_change",
+			retryable: false,
+			code: "operation_aborted",
 		});
 	});
 });

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { QueryClient } from "@tanstack/react-query";
+import {
+	environmentManager,
+	focusManager,
+	QueryClient,
+	QueryObserver,
+} from "@tanstack/react-query";
 import { checkoutReturnMarker, checkoutReturnWasCanceled } from "@/hosted/billing/checkout-return";
 import type {
 	ComputeSubscriptionActionResult,
@@ -11,10 +16,12 @@ import {
 	applyDeploymentSubscriptionResult,
 	billingKeys,
 	billingRecoveryRefetchIntervalFor,
+	HOSTED_DEPLOYMENTS_REFRESH_POLICY,
 	reconcileDeploymentSnapshots,
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
 import { deploymentFailureProjection } from "@/hosted/deployment-failure";
+import { DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 function deployment(
@@ -238,6 +245,47 @@ describe("billingRecoveryRefetchIntervalFor", () => {
 			"hdep_unpaid",
 		);
 		expect(billingRecoveryRefetchIntervalFor([unpaid], unpaid.resource.id)).toBe(false);
+	});
+});
+
+describe("hosted deployment refresh policy", () => {
+	test("uses TanStack focus state to pause steady refreshes in a background tab", async () => {
+		expect(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS).toBe(60_000);
+		expect(HOSTED_DEPLOYMENTS_REFRESH_POLICY).toEqual({
+			refetchIntervalInBackground: false,
+			refetchOnWindowFocus: true,
+		});
+
+		environmentManager.setIsServer(() => false);
+		focusManager.setFocused(false);
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		let calls = 0;
+		const observer = new QueryObserver(queryClient, {
+			queryKey: ["test", "hosted-deployment-foreground-refresh"],
+			queryFn: async () => {
+				calls += 1;
+				return [];
+			},
+			refetchInterval: 5,
+			...HOSTED_DEPLOYMENTS_REFRESH_POLICY,
+		});
+		const unsubscribe = observer.subscribe(() => undefined);
+
+		try {
+			await Bun.sleep(20);
+			expect(calls).toBe(1);
+
+			focusManager.setFocused(true);
+			for (let attempt = 0; attempt < 20 && calls === 1; attempt += 1) {
+				await Bun.sleep(5);
+			}
+			expect(calls).toBeGreaterThan(1);
+		} finally {
+			unsubscribe();
+			queryClient.clear();
+			focusManager.setFocused(undefined);
+			environmentManager.setIsServer(() => typeof window === "undefined");
+		}
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -3,13 +3,14 @@
 import {
 	keepPreviousData,
 	type QueryClient,
+	replaceEqualDeep,
 	type UseQueryOptions,
 	useInfiniteQuery,
 	useMutation,
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
 	ComputeFixPaymentRequest,
@@ -37,7 +38,12 @@ import {
 	subscriptionCreateQuoteView,
 	subscriptionCreateRequest,
 } from "@/hosted/billing/subscription/subscription-create-adapter";
-import { deploymentRefetchInterval } from "@/hosted/deployment-status";
+import {
+	deploymentPollingState,
+	isTransitionalStatus,
+	parseDeploymentStatus,
+	type SettlingTracker,
+} from "@/hosted/deployment-status";
 import { runtimeEnvironmentId } from "@/hosted/runtimes";
 
 export { billingKeys } from "@/hosted/billing/query-keys";
@@ -370,6 +376,36 @@ export function useUsage() {
 
 const BILLING_RECOVERY_POLL_INTERVAL_MS = 30_000;
 
+export function reconcileDeploymentSnapshots(
+	previous: readonly HostedDeployment[] | undefined,
+	incoming: HostedDeployment[],
+): HostedDeployment[] {
+	const previousById = new Map(
+		(previous ?? []).map((deployment) => [deployment.resource.id, deployment]),
+	);
+	const reconciled = incoming.map((deployment) => {
+		if (deployment.accepted_operation) return deployment;
+		const acceptedOperation = previousById.get(deployment.resource.id)?.accepted_operation;
+		if (!acceptedOperation) return deployment;
+
+		const status = parseDeploymentStatus(deployment.resource.status.summary_state);
+		const failure = deployment.resource.status.failure;
+		const operationApplies = isTransitionalStatus(status)
+			? true
+			: status.kind === "failed" &&
+				failure !== null &&
+				failure !== undefined &&
+				failure.observedGeneration >= acceptedOperation.metadata.targetGeneration;
+		return operationApplies ? { ...deployment, accepted_operation: acceptedOperation } : deployment;
+	});
+	return replaceEqualDeep(previous, reconciled) as HostedDeployment[];
+}
+
+function reconcileDeploymentQueryData(previous: unknown, incoming: unknown): unknown {
+	if (!Array.isArray(incoming)) return incoming;
+	return reconcileDeploymentSnapshots(Array.isArray(previous) ? previous : undefined, incoming);
+}
+
 export function billingRecoveryRefetchIntervalFor(
 	deployments: readonly HostedDeployment[] | undefined,
 	targetId: string | null | undefined,
@@ -402,29 +438,47 @@ export function useHostedDeployments({
 	) => number | false;
 } = {}) {
 	const client = useBillingClient();
-	return useBillingQuery({
+	const transitionTrackersRef = useRef<ReadonlyMap<string, SettlingTracker>>(new Map());
+	const deriveDeploymentPollingState = useCallback(
+		(deployments: readonly HostedDeployment[] | undefined, nowMs: number) =>
+			deploymentPollingState(deployments, transitionTrackersRef.current, nowMs),
+		[],
+	);
+	const query = useBillingQuery({
 		queryKey: billingKeys.deployments,
 		enabled: isDeployApiConfigured() && enabled,
 		queryFn: () => client.listDeployments(),
+		structuralSharing: reconcileDeploymentQueryData,
 		refetchInterval: (q) => {
-			const inventoryInterval = deploymentRefetchInterval(
-				q.state.data?.map((deployment) => ({
-					status: deployment.resource.status.summary_state,
-				})),
-			);
+			const inventoryInterval = deriveDeploymentPollingState(
+				q.state.data,
+				Date.now(),
+			).refetchInterval;
 			const billingInterval = billingRecoveryRefetchIntervalFor(
 				q.state.data,
 				pollBillingRecoveryFor,
 			);
 			const detailInterval = additionalRefetchInterval?.(q.state.data) ?? false;
-			return [inventoryInterval, billingInterval, detailInterval].reduce<number>(
-				(shortest, interval) =>
-					typeof interval === "number" ? Math.min(shortest, interval) : shortest,
-				inventoryInterval,
-			);
+			return shortestRefetchInterval(inventoryInterval, billingInterval, detailInterval);
 		},
 		refetchIntervalInBackground: false,
 	});
+	const deploymentPolling = deriveDeploymentPollingState(query.data, Date.now());
+
+	useEffect(() => {
+		transitionTrackersRef.current = deploymentPolling.trackers;
+	}, [deploymentPolling.trackers]);
+
+	return { ...query, deploymentTransitions: deploymentPolling.transitions };
+}
+
+function shortestRefetchInterval(...intervals: readonly (number | false)[]): number | false {
+	let shortest: number | false = false;
+	for (const interval of intervals) {
+		if (typeof interval !== "number") continue;
+		shortest = typeof shortest === "number" ? Math.min(shortest, interval) : interval;
+	}
+	return shortest;
 }
 
 export function useResolveDeploymentRequest() {

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -376,6 +376,12 @@ export function useUsage() {
 
 const BILLING_RECOVERY_POLL_INTERVAL_MS = 30_000;
 
+/** Foreground polling is a bridge until deployment SSE is wired into this client. */
+export const HOSTED_DEPLOYMENTS_REFRESH_POLICY = {
+	refetchIntervalInBackground: false,
+	refetchOnWindowFocus: true,
+} as const;
+
 export function reconcileDeploymentSnapshots(
 	previous: readonly HostedDeployment[] | undefined,
 	incoming: HostedDeployment[],
@@ -461,7 +467,7 @@ export function useHostedDeployments({
 			const detailInterval = additionalRefetchInterval?.(q.state.data) ?? false;
 			return shortestRefetchInterval(inventoryInterval, billingInterval, detailInterval);
 		},
-		refetchIntervalInBackground: false,
+		...HOSTED_DEPLOYMENTS_REFRESH_POLICY,
 	});
 	const deploymentPolling = deriveDeploymentPollingState(query.data, Date.now());
 

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -24,12 +24,14 @@ describe("deploymentFailureReason", () => {
 	});
 
 	test("projects the authoritative reason and failed verb for every tab", () => {
+		const actionableReason =
+			"Top up your wallet and retry the plan change. Operation ID: operations/plan-change-failed.";
 		const operation: DeploymentOperation = {
-			name: "operations/restart-failed",
+			name: "operations/plan-change-failed",
 			metadata: {
 				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
 				deploymentId: "hdep_failed",
-				verb: "restart",
+				verb: "plan_change" as DeploymentOperation["metadata"]["verb"],
 				targetGeneration: 2,
 				manifestETag: "manifest-failed",
 				createTime: "2026-07-25T00:00:00Z",
@@ -43,25 +45,25 @@ describe("deploymentFailureReason", () => {
 			status: "failed",
 			acceptedOperation: operation,
 			failure: {
-				type: "https://api.clawdi.ai/problems/runtime-readiness-timeout",
-				title: "Runtime restart failed",
-				status: 504,
-				detail: "The runtime did not become ready before the deadline.",
+				type: "https://api.clawdi.ai/problems/operation_aborted",
+				title: "Deployment operation was aborted",
+				status: 409,
+				detail: actionableReason,
 				instance: "hdep_failed",
-				code: "runtime_readiness_timeout",
-				phase: "readiness",
-				retryable: true,
-				conditionReason: "RuntimeReadinessTimeout",
-				conditionMessage: "The runtime did not become ready.",
+				code: "operation_aborted",
+				phase: "plan_change",
+				retryable: false,
+				conditionReason: "OperationAborted",
+				conditionMessage: "Deployment operation was aborted",
 				observedGeneration: 2,
 			},
 		});
 
 		expect(deploymentFailureProjection(deployment)).toEqual({
-			reason: "Runtime restart failed",
-			failedVerb: "restart",
-			retryable: true,
-			code: "runtime_readiness_timeout",
+			reason: actionableReason,
+			failedVerb: "plan_change",
+			retryable: false,
+			code: "operation_aborted",
 		});
 	});
 

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { deploymentFailureReason } from "@/hosted/deployment-failure";
+import type { DeploymentOperation } from "@/hosted/billing/contracts";
+import { deploymentFailureProjection, deploymentFailureReason } from "@/hosted/deployment-failure";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("deploymentFailureReason", () => {
 	test("uses the compatibility Problem title instead of internal detail", () => {
@@ -19,5 +21,52 @@ describe("deploymentFailureReason", () => {
 				failure: { title: "  ", conditionMessage: "The runtime did not become ready." },
 			}),
 		).toBe("The runtime did not become ready.");
+	});
+
+	test("projects the authoritative reason and failed verb for every tab", () => {
+		const operation: DeploymentOperation = {
+			name: "operations/restart-failed",
+			metadata: {
+				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+				deploymentId: "hdep_failed",
+				verb: "restart",
+				targetGeneration: 2,
+				manifestETag: "manifest-failed",
+				createTime: "2026-07-25T00:00:00Z",
+				updateTime: "2026-07-25T00:01:00Z",
+			},
+			done: false,
+			response: null,
+		};
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_failed",
+			status: "failed",
+			acceptedOperation: operation,
+			failure: {
+				type: "https://api.clawdi.ai/problems/runtime-readiness-timeout",
+				title: "Runtime restart failed",
+				status: 504,
+				detail: "The runtime did not become ready before the deadline.",
+				instance: "hdep_failed",
+				code: "runtime_readiness_timeout",
+				phase: "readiness",
+				retryable: true,
+				conditionReason: "RuntimeReadinessTimeout",
+				conditionMessage: "The runtime did not become ready.",
+				observedGeneration: 2,
+			},
+		});
+
+		expect(deploymentFailureProjection(deployment)).toEqual({
+			reason: "Runtime restart failed",
+			failedVerb: "restart",
+			retryable: true,
+			code: "runtime_readiness_timeout",
+		});
+	});
+
+	test("does not expose a stale failure outside the authoritative failed state", () => {
+		const deployment = hostedDeploymentFixture({ status: "starting" });
+		expect(deploymentFailureProjection(deployment)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -1,19 +1,30 @@
-import type { DeploymentOperation, HostedDeployment } from "@/hosted/billing/contracts";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 
 const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
 
 export type DeploymentFailureProjection = {
 	reason: string;
-	failedVerb: DeploymentOperation["metadata"]["verb"] | null;
+	failedVerb: DeploymentOperationVerb | null;
 	retryable: boolean | null;
 	code: string;
 };
 
 export function deploymentFailureReason(input: {
-	failure?: { title: string; conditionMessage: string } | null;
+	failure?: {
+		title: string;
+		conditionMessage: string;
+		detail?: string;
+		phase?: string | null;
+	} | null;
 }): string | null {
-	for (const candidate of [input.failure?.title, input.failure?.conditionMessage]) {
-		const reason = (candidate ?? "").replace(/\s+/g, " ").trim();
+	const failure = input.failure;
+	const candidates =
+		failure?.phase === "plan_change"
+			? [failure.detail, failure.title, failure.conditionMessage]
+			: [failure?.title, failure?.conditionMessage];
+	for (const candidate of candidates) {
+		const reason = (candidate ?? "").trim();
 		if (reason) return reason;
 	}
 	return null;

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -1,4 +1,13 @@
+import type { DeploymentOperation, HostedDeployment } from "@/hosted/billing/contracts";
+
 const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
+
+export type DeploymentFailureProjection = {
+	reason: string;
+	failedVerb: DeploymentOperation["metadata"]["verb"] | null;
+	retryable: boolean | null;
+	code: string;
+};
 
 export function deploymentFailureReason(input: {
 	failure?: { title: string; conditionMessage: string } | null;
@@ -8,6 +17,22 @@ export function deploymentFailureReason(input: {
 		if (reason) return reason;
 	}
 	return null;
+}
+
+/** One tab-agnostic failure view backed by the authoritative failed snapshot. */
+export function deploymentFailureProjection(
+	deployment: HostedDeployment | null | undefined,
+): DeploymentFailureProjection | null {
+	if (deployment?.resource.status.summary_state !== "failed") return null;
+	const failure = deployment.resource.status.failure;
+	const reason = deploymentFailureReason(deployment.resource.status);
+	if (!failure || !reason) return null;
+	return {
+		reason,
+		failedVerb: deployment.accepted_operation?.metadata.verb ?? null,
+		retryable: failure.retryable ?? null,
+		code: failure.code,
+	};
 }
 
 export function compactDeploymentFailureReason(

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -6,6 +6,7 @@ import {
 	canRestart,
 	canStart,
 	canStop,
+	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
 	DEPLOYMENT_TRANSITION_TIMEOUT_MS,
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 	deploymentPollingState,
@@ -201,7 +202,7 @@ describe("DeploymentStatus", () => {
 		});
 	});
 
-	test("stops immediately when a lifecycle operation reaches a terminal state", () => {
+	test("drops fast polling immediately when a lifecycle operation reaches a terminal state", () => {
 		const nowMs = Date.parse("2026-07-25T00:00:00Z");
 		const operation = acceptedOperation("stop");
 		const pending = deploymentPollingState(
@@ -227,7 +228,8 @@ describe("DeploymentStatus", () => {
 			nowMs + DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 		);
 
-		expect(terminal.refetchInterval).toBe(false);
+		expect(terminal.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
+		expect(terminal.refetchInterval).not.toBe(DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS);
 		expect(terminal.transitions.size).toBe(0);
 		expect(terminal.trackers.size).toBe(0);
 	});
@@ -255,12 +257,13 @@ describe("DeploymentStatus", () => {
 		});
 	});
 
-	test("does not schedule perpetual refetches for steady inventory", () => {
+	test("schedules a modest reconciliation interval for steady inventory", () => {
 		const deployments = [
 			hostedDeploymentFixture({ status: "running" }),
 			hostedDeploymentFixture({ id: "hdep_stopped", status: "stopped" }),
 			hostedDeploymentFixture({ id: "hdep_failed", status: "failed" }),
 		];
-		expect(deploymentRefetchInterval(deployments)).toBe(false);
+		expect(deploymentRefetchInterval(deployments)).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
+		expect(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS).toBe(60_000);
 	});
 });

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import type { DeploymentOperation } from "@/hosted/billing/contracts";
 import {
 	canDelete,
 	canQueryDeploymentProjection,
 	canRestart,
 	canStart,
 	canStop,
-	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+	DEPLOYMENT_TRANSITION_TIMEOUT_MS,
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+	deploymentPollingState,
 	deploymentRefetchInterval,
 	deploymentStatusLabel,
 	deploymentStatusTone,
@@ -17,6 +19,24 @@ import {
 	parseDeploymentStatus,
 	shouldPollDeployments,
 } from "@/hosted/deployment-status";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
+
+function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+	return {
+		name: `operations/${verb}-polling`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "hdep_polling",
+			verb,
+			targetGeneration: 2,
+			manifestETag: "manifest-polling",
+			createTime: "2026-07-25T00:00:00Z",
+			updateTime: "2026-07-25T00:00:00Z",
+		},
+		done: false,
+		response: null,
+	};
+}
 
 describe("DeploymentStatus", () => {
 	test("matches the hosted backend deployment status enum", () => {
@@ -144,7 +164,7 @@ describe("DeploymentStatus", () => {
 		expect(canDelete(parseDeploymentStatus("deleted"))).toBe(false);
 	});
 
-	test("polls while any deployment is non-terminal", () => {
+	test("classifies whether any deployment is non-terminal", () => {
 		expect(
 			shouldPollDeployments([
 				{ status: "running" },
@@ -162,11 +182,85 @@ describe("DeploymentStatus", () => {
 		expect(shouldPollDeployments([{ status: "new_backend_status" }])).toBe(true);
 		expect(shouldPollDeployments([])).toBe(false);
 		expect(shouldPollDeployments(undefined)).toBe(false);
-		expect(deploymentRefetchInterval([{ status: "running" }])).toBe(
-			DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+	});
+
+	test("polls a lifecycle operation only while it is plausibly converging", () => {
+		const nowMs = Date.parse("2026-07-25T00:00:00Z");
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_polling",
+			status: "starting",
+			acceptedOperation: acceptedOperation("start"),
+		});
+		const pending = deploymentPollingState([deployment], new Map(), nowMs);
+
+		expect(pending.refetchInterval).toBe(DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS);
+		expect(pending.transitions.get("hdep_polling")).toEqual({
+			kind: "converging",
+			verb: "start",
+			startedAtMs: nowMs,
+		});
+	});
+
+	test("stops immediately when a lifecycle operation reaches a terminal state", () => {
+		const nowMs = Date.parse("2026-07-25T00:00:00Z");
+		const operation = acceptedOperation("stop");
+		const pending = deploymentPollingState(
+			[
+				hostedDeploymentFixture({
+					id: "hdep_polling",
+					status: "stopping",
+					acceptedOperation: operation,
+				}),
+			],
+			new Map(),
+			nowMs,
 		);
-		expect(deploymentRefetchInterval([{ status: "starting" }])).toBe(
-			DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+		const terminal = deploymentPollingState(
+			[
+				hostedDeploymentFixture({
+					id: "hdep_polling",
+					status: "stopped",
+					acceptedOperation: operation,
+				}),
+			],
+			pending.trackers,
+			nowMs + DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 		);
+
+		expect(terminal.refetchInterval).toBe(false);
+		expect(terminal.transitions.size).toBe(0);
+		expect(terminal.trackers.size).toBe(0);
+	});
+
+	test("stops at five minutes and distinguishes timeout from convergence", () => {
+		const nowMs = Date.parse("2026-07-25T00:00:00Z");
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_polling",
+			status: "restarting",
+			acceptedOperation: acceptedOperation("restart"),
+		});
+		const pending = deploymentPollingState([deployment], new Map(), nowMs);
+		const timedOut = deploymentPollingState(
+			[deployment],
+			pending.trackers,
+			nowMs + DEPLOYMENT_TRANSITION_TIMEOUT_MS,
+		);
+
+		expect(pending.transitions.get("hdep_polling")?.kind).toBe("converging");
+		expect(timedOut.refetchInterval).toBe(false);
+		expect(timedOut.transitions.get("hdep_polling")).toEqual({
+			kind: "timed_out",
+			verb: "restart",
+			startedAtMs: nowMs,
+		});
+	});
+
+	test("does not schedule perpetual refetches for steady inventory", () => {
+		const deployments = [
+			hostedDeploymentFixture({ status: "running" }),
+			hostedDeploymentFixture({ id: "hdep_stopped", status: "stopped" }),
+			hostedDeploymentFixture({ id: "hdep_failed", status: "failed" }),
+		];
+		expect(deploymentRefetchInterval(deployments)).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -9,6 +9,7 @@ import {
 	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
 	DEPLOYMENT_TRANSITION_TIMEOUT_MS,
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+	type DeploymentOperationVerb,
 	deploymentPollingState,
 	deploymentRefetchInterval,
 	deploymentStatusLabel,
@@ -22,13 +23,13 @@ import {
 } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
-function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
 	return {
 		name: `operations/${verb}-polling`,
 		metadata: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
 			deploymentId: "hdep_polling",
-			verb,
+			verb: verb as DeploymentOperation["metadata"]["verb"],
 			targetGeneration: 2,
 			manifestETag: "manifest-polling",
 			createTime: "2026-07-25T00:00:00Z",
@@ -202,14 +203,14 @@ describe("DeploymentStatus", () => {
 		});
 	});
 
-	test("drops fast polling immediately when a lifecycle operation reaches a terminal state", () => {
+	test("drops fast plan-change polling immediately when it reaches a terminal state", () => {
 		const nowMs = Date.parse("2026-07-25T00:00:00Z");
-		const operation = acceptedOperation("stop");
+		const operation = acceptedOperation("plan_change");
 		const pending = deploymentPollingState(
 			[
 				hostedDeploymentFixture({
 					id: "hdep_polling",
-					status: "stopping",
+					status: "updating",
 					acceptedOperation: operation,
 				}),
 			],
@@ -220,7 +221,7 @@ describe("DeploymentStatus", () => {
 			[
 				hostedDeploymentFixture({
 					id: "hdep_polling",
-					status: "stopped",
+					status: "running",
 					acceptedOperation: operation,
 				}),
 			],
@@ -238,8 +239,8 @@ describe("DeploymentStatus", () => {
 		const nowMs = Date.parse("2026-07-25T00:00:00Z");
 		const deployment = hostedDeploymentFixture({
 			id: "hdep_polling",
-			status: "restarting",
-			acceptedOperation: acceptedOperation("restart"),
+			status: "updating",
+			acceptedOperation: acceptedOperation("plan_change"),
 		});
 		const pending = deploymentPollingState([deployment], new Map(), nowMs);
 		const timedOut = deploymentPollingState(
@@ -252,7 +253,7 @@ describe("DeploymentStatus", () => {
 		expect(timedOut.refetchInterval).toBe(false);
 		expect(timedOut.transitions.get("hdep_polling")).toEqual({
 			kind: "timed_out",
-			verb: "restart",
+			verb: "plan_change",
 			startedAtMs: nowMs,
 		});
 	});

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -32,6 +32,7 @@ export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentSta
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
 export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;
+export const DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS = 60_000;
 
 export type SettlingTracker = {
 	key: string;
@@ -311,8 +312,8 @@ export function shouldPollDeployments(
 
 /**
  * Poll each accepted lifecycle operation only during its bounded convergence
- * window. Stable snapshots are event-driven (query invalidation, focus, or a
- * manual refetch) and do not schedule a perpetual inventory timer.
+ * window. Until the existing deployment SSE stream is wired into the client,
+ * stable snapshots use a modest foreground-only reconciliation interval.
  */
 export function deploymentPollingState(
 	deployments: readonly HostedDeployment[] | null | undefined,
@@ -350,6 +351,9 @@ export function deploymentPollingState(
 					? Math.min(refetchInterval, pollState.refetchInterval)
 					: pollState.refetchInterval;
 		}
+	}
+	if (deployments !== null && deployments !== undefined && transitions.size === 0) {
+		refetchInterval = DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS;
 	}
 
 	return { refetchInterval, trackers: nextTrackers, transitions };

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -1,3 +1,5 @@
+import type { DeploymentOperation, HostedDeployment } from "@/hosted/billing/contracts";
+
 export const KNOWN_DEPLOYMENT_STATUSES = [
 	"creating",
 	"starting",
@@ -29,7 +31,30 @@ export type UnknownDeploymentStatus = {
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
-export const DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS = 75_000;
+export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;
+
+export type SettlingTracker = {
+	key: string;
+	startedAtMs: number;
+};
+
+export type SettlingPollState = {
+	refetchInterval: number | false;
+	timedOut: boolean;
+	tracker: SettlingTracker;
+};
+
+export type DeploymentTransitionState = {
+	kind: "converging" | "timed_out";
+	verb: DeploymentOperation["metadata"]["verb"] | null;
+	startedAtMs: number;
+};
+
+export type DeploymentPollingState = {
+	refetchInterval: number | false;
+	trackers: ReadonlyMap<string, SettlingTracker>;
+	transitions: ReadonlyMap<string, DeploymentTransitionState>;
+};
 
 const KNOWN_STATUS_SET = new Set<string>(KNOWN_DEPLOYMENT_STATUSES);
 const LEGACY_STATUS_ALIASES = new Map<string, KnownDeploymentStatus>([["ready", "running"]]);
@@ -249,6 +274,33 @@ export function canDelete(status: DeploymentStatus): boolean {
 	return status.kind !== "deleting" && status.kind !== "deleted";
 }
 
+/** Shared started-at/timeout primitive for lifecycle and runtime-UI convergence. */
+export function boundedSettlingPollState({
+	key,
+	startedAtMs,
+	tracker,
+	nowMs,
+	pollIntervalMs,
+	timeoutMs,
+}: {
+	key: string;
+	startedAtMs: number;
+	tracker: SettlingTracker | null;
+	nowMs: number;
+	pollIntervalMs: number;
+	timeoutMs: number;
+}): SettlingPollState {
+	const safeStartedAtMs =
+		Number.isFinite(startedAtMs) && startedAtMs <= nowMs ? startedAtMs : nowMs;
+	const nextTracker = tracker?.key === key ? tracker : { key, startedAtMs: safeStartedAtMs };
+	const timedOut = nowMs - nextTracker.startedAtMs >= timeoutMs;
+	return {
+		refetchInterval: timedOut ? false : pollIntervalMs,
+		timedOut,
+		tracker: nextTracker,
+	};
+}
+
 export function shouldPollDeployments(
 	items: readonly { status: string | null | undefined }[] | null | undefined,
 ): boolean {
@@ -258,15 +310,65 @@ export function shouldPollDeployments(
 }
 
 /**
- * Transitional deployments converge quickly; stable snapshots still reconcile
- * periodically so changes made in another tab or control plane become visible.
+ * Poll each accepted lifecycle operation only during its bounded convergence
+ * window. Stable snapshots are event-driven (query invalidation, focus, or a
+ * manual refetch) and do not schedule a perpetual inventory timer.
  */
+export function deploymentPollingState(
+	deployments: readonly HostedDeployment[] | null | undefined,
+	trackers: ReadonlyMap<string, SettlingTracker>,
+	nowMs: number,
+): DeploymentPollingState {
+	const nextTrackers = new Map<string, SettlingTracker>();
+	const transitions = new Map<string, DeploymentTransitionState>();
+	let refetchInterval: number | false = false;
+
+	for (const deployment of deployments ?? []) {
+		const status = parseDeploymentStatus(deployment.resource.status.summary_state);
+		if (!isTransitionalStatus(status)) continue;
+
+		const deploymentId = deployment.resource.id;
+		const operation = deployment.accepted_operation;
+		const operationStartedAtMs = Date.parse(operation?.metadata.createTime ?? "");
+		const pollState = boundedSettlingPollState({
+			key: operation?.name ?? deploymentTransitionFallbackKey(deployment),
+			startedAtMs: Number.isFinite(operationStartedAtMs) ? operationStartedAtMs : nowMs,
+			tracker: trackers.get(deploymentId) ?? null,
+			nowMs,
+			pollIntervalMs: DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+			timeoutMs: DEPLOYMENT_TRANSITION_TIMEOUT_MS,
+		});
+		nextTrackers.set(deploymentId, pollState.tracker);
+		transitions.set(deploymentId, {
+			kind: pollState.timedOut ? "timed_out" : "converging",
+			verb: operation?.metadata.verb ?? null,
+			startedAtMs: pollState.tracker.startedAtMs,
+		});
+		if (typeof pollState.refetchInterval === "number") {
+			refetchInterval =
+				typeof refetchInterval === "number"
+					? Math.min(refetchInterval, pollState.refetchInterval)
+					: pollState.refetchInterval;
+		}
+	}
+
+	return { refetchInterval, trackers: nextTrackers, transitions };
+}
+
 export function deploymentRefetchInterval(
-	items: readonly { status: string | null | undefined }[] | null | undefined,
-): number {
-	return shouldPollDeployments(items)
-		? DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS
-		: DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS;
+	deployments: readonly HostedDeployment[] | null | undefined,
+	trackers: ReadonlyMap<string, SettlingTracker> = new Map(),
+	nowMs = Date.now(),
+): number | false {
+	return deploymentPollingState(deployments, trackers, nowMs).refetchInterval;
+}
+
+function deploymentTransitionFallbackKey(deployment: HostedDeployment): string {
+	return [
+		deployment.resource.id,
+		deployment.resource.metadata.generation,
+		deployment.resource.spec.desired_lifecycle,
+	].join(":");
 }
 
 function titleCaseStatus(raw: string): string {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -29,6 +29,7 @@ export type UnknownDeploymentStatus = {
 };
 
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
+export type DeploymentOperationVerb = DeploymentOperation["metadata"]["verb"] | "plan_change";
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
 export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;
@@ -47,7 +48,7 @@ export type SettlingPollState = {
 
 export type DeploymentTransitionState = {
 	kind: "converging" | "timed_out";
-	verb: DeploymentOperation["metadata"]["verb"] | null;
+	verb: DeploymentOperationVerb | null;
 	startedAtMs: number;
 };
 

--- a/apps/web/src/hosted/use-hosted-deployment-inventory.ts
+++ b/apps/web/src/hosted/use-hosted-deployment-inventory.ts
@@ -4,6 +4,10 @@ import { useMemo } from "react";
 import { isDeployApiConfigured } from "@/hosted/billing/billing-client";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useHostedDeployments } from "@/hosted/billing/hooks";
+import {
+	type DeploymentFailureProjection,
+	deploymentFailureProjection,
+} from "@/hosted/deployment-failure";
 import { resolveHostedInventory } from "@/hosted/hosted-agent-resolution";
 
 /** Single query adapter for hosted-agent membership across every surface. */
@@ -35,9 +39,19 @@ export function useHostedDeploymentInventory({
 			}),
 		[configured, enabled, query.data, query.error, query.isPending],
 	);
+	const deploymentFailures = useMemo(() => {
+		const failures = new Map<string, DeploymentFailureProjection>();
+		for (const deployment of resolution.deployments ?? []) {
+			const failure = deploymentFailureProjection(deployment);
+			if (failure) failures.set(deployment.resource.id, failure);
+		}
+		return failures;
+	}, [resolution.deployments]);
 
 	return {
 		...resolution,
+		deploymentFailures,
+		deploymentTransitions: query.deploymentTransitions,
 		isFetching: query.isFetching,
 		refetch: query.refetch,
 	};


### PR DESCRIPTION
## Summary

- reuse the runtime UI started-at tracker primitive to bound lifecycle transition polling to five minutes
- stop fast transition polling on terminal states and timeout while exposing a distinct timeout projection
- expose tab-agnostic deployment transition and failure projections, including the accepted verb and authoritative failure reason
- preserve accepted operation metadata across transitional/failed server snapshots so a failure replaces optimistic pending state without losing the failed verb
- project accepted `plan_change` operations through the same `updating` state, bounded polling, timeout, terminal, and failure paths
- bridge external deployment changes with a 60-second steady-state refresh that TanStack Query runs only while the page is focused/visible

## Plan-change LRO compatibility

`plan_change` uses the existing optimistic transition keeper; no parallel pending state was added. The local verb type is forward-compatible with the regenerated contract while current main still has the pre-#1028 generated union. Plan-change failures prefer the public server `detail` when `phase === "plan_change"`, preserving actionable re-quote, top-up, payment-method, or support guidance verbatim while other lifecycle failures retain the existing title-first compatibility behavior.

## Steady-state bridge

Stable deployment inventory refreshes every 60 seconds with `refetchIntervalInBackground: false` and explicit `refetchOnWindowFocus: true`. TanStack Query focus management suppresses interval fetches for hidden/background tabs. Transitional deployments still use the 10-second cadence for at most five minutes; a timed-out transition returns `false`, so the steady interval cannot extend its timeout.

This polling policy is explicitly a bridge. Wiring the existing owner/per-deployment SSE stream through `billing-client.ts` is the proper follow-up fix.

## Verification

- `bun run check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `VITE_CLAWDI_API_URL=http://localhost:8000 VITE_CLAWDI_DEPLOY_API_URL=http://localhost:50021 VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun test apps/web/src/hosted/deployment-status.test.ts apps/web/src/hosted/deployment-failure.test.ts apps/web/src/hosted/agents/deployment-hooks.test.ts apps/web/src/hosted/billing/hooks.test.ts` (38 pass)

No e2e files were changed; Playwright was not run.