### PR TITLE
fix(web): keep deployment waits and usage states honest

### DIFF
--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -73,6 +73,7 @@ export function AgentHome({
 		isLoading,
 		isFetching,
 		runtimeUiSettlingTimedOut,
+		deploymentTransitionTimedOut,
 		error,
 		refetch,
 	} = useAgentDeployment(environmentId, deploymentSelector);
@@ -223,6 +224,9 @@ export function AgentHome({
 				}
 				autoOpenRuntimeUi={requestedFromCloudRedirect && environmentId === deployment.resource.id}
 				runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+				isCheckingDeployment={isFetching}
+				onCheckDeploymentAgain={handleCheckAgain}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { QueryClient } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import type { DeploymentOperation, HostedDeployment } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
@@ -17,12 +19,15 @@ type ProjectAcceptedDeploymentTransition =
 	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
 type RuntimeUiSettlingPollState =
 	typeof import("@/hosted/agents/deployment-hooks").runtimeUiSettlingPollState;
+type OverviewProvisioningPanel =
+	typeof import("@/hosted/agents/hosted-agent-detail").OverviewProvisioningPanel;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
 let settlingPollState: RuntimeUiSettlingPollState | null = null;
 let settlingPollIntervalMs: number | null = null;
 let settlingTimeoutMs: number | null = null;
+let overviewProvisioningPanel: OverviewProvisioningPanel | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -34,6 +39,53 @@ beforeAll(async () => {
 	settlingPollState = module.runtimeUiSettlingPollState;
 	settlingPollIntervalMs = module.RUNTIME_UI_SETTLING_POLL_INTERVAL_MS;
 	settlingTimeoutMs = module.RUNTIME_UI_SETTLING_TIMEOUT_MS;
+	overviewProvisioningPanel = (await import("@/hosted/agents/hosted-agent-detail"))
+		.OverviewProvisioningPanel;
+});
+
+describe("deployment transition timeout rendering", () => {
+	test("replaces the automatic-update promise with an honest timeout and check action", () => {
+		if (!overviewProvisioningPanel) throw new Error("agent detail was not loaded");
+		const deployment = hostedDeploymentFixture({ status: "creating" });
+		const commonProps = {
+			deployment,
+			runtime: "openclaw" as const,
+			runtimeUiAvailable: false,
+			runtimeUiSettlingTimedOut: false,
+			isCheckingDeployment: false,
+			onCheckDeploymentAgain: () => undefined,
+			terminalHref: "/agents/env_test/terminal",
+		};
+
+		const converging = renderToStaticMarkup(
+			createElement(overviewProvisioningPanel, {
+				...commonProps,
+				deploymentTransitionTimedOut: false,
+			}),
+		);
+		const timedOut = renderToStaticMarkup(
+			createElement(overviewProvisioningPanel, {
+				...commonProps,
+				deploymentTransitionTimedOut: true,
+			}),
+		);
+
+		expect(converging).toContain("Provisioning your agent…");
+		expect(converging).toContain("This page updates automatically.");
+		expect(timedOut).toContain("Deployment is taking longer than expected");
+		expect(timedOut).toContain("Automatic checks have stopped.");
+		expect(timedOut).toContain("Check again");
+		expect(timedOut).not.toContain("This page updates automatically.");
+	});
+
+	test("wires the timed-out inventory state and real refetch action into the detail", () => {
+		const source = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("deploymentTransitionTimedOut,");
+		expect(source).toContain("deploymentTransitionTimedOut={deploymentTransitionTimedOut}");
+		expect(source).toContain("onCheckDeploymentAgain={handleCheckAgain}");
+		expect(source).toContain("void refetch();");
+	});
 });
 
 describe("runtime UI settling polling", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -399,6 +399,9 @@ export function HostedAgentDetail({
 	onDeleteAccepted,
 	autoOpenRuntimeUi = false,
 	runtimeUiSettlingTimedOut = false,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
@@ -407,6 +410,9 @@ export function HostedAgentDetail({
 	onDeleteAccepted: (deploymentId: string) => void;
 	autoOpenRuntimeUi?: boolean;
 	runtimeUiSettlingTimedOut?: boolean;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
 }) {
 	const api = useApi();
 	const router = useRouter();
@@ -572,6 +578,9 @@ export function HostedAgentDetail({
 							sessionLink={(session) => scopedSessionLink(session.id)}
 							terminalHref={terminalHref}
 							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							isCheckingDeployment={isCheckingDeployment}
+							onCheckDeploymentAgain={onCheckDeploymentAgain}
 						/>
 					) : null}
 					{activeTab === "console" ? (
@@ -580,6 +589,9 @@ export function HostedAgentDetail({
 							runtime={runtime}
 							terminalHref={terminalHref}
 							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							isCheckingDeployment={isCheckingDeployment}
+							onCheckDeploymentAgain={onCheckDeploymentAgain}
 						/>
 					) : null}
 					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
@@ -882,72 +894,98 @@ function DeploymentReadinessProgress({ stage }: { stage: DeploymentReadinessStag
 	);
 }
 
-function OverviewProvisioningPanel({
+export function OverviewProvisioningPanel({
 	deployment,
 	runtime,
 	runtimeUiAvailable,
 	runtimeUiSettlingTimedOut,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
 	terminalHref,
 }: {
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	runtimeUiAvailable: boolean;
 	runtimeUiSettlingTimedOut: boolean;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
 	terminalHref: string;
 }) {
 	const status = deployment.resource.status;
 	const stage = deploymentReadinessStage(status, runtimeUiAvailable);
 	const parsedStatus = parseDeploymentStatus(status.summary_state);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
-	const title = runtimeUiSettlingTimedOut
-		? "Live UI is taking longer than expected"
-		: stage === "provisioning"
-			? "Provisioning your agent…"
-			: stage === "booting"
-				? status.summary_state === "running"
-					? "Starting the live UI…"
-					: "Booting your agent…"
-				: "Your agent is ready";
-	const description = runtimeUiSettlingTimedOut
-		? `${browserUiLabel} did not publish within the startup window. Automatic periodic checks will continue, and Terminal is available now.`
-		: stage === "provisioning"
-			? "Hosted compute is being prepared. This page updates automatically."
-			: stage === "booting"
-				? "Opening the live UI automatically… Terminal is available while the runtime finishes booting."
-				: "The live UI is ready to use.";
+	const settlingTimedOut = deploymentTransitionTimedOut || runtimeUiSettlingTimedOut;
+	const title = deploymentTransitionTimedOut
+		? "Deployment is taking longer than expected"
+		: runtimeUiSettlingTimedOut
+			? "Live UI is taking longer than expected"
+			: stage === "provisioning"
+				? "Provisioning your agent…"
+				: stage === "booting"
+					? status.summary_state === "running"
+						? "Starting the live UI…"
+						: "Booting your agent…"
+					: "Your agent is ready";
+	const description = deploymentTransitionTimedOut
+		? "The latest deployment change did not finish within five minutes. Automatic checks have stopped. Check again to load the latest status."
+		: runtimeUiSettlingTimedOut
+			? `${browserUiLabel} did not publish within the startup window. Automatic periodic checks will continue, and Terminal is available now.`
+			: stage === "provisioning"
+				? "Hosted compute is being prepared. This page updates automatically."
+				: stage === "booting"
+					? "Opening the live UI automatically… Terminal is available while the runtime finishes booting."
+					: "The live UI is ready to use.";
 	return (
 		<div
 			className={cn(
 				"rounded-xl border p-5",
-				runtimeUiSettlingTimedOut
+				settlingTimedOut
 					? "border-warning/30 bg-warning-muted text-warning-muted-foreground"
 					: "border-info-muted bg-info-muted text-info-muted-foreground",
 			)}
 		>
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-start">
 				<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-info-muted bg-background">
-					{runtimeUiSettlingTimedOut ? (
-						<AlertCircle className="size-5" />
-					) : (
-						<Spinner className="size-5" />
-					)}
+					{settlingTimedOut ? <AlertCircle className="size-5" /> : <Spinner className="size-5" />}
 				</div>
 				<div className="min-w-0 flex-1">
 					<h2 className="text-sm font-semibold text-foreground">{title}</h2>
 					<p className="mt-1 text-sm">{description}</p>
-					<DeploymentReadinessProgress stage={stage} />
+					{deploymentTransitionTimedOut ? null : <DeploymentReadinessProgress stage={stage} />}
 					<p className="mt-2 text-xs">Current status: {deploymentStatusLabel(parsedStatus)}.</p>
-					{stage === "booting" ? (
-						<Button
-							render={<Link to={terminalHref} />}
-							nativeButton={false}
-							variant="outline"
-							size="sm"
-							className="mt-3"
-						>
-							<TerminalSquare className="size-3.5" />
-							Use Terminal now
-						</Button>
+					{deploymentTransitionTimedOut || stage === "booting" ? (
+						<div className="mt-3 flex flex-wrap gap-2">
+							{deploymentTransitionTimedOut ? (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									disabled={isCheckingDeployment}
+									onClick={onCheckDeploymentAgain}
+								>
+									{isCheckingDeployment ? (
+										<Spinner className="size-3.5" />
+									) : (
+										<RefreshCw className="size-3.5" />
+									)}
+									Check again
+								</Button>
+							) : null}
+							{stage === "booting" ? (
+								<Button
+									render={<Link to={terminalHref} />}
+									nativeButton={false}
+									variant="outline"
+									size="sm"
+								>
+									<TerminalSquare className="size-3.5" />
+									Use Terminal now
+								</Button>
+							) : null}
+						</div>
 					) : null}
 				</div>
 			</div>
@@ -1024,6 +1062,9 @@ function OverviewTab({
 	sessionLink,
 	terminalHref,
 	runtimeUiSettlingTimedOut,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
 }: {
 	deployment: HostedDeployment;
 	runtime: Runtime;
@@ -1042,6 +1083,9 @@ function OverviewTab({
 	};
 	terminalHref: string;
 	runtimeUiSettlingTimedOut: boolean;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
 }) {
 	const spec = deployment.resource.spec;
 	const providers = useUserAiProviders();
@@ -1068,13 +1112,17 @@ function OverviewTab({
 		: "Sessions appear once your agent is running.";
 	return (
 		<div className="flex flex-col gap-5">
-			{isProvisioningStatus(deploymentStatus) ||
+			{deploymentTransitionTimedOut ||
+			isProvisioningStatus(deploymentStatus) ||
 			(deploymentStatus.kind === "running" && !runtimeUiAvailable) ? (
 				<OverviewProvisioningPanel
 					deployment={deployment}
 					runtime={runtime}
 					runtimeUiAvailable={runtimeUiAvailable}
 					runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+					deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+					isCheckingDeployment={isCheckingDeployment}
+					onCheckDeploymentAgain={onCheckDeploymentAgain}
 					terminalHref={terminalHref}
 				/>
 			) : null}
@@ -1237,11 +1285,17 @@ function ConsoleTab({
 	runtime,
 	terminalHref,
 	runtimeUiSettlingTimedOut,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
 }: {
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	terminalHref: string;
 	runtimeUiSettlingTimedOut: boolean;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
 }) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const isRunning = isRunningStatus(status);
@@ -1339,14 +1393,41 @@ function ConsoleTab({
 	if (!isRunning) {
 		return (
 			<EmptyState
-				icon={MonitorPlay}
-				title={isProvisioning ? provisioningTitle(status) : "Compute is not running"}
-				description={
-					isProvisioning
-						? `The live ${browserUiLabel} opens here once your agent is running. This page updates automatically.`
-						: `Start the compute to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
+				icon={deploymentTransitionTimedOut ? AlertCircle : MonitorPlay}
+				title={
+					deploymentTransitionTimedOut
+						? "Deployment is taking longer than expected"
+						: isProvisioning
+							? provisioningTitle(status)
+							: "Compute is not running"
 				}
-				action={canStartDeployment(status) ? <StartComputeAction deployment={deployment} /> : null}
+				description={
+					deploymentTransitionTimedOut
+						? "The latest deployment change did not finish within five minutes. Automatic checks have stopped. Check again to load the latest status."
+						: isProvisioning
+							? `The live ${browserUiLabel} opens here once your agent is running. This page updates automatically.`
+							: `Start the compute to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
+				}
+				action={
+					deploymentTransitionTimedOut ? (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={isCheckingDeployment}
+							onClick={onCheckDeploymentAgain}
+						>
+							{isCheckingDeployment ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<RefreshCw className="size-3.5" />
+							)}
+							Check again
+						</Button>
+					) : canStartDeployment(status) ? (
+						<StartComputeAction deployment={deployment} />
+					) : null
+				}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -37,6 +37,7 @@ export type HostedComputeSubscription = NonNullable<
 export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"];
 export type HostedEventStreamSnapshotHandoff = Schemas["EventStreamSnapshotHandoff"];
 export type HostedFundingFact = Schemas["V2HostedCommercialFundingFactInfo"];
+export type HostedUsageSummary = Schemas["V2HostedUsageSummaryResponse"];
 export type HostedRuntimeConfiguration = Schemas["RuntimeConfiguration"];
 export type ManagedModelCatalogItem = Schemas["V2ManagedModelCatalogItem"];
 export type RuntimeUiCredentials = Schemas["V2HostedRuntimeUiCredentials"];

--- a/apps/web/src/hosted/billing/usage/usage-page.test.ts
+++ b/apps/web/src/hosted/billing/usage/usage-page.test.ts
@@ -1,0 +1,122 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { HostedUsageSummary } from "@/hosted/billing/contracts";
+
+type UsageSummaryView = typeof import("@/hosted/billing/usage/usage-page").UsageSummaryView;
+
+let usageSummaryView: UsageSummaryView | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	usageSummaryView = (await import("@/hosted/billing/usage/usage-page")).UsageSummaryView;
+});
+
+const PERIOD = {
+	period_start: "2026-07-01T00:00:00Z",
+	period_end: "2026-08-01T00:00:00Z",
+} as const;
+
+function renderUsage(usage: HostedUsageSummary): string {
+	if (!usageSummaryView) throw new Error("usage page was not loaded");
+	return renderToStaticMarkup(
+		createElement(usageSummaryView, {
+			usage,
+			providers: [],
+			managedModels: [],
+			isRetrying: false,
+			onRetry: () => undefined,
+		}),
+	);
+}
+
+describe("usage availability rendering", () => {
+	test("wires the retry control to the usage query refetch", () => {
+		const source = readFileSync(new URL("./usage-page.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("<UsageRetryButton");
+		expect(source).toContain("void usage.refetch();");
+	});
+
+	test("renders a real complete zero as no usage", () => {
+		const markup = renderUsage({
+			...PERIOD,
+			availability: "complete",
+			unavailable_sections: [],
+			total_usd: "0.0000",
+			total_requests: 0,
+			by_model: [],
+			by_day: [],
+		});
+
+		expect(markup).toContain("No usage yet");
+		expect(markup).not.toContain("can’t load your usage");
+	});
+
+	test("renders an unavailable response without fabricating a zero", () => {
+		const markup = renderUsage({
+			...PERIOD,
+			availability: "unavailable",
+			unavailable_sections: ["totals", "by_model", "by_day"],
+			total_usd: null,
+			total_requests: null,
+			by_model: [],
+			by_day: [],
+		});
+
+		expect(markup).toContain("We can’t load your usage right now");
+		expect(markup).toContain("Retry");
+		expect(markup).not.toContain("No usage yet");
+		expect(markup).not.toContain("$0.00");
+		expect(markup).not.toContain("Managed-AI spend in window");
+	});
+
+	test("names a missing daily section while preserving read totals and model usage", () => {
+		const markup = renderUsage({
+			...PERIOD,
+			availability: "partial",
+			unavailable_sections: ["by_day"],
+			total_usd: "12.50",
+			total_requests: 37,
+			by_model: [
+				{
+					model: "model-read-successfully",
+					provider: null,
+					amount_usd: "12.50",
+					requests: 37,
+				},
+			],
+			by_day: [],
+		});
+
+		expect(markup).toContain("Some usage data is unavailable");
+		expect(markup).toContain("the daily breakdown");
+		expect(markup).toContain("Daily breakdown unavailable");
+		expect(markup).toContain("$12.50");
+		expect(markup).toContain("37");
+		expect(markup).toContain("model-read-successfully");
+	});
+
+	test("hides missing totals and model values while preserving a read daily section", () => {
+		const markup = renderUsage({
+			...PERIOD,
+			availability: "partial",
+			unavailable_sections: ["totals", "by_model"],
+			total_usd: null,
+			total_requests: null,
+			by_model: [],
+			by_day: [{ date: "2026-07-20", amount_usd: "9.25" }],
+		});
+
+		expect(markup).toContain("spend and request totals and the model breakdown");
+		expect(markup).toContain("Usage totals unavailable");
+		expect(markup).toContain("Model breakdown unavailable");
+		expect(markup).toContain("$9.25");
+		expect(markup).not.toContain("Managed-AI spend in window");
+		expect(markup).not.toContain("Requests in window");
+		expect(markup).not.toContain("No usage yet");
+	});
+});

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { Activity } from "lucide-react";
+import { Activity, AlertCircle, RefreshCw } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
+import type { HostedUsageSummary, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useManagedModelCatalog, useUsage } from "@/hosted/billing/hooks";
@@ -17,15 +21,40 @@ import {
 	modelOptionsForProvider,
 	providerDisplayLabel,
 } from "@/hosted/v2/ai-providers/model-binding";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Managed-AI usage in USD for the current reporting window across your agents.";
 const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
+type UnavailableUsageSection = HostedUsageSummary["unavailable_sections"][number];
+
+const UNAVAILABLE_USAGE_SECTION_LABELS = {
+	totals: "spend and request totals",
+	by_model: "the model breakdown",
+	by_day: "the daily breakdown",
+} satisfies Record<UnavailableUsageSection, string>;
+
 function decimalUsdNumber(value: string): number {
 	const parsed = Number(value);
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function decimalUsdIsZero(value: string): boolean {
+	return /^[+-]?0+(?:\.0+)?$/.test(value.trim());
+}
+
+function readableList(items: readonly string[]): string {
+	if (items.length < 2) return items[0] ?? "some usage data";
+	if (items.length === 2) return `${items[0]} and ${items[1]}`;
+	return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function unavailableUsageSections(usage: HostedUsageSummary): UnavailableUsageSection[] {
+	const sections = new Set(usage.unavailable_sections);
+	if (usage.total_usd === null || usage.total_requests === null) sections.add("totals");
+	return [...sections];
 }
 
 export function UsagePage() {
@@ -49,25 +78,82 @@ export function UsagePage() {
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={usage.error}
-					onRetry={() => usage.refetch()}
+					onRetry={() => {
+						void usage.refetch();
+					}}
 				/>
 			</div>
 		);
 	}
 
-	const u = usage.data;
-	const hasDailyBreakdown = u.by_day.length > 0;
-	const firstDailyPoint = u.by_day[0];
-	const lastDailyPoint = u.by_day[u.by_day.length - 1];
-	const windowLabel = `${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)}`;
+	return (
+		<UsageSummaryView
+			usage={usage.data}
+			providers={providers.data ?? []}
+			managedModels={managedModelCatalog.data?.models ?? []}
+			isRetrying={usage.isFetching}
+			onRetry={() => {
+				void usage.refetch();
+			}}
+		/>
+	);
+}
+
+export function UsageSummaryView({
+	usage,
+	providers,
+	managedModels,
+	isRetrying,
+	onRetry,
+}: {
+	usage: HostedUsageSummary;
+	providers: readonly AiProvider[];
+	managedModels: readonly ManagedModelCatalogItem[];
+	isRetrying: boolean;
+	onRetry: () => void;
+}) {
+	const missingSections = unavailableUsageSections(usage);
+	const missingSectionSet = new Set(missingSections);
+	const totals =
+		!missingSectionSet.has("totals") && usage.total_usd !== null && usage.total_requests !== null
+			? { usd: usage.total_usd, requests: usage.total_requests }
+			: null;
+
+	if (usage.availability === "unavailable") {
+		return (
+			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
+				<PageHeader title="Usage" description={DESCRIPTION} />
+				<EmptyState
+					icon={AlertCircle}
+					title="We can’t load your usage right now"
+					description="The usage provider is temporarily unavailable. No spend or request total is shown because we could not read it."
+					action={<UsageRetryButton isRetrying={isRetrying} onRetry={onRetry} />}
+				/>
+			</div>
+		);
+	}
+
+	const hasDailyBreakdown = usage.by_day.length > 0;
+	const firstDailyPoint = usage.by_day[0];
+	const lastDailyPoint = usage.by_day[usage.by_day.length - 1];
+	const windowLabel = `${formatShortDate(usage.period_start)} – ${formatShortDate(usage.period_end)}`;
 	const dailyChartLabel =
 		hasDailyBreakdown && firstDailyPoint && lastDailyPoint
 			? `Daily USD usage returned for ${formatShortDate(firstDailyPoint.date)} to ${formatShortDate(lastDailyPoint.date)} within the ${windowLabel} reporting window.`
 			: undefined;
-	const maxDay = Math.max(0, ...u.by_day.map((day) => decimalUsdNumber(day.amount_usd)));
-	const maxModel = Math.max(0, ...u.by_model.map((model) => decimalUsdNumber(model.amount_usd)));
+	const maxDay = Math.max(0, ...usage.by_day.map((day) => decimalUsdNumber(day.amount_usd)));
+	const maxModel = Math.max(
+		0,
+		...usage.by_model.map((model) => decimalUsdNumber(model.amount_usd)),
+	);
+	const isRealZero =
+		usage.availability === "complete" &&
+		totals !== null &&
+		decimalUsdIsZero(totals.usd) &&
+		totals.requests === 0 &&
+		usage.by_model.length === 0;
 
-	if (decimalUsdNumber(u.total_usd) === 0 && u.by_model.length === 0) {
+	if (isRealZero) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
@@ -84,46 +170,84 @@ export function UsagePage() {
 		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 			<PageHeader
 				title="Usage"
-				description={`${windowLabel} reporting window. Totals below are for this window; wallet balance carries over.`}
+				description={
+					totals
+						? `${windowLabel} reporting window. Totals below are for this window; wallet balance carries over.`
+						: `${windowLabel} reporting window. Available usage details for this window are shown below.`
+				}
 			/>
 
-			{/* Totals */}
-			<div className="grid gap-3 sm:grid-cols-2">
-				<Card data-hosted="true">
-					<CardContent>
-						<div className="text-3xl font-semibold tabular-nums">{formatUsdExact(u.total_usd)}</div>
-						<div className="text-sm text-muted-foreground">Managed-AI spend in window</div>
-					</CardContent>
-				</Card>
-				<Card data-hosted="true">
-					<CardContent>
-						<div className="text-3xl font-semibold tabular-nums">
-							{u.total_requests.toLocaleString()}
-						</div>
-						<div className="text-sm text-muted-foreground">Requests in window</div>
-					</CardContent>
-				</Card>
-			</div>
+			{missingSections.length > 0 ? (
+				<Alert data-hosted="true">
+					<AlertCircle />
+					<AlertTitle>Some usage data is unavailable</AlertTitle>
+					<AlertDescription className="flex flex-col items-start gap-3">
+						<span>
+							We couldn’t read{" "}
+							{readableList(
+								missingSections.map((section) => UNAVAILABLE_USAGE_SECTION_LABELS[section]),
+							)}
+							. Other usage shown below was read successfully.
+						</span>
+						<UsageRetryButton isRetrying={isRetrying} onRetry={onRetry} />
+					</AlertDescription>
+				</Alert>
+			) : null}
 
-			{/* Daily consumption */}
+			{totals ? (
+				<div className="grid gap-3 sm:grid-cols-2">
+					<Card data-hosted="true">
+						<CardContent>
+							<div className="text-3xl font-semibold tabular-nums">
+								{formatUsdExact(totals.usd)}
+							</div>
+							<div className="text-sm text-muted-foreground">Managed-AI spend in window</div>
+						</CardContent>
+					</Card>
+					<Card data-hosted="true">
+						<CardContent>
+							<div className="text-3xl font-semibold tabular-nums">
+								{totals.requests.toLocaleString()}
+							</div>
+							<div className="text-sm text-muted-foreground">Requests in window</div>
+						</CardContent>
+					</Card>
+				</div>
+			) : (
+				<Card data-hosted="true">
+					<CardContent>
+						<EmptyState
+							variant="inset"
+							title="Usage totals unavailable"
+							description="Spend and request totals are hidden because they could not be read."
+							className="py-4 md:p-4"
+						/>
+					</CardContent>
+				</Card>
+			)}
+
 			<Card data-hosted="true">
 				<CardHeader>
 					<CardTitle className="text-base">Daily consumption</CardTitle>
 				</CardHeader>
 				<CardContent>
-					{hasDailyBreakdown ? (
+					{missingSectionSet.has("by_day") ? (
+						<EmptyState
+							variant="inset"
+							title="Daily breakdown unavailable"
+							description="No daily values are shown because the breakdown could not be read."
+							className="py-4 md:p-4"
+						/>
+					) : hasDailyBreakdown ? (
 						<>
 							<div className="flex h-28 items-end gap-1" role="img" aria-label={dailyChartLabel}>
-								{u.by_day.map((d) => (
+								{usage.by_day.map((day) => (
 									<div
-										key={d.date}
-										title={`${formatShortDate(d.date)}: ${formatUsdExact(d.amount_usd)}`}
+										key={day.date}
+										title={`${formatShortDate(day.date)}: ${formatUsdExact(day.amount_usd)}`}
 										className="flex-1 rounded-t bg-primary/70 transition-colors hover:bg-primary"
 										style={{
-											height: `${Math.max(
-												2,
-												maxDay > 0 ? (decimalUsdNumber(d.amount_usd) / maxDay) * 100 : 0,
-											)}%`,
+											height: `${Math.max(2, maxDay > 0 ? (decimalUsdNumber(day.amount_usd) / maxDay) * 100 : 0)}%`,
 										}}
 									/>
 								))}
@@ -141,10 +265,10 @@ export function UsagePage() {
 									</tr>
 								</thead>
 								<tbody>
-									{u.by_day.map((d) => (
-										<tr key={d.date}>
-											<td>{d.date}</td>
-											<td>{formatUsdExact(d.amount_usd)}</td>
+									{usage.by_day.map((day) => (
+										<tr key={day.date}>
+											<td>{day.date}</td>
+											<td>{formatUsdExact(day.amount_usd)}</td>
 										</tr>
 									))}
 								</tbody>
@@ -153,54 +277,58 @@ export function UsagePage() {
 					) : (
 						<EmptyState
 							variant="inset"
-							description="No daily breakdown available"
+							description="No daily usage in this reporting window"
 							className="py-4 md:p-4"
 						/>
 					)}
 				</CardContent>
 			</Card>
 
-			{/* By model */}
 			<Card data-hosted="true">
 				<CardHeader>
 					<CardTitle className="text-base">By model</CardTitle>
 				</CardHeader>
 				<CardContent className="flex flex-col gap-4">
-					{u.by_model.length === 0 ? (
+					{missingSectionSet.has("by_model") ? (
 						<EmptyState
 							variant="inset"
-							description="No model breakdown available"
+							title="Model breakdown unavailable"
+							description="No model values are shown because the breakdown could not be read."
+							className="py-4 md:p-4"
+						/>
+					) : usage.by_model.length === 0 ? (
+						<EmptyState
+							variant="inset"
+							description="No model usage in this reporting window"
 							className="py-4 md:p-4"
 						/>
 					) : (
-						u.by_model.map((m) => {
-							const providerId = m.provider ?? MANAGED_PROVIDER_ID;
+						usage.by_model.map((model) => {
+							const providerId = model.provider ?? MANAGED_PROVIDER_ID;
 							const modelName = modelDisplayName(
-								m.model,
-								modelOptionsForProvider(
-									providerId,
-									providers.data ?? [],
-									managedModelCatalog.data?.models ?? [],
-								),
+								model.model,
+								modelOptionsForProvider(providerId, providers, managedModels),
 							);
-							const providerName = providerDisplayLabel(providerId, providers.data);
+							const providerName = providerDisplayLabel(providerId, providers);
 							return (
-								<div key={`${m.provider ?? "managed"}:${m.model}`} className="space-y-1">
+								<div key={`${model.provider ?? "managed"}:${model.model}`} className="space-y-1">
 									<div className="flex items-baseline justify-between gap-2 text-sm">
 										<span className="truncate font-medium">{modelName}</span>
-										<span className="shrink-0 tabular-nums">{formatUsdExact(m.amount_usd)}</span>
+										<span className="shrink-0 tabular-nums">
+											{formatUsdExact(model.amount_usd)}
+										</span>
 									</div>
 									<div className="h-2 overflow-hidden rounded-full bg-muted">
 										<div
 											className="h-2 rounded-full bg-primary"
 											style={{
-												width: `${maxModel > 0 ? (decimalUsdNumber(m.amount_usd) / maxModel) * 100 : 0}%`,
+												width: `${maxModel > 0 ? (decimalUsdNumber(model.amount_usd) / maxModel) * 100 : 0}%`,
 											}}
 										/>
 									</div>
 									<div className="text-xs text-muted-foreground">
-										{providerName} · {m.requests.toLocaleString()} request
-										{m.requests === 1 ? "" : "s"}
+										{providerName} · {model.requests.toLocaleString()} request
+										{model.requests === 1 ? "" : "s"}
 									</div>
 								</div>
 							);
@@ -209,5 +337,14 @@ export function UsagePage() {
 				</CardContent>
 			</Card>
 		</div>
+	);
+}
+
+function UsageRetryButton({ isRetrying, onRetry }: { isRetrying: boolean; onRetry: () => void }) {
+	return (
+		<Button type="button" variant="outline" size="sm" disabled={isRetrying} onClick={onRetry}>
+			{isRetrying ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
+			Retry
+		</Button>
 	);
 }

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1721,10 +1721,17 @@ export interface components {
             period_start: string;
             /** Period End */
             period_end: string;
+            /**
+             * Availability
+             * @enum {string}
+             */
+            availability: "complete" | "partial" | "unavailable";
+            /** Unavailable Sections */
+            unavailable_sections: ("totals" | "by_model" | "by_day")[];
             /** Total Usd */
-            total_usd: string;
+            total_usd: string | null;
             /** Total Requests */
-            total_requests: number;
+            total_requests: number | null;
             /** By Model */
             by_model: components["schemas"]["V2HostedUsageModelBreakdown"][];
             /** By Day */

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -32,6 +32,8 @@ const wallet: DeploySchemas["V2WalletResponse"] = {
 const usage: DeploySchemas["V2HostedUsageSummaryResponse"] = {
 	period_start: "2026-07-01",
 	period_end: "2026-07-31",
+	availability: "complete",
+	unavailable_sections: [],
 	total_usd: "0.000001",
 	total_requests: 1,
 	by_model: [
@@ -76,6 +78,7 @@ describe("USD-native v2 billing contract", () => {
 			auto_reload_amount_cents: 2500,
 		});
 		expect(usage.total_usd).toBe("0.000001");
+		expect(usage.availability).toBe("complete");
 		expect(usage.by_model[0]?.amount_usd).toBe("0.000001");
 	});
 });


### PR DESCRIPTION
## Summary

- surface the five-minute deployment transition timeout in hosted agent overview and console views, stop the automatic-update claim, and provide a real inventory refetch action
- keep transition polling bounded at five minutes instead of silently switching to an indefinite slower poll; the explicit Check again action preserves recovery without turning a stuck operation into permanent polling
- regenerate the deploy client from `Clawdi-AI/clawdi-hosted` `main` at `7e8fad8bc3320b51a981cc31f5b1cc3bba507151`
- render complete, partial, and unavailable usage responses without coercing unavailable totals to zero; partial responses identify and hide each missing section

## Contract generation

Exported the exact hosted `main` commit from the read-only hosted checkout into a temporary directory, ran hosted's `backend/scripts/generate_openapi.py` against the FastAPI app, then ran:

```sh
bun run --cwd apps/web generate-deploy-api /tmp/<generated-hosted-openapi>.json
```

The generated deploy-client drift is usage-only: `availability`, `unavailable_sections`, and nullable `total_usd` / `total_requests`. No other filtered deploy contract changed.

## Verification

- `bun run typecheck` — 4/4 packages successful
- `bun run lint` — 694 files checked, no fixes
- `bun test` — 1672 passed, 0 failed, 6623 assertions across 175 files
- focused SSR/state regressions — 20 passed, 0 failed
