### PR TITLE
fix(scripts): correct bun flag order in regeneration instructions

### DIFF
--- a/scripts/check-deploy-generated-api.sh
+++ b/scripts/check-deploy-generated-api.sh
@@ -92,6 +92,6 @@ fi
 
 diff -u "$committed_path" "$expected_path" || true
 echo \
-	"packages/shared/src/api/deploy.generated.ts is stale. Regenerate with \`DEPLOY_OPENAPI_SOURCE=$spec_source bun --cwd apps/web run generate-deploy-api\` and commit the result." \
+	"packages/shared/src/api/deploy.generated.ts is stale. Regenerate with \`DEPLOY_OPENAPI_SOURCE=$spec_source bun run --cwd apps/web generate-deploy-api\` and commit the result." \
 	>&2
 exit 1

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -17,10 +17,10 @@ only the surface we actually consume so:
 
 Usage:
 
-Local development (the default behind `bun --cwd apps/web run generate-deploy-api`):
+Local development (the default behind `bun run --cwd apps/web generate-deploy-api`):
 
     DEPLOY_OPENAPI_SOURCE=http://localhost:50021/openapi.json \
-      bun --cwd apps/web run generate-deploy-api
+      bun run --cwd apps/web generate-deploy-api
 
 Regenerating against a reviewed checked-in hosted contract before coordinated
 deployment:
@@ -28,7 +28,7 @@ deployment:
     cd /path/to/clawdi-hosted/backend
     python3 -m http.server 50021
     DEPLOY_OPENAPI_SOURCE=http://localhost:50021/openapi.json \
-      bun --cwd apps/web run generate-deploy-api
+      bun run --cwd apps/web generate-deploy-api
 
 To consume a new endpoint, add its path + HTTP method to
 `KEEP_OPERATIONS_BY_PATH` and rerun the generate command. Schema closure is


### PR DESCRIPTION
## What

Four occurrences of `bun --cwd apps/web run generate-deploy-api` become `bun run --cwd apps/web generate-deploy-api`.

## Why

On Bun 1.3.14 the first form prints `bun run` usage help and **exits 0 without running anything** — the directory flag has to follow the subcommand. Anyone following these instructions saw a successful exit, regenerated nothing, and still had a stale client.

The worst placement is `scripts/check-deploy-generated-api.sh:95`, which is the `deploy-contract-drift` gate's own remediation message. The gate told developers to run a command that silently did nothing, so the gate stayed red with no visible reason why.

**CI is unaffected.** `.github/workflows/client-ci.yml` already uses the working `bun run --cwd` order in all three of its invocations, so no check has been silently passing. This repairs only the human-facing instructions.

## Verification

Ran the corrected command:

```
DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json bun run --cwd apps/web generate-deploy-api
✨ openapi-typescript 7.13.0
🚀 → packages/shared/src/api/deploy.generated.ts [216.7ms]
exit=0
```

It regenerates `packages/shared/src/api/deploy.generated.ts` with **zero diff** against main, which incidentally also confirms the committed client matches the deployed contract.

Found by the agent rebasing #492, which hit the broken form while following the gate's own advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)