### PR TITLE
fix(web): collapse whitespace in deployment failure reasons

### DIFF
--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -24,7 +24,10 @@ export function deploymentFailureReason(input: {
 			? [failure.detail, failure.title, failure.conditionMessage]
 			: [failure?.title, failure?.conditionMessage];
 	for (const candidate of candidates) {
-		const reason = (candidate ?? "").trim();
+		// Backend reasons are concatenated from conditions, so they arrive with
+		// ragged padding. Collapse it once here — every label and tooltip is
+		// derived from this value.
+		const reason = (candidate ?? "").replace(/\s+/g, " ").trim();
 		if (reason) return reason;
 	}
 	return null;


### PR DESCRIPTION
Main went red after #484/#486 landed.

`deploymentFailureReason` only trimmed the ends, so a backend reason concatenated from several conditions kept its inner whitespace run and rendered as `startup_probe_failing;   restart_count=2` in the tooltip.

The failing assertion encodes the correct behaviour, so the product is fixed rather than the test. Collapsing at the single derivation point covers both the label and the tooltip.

`bun test`: 583 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)