### PR TITLE
fix(web): make accepted and one-time states honest

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -75,9 +75,7 @@ const basicPlan = {
 	slug: "compute_basic",
 	name: "Compute Basic",
 	price_cents: 900,
-	points_per_usd: 100,
-	signup_grant_credits: 500,
-	subscription_grant_credits: 0,
+	signup_grant_usd: "5.00",
 	vcpu: 2,
 	ram_gb: 4,
 	disk_size: 20,
@@ -102,9 +100,7 @@ const performancePlan = {
 	slug: "compute_performance",
 	name: "Compute Performance",
 	price_cents: 1_900,
-	points_per_usd: 100,
-	signup_grant_credits: 500,
-	subscription_grant_credits: 500,
+	signup_grant_usd: "5.00",
 	vcpu: 4,
 	ram_gb: 8,
 	disk_size: 40,
@@ -393,6 +389,7 @@ const walletAnnualDeployment = {
 	...paidBasicDeployment,
 	id: "hdep_wallet_created",
 	name: "Annual Wallet Basic",
+	status: "creating",
 	compute_subscription: {
 		...walletActiveDeployment.compute_subscription,
 		billing_term_months: 12,
@@ -405,16 +402,16 @@ function walletSubscriptionQuote({
 	planSlug,
 	billingTermMonths,
 	termPriceCents,
-	exactDebitCredits,
-	balanceBeforeCredits,
-	balanceAfterCredits,
+	debitAmountUsd,
+	balanceBeforeUsd,
+	balanceAfterUsd,
 }: {
 	planSlug: "compute_basic" | "compute_performance";
 	billingTermMonths: 1 | 12;
 	termPriceCents: number;
-	exactDebitCredits: string;
-	balanceBeforeCredits: string;
-	balanceAfterCredits: string;
+	debitAmountUsd: string;
+	balanceBeforeUsd: string;
+	balanceAfterUsd: string;
 }) {
 	return {
 		plan_slug: planSlug,
@@ -424,10 +421,9 @@ function walletSubscriptionQuote({
 		term_price_cents: termPriceCents,
 		preview_invoice_id: `upcoming_${planSlug}_${billingTermMonths}`,
 		expires_at: "2026-07-16T00:15:00Z",
-		debit_credits: exactDebitCredits,
-		points_per_usd: 1_000,
-		balance_before_credits: balanceBeforeCredits,
-		balance_after_credits: balanceAfterCredits,
+		debit_amount_usd: debitAmountUsd,
+		balance_before_usd: balanceBeforeUsd,
+		balance_after_usd: balanceAfterUsd,
 	};
 }
 
@@ -736,6 +732,8 @@ type HostedApiStubOptions = {
 	cancelResponses?: StubResponse[];
 	checkoutRequests?: string[];
 	checkoutResponses?: StubResponse[];
+	channelAccount?: unknown;
+	channelAgentLinks?: readonly unknown[];
 	cloudAgentOverrides?: Record<string, unknown>;
 	cloudAgents?: readonly unknown[];
 	cloudAgentsResponse?: StubResponse;
@@ -765,6 +763,8 @@ type HostedApiStubOptions = {
 	planQuoteRequests?: string[];
 	planQuoteResponses?: unknown[];
 	restartRequests?: string[];
+	rotateAgentTokenRequests?: string[];
+	rotateAgentTokenResponses?: unknown[];
 	runtimeUiRedemptionRequests?: string[];
 	runtimeUiRedemptionResponses?: StubResponse[];
 	resumeRequests?: string[];
@@ -990,8 +990,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 								invoice_id: "in_wallet_browser",
 								deploy_request_id: deployRequestId,
 								deployment_id: "hdep_wallet_created",
-								debited_credits: "86400",
-								balance_after_credits: "13600",
+								debited_usd: "86.40",
+								balance_after_usd: "13.60",
 								current_period_start: "2026-07-15T00:00:00Z",
 								current_period_end: "2027-07-15T00:00:00Z",
 								entitled_until: "2027-07-15T00:00:00Z",
@@ -1020,9 +1020,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					planSlug: "compute_basic",
 					billingTermMonths: 1,
 					termPriceCents: 900,
-					exactDebitCredits: "9000",
-					balanceBeforeCredits: "25000",
-					balanceAfterCredits: "16000",
+					debitAmountUsd: "9.00",
+					balanceBeforeUsd: "25.00",
+					balanceAfterUsd: "16.00",
 				});
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
@@ -1260,9 +1260,25 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			});
 		}
 		if (p === "/v1/ai-providers") return fulfillJson(r, { providers: [] });
-		if (p === "/v1/channels") return fulfillJson(r, []);
+		if (p === "/v1/channels") {
+			return fulfillJson(r, options.channelAccount ? [options.channelAccount] : []);
+		}
 		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
 		if (p === "/v1/channels/health") return fulfillJson(r, { items: [] });
+		if (p.match(/^\/v1\/channels\/[^/]+$/) && r.request().method() === "GET") {
+			return fulfillJson(r, options.channelAccount ?? { detail: "Channel not found" }, 200);
+		}
+		if (p.endsWith("/agent-links") && r.request().method() === "GET") {
+			return fulfillJson(r, options.channelAgentLinks ?? []);
+		}
+		if (p.endsWith("/token") && r.request().method() === "POST") {
+			options.rotateAgentTokenRequests?.push(p);
+			return fulfillJson(r, options.rotateAgentTokenResponses?.shift() ?? { agent_token: null });
+		}
+		if (p.endsWith("/bindings") && r.request().method() === "GET") return fulfillJson(r, []);
+		if (p.endsWith("/activity") && r.request().method() === "GET") {
+			return fulfillJson(r, { items: [] });
+		}
 		if (p === "/v1/projects") return fulfillJson(r, []);
 		if (p === "/v1/sessions") return fulfillJson(r, emptyPage);
 		if (p === "/v1/auth/keys") return fulfillJson(r, []);
@@ -2188,9 +2204,9 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 				planSlug: "compute_basic",
 				billingTermMonths: 12,
 				termPriceCents: 8_640,
-				exactDebitCredits: "86400",
-				balanceBeforeCredits: "100000",
-				balanceAfterCredits: "13600",
+				debitAmountUsd: "86.40",
+				balanceBeforeUsd: "100.00",
+				balanceAfterUsd: "13.60",
 			}),
 		],
 		walletState: { ...walletState, balance_usd: "100.00" },
@@ -2199,17 +2215,17 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
+	await expect(page.getByText("$9.00/mo", { exact: true })).toBeVisible();
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
 	await page.getByRole("button", { name: /Wallet balance/ }).click();
 	await expect.poll(() => subscriptionQuoteRequests.length).toBe(1);
 	const equation = page.getByTestId("wallet-debit-equation");
 	await expect(equation).toContainText("Balance before");
-	await expect(equation).toContainText("100,000 credits");
+	await expect(equation).toContainText("$100.00");
 	await expect(equation).toContainText("Exact debit");
-	await expect(equation).toContainText("86,400 credits");
 	await expect(equation).toContainText("$86.40");
 	await expect(equation).toContainText("Balance after");
-	await expect(equation).toContainText("13,600 credits");
+	await expect(equation).toContainText("$13.60");
 
 	await page.getByRole("button", { name: "Pay $86.40 from Wallet & deploy" }).click();
 	await expect.poll(() => checkoutRequests.length).toBe(1);
@@ -2228,11 +2244,19 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 		quote: {
 			funding_source: "wallet",
 			term_price_cents: 8_640,
-			debit_credits: "86400",
-			balance_after_credits: "13600",
+			debit_amount_usd: "86.40",
+			balance_before_usd: "100.00",
+			balance_after_usd: "13.60",
 		},
 	});
 	await expect(page).toHaveURL(/\/agents\/hdep_wallet_created(?:\?|\/)/);
+	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("Your Basic agent is provisioning now. $86.40 was paid from Wallet.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(page.getByText("Agent deployed", { exact: true })).toHaveCount(0);
 	expect(errors, `wallet annual deploy: ${errors.join(" | ")}`).toEqual([]);
 });
 
@@ -3100,6 +3124,42 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	).toEqual([]);
 });
 
+test("pending welcome balance stops polling and offers a bounded refresh", async ({ page }) => {
+	await page.clock.install({ time: new Date("2026-07-25T12:00:00Z") });
+	const ledgerRequests: string[] = [];
+	const pendingGrant = {
+		operation: "grant_signup",
+		description: "Welcome balance",
+		amount_usd: "5.00",
+		status: "pending",
+		receipt_url: null,
+		created_at: "2026-07-25T12:00:00Z",
+		applied_at: null,
+	};
+	await stubHostedApi(page, {
+		deployments: [],
+		ledgerRequests,
+		ledgerResponseForRequest: () => ({ items: [pendingGrant], has_more: false }),
+		plans: [basicPlan],
+	});
+
+	await page.goto("/agents");
+	await expect(page.getByText("Adding your welcome balance…", { exact: true })).toBeVisible();
+	await page.clock.fastForward(60_001);
+	await expect(
+		page.getByText("Your welcome balance is taking longer than expected", { exact: true }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Refresh balance", exact: true })).toBeVisible();
+
+	const requestsAtTimeout = ledgerRequests.length;
+	await page.clock.fastForward(120_000);
+	expect(ledgerRequests).toHaveLength(requestsAtTimeout);
+
+	await page.getByRole("button", { name: "Refresh balance", exact: true }).click();
+	await expect.poll(() => ledgerRequests.length).toBeGreaterThan(requestsAtTimeout);
+	await expect(page.getByText("Adding your welcome balance…", { exact: true })).toBeVisible();
+});
+
 test("Wallet opens the shared billing portal action", async ({ page }) => {
 	const portalRequests: string[] = [];
 	await stubHostedApi(page, { portalRequests });
@@ -3413,4 +3473,82 @@ test("channels connect dialog opens without browser errors", async ({ page }) =>
 	await expect(page.locator('[data-slot="dialog-content"]').first()).toBeVisible();
 	await page.waitForTimeout(150);
 	expect(errors, `connect dialog: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("rotated channel token blocks silent loss and explains recovery", async ({
+	page,
+	context,
+}) => {
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+	const channelId = "11111111-1111-4111-8111-111111111111";
+	const linkId = "22222222-2222-4222-8222-222222222222";
+	const token = "one-time-browser-token";
+	const channelAccount = {
+		id: channelId,
+		provider: "telegram",
+		name: "Browser Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/browser",
+		created_at: "2026-07-25T12:00:00Z",
+	};
+	const channelLink = {
+		id: linkId,
+		account_id: channelId,
+		agent_id: "33333333-3333-4333-8333-333333333333",
+		status: "active",
+		created_at: "2026-07-25T12:00:00Z",
+	};
+	const rotateAgentTokenRequests: string[] = [];
+	await stubHostedApi(page, {
+		channelAccount,
+		channelAgentLinks: [channelLink],
+		rotateAgentTokenRequests,
+		rotateAgentTokenResponses: [
+			{ ...channelLink, agent_token: token },
+			{ ...channelLink, agent_token: null },
+		],
+	});
+
+	await page.goto(`/channels/${channelId}`);
+	await page.getByRole("button", { name: "Rotate token", exact: true }).click();
+	await expect.poll(() => rotateAgentTokenRequests.length).toBe(1);
+	await expect(
+		page.getByText(
+			"Shown only once. Copy it or confirm you saved it before leaving this page; it cannot be recovered later.",
+			{ exact: true },
+		),
+	).toBeVisible();
+
+	const serializedBrowserStorage = await page.evaluate(() =>
+		JSON.stringify({ localStorage: { ...localStorage }, sessionStorage: { ...sessionStorage } }),
+	);
+	expect(serializedBrowserStorage).not.toContain(token);
+
+	const agentsLink = page.getByTestId("app-sidebar").locator('a[href="/agents"]').first();
+	await agentsLink.click();
+	const leaveDialog = page.getByRole("alertdialog");
+	await expect(leaveDialog).toContainText("Leave without saving the new token?");
+	await expect(leaveDialog).toContainText(
+		"This token was shown once and is not recoverable — rotate again to get a new one.",
+	);
+	await expect(page).toHaveURL(new RegExp(`/channels/${channelId}$`));
+	await leaveDialog.getByRole("button", { name: "Stay and copy token", exact: true }).click();
+
+	await page.getByRole("button", { name: "Copy New agent token", exact: true }).click();
+	await expect(page.getByText("Token copied to clipboard", { exact: true })).toBeVisible();
+	await agentsLink.click();
+	await expect(page).toHaveURL(/\/agents\/?$/);
+
+	await page.goto(`/channels/${channelId}`);
+	await page.getByRole("button", { name: "Rotate token", exact: true }).click();
+	await expect.poll(() => rotateAgentTokenRequests.length).toBe(2);
+	await expect(
+		page.getByText(
+			"This token was shown once and is not recoverable — rotate again to get a new one.",
+			{ exact: true },
+		),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Copy New agent token" })).toHaveCount(0);
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -71,11 +71,13 @@ type DeploymentMutationFixture = {
 	} | null;
 };
 
+// Mirrors the user-facing GET /v2/subscription/plans response. clawdi-hosted resolves
+// the owner-approved Stripe prices from scripts/stripe/create-compute-{basic,performance}.py.
 const basicPlan = {
 	slug: "compute_basic",
 	name: "Compute Basic",
-	price_cents: 900,
-	signup_grant_usd: "5.00",
+	price_cents: 1_000,
+	signup_grant_usd: "5",
 	vcpu: 2,
 	ram_gb: 4,
 	disk_size: 20,
@@ -83,15 +85,15 @@ const basicPlan = {
 	offers: [
 		{
 			billing_term_months: 1,
-			price_cents: 900,
-			effective_monthly_price_cents: 900,
+			price_cents: 1_000,
+			effective_monthly_price_cents: 1_000,
 			discount_percent: 0,
 		},
 		{
 			billing_term_months: 12,
-			price_cents: 8_640,
-			effective_monthly_price_cents: 720,
-			discount_percent: 20,
+			price_cents: 10_000,
+			effective_monthly_price_cents: 833,
+			discount_percent: 17,
 		},
 	],
 };
@@ -99,8 +101,8 @@ const basicPlan = {
 const performancePlan = {
 	slug: "compute_performance",
 	name: "Compute Performance",
-	price_cents: 1_900,
-	signup_grant_usd: "5.00",
+	price_cents: 2_000,
+	signup_grant_usd: "5",
 	vcpu: 4,
 	ram_gb: 8,
 	disk_size: 40,
@@ -108,15 +110,15 @@ const performancePlan = {
 	offers: [
 		{
 			billing_term_months: 1,
-			price_cents: 1_900,
-			effective_monthly_price_cents: 1_900,
+			price_cents: 2_000,
+			effective_monthly_price_cents: 2_000,
 			discount_percent: 0,
 		},
 		{
 			billing_term_months: 12,
-			price_cents: 18_000,
-			effective_monthly_price_cents: 1_500,
-			discount_percent: 21,
+			price_cents: 20_000,
+			effective_monthly_price_cents: 1_666,
+			discount_percent: 17,
 		},
 	],
 };
@@ -166,7 +168,7 @@ const paidBasicDeployment: DeploymentMutationFixture = {
 		funding_source: "stripe",
 		payment_state: "ok",
 		billing_term_months: 12,
-		price_cents: 8_640,
+		price_cents: 10_000,
 		currency: "usd",
 		cancel_at_period_end: false,
 		current_period_end: "2027-07-15T00:00:00Z",
@@ -190,7 +192,7 @@ const performanceDeployment = {
 	name: "Performance agent",
 	compute_subscription: {
 		...paidBasicDeployment.compute_subscription,
-		price_cents: 18_000,
+		price_cents: 20_000,
 	},
 	config_info: {
 		...paidBasicDeployment.config_info,
@@ -326,7 +328,7 @@ const walletActiveDeployment = {
 		funding_source: "wallet",
 		payment_state: "ok",
 		billing_term_months: 1,
-		price_cents: 900,
+		price_cents: 1_000,
 		currency: "usd",
 		cancel_at_period_end: false,
 		current_period_end: "2026-08-15T00:00:00Z",
@@ -393,7 +395,7 @@ const walletAnnualDeployment = {
 	compute_subscription: {
 		...walletActiveDeployment.compute_subscription,
 		billing_term_months: 12,
-		price_cents: 8_640,
+		price_cents: 10_000,
 		current_period_end: "2027-07-15T00:00:00Z",
 	},
 };
@@ -968,6 +970,10 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			const request = JSON.parse(requestBody) as {
 				funding_source?: string;
 				deploy_config?: { deploy_request_id?: string };
+				quote?: {
+					debit_amount_usd?: string | null;
+					balance_after_usd?: string | null;
+				};
 			};
 			const deployRequestId = request.deploy_config?.deploy_request_id;
 			const createdDeployment: DeploymentMutationFixture = {
@@ -990,8 +996,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 								invoice_id: "in_wallet_browser",
 								deploy_request_id: deployRequestId,
 								deployment_id: "hdep_wallet_created",
-								debited_usd: "86.40",
-								balance_after_usd: "13.60",
+								debited_usd: request.quote?.debit_amount_usd ?? null,
+								balance_after_usd: request.quote?.balance_after_usd ?? null,
 								current_period_start: "2026-07-15T00:00:00Z",
 								current_period_end: "2027-07-15T00:00:00Z",
 								entitled_until: "2027-07-15T00:00:00Z",
@@ -1013,16 +1019,32 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, response.body, response.status);
 		}
 		if (p === "/v2/subscription/quote" && r.request().method() === "POST") {
-			options.subscriptionQuoteRequests?.push(r.request().postData() ?? "");
+			const requestBody = r.request().postData() ?? "";
+			options.subscriptionQuoteRequests?.push(requestBody);
+			const request = JSON.parse(requestBody) as {
+				plan_slug?: "compute_basic" | "compute_performance";
+				billing_term_months?: 1 | 12;
+			};
+			const planSlug =
+				request.plan_slug === "compute_performance" ? "compute_performance" : "compute_basic";
+			const billingTermMonths = request.billing_term_months === 12 ? 12 : 1;
+			const plan = planSlug === "compute_performance" ? performancePlan : basicPlan;
+			const offer = plan.offers.find(
+				(candidate) => candidate.billing_term_months === billingTermMonths,
+			);
+			if (!offer) throw new Error("Missing hosted smoke billing offer fixture");
+			const balanceBeforeUsd = currentWallet.balance_usd;
+			const debitAmountUsd = (offer.price_cents / 100).toFixed(2);
+			const balanceAfterUsd = (Number(balanceBeforeUsd) - offer.price_cents / 100).toFixed(2);
 			const response =
 				options.subscriptionQuoteResponses?.shift() ??
 				walletSubscriptionQuote({
-					planSlug: "compute_basic",
-					billingTermMonths: 1,
-					termPriceCents: 900,
-					debitAmountUsd: "9.00",
-					balanceBeforeUsd: "25.00",
-					balanceAfterUsd: "16.00",
+					planSlug,
+					billingTermMonths,
+					termPriceCents: offer.price_cents,
+					debitAmountUsd,
+					balanceBeforeUsd,
+					balanceAfterUsd,
 				});
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
@@ -2203,10 +2225,10 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 			walletSubscriptionQuote({
 				planSlug: "compute_basic",
 				billingTermMonths: 12,
-				termPriceCents: 8_640,
-				debitAmountUsd: "86.40",
+				termPriceCents: 10_000,
+				debitAmountUsd: "100.00",
 				balanceBeforeUsd: "100.00",
-				balanceAfterUsd: "13.60",
+				balanceAfterUsd: "0.00",
 			}),
 		],
 		walletState: { ...walletState, balance_usd: "100.00" },
@@ -2215,19 +2237,20 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$9.00/mo", { exact: true })).toBeVisible();
+	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
+	await expect(page.getByText(/2 vCPU \/ 4 GB · \$8\.33\/mo, billed \$100\.00\/yr/)).toBeVisible();
 	await page.getByRole("button", { name: /Wallet balance/ }).click();
 	await expect.poll(() => subscriptionQuoteRequests.length).toBe(1);
 	const equation = page.getByTestId("wallet-debit-equation");
 	await expect(equation).toContainText("Balance before");
 	await expect(equation).toContainText("$100.00");
 	await expect(equation).toContainText("Exact debit");
-	await expect(equation).toContainText("$86.40");
+	await expect(equation).toContainText("$100.00");
 	await expect(equation).toContainText("Balance after");
-	await expect(equation).toContainText("$13.60");
+	await expect(equation).toContainText("$0.00");
 
-	await page.getByRole("button", { name: "Pay $86.40 from Wallet & deploy" }).click();
+	await page.getByRole("button", { name: "Pay $100.00 from Wallet & deploy" }).click();
 	await expect.poll(() => checkoutRequests.length).toBe(1);
 	const quote = JSON.parse(subscriptionQuoteRequests[0] ?? "{}");
 	const activation = JSON.parse(checkoutRequests[0] ?? "{}");
@@ -2243,16 +2266,16 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 		deploy_config: { compute_plan_slug: "compute_basic" },
 		quote: {
 			funding_source: "wallet",
-			term_price_cents: 8_640,
-			debit_amount_usd: "86.40",
+			term_price_cents: 10_000,
+			debit_amount_usd: "100.00",
 			balance_before_usd: "100.00",
-			balance_after_usd: "13.60",
+			balance_after_usd: "0.00",
 		},
 	});
 	await expect(page).toHaveURL(/\/agents\/hdep_wallet_created(?:\?|\/)/);
 	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
 	await expect(
-		page.getByText("Your Basic agent is provisioning now. $86.40 was paid from Wallet.", {
+		page.getByText("Your Basic agent is provisioning now. $100.00 was paid from Wallet.", {
 			exact: true,
 		}),
 	).toBeVisible();

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -689,7 +689,7 @@ export function DeployWizard() {
 				const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
-				toast.success("Agent deployed", {
+				toast.success("Agent deployment started", {
 					description: `Your ${tierLabel} agent is provisioning now.`,
 				});
 				void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
@@ -787,8 +787,8 @@ export function DeployWizard() {
 					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
-					toast.success("Agent deployed", {
-						description: `${walletDebit ? formatUsdExact(walletDebit.debitAmountUsd) : formatCents(paidSelection.offer.price_cents)} was paid from Wallet.`,
+					toast.success("Agent deployment started", {
+						description: `Your ${paidSelection.tierLabel} agent is provisioning now. ${walletDebit ? formatUsdExact(walletDebit.debitAmountUsd) : formatCents(paidSelection.offer.price_cents)} was paid from Wallet.`,
 					});
 					void router.navigate(acceptedDeploymentNavigation(outcome.deploymentId));
 					return;
@@ -871,7 +871,7 @@ export function DeployWizard() {
 				});
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
-			toast.success("Agent deployed", {
+			toast.success("Agent deployment started", {
 				description: "Your first Basic agent is provisioning now for free.",
 			});
 			void router.navigate(acceptedDeploymentNavigation(created.deploymentId));

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { Gift, PartyPopper, Rocket } from "lucide-react";
+import { Gift, PartyPopper, RefreshCw, Rocket } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -11,6 +12,9 @@ import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
 import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
+
+const WELCOME_GRANT_RECHECK_INTERVAL_MS = 5_000;
+const WELCOME_GRANT_TIMEOUT_MS = 60_000;
 
 /**
  * Pure-$0 welcome + signup-grant feedback.
@@ -25,9 +29,74 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 	const ledger = useWalletLedger(50);
 	const deployments = useHostedDeployments();
 	const plans = usePlans();
+	const grant = ledger.data?.items.find((entry) => entry.operation === "grant_signup");
+	const grantApplied = grant?.status === "applied";
+	const grantPending = grant?.status === "pending";
+	const hasDeployments = (deployments.data?.length ?? 0) > 0;
+	const ledgerHasError = Boolean(ledger.error);
+	const [grantCheckTimedOut, setGrantCheckTimedOut] = useState(false);
+	const [grantCheckGeneration, setGrantCheckGeneration] = useState(0);
+	const grantRefetchInFlight = useRef(false);
+	const refetchLedger = ledger.refetch;
+
+	useEffect(() => {
+		if (hasDeployments || ledgerHasError || !grantPending || grantCheckTimedOut) return;
+		const deadline = Date.now() + WELCOME_GRANT_TIMEOUT_MS;
+		let disposed = false;
+
+		function recheckVisibleLedger() {
+			if (disposed || document.visibilityState !== "visible" || grantRefetchInFlight.current) {
+				return;
+			}
+			grantRefetchInFlight.current = true;
+			void refetchLedger()
+				.catch(() => undefined)
+				.finally(() => {
+					grantRefetchInFlight.current = false;
+				});
+		}
+
+		const interval = window.setInterval(() => {
+			if (Date.now() >= deadline) {
+				setGrantCheckTimedOut(true);
+				return;
+			}
+			recheckVisibleLedger();
+		}, WELCOME_GRANT_RECHECK_INTERVAL_MS);
+		const timeout = window.setTimeout(() => setGrantCheckTimedOut(true), WELCOME_GRANT_TIMEOUT_MS);
+		const handleVisibilityChange = () => {
+			if (document.visibilityState !== "visible") return;
+			if (Date.now() >= deadline) {
+				setGrantCheckTimedOut(true);
+				return;
+			}
+			recheckVisibleLedger();
+		};
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			disposed = true;
+			window.clearInterval(interval);
+			window.clearTimeout(timeout);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [
+		grantCheckGeneration,
+		grantCheckTimedOut,
+		grantPending,
+		hasDeployments,
+		ledgerHasError,
+		refetchLedger,
+	]);
+
+	function retryGrantCheck() {
+		setGrantCheckTimedOut(false);
+		setGrantCheckGeneration((generation) => generation + 1);
+		void refetchLedger().catch(() => undefined);
+	}
 
 	// Past onboarding — they already have at least one agent.
-	if ((deployments.data?.length ?? 0) > 0) return null;
+	if (hasDeployments) return null;
 	if (ledger.isLoading || wallet.isLoading || deployments.isLoading) {
 		return (
 			<Card data-hosted="true" aria-label="Loading welcome balance">
@@ -62,9 +131,6 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 	}
 	if (!wallet.data) return null;
 
-	const grant = ledger.data?.items.find((e) => e.operation === "grant_signup");
-	const grantApplied = grant?.status === "applied";
-	const grantPending = grant?.status === "pending";
 	const configuredSignupGrantUsd = largestSignupGrantUsd(plans.data);
 	const grantAmount = grant
 		? formatUsdExact(grant.amount_usd.trim().replace(/^[+-]/, ""))
@@ -84,23 +150,40 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 							{grantApplied
 								? `You’re all set — ${grantAmount} added to your Wallet`
 								: grantPending
-									? "Adding your welcome balance…"
+									? grantCheckTimedOut
+										? "Your welcome balance is taking longer than expected"
+										: "Adding your welcome balance…"
 									: "Welcome to Clawdi"}
 						</p>
 						<p className="text-sm text-muted-foreground">
 							{grantApplied
 								? "Your free Basic compute slot is ready. Deploy your first agent — managed AI is on us to start."
 								: grantPending
-									? grantAmount
-										? `Your ${grantAmount} welcome balance is on the way. You can deploy now; it’ll be ready in a moment.`
-										: "Your welcome balance is on the way. You can deploy now; it’ll be ready in a moment."
+									? grantCheckTimedOut
+										? "It hasn’t appeared yet. Refresh to check again."
+										: grantAmount
+											? `Your ${grantAmount} welcome balance is on the way. You can deploy now; it’ll be ready in a moment.`
+											: "Your welcome balance is on the way. You can deploy now; it’ll be ready in a moment."
 									: "Your free Basic compute slot is ready. Deploy your first agent to get going."}
 						</p>
 					</div>
 				</div>
 				{grantPending || showDeployAction ? (
-					<div className="flex items-center gap-2">
-						{grantPending ? <Spinner className="size-4 text-muted-foreground" /> : null}
+					<div className="flex flex-wrap items-center gap-2">
+						{grantPending && !grantCheckTimedOut ? (
+							<Spinner className="size-4 text-muted-foreground" />
+						) : null}
+						{grantPending && grantCheckTimedOut ? (
+							<Button
+								type="button"
+								variant="outline"
+								onClick={retryGrantCheck}
+								disabled={ledger.isFetching}
+							>
+								{ledger.isFetching ? <Spinner /> : <RefreshCw />}
+								Refresh balance
+							</Button>
+						) : null}
 						{showDeployAction ? (
 							<Button render={<Link to="/deploy" />} nativeButton={false}>
 								<Rocket /> Deploy an agent

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
@@ -1,11 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import { nativeTransportSummary, pairCodeRequiresExplicitAgent } from "./channel-detail-page.logic";
+import {
+	acknowledgeRotatedToken,
+	hasAtRiskRotatedToken,
+	nativeTransportSummary,
+	pairCodeRequiresExplicitAgent,
+	rotatedTokenDisplayState,
+} from "./channel-detail-page.logic";
 
 describe("pairCodeRequiresExplicitAgent", () => {
 	test("only permits the implicit linked-agent default for exactly one link", () => {
 		expect(pairCodeRequiresExplicitAgent(0)).toBe(true);
 		expect(pairCodeRequiresExplicitAgent(1)).toBe(false);
 		expect(pairCodeRequiresExplicitAgent(2)).toBe(true);
+	});
+});
+
+describe("rotated token display state", () => {
+	test("keeps a returned token at risk until the user acknowledges it", () => {
+		const state = rotatedTokenDisplayState("one-time-secret");
+
+		expect(state).toEqual({
+			status: "available",
+			token: "one-time-secret",
+			acknowledged: false,
+		});
+		expect(hasAtRiskRotatedToken({ link: state }, false)).toBe(true);
+		expect(hasAtRiskRotatedToken({ link: acknowledgeRotatedToken(state) }, false)).toBe(false);
+	});
+
+	test("treats an absent response token as unrecoverable and guards pending rotations", () => {
+		expect(rotatedTokenDisplayState(null)).toEqual({ status: "unrecoverable" });
+		expect(rotatedTokenDisplayState("   ")).toEqual({ status: "unrecoverable" });
+		expect(hasAtRiskRotatedToken({}, true)).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
@@ -2,6 +2,32 @@ export function pairCodeRequiresExplicitAgent(linkedAgentCount: number): boolean
 	return linkedAgentCount !== 1;
 }
 
+export type RotatedTokenDisplayState =
+	| { status: "available"; token: string; acknowledged: boolean }
+	| { status: "unrecoverable" };
+
+export function rotatedTokenDisplayState(
+	token: string | null | undefined,
+): RotatedTokenDisplayState {
+	return token?.trim()
+		? { status: "available", token, acknowledged: false }
+		: { status: "unrecoverable" };
+}
+
+export function acknowledgeRotatedToken(state: RotatedTokenDisplayState): RotatedTokenDisplayState {
+	return state.status === "available" ? { ...state, acknowledged: true } : state;
+}
+
+export function hasAtRiskRotatedToken(
+	states: Readonly<Record<string, RotatedTokenDisplayState>>,
+	rotationPending: boolean,
+): boolean {
+	return (
+		rotationPending ||
+		Object.values(states).some((state) => state.status === "available" && !state.acknowledged)
+	);
+}
+
 export type NativeTransportSummary = {
 	status: string;
 	connection: string;

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useRouter } from "@tanstack/react-router";
+import { useBlocker, useRouter } from "@tanstack/react-router";
 import {
 	ArrowDownLeft,
 	ArrowUpRight,
+	Check,
+	Copy,
+	Eye,
+	EyeOff,
 	KeyRound,
 	Link2,
 	Link2Off,
@@ -16,7 +20,8 @@ import {
 	Trash2,
 	TriangleAlert,
 } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
@@ -31,6 +36,16 @@ import { IconChip } from "@/components/icon-chip";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Label } from "@/components/ui/label";
@@ -47,8 +62,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
 import {
+	acknowledgeRotatedToken,
+	hasAtRiskRotatedToken,
 	nativeTransportSummary,
 	pairCodeRequiresExplicitAgent,
+	type RotatedTokenDisplayState,
+	rotatedTokenDisplayState,
 } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type {
@@ -74,7 +93,6 @@ import {
 	useDeleteChannel,
 	useEnvironments,
 	useRevokeWhatsappTenantCred,
-	useRotateAgentToken,
 	useSyncCommands,
 	useUnlinkChannelAgent,
 	useWhatsappTenantCreds,
@@ -90,6 +108,7 @@ import {
 	agentOwnershipKindFromId,
 	useAgentOwnership,
 } from "@/lib/agent-ownership";
+import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { cn, relativeTime } from "@/lib/utils";
 
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
@@ -358,6 +377,99 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 
 // ── Agents ───────────────────────────────────────────────────────────────────
 
+function RotatedTokenCard({
+	state,
+	onAcknowledge,
+}: {
+	state: RotatedTokenDisplayState;
+	onAcknowledge: () => void;
+}) {
+	const [revealed, setRevealed] = useState(false);
+	const [copied, setCopied] = useState(false);
+	const tokenIdentity = state.status === "available" ? state.token : null;
+
+	useEffect(() => {
+		setRevealed(false);
+		setCopied(false);
+	}, [tokenIdentity]);
+
+	if (state.status === "unrecoverable") {
+		return (
+			<div
+				role="alert"
+				className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3"
+			>
+				<TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+				<div className="space-y-1">
+					<p className="text-xs font-medium text-destructive">New token is not recoverable</p>
+					<p className="text-xs text-muted-foreground">
+						This token was shown once and is not recoverable — rotate again to get a new one.
+					</p>
+				</div>
+			</div>
+		);
+	}
+	const token = state.token;
+
+	async function copyToken() {
+		try {
+			await navigator.clipboard.writeText(token);
+			setCopied(true);
+			onAcknowledge();
+			toast.success("Token copied to clipboard");
+			window.setTimeout(() => setCopied(false), 1_500);
+		} catch {
+			toast.error("Couldn’t copy — select and copy manually.");
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3">
+			<div className="text-xs font-medium text-primary">New agent token</div>
+			<div className="flex items-center gap-2">
+				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
+					{revealed ? state.token : "••••••••••••"}
+				</code>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={() => setRevealed((visible) => !visible)}
+					aria-label={`${revealed ? "Hide" : "Show"} New agent token`}
+					aria-pressed={revealed}
+				>
+					{revealed ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+				</Button>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={() => void copyToken()}
+					aria-label="Copy New agent token"
+				>
+					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+				</Button>
+			</div>
+			<p className="text-xs text-muted-foreground">
+				{state.acknowledged
+					? "This token is shown only once and cannot be recovered later. If you lose it, rotate again to get a new one."
+					: "Shown only once. Copy it or confirm you saved it before leaving this page; it cannot be recovered later."}
+			</p>
+			{state.acknowledged ? null : (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="self-start"
+					onClick={onAcknowledge}
+				>
+					I’ve saved this token
+				</Button>
+			)}
+		</div>
+	);
+}
+
 function AgentsTab({
 	accountId,
 	accountName,
@@ -369,37 +481,90 @@ function AgentsTab({
 	provider: string;
 	readOnly?: boolean;
 }) {
+	const api = useApi();
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
-	const rotate = useRotateAgentToken(accountId);
 	const unlink = useUnlinkChannelAgent(accountId);
 	const [linkOpen, setLinkOpen] = useState(false);
-	const [rotated, setRotated] = useState<Record<string, string>>({});
+	const [rotated, setRotated] = useState<Record<string, RotatedTokenDisplayState>>({});
+	const rotationControllersRef = useRef<Map<string, AbortController>>(new Map());
 	const rotatingLinksRef = useRef<Set<string>>(new Set());
 	const [rotatingLinks, setRotatingLinks] = useState<ReadonlySet<string>>(() => new Set());
+	const hasTokenAtRisk = hasAtRiskRotatedToken(rotated, rotatingLinks.size > 0);
+	const tokenAtRiskRef = useRef(hasTokenAtRisk);
+	tokenAtRiskRef.current = hasTokenAtRisk;
+	const shouldBlockNavigation = useCallback(() => tokenAtRiskRef.current, []);
+	const blocker = useBlocker({
+		shouldBlockFn: shouldBlockNavigation,
+		enableBeforeUnload: shouldBlockNavigation,
+		withResolver: true,
+	});
 
-	function rotateToken(linkId: string) {
+	useEffect(
+		() => () => {
+			for (const controller of rotationControllersRef.current.values()) controller.abort();
+			rotationControllersRef.current.clear();
+		},
+		[],
+	);
+
+	async function rotateToken(linkId: string) {
 		if (rotatingLinksRef.current.has(linkId)) return;
 		rotatingLinksRef.current.add(linkId);
+		tokenAtRiskRef.current = true;
 		setRotatingLinks((prev) => new Set(prev).add(linkId));
-		rotate.mutate(linkId, {
-			onSuccess: (data) => {
-				const token = data.agent_token;
-				if (!token) return;
-				setRotated((prev) => ({
-					...prev,
-					[linkId]: token,
-				}));
-			},
-			onSettled: () => {
-				rotatingLinksRef.current.delete(linkId);
-				setRotatingLinks((prev) => {
-					const next = new Set(prev);
-					next.delete(linkId);
-					return next;
-				});
-			},
+		setRotated((prev) => {
+			const next = { ...prev };
+			delete next[linkId];
+			return next;
 		});
+		const controller = new AbortController();
+		rotationControllersRef.current.set(linkId, controller);
+		try {
+			const data = unwrap(
+				await api.POST("/v1/channels/{account_id}/agent-links/{link_id}/token", {
+					params: { path: { account_id: accountId, link_id: linkId } },
+					signal: controller.signal,
+				}),
+			);
+			const state = rotatedTokenDisplayState(data.agent_token);
+			setRotated((prev) => ({ ...prev, [linkId]: state }));
+			toast.success("Token rotated", {
+				description:
+					state.status === "available"
+						? "Copy the new token below — the previous one is now invalid."
+						: "The previous token is now invalid. Rotate again to receive a new token.",
+			});
+		} catch (error) {
+			if (controller.signal.aborted) return;
+			setRotated((prev) => ({ ...prev, [linkId]: { status: "unrecoverable" } }));
+			toastApiError("Couldn’t rotate token")(error);
+		} finally {
+			rotationControllersRef.current.delete(linkId);
+			rotatingLinksRef.current.delete(linkId);
+			setRotatingLinks((prev) => {
+				const next = new Set(prev);
+				next.delete(linkId);
+				return next;
+			});
+		}
+	}
+
+	function acknowledgeToken(linkId: string) {
+		setRotated((prev) => {
+			const state = prev[linkId];
+			return state ? { ...prev, [linkId]: acknowledgeRotatedToken(state) } : prev;
+		});
+	}
+
+	function leaveWithoutToken() {
+		tokenAtRiskRef.current = false;
+		for (const controller of rotationControllersRef.current.values()) controller.abort();
+		rotationControllersRef.current.clear();
+		setRotated((prev) =>
+			Object.fromEntries(Object.keys(prev).map((linkId) => [linkId, { status: "unrecoverable" }])),
+		);
+		if (blocker.status === "blocked") blocker.proceed();
 	}
 
 	if (links.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
@@ -498,10 +663,9 @@ function AgentsTab({
 								</div>
 								{rotated[link.id] ? (
 									<div className="mt-3">
-										<TokenReveal
-											label="New agent token"
-											value={rotated[link.id]}
-											note="The previous token is now invalid. Update the agent with this value."
+										<RotatedTokenCard
+											state={rotated[link.id]}
+											onAcknowledge={() => acknowledgeToken(link.id)}
 										/>
 									</div>
 								) : null}
@@ -520,6 +684,34 @@ function AgentsTab({
 					provider={provider}
 				/>
 			)}
+
+			<AlertDialog
+				open={blocker.status === "blocked"}
+				onOpenChange={(open) => {
+					if (!open && blocker.status === "blocked") blocker.reset();
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							{rotatingLinks.size > 0
+								? "Leave while token rotation is in progress?"
+								: "Leave without saving the new token?"}
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							{rotatingLinks.size > 0
+								? "The one-time token may be returned after this page closes. If you leave, it could be lost and cannot be recovered — rotate again to get a new one."
+								: "This token is shown only once and has not been copied or acknowledged. If you leave, it will be lost. This token was shown once and is not recoverable — rotate again to get a new one."}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Stay and copy token</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onClick={leaveWithoutToken}>
+							Leave and lose token
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- describe accepted deployments as provisioning across wallet, checkout-return, and free paths
- guard one-time rotated channel tokens until copied or acknowledged, with explicit unrecoverable recovery copy and no plaintext persistence
- bound welcome-grant rechecks to a visible-tab-aware 60-second window with a manual refresh state
- refresh the three affected hosted smoke flows to the current USD billing contract

## Verification

- bun run check
- bun run lint
- bun run typecheck
- bun run build
- bun test apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
- bun run --cwd apps/web e2e:hosted --grep "wallet annual quotes|pending welcome balance|rotated channel token"

No backend changes or production operations are included.