### PR TITLE
feat(api): add atomic AI provider accepts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -193,6 +193,7 @@ app.add_middleware(
         "X-Correlation-ID",
         "X-Clawdi-Environment-Id",
         "X-Clawdi-Token",
+        "Idempotency-Key",
         # `If-None-Match` carries the daemon's last seen
         # `skills_revision` for the conditional GET /v1/skills.
         # The CLI daemon hits this without going through CORS, so

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -5,24 +5,31 @@ import json
 import re
 import secrets
 from datetime import UTC, datetime, timedelta
+from typing import Annotated
 from urllib.parse import urlencode, urlparse
+from uuid import UUID
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import (
     AuthContext,
+    get_auth_short_session,
     require_user_auth,
     require_user_auth_unbound,
     require_user_cli,
 )
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import async_session_factory, get_session
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.schemas.ai_provider import (
+    AiProviderAcceptRequest,
+    AiProviderAcceptResponse,
+    AiProviderApiKeyAcceptCredential,
     AiProviderAuth,
     AiProviderAuthImportRequest,
     AiProviderAuthResolveRequest,
@@ -31,10 +38,13 @@ from app.schemas.ai_provider import (
     AiProviderListResponse,
     AiProviderManagedApiKeyRequest,
     AiProviderModel,
+    AiProviderOAuthAcceptCredential,
     AiProviderOAuthCompleteRequest,
+    AiProviderOAuthPendingAcceptResponse,
     AiProviderOAuthStartRequest,
     AiProviderOAuthStartResponse,
     AiProviderPatch,
+    AiProviderReadyAcceptResponse,
     AiProviderResponse,
     AiProviderUpsert,
     AiProviderValidationResponse,
@@ -48,6 +58,13 @@ from app.services.managed_ai_provider import (
     is_v2_deployment_managed_provider_id,
     managed_provider_api_mode,
     runtime_managed_provider_id,
+)
+from app.services.platform_contract import (
+    PlatformReplay,
+    lock_platform_idempotency,
+    platform_request_hash,
+    read_platform_replay,
+    store_platform_response,
 )
 from app.services.sync_events import queue_provider_runtime_manifest_changed
 from app.services.vault_crypto import decrypt, encrypt
@@ -93,6 +110,32 @@ RESERVED_OAUTH_AUTHORIZE_PARAMS = {
     "scope",
     "state",
 }
+
+IdempotencyKey = Annotated[
+    str,
+    Header(alias="Idempotency-Key", min_length=1, max_length=200),
+]
+
+_AI_PROVIDER_ACCEPT_OPERATION = "ai_provider.accept"
+_AI_PROVIDER_OAUTH_COMPLETE_OPERATION = "ai_provider.oauth.complete"
+_OAUTH_PENDING_SOURCE = "oauth_pending"
+
+
+async def _require_ai_provider_accept_auth(
+    auth: AuthContext = Depends(get_auth_short_session),
+) -> AuthContext:
+    if auth.is_cli and auth.api_key is not None:
+        if auth.api_key.scopes is not None:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "This endpoint is not available to scoped api keys",
+            )
+        if auth.api_key.environment_id is not None:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "user-level auth is required (Agent API keys cannot manage account resources)",
+            )
+    return auth
 
 
 @router.get("", response_model=AiProviderListResponse, response_model_exclude_none=True)
@@ -147,6 +190,57 @@ async def upsert_ai_provider(
     await db.commit()
     await db.refresh(provider)
     return await _to_response(db, auth, provider)
+
+
+@router.post(
+    "/accept",
+    response_model=AiProviderAcceptResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_201_CREATED,
+)
+async def accept_ai_provider(
+    body: AiProviderAcceptRequest,
+    idempotency_key: IdempotencyKey,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> AiProviderAcceptResponse | JSONResponse:
+    """Atomically create a provider and its first usable auth state."""
+
+    request_hash = _ai_provider_accept_request_hash(body)
+    try:
+        replay = await _load_ai_provider_accept_replay(
+            db,
+            operation=_AI_PROVIDER_ACCEPT_OPERATION,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            owner_user_id=auth.user_id,
+        )
+        if replay is not None:
+            await db.commit()
+            return JSONResponse(status_code=replay.status_code, content=replay.body)
+
+        result = await _accept_ai_provider(db, auth, body)
+        response_body = result.model_dump(mode="json", exclude_none=True)
+        store_platform_response(
+            db,
+            operation=_AI_PROVIDER_ACCEPT_OPERATION,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            owner_user_id=auth.user_id,
+            resource_type=(
+                "ai_provider_oauth_setup"
+                if isinstance(result, AiProviderOAuthPendingAcceptResponse)
+                else "ai_provider"
+            ),
+            resource_id=result.provider.provider_id,
+            response_status=status.HTTP_201_CREATED,
+            response_body=response_body,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return result
 
 
 @router.get("/{provider_id}", response_model=AiProviderResponse, response_model_exclude_none=True)
@@ -462,6 +556,489 @@ async def complete_ai_provider_oauth(
     await db.commit()
     await db.refresh(provider)
     return await _to_response(db, auth, provider)
+
+
+@router.post(
+    "/{provider_id}/accept",
+    response_model=AiProviderReadyAcceptResponse,
+    response_model_exclude_none=True,
+)
+async def complete_ai_provider_accept(
+    provider_id: str,
+    body: AiProviderOAuthCompleteRequest,
+    idempotency_key: IdempotencyKey,
+    auth: AuthContext = Depends(_require_ai_provider_accept_auth),
+) -> AiProviderReadyAcceptResponse | JSONResponse:
+    """Complete an OAuth-pending provider without spanning remote I/O with a DB session."""
+
+    request_hash = _ai_provider_oauth_complete_request_hash(provider_id, body)
+    async with async_session_factory() as db:
+        replay = await _load_ai_provider_accept_replay(
+            db,
+            operation=_AI_PROVIDER_OAUTH_COMPLETE_OPERATION,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            owner_user_id=auth.user_id,
+        )
+        if replay is not None:
+            await db.commit()
+            return JSONResponse(status_code=replay.status_code, content=replay.body)
+        provider = await _get_provider_or_404(db, auth, provider_id)
+        oauth_state = _validate_pending_oauth_accept(provider, auth, body)
+        await db.rollback()
+
+    payload_text, provider_auth_type, metadata = await _exchange_oauth_code(
+        body,
+        oauth_state,
+    )
+
+    async with async_session_factory() as db:
+        try:
+            replay = await _load_ai_provider_accept_replay(
+                db,
+                operation=_AI_PROVIDER_OAUTH_COMPLETE_OPERATION,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+                owner_user_id=auth.user_id,
+            )
+            if replay is not None:
+                await db.commit()
+                return JSONResponse(status_code=replay.status_code, content=replay.body)
+
+            provider = await _get_provider_or_404_for_update(db, auth, provider_id)
+            _validate_pending_oauth_accept(provider, auth, body)
+            previous_signature = _runtime_manifest_provider_signature(provider)
+            profile = _normalize_profile(str(oauth_state.get("profile") or "default"))
+            await _store_auth_payload(
+                db,
+                auth,
+                provider.provider_id,
+                profile,
+                provider_auth_type,
+                payload_text,
+                metadata,
+            )
+            provider.auth_type = provider_auth_type
+            provider.auth_ref = None
+            provider.auth_metadata = metadata
+            if previous_signature != _runtime_manifest_provider_signature(provider):
+                await queue_provider_runtime_manifest_changed(
+                    db,
+                    auth.user_id,
+                    provider.provider_id,
+                )
+            await db.flush()
+            await db.refresh(provider)
+            provider_response = await _to_response(db, auth, provider)
+            if not provider_response.usable:
+                raise RuntimeError("completed AI provider accept is not usable")
+            result = AiProviderReadyAcceptResponse(
+                status="ready",
+                provider=provider_response,
+            )
+            response_body = result.model_dump(mode="json", exclude_none=True)
+            store_platform_response(
+                db,
+                operation=_AI_PROVIDER_OAUTH_COMPLETE_OPERATION,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+                owner_user_id=auth.user_id,
+                resource_type="ai_provider",
+                resource_id=provider_response.provider_id,
+                response_status=status.HTTP_200_OK,
+                response_body=response_body,
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+    return result
+
+
+def _ai_provider_accept_request_hash(body: AiProviderAcceptRequest) -> str:
+    credential = body.credential
+    if isinstance(credential, AiProviderApiKeyAcceptCredential):
+        credential_payload = {
+            "type": credential.type,
+            "value_sha256": hashlib.sha256(
+                credential.value.get_secret_value().encode()
+            ).hexdigest(),
+        }
+    else:
+        credential_payload = credential.model_dump(mode="json", exclude_none=False)
+    return platform_request_hash(
+        {
+            "provider": body.provider.model_dump(mode="json", exclude_none=False),
+            "credential": credential_payload,
+        }
+    )
+
+
+def _ai_provider_oauth_complete_request_hash(
+    provider_id: str,
+    body: AiProviderOAuthCompleteRequest,
+) -> str:
+    return platform_request_hash(
+        {
+            "provider_id": provider_id,
+            "state_sha256": hashlib.sha256(body.state.encode()).hexdigest(),
+            "code_sha256": hashlib.sha256(body.code.encode()).hexdigest(),
+            "redirect_uri": body.redirect_uri,
+        }
+    )
+
+
+async def _load_ai_provider_accept_replay(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+    request_hash: str,
+    owner_user_id: UUID,
+) -> PlatformReplay | None:
+    existing = await lock_platform_idempotency(
+        db,
+        operation=operation,
+        idempotency_key=idempotency_key,
+    )
+    if existing is None:
+        return None
+    if existing.request_hash != request_hash or existing.owner_user_id != owner_user_id:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Idempotency-Key was already used with a different request",
+        )
+    return read_platform_replay(existing)
+
+
+async def _accept_ai_provider(
+    db: AsyncSession,
+    auth: AuthContext,
+    body: AiProviderAcceptRequest,
+) -> AiProviderAcceptResponse:
+    provider_body = body.provider
+    _raise_if_deployment_managed_provider_id(provider_body.provider_id)
+    if provider_body.provider_id in V2_MANAGED_AI_PROVIDER_IDS:
+        provider_body = provider_body.model_copy(update={"provider_id": V2_MANAGED_AI_PROVIDER_ID})
+    _validate_ai_provider_accept_contract(provider_body, body.credential)
+    errors = _validate_provider(provider_body)
+    if errors:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, {"errors": errors})
+
+    existing = await _find_provider(
+        db,
+        auth,
+        provider_body.provider_id,
+        include_archived=True,
+    )
+    if existing is not None and existing.archived_at is None:
+        existing_response = await _to_response(db, auth, existing)
+        if existing_response.usable or not _accept_can_resume(existing, body.credential):
+            raise HTTPException(status.HTTP_409_CONFLICT, "AI Provider already exists")
+
+    previous_signature = _runtime_manifest_provider_signature(existing)
+    provider = existing or AiProvider(
+        owner_user_id=auth.user_id,
+        provider_id=provider_body.provider_id,
+    )
+    _apply_provider_body(provider, provider_body)
+    provider.archived_at = None
+    db.add(provider)
+    # Make the provider row real inside the transaction before the credential
+    # write. A later failure must roll this flush back, never expose a half row.
+    await db.flush()
+
+    if isinstance(body.credential, AiProviderApiKeyAcceptCredential):
+        profile = str(provider.auth_metadata.get("profile") or "default")
+        await _store_auth_payload(
+            db,
+            auth,
+            provider.provider_id,
+            profile,
+            "api_key",
+            body.credential.value.get_secret_value(),
+            provider.auth_metadata,
+        )
+        if previous_signature != _runtime_manifest_provider_signature(provider):
+            await queue_provider_runtime_manifest_changed(
+                db,
+                auth.user_id,
+                provider.provider_id,
+            )
+        await db.flush()
+        await db.refresh(provider)
+        provider_response = await _to_response(db, auth, provider)
+        if not provider_response.usable:
+            raise RuntimeError("API-key AI provider accept is not usable")
+        return AiProviderReadyAcceptResponse(
+            status="ready",
+            provider=provider_response,
+        )
+
+    authorization = _build_oauth_accept_authorization(
+        provider_id=provider.provider_id,
+        owner_user_id=auth.user_id,
+        body=body.credential,
+    )
+    provider.auth_metadata = {
+        "tool": authorization.oauth_provider,
+        "profile": authorization.profile,
+        "source": _OAUTH_PENDING_SOURCE,
+        "state_sha256": hashlib.sha256(authorization.state.encode()).hexdigest(),
+        "redirect_uri": authorization.redirect_uri,
+        "expires_at": authorization.expires_at.isoformat(),
+    }
+    if previous_signature != _runtime_manifest_provider_signature(provider):
+        await queue_provider_runtime_manifest_changed(
+            db,
+            auth.user_id,
+            provider.provider_id,
+        )
+    await db.flush()
+    await db.refresh(provider)
+    provider_response = await _to_response(db, auth, provider)
+    if provider_response.usable:
+        raise RuntimeError("OAuth-pending AI provider accept is already usable")
+    return AiProviderOAuthPendingAcceptResponse(
+        status="pending",
+        provider=provider_response,
+        authorization=authorization,
+    )
+
+
+def _validate_ai_provider_accept_contract(
+    provider: AiProviderUpsert,
+    credential: AiProviderApiKeyAcceptCredential | AiProviderOAuthAcceptCredential,
+) -> None:
+    if isinstance(credential, AiProviderApiKeyAcceptCredential):
+        if provider.auth.type != "api_key" or provider.auth.source != "managed":
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                "API-key accept requires managed api_key provider auth",
+            )
+        return
+
+    oauth_provider = _normalize_profile(credential.provider)
+    _validate_supported_oauth_provider(oauth_provider)
+    if (
+        provider.auth.type != "agent_profile"
+        or provider.auth.tool != oauth_provider
+        or provider.auth.profile != "default"
+    ):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "OAuth accept requires the default Codex agent profile",
+        )
+
+
+def _accept_can_resume(
+    provider: AiProvider,
+    credential: AiProviderApiKeyAcceptCredential | AiProviderOAuthAcceptCredential,
+) -> bool:
+    metadata = provider.auth_metadata or {}
+    if isinstance(credential, AiProviderApiKeyAcceptCredential):
+        return provider.auth_type == "api_key" and metadata.get("source") == "managed"
+    return (
+        provider.auth_type == "agent_profile"
+        and metadata.get("tool") == _normalize_profile(credential.provider)
+        and str(metadata.get("profile") or "default") == "default"
+    )
+
+
+def _build_oauth_accept_authorization(
+    *,
+    provider_id: str,
+    owner_user_id: UUID,
+    body: AiProviderOAuthAcceptCredential,
+) -> AiProviderOAuthStartResponse:
+    oauth_provider = _normalize_profile(body.provider)
+    _validate_supported_oauth_provider(oauth_provider)
+    profile = "default"
+    config = _oauth_config_for(oauth_provider)
+    authorization_url = _required_oauth_config(
+        config,
+        "authorization_url",
+        oauth_provider,
+    )
+    client_id = _required_oauth_config(config, "client_id", oauth_provider)
+    redirect_uri = body.redirect_uri or _required_oauth_config(
+        config,
+        "redirect_uri",
+        oauth_provider,
+    )
+    _validate_oauth_url(authorization_url, "authorization_url")
+    _validate_redirect_uri(redirect_uri)
+
+    code_verifier = secrets.token_urlsafe(48)
+    code_challenge = _code_challenge(code_verifier)
+    expires_at = datetime.now(UTC) + timedelta(seconds=OAUTH_STATE_TTL_SECONDS)
+    state = _encode_oauth_state(
+        {
+            "provider_id": provider_id,
+            "owner_user_id": str(owner_user_id),
+            "oauth_provider": oauth_provider,
+            "profile": profile,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+            "expires_at": expires_at.isoformat(),
+        }
+    )
+    params: dict[str, str] = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    scope = str(config.get("scope") or "")
+    if scope:
+        params["scope"] = scope
+    audience = str(config.get("audience") or "")
+    if audience:
+        params["audience"] = audience
+    extra = config.get("extra_authorize_params")
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if isinstance(key, str) and isinstance(value, str):
+                if key in RESERVED_OAUTH_AUTHORIZE_PARAMS:
+                    raise HTTPException(
+                        status.HTTP_503_SERVICE_UNAVAILABLE,
+                        f"AI Provider OAuth config for {oauth_provider} cannot override {key}",
+                    )
+                params[key] = value
+
+    separator = "&" if "?" in authorization_url else "?"
+    return AiProviderOAuthStartResponse(
+        provider_id=runtime_managed_provider_id(provider_id),
+        oauth_provider=oauth_provider,
+        profile=profile,
+        auth_url=f"{authorization_url}{separator}{urlencode(params)}",
+        state=state,
+        redirect_uri=redirect_uri,
+        expires_at=expires_at,
+    )
+
+
+def _validate_pending_oauth_accept(
+    provider: AiProvider,
+    auth: AuthContext,
+    body: AiProviderOAuthCompleteRequest,
+) -> dict:
+    metadata = dict(provider.auth_metadata or {})
+    expected_state_hash = str(metadata.get("state_sha256") or "")
+    presented_state_hash = hashlib.sha256(body.state.encode()).hexdigest()
+    if (
+        provider.auth_type != "agent_profile"
+        or metadata.get("source") != _OAUTH_PENDING_SOURCE
+        or not expected_state_hash
+        or not secrets.compare_digest(expected_state_hash, presented_state_hash)
+    ):
+        raise HTTPException(status.HTTP_409_CONFLICT, "AI Provider OAuth setup is not pending")
+
+    state = _decode_oauth_state(body.state)
+    if state.get("provider_id") != provider.provider_id or state.get("owner_user_id") != str(
+        auth.user_id
+    ):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state does not match this user")
+    expires_at = _parse_state_datetime(str(state.get("expires_at") or ""))
+    if expires_at < datetime.now(UTC):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state expired")
+    if str(metadata.get("expires_at") or "") != expires_at.isoformat():
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state does not match this setup")
+    oauth_provider = _normalize_profile(str(state.get("oauth_provider") or ""))
+    _validate_supported_oauth_provider(oauth_provider)
+    if metadata.get("tool") != oauth_provider:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state does not match this setup")
+    profile = _normalize_profile(str(state.get("profile") or "default"))
+    if metadata.get("profile") != profile:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state does not match this setup")
+    state_redirect_uri = str(state.get("redirect_uri") or "")
+    redirect_uri = body.redirect_uri or state_redirect_uri
+    _validate_redirect_uri(redirect_uri)
+    if redirect_uri != state_redirect_uri or metadata.get("redirect_uri") != state_redirect_uri:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth redirect_uri does not match state")
+    return dict(state)
+
+
+async def _exchange_oauth_code(
+    body: AiProviderOAuthCompleteRequest,
+    state: dict,
+) -> tuple[str, str, dict]:
+    oauth_provider = _normalize_profile(str(state.get("oauth_provider") or ""))
+    profile = _normalize_profile(str(state.get("profile") or "default"))
+    redirect_uri = body.redirect_uri or str(state.get("redirect_uri") or "")
+    config = _oauth_config_for(oauth_provider)
+    token_url = _required_oauth_config(config, "token_url", oauth_provider)
+    client_id = _required_oauth_config(config, "client_id", oauth_provider)
+    _validate_oauth_url(token_url, "token_url")
+    form = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "code": body.code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": str(state.get("code_verifier") or ""),
+    }
+    client_secret = str(config.get("client_secret") or "")
+    if client_secret:
+        form["client_secret"] = client_secret
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(token_url, data=form)
+            if response.status_code >= 400:
+                raise HTTPException(
+                    status.HTTP_502_BAD_GATEWAY,
+                    "OAuth token exchange failed",
+                )
+            return await _oauth_payload_from_token_response(
+                client,
+                oauth_provider,
+                config,
+                response,
+                profile,
+            )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            "OAuth token exchange failed",
+        ) from exc
+
+
+async def _get_provider_or_404_for_update(
+    db: AsyncSession,
+    auth: AuthContext,
+    provider_id: str,
+) -> AiProvider:
+    provider_ids = (
+        V2_MANAGED_AI_PROVIDER_IDS
+        if provider_id in V2_MANAGED_AI_PROVIDER_IDS
+        else frozenset({provider_id})
+    )
+    providers = (
+        (
+            await db.execute(
+                select(AiProvider)
+                .where(
+                    AiProvider.owner_user_id == auth.user_id,
+                    AiProvider.provider_id.in_(provider_ids),
+                    AiProvider.archived_at.is_(None),
+                )
+                .with_for_update()
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not providers:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "AI Provider not found")
+    priority = {V2_MANAGED_AI_PROVIDER_ID: 0, provider_id: 1}
+    provider = min(
+        providers,
+        key=lambda candidate: priority.get(candidate.provider_id, 2),
+    )
+    if is_v2_deployment_managed_provider_id(provider.provider_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "AI Provider not found")
+    return provider
 
 
 async def _oauth_payload_from_token_response(

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -368,6 +368,13 @@ class AiProviderManagedApiKeyRequest(BaseModel):
     runtime_env_name: str | None = Field(default=None, max_length=128)
 
 
+class AiProviderApiKeyAcceptCredential(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    type: Literal["api_key"]
+    value: SecretStr
+
+
 class _AiProviderAuthImportRequest(BaseModel):
     model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
@@ -426,6 +433,20 @@ class AiProviderOAuthStartRequest(BaseModel):
     redirect_uri: str | None = Field(default=None, max_length=1000)
 
 
+class AiProviderOAuthAcceptCredential(AiProviderOAuthStartRequest):
+    type: Literal["oauth"]
+
+
+class AiProviderAcceptRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    provider: AiProviderUpsert
+    credential: Annotated[
+        AiProviderApiKeyAcceptCredential | AiProviderOAuthAcceptCredential,
+        Field(discriminator="type"),
+    ]
+
+
 class AiProviderOAuthStartResponse(BaseModel):
     provider_id: str
     oauth_provider: str
@@ -434,6 +455,23 @@ class AiProviderOAuthStartResponse(BaseModel):
     state: str
     redirect_uri: str
     expires_at: datetime
+
+
+class AiProviderReadyAcceptResponse(BaseModel):
+    status: Literal["ready"]
+    provider: AiProviderResponse
+
+
+class AiProviderOAuthPendingAcceptResponse(BaseModel):
+    status: Literal["pending"]
+    provider: AiProviderResponse
+    authorization: AiProviderOAuthStartResponse
+
+
+type AiProviderAcceptResponse = Annotated[
+    AiProviderReadyAcceptResponse | AiProviderOAuthPendingAcceptResponse,
+    Field(discriminator="status"),
+]
 
 
 class AiProviderOAuthCompleteRequest(BaseModel):

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -1,17 +1,20 @@
 import base64
+import hashlib
 import json
 import uuid
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
+from sqlalchemy import func, select
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
 from app.main import app
-from app.models.ai_provider import AiProvider
+from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
+from app.models.platform_idempotency import PlatformMutationIdempotency
 from app.services import sync_events
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
@@ -27,6 +30,7 @@ from app.services.managed_ai_provider import (
     runtime_managed_provider_id,
     v2_deployment_managed_provider_id,
 )
+from app.services.vault_crypto import decrypt
 from tests.conftest import create_env_with_project
 
 _TEST_SYSTEM = {}
@@ -204,6 +208,43 @@ def _test_jwt(account_id: str = "account-123") -> str:
     )
 
 
+def _api_key_accept_body(value: str = "sk-atomic-secret") -> dict:
+    return {
+        "provider": {
+            "provider_id": "openai-atomic",
+            "type": "openai",
+            "label": "OpenAI",
+            "base_url": "https://api.openai.com/v1",
+            "models": [{"id": "gpt-5.2"}],
+            "api_mode": "openai_responses",
+            "auth": {"type": "api_key", "source": "managed", "profile": "default"},
+            "managed_by": "user",
+            "runtime_env_name": "OPENAI_API_KEY",
+        },
+        "credential": {"type": "api_key", "value": value},
+    }
+
+
+def _oauth_accept_body() -> dict:
+    return {
+        "provider": {
+            "provider_id": "openai-codex-accept",
+            "type": "openai",
+            "label": "OpenAI Codex",
+            "base_url": "https://api.openai.com/v1",
+            "models": [{"id": "gpt-5.2"}],
+            "api_mode": "openai_responses",
+            "auth": {"type": "agent_profile", "tool": "codex", "profile": "default"},
+            "managed_by": "user",
+        },
+        "credential": {
+            "type": "oauth",
+            "provider": "codex",
+            "redirect_uri": "https://cloud.example/oauth/callback",
+        },
+    }
+
+
 @pytest.mark.asyncio
 async def test_ai_provider_crud_is_account_scoped_metadata(client: httpx.AsyncClient):
     created = await client.post(
@@ -327,6 +368,220 @@ async def test_ai_provider_usability_requires_the_active_stored_credential(
         provider["provider_id"]: provider["usable"]
         for provider in completed_listing.json()["providers"]
     } == {"openai-codex": True, "openai-main": True}
+
+
+@pytest.mark.asyncio
+async def test_api_key_accept_is_atomic_usable_and_idempotent(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+):
+    user_id = seed_user.id
+    env = await create_env_with_project(
+        db_session,
+        user_id=user_id,
+        machine_id=f"provider-accept-{uuid.uuid4().hex[:8]}",
+        machine_name="Provider Accept",
+        agent_type="openclaw",
+    )
+    environment_id = env.id
+    db_session.add(
+        HostedRuntimeState(
+            environment_id=environment_id,
+            deployment_id="dep-provider-accept",
+            instance_id="hri-provider-accept",
+            generation=1,
+            cli_package_spec="clawdi@0.13.0",
+            locale={"language": "en", "timezone": "UTC"},
+            system=_TEST_SYSTEM,
+            live_sync={"enabled": False, "agents": []},
+            recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            runtimes={
+                "openclaw": {
+                    "enabled": True,
+                    "providerMode": "configured",
+                    "provider_ids": ["openai-atomic"],
+                    "primary_model": {
+                        "provider_id": "openai-atomic",
+                        "model": "gpt-5.2",
+                    },
+                    "install": {"source": "official"},
+                }
+            },
+        )
+    )
+    await db_session.commit()
+
+    queue = sync_events.subscribe(user_id, frozenset(), environment_id=environment_id)
+    headers = {"Idempotency-Key": "provider-accept-api-key"}
+    try:
+        accepted = await client.post(
+            "/v1/ai-providers/accept",
+            headers=headers,
+            json=_api_key_accept_body(),
+        )
+        assert accepted.status_code == 201, accepted.text
+        assert "sk-atomic-secret" not in accepted.text
+        assert accepted.json()["status"] == "ready"
+        assert accepted.json()["provider"]["usable"] is True
+        assert queue.get_nowait() == {
+            "type": "runtime_manifest_changed",
+            "environment_id": str(environment_id),
+        }
+
+        replay = await client.post(
+            "/v1/ai-providers/accept",
+            headers=headers,
+            json=_api_key_accept_body(),
+        )
+        assert replay.status_code == 201, replay.text
+        assert replay.json() == accepted.json()
+        assert queue.empty()
+
+        listing = await client.get("/v1/ai-providers")
+        assert listing.status_code == 200, listing.text
+        assert listing.json()["providers"][0]["usable"] is True
+
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(AiProvider)
+                .where(
+                    AiProvider.owner_user_id == user_id,
+                    AiProvider.provider_id == "openai-atomic",
+                )
+            )
+            == 1
+        )
+        payload = (
+            await db_session.execute(
+                select(AiProviderAuthPayload).where(
+                    AiProviderAuthPayload.owner_user_id == user_id,
+                    AiProviderAuthPayload.provider_id == "openai-atomic",
+                    AiProviderAuthPayload.archived_at.is_(None),
+                )
+            )
+        ).scalar_one()
+        assert payload.encrypted_payload != b"sk-atomic-secret"
+        assert decrypt(payload.encrypted_payload, payload.nonce) == "sk-atomic-secret"
+
+        idempotency = (
+            await db_session.execute(
+                select(PlatformMutationIdempotency).where(
+                    PlatformMutationIdempotency.operation == "ai_provider.accept",
+                    PlatformMutationIdempotency.idempotency_key == "provider-accept-api-key",
+                )
+            )
+        ).scalar_one()
+        assert idempotency.resource_type == "ai_provider"
+        assert b"sk-atomic-secret" not in idempotency.encrypted_response
+
+        reused = await client.post(
+            "/v1/ai-providers/accept",
+            headers=headers,
+            json=_api_key_accept_body("sk-different-secret"),
+        )
+        assert reused.status_code == 409, reused.text
+        assert "sk-different-secret" not in reused.text
+    finally:
+        sync_events.unsubscribe(user_id, queue)
+
+
+@pytest.mark.asyncio
+async def test_api_key_accept_rolls_back_everything_after_provider_write_failure(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user_id = seed_user.id
+    env = await create_env_with_project(
+        db_session,
+        user_id=user_id,
+        machine_id=f"provider-accept-failure-{uuid.uuid4().hex[:8]}",
+        machine_name="Provider Accept Failure",
+        agent_type="openclaw",
+    )
+    environment_id = env.id
+    db_session.add(
+        HostedRuntimeState(
+            environment_id=environment_id,
+            deployment_id="dep-provider-accept-failure",
+            instance_id="hri-provider-accept-failure",
+            generation=1,
+            cli_package_spec="clawdi@0.13.0",
+            locale={"language": "en", "timezone": "UTC"},
+            system=_TEST_SYSTEM,
+            live_sync={"enabled": False, "agents": []},
+            recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            runtimes={
+                "openclaw": {
+                    "enabled": True,
+                    "providerMode": "configured",
+                    "provider_ids": ["openai-atomic"],
+                    "primary_model": {
+                        "provider_id": "openai-atomic",
+                        "model": "gpt-5.2",
+                    },
+                    "install": {"source": "official"},
+                }
+            },
+        )
+    )
+    await db_session.commit()
+
+    def _fail_idempotency_write(*args, **kwargs):
+        raise RuntimeError("forced accept failure")
+
+    monkeypatch.setattr(
+        "app.routes.ai_providers.store_platform_response",
+        _fail_idempotency_write,
+    )
+    queue = sync_events.subscribe(user_id, frozenset(), environment_id=environment_id)
+    try:
+        with pytest.raises(RuntimeError, match="forced accept failure"):
+            await client.post(
+                "/v1/ai-providers/accept",
+                headers={"Idempotency-Key": "provider-accept-failure"},
+                json=_api_key_accept_body(),
+            )
+
+        assert queue.empty()
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(AiProvider)
+                .where(
+                    AiProvider.owner_user_id == user_id,
+                    AiProvider.provider_id == "openai-atomic",
+                )
+            )
+            == 0
+        )
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(AiProviderAuthPayload)
+                .where(
+                    AiProviderAuthPayload.owner_user_id == user_id,
+                    AiProviderAuthPayload.provider_id == "openai-atomic",
+                )
+            )
+            == 0
+        )
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(PlatformMutationIdempotency)
+                .where(
+                    PlatformMutationIdempotency.operation == "ai_provider.accept",
+                    PlatformMutationIdempotency.idempotency_key == "provider-accept-failure",
+                )
+            )
+            == 0
+        )
+    finally:
+        sync_events.unsubscribe(user_id, queue)
 
 
 @pytest.mark.asyncio
@@ -1659,6 +1914,149 @@ async def test_ai_provider_oauth_start_requires_clean_redirect_and_params(
         )
         assert unsupported_provider.status_code == 422, unsupported_provider.text
         assert "Codex only" in unsupported_provider.text
+    finally:
+        settings.ai_provider_oauth_config_json = previous
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_oauth_accept_persists_pending_then_completes_same_provider_idempotently(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user_id = seed_user.id
+    previous = settings.ai_provider_oauth_config_json
+    settings.ai_provider_oauth_config_json = json.dumps(
+        {
+            "codex": {
+                "authorization_url": "https://oauth.example/authorize",
+                "token_url": "https://oauth.example/token",
+                "client_id": "clawdi-client",
+                "scope": "openid profile",
+            }
+        }
+    )
+    token_requests: list[dict] = []
+
+    class FakeOAuthClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, data):
+            token_requests.append({"url": url, "data": data})
+            if data["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange":
+                return httpx.Response(200, json={"access_token": "sk-codex-api-key"})
+            return httpx.Response(
+                200,
+                json={
+                    "id_token": _test_jwt(),
+                    "access_token": "oauth-access-token",
+                    "refresh_token": "oauth-refresh-token",
+                },
+            )
+
+    monkeypatch.setattr("app.routes.ai_providers.httpx.AsyncClient", FakeOAuthClient)
+    try:
+        start_headers = {"Idempotency-Key": "provider-accept-oauth-start"}
+        started = await client.post(
+            "/v1/ai-providers/accept",
+            headers=start_headers,
+            json=_oauth_accept_body(),
+        )
+        assert started.status_code == 201, started.text
+        assert started.json()["status"] == "pending"
+        assert started.json()["provider"]["usable"] is False
+        authorization = started.json()["authorization"]
+        params = parse_qs(urlparse(authorization["auth_url"]).query)
+        assert params["state"] == [authorization["state"]]
+
+        pending_metadata = await db_session.scalar(
+            select(AiProvider.auth_metadata).where(
+                AiProvider.owner_user_id == user_id,
+                AiProvider.provider_id == "openai-codex-accept",
+            )
+        )
+        assert pending_metadata["source"] == "oauth_pending"
+        assert (
+            pending_metadata["state_sha256"]
+            == hashlib.sha256(authorization["state"].encode()).hexdigest()
+        )
+
+        start_replay = await client.post(
+            "/v1/ai-providers/accept",
+            headers=start_headers,
+            json=_oauth_accept_body(),
+        )
+        assert start_replay.status_code == 201, start_replay.text
+        assert start_replay.json() == started.json()
+
+        completion_body = {
+            "state": authorization["state"],
+            "code": "oauth-code",
+            "redirect_uri": "https://cloud.example/oauth/callback",
+        }
+        completion_headers = {"Idempotency-Key": "provider-accept-oauth-complete"}
+        completed = await client.post(
+            "/v1/ai-providers/openai-codex-accept/accept",
+            headers=completion_headers,
+            json=completion_body,
+        )
+        assert completed.status_code == 200, completed.text
+        assert completed.json()["status"] == "ready"
+        assert completed.json()["provider"]["usable"] is True
+        assert "oauth-access-token" not in completed.text
+        assert "oauth-refresh-token" not in completed.text
+        assert "sk-codex-api-key" not in completed.text
+        assert len(token_requests) == 2
+
+        completion_replay = await client.post(
+            "/v1/ai-providers/openai-codex-accept/accept",
+            headers=completion_headers,
+            json=completion_body,
+        )
+        assert completion_replay.status_code == 200, completion_replay.text
+        assert completion_replay.json() == completed.json()
+        assert len(token_requests) == 2
+
+        db_session.expire_all()
+        await db_session.refresh(seed_user)
+        listing = await client.get("/v1/ai-providers")
+        assert listing.status_code == 200, listing.text
+        assert listing.json()["providers"][0]["usable"] is True
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(AiProvider)
+                .where(
+                    AiProvider.owner_user_id == user_id,
+                    AiProvider.provider_id == "openai-codex-accept",
+                )
+            )
+            == 1
+        )
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(PlatformMutationIdempotency)
+                .where(
+                    PlatformMutationIdempotency.idempotency_key.in_(
+                        [
+                            "provider-accept-oauth-start",
+                            "provider-accept-oauth-complete",
+                        ]
+                    )
+                )
+            )
+            == 2
+        )
     finally:
         settings.ai_provider_oauth_config_json = previous
 

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
@@ -1919,7 +1920,6 @@ async def test_ai_provider_oauth_start_requires_clean_redirect_and_params(
 
 
 @pytest.mark.asyncio
-@pytest.mark.committed_db
 async def test_oauth_accept_persists_pending_then_completes_same_provider_idempotently(
     client: httpx.AsyncClient,
     db_session,
@@ -1927,6 +1927,16 @@ async def test_oauth_accept_persists_pending_then_completes_same_provider_idempo
     monkeypatch: pytest.MonkeyPatch,
 ):
     user_id = seed_user.id
+    connection = await db_session.connection()
+    completion_session_factory = async_sessionmaker(
+        bind=connection,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+    monkeypatch.setattr(
+        "app.routes.ai_providers.async_session_factory",
+        completion_session_factory,
+    )
     previous = settings.ai_provider_oauth_config_json
     settings.ai_provider_oauth_config_json = json.dumps(
         {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -74,6 +74,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/ai-providers/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept Ai Provider
+         * @description Atomically create a provider and its first usable auth state.
+         */
+        post: operations["accept_ai_provider_v1_ai_providers_accept_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/ai-providers/{provider_id}": {
         parameters: {
             query?: never;
@@ -172,6 +192,26 @@ export interface paths {
         put?: never;
         /** Complete Ai Provider Oauth */
         post: operations["complete_ai_provider_oauth_v1_ai_providers__provider_id__auth_oauth_complete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ai-providers/{provider_id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete Ai Provider Accept
+         * @description Complete an OAuth-pending provider without spanning remote I/O with a DB session.
+         */
+        post: operations["complete_ai_provider_accept_v1_ai_providers__provider_id__accept_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2796,6 +2836,13 @@ export interface components {
             /** Default Project Id */
             default_project_id: string;
         };
+        /** AiProviderAcceptRequest */
+        AiProviderAcceptRequest: {
+            provider: components["schemas"]["AiProviderUpsert"];
+            /** Credential */
+            credential: components["schemas"]["AiProviderApiKeyAcceptCredential"] | components["schemas"]["AiProviderOAuthAcceptCredential"];
+        };
+        AiProviderAcceptResponse: components["schemas"]["AiProviderReadyAcceptResponse"] | components["schemas"]["AiProviderOAuthPendingAcceptResponse"];
         /** AiProviderAgentProfileAuth */
         AiProviderAgentProfileAuth: {
             /**
@@ -2827,6 +2874,19 @@ export interface components {
             type: "agent_profile";
             /** Tool */
             tool: string;
+        };
+        /** AiProviderApiKeyAcceptCredential */
+        AiProviderApiKeyAcceptCredential: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "api_key";
+            /**
+             * Value
+             * Format: password
+             */
+            value: string;
         };
         AiProviderApiKeyAuth: components["schemas"]["AiProviderEnvApiKeyAuth"] | components["schemas"]["AiProviderVaultApiKeyAuth"] | components["schemas"]["AiProviderManagedApiKeyAuth"];
         AiProviderAuth: components["schemas"]["AiProviderSecretRefAuth"] | components["schemas"]["AiProviderApiKeyAuth"] | components["schemas"]["AiProviderOAuthProfileAuth"] | components["schemas"]["AiProviderAgentProfileAuth"] | components["schemas"]["AiProviderNoneAuth"];
@@ -2981,6 +3041,18 @@ export interface components {
              */
             type: "none";
         };
+        /** AiProviderOAuthAcceptCredential */
+        AiProviderOAuthAcceptCredential: {
+            /** Provider */
+            provider: string;
+            /** Redirect Uri */
+            redirect_uri?: string | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "oauth";
+        };
         /** AiProviderOAuthCompleteRequest */
         AiProviderOAuthCompleteRequest: {
             /** State */
@@ -2989,6 +3061,16 @@ export interface components {
             code: string;
             /** Redirect Uri */
             redirect_uri?: string | null;
+        };
+        /** AiProviderOAuthPendingAcceptResponse */
+        AiProviderOAuthPendingAcceptResponse: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            status: "pending";
+            provider: components["schemas"]["AiProviderResponse"];
+            authorization: components["schemas"]["AiProviderOAuthStartResponse"];
         };
         /** AiProviderOAuthProfileAuth */
         AiProviderOAuthProfileAuth: {
@@ -3070,6 +3152,15 @@ export interface components {
             } | null;
             /** Models */
             models?: components["schemas"]["AiProviderModel"][] | null;
+        };
+        /** AiProviderReadyAcceptResponse */
+        AiProviderReadyAcceptResponse: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            status: "ready";
+            provider: components["schemas"]["AiProviderResponse"];
         };
         /** AiProviderResponse */
         AiProviderResponse: {
@@ -7053,6 +7144,41 @@ export interface operations {
             };
         };
     };
+    accept_ai_provider_v1_ai_providers_accept_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AiProviderAcceptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AiProviderAcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_ai_provider_v1_ai_providers__provider_id__get: {
         parameters: {
             query?: never;
@@ -7308,6 +7434,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AiProviderResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    complete_ai_provider_accept_v1_ai_providers__provider_id__accept_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+            };
+            path: {
+                provider_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AiProviderOAuthCompleteRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AiProviderReadyAcceptResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- add an additive idempotent AI-provider accept contract
- create API-key providers, encrypted credentials, manifest invalidation, and the idempotency record in one transaction
- create explicit OAuth-pending providers and complete them through a second accept without holding a database session across token exchange
- regenerate the same-repository OpenAPI TypeScript client; leave apps/web and deploy.generated.ts unchanged

## Verification

- scripts/test.sh backend: 1353 passed, 7 skipped
- provider-focused suite: 89 passed
- backend ruff check and format check: passed
- backend compileall: passed
- generated API consistency check: passed
- bun run check: 700 files checked
