### PR TITLE
fix(web): polish hosted user journeys

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1383,6 +1383,43 @@ async function gotoHostedSettingsDialog(page: Page, section: string) {
 	throw new Error("Settings dialog did not open.");
 }
 
+test("empty account offers two working first-agent paths", async ({ page }) => {
+	await stubHostedApi(page, { deployments: [], cloudAgents: [] });
+	await page.goto("/");
+
+	const firstAgent = page.locator("main").getByText("Get your first agent running", {
+		exact: true,
+	});
+	await expect(firstAgent).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Deploy a hosted agent", exact: true }),
+	).toHaveAttribute("href", "/deploy");
+
+	await page.getByRole("button", { name: "Connect via CLI", exact: true }).click();
+	await expect(page.getByText("Connect an agent you already run", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("Run the setup command on the machine where your agent lives."),
+	).toBeVisible();
+});
+
+test("existing Cloud customers keep billing settings when new deploys are disabled", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		canCreateCloudAgents: false,
+		deployments: [includedBasicDeployment],
+	});
+	await page.goto("/channels");
+	await page.waitForLoadState("networkidle");
+
+	await page.getByRole("button", { name: "Settings", exact: true }).click();
+	const dialog = page.getByTestId("settings-dialog");
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("button", { name: /^Wallet/ })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: /^Compute/ })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: /^Usage/ })).toBeVisible();
+});
+
 test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page);

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1856,6 +1856,9 @@ export function AppSidebar({
 			<SettingsDialog
 				open={settingsOpen}
 				section={activeSettingsSection}
+				hasExistingCloudAgents={
+					hostedAgentTiles?.some((tile) => tile.source === "on-clawdi") ?? false
+				}
 				onSectionChange={changeSettingsSection}
 				onOpenChange={setSettingsOpen}
 			/>

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -135,11 +135,13 @@ const SETTINGS_NAV: SettingsNavItem[] = [
 export function SettingsDialog({
 	open,
 	section,
+	hasExistingCloudAgents = false,
 	onSectionChange,
 	onOpenChange,
 }: {
 	open: boolean;
 	section: SettingsSectionId;
+	hasExistingCloudAgents?: boolean;
 	onSectionChange: (section: SettingsSectionId) => void;
 	onOpenChange: (open: boolean) => void;
 }) {
@@ -166,6 +168,7 @@ export function SettingsDialog({
 	const showBilling =
 		IS_HOSTED_BUILD &&
 		(hostedAccess.canCreateCloudAgents ||
+			hasExistingCloudAgents ||
 			(requestedBillingSection &&
 				(!mounted || hostedAccess.isLoading || Boolean(hostedAccess.error))));
 	const items = SETTINGS_NAV.filter((item) => !item.cloudOnly || showBilling);
@@ -179,7 +182,8 @@ export function SettingsDialog({
 		IS_HOSTED_BUILD &&
 		mounted &&
 		Boolean(hostedAccess.error) &&
-		!hostedAccess.canCreateCloudAgents;
+		!hostedAccess.canCreateCloudAgents &&
+		!hasExistingCloudAgents;
 
 	useEffect(() => {
 		if (!open) return;

--- a/apps/web/src/hosted/agent-identity.test.ts
+++ b/apps/web/src/hosted/agent-identity.test.ts
@@ -6,8 +6,10 @@ describe("deploymentDisplayName", () => {
 		expect(deploymentDisplayName(" Research Agent ")).toBe("Research Agent");
 	});
 
-	test("keeps backend-provided deployment names as the display source of truth", () => {
-		expect(deploymentDisplayName("v2-hosted-a1b2c3d4")).toBe("v2-hosted-a1b2c3d4");
+	test("hides generated backend deployment names", () => {
+		expect(deploymentDisplayName("v2-hosted-a1b2c3d4")).toBe("Clawdi Cloud agent");
+		expect(deploymentDisplayName("clawdi-v2-deployment-10", "hermes")).toBe("Hermes");
+		expect(deploymentDisplayName("clawdi-v3-deployment-build-27", "openclaw")).toBe("OpenClaw");
 	});
 
 	test("keeps the existing runtime-prefix cleanup", () => {

--- a/apps/web/src/hosted/agent-identity.ts
+++ b/apps/web/src/hosted/agent-identity.ts
@@ -14,7 +14,8 @@ import { runtimeDisplayName } from "@/hosted/runtimes";
  * a 422 against `/v1/sessions`.
  */
 const CLOUD_ENV_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const GENERATED_DEPLOYMENT_NAME_RE = /^deployment-create-/i;
+const GENERATED_DEPLOYMENT_NAME_RE =
+	/^(?:deployment-create-|clawdi-v\d+-deployment(?:-|$)|v\d+-hosted(?:-|$))/i;
 
 /** Whether `value` looks like a real cloud-api env id (UUID), not a deployment id. */
 export function isCloudEnvId(value: string): boolean {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -956,7 +956,7 @@ function OverviewProvisioningPanel({
 }
 
 function DeploymentFailureReasonText({ reason }: { reason: string }) {
-	return <p className="mt-2 whitespace-pre-wrap break-words font-mono text-xs">{reason}</p>;
+	return <p className="mt-2 whitespace-pre-wrap break-words text-sm">{reason}</p>;
 }
 
 function OverviewFailedPanel({
@@ -1568,9 +1568,9 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 			if (terminalRequestRef.current !== requestId) return;
 			if (!session.websocket_url) {
 				setTerminalStatus("disconnected");
-				setTerminalFailure("The deployment did not return a terminal websocket URL.");
+				setTerminalFailure("The secure terminal could not be opened. Try again.");
 				toast.error("Terminal unavailable", {
-					description: "The deployment did not return a terminal websocket URL.",
+					description: "The secure terminal could not be opened. Try again.",
 				});
 				return;
 			}
@@ -1677,11 +1677,10 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 						</div>
 						<div>
 							<h2 className="text-base font-semibold">
-								{terminalFailure ? "Terminal unavailable" : "Opening deployment terminal"}
+								{terminalFailure ? "Terminal unavailable" : "Opening secure terminal"}
 							</h2>
 							<p className="mt-1 text-sm text-muted-foreground">
-								{terminalFailure ??
-									"Starting a real shell in the hosted deployment as the default runtime user."}
+								{terminalFailure ?? "Starting a secure shell for your agent."}
 							</p>
 						</div>
 						{terminalFailure ? (

--- a/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
@@ -210,7 +210,7 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 					return;
 				}
 				setStatus("disconnected");
-				writeTerminalNotice(term, "terminal websocket could not be opened");
+				writeTerminalNotice(term, "secure terminal could not be opened");
 				return;
 			}
 			ws.binaryType = "arraybuffer";

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -7,8 +7,16 @@ const planComparisonSource = readFileSync(
 	new URL("../subscription/plan-comparison.tsx", import.meta.url),
 	"utf8",
 );
+const planChangeDialogSource = readFileSync(
+	new URL("../subscription/plan-change-dialog.tsx", import.meta.url),
+	"utf8",
+);
 const agentDetailSource = readFileSync(
 	new URL("../../agents/hosted-agent-detail.tsx", import.meta.url),
+	"utf8",
+);
+const terminalPanelSource = readFileSync(
+	new URL("../../agents/hosted-terminal-panel.tsx", import.meta.url),
 	"utf8",
 );
 const modelBindingPickerSource = readFileSync(
@@ -33,9 +41,13 @@ describe("deploy wizard personalization", () => {
 describe("deploy wizard product copy and flow", () => {
 	test("uses customer language and keeps channels out of the decision flow", () => {
 		expect(wizardSource).toContain('title="Agent software"');
+		expect(wizardSource).toContain("<DeploySectionSkeleton columns={2} />");
+		expect(wizardSource).toContain('description="Choose a compute plan and how paid plans renew."');
 		expect(wizardSource).toContain("After your agent is ready, connect channels from its page.");
 		expect(wizardSource).not.toContain('title="Runtimes"');
 		expect(wizardSource).not.toContain("execution engine");
+		expect(wizardSource).not.toContain("per-deployment funding");
+		expect(wizardSource).not.toContain("server quote");
 		expect(wizardSource).not.toContain('title="Link after deploy"');
 	});
 
@@ -62,6 +74,23 @@ describe("hosted agent security and copy", () => {
 		expect(agentDetailSource).toContain('account?.name ?? "Unnamed channel"');
 		expect(agentDetailSource).not.toContain('"No changes"');
 		expect(agentDetailSource).not.toContain("This runtime is bound to");
+	});
+
+	test("uses product language for terminal startup and failures", () => {
+		expect(agentDetailSource).toContain("Opening secure terminal");
+		expect(agentDetailSource).toContain("Starting a secure shell for your agent.");
+		expect(agentDetailSource).not.toContain("terminal websocket URL");
+		expect(agentDetailSource).not.toContain("Opening deployment terminal");
+		expect(terminalPanelSource).toContain("secure terminal could not be opened");
+		expect(terminalPanelSource).not.toContain("terminal websocket could not be opened");
+	});
+});
+
+describe("plan-change copy", () => {
+	test("reviews price and timing without exposing server terminology", () => {
+		expect(planChangeDialogSource).toContain("review the exact price and timing");
+		expect(planChangeDialogSource).toContain("Listed recurring price {formatCents");
+		expect(planChangeDialogSource).not.toContain("server quote");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -330,7 +330,7 @@ function computeStatusLine({
 	if (paymentMethod === "wallet") {
 		return {
 			tone: "muted",
-			message: "Wallet debits the exact server quote now and renews on the selected billing term.",
+			message: "Wallet charges the exact amount shown now and renews on the selected billing term.",
 		};
 	}
 
@@ -957,7 +957,7 @@ export function DeployWizard() {
 		return (
 			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 				<PageHeader title="Deploy an Agent" description="Preparing your compute options…" />
-				<DeploySectionSkeleton columns={3} />
+				<DeploySectionSkeleton columns={2} />
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
@@ -1119,7 +1119,7 @@ export function DeployWizard() {
 
 				<SettingsSection
 					title="Compute"
-					description="Basic and Performance agents use per-deployment funding selected below."
+					description="Choose a compute plan and how paid plans renew."
 				>
 					<div className="flex flex-col gap-3">
 						{!deployments.isSuccess ? (

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -326,7 +326,7 @@ describe("reconcileDeploymentSnapshots", () => {
 		expect(reconciled?.resource.status.summary_state).toBe("failed");
 		expect(reconciled?.resource.status.failure).toEqual(failure);
 		expect(deploymentFailureProjection(reconciled)).toEqual({
-			reason: actionableReason,
+			reason: "Re-quote the plan change and try again.",
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -168,7 +168,7 @@ export function PlanChangeDialog({
 							? quote.change_kind === "immediate_upgrade"
 								? "The quoted proration is charged now. Compute changes after payment is confirmed."
 								: `The current plan remains active until ${formatShortDate(quote.effective_at)}.`
-							: "Choose a compute plan and monthly or annual billing, then review the server quote."}
+							: "Choose a compute plan and monthly or annual billing, then review the exact price and timing."}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -223,7 +223,7 @@ export function PlanChangeDialog({
 								<TriangleAlert aria-hidden />
 								<AlertTitle>Not enough Wallet balance</AlertTitle>
 								<AlertDescription className="flex flex-col items-start gap-3">
-									<span>Top up the shortfall, then request a fresh server quote.</span>
+									<span>Top up the shortfall, then request a fresh price.</span>
 									{onTopUp ? (
 										<Button type="button" size="sm" variant="outline" onClick={onTopUp}>
 											<WalletCards data-icon="inline-start" /> Top up Wallet
@@ -336,8 +336,7 @@ export function PlanChangeDialog({
 						) : null}
 						{selectedOffer ? (
 							<p className="text-sm text-muted-foreground">
-								Server quote required · listed recurring price{" "}
-								{formatCents(selectedOffer.price_cents)}
+								Listed recurring price {formatCents(selectedOffer.price_cents)}
 								{selectedOffer.billing_term_months === 1 ? "/month" : "/year"}
 							</p>
 						) : null}

--- a/apps/web/src/hosted/cloud-deployment-management.test.ts
+++ b/apps/web/src/hosted/cloud-deployment-management.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { cloudDeploymentManagementGate } from "@/hosted/cloud-deployment-management";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
@@ -37,5 +38,22 @@ describe("cloudDeploymentManagementGate", () => {
 			showExistingManagement: true,
 			showNewDeploymentSurfaces: true,
 		});
+	});
+});
+
+describe("existing Cloud agent settings access", () => {
+	test("passes loaded Cloud membership into settings and keeps billing visible", () => {
+		const sidebar = readFileSync(new URL("../components/app-sidebar.tsx", import.meta.url), "utf8");
+		const settings = readFileSync(
+			new URL("../components/settings-dialog.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(sidebar).toContain("hasExistingCloudAgents={");
+		expect(sidebar).toContain('tile.source === "on-clawdi"');
+		expect(settings).toContain(
+			"hostedAccess.canCreateCloudAgents ||\n\t\t\thasExistingCloudAgents ||",
+		);
+		expect(settings).toContain("!hasExistingCloudAgents;");
 	});
 });

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -60,11 +60,25 @@ describe("deploymentFailureReason", () => {
 		});
 
 		expect(deploymentFailureProjection(deployment)).toEqual({
-			reason: actionableReason,
+			reason: "Top up your wallet and retry the plan change.",
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",
 		});
+	});
+
+	test("removes internal operation and deployment references from visible failures", () => {
+		expect(
+			deploymentFailureReason({
+				failure: {
+					title: " ",
+					phase: "plan_change",
+					detail:
+						"Try again. Operation ID: operations/op-secret. Deployment ID: hdep_internal. Agent ID: 123e4567-e89b-42d3-a456-426614174000.",
+					conditionMessage: "Plan change failed.",
+				},
+			}),
+		).toBe("Try again.");
 	});
 
 	test("does not expose a stale failure outside the authoritative failed state", () => {

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -2,6 +2,22 @@ import type { HostedDeployment } from "@/hosted/billing/contracts";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 
 const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
+const INTERNAL_OPERATION_REFERENCE_RE =
+	/\s*(?:operation\s+id\s*:\s*)?operations\/[A-Za-z0-9._~-]+[.!]?/gi;
+const INTERNAL_DEPLOYMENT_REFERENCE_RE =
+	/\s*(?:deployment\s+id\s*:\s*)?hdep_[A-Za-z0-9._~-]+[.!]?/gi;
+const INTERNAL_UUID_REFERENCE_RE =
+	/\s*(?:(?:agent|environment|deployment)\s+id\s*:\s*)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[.!]?/gi;
+
+function userFacingFailureReason(value: string): string {
+	return value
+		.replace(/\s+/g, " ")
+		.replace(INTERNAL_OPERATION_REFERENCE_RE, "")
+		.replace(INTERNAL_DEPLOYMENT_REFERENCE_RE, "")
+		.replace(INTERNAL_UUID_REFERENCE_RE, "")
+		.replace(/\s+([,.!?])/g, "$1")
+		.trim();
+}
 
 export type DeploymentFailureProjection = {
 	reason: string;
@@ -27,7 +43,7 @@ export function deploymentFailureReason(input: {
 		// Backend reasons are concatenated from conditions, so they arrive with
 		// ragged padding. Collapse it once here — every label and tooltip is
 		// derived from this value.
-		const reason = (candidate ?? "").replace(/\s+/g, " ").trim();
+		const reason = userFacingFailureReason(candidate ?? "");
 		if (reason) return reason;
 	}
 	return null;


### PR DESCRIPTION
## Summary

- walk all 12 hosted dashboard journeys and keep the existing honest LRO behavior where it is already good
- hide generated deployment names, operation references, deployment ids, and UUIDs from user-facing labels and failures
- replace backend/protocol wording in deploy, plan-change, and terminal surfaces with customer language
- keep Wallet, Compute, and Usage settings reachable for existing Cloud customers when new deployments are disabled
- add production-path unit coverage plus browser coverage for first arrival and the existing-customer settings gate

## Journey findings

First arrival, channels/token rotation, managed models, usage, Wallet, restart/stop, deployment deletion, and the existing deployment LRO transitions were already responsive and honest on current main. This PR does not invent work in those flows.

Account deletion cannot honestly expose the fan-out LRO yet: `DELETE /v1/me` returns an empty 204, exposes no account or child operation receipt, and removes the authorization needed to observe later progress or partial failures. No fake progress or success UI was added.

SSE is intentionally split into a follow-up. A correct client needs snapshot-then-fetch-stream auth, a generated event contract, replay ordering/deduplication, cursor-reset and Retry-After handling, a single account-scoped connection, visibility cleanup, and coordination with polling. The handoff snapshot contains core resources while the existing cache contains richer commercial/UI projections, so this is not a contained UX patch. Bounded polling remains unchanged.

Runtime switching remains out of scope; no UI, route, disabled control, or TODO was added.

## Verification

- `bun run typecheck`: 4/4 workspace packages successful
- `bun run lint`: 693 files checked, 0 errors
- `bun test`: 1,665 passed, 0 failed, 6,590 assertions across 174 files
- focused hosted browser journeys: 2 passed, 0 failed

The broader hosted smoke suite was attempted but stopped after 4 of its first 10 older scenarios failed on stale expectations such as “AI Credits wallet” and “Delete compute”; the two new scenarios passed. Updating unrelated smoke expectations is deliberately not included in this UX change.
