### PR TITLE
fix: gate v2 AI providers on usable credentials

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -124,6 +124,14 @@ describe("managed model picker", () => {
 	});
 });
 
+describe("AI provider usability gate", () => {
+	test("builds every deploy-provider choice from the usable subset", () => {
+		expect(wizardSource).toContain("usableProviders(aiProviders.data ?? [])");
+		expect(wizardSource).toContain("{providerList.map((provider) => (");
+		expect(wizardSource).not.toContain("{aiProviders.data?.map((provider) => (");
+	});
+});
+
 describe("billing-read gates", () => {
 	test("keeps deploy disabled until inventory succeeds and offers retries", () => {
 		expect(wizardSource).toContain("deployments.isSuccess &&");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -150,6 +150,7 @@ import {
 	modelOptionsForProvider,
 	providerCatalogDescription,
 	providerDisplayLabel,
+	usableProviders,
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
@@ -474,7 +475,7 @@ export function DeployWizard() {
 	const walletInsufficient = walletShortfallUsd !== null;
 	const basicUnavailable = basicSelection.mode === "unavailable";
 
-	const providerList = aiProviders.data ?? [];
+	const providerList = usableProviders(aiProviders.data ?? []);
 	const managedModels = managedModelCatalog.data?.models ?? [];
 	const {
 		draft: aiBindingDraft,

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -82,6 +82,16 @@ describe("providerAuthForSubmit", () => {
 			}),
 		).toEqual({ type: "api_key", source: "managed" });
 	});
+
+	test("requires a key when a managed-key placeholder has no stored credential", () => {
+		expect(apiKeyEditState("api_key", { type: "api_key", source: "managed" }, false)).toMatchObject(
+			{
+				canKeepManagedApiKey: false,
+				canKeepExistingKey: false,
+				keyRequired: true,
+			},
+		);
+	});
 });
 
 describe("provider edit integrity", () => {
@@ -117,6 +127,7 @@ describe("provider edit integrity", () => {
 			base_url: "https://old.example/v1",
 			api_mode: "openai_chat",
 			auth: { type: "api_key", source: "env", ref: "env:OPENAI_API_KEY" },
+			usable: true,
 			managed_by: "user",
 			runtime_env_name: "OPENAI_API_KEY",
 			models: [{ id: "gpt-old" }],

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -59,8 +59,9 @@ export function authFor(method: AuthMethod): AiProviderUpsertAuth {
 export function apiKeyEditState(
 	authMethod: AuthMethod,
 	editingAuth: AiProviderAuth | null | undefined,
+	credentialUsable = true,
 ): ApiKeyEditState {
-	const keepable = keepableExistingApiKeyAuth(editingAuth);
+	const keepable = credentialUsable ? keepableExistingApiKeyAuth(editingAuth) : null;
 	const keepKind = authMethod === "api_key" ? keepable?.kind : undefined;
 	const canKeepExistingKey = keepKind !== undefined;
 	return {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -301,7 +301,7 @@ export function AddProviderDialog({
 	// `none` auth only works with a loopback/private base_url (backend rule).
 	const noneAuthOk = authMethod !== "none" || isLoopbackOrPrivateUrl(baseUrl.trim());
 	const apiKeyState = isEdit
-		? apiKeyEditState(authMethod, editing?.auth)
+		? apiKeyEditState(authMethod, editing?.auth, editing?.usable)
 		: apiKeyEditState(authMethod, null);
 	const { keyRequired, labelSuffix: apiKeyLabelSuffix, helpText: apiKeyHelpText } = apiKeyState;
 	const providerListReady = providerListAllowsSubmit(isEdit, providers.isSuccess);
@@ -515,18 +515,7 @@ export function AddProviderDialog({
 		popupRef.current = null;
 	}
 
-	/**
-	 * Remove the placeholder provider we created if sign-in is left unfinished.
-	 *
-	 * This covers closing the DIALOG only. If the user closes the browser tab
-	 * mid-OAuth this never runs, and we deliberately don't reconcile the orphan on
-	 * next mount: AiProviderResponse exposes no verified/status field, and a
-	 * never-completed placeholder is byte-for-byte identical to a connected Codex
-	 * provider (both `auth: {agent_profile, codex, default}`). Any client-side
-	 * "looks incomplete" heuristic would risk deleting a legitimately connected
-	 * provider, so honest reconciliation needs backend completion state the
-	 * dashboard doesn't have.
-	 */
+	/** Remove the placeholder created by this dialog when its sign-in is abandoned. */
 	function abandonCodexIfIncomplete() {
 		if (!oauth) return;
 		if (!completedRef.current && createdFreshRef.current) {
@@ -757,9 +746,17 @@ export function AddProviderDialog({
 				) : (
 					<>
 						<DialogHeader className="shrink-0 px-6 pt-6">
-							<DialogTitle>{isEdit ? "Edit provider" : "Add a provider"}</DialogTitle>
+							<DialogTitle>
+								{editing?.usable === false
+									? "Finish provider setup"
+									: isEdit
+										? "Edit provider"
+										: "Add a provider"}
+							</DialogTitle>
 							<DialogDescription>
-								Route inference through your own account by API key, sign-in, or a custom endpoint.
+								{editing?.usable === false
+									? "Add the missing credential so agents can use this provider."
+									: "Route inference through your own account by API key, sign-in, or a custom endpoint."}
 							</DialogDescription>
 						</DialogHeader>
 
@@ -940,7 +937,9 @@ export function AddProviderDialog({
 										) : null}
 										{keyRequired && isEdit && !apiKey.trim() ? (
 											<p className="text-xs text-destructive">
-												Enter a key to switch this provider to managed API-key auth.
+												{editing?.usable === false
+													? "Enter a key to finish provider setup."
+													: "Enter a key to switch this provider to managed API-key auth."}
 											</p>
 										) : null}
 									</div>

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -25,6 +25,7 @@ const apiKeyProvider: AiProvider = {
 	models: [{ id: "gpt-custom" }],
 	api_mode: "openai_responses",
 	auth: { type: "api_key", source: "managed" },
+	usable: true,
 	managed_by: "user",
 	runtime_env_name: "OPENAI_API_KEY",
 	capabilities: null,
@@ -129,6 +130,24 @@ describe("AI provider binding fields", () => {
 				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
 			).toEqual([oauthProvider.provider_id, apiKeyProvider.provider_id]);
 		}
+	});
+
+	test("rejects an unusable provider even if stale UI state selects it", () => {
+		const unfinishedProvider = { ...oauthProvider, usable: false };
+		const draft = {
+			bindingMode: "configured" as const,
+			providerChoices: [unfinishedProvider.provider_id],
+			primaryProviderChoice: unfinishedProvider.provider_id,
+			primaryModel: "gpt-custom",
+		};
+
+		expect(() =>
+			buildAiBindingFields(draft, {
+				managedModels,
+				mode: "create",
+				providers: [unfinishedProvider],
+			}),
+		).toThrow("has no usable credential");
 	});
 });
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -101,6 +101,16 @@ export function buildAiBindingFields(
 				};
 	}
 
+	const unusableProvider = draft.providerChoices
+		.map((choice) => providers.find((provider) => provider.provider_id === choice))
+		.find((provider) => provider?.usable === false);
+	if (unusableProvider) {
+		throw new AiBindingBuildError(
+			"Provider needs setup",
+			`${unusableProvider.label?.trim() || unusableProvider.provider_id} has no usable credential. Finish its setup or choose another provider.`,
+		);
+	}
+
 	const selectedChoices = normalizeSelectedProviderIds(
 		draft.providerChoices,
 		draft.primaryProviderChoice,

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ListChecks, Pencil, Plus, Trash2 } from "lucide-react";
+import { CircleAlert, ListChecks, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -43,7 +43,11 @@ import {
 	providerRemovalImpact,
 	providerUsage,
 } from "@/hosted/v2/ai-providers/ai-providers-page.logic";
-import { AuthBadge, ManagedProviderCard } from "@/hosted/v2/ai-providers/ai-providers-ui";
+import {
+	AuthBadge,
+	ManagedProviderCard,
+	ProviderUsabilityBadge,
+} from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { modelDisplayName, providerDisplayLabel } from "@/hosted/v2/ai-providers/model-binding";
 import {
 	API_MODE_LABEL,
@@ -165,7 +169,12 @@ function ProviderCard({
 				align="start"
 				icon={<EntityIcon kind="provider" id={provider.type} label={providerLabel} />}
 				title={providerLabel}
-				titleAdornment={<AuthBadge auth={provider.auth} />}
+				titleAdornment={
+					<span className="inline-flex items-center gap-1.5">
+						<AuthBadge auth={provider.auth} />
+						<ProviderUsabilityBadge usable={provider.usable} />
+					</span>
+				}
 				meta={[
 					`${meta.label} · ${modelSummary}${
 						provider.api_mode
@@ -176,6 +185,9 @@ function ProviderCard({
 						{provider.base_url}
 						{provider.runtime_env_name ? ` · ${provider.runtime_env_name}` : ""}
 					</span>,
+					provider.usable
+						? null
+						: "Credential setup is incomplete. Finish setup before using this provider.",
 				]}
 			/>
 			<div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
@@ -189,9 +201,14 @@ function ProviderCard({
 					<ListChecks />
 					Check fields
 				</Button>
-				<Button variant="outline" size="sm" onClick={onEdit} aria-label={`Edit ${providerLabel}`}>
-					<Pencil />
-					Edit
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={onEdit}
+					aria-label={`${provider.usable ? "Edit" : "Finish setup for"} ${providerLabel}`}
+				>
+					{provider.usable ? <Pencil /> : <CircleAlert />}
+					{provider.usable ? "Edit" : "Finish setup"}
 				</Button>
 				<RemoveProviderAction provider={provider} usage={usage} />
 			</div>

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ProviderUsabilityBadge } from "@/hosted/v2/ai-providers/ai-providers-ui";
 
@@ -10,7 +11,7 @@ const providerPageSource = readFileSync(
 
 describe("ProviderUsabilityBadge", () => {
 	test("badges an unfinished provider as needing setup, never connected", () => {
-		const markup = renderToStaticMarkup(<ProviderUsabilityBadge usable={false} />);
+		const markup = renderToStaticMarkup(createElement(ProviderUsabilityBadge, { usable: false }));
 
 		expect(markup).toContain("Needs setup");
 		expect(markup).not.toContain("Connected");
@@ -24,7 +25,7 @@ describe("ProviderUsabilityBadge", () => {
 	});
 
 	test("badges a credential-backed provider as connected", () => {
-		const markup = renderToStaticMarkup(<ProviderUsabilityBadge usable />);
+		const markup = renderToStaticMarkup(createElement(ProviderUsabilityBadge, { usable: true }));
 
 		expect(markup).toContain("Connected");
 		expect(markup).toContain('data-status="success"');

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ProviderUsabilityBadge } from "@/hosted/v2/ai-providers/ai-providers-ui";
+
+const providerPageSource = readFileSync(
+	new URL("./ai-providers-page.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("ProviderUsabilityBadge", () => {
+	test("badges an unfinished provider as needing setup, never connected", () => {
+		const markup = renderToStaticMarkup(<ProviderUsabilityBadge usable={false} />);
+
+		expect(markup).toContain("Needs setup");
+		expect(markup).not.toContain("Connected");
+		expect(markup).toContain('data-status="warning"');
+	});
+
+	test("uses the backend state for the list badge and recovery action", () => {
+		expect(providerPageSource).toContain("<ProviderUsabilityBadge usable={provider.usable} />");
+		expect(providerPageSource).toContain('provider.usable ? "Edit" : "Finish setup"');
+		expect(providerPageSource).toContain("<RemoveProviderAction provider={provider}");
+	});
+
+	test("badges a credential-backed provider as connected", () => {
+		const markup = renderToStaticMarkup(<ProviderUsabilityBadge usable />);
+
+		expect(markup).toContain("Connected");
+		expect(markup).toContain('data-status="success"');
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -50,6 +50,14 @@ export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
 	);
 }
 
+export function ProviderUsabilityBadge({ usable }: { usable: boolean }) {
+	return (
+		<StatusBadge status={usable ? "success" : "warning"} withDot>
+			{usable ? "Connected" : "Needs setup"}
+		</StatusBadge>
+	);
+}
+
 /** The always-on managed default, no setup. */
 export function ManagedProviderCard() {
 	return (

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -7,8 +7,10 @@ import {
 	modelBindingDisplayName,
 	modelDisplayName,
 	modelOptionsForProvider,
+	primaryProviderPickerItems,
 	providerChoiceFromRef,
 	providerDisplayLabel,
+	usableProviders,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
@@ -60,6 +62,7 @@ describe("model binding", () => {
 				models: [{ id: "gpt-5.5", label: "GPT Latest" }, { id: "gpt-5.4" }],
 				api_mode: "openai_responses",
 				auth: { type: "api_key", source: "managed" },
+				usable: true,
 				managed_by: "user",
 				runtime_env_name: "OPENAI_API_KEY",
 				capabilities: null,
@@ -75,6 +78,28 @@ describe("model binding", () => {
 		expect(providerDisplayLabel(providers[0])).toBe("OpenAI");
 		expect(providerDisplayLabel("openai-main", providers)).toBe("OpenAI");
 		expect(providerDisplayLabel({ ...providers[0], label: null })).toBe("OpenAI");
+	});
+
+	test("does not offer an unfinished provider as a deploy selection", () => {
+		const unfinishedProvider = {
+			id: "row-codex",
+			provider_id: "openai-codex",
+			scope: "account_global",
+			type: "openai",
+			base_url: "https://api.openai.com/v1",
+			models: [{ id: "gpt-5.5" }],
+			api_mode: "openai_responses",
+			auth: { type: "agent_profile", tool: "codex", profile: "default" },
+			usable: false,
+			managed_by: "user",
+			created_at: "2026-01-01T00:00:00Z",
+			updated_at: "2026-01-01T00:00:00Z",
+			label: "Codex",
+		} satisfies AiProvider;
+		const selectable = usableProviders([unfinishedProvider]);
+
+		expect(selectable).toEqual([]);
+		expect(primaryProviderPickerItems([unfinishedProvider.provider_id], selectable)).toEqual([]);
 	});
 
 	test("maps deployment-scoped managed provider ids to the friendly managed choice", () => {

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -70,6 +70,10 @@ export function isManagedProviderId(providerId: string | null | undefined): bool
 	return typeof providerId === "string" && isClawdiManagedProviderId(providerId);
 }
 
+export function usableProviders(providers: readonly AiProvider[]): AiProvider[] {
+	return providers.filter((provider) => provider.usable);
+}
+
 export function providerDisplayLabel(
 	provider: AiProvider | string,
 	providers: readonly AiProvider[] = [],

--- a/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
@@ -17,6 +17,7 @@ const provider: AiProvider = {
 	models: [{ id: "gpt-5.1" }],
 	api_mode: "openai_responses",
 	auth: { type: "agent_profile", tool: "codex", profile: "default" },
+	usable: true,
 	managed_by: "user",
 	runtime_env_name: null,
 	capabilities: { chat: true, responses: true, ignored: "yes" },

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -111,11 +111,12 @@ async def list_ai_providers(
         .scalars()
         .all()
     )
+    visible_rows = [
+        row for row in rows if not is_v2_deployment_managed_provider_id(row.provider_id)
+    ]
+    responses = await _to_responses(db, auth, visible_rows)
     providers_by_public_id: dict[str, AiProviderResponse] = {}
-    for row in rows:
-        if is_v2_deployment_managed_provider_id(row.provider_id):
-            continue
-        response = _to_response(row)
+    for response in responses:
         providers_by_public_id.setdefault(response.provider_id, response)
     return AiProviderListResponse(providers=list(providers_by_public_id.values()))
 
@@ -145,7 +146,7 @@ async def upsert_ai_provider(
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
     await db.refresh(provider)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 @router.get("/{provider_id}", response_model=AiProviderResponse, response_model_exclude_none=True)
@@ -155,7 +156,7 @@ async def get_ai_provider(
     db: AsyncSession = Depends(get_session),
 ) -> AiProviderResponse:
     provider = await _get_provider_or_404(db, auth, provider_id)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 @router.patch("/{provider_id}", response_model=AiProviderResponse, response_model_exclude_none=True)
@@ -167,7 +168,7 @@ async def patch_ai_provider(
 ) -> AiProviderResponse:
     provider = await _get_provider_or_404(db, auth, provider_id)
     previous_signature = _runtime_manifest_provider_signature(provider)
-    merged = _to_response(provider)
+    merged = await _to_response(db, auth, provider)
     update = {field: getattr(body, field) for field in body.model_fields_set}
     null_errors = _validate_patch_nulls(update)
     if null_errors:
@@ -182,7 +183,7 @@ async def patch_ai_provider(
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
     await db.refresh(provider)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 @router.delete("/{provider_id}", response_model=AiProviderDeleteResponse)
@@ -224,7 +225,7 @@ async def validate_ai_provider(
     db: AsyncSession = Depends(get_session),
 ) -> AiProviderValidationResponse:
     provider = await _get_provider_or_404(db, auth, provider_id)
-    body = _to_response(provider)
+    body = await _to_response(db, auth, provider)
     errors = _validate_provider(body)
     return AiProviderValidationResponse(valid=not errors, errors=errors, warnings=[])
 
@@ -263,7 +264,7 @@ async def set_ai_provider_api_key(
     await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
     await db.refresh(provider)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 @router.post(
@@ -309,7 +310,7 @@ async def import_ai_provider_auth(
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
     await db.refresh(provider)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 @router.post(
@@ -460,7 +461,7 @@ async def complete_ai_provider_oauth(
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
     await db.refresh(provider)
-    return _to_response(provider)
+    return await _to_response(db, auth, provider)
 
 
 async def _oauth_payload_from_token_response(
@@ -867,7 +868,62 @@ def _to_auth(provider: AiProvider) -> AiProviderAuth:
         ) from exc
 
 
-def _to_response(provider: AiProvider) -> AiProviderResponse:
+async def _to_response(
+    db: AsyncSession,
+    auth: AuthContext,
+    provider: AiProvider,
+) -> AiProviderResponse:
+    return (await _to_responses(db, auth, [provider]))[0]
+
+
+async def _to_responses(
+    db: AsyncSession,
+    auth: AuthContext,
+    providers: list[AiProvider],
+) -> list[AiProviderResponse]:
+    payload_provider_ids = {
+        provider.provider_id for provider in providers if _active_auth_profile(provider) is not None
+    }
+    payload_keys: set[tuple[str, str, str]] = set()
+    if payload_provider_ids:
+        rows = (
+            await db.execute(
+                select(
+                    AiProviderAuthPayload.provider_id,
+                    AiProviderAuthPayload.auth_profile,
+                    AiProviderAuthPayload.kind,
+                ).where(
+                    AiProviderAuthPayload.owner_user_id == auth.user_id,
+                    AiProviderAuthPayload.provider_id.in_(payload_provider_ids),
+                    AiProviderAuthPayload.archived_at.is_(None),
+                )
+            )
+        ).all()
+        payload_keys = {(row.provider_id, row.auth_profile, row.kind) for row in rows}
+    return [
+        _build_response(provider, usable=_provider_is_usable(provider, payload_keys))
+        for provider in providers
+    ]
+
+
+def _provider_is_usable(
+    provider: AiProvider,
+    payload_keys: set[tuple[str, str, str]],
+) -> bool:
+    active_profile = _active_auth_profile(provider)
+    if active_profile is not None:
+        return (provider.provider_id, active_profile, provider.auth_type) in payload_keys
+    if provider.auth_type == "none":
+        return True
+    if provider.auth_type == "secret_ref":
+        return bool(provider.auth_ref)
+    if provider.auth_type == "api_key":
+        source = (provider.auth_metadata or {}).get("source")
+        return source in {"env", "vault"} and bool(provider.auth_ref)
+    return False
+
+
+def _build_response(provider: AiProvider, *, usable: bool) -> AiProviderResponse:
     return AiProviderResponse(
         id=str(provider.id),
         provider_id=runtime_managed_provider_id(provider.provider_id),
@@ -877,6 +933,7 @@ def _to_response(provider: AiProvider) -> AiProviderResponse:
         base_url=provider.base_url,
         api_mode=provider.api_mode,
         auth=_to_auth(provider),
+        usable=usable,
         managed_by=provider.managed_by,
         runtime_env_name=provider.runtime_env_name,
         capabilities=provider.capabilities,

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -336,6 +336,12 @@ class AiProviderResponse(AiProviderBase):
     provider_id: str
     scope: str
     auth: AiProviderAuth
+    usable: bool = Field(
+        description=(
+            "Whether the provider has the credential material required for runtime use. "
+            "This does not validate the credential or test endpoint connectivity."
+        )
+    )
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -268,6 +268,68 @@ async def test_ai_provider_crud_is_account_scoped_metadata(client: httpx.AsyncCl
 
 
 @pytest.mark.asyncio
+async def test_ai_provider_usability_requires_the_active_stored_credential(
+    client: httpx.AsyncClient,
+):
+    codex_placeholder = await client.post(
+        "/v1/ai-providers",
+        json={
+            "provider_id": "openai-codex",
+            "type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "auth": {"type": "agent_profile", "tool": "codex", "profile": "default"},
+        },
+    )
+    api_key_placeholder = await client.post(
+        "/v1/ai-providers",
+        json={
+            "provider_id": "openai-main",
+            "type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "auth": {"type": "api_key", "source": "managed", "profile": "default"},
+        },
+    )
+
+    assert codex_placeholder.status_code == 200, codex_placeholder.text
+    assert api_key_placeholder.status_code == 200, api_key_placeholder.text
+    assert codex_placeholder.json()["usable"] is False
+    assert api_key_placeholder.json()["usable"] is False
+
+    initial_listing = await client.get("/v1/ai-providers")
+    assert initial_listing.status_code == 200, initial_listing.text
+    assert {
+        provider["provider_id"]: provider["usable"]
+        for provider in initial_listing.json()["providers"]
+    } == {"openai-codex": False, "openai-main": False}
+
+    imported = await client.post(
+        "/v1/ai-providers/openai-codex/auth/import",
+        json={
+            "type": "agent_profile",
+            "tool": "codex",
+            "profile": "default",
+            "payload": '{"tokens":{"access_token":"oauth-access-token"}}',
+        },
+    )
+    key_stored = await client.post(
+        "/v1/ai-providers/openai-main/auth/api-key",
+        json={"value": "sk-managed-secret"},
+    )
+
+    assert imported.status_code == 200, imported.text
+    assert key_stored.status_code == 200, key_stored.text
+    assert imported.json()["usable"] is True
+    assert key_stored.json()["usable"] is True
+
+    completed_listing = await client.get("/v1/ai-providers")
+    assert completed_listing.status_code == 200, completed_listing.text
+    assert {
+        provider["provider_id"]: provider["usable"]
+        for provider in completed_listing.json()["providers"]
+    } == {"openai-codex": True, "openai-main": True}
+
+
+@pytest.mark.asyncio
 async def test_canonical_and_legacy_managed_ids_resolve_while_deployment_id_is_hidden(
     client: httpx.AsyncClient,
     db_session,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3106,6 +3106,11 @@ export interface components {
             scope: string;
             auth: components["schemas"]["AiProviderAuth"];
             /**
+             * Usable
+             * @description Whether the provider has the credential material required for runtime use. This does not validate the credential or test endpoint connectivity.
+             */
+            usable: boolean;
+            /**
              * Created At
              * Format: date-time
              */


### PR DESCRIPTION
## Summary

- add the required AiProviderResponse.usable field and derive it from the active, unarchived stored auth payload for managed API keys and OAuth/agent profiles
- show unfinished providers as Needs setup with finish and remove actions in the v2 provider list
- exclude unusable providers from v2 deploy choices and reject stale unusable selections while building a deployment request
- regenerate the shared OpenAPI TypeScript client

The field reports credential-material readiness only. It does not validate a credential with the upstream provider or test endpoint connectivity. No v1 UI behavior changes.

## Verification

- bun run typecheck: 4/4 tasks successful
- bun run lint: 695 files checked
- bun test: 1679 passed, 0 failed
- scripts/test.sh backend: 1350 passed, 7 skipped, 0 failed
- backend generated API check: passed
- backend Ruff and compileall checks: passed

## Follow-up recommendation

Server-side reaping is appropriate for expired, unusable, unreferenced OAuth setup placeholders, but this PR does not add a scheduler. A future cleanup should persist an explicit setup-attempt expiry (or equivalent marker) so it can distinguish an expired OAuth attempt from a provider the user intentionally plans to finish later.