### PR TITLE
fix(hosted): show honest usage and wallet states

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2659,12 +2659,17 @@ function ComputeSettingsSections({
 					defaultFundingSource={isWalletFunded ? "wallet" : "stripe"}
 					fundingSourceSelectable={isIncludedBasic}
 					quote={planChangeQuote}
-					walletBalanceUsd={wallet.data?.balance_usd ?? null}
+					walletBalanceUsd={
+						wallet.error || wallet.isFetching ? null : (wallet.data?.balance_usd ?? null)
+					}
+					walletBalanceError={wallet.error}
+					isWalletBalanceFetching={wallet.isFetching}
 					isQuoting={quotePlanChange.isPending}
 					isConfirming={changePlan.isPending}
 					onQuote={requestPlanChangeQuote}
 					onConfirm={confirmPlanChange}
 					onTopUp={() => walletTopUp.show()}
+					onRetryWalletBalance={() => void wallet.refetch()}
 				/>
 			) : null}
 

--- a/apps/web/src/hosted/billing/components/wallet-debit-equation.test.tsx
+++ b/apps/web/src/hosted/billing/components/wallet-debit-equation.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+	trustworthyWalletBalanceUsd,
+	WalletDebitEquation,
+} from "@/hosted/billing/components/wallet-debit-equation";
+import { walletPlanChangeDecision } from "@/hosted/billing/subscription/plan-change-dialog";
+
+const planChangeSource = readFileSync(
+	new URL("../subscription/plan-change-dialog.tsx", import.meta.url),
+	"utf8",
+);
+const agentDetailSource = readFileSync(
+	new URL("../../agents/hosted-agent-detail.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("WalletDebitEquation availability", () => {
+	test("shows the shared Wallet retry panel without a cached balance after a read error", () => {
+		const html = renderToStaticMarkup(
+			<WalletDebitEquation
+				balanceBeforeUsd={null}
+				debitAmountUsd="25"
+				balanceAfterUsd={null}
+				balanceError={new Error("Wallet read failed")}
+				onRetryBalance={() => undefined}
+			/>,
+		);
+
+		expect(html).toContain("Couldn&#x27;t load your Wallet balance");
+		expect(html).toContain("Retry");
+		expect(html).not.toContain("Balance before");
+		expect(html).not.toContain("$100.00");
+	});
+
+	test("does not treat cached data as trustworthy while refetching", () => {
+		expect(
+			trustworthyWalletBalanceUsd({ balanceUsd: "100", error: null, isFetching: true }),
+		).toBeNull();
+		expect(
+			walletPlanChangeDecision({
+				fundingSource: "wallet",
+				changeKind: "immediate_upgrade",
+				amountUsd: "25",
+				balanceUsd: "100",
+				balanceError: null,
+				isBalanceFetching: true,
+			}),
+		).toMatchObject({
+			trustedBalanceUsd: null,
+			balanceAfterUsd: null,
+			walletInsufficient: false,
+			balanceReadUnavailable: true,
+		});
+	});
+});
+
+describe("plan-change Wallet decision", () => {
+	test("does not compute sufficiency from a cached balance after wallet.error", () => {
+		const decision = walletPlanChangeDecision({
+			fundingSource: "wallet",
+			changeKind: "immediate_upgrade",
+			amountUsd: "25",
+			balanceUsd: "100",
+			balanceError: new Error("background refetch failed"),
+			isBalanceFetching: false,
+		});
+
+		expect(decision).toEqual({
+			trustedBalanceUsd: null,
+			balanceAfterUsd: null,
+			walletInsufficient: false,
+			balanceReadUnavailable: true,
+		});
+		expect(planChangeSource).toContain("walletDecision.balanceReadUnavailable");
+		expect(agentDetailSource).toContain(
+			"wallet.error || wallet.isFetching ? null : (wallet.data?.balance_usd ?? null)",
+		);
+	});
+});

--- a/apps/web/src/hosted/billing/components/wallet-debit-equation.tsx
+++ b/apps/web/src/hosted/billing/components/wallet-debit-equation.tsx
@@ -1,4 +1,20 @@
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Spinner } from "@/components/ui/spinner";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
+
+export function trustworthyWalletBalanceUsd({
+	balanceUsd,
+	error,
+	isFetching,
+}: {
+	balanceUsd: string | null;
+	error: unknown;
+	isFetching: boolean;
+}): string | null {
+	return error || isFetching ? null : balanceUsd;
+}
 
 function EquationValue({ label, amountUsd }: { label: string; amountUsd: string }) {
 	return (
@@ -13,11 +29,39 @@ export function WalletDebitEquation({
 	balanceBeforeUsd,
 	debitAmountUsd,
 	balanceAfterUsd,
+	balanceError,
+	isBalanceFetching = false,
+	onRetryBalance,
 }: {
-	balanceBeforeUsd: string;
+	balanceBeforeUsd: string | null;
 	debitAmountUsd: string;
-	balanceAfterUsd: string;
+	balanceAfterUsd: string | null;
+	balanceError?: unknown;
+	isBalanceFetching?: boolean;
+	onRetryBalance?: () => void;
 }) {
+	if (balanceError) {
+		return (
+			<ApiErrorPanel
+				normalizer={billingErrorNormalizer}
+				error={balanceError}
+				title="Couldn't load your Wallet balance"
+				onRetry={onRetryBalance}
+			/>
+		);
+	}
+	if (isBalanceFetching || balanceBeforeUsd === null || balanceAfterUsd === null) {
+		return (
+			<Alert data-hosted="true">
+				<Spinner />
+				<AlertTitle>Refreshing Wallet balance</AlertTitle>
+				<AlertDescription>
+					The balance equation will appear after a fresh Wallet read completes.
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
 	const accessibleEquation = `${formatUsdExact(balanceBeforeUsd)} minus ${formatUsdExact(
 		debitAmountUsd,
 	)} equals ${formatUsdExact(balanceAfterUsd)}`;

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { CalendarClock, CreditCard, TriangleAlert, WalletCards } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,13 +25,17 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
-import { WalletDebitEquation } from "@/hosted/billing/components/wallet-debit-equation";
+import {
+	trustworthyWalletBalanceUsd,
+	WalletDebitEquation,
+} from "@/hosted/billing/components/wallet-debit-equation";
 import type {
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeQuoteResponse,
 	ComputePlanSlug,
 	Plan,
 } from "@/hosted/billing/contracts";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
 import {
 	computeTierLabel,
@@ -56,6 +61,40 @@ function planSlug(value: string | null): ComputePlanSlug | null {
 	return value === "compute_basic" || value === "compute_performance" ? value : null;
 }
 
+export function walletPlanChangeDecision({
+	fundingSource,
+	changeKind,
+	amountUsd,
+	balanceUsd,
+	balanceError,
+	isBalanceFetching,
+}: {
+	fundingSource: "stripe" | "wallet";
+	changeKind: ComputePlanChangeQuoteResponse["change_kind"] | null;
+	amountUsd: string | null;
+	balanceUsd: string | null;
+	balanceError: unknown;
+	isBalanceFetching: boolean;
+}) {
+	const trustedBalanceUsd = trustworthyWalletBalanceUsd({
+		balanceUsd,
+		error: balanceError,
+		isFetching: isBalanceFetching,
+	});
+	const balanceRequired =
+		fundingSource === "wallet" && changeKind === "immediate_upgrade" && amountUsd !== null;
+	const balanceAfterUsd =
+		balanceRequired && trustedBalanceUsd
+			? walletBalanceAfterDebit(trustedBalanceUsd, amountUsd)
+			: null;
+	return {
+		trustedBalanceUsd,
+		balanceAfterUsd,
+		walletInsufficient: balanceAfterUsd?.startsWith("-") ?? false,
+		balanceReadUnavailable: balanceRequired && trustedBalanceUsd === null,
+	};
+}
+
 export function PlanChangeDialog({
 	open,
 	onOpenChange,
@@ -66,11 +105,14 @@ export function PlanChangeDialog({
 	fundingSourceSelectable,
 	quote,
 	walletBalanceUsd,
+	walletBalanceError,
+	isWalletBalanceFetching,
 	isQuoting,
 	isConfirming,
 	onQuote,
 	onConfirm,
 	onTopUp,
+	onRetryWalletBalance,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -81,11 +123,14 @@ export function PlanChangeDialog({
 	fundingSourceSelectable: boolean;
 	quote: ComputePlanChangeQuoteResponse | null;
 	walletBalanceUsd: string | null;
+	walletBalanceError: unknown;
+	isWalletBalanceFetching: boolean;
 	isQuoting: boolean;
 	isConfirming: boolean;
 	onQuote: (selection: PlanChangeSelection) => void;
 	onConfirm: (operationId: string) => void;
 	onTopUp?: () => void;
+	onRetryWalletBalance: () => void;
 }) {
 	const initialSelection = useMemo(
 		() =>
@@ -107,16 +152,22 @@ export function PlanChangeDialog({
 	);
 	const noChange = isSamePlanChangeSelection(selection, currentPlanSlug, currentBillingTermMonths);
 	const quoteFundingSource = quote?.funding_source ?? selection.funding_source;
-	const walletBalanceAfter =
-		quoteFundingSource === "wallet" && quote?.amount_usd && walletBalanceUsd
-			? walletBalanceAfterDebit(walletBalanceUsd, quote.amount_usd)
-			: null;
-	const walletInsufficient = walletBalanceAfter?.startsWith("-") ?? false;
+	const walletDecision = walletPlanChangeDecision({
+		fundingSource: quoteFundingSource,
+		changeKind: quote?.change_kind ?? null,
+		amountUsd: quote?.amount_usd ?? null,
+		balanceUsd: walletBalanceUsd,
+		balanceError: walletBalanceError,
+		isBalanceFetching: isWalletBalanceFetching,
+	});
+	const walletBalanceAfter = walletDecision.balanceAfterUsd;
+	const walletInsufficient = walletDecision.walletInsufficient;
 	const walletQuoteMissingAmount =
 		quoteFundingSource === "wallet" &&
 		quote?.change_kind === "immediate_upgrade" &&
 		!quote.amount_usd;
-	const walletReady = selection.funding_source !== "wallet" || walletBalanceUsd !== null;
+	const walletReady =
+		selection.funding_source !== "wallet" || walletDecision.trustedBalanceUsd !== null;
 
 	useEffect(() => {
 		if (open) setSelection(initialSelection);
@@ -199,13 +250,14 @@ export function PlanChangeDialog({
 						</div>
 						{quoteFundingSource === "wallet" &&
 						quote.change_kind === "immediate_upgrade" &&
-						quote.amount_usd &&
-						walletBalanceUsd &&
-						walletBalanceAfter ? (
+						quote.amount_usd ? (
 							<WalletDebitEquation
-								balanceBeforeUsd={walletBalanceUsd}
+								balanceBeforeUsd={walletDecision.trustedBalanceUsd}
 								debitAmountUsd={quote.amount_usd}
 								balanceAfterUsd={walletBalanceAfter}
+								balanceError={walletBalanceError}
+								isBalanceFetching={isWalletBalanceFetching}
+								onRetryBalance={onRetryWalletBalance}
 							/>
 						) : null}
 						{quote.change_kind === "scheduled_downgrade" ? (
@@ -247,7 +299,12 @@ export function PlanChangeDialog({
 							</Button>
 							<Button
 								onClick={() => onConfirm(quote.operation_id)}
-								disabled={isConfirming || walletInsufficient || walletQuoteMissingAmount}
+								disabled={
+									isConfirming ||
+									walletInsufficient ||
+									walletQuoteMissingAmount ||
+									walletDecision.balanceReadUnavailable
+								}
 							>
 								{isConfirming ? (
 									<Spinner data-icon="inline-start" />
@@ -329,9 +386,16 @@ export function PlanChangeDialog({
 								Funding source: {selection.funding_source === "wallet" ? "Wallet" : "Card"}
 							</p>
 						)}
-						{selection.funding_source === "wallet" && !walletReady ? (
+						{selection.funding_source === "wallet" && walletBalanceError ? (
+							<ApiErrorPanel
+								normalizer={billingErrorNormalizer}
+								error={walletBalanceError}
+								title="Couldn't load your Wallet balance"
+								onRetry={onRetryWalletBalance}
+							/>
+						) : selection.funding_source === "wallet" && !walletReady ? (
 							<p className="text-sm text-muted-foreground" role="status">
-								Loading Wallet balance…
+								Refreshing Wallet balance…
 							</p>
 						) : null}
 						{selectedOffer ? (

--- a/apps/web/src/hosted/billing/usage/usage-page.test.ts
+++ b/apps/web/src/hosted/billing/usage/usage-page.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { partialUsageDescription, usagePageState } from "@/hosted/billing/usage/usage-page";
+
+type Usage = Parameters<typeof usagePageState>[0];
+
+function usage(overrides: Partial<Usage> = {}): Usage {
+	return {
+		period_start: "2026-07-01T00:00:00Z",
+		period_end: "2026-08-01T00:00:00Z",
+		availability: "complete",
+		unavailable_sections: [],
+		total_usd: "0",
+		total_requests: 0,
+		by_model: [],
+		by_day: [],
+		...overrides,
+	};
+}
+
+describe("usage page availability", () => {
+	test("renders unreadable usage as unavailable instead of no usage", () => {
+		expect(
+			usagePageState(
+				usage({
+					availability: "unavailable",
+					unavailable_sections: ["totals", "by_model", "by_day"],
+					total_usd: null,
+					total_requests: null,
+				}),
+			),
+		).toEqual({ kind: "unavailable" });
+	});
+
+	test("keeps a complete zero-usage account in the genuine empty state", () => {
+		expect(usagePageState(usage())).toEqual({ kind: "empty" });
+	});
+
+	test("labels successful totals with a missing daily query as partial", () => {
+		const state = usagePageState(
+			usage({
+				availability: "partial",
+				unavailable_sections: ["by_day"],
+				total_usd: "0.125",
+				total_requests: 3,
+				by_model: [{ model: "gpt-test", provider: null, amount_usd: "0.125", requests: 3 }],
+			}),
+		);
+
+		expect(state.kind).toBe("partial");
+		expect(state).toEqual({
+			kind: "partial",
+			description:
+				"The daily breakdown is temporarily unavailable. The totals and model breakdown below are complete.",
+		});
+	});
+
+	test("names totals and model breakdown when only daily data loaded", () => {
+		expect(partialUsageDescription(["totals", "by_model"])).toContain(
+			"Usage totals and the model breakdown",
+		);
+	});
+});

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Activity } from "lucide-react";
+import type { DeployComponents } from "@clawdi/shared/api";
+import { Activity, RefreshCw, TriangleAlert } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -22,6 +25,48 @@ import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Managed-AI usage in USD for the current reporting window across your agents.";
 const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
+const USAGE_UNAVAILABLE_ERROR = new Error(
+	"Usage data is temporarily unavailable. No usage totals were shown.",
+);
+
+type HostedUsage = DeployComponents["schemas"]["V2HostedUsageSummaryResponse"];
+type UsageUnavailableSection = HostedUsage["unavailable_sections"][number];
+
+export type UsagePageState =
+	| { kind: "unavailable" }
+	| { kind: "empty" }
+	| { kind: "partial"; description: string }
+	| { kind: "complete" };
+
+export function partialUsageDescription(sections: readonly UsageUnavailableSection[]): string {
+	const totalsUnavailable = sections.includes("totals");
+	const modelsUnavailable = sections.includes("by_model");
+	const dailyUnavailable = sections.includes("by_day");
+	if (totalsUnavailable && modelsUnavailable && !dailyUnavailable) {
+		return "Usage totals and the model breakdown are temporarily unavailable. Only the daily breakdown could be loaded.";
+	}
+	if (dailyUnavailable && !totalsUnavailable && !modelsUnavailable) {
+		return "The daily breakdown is temporarily unavailable. The totals and model breakdown below are complete.";
+	}
+	return "Some usage data is temporarily unavailable. Missing sections are labelled below.";
+}
+
+export function usagePageState(usage: HostedUsage): UsagePageState {
+	if (usage.availability === "unavailable") return { kind: "unavailable" };
+	if (usage.availability === "partial") {
+		return {
+			kind: "partial",
+			description: partialUsageDescription(usage.unavailable_sections),
+		};
+	}
+	if (usage.total_usd === null || usage.total_requests === null) {
+		return { kind: "unavailable" };
+	}
+	if (decimalUsdNumber(usage.total_usd) === 0 && usage.by_model.length === 0) {
+		return { kind: "empty" };
+	}
+	return { kind: "complete" };
+}
 
 function decimalUsdNumber(value: string): number {
 	const parsed = Number(value);
@@ -56,7 +101,25 @@ export function UsagePage() {
 	}
 
 	const u = usage.data;
+	const pageState = usagePageState(u);
+	if (pageState.kind === "unavailable") {
+		return (
+			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
+				<PageHeader title="Usage" description={DESCRIPTION} />
+				<ApiErrorPanel
+					normalizer={billingErrorNormalizer}
+					error={USAGE_UNAVAILABLE_ERROR}
+					title="Couldn't load usage"
+					onRetry={() => usage.refetch()}
+				/>
+			</div>
+		);
+	}
+
 	const hasDailyBreakdown = u.by_day.length > 0;
+	const totalsUnavailable = u.total_usd === null || u.total_requests === null;
+	const dailyUnavailable = u.unavailable_sections.includes("by_day");
+	const modelsUnavailable = u.unavailable_sections.includes("by_model");
 	const firstDailyPoint = u.by_day[0];
 	const lastDailyPoint = u.by_day[u.by_day.length - 1];
 	const windowLabel = `${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)}`;
@@ -67,7 +130,7 @@ export function UsagePage() {
 	const maxDay = Math.max(0, ...u.by_day.map((day) => decimalUsdNumber(day.amount_usd)));
 	const maxModel = Math.max(0, ...u.by_model.map((model) => decimalUsdNumber(model.amount_usd)));
 
-	if (decimalUsdNumber(u.total_usd) === 0 && u.by_model.length === 0) {
+	if (pageState.kind === "empty") {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
@@ -84,21 +147,40 @@ export function UsagePage() {
 		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 			<PageHeader
 				title="Usage"
-				description={`${windowLabel} reporting window. Totals below are for this window; wallet balance carries over.`}
+				description={
+					pageState.kind === "partial"
+						? `${windowLabel} reporting window. Available data is shown below; missing sections are labelled.`
+						: `${windowLabel} reporting window. Totals below are for this window; wallet balance carries over.`
+				}
 			/>
+
+			{pageState.kind === "partial" ? (
+				<Alert>
+					<TriangleAlert aria-hidden />
+					<AlertTitle>Some usage data couldn't be loaded</AlertTitle>
+					<AlertDescription className="flex flex-col items-start gap-3">
+						<span>{pageState.description}</span>
+						<Button type="button" size="sm" variant="outline" onClick={() => usage.refetch()}>
+							<RefreshCw /> Retry
+						</Button>
+					</AlertDescription>
+				</Alert>
+			) : null}
 
 			{/* Totals */}
 			<div className="grid gap-3 sm:grid-cols-2">
 				<Card data-hosted="true">
 					<CardContent>
-						<div className="text-3xl font-semibold tabular-nums">{formatUsdExact(u.total_usd)}</div>
+						<div className="text-3xl font-semibold tabular-nums">
+							{u.total_usd === null ? "Unavailable" : formatUsdExact(u.total_usd)}
+						</div>
 						<div className="text-sm text-muted-foreground">Managed-AI spend in window</div>
 					</CardContent>
 				</Card>
 				<Card data-hosted="true">
 					<CardContent>
 						<div className="text-3xl font-semibold tabular-nums">
-							{u.total_requests.toLocaleString()}
+							{u.total_requests === null ? "Unavailable" : u.total_requests.toLocaleString()}
 						</div>
 						<div className="text-sm text-muted-foreground">Requests in window</div>
 					</CardContent>
@@ -111,7 +193,13 @@ export function UsagePage() {
 					<CardTitle className="text-base">Daily consumption</CardTitle>
 				</CardHeader>
 				<CardContent>
-					{hasDailyBreakdown ? (
+					{dailyUnavailable ? (
+						<EmptyState
+							variant="inset"
+							description="Daily breakdown temporarily unavailable"
+							className="py-4 md:p-4"
+						/>
+					) : hasDailyBreakdown ? (
 						<>
 							<div className="flex h-28 items-end gap-1" role="img" aria-label={dailyChartLabel}>
 								{u.by_day.map((d) => (
@@ -166,7 +254,13 @@ export function UsagePage() {
 					<CardTitle className="text-base">By model</CardTitle>
 				</CardHeader>
 				<CardContent className="flex flex-col gap-4">
-					{u.by_model.length === 0 ? (
+					{modelsUnavailable || totalsUnavailable ? (
+						<EmptyState
+							variant="inset"
+							description="Model breakdown temporarily unavailable"
+							className="py-4 md:p-4"
+						/>
+					) : u.by_model.length === 0 ? (
 						<EmptyState
 							variant="inset"
 							description="No model breakdown available"

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1721,10 +1721,17 @@ export interface components {
             period_start: string;
             /** Period End */
             period_end: string;
+            /**
+             * Availability
+             * @enum {string}
+             */
+            availability: "complete" | "partial" | "unavailable";
+            /** Unavailable Sections */
+            unavailable_sections: ("totals" | "by_model" | "by_day")[];
             /** Total Usd */
-            total_usd: string;
+            total_usd: string | null;
             /** Total Requests */
-            total_requests: number;
+            total_requests: number | null;
             /** By Model */
             by_model: components["schemas"]["V2HostedUsageModelBreakdown"][];
             /** By Day */

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -32,6 +32,8 @@ const wallet: DeploySchemas["V2WalletResponse"] = {
 const usage: DeploySchemas["V2HostedUsageSummaryResponse"] = {
 	period_start: "2026-07-01",
 	period_end: "2026-07-31",
+	availability: "complete",
+	unavailable_sections: [],
 	total_usd: "0.000001",
 	total_requests: 1,
 	by_model: [
@@ -42,6 +44,17 @@ const usage: DeploySchemas["V2HostedUsageSummaryResponse"] = {
 			requests: 1,
 		},
 	],
+	by_day: [{ date: "2026-07-24", amount_usd: "0.000001" }],
+};
+
+const partialUsage: DeploySchemas["V2HostedUsageSummaryResponse"] = {
+	period_start: "2026-07-01",
+	period_end: "2026-07-31",
+	availability: "partial",
+	unavailable_sections: ["totals", "by_model"],
+	total_usd: null,
+	total_requests: null,
+	by_model: [],
 	by_day: [{ date: "2026-07-24", amount_usd: "0.000001" }],
 };
 
@@ -77,5 +90,11 @@ describe("USD-native v2 billing contract", () => {
 		});
 		expect(usage.total_usd).toBe("0.000001");
 		expect(usage.by_model[0]?.amount_usd).toBe("0.000001");
+		expect(partialUsage).toMatchObject({
+			availability: "partial",
+			unavailable_sections: ["totals", "by_model"],
+			total_usd: null,
+			total_requests: null,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- render explicit complete, partial, and unavailable usage states from the v2 API
- keep the real zero-usage empty state only for a complete successful read
- label each missing partial section and provide Retry
- treat cached Wallet balance as untrusted whenever its query has errored or is refetching
- reuse the existing billing ApiErrorPanel + Retry pattern in the plan-change dialog
- hide the balance equation and block confirmation on read availability until a fresh Wallet read succeeds
- regenerate the deploy API client from the companion backend schema

The Wallet change fixes misleading UI only. The backend already performs the authoritative live preflight before any debit or plan change, so this is not a money-safety defect.

## Dependency and merge order

Companion backend PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/1029

Merge and deploy the hosted backend PR first, then this frontend PR. This branch contains the regenerated client for the new required availability fields and nullable usage totals.

## Verification

- bun run check
- bun run lint
- bun run typecheck
- bun run build
- affected usage and Wallet component tests — 7 passed
- shared generated-contract tests — 3 passed

Browser verification was not run because the surface requires an authenticated hosted API session; component rendering tests, state-logic tests, typecheck, and the production build cover the changed paths.

## Scope

No legacy v1 files, off-limits files, or .github files were touched.
