### PR TITLE
fix(web): keep secrets out of client caches

### DIFF
--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -24,6 +24,27 @@ const agents = [
 		explicit_identity: true,
 		default_project_id: "project-smoke",
 	},
+	{
+		id: "agent-smoke-2",
+		name: "smoke-hermes",
+		default_name: "Smoke Hermes",
+		machine_name: "smoke-hermes.local",
+		display_name: "Smoke Hermes",
+		avatar_url: null,
+		sort_order: 1,
+		agent_type: "hermes",
+		agent_version: "1.0.0",
+		os: "linux",
+		last_seen_at: now.toISOString(),
+		last_sync_at: now.toISOString(),
+		last_sync_error: null,
+		last_revision_seen: 8,
+		queue_depth_high_water: 0,
+		dropped_count: 0,
+		sync_enabled: true,
+		explicit_identity: true,
+		default_project_id: "project-smoke",
+	},
 ];
 
 const projects = [
@@ -100,9 +121,22 @@ async function fulfillJson(route: Route, body: unknown) {
 	});
 }
 
-async function stubDashboardApi(page: Page) {
+async function stubDashboardApi(page: Page, agentOrderRequests: string[] = []) {
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents/order" && route.request().method() === "PATCH") {
+			agentOrderRequests.push(route.request().postData() ?? "");
+			const requested = JSON.parse(route.request().postData() ?? "{}") as {
+				agent_ids?: string[];
+			};
+			const byId = new Map(agents.map((agent) => [agent.id, agent]));
+			const ordered = (requested.agent_ids ?? [])
+				.map((id) => byId.get(id))
+				.filter((agent) => agent !== undefined)
+				.map((agent, index) => ({ ...agent, sort_order: index }));
+			await fulfillJson(route, ordered);
+			return;
+		}
 		if (url.pathname === "/v1/agents") {
 			await fulfillJson(route, agents);
 			return;
@@ -183,4 +217,32 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await page.getByTestId("settings-theme-select").click();
 	await expect(page.getByRole("option", { name: "Dark" })).toBeVisible();
 	await expectNoBrowserErrors(page, browserErrors, "settings select");
+});
+
+test("agent rail exposes current order and supports keyboard sorting", async ({ page }) => {
+	const agentOrderRequests: string[] = [];
+	await stubDashboardApi(page, agentOrderRequests);
+	await page.goto("/");
+
+	const firstHandle = page.getByRole("button", {
+		name: "Reorder Smoke Codex · Codex, position 1 of 2",
+		exact: true,
+	});
+	await expect(firstHandle).toBeVisible();
+	await firstHandle.focus();
+	await expect(firstHandle).toBeFocused();
+	await page.keyboard.press("Space");
+	await page.keyboard.press("ArrowDown");
+	await page.keyboard.press("Space");
+
+	await expect.poll(() => agentOrderRequests.length).toBe(1);
+	expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
+		agent_ids: ["agent-smoke-2", "agent-smoke-1"],
+	});
+	await expect(
+		page.getByRole("button", {
+			name: "Reorder Smoke Codex · Codex, position 2 of 2",
+			exact: true,
+		}),
+	).toBeVisible();
 });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
 	DndContext,
 	type DragEndEvent,
 	type DragOverEvent,
+	KeyboardSensor,
 	type Modifier,
 	PointerSensor,
 	TouchSensor,
@@ -15,6 +16,7 @@ import {
 import {
 	arrayMove,
 	SortableContext,
+	sortableKeyboardCoordinates,
 	useSortable,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
@@ -26,6 +28,7 @@ import {
 	CircleHelp,
 	Cloud,
 	ExternalLink,
+	GripVertical,
 	History,
 	Layers,
 	LayoutDashboard,
@@ -848,6 +851,8 @@ function RailFocusButton({
 
 function SortableAgentRailItem({
 	agent,
+	position,
+	itemCount,
 	active,
 	onNavigate,
 	onClickCapture,
@@ -856,6 +861,8 @@ function SortableAgentRailItem({
 	showTooltip,
 }: {
 	agent: AgentTile;
+	position: number;
+	itemCount: number;
 	active: boolean;
 	onNavigate: React.MouseEventHandler<HTMLAnchorElement>;
 	onClickCapture: React.MouseEventHandler<HTMLAnchorElement>;
@@ -863,10 +870,15 @@ function SortableAgentRailItem({
 	onTouchStartCapture: React.TouchEventHandler<HTMLAnchorElement>;
 	showTooltip: boolean;
 }) {
-	const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-		id: agent.id,
-		disabled: !agent.env,
-	});
+	const {
+		attributes,
+		listeners,
+		setActivatorNodeRef,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id: agent.id, disabled: !agent.env });
 	const kind = agentTileChromeKind(agent);
 	const identity = agent.env ?? {
 		id: agent.id,
@@ -890,10 +902,7 @@ function SortableAgentRailItem({
 		transition: isDragging ? undefined : transition,
 		zIndex: isDragging ? 20 : undefined,
 	};
-	const dragPointerDown: React.PointerEventHandler<HTMLAnchorElement> | undefined =
-		listeners?.onPointerDown ? (event) => listeners.onPointerDown?.(event) : undefined;
-	const dragTouchStart: React.TouchEventHandler<HTMLAnchorElement> | undefined =
-		listeners?.onTouchStart ? (event) => listeners.onTouchStart?.(event) : undefined;
+	const reorderLabel = `Reorder ${baseIdentityLabel}, position ${position} of ${itemCount}`;
 
 	return (
 		<SidebarMenuItem
@@ -913,9 +922,7 @@ function SortableAgentRailItem({
 				onNavigate={onNavigate}
 				onClickCapture={onClickCapture}
 				onPointerDownCapture={onPointerDownCapture}
-				onPointerDown={dragPointerDown}
 				onTouchStartCapture={onTouchStartCapture}
-				onTouchStart={dragTouchStart}
 				showTooltip={showTooltip}
 			>
 				<span className="relative inline-flex rounded-md">
@@ -937,6 +944,20 @@ function SortableAgentRailItem({
 					) : null}
 				</span>
 			</RailFocusButton>
+			<Button
+				ref={setActivatorNodeRef}
+				type="button"
+				variant="ghost"
+				size="icon-sm"
+				className="absolute right-0 bottom-0 z-30 size-5 cursor-grab rounded-sm bg-sidebar/85 text-muted-foreground opacity-70 shadow-sm hover:opacity-100 focus-visible:opacity-100 active:cursor-grabbing"
+				disabled={!agent.env}
+				aria-label={reorderLabel}
+				title={reorderLabel}
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical aria-hidden="true" className="size-3" />
+			</Button>
 		</SidebarMenuItem>
 	);
 }
@@ -969,6 +990,7 @@ function FocusRailContent({
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE } }),
 		useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
 	);
 	useEffect(() => {
 		if (!draggingRailItem.current) {
@@ -1155,10 +1177,12 @@ function FocusRailContent({
 						onDragEnd={onDragEnd}
 					>
 						<SortableContext items={orderedAgentIds} strategy={verticalListSortingStrategy}>
-							{orderedAgents.map((agent) => (
+							{orderedAgents.map((agent, index) => (
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
+									position={index + 1}
+									itemCount={orderedAgents.length}
 									active={Boolean(activeAgentId && agentTileMatchesRouteId(agent, activeAgentId))}
 									onNavigate={onRailAgentNavigate}
 									onClickCapture={onRailAgentClickCapture}

--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -15,7 +16,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { useAuthFields, useConnectCredentials } from "@/lib/connectors-data";
+import { unwrap, useApi } from "@/lib/api";
+import { useAuthFields } from "@/lib/connectors-data";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
 import { buildCredentialPayload, getVisibleCredentialFields } from "./credentials-dialog.logic";
 
@@ -26,8 +29,8 @@ import { buildCredentialPayload, getVisibleCredentialFields } from "./credential
  * detail page's existing `window.open(connect_url)`) and credentials
  * (this dialog). The dialog fetches the field schema lazily on open
  * so the user pays no cost for OAuth-only deployments. All hosted vs
- * OSS branching is encapsulated in `useAuthFields` /
- * `useConnectCredentials` from `@/lib/connectors-data`.
+ * OSS branching is encapsulated in `useAuthFields`; credential submission is
+ * an imperative sensitive action so plaintext never enters MutationCache.
  */
 export function ConnectorCredentialsDialog({
 	open,
@@ -41,7 +44,17 @@ export function ConnectorCredentialsDialog({
 	displayName: string;
 }) {
 	const fields = useAuthFields(appName, { enabled: open });
-	const submit = useConnectCredentials();
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const submit = useSensitiveAction(async (credentials: Record<string, string>): Promise<void> => {
+		unwrap(
+			await api.POST("/v1/connectors/{app_name}/connect-credentials", {
+				params: { path: { app_name: appName } },
+				body: { credentials },
+			}),
+		);
+		queryClient.invalidateQueries({ queryKey: ["connections"] });
+	});
 	const [values, setValues] = useState<Record<string, string>>({});
 	const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -65,7 +78,6 @@ export function ConnectorCredentialsDialog({
 	const inflightSubmitRef = useRef(false);
 	useEffect(() => {
 		openGenRef.current += 1;
-		if (!open) return;
 		setValues({});
 		setSubmitError(null);
 	}, [open]);
@@ -83,11 +95,12 @@ export function ConnectorCredentialsDialog({
 		setSubmitError(null);
 		try {
 			const credentials = buildCredentialPayload(allFields, values);
-			await submit.mutateAsync({ appName, credentials });
+			await submit.execute(credentials);
 			// Drop the result if the dialog has been reopened — toasts
 			// and `onOpenChange(false)` should target the session that
 			// initiated the mutation, not whatever the user is doing now.
 			if (gen !== openGenRef.current) return;
+			setValues({});
 			toast.success(`${displayName} connected`);
 			onOpenChange(false);
 		} catch (e) {

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,39 +1,16 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import { useEffect, useRef, useState } from "react";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { ApiError } from "@/lib/api-errors";
 import { useCurrentUser } from "@/lib/auth-client";
+import { createAppQueryClient } from "@/lib/query-client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-	const [queryClient] = useState(
-		() =>
-			new QueryClient({
-				defaultOptions: {
-					queries: {
-						staleTime: 30_000,
-						retry: (failureCount, error) => {
-							if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
-								return false;
-							}
-							// Fetch-level failures (no HTTP response) get a longer budget
-							// (~7s of backoff) than server errors (~3s): backend deploys
-							// swap containers behind the proxy, and for a few seconds the
-							// proxy answers with its own CORS-less 502, which the browser
-							// can only see as a fetch failure.
-							if (!(error instanceof ApiError)) {
-								return failureCount < 3;
-							}
-							return failureCount < 2;
-						},
-					},
-				},
-			}),
-	);
+	const [queryClient] = useState(createAppQueryClient);
 	return (
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<NuqsAdapter>

--- a/apps/web/src/components/root-error.tsx
+++ b/apps/web/src/components/root-error.tsx
@@ -23,7 +23,9 @@ export default function RootError({
 	reset: () => void;
 }) {
 	useEffect(() => {
-		console.error("Unhandled app error:", error);
+		// Error objects can carry request details. Keep the production signal
+		// without serializing a possibly secret-bearing payload into browser logs.
+		console.error("Unhandled app error");
 	}, [error]);
 
 	return (

--- a/apps/web/src/components/settings/api-keys-panel.test.ts
+++ b/apps/web/src/components/settings/api-keys-panel.test.ts
@@ -16,7 +16,8 @@ describe("API keys query states", () => {
 describe("API key creation safeguards", () => {
 	test("trims labels and rejects whitespace-only input", () => {
 		expect(source).toContain("const normalizedNewLabel = newLabel.trim()");
-		expect(source).toContain("createKey.mutate(normalizedNewLabel)");
+		expect(source).toContain("createKey.execute(normalizedNewLabel)");
+		expect(source).toContain("const createKey = useSensitiveAction(");
 		expect(source).toContain("disabled={!normalizedNewLabel || createKey.isPending");
 	});
 
@@ -27,8 +28,8 @@ describe("API key creation safeguards", () => {
 		expect(source).toContain("I&apos;ve saved it");
 	});
 
-	test("normalizes create and revoke mutation errors", () => {
-		expect(source).toContain('onError: toastApiError("Couldn\'t create key")');
+	test("normalizes create-action and revoke-mutation errors", () => {
+		expect(source).toContain('toastApiError("Couldn\'t create key")(error)');
 		expect(source).toContain('onError: toastApiError("Couldn\'t turn off key")');
 		expect(source).not.toMatch(/onError:.*\.detail/);
 	});

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -16,6 +16,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /** API Keys settings — CLI-facing bearer tokens. */
 export function ApiKeysPanel() {
@@ -35,15 +36,17 @@ export function ApiKeysPanel() {
 		queryFn: async () => unwrap(await api.GET("/v1/auth/keys")),
 	});
 
-	const createKey = useMutation({
-		mutationFn: async (label: string) =>
-			unwrap(await api.POST("/v1/auth/keys", { body: { label } })),
-		onSuccess: (data) => {
+	const createKey = useSensitiveAction(async (label: string) => {
+		try {
+			const data = unwrap(await api.POST("/v1/auth/keys", { body: { label } }));
 			setCreatedKey(data.raw_key);
 			setNewLabel("");
 			queryClient.invalidateQueries({ queryKey: ["api-keys"] });
-		},
-		onError: toastApiError("Couldn't create key"),
+			return data;
+		} catch (error) {
+			toastApiError("Couldn't create key")(error);
+			throw error;
+		}
 	});
 
 	const revokeKey = useMutation({
@@ -166,7 +169,7 @@ export function ApiKeysPanel() {
 				onSubmit={(e) => {
 					e.preventDefault();
 					if (normalizedNewLabel && createdKey === null) {
-						createKey.mutate(normalizedNewLabel);
+						void createKey.execute(normalizedNewLabel).catch(() => undefined);
 					}
 				}}
 			>

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -14,7 +14,7 @@ import {
 	UserMinus,
 	Users,
 } from "lucide-react";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { isCustomProject } from "@/components/projects/project-metadata";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -45,6 +45,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
 
 /**
@@ -131,7 +132,7 @@ export function ShareProjectDialog({
 								<Link2 className="size-3.5 text-muted-foreground" />
 								Share link
 							</h3>
-							<ShareLinksPanel projectId={projectId} />
+							<ShareLinksPanel projectId={projectId} open={open} />
 						</section>
 						<p className="border-t pt-3 text-xs text-muted-foreground">
 							Everyone joins as a viewer: they read skills and key names here, and their agents can
@@ -153,13 +154,16 @@ export function ShareProjectDialog({
 	);
 }
 
-function ShareLinksPanel({ projectId }: { projectId: string }) {
+function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean }) {
 	const api = useApi();
 	const qc = useQueryClient();
 	const [label, setLabel] = useState("");
 	// The just-created link's full URL is shown once because the server
 	// stores only the prefix going forward.
 	const [freshLink, setFreshLink] = useState<ShareLinkCreated | null>(null);
+	useEffect(() => {
+		if (!open) setFreshLink(null);
+	}, [open]);
 
 	const links = useQuery({
 		queryKey: ["share-links", projectId],
@@ -171,17 +175,15 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 			),
 	});
 
-	const create = useMutation({
-		mutationFn: async (nextLabel: string): Promise<ShareLinkCreated> => {
+	const create = useSensitiveAction(async (nextLabel: string): Promise<ShareLinkCreated> => {
+		try {
 			const trimmedLabel = nextLabel.trim();
-			return unwrap(
+			const body = unwrap(
 				await api.POST("/v1/projects/{project_id}/share-links", {
 					params: { path: { project_id: projectId } },
 					body: { label: trimmedLabel.length > 0 ? trimmedLabel : null },
 				}),
 			);
-		},
-		onSuccess: (body) => {
 			setLabel("");
 			setFreshLink(body);
 			qc.invalidateQueries({ queryKey: ["share-links", projectId] });
@@ -194,8 +196,8 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 			toast.success("Share link created", {
 				description: "Copy it before closing this dialog. You can turn it off later.",
 			});
-		},
-		onError: (e) => {
+			return body;
+		} catch (e) {
 			toast.error(
 				e instanceof ApiError && e.status === 409
 					? "Set a display name on your profile before sharing."
@@ -203,7 +205,8 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 						? e.message
 						: "Couldn't create link",
 			);
-		},
+			throw e;
+		}
 	});
 
 	const revoke = useMutation({
@@ -239,7 +242,7 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 				className="space-y-2 rounded-lg border p-3"
 				onSubmit={(e) => {
 					e.preventDefault();
-					create.mutate(label);
+					void create.execute(label).catch(() => undefined);
 				}}
 			>
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Check, Plus } from "lucide-react";
 import { type ReactElement, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -32,6 +32,7 @@ import { buildKeyImportPreview } from "@/components/vault/key-import-logic";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
 
 /* The #2 job of this dashboard: get keys in, fast. Paste-first composer —
@@ -152,8 +153,8 @@ export function AddKeysDialog({
 		!destinationLoadError &&
 		!existingItems.error;
 
-	const save = useMutation({
-		mutationFn: async () => {
+	const save = useSensitiveAction(async () => {
+		try {
 			let slug = effectiveSlug;
 			let targetVaultId = selectedVaultId;
 			let projectId: string | undefined;
@@ -191,9 +192,7 @@ export function AddKeysDialog({
 					}),
 				);
 			}
-			return { slug, vaultId: targetVaultId, summary: importPlan.summary };
-		},
-		onSuccess: ({ slug, vaultId: targetVaultId, summary }) => {
+			const summary = importPlan.summary;
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			qc.invalidateQueries({
 				queryKey: targetVaultId ? ["vault-items", targetVaultId] : ["vault-items"],
@@ -205,13 +204,15 @@ export function AddKeysDialog({
 						? `${summary.created} new, ${summary.updated} updated, ${summary.skipped} skipped in vault://${slug}.`
 						: `In vault://${slug}. Agents read them through the CLI at runtime.`,
 			});
+			setText("");
 			setOpen(false);
-		},
-		onError: (e) => toast.error("Couldn't save keys", { description: errorMessage(e) }),
+		} catch (error) {
+			toast.error("Couldn't save keys", { description: errorMessage(error) });
+			throw error;
+		}
 	});
 
 	useEffect(() => {
-		if (!open) return;
 		setText("");
 		setNewVaultName("");
 		setVaultChoice(vaultId ?? "");
@@ -393,7 +394,10 @@ export function AddKeysDialog({
 							{count} {count === 1 ? "key" : "keys"} detected
 							{importPlan.summary.skipped > 0 ? ` · ${importPlan.summary.skipped} skipped` : ""}
 						</span>
-						<Button onClick={() => save.mutate()} disabled={!canSave || save.isPending}>
+						<Button
+							onClick={() => void save.execute().catch(() => undefined)}
+							disabled={!canSave || save.isPending}
+						>
 							{save.isPending ? <Spinner /> : <Check className="size-3.5" />}
 							Save {importableCount > 0 ? importableCount : ""}
 						</Button>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
@@ -54,11 +54,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
-import {
-	useCreateTerminalSession,
-	useDeploymentLifecycle,
-	useUpdateDeployment,
-} from "@/hosted/agents/deployment-hooks";
+import { useDeploymentLifecycle, useUpdateDeployment } from "@/hosted/agents/deployment-hooks";
 import {
 	HostedTerminalPanel,
 	type HostedTerminalStatus,
@@ -204,6 +200,7 @@ import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn } from "@/lib/utils";
 
 type Runtime = HostedRuntime;
@@ -1328,6 +1325,7 @@ function ConsoleTab({
 	const toggleCredentials = () => {
 		if (showCredentials) {
 			setShowCredentials(false);
+			if (runtime === "hermes") setCredentials(null);
 			return;
 		}
 		if (credentials?.runtime === runtime) setShowCredentials(true);
@@ -1548,8 +1546,9 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 		deployment.resource.spec.name,
 		deployment.resource.spec.runtime,
 	);
-	const terminal = useCreateTerminalSession();
-	const { isPending: isOpeningTerminal, mutateAsync: createTerminalSession } = terminal;
+	const client = useBillingClient();
+	const terminal = useSensitiveAction(({ id }: { id: string }) => client.createTerminalSession(id));
+	const { isPending: isOpeningTerminal, execute: createTerminalSession } = terminal;
 	const [websocketUrl, setWebsocketUrl] = useState<string | null>(null);
 	const [terminalStatus, setTerminalStatus] = useState<HostedTerminalStatus>("disconnected");
 	const [terminalFailure, setTerminalFailure] = useState<string | null>(null);
@@ -1561,6 +1560,7 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 		if (!isRunning || isOpeningTerminal) return;
 		const requestId = terminalRequestRef.current + 1;
 		terminalRequestRef.current = requestId;
+		setWebsocketUrl(null);
 		setTerminalFailure(null);
 		setTerminalStatus("connecting");
 		try {
@@ -1575,10 +1575,11 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 				return;
 			}
 			setWebsocketUrl(session.websocket_url);
-		} catch {
+		} catch (error) {
 			if (terminalRequestRef.current !== requestId) return;
 			setTerminalStatus("disconnected");
 			setTerminalFailure("Couldn't open terminal. Try again.");
+			toast.error("Couldn't open terminal", { description: normalizeBillingError(error) });
 		}
 	}, [createTerminalSession, deployment.resource.id, isOpeningTerminal, isRunning]);
 
@@ -1615,6 +1616,10 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 
 	const handleTerminalStatusChange = useCallback((status: HostedTerminalStatus) => {
 		setTerminalStatus(status);
+		if (status === "disconnected") {
+			setWebsocketUrl(null);
+			setTerminalFailure("Terminal connection closed. Reconnect to start a new session.");
+		}
 	}, []);
 
 	if (status.kind === "stopped") {
@@ -2051,15 +2056,14 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 		return map;
 	}, [channels.data, botPool.data]);
 
-	const link = useMutation({
-		mutationFn: async (channelId: string) =>
-			unwrap(
+	const link = useSensitiveAction(async (channelId: string) => {
+		try {
+			const data = unwrap(
 				await api.POST("/v1/channels/{account_id}/agent-links", {
 					params: { path: { account_id: channelId } },
 					body: { agent_id: environmentId },
 				}),
-			),
-		onSuccess: (data) => {
+			);
 			if (data.agent_token != null) setToken(data.agent_token);
 			setAccountId("");
 			qc.invalidateQueries({ queryKey: ["agent-channel-links", environmentId] });
@@ -2067,18 +2071,23 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 			qc.invalidateQueries({ queryKey: ["channel-bot-pool"] });
 			qc.invalidateQueries({ queryKey: ["channels"] });
 			toast.success("Channel linked");
-		},
-		onError: toastApiError("Couldn't link channel"),
+			return data;
+		} catch (error) {
+			toastApiError("Couldn't link channel")(error);
+			throw error;
+		}
 	});
 
-	function submitLink() {
+	async function submitLink() {
 		if (!accountId || linkInFlightRef.current) return;
 		linkInFlightRef.current = true;
-		link.mutate(accountId, {
-			onSettled: () => {
-				linkInFlightRef.current = false;
-			},
-		});
+		try {
+			await link.execute(accountId);
+		} catch {
+			// The action already surfaces the API error.
+		} finally {
+			linkInFlightRef.current = false;
+		}
 	}
 
 	if (!hasEnvironmentId) {
@@ -2151,7 +2160,7 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 						</SelectContent>
 					</Select>
 					<Button
-						onClick={submitLink}
+						onClick={() => void submitLink()}
 						disabled={!accountId || link.isPending || channels.isLoading || botPool.isLoading}
 					>
 						{link.isPending ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
@@ -2207,6 +2216,14 @@ function LinkedChannelRow({
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
+	async function createPairCode() {
+		try {
+			const data = await pair.execute({ agent_link_id: link.id });
+			setCode({ code: data.code, expires_at: data.expires_at });
+		} catch {
+			// useCreatePairCode already surfaces the API error.
+		}
+	}
 	return (
 		<div className="rounded-lg border p-3">
 			<div className="flex items-center gap-3">
@@ -2222,12 +2239,7 @@ function LinkedChannelRow({
 					variant="outline"
 					size="sm"
 					disabled={pair.isPending}
-					onClick={() =>
-						pair.mutate(
-							{ agent_link_id: link.id },
-							{ onSuccess: (d) => setCode({ code: d.code, expires_at: d.expires_at }) },
-						)
-					}
+					onClick={() => void createPairCode()}
 				>
 					<QrCode className="size-3.5" />
 					Pair code

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -92,7 +92,6 @@ import {
 	usePlans,
 	useQuotePlanChange,
 	useResumeSubscription,
-	useWallet,
 } from "@/hosted/billing/hooks";
 import {
 	type PlanChangeSelection,
@@ -124,6 +123,7 @@ import {
 	useWalletTopUpDialog,
 	type WalletFundingErrorCopy,
 } from "@/hosted/billing/wallet/wallet-funding";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
 	canDelete as canDeleteDeployment,
@@ -2422,7 +2422,7 @@ function ComputeSettingsSections({
 	const changePlan = useChangePlan();
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
-	const wallet = useWallet({
+	const wallet = useWalletSnapshot({
 		enabled:
 			deployment.commercial_display?.compute_subscription?.funding_source === "wallet" ||
 			(hostedAccess.canCreateCloudAgents && planChangeOpen),

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -17,7 +17,8 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { normalizeBillingError } from "@/hosted/billing/errors";
-import { useFixPayment, useWallet } from "@/hosted/billing/hooks";
+import { useWallet } from "@/hosted/billing/hooks";
+import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { formatShortDate } from "@/lib/format";
@@ -28,7 +29,7 @@ import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.l
 export function ComputeDunningBanner({ deployment }: { deployment: HostedDeployment }) {
 	const state = computeDunningState(deployment);
 	const hostedAccess = useHostedProductAccess();
-	const fixPayment = useFixPayment();
+	const fixPayment = useSensitiveFixPayment();
 	const runAction = useActionLock();
 	const wallet = useWallet({
 		enabled: state?.ctaTarget === "top_up",
@@ -58,7 +59,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 			return;
 		}
 		try {
-			const result = await fixPayment.mutateAsync({ deployment_id: deployment.resource.id });
+			const result = await fixPayment.execute({ deployment_id: deployment.resource.id });
 			const url = result.url || result.portal_url;
 			if (url) {
 				window.location.href = url;

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -17,10 +17,10 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { normalizeBillingError } from "@/hosted/billing/errors";
-import { useWallet } from "@/hosted/billing/hooks";
 import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { settingsQueryHref } from "@/lib/settings-routes";
@@ -31,7 +31,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 	const hostedAccess = useHostedProductAccess();
 	const fixPayment = useSensitiveFixPayment();
 	const runAction = useActionLock();
-	const wallet = useWallet({
+	const wallet = useWalletSnapshot({
 		enabled: state?.ctaTarget === "top_up",
 	});
 	const [topUpOpen, setTopUpOpen] = useState(false);

--- a/apps/web/src/hosted/billing/components/low-balance-banner.logic.ts
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.logic.ts
@@ -1,4 +1,4 @@
-import type { WalletState } from "@/hosted/billing/contracts";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import { isLowBalance } from "@/hosted/billing/wallet/wallet-constants";
 
 /** Which primary CTA the banner should lead with. */
@@ -24,7 +24,9 @@ export interface LowBalanceBannerState {
  * confirm control on the auto-reload card; otherwise a low balance shows a
  * top-up CTA. Returns `show: false` when there's nothing to surface.
  */
-export function lowBalanceBannerState(wallet: WalletState | undefined): LowBalanceBannerState {
+export function lowBalanceBannerState(
+	wallet: WalletCacheSnapshot | undefined,
+): LowBalanceBannerState {
 	if (!wallet) {
 		return {
 			show: false,

--- a/apps/web/src/hosted/billing/components/low-balance-banner.tsx
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.tsx
@@ -4,8 +4,8 @@ import { AlertTriangle, CreditCard, Repeat } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { lowBalanceBannerState } from "@/hosted/billing/components/low-balance-banner.logic";
-import type { WalletState } from "@/hosted/billing/contracts";
 import { formatUsdExact } from "@/hosted/billing/format";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 
 /**
  * Low-balance / payment-attention banner.
@@ -23,7 +23,7 @@ export function LowBalanceBanner({
 	onTopUp,
 	onAutoReload,
 }: {
-	wallet: WalletState | undefined;
+	wallet: WalletCacheSnapshot | undefined;
 	hasWalletCompute?: boolean;
 	onTopUp?: () => void;
 	onAutoReload?: () => void;

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -101,7 +101,6 @@ import {
 	usePlans,
 	useResolveDeploymentRequest,
 	useSubscriptionCreateQuote,
-	useWallet,
 } from "@/hosted/billing/hooks";
 import {
 	forgetIdempotencyAttempt,
@@ -133,6 +132,7 @@ import {
 	SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY,
 	useWalletTopUpDialog,
 } from "@/hosted/billing/wallet/wallet-funding";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import {
@@ -463,7 +463,7 @@ export function DeployWizard() {
 					fundingSource: paymentMethod === "wallet" ? "wallet" : "stripe",
 				}
 			: null;
-	const wallet = useWallet({
+	const wallet = useWalletSnapshot({
 		enabled: paymentMethod === "wallet",
 	});
 	const subscriptionCreateQuote = useSubscriptionCreateQuote(subscriptionCreateSelection, {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -96,7 +96,6 @@ import {
 } from "@/hosted/billing/format";
 import {
 	useCheckoutReturnRefresh,
-	useCreateSubscription,
 	useHostedDeployments,
 	useManagedModelCatalog,
 	usePlans,
@@ -111,6 +110,7 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
+import { useSensitiveCreateSubscription } from "@/hosted/billing/sensitive-actions";
 import {
 	type SubscriptionCreateRequestView,
 	type SubscriptionCreateSelection,
@@ -367,7 +367,7 @@ export function DeployWizard() {
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
-	const createSubscription = useCreateSubscription();
+	const createSubscription = useSensitiveCreateSubscription();
 	const billingClient = useBillingClient();
 	const resolveDeploymentRequest = useResolveDeploymentRequest();
 	const refreshCheckoutReturn = useCheckoutReturnRefresh();
@@ -651,7 +651,7 @@ export function DeployWizard() {
 			newIdempotencyKey,
 		);
 		const outcome = await createSubscription
-			.mutateAsync({
+			.execute({
 				...request,
 				uiMode: "hosted",
 				idempotencyKey: checkoutAttemptRef.current.key,
@@ -768,7 +768,7 @@ export function DeployWizard() {
 					);
 					walletCreateAttemptRef.current = attempt;
 					const outcome = await createSubscription
-						.mutateAsync({
+						.execute({
 							selection,
 							target,
 							uiMode: CHECKOUT_ELEMENTS_UI_MODE,
@@ -801,7 +801,7 @@ export function DeployWizard() {
 					newIdempotencyKey,
 				);
 				const outcome = await createSubscription
-					.mutateAsync({
+					.execute({
 						selection,
 						target,
 						uiMode: CHECKOUT_ELEMENTS_UI_MODE,

--- a/apps/web/src/hosted/billing/sensitive-actions.ts
+++ b/apps/web/src/hosted/billing/sensitive-actions.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useBillingClient } from "@/hosted/billing/billing-client";
+import type {
+	ComputeFixPaymentRequest,
+	PortalRequest,
+	WalletAutoReloadRequest,
+	WalletTopupRequest,
+} from "@/hosted/billing/contracts";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import {
+	type SubscriptionCreateRequestView,
+	subscriptionCreateOutcome,
+	subscriptionCreateRequest,
+} from "@/hosted/billing/subscription/subscription-create-adapter";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
+
+function useInvalidateBillingAfterCheckout() {
+	const queryClient = useQueryClient();
+	return () => {
+		queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
+		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
+		queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
+		queryClient.invalidateQueries({ queryKey: ["agents"] });
+	};
+}
+
+export function useSensitiveTopUp() {
+	const client = useBillingClient();
+	return useSensitiveAction(
+		({ body, idempotencyKey }: { body: WalletTopupRequest; idempotencyKey: string }) =>
+			client.topUp(body, idempotencyKey),
+	);
+}
+
+export function useSensitiveSetAutoReload() {
+	const client = useBillingClient();
+	return useSensitiveAction((body: WalletAutoReloadRequest) => client.setAutoReload(body));
+}
+
+export function useSensitiveCreateSubscription() {
+	const client = useBillingClient();
+	const invalidate = useInvalidateBillingAfterCheckout();
+	return useSensitiveAction(async (request: SubscriptionCreateRequestView) => {
+		const apiRequest = subscriptionCreateRequest(request);
+		const result = subscriptionCreateOutcome(
+			await client.checkout(apiRequest.body, apiRequest.idempotencyKey),
+		);
+		invalidate();
+		return result;
+	});
+}
+
+export function useSensitiveBillingPortal() {
+	const client = useBillingClient();
+	return useSensitiveAction((body: PortalRequest) => client.portal(body));
+}
+
+export function useSensitiveFixPayment() {
+	const client = useBillingClient();
+	return useSensitiveAction((body: ComputeFixPaymentRequest) => client.fixPayment(body));
+}
+
+export function useSensitiveWalletSnapshot() {
+	const client = useBillingClient();
+	return useSensitiveAction(() => client.getWallet());
+}

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -35,7 +35,7 @@ import {
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
-import { useSubscriptionCreateQuote, useWallet } from "@/hosted/billing/hooks";
+import { useSubscriptionCreateQuote } from "@/hosted/billing/hooks";
 import {
 	forgetIdempotencyAttempt,
 	type IdempotencyAttempt,
@@ -63,6 +63,7 @@ import {
 	SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY,
 	useWalletTopUpDialog,
 } from "@/hosted/billing/wallet/wallet-funding";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
 const PLAN_ITEMS = [
@@ -121,7 +122,7 @@ export function SubscriptionCreateDialog({
 					fundingSource,
 				}
 			: null;
-	const wallet = useWallet({
+	const wallet = useWalletSnapshot({
 		enabled: open && hostedAccess.canCreateCloudAgents && fundingSource === "wallet",
 	});
 	const createQuote = useSubscriptionCreateQuote(createSelection, {

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -35,11 +35,7 @@ import {
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
-import {
-	useCreateSubscription,
-	useSubscriptionCreateQuote,
-	useWallet,
-} from "@/hosted/billing/hooks";
+import { useSubscriptionCreateQuote, useWallet } from "@/hosted/billing/hooks";
 import {
 	forgetIdempotencyAttempt,
 	type IdempotencyAttempt,
@@ -47,6 +43,7 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
+import { useSensitiveCreateSubscription } from "@/hosted/billing/sensitive-actions";
 import {
 	type SubscriptionCreateSelection,
 	type SubscriptionFundingSource,
@@ -104,7 +101,7 @@ export function SubscriptionCreateDialog({
 	initialBillingTermMonths: number;
 }) {
 	const hostedAccess = useHostedProductAccess();
-	const createSubscription = useCreateSubscription();
+	const createSubscription = useSensitiveCreateSubscription();
 	const runAction = useActionLock();
 	const createAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const [planSlug, setPlanSlug] = useState(initialPlanSlug);
@@ -199,7 +196,7 @@ export function SubscriptionCreateDialog({
 				fingerprint,
 				newIdempotencyKey,
 			);
-			const outcome = await createSubscription.mutateAsync({
+			const outcome = await createSubscription.execute({
 				selection: createSelection,
 				target,
 				uiMode: "hosted",

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -12,7 +12,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Spinner } from "@/components/ui/spinner";
 import { SubscriptionSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import { usePlans, usePortal } from "@/hosted/billing/hooks";
+import { usePlans } from "@/hosted/billing/hooks";
+import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { BillingHistorySection } from "@/hosted/billing/subscription/billing-history-section";
 import { PlanComparison } from "@/hosted/billing/subscription/plan-comparison";
 import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
@@ -29,14 +30,14 @@ const SUBSCRIPTION_PAGE_CLASS = cn(
 
 export function SubscriptionPage() {
 	const plans = usePlans();
-	const portal = usePortal();
+	const portal = useSensitiveBillingPortal();
 	const hostedAccess = useHostedProductAccess();
 	const runAction = useActionLock();
 	const [term, setTerm] = useState(1);
 
 	async function openBillingPortal() {
 		try {
-			const res = await portal.mutateAsync({});
+			const res = await portal.execute({});
 			if (res.url || res.portal_url) {
 				window.location.href = res.url || res.portal_url;
 				return;

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -10,8 +10,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
-import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { useHostedDeployments, usePlans, useWalletLedger } from "@/hosted/billing/hooks";
 import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 
 const WELCOME_GRANT_RECHECK_INTERVAL_MS = 5_000;
 const WELCOME_GRANT_TIMEOUT_MS = 60_000;
@@ -25,7 +26,7 @@ const WELCOME_GRANT_TIMEOUT_MS = 60_000;
  * agent. Read failures render a retry action instead of hiding onboarding.
  */
 export function WelcomeWalletCard({ showDeployAction = true }: { showDeployAction?: boolean }) {
-	const wallet = useWallet();
+	const wallet = useWalletSnapshot();
 	const ledger = useWalletLedger(50);
 	const deployments = useHostedDeployments();
 	const plans = usePlans();

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -2,14 +2,15 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, CreditCard, RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useSettingsEditState } from "@/components/settings-edit-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
-import { billingKeys } from "@/hosted/billing/hooks";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import { useSensitiveWalletSnapshot } from "@/hosted/billing/sensitive-actions";
 import {
 	type PaymentOutcome,
 	StripePaymentForm,
@@ -29,20 +30,47 @@ import {
 export function AutoReloadActionConfirm({
 	wallet,
 	onTopUp,
+	initialClientSecret,
+	onDiscardClientSecret,
 }: {
 	wallet: WalletState;
 	onTopUp?: () => void;
+	initialClientSecret?: string | null;
+	onDiscardClientSecret?: () => void;
 }) {
 	const qc = useQueryClient();
+	const walletSnapshot = useSensitiveWalletSnapshot();
 	const [confirming, setConfirming] = useState(false);
 	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
-	useSettingsEditState({ dirty: false, busy: confirming && paymentSubmitting });
+	const [clientSecret, setClientSecret] = useState<string | null>(
+		() => initialClientSecret ?? null,
+	);
+	const [secretUnavailable, setSecretUnavailable] = useState(false);
+	useSettingsEditState({
+		dirty: false,
+		busy: walletSnapshot.isPending || (confirming && paymentSubmitting),
+	});
 
 	const action = wallet.auto_reload_action;
+	useEffect(() => {
+		if (initialClientSecret) {
+			setClientSecret(initialClientSecret);
+			setSecretUnavailable(false);
+		}
+	}, [initialClientSecret]);
+
+	useEffect(() => {
+		if (!action) {
+			setClientSecret(null);
+			setConfirming(false);
+			setSecretUnavailable(false);
+		}
+	}, [action]);
+
 	if (!action) return null;
+	const actionAttemptId = action.attempt_id;
 
 	const declined = action.error_code != null;
-	const clientSecret = action.client_secret;
 	const variant = declined ? "destructive" : "default";
 	const title = declined ? "Last auto-reload was declined" : "Confirm your last auto-reload";
 	const charge = formatCents(wallet.auto_reload_amount_cents);
@@ -54,6 +82,8 @@ export function AutoReloadActionConfirm({
 		qc.invalidateQueries({ queryKey: billingKeys.ledgerRoot });
 		setPaymentSubmitting(false);
 		setConfirming(false);
+		setClientSecret(null);
+		onDiscardClientSecret?.();
 		toast.success(status === "succeeded" ? "Payment confirmed" : "Payment processing", {
 			description:
 				status === "succeeded"
@@ -62,8 +92,43 @@ export function AutoReloadActionConfirm({
 		});
 	}
 
+	function cancelConfirmation() {
+		setPaymentSubmitting(false);
+		setConfirming(false);
+		setClientSecret(null);
+		onDiscardClientSecret?.();
+	}
+
+	async function beginConfirmation() {
+		if (walletSnapshot.isPending) return;
+		if (clientSecret) {
+			setConfirming(true);
+			return;
+		}
+		try {
+			const latest = await walletSnapshot.execute();
+			const latestAction = latest.auto_reload_action;
+			const secret =
+				latestAction?.attempt_id === actionAttemptId ? latestAction.client_secret : null;
+			if (!secret) {
+				setSecretUnavailable(true);
+				toast.error("Payment confirmation unavailable", {
+					description: "Top up manually or refresh the Wallet and try again.",
+				});
+				return;
+			}
+			setClientSecret(secret);
+			setSecretUnavailable(false);
+			setConfirming(true);
+		} catch {
+			toast.error("Couldn’t load payment confirmation", {
+				description: "Check your connection and try again.",
+			});
+		}
+	}
+
 	// No client secret → we can't drive the confirmation; point at a manual top-up.
-	if (!clientSecret) {
+	if (secretUnavailable) {
 		return (
 			<Alert data-hosted="true" variant={variant}>
 				<AlertCircle />
@@ -94,20 +159,27 @@ export function AutoReloadActionConfirm({
 						? `Your saved card was declined. Retry the ${charge} top-up before the remaining balance runs out.`
 						: `Your bank asked to confirm this ${charge} top-up. Complete it before the remaining balance runs out.`}
 				</span>
-				{confirming ? (
+				{confirming && clientSecret ? (
 					<div className="w-full">
 						<StripePaymentForm
 							clientSecret={clientSecret}
 							onComplete={onComplete}
-							onCancel={() => setConfirming(false)}
+							onCancel={cancelConfirmation}
 							summary={`Auto-reload charge: ${charge}`}
 							submitLabel={`${declined ? "Retry" : "Confirm"} ${charge} payment`}
 							onSubmittingChange={setPaymentSubmitting}
 						/>
 					</div>
 				) : (
-					<Button type="button" size="sm" onClick={() => setConfirming(true)}>
-						{declined ? (
+					<Button
+						type="button"
+						size="sm"
+						onClick={() => void beginConfirmation()}
+						disabled={walletSnapshot.isPending}
+					>
+						{walletSnapshot.isPending ? (
+							<>Loading payment…</>
+						) : declined ? (
 							<>
 								<RefreshCw /> Retry payment
 							</>

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -7,7 +7,6 @@ import { toast } from "sonner";
 import { useSettingsEditState } from "@/components/settings-edit-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { useSensitiveWalletSnapshot } from "@/hosted/billing/sensitive-actions";
@@ -15,13 +14,14 @@ import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 
 /**
  * SCA / decline-recovery control for a pending auto-reload. When the wallet
- * carries a `auto_reload_action` with a `client_secret`, the user can complete
- * the bank confirmation (SCA) or retry a declined charge right here: mounting
- * Stripe Elements against that PaymentIntent secret so the top-up actually
- * finishes from the dashboard.
+ * carries pending `auto_reload_action` metadata, the user can complete the bank
+ * confirmation (SCA) or retry a declined charge right here. The PaymentIntent
+ * secret is fetched outside QueryCache and kept only in this component while
+ * Stripe Elements is mounted.
  *
  * On success the wallet refetch clears `auto_reload_action`, so this control
  * unmounts itself. Without a `client_secret` (backend couldn't attach one) it
@@ -33,7 +33,7 @@ export function AutoReloadActionConfirm({
 	initialClientSecret,
 	onDiscardClientSecret,
 }: {
-	wallet: WalletState;
+	wallet: WalletCacheSnapshot;
 	onTopUp?: () => void;
 	initialClientSecret?: string | null;
 	onDiscardClientSecret?: () => void;

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -1,9 +1,10 @@
-import type { WalletAutoReloadRequest, WalletState } from "@/hosted/billing/contracts";
+import type { WalletAutoReloadRequest } from "@/hosted/billing/contracts";
 import {
 	BillingApiError,
 	billingErrorDetail,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
@@ -85,7 +86,7 @@ export function autoReloadFormState({
 	};
 }
 
-export function autoReloadDraftFromWallet(wallet: WalletState): AutoReloadDraft {
+export function autoReloadDraftFromWallet(wallet: WalletCacheSnapshot): AutoReloadDraft {
 	return {
 		enabled: wallet.auto_reload_enabled,
 		threshold: dollars(Number(wallet.auto_reload_threshold_usd)),

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, CreditCard, Repeat } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -20,7 +21,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
-import { useSetAutoReload } from "@/hosted/billing/hooks";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import { useSensitiveSetAutoReload } from "@/hosted/billing/sensitive-actions";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { AutoReloadActionConfirm } from "@/hosted/billing/wallet/auto-reload-action";
 import {
@@ -46,13 +48,15 @@ const PRISTINE_FIELDS: BlurredFields = { threshold: false, amount: false, cap: f
 const ALL_FIELDS_BLURRED: BlurredFields = { threshold: true, amount: true, cap: true };
 
 export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTopUp?: () => void }) {
-	const save = useSetAutoReload();
+	const save = useSensitiveSetAutoReload();
+	const queryClient = useQueryClient();
 	const runAction = useActionLock();
 	const initialDraft = autoReloadDraftFromWallet(wallet);
 	const [baseline, setBaseline] = useState<AutoReloadDraft>(initialDraft);
 	const [draft, setDraft] = useState<AutoReloadDraft>(initialDraft);
 	const [blurred, setBlurred] = useState<BlurredFields>(PRISTINE_FIELDS);
 	const [requestError, setRequestError] = useState<AutoReloadSaveError | null>(null);
+	const [actionClientSecret, setActionClientSecret] = useState<string | null>(null);
 	const draftRef = useRef(draft);
 	const baselineRef = useRef(baseline);
 	const pendingRef = useRef(save.isPending);
@@ -84,6 +88,10 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 		wallet.auto_reload_monthly_cap_cents,
 	]);
 
+	useEffect(() => {
+		if (!wallet.auto_reload_action) setActionClientSecret(null);
+	}, [wallet.auto_reload_action?.attempt_id, wallet.auto_reload_action]);
+
 	function updateDraft<K extends keyof AutoReloadDraft>(key: K, value: AutoReloadDraft[K]) {
 		setDraft((current) => ({ ...current, [key]: value }));
 		setRequestError(null);
@@ -105,7 +113,9 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 		if (!dirty || !request || save.isPending) return;
 		setRequestError(null);
 		try {
-			const nextWallet = await save.mutateAsync(request);
+			const nextWallet = await save.execute(request);
+			setActionClientSecret(nextWallet.auto_reload_action?.client_secret ?? null);
+			queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 			const next = autoReloadDraftFromWallet(nextWallet);
 			setBaseline(next);
 			setDraft(next);
@@ -162,7 +172,12 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 			</CardHeader>
 
 			<CardContent className="flex flex-col gap-4">
-				<AutoReloadActionConfirm wallet={wallet} onTopUp={onTopUp} />
+				<AutoReloadActionConfirm
+					wallet={wallet}
+					onTopUp={onTopUp}
+					initialClientSecret={actionClientSecret}
+					onDiscardClientSecret={() => setActionClientSecret(null)}
+				/>
 
 				{requestError ? (
 					<Alert variant="destructive">

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -19,7 +19,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { useSensitiveSetAutoReload } from "@/hosted/billing/sensitive-actions";
@@ -34,6 +33,7 @@ import {
 	autoReloadRequest,
 	autoReloadSaveError,
 } from "@/hosted/billing/wallet/auto-reload-card.logic";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
@@ -47,7 +47,13 @@ type BlurredFields = Record<AutoReloadField, boolean>;
 const PRISTINE_FIELDS: BlurredFields = { threshold: false, amount: false, cap: false };
 const ALL_FIELDS_BLURRED: BlurredFields = { threshold: true, amount: true, cap: true };
 
-export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTopUp?: () => void }) {
+export function AutoReloadCard({
+	wallet,
+	onTopUp,
+}: {
+	wallet: WalletCacheSnapshot;
+	onTopUp?: () => void;
+}) {
 	const save = useSensitiveSetAutoReload();
 	const queryClient = useQueryClient();
 	const runAction = useActionLock();

--- a/apps/web/src/hosted/billing/wallet/balance-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/balance-card.tsx
@@ -4,8 +4,8 @@ import { Coins, CreditCard, Info, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type { WalletState } from "@/hosted/billing/contracts";
 import { formatUsdExact } from "@/hosted/billing/format";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import { isLowBalance } from "@/hosted/billing/wallet/wallet-constants";
 
 /**
@@ -18,7 +18,7 @@ export function BalanceCard({
 	hasWalletCompute = false,
 	onTopUp,
 }: {
-	wallet: WalletState;
+	wallet: WalletCacheSnapshot;
 	hasWalletCompute?: boolean;
 	onTopUp: () => void;
 }) {

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -26,8 +26,8 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { isIdempotencyKeyReusedError, normalizeBillingError } from "@/hosted/billing/errors";
 import { formatCents } from "@/hosted/billing/format";
-import { useTopUp } from "@/hosted/billing/hooks";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
+import { useSensitiveTopUp } from "@/hosted/billing/sensitive-actions";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	type PaymentOutcome,
@@ -63,7 +63,7 @@ export function TopUpDialog({
 	initialAmountCents?: number | null;
 	presentation?: TopUpPresentation;
 }) {
-	const topUp = useTopUp();
+	const topUp = useSensitiveTopUp();
 	const qc = useQueryClient();
 	const runAction = useActionLock();
 	const [step, setStep] = useState<Step>("amount");
@@ -99,6 +99,7 @@ export function TopUpDialog({
 
 	function close(next: boolean) {
 		if (!next && (topUp.isPending || paymentSubmitting)) return;
+		if (!next) reset();
 		onOpenChange(next);
 	}
 
@@ -115,7 +116,7 @@ export function TopUpDialog({
 		setAmountTouched(true);
 		topupKeyRef.current ??= newIdempotencyKey("topup");
 		try {
-			const result = await topUp.mutateAsync({
+			const result = await topUp.execute({
 				body: { amount_cents: amountCents },
 				idempotencyKey: topupKeyRef.current,
 			});
@@ -126,7 +127,10 @@ export function TopUpDialog({
 				},
 				// Successful completion is not a dismiss attempt. Close directly so the
 				// in-flight guard cannot leave a completed payment flow stranded open.
-				closeDialog: () => onOpenChange(false),
+				closeDialog: () => {
+					reset();
+					onOpenChange(false);
+				},
 				toastSuccess: toast.success,
 				toastError: toast.error,
 				onComplete,
@@ -148,6 +152,9 @@ export function TopUpDialog({
 	// inline by StripePaymentForm, which keeps the payment flow open until it settles
 	// rather than closing on an unconfirmed payment.
 	function onPaid(status: PaymentOutcome) {
+		setClientSecret(null);
+		setStep("amount");
+		setPaymentSubmitting(false);
 		completeTopup(status === "succeeded" ? "succeeded" : "processing", {
 			queryClient: qc,
 			resetAttempt: () => {
@@ -229,7 +236,10 @@ export function TopUpDialog({
 			<StripePaymentForm
 				clientSecret={clientSecret}
 				onComplete={onPaid}
-				onCancel={() => setStep("amount")}
+				onCancel={() => {
+					setClientSecret(null);
+					setStep("amount");
+				}}
 				summary={`Top-up charge: ${formatCents(amountCents)}`}
 				submitLabel={`Pay ${formatCents(amountCents)}`}
 				onSubmittingChange={setPaymentSubmitting}

--- a/apps/web/src/hosted/billing/wallet/wallet-cache.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-cache.ts
@@ -1,0 +1,32 @@
+import type { WalletAutoReloadAction, WalletState } from "@/hosted/billing/contracts";
+
+export type WalletCacheSnapshot = Omit<WalletState, "auto_reload_action"> & {
+	auto_reload_action?: Omit<WalletAutoReloadAction, "client_secret"> | null;
+};
+
+/**
+ * Allowlist the wallet fields that are safe for TanStack Query to own.
+ * Payment-attempt client secrets are fetched imperatively and kept in the
+ * payment component for only the lifetime of that attempt.
+ */
+export function walletSnapshotForCache(wallet: WalletState): WalletCacheSnapshot {
+	const snapshot: Omit<WalletCacheSnapshot, "auto_reload_action"> = {
+		balance_usd: wallet.balance_usd,
+		x402_enabled: wallet.x402_enabled,
+		auto_reload_enabled: wallet.auto_reload_enabled,
+		auto_reload_threshold_usd: wallet.auto_reload_threshold_usd,
+		auto_reload_amount_cents: wallet.auto_reload_amount_cents,
+		auto_reload_monthly_cap_cents: wallet.auto_reload_monthly_cap_cents,
+	};
+	const action = wallet.auto_reload_action;
+	if (action === undefined) return snapshot;
+	if (action === null) return { ...snapshot, auto_reload_action: null };
+	return {
+		...snapshot,
+		auto_reload_action: {
+			attempt_id: action.attempt_id,
+			payment_intent_id: action.payment_intent_id,
+			error_code: action.error_code,
+		},
+	};
+}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -12,12 +12,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import {
-	useHostedDeployments,
-	usePortal,
-	useWallet,
-	useWalletLedger,
-} from "@/hosted/billing/hooks";
+import { useHostedDeployments, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { getStripe } from "@/hosted/billing/stripe";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { AutoReloadCard } from "@/hosted/billing/wallet/auto-reload-card";
@@ -62,7 +58,7 @@ function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
 export function WalletPage() {
 	const wallet = useWallet();
 	const deployments = useHostedDeployments();
-	const portal = usePortal();
+	const portal = useSensitiveBillingPortal();
 	const runAction = useActionLock();
 	const queryClient = useQueryClient();
 	const [ledgerLimit, setLedgerLimit] = useState(LEDGER_PAGE_SIZE);
@@ -74,7 +70,7 @@ export function WalletPage() {
 
 	async function openBillingPortal() {
 		try {
-			const res = await portal.mutateAsync({});
+			const res = await portal.execute({});
 			if (res.url || res.portal_url) {
 				window.location.href = res.url || res.portal_url;
 				return;

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -12,7 +12,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import { useHostedDeployments, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { useHostedDeployments, useWalletLedger } from "@/hosted/billing/hooks";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { getStripe } from "@/hosted/billing/stripe";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
@@ -28,6 +28,7 @@ import {
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
 import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
@@ -56,7 +57,7 @@ function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
 }
 
 export function WalletPage() {
-	const wallet = useWallet();
+	const wallet = useWalletSnapshot();
 	const deployments = useHostedDeployments();
 	const portal = useSensitiveBillingPortal();
 	const runAction = useActionLock();

--- a/apps/web/src/hosted/billing/wallet/wallet-query.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-query.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
+import { billingQueryRetry } from "@/hosted/billing/errors";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import { walletSnapshotForCache } from "@/hosted/billing/wallet/wallet-cache";
+
+/** Wallet polling whose query function projects out secrets before caching. */
+export function useWalletSnapshot({ enabled = true }: { enabled?: boolean } = {}) {
+	const client = useBillingClient();
+	return useQuery({
+		queryKey: billingKeys.wallet,
+		queryFn: async () => walletSnapshotForCache(await client.getWallet()),
+		enabled: isDeployApiConfigured() && enabled,
+		retry: billingQueryRetry,
+		refetchInterval: 30_000,
+	});
+}

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -349,7 +349,9 @@ describe("hosted product route exposure", () => {
 		expect(route).not.toContain("HostedProductGate");
 		expect(callback).toContain("ch.postMessage(result)");
 		expect(callback).toContain("window.opener?.postMessage(");
-		expect(callback).toContain("localStorage.setItem(CODEX_OAUTH_STORAGE_KEY");
+		expect(callback).toContain("window.history.replaceState(");
+		expect(callback).not.toContain("localStorage");
+		expect(callback).not.toContain("sessionStorage");
 	});
 
 	test("Cloud-agents-off agent index copy stays neutral", () => {

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { QueryClient } from "@tanstack/react-query";
+import type { WalletState } from "@/hosted/billing/contracts";
+import { walletSnapshotForCache } from "@/hosted/billing/wallet/wallet-cache";
+import { whatsappCredentialMetadataForCache } from "@/hosted/v2/channels/whatsapp-credential-cache";
+import { cacheValueContains } from "@/lib/sensitive-cache";
+import { executeSensitiveAction } from "@/lib/use-sensitive-action";
+import { memorySettingsForCache } from "@/pages/dashboard/memories/memory-settings-cache";
+
+function cachedState(queryClient: QueryClient) {
+	return {
+		queries: queryClient
+			.getQueryCache()
+			.getAll()
+			.map((query) => ({ queryKey: query.queryKey, state: query.state })),
+		mutations: queryClient
+			.getMutationCache()
+			.getAll()
+			.map((mutation) => mutation.state),
+	};
+}
+
+function createUnsanitizedQueryClient(): QueryClient {
+	// Deliberately bypass createAppQueryClient and its sensitive-cache guard.
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, structuralSharing: false },
+		},
+	});
+}
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function productionSourceFiles(root: string): string[] {
+	return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(root, entry.name);
+		if (entry.isDirectory()) return productionSourceFiles(path);
+		if (!entry.isFile() || !/\.(?:ts|tsx)$/.test(entry.name) || entry.name.includes(".test.")) {
+			return [];
+		}
+		return [path];
+	});
+}
+
+describe("structural secret boundaries without the denylist", () => {
+	test("fixed query flows stay secret-free in a raw QueryClient", async () => {
+		const queryClient = createUnsanitizedQueryClient();
+		const secrets = {
+			stripe: "pi_raw-query-client-secret",
+			walletFuture: "future-wallet-secret-with-an-unregistered-name",
+			whatsapp: "whatsapp-auth-material",
+			mem0: "mem0-raw-query-api-key",
+			settingsFuture: "future-settings-secret-with-an-unregistered-name",
+		};
+		const wallet: WalletState = {
+			balance_usd: "25.00",
+			x402_enabled: true,
+			auto_reload_enabled: true,
+			auto_reload_threshold_usd: "5",
+			auto_reload_amount_cents: 2_500,
+			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_action: {
+				attempt_id: 7,
+				payment_intent_id: "pi_structural_test",
+				client_secret: secrets.stripe,
+				error_code: null,
+			},
+		};
+		const walletWithFutureSecret = {
+			...wallet,
+			future_material: { value: secrets.walletFuture },
+		};
+		const whatsappMetadataWithSecrets = [
+			{
+				credential_id: "credential-id",
+				agent_link_id: "link-id",
+				agent_id: "agent-id",
+				jid: "15555550123@s.whatsapp.net",
+				identity_pub_key_hex: "public-key",
+				created_at: "2026-07-25T00:00:00Z",
+				creds: { material: secrets.whatsapp },
+				websocket_url: `wss://example.invalid?material=${secrets.whatsapp}`,
+			},
+		];
+
+		await Promise.all([
+			queryClient.prefetchQuery({
+				queryKey: ["billing", "wallet"],
+				queryFn: async () => walletSnapshotForCache(walletWithFutureSecret),
+			}),
+			queryClient.prefetchQuery({
+				queryKey: ["whatsapp-tenant-creds", "account-id"],
+				queryFn: async () => whatsappCredentialMetadataForCache(whatsappMetadataWithSecrets),
+			}),
+			queryClient.prefetchQuery({
+				queryKey: ["settings"],
+				queryFn: async () =>
+					memorySettingsForCache({
+						memory_provider: "mem0",
+						mem0_api_key: secrets.mem0,
+						future_material: secrets.settingsFuture,
+					}),
+			}),
+		]);
+
+		expect(queryClient.getQueryData(["billing", "wallet"])).toMatchObject({
+			balance_usd: "25.00",
+			auto_reload_action: {
+				attempt_id: 7,
+				payment_intent_id: "pi_structural_test",
+			},
+		});
+		expect(
+			queryClient.getQueryData<ReturnType<typeof memorySettingsForCache>>(["settings"]),
+		).toEqual({
+			memory_provider: "mem0",
+			mem0_api_key_configured: true,
+		});
+		for (const secret of Object.values(secrets)) {
+			expect(cacheValueContains(cachedState(queryClient), secret)).toBe(false);
+		}
+		expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+	});
+
+	test("every fixed sensitive action bypasses MutationCache with secret args and results", async () => {
+		const queryClient = createUnsanitizedQueryClient();
+		const flows = [
+			"channel create",
+			"channel link",
+			"channel token rotation",
+			"channel pair code",
+			"agent-detail channel link",
+			"provider API key",
+			"Codex OAuth start and complete",
+			"dashboard bearer key",
+			"Stripe top-up",
+			"Stripe auto-reload",
+			"Stripe subscription checkout",
+			"Stripe portal and payment fix",
+			"connector credentials and connect URL",
+			"WhatsApp credential create",
+			"project share token",
+			"CLI device code",
+			"Vault plaintext import",
+			"Mem0 API key",
+			"terminal websocket URL",
+		] as const;
+
+		for (const [index, flow] of flows.entries()) {
+			const argumentSecret = `argument-secret-${index}`;
+			const resultSecret = `result-secret-${index}`;
+			const result = await executeSensitiveAction(
+				async (secret: string) => ({ flow, secret: resultSecret, accepted: secret.length > 0 }),
+				argumentSecret,
+			);
+			expect(result).toEqual({ flow, secret: resultSecret, accepted: true });
+			expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+			expect(cacheValueContains(cachedState(queryClient), argumentSecret)).toBe(false);
+			expect(cacheValueContains(cachedState(queryClient), resultSecret)).toBe(false);
+		}
+	});
+
+	test("active call sites are wired to structural actions and safe query projections", () => {
+		const actionContracts: Array<[string, string[]]> = [
+			[
+				"hosted/v2/channels/channels-hooks.ts",
+				[
+					"export function useCreateChannel()",
+					"export function useLinkAgent(accountId: string)",
+					"export function useRotateAgentToken(accountId: string)",
+					"export function useCreatePairCode(accountId: string)",
+					"export function useCreateWhatsappTenantCred(accountId: string)",
+					"return useSensitiveAction",
+				],
+			],
+			[
+				"hosted/v2/ai-providers/ai-providers-hooks.ts",
+				["useSetApiKey", "useOAuthStart", "useOAuthComplete", "return useSensitiveAction"],
+			],
+			[
+				"hosted/billing/sensitive-actions.ts",
+				[
+					"useSensitiveTopUp",
+					"useSensitiveSetAutoReload",
+					"useSensitiveCreateSubscription",
+					"useSensitiveBillingPortal",
+					"useSensitiveFixPayment",
+					"useSensitiveWalletSnapshot",
+				],
+			],
+			[
+				"hosted/agents/hosted-agent-detail.tsx",
+				["const terminal = useSensitiveAction", "const link = useSensitiveAction"],
+			],
+			["components/connectors/credentials-dialog.tsx", ["const submit = useSensitiveAction"]],
+			["components/settings/api-keys-panel.tsx", ["const createKey = useSensitiveAction"]],
+			["components/sharing/share-project-dialog.tsx", ["const create = useSensitiveAction"]],
+			["components/vault/add-keys-dialog.tsx", ["const save = useSensitiveAction"]],
+			["pages/dashboard/connectors/[name]/page.tsx", ["const connectAction = useSensitiveAction"]],
+			["pages/dashboard/memories/page.tsx", ["const saveMem0Key = useSensitiveAction"]],
+			["pages/share/project-share-page.tsx", ["const upgrade = useSensitiveAction"]],
+			[
+				"pages/cli-authorize/page.tsx",
+				["const approve = useSensitiveAction", "const deny = useSensitiveAction"],
+			],
+		];
+		for (const [path, fragments] of actionContracts) {
+			const contents = source(path);
+			for (const fragment of fragments) expect(contents).toContain(fragment);
+		}
+		expect(
+			source("hosted/v2/channels/channels-hooks.ts").split("return useSensitiveAction"),
+		).toHaveLength(6);
+		expect(
+			source("hosted/v2/ai-providers/ai-providers-hooks.ts").split("return useSensitiveAction"),
+		).toHaveLength(4);
+		expect(
+			source("hosted/billing/sensitive-actions.ts").split("return useSensitiveAction"),
+		).toHaveLength(7);
+
+		const walletConsumers = [
+			"hosted/billing/deploy/deploy-wizard.tsx",
+			"hosted/billing/wallet/wallet-page.tsx",
+			"hosted/billing/subscription/welcome-wallet-card.tsx",
+			"hosted/billing/subscription/subscription-create-dialog.tsx",
+			"hosted/billing/components/compute-dunning-banner.tsx",
+			"hosted/agents/hosted-agent-detail.tsx",
+		];
+		for (const path of walletConsumers) {
+			expect(source(path)).toContain("useWalletSnapshot");
+		}
+		expect(source("hosted/billing/wallet/wallet-query.ts")).toContain(
+			"walletSnapshotForCache(await client.getWallet())",
+		);
+		expect(source("hosted/v2/channels/channels-hooks.ts")).toContain(
+			"whatsappCredentialMetadataForCache(",
+		);
+		expect(source("pages/dashboard/memories/page.tsx")).toContain(
+			"memorySettingsForCache(unwrap(await api.GET",
+		);
+
+		const sourceRoot = fileURLToPath(new URL("../", import.meta.url));
+		const legacySensitiveHooks = [
+			"useWallet",
+			"useTopUp",
+			"useSetAutoReload",
+			"useCreateSubscription",
+			"usePortal",
+			"useFixPayment",
+		];
+		const legacyCallers: string[] = [];
+		for (const path of productionSourceFiles(sourceRoot)) {
+			if (path.endsWith("/hosted/billing/hooks.ts")) continue;
+			const contents = readFileSync(path, "utf8");
+			for (const hook of legacySensitiveHooks) {
+				if (new RegExp(`\\b${hook}\\s*\\(`).test(contents)) {
+					legacyCallers.push(`${path}:${hook}`);
+				}
+			}
+		}
+		expect(legacyCallers).toEqual([]);
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -55,8 +55,8 @@ import { ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import {
 	CLAWDI_CODEX_OAUTH_PROVIDER_ID,
 	CODEX_OAUTH_CHANNEL,
-	CODEX_OAUTH_STORAGE_KEY,
 	type CodexOAuthResult,
+	codexOAuthStateMatches,
 	codexProviderBody,
 	codexRedirectUri,
 	parseCodexCallback,
@@ -347,7 +347,7 @@ export function AddProviderDialog({
 				createdFreshRef.current = false;
 			}
 			const started = await oauthStart
-				.mutateAsync({
+				.execute({
 					providerId: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
 					provider: "codex",
 					redirect_uri: redirectUri,
@@ -364,9 +364,6 @@ export function AddProviderDialog({
 			completedRef.current = false;
 			abandonedRef.current = false;
 			setOauthIssue(null);
-			try {
-				localStorage.removeItem(CODEX_OAUTH_STORAGE_KEY);
-			} catch {}
 			setOauth({
 				providerId: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
 				state: started.state,
@@ -404,7 +401,7 @@ export function AddProviderDialog({
 			// before changing provider fields. A key-storage failure therefore
 			// leaves the entire existing provider untouched.
 			const keyStored = await setKey
-				.mutateAsync({
+				.execute({
 					providerId,
 					value: apiKey.trim(),
 					runtime_env_name: runtimeEnvForSubmit,
@@ -437,7 +434,7 @@ export function AddProviderDialog({
 				// Create has no prior auth to preserve. Remove the new provider if
 				// key storage fails so no unusable record remains.
 				const keyStored = await setKey
-					.mutateAsync({
+					.execute({
 						providerId,
 						value: apiKey.trim(),
 						runtime_env_name: runtimeEnvForSubmit,
@@ -451,6 +448,7 @@ export function AddProviderDialog({
 		}
 
 		toast.success(isEdit ? "Provider updated" : "Provider added");
+		setApiKey("");
 		if (!isEdit) onCreated?.(saved.provider_id);
 		onOpenChange(false);
 	}
@@ -489,7 +487,7 @@ export function AddProviderDialog({
 	async function restartSignIn() {
 		if (!oauth || oauthStart.isPending) return;
 		const started = await oauthStart
-			.mutateAsync({
+			.execute({
 				providerId: oauth.providerId,
 				provider: "codex",
 				redirect_uri: oauth.redirectUri,
@@ -498,9 +496,6 @@ export function AddProviderDialog({
 		if (!started) return; // oauthStart.onError already toasts
 		completedRef.current = false;
 		abandonedRef.current = false;
-		try {
-			localStorage.removeItem(CODEX_OAUTH_STORAGE_KEY);
-		} catch {}
 		// Fresh session resets the expiry/poll effect (keyed on `oauth`).
 		setOauth({
 			providerId: oauth.providerId,
@@ -544,13 +539,14 @@ export function AddProviderDialog({
 		setOauth(null);
 		setOauthCode("");
 		setOauthIssue(null);
-		try {
-			localStorage.removeItem(CODEX_OAUTH_STORAGE_KEY);
-		} catch {}
 	}
 
 	function requestClose(next: boolean) {
-		if (!next) abandonCodexIfIncomplete();
+		if (!next) {
+			abandonCodexIfIncomplete();
+			setApiKey("");
+			setOauthCode("");
+		}
 		onOpenChange(next);
 	}
 
@@ -573,11 +569,17 @@ export function AddProviderDialog({
 			if (result.error) toast.error("ChatGPT sign-in failed", { description: result.error });
 			return;
 		}
+		if (!codexOAuthStateMatches(oauth.state, result)) {
+			toast.error("ChatGPT sign-in could not be verified", {
+				description: "The OAuth state did not match. Restart sign-in and try again.",
+			});
+			return;
+		}
 		completedRef.current = true;
 		const done = await oauthComplete
-			.mutateAsync({
+			.execute({
 				providerId: oauth.providerId,
-				state: result.state || oauth.state,
+				state: result.state,
 				code: result.code,
 				redirect_uri: oauth.redirectUri,
 			})
@@ -588,6 +590,7 @@ export function AddProviderDialog({
 			createdFreshRef.current = false;
 			closeOAuthPopup();
 			setOauth(null);
+			setOauthCode("");
 			if (!isEdit) onCreated?.(oauth.providerId);
 			onOpenChange(false);
 		} else {
@@ -596,8 +599,8 @@ export function AddProviderDialog({
 	};
 
 	// While a Codex sign-in is in flight, listen for the callback route handing
-	// back code+state over any of three channels (postMessage, BroadcastChannel,
-	// localStorage) and complete automatically.
+	// back code+state over the two in-memory cross-window channels and complete
+	// automatically. The manual paste field remains the no-channel fallback.
 	useEffect(() => {
 		if (!oauth) return;
 		const handle = (r: CodexOAuthResult | null) => {
@@ -613,19 +616,10 @@ export function AddProviderDialog({
 				handle(e.data as CodexOAuthResult);
 			}
 		};
-		const onStorage = (e: StorageEvent) => {
-			if (e.key === CODEX_OAUTH_STORAGE_KEY && e.newValue) {
-				try {
-					handle(JSON.parse(e.newValue) as CodexOAuthResult);
-				} catch {}
-			}
-		};
 		window.addEventListener("message", onMessage);
-		window.addEventListener("storage", onStorage);
 		return () => {
 			ch?.close();
 			window.removeEventListener("message", onMessage);
-			window.removeEventListener("storage", onStorage);
 		};
 	}, [oauth]);
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -9,6 +9,7 @@ import type {
 	AiProviderUpsert,
 } from "@/hosted/v2/ai-providers/types";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /** Typed data hooks for the AI Providers surface (cloud-api `/v1/ai-providers`). */
 
@@ -129,17 +130,23 @@ export function useDeleteProviderQuiet() {
 export function useSetApiKey() {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (vars: { providerId: string; value: string; runtime_env_name?: string }) =>
-			unwrap(
-				await api.POST("/v1/ai-providers/{provider_id}/auth/api-key", {
-					params: { path: { provider_id: vars.providerId } },
-					body: { value: vars.value, runtime_env_name: vars.runtime_env_name },
-				}),
-			),
-		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
-		onError: toastApiError("Couldn't save API key"),
-	});
+	return useSensitiveAction(
+		async (vars: { providerId: string; value: string; runtime_env_name?: string }) => {
+			try {
+				const result = unwrap(
+					await api.POST("/v1/ai-providers/{provider_id}/auth/api-key", {
+						params: { path: { provider_id: vars.providerId } },
+						body: { value: vars.value, runtime_env_name: vars.runtime_env_name },
+					}),
+				);
+				qc.invalidateQueries({ queryKey: KEY });
+				return result;
+			} catch (error) {
+				toastApiError("Couldn't save API key")(error);
+				throw error;
+			}
+		},
+	);
 }
 
 /** Static saved-field check; this endpoint does not probe credentials or connectivity. */
@@ -158,35 +165,41 @@ export function useCheckProviderFields() {
 
 export function useOAuthStart() {
 	const api = useApi();
-	return useMutation({
-		mutationFn: async (vars: { providerId: string; provider: string; redirect_uri?: string }) =>
-			unwrap(
-				await api.POST("/v1/ai-providers/{provider_id}/auth/oauth/start", {
-					params: { path: { provider_id: vars.providerId } },
-					body: { provider: vars.provider, redirect_uri: vars.redirect_uri },
-				}),
-			),
-		onError: toastApiError("Couldn't start sign-in"),
-	});
+	return useSensitiveAction(
+		async (vars: { providerId: string; provider: string; redirect_uri?: string }) => {
+			try {
+				return unwrap(
+					await api.POST("/v1/ai-providers/{provider_id}/auth/oauth/start", {
+						params: { path: { provider_id: vars.providerId } },
+						body: { provider: vars.provider, redirect_uri: vars.redirect_uri },
+					}),
+				);
+			} catch (error) {
+				toastApiError("Couldn't start sign-in")(error);
+				throw error;
+			}
+		},
+	);
 }
 
 export function useOAuthComplete() {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (vars: {
-			providerId: string;
-			state: string;
-			code: string;
-			redirect_uri?: string;
-		}) =>
-			unwrap(
-				await api.POST("/v1/ai-providers/{provider_id}/auth/oauth/complete", {
-					params: { path: { provider_id: vars.providerId } },
-					body: { state: vars.state, code: vars.code, redirect_uri: vars.redirect_uri },
-				}),
-			),
-		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
-		onError: toastApiError("Couldn't finish sign-in"),
-	});
+	return useSensitiveAction(
+		async (vars: { providerId: string; state: string; code: string; redirect_uri?: string }) => {
+			try {
+				const result = unwrap(
+					await api.POST("/v1/ai-providers/{provider_id}/auth/oauth/complete", {
+						params: { path: { provider_id: vars.providerId } },
+						body: { state: vars.state, code: vars.code, redirect_uri: vars.redirect_uri },
+					}),
+				);
+				qc.invalidateQueries({ queryKey: KEY });
+				return result;
+			} catch (error) {
+				toastApiError("Couldn't finish sign-in")(error);
+				throw error;
+			}
+		},
+	);
 }

--- a/apps/web/src/hosted/v2/ai-providers/codex-oauth-callback.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/codex-oauth-callback.tsx
@@ -4,16 +4,15 @@ import { CircleAlert, CircleCheck } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
 	CODEX_OAUTH_CHANNEL,
-	CODEX_OAUTH_STORAGE_KEY,
 	type CodexOAuthResult,
 	parseCodexCallback,
 } from "@/hosted/v2/ai-providers/codex-oauth";
 
 /**
  * The Codex OAuth landing page. ChatGPT redirects here with `?code&state`;
- * this hands them back to the add-provider dialog (the opener) over three
- * channels for resilience — postMessage to the opener, a BroadcastChannel,
- * and localStorage — then closes itself when it was opened as a popup.
+ * this hands them back to the add-provider dialog (the opener) over two
+ * in-memory channels — postMessage to the opener and a BroadcastChannel —
+ * then closes itself when it was opened as a popup.
  */
 export function CodexOAuthCallback() {
 	const [state, setState] = useState<"ok" | "error">("ok");
@@ -25,6 +24,10 @@ export function CodexOAuthCallback() {
 			state: "",
 			error: "missing_code",
 		};
+		// The callback query is browser-history data. Strip code/state before
+		// handing them to the opener so refresh, screenshots, and diagnostics no
+		// longer expose the authorization material.
+		window.history.replaceState(window.history.state, "", window.location.pathname);
 		setState(result.error || !result.code ? "error" : "ok");
 
 		try {
@@ -40,14 +43,8 @@ export function CodexOAuthCallback() {
 				window.location.origin,
 			);
 		} catch {
-			// Cross-origin opener — ignore; storage/broadcast still deliver.
+			// Cross-origin opener — ignore; BroadcastChannel or manual paste still delivers.
 		}
-		try {
-			localStorage.setItem(CODEX_OAUTH_STORAGE_KEY, JSON.stringify(result));
-		} catch {
-			// Storage blocked — best-effort only.
-		}
-
 		// Opened as a popup with a usable result → auto-close shortly.
 		if (window.opener && !result.error && result.code) {
 			const t = setTimeout(() => window.close(), 1000);

--- a/apps/web/src/hosted/v2/ai-providers/codex-oauth.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/codex-oauth.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { codexOAuthStateMatches, parseCodexCallback } from "@/hosted/v2/ai-providers/codex-oauth";
+
+describe("Codex OAuth callback validation", () => {
+	test("accepts only an exact, non-empty state match", () => {
+		expect(
+			codexOAuthStateMatches("expected-state", {
+				code: "authorization-code",
+				state: "expected-state",
+			}),
+		).toBe(true);
+		expect(
+			codexOAuthStateMatches("expected-state", {
+				code: "authorization-code",
+				state: "attacker-state",
+			}),
+		).toBe(false);
+		expect(
+			codexOAuthStateMatches("expected-state", { code: "authorization-code", state: "" }),
+		).toBe(false);
+	});
+
+	test("requires both code and state when parsing a successful callback", () => {
+		expect(parseCodexCallback("?code=authorization-code&state=expected-state")).toEqual({
+			code: "authorization-code",
+			state: "expected-state",
+		});
+		expect(parseCodexCallback("?code=authorization-code")).toBeNull();
+		expect(parseCodexCallback("?state=expected-state")).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/codex-oauth.ts
+++ b/apps/web/src/hosted/v2/ai-providers/codex-oauth.ts
@@ -23,14 +23,17 @@ import type { AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 export const CLAWDI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
 
-/** Cross-window channel + storage key the callback uses to hand back code+state. */
+/** In-memory cross-window channel used to hand code+state back to the opener. */
 export const CODEX_OAUTH_CHANNEL = "clawdi-codex-oauth";
-export const CODEX_OAUTH_STORAGE_KEY = "clawdi:codex-oauth-result";
 
 export interface CodexOAuthResult {
 	code: string;
 	state: string;
 	error?: string;
+}
+
+export function codexOAuthStateMatches(expectedState: string, result: CodexOAuthResult): boolean {
+	return result.state.length > 0 && result.state === expectedState;
 }
 
 /** The v2 app's own OAuth callback route — the redirect_uri the flow uses. */

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -806,7 +806,9 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 						</div>
 					) : null}
 					<Button
-						onClick={() => effectiveLink && create.mutate({ agent_link_id: effectiveLink })}
+						onClick={() => {
+							if (effectiveLink) void create.execute({ agent_link_id: effectiveLink });
+						}}
 						disabled={!effectiveLink || create.isPending}
 					>
 						<Smartphone className="size-4" />
@@ -948,27 +950,29 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 		if (!canGenerate || generateLocked.current) return;
 		generateLocked.current = true;
 		setResult(null);
-		create.mutate(
-			{ agent_id: agentId || undefined, ttl_seconds: Number(ttl) },
-			{
-				onSuccess: (data) => {
-					if (data.agent_token) {
-						setRevealedAgentToken({
-							agentLinkId: data.agent_link_id,
-							value: data.agent_token,
-						});
-					}
-					setResult({
-						code: data.code,
-						expires_at: data.expires_at,
-						agent_link_id: data.agent_link_id,
+		void (async () => {
+			try {
+				const data = await create.execute({
+					agent_id: agentId || undefined,
+					ttl_seconds: Number(ttl),
+				});
+				if (data.agent_token) {
+					setRevealedAgentToken({
+						agentLinkId: data.agent_link_id,
+						value: data.agent_token,
 					});
-				},
-				onSettled: () => {
-					generateLocked.current = false;
-				},
-			},
-		);
+				}
+				setResult({
+					code: data.code,
+					expires_at: data.expires_at,
+					agent_link_id: data.agent_link_id,
+				});
+			} catch {
+				// useSensitiveAction already surfaces the API error.
+			} finally {
+				generateLocked.current = false;
+			}
+		})();
 	}
 
 	if (provider === "whatsapp" && !WHATSAPP_LINKING_READY) {

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -9,6 +9,7 @@ import {
 	removeDeletedChannelQueries,
 } from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
+import { whatsappCredentialMetadataForCache } from "@/hosted/v2/channels/whatsapp-credential-cache";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
@@ -283,10 +284,12 @@ export function useWhatsappTenantCreds(accountId: string, enabled = true) {
 	return useQuery({
 		queryKey: keys.whatsappCreds(accountId),
 		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/channels/whatsapp/{account_id}/tenant-creds", {
-					params: { path: { account_id: accountId } },
-				}),
+			whatsappCredentialMetadataForCache(
+				unwrap(
+					await api.GET("/v1/channels/whatsapp/{account_id}/tenant-creds", {
+						params: { path: { account_id: accountId } },
+					}),
+				),
 			),
 		enabled,
 	});

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -10,6 +10,7 @@ import {
 } from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /**
  * Typed data hooks for the native channels surface. All reads/writes go
@@ -109,14 +110,17 @@ export function useEnvironments() {
 export function useCreateChannel() {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (body: ChannelCreate) => unwrap(await api.POST("/v1/channels", { body })),
-		onSuccess: () => {
+	return useSensitiveAction(async (body: ChannelCreate) => {
+		try {
+			const result = unwrap(await api.POST("/v1/channels", { body }));
 			qc.invalidateQueries({ queryKey: keys.list });
 			qc.invalidateQueries({ queryKey: keys.pool });
 			qc.invalidateQueries({ queryKey: keys.health });
-		},
-		onError: toastApiError("Couldn't connect channel"),
+			return result;
+		} catch (error) {
+			toastApiError("Couldn't connect channel")(error);
+			throw error;
+		}
 	});
 }
 
@@ -141,34 +145,35 @@ export function useDeleteChannel() {
 export function useLinkAgent(accountId: string) {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (agentId: string) =>
-			unwrap(
+	return useSensitiveAction(async (agentId: string) => {
+		try {
+			const result = unwrap(
 				await api.POST("/v1/channels/{account_id}/agent-links", {
 					params: { path: { account_id: accountId } },
 					body: { agent_id: agentId },
 				}),
-			),
-		onSuccess: () => {
+			);
 			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
 			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
 			qc.invalidateQueries({ queryKey: keys.pool });
-		},
-		onError: toastApiError("Couldn't link agent"),
+			return result;
+		} catch (error) {
+			toastApiError("Couldn't link agent")(error);
+			throw error;
+		}
 	});
 }
 
 export function useRotateAgentToken(accountId: string) {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (linkId: string) =>
-			unwrap(
+	return useSensitiveAction(async (linkId: string) => {
+		try {
+			const data = unwrap(
 				await api.POST("/v1/channels/{account_id}/agent-links/{link_id}/token", {
 					params: { path: { account_id: accountId, link_id: linkId } },
 				}),
-			),
-		onSuccess: (data) => {
+			);
 			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
 			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
 			// Always confirm — the new token is also revealed inline when present,
@@ -178,29 +183,36 @@ export function useRotateAgentToken(accountId: string) {
 					? "Copy the new token below — the previous one is now invalid."
 					: "The previous token is now invalid.",
 			});
-		},
-		onError: toastApiError("Couldn't rotate token"),
+			return data;
+		} catch (error) {
+			toastApiError("Couldn't rotate token")(error);
+			throw error;
+		}
 	});
 }
 
 export function useCreatePairCode(accountId: string) {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string; ttl_seconds?: number }) =>
-			unwrap(
-				await api.POST("/v1/channels/{account_id}/pair-codes", {
-					params: { path: { account_id: accountId } },
-					body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
-				}),
-			),
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
-			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
-			qc.invalidateQueries({ queryKey: keys.bindings(accountId) });
+	return useSensitiveAction(
+		async (vars: { agent_id?: string; agent_link_id?: string; ttl_seconds?: number }) => {
+			try {
+				const result = unwrap(
+					await api.POST("/v1/channels/{account_id}/pair-codes", {
+						params: { path: { account_id: accountId } },
+						body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
+					}),
+				);
+				qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+				qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+				qc.invalidateQueries({ queryKey: keys.bindings(accountId) });
+				return result;
+			} catch (error) {
+				toastApiError("Couldn't create pairing code")(error);
+				throw error;
+			}
 		},
-		onError: toastApiError("Couldn't create pairing code"),
-	});
+	);
 }
 
 /** An agent's linked channels (+account summary) — fixes the per-channel N+1. */
@@ -283,8 +295,8 @@ export function useWhatsappTenantCreds(accountId: string, enabled = true) {
 export function useCreateWhatsappTenantCred(accountId: string) {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string }) =>
+	return useSensitiveAction(async (vars: { agent_id?: string; agent_link_id?: string }) => {
+		try {
 			unwrap(
 				await api.POST("/v1/channels/whatsapp/{account_id}/tenant-creds", {
 					params: { path: { account_id: accountId } },
@@ -292,14 +304,15 @@ export function useCreateWhatsappTenantCred(accountId: string) {
 					// it required — send the primary device.
 					body: { device: 1, ...vars },
 				}),
-			),
-		onSuccess: () => {
+			);
 			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
 			toast.success("Device credential minted", {
 				description: "Finish pairing from the agent runtime to link the number.",
 			});
-		},
-		onError: toastApiError("Couldn't link WhatsApp device"),
+		} catch (error) {
+			toastApiError("Couldn't link WhatsApp device")(error);
+			throw error;
+		}
 	});
 }
 

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -117,21 +117,28 @@ export function ConnectBotDialog({
 		return { provider, name: trimmedName };
 	}
 
-	function submit() {
+	async function submit() {
 		if (!canSubmit || submitLocked.current) return;
 		const body = buildBody();
 		if (!body) return;
 		submitLocked.current = true;
-		create.mutate(body, {
-			onSuccess: (data) => setCreated(data),
-			onSettled: () => {
-				submitLocked.current = false;
-			},
-		});
+		try {
+			const data = await create.execute(body);
+			setToken("");
+			setCreated(data);
+		} catch {
+			// useCreateChannel already surfaces the API error; retain the token for retry.
+		} finally {
+			submitLocked.current = false;
+		}
 	}
 
 	function handleOpenChange(nextOpen: boolean) {
 		if (!channelDialogOpenChangeAllowed(nextOpen, create.isPending || submitLocked.current)) return;
+		if (!nextOpen) {
+			setToken("");
+			setCreated(null);
+		}
 		onOpenChange(nextOpen);
 	}
 
@@ -367,7 +374,7 @@ export function ConnectBotDialog({
 							>
 								Cancel
 							</Button>
-							<Button onClick={submit} disabled={!canSubmit || isSubmitting}>
+							<Button onClick={() => void submit()} disabled={!canSubmit || isSubmitting}>
 								{create.isPending ? "Connecting…" : "Connect"}
 							</Button>
 						</DialogFooter>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -107,37 +107,24 @@ export function LinkAgentDialog({
 		setWhatsappCredentialMinted(false);
 	}, [open]);
 
-	function submit() {
+	async function submit() {
 		if (!agentId || blockReason || guardLoading || submitLocked.current) return;
 		const agent = selectedAgent;
 		submitLocked.current = true;
-		let credentialMutationStarted = false;
-		link.mutate(agentId, {
-			onSuccess: (data) => {
-				if (shouldMintWhatsappTenantCredential(provider, agent)) {
-					credentialMutationStarted = true;
-					createWhatsappCredential.mutate(
-						{ agent_link_id: data.id },
-						{
-							onSuccess: () => {
-								setWhatsappCredentialMinted(true);
-							},
-							onSettled: () => {
-								submitLocked.current = false;
-							},
-						},
-					);
-					return;
-				}
-				if (data.agent_token) setToken(data.agent_token);
-				else setLinkedNoToken(true);
-			},
-			onSettled: () => {
-				if (!credentialMutationStarted) {
-					submitLocked.current = false;
-				}
-			},
-		});
+		try {
+			const data = await link.execute(agentId);
+			if (shouldMintWhatsappTenantCredential(provider, agent)) {
+				await createWhatsappCredential.execute({ agent_link_id: data.id });
+				setWhatsappCredentialMinted(true);
+				return;
+			}
+			if (data.agent_token) setToken(data.agent_token);
+			else setLinkedNoToken(true);
+		} catch {
+			// The sensitive action hooks already surface API failures.
+		} finally {
+			submitLocked.current = false;
+		}
 	}
 
 	function handleOpenChange(nextOpen: boolean) {
@@ -148,6 +135,7 @@ export function LinkAgentDialog({
 			)
 		)
 			return;
+		if (!nextOpen) setToken(null);
 		onOpenChange(nextOpen);
 	}
 
@@ -262,7 +250,7 @@ export function LinkAgentDialog({
 								Cancel
 							</Button>
 							<Button
-								onClick={submit}
+								onClick={() => void submit()}
 								disabled={!agentId || Boolean(blockReason) || guardLoading || isSubmitting}
 							>
 								{createWhatsappCredential.isPending

--- a/apps/web/src/hosted/v2/channels/whatsapp-credential-cache.ts
+++ b/apps/web/src/hosted/v2/channels/whatsapp-credential-cache.ts
@@ -1,0 +1,17 @@
+import type { components } from "@/lib/api-schemas";
+
+type WhatsAppTenantCredentialMetadata = components["schemas"]["WhatsAppTenantCredentialMetadata"];
+
+/** Allowlist the non-secret device metadata that the linked-devices UI caches. */
+export function whatsappCredentialMetadataForCache(
+	credentials: readonly WhatsAppTenantCredentialMetadata[],
+): WhatsAppTenantCredentialMetadata[] {
+	return credentials.map((credential) => ({
+		credential_id: credential.credential_id,
+		agent_link_id: credential.agent_link_id,
+		agent_id: credential.agent_id,
+		jid: credential.jid,
+		identity_pub_key_hex: credential.identity_pub_key_hex,
+		created_at: credential.created_at,
+	}));
+}

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -154,40 +154,6 @@ export function useAuthFields(appName: string, { enabled }: { enabled: boolean }
 // ─────────────────────────────────────────────────────────────────────
 // Mutations
 
-export function useConnect() {
-	const api = useApi();
-	return useMutation({
-		mutationFn: async ({ appName, redirectUrl }: { appName: string; redirectUrl?: string }) =>
-			unwrap(
-				await api.POST("/v1/connectors/{app_name}/connect", {
-					params: { path: { app_name: appName } },
-					body: redirectUrl ? { redirect_url: redirectUrl } : {},
-				}),
-			),
-	});
-}
-
-export function useConnectCredentials() {
-	const api = useApi();
-	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async ({
-			appName,
-			credentials,
-		}: {
-			appName: string;
-			credentials: Record<string, string>;
-		}) =>
-			unwrap(
-				await api.POST("/v1/connectors/{app_name}/connect-credentials", {
-					params: { path: { app_name: appName } },
-					body: { credentials },
-				}),
-			),
-		onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
-	});
-}
-
 export function useDisconnect() {
 	const api = useApi();
 	const qc = useQueryClient();

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,32 @@
+import { QueryClient, replaceEqualDeep } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api-errors";
+import { sanitizeQueryCacheValue } from "@/lib/sensitive-cache";
+
+export function createAppQueryClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: {
+				staleTime: 30_000,
+				// API payloads are sanitized before QueryCache owns them. This is
+				// structural prevention: a client secret is never briefly cached and
+				// then cleaned up after observers/devtools have seen it.
+				structuralSharing: (oldData, newData) =>
+					replaceEqualDeep(oldData, sanitizeQueryCacheValue(newData)),
+				retry: (failureCount, error) => {
+					if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+						return false;
+					}
+					// Fetch-level failures (no HTTP response) get a longer budget
+					// (~7s of backoff) than server errors (~3s): backend deploys
+					// swap containers behind the proxy, and for a few seconds the
+					// proxy answers with its own CORS-less 502, which the browser
+					// can only see as a fetch failure.
+					if (!(error instanceof ApiError)) {
+						return failureCount < 3;
+					}
+					return failureCount < 2;
+				},
+			},
+		},
+	});
+}

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -7,9 +7,8 @@ export function createAppQueryClient(): QueryClient {
 		defaultOptions: {
 			queries: {
 				staleTime: 30_000,
-				// API payloads are sanitized before QueryCache owns them. This is
-				// structural prevention: a client secret is never briefly cached and
-				// then cleaned up after observers/devtools have seen it.
+				// Last-resort defense in depth for an accidentally unsafe query. Active
+				// secret-bearing flows project secrets out before returning query data.
 				structuralSharing: (oldData, newData) =>
 					replaceEqualDeep(oldData, sanitizeQueryCacheValue(newData)),
 				retry: (failureCount, error) => {

--- a/apps/web/src/lib/sensitive-cache.test.ts
+++ b/apps/web/src/lib/sensitive-cache.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { createAppQueryClient } from "@/lib/query-client";
+import { cacheValueContains } from "@/lib/sensitive-cache";
+import { executeSensitiveAction } from "@/lib/use-sensitive-action";
+
+function cachedState(queryClient: ReturnType<typeof createAppQueryClient>) {
+	return {
+		queries: queryClient
+			.getQueryCache()
+			.getAll()
+			.map((query) => ({ queryKey: query.queryKey, state: query.state })),
+		mutations: queryClient
+			.getMutationCache()
+			.getAll()
+			.map((mutation) => mutation.state),
+	};
+}
+
+describe("sensitive cache boundaries", () => {
+	test("strips Stripe and credential fields before query data is cached", async () => {
+		const queryClient = createAppQueryClient();
+		const clientSecret = "pi_cache_test_secret_123";
+		const providerToken = "provider-token-cache-test";
+
+		await queryClient.prefetchQuery({
+			queryKey: ["billing", "wallet"],
+			queryFn: async () => ({
+				balance_cents: 2_500,
+				auto_reload_action: {
+					attempt_id: 7,
+					client_secret: clientSecret,
+				},
+			}),
+		});
+		queryClient.setQueryData(["credential-test"], {
+			provider_token: providerToken,
+			nested: { mem0_api_key: "mem0-cache-test", raw_key: "raw-cache-test", safe: "kept" },
+		});
+
+		const wallet = queryClient.getQueryData<Record<string, unknown>>(["billing", "wallet"]);
+		expect(wallet?.balance_cents).toBe(2_500);
+		expect(wallet?.auto_reload_action).toEqual({ attempt_id: 7 });
+		expect(queryClient.getQueryData<Record<string, unknown>>(["credential-test"])).toEqual({
+			nested: { safe: "kept" },
+		});
+		expect(cacheValueContains(cachedState(queryClient), clientSecret)).toBe(false);
+		expect(cacheValueContains(cachedState(queryClient), providerToken)).toBe(false);
+	});
+
+	test("imperative secret actions leave MutationCache empty after settlement", async () => {
+		const queryClient = createAppQueryClient();
+		const apiKey = "sk-sensitive-action-test";
+		const oneTimeToken = "one-time-sensitive-action-test";
+
+		const result = await executeSensitiveAction(
+			async (value: string) => ({ agent_token: oneTimeToken, accepted: value.length > 0 }),
+			apiKey,
+		);
+
+		expect(result).toEqual({ agent_token: oneTimeToken, accepted: true });
+		expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+		expect(cacheValueContains(cachedState(queryClient), apiKey)).toBe(false);
+		expect(cacheValueContains(cachedState(queryClient), oneTimeToken)).toBe(false);
+	});
+});

--- a/apps/web/src/lib/sensitive-cache.test.ts
+++ b/apps/web/src/lib/sensitive-cache.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import type { QueryClient } from "@tanstack/react-query";
 import { createAppQueryClient } from "@/lib/query-client";
-import { cacheValueContains } from "@/lib/sensitive-cache";
+import { cacheValueContains, sanitizeQueryCacheValue } from "@/lib/sensitive-cache";
 import { executeSensitiveAction } from "@/lib/use-sensitive-action";
 
-function cachedState(queryClient: ReturnType<typeof createAppQueryClient>) {
+function cachedState(queryClient: QueryClient) {
 	return {
 		queries: queryClient
 			.getQueryCache()
@@ -61,5 +62,29 @@ describe("sensitive cache boundaries", () => {
 		expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
 		expect(cacheValueContains(cachedState(queryClient), apiKey)).toBe(false);
 		expect(cacheValueContains(cachedState(queryClient), oneTimeToken)).toBe(false);
+	});
+
+	test("matches mixed-case fields through arrays and deeply nested JSON payloads", () => {
+		const secrets = {
+			client: "mixed-case-client-secret",
+			credential: "array-object-credential",
+			deep: "deeply-nested-token",
+		};
+		let deeplyNested: unknown = { ToKeN: secrets.deep, safe: "deep value" };
+		for (let depth = 0; depth < 128; depth += 1) {
+			deeplyNested = depth % 2 === 0 ? [{ child: deeplyNested }] : { child: deeplyNested };
+		}
+		const payload = {
+			CLIENT_SECRET: secrets.client,
+			items: [{ CrEdEnTiAlS: secrets.credential, safe: "array value" }],
+			deeplyNested,
+		};
+
+		const sanitized = sanitizeQueryCacheValue(payload);
+		for (const secret of Object.values(secrets)) {
+			expect(cacheValueContains(sanitized, secret)).toBe(false);
+		}
+		expect(cacheValueContains(sanitized, "array value")).toBe(true);
+		expect(cacheValueContains(sanitized, "deep value")).toBe(true);
 	});
 });

--- a/apps/web/src/lib/sensitive-cache.ts
+++ b/apps/web/src/lib/sensitive-cache.ts
@@ -1,0 +1,67 @@
+const SENSITIVE_CACHE_FIELDS = new Set([
+	"access_token",
+	"agent_token",
+	"api_key",
+	"auth_cert",
+	"auth_url",
+	"checkout_url",
+	"client_secret",
+	"connect_url",
+	"credential",
+	"credentials",
+	"creds",
+	"mcp_token",
+	"mem0_api_key",
+	"password",
+	"payment_intent_client_secret",
+	"portal_url",
+	"private_key",
+	"provider_token",
+	"raw_key",
+	"raw_token",
+	"refresh_token",
+	"secret",
+	"token",
+	"websocket_url",
+]);
+
+function isPlainRecord(value: object): value is Record<string, unknown> {
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+/** Remove plaintext secret fields before a response becomes QueryCache data. */
+export function sanitizeQueryCacheValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		let changed = false;
+		const next = value.map((item) => {
+			const sanitized = sanitizeQueryCacheValue(item);
+			if (sanitized !== item) changed = true;
+			return sanitized;
+		});
+		return changed ? next : value;
+	}
+	if (typeof value !== "object" || value === null || !isPlainRecord(value)) return value;
+
+	let changed = false;
+	const entries: Array<[string, unknown]> = [];
+	for (const [key, item] of Object.entries(value)) {
+		if (SENSITIVE_CACHE_FIELDS.has(key.toLowerCase())) {
+			changed = true;
+			continue;
+		}
+		const sanitized = sanitizeQueryCacheValue(item);
+		if (sanitized !== item) changed = true;
+		entries.push([key, sanitized]);
+	}
+	return changed ? Object.fromEntries(entries) : value;
+}
+
+export function cacheValueContains(value: unknown, needle: string): boolean {
+	if (typeof value === "string") return value.includes(needle);
+	if (Array.isArray(value)) return value.some((item) => cacheValueContains(item, needle));
+	if (typeof value !== "object" || value === null) return false;
+	return Object.entries(value).some(
+		([key, item]) => key.includes(needle) || cacheValueContains(item, needle),
+	);
+}

--- a/apps/web/src/lib/sensitive-cache.ts
+++ b/apps/web/src/lib/sensitive-cache.ts
@@ -1,3 +1,6 @@
+// Defense in depth only. Secret-bearing queries and actions must avoid or
+// remove secrets structurally before TanStack owns the value. Adding a field
+// name here is not the fix for a new secret-bearing flow.
 const SENSITIVE_CACHE_FIELDS = new Set([
 	"access_token",
 	"agent_token",

--- a/apps/web/src/lib/use-sensitive-action.ts
+++ b/apps/web/src/lib/use-sensitive-action.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function executeSensitiveAction<TArgs extends unknown[], TResult>(
+	action: (...args: TArgs) => Promise<TResult>,
+	...args: TArgs
+): Promise<TResult> {
+	return action(...args);
+}
+
+/**
+ * Runs a secret-bearing request without creating a TanStack mutation.
+ *
+ * Arguments and results exist only on the caller's async stack. This hook
+ * deliberately stores only pending/error UI state, so plaintext credentials,
+ * one-time tokens, and payment secrets cannot enter MutationCache.
+ */
+export function useSensitiveAction<TArgs extends unknown[], TResult>(
+	action: (...args: TArgs) => Promise<TResult>,
+) {
+	const actionRef = useRef(action);
+	const mountedRef = useRef(true);
+	const pendingCountRef = useRef(0);
+	const [isPending, setIsPending] = useState(false);
+	const [error, setError] = useState<unknown>(null);
+	actionRef.current = action;
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+
+	const execute = useCallback(async (...args: TArgs): Promise<TResult> => {
+		pendingCountRef.current += 1;
+		if (mountedRef.current) {
+			setIsPending(true);
+			setError(null);
+		}
+		try {
+			return await executeSensitiveAction(actionRef.current, ...args);
+		} catch (nextError) {
+			if (mountedRef.current) setError(nextError);
+			throw nextError;
+		} finally {
+			pendingCountRef.current -= 1;
+			if (mountedRef.current && pendingCountRef.current === 0) setIsPending(false);
+		}
+	}, []);
+
+	const reset = useCallback(() => {
+		if (mountedRef.current) setError(null);
+	}, []);
+
+	return { execute, isPending, error, reset };
+}

--- a/apps/web/src/pages/cli-authorize/page.tsx
+++ b/apps/web/src/pages/cli-authorize/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import type { DeviceLookupResponse } from "@clawdi/shared/api";
-import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle2, Clock, Terminal, XCircle } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -13,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 const CLI_AUTHORIZE_ERROR_NORMALIZER: ApiErrorNormalizer = {
 	isAuthError: isApiAuthError,
@@ -53,32 +53,52 @@ function CliAuthorizeContent() {
 	const code = rawCode.toUpperCase().trim();
 	const api = useApi();
 	const [terminalState, setTerminalState] = useState<"approved" | "denied" | null>(null);
+	const lookupRequestRef = useRef(0);
+	const [lookup, setLookup] = useState<{
+		data: DeviceLookupResponse | null;
+		error: unknown;
+		isLoading: boolean;
+	}>({ data: null, error: null, isLoading: code.length > 0 });
 
-	const lookup = useQuery({
-		enabled: code.length > 0,
-		queryKey: ["cli-authorize", code],
-		queryFn: async (): Promise<DeviceLookupResponse> =>
-			unwrap(
-				await api.GET("/v1/cli/auth/lookup", {
-					params: { query: { code } },
-				}),
-			),
+	useEffect(() => {
+		if (!code) {
+			setLookup({ data: null, error: null, isLoading: false });
+			return;
+		}
+		const requestId = lookupRequestRef.current + 1;
+		lookupRequestRef.current = requestId;
+		setLookup({ data: null, error: null, isLoading: true });
+		void (async () => {
+			try {
+				const data = unwrap(
+					await api.GET("/v1/cli/auth/lookup", {
+						params: { query: { code } },
+					}),
+				);
+				if (lookupRequestRef.current === requestId) {
+					setLookup({ data, error: null, isLoading: false });
+				}
+			} catch (error) {
+				if (lookupRequestRef.current === requestId) {
+					setLookup({ data: null, error, isLoading: false });
+				}
+			}
+		})();
+		return () => {
+			lookupRequestRef.current += 1;
+		};
+	}, [api, code]);
+
+	const approve = useSensitiveAction(async () => {
+		const res = await api.POST("/v1/cli/auth/approve", { body: { user_code: code } });
+		unwrap(res);
+		setTerminalState("approved");
 	});
 
-	const approve = useMutation({
-		mutationFn: async () => {
-			const res = await api.POST("/v1/cli/auth/approve", { body: { user_code: code } });
-			unwrap(res);
-		},
-		onSuccess: () => setTerminalState("approved"),
-	});
-
-	const deny = useMutation({
-		mutationFn: async () => {
-			const res = await api.POST("/v1/cli/auth/deny", { body: { user_code: code } });
-			unwrap(res);
-		},
-		onSuccess: () => setTerminalState("denied"),
+	const deny = useSensitiveAction(async () => {
+		const res = await api.POST("/v1/cli/auth/deny", { body: { user_code: code } });
+		unwrap(res);
+		setTerminalState("denied");
 	});
 
 	if (!code) {
@@ -195,19 +215,22 @@ function CliAuthorizeContent() {
 					<div className="flex items-center justify-end gap-2">
 						<Button
 							variant="ghost"
-							onClick={() => deny.mutate()}
+							onClick={() => void deny.execute().catch(() => undefined)}
 							disabled={deny.isPending || approve.isPending}
 						>
 							{deny.isPending ? "Denying…" : "Deny"}
 						</Button>
-						<Button onClick={() => approve.mutate()} disabled={approve.isPending || deny.isPending}>
+						<Button
+							onClick={() => void approve.execute().catch(() => undefined)}
+							disabled={approve.isPending || deny.isPending}
+						>
 							{approve.isPending ? "Authorizing…" : "Authorize"}
 						</Button>
 					</div>
 
-					{(approve.error || deny.error) && (
+					{approve.error || deny.error ? (
 						<ApiErrorPanel error={approve.error || deny.error} title="Action failed" />
-					)}
+					) : null}
 				</CardContent>
 			</Card>
 		</Shell>

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -20,16 +20,17 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { unwrap, useApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { ConnectorTool } from "@/lib/api-schemas";
 import {
 	isActiveConnection,
 	useAvailableApp,
-	useConnect,
 	useConnections,
 	useConnectorTools,
 	useDisconnect,
 } from "@/lib/connectors-data";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage } from "@/lib/utils";
 
 /** Strip leading underscores/dashes and title-case for fallback display. */
@@ -102,7 +103,15 @@ function ConnectorDetail({ name }: { name: string }) {
 	// Query's per-connection window-focus refetch always checks for the
 	// new ACTIVE connection when the user returns to this tab. No polling
 	// loop needed.
-	const connectMutation = useConnect();
+	const api = useApi();
+	const connectAction = useSensitiveAction(async (redirectUrl: string) =>
+		unwrap(
+			await api.POST("/v1/connectors/{app_name}/connect", {
+				params: { path: { app_name: name } },
+				body: { redirect_url: redirectUrl },
+			}),
+		),
+	);
 
 	// Per-row disconnect single-flight guard.
 	//
@@ -219,23 +228,20 @@ function ConnectorDetail({ name }: { name: string }) {
 		// back to our origin and the connections query force-refetches on
 		// window focus to reflect the new ACTIVE connection.
 		const redirectUrl = window.location.href;
-		connectMutation.mutate(
-			{ appName: name, redirectUrl },
-			{
-				onSuccess: (result) => {
-					if (!popup.closed) popup.location.href = result.connect_url;
-				},
-				onError: (e) => {
-					popup.close();
-					toast.error("Couldn't start connection", { description: errorMessage(e) });
-				},
-				onSettled: () => {
-					inflightConnectRef.current = false;
-				},
-			},
-		);
+		void connectAction
+			.execute(redirectUrl)
+			.then((result) => {
+				if (!popup.closed) popup.location.href = result.connect_url;
+			})
+			.catch((error) => {
+				popup.close();
+				toast.error("Couldn't start connection", { description: errorMessage(error) });
+			})
+			.finally(() => {
+				inflightConnectRef.current = false;
+			});
 	};
-	const isStarting = connectMutation.isPending;
+	const isStarting = connectAction.isPending;
 	const isConnectDisabled = isStarting || hasUnsupportedAuthType || isSetupBlocked;
 	const isReady = isConnected || usesNoAuth;
 	useSetBreadcrumbTitle(displayName);

--- a/apps/web/src/pages/dashboard/memories/memory-settings-cache.ts
+++ b/apps/web/src/pages/dashboard/memories/memory-settings-cache.ts
@@ -1,0 +1,16 @@
+export interface MemorySettingsCacheSnapshot {
+	memory_provider: string;
+	mem0_api_key_configured: boolean;
+}
+
+/** Project settings into the only non-secret fields this page caches. */
+export function memorySettingsForCache(
+	settings: Record<string, unknown>,
+): MemorySettingsCacheSnapshot {
+	const mem0ApiKey = settings.mem0_api_key;
+	return {
+		memory_provider:
+			typeof settings.memory_provider === "string" ? settings.memory_provider : "builtin",
+		mem0_api_key_configured: typeof mem0ApiKey === "string" && mem0ApiKey.length > 0,
+	};
+}

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -48,6 +48,7 @@ import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
+import { memorySettingsForCache } from "@/pages/dashboard/memories/memory-settings-cache";
 
 const CATEGORIES = [
 	{ value: "all", label: "All" },
@@ -76,18 +77,7 @@ export default function MemoriesPage() {
 
 	const { data: settings } = useQuery({
 		queryKey: ["settings"],
-		queryFn: async (): Promise<{
-			memory_provider: string;
-			mem0_api_key_configured: boolean;
-		}> => {
-			const value = unwrap(await api.GET("/v1/settings"));
-			const mem0ApiKey = value.mem0_api_key;
-			return {
-				memory_provider:
-					typeof value.memory_provider === "string" ? value.memory_provider : "builtin",
-				mem0_api_key_configured: typeof mem0ApiKey === "string" && mem0ApiKey.length > 0,
-			};
-		},
+		queryFn: async () => memorySettingsForCache(unwrap(await api.GET("/v1/settings"))),
 	});
 
 	const provider =

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -46,6 +46,7 @@ import type { Memory } from "@/lib/api-schemas";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { useDebouncedValue } from "@/lib/use-debounced";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 const CATEGORIES = [
@@ -75,22 +76,49 @@ export default function MemoriesPage() {
 
 	const { data: settings } = useQuery({
 		queryKey: ["settings"],
-		queryFn: async () => unwrap(await api.GET("/v1/settings")),
+		queryFn: async (): Promise<{
+			memory_provider: string;
+			mem0_api_key_configured: boolean;
+		}> => {
+			const value = unwrap(await api.GET("/v1/settings"));
+			const mem0ApiKey = value.mem0_api_key;
+			return {
+				memory_provider:
+					typeof value.memory_provider === "string" ? value.memory_provider : "builtin",
+				mem0_api_key_configured: typeof mem0ApiKey === "string" && mem0ApiKey.length > 0,
+			};
+		},
 	});
 
 	const provider =
 		typeof settings?.memory_provider === "string" ? settings.memory_provider : "builtin";
-	const mem0Key = typeof settings?.mem0_api_key === "string" ? settings.mem0_api_key : "";
-	const hasMem0Key = mem0Key !== "";
+	const hasMem0Key = settings?.mem0_api_key_configured === true;
 
 	const updateSettings = useMutation({
-		mutationFn: async (patch: Record<string, string>) =>
-			unwrap(await api.PATCH("/v1/settings", { body: { settings: patch } })),
+		mutationFn: async (memoryProvider: "builtin" | "mem0") =>
+			unwrap(
+				await api.PATCH("/v1/settings", {
+					body: { settings: { memory_provider: memoryProvider } },
+				}),
+			),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["settings"] });
 			queryClient.invalidateQueries({ queryKey: ["memories"] });
 		},
 		onError: (e) => toast.error("Couldn't update settings", { description: errorMessage(e) }),
+	});
+	const saveMem0Key = useSensitiveAction(async (key: string) => {
+		try {
+			const result = unwrap(
+				await api.PATCH("/v1/settings", { body: { settings: { mem0_api_key: key } } }),
+			);
+			queryClient.invalidateQueries({ queryKey: ["settings"] });
+			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			return result;
+		} catch (error) {
+			toast.error("Couldn't update settings", { description: errorMessage(error) });
+			throw error;
+		}
 	});
 
 	const { data, isLoading, isFetching, error, refetch } = useQuery({
@@ -145,10 +173,7 @@ export default function MemoriesPage() {
 			<PageHeader title="Memories" description={MEMORIES_RESOURCE.managementDescription} />
 
 			{provider === "mem0" && !hasMem0Key ? (
-				<Mem0KeyForm
-					onSave={(key) => updateSettings.mutate({ mem0_api_key: key })}
-					isPending={updateSettings.isPending}
-				/>
+				<Mem0KeyForm onSave={saveMem0Key.execute} isPending={saveMem0Key.isPending} />
 			) : null}
 
 			<ListToolbar
@@ -190,7 +215,7 @@ export default function MemoriesPage() {
 							onValueChange={(v) => {
 								const selected = v[0];
 								if (selected === "builtin" || selected === "mem0") {
-									updateSettings.mutate({ memory_provider: selected });
+									updateSettings.mutate(selected);
 								}
 							}}
 							disabled={updateSettings.isPending}
@@ -349,8 +374,23 @@ function MemoryNotesGrid({
 	);
 }
 
-function Mem0KeyForm({ onSave, isPending }: { onSave: (key: string) => void; isPending: boolean }) {
+function Mem0KeyForm({
+	onSave,
+	isPending,
+}: {
+	onSave: (key: string) => Promise<unknown>;
+	isPending: boolean;
+}) {
 	const [apiKey, setApiKey] = useState("");
+	async function submit() {
+		if (!apiKey || isPending) return;
+		try {
+			await onSave(apiKey);
+			setApiKey("");
+		} catch {
+			// The parent action surfaces the error; retain the value for an explicit retry.
+		}
+	}
 	return (
 		<Card>
 			<CardHeader>
@@ -378,10 +418,10 @@ function Mem0KeyForm({ onSave, isPending }: { onSave: (key: string) => void; isP
 						autoComplete="off"
 						spellCheck={false}
 						onKeyDown={(e) => {
-							if (e.key === "Enter" && apiKey) onSave(apiKey);
+							if (e.key === "Enter" && apiKey) void submit();
 						}}
 					/>
-					<Button onClick={() => apiKey && onSave(apiKey)} disabled={!apiKey || isPending}>
+					<Button onClick={() => void submit()} disabled={!apiKey || isPending}>
 						{isPending ? <Spinner /> : <Key />}
 						Save API Key
 					</Button>

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
@@ -12,6 +11,7 @@ import {
 	ShieldCheck,
 	Sparkles,
 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +23,7 @@ import { unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { useCurrentUser, useDashboardAuth } from "@/lib/auth-client";
 import { projectDetailHref } from "@/lib/project-resource-model";
+import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /**
  * Public project-share landing page.
@@ -76,33 +77,51 @@ export default function SharePage({ token }: { token: string }) {
 	const router = useRouter();
 	const { isSignedIn, getToken } = useDashboardAuth();
 	const { user } = useCurrentUser();
+	const previewRequestRef = useRef(0);
+	const [preview, setPreview] = useState<{
+		data: SharePreview | null;
+		error: unknown;
+		isLoading: boolean;
+	}>({ data: null, error: null, isLoading: true });
+	const [upgradeSucceeded, setUpgradeSucceeded] = useState(false);
 
-	const preview = useQuery({
-		queryKey: ["share-preview", token],
-		queryFn: async (): Promise<SharePreview> => {
-			const result = await api.GET("/v1/share/{token}/preview", {
-				params: { path: { token } },
-			});
-			if (result.error !== undefined) throw shareErrorFromApi(result.response.status, result.error);
-			return unwrap(result);
-		},
-		retry: false,
-	});
+	useEffect(() => {
+		const requestId = previewRequestRef.current + 1;
+		previewRequestRef.current = requestId;
+		setPreview({ data: null, error: null, isLoading: true });
+		void (async () => {
+			try {
+				const result = await api.GET("/v1/share/{token}/preview", {
+					params: { path: { token } },
+				});
+				if (result.error !== undefined)
+					throw shareErrorFromApi(result.response.status, result.error);
+				if (previewRequestRef.current === requestId) {
+					setPreview({ data: unwrap(result), error: null, isLoading: false });
+				}
+			} catch (error) {
+				if (previewRequestRef.current === requestId) {
+					setPreview({ data: null, error, isLoading: false });
+				}
+			}
+		})();
+		return () => {
+			previewRequestRef.current += 1;
+		};
+	}, [api, token]);
 
-	const upgrade = useMutation({
-		mutationFn: async () => {
-			const bearer = await getToken();
-			if (!bearer) throw new ShareError("unknown");
-			const result = await api.POST("/v1/share/{token}/upgrade", {
-				params: { path: { token } },
-				body: { use_as: "attached" },
-			});
-			if (result.error !== undefined) throw shareErrorFromApi(result.response.status, result.error);
-			return unwrap(result);
-		},
-		onSuccess: (result) => {
-			void router.navigate({ href: `${projectDetailHref(result.project_id)}?joined=share` });
-		},
+	const upgrade = useSensitiveAction(async () => {
+		const bearer = await getToken();
+		if (!bearer) throw new ShareError("unknown");
+		const result = await api.POST("/v1/share/{token}/upgrade", {
+			params: { path: { token } },
+			body: { use_as: "attached" },
+		});
+		if (result.error !== undefined) throw shareErrorFromApi(result.response.status, result.error);
+		const body = unwrap(result);
+		setUpgradeSucceeded(true);
+		void router.navigate({ href: `${projectDetailHref(body.project_id)}?joined=share` });
+		return body;
 	});
 
 	if (preview.isLoading) {
@@ -162,7 +181,7 @@ export default function SharePage({ token }: { token: string }) {
 
 					<Separator />
 
-					{upgrade.isSuccess ? (
+					{upgradeSucceeded ? (
 						<Alert>
 							<CheckCircle2 />
 							<AlertTitle>You're In</AlertTitle>
@@ -180,7 +199,7 @@ export default function SharePage({ token }: { token: string }) {
 					) : isSignedIn ? (
 						<div className="space-y-3">
 							<Button
-								onClick={() => upgrade.mutate()}
+								onClick={() => void upgrade.execute().catch(() => undefined)}
 								disabled={upgrade.isPending}
 								className="w-full"
 								size="lg"


### PR DESCRIPTION
## Summary

- keep secret-bearing requests out of TanStack MutationCache with the shared imperative useSensitiveAction boundary
- project every active secret-bearing query into an explicit safe shape before QueryCache ownership; the global field-name sanitizer is defense in depth only
- remove the Codex OAuth storage handoff in favor of same-origin postMessage plus BroadcastChannel, clear callback parameters immediately, and preserve exact non-empty state verification
- add a design-system drag handle plus dnd-kit keyboard sorting and positional accessible names for agent ordering

## Four high findings

1. **MutationCache:** sensitive operations do not use TanStack mutations. useSensitiveAction stores only pending/error UI state; arguments and results remain on the caller stack or in explicitly scoped component state. This is structural prevention, not settle-time cleanup.
2. **Wallet QueryCache:** all six active wallet consumers now use useWalletSnapshot. Its queryFn applies an explicit allowlist projection before returning data, retaining only balance/config and non-secret auto-reload attempt metadata. Stripe client secrets are fetched imperatively into payment component state and discarded on completion, cancellation, close, or terminal action removal.
3. **Codex OAuth:** the flow needs popup continuity, not redirect persistence. The callback uses same-origin postMessage and BroadcastChannel, strips code/state from browser history immediately, and preserves CSRF protection through exact non-empty state validation. No browser storage is used.
4. **Agent sorting:** each sortable agent uses the design-system Button drag handle, KeyboardSensor with sortableKeyboardCoordinates, and an accessible name that exposes the agent and current position.

## Denylist is not load-bearing

SENSITIVE_CACHE_FIELDS and the QueryClient sanitizer are explicitly documented as defense in depth. The code comment states that adding a field name is not the fix for a new flow.

The structural proof test deliberately creates a raw QueryClient with structural sharing disabled and never imports createAppQueryClient. It writes the projected Wallet, WhatsApp credential metadata, and Mem0 settings payloads into that unsanitized QueryCache, including both registered field names and deliberately unregistered future secret names, then inspects the complete QueryCache state and finds no secret value.

The same test enumerates 19 fixed sensitive action families with secret-bearing arguments and results, runs them through the imperative action boundary, and proves the raw QueryClient MutationCache remains empty. Source-contract assertions bind that behavior to every active call site and fail if any active caller returns to the old sensitive billing hooks.

**Active structural exceptions: none.** The pre-existing unsafe billing hook exports inside the PR #484/#485-owned hooks.ts remain untouched, but whole-source assertions prove they have zero active callers.

Wallet, WhatsApp tenant credential metadata, and Mem0 settings all use explicit allowlist projections. The allowlists also discard unexpected future response properties regardless of field name.

## Recursive sanitizer coverage

The defense-in-depth sanitizer lowercases every object key before exact matching and recursively traverses arrays plus nested plain/null-prototype records. Tests cover mixed-case names, arrays of objects, and 128 alternating object/array levels. There is no configured depth cutoff; at pathological JavaScript call-stack depth it fails the cache write rather than returning an unsanitized payload. Non-plain class instances are intentionally not traversed because API responses are JSON arrays/plain records.

## Additional instances closed by the full v2 scan

- connector API credentials and connector OAuth connect URLs
- WhatsApp tenant credential responses
- project-share raw link tokens and public share capability tokens
- CLI device authorization codes
- Vault plaintext imports
- Mem0 API keys in both settings queries and settings mutations
- hosted terminal websocket URLs containing auth tokens
- Stripe subscription checkout, billing portal, fix-payment, top-up, and auto-reload actions
- dashboard bearer-key creation and provider API-key submission
- channel bot/link/rotation/pair tokens, including expiry cleanup for revealed pairing tokens
- generic root-error logging of arbitrary error payloads

## Verification

- bun run check
- bun run lint
- bun run typecheck
- bun run build
- bun run test -- web (Docker-backed full web suite)
- sidebar-runtime-smoke.pw.ts: 2/2 passed, including keyboard sorting
- targeted hosted security paths: 2/2 passed, including complete Stripe Payment Elements and OAuth/storage checks
- full hosted-smoke.pw.ts: 35/56, exactly reproducing the known 21 stale failures

The 21 hosted failures are the same pre-existing stale copy/credits/billing-field assertions, old TokenReveal DOM assertions, and existing sidebar SSR hydration mismatch. None is caused by this PR. The wallet annual, auto-reload, full top-up/storage, and OAuth/storage paths pass. Console errors were not filtered and assertions were not weakened.

No secret-bearing value remains in any active QueryCache, MutationCache, browser storage channel, or browser log. No legacy v1, .github, generated file, or PR #484/#485-owned file was changed.
