### PR TITLE
fix(web): match deployment failure remediation

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -92,7 +92,7 @@ describe("deployment failure remediation rendering", () => {
 
 		expect(markup).toContain("Plan change failed");
 		expect(markup).toContain("Top up your wallet and retry the plan change.");
-		expect(markup).toContain("Review plan change");
+		expect(markup).toContain("Review plan");
 		expect(markup).not.toContain("Agent setup failed");
 		expect(markup).not.toContain("retry startup");
 		expect(markup).not.toContain("Restart compute");

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -21,6 +21,7 @@ type RuntimeUiSettlingPollState =
 	typeof import("@/hosted/agents/deployment-hooks").runtimeUiSettlingPollState;
 type OverviewProvisioningPanel =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewProvisioningPanel;
+type OverviewFailedPanel = typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailedPanel;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
@@ -28,6 +29,7 @@ let settlingPollState: RuntimeUiSettlingPollState | null = null;
 let settlingPollIntervalMs: number | null = null;
 let settlingTimeoutMs: number | null = null;
 let overviewProvisioningPanel: OverviewProvisioningPanel | null = null;
+let overviewFailedPanel: OverviewFailedPanel | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -39,8 +41,62 @@ beforeAll(async () => {
 	settlingPollState = module.runtimeUiSettlingPollState;
 	settlingPollIntervalMs = module.RUNTIME_UI_SETTLING_POLL_INTERVAL_MS;
 	settlingTimeoutMs = module.RUNTIME_UI_SETTLING_TIMEOUT_MS;
-	overviewProvisioningPanel = (await import("@/hosted/agents/hosted-agent-detail"))
-		.OverviewProvisioningPanel;
+	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
+	overviewProvisioningPanel = detailModule.OverviewProvisioningPanel;
+	overviewFailedPanel = detailModule.OverviewFailedPanel;
+});
+
+describe("deployment failure remediation rendering", () => {
+	test("routes a failed plan change through review without startup or bare restart copy", () => {
+		if (!overviewFailedPanel) throw new Error("agent detail was not loaded");
+		const operation: DeploymentOperation = {
+			name: "operations/plan-change-failed",
+			metadata: {
+				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+				deploymentId: "hdep_failed",
+				verb: "plan_change" as DeploymentOperation["metadata"]["verb"],
+				targetGeneration: 2,
+				manifestETag: "manifest-failed",
+				createTime: "2026-07-25T00:00:00Z",
+				updateTime: "2026-07-25T00:01:00Z",
+			},
+			done: false,
+			response: null,
+		};
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_failed",
+			status: "failed",
+			acceptedOperation: operation,
+			failure: {
+				type: "https://api.clawdi.ai/problems/operation_aborted",
+				title: "Deployment operation was aborted",
+				status: 409,
+				detail: "Top up your wallet and retry the plan change.",
+				instance: "hdep_failed",
+				code: "operation_aborted",
+				phase: "plan_change",
+				retryable: false,
+				conditionReason: "OperationAborted",
+				conditionMessage: "Deployment operation was aborted",
+				observedGeneration: 2,
+			},
+		});
+
+		const markup = renderToStaticMarkup(
+			createElement(overviewFailedPanel, {
+				deployment,
+				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				onDeleteAccepted: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("Plan change failed");
+		expect(markup).toContain("Top up your wallet and retry the plan change.");
+		expect(markup).toContain("Review plan change");
+		expect(markup).not.toContain("Agent setup failed");
+		expect(markup).not.toContain("retry startup");
+		expect(markup).not.toContain("Restart compute");
+	});
 });
 
 describe("deployment transition timeout rendering", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -467,7 +467,7 @@ export function HostedAgentDetail({
 	const consoleUrl = runtimeConsoleUrl(deployment, runtime);
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const terminalHref = agentSectionHref(environmentId, "terminal", searchStr);
-	const planChangeHref = agentSectionHref(environmentId, "settings", searchStr);
+	const planChangeHref = `${agentSectionHref(environmentId, "settings", searchStr)}#compute-plan-controls`;
 
 	useEffect(() => {
 		if (
@@ -828,7 +828,12 @@ function RuntimeStatusValue({
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 }) {
-	const status = hostedRuntimeStatusView(deployment.resource.status, agent);
+	const failure = deploymentFailurePresentation(deployment);
+	const status = hostedRuntimeStatusView(
+		deployment.resource.status,
+		agent,
+		failure?.failedVerb ? failure : null,
+	);
 	return (
 		<div className="flex min-w-0 flex-col gap-1">
 			<span

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -19,6 +19,7 @@ import {
 	Sparkles,
 	TerminalSquare,
 	Trash2,
+	WalletCards,
 	Zap,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -124,7 +125,10 @@ import {
 	type WalletFundingErrorCopy,
 } from "@/hosted/billing/wallet/wallet-funding";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
-import { deploymentFailureReason } from "@/hosted/deployment-failure";
+import {
+	type DeploymentFailurePresentation,
+	deploymentFailurePresentation,
+} from "@/hosted/deployment-failure";
 import {
 	canDelete as canDeleteDeployment,
 	canQueryDeploymentProjection,
@@ -200,6 +204,7 @@ import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
+import { settingsQueryHref } from "@/lib/settings-routes";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn } from "@/lib/utils";
 
@@ -322,11 +327,13 @@ function DeleteComputeAction({
 	onDeleteAccepted,
 	variant = "destructive",
 	className,
+	label = "Delete",
 }: {
 	deployment: HostedDeployment;
 	onDeleteAccepted: (deploymentId: string) => void;
 	variant?: React.ComponentProps<typeof Button>["variant"];
 	className?: string;
+	label?: string;
 }) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const canDelete = canDeleteDeployment(status);
@@ -337,7 +344,7 @@ function DeleteComputeAction({
 		>
 			<Button type="button" variant={variant} size="sm" className={className} disabled={!canDelete}>
 				<Trash2 />
-				Delete
+				{label}
 			</Button>
 		</HostedDeploymentDeleteAction>
 	);
@@ -460,6 +467,7 @@ export function HostedAgentDetail({
 	const consoleUrl = runtimeConsoleUrl(deployment, runtime);
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const terminalHref = agentSectionHref(environmentId, "terminal", searchStr);
+	const planChangeHref = agentSectionHref(environmentId, "settings", searchStr);
 
 	useEffect(() => {
 		if (
@@ -577,6 +585,7 @@ export function HostedAgentDetail({
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
 							terminalHref={terminalHref}
+							planChangeHref={planChangeHref}
 							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							isCheckingDeployment={isCheckingDeployment}
@@ -997,50 +1006,100 @@ function DeploymentFailureReasonText({ reason }: { reason: string }) {
 	return <p className="mt-2 whitespace-pre-wrap break-words text-sm">{reason}</p>;
 }
 
-function OverviewFailedPanel({
+function OverviewFailureAction({
 	deployment,
-	restartLabel = "Restart compute",
+	failure,
+	planChangeHref,
+	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
-	restartLabel?: string;
+	failure: DeploymentFailurePresentation;
+	planChangeHref: string;
+	onDeleteAccepted: (deploymentId: string) => void;
+}) {
+	const remediation = failure.remediation;
+	return (
+		<div className="flex shrink-0 flex-wrap gap-2">
+			{remediation.requiresWalletTopUp && remediation.kind === "restart" ? (
+				<Button
+					render={<a href={settingsQueryHref("billing-wallet")} />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+				>
+					<WalletCards className="size-3.5" />
+					Open Wallet
+				</Button>
+			) : null}
+			{remediation.kind === "restart" ? (
+				<RestartComputeAction deployment={deployment} label={remediation.label} />
+			) : remediation.kind === "review_plan_change" ? (
+				<Button
+					render={<a href={planChangeHref} />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+				>
+					{remediation.label}
+				</Button>
+			) : remediation.kind === "retry_delete" ? (
+				<DeleteComputeAction
+					deployment={deployment}
+					onDeleteAccepted={onDeleteAccepted}
+					label={remediation.label}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+export function OverviewFailedPanel({
+	deployment,
+	planChangeHref,
+	onDeleteAccepted,
+}: {
+	deployment: HostedDeployment;
+	planChangeHref: string;
+	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
-	const failureReason = deploymentFailureReason(deployment.resource.status);
-	if (failureReason) {
+	const failure = deploymentFailurePresentation(deployment);
+	if (failure) {
 		return (
 			<Alert data-hosted="true" variant="destructive">
 				<AlertCircle className="size-4" />
-				<AlertTitle>Agent setup failed</AlertTitle>
+				<AlertTitle>{failure.title}</AlertTitle>
 				<AlertDescription className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
 					<div className="min-w-0">
 						<p>
-							Restart the compute to retry startup. Current status: {deploymentStatusLabel(status)}.
+							{failure.description} Current status: {deploymentStatusLabel(status)}.
 						</p>
-						<DeploymentFailureReasonText reason={failureReason} />
+						<DeploymentFailureReasonText reason={failure.reason} />
 					</div>
-					<div className="shrink-0">
-						<RestartComputeAction deployment={deployment} label={restartLabel} />
-					</div>
+					<OverviewFailureAction
+						deployment={deployment}
+						failure={failure}
+						planChangeHref={planChangeHref}
+						onDeleteAccepted={onDeleteAccepted}
+					/>
 				</AlertDescription>
 			</Alert>
 		);
 	}
 	return (
 		<div className="rounded-xl border border-destructive-muted bg-destructive-muted p-5 text-destructive-muted-foreground">
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
 				<div className="flex min-w-0 gap-3">
 					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-destructive-muted bg-background">
-						<RefreshCw className="size-5" />
+						<AlertCircle className="size-5" />
 					</div>
 					<div className="min-w-0">
-						<h2 className="text-sm font-semibold text-foreground">Agent setup failed</h2>
+						<h2 className="text-sm font-semibold text-foreground">Deployment operation failed</h2>
 						<p className="mt-1 text-sm">
-							Restart the compute to retry startup. Current status: {deploymentStatusLabel(status)}.
+							The failure reason and operation are unavailable, so there is no safe automatic retry.
+							Current status: {deploymentStatusLabel(status)}.
 						</p>
 					</div>
-				</div>
-				<div className="shrink-0">
-					<RestartComputeAction deployment={deployment} label={restartLabel} />
 				</div>
 			</div>
 		</div>
@@ -1061,6 +1120,7 @@ function OverviewTab({
 	onRetrySessions,
 	sessionLink,
 	terminalHref,
+	planChangeHref,
 	runtimeUiSettlingTimedOut,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
@@ -1082,6 +1142,7 @@ function OverviewTab({
 		params: { id: string; sessionId: string };
 	};
 	terminalHref: string;
+	planChangeHref: string;
 	runtimeUiSettlingTimedOut: boolean;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
@@ -1127,7 +1188,11 @@ function OverviewTab({
 				/>
 			) : null}
 			{deploymentStatus.kind === "failed" ? (
-				<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
+				<OverviewFailedPanel
+					deployment={deployment}
+					planChangeHref={planChangeHref}
+					onDeleteAccepted={onDeleteAccepted}
+				/>
 			) : null}
 			{deploymentStatus.kind === "stopped" ? (
 				<StoppedAgentState deployment={deployment} variant="inset" />

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -5,6 +5,7 @@ import {
 	deploymentFailureProjection,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
+import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("deploymentFailureReason", () => {
@@ -79,7 +80,7 @@ describe("deploymentFailureReason", () => {
 				"Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying.",
 			remediation: {
 				kind: "review_plan_change",
-				label: "Review plan change",
+				label: "Review plan",
 				requiresWalletTopUp: true,
 			},
 		});
@@ -97,6 +98,56 @@ describe("deploymentFailureReason", () => {
 				},
 			}),
 		).toBe("Try again.");
+	});
+
+	test("maps every failed operation to a truthful safe remediation", () => {
+		const cases = [
+			["create", "Agent setup failed", "restart"],
+			["start", "Agent startup failed", "restart"],
+			["stop", "Compute stop failed", "none"],
+			["restart", "Compute restart failed", "restart"],
+			["update", "Agent update failed", "none"],
+			["runtime_switch", "Runtime switch failed", "none"],
+			["rename", "Agent rename failed", "none"],
+			["delete", "Agent deletion failed", "retry_delete"],
+			["plan_change", "Plan change failed", "review_plan_change"],
+		] as const satisfies readonly [DeploymentOperationVerb, string, string][];
+
+		for (const [verb, title, remediationKind] of cases) {
+			const deployment = hostedDeploymentFixture({
+				status: "failed",
+				acceptedOperation: {
+					name: `operations/${verb}-failed`,
+					metadata: {
+						"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+						deploymentId: "hdep_failed",
+						verb: verb as DeploymentOperation["metadata"]["verb"],
+						targetGeneration: 2,
+						manifestETag: "manifest-failed",
+						createTime: "2026-07-25T00:00:00Z",
+						updateTime: "2026-07-25T00:01:00Z",
+					},
+					done: false,
+					response: null,
+				},
+				failure: {
+					type: "https://api.clawdi.ai/problems/operation_failed",
+					title: "The requested operation did not complete.",
+					status: 409,
+					detail: "The requested operation did not complete.",
+					instance: "hdep_failed",
+					code: "operation_failed",
+					retryable: true,
+					conditionReason: "OperationFailed",
+					conditionMessage: "The requested operation did not complete.",
+					observedGeneration: 2,
+				},
+			});
+			const presentation = deploymentFailurePresentation(deployment);
+
+			expect(presentation?.title).toBe(title);
+			expect(presentation?.remediation.kind).toBe(remediationKind);
+		}
 	});
 
 	test("does not expose a stale failure outside the authoritative failed state", () => {

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
-import { deploymentFailureProjection, deploymentFailureReason } from "@/hosted/deployment-failure";
+import {
+	deploymentFailurePresentation,
+	deploymentFailureProjection,
+	deploymentFailureReason,
+} from "@/hosted/deployment-failure";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("deploymentFailureReason", () => {
@@ -64,6 +68,20 @@ describe("deploymentFailureReason", () => {
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",
+		});
+		expect(deploymentFailurePresentation(deployment)).toEqual({
+			reason: "Top up your wallet and retry the plan change.",
+			failedVerb: "plan_change",
+			retryable: false,
+			code: "operation_aborted",
+			title: "Plan change failed",
+			description:
+				"Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying.",
+			remediation: {
+				kind: "review_plan_change",
+				label: "Review plan change",
+				requiresWalletTopUp: true,
+			},
 		});
 	});
 

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -26,6 +26,132 @@ export type DeploymentFailureProjection = {
 	code: string;
 };
 
+export type DeploymentFailureRemediation =
+	| { kind: "restart"; label: string; requiresWalletTopUp: boolean }
+	| { kind: "review_plan_change"; label: string; requiresWalletTopUp: boolean }
+	| { kind: "retry_delete"; label: string; requiresWalletTopUp: false }
+	| { kind: "none"; label: null; requiresWalletTopUp: boolean };
+
+export type DeploymentFailurePresentation = DeploymentFailureProjection & {
+	title: string;
+	description: string;
+	remediation: DeploymentFailureRemediation;
+};
+
+const WALLET_FUNDING_REASON_RE =
+	/\b(?:top[ -]?up|insufficient(?: wallet)? (?:balance|funds?)|wallet (?:balance|funds?).*(?:low|short|empty|exhausted|depleted)|refund debt)\b/i;
+const WALLET_FUNDING_CODES = new Set([
+	"insufficient_balance",
+	"insufficient_wallet_balance",
+	"open_refund_debt",
+]);
+
+/** Stable product name for every operation verb; never render the wire value. */
+export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): string {
+	switch (verb) {
+		case "create":
+			return "Agent setup";
+		case "start":
+			return "Agent startup";
+		case "stop":
+			return "Compute stop";
+		case "restart":
+			return "Compute restart";
+		case "update":
+			return "Agent update";
+		case "runtime_switch":
+			return "Runtime switch";
+		case "rename":
+			return "Agent rename";
+		case "delete":
+			return "Agent deletion";
+		case "plan_change":
+			return "Plan change";
+		case null:
+			return "Deployment operation";
+	}
+}
+
+function deploymentFailureNeedsWalletTopUp(failure: DeploymentFailureProjection): boolean {
+	return WALLET_FUNDING_CODES.has(failure.code) || WALLET_FUNDING_REASON_RE.test(failure.reason);
+}
+
+/** Shared honest copy/action decision for detail, status, and tile surfaces. */
+export function deploymentFailurePresentation(
+	deployment: HostedDeployment | null | undefined,
+): DeploymentFailurePresentation | null {
+	const failure = deploymentFailureProjection(deployment);
+	if (!failure) return null;
+	const operationLabel = deploymentOperationLabel(failure.failedVerb);
+	const operationName = operationLabel.toLocaleLowerCase();
+	const requiresWalletTopUp = deploymentFailureNeedsWalletTopUp(failure);
+
+	switch (failure.failedVerb) {
+		case "create":
+		case "start":
+			return {
+				...failure,
+				title: `${operationLabel} failed`,
+				description: requiresWalletTopUp
+					? `Top up your Wallet, then retry ${operationName}.`
+					: `Restart the compute to retry ${operationName}.`,
+				remediation: {
+					kind: "restart",
+					label: "Retry startup",
+					requiresWalletTopUp,
+				},
+			};
+		case "restart":
+			return {
+				...failure,
+				title: `${operationLabel} failed`,
+				description: requiresWalletTopUp
+					? "Top up your Wallet, then retry the compute restart."
+					: "Retry the compute restart after reviewing the reason below.",
+				remediation: {
+					kind: "restart",
+					label: "Retry restart",
+					requiresWalletTopUp,
+				},
+			};
+		case "plan_change":
+			return {
+				...failure,
+				title: `${operationLabel} failed`,
+				description: requiresWalletTopUp
+					? "Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying."
+					: "Open Compute settings to request a fresh quote and confirm the price before retrying.",
+				remediation: {
+					kind: "review_plan_change",
+					label: "Review plan change",
+					requiresWalletTopUp,
+				},
+			};
+		case "delete":
+			return {
+				...failure,
+				title: `${operationLabel} failed`,
+				description: "The deployment was not deleted. Review the reason, then retry deletion.",
+				remediation: {
+					kind: "retry_delete",
+					label: "Retry delete",
+					requiresWalletTopUp: false,
+				},
+			};
+		case "stop":
+		case "update":
+		case "runtime_switch":
+		case "rename":
+		case null:
+			return {
+				...failure,
+				title: `${operationLabel} failed`,
+				description: `Review the reason below. There is no safe one-click retry for this ${operationName} failure.`,
+				remediation: { kind: "none", label: null, requiresWalletTopUp },
+			};
+	}
+}
+
 export function deploymentFailureReason(input: {
 	failure?: {
 		title: string;

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -123,7 +123,7 @@ export function deploymentFailurePresentation(
 					: "Open Compute settings to request a fresh quote and confirm the price before retrying.",
 				remediation: {
 					kind: "review_plan_change",
-					label: "Review plan change",
+					label: "Review plan",
 					requiresWalletTopUp,
 				},
 			};

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Play, Trash2 } from "lucide-react";
+import { Play, RefreshCw, Trash2, WalletCards } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
@@ -8,9 +8,17 @@ import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-
 import { useDeploymentLifecycle } from "@/hosted/agents/deployment-hooks";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { deploymentFailurePresentation } from "@/hosted/deployment-failure";
 import { canDelete, canStart, parseDeploymentStatus } from "@/hosted/deployment-status";
+import { settingsQueryHref } from "@/lib/settings-routes";
 
-export function HostedDeploymentTileAction({ deployment }: { deployment: HostedDeployment }) {
+export function HostedDeploymentTileAction({
+	deployment,
+	remediationHref,
+}: {
+	deployment: HostedDeployment;
+	remediationHref?: string;
+}) {
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const name = deploymentDisplayName(
@@ -20,39 +28,93 @@ export function HostedDeploymentTileAction({ deployment }: { deployment: HostedD
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const startEnabled = status.kind === "stopped" && canStart(status);
 	const deleteEnabled = canDelete(status);
+	const failure = deploymentFailurePresentation(deployment);
+	const remediation = failure?.remediation;
+	const retryDelete = remediation?.kind === "retry_delete";
+	const showRestart = remediation?.kind === "restart" && !remediation.requiresWalletTopUp;
+	const showDelete = !remediationHref || !remediation || remediation.kind === "none" || retryDelete;
+	const lifecyclePending = lifecycle.isPending;
+
+	function runLifecycle(action: "start" | "restart") {
+		void runAction(async () => {
+			await lifecycle.mutateAsync({ id: deployment.resource.id, action });
+		}).catch(() => undefined);
+	}
 
 	return (
 		<div data-hosted="true" className="flex items-center gap-1">
+			{remediation?.requiresWalletTopUp && remediation.kind === "restart" ? (
+				<Button
+					render={<a href={settingsQueryHref("billing-wallet")} />}
+					nativeButton={false}
+					variant="outline"
+					size="xs"
+					aria-label={`Open Wallet for ${name}`}
+					title={`Open Wallet for ${name}`}
+				>
+					<WalletCards />
+					Open Wallet
+				</Button>
+			) : null}
+			{remediation?.kind === "review_plan_change" && remediationHref ? (
+				<Button
+					render={<a href={remediationHref} />}
+					nativeButton={false}
+					variant="outline"
+					size="xs"
+					aria-label={`${remediation.label} for ${name}`}
+					title={`${remediation.label} for ${name}`}
+				>
+					{remediation.label}
+				</Button>
+			) : null}
+			{showRestart ? (
+				<Button
+					type="button"
+					variant="outline"
+					size="xs"
+					disabled={lifecyclePending}
+					aria-label={`${remediation.label} for ${name}`}
+					title={`${remediation.label} for ${name}`}
+					onClick={() => runLifecycle("restart")}
+				>
+					{lifecyclePending && lifecycle.variables?.action === "restart" ? (
+						<Spinner />
+					) : (
+						<RefreshCw />
+					)}
+					{remediation.label}
+				</Button>
+			) : null}
 			{startEnabled ? (
 				<Button
 					type="button"
 					size="xs"
-					disabled={lifecycle.isPending}
+					disabled={lifecyclePending}
 					aria-label={`Start ${name}`}
 					title={`Start ${name}`}
-					onClick={() =>
-						void runAction(async () => {
-							await lifecycle.mutateAsync({ id: deployment.resource.id, action: "start" });
-						}).catch(() => undefined)
-					}
+					onClick={() => runLifecycle("start")}
 				>
-					{lifecycle.isPending ? <Spinner /> : <Play />}
+					{lifecyclePending ? <Spinner /> : <Play />}
 					Start
 				</Button>
 			) : null}
-			<HostedDeploymentDeleteAction deployment={deployment}>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon-xs"
-					className="text-muted-foreground hover:text-destructive"
-					disabled={!deleteEnabled}
-					aria-label={`Delete ${name}`}
-					title={`Delete ${name}`}
-				>
-					<Trash2 />
-				</Button>
-			</HostedDeploymentDeleteAction>
+			{showDelete ? (
+				<HostedDeploymentDeleteAction deployment={deployment}>
+					<Button
+						type="button"
+						variant={retryDelete ? "outline" : "ghost"}
+						size={retryDelete ? "xs" : "icon-xs"}
+						className="text-muted-foreground hover:text-destructive"
+						disabled={!deleteEnabled}
+						aria-label={retryDelete ? `${remediation.label} for ${name}` : `Delete ${name}`}
+						title={retryDelete ? `${remediation.label} for ${name}` : `Delete ${name}`}
+					>
+						<Trash2 />
+						{retryDelete ? remediation.label : null}
+					</Button>
+				</HostedDeploymentDeleteAction>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,10 +1,13 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import type { components } from "@clawdi/shared/api";
+import { isValidElement } from "react";
 import type {
+	DeploymentOperation,
 	HostedComputeSubscription,
 	HostedDeployment,
 	HostedDeploymentStatus,
 } from "@/hosted/billing/contracts";
+import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
@@ -98,6 +101,23 @@ function deploymentFailure(reason: string): NonNullable<HostedDeploymentStatus["
 	};
 }
 
+function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
+	return {
+		name: `operations/${verb}-failed`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "dep_123",
+			verb: verb as DeploymentOperation["metadata"]["verb"],
+			targetGeneration: 2,
+			manifestETag: "manifest-failed",
+			createTime: "2026-07-25T00:00:00Z",
+			updateTime: "2026-07-25T00:01:00Z",
+		},
+		done: false,
+		response: null,
+	};
+}
+
 function deployment(
 	overrides: {
 		id?: string;
@@ -108,6 +128,7 @@ function deployment(
 		computeSubscription?: HostedComputeSubscription;
 		computePlanSlug?: "compute_basic" | "compute_performance";
 		failureReason?: string;
+		failedVerb?: DeploymentOperationVerb;
 		environmentId?: string | null;
 	} = {},
 ): HostedDeployment {
@@ -124,6 +145,7 @@ function deployment(
 		computeSubscription: overrides.computeSubscription,
 		currentPlanSlug: overrides.computePlanSlug,
 		failure: overrides.failureReason ? deploymentFailure(overrides.failureReason) : undefined,
+		acceptedOperation: overrides.failedVerb ? acceptedOperation(overrides.failedVerb) : undefined,
 	});
 }
 
@@ -227,8 +249,34 @@ describe("deploymentToTiles", () => {
 			},
 		});
 		expect(tile?.manageHref).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123`);
-		expect(tile?.action).toBeUndefined();
+		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
+	});
+
+	test("gives a failed plan change its own status and confirmed-flow remediation", () => {
+		const environmentId = "env-failed-plan-change";
+		const reason = "Top up your Wallet and retry the plan change.";
+		const [tile] = hostedDeploymentToTiles(
+			deployment({
+				status: "failed",
+				failureReason: reason,
+				failedVerb: "plan_change",
+				environmentId,
+			}),
+		);
+
+		expect(tile?.secondaryStatus).toEqual({
+			label: `Plan change failed: ${reason}`,
+			title:
+				"Plan change failed. Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying. Reason: Top up your Wallet and retry the plan change.",
+			textClass: "text-destructive-muted-foreground font-medium",
+		});
+		expect(
+			isValidElement<{ remediationHref?: string }>(tile?.action) &&
+				tile.action.props.remediationHref,
+		).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123#compute-plan-controls`);
+		expect(tile?.secondaryStatus?.label).not.toContain("startup");
+		expect(tile?.secondaryStatus?.label).not.toContain("restart");
 	});
 
 	test("keeps Start and Delete actions on a stopped tile with a retained env identity", () => {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -12,6 +12,8 @@ import type { HostedDeployment, HostedDeploymentStatus } from "@/hosted/billing/
 import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-management";
 import {
 	compactDeploymentFailureReason,
+	type DeploymentFailurePresentation,
+	deploymentFailurePresentation,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
 import {
@@ -59,6 +61,7 @@ export interface HostedRuntimeStatusView {
 export function hostedRuntimeStatusView(
 	deployment: DeploymentStatusInput,
 	env: Env | null | undefined,
+	failurePresentation?: DeploymentFailurePresentation | null,
 ): HostedRuntimeStatusView {
 	const compute = parseDeploymentStatus(deployment.summary_state);
 	const computeLabel = deploymentStatusLabel(compute);
@@ -70,8 +73,14 @@ export function hostedRuntimeStatusView(
 	if (failureReason) {
 		secondary = {
 			kind: "failure_reason",
-			label: `Failure: ${compactDeploymentFailureReason(failureReason)}`,
-			tooltip: failureReason,
+			label: failurePresentation
+				? compactDeploymentFailureReason(
+						`${failurePresentation.title}: ${failurePresentation.reason}`,
+					)
+				: `Failure: ${compactDeploymentFailureReason(failureReason)}`,
+			tooltip: failurePresentation
+				? `${failurePresentation.title}. ${failurePresentation.description} Reason: ${failurePresentation.reason}`
+				: failureReason,
 			textClass: statusTextVariants({ status: "destructive" }),
 		};
 	} else if (computeIsRunning && sync && sync.kind !== "live") {
@@ -192,8 +201,14 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 		? deploymentDisplayName(agentDisplayName(matchedEnv), runtime)
 		: runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;
-	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv ?? null);
-	const showTileActions = runtimeStatus.compute.kind === "stopped" || !envId;
+	const failurePresentation = deploymentFailurePresentation(d);
+	const runtimeStatus = hostedRuntimeStatusView(
+		d.resource.status,
+		matchedEnv ?? null,
+		failurePresentation?.failedVerb ? failurePresentation : null,
+	);
+	const showTileActions =
+		runtimeStatus.compute.kind === "stopped" || runtimeStatus.compute.kind === "failed" || !envId;
 	const dunningStatus = computeDunningTileStatus(d);
 	const failureReasonStatus =
 		runtimeStatus.secondary?.kind === "failure_reason" ? runtimeStatus.secondary : null;
@@ -211,7 +226,10 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 			href: detailHref,
 			external: false,
 			action: showTileActions
-				? createElement(HostedDeploymentTileAction, { deployment: d })
+				? createElement(HostedDeploymentTileAction, {
+						deployment: d,
+						remediationHref: settingsHref ? `${settingsHref}#compute-plan-controls` : undefined,
+					})
 				: undefined,
 			manageHref: settingsHref,
 			active: runtimeStatus.active,


### PR DESCRIPTION
## Summary

- derive failure titles and remediation from the accepted operation verb and sanitized reason
- route failed plan changes to the existing quote-and-confirm flow without replaying the paid mutation
- expose matching failure status and safe actions on hosted agent detail and tile surfaces
- cover plan-change failures with rendering and tile regressions

## Verification

- bun run typecheck (4/4 packages)
- bun run lint (694 files)
- bun test (1675 pass, 0 fail, 175 files, 6652 assertions)