### PR TITLE
fix(web): clarify the v2 deploy path

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1442,6 +1442,33 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	expect(errors, `language select: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("deploy keeps Managed AI compact and provider selection exclusive", async ({ page }) => {
+	await stubHostedApi(page, { plans: [basicPlan], deployments: [] });
+	await page.goto("/deploy");
+
+	await expect(page.getByText("Using Managed AI", { exact: true })).toBeVisible();
+	const addProvider = page.getByRole("button", { name: /^Add a provider/ });
+	await expect(addProvider).toHaveCount(0);
+	await page.getByRole("button", { name: "Change", exact: true }).click();
+
+	const managed = page.getByRole("button", { name: /^Managed AI/ });
+	const unmanaged = page.getByRole("button", { name: /^Configure inside agent/ });
+	await expect(addProvider).toBeVisible();
+	await expect(managed).toHaveAttribute("aria-pressed", "true");
+	await expect(unmanaged).toHaveAttribute("aria-pressed", "false");
+
+	await unmanaged.click();
+	await expect(unmanaged).toHaveAttribute("aria-pressed", "true");
+	await expect(managed).toHaveAttribute("aria-pressed", "false");
+	await managed.click();
+	await expect(managed).toHaveAttribute("aria-pressed", "true");
+	await expect(unmanaged).toHaveAttribute("aria-pressed", "false");
+
+	await page.getByRole("button", { name: "Done", exact: true }).click();
+	await expect(addProvider).toHaveCount(0);
+	await expect(page.getByText("Using Managed AI", { exact: true })).toBeVisible();
+});
+
 test("free Basic Deploy submits the declarative create contract", async ({ page }) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
 	const convergencePollRequests: string[] = [];

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1446,6 +1446,10 @@ test("deploy keeps Managed AI compact and provider selection exclusive", async (
 	await stubHostedApi(page, { plans: [basicPlan], deployments: [] });
 	await page.goto("/deploy");
 
+	await expect(page.getByRole("button", { name: /^Hermes/ })).toContainText("Recommended");
+	await expect(
+		page.getByText("Agent software can’t be changed later", { exact: true }),
+	).toBeVisible();
 	await expect(page.getByText("Using Managed AI", { exact: true })).toBeVisible();
 	const addProvider = page.getByRole("button", { name: /^Add a provider/ });
 	await expect(addProvider).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1560,7 +1560,10 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	await checkoutDialog.getByRole("button", { name: "Subscribe", exact: true }).click();
 
 	await expect(page).toHaveURL(/\/agents\/hdep_created/);
-	await expect(page.getByText("Provisioning your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByText("Getting your agent ready…", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("This step should finish within five minutes.", { exact: false }),
+	).toBeVisible();
 	expect(deploymentRequestReads).toHaveLength(1);
 	expect(operationPollRequests).toEqual([]);
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1013,6 +1013,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 								client_secret: null,
 							},
 						});
+			if (response.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
 			if (response.status < 400 && request.funding_source === "wallet") {
 				options.onWalletCheckoutSuccess?.();
 			}
@@ -2163,7 +2166,7 @@ test("Basic create always follows the wizard-selected funding path", async ({ pa
 	expect(errors, `funded Basic deploy: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("entitled card subscription activation shows reuse banner without checkout", async ({
+test("entitled card subscription activation opens the accepted deployment without checkout", async ({
 	page,
 }) => {
 	const errors = collectBrowserErrors(page);
@@ -2178,6 +2181,7 @@ test("entitled card subscription activation shows reuse banner without checkout"
 					funding_source: "stripe",
 					checkout_url: "",
 					deploy_request_id: "reuse-active-subscription",
+					deployment_id: "hdep_included",
 					current_period_end: "2027-07-15T00:00:00Z",
 					entitled_until: "2027-07-15T00:00:00Z",
 				},
@@ -2191,16 +2195,10 @@ test("entitled card subscription activation shows reuse banner without checkout"
 
 	await page.getByRole("button", { name: "Continue to checkout" }).click();
 	await expect.poll(() => checkoutRequests.length).toBe(1);
-	const banner = page.getByTestId("subscription-reuse-banner");
-	await expect(banner).toBeVisible();
-	await expect(banner).toContainText(
-		"Reusing your active subscription — valid until Jul 15, 2027, no additional charge.",
-	);
+	await expect(page).toHaveURL(/\/agents\/hdep_included(?:\?|\/)/);
+	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
 	await expect(page.getByRole("dialog", { name: /Complete .* checkout/ })).toHaveCount(0);
 	await expect(page.getByText("Mock secure payment form", { exact: true })).toHaveCount(0);
-	await expect(
-		page.getByRole("button", { name: "Deployment started", exact: true }),
-	).toBeDisabled();
 	expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
 		funding_source: "stripe",
 		deploy_config: { compute_plan_slug: "compute_basic" },
@@ -2255,6 +2253,21 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	const subscriptionQuoteRequests: string[] = [];
 	await stubHostedApi(page, {
 		checkoutRequests,
+		checkoutResponses: [
+			{
+				status: 202,
+				delayMs: 500,
+				body: {
+					flow_type: "subscription_activation",
+					funding_source: "wallet",
+					checkout_url: "",
+					deployment_id: "hdep_wallet_created",
+					deploy_request_id: "wallet-annual-delayed",
+					debited_usd: "100.00",
+					balance_after_usd: "0.00",
+				},
+			},
+		],
 		deployments,
 		plans: [basicPlan, performancePlan],
 		subscriptionQuoteRequests,
@@ -2288,6 +2301,11 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	await expect(equation).toContainText("$0.00");
 
 	await page.getByRole("button", { name: "Pay $100.00 from Wallet & deploy" }).click();
+	const accepting = page.getByRole("button", { name: "Confirming payment & creating agent…" });
+	await expect(accepting).toBeDisabled();
+	await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+	await page.waitForTimeout(100);
+	expect(subscriptionQuoteRequests).toHaveLength(1);
 	await expect.poll(() => checkoutRequests.length).toBe(1);
 	const quote = JSON.parse(subscriptionQuoteRequests[0] ?? "{}");
 	const activation = JSON.parse(checkoutRequests[0] ?? "{}");
@@ -2312,7 +2330,7 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	await expect(page).toHaveURL(/\/agents\/hdep_wallet_created(?:\?|\/)/);
 	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
 	await expect(
-		page.getByText("Your Basic agent is provisioning now. $100.00 was paid from Wallet.", {
+		page.getByText("Your Basic agent is getting ready now. $100.00 was paid from Wallet.", {
 			exact: true,
 		}),
 	).toBeVisible();

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -72,7 +72,7 @@ describe("deployment transition timeout rendering", () => {
 
 		expect(converging).toContain("Getting your agent ready…");
 		expect(converging).toContain("This step should finish within five minutes.");
-		expect(converging).toContain("we’ll keep checking automatically");
+		expect(converging).toContain("will keep getting ready if you leave this page");
 		expect(converging).not.toContain("Provisioning");
 		expect(converging).not.toContain("Booting");
 		expect(converging).not.toContain("Current status");
@@ -81,7 +81,7 @@ describe("deployment transition timeout rendering", () => {
 		expect(timedOut).toContain("did not finish getting ready within five minutes");
 		expect(timedOut).toContain("Automatic checks have stopped.");
 		expect(timedOut).toContain("Check again");
-		expect(timedOut).not.toContain("we’ll keep checking automatically");
+		expect(timedOut).not.toContain("will keep getting ready if you leave this page");
 	});
 
 	test("sets an honest five-minute expectation while the product UI opens", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -70,12 +70,33 @@ describe("deployment transition timeout rendering", () => {
 			}),
 		);
 
-		expect(converging).toContain("Provisioning your agent…");
-		expect(converging).toContain("This page updates automatically.");
-		expect(timedOut).toContain("Deployment is taking longer than expected");
+		expect(converging).toContain("Getting your agent ready…");
+		expect(converging).toContain("This step should finish within five minutes.");
+		expect(converging).toContain("we’ll keep checking automatically");
+		expect(converging).not.toContain("Provisioning");
+		expect(converging).not.toContain("Booting");
+		expect(converging).not.toContain("Current status");
+		expect(converging).not.toContain("Deployment progress");
+		expect(timedOut).toContain("Your agent is taking longer than expected");
+		expect(timedOut).toContain("did not finish getting ready within five minutes");
 		expect(timedOut).toContain("Automatic checks have stopped.");
 		expect(timedOut).toContain("Check again");
-		expect(timedOut).not.toContain("This page updates automatically.");
+		expect(timedOut).not.toContain("we’ll keep checking automatically");
+	});
+
+	test("sets an honest five-minute expectation while the product UI opens", () => {
+		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
+		const panelStart = source.indexOf("export function OverviewProvisioningPanel");
+		const panelEnd = source.indexOf("function OverviewFailedPanel", panelStart);
+		const panelSource = source.slice(panelStart, panelEnd);
+
+		expect(panelSource).toContain("`Opening ");
+		expect(panelSource).toContain("browserUiLabel}…`");
+		expect(panelSource).toContain("This step should finish within five minutes.");
+		expect(panelSource).toContain("We’ll open ");
+		expect(panelSource).toContain("browserUiLabel} automatically");
+		expect(panelSource).not.toContain('"Booting"');
+		expect(panelSource).not.toContain("Current status");
 	});
 
 	test("wires the timed-out inventory state and real refetch action into the detail", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -857,43 +857,6 @@ function deploymentReadinessStage(
 	return "provisioning";
 }
 
-function DeploymentReadinessProgress({ stage }: { stage: DeploymentReadinessStage }) {
-	const steps = ["Provisioning", "Booting", "Ready"] as const;
-	const stageIndex = { provisioning: 0, booting: 1, ready: 2 }[stage];
-	return (
-		<ol aria-label="Deployment progress" className="mt-3 flex items-center gap-2 text-xs">
-			{steps.map((step, index) => {
-				const complete = index < stageIndex || stage === "ready";
-				const current = index === stageIndex && stage !== "ready";
-				return (
-					<li
-						key={step}
-						className={cn(
-							"flex items-center gap-1.5",
-							complete || current ? "font-medium text-foreground" : "text-muted-foreground",
-						)}
-						aria-current={current ? "step" : undefined}
-					>
-						<span
-							aria-hidden
-							className={cn(
-								"size-1.5 rounded-full",
-								complete ? "bg-success" : current ? "bg-info" : "bg-border",
-							)}
-						/>
-						{step}
-						{index < steps.length - 1 ? (
-							<span aria-hidden className="ml-0.5 text-border">
-								→
-							</span>
-						) : null}
-					</li>
-				);
-			})}
-		</ol>
-	);
-}
-
 export function OverviewProvisioningPanel({
 	deployment,
 	runtime,
@@ -915,29 +878,26 @@ export function OverviewProvisioningPanel({
 }) {
 	const status = deployment.resource.status;
 	const stage = deploymentReadinessStage(status, runtimeUiAvailable);
-	const parsedStatus = parseDeploymentStatus(status.summary_state);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const settlingTimedOut = deploymentTransitionTimedOut || runtimeUiSettlingTimedOut;
 	const title = deploymentTransitionTimedOut
-		? "Deployment is taking longer than expected"
+		? "Your agent is taking longer than expected"
 		: runtimeUiSettlingTimedOut
-			? "Live UI is taking longer than expected"
+			? `${browserUiLabel} is taking longer than expected`
 			: stage === "provisioning"
-				? "Provisioning your agent…"
+				? "Getting your agent ready…"
 				: stage === "booting"
-					? status.summary_state === "running"
-						? "Starting the live UI…"
-						: "Booting your agent…"
+					? `Opening ${browserUiLabel}…`
 					: "Your agent is ready";
 	const description = deploymentTransitionTimedOut
-		? "The latest deployment change did not finish within five minutes. Automatic checks have stopped. Check again to load the latest status."
+		? "Your agent did not finish getting ready within five minutes. Automatic checks have stopped. Check again to load the latest update."
 		: runtimeUiSettlingTimedOut
-			? `${browserUiLabel} did not publish within the startup window. Automatic periodic checks will continue, and Terminal is available now.`
+			? `${browserUiLabel} did not open within five minutes. We’ll keep checking automatically, and Terminal is available now.`
 			: stage === "provisioning"
-				? "Hosted compute is being prepared. This page updates automatically."
+				? "This step should finish within five minutes. You can leave this page; we’ll keep checking automatically."
 				: stage === "booting"
-					? "Opening the live UI automatically… Terminal is available while the runtime finishes booting."
-					: "The live UI is ready to use.";
+					? `This step should finish within five minutes. We’ll open ${browserUiLabel} automatically; Terminal is available now.`
+					: `${browserUiLabel} is ready to use.`;
 	return (
 		<div
 			className={cn(
@@ -954,8 +914,6 @@ export function OverviewProvisioningPanel({
 				<div className="min-w-0 flex-1">
 					<h2 className="text-sm font-semibold text-foreground">{title}</h2>
 					<p className="mt-1 text-sm">{description}</p>
-					{deploymentTransitionTimedOut ? null : <DeploymentReadinessProgress stage={stage} />}
-					<p className="mt-2 text-xs">Current status: {deploymentStatusLabel(parsedStatus)}.</p>
 					{deploymentTransitionTimedOut || stage === "booting" ? (
 						<div className="mt-3 flex flex-wrap gap-2">
 							{deploymentTransitionTimedOut ? (
@@ -1107,14 +1065,16 @@ function OverviewTab({
 	const deploymentStatus = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const runtimeUiAvailable = Boolean(runtimeConsoleUrl(deployment, runtime));
+	const agentGettingReady =
+		deploymentTransitionTimedOut ||
+		isProvisioningStatus(deploymentStatus) ||
+		(deploymentStatus.kind === "running" && !runtimeUiAvailable);
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
 	return (
 		<div className="flex flex-col gap-5">
-			{deploymentTransitionTimedOut ||
-			isProvisioningStatus(deploymentStatus) ||
-			(deploymentStatus.kind === "running" && !runtimeUiAvailable) ? (
+			{agentGettingReady ? (
 				<OverviewProvisioningPanel
 					deployment={deployment}
 					runtime={runtime}
@@ -1132,11 +1092,18 @@ function OverviewTab({
 			{deploymentStatus.kind === "stopped" ? (
 				<StoppedAgentState deployment={deployment} variant="inset" />
 			) : null}
-			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-				<StatCard
-					label="Status"
-					value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
-				/>
+			<div
+				className={cn(
+					"grid gap-2 sm:grid-cols-2",
+					agentGettingReady ? "lg:grid-cols-3" : "lg:grid-cols-4",
+				)}
+			>
+				{agentGettingReady ? null : (
+					<StatCard
+						label="Status"
+						value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
+					/>
+				)}
 				<StatCard label="Compute" value={isPerformance ? "Performance" : "Basic"} />
 				<StatCard label="Model" value={model} />
 				<StatCard

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -894,7 +894,7 @@ export function OverviewProvisioningPanel({
 		: runtimeUiSettlingTimedOut
 			? `${browserUiLabel} did not open within five minutes. We’ll keep checking automatically, and Terminal is available now.`
 			: stage === "provisioning"
-				? "This step should finish within five minutes. You can leave this page; we’ll keep checking automatically."
+				? "This step should finish within five minutes. Your agent will keep getting ready if you leave this page."
 				: stage === "booting"
 					? `This step should finish within five minutes. We’ll open ${browserUiLabel} automatically; Terminal is available now.`
 					: `${browserUiLabel} is ready to use.`;

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -32,7 +32,6 @@ export type StripeCheckoutSummary = {
 type StripeCheckoutDialogProps = {
 	clientSecret: string | null;
 	description: string;
-	onBeforeConfirm: () => Promise<boolean>;
 	onComplete: () => void;
 	onFallback: () => Promise<void>;
 	onOpenChange: (open: boolean) => void;
@@ -156,18 +155,17 @@ function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | nu
 }
 
 function CheckoutElementForm({
-	onBeforeConfirm,
 	onComplete,
 	onLoadError,
 	onSubmittingChange,
 }: {
-	onBeforeConfirm: () => Promise<boolean>;
 	onComplete: () => void;
 	onLoadError: (message: string) => void;
 	onSubmittingChange: (submitting: boolean) => void;
 }) {
 	const checkoutState = useCheckoutElements();
 	const [submitting, setSubmitting] = useState(false);
+	const [takingLong, setTakingLong] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const submittingRef = useRef(false);
 	const loadErrorMessage = checkoutState.type === "error" ? checkoutState.error.message : null;
@@ -175,8 +173,15 @@ function CheckoutElementForm({
 	function finishSubmitting() {
 		submittingRef.current = false;
 		setSubmitting(false);
+		setTakingLong(false);
 		onSubmittingChange(false);
 	}
+
+	useEffect(() => {
+		if (!submitting) return;
+		const timeout = window.setTimeout(() => setTakingLong(true), 5_000);
+		return () => window.clearTimeout(timeout);
+	}, [submitting]);
 
 	useEffect(() => {
 		if (loadErrorMessage) onLoadError(loadErrorMessage);
@@ -214,17 +219,6 @@ function CheckoutElementForm({
 		onSubmittingChange(true);
 		setError(null);
 		try {
-			if (!(await onBeforeConfirm())) {
-				setError("Checkout is temporarily unavailable. No payment was submitted.");
-				finishSubmitting();
-				return;
-			}
-		} catch {
-			setError("We couldn’t verify checkout availability. Please try again.");
-			finishSubmitting();
-			return;
-		}
-		try {
 			const result = await checkout.confirm({ redirect: "if_required" });
 			if (result.type === "error") {
 				setError(result.error.message || "We could not confirm this payment. Please try again.");
@@ -257,6 +251,12 @@ function CheckoutElementForm({
 					<AlertDescription>{error}</AlertDescription>
 				</Alert>
 			) : null}
+			{takingLong ? (
+				<p className="text-sm text-muted-foreground" role="status">
+					Your payment is still being confirmed. Keep this checkout open; we’ll continue as soon as
+					Stripe responds.
+				</p>
+			) : null}
 			<div className="flex justify-end">
 				<Button
 					type="button"
@@ -265,7 +265,7 @@ function CheckoutElementForm({
 				>
 					{submitting ? (
 						<>
-							<Spinner data-icon="inline-start" /> Processing…
+							<Spinner data-icon="inline-start" /> Confirming payment…
 						</>
 					) : (
 						"Subscribe"
@@ -279,7 +279,6 @@ function CheckoutElementForm({
 export function StripeCheckoutDialog({
 	clientSecret,
 	description,
-	onBeforeConfirm,
 	onComplete,
 	onFallback,
 	onOpenChange,
@@ -408,7 +407,6 @@ export function StripeCheckoutDialog({
 						options={providerOptions}
 					>
 						<CheckoutElementForm
-							onBeforeConfirm={onBeforeConfirm}
 							onComplete={completeCheckout}
 							onLoadError={handleProviderLoadError}
 							onSubmittingChange={setCheckoutSubmitting}

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
 	DEFAULT_DEPLOY_AI_ACCESS_MODE,
 	DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
+	DEFAULT_DEPLOY_ASSISTANT_NAME,
 	DEFAULT_DEPLOY_PRIMARY_MODEL,
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
-	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import { MANAGED_AI_CHOICE } from "@/hosted/v2/ai-providers/model-binding";
 
@@ -16,22 +16,6 @@ describe("deploy wizard defaults", () => {
 		expect(DEFAULT_DEPLOY_AI_PROVIDER_CHOICES).toEqual([MANAGED_AI_CHOICE]);
 		expect(DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE).toBe(MANAGED_AI_CHOICE);
 		expect(DEFAULT_DEPLOY_PRIMARY_MODEL).toBe("");
-	});
-
-	test("follows runtime display names until the agent name is edited", () => {
-		expect(
-			deployAssistantNameAfterRuntimeChange({
-				currentName: "Hermes",
-				hasBeenEdited: false,
-				runtime: "openclaw",
-			}),
-		).toBe("OpenClaw");
-		expect(
-			deployAssistantNameAfterRuntimeChange({
-				currentName: "Research Assistant",
-				hasBeenEdited: true,
-				runtime: "hermes",
-			}),
-		).toBe("Research Assistant");
+		expect(DEFAULT_DEPLOY_ASSISTANT_NAME).toBe("My agent");
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -1,4 +1,4 @@
-import { type HostedRuntime, runtimeDisplayName } from "@/hosted/runtimes";
+import type { HostedRuntime } from "@/hosted/runtimes";
 import { MANAGED_AI_CHOICE } from "@/hosted/v2/ai-providers/model-binding";
 
 export type DeployWizardAiAccessMode = "unmanaged" | "configured";
@@ -11,15 +11,4 @@ export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;
 export const DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE = MANAGED_AI_CHOICE;
 // The managed catalog supplies the real default model after it loads.
 export const DEFAULT_DEPLOY_PRIMARY_MODEL = "";
-
-export function deployAssistantNameAfterRuntimeChange({
-	currentName,
-	hasBeenEdited,
-	runtime,
-}: {
-	currentName: string;
-	hasBeenEdited: boolean;
-	runtime: HostedRuntime;
-}): string {
-	return hasBeenEdited ? currentName : runtimeDisplayName(runtime);
-}
+export const DEFAULT_DEPLOY_ASSISTANT_NAME = "My agent";

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -3,8 +3,7 @@ import { MANAGED_AI_CHOICE } from "@/hosted/v2/ai-providers/model-binding";
 
 export type DeployWizardAiAccessMode = "unmanaged" | "configured";
 
-// Deploy-form pre-selection. Independent from the config-interpretation
-// fallback in runtimes.ts (which stays openclaw for existing deployment records).
+// Product pre-selection for new deployments.
 export const DEFAULT_DEPLOY_RUNTIME: HostedRuntime = "hermes";
 export const DEFAULT_DEPLOY_AI_ACCESS_MODE: DeployWizardAiAccessMode = "configured";
 export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -92,7 +92,7 @@ describe("buildHostedDeployRequest", () => {
 		});
 	});
 
-	test("serializes backend provider pool contract at the deploy body boundary", () => {
+	test("serializes one selected provider at the deploy body boundary", () => {
 		const request = buildHostedDeployRequest({
 			computePlanSlug: "compute_performance",
 			runtime: "hermes",
@@ -104,7 +104,7 @@ describe("buildHostedDeployRequest", () => {
 			aiFields: {
 				ai_provider_id: "anthropic-prod",
 				ai_provider_auth_kind: "api_key",
-				provider_ids: ["openai-prod", "anthropic-prod"],
+				provider_ids: ["anthropic-prod"],
 				primary_model: {
 					provider_id: "anthropic-prod",
 					model: "claude-sonnet-5",
@@ -116,7 +116,7 @@ describe("buildHostedDeployRequest", () => {
 			runtime: "hermes",
 			ai_provider_id: "anthropic-prod",
 			ai_provider_auth_kind: "api_key",
-			provider_ids: ["openai-prod", "anthropic-prod"],
+			provider_ids: ["anthropic-prod"],
 			primary_model: {
 				provider_id: "anthropic-prod",
 				model: "claude-sonnet-5",

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -12,7 +12,7 @@ type DeployPersona = {
 	timezone: string;
 };
 
-export const DEPLOY_ASSISTANT_NAME_MAX_LENGTH = 255;
+export const DEPLOY_ASSISTANT_NAME_MAX_LENGTH = 64;
 
 export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> &
 	Partial<

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -51,8 +51,9 @@ describe("deploy wizard product copy and flow", () => {
 		expect(wizardSource).not.toContain('title="Link after deploy"');
 	});
 
-	test("links checkout fallback recovery to the agents list", () => {
-		expect(wizardSource).toContain('label: "View agents"');
+	test("links unresolved post-payment recovery to the agents list", () => {
+		expect(wizardSource).toContain("submitError.blocksRetry");
+		expect(wizardSource).toContain("View agents");
 		expect(wizardSource).toContain('router.navigate({ href: "/agents" })');
 	});
 });
@@ -132,5 +133,43 @@ describe("billing-read gates", () => {
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
 		expect(wizardSource).toContain('title="Couldn\'t load your Wallet balance"');
 		expect(wizardSource).toContain("onRetry={() => void wallet.refetch()}");
+	});
+});
+
+describe("deploy acceptance", () => {
+	test("pauses quote reads, submits the last successful quote, and navigates on acceptance", () => {
+		expect(wizardSource).toContain('enabled: paymentMethod === "wallet" && !submitting');
+		expect(wizardSource).toContain(
+			"const lastSuccessfulSubscriptionQuote = subscriptionCreateQuote.data ?? null;",
+		);
+		expect(wizardSource.match(/quote: lastSuccessfulSubscriptionQuote/g)).toHaveLength(3);
+		expect(wizardSource).toContain(
+			"submitting || lastSuccessfulSubscriptionQuote ? null : subscriptionCreateQuote.error;",
+		);
+		expect(wizardSource).not.toContain("await subscriptionCreateQuote.refetch()");
+		expect(wizardSource).not.toContain("subscription-checkout-hosted-fallback");
+		expect(wizardSource).toContain("fallbackUrl: checkoutRedirectUrl(result)");
+		const onDeployStart = wizardSource.indexOf("async function onDeploy()");
+		const walletBranch = wizardSource.slice(
+			wizardSource.indexOf('if (paymentMethod === "wallet")', onDeployStart),
+			wizardSource.indexOf("const checkoutFingerprint"),
+		);
+		expect(walletBranch).not.toContain("refreshCheckoutReturn");
+		expect(walletBranch).not.toContain("recheckCanCreateCloudAgents");
+		expect(wizardSource).toContain(
+			"router.navigate(acceptedDeploymentNavigation(outcome.deploymentId))",
+		);
+	});
+
+	test("shows a scoped honest busy state and keeps a persistent actionable failure", () => {
+		expect(wizardSource).toContain("setSubmitBusyLabel(");
+		expect(wizardSource).toContain('"Confirming payment & creating agent…"');
+		expect(wizardSource).toContain('"Opening secure checkout…"');
+		expect(wizardSource).toContain('"Creating agent…"');
+		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');
+		expect(wizardSource).toContain("{submitting ? submitBusyLabel : deployLabel}");
+		expect(wizardSource).toContain('role="alert"');
+		expect(wizardSource).toContain("Your choices are unchanged; review them and try again.");
+		expect(wizardSource).not.toContain('submitting ? "Working…"');
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -23,6 +23,10 @@ const modelBindingPickerSource = readFileSync(
 	new URL("../../v2/ai-providers/model-binding-picker.tsx", import.meta.url),
 	"utf8",
 );
+const welcomeWalletSource = readFileSync(
+	new URL("../subscription/welcome-wallet-card.tsx", import.meta.url),
+	"utf8",
+);
 
 describe("deploy wizard personalization", () => {
 	test("uses a stable dashboard name within the strictest backend limit", () => {
@@ -154,6 +158,17 @@ describe("deploy provider choice", () => {
 		expect(wizardSource).toContain("{aiProviderEditorOpen ? (");
 		expect(wizardSource).toContain('title="Add a provider"');
 		expect(wizardSource).toContain('title={authCardLabel("unmanaged")}');
+	});
+
+	test("explains that the welcome balance is used before added Wallet funds", () => {
+		expect(welcomeWalletSource).toContain(
+			"welcome balance covers Managed AI first; after that, usage draws from your Wallet.",
+		);
+		expect(wizardSource).toContain(
+			"Your welcome balance covers it first; after that, usage draws from your Wallet.",
+		);
+		expect(welcomeWalletSource).not.toContain("managed AI is on us to start");
+		expect(wizardSource).not.toContain("Managed-AI usage paid directly from your Wallet");
 	});
 
 	test("uses an exclusive provider selection and hides the redundant provider picker", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -25,14 +25,24 @@ const modelBindingPickerSource = readFileSync(
 );
 
 describe("deploy wizard personalization", () => {
-	test("renders the required bounded agent name input", () => {
+	test("uses a stable dashboard name within the strictest backend limit", () => {
 		expect(wizardSource).toContain('htmlFor="agent-name"');
-		expect(wizardSource).toContain('<Label htmlFor="agent-name">');
+		expect(wizardSource).toContain('<Label htmlFor="agent-name">Name in Clawdi</Label>');
 		expect(wizardSource).toContain('id="agent-name"');
 		expect(wizardSource).toContain("maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}");
-		expect(DEPLOY_ASSISTANT_NAME_MAX_LENGTH).toBe(255);
+		expect(DEPLOY_ASSISTANT_NAME_MAX_LENGTH).toBe(64);
+		expect(wizardSource).toContain(
+			"trimmedAssistantName.length > DEPLOY_ASSISTANT_NAME_MAX_LENGTH",
+		);
+		expect(wizardSource).toContain("Used to identify this agent in Clawdi.");
+		expect(wizardSource).toContain("useState(DEFAULT_DEPLOY_ASSISTANT_NAME)");
+		expect(wizardSource).not.toContain("assistantNameEditedRef");
+		expect(wizardSource).not.toContain("deployAssistantNameAfterRuntimeChange");
 		expect(wizardSource).toContain("required");
 		expect(wizardSource).toContain("aria-invalid={nameError ? true : undefined}");
+		expect(wizardSource).toContain(
+			'aria-describedby={nameError ? "agent-name-error" : "agent-name-help"}',
+		);
 		expect(wizardSource).toContain('type="submit"');
 		expect(wizardSource).toContain("submitBlockingReason");
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -27,6 +27,7 @@ const welcomeWalletSource = readFileSync(
 	new URL("../subscription/welcome-wallet-card.tsx", import.meta.url),
 	"utf8",
 );
+const runtimesSource = readFileSync(new URL("../../runtimes.ts", import.meta.url), "utf8");
 
 describe("deploy wizard personalization", () => {
 	test("uses a stable dashboard name within the strictest backend limit", () => {
@@ -63,6 +64,19 @@ describe("deploy wizard product copy and flow", () => {
 		expect(wizardSource).not.toContain("per-deployment funding");
 		expect(wizardSource).not.toContain("server quote");
 		expect(wizardSource).not.toContain('title="Link after deploy"');
+	});
+
+	test("makes the recommended permanent agent software choice answerable", () => {
+		expect(wizardSource).toContain('<Badge variant="secondary">Recommended</Badge>');
+		expect(wizardSource).toContain("Agent software can’t be changed later");
+		expect(wizardSource).toContain(
+			"To switch after deployment, you must delete this agent and deploy a new one.",
+		);
+		expect(runtimesSource).toContain("Chat with and manage your agent in the Hermes Dashboard.");
+		expect(runtimesSource).toContain("already use OpenClaw and want its Control UI and workflows.");
+		expect(runtimesSource).not.toContain("Your own personal AI assistant.");
+		expect(runtimesSource).not.toContain("The agent that grows with you.");
+		expect(runtimesSource).not.toContain("DEFAULT_HOSTED_RUNTIME");
 	});
 
 	test("links unresolved post-payment recovery to the agents list", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -133,6 +133,38 @@ describe("managed model picker", () => {
 		expect(modelBindingPickerSource).toContain("Loading managed models…");
 		expect(modelBindingPickerSource).toContain('title="Couldn\'t load managed models"');
 	});
+
+	test("does not blame the user while the Managed AI catalog is loading or unavailable", () => {
+		expect(wizardSource).toContain('return "Loading Managed AI models."');
+		expect(wizardSource).toContain('return "Retry loading Managed AI models above."');
+		expect(wizardSource).toContain('return "Choose an available primary model."');
+		expect(wizardSource.indexOf('return "Loading Managed AI models."')).toBeLessThan(
+			wizardSource.indexOf('return "Choose an available primary model."'),
+		);
+	});
+});
+
+describe("deploy provider choice", () => {
+	test("keeps Managed AI compact by default and expands every alternative on demand", () => {
+		expect(wizardSource).toContain("useState(false)");
+		expect(wizardSource).toContain("title={aiProviderSummaryTitle}");
+		expect(wizardSource).toContain("primaryProviderLabel");
+		expect(wizardSource).toContain("Using ");
+		expect(wizardSource).toContain('{aiProviderEditorOpen ? "Done" : "Change"}');
+		expect(wizardSource).toContain("{aiProviderEditorOpen ? (");
+		expect(wizardSource).toContain('title="Add a provider"');
+		expect(wizardSource).toContain('title={authCardLabel("unmanaged")}');
+	});
+
+	test("uses an exclusive provider selection and hides the redundant provider picker", () => {
+		expect(wizardSource).toContain("selectProvider: selectAiProviderChoice");
+		expect(wizardSource).toContain("selectAiProviderChoice(MANAGED_AI_CHOICE)");
+		expect(wizardSource).toContain("selectAiProviderChoice(provider.provider_id)");
+		expect(wizardSource).toContain("showProviderSelect={false}");
+		expect(wizardSource).not.toContain("toggleAiProviderChoice");
+		expect(wizardSource).not.toContain("selectedProviderCount");
+		expect(wizardSource).not.toContain("aiProviderChoices.includes");
+	});
 });
 
 describe("billing-read gates", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -28,6 +28,14 @@ const welcomeWalletSource = readFileSync(
 	"utf8",
 );
 const runtimesSource = readFileSync(new URL("../../runtimes.ts", import.meta.url), "utf8");
+const addProviderDialogSource = readFileSync(
+	new URL("../../v2/ai-providers/add-provider-dialog.tsx", import.meta.url),
+	"utf8",
+);
+const aiProviderHooksSource = readFileSync(
+	new URL("../../v2/ai-providers/ai-providers-hooks.ts", import.meta.url),
+	"utf8",
+);
 
 describe("deploy wizard personalization", () => {
 	test("uses a stable dashboard name within the strictest backend limit", () => {
@@ -242,5 +250,15 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain('role="alert"');
 		expect(wizardSource).toContain("Your choices are unchanged; review them and try again.");
 		expect(wizardSource).not.toContain('submitting ? "Working…"');
+	});
+
+	test("keeps the reachable provider mutation busy state scoped and does not await refetch", () => {
+		expect(addProviderDialogSource).toContain("const runAction = useActionLock()");
+		expect(addProviderDialogSource).toContain("void runAction(submit)");
+		expect(addProviderDialogSource).toContain('<Spinner data-icon="inline-start" />');
+		expect(addProviderDialogSource).toContain('"Opening sign-in…"');
+		expect(addProviderDialogSource).toContain('"Adding provider…"');
+		expect(addProviderDialogSource).toContain('"Saving provider…"');
+		expect(aiProviderHooksSource).toContain("void qc.invalidateQueries({ queryKey: KEY })");
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -15,7 +15,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
-import { EntityChoiceCard } from "@/components/entity-card";
+import { EntityChoiceCard, EntityRow } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { IconChip } from "@/components/icon-chip";
 import { PageHeader } from "@/components/page-header";
@@ -145,8 +145,6 @@ import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-provide
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
 	MANAGED_AI_CHOICE,
-	MANAGED_PROVIDER_ID,
-	MANAGED_PROVIDER_LABEL,
 	modelDisplayName,
 	modelOptionsForProvider,
 	providerCatalogDescription,
@@ -179,6 +177,7 @@ const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
+const DEPLOY_MANAGED_AI_LABEL = "Managed AI";
 
 function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
 	return { href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace };
@@ -376,6 +375,7 @@ export function DeployWizard() {
 	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
+	const [aiProviderEditorOpen, setAiProviderEditorOpen] = useState(false);
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
@@ -490,10 +490,9 @@ export function DeployWizard() {
 		managedPrimaryModelReady,
 		selectedProviderChoices,
 		selectCreatedProvider: selectCreatedAiProvider,
+		selectProvider: selectAiProviderChoice,
 		setBindingMode: setAiAccessMode,
 		setPrimaryModel,
-		setPrimaryProvider,
-		toggleProvider: toggleAiProviderChoice,
 	} = useAiProviderBindingDraft({
 		initialDraft: {
 			bindingMode: DEFAULT_DEPLOY_AI_ACCESS_MODE,
@@ -511,12 +510,15 @@ export function DeployWizard() {
 		},
 		providers: providerList,
 	});
-	const {
-		bindingMode: aiAccessMode,
-		primaryModel,
-		primaryProviderChoice,
-		providerChoices: aiProviderChoices,
-	} = aiBindingDraft;
+	const { bindingMode: aiAccessMode, primaryModel, primaryProviderChoice } = aiBindingDraft;
+	const managedProviderSelected =
+		aiAccessMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE;
+	const managedModelsNeedRetry =
+		managedProviderSelected &&
+		managedModels.length === 0 &&
+		(Boolean(managedModelCatalog.error) || managedModelCatalog.isSuccess);
+	const managedModelsLoading =
+		managedProviderSelected && managedModels.length === 0 && !managedModelsNeedRetry;
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
 	const trimmedAssistantName = assistantName.trim();
@@ -536,7 +538,11 @@ export function DeployWizard() {
 				: "Checking your free Basic agent availability.";
 		}
 		if (!computePlanReady) return "Choose an available compute plan.";
-		if (!managedPrimaryModelReady) return "Choose an available primary model.";
+		if (!managedPrimaryModelReady) {
+			if (managedModelsNeedRetry) return "Retry loading Managed AI models above.";
+			if (managedModelsLoading) return "Loading Managed AI models.";
+			return "Choose an available primary model.";
+		}
 		if (paidSelection && paymentMethod === "wallet") {
 			if (!wallet.isSuccess || !wallet.data) {
 				return wallet.error
@@ -900,20 +906,18 @@ export function DeployWizard() {
 						: "Review wallet quote"
 			: "Continue to checkout"
 		: "Deploy agent";
-	const selectedProviderCount = aiAccessMode === "configured" ? selectedProviderChoices.length : 0;
 	const primaryProvider = providerList.find(
 		(provider) => provider.provider_id === primaryProviderChoice,
 	);
+	const primaryProviderLabel =
+		primaryProviderChoice === MANAGED_AI_CHOICE
+			? DEPLOY_MANAGED_AI_LABEL
+			: providerDisplayLabel(primaryProvider ?? primaryProviderChoice);
 	const aiSummary =
 		aiAccessMode === "unmanaged"
 			? authCardLabel("unmanaged")
 			: [
-					`${providerDisplayLabel(
-						primaryProvider ??
-							(primaryProviderChoice === MANAGED_AI_CHOICE
-								? MANAGED_PROVIDER_ID
-								: primaryProviderChoice),
-					)}${selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""}`,
+					primaryProviderLabel,
 					primaryModel
 						? modelDisplayName(
 								primaryModel,
@@ -923,6 +927,21 @@ export function DeployWizard() {
 				]
 					.filter(Boolean)
 					.join(" · ");
+	const aiProviderSummaryTitle =
+		aiAccessMode === "unmanaged" ? authCardLabel("unmanaged") : `Using ${primaryProviderLabel}`;
+	const aiProviderSummaryMeta =
+		aiAccessMode === "unmanaged"
+			? "Add model access inside the agent after it is ready."
+			: managedModelsLoading
+				? "Loading available models…"
+				: managedModelsNeedRetry
+					? "Models couldn’t be loaded."
+					: primaryModel
+						? modelDisplayName(
+								primaryModel,
+								modelOptionsForProvider(primaryProviderChoice, providerList, managedModels),
+							)
+						: "Choose a model.";
 	const runtimeSummary = runtimeDisplayName(runtime);
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Basic"} compute`,
@@ -1001,104 +1020,146 @@ export function DeployWizard() {
 
 				<SettingsSection
 					title="AI providers"
-					description="Choose how your agent accesses AI models and select its primary model."
+					description="Managed AI is selected by default. Change it only if you want to use your own provider."
 				>
-					<div className={TWO_TILE_GRID_CLASS}>
-						<EntityChoiceCard
-							selected={aiAccessMode === "unmanaged"}
-							onClick={() => setAiAccessMode("unmanaged")}
-							icon={
-								<IconChip tint="bg-muted text-muted-foreground">
-									<Settings2 />
-								</IconChip>
-							}
-							title={authCardLabel("unmanaged")}
-							description="Deploy first, then configure model access inside the agent."
-							badge={
-								<Badge variant={aiAccessMode === "unmanaged" ? "secondary" : "outline"}>
-									{aiAccessMode === "unmanaged" ? "Selected" : "Optional"}
-								</Badge>
-							}
-						/>
-						<EntityChoiceCard
-							selected={
-								aiAccessMode === "configured" && aiProviderChoices.includes(MANAGED_AI_CHOICE)
-							}
-							onClick={() => toggleAiProviderChoice(MANAGED_AI_CHOICE)}
-							icon={
+					<EntityRow
+						icon={
+							managedProviderSelected ? (
 								<IconChip tint="bg-primary/10 text-primary">
 									<Sparkles />
 								</IconChip>
-							}
-							title={MANAGED_PROVIDER_LABEL}
-							description="Managed-AI usage paid directly from your Wallet."
-							badge={
-								<Badge variant="secondary">
-									{aiAccessMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE
-										? "Default"
-										: "Managed"}
-								</Badge>
-							}
-						/>
-						{aiProviders.isLoading ? (
-							<Skeleton className="h-[74px] w-full rounded-lg" />
-						) : aiProviders.error ? (
-							<div className="sm:col-span-2">
-								<ApiErrorPanel
-									title="Couldn't load providers"
-									error={aiProviders.error}
-									onRetry={() => aiProviders.refetch()}
-									normalizer={aiProviderErrorNormalizer}
+							) : primaryProvider ? (
+								<ProviderTypeChip type={primaryProvider.type} />
+							) : (
+								<IconChip tint="bg-muted text-muted-foreground">
+									<Settings2 />
+								</IconChip>
+							)
+						}
+						title={aiProviderSummaryTitle}
+						meta={aiProviderSummaryMeta}
+						actions={
+							<>
+								{managedModelsNeedRetry ? (
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										disabled={managedModelCatalog.isFetching}
+										onClick={() => void managedModelCatalog.refetch()}
+									>
+										{managedModelCatalog.isFetching ? <Spinner data-icon="inline-start" /> : null}
+										{managedModelCatalog.isFetching ? "Retrying…" : "Retry"}
+									</Button>
+								) : null}
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									aria-expanded={aiProviderEditorOpen}
+									onClick={() => setAiProviderEditorOpen((open) => !open)}
+								>
+									{aiProviderEditorOpen ? "Done" : "Change"}
+								</Button>
+							</>
+						}
+					/>
+					{aiProviderEditorOpen ? (
+						<div className="mt-4 flex flex-col gap-4">
+							<div className={TWO_TILE_GRID_CLASS}>
+								<EntityChoiceCard
+									selected={aiAccessMode === "unmanaged"}
+									onClick={() => setAiAccessMode("unmanaged")}
+									icon={
+										<IconChip tint="bg-muted text-muted-foreground">
+											<Settings2 />
+										</IconChip>
+									}
+									title={authCardLabel("unmanaged")}
+									description="Deploy first, then configure model access inside the agent."
+									badge={
+										aiAccessMode === "unmanaged" ? (
+											<Badge variant="secondary">Selected</Badge>
+										) : null
+									}
+								/>
+								<EntityChoiceCard
+									selected={managedProviderSelected}
+									onClick={() => selectAiProviderChoice(MANAGED_AI_CHOICE)}
+									icon={
+										<IconChip tint="bg-primary/10 text-primary">
+											<Sparkles />
+										</IconChip>
+									}
+									title={DEPLOY_MANAGED_AI_LABEL}
+									description="Managed-AI usage paid directly from your Wallet."
+									badge={<Badge variant="secondary">Default</Badge>}
+								/>
+								{aiProviders.isLoading ? (
+									<Skeleton className="h-[74px] w-full rounded-lg" />
+								) : aiProviders.error ? (
+									<div className="sm:col-span-2">
+										<ApiErrorPanel
+											title="Couldn't load providers"
+											error={aiProviders.error}
+											onRetry={() => aiProviders.refetch()}
+											normalizer={aiProviderErrorNormalizer}
+										/>
+									</div>
+								) : null}
+								{providerList.map((provider) => (
+									<EntityChoiceCard
+										key={provider.provider_id}
+										selected={
+											aiAccessMode === "configured" &&
+											primaryProviderChoice === provider.provider_id
+										}
+										onClick={() => selectAiProviderChoice(provider.provider_id)}
+										icon={<ProviderTypeChip type={provider.type} />}
+										title={providerDisplayLabel(provider)}
+										description={providerCatalogDescription(provider)}
+										badge={
+											primaryProviderChoice === provider.provider_id ? (
+												<Badge variant="secondary">Selected</Badge>
+											) : (
+												<AuthBadge auth={provider.auth} />
+											)
+										}
+									/>
+								))}
+								<AddTile
+									title="Add a provider"
+									description="Connect OpenAI, Anthropic, or another endpoint."
+									onClick={() => setAddProviderOpen(true)}
 								/>
 							</div>
-						) : null}
-						{providerList.map((provider) => (
-							<EntityChoiceCard
-								key={provider.provider_id}
-								selected={
-									aiAccessMode === "configured" && aiProviderChoices.includes(provider.provider_id)
-								}
-								onClick={() => toggleAiProviderChoice(provider.provider_id)}
-								icon={<ProviderTypeChip type={provider.type} />}
-								title={providerDisplayLabel(provider)}
-								description={providerCatalogDescription(provider)}
-								badge={
-									primaryProviderChoice === provider.provider_id ? (
-										<Badge variant="secondary">Primary</Badge>
-									) : (
-										<AuthBadge auth={provider.auth} />
-									)
-								}
-							/>
-						))}
-						<AddTile
-							title="Add a provider"
-							description="Connect OpenAI, Anthropic, or another endpoint."
-							onClick={() => setAddProviderOpen(true)}
-						/>
-					</div>
-					{aiAccessMode === "unmanaged" ? (
-						<p className="mt-4 text-sm text-muted-foreground">
-							No AI provider will be selected for you. Add one inside the agent after it is ready.
-						</p>
-					) : (
-						<ModelBindingPicker
-							idPrefix="deploy"
-							className="mt-4"
-							providers={providerList}
-							managedModels={managedModels}
-							managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
-							managedModelsError={managedModelCatalog.error}
-							managedModelsErrorNormalizer={billingErrorNormalizer}
-							onManagedModelsRetry={() => void managedModelCatalog.refetch()}
-							customProviders={providerList}
-							selectedProviderChoices={selectedProviderChoices}
-							primaryProviderChoice={primaryProviderChoice}
-							primaryModel={primaryModel}
-							onPrimaryProviderChange={setPrimaryProvider}
-							onPrimaryModelChange={setPrimaryModel}
-						/>
-					)}
+							{aiAccessMode === "unmanaged" ? (
+								<p className="text-sm text-muted-foreground">
+									No AI provider will be selected for you. Add one inside the agent after it is
+									ready.
+								</p>
+							) : (
+								<ModelBindingPicker
+									idPrefix="deploy"
+									providers={providerList}
+									managedModels={managedModels}
+									managedModelsLoading={
+										managedModels.length === 0 && managedModelCatalog.isFetching
+									}
+									managedModelsError={managedModelCatalog.error}
+									managedModelsErrorNormalizer={billingErrorNormalizer}
+									onManagedModelsRetry={() => void managedModelCatalog.refetch()}
+									customProviders={providerList}
+									showProviderSelect={false}
+									selectedProviderChoices={selectedProviderChoices}
+									primaryProviderChoice={primaryProviderChoice}
+									primaryModel={primaryModel}
+									onPrimaryProviderChange={selectAiProviderChoice}
+									onPrimaryModelChange={setPrimaryModel}
+								/>
+							)}
+						</div>
+					) : null}
 				</SettingsSection>
 
 				<SettingsSection
@@ -1339,8 +1400,7 @@ export function DeployWizard() {
 									</p>
 								) : (
 									<p id="agent-name-help" className="text-xs text-muted-foreground">
-										Used to identify this agent in Clawdi. {DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
-										characters maximum.
+										{`Used to identify this agent in Clawdi. ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters maximum.`}
 									</p>
 								)}
 							</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1020,7 +1020,7 @@ export function DeployWizard() {
 
 				<SettingsSection
 					title="AI providers"
-					description="Managed AI is selected by default. Change it only if you want to use your own provider."
+					description="Managed AI is selected by default. Your welcome balance covers it first; after that, usage draws from your Wallet."
 				>
 					<EntityRow
 						icon={
@@ -1092,7 +1092,7 @@ export function DeployWizard() {
 										</IconChip>
 									}
 									title={DEPLOY_MANAGED_AI_LABEL}
-									description="Managed-AI usage paid directly from your Wallet."
+									description="Your welcome balance covers usage first; after that, it draws from your Wallet."
 									badge={<Badge variant="secondary">Default</Badge>}
 								/>
 								{aiProviders.isLoading ? (

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1005,6 +1005,7 @@ export function DeployWizard() {
 							}
 							title={runtimeDisplayName("hermes")}
 							description={runtimeBlurb("hermes")}
+							badge={<Badge variant="secondary">Recommended</Badge>}
 						/>
 						<EntityChoiceCard
 							selected={runtime === "openclaw"}
@@ -1016,6 +1017,13 @@ export function DeployWizard() {
 							description={runtimeBlurb("openclaw")}
 						/>
 					</div>
+					<Alert className="mt-4 max-w-2xl">
+						<TriangleAlert />
+						<AlertTitle>Agent software can’t be changed later</AlertTitle>
+						<AlertDescription>
+							To switch after deployment, you must delete this agent and deploy a new one.
+						</AlertDescription>
+					</Alert>
 				</SettingsSection>
 
 				<SettingsSection

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -60,10 +60,10 @@ import type {
 import {
 	DEFAULT_DEPLOY_AI_ACCESS_MODE,
 	DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
+	DEFAULT_DEPLOY_ASSISTANT_NAME,
 	DEFAULT_DEPLOY_PRIMARY_MODEL,
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
-	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
 	resolveBasicDeploySelection,
@@ -371,12 +371,8 @@ export function DeployWizard() {
 	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const includedCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
-	const assistantNameEditedRef = useRef(false);
-
 	const [runtime, setRuntime] = useState(DEFAULT_DEPLOY_RUNTIME);
-	const [assistantName, setAssistantName] = useState(() =>
-		runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME),
-	);
+	const [assistantName, setAssistantName] = useState(DEFAULT_DEPLOY_ASSISTANT_NAME);
 	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
@@ -523,7 +519,13 @@ export function DeployWizard() {
 	} = aiBindingDraft;
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
-	const nameError = assistantName.trim().length === 0 ? "Enter a name for your agent." : null;
+	const trimmedAssistantName = assistantName.trim();
+	const nameError =
+		trimmedAssistantName.length === 0
+			? "Enter a name for this agent."
+			: trimmedAssistantName.length > DEPLOY_ASSISTANT_NAME_MAX_LENGTH
+				? `Use ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters or fewer.`
+				: null;
 	const submitBlockingReason = (() => {
 		if (submitting) return null;
 		if (nameError) return nameError;
@@ -556,13 +558,6 @@ export function DeployWizard() {
 
 	function selectRuntime(nextRuntime: HostedRuntime) {
 		setRuntime(nextRuntime);
-		setAssistantName((currentName) =>
-			deployAssistantNameAfterRuntimeChange({
-				currentName,
-				hasBeenEdited: assistantNameEditedRef.current,
-				runtime: nextRuntime,
-			}),
-		);
 	}
 
 	useEffect(() => {
@@ -1323,29 +1318,31 @@ export function DeployWizard() {
 				<div className="sm:pb-24">
 					<SettingsSection
 						title="Personalize"
-						description="Name your agent and optionally choose its language and timezone."
+						description="Choose how this agent appears in Clawdi, plus its language and timezone."
 					>
 						<div className="grid max-w-2xl gap-4 sm:grid-cols-2">
 							<div className="flex flex-col gap-1.5 sm:col-span-2">
-								<Label htmlFor="agent-name">Name</Label>
+								<Label htmlFor="agent-name">Name in Clawdi</Label>
 								<Input
 									id="agent-name"
 									value={assistantName}
 									maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
 									required
 									aria-invalid={nameError ? true : undefined}
-									aria-describedby={nameError ? "agent-name-error" : undefined}
-									onChange={(event) => {
-										assistantNameEditedRef.current = true;
-										setAssistantName(event.target.value);
-									}}
+									aria-describedby={nameError ? "agent-name-error" : "agent-name-help"}
+									onChange={(event) => setAssistantName(event.target.value)}
 									onBlur={() => setAssistantName((name) => name.trim())}
 								/>
 								{nameError ? (
 									<p id="agent-name-error" className="text-xs text-destructive" role="alert">
 										{nameError}
 									</p>
-								) : null}
+								) : (
+									<p id="agent-name-help" className="text-xs text-muted-foreground">
+										Used to identify this agent in Clawdi. {DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
+										characters maximum.
+									</p>
+								)}
 							</div>
 							<div className="flex flex-col gap-1.5">
 								<label htmlFor="agent-language" className="text-sm text-muted-foreground">

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -86,6 +86,7 @@ import {
 	billingErrorNormalizer,
 	DeploymentRequestTerminalError,
 	isIdempotencyKeyReusedError,
+	isNetworkError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import {
@@ -155,14 +156,13 @@ import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picke
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
-import { formatShortDate } from "@/lib/format";
-import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { cn } from "@/lib/utils";
 
 type Compute = "basic" | "performance";
 type DeployPaymentMethod = "card" | "wallet";
 type NativeDeployCheckout = {
 	clientSecret: string;
+	fallbackUrl: string | null;
 	previousDeploymentIds: string[];
 	request: SubscriptionCreateRequestView;
 	summary: StripeCheckoutSummary;
@@ -174,9 +174,6 @@ type PaidDeploySelection = {
 	offer: BillingOffer;
 	plan: Plan;
 	tierLabel: "Basic" | "Performance";
-};
-type SubscriptionReuseNotice = {
-	validUntil: string | null;
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
@@ -362,7 +359,6 @@ export function DeployWizard() {
 		onCancelCopy: "You were not charged. Your agent was not deployed.",
 		onNavigate: navigateCheckoutReturn,
 	});
-	const hostedAccess = useHostedProductAccess();
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
@@ -386,10 +382,18 @@ export function DeployWizard() {
 	const [timezone, setTimezone] = useState("");
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
-	const [subscriptionReuseNotice, setSubscriptionReuseNotice] =
-		useState<SubscriptionReuseNotice | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
+	const [submitTakingLong, setSubmitTakingLong] = useState(false);
+	const [submitError, setSubmitError] = useState<{
+		blocksRetry?: boolean;
+		description: string;
+		title: string;
+	} | null>(null);
+	const [submitBusyLabel, setSubmitBusyLabel] = useState("Creating agent…");
+	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState(
+		"Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+	);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
 	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
 
@@ -399,6 +403,11 @@ export function DeployWizard() {
 		setTimezone((tz) => tz || browserTimezone());
 		setLanguage((lang) => lang || browserLanguage());
 	}, []);
+	useEffect(() => {
+		if (!submitting) return;
+		const timeout = window.setTimeout(() => setSubmitTakingLong(true), 5_000);
+		return () => window.clearTimeout(timeout);
+	}, [submitting]);
 	const tzOptions = useMemo(() => {
 		const all = supportedTimezones();
 		if (timezone && !all.includes(timezone)) return [timezone, ...all];
@@ -467,9 +476,13 @@ export function DeployWizard() {
 		enabled: paymentMethod === "wallet",
 	});
 	const subscriptionCreateQuote = useSubscriptionCreateQuote(subscriptionCreateSelection, {
-		enabled: paymentMethod === "wallet",
+		enabled: paymentMethod === "wallet" && !submitting,
 	});
-	const walletDebit = subscriptionCreateQuote.data?.walletDebit ?? null;
+	const lastSuccessfulSubscriptionQuote = subscriptionCreateQuote.data ?? null;
+	const visibleSubscriptionQuoteError =
+		submitting || lastSuccessfulSubscriptionQuote ? null : subscriptionCreateQuote.error;
+	const visibleSubscriptionQuoteFetching = !submitting && subscriptionCreateQuote.isFetching;
+	const walletDebit = lastSuccessfulSubscriptionQuote?.walletDebit ?? null;
 	const walletShortfallUsd = walletDebitShortfallUsd(walletDebit);
 	const walletInsufficient = walletShortfallUsd !== null;
 	const basicUnavailable = basicSelection.mode === "unavailable";
@@ -528,15 +541,14 @@ export function DeployWizard() {
 					? "Retry loading your Wallet balance above."
 					: "Loading your Wallet balance.";
 			}
-			if (subscriptionCreateQuote.error) return "Retry the Wallet quote above.";
-			if (subscriptionCreateQuote.isFetching) return "Refreshing your Wallet quote.";
+			if (visibleSubscriptionQuoteError) return "Retry the Wallet quote above.";
+			if (visibleSubscriptionQuoteFetching) return "Refreshing your Wallet quote.";
 			if (!walletDebit) return "Waiting for your Wallet quote.";
 			if (walletInsufficient) return "Top up your Wallet to continue.";
 		}
 		return null;
 	})();
-	const canSubmit =
-		!submitting && subscriptionReuseNotice === null && submitBlockingReason === null;
+	const canSubmit = !submitting && !submitError?.blocksRetry && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
@@ -612,135 +624,116 @@ export function DeployWizard() {
 		return false;
 	}
 
-	async function recheckCanCreateCloudAgents(): Promise<boolean> {
-		const available = await hostedAccess.recheckCanCreateCloudAgents();
-		if (!available) {
-			setCheckoutSession(null);
-			walletTopUp.reset();
-		}
-		return available;
-	}
-
-	function showSubscriptionReuseNotice({
-		currentPeriodEnd,
-		entitledUntil,
-	}: {
-		currentPeriodEnd: string | null;
-		entitledUntil: string | null;
-	}) {
+	function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
 		setCheckoutSession(null);
-		setSubscriptionReuseNotice({
-			validUntil: currentPeriodEnd ?? entitledUntil,
-		});
 		toast.success("Agent deployment started", {
-			description: "Your active subscription was reused without another charge.",
+			description:
+				"Your active subscription was reused without another charge. Your agent is getting ready now.",
 		});
+		void router.navigate(acceptedDeploymentNavigation(deploymentId));
 	}
-	async function fallbackToHostedCheckout(request: SubscriptionCreateRequestView) {
-		if (!(await recheckCanCreateCloudAgents())) return;
-		const fingerprint = idempotencyFingerprint({
-			selection: request.selection,
-			target: request.target,
-			uiMode: "hosted",
-			quote: request.quote,
-		});
-		checkoutAttemptRef.current = idempotencyAttemptFor(
-			checkoutAttemptRef.current,
-			"subscription-checkout-hosted-fallback",
-			fingerprint,
-			newIdempotencyKey,
-		);
-		const outcome = await createSubscription
-			.execute({
-				...request,
-				uiMode: "hosted",
-				idempotencyKey: checkoutAttemptRef.current.key,
-			})
-			.catch((error: unknown) => {
-				if (isIdempotencyKeyReusedError(error)) {
-					forgetIdempotencyAttempt("subscription-checkout-hosted-fallback", fingerprint);
-					checkoutAttemptRef.current = null;
-				}
-				throw error;
-			});
-		if (outcome.flowType === "subscription_activation") {
-			forgetIdempotencyAttempt("subscription-checkout-hosted-fallback", fingerprint);
-			checkoutAttemptRef.current = null;
-			showSubscriptionReuseNotice(outcome);
-			return;
-		}
-		if (redirectTo(checkoutRedirectUrl(outcome.checkout))) return;
-		throw new Error("No checkout URL was returned.");
-	}
-
 	async function handleCheckoutComplete(
 		previousDeploymentIds: readonly string[],
 		tierLabel: "Basic" | "Performance",
 		request: SubscriptionCreateRequestView | null,
 	) {
 		setCheckoutSession(null);
+		setSubmitError(null);
+		setSubmitTakingLong(false);
+		setSubmitBusyLabel("Creating agent…");
+		setSubmitTakingLongCopy(
+			"Payment was confirmed and agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+		);
+		setSubmitting(true);
 		let requestFingerprint: string | null = null;
-		if (request) {
-			requestFingerprint = idempotencyFingerprint({
-				selection: request.selection,
-				target: request.target,
-			});
-			try {
-				const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
-				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
-				checkoutAttemptRef.current = null;
-				toast.success("Agent deployment started", {
-					description: `Your ${tierLabel} agent is provisioning now.`,
+		try {
+			if (request) {
+				requestFingerprint = idempotencyFingerprint({
+					selection: request.selection,
+					target: request.target,
 				});
-				void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
-				return;
-			} catch (error) {
-				if (error instanceof DeploymentRequestTerminalError) {
+				try {
+					const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
 					forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 					checkoutAttemptRef.current = null;
-					toast.error("Couldn’t deploy", { description: normalizeBillingError(error) });
+					toast.success("Agent deployment started", {
+						description: `Your ${tierLabel} agent is getting ready now.`,
+					});
+					void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
 					return;
+				} catch (error) {
+					if (error instanceof DeploymentRequestTerminalError) {
+						forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
+						checkoutAttemptRef.current = null;
+						const normalized = normalizeBillingError(error);
+						setSubmitError({
+							blocksRetry: true,
+							title: "Payment succeeded, but the agent could not be started",
+							description: `${normalized} Don’t submit another payment; check Agents for the latest state.`,
+						});
+						toast.error("Couldn’t create agent", { description: normalized });
+						return;
+					}
+					// Stripe may complete before its deployment request is visible. Fall back
+					// to one inventory refresh after the bounded request-status watch ends.
 				}
-				// Stripe may complete before its deploy request is visible. Fall back
-				// to the inventory refresh path and let normal polling pick it up.
 			}
-		}
-		let refreshedDeployments: Awaited<ReturnType<typeof refreshCheckoutReturn>>;
-		try {
-			refreshedDeployments = await refreshCheckoutReturn();
-		} catch {
-			toast.success("Checkout complete", {
-				description: `Your ${tierLabel} deployment is provisioning. We’ll refresh it on the next load.`,
-			});
-			return;
-		}
-		const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
-		if (deploymentId) {
+			let refreshedDeployments: Awaited<ReturnType<typeof refreshCheckoutReturn>>;
+			try {
+				refreshedDeployments = await refreshCheckoutReturn();
+			} catch {
+				setSubmitError({
+					blocksRetry: true,
+					title: "Payment succeeded; agent status is unavailable",
+					description:
+						"We couldn’t refresh your agent list. Don’t submit another payment; open Agents and check again in a moment.",
+				});
+				return;
+			}
+			const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
+			if (!deploymentId) {
+				setSubmitError({
+					blocksRetry: true,
+					title: "Payment succeeded; your agent is not visible yet",
+					description:
+						"Don’t submit another payment. Open Agents and check again in a moment while the accepted request appears.",
+				});
+				return;
+			}
 			if (requestFingerprint) {
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
 			}
-			toast.success("Checkout complete", {
-				description: `Your ${tierLabel} deployment is provisioning now.`,
+			toast.success("Agent deployment started", {
+				description: `Your ${tierLabel} agent is getting ready now.`,
 			});
 			void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
-			return;
+		} finally {
+			setSubmitting(false);
+			setSubmitTakingLong(false);
 		}
-		toast.success("Checkout complete", {
-			description: `Your ${tierLabel} deployment is provisioning. Check your agents list in a moment.`,
-			action: {
-				label: "View agents",
-				onClick: () => void router.navigate({ href: "/agents" }),
-			},
-		});
 	}
 
 	async function onDeploy() {
 		if (!canSubmit) return;
-		setSubscriptionReuseNotice(null);
+		setSubmitError(null);
+		setSubmitTakingLong(false);
+		setSubmitBusyLabel(
+			paidSelection
+				? paymentMethod === "wallet"
+					? "Confirming payment & creating agent…"
+					: "Opening secure checkout…"
+				: "Creating agent…",
+		);
+		setSubmitTakingLongCopy(
+			paidSelection
+				? paymentMethod === "wallet"
+					? "Payment and agent creation are still being confirmed. Keep this page open; we’ll take you to your agent as soon as both are confirmed."
+					: "Secure checkout is still opening. No payment has been submitted yet; keep this page open to continue."
+				: "Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+		);
 		setSubmitting(true);
 		try {
-			if (!(await recheckCanCreateCloudAgents())) return;
 			const aiFields = aiDeployFields();
 			if (!aiFields) return;
 			if (paidSelection) {
@@ -773,7 +766,7 @@ export function DeployWizard() {
 							target,
 							uiMode: CHECKOUT_ELEMENTS_UI_MODE,
 							idempotencyKey: attempt.key,
-							quote: subscriptionCreateQuote.data ?? null,
+							quote: lastSuccessfulSubscriptionQuote,
 						})
 						.catch((error: unknown) => {
 							if (isIdempotencyKeyReusedError(error)) {
@@ -783,12 +776,14 @@ export function DeployWizard() {
 							throw error;
 						});
 					if (outcome.flowType !== "subscription_activation") {
-						throw new Error("Wallet subscription returned a checkout flow.");
+						throw new Error(
+							"Wallet payment could not be confirmed. Review the payment method and try again.",
+						);
 					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
 					toast.success("Agent deployment started", {
-						description: `Your ${paidSelection.tierLabel} agent is provisioning now. ${walletDebit ? formatUsdExact(walletDebit.debitAmountUsd) : formatCents(paidSelection.offer.price_cents)} was paid from Wallet.`,
+						description: `Your ${paidSelection.tierLabel} agent is getting ready now. ${walletDebit ? formatUsdExact(walletDebit.debitAmountUsd) : formatCents(paidSelection.offer.price_cents)} was paid from Wallet.`,
 					});
 					void router.navigate(acceptedDeploymentNavigation(outcome.deploymentId));
 					return;
@@ -806,7 +801,7 @@ export function DeployWizard() {
 						target,
 						uiMode: CHECKOUT_ELEMENTS_UI_MODE,
 						idempotencyKey: checkoutAttemptRef.current.key,
-						quote: subscriptionCreateQuote.data ?? null,
+						quote: lastSuccessfulSubscriptionQuote,
 					})
 					.catch((error: unknown) => {
 						if (isIdempotencyKeyReusedError(error)) {
@@ -818,13 +813,14 @@ export function DeployWizard() {
 				if (outcome.flowType === "subscription_activation") {
 					forgetIdempotencyAttempt("subscription-checkout", checkoutFingerprint);
 					checkoutAttemptRef.current = null;
-					showSubscriptionReuseNotice(outcome);
+					navigateToReusedSubscription(outcome);
 					return;
 				}
 				const result = outcome.checkout;
 				if (hasCheckoutClientSecret(result)) {
 					setCheckoutSession({
 						clientSecret: result.client_secret,
+						fallbackUrl: checkoutRedirectUrl(result),
 						previousDeploymentIds: (deployments.data ?? []).map(
 							(deployment) => deployment.resource.id,
 						),
@@ -833,7 +829,7 @@ export function DeployWizard() {
 							target,
 							uiMode: CHECKOUT_ELEMENTS_UI_MODE,
 							idempotencyKey: checkoutAttemptRef.current.key,
-							quote: subscriptionCreateQuote.data ?? null,
+							quote: lastSuccessfulSubscriptionQuote,
 						},
 						summary: computeCheckoutSummary({
 							offer: paidSelection.offer,
@@ -846,10 +842,9 @@ export function DeployWizard() {
 					return;
 				}
 				if (redirectTo(checkoutRedirectUrl(result))) return;
-				toast.error("Couldn't start checkout", {
-					description: "No checkout URL was returned. Please try again.",
-				});
-				return;
+				throw new Error(
+					"Secure checkout could not be opened. Review the payment method and try again.",
+				);
 			}
 			const deployConfig = buildDeployRequest(aiFields, COMPUTE_BASIC_SLUG);
 			const fingerprint = idempotencyFingerprint(deployConfig);
@@ -872,33 +867,44 @@ export function DeployWizard() {
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
 			toast.success("Agent deployment started", {
-				description: "Your first Basic agent is provisioning now for free.",
+				description: "Your first Basic agent is getting ready now for free.",
 			});
 			void router.navigate(acceptedDeploymentNavigation(created.deploymentId));
 		} catch (e) {
+			const normalized = normalizeBillingError(e);
+			setSubmitError(
+				isNetworkError(e)
+					? {
+							title: "We couldn’t confirm this attempt",
+							description: `${normalized} Your choices are unchanged; retry to safely check the same payment attempt.`,
+						}
+					: {
+							title: "Your agent wasn’t created",
+							description: `${normalized} Your choices are unchanged; review them and try again.`,
+						},
+			);
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();
 				if (walletTopUp.handleFundingError(e)) return;
 			}
-			toast.error("Couldn’t deploy", { description: normalizeBillingError(e) });
+			toast.error("Couldn’t deploy", { description: normalized });
 		} finally {
 			setSubmitting(false);
+			setSubmitTakingLong(false);
 		}
 	}
 
-	const deployLabel = subscriptionReuseNotice
-		? "Deployment started"
-		: paidSelection
-			? paymentMethod === "wallet"
-				? subscriptionCreateQuote.isFetching
-					? "Getting wallet quote…"
-					: walletInsufficient
-						? "Top up to deploy"
-						: walletDebit
-							? `Pay ${formatUsdExact(walletDebit.debitAmountUsd)} from Wallet & deploy`
-							: "Review wallet quote"
-				: "Continue to checkout"
-			: "Deploy agent";
+	const deployLabel = paidSelection
+		? paymentMethod === "wallet"
+			? visibleSubscriptionQuoteFetching
+				? "Getting wallet quote…"
+				: walletInsufficient
+					? "Top up to deploy"
+					: walletDebit
+						? `Pay ${formatUsdExact(walletDebit.debitAmountUsd)} from Wallet & deploy`
+						: "Review wallet quote"
+			: "Continue to checkout"
+		: "Deploy agent";
 	const selectedProviderCount = aiAccessMode === "configured" ? selectedProviderChoices.length : 0;
 	const primaryProvider = providerList.find(
 		(provider) => provider.provider_id === primaryProviderChoice,
@@ -972,23 +978,6 @@ export function DeployWizard() {
 					title="Deploy an Agent"
 					description="Choose how your agent runs and which AI model it will use."
 				/>
-				{subscriptionReuseNotice ? (
-					<Alert
-						data-testid="subscription-reuse-banner"
-						aria-live="polite"
-						className="border-emerald-500/35 bg-emerald-500/5"
-					>
-						<Sparkles />
-						<AlertTitle>Active subscription reused</AlertTitle>
-						<AlertDescription>
-							{subscriptionReuseNotice.validUntil
-								? `Reusing your active subscription — valid until ${formatShortDate(
-										subscriptionReuseNotice.validUntil,
-									)}, no additional charge.`
-								: "Reusing your active subscription — no additional charge."}
-						</AlertDescription>
-					</Alert>
-				) : null}
 				<SettingsSection
 					title="Agent software"
 					description="Choose the software that will power your agent."
@@ -1268,14 +1257,14 @@ export function DeployWizard() {
 												onRetry={() => void wallet.refetch()}
 												title="Couldn't load your Wallet balance"
 											/>
-										) : subscriptionCreateQuote.isFetching && !subscriptionCreateQuote.data ? (
+										) : visibleSubscriptionQuoteFetching && !lastSuccessfulSubscriptionQuote ? (
 											<p className="text-sm text-muted-foreground" role="status">
 												Getting the exact wallet debit…
 											</p>
-										) : subscriptionCreateQuote.error ? (
+										) : visibleSubscriptionQuoteError ? (
 											<ApiErrorPanel
 												normalizer={billingErrorNormalizer}
-												error={subscriptionCreateQuote.error}
+												error={visibleSubscriptionQuoteError}
 												onRetry={() => void subscriptionCreateQuote.refetch()}
 												title="Couldn’t get subscription quote"
 											/>
@@ -1420,9 +1409,28 @@ export function DeployWizard() {
 								) : (
 									<Rocket data-icon="inline-start" />
 								)}
-								{submitting ? "Working…" : deployLabel}
+								{submitting ? submitBusyLabel : deployLabel}
 							</Button>
-							{submitBlockingReason ? (
+							{submitError ? (
+								<div className="max-w-sm text-xs text-destructive sm:text-right" role="alert">
+									<p className="font-medium">{submitError.title}</p>
+									<p>{submitError.description}</p>
+									{submitError.blocksRetry ? (
+										<Button
+											type="button"
+											variant="link"
+											className="h-auto px-0 text-destructive"
+											onClick={() => void router.navigate({ href: "/agents" })}
+										>
+											View agents
+										</Button>
+									) : null}
+								</div>
+							) : submitTakingLong ? (
+								<p className="max-w-sm text-xs text-muted-foreground sm:text-right" role="status">
+									{submitTakingLongCopy}
+								</p>
+							) : submitBlockingReason ? (
 								<p
 									id="deploy-blocking-reason"
 									className={cn(
@@ -1448,7 +1456,9 @@ export function DeployWizard() {
 			{wallet.data ? (
 				<TopUpDialog
 					{...walletTopUp.dialogProps}
-					onComplete={() => void subscriptionCreateQuote.refetch()}
+					onComplete={() => {
+						if (!submitting) void subscriptionCreateQuote.refetch();
+					}}
 				/>
 			) : null}
 			<StripeCheckoutDialog
@@ -1460,7 +1470,6 @@ export function DeployWizard() {
 				title={`Complete ${checkoutSession?.tierLabel ?? "compute"} checkout`}
 				description="Enter payment details without leaving this page. Redirect-based payment methods return here after confirmation."
 				summary={checkoutSession?.summary ?? null}
-				onBeforeConfirm={recheckCanCreateCloudAgents}
 				onComplete={() =>
 					void handleCheckoutComplete(
 						checkoutSession?.previousDeploymentIds ?? [],
@@ -1469,9 +1478,9 @@ export function DeployWizard() {
 					)
 				}
 				onFallback={() =>
-					checkoutSession
-						? fallbackToHostedCheckout(checkoutSession.request)
-						: Promise.reject(new Error("Missing checkout request."))
+					redirectTo(checkoutSession?.fallbackUrl)
+						? Promise.resolve()
+						: Promise.reject(new Error("Secure checkout fallback is unavailable."))
 				}
 			/>
 		</div>

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -158,7 +158,7 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 						</p>
 						<p className="text-sm text-muted-foreground">
 							{grantApplied
-								? "Your free Basic compute slot is ready. Deploy your first agent — managed AI is on us to start."
+								? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Managed AI first; after that, usage draws from your Wallet.`
 								: grantPending
 									? grantCheckTimedOut
 										? "It hasn’t appeared yet. Refresh to check again."

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -2,16 +2,15 @@ import type { AiProviderAuthKind, HostedDeployment } from "@/hosted/billing/cont
 
 export const HOSTED_RUNTIMES = ["openclaw", "hermes"] as const;
 export type HostedRuntime = (typeof HOSTED_RUNTIMES)[number];
-export const DEFAULT_HOSTED_RUNTIME: HostedRuntime = "openclaw";
 
 const RUNTIME_META = {
 	openclaw: {
 		label: "OpenClaw",
-		blurb: "Your own personal AI assistant.",
+		blurb: "Choose this if you already use OpenClaw and want its Control UI and workflows.",
 	},
 	hermes: {
 		label: "Hermes",
-		blurb: "The agent that grows with you.",
+		blurb: "Recommended for most people. Chat with and manage your agent in the Hermes Dashboard.",
 	},
 } as const satisfies Record<HostedRuntime, { label: string; blurb: string }>;
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	type AuthMethod,
 	apiKeyEditState,
@@ -135,6 +136,7 @@ export function AddProviderDialog({
 	const setKey = useSetApiKey();
 	const oauthStart = useOAuthStart();
 	const oauthComplete = useOAuthComplete();
+	const runAction = useActionLock();
 
 	const isEdit = Boolean(editing);
 	const [type, setType] = useState<ProviderTypeId>("openai");
@@ -735,10 +737,16 @@ export function AddProviderDialog({
 										/>
 										<Button
 											size="sm"
-											onClick={submitPastedCallback}
+											onClick={() => void runAction(submitPastedCallback)}
 											disabled={!oauthCode.trim() || oauthComplete.isPending}
 										>
-											{oauthComplete.isPending ? "Finishing…" : "Finish sign-in"}
+											{oauthComplete.isPending ? (
+												<>
+													<Spinner data-icon="inline-start" /> Finishing sign-in…
+												</>
+											) : (
+												"Finish sign-in"
+											)}
 										</Button>
 										<p>
 											If it never returns, an admin may need to register this app’s callback URL in
@@ -1034,14 +1042,23 @@ export function AddProviderDialog({
 							<Button variant="outline" onClick={() => requestClose(false)}>
 								Cancel
 							</Button>
-							<Button onClick={submit} disabled={!canSubmit || busy}>
-								{busy
-									? "Saving…"
-									: authMethod === "oauth"
-										? "Continue to sign-in"
-										: isEdit
-											? "Save changes"
-											: "Add provider"}
+							<Button onClick={() => void runAction(submit)} disabled={!canSubmit || busy}>
+								{busy ? (
+									<>
+										<Spinner data-icon="inline-start" />
+										{authMethod === "oauth"
+											? "Opening sign-in…"
+											: isEdit
+												? "Saving provider…"
+												: "Adding provider…"}
+									</>
+								) : authMethod === "oauth" ? (
+									"Continue to sign-in"
+								) : isEdit ? (
+									"Save changes"
+								) : (
+									"Add provider"
+								)}
 							</Button>
 						</DialogFooter>
 					</>

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -10,6 +10,7 @@ import { MANAGED_AI_CHOICE, MANAGED_PROVIDER_ID } from "@/hosted/v2/ai-providers
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import {
 	changeAiBindingPrimaryProvider,
+	selectAiBindingProvider,
 	toggleAiBindingProvider,
 } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 
@@ -133,6 +134,34 @@ describe("AI provider binding fields", () => {
 });
 
 describe("AI provider binding draft transitions", () => {
+	test("selects exactly one provider for the deploy flow", () => {
+		const selected = selectAiBindingProvider(
+			{
+				bindingMode: "configured",
+				providerChoices: [MANAGED_AI_CHOICE, oauthProvider.provider_id],
+				primaryProviderChoice: MANAGED_AI_CHOICE,
+				primaryModel: "gpt-managed",
+			},
+			apiKeyProvider.provider_id,
+			{
+				managedModels,
+				operationMode: "create",
+				providers: [apiKeyProvider, oauthProvider],
+			},
+		);
+
+		expect(selected.providerChoices).toEqual([apiKeyProvider.provider_id]);
+		expect(selected.primaryProviderChoice).toBe(apiKeyProvider.provider_id);
+		expect(selected.primaryModel).toBe("gpt-custom");
+		expect(
+			buildAiBindingFields(selected, {
+				managedModels,
+				mode: "create",
+				providers: [apiKeyProvider, oauthProvider],
+			}).provider_ids,
+		).toEqual([apiKeyProvider.provider_id]);
+	});
+
 	test("preserves the create and update model-fallback difference", () => {
 		const draft = {
 			bindingMode: "configured" as const,

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -41,7 +41,9 @@ export function useCreateProvider() {
 	return useMutation({
 		mutationFn: async (body: AiProviderUpsert) =>
 			unwrap(await api.POST("/v1/ai-providers", { body, params: { query: { replace: false } } })),
-		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+		onSuccess: () => {
+			void qc.invalidateQueries({ queryKey: KEY });
+		},
 		onError: toastApiError("Couldn't add provider"),
 	});
 }

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -35,6 +35,7 @@ export function ModelBindingPicker({
 	onManagedModelsRetry,
 	customProviders,
 	additionalProviderItems = [],
+	showProviderSelect = true,
 	selectedProviderChoices,
 	primaryProviderChoice,
 	primaryModel,
@@ -51,6 +52,7 @@ export function ModelBindingPicker({
 	onManagedModelsRetry: () => void;
 	customProviders: readonly AiProvider[];
 	additionalProviderItems?: readonly ModelBindingPickerItem[];
+	showProviderSelect?: boolean;
 	selectedProviderChoices: readonly string[];
 	primaryProviderChoice: string;
 	primaryModel: string;
@@ -81,30 +83,32 @@ export function ModelBindingPicker({
 			data-v2="true"
 			className={cn("flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3", className)}
 		>
-			<div className="grid gap-3 sm:grid-cols-2">
-				<div className="flex flex-col gap-1.5">
-					<Label htmlFor={providerInputId}>Primary provider</Label>
-					<Select
-						items={primaryProviderItems}
-						value={primaryProviderChoice}
-						onValueChange={(value) => {
-							if (value) onPrimaryProviderChange(value);
-						}}
-					>
-						<SelectTrigger id={providerInputId} className="w-full">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectGroup>
-								{primaryProviderItems.map((item) => (
-									<SelectItem key={item.value} value={item.value}>
-										{item.label}
-									</SelectItem>
-								))}
-							</SelectGroup>
-						</SelectContent>
-					</Select>
-				</div>
+			<div className={cn("grid gap-3", showProviderSelect && "sm:grid-cols-2")}>
+				{showProviderSelect ? (
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor={providerInputId}>Primary provider</Label>
+						<Select
+							items={primaryProviderItems}
+							value={primaryProviderChoice}
+							onValueChange={(value) => {
+								if (value) onPrimaryProviderChange(value);
+							}}
+						>
+							<SelectTrigger id={providerInputId} className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectGroup>
+									{primaryProviderItems.map((item) => (
+										<SelectItem key={item.value} value={item.value}>
+											{item.label}
+										</SelectItem>
+									))}
+								</SelectGroup>
+							</SelectContent>
+						</Select>
+					</div>
+				) : null}
 				{isManaged && managedModelsLoading ? (
 					<div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
 						<Spinner className="size-3.5" /> Loading managed models…

--- a/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
@@ -86,6 +86,14 @@ export function toggleAiBindingProvider(
 		: changeAiBindingPrimaryProvider(next, choices[0] ?? MANAGED_AI_CHOICE, context);
 }
 
+export function selectAiBindingProvider(
+	draft: AiProviderBindingDraft,
+	choice: string,
+	context: DraftContext,
+): AiProviderBindingDraft {
+	return changeAiBindingPrimaryProvider({ ...draft, providerChoices: [choice] }, choice, context);
+}
+
 export function useAiProviderBindingDraft({
 	initialDraft,
 	managedCatalogReady,
@@ -184,6 +192,8 @@ export function useAiProviderBindingDraft({
 			setDraft((current) => ({ ...current, primaryModel })),
 		setPrimaryProvider: (choice: string) =>
 			setDraft((current) => changeAiBindingPrimaryProvider(current, choice, context)),
+		selectProvider: (choice: string) =>
+			setDraft((current) => selectAiBindingProvider(current, choice, context)),
 		toggleProvider: (choice: string) =>
 			setDraft((current) => toggleAiBindingProvider(current, choice, context)),
 		selectCreatedProvider: (id: string, dataUpdatedAt: number) => {


### PR DESCRIPTION
## Summary

- give agent startup a sourced five-minute expectation and replace repeated infrastructure status with one product-facing update
- make Deploy use a scoped honest busy state, pause quote reads during checkout, submit the last successful quote, and navigate immediately after the accepted deployment id is confirmed
- keep failures on the intact wizard with actionable recovery and never optimistically navigate past payment
- collapse the default Managed AI choice, distinguish catalog loading/empty/error, and make deploy-time provider selection exclusive
- explain that the welcome balance covers Managed AI first and later usage draws from the Wallet, without inventing a rate
- make Hermes the clearly recommended new-deploy choice, explain both native UIs, and warn that agent software requires delete-and-redeploy to change
- use a neutral stable deployment name, enforce the backend-safe 64-character limit before submit, and stop runtime changes from rewriting it
- give the reachable provider mutation a scoped spinner/label, synchronous double-submit guard, and non-blocking list refresh

## Verification

- `bun run typecheck`: 4/4 tasks successful
- `bun run lint`: 694 files checked, 0 errors
- `bun test`: 1681 passed, 0 failed, 6703 assertions across 175 files
- hosted Chromium deploy core path: 5 passed in 30.5s

## Paired backend follow-ups

- narrow `assistant_name` from 80 to 64 in `backend/app/v2/hosted/schemas.py` and `deployment_contracts.py`; `public_operations.py` is already 64
- an atomic provider+credential/OAuth-start accept endpoint is needed to reduce Add provider from its current required multi-call contract to one accept
