### PR TITLE
fix(web): complete the v2 channel linking journey

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2100,7 +2100,10 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 	// undefined↔string flip) while staying falsy for the gated Link button.
 	const [accountId, setAccountId] = useState("");
 	const [token, setToken] = useState<string | null>(null);
+	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
 	const linkInFlightRef = useRef(false);
+	const unlinkingLinkIdsRef = useRef<Set<string>>(new Set());
+	const [unlinkingLinkIds, setUnlinkingLinkIds] = useState<ReadonlySet<string>>(() => new Set());
 
 	const linkedIds = useMemo(
 		() => new Set((linked.data ?? []).map((l) => l.account_id)),
@@ -2161,13 +2164,35 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 	async function submitLink() {
 		if (!accountId || linkInFlightRef.current) return;
 		linkInFlightRef.current = true;
+		setLinkingAccountId(accountId);
 		try {
 			await link.execute(accountId);
 		} catch {
 			// The action already surfaces the API error.
 		} finally {
 			linkInFlightRef.current = false;
+			setLinkingAccountId(null);
 		}
+	}
+
+	function startUnlink(accountIdToUnlink: string, linkId: string) {
+		if (unlinkingLinkIdsRef.current.has(linkId)) return;
+		unlinkingLinkIdsRef.current.add(linkId);
+		setUnlinkingLinkIds((prev) => new Set(prev).add(linkId));
+		void (async () => {
+			try {
+				await unlink.mutateAsync({ accountId: accountIdToUnlink, linkId });
+			} catch {
+				// useUnlinkAgentChannel already surfaces the API error.
+			} finally {
+				unlinkingLinkIdsRef.current.delete(linkId);
+				setUnlinkingLinkIds((prev) => {
+					const next = new Set(prev);
+					next.delete(linkId);
+					return next;
+				});
+			}
+		})();
 	}
 
 	if (!hasEnvironmentId) {
@@ -2207,8 +2232,8 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 							key={l.id}
 							link={l}
 							fallbackAccount={accountSummaries.get(l.account_id)}
-							unlinking={unlink.isPending}
-							onUnlink={() => unlink.mutate({ accountId: l.account_id, linkId: l.id })}
+							unlinking={unlinkingLinkIds.has(l.id)}
+							onUnlink={() => startUnlink(l.account_id, l.id)}
 						/>
 					))
 				)}
@@ -2241,10 +2266,12 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 					</Select>
 					<Button
 						onClick={() => void submitLink()}
-						disabled={!accountId || link.isPending || channels.isLoading || botPool.isLoading}
+						disabled={
+							!accountId || linkingAccountId !== null || channels.isLoading || botPool.isLoading
+						}
 					>
-						{link.isPending ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-						Link
+						{linkingAccountId ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+						{linkingAccountId ? "Linking…" : "Link"}
 					</Button>
 				</div>
 				{channels.error || botPool.error ? (
@@ -2290,6 +2317,8 @@ function LinkedChannelRow({
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<{ code: string; expires_at: string } | null>(null);
+	const [creatingPairCode, setCreatingPairCode] = useState(false);
+	const pairInFlightRef = useRef(false);
 	// The list-by-agent payload may omit the nested `account`. Fall back to the
 	// loaded channels/bot-pool summary, then to the raw account id, so a missing
 	// account NEVER white-screens (apps/web/src has no ErrorBoundary).
@@ -2297,11 +2326,17 @@ function LinkedChannelRow({
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
 	async function createPairCode() {
+		if (pairInFlightRef.current) return;
+		pairInFlightRef.current = true;
+		setCreatingPairCode(true);
 		try {
 			const data = await pair.execute({ agent_link_id: link.id });
 			setCode({ code: data.code, expires_at: data.expires_at });
 		} catch {
 			// useCreatePairCode already surfaces the API error.
+		} finally {
+			pairInFlightRef.current = false;
+			setCreatingPairCode(false);
 		}
 	}
 	return (
@@ -2318,11 +2353,11 @@ function LinkedChannelRow({
 				<Button
 					variant="outline"
 					size="sm"
-					disabled={pair.isPending}
+					disabled={creatingPairCode}
 					onClick={() => void createPairCode()}
 				>
-					<QrCode className="size-3.5" />
-					Pair code
+					{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
+					{creatingPairCode ? "Creating code…" : "Pair code"}
 				</Button>
 				<ConfirmAction
 					title="Unlink this channel?"
@@ -2338,7 +2373,7 @@ function LinkedChannelRow({
 						disabled={unlinking}
 						aria-label="Unlink channel"
 					>
-						<Link2Off className="size-4" />
+						{unlinking ? <Spinner className="size-4" /> : <Link2Off className="size-4" />}
 					</Button>
 				</ConfirmAction>
 			</div>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -5,6 +5,8 @@ import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-quer
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
+	Bot,
+	CircleCheck,
 	Cpu,
 	ExternalLink,
 	Info,
@@ -177,15 +179,23 @@ import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picke
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
-import { ChannelStatusBadge, ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
+import {
+	ChannelStatusBadge,
+	HealthBadge,
+	ProviderChip,
+	TokenReveal,
+} from "@/hosted/v2/channels/channel-ui";
 import {
 	useAgentChannelLinks,
 	useBotPool,
+	useChannelHealth,
 	useChannels,
 	useCreatePairCode,
 	useUnlinkAgentChannel,
 } from "@/hosted/v2/channels/channels-hooks";
+import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import {
+	channelActivityAfterLink,
 	channelProviderLinkingReady,
 	pairingCommand,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -552,7 +562,7 @@ export function HostedAgentDetail({
 					/>
 				)}
 				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
-				{deploymentProjectionQueryable ? (
+				{deploymentProjectionQueryable && activeTab !== "channels" ? (
 					<HostedProjectionNotice
 						projection={projection}
 						isFetching={agentQuery.isFetching}
@@ -625,9 +635,15 @@ export function HostedAgentDetail({
 						!deploymentProjectionQueryable ? (
 							<StoppedAgentState deployment={deployment} />
 						) : projection.status === "resolved" ? (
-							<ChannelsTab environmentId={environmentId} enabled={deploymentProjectionQueryable} />
+							<ChannelsTab environmentId={environmentId} />
 						) : (
-							<ProjectionDependentUnavailable label="Channels" />
+							<ChannelsSyncState
+								isChecking={isCheckingDeployment || agentQuery.isFetching}
+								onCheckAgain={() => {
+									onCheckDeploymentAgain();
+									if (cloudEnvironmentId) void agentQuery.refetch();
+								}}
+							/>
 						)
 					) : null}
 					{activeTab === "settings" ? (
@@ -2088,45 +2104,115 @@ function AiProviderTab({
 
 // ── Channels ─────────────────────────────────────────────────────────────────
 
-function ChannelsTab({ environmentId, enabled }: { environmentId: string; enabled: boolean }) {
+function ChannelsSyncState({
+	isChecking,
+	onCheckAgain,
+}: {
+	isChecking: boolean;
+	onCheckAgain: () => void;
+}) {
+	return (
+		<EmptyState
+			icon={isChecking ? <Spinner className="size-5" /> : Link2}
+			title="Getting channels ready"
+			description="Your agent is finishing setup. This usually takes a few minutes, and this page checks automatically."
+			action={
+				<div className="flex flex-wrap justify-center gap-2">
+					<Button
+						type="button"
+						size="sm"
+						variant="outline"
+						disabled={isChecking}
+						onClick={onCheckAgain}
+					>
+						{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
+						{isChecking ? "Checking…" : "Check now"}
+					</Button>
+					<Button render={<Link to="/channels" />} nativeButton={false} size="sm" variant="outline">
+						Choose a channel while you wait
+					</Button>
+				</div>
+			}
+		/>
+	);
+}
+
+type LinkableChannel = { id: string; provider: string; name: string };
+
+function channelSelectItems(channels: LinkableChannel[]) {
+	return channels.map((channel) => ({
+		value: channel.id,
+		label: `${providerMeta(channel.provider).label} · ${channel.name}`,
+	}));
+}
+
+function ChannelsTab({ environmentId }: { environmentId: string }) {
 	const api = useApi();
 	const qc = useQueryClient();
 	const channels = useChannels();
 	const botPool = useBotPool();
-	const hasEnvironmentId = enabled && isCloudEnvId(environmentId);
-	const linked = useAgentChannelLinks(environmentId, hasEnvironmentId);
+	const health = useChannelHealth();
+	const linked = useAgentChannelLinks(environmentId, isCloudEnvId(environmentId));
 	const unlink = useUnlinkAgentChannel(environmentId);
-	// "" = no channel selected. Sentinel keeps the Select controlled (no
-	// undefined↔string flip) while staying falsy for the gated Link button.
-	const [accountId, setAccountId] = useState("");
-	const [token, setToken] = useState<string | null>(null);
+	const [readyBotId, setReadyBotId] = useState("");
+	const [ownedChannelId, setOwnedChannelId] = useState("");
+	const [recentLink, setRecentLink] = useState<AgentChannelLink | null>(null);
+	const [recentToken, setRecentToken] = useState<{ linkId: string; value: string } | null>(null);
+	const [connectOpen, setConnectOpen] = useState(false);
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
 	const linkInFlightRef = useRef(false);
 	const unlinkingLinkIdsRef = useRef<Set<string>>(new Set());
 	const [unlinkingLinkIds, setUnlinkingLinkIds] = useState<ReadonlySet<string>>(() => new Set());
 
 	const linkedIds = useMemo(
-		() => new Set((linked.data ?? []).map((l) => l.account_id)),
-		[linked.data],
+		() =>
+			new Set([
+				...(linked.data ?? []).map((link) => link.account_id),
+				...(recentLink ? [recentLink.account_id] : []),
+			]),
+		[linked.data, recentLink],
 	);
-	const linkable = useMemo(() => {
-		const mine = (channels.data ?? []).map((c) => ({
-			id: c.id,
-			provider: c.provider,
-			name: c.name,
-		}));
-		const shared = Object.values(botPool.data?.providers ?? {})
-			.flat()
-			.filter((b) => b.access === "public" && b.available)
-			.map((b) => ({ id: b.id, provider: b.provider, name: b.name }));
-		return [...mine, ...shared].filter(
-			(c) => channelProviderLinkingReady(c.provider) && !linkedIds.has(c.id),
-		);
-	}, [channels.data, botPool.data, linkedIds]);
-	const linkableItems = linkable.map((channel) => ({
-		value: channel.id,
-		label: `${providerMeta(channel.provider).label} · ${channel.name}`,
-	}));
+	const visibleLinks = useMemo(() => {
+		const items = linked.data ?? [];
+		return recentLink && !items.some((link) => link.id === recentLink.id)
+			? [recentLink, ...items]
+			: items;
+	}, [linked.data, recentLink]);
+	const ownedChannels = useMemo(
+		() =>
+			(channels.data ?? [])
+				.map((channel) => ({
+					id: channel.id,
+					provider: channel.provider,
+					name: channel.name,
+				}))
+				.filter(
+					(channel) => channelProviderLinkingReady(channel.provider) && !linkedIds.has(channel.id),
+				),
+		[channels.data, linkedIds],
+	);
+	const readyBots = useMemo(
+		() =>
+			Object.values(botPool.data?.providers ?? {})
+				.flat()
+				.filter(
+					(bot) =>
+						bot.access === "public" &&
+						bot.available &&
+						channelProviderLinkingReady(bot.provider) &&
+						!linkedIds.has(bot.id),
+				)
+				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
+		[botPool.data, linkedIds],
+	);
+	const selectedReadyBotId = readyBotId || (readyBots.length === 1 ? readyBots[0]?.id : "");
+	const selectedOwnedChannelId =
+		ownedChannelId || (ownedChannels.length === 1 ? ownedChannels[0]?.id : "");
+
+	useEffect(() => {
+		if (!botPool.isLoading && !botPool.error && readyBots.length === 0) setAdvancedOpen(true);
+	}, [botPool.error, botPool.isLoading, readyBots.length]);
 
 	// Provider/name labels for linked rows whose API payload omits the nested
 	// `account` (the list-by-agent endpoint isn't guaranteed to embed it).
@@ -2138,6 +2224,10 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 			for (const b of list) map.set(b.id, { provider: b.provider, name: b.name });
 		return map;
 	}, [channels.data, botPool.data]);
+	const healthByAccount = useMemo(
+		() => new Map((health.data?.items ?? []).map((item) => [item.account_id, item])),
+		[health.data],
+	);
 
 	const link = useSensitiveAction(async (channelId: string) => {
 		try {
@@ -2147,13 +2237,21 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 					body: { agent_id: environmentId },
 				}),
 			);
-			if (data.agent_token != null) setToken(data.agent_token);
-			setAccountId("");
+			setRecentToken(data.agent_token ? { linkId: data.id, value: data.agent_token } : null);
+			setRecentLink({
+				id: data.id,
+				account_id: data.account_id,
+				agent_id: data.agent_id,
+				status: data.status,
+				created_at: data.created_at,
+			});
 			qc.invalidateQueries({ queryKey: ["agent-channel-links", environmentId] });
 			qc.invalidateQueries({ queryKey: ["channel-agent-links", data.account_id] });
 			qc.invalidateQueries({ queryKey: ["channel-bot-pool"] });
 			qc.invalidateQueries({ queryKey: ["channels"] });
-			toast.success("Channel linked");
+			toast.success("Channel linked", {
+				description: "Create a pairing code in the linked channel card to connect a conversation.",
+			});
 			return data;
 		} catch (error) {
 			toastApiError("Couldn't link channel")(error);
@@ -2161,12 +2259,14 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 		}
 	});
 
-	async function submitLink() {
-		if (!accountId || linkInFlightRef.current) return;
+	async function submitLink(channelId: string) {
+		if (!channelId || linkInFlightRef.current) return;
 		linkInFlightRef.current = true;
-		setLinkingAccountId(accountId);
+		setLinkingAccountId(channelId);
 		try {
-			await link.execute(accountId);
+			await link.execute(channelId);
+			setReadyBotId("");
+			setOwnedChannelId("");
 		} catch {
 			// The action already surfaces the API error.
 		} finally {
@@ -2182,6 +2282,8 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 		void (async () => {
 			try {
 				await unlink.mutateAsync({ accountId: accountIdToUnlink, linkId });
+				setRecentToken((current) => (current?.linkId === linkId ? null : current));
+				setRecentLink((current) => (current?.id === linkId ? null : current));
 			} catch {
 				// useUnlinkAgentChannel already surfaces the API error.
 			} finally {
@@ -2195,111 +2297,197 @@ function ChannelsTab({ environmentId, enabled }: { environmentId: string; enable
 		})();
 	}
 
-	if (!hasEnvironmentId) {
-		return (
-			<EmptyState
-				icon={Link2}
-				title="Channels available once provisioning finishes"
-				description="The deployment is still minting its cloud agent id. When the agent is ready, link channels here."
-			/>
-		);
-	}
-
 	return (
 		<div className="space-y-4">
-			<LiveNote>Linking a channel applies its token live — no restart.</LiveNote>
+			<LiveNote>
+				Hosted agents apply channel credentials automatically — no restart or token copy.
+			</LiveNote>
 
 			{/* Linked channels */}
 			<div className="space-y-2">
 				<div className="text-sm font-medium">Linked channels</div>
-				{linked.isLoading ? (
+				{linked.isLoading && visibleLinks.length === 0 ? (
 					<Skeleton className="h-16 w-full rounded-lg" />
-				) : linked.error ? (
+				) : linked.error && visibleLinks.length === 0 ? (
 					<ApiErrorPanel
 						error={linked.error}
 						onRetry={() => linked.refetch()}
 						title="Couldn't load linked channels"
 					/>
-				) : (linked.data ?? []).length === 0 ? (
+				) : visibleLinks.length === 0 ? (
 					<EmptyState
 						variant="inset"
 						title="No channels linked"
 						description="Link a channel below so this agent can send and receive messages."
 					/>
 				) : (
-					(linked.data ?? []).map((l) => (
+					visibleLinks.map((l) => (
 						<LinkedChannelRow
 							key={l.id}
 							link={l}
 							fallbackAccount={accountSummaries.get(l.account_id)}
+							health={healthByAccount.get(l.account_id)}
+							healthLoading={health.isLoading}
+							healthError={Boolean(health.error)}
+							token={recentToken?.linkId === l.id ? recentToken.value : undefined}
 							unlinking={unlinkingLinkIds.has(l.id)}
 							onUnlink={() => startUnlink(l.account_id, l.id)}
 						/>
 					))
 				)}
-			</div>
-
-			{/* Link a channel */}
-			<div className="space-y-2 rounded-lg border p-4">
-				<div className="text-sm font-medium">Link a channel</div>
-				<p className="text-xs text-muted-foreground">
-					Connect this agent to one of your channels or a shared-pool bot.
-				</p>
-				<div className="flex flex-col gap-2 sm:flex-row">
-					<Select
-						items={linkableItems}
-						value={accountId}
-						onValueChange={(value) => {
-							if (value !== null) setAccountId(value);
-						}}
-					>
-						<SelectTrigger aria-label="Link a channel" className="flex-1">
-							<SelectValue placeholder="Choose a channel…" />
-						</SelectTrigger>
-						<SelectContent>
-							{linkable.map((c) => (
-								<SelectItem key={c.id} value={c.id}>
-									{providerMeta(c.provider).label} · {c.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-					<Button
-						onClick={() => void submitLink()}
-						disabled={
-							!accountId || linkingAccountId !== null || channels.isLoading || botPool.isLoading
-						}
-					>
-						{linkingAccountId ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-						{linkingAccountId ? "Linking…" : "Link"}
-					</Button>
-				</div>
-				{channels.error || botPool.error ? (
+				{linked.error && visibleLinks.length > 0 ? (
 					<ApiErrorPanel
-						error={channels.error ?? botPool.error}
-						onRetry={() => {
-							channels.refetch();
-							botPool.refetch();
-						}}
-						title="Couldn't load available channels"
-					/>
-				) : null}
-				{token ? (
-					<TokenReveal
-						label="Agent token"
-						value={token}
-						note="Copy it now — used by the runtime to send and receive on this channel."
+						error={linked.error}
+						onRetry={() => linked.refetch()}
+						title="Couldn't refresh every linked channel"
 					/>
 				) : null}
 			</div>
 
-			<p className="text-xs text-muted-foreground">
-				Health, activity, and command sync for each channel live on{" "}
-				<Link to="/channels" className="underline">
-					Channels
-				</Link>
-				.
-			</p>
+			<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
+				<div className="flex items-start gap-3">
+					<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-background text-primary ring-1 ring-primary/20">
+						<Bot className="size-4" />
+					</div>
+					<div>
+						<div className="text-sm font-medium">Fastest: use a ready-to-go bot</div>
+						<p className="mt-1 text-xs text-muted-foreground">
+							No bot account, credentials, or developer setup. Choose one and link it now.
+						</p>
+					</div>
+				</div>
+				{botPool.isLoading ? (
+					<Skeleton className="h-9 w-full rounded-md" />
+				) : botPool.error ? (
+					<ApiErrorPanel
+						error={botPool.error}
+						onRetry={() => botPool.refetch()}
+						title="Couldn't load ready-to-go bots"
+					/>
+				) : readyBots.length > 0 ? (
+					<div className="flex flex-col gap-2 sm:flex-row">
+						<Select
+							items={channelSelectItems(readyBots)}
+							value={selectedReadyBotId}
+							onValueChange={(value) => {
+								if (value !== null) setReadyBotId(value);
+							}}
+						>
+							<SelectTrigger aria-label="Choose a ready-to-go bot" className="flex-1 bg-background">
+								<SelectValue placeholder="Choose a ready-to-go bot…" />
+							</SelectTrigger>
+							<SelectContent>
+								{readyBots.map((bot) => (
+									<SelectItem key={bot.id} value={bot.id}>
+										{providerMeta(bot.provider).label} · {bot.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Button
+							disabled={!selectedReadyBotId || linkingAccountId !== null}
+							onClick={() => void submitLink(selectedReadyBotId)}
+						>
+							{linkingAccountId === selectedReadyBotId ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<Link2 className="size-3.5" />
+							)}
+							{linkingAccountId === selectedReadyBotId ? "Linking…" : "Link bot"}
+						</Button>
+					</div>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						No ready-to-go bots are available right now. You can use your own bot below.
+					</p>
+				)}
+			</div>
+
+			<details
+				open={advancedOpen}
+				onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+				className="group rounded-lg border p-4"
+			>
+				<summary className="cursor-pointer text-sm font-medium">
+					Use your own bot (advanced)
+				</summary>
+				<div className="mt-3 space-y-3">
+					<p className="text-xs text-muted-foreground">
+						Choose a Telegram or Discord bot you already connected, or connect a new one.
+					</p>
+					{channels.isLoading ? (
+						<Skeleton className="h-9 w-full rounded-md" />
+					) : channels.error ? (
+						<ApiErrorPanel
+							error={channels.error}
+							onRetry={() => channels.refetch()}
+							title="Couldn't load your bots"
+						/>
+					) : ownedChannels.length > 0 ? (
+						<div className="flex flex-col gap-2 sm:flex-row">
+							<Select
+								items={channelSelectItems(ownedChannels)}
+								value={selectedOwnedChannelId}
+								onValueChange={(value) => {
+									if (value !== null) setOwnedChannelId(value);
+								}}
+							>
+								<SelectTrigger aria-label="Choose your bot" className="flex-1">
+									<SelectValue placeholder="Choose your bot…" />
+								</SelectTrigger>
+								<SelectContent>
+									{ownedChannels.map((channel) => (
+										<SelectItem key={channel.id} value={channel.id}>
+											{providerMeta(channel.provider).label} · {channel.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Button
+								disabled={!selectedOwnedChannelId || linkingAccountId !== null}
+								onClick={() => void submitLink(selectedOwnedChannelId)}
+							>
+								{linkingAccountId === selectedOwnedChannelId ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<Link2 className="size-3.5" />
+								)}
+								{linkingAccountId === selectedOwnedChannelId ? "Linking…" : "Link my bot"}
+							</Button>
+						</div>
+					) : (
+						<EmptyState
+							variant="inset"
+							title="No bot connected yet"
+							description="Connect a Telegram or Discord bot, then it will appear here automatically."
+							action={
+								<Button onClick={() => setConnectOpen(true)}>
+									<Plus className="size-3.5" />
+									Connect my bot
+								</Button>
+							}
+						/>
+					)}
+					<div className="flex flex-wrap gap-2">
+						{ownedChannels.length > 0 ? (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => setConnectOpen(true)}
+							>
+								<Plus className="size-3.5" />
+								Connect another bot
+							</Button>
+						) : null}
+						<Button render={<Link to="/channels" />} nativeButton={false} variant="ghost" size="sm">
+							View all channel options
+						</Button>
+					</div>
+				</div>
+			</details>
+
+			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
 		</div>
 	);
 }
@@ -2309,11 +2497,19 @@ function LinkedChannelRow({
 	onUnlink,
 	unlinking,
 	fallbackAccount,
+	health,
+	healthLoading,
+	healthError,
+	token,
 }: {
 	link: AgentChannelLink;
 	onUnlink: () => void;
 	unlinking: boolean;
 	fallbackAccount?: { provider: string; name: string };
+	health?: components["schemas"]["ChannelHealthItemResponse"];
+	healthLoading: boolean;
+	healthError: boolean;
+	token?: string;
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<{ code: string; expires_at: string } | null>(null);
@@ -2325,6 +2521,14 @@ function LinkedChannelRow({
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
+	const providerLabel = provider ? providerMeta(provider).label : "your chat app";
+	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
+	const chatInstruction =
+		provider === "telegram"
+			? `Open Telegram and start a conversation with the bot you connected as “${name}”.`
+			: provider === "discord"
+				? `Open Discord and choose the server channel or direct message where “${name}” should answer.`
+				: `Open the conversation where you want “${name}” to answer.`;
 	async function createPairCode() {
 		if (pairInFlightRef.current) return;
 		pairInFlightRef.current = true;
@@ -2340,25 +2544,17 @@ function LinkedChannelRow({
 		}
 	}
 	return (
-		<div className="rounded-lg border p-3">
+		<div className="rounded-lg border p-4">
 			<div className="flex items-center gap-3">
 				<ProviderChip provider={provider} />
 				<div className="min-w-0 flex-1">
 					<div className="truncate text-sm font-medium">{name}</div>
-					<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
 						{provider ? <span>{providerMeta(provider).label}</span> : null}
 						<ChannelStatusBadge status={link.status} />
+						{health ? <HealthBadge status={health.health_status} /> : null}
 					</div>
 				</div>
-				<Button
-					variant="outline"
-					size="sm"
-					disabled={creatingPairCode}
-					onClick={() => void createPairCode()}
-				>
-					{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
-					{creatingPairCode ? "Creating code…" : "Pair code"}
-				</Button>
 				<ConfirmAction
 					title="Unlink this channel?"
 					description={<p>The agent stops sending and receiving on this channel.</p>}
@@ -2377,14 +2573,104 @@ function LinkedChannelRow({
 					</Button>
 				</ConfirmAction>
 			</div>
-			{code ? (
-				<div className="mt-2 rounded-md border border-primary/30 bg-primary/5 p-2 text-sm">
-					Send{" "}
-					<span className="font-mono font-semibold tracking-wider">
-						{pairingCommand(code.code)}
-					</span>{" "}
-					from the chat to pair it.
+
+			<div
+				role="status"
+				aria-live="polite"
+				className={cn(
+					"mt-3 rounded-lg border p-3",
+					hasActivity ? "border-success/30 bg-success-muted" : "bg-muted/30",
+				)}
+			>
+				<div className="flex items-center gap-2 text-sm font-medium">
+					{healthLoading ? (
+						<Spinner className="size-4" />
+					) : healthError ? (
+						<AlertCircle className="size-4 text-warning-muted-foreground" />
+					) : hasActivity ? (
+						<CircleCheck className="size-4 text-success-muted-foreground" />
+					) : (
+						<span className="size-2 animate-pulse rounded-full bg-info" aria-hidden />
+					)}
+					{healthLoading
+						? "Checking channel activity…"
+						: healthError
+							? "Channel activity is temporarily unavailable"
+							: hasActivity
+								? "Channel activity detected"
+								: "Waiting for channel activity"}
 				</div>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{healthError
+						? "Automatic checks will continue. You can finish the steps below while Clawdi reconnects."
+						: hasActivity
+							? "Clawdi can see activity on this channel. This signal does not yet confirm that the agent received a normal message."
+							: "This page checks automatically every 20 seconds. No refresh needed."}
+				</p>
+			</div>
+
+			{hasActivity ? (
+				<div className="mt-3 text-sm">
+					<p className="font-medium">Send a normal message to start chatting</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Open {providerLabel} and message the conversation you paired. Channel-level activity is
+						live; agent delivery confirmation is not available yet.
+					</p>
+				</div>
+			) : (
+				<div className="mt-3 space-y-3">
+					<div>
+						<p className="text-sm font-medium">Finish connecting your conversation</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Linking gives this agent access to the bot. Pairing chooses the exact conversation
+							where it should answer.
+						</p>
+					</div>
+					<ol className="list-decimal space-y-2 pl-4 text-sm text-muted-foreground">
+						<li>
+							<Button
+								variant="outline"
+								size="sm"
+								className="ml-1"
+								disabled={creatingPairCode}
+								onClick={() => void createPairCode()}
+							>
+								{creatingPairCode ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<QrCode className="size-3.5" />
+								)}
+								{creatingPairCode ? "Creating code…" : "Create pairing code"}
+							</Button>
+						</li>
+						<li>{chatInstruction}</li>
+						<li>Send the command below in that conversation, then send a normal message.</li>
+					</ol>
+					{code ? (
+						<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+							<p className="text-xs font-medium text-primary">Send this exact command</p>
+							<code className="mt-1 block break-all font-mono font-semibold tracking-wide">
+								{pairingCommand(code.code)}
+							</code>
+							<p className="mt-1 text-xs text-muted-foreground">
+								The code is one-time and expires automatically.
+							</p>
+						</div>
+					) : null}
+				</div>
+			)}
+
+			{token ? (
+				<details className="mt-3 rounded-md border p-3">
+					<summary className="cursor-pointer text-xs font-medium">Agent token (advanced)</summary>
+					<div className="mt-2">
+						<TokenReveal
+							label="Agent token"
+							value={token}
+							note="Hosted agents configure this automatically. You do not need to copy it unless support asks you to."
+						/>
+					</div>
+				</details>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+describe("channel default path", () => {
+	test("puts ready-to-go bots before personal bot management", () => {
+		const channelsPage = source("./channels-page.tsx");
+		const readyIndex = channelsPage.indexOf("<ReadyBotsSection");
+		const personalIndex = channelsPage.indexOf("<YourChannelsSection");
+
+		expect(readyIndex).toBeGreaterThanOrEqual(0);
+		expect(personalIndex).toBeGreaterThan(readyIndex);
+		expect(channelsPage).toContain("Start instantly with a ready-to-go bot");
+		expect(channelsPage).toContain("Connect your own bot");
+		expect(channelsPage).toContain("Ready-to-go bots");
+		expect(channelsPage).not.toContain("Shared bots");
+		expect(channelsPage).not.toContain("shared bot");
+	});
+
+	test("renders actionable provider steps and real external links in the connect dialog", () => {
+		const connectDialog = source("./connect-bot-dialog.tsx");
+
+		expect(connectDialog).toContain("meta.setupSteps.map");
+		expect(connectDialog).toContain("href={meta.setupUrl}");
+		expect(connectDialog).toContain('target="_blank"');
+		expect(connectDialog).toContain("This is the name shown in Clawdi");
+		expect(connectDialog).toContain("Server ID");
+		expect(connectDialog).not.toContain("Guild ID");
+	});
+
+	test("moves a successful ready-bot link into the agent finish line", () => {
+		const linkDialog = source("./link-agent-dialog.tsx");
+
+		expect(linkDialog).toContain("The bot is linked to this agent");
+		expect(linkDialog).toContain("Next, create a pairing code");
+		expect(linkDialog).toContain('params={{ id: agentId, section: "channels" }}');
+		expect(linkDialog).toContain("Finish channel setup");
+		expect(linkDialog).toContain("Agent token (advanced)");
+	});
+
+	test("uses customer-facing labels for public bot access", () => {
+		const channelUi = source("./channel-ui.tsx");
+		const channelDetail = source("./channel-detail-page.tsx");
+
+		expect(channelUi).toContain('owner ? "Your bot" : "Ready to use"');
+		expect(channelDetail).toContain('"Ready-to-go bot" : "Your bot"');
+		expect(channelDetail).not.toContain('"Shared bot"');
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -215,6 +215,25 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 	const health = useChannelHealth();
 	const router = useRouter();
 	const del = useDeleteChannel();
+	const [removing, setRemoving] = useState(false);
+	const removeLockedRef = useRef(false);
+
+	function removeChannel() {
+		if (removeLockedRef.current) return;
+		removeLockedRef.current = true;
+		setRemoving(true);
+		void (async () => {
+			try {
+				await del.mutateAsync(id);
+				await router.navigate({ href: "/channels" });
+			} catch {
+				// useDeleteChannel already surfaces the API error.
+			} finally {
+				removeLockedRef.current = false;
+				setRemoving(false);
+			}
+		})();
+	}
 
 	useSetBreadcrumbTitle(channel.data?.name);
 
@@ -297,15 +316,15 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 						}
 						confirmLabel="Remove channel"
 						destructive
-						onConfirm={() =>
-							del.mutateAsync(id, {
-								onSuccess: () => void router.navigate({ href: "/channels" }),
-							})
-						}
+						onConfirm={removeChannel}
 					>
-						<Button variant="outline" className="text-muted-foreground hover:text-destructive">
-							<Trash2 className="size-4" />
-							Remove
+						<Button
+							variant="outline"
+							className="text-muted-foreground hover:text-destructive"
+							disabled={removing}
+						>
+							{removing ? <Spinner className="size-4" /> : <Trash2 className="size-4" />}
+							{removing ? "Removing…" : "Remove"}
 						</Button>
 					</ConfirmAction>
 				}
@@ -490,6 +509,8 @@ function AgentsTab({
 	const rotationControllersRef = useRef<Map<string, AbortController>>(new Map());
 	const rotatingLinksRef = useRef<Set<string>>(new Set());
 	const [rotatingLinks, setRotatingLinks] = useState<ReadonlySet<string>>(() => new Set());
+	const unlinkingLinksRef = useRef<Set<string>>(new Set());
+	const [unlinkingLinks, setUnlinkingLinks] = useState<ReadonlySet<string>>(() => new Set());
 	const hasTokenAtRisk = hasAtRiskRotatedToken(rotated, rotatingLinks.size > 0);
 	const tokenAtRiskRef = useRef(hasTokenAtRisk);
 	tokenAtRiskRef.current = hasTokenAtRisk;
@@ -557,6 +578,26 @@ function AgentsTab({
 		});
 	}
 
+	function unlinkAgent(linkId: string) {
+		if (unlinkingLinksRef.current.has(linkId)) return;
+		unlinkingLinksRef.current.add(linkId);
+		setUnlinkingLinks((prev) => new Set(prev).add(linkId));
+		void (async () => {
+			try {
+				await unlink.mutateAsync(linkId);
+			} catch {
+				// useUnlinkChannelAgent already surfaces the API error.
+			} finally {
+				unlinkingLinksRef.current.delete(linkId);
+				setUnlinkingLinks((prev) => {
+					const next = new Set(prev);
+					next.delete(linkId);
+					return next;
+				});
+			}
+		})();
+	}
+
 	function leaveWithoutToken() {
 		tokenAtRiskRef.current = false;
 		for (const controller of rotationControllersRef.current.values()) controller.abort();
@@ -615,6 +656,7 @@ function AgentsTab({
 				<div className="flex flex-col gap-2">
 					{items.map((link: ChannelAgentLink) => {
 						const isRotating = rotatingLinks.has(link.id);
+						const isUnlinking = unlinkingLinks.has(link.id);
 						return (
 							<div key={link.id} className={ENTITY_CARD_BASE}>
 								<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -646,16 +688,20 @@ function AgentsTab({
 												description={<p>It stops sending and receiving on {accountName}.</p>}
 												confirmLabel="Unlink"
 												destructive
-												onConfirm={() => unlink.mutateAsync(link.id)}
+												onConfirm={() => unlinkAgent(link.id)}
 											>
 												<Button
 													variant="ghost"
 													size="icon-sm"
 													className="text-muted-foreground hover:text-destructive"
-													disabled={unlink.isPending && unlink.variables === link.id}
+													disabled={isUnlinking}
 													aria-label="Unlink agent"
 												>
-													<Link2Off className="size-4" />
+													{isUnlinking ? (
+														<Spinner className="size-4" />
+													) : (
+														<Link2Off className="size-4" />
+													)}
 												</Button>
 											</ConfirmAction>
 										</div>
@@ -726,6 +772,12 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 	const revoke = useRevokeWhatsappTenantCred(accountId);
 	const ownership = useAgentOwnership();
 	const [linkId, setLinkId] = useState("");
+	const [creatingCredential, setCreatingCredential] = useState(false);
+	const createCredentialLockedRef = useRef(false);
+	const revokingCredentialsRef = useRef<Set<string>>(new Set());
+	const [revokingCredentials, setRevokingCredentials] = useState<ReadonlySet<string>>(
+		() => new Set(),
+	);
 
 	const linkItems = links.data ?? [];
 	const devices = creds.data ?? [];
@@ -735,6 +787,42 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 		value: link.id,
 		label: envName(envs.data, link.agent_id, ownership),
 	}));
+
+	function linkDevice() {
+		if (!effectiveLink || createCredentialLockedRef.current) return;
+		createCredentialLockedRef.current = true;
+		setCreatingCredential(true);
+		void (async () => {
+			try {
+				await create.execute({ agent_link_id: effectiveLink });
+			} catch {
+				// useCreateWhatsappTenantCred already surfaces the API error.
+			} finally {
+				createCredentialLockedRef.current = false;
+				setCreatingCredential(false);
+			}
+		})();
+	}
+
+	function revokeDevice(credentialId: string) {
+		if (revokingCredentialsRef.current.has(credentialId)) return;
+		revokingCredentialsRef.current.add(credentialId);
+		setRevokingCredentials((prev) => new Set(prev).add(credentialId));
+		void (async () => {
+			try {
+				await revoke.mutateAsync(credentialId);
+			} catch {
+				// useRevokeWhatsappTenantCred already surfaces the API error.
+			} finally {
+				revokingCredentialsRef.current.delete(credentialId);
+				setRevokingCredentials((prev) => {
+					const next = new Set(prev);
+					next.delete(credentialId);
+					return next;
+				});
+			}
+		})();
+	}
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -805,14 +893,13 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 							</Select>
 						</div>
 					) : null}
-					<Button
-						onClick={() => {
-							if (effectiveLink) void create.execute({ agent_link_id: effectiveLink });
-						}}
-						disabled={!effectiveLink || create.isPending}
-					>
-						<Smartphone className="size-4" />
-						{create.isPending ? "Minting…" : "Link a device"}
+					<Button onClick={linkDevice} disabled={!effectiveLink || creatingCredential}>
+						{creatingCredential ? (
+							<Spinner className="size-4" />
+						) : (
+							<Smartphone className="size-4" />
+						)}
+						{creatingCredential ? "Linking device…" : "Link a device"}
 					</Button>
 				</div>
 			)}
@@ -855,16 +942,20 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 								description={<p>The WhatsApp credential is revoked. This can't be undone.</p>}
 								confirmLabel="Unlink"
 								destructive
-								onConfirm={() => revoke.mutateAsync(d.credential_id)}
+								onConfirm={() => revokeDevice(d.credential_id)}
 							>
 								<Button
 									variant="ghost"
 									size="icon-sm"
 									className="text-muted-foreground hover:text-destructive"
-									disabled={revoke.isPending}
+									disabled={revokingCredentials.has(d.credential_id)}
 									aria-label="Unlink device"
 								>
-									<Trash2 className="size-4" />
+									{revokingCredentials.has(d.credential_id) ? (
+										<Spinner className="size-4" />
+									) : (
+										<Trash2 className="size-4" />
+									)}
 								</Button>
 							</ConfirmAction>
 						</div>
@@ -911,13 +1002,14 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const [result, setResult] = useState<PairCodeResult | null>(null);
 	const [revealedAgentToken, setRevealedAgentToken] = useState<RevealedAgentToken | null>(null);
 	const [nowMs, setNowMs] = useState(() => Date.now());
+	const [generating, setGenerating] = useState(false);
 	const agentItems = (envs.data ?? []).map((env) => ({
 		value: env.id,
 		label: envName(envs.data, env.id, ownership),
 	}));
 	const generateLocked = useRef(false);
 	const meta = providerMeta(provider);
-	const isGenerating = create.isPending || generateLocked.current;
+	const isGenerating = generating || create.isPending;
 	const linkedAgentCount = links.data?.length ?? 0;
 	const requiresExplicitAgent = pairCodeRequiresExplicitAgent(linkedAgentCount);
 	const selectionMessage =
@@ -949,6 +1041,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	function generate() {
 		if (!canGenerate || generateLocked.current) return;
 		generateLocked.current = true;
+		setGenerating(true);
 		setResult(null);
 		void (async () => {
 			try {
@@ -971,6 +1064,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 				// useSensitiveAction already surfaces the API error.
 			} finally {
 				generateLocked.current = false;
+				setGenerating(false);
 			}
 		})();
 	}
@@ -1323,6 +1417,24 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 	const meta = providerMeta(provider);
 	const supportsCommands = provider === "telegram" || provider === "discord";
 	const commands = sync.data?.commands ?? [];
+	const [syncing, setSyncing] = useState(false);
+	const syncLockedRef = useRef(false);
+
+	function syncCommands() {
+		if (syncLockedRef.current) return;
+		syncLockedRef.current = true;
+		setSyncing(true);
+		void (async () => {
+			try {
+				await sync.mutateAsync();
+			} catch {
+				// useSyncCommands already surfaces the API error.
+			} finally {
+				syncLockedRef.current = false;
+				setSyncing(false);
+			}
+		})();
+	}
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -1334,9 +1446,9 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 
 			{supportsCommands ? (
 				<>
-					<Button onClick={() => sync.mutate()} disabled={sync.isPending}>
-						<RefreshCw className="size-4" />
-						{sync.isPending ? "Syncing…" : "Sync commands"}
+					<Button onClick={syncCommands} disabled={syncing}>
+						{syncing ? <Spinner className="size-4" /> : <RefreshCw className="size-4" />}
+						{syncing ? "Syncing…" : "Sync commands"}
 					</Button>
 					{commands.length > 0 ? (
 						<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-2")}>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -298,7 +298,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 			<PageHeader
 				title={ch.name}
-				description={`${meta.label} · ${ch.visibility === "public" ? "Shared bot" : "Private bot"}`}
+				description={`${meta.label} · ${ch.visibility === "public" ? "Ready-to-go bot" : "Your bot"}`}
 				icon={<EntityIcon kind="channel" id={ch.provider} label={meta.label} size="lg" />}
 				status={
 					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
@@ -852,7 +852,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 				<EmptyState
 					variant="inset"
 					title="Link an agent first"
-					description="A WhatsApp device is minted per agent. Link an agent on the Agents tab, then come back."
+					description="Each agent needs its own WhatsApp connection. Link an agent on the Agents tab, then come back."
 				/>
 			) : (
 				<div className="flex flex-col gap-2">

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const agentChannels = readFileSync(
+	new URL("../../agents/hosted-agent-detail.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("hosted-agent channel finish line", () => {
+	test("assembles the existing live health query into an honest automatic activity state", () => {
+		expect(agentChannels).toContain("const health = useChannelHealth()");
+		expect(agentChannels).toContain("channelActivityAfterLink(");
+		expect(agentChannels).toContain("This page checks automatically every 20 seconds");
+		expect(agentChannels).toContain("Channel activity detected");
+		expect(agentChannels).toContain(
+			"This signal does not yet confirm that the agent received a normal message.",
+		);
+		expect(agentChannels).toContain("<ChannelStatusBadge status={link.status} />");
+		expect(agentChannels).toContain("<HealthBadge");
+	});
+
+	test("explains linking, pairing, the target conversation, and the hosted token boundary", () => {
+		expect(agentChannels).toContain("Linking gives this agent access to the bot");
+		expect(agentChannels).toContain("Pairing chooses the exact conversation");
+		expect(agentChannels).toContain("Open Telegram and start a conversation");
+		expect(agentChannels).toContain("Open Discord and choose the server channel");
+		expect(agentChannels).toContain("Create pairing code");
+		expect(agentChannels).toContain("Hosted agents configure this automatically");
+	});
+
+	test("leads with the no-credential path and gives the empty advanced path a primary action", () => {
+		const readyBotIndex = agentChannels.indexOf("Fastest: use a ready-to-go bot");
+		const advancedIndex = agentChannels.indexOf("Use your own bot (advanced)");
+		expect(readyBotIndex).toBeGreaterThanOrEqual(0);
+		expect(advancedIndex).toBeGreaterThan(readyBotIndex);
+		expect(agentChannels).toContain("No bot account, credentials, or developer setup");
+		expect(agentChannels).toContain("No bot connected yet");
+		expect(agentChannels).toContain("Connect my bot");
+	});
+
+	test("replaces setup jargon with a bounded automatic wait and exits", () => {
+		expect(agentChannels).toContain('title="Getting channels ready"');
+		expect(agentChannels).toContain("This usually takes a few minutes");
+		expect(agentChannels).toContain("Choose a channel while you wait");
+		expect(agentChannels).not.toContain("minting its cloud agent id");
+		expect(agentChannels).not.toContain("shared-pool");
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function expectFeedbackBeforeRequest(contents: string, feedback: string, request: string) {
+	const feedbackIndex = contents.indexOf(feedback);
+	const requestIndex = contents.indexOf(request, feedbackIndex);
+	expect(feedbackIndex).toBeGreaterThanOrEqual(0);
+	expect(requestIndex).toBeGreaterThan(feedbackIndex);
+}
+
+describe("channel mutation feedback", () => {
+	test("acknowledges connect and shared-bot link before starting their requests", () => {
+		const connect = source("./connect-bot-dialog.tsx");
+		const link = source("./link-agent-dialog.tsx");
+
+		expectFeedbackBeforeRequest(connect, "setSubmitting(true)", "await create.execute(body)");
+		expectFeedbackBeforeRequest(link, "setSubmitting(true)", "await link.execute(agentId)");
+		expect(connect).toContain('{isSubmitting ? "Close" : "Cancel"}');
+		expect(link).toContain('{isSubmitting ? "Close" : "Cancel"}');
+		expect(connect).not.toContain("channelDialogOpenChangeAllowed");
+		expect(link).not.toContain("channelDialogOpenChangeAllowed");
+	});
+
+	test("keeps agent-page link, unlink, and pair-code feedback scoped to the acting control", () => {
+		const detail = source("../../agents/hosted-agent-detail.tsx");
+
+		expectFeedbackBeforeRequest(
+			detail,
+			"setLinkingAccountId(accountId)",
+			"await link.execute(accountId)",
+		);
+		expectFeedbackBeforeRequest(
+			detail,
+			"setUnlinkingLinkIds((prev) => new Set(prev).add(linkId))",
+			"await unlink.mutateAsync",
+		);
+		expectFeedbackBeforeRequest(detail, "setCreatingPairCode(true)", "await pair.execute");
+		expect(detail).toContain("unlinking={unlinkingLinkIds.has(l.id)}");
+		expect(detail).toContain('{linkingAccountId ? "Linking…" : "Link"}');
+		expect(detail).toContain('{creatingPairCode ? "Creating code…" : "Pair code"}');
+	});
+
+	test("uses per-action feedback for detail-page mutations", () => {
+		const detail = source("./channel-detail-page.tsx");
+
+		for (const [feedback, request] of [
+			["setRemoving(true)", "await del.mutateAsync(id)"],
+			["setRotatingLinks((prev)", "await api.POST"],
+			["setUnlinkingLinks((prev)", "await unlink.mutateAsync(linkId)"],
+			["setCreatingCredential(true)", "await create.execute"],
+			["setRevokingCredentials((prev)", "await revoke.mutateAsync"],
+			["setGenerating(true)", "await create.execute"],
+			["setSyncing(true)", "await sync.mutateAsync"],
+		] as const) {
+			expectFeedbackBeforeRequest(detail, feedback, request);
+		}
+		expect(detail).toContain("const isRotating = rotatingLinks.has(link.id)");
+		expect(detail).toContain("const isUnlinking = unlinkingLinks.has(link.id)");
+		expect(detail).toContain("revokingCredentials.has(d.credential_id)");
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -30,8 +30,8 @@ describe("channel mutation feedback", () => {
 
 		expectFeedbackBeforeRequest(
 			detail,
-			"setLinkingAccountId(accountId)",
-			"await link.execute(accountId)",
+			"setLinkingAccountId(channelId)",
+			"await link.execute(channelId)",
 		);
 		expectFeedbackBeforeRequest(
 			detail,
@@ -40,8 +40,8 @@ describe("channel mutation feedback", () => {
 		);
 		expectFeedbackBeforeRequest(detail, "setCreatingPairCode(true)", "await pair.execute");
 		expect(detail).toContain("unlinking={unlinkingLinkIds.has(l.id)}");
-		expect(detail).toContain('{linkingAccountId ? "Linking…" : "Link"}');
-		expect(detail).toContain('{creatingPairCode ? "Creating code…" : "Pair code"}');
+		expect(detail).toContain('linkingAccountId === selectedReadyBotId ? "Linking…" : "Link bot"');
+		expect(detail).toContain('{creatingPairCode ? "Creating code…" : "Create pairing code"}');
 	});
 
 	test("uses per-action feedback for detail-page mutations", () => {

--- a/apps/web/src/hosted/v2/channels/channel-providers.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.test.ts
@@ -20,6 +20,19 @@ describe("channel provider registry", () => {
 		});
 	});
 
+	test("provides official setup links and complete bring-your-own steps", () => {
+		expect(providerMeta("telegram")).toMatchObject({
+			setupUrl: "https://t.me/BotFather",
+			setupLinkLabel: "Open @BotFather in Telegram",
+		});
+		expect(providerMeta("telegram").setupSteps).toHaveLength(3);
+		expect(providerMeta("discord")).toMatchObject({
+			setupUrl: "https://discord.com/developers/applications",
+			setupLinkLabel: "Open the Discord Developer Portal",
+		});
+		expect(providerMeta("discord").setupSteps).toHaveLength(3);
+	});
+
 	test("orders supported providers first and appends legacy providers from data", () => {
 		expect(orderedProviderIds(["imessage", "discord", "telegram", "custom", "telegram"])).toEqual([
 			"telegram",

--- a/apps/web/src/hosted/v2/channels/channel-providers.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.ts
@@ -22,6 +22,9 @@ export interface ChannelProviderMeta {
 	tokenLabel?: string;
 	tokenPlaceholder?: string;
 	hint: string;
+	setupUrl?: string;
+	setupLinkLabel?: string;
+	setupSteps?: readonly string[];
 	unavailable?: boolean;
 }
 
@@ -39,7 +42,14 @@ export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMe
 		connect: "token",
 		tokenLabel: "Bot token",
 		tokenPlaceholder: "123456:ABC-DEF…",
-		hint: "Create a bot with @BotFather and paste its token.",
+		hint: "Telegram's official @BotFather creates the bot and gives you its token.",
+		setupUrl: "https://t.me/BotFather",
+		setupLinkLabel: "Open @BotFather in Telegram",
+		setupSteps: [
+			"Send /newbot to @BotFather and follow the prompts to choose a name and username.",
+			"Copy the HTTP API token from @BotFather.",
+			"Give the connection a friendly name below, then paste the token.",
+		],
 	},
 	discord: {
 		id: "discord",
@@ -48,7 +58,14 @@ export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMe
 		connect: "discord",
 		tokenLabel: "Bot token",
 		tokenPlaceholder: "Bot token",
-		hint: "Paste the bot token and application ID from your Discord application. Include the public key when available.",
+		hint: "Create a Discord application, add its bot to your server, then copy the credentials below.",
+		setupUrl: "https://discord.com/developers/applications",
+		setupLinkLabel: "Open the Discord Developer Portal",
+		setupSteps: [
+			"Create an application, open its Bot page, and copy or reset the bot token.",
+			"On General Information, copy the application ID and, if you use interactions, the public key.",
+			"Use the Installation page to add the bot to the Discord server where it should answer.",
+		],
 	},
 	whatsapp: {
 		id: "whatsapp",

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -47,7 +47,9 @@ export function HealthBadge({ status, className }: { status: string; className?:
 export function AccessBadge({ access }: { access: string }) {
 	const owner = access === "owner";
 	return (
-		<StatusBadge status={owner ? "info" : "neutral"}>{owner ? "Your bot" : "Shared"}</StatusBadge>
+		<StatusBadge status={owner ? "info" : "neutral"}>
+			{owner ? "Your bot" : "Ready to use"}
+		</StatusBadge>
 	);
 }
 

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -309,7 +309,7 @@ export function useCreateWhatsappTenantCred(accountId: string) {
 				}),
 			);
 			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
-			toast.success("Device credential minted", {
+			toast.success("WhatsApp access is ready", {
 				description: "Finish pairing from the agent runtime to link the number.",
 			});
 		} catch (error) {

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -35,7 +35,8 @@ import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.logic";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Connect Telegram and Discord to your agents. WhatsApp is coming soon.";
+const DESCRIPTION =
+	"Start instantly with a ready-to-go bot, or connect your own Telegram or Discord bot for full control.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 type ProviderFilter = "all" | ChannelProviderId;
@@ -76,14 +77,21 @@ export function ChannelsPage() {
 					</>
 				}
 				actions={
-					<Button size="sm" onClick={() => setConnectOpen(true)}>
+					<Button size="sm" variant="outline" onClick={() => setConnectOpen(true)}>
 						<Plus />
-						Connect a bot
+						Connect your own bot
 					</Button>
 				}
 			/>
 
 			<div className="flex flex-col gap-7">
+				<ReadyBotsSection
+					providers={poolProviders}
+					isLoading={botPool.isLoading}
+					error={botPool.error}
+					onRetry={() => botPool.refetch()}
+					filter={filter}
+				/>
 				<YourChannelsSection
 					channels={channelItems}
 					isLoading={channels.isLoading}
@@ -94,13 +102,6 @@ export function ChannelsPage() {
 					onRetryHealth={() => health.refetch()}
 					filter={filter}
 					onConnect={() => setConnectOpen(true)}
-				/>
-				<SharedBotsSection
-					providers={poolProviders}
-					isLoading={botPool.isLoading}
-					error={botPool.error}
-					onRetry={() => botPool.refetch()}
-					filter={filter}
 				/>
 			</div>
 
@@ -171,12 +172,12 @@ function YourChannelsSection({
 		content = (
 			<EmptyState
 				icon={MessagesSquare}
-				title="No channels yet"
-				description="Connect a bot, or link a shared bot to an agent from the Shared bots section."
+				title="No personal bots yet"
+				description="Personal bots are optional. Use a ready-to-go bot above, or connect one here when you need full control."
 				action={
-					<Button onClick={onConnect}>
+					<Button variant="outline" onClick={onConnect}>
 						<Plus />
-						Connect a bot
+						Connect your own bot
 					</Button>
 				}
 			/>
@@ -186,11 +187,11 @@ function YourChannelsSection({
 			<EmptyState
 				icon={MessagesSquare}
 				title={`No ${providerLabel(filter)} channels`}
-				description="Try another provider filter, or connect a new bot."
+				description="Try another provider filter, or connect your own bot."
 				action={
-					<Button onClick={onConnect}>
+					<Button variant="outline" onClick={onConnect}>
 						<Plus />
-						Connect a bot
+						Connect your own bot
 					</Button>
 				}
 			/>
@@ -213,7 +214,7 @@ function YourChannelsSection({
 
 	return (
 		<section className="flex flex-col gap-3">
-			<SectionLabel count={!isLoading ? visibleCount : undefined}>Your channels</SectionLabel>
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Your bots</SectionLabel>
 			{healthError ? (
 				<ApiErrorPanel
 					error={healthError}
@@ -278,7 +279,7 @@ function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: st
 	);
 }
 
-function SharedBotsSection({
+function ReadyBotsSection({
 	providers,
 	isLoading,
 	error,
@@ -309,18 +310,22 @@ function SharedBotsSection({
 			</div>
 		);
 	} else if (error) {
-		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load shared bots" />;
+		content = (
+			<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load ready-to-go bots" />
+		);
 	} else if (groups.length === 0) {
 		content = (
 			<EmptyState
 				icon={Users}
 				title={
-					filter === "all" ? "No shared bots available" : `No ${providerLabel(filter)} shared bots`
+					filter === "all"
+						? "No ready-to-go bots available"
+						: `No ${providerLabel(filter)} ready-to-go bots`
 				}
 				description={
 					filter === "all"
-						? "Shared bots you can link to instantly will appear here."
-						: "Try another provider filter to see linkable shared bots."
+						? "Bots you can link without credentials will appear here."
+						: "Try another provider filter to see bots you can link instantly."
 				}
 			/>
 		);
@@ -356,7 +361,7 @@ function SharedBotsSection({
 
 	return (
 		<section className="flex flex-col gap-3">
-			<SectionLabel count={!isLoading ? visibleCount : undefined}>Shared bots</SectionLabel>
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Ready-to-go bots</SectionLabel>
 			{content}
 			{linkTarget ? (
 				<LinkAgentDialog

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
@@ -37,10 +37,10 @@ describe("Discord snowflake fields", () => {
 		);
 	});
 
-	test("allows an empty optional guild ID but validates supplied values", () => {
+	test("allows an empty optional server ID but validates supplied values", () => {
 		expect(discordGuildIdError("   ")).toBeNull();
 		expect(discordGuildIdError("1234567890123456789")).toBeNull();
-		expect(discordGuildIdError("1234567890123456")).toBe("Enter a valid numeric guild ID.");
+		expect(discordGuildIdError("1234567890123456")).toBe("Enter a valid numeric server ID.");
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
@@ -30,7 +30,7 @@ export function discordApplicationIdError(value: string): string | null {
 export function discordGuildIdError(value: string): string | null {
 	const trimmed = value.trim();
 	if (!trimmed) return null;
-	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric guild ID.";
+	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric server ID.";
 }
 
 export function discordPublicKeyError(value: string): string | null {

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
@@ -29,10 +30,7 @@ import {
 	discordGuildIdError,
 	discordPublicKeyError,
 } from "@/hosted/v2/channels/connect-bot-dialog.logic";
-import {
-	channelDialogOpenChangeAllowed,
-	WHATSAPP_LINKING_READY,
-} from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.logic";
 
 /**
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
@@ -57,7 +55,11 @@ export function ConnectBotDialog({
 	const [publicKey, setPublicKey] = useState("");
 	const [guildId, setGuildId] = useState("");
 	const [created, setCreated] = useState<ChannelCreated | null>(null);
+	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
+	const openRef = useRef(open);
+	const dialogSessionRef = useRef(0);
+	openRef.current = open;
 
 	useEffect(() => {
 		if (!open) return;
@@ -76,7 +78,7 @@ export function ConnectBotDialog({
 	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
 	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
 	const guildIdError = discordSelected ? discordGuildIdError(guildId) : null;
-	const isSubmitting = create.isPending || submitLocked.current;
+	const isSubmitting = submitting || create.isPending;
 
 	function changeProvider(next: ChannelProviderId) {
 		if (next === "whatsapp" && !WHATSAPP_LINKING_READY) return;
@@ -122,20 +124,29 @@ export function ConnectBotDialog({
 		const body = buildBody();
 		if (!body) return;
 		submitLocked.current = true;
+		setSubmitting(true);
+		const dialogSession = dialogSessionRef.current;
 		try {
 			const data = await create.execute(body);
 			setToken("");
-			setCreated(data);
+			if (openRef.current && dialogSessionRef.current === dialogSession) {
+				setCreated(data);
+			} else {
+				toast.success("Channel connected", {
+					description: `${data.name} is ready on the Channels page.`,
+				});
+			}
 		} catch {
 			// useCreateChannel already surfaces the API error; retain the token for retry.
 		} finally {
 			submitLocked.current = false;
+			setSubmitting(false);
 		}
 	}
 
 	function handleOpenChange(nextOpen: boolean) {
-		if (!channelDialogOpenChangeAllowed(nextOpen, create.isPending || submitLocked.current)) return;
 		if (!nextOpen) {
+			dialogSessionRef.current += 1;
 			setToken("");
 			setCreated(null);
 		}
@@ -189,11 +200,7 @@ export function ConnectBotDialog({
 							/>
 						) : null}
 						<DialogFooter>
-							<Button
-								variant="outline"
-								onClick={() => handleOpenChange(false)}
-								disabled={isSubmitting}
-							>
+							<Button variant="outline" onClick={() => handleOpenChange(false)}>
 								Close
 							</Button>
 							<Button
@@ -367,15 +374,11 @@ export function ConnectBotDialog({
 						</div>
 
 						<DialogFooter>
-							<Button
-								variant="outline"
-								onClick={() => handleOpenChange(false)}
-								disabled={isSubmitting}
-							>
-								Cancel
+							<Button variant="outline" onClick={() => handleOpenChange(false)}>
+								{isSubmitting ? "Close" : "Cancel"}
 							</Button>
 							<Button onClick={() => void submit()} disabled={!canSubmit || isSubmitting}>
-								{create.isPending ? "Connecting…" : "Connect"}
+								{isSubmitting ? "Connecting…" : "Connect"}
 							</Button>
 						</DialogFooter>
 					</>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
+import { ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EntityChoiceCard } from "@/components/entity-card";
@@ -257,7 +258,27 @@ export function ConnectBotDialog({
 
 							<div className="flex items-start gap-3 rounded-lg border bg-muted/30 p-3">
 								<ProviderChip provider={provider} />
-								<p className="text-xs text-muted-foreground">{meta.hint}</p>
+								<div className="space-y-2 text-xs text-muted-foreground">
+									<p>{meta.hint}</p>
+									{meta.setupSteps ? (
+										<ol className="list-decimal space-y-1 pl-4">
+											{meta.setupSteps.map((step) => (
+												<li key={step}>{step}</li>
+											))}
+										</ol>
+									) : null}
+									{meta.setupUrl && meta.setupLinkLabel ? (
+										<a
+											href={meta.setupUrl}
+											target="_blank"
+											rel="noreferrer"
+											className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4"
+										>
+											{meta.setupLinkLabel}
+											<ExternalLink className="size-3" />
+										</a>
+									) : null}
+								</div>
 							</div>
 
 							<div className="flex flex-col gap-1.5">
@@ -269,6 +290,9 @@ export function ConnectBotDialog({
 									placeholder="Support Bot"
 									autoComplete="off"
 								/>
+								<p className="text-xs text-muted-foreground">
+									This is the name shown in Clawdi; it does not rename the bot.
+								</p>
 							</div>
 
 							{/* Telegram / Discord bot token. */}
@@ -319,7 +343,7 @@ export function ConnectBotDialog({
 											</p>
 										) : (
 											<p id="connect-app-id-help" className="text-xs text-muted-foreground">
-												Required to publish slash commands.
+												Find this on General Information in the Discord Developer Portal.
 											</p>
 										)}
 									</div>
@@ -345,29 +369,36 @@ export function ConnectBotDialog({
 											</p>
 										) : (
 											<p id="connect-public-key-help" className="text-xs text-muted-foreground">
-												Stored with the Discord application metadata.
+												Find this on General Information. Leave it blank if you do not use Discord
+												interactions.
 											</p>
 										)}
 									</div>
 									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-guild-id">
-											Guild ID <span className="text-muted-foreground">· optional</span>
+											Server ID <span className="text-muted-foreground">· optional</span>
 										</Label>
 										<Input
 											id="connect-guild-id"
 											value={guildId}
 											onChange={(e) => setGuildId(e.target.value)}
-											placeholder="Default command scope"
+											placeholder="Discord server ID"
 											autoComplete="off"
 											spellCheck={false}
 											aria-invalid={Boolean(guildIdError)}
-											aria-describedby={guildIdError ? "connect-guild-id-err" : undefined}
+											aria-describedby={
+												guildIdError ? "connect-guild-id-err" : "connect-server-id-help"
+											}
 										/>
 										{guildIdError ? (
 											<p id="connect-guild-id-err" className="text-xs text-destructive">
 												{guildIdError}
 											</p>
-										) : null}
+										) : (
+											<p id="connect-server-id-help" className="text-xs text-muted-foreground">
+												Leave blank unless commands should be limited to one Discord server.
+											</p>
+										)}
 									</div>
 								</>
 							) : null}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-	channelDialogOpenChangeAllowed,
 	channelProviderLinkingReady,
 	linkAgentBlockReason,
 	pairingCommand,
@@ -17,12 +16,6 @@ describe("hosted channel instructions and gates", () => {
 		expect(channelProviderLinkingReady("telegram")).toBe(true);
 		expect(channelProviderLinkingReady("discord")).toBe(true);
 		expect(channelProviderLinkingReady("whatsapp")).toBe(false);
-	});
-
-	test("keeps one-time results in view while a connect or link request is pending", () => {
-		expect(channelDialogOpenChangeAllowed(false, true)).toBe(false);
-		expect(channelDialogOpenChangeAllowed(false, false)).toBe(true);
-		expect(channelDialogOpenChangeAllowed(true, true)).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	channelActivityAfterLink,
 	channelProviderLinkingReady,
 	linkAgentBlockReason,
 	pairingCommand,
@@ -16,6 +17,13 @@ describe("hosted channel instructions and gates", () => {
 		expect(channelProviderLinkingReady("telegram")).toBe(true);
 		expect(channelProviderLinkingReady("discord")).toBe(true);
 		expect(channelProviderLinkingReady("whatsapp")).toBe(false);
+	});
+
+	test("only treats real account activity after linking as new channel activity", () => {
+		expect(channelActivityAfterLink(null, "2026-07-26T09:00:00Z")).toBe(false);
+		expect(channelActivityAfterLink("2026-07-26T08:59:59Z", "2026-07-26T09:00:00Z")).toBe(false);
+		expect(channelActivityAfterLink("2026-07-26T09:00:01Z", "2026-07-26T09:00:00Z")).toBe(true);
+		expect(channelActivityAfterLink("not-a-date", "2026-07-26T09:00:00Z")).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -61,7 +61,9 @@ describe("linkAgentBlockReason", () => {
 				],
 				accountId: "tg-current",
 			}),
-		).toContain("one-telegram-link-per-Hermes-agent");
+		).toBe(
+			"Hermes agents can use one active Telegram bot at a time. Unlink the current Telegram bot before linking another.",
+		);
 	});
 
 	test("allows the current existing link and non-Hermes multi-link behavior", () => {

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -23,6 +23,17 @@ export function pairingCommand(code: string): string {
 	return `/bot_pair ${code}`;
 }
 
+/** Account-level activity is useful, but it is not proof of agent-runtime delivery. */
+export function channelActivityAfterLink(
+	lastMessageAt: string | null | undefined,
+	linkCreatedAt: string,
+): boolean {
+	if (!lastMessageAt) return false;
+	const messageTime = Date.parse(lastMessageAt);
+	const linkTime = Date.parse(linkCreatedAt);
+	return Number.isFinite(messageTime) && Number.isFinite(linkTime) && messageTime >= linkTime;
+}
+
 export function shouldMintWhatsappTenantCredential(provider: string, agent: Agent): boolean {
 	return WHATSAPP_LINKING_READY && provider === "whatsapp" && agent !== null && agent !== undefined;
 }

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -60,5 +60,9 @@ export function linkAgentBlockReason({
 			link.account.provider === provider,
 	);
 	if (!hasExistingProviderLink) return null;
-	return `one-${provider}-link-per-Hermes-agent: Hermes agents support one active ${provider} link. Unlink the existing ${provider} channel before linking another.`;
+	return `Hermes agents can use one active ${providerMetaLabel(provider)} bot at a time. Unlink the current ${providerMetaLabel(provider)} bot before linking another.`;
+}
+
+function providerMetaLabel(provider: string): string {
+	return provider === "telegram" ? "Telegram" : provider === "discord" ? "Discord" : "channel";
 }

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -19,10 +19,6 @@ export function channelProviderLinkingReady(provider: string): boolean {
 	return provider !== "whatsapp" || WHATSAPP_LINKING_READY;
 }
 
-export function channelDialogOpenChangeAllowed(nextOpen: boolean, isSubmitting: boolean): boolean {
-	return nextOpen || !isSubmitting;
-}
-
 export function pairingCommand(code: string): string {
 	return `/bot_pair ${code}`;
 }

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -3,6 +3,7 @@
 import type { components } from "@clawdi/shared/api";
 import { CircleCheck, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
 	AgentLabel,
@@ -39,7 +40,6 @@ import {
 	useLinkAgent,
 } from "@/hosted/v2/channels/channels-hooks";
 import {
-	channelDialogOpenChangeAllowed,
 	linkAgentBlockReason,
 	shouldMintWhatsappTenantCredential,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -80,7 +80,11 @@ export function LinkAgentDialog({
 	const [token, setToken] = useState<string | null>(null);
 	const [linkedNoToken, setLinkedNoToken] = useState(false);
 	const [whatsappCredentialMinted, setWhatsappCredentialMinted] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
+	const openRef = useRef(open);
+	const dialogSessionRef = useRef(0);
+	openRef.current = open;
 
 	const agents = useMemo(() => [...(envs.data ?? [])].sort(compareAgentEnvironments), [envs.data]);
 	const selectedAgent = agents.find((env) => env.id === agentId);
@@ -97,7 +101,7 @@ export function LinkAgentDialog({
 		accountId,
 	});
 	const guardLoading = shouldCheckHermesSingleLink && selectedAgentLinks.isLoading;
-	const isSubmitting = link.isPending || createWhatsappCredential.isPending || submitLocked.current;
+	const isSubmitting = submitting || link.isPending || createWhatsappCredential.isPending;
 
 	useEffect(() => {
 		if (!open) return;
@@ -111,31 +115,42 @@ export function LinkAgentDialog({
 		if (!agentId || blockReason || guardLoading || submitLocked.current) return;
 		const agent = selectedAgent;
 		submitLocked.current = true;
+		setSubmitting(true);
+		const dialogSession = dialogSessionRef.current;
 		try {
 			const data = await link.execute(agentId);
 			if (shouldMintWhatsappTenantCredential(provider, agent)) {
 				await createWhatsappCredential.execute({ agent_link_id: data.id });
-				setWhatsappCredentialMinted(true);
+				if (openRef.current && dialogSessionRef.current === dialogSession) {
+					setWhatsappCredentialMinted(true);
+				} else {
+					toast.success("Agent linked", {
+						description: `${accountName} is linked. Finish device pairing from the agent runtime.`,
+					});
+				}
 				return;
 			}
-			if (data.agent_token) setToken(data.agent_token);
-			else setLinkedNoToken(true);
+			if (openRef.current && dialogSessionRef.current === dialogSession) {
+				if (data.agent_token) setToken(data.agent_token);
+				else setLinkedNoToken(true);
+			} else {
+				toast.success("Agent linked", {
+					description: `${accountName} is linked. Open the agent's Channels tab to pair a chat.`,
+				});
+			}
 		} catch {
 			// The sensitive action hooks already surface API failures.
 		} finally {
 			submitLocked.current = false;
+			setSubmitting(false);
 		}
 	}
 
 	function handleOpenChange(nextOpen: boolean) {
-		if (
-			!channelDialogOpenChangeAllowed(
-				nextOpen,
-				link.isPending || createWhatsappCredential.isPending || submitLocked.current,
-			)
-		)
-			return;
-		if (!nextOpen) setToken(null);
+		if (!nextOpen) {
+			dialogSessionRef.current += 1;
+			setToken(null);
+		}
 		onOpenChange(nextOpen);
 	}
 
@@ -237,27 +252,17 @@ export function LinkAgentDialog({
 
 				<DialogFooter>
 					{token || linkedNoToken || whatsappCredentialMinted ? (
-						<Button onClick={() => handleOpenChange(false)} disabled={isSubmitting}>
-							Done
-						</Button>
+						<Button onClick={() => handleOpenChange(false)}>Done</Button>
 					) : (
 						<>
-							<Button
-								variant="outline"
-								onClick={() => handleOpenChange(false)}
-								disabled={isSubmitting}
-							>
-								Cancel
+							<Button variant="outline" onClick={() => handleOpenChange(false)}>
+								{isSubmitting ? "Close" : "Cancel"}
 							</Button>
 							<Button
 								onClick={() => void submit()}
 								disabled={!agentId || Boolean(blockReason) || guardLoading || isSubmitting}
 							>
-								{createWhatsappCredential.isPending
-									? "Minting device…"
-									: link.isPending
-										? "Linking…"
-										: "Link agent"}
+								{isSubmitting ? "Linking…" : "Link agent"}
 							</Button>
 						</>
 					)}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
+import { Link } from "@tanstack/react-router";
 import { CircleCheck, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -165,32 +166,58 @@ export function LinkAgentDialog({
 			}),
 		[agents, ownership],
 	);
+	const linkComplete = Boolean(token || linkedNoToken || whatsappCredentialMinted);
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
 				<DialogHeader>
-					<DialogTitle>Link an agent</DialogTitle>
+					<DialogTitle>{linkComplete ? "Agent linked" : "Link an agent"}</DialogTitle>
 					<DialogDescription>
-						Connect one of your agents to <span className="font-medium">{accountName}</span>.
+						{linkComplete ? (
+							<>
+								<span className="font-medium">{accountName}</span> is linked. Finish setup from the
+								agent's Channels page.
+							</>
+						) : (
+							<>
+								Connect one of your agents to <span className="font-medium">{accountName}</span>.
+							</>
+						)}
 					</DialogDescription>
 				</DialogHeader>
 
-				{token ? (
-					<TokenReveal
-						label="Agent token"
-						value={token}
-						note="Copy it now — it won't be shown again. The agent runtime uses this to send and receive on this channel."
-					/>
+				{token || linkedNoToken ? (
+					<div className="space-y-3 rounded-lg border border-success/30 bg-success-muted p-3 text-sm">
+						<div className="flex items-start gap-2 text-success-muted-foreground">
+							<CircleCheck className="mt-0.5 size-4 shrink-0" />
+							<div>
+								<p className="font-medium">The bot is linked to this agent</p>
+								<p className="mt-1 text-xs">
+									Next, create a pairing code and send it in the exact chat where the agent should
+									answer.
+								</p>
+							</div>
+						</div>
+						{token ? (
+							<details className="rounded-md border bg-background p-3">
+								<summary className="cursor-pointer text-xs font-medium">
+									Agent token (advanced)
+								</summary>
+								<div className="mt-2">
+									<TokenReveal
+										label="Agent token"
+										value={token}
+										note="Hosted agents configure this automatically. Only copy it for a self-managed runtime that asks for it."
+									/>
+								</div>
+							</details>
+						) : null}
+					</div>
 				) : whatsappCredentialMinted ? (
 					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
 						<CircleCheck className="size-4 shrink-0" />
-						Device credential minted. Finish pairing from the agent runtime to link the number.
-					</div>
-				) : linkedNoToken ? (
-					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
-						<CircleCheck className="size-4 shrink-0" />
-						This agent is already linked to the channel.
+						WhatsApp access is ready. Finish linking the number from the agent runtime.
 					</div>
 				) : envs.isLoading ? (
 					<Skeleton className="h-10 w-full rounded-md" />
@@ -251,8 +278,20 @@ export function LinkAgentDialog({
 				)}
 
 				<DialogFooter>
-					{token || linkedNoToken || whatsappCredentialMinted ? (
-						<Button onClick={() => handleOpenChange(false)}>Done</Button>
+					{linkComplete ? (
+						<>
+							<Button variant="outline" onClick={() => handleOpenChange(false)}>
+								Close
+							</Button>
+							<Button
+								render={
+									<Link to="/agents/$id/$section" params={{ id: agentId, section: "channels" }} />
+								}
+								nativeButton={false}
+							>
+								Finish channel setup
+							</Button>
+						</>
 					) : (
 						<>
 							<Button variant="outline" onClick={() => handleOpenChange(false)}>


### PR DESCRIPTION
## Summary

- give every channel mutation a control-scoped busy state, bounded request, honest terminal result, and an exit
- turn each linked-channel row into the finish line: explain linking versus pairing, identify the target chat, generate the command, and watch live channel activity automatically
- lead with ready-to-go bots and keep personal Telegram or Discord bots as the advanced path
- replace channel setup dead ends with automatic checks, bounded expectations, retry, and primary exits
- keep one-time agent tokens in component memory only and place them behind an advanced disclosure

## Honest signal boundary

The current health API exposes account-level last_message_at. It does not expose per-agent-link runtime receipt, and pairing commands count as channel messages. The UI therefore reports Channel activity detected, never Agent received its first message. An exact completion signal needs a per-agent-link timestamp that is written only when a normal inbound message is consumed by the agent runtime, not when a pairing command is handled.

## Scope

Channel surfaces only. No deploy wizard, readiness panel, or billing changes.

## Verification

- bun run typecheck: 4 of 4 packages successful
- bun run lint: 697 files checked, 0 issues
- bun test: 1684 passed, 0 failed, 6706 assertions across 178 files
