### PR TITLE
fix(web): retire hosted deploy compatibility overlay

### DIFF
--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -29,36 +29,8 @@ export type DeploymentDesiredLifecycle = "running" | "stopped";
 export type DeployRequest = Schemas["V2HostedDeployRequest"];
 export type HostedDeploymentSpec = Schemas["HostedDeploymentSpec"];
 export type HostedDeploymentStatus = Schemas["HostedDeploymentStatus"];
-type GeneratedHostedDeployment = Schemas["V2HostedDeploymentReadResponse"];
-type GeneratedHostedDeploymentResource = GeneratedHostedDeployment["resource"];
-type GeneratedDeploymentOperation = Schemas["LongRunningOperation"];
-type GeneratedDeploymentOperationResponse = Schemas["DeploymentOperationResponse"];
-type CompatibleHostedDeploymentResource = Omit<GeneratedHostedDeploymentResource, "status"> & {
-	status: HostedDeploymentStatus | null;
-};
-
-export type DeploymentOperation = Omit<GeneratedDeploymentOperation, "response"> & {
-	response?:
-		| (Omit<GeneratedDeploymentOperationResponse, "deployment"> & {
-				deployment: CompatibleHostedDeploymentResource;
-		  })
-		| Schemas["EmptyResponse"]
-		| null;
-};
-
-/**
- * Web-first compatibility overlay for deployment reads that may be unable to
- * provide status or compute-slot occupancy. Keep the generated client synced
- * to the deployed contract; model the temporarily wider read boundary here.
- */
-export type HostedDeployment = Omit<
-	GeneratedHostedDeployment,
-	"accepted_operation" | "compute_slot_occupancy" | "resource"
-> & {
-	accepted_operation?: DeploymentOperation | null;
-	compute_slot_occupancy: GeneratedHostedDeployment["compute_slot_occupancy"] | null;
-	resource: CompatibleHostedDeploymentResource;
-};
+export type DeploymentOperation = Schemas["LongRunningOperation"];
+export type HostedDeployment = Schemas["V2HostedDeploymentReadResponse"];
 export type HostedComputeSubscription = NonNullable<
 	NonNullable<HostedDeployment["commercial_display"]>["compute_subscription"]
 >;

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -41,7 +41,12 @@ export type UnknownDeploymentStatus =
 	  };
 
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
-export type DeploymentOperationVerb = DeploymentOperation["metadata"]["verb"] | "plan_change";
+// `plan_change` is a projected failure phase; `runtime_switch` remains a live
+// legacy wire value while the hosted main rollout converges.
+export type DeploymentOperationVerb =
+	| DeploymentOperation["metadata"]["verb"]
+	| "plan_change"
+	| "runtime_switch";
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
 export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -553,7 +553,7 @@ export interface components {
              * Verb
              * @enum {string}
              */
-            verb: "create" | "start" | "stop" | "restart" | "update" | "runtime_switch" | "rename" | "delete";
+            verb: "create" | "start" | "stop" | "restart" | "update" | "rename" | "delete";
             /** Targetgeneration */
             targetGeneration: number;
             /** Manifestetag */
@@ -666,7 +666,7 @@ export interface components {
             deployment_target: string;
             metadata: components["schemas"]["DeploymentMetadata"];
             spec: components["schemas"]["HostedDeploymentSpec"];
-            status: components["schemas"]["HostedDeploymentStatus"];
+            status: components["schemas"]["HostedDeploymentStatus"] | null;
         };
         /** HostedDeploymentSpec */
         HostedDeploymentSpec: {
@@ -1649,7 +1649,7 @@ export interface components {
              * @default false
              */
             upgrade_available: boolean;
-            compute_slot_occupancy: components["schemas"]["V2HostedComputeSlotOccupancy"];
+            compute_slot_occupancy: components["schemas"]["V2HostedComputeSlotOccupancy"] | null;
         };
         /** V2HostedRuntimeUiCredentials */
         V2HostedRuntimeUiCredentials: {


### PR DESCRIPTION
## Summary

- regenerate the hosted deploy client from clawdi-hosted main after #1036
- remove the temporary nullable deployment compatibility overlay
- use generated deployment read and operation types directly
- preserve `runtime_switch` only in the UI compatibility verb union while the currently deployed hosted API still advertises that legacy value

## Verification

- [x] `bun run typecheck` — 4/4 tasks successful
- [x] `bun run lint` — 700 files checked
- [x] `bun test` — 1712 pass, 0 fail, 6871 assertions across 180 files
- [ ] hosted deploy contract drift — blocked because live `https://api.clawdi.ai/openapi.json` still serves the pre-#1036 contract; hosted main is already updated

The exact CI command currently reports the three expected live/main differences: nullable deployment status, nullable compute-slot occupancy, and removal of `runtime_switch` from the generated enum.