### PR TITLE
Fix v2 browser walkthrough UX defects

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2164,10 +2164,15 @@ test("shared legacy environment routes an older tile's actions to its deployment
 
 	await page.goto("/agents");
 	const agents = page.locator("main");
-	const newerTile = agents.getByRole("link").filter({ hasText: "Newer twin" });
-	const olderTile = agents.getByRole("link").filter({ hasText: "Older twin" });
+	const newerTile = agents.getByRole("link", { name: "Open Newer twin", exact: true });
+	const olderTile = agents.getByRole("link", { name: "Open Older twin", exact: true });
 	await expect(newerTile).toBeVisible();
 	await expect(olderTile).toBeVisible();
+	await expect(newerTile.locator("..").getByText("Running", { exact: true })).toHaveCount(0);
+	await expect(olderTile.locator("..").getByText("Stopped", { exact: true })).toHaveCount(0);
+	const rail = page.getByTestId("app-sidebar-agent-tiles");
+	await expect(rail.getByLabel("Newer twin", { exact: true })).toBeVisible();
+	await expect(rail.getByLabel("Older twin", { exact: true })).toBeVisible();
 	await olderTile.click();
 	await page.getByRole("link", { name: "Settings", exact: true }).click();
 	await expect(page).toHaveURL(

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3665,6 +3665,21 @@ test("command palette opens with Ctrl+K", async ({ page }) => {
 	expect(errors, `command palette: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("app 404 offers a working exit to the dashboard", async ({ page }) => {
+	await stubHostedApi(page);
+	const response = await page.goto("/this-clawdi-page-does-not-exist");
+	expect(response?.status()).toBe(404);
+
+	const dashboardExit = page.getByRole("link", { name: "Back to dashboard", exact: true });
+	await expect(dashboardExit).toHaveAttribute("href", "/");
+	const errors = collectBrowserErrors(page);
+	await dashboardExit.click();
+
+	await expect(page).toHaveURL(/\/$/);
+	await expect(page.getByTestId("app-sidebar")).toBeVisible();
+	expect(errors, `app 404: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("channels connect dialog opens without browser errors", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -440,7 +440,7 @@ function planChangeQuoteResponse({
 	changeKind,
 	effectiveAt,
 	amountCents,
-	amountCredits,
+	amountUsd,
 }: {
 	operationId: string;
 	subscriptionId: number;
@@ -452,7 +452,7 @@ function planChangeQuoteResponse({
 	changeKind: "immediate_upgrade" | "scheduled_downgrade";
 	effectiveAt: string;
 	amountCents: number;
-	amountCredits: string | null;
+	amountUsd: string | null;
 }) {
 	return {
 		operation_id: operationId,
@@ -468,8 +468,7 @@ function planChangeQuoteResponse({
 		proration_date: "2026-07-16T00:00:00Z",
 		expires_at: "2026-07-16T00:15:00Z",
 		amount_cents: amountCents,
-		amount_credits: amountCredits,
-		points_per_usd: fundingSource === "wallet" ? 1_000 : null,
+		amount_usd: amountUsd,
 		currency: "usd",
 		stripe_invoice_preview_id: "in_preview_browser",
 	};
@@ -1091,8 +1090,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				proration_date: "2026-07-16T00:00:00Z",
 				expires_at: "2026-07-16T00:15:00Z",
 				amount_cents: 1_000,
-				amount_credits: null,
-				points_per_usd: null,
+				amount_usd: null,
 				currency: "usd",
 				stripe_invoice_preview_id: "in_preview_browser",
 			};
@@ -1457,8 +1455,21 @@ test("existing Cloud customers keep billing settings when new deploys are disabl
 
 test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
-	await stubHostedApi(page);
+	await stubHostedApi(page, { plans: [basicPlan], deployments: [] });
 	await page.goto("/deploy");
+
+	const nameInput = page.getByRole("textbox", { name: "Name in Clawdi" });
+	const maxLengthName = "a".repeat(64);
+	await nameInput.fill(maxLengthName);
+	await expect(
+		page.getByText("64 / 64 characters — limit reached.", { exact: true }),
+	).toBeVisible();
+	await expect(page.locator('[role="status"][aria-live="polite"]')).toHaveText(
+		"Name limit reached. You can enter up to 64 characters.",
+	);
+	await nameInput.press("End");
+	await nameInput.type("b");
+	await expect(nameInput).toHaveValue(maxLengthName);
 
 	// The Personalize section's language select is always present.
 	const languageSelect = page.locator("#agent-language");
@@ -1617,7 +1628,7 @@ test("accepted detail delete navigates after deployment membership disappears", 
 	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete compute", exact: true })
+		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
@@ -1642,6 +1653,7 @@ test("managed model picker lists the curated catalog without Custom or image mod
 	});
 	await page.goto("/deploy");
 
+	await page.getByRole("button", { name: "Change", exact: true }).click();
 	await expect(page.locator("#deploy-catalog-model")).toContainText("Luna");
 	await page.locator("#deploy-catalog-model").click();
 	await expect(page.getByRole("option", { name: "Luna", exact: true })).toBeVisible();
@@ -1670,7 +1682,7 @@ test("Basic paid checkout stays hidden until deployment inventory succeeds", asy
 	await page.goto("/deploy");
 
 	await expect(page.getByText("Checking your free Basic slot…", { exact: true })).toBeVisible();
-	await expect(page.getByText("$9/mo", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("$10.00/mo", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Continue to checkout" })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Deploy agent" })).toBeDisabled();
 
@@ -1704,7 +1716,7 @@ test("empty plans and wallet failures expose working retries", async ({ page }) 
 
 	const walletError = page
 		.getByRole("alert")
-		.filter({ hasText: "Couldn't load your AI Credits wallet" });
+		.filter({ hasText: "Couldn't load your Wallet balance" });
 	await expect(walletError).toBeVisible();
 	await walletError.getByRole("button", { name: "Retry" }).click();
 	await expect(page.getByTestId("wallet-debit-equation")).toBeVisible();
@@ -1726,7 +1738,7 @@ test("hosted locale settings submit canonical deployment PATCH", async ({ page }
 
 	await page.locator("#hosted-agent-language").click();
 	await page.getByRole("option", { name: "Español" }).click();
-	await page.getByRole("button", { name: "Apply locale settings" }).click();
+	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 
 	expect(updateDeploymentRequests[0]?.idempotencyKey).toMatch(/^deployment-update-/);
@@ -1749,7 +1761,7 @@ test("hosted AI provider Apply submits canonical deployment PATCH", async ({ pag
 	await page.goto("/agents/hdep_included/model-provider?source=on-clawdi");
 
 	await page.getByRole("button", { name: /Configure inside agent/ }).click();
-	await page.getByRole("button", { name: "Apply provider settings" }).click();
+	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		ai_provider_auth_kind: "unmanaged",
@@ -1781,7 +1793,7 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 
 	await page.getByRole("button", { name: /Managed by Clawdi/ }).click();
 	await expect(page.locator("#agent-catalog-model")).toContainText("Luna");
-	await page.getByRole("button", { name: "Apply provider settings" }).click();
+	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		ai_provider_auth_kind: "managed",
@@ -1809,25 +1821,21 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect.poll(() => new URL(page.url()).searchParams.get("d")).toBe("hdep_failed_projection");
-	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toBeVisible();
-	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toBeVisible();
+	await expect(main.getByText("Some agent details are not ready", { exact: true })).toBeVisible();
+	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toHaveCount(0);
+	await expect(
+		main.getByText("The Clawdi service could not complete this request.", { exact: true }),
+	).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
 	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
 
-	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
-	await page
-		.getByRole("alertdialog")
-		.getByRole("button", { name: "Retry startup", exact: true })
-		.click();
-	await expect
-		.poll(() => restartRequests)
-		.toEqual(["/v2/deployments/hdep_failed_projection/restart"]);
+	expect(restartRequests).toEqual([]);
 
 	await main.getByRole("button", { name: "Delete", exact: true }).click();
 	await page
@@ -1886,7 +1894,9 @@ test("stopped detail stays recoverable without querying its removed projection",
 		).toBeVisible();
 		await expect(main.getByRole("button", { name: "Start", exact: true })).toBeVisible();
 		await expect(main.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
-		await expect(main.getByText("Agent sync record unavailable", { exact: true })).toHaveCount(0);
+		await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(
+			0,
+		);
 	}
 
 	const removedProjectionRequests = cloudRequests.filter((path) => {
@@ -1923,23 +1933,19 @@ test("failed deployment with a retained projection keeps status-authoritative na
 
 	await page.goto(`/agents/${retainedProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText(retainedProjectionFailureReason, { exact: true })).toBeVisible();
+	await expect(main.getByText(retainedProjectionFailureReason, { exact: true })).toHaveCount(0);
+	await expect(
+		main.getByText("The Clawdi service could not complete this request.", { exact: true }),
+	).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
 	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
 
-	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
-	await page
-		.getByRole("alertdialog")
-		.getByRole("button", { name: "Retry startup", exact: true })
-		.click();
-	await expect
-		.poll(() => restartRequests)
-		.toEqual(["/v2/deployments/hdep_failed_retained_projection/restart"]);
+	expect(restartRequests).toEqual([]);
 
 	await main.getByRole("button", { name: "Delete", exact: true }).click();
 	await page
@@ -1963,11 +1969,11 @@ test("missing live projection recovers on Check again without losing deployment 
 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toBeVisible();
+	await expect(main.getByText("Some agent details are not ready", { exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await main.getByRole("button", { name: "Check again", exact: true }).click();
-	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Overview" })).toBeVisible();
 });
 
@@ -1985,7 +1991,7 @@ test("projection service errors stay visible while deployment tools remain avail
 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText("Agent sync service unavailable", { exact: true })).toBeVisible();
+	await expect(main.getByText("Couldn’t load all agent details", { exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	const renderErrors = errors.filter(
@@ -2018,9 +2024,9 @@ test("running deployment without a UI endpoint auto-opens the live UI when polli
 
 	await page.goto(`/agents/${pendingRuntimeUiDeployment.id}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText("Starting the live UI…", { exact: true })).toBeVisible();
+	await expect(main.getByText("Opening Hermes Dashboard…", { exact: true })).toBeVisible();
 	await expect(
-		main.getByText("Opening the live UI automatically…", { exact: false }),
+		main.getByText("We’ll open Hermes Dashboard automatically", { exact: false }),
 	).toBeVisible();
 	await expect(main.getByRole("button", { name: "Use Terminal now", exact: true })).toBeVisible();
 
@@ -2076,7 +2082,11 @@ test("Runtime UI credential failure renders a retryable error instead of a perma
 	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toBeVisible();
 	await main.getByRole("button", { name: "Retry", exact: true }).click();
 	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toHaveCount(0);
-	await expect(main.locator('input[value="recovered-password"]')).toBeVisible();
+	const passwordValue = main.locator("code");
+	await expect(passwordValue).toHaveText("••••••••••••");
+	await expect(passwordValue).not.toContainText("recovered-password");
+	await main.getByRole("button", { name: "Show Password", exact: true }).click();
+	await expect(passwordValue).toHaveText("recovered-password");
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(2);
 });
 
@@ -2105,7 +2115,11 @@ test("OpenClaw Console opens through the direct gateway token handoff", async ({
 		"https://runtime.example/openclaw/#token=gateway-token",
 	);
 	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
-	await expect(main.locator('input[value="gateway-token"]')).toBeVisible();
+	const tokenValue = main.locator("code");
+	await expect(tokenValue).toHaveText("••••••••••••");
+	await expect(tokenValue).not.toContainText("gateway-token");
+	await main.getByRole("button", { name: "Show Token", exact: true }).click();
+	await expect(tokenValue).toHaveText("gateway-token");
 	const popupPromise = page.waitForEvent("popup");
 	await main.getByRole("button", { name: "Open OpenClaw Control UI" }).click();
 	const popup = await popupPromise;
@@ -2211,14 +2225,14 @@ test("Basic create always follows the wizard-selected funding path", async ({ pa
 	await page.emulateMedia({ reducedMotion: "reduce" });
 	await stubHostedApi(page, {
 		checkoutRequests,
-		deployments: [paidBasicDeployment],
+		deployments: [includedBasicDeployment],
 		plans: [basicPlan, performancePlan],
 	});
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$9/mo", { exact: true })).toBeVisible();
-	await expect(page.getByText(/2 vCPU \/ 4 GB · \$9\/mo/)).toBeVisible();
+	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
+	await expect(page.getByText(/2 vCPU \/ 4 GB · \$10\.00\/mo/)).toBeVisible();
 	await expectNoQuarterlyCopy(page);
 	await capturePricingScreenshot(page, "/tmp/basic-paid-funded-slot-available-final.png");
 
@@ -2287,7 +2301,7 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$9/mo", { exact: true })).toBeVisible();
+	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
 	await expect(page.getByText("Monthly", { exact: true })).toBeVisible();
 	const annualTerm = page.getByRole("button", { name: /Annual.*%/ });
 	await expect(annualTerm).toBeVisible();
@@ -2295,8 +2309,10 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await annualTerm.click();
 	await expect(page.getByText("Wallet balance", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /Wallet balance/ })).toBeVisible();
-	await expect(page.getByText(/2 vCPU \/ 4 GB · \$7.2\/mo, billed \$86.4\/yr/)).toBeVisible();
-	await expect(page.getByText(/this Basic agent at \$7.2\/mo, billed \$86.4\/yr/)).toBeVisible();
+	await expect(page.getByText(/2 vCPU \/ 4 GB · \$8\.33\/mo, billed \$100\.00\/yr/)).toBeVisible();
+	await expect(
+		page.getByText(/this Basic agent at \$8\.33\/mo, billed \$100\.00\/yr/),
+	).toBeVisible();
 	await capturePricingScreenshot(page, "/tmp/basic-free-funded-slot-occupied-final.png");
 
 	await page.getByRole("button", { name: "Continue to checkout" }).click();
@@ -2456,7 +2472,7 @@ test("included Basic uses unified card quote and change without creating a secon
 				changeKind: "immediate_upgrade",
 				effectiveAt: "2026-07-16T00:00:00Z",
 				amountCents: 18_000,
-				amountCredits: null,
+				amountUsd: null,
 			}),
 		],
 		plans: [basicPlan, performancePlan],
@@ -2549,7 +2565,7 @@ test("included Basic uses unified wallet quote and change with exact debit", asy
 				changeKind: "immediate_upgrade",
 				effectiveAt: "2026-07-16T00:00:00Z",
 				amountCents: 1_900,
-				amountCredits: "19000",
+				amountUsd: "19.00",
 			}),
 		],
 		plans: [basicPlan, performancePlan],
@@ -2572,9 +2588,9 @@ test("included Basic uses unified wallet quote and change with exact debit", asy
 		funding_source: "wallet",
 	});
 	const equation = changeDialog.getByTestId("wallet-debit-equation");
-	await expect(equation).toContainText("25,000 credits");
-	await expect(equation).toContainText("19,000 credits");
-	await expect(equation).toContainText("6,000 credits");
+	await expect(equation).toContainText("$25.00");
+	await expect(equation).toContainText("$19.00");
+	await expect(equation).toContainText("$6.00");
 	await changeDialog.getByRole("button", { name: "Confirm upgrade" }).click();
 
 	await expect.poll(() => planChangeRequests.length).toBe(1);
@@ -2635,7 +2651,7 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 				changeKind: "immediate_upgrade",
 				effectiveAt: "2026-07-16T00:00:00Z",
 				amountCents: 9_360,
-				amountCredits: null,
+				amountUsd: null,
 			}),
 		],
 		plans: [basicPlan, performancePlan],
@@ -2718,7 +2734,7 @@ test("paid wallet subscription confirms an immediate quoted upgrade", async ({ p
 				changeKind: "immediate_upgrade",
 				effectiveAt: "2026-07-16T00:00:00Z",
 				amountCents: 1_000,
-				amountCredits: "10000",
+				amountUsd: "10.00",
 			}),
 		],
 		plans: [basicPlan, performancePlan],
@@ -2734,9 +2750,9 @@ test("paid wallet subscription confirms an immediate quoted upgrade", async ({ p
 	await review.click();
 	await expect.poll(() => planQuoteRequests.length).toBe(1);
 	const equation = changeDialog.getByTestId("wallet-debit-equation");
-	await expect(equation).toContainText("25,000 credits");
-	await expect(equation).toContainText("10,000 credits");
-	await expect(equation).toContainText("15,000 credits");
+	await expect(equation).toContainText("$25.00");
+	await expect(equation).toContainText("$10.00");
+	await expect(equation).toContainText("$15.00");
 	await changeDialog.getByRole("button", { name: "Confirm upgrade" }).click();
 
 	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
@@ -2785,7 +2801,7 @@ test("paid Performance schedules its quoted downgrade for the effective date", a
 				changeKind: "scheduled_downgrade",
 				effectiveAt: "2027-07-15T00:00:00Z",
 				amountCents: 0,
-				amountCredits: null,
+				amountUsd: null,
 			}),
 		],
 		plans: [basicPlan, performancePlan],
@@ -2857,7 +2873,9 @@ test("terminal fallback starts a new subscription against the fallback deploymen
 	});
 	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");
 
-	await expect(page.getByText("Compute subscription ended", { exact: true })).toBeVisible();
+	await expect(
+		page.locator("main").getByText("Compute subscription ended", { exact: true }),
+	).toBeVisible();
 	await expect(
 		page.getByRole("alert").getByRole("button", { name: "Start a new subscription" }),
 	).toBeVisible();
@@ -3138,7 +3156,7 @@ test("paid Basic checkout abandonment preserves the checkout-ready wizard", asyn
 
 	await expect(page.getByText("Checkout canceled", { exact: true })).toBeVisible();
 	await expect(page.getByText("You were not charged. Your agent was not deployed.")).toBeVisible();
-	await expect(page.getByText("$9/mo", { exact: true })).toBeVisible();
+	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Continue to checkout" })).toBeVisible();
 	await expect(page.getByText("First slot free", { exact: true })).toHaveCount(0);
 	expect(checkoutRequests).toEqual([]);
@@ -3230,7 +3248,7 @@ test("Stripe invoice history shows both rails and a server-visible zero proratio
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog.getByText("Billing history", { exact: true })).toBeVisible();
 	const billingTable = settingsDialog.getByRole("table");
-	await expect(billingTable.getByText("Paid with AI Credits", { exact: true })).toBeVisible();
+	await expect(billingTable.getByText("Paid from Wallet", { exact: true })).toBeVisible();
 	await expect(billingTable.getByText("Paid by card", { exact: true })).toHaveCount(2);
 	await expect(
 		billingTable.locator('a[href="https://invoice.stripe.test/in_wallet"]'),
@@ -3245,7 +3263,7 @@ test("Stripe invoice history shows both rails and a server-visible zero proratio
 	await expect(
 		settingsDialog.getByText("Couldn’t load more billing history", { exact: true }),
 	).toBeVisible();
-	await expect(billingTable.getByText("Paid with AI Credits", { exact: true })).toBeVisible();
+	await expect(billingTable.getByText("Paid from Wallet", { exact: true })).toBeVisible();
 	await settingsDialog.getByRole("button", { name: "Retry" }).click();
 	await expect.poll(() => billingHistoryRequests.length).toBe(3);
 	expect(new URL(billingHistoryRequests[1] ?? "http://invalid").searchParams.get("cursor")).toBe(
@@ -3644,7 +3662,7 @@ test("compute plans keep signup credits without advertising subscription credit 
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog).toBeVisible();
 	await expect(
-		settingsDialog.getByText("$5.00 in AI Credits on signup", { exact: true }),
+		settingsDialog.getByText("$5.00 welcome balance on signup", { exact: true }),
 	).toBeVisible();
 	await expect(settingsDialog).not.toContainText("AI Credits per subscription");
 	await expect(settingsDialog).not.toContainText("AI Credits added to Wallet");
@@ -3685,14 +3703,14 @@ test("channels connect dialog opens without browser errors", async ({ page }) =>
 	await stubHostedApi(page);
 	await page.goto("/channels");
 
-	const connect = page.getByRole("button", { name: /connect a bot/i }).first();
+	const connect = page.getByRole("button", { name: "Connect your own bot", exact: true }).first();
 	await expect(connect).toBeVisible();
 	await page.waitForTimeout(150);
 	expect(errors, `channels render: ${errors.join(" | ")}`).toEqual([]);
 
 	await expect(page.locator('[data-slot="tabs-list"]')).toHaveCount(0);
-	await expect(page.getByText("Your channels").first()).toBeVisible();
-	await expect(page.getByText("Shared bots").first()).toBeVisible();
+	await expect(page.getByText("Ready-to-go bots", { exact: true })).toBeVisible();
+	await expect(page.getByText("Your bots", { exact: true })).toBeVisible();
 	await expectNonZeroBox(page.locator('[data-sidebar="separator"]').first(), "sidebar separator");
 
 	// Open the Base UI Dialog + interact with its provider picker.

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2000,17 +2000,19 @@ test("projection service errors stay visible while deployment tools remain avail
 	expect(renderErrors, `projection failure render: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("running deployment without a UI endpoint auto-opens the live UI when polling resolves", async ({
+test("deployment detail stays put, becomes ready, and keeps manual Runtime UI access", async ({
 	page,
 }) => {
 	const pendingRuntimeUiDeployment = {
 		...runningMissingProjectionDeployment,
 		id: "hdep_runtime_ui_settling",
 		name: "Runtime UI settling agent",
+		status: "creating",
 		hermes_control_ui_url: null,
 	};
 	const readyRuntimeUiDeployment = {
 		...pendingRuntimeUiDeployment,
+		status: "running",
 		hermes_control_ui_url: "https://runtime.example/hermes",
 	};
 	const deployments: unknown[] = [pendingRuntimeUiDeployment];
@@ -2024,24 +2026,30 @@ test("running deployment without a UI endpoint auto-opens the live UI when polli
 
 	await page.goto(`/agents/${pendingRuntimeUiDeployment.id}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText("Opening Hermes Dashboard…", { exact: true })).toBeVisible();
-	await expect(
-		main.getByText("We’ll open Hermes Dashboard automatically", { exact: false }),
-	).toBeVisible();
-	await expect(main.getByRole("button", { name: "Use Terminal now", exact: true })).toBeVisible();
+	await expect(main.getByText("Getting your agent ready…", { exact: true })).toBeVisible();
+	await expect(page).toHaveURL(
+		(url) => url.pathname === `/agents/${pendingRuntimeUiDeployment.id}`,
+	);
 
 	deployments.splice(0, 1, readyRuntimeUiDeployment);
 
 	await expect
-		.poll(() => deploymentListRequests.length, { timeout: 10_000 })
+		.poll(() => deploymentListRequests.length, { timeout: 15_000 })
 		.toBeGreaterThanOrEqual(2);
+	await expect(main.getByText("Your agent is ready", { exact: true })).toBeVisible();
+	await expect(page).toHaveURL(
+		(url) => url.pathname === `/agents/${pendingRuntimeUiDeployment.id}`,
+	);
+	expect(runtimeUiRedemptionRequests).toEqual([]);
+	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveCount(0);
+
+	await page.getByRole("link", { name: "Runtime UI", exact: true }).click();
 	await expect(page).toHaveURL(
 		(url) =>
-			url.pathname === `/agents/${missingProjectionEnvironmentId}/console` &&
+			url.pathname === `/agents/${pendingRuntimeUiDeployment.id}/console` &&
 			url.searchParams.get("source") === "on-clawdi" &&
 			url.searchParams.get("d") === pendingRuntimeUiDeployment.id,
 	);
-	expect(runtimeUiRedemptionRequests).toEqual([]);
 	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
 		"src",
 		"https://runtime.example/hermes",

--- a/apps/web/src/components/app-not-found.test.tsx
+++ b/apps/web/src/components/app-not-found.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AppNotFound } from "./app-not-found";
+
+describe("AppNotFound", () => {
+	test("offers working exits from the missing page", () => {
+		const markup = renderToStaticMarkup(createElement(AppNotFound));
+
+		expect(markup).toContain('href="/"');
+		expect(markup).toContain("Back to dashboard");
+		expect(markup).toContain('href="https://clawdi.ai"');
+	});
+});

--- a/apps/web/src/components/app-not-found.tsx
+++ b/apps/web/src/components/app-not-found.tsx
@@ -1,0 +1,25 @@
+import { ExternalLink, LayoutDashboard } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function AppNotFound() {
+	return (
+		<main className="flex min-h-dvh items-center justify-center bg-background p-6">
+			<section className="w-full max-w-md text-center">
+				<p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">404</p>
+				<h1 className="mt-2 text-xl font-semibold">Page not found</h1>
+				<p className="mt-2 text-sm text-muted-foreground">This Clawdi page does not exist.</p>
+				<div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
+					<a href="/" className={cn(buttonVariants())}>
+						<LayoutDashboard data-icon="inline-start" />
+						Back to dashboard
+					</a>
+					<a href="https://clawdi.ai" className={cn(buttonVariants({ variant: "outline" }))}>
+						Go to Clawdi website
+						<ExternalLink data-icon="inline-end" />
+					</a>
+				</div>
+			</section>
+		</main>
+	);
+}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -132,6 +132,7 @@ import {
 	SETTINGS_SECTION_IDS,
 	type SettingsSectionId,
 } from "@/lib/settings-routes";
+import { useHydrated } from "@/lib/use-hydrated";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 type AgentChromeKind = AgentOwnershipKind;
@@ -1695,7 +1696,7 @@ export function AppSidebar({
 	const { isMobile, setOpenMobile, state: sidebarState } = useSidebar();
 	const api = useApi();
 	const hostedAccess = useHostedProductAccess();
-	const [mounted, setMounted] = useState(false);
+	const hydrated = useHydrated();
 	const [hostedAgentTiles, setHostedAgentTiles] = useState<AgentTile[] | null>(null);
 	const [hostedMembershipResolved, setHostedMembershipResolved] = useState(false);
 	const updateHostedAgentList = useCallback(
@@ -1705,11 +1706,8 @@ export function AppSidebar({
 		},
 		[],
 	);
-	useEffect(() => {
-		setMounted(true);
-	}, []);
 	const showCloudFeatures =
-		mounted && IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error");
+		hydrated && IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error");
 	const agentRoute = parseAgentPathname(pathname);
 	const activeAgentId = agentRoute?.agentId ?? null;
 	const { data: environments } = useQuery({
@@ -1717,12 +1715,12 @@ export function AppSidebar({
 		queryFn: async () => unwrap(await api.GET("/v1/agents")),
 		refetchInterval: activeAgentId ? 10_000 : false,
 	});
-	const hydratedEnvironments = mounted ? environments : undefined;
+	const hydratedEnvironments = hydrated ? environments : undefined;
 	const selfManagedTiles = useMemo(
 		() => selfManagedAgentTiles(hydratedEnvironments),
 		[hydratedEnvironments],
 	);
-	const unifiedAgentListEnabled = mounted && Boolean(HostedUnifiedAgentListSensor);
+	const unifiedAgentListEnabled = hydrated && Boolean(HostedUnifiedAgentListSensor);
 	const agentsLoaded = unifiedAgentListEnabled
 		? hostedAgentTiles !== null && hostedMembershipResolved
 		: hydratedEnvironments !== undefined;

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1365,21 +1365,29 @@ function runtimeDisplayLabel(agentType: string | null | undefined): string {
 function HostedFocusTileStatus({ tile }: { tile: AgentTile }) {
 	return (
 		<span
-			className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap text-muted-foreground"
+			className="flex w-full min-w-0 items-start gap-1.5 text-muted-foreground"
 			title={tile.secondaryStatus?.title ?? tile.statusLabel}
 		>
 			<StatusDot
 				status={tile.statusDot?.tone ?? "neutral"}
-				className={
-					tile.statusDot?.tone ? undefined : "border border-muted-foreground/50 bg-transparent"
-				}
+				className={cn(
+					"mt-1 shrink-0",
+					tile.statusDot?.tone ? undefined : "border border-muted-foreground/50 bg-transparent",
+				)}
 			/>
-			<span>{tile.statusLabel}</span>
-			{tile.secondaryStatus ? (
-				<span className={tile.secondaryStatus.textClass ?? "text-muted-foreground"}>
-					· {tile.secondaryStatus.label}
-				</span>
-			) : null}
+			<span className="min-w-0 flex-1">
+				<span>{tile.statusLabel}</span>
+				{tile.secondaryStatus ? (
+					<span
+						className={cn(
+							"block whitespace-normal break-words [overflow-wrap:anywhere]",
+							tile.secondaryStatus.textClass ?? "text-muted-foreground",
+						)}
+					>
+						{tile.secondaryStatus.label}
+					</span>
+				) : null}
+			</span>
 		</span>
 	);
 }

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -194,22 +194,22 @@ const HOSTED_AGENT_SECTIONS: {
 	{
 		id: "overview",
 		icon: LayoutDashboard,
-		tooltip: "Runtime overview",
+		tooltip: "Agent overview",
 	},
 	{
 		id: "console",
 		icon: MonitorPlay,
-		tooltip: "Open the hosted runtime UI",
+		tooltip: "Open this agent's browser interface",
 	},
 	{
 		id: "terminal",
 		icon: TerminalSquare,
-		tooltip: "Open a hosted shell",
+		tooltip: "Open a terminal for this agent",
 	},
 	{
 		id: "sessions",
 		icon: MessageSquare,
-		tooltip: "Sessions from this runtime",
+		tooltip: "Sessions from this agent",
 	},
 	{
 		id: "skills",
@@ -219,17 +219,17 @@ const HOSTED_AGENT_SECTIONS: {
 	{
 		id: "ai",
 		icon: Zap,
-		tooltip: "Runtime model provider binding",
+		tooltip: "AI provider and model",
 	},
 	{
 		id: "channels",
 		icon: Link2,
-		tooltip: "Channels linked to this runtime",
+		tooltip: "Channels linked to this agent",
 	},
 	{
 		id: "settings",
 		icon: Settings,
-		tooltip: "Profile, compute, and lifecycle",
+		tooltip: "Name, preferences, plan, and lifecycle",
 	},
 ];
 
@@ -1218,7 +1218,7 @@ function agentHeaderMeta(
 		kind === "cloud" ? agentSourceKindLabel("hosted") : kind === "legacy" ? "Legacy" : null;
 	// Legacy v1 agents run in a hosted runtime image too, so both hosted
 	// kinds get the "runtime" suffix.
-	const runtime = kind !== "connected";
+	const runtime = kind === "legacy";
 	const typeLabel = agentTypeLabel(agent.agent_type);
 	const version = agentVersionLabel(agent.agent_version);
 	const relativeSeen = agent.last_seen_at ? relativeTime(agent.last_seen_at) : null;
@@ -1286,8 +1286,8 @@ function FocusHeader({
 	const displayName = displayMachineName(name);
 	const meta = activeAgent ? agentHeaderMeta(activeAgent, activeAgentKind) : null;
 	const contextLabel = activeAgentTile?.contextLabel ?? null;
-	const activityLabel = meta?.activityLabel ?? "Sync record unavailable";
-	const visibleLabel = meta?.visibleLabel ?? runtimeDisplayLabel(activeAgentTile?.agentType);
+	const activityLabel = meta?.activityLabel ?? "Agent details unavailable";
+	const visibleLabel = meta?.visibleLabel ?? hostedAgentDisplayLabel(activeAgentTile?.agentType);
 	const detailLabel = [contextLabel, meta?.detailLabel ?? visibleLabel].filter(Boolean).join(" · ");
 	const title = [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
 	const manageHref =
@@ -1358,8 +1358,8 @@ function FocusHeader({
 	);
 }
 
-function runtimeDisplayLabel(agentType: string | null | undefined): string {
-	return agentType ? `${agentTypeLabel(agentType)} runtime` : "Hosted runtime";
+function hostedAgentDisplayLabel(agentType: string | null | undefined): string {
+	return agentType ? agentTypeLabel(agentType) : "Clawdi Cloud agent";
 }
 
 function HostedFocusTileStatus({ tile }: { tile: AgentTile }) {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -891,13 +891,8 @@ function SortableAgentRailItem({
 		kind === "legacy"
 			? `Legacy · ${agentTextLabel(identity, { includeSource: false, ownershipKind: kind })}`
 			: agentTextLabel(identity, { includeSource: kind === "cloud", ownershipKind: kind });
-	const identityLabel = [baseIdentityLabel, agent.contextLabel].filter(Boolean).join(" · ");
-	const statusLabel =
-		kind === "cloud"
-			? [agent.statusLabel, agent.secondaryStatus?.label].filter(Boolean).join(" · ")
-			: null;
-	const label = statusLabel ? `${identityLabel} · ${statusLabel}` : identityLabel;
-	const caption = displayMachineName(agent.contextLabel ?? agent.name);
+	const label = kind === "cloud" ? agent.name : baseIdentityLabel;
+	const caption = displayMachineName(agent.name);
 	const style: React.CSSProperties = {
 		transform: CSS.Transform.toString(transform),
 		transition: isDragging ? undefined : transition,
@@ -1247,8 +1242,6 @@ function FocusHeader({
 	activeAgentKind: AgentChromeKind;
 	activeAgentId: string | null;
 }) {
-	const searchStr = useLocation({ select: (location) => location.searchStr });
-	const routeQuery = agentDeploymentRouteQuery(searchStr);
 	if (!activeAgent && !activeAgentId) {
 		return (
 			<div className="min-w-0">
@@ -1281,23 +1274,22 @@ function FocusHeader({
 		);
 	}
 
-	const name = activeAgent
-		? agentDisplayName(activeAgent)
-		: (activeAgentTile?.name ?? "Clawdi Cloud agent");
+	const name =
+		activeAgentTile?.name ?? (activeAgent ? agentDisplayName(activeAgent) : "Clawdi Cloud agent");
 	const displayName = displayMachineName(name);
-	const meta = activeAgent ? agentHeaderMeta(activeAgent, activeAgentKind) : null;
-	const contextLabel = activeAgentTile?.contextLabel ?? null;
+	const meta =
+		activeAgentKind !== "cloud" && activeAgent
+			? agentHeaderMeta(activeAgent, activeAgentKind)
+			: null;
 	const activityLabel = meta?.activityLabel ?? "Agent details unavailable";
-	const visibleLabel = meta?.visibleLabel ?? hostedAgentDisplayLabel(activeAgentTile?.agentType);
-	const detailLabel = [contextLabel, meta?.detailLabel ?? visibleLabel].filter(Boolean).join(" · ");
-	const title = [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
-	const manageHref =
+	const visibleLabel = meta?.visibleLabel;
+	const detailLabel = meta?.detailLabel;
+	const title =
 		activeAgentKind === "cloud"
-			? (activeAgentTile?.manageHref ??
-				agentSectionHref(activeAgentId ?? activeAgent?.id ?? "", "settings", routeQuery))
-			: activeAgentKind === "legacy"
-				? (legacyHostedDashboardUrl() ?? undefined)
-				: undefined;
+			? name
+			: [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
+	const manageHref =
+		activeAgentKind === "legacy" ? (legacyHostedDashboardUrl() ?? undefined) : undefined;
 	return (
 		<div className="min-w-0 text-left">
 			<div className="flex min-w-0 items-center gap-2" title={title}>
@@ -1318,78 +1310,30 @@ function FocusHeader({
 			</div>
 			{visibleLabel ? (
 				<div className="mt-1 truncate text-xs leading-4 text-muted-foreground" title={detailLabel}>
-					{[contextLabel, visibleLabel].filter(Boolean).join(" · ")}
+					{visibleLabel}
 				</div>
 			) : null}
-			<div
-				className={cn(
-					"mt-2 flex min-w-0 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4",
-					activeAgentKind === "cloud"
-						? "flex-col items-start gap-0.5"
-						: "items-center justify-between gap-2",
-				)}
-			>
-				{/* Legacy agents share the hosted copy variant (supervised
-				 * daemon, no CLI steps), while remediation stays in the legacy
-				 * v1 dashboard when that URL is configured. */}
-				{activeAgentKind === "cloud" && activeAgentTile ? (
-					<HostedFocusTileStatus tile={activeAgentTile} />
-				) : activeAgent ? (
-					<DaemonStatusBadge
-						env={activeAgent}
-						source={activeAgentKind === "legacy" ? "on-clawdi" : "self-managed"}
-						manageHref={manageHref}
-						compact
-						tooltipDetail={detailLabel}
-					/>
-				) : (
-					<FocusStatusFallback />
-				)}
-				<span
-					className={cn(
-						"min-w-0 truncate text-muted-foreground",
-						activeAgentKind === "cloud" && "w-full pl-3.5",
+			{activeAgentKind !== "cloud" ? (
+				<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
+					{/* Legacy agents use hosted daemon copy and keep remediation in
+					 * the legacy v1 dashboard when that URL is configured. */}
+					{activeAgent ? (
+						<DaemonStatusBadge
+							env={activeAgent}
+							source={activeAgentKind === "legacy" ? "on-clawdi" : "self-managed"}
+							manageHref={manageHref}
+							compact
+							tooltipDetail={detailLabel}
+						/>
+					) : (
+						<FocusStatusFallback />
 					)}
-					title={activityLabel}
-				>
-					{activityLabel}
-				</span>
-			</div>
-		</div>
-	);
-}
-
-function hostedAgentDisplayLabel(agentType: string | null | undefined): string {
-	return agentType ? agentTypeLabel(agentType) : "Clawdi Cloud agent";
-}
-
-function HostedFocusTileStatus({ tile }: { tile: AgentTile }) {
-	return (
-		<span
-			className="flex w-full min-w-0 items-start gap-1.5 text-muted-foreground"
-			title={tile.secondaryStatus?.title ?? tile.statusLabel}
-		>
-			<StatusDot
-				status={tile.statusDot?.tone ?? "neutral"}
-				className={cn(
-					"mt-1 shrink-0",
-					tile.statusDot?.tone ? undefined : "border border-muted-foreground/50 bg-transparent",
-				)}
-			/>
-			<span className="min-w-0 flex-1">
-				<span>{tile.statusLabel}</span>
-				{tile.secondaryStatus ? (
-					<span
-						className={cn(
-							"block whitespace-normal break-words [overflow-wrap:anywhere]",
-							tile.secondaryStatus.textClass ?? "text-muted-foreground",
-						)}
-					>
-						{tile.secondaryStatus.label}
+					<span className="min-w-0 truncate text-muted-foreground" title={activityLabel}>
+						{activityLabel}
 					</span>
-				) : null}
-			</span>
-		</span>
+				</div>
+			) : null}
+		</div>
 	);
 }
 

--- a/apps/web/src/components/auth-provider.test.tsx
+++ b/apps/web/src/components/auth-provider.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AuthLoadScreen } from "./auth-provider";
+
+describe("AuthLoadScreen", () => {
+	test("shows an immediate branded loading state without claiming auth is ready", () => {
+		const markup = renderToStaticMarkup(createElement(AuthLoadScreen));
+
+		expect(markup).toContain('alt="Clawdi"');
+		expect(markup).toContain('role="status"');
+		expect(markup).toContain("Connecting to secure sign-in");
+		expect(markup).not.toContain("Secure sign-in did not load");
+	});
+
+	test("shows an actionable failure with a non-reload exit", () => {
+		const markup = renderToStaticMarkup(createElement(AuthLoadScreen, { failed: true }));
+
+		expect(markup).toContain("Secure sign-in did not load");
+		expect(markup).toContain("No sign-in attempt was submitted");
+		expect(markup).toContain("Try again");
+		expect(markup).toContain('href="https://clawdi.ai"');
+	});
+});

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -1,8 +1,64 @@
-import { ClerkProvider } from "@clerk/tanstack-react-start";
+import { ClerkFailed, ClerkLoaded, ClerkLoading, ClerkProvider } from "@clerk/tanstack-react-start";
 import { shadcn } from "@clerk/themes";
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { env } from "@/lib/env";
+import { cn } from "@/lib/utils";
 
 const isDevAuthBypass = env.VITE_DEV_AUTH_BYPASS;
+const AUTH_LOAD_TIMEOUT_MS = 15_000;
+
+export function AuthLoadScreen({ failed = false }: { failed?: boolean }) {
+	return (
+		<main className="flex min-h-dvh items-center justify-center bg-background px-4">
+			<section className="w-full max-w-md rounded-xl border bg-card p-6 text-center shadow-sm">
+				<img src="/clawdi-logo-transparent.png" alt="Clawdi" className="mx-auto h-10 w-auto" />
+				{failed ? (
+					<>
+						<h1 className="mt-5 text-xl font-semibold tracking-tight">
+							Secure sign-in did not load
+						</h1>
+						<p className="mt-2 text-sm text-muted-foreground">
+							Clawdi could not load its sign-in service. No sign-in attempt was submitted. Check
+							your connection, then try again.
+						</p>
+						<div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
+							<Button onClick={() => window.location.reload()}>
+								<RefreshCw data-icon="inline-start" />
+								Try again
+							</Button>
+							<a href="https://clawdi.ai" className={cn(buttonVariants({ variant: "outline" }))}>
+								Go to Clawdi website
+								<ExternalLink data-icon="inline-end" />
+							</a>
+						</div>
+					</>
+				) : (
+					<div role="status" aria-live="polite" className="mt-5">
+						<Spinner className="mx-auto size-5" />
+						<h1 className="mt-3 text-lg font-semibold">Connecting to secure sign-in</h1>
+						<p className="mt-1 text-sm text-muted-foreground">
+							This can take longer on a slow connection.
+						</p>
+					</div>
+				)}
+			</section>
+		</main>
+	);
+}
+
+function TimedAuthLoading() {
+	const [timedOut, setTimedOut] = useState(false);
+
+	useEffect(() => {
+		const timeoutId = window.setTimeout(() => setTimedOut(true), AUTH_LOAD_TIMEOUT_MS);
+		return () => window.clearTimeout(timeoutId);
+	}, []);
+
+	return <AuthLoadScreen failed={timedOut} />;
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
 	if (isDevAuthBypass) return <>{children}</>;
@@ -16,7 +72,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 			signUpFallbackRedirectUrl="/"
 			signUpUrl="/sign-up"
 		>
-			{children}
+			<ClerkLoading>
+				<TimedAuthLoading />
+			</ClerkLoading>
+			<ClerkFailed>
+				<AuthLoadScreen failed />
+			</ClerkFailed>
+			<ClerkLoaded>{children}</ClerkLoaded>
 		</ClerkProvider>
 	);
 }

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -60,6 +60,7 @@ describe("selfManagedAgentTiles", () => {
 		expect(tile).toMatchObject({
 			name: "Launch runner",
 		});
+		expect("statusLabel" in tile).toBe(false);
 		expect("runtimeLabel" in tile).toBe(false);
 	});
 });
@@ -72,7 +73,6 @@ describe("agentTileMatchesRouteId", () => {
 			source: "on-clawdi",
 			name: "Hosted agent",
 			agentType: "openclaw",
-			statusLabel: "Running",
 			href: `/agents/${projected.id}?source=on-clawdi&d=hdep_paid`,
 			active: true,
 			env: projected,
@@ -98,7 +98,6 @@ describe("fleetSummaryFromTiles", () => {
 			source: "on-clawdi",
 			name: "Codex",
 			agentType: "codex",
-			statusLabel: "Running",
 			lastSeenAt: null,
 			href: "/agents/dep_123",
 			active: true,
@@ -109,7 +108,6 @@ describe("fleetSummaryFromTiles", () => {
 			source: "on-clawdi",
 			name: "Stopped Codex",
 			agentType: "codex",
-			statusLabel: "Stopped",
 			lastSeenAt: newestSeenAt,
 			href: "/agents/dep_456",
 			active: true,

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -14,7 +14,7 @@ import {
 	displayMachineName,
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
-import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
+import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CARD_BASE,
@@ -23,7 +23,6 @@ import {
 	EntityCardSkeleton,
 	EntityHeader,
 } from "@/components/entity-card";
-import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { agentSectionHref, parseAgentPathname } from "@/lib/agent-routes";
 import { cn, relativeTime } from "@/lib/utils";
 
@@ -50,24 +49,11 @@ export function selfManagedAgentTiles(environments: Env[] | undefined): AgentTil
 		avatarUrl: env.avatar_url,
 		sortOrder: env.sort_order,
 		agentType: env.agent_type,
-		statusLabel: env.last_seen_at ? `Active ${relativeTime(env.last_seen_at)}` : "Never seen",
 		lastSeenAt: env.last_seen_at,
 		href: agentSectionHref(env.id),
 		active: isAgentActive(env.last_seen_at),
 		env,
 	}));
-}
-
-export interface AgentTileStatusDot {
-	label: string;
-	tone?: StatusTone;
-	dotClass?: string;
-}
-
-export interface AgentTileSecondaryStatus {
-	label: string;
-	title?: string;
-	textClass?: string;
 }
 
 /**
@@ -83,10 +69,6 @@ export interface AgentTile {
 	avatarUrl?: string | null;
 	sortOrder?: number | null;
 	agentType: string | null;
-	/** Optional deployment/source context for callers that group or label hosted tiles. */
-	contextLabel?: string | null;
-	/** Humanized fallback when there is no last-seen timestamp ("Running", "Never seen"). */
-	statusLabel: string;
 	/** Used to compute the "N active now" count in the card description. */
 	lastSeenAt?: string | null;
 	/** Primary click target. Points at the in-app env detail page
@@ -97,17 +79,10 @@ export interface AgentTile {
 	external?: boolean;
 	/** Optional card-level action supplied by the owning integration. */
 	action?: ReactNode;
-	/** Optional hosted remediation target retained for surfaces that open
-	 * status dialogs. Tiles render daemon status as a non-interactive dot. */
+	/** Optional remediation target for legacy status dialogs. */
 	manageHref?: string;
-	/** Counted in the "N active now" header line; no per-tile indicator rendered. */
+	/** Counted in the "N active now" header line. */
 	active: boolean;
-	/** Primary status dot. Hosted tiles use compute status here; connected tiles
-	 * omit it and fall back to live-sync status. */
-	statusDot?: AgentTileStatusDot;
-	/** Secondary qualifier appended to the tile meta line. Hosted tiles use this
-	 * only for meaningful sync qualifiers such as "Sync paused". */
-	secondaryStatus?: AgentTileSecondaryStatus | null;
 	/** Self-managed envs carry the full EnvironmentResponse so the
 	 * tile can render a sync indicator. Hosted tiles join their
 	 * cloud-api env via `clawdi_cloud_environments` and end up with
@@ -281,24 +256,16 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		machine_name: tile.name,
 		agent_type: tile.agentType,
 	});
-	const meta: string[] = [];
-	if (tile.contextLabel) meta.push(tile.contextLabel);
-	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
-	if (onClawdi) meta.push(tile.statusLabel);
 	const activityLabel = agentTileActivityLabel(tile);
-	if (activityLabel && !onClawdi) meta.push(activityLabel);
-	const statusVisual = daemonStatusVisual(
-		tile.env,
-		onClawdi || legacyHosted ? "on-clawdi" : "self-managed",
-	);
-	const statusDot = tile.statusDot ?? {
-		label: statusVisual.label,
-		dotClass: statusVisual.dotClass,
-	};
-
-	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
-	const linkIdentity = tile.contextLabel ? `${tile.name} (${tile.contextLabel})` : tile.name;
-	const linkLabel = `Open ${linkIdentity}. Status: ${linkStatus}`;
+	const meta = onClawdi
+		? []
+		: [identity.secondaryLabel, activityLabel].filter((value): value is string => Boolean(value));
+	const statusVisual = onClawdi
+		? null
+		: daemonStatusVisual(tile.env, legacyHosted ? "on-clawdi" : "self-managed");
+	const linkLabel = statusVisual
+		? `Open ${tile.name}. Status: ${statusVisual.label}`
+		: `Open ${tile.name}`;
 
 	return (
 		<div
@@ -306,14 +273,14 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 				ENTITY_CARD_BASE,
 				"group relative z-0 h-full transition-colors hover:bg-muted/50",
 			)}
-			title={tile.href ? undefined : `Status: ${linkStatus}`}
+			title={tile.href ? undefined : tile.name}
 		>
 			<EntityHeader
 				align="start"
 				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
 				title={
 					<span className="flex min-w-0 items-center gap-1.5">
-						<AgentStatusDot visual={statusDot} />
+						{statusVisual ? <AgentStatusDot visual={statusVisual} /> : null}
 						<span className="min-w-0 truncate" title={tile.name}>
 							{displayMachineName(tile.name)}
 						</span>
@@ -323,17 +290,6 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 				titleAdornment={sourcePill}
 				className={cn("min-w-0 flex-1", tile.action && "pr-28")}
 			/>
-			{onClawdi && tile.secondaryStatus ? (
-				<div
-					className={cn(
-						"mt-0.5 pl-11 text-xs leading-4",
-						tile.secondaryStatus.textClass ?? "text-muted-foreground",
-					)}
-					title={tile.secondaryStatus.title}
-				>
-					{tile.secondaryStatus.label}
-				</div>
-			) : null}
 			{tile.external ? (
 				<ArrowUpRight
 					aria-hidden
@@ -362,14 +318,10 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	);
 }
 
-function AgentStatusDot({ visual }: { visual: AgentTileStatusDot }) {
+function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
 	return (
 		<span title={visual.label} className="inline-flex shrink-0 items-center">
-			{visual.tone ? (
-				<StatusDot status={visual.tone} />
-			) : (
-				<span aria-hidden className={cn("size-1.5 rounded-full", visual.dotClass)} />
-			)}
+			<span aria-hidden className={cn("size-1.5 rounded-full", visual.dotClass)} />
 			<span className="sr-only">{visual.label}</span>
 		</span>
 	);

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "@tanstack/react-router";
 import { CirclePlus, Loader2, Rocket, TerminalSquare } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import { IconChip } from "@/components/icon-chip";
@@ -18,6 +18,7 @@ import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { useHydrated } from "@/lib/use-hydrated";
 import { cn } from "@/lib/utils";
 
 export function NewAgentButton({
@@ -33,15 +34,12 @@ export function NewAgentButton({
 } = {}) {
 	const router = useRouter();
 	const hostedAccess = useHostedProductAccess();
-	const [mounted, setMounted] = useState(false);
+	const hydrated = useHydrated();
 	const [chooserOpen, setChooserOpen] = useState(false);
 	const [connectOpen, setConnectOpen] = useState(false);
-	useEffect(() => {
-		setMounted(true);
-	}, []);
-	const canDeployManagedAgent = mounted && IS_HOSTED && hostedAccess.canCreateCloudAgents;
-	const checkingDeployAccess = mounted && IS_HOSTED && hostedAccess.isLoading;
-	const deployAccessError = mounted && IS_HOSTED && hostedAccess.isError;
+	const canDeployManagedAgent = hydrated && IS_HOSTED && hostedAccess.canCreateCloudAgents;
+	const checkingDeployAccess = hydrated && IS_HOSTED && hostedAccess.isLoading;
+	const deployAccessError = hydrated && IS_HOSTED && hostedAccess.isError;
 
 	function handleClick() {
 		if (checkingDeployAccess) return;

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -74,7 +74,6 @@ export function AgentHome({
 		membershipResolved,
 		isLoading,
 		isFetching,
-		runtimeUiSettlingTimedOut,
 		deploymentTransitionTimedOut,
 		error,
 		refetch,
@@ -226,8 +225,6 @@ export function AgentHome({
 				onDeleteAccepted={(deploymentId) =>
 					setUserDeleteIntent({ deploymentId, environmentId, deploymentSelector })
 				}
-				autoOpenRuntimeUi={requestedFromCloudRedirect && environmentId === deployment.resource.id}
-				runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 				isCheckingDeployment={isFetching}
 				onCheckDeploymentAgain={handleCheckAgain}

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -243,7 +243,7 @@ export function AgentHome({
 			>
 				<EmptyState
 					title="Clawdi Cloud agent not found"
-					description="This Clawdi Cloud agent may still be provisioning or may have been removed."
+					description="This Clawdi Cloud agent may still be getting ready or may have been removed."
 					action={
 						<Button type="button" variant="outline" size="sm" onClick={handleCheckAgain}>
 							<RefreshCw /> Check again

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -124,7 +124,7 @@ export function HostedDeploymentDeleteAction({
 				<AlertDialogHeader>
 					<AlertDialogTitle>{`Delete ${name}?`}</AlertDialogTitle>
 					<AlertDialogDescription>
-						The hosted agent and its deployment are torn down. This can’t be undone.
+						This permanently deletes the agent and releases its resources. This can’t be undone.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -109,6 +109,24 @@ describe("deployment failure remediation rendering", () => {
 		expect(markup).not.toContain("retry startup");
 		expect(markup).not.toContain("Restart compute");
 	});
+
+	test("gives an unexplained failure customer language and a working next step", () => {
+		if (!overviewFailedPanel) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(overviewFailedPanel, {
+				deployment: hostedDeploymentFixture({ status: "failed" }),
+				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				onDeleteAccepted: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("Agent change failed");
+		expect(markup).toContain("Clawdi couldn’t complete the last change to this agent");
+		expect(markup).toContain("It isn’t safe to try again automatically");
+		expect(markup).toContain('href="mailto:support@clawdi.ai"');
+		expect(markup).not.toContain("Deployment operation");
+		expect(markup).not.toContain("failure reason and operation");
+	});
 });
 
 describe("deployment transition timeout rendering", () => {
@@ -195,6 +213,8 @@ describe("hosted agent customer language", () => {
 			"Manage hosted compute independently of synced agent data.",
 			"Apply locale changes directly",
 			"finishes booting",
+			"Deployment operation failed",
+			"failure reason and operation",
 		]) {
 			expect(customerCopy).not.toContain(internalCopy);
 		}

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -21,18 +21,13 @@ type InvalidateDeploymentSnapshots =
 	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
 type ProjectAcceptedDeploymentTransition =
 	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
-type RuntimeUiSettlingPollState =
-	typeof import("@/hosted/agents/deployment-hooks").runtimeUiSettlingPollState;
-type OverviewProvisioningPanel =
-	typeof import("@/hosted/agents/hosted-agent-detail").OverviewProvisioningPanel;
+type OverviewReadinessPanel =
+	typeof import("@/hosted/agents/hosted-agent-detail").OverviewReadinessPanel;
 type OverviewFailedPanel = typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailedPanel;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
-let settlingPollState: RuntimeUiSettlingPollState | null = null;
-let settlingPollIntervalMs: number | null = null;
-let settlingTimeoutMs: number | null = null;
-let overviewProvisioningPanel: OverviewProvisioningPanel | null = null;
+let overviewReadinessPanel: OverviewReadinessPanel | null = null;
 let overviewFailedPanel: OverviewFailedPanel | null = null;
 
 function requiredDeploymentStatus(
@@ -51,11 +46,8 @@ beforeAll(async () => {
 	const module = await import("@/hosted/agents/deployment-hooks");
 	invalidateSnapshots = module.invalidateDeploymentSnapshots;
 	projectAcceptedTransition = module.projectAcceptedDeploymentTransition;
-	settlingPollState = module.runtimeUiSettlingPollState;
-	settlingPollIntervalMs = module.RUNTIME_UI_SETTLING_POLL_INTERVAL_MS;
-	settlingTimeoutMs = module.RUNTIME_UI_SETTLING_TIMEOUT_MS;
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
-	overviewProvisioningPanel = detailModule.OverviewProvisioningPanel;
+	overviewReadinessPanel = detailModule.OverviewReadinessPanel;
 	overviewFailedPanel = detailModule.OverviewFailedPanel;
 });
 
@@ -121,26 +113,22 @@ describe("deployment failure remediation rendering", () => {
 
 describe("deployment transition timeout rendering", () => {
 	test("replaces the automatic-update promise with an honest timeout and check action", () => {
-		if (!overviewProvisioningPanel) throw new Error("agent detail was not loaded");
+		if (!overviewReadinessPanel) throw new Error("agent detail was not loaded");
 		const deployment = hostedDeploymentFixture({ status: "creating" });
 		const commonProps = {
 			deployment,
-			runtime: "openclaw" as const,
-			runtimeUiAvailable: false,
-			runtimeUiSettlingTimedOut: false,
 			isCheckingDeployment: false,
 			onCheckDeploymentAgain: () => undefined,
-			terminalHref: "/agents/env_test/terminal",
 		};
 
 		const converging = renderToStaticMarkup(
-			createElement(overviewProvisioningPanel, {
+			createElement(overviewReadinessPanel, {
 				...commonProps,
 				deploymentTransitionTimedOut: false,
 			}),
 		);
 		const timedOut = renderToStaticMarkup(
-			createElement(overviewProvisioningPanel, {
+			createElement(overviewReadinessPanel, {
 				...commonProps,
 				deploymentTransitionTimedOut: true,
 			}),
@@ -160,19 +148,22 @@ describe("deployment transition timeout rendering", () => {
 		expect(timedOut).not.toContain("will keep getting ready if you leave this page");
 	});
 
-	test("sets an honest five-minute expectation while the product UI opens", () => {
-		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
-		const panelStart = source.indexOf("export function OverviewProvisioningPanel");
-		const panelEnd = source.indexOf("function OverviewFailedPanel", panelStart);
-		const panelSource = source.slice(panelStart, panelEnd);
+	test("makes the authoritative running state unambiguously ready", () => {
+		if (!overviewReadinessPanel) throw new Error("agent detail was not loaded");
+		const ready = renderToStaticMarkup(
+			createElement(overviewReadinessPanel, {
+				deployment: hostedDeploymentFixture({ status: "running" }),
+				deploymentTransitionTimedOut: false,
+				isCheckingDeployment: false,
+				onCheckDeploymentAgain: () => undefined,
+			}),
+		);
 
-		expect(panelSource).toContain("`Opening ");
-		expect(panelSource).toContain("browserUiLabel}…`");
-		expect(panelSource).toContain("This step should finish within five minutes.");
-		expect(panelSource).toContain("We’ll open ");
-		expect(panelSource).toContain("browserUiLabel} automatically");
-		expect(panelSource).not.toContain('"Booting"');
-		expect(panelSource).not.toContain("Current status");
+		expect(ready).toContain("Your agent is ready");
+		expect(ready).toContain("running and ready to use");
+		expect(ready).not.toContain("automatically");
+		expect(ready).not.toContain("Provisioning");
+		expect(ready).not.toContain("Booting");
 	});
 
 	test("wires the timed-out inventory state and real refetch action into the detail", () => {
@@ -211,128 +202,6 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain("Clawdi can’t load every part of this agent right now.");
 		expect(detailSource).toContain("title={`Agent status: ");
 		expect(sidebarSource).toContain('"Agent details unavailable"');
-	});
-});
-
-describe("runtime UI settling polling", () => {
-	test("derives the same pending tracker across repeated render-phase calculations", () => {
-		if (!settlingPollState) throw new Error("deployment hooks were not loaded");
-		const nowMs = Date.parse("2026-07-23T12:00:00Z");
-		const deployment = hostedDeploymentFixture({ status: "running", runtime: "hermes" });
-		const committedTracker = null;
-
-		const firstRender = settlingPollState(deployment, "hermes", committedTracker, nowMs);
-		const repeatedRender = settlingPollState(deployment, "hermes", committedTracker, nowMs);
-
-		expect(repeatedRender).toEqual(firstRender);
-		expect(committedTracker).toBeNull();
-	});
-
-	test("commits the derived tracker only from an effect", () => {
-		const source = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
-		const hookStart = source.indexOf("export function useAgentDeployment");
-		const hookEnd = source.indexOf("export type {", hookStart);
-		const hookSource = source.slice(hookStart, hookEnd);
-		const assignments = hookSource.match(/runtimeUiSettlingTrackerRef\.current\s*=/g) ?? [];
-
-		expect(assignments).toHaveLength(1);
-		expect(hookSource).toContain(
-			"useEffect(() => {\n\t\truntimeUiSettlingTrackerRef.current = runtimeUiSettling.tracker;",
-		);
-	});
-
-	test("rapidly polls a running deployment until its selected runtime UI appears", () => {
-		if (!settlingPollState || !settlingPollIntervalMs) {
-			throw new Error("deployment hooks were not loaded");
-		}
-		const nowMs = Date.parse("2026-07-23T12:00:00Z");
-		const deployment = hostedDeploymentFixture({ status: "running", runtime: "hermes" });
-		const pending = settlingPollState(deployment, "hermes", null, nowMs);
-
-		expect(pending.refetchInterval).toBe(settlingPollIntervalMs);
-		expect(pending.timedOut).toBe(false);
-		expect(pending.tracker?.startedAtMs).toBe(nowMs);
-
-		const ready = settlingPollState(
-			hostedDeploymentFixture({
-				status: "running",
-				runtime: "hermes",
-				runtimeUiEndpoint: {
-					runtime: "hermes",
-					role: "control_ui",
-					url: "https://runtime.example/hermes",
-					auth_mode: "password",
-					browser_mode: "top_level",
-				},
-			}),
-			"hermes",
-			pending.tracker,
-			nowMs + settlingPollIntervalMs,
-		);
-		expect(ready).toEqual({ refetchInterval: false, timedOut: false, tracker: null });
-	});
-
-	test("bounds rapid polling to the runtime UI boot window", () => {
-		if (!settlingPollState || !settlingTimeoutMs) {
-			throw new Error("deployment hooks were not loaded");
-		}
-		const nowMs = Date.parse("2026-07-23T12:00:00Z");
-		const deployment = hostedDeploymentFixture({ status: "running" });
-		const pending = settlingPollState(deployment, "openclaw", null, nowMs);
-		const timedOut = settlingPollState(
-			deployment,
-			"openclaw",
-			pending.tracker,
-			nowMs + settlingTimeoutMs,
-		);
-
-		expect(timedOut.refetchInterval).toBe(false);
-		expect(timedOut.timedOut).toBe(true);
-		expect(timedOut.tracker).toEqual(pending.tracker);
-	});
-
-	test("uses an A4 Ready transition to recognize an already-stuck boot", () => {
-		if (!settlingPollState || !settlingTimeoutMs) {
-			throw new Error("deployment hooks were not loaded");
-		}
-		const nowMs = Date.parse("2026-07-23T12:00:00Z");
-		const deployment = hostedDeploymentFixture({ status: "running" });
-		requiredDeploymentStatus(deployment).conditions = [
-			{
-				type: "Ready",
-				status: "True",
-				observedGeneration: 1,
-				lastTransitionTime: new Date(nowMs - settlingTimeoutMs).toISOString(),
-				reason: "RuntimeReady",
-				message: "Runtime reported ready",
-			},
-		];
-
-		const state = settlingPollState(deployment, "openclaw", null, nowMs);
-		expect(state.refetchInterval).toBe(false);
-		expect(state.timedOut).toBe(true);
-	});
-
-	test("does not override polling for non-running lifecycle states", () => {
-		if (!settlingPollState) throw new Error("deployment hooks were not loaded");
-		const state = settlingPollState(
-			hostedDeploymentFixture({ status: "starting" }),
-			"openclaw",
-			null,
-			Date.now(),
-		);
-		expect(state).toEqual({ refetchInterval: false, timedOut: false, tracker: null });
-	});
-
-	test("does not treat unavailable deployment status as a running runtime", () => {
-		if (!settlingPollState) throw new Error("deployment hooks were not loaded");
-		const state = settlingPollState(
-			hostedDeploymentFixture({ status: null }),
-			"openclaw",
-			null,
-			Date.now(),
-		);
-		expect(state).toEqual({ refetchInterval: false, timedOut: false, tracker: null });
 	});
 });
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -84,7 +84,8 @@ describe("deployment failure remediation rendering", () => {
 				type: "https://api.clawdi.ai/problems/operation_aborted",
 				title: "Deployment operation was aborted",
 				status: 409,
-				detail: "Top up your wallet and retry the plan change.",
+				detail:
+					"MissingGreenlet prevented synchronous plan confirmation for operations/plan-change-failed.",
 				instance: "hdep_failed",
 				code: "operation_aborted",
 				phase: "plan_change",
@@ -104,8 +105,14 @@ describe("deployment failure remediation rendering", () => {
 		);
 
 		expect(markup).toContain("Plan change failed");
-		expect(markup).toContain("Top up your wallet and retry the plan change.");
-		expect(markup).toContain("Review plan");
+		expect(markup).toContain("The Clawdi service could not confirm the plan change.");
+		expect(markup).toContain("Your plan was not changed and you were not charged.");
+		expect(markup).toContain("Get a fresh quote and confirm the price before trying again.");
+		expect(markup).toContain("Get fresh quote");
+		expect(markup).not.toContain("MissingGreenlet");
+		expect(markup).not.toContain("operations/plan-change-failed");
+		expect(markup).not.toContain("provisioning");
+		expect(markup).not.toContain("synchronous plan confirmation");
 		expect(markup).not.toContain("Agent setup failed");
 		expect(markup).not.toContain("retry startup");
 		expect(markup).not.toContain("Restart compute");
@@ -410,7 +417,9 @@ describe("deployment mutation settlement", () => {
 		expect(failed).toHaveLength(1);
 		const failedStatus = requiredDeploymentStatus(failed?.[0]);
 		expect(failedStatus.summary_state).toBe("failed");
-		expect(deploymentFailureReason(failedStatus)).toBe("Deployment deletion failed");
+		expect(deploymentFailureReason(failedStatus)).toBe(
+			"The Clawdi service could not complete this request.",
+		);
 	});
 
 	test("does not fabricate a status while projecting an accepted operation", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -185,6 +185,35 @@ describe("deployment transition timeout rendering", () => {
 	});
 });
 
+describe("hosted agent customer language", () => {
+	test("keeps delayed and unavailable states honest without implementation vocabulary", () => {
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		const sidebarSource = readFileSync(
+			new URL("../../components/app-sidebar.tsx", import.meta.url),
+			"utf8",
+		);
+		const customerCopy = `${detailSource}\n${sidebarSource}`;
+
+		for (const internalCopy of [
+			"Sync record unavailable",
+			"synced agent record",
+			"Deployment actions",
+			"Manage hosted compute independently of synced agent data.",
+			"Apply locale changes directly",
+			"finishes booting",
+		]) {
+			expect(customerCopy).not.toContain(internalCopy);
+		}
+		expect(detailSource).toContain("Some agent details are unavailable");
+		expect(detailSource).toContain("Clawdi can’t load every part of this agent right now.");
+		expect(detailSource).toContain("title={`Agent status: ");
+		expect(sidebarSource).toContain('"Agent details unavailable"');
+	});
+});
+
 describe("runtime UI settling polling", () => {
 	test("derives the same pending tracker across repeated render-phase calculations", () => {
 		if (!settlingPollState) throw new Error("deployment hooks were not loaded");

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { toast } from "sonner";
 import { type AcceptedOperation, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
@@ -22,20 +22,9 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
-import {
-	boundedSettlingPollState,
-	type DeploymentOperationVerb,
-	type SettlingTracker,
-} from "@/hosted/deployment-status";
+import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
-import {
-	defaultDeploymentRuntime,
-	deploymentRuntime,
-	type HostedRuntime,
-	isHostedRuntime,
-	runtimeConsoleUrl,
-	runtimeEnvironmentId,
-} from "@/hosted/runtimes";
+import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 
 const SETTLING_REFRESH_DELAYS_MS = [2_000, 10_000, 20_000, 30_000] as const;
@@ -50,59 +39,6 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 	rename: "updating",
 	delete: "deleting",
 } satisfies Record<DeploymentOperationVerb, HostedDeploymentStatus["summary_state"]>;
-
-export const RUNTIME_UI_SETTLING_POLL_INTERVAL_MS = 3_000;
-export const RUNTIME_UI_SETTLING_TIMEOUT_MS = 5 * 60_000;
-
-export type RuntimeUiSettlingTracker = SettlingTracker;
-
-export type RuntimeUiSettlingPollState = {
-	refetchInterval: number | false;
-	timedOut: boolean;
-	tracker: RuntimeUiSettlingTracker | null;
-};
-
-/**
- * A4 may report compute as running just before its runtime UI endpoint is
- * published. Keep that short-lived gap on the fast deployment-query cadence,
- * but stop rapid polling after the boot window. Returning false lets the
- * shared query fall back to its modest foreground reconciliation interval.
- */
-export function runtimeUiSettlingPollState(
-	deployment: HostedDeployment | null | undefined,
-	runtime: HostedRuntime | null | undefined,
-	tracker: RuntimeUiSettlingTracker | null,
-	nowMs: number,
-): RuntimeUiSettlingPollState {
-	if (!deployment || !runtime || runtimeConsoleUrl(deployment, runtime)) {
-		return { refetchInterval: false, timedOut: false, tracker: null };
-	}
-	const status = deployment.resource.status;
-	if (status === null || status.summary_state !== "running") {
-		return { refetchInterval: false, timedOut: false, tracker: null };
-	}
-
-	const key = `${deployment.resource.id}:${deployment.resource.metadata.generation}:${runtime}`;
-	return boundedSettlingPollState({
-		key,
-		startedAtMs: runtimeUiSettlingStartedAtMs(status, nowMs),
-		tracker,
-		nowMs,
-		pollIntervalMs: RUNTIME_UI_SETTLING_POLL_INTERVAL_MS,
-		timeoutMs: RUNTIME_UI_SETTLING_TIMEOUT_MS,
-	});
-}
-
-function runtimeUiSettlingStartedAtMs(status: HostedDeploymentStatus, nowMs: number): number {
-	const transitionTimes = status.conditions.flatMap((condition) => {
-		if (condition.type !== "Ready" || condition.status !== "True") {
-			return [];
-		}
-		const parsed = Date.parse(condition.lastTransitionTime);
-		return Number.isFinite(parsed) && parsed <= nowMs ? [parsed] : [];
-	});
-	return transitionTimes.length > 0 ? Math.max(...transitionTimes) : nowMs;
-}
 
 export function invalidateDeploymentSnapshots(qc: QueryClient) {
 	void qc.invalidateQueries({ queryKey: billingKeys.deployments });
@@ -179,45 +115,14 @@ function toastDeploymentConflict(error: unknown): boolean {
  * selector disambiguates duplicate inventory rows.
  */
 export function useAgentDeployment(environmentId: string, deploymentSelector?: string | null) {
-	const runtimeUiSettlingTrackerRef = useRef<RuntimeUiSettlingTracker | null>(null);
-	const deriveRuntimeUiSettlingState = useCallback(
-		(deployments: readonly HostedDeployment[] | null | undefined, nowMs: number) => {
-			const resolution = resolveAgentDeployment(
-				deployments ?? [],
-				environmentId,
-				deploymentSelector,
-			);
-			const match = resolution.match;
-			const runtime =
-				match?.runtime && isHostedRuntime(match.runtime)
-					? match.runtime
-					: match
-						? defaultDeploymentRuntime(match.deployment)
-						: null;
-			return runtimeUiSettlingPollState(
-				match?.deployment,
-				runtime,
-				runtimeUiSettlingTrackerRef.current,
-				nowMs,
-			);
-		},
-		[deploymentSelector, environmentId],
-	);
-	const additionalRefetchInterval = useCallback(
-		(deployments: readonly HostedDeployment[] | undefined) =>
-			deriveRuntimeUiSettlingState(deployments, Date.now()).refetchInterval,
-		[deriveRuntimeUiSettlingState],
-	);
 	const inventory = useHostedDeploymentInventory({
 		pollBillingRecoveryFor: deploymentSelector ?? environmentId,
-		additionalRefetchInterval,
 	});
 	const resolution = useMemo(
 		() => resolveAgentDeployment(inventory.deployments ?? [], environmentId, deploymentSelector),
 		[inventory.deployments, environmentId, deploymentSelector],
 	);
 	const match = resolution.match;
-	const runtimeUiSettling = deriveRuntimeUiSettlingState(inventory.deployments, Date.now());
 	const deploymentId = match?.deployment.resource.id;
 	const deploymentTransition = deploymentId
 		? (inventory.deploymentTransitions.get(deploymentId) ?? null)
@@ -225,10 +130,6 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 	const deploymentFailure = deploymentId
 		? (inventory.deploymentFailures.get(deploymentId) ?? null)
 		: null;
-
-	useEffect(() => {
-		runtimeUiSettlingTrackerRef.current = runtimeUiSettling.tracker;
-	}, [runtimeUiSettling.tracker]);
 
 	// The env id to drive per-env queries (sessions, channel links). For an
 	// env-id route it's the route param itself; for a deployment-id route
@@ -250,7 +151,6 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		membershipResolved: inventory.status === "resolved",
 		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
 		isFetching: inventory.isFetching,
-		runtimeUiSettlingTimedOut: runtimeUiSettling.timedOut,
 		deploymentTransition,
 		deploymentTransitionTimedOut: deploymentTransition?.kind === "timed_out",
 		deploymentFailure,

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -10,6 +10,7 @@ import {
 	Cpu,
 	ExternalLink,
 	Info,
+	LifeBuoy,
 	Link2,
 	Link2Off,
 	type LucideIcon,
@@ -1026,19 +1027,29 @@ export function OverviewFailedPanel({
 	}
 	return (
 		<div className="rounded-xl border border-destructive-muted bg-destructive-muted p-5 text-destructive-muted-foreground">
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 				<div className="flex min-w-0 gap-3">
 					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-destructive-muted bg-background">
 						<AlertCircle className="size-5" />
 					</div>
 					<div className="min-w-0">
-						<h2 className="text-sm font-semibold text-foreground">Deployment operation failed</h2>
+						<h2 className="text-sm font-semibold text-foreground">Agent change failed</h2>
 						<p className="mt-1 text-sm">
-							The failure reason and operation are unavailable, so there is no safe automatic retry.
-							Current status: {deploymentStatusLabel(status)}.
+							Clawdi couldn’t complete the last change to this agent or determine why. It isn’t safe
+							to try again automatically. Contact support before trying again. Current status:{" "}
+							{deploymentStatusLabel(status)}.
 						</p>
 					</div>
 				</div>
+				<Button
+					render={<a href="mailto:support@clawdi.ai" />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+					className="shrink-0"
+				>
+					<LifeBuoy data-icon="inline-start" /> Contact support
+				</Button>
 			</div>
 		</div>
 	);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -253,15 +253,15 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Info,
 	},
 	console: {
-		description: "Open the runtime's live browser UI.",
+		description: "Open this agent's browser interface.",
 		icon: MonitorPlay,
 	},
 	terminal: {
-		description: "Start a browser terminal in this deployment.",
+		description: "Open a terminal for this agent.",
 		icon: TerminalSquare,
 	},
 	sessions: {
-		description: "History synced by this hosted runtime.",
+		description: "Conversation history from this agent.",
 		icon: RefreshCw,
 	},
 	skills: {
@@ -269,7 +269,7 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Sparkles,
 	},
 	ai: {
-		description: "Runtime-scoped provider and model binding.",
+		description: "AI provider and model used by this agent.",
 		icon: Zap,
 	},
 	channels: {
@@ -277,7 +277,7 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Link2,
 	},
 	settings: {
-		description: "Profile, compute, and lifecycle controls.",
+		description: "Name, preferences, plan, and lifecycle controls.",
 		icon: Settings,
 	},
 };
@@ -308,7 +308,7 @@ function provisioningTitle(status: DeploymentStatus): string {
 
 function RestartComputeAction({
 	deployment,
-	label = "Restart compute",
+	label = "Restart agent",
 }: {
 	deployment: HostedDeployment;
 	label?: string;
@@ -319,8 +319,8 @@ function RestartComputeAction({
 	const canRestart = canRestartDeployment(status);
 	return (
 		<ConfirmAction
-			title="Restart compute?"
-			description={<p>This restarts this hosted agent.</p>}
+			title="Restart agent?"
+			description={<p>This restarts the whole agent.</p>}
 			confirmLabel={label}
 			onConfirm={() =>
 				runAction(async () => {
@@ -370,7 +370,7 @@ function DeleteComputeAction({
 
 function StartComputeAction({
 	deployment,
-	label = "Start compute",
+	label = "Start agent",
 }: {
 	deployment: HostedDeployment;
 	label?: string;
@@ -704,7 +704,7 @@ function HostedProjectionNotice({
 			<ApiErrorPanel
 				error={projection.error}
 				onRetry={onRetry}
-				title="Couldn’t sync agent details"
+				title="Couldn’t load all agent details"
 			/>
 		);
 	}
@@ -712,11 +712,11 @@ function HostedProjectionNotice({
 		return (
 			<Alert data-hosted="true">
 				<AlertCircle />
-				<AlertTitle>Some details are still syncing</AlertTitle>
+				<AlertTitle>Some agent details are not ready</AlertTitle>
 				<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 					<span>
-						You can manage compute and open available tools now. Sessions, skills, profile, and
-						channels will appear when syncing finishes.
+						Sessions, skills, profile, and channels will appear when they’re ready. Available
+						actions and tools still work.
 					</span>
 					<Button type="button" variant="outline" size="sm" disabled={isFetching} onClick={onRetry}>
 						{isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
@@ -730,9 +730,9 @@ function HostedProjectionNotice({
 		return (
 			<Alert data-hosted="true">
 				<Spinner className="size-4" />
-				<AlertTitle>Some details are still syncing</AlertTitle>
+				<AlertTitle>Loading agent details</AlertTitle>
 				<AlertDescription>
-					You can manage compute while the rest of this agent finishes syncing.
+					Available actions still work while the rest of this agent loads.
 				</AlertDescription>
 			</Alert>
 		);
@@ -740,9 +740,9 @@ function HostedProjectionNotice({
 	return (
 		<Alert data-hosted="true">
 			<AlertCircle />
-			<AlertTitle>Finishing agent setup</AlertTitle>
+			<AlertTitle>Some agent details are unavailable</AlertTitle>
 			<AlertDescription>
-				You can manage compute now. The rest of this agent will appear when setup finishes.
+				Clawdi can’t load every part of this agent right now. Available actions still work.
 			</AlertDescription>
 		</Alert>
 	);
@@ -752,7 +752,7 @@ function ProjectionDependentUnavailable({ label }: { label: string }) {
 	return (
 		<EmptyState
 			title={`${label} unavailable`}
-			description="This section will be available when the agent finishes syncing. You can manage compute in the meantime."
+			description="Clawdi can’t load this part of the agent yet. Other available actions still work."
 		/>
 	);
 }
@@ -768,7 +768,7 @@ function StoppedAgentState({
 		<EmptyState
 			variant={variant}
 			title="Stopped"
-			description="Hosted compute has been released. Start this agent to provision compute again."
+			description="This agent is stopped. Start it to use its tools again."
 			action={<StartComputeAction deployment={deployment} label="Start" />}
 		/>
 	);
@@ -873,7 +873,7 @@ function RuntimeStatusValue({
 		<div className="flex min-w-0 flex-col gap-1">
 			<span
 				className={cn("inline-flex min-w-0 items-center gap-1.5", status.primary.textClass)}
-				title={`Compute ${status.primary.label}`}
+				title={`Agent status: ${status.primary.label}`}
 			>
 				<StatusDot status={status.primary.tone} />
 				<span className="truncate">{status.primary.label}</span>
@@ -1231,7 +1231,7 @@ function OverviewTab({
 					<EmptyState
 						variant="inset"
 						title="Sessions unavailable"
-						description="Sessions depend on the synced agent record and will recover when it becomes available."
+						description="Sessions will appear when the rest of this agent is ready."
 					/>
 				) : sessionsError ? (
 					<ApiErrorPanel
@@ -1268,8 +1268,8 @@ function OverviewDeploymentActions({
 	const failed = status.kind === "failed";
 	return (
 		<SettingsSection
-			title="Deployment actions"
-			description="Manage hosted compute independently of synced agent data."
+			title="Agent actions"
+			description="These actions remain available while other agent details load."
 		>
 			<div className="flex flex-wrap gap-2.5">
 				{canRestartDeployment(status) && !failed ? (
@@ -1312,7 +1312,7 @@ function RuntimeUiOpenButton({
 	const openUi = useCallback(async () => {
 		const popup = openSecureRuntimeWindow(window.open.bind(window));
 		if (!popup) {
-			toast.error("Couldn't open runtime UI", {
+			toast.error("Couldn't open agent interface", {
 				description: "Your browser blocked the new window.",
 			});
 			return;
@@ -1329,7 +1329,7 @@ function RuntimeUiOpenButton({
 			popup.location.replace(url);
 		} catch {
 			popup.close();
-			toast.error("Couldn't open runtime UI", { description: "Please try again." });
+			toast.error("Couldn't open agent interface", { description: "Please try again." });
 		} finally {
 			setIsPending(false);
 		}
@@ -1477,17 +1477,17 @@ function ConsoleTab({
 				icon={deploymentTransitionTimedOut ? AlertCircle : MonitorPlay}
 				title={
 					deploymentTransitionTimedOut
-						? "Deployment is taking longer than expected"
+						? "Your agent is taking longer than expected"
 						: isProvisioning
 							? provisioningTitle(status)
-							: "Compute is not running"
+							: "Agent is not running"
 				}
 				description={
 					deploymentTransitionTimedOut
-						? "The latest deployment change did not finish within five minutes. Automatic checks have stopped. Check again to load the latest status."
+						? "The latest change to this agent did not finish within five minutes. Automatic checks have stopped. Check again to load the latest status."
 						: isProvisioning
 							? `The live ${browserUiLabel} opens here once your agent is running. This page updates automatically.`
-							: `Start the compute to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
+							: `Start the agent to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
 				}
 				action={
 					deploymentTransitionTimedOut ? (
@@ -1525,8 +1525,8 @@ function ConsoleTab({
 				}
 				description={
 					runtimeUiSettlingTimedOut
-						? `${label} did not publish its browser UI within the startup window. Automatic periodic checks will continue.`
-						: `Opening the live UI automatically… You can use Terminal right now while ${label} finishes booting.`
+						? `${label} did not open its browser interface within five minutes. Automatic periodic checks will continue.`
+						: `Opening the live UI automatically… You can use Terminal right now while ${label} finishes getting ready.`
 				}
 				action={
 					<Button
@@ -1792,11 +1792,11 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 		return (
 			<EmptyState
 				icon={TerminalSquare}
-				title={isProvisioning ? provisioningTitle(status) : "Compute is not running"}
+				title={isProvisioning ? provisioningTitle(status) : "Agent is not running"}
 				description={
 					isProvisioning
 						? "The browser terminal opens once your agent is running. This page updates automatically."
-						: `Start the compute to open a deployment shell. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
+						: `Start the agent to open a terminal. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
 				}
 				action={canStartDeployment(status) ? <StartComputeAction deployment={deployment} /> : null}
 			/>
@@ -2764,23 +2764,16 @@ function HostedAgentSettingsTab({
 			) : (
 				<ProjectionDependentUnavailable label="Profile settings" />
 			)}
-			<LanguageTimezoneSettingsSection deployment={deployment} runtime={runtime} />
+			<LanguageTimezoneSettingsSection deployment={deployment} />
 			<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
 		</div>
 	);
 }
 
-function LanguageTimezoneSettingsSection({
-	deployment,
-	runtime,
-}: {
-	deployment: HostedDeployment;
-	runtime: Runtime;
-}) {
+function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDeployment }) {
 	const runtimeConfiguration = deployment.resource.spec.runtime_configuration;
 	const configLanguage = runtimeConfiguration.language ?? "";
 	const configTimezone = runtimeConfiguration.timezone ?? "";
-	const runtimeLabel = runtimeDisplayName(runtime);
 	const updateDeployment = useUpdateDeployment();
 	const updateInProgress =
 		deploymentStatusFromResource(deployment.resource.status).kind === "updating";
@@ -2802,10 +2795,10 @@ function LanguageTimezoneSettingsSection({
 	return (
 		<SettingsSection
 			title="Language & timezone"
-			description="Locale context configured for this hosted agent."
+			description="Language and time zone used by this agent."
 		>
 			<div className="flex max-w-2xl flex-col gap-4">
-				<LiveNote>{`Apply locale changes directly to this ${runtimeLabel} deployment.`}</LiveNote>
+				<LiveNote>Changes apply to this agent.</LiveNote>
 				<div className="grid gap-4 sm:grid-cols-2">
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="hosted-agent-language">Language</Label>
@@ -3352,15 +3345,12 @@ function ComputeSettingsSections({
 				</div>
 			</SettingsSection>
 
-			<SettingsSection
-				title="Lifecycle"
-				description="Restart, stop, or start the whole hosted compute."
-			>
+			<SettingsSection title="Lifecycle" description="Restart, stop, or start this agent.">
 				<div className="flex flex-wrap gap-2.5">
 					<ConfirmAction
-						title="Restart compute?"
-						description={<p>This restarts this hosted agent.</p>}
-						confirmLabel="Restart compute"
+						title="Restart agent?"
+						description={<p>This restarts the whole agent.</p>}
+						confirmLabel="Restart agent"
 						onConfirm={() => runAction(() => runLifecycleAction("restart"))}
 					>
 						<Button variant="outline" size="sm" disabled={lifecycle.isPending || !canRestart}>
@@ -3374,14 +3364,14 @@ function ComputeSettingsSections({
 					</ConfirmAction>
 					{primaryLifecycleAction === "stop" ? (
 						<ConfirmAction
-							title="Stop compute?"
+							title="Stop agent?"
 							description={
 								<p>
-									This stops the hosted agent. Runtime UI, terminal access, sessions, and channels
-									pause until you start it again.
+									This pauses its browser tools, terminal, sessions, and channels until you start it
+									again.
 								</p>
 							}
-							confirmLabel="Stop compute"
+							confirmLabel="Stop agent"
 							onConfirm={() => runAction(() => runLifecycleAction("stop"))}
 						>
 							<Button
@@ -3417,14 +3407,14 @@ function ComputeSettingsSections({
 
 			<SettingsSection
 				title="Danger zone"
-				description="Tear down this hosted compute and its agent runtime."
+				description="Permanently delete this agent."
 				variant="destructive"
 			>
 				<div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 					<div>
-						<div className="text-sm font-medium">Delete this compute</div>
+						<div className="text-sm font-medium">Delete this agent</div>
 						<p className="text-xs text-muted-foreground">
-							Tears down this deployment and its agent runtime. This can’t be undone.
+							Deletes this agent and releases its resources. This can’t be undone.
 						</p>
 					</div>
 					<DeleteComputeAction

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -78,7 +78,6 @@ import type {
 	ComputePlanChangeQuoteResponse,
 	DeploymentUpdateRequest,
 	HostedDeployment,
-	HostedDeploymentStatus,
 } from "@/hosted/billing/contracts";
 import {
 	LANGUAGE_OPTIONS,
@@ -422,8 +421,6 @@ export function HostedAgentDetail({
 	runtime,
 	section = "overview",
 	onDeleteAccepted,
-	autoOpenRuntimeUi = false,
-	runtimeUiSettlingTimedOut = false,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
@@ -433,8 +430,6 @@ export function HostedAgentDetail({
 	runtime: Runtime;
 	section?: AgentSectionId;
 	onDeleteAccepted: (deploymentId: string) => void;
-	autoOpenRuntimeUi?: boolean;
-	runtimeUiSettlingTimedOut?: boolean;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
@@ -487,27 +482,6 @@ export function HostedAgentDetail({
 	const terminalHref = agentSectionHref(environmentId, "terminal", searchStr);
 	const planChangeHref = `${agentSectionHref(environmentId, "settings", searchStr)}#compute-plan-controls`;
 
-	useEffect(() => {
-		if (
-			!autoOpenRuntimeUi ||
-			activeTab !== "overview" ||
-			!canOpenHostedRuntimeUi(deploymentStatus, consoleUrl)
-		) {
-			return;
-		}
-		void router.navigate({
-			href: agentSectionHref(environmentId, "console", searchStr),
-			replace: true,
-		});
-	}, [
-		activeTab,
-		autoOpenRuntimeUi,
-		consoleUrl,
-		deploymentStatus.kind,
-		environmentId,
-		router,
-		searchStr,
-	]);
 	const scopedSessionLink = (sessionId: string) => ({
 		to: "/agents/$id/sessions/$sessionId" as const,
 		params: { id: environmentId, sessionId },
@@ -598,7 +572,6 @@ export function HostedAgentDetail({
 					{deploymentStatus.known && activeTab === "overview" ? (
 						<OverviewTab
 							deployment={deployment}
-							runtime={runtime}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
 							showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}
@@ -609,9 +582,7 @@ export function HostedAgentDetail({
 							sessionsError={sessions.error}
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
-							terminalHref={terminalHref}
 							planChangeHref={planChangeHref}
-							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							isCheckingDeployment={isCheckingDeployment}
 							onCheckDeploymentAgain={onCheckDeploymentAgain}
@@ -622,7 +593,6 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							runtime={runtime}
 							terminalHref={terminalHref}
-							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							isCheckingDeployment={isCheckingDeployment}
 							onCheckDeploymentAgain={onCheckDeploymentAgain}
@@ -890,40 +860,16 @@ function RuntimeStatusValue({
 	);
 }
 
-type DeploymentReadinessStage = "provisioning" | "booting" | "ready";
-
-function deploymentReadinessStage(
-	status: HostedDeploymentStatus,
-	runtimeUiAvailable: boolean,
-): DeploymentReadinessStage {
-	if (runtimeUiAvailable) return "ready";
-	const computeReady = status.conditions.some(
-		(condition) => condition.type === "Ready" && condition.status === "True",
-	);
-	if (status.summary_state === "starting" || status.summary_state === "running" || computeReady) {
-		return "booting";
-	}
-	return "provisioning";
-}
-
-export function OverviewProvisioningPanel({
+export function OverviewReadinessPanel({
 	deployment,
-	runtime,
-	runtimeUiAvailable,
-	runtimeUiSettlingTimedOut,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
-	terminalHref,
 }: {
 	deployment: HostedDeployment;
-	runtime: Runtime;
-	runtimeUiAvailable: boolean;
-	runtimeUiSettlingTimedOut: boolean;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
-	terminalHref: string;
 }) {
 	const status = deployment.resource.status;
 	if (status === null) {
@@ -935,72 +881,57 @@ export function OverviewProvisioningPanel({
 			/>
 		);
 	}
-	const stage = deploymentReadinessStage(status, runtimeUiAvailable);
-	const browserUiLabel = runtimeBrowserUiLabel(runtime);
-	const settlingTimedOut = deploymentTransitionTimedOut || runtimeUiSettlingTimedOut;
+	const ready = status.summary_state === "running";
 	const title = deploymentTransitionTimedOut
 		? "Your agent is taking longer than expected"
-		: runtimeUiSettlingTimedOut
-			? `${browserUiLabel} is taking longer than expected`
-			: stage === "provisioning"
-				? "Getting your agent ready…"
-				: stage === "booting"
-					? `Opening ${browserUiLabel}…`
-					: "Your agent is ready";
+		: ready
+			? "Your agent is ready"
+			: "Getting your agent ready…";
 	const description = deploymentTransitionTimedOut
 		? "Your agent did not finish getting ready within five minutes. Automatic checks have stopped. Check again to load the latest update."
-		: runtimeUiSettlingTimedOut
-			? `${browserUiLabel} did not open within five minutes. We’ll keep checking automatically, and Terminal is available now.`
-			: stage === "provisioning"
-				? "This step should finish within five minutes. Your agent will keep getting ready if you leave this page."
-				: stage === "booting"
-					? `This step should finish within five minutes. We’ll open ${browserUiLabel} automatically; Terminal is available now.`
-					: `${browserUiLabel} is ready to use.`;
+		: ready
+			? "Your agent is running and ready to use."
+			: "This step should finish within five minutes. Your agent will keep getting ready if you leave this page.";
 	return (
 		<div
 			className={cn(
 				"rounded-xl border p-5",
-				settlingTimedOut
+				deploymentTransitionTimedOut
 					? "border-warning/30 bg-warning-muted text-warning-muted-foreground"
-					: "border-info-muted bg-info-muted text-info-muted-foreground",
+					: ready
+						? "border-success/30 bg-success-muted text-success-muted-foreground"
+						: "border-info-muted bg-info-muted text-info-muted-foreground",
 			)}
 		>
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-				<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-info-muted bg-background">
-					{settlingTimedOut ? <AlertCircle className="size-5" /> : <Spinner className="size-5" />}
+				<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-background">
+					{deploymentTransitionTimedOut ? (
+						<AlertCircle className="size-5" />
+					) : ready ? (
+						<CircleCheck className="size-5" />
+					) : (
+						<Spinner className="size-5" />
+					)}
 				</div>
 				<div className="min-w-0 flex-1">
 					<h2 className="text-sm font-semibold text-foreground">{title}</h2>
 					<p className="mt-1 text-sm">{description}</p>
-					{deploymentTransitionTimedOut || stage === "booting" ? (
+					{deploymentTransitionTimedOut ? (
 						<div className="mt-3 flex flex-wrap gap-2">
-							{deploymentTransitionTimedOut ? (
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									disabled={isCheckingDeployment}
-									onClick={onCheckDeploymentAgain}
-								>
-									{isCheckingDeployment ? (
-										<Spinner className="size-3.5" />
-									) : (
-										<RefreshCw className="size-3.5" />
-									)}
-									Check again
-								</Button>
-							) : null}
-							{stage === "booting" ? (
-								<Button
-									render={<Link to={terminalHref} />}
-									nativeButton={false}
-									variant="outline"
-									size="sm"
-								>
-									<TerminalSquare className="size-3.5" />
-									Use Terminal now
-								</Button>
-							) : null}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								disabled={isCheckingDeployment}
+								onClick={onCheckDeploymentAgain}
+							>
+								{isCheckingDeployment ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<RefreshCw className="size-3.5" />
+								)}
+								Check again
+							</Button>
 						</div>
 					) : null}
 				</div>
@@ -1115,7 +1046,6 @@ export function OverviewFailedPanel({
 
 function OverviewTab({
 	deployment,
-	runtime,
 	agent,
 	isPerformance,
 	showDeploymentActions,
@@ -1126,15 +1056,12 @@ function OverviewTab({
 	sessionsError,
 	onRetrySessions,
 	sessionLink,
-	terminalHref,
 	planChangeHref,
-	runtimeUiSettlingTimedOut,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
 	deployment: HostedDeployment;
-	runtime: Runtime;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
@@ -1148,9 +1075,7 @@ function OverviewTab({
 		to: "/agents/$id/sessions/$sessionId";
 		params: { id: string; sessionId: string };
 	};
-	terminalHref: string;
 	planChangeHref: string;
-	runtimeUiSettlingTimedOut: boolean;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
@@ -1174,26 +1099,21 @@ function OverviewTab({
 	);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
-	const runtimeUiAvailable = Boolean(runtimeConsoleUrl(deployment, runtime));
-	const agentGettingReady =
+	const showReadinessPanel =
 		deploymentTransitionTimedOut ||
 		isProvisioningStatus(deploymentStatus) ||
-		(deploymentStatus.kind === "running" && !runtimeUiAvailable);
+		deploymentStatus.kind === "running";
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
 	return (
 		<div className="flex flex-col gap-5">
-			{agentGettingReady ? (
-				<OverviewProvisioningPanel
+			{showReadinessPanel ? (
+				<OverviewReadinessPanel
 					deployment={deployment}
-					runtime={runtime}
-					runtimeUiAvailable={runtimeUiAvailable}
-					runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 					deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 					isCheckingDeployment={isCheckingDeployment}
 					onCheckDeploymentAgain={onCheckDeploymentAgain}
-					terminalHref={terminalHref}
 				/>
 			) : null}
 			{deploymentStatus.kind === "failed" ? (
@@ -1209,10 +1129,10 @@ function OverviewTab({
 			<div
 				className={cn(
 					"grid gap-2 sm:grid-cols-2",
-					agentGettingReady ? "lg:grid-cols-3" : "lg:grid-cols-4",
+					showReadinessPanel ? "lg:grid-cols-3" : "lg:grid-cols-4",
 				)}
 			>
-				{agentGettingReady ? null : (
+				{showReadinessPanel ? null : (
 					<StatCard
 						label="Status"
 						value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
@@ -1365,7 +1285,6 @@ function ConsoleTab({
 	deployment,
 	runtime,
 	terminalHref,
-	runtimeUiSettlingTimedOut,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
@@ -1373,7 +1292,6 @@ function ConsoleTab({
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	terminalHref: string;
-	runtimeUiSettlingTimedOut: boolean;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
@@ -1517,27 +1435,35 @@ function ConsoleTab({
 	if (!url) {
 		return (
 			<EmptyState
-				icon={runtimeUiSettlingTimedOut ? AlertCircle : <Spinner className="size-5" />}
-				title={
-					runtimeUiSettlingTimedOut
-						? "Live UI is taking longer than expected"
-						: "Starting the live UI…"
-				}
-				description={
-					runtimeUiSettlingTimedOut
-						? `${label} did not open its browser interface within five minutes. Automatic periodic checks will continue.`
-						: `Opening the live UI automatically… You can use Terminal right now while ${label} finishes getting ready.`
-				}
+				icon={MonitorPlay}
+				title={`${browserUiLabel} isn’t ready yet`}
+				description={`Your agent is ready. Check again in a moment, or use Terminal now while ${label} starts its browser interface.`}
 				action={
-					<Button
-						render={<Link to={terminalHref} />}
-						nativeButton={false}
-						variant="outline"
-						size="sm"
-					>
-						<TerminalSquare className="size-3.5" />
-						Use Terminal now
-					</Button>
+					<div className="flex flex-wrap justify-center gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={isCheckingDeployment}
+							onClick={onCheckDeploymentAgain}
+						>
+							{isCheckingDeployment ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<RefreshCw className="size-3.5" />
+							)}
+							Check again
+						</Button>
+						<Button
+							render={<Link to={terminalHref} />}
+							nativeButton={false}
+							variant="outline"
+							size="sm"
+						>
+							<TerminalSquare className="size-3.5" />
+							Use Terminal now
+						</Button>
+					</div>
 				}
 			/>
 		);

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -6,11 +6,7 @@ import type {
 	HostedFundingFact,
 } from "@/hosted/billing/contracts";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
-import {
-	computeDunningState,
-	computeDunningTileStatus,
-	fallbackReasonSentence,
-} from "./compute-dunning.logic";
+import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.logic";
 
 function deployment({
 	computeSubscription = null,
@@ -115,11 +111,6 @@ describe("computeDunningState", () => {
 			recoveryAction: "fix_payment",
 			ctaTarget: "fix_payment",
 		});
-		expect(computeDunningTileStatus(deploymentWithPastDueCard)).toEqual({
-			label: "Payment past due",
-			title: "Fix the card payment method for the open invoice.",
-			textClass: "text-warning-muted-foreground",
-		});
 	});
 
 	test("routes action-required subscriptions to the hosted invoice when present", () => {
@@ -172,7 +163,7 @@ describe("computeDunningState", () => {
 				fundingSource,
 				recoveryAction: "start_new",
 				ctaTarget: "start_new",
-				tileTextClass: "text-destructive",
+				tone: "destructive",
 			});
 			expect(state?.description).toContain("Start a new subscription");
 		}
@@ -220,9 +211,6 @@ describe("computeDunningState", () => {
 			"can’t determine whether this deployment stopped or is using included Basic",
 		);
 		expect(unavailable?.description).not.toContain("is now using included Basic");
-		expect(unavailable?.tileTitle).toBe(
-			"Performance compute ended. Current deployment status is unavailable.",
-		);
 	});
 
 	test("does not recover a detached or already recovered subscription", () => {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -39,9 +39,6 @@ export type ComputeDunningState = {
 	fallbackPlanLabel: string | null;
 	fallbackReason: FundingRevocationReason | null;
 	recoveryPlanSlug: ComputePlanSlug | null;
-	tileLabel: string;
-	tileTitle: string;
-	tileTextClass: string;
 };
 
 export function fallbackReasonSentence(
@@ -91,40 +88,30 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 					tone: "destructive" as const,
 					title: "Compute subscription ended",
 					secondaryTarget: null,
-					tileLabel: "Compute subscription ended",
-					tileTextClass: "text-destructive",
 				};
 			case "canceled":
 				return {
 					tone: "neutral" as const,
 					title: "Compute subscription ended",
 					secondaryTarget: null,
-					tileLabel: "Compute subscription ended",
-					tileTextClass: "text-muted-foreground",
 				};
 			case "refunded":
 				return {
 					tone: "neutral" as const,
 					title: "Compute payment refunded",
 					secondaryTarget: "billing_history" as const,
-					tileLabel: "Compute payment refunded",
-					tileTextClass: "text-muted-foreground",
 				};
 			case "disputed":
 				return {
 					tone: "warning" as const,
 					title: "Compute payment disputed",
 					secondaryTarget: "support" as const,
-					tileLabel: "Compute payment disputed",
-					tileTextClass: "text-warning-muted-foreground",
 				};
 			case "admin_forced":
 				return {
 					tone: "neutral" as const,
 					title: "Compute funding changed",
 					secondaryTarget: "support" as const,
-					tileLabel: "Compute funding changed",
-					tileTextClass: "text-muted-foreground",
 				};
 		}
 	})();
@@ -145,11 +132,6 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fallbackReason: fallback.reason,
 		recoveryPlanSlug,
 		ctaTarget: "start_new",
-		tileTitle: statusUnavailable
-			? `${fallbackPlanLabel} ended. Current deployment status is unavailable.`
-			: stopped
-				? `${fallbackPlanLabel} ended and the deployment stopped.`
-				: `${fallbackPlanLabel} ended and fell back to included Basic.`,
 	};
 }
 
@@ -187,9 +169,6 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			description:
 				"This paid subscription is terminal. Start a new subscription for the fallback deployment to restore paid compute.",
 			ctaTarget: "start_new",
-			tileLabel: "Compute subscription ended",
-			tileTitle: `${computeName} ended. Start a new subscription to restore paid compute.`,
-			tileTextClass: "text-destructive",
 		};
 	}
 
@@ -202,9 +181,6 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			title: "Payment authentication required",
 			description: `Complete the payment authentication to keep ${computeName} active.`,
 			ctaTarget: common.invoiceUrl ? "invoice" : "fix_payment",
-			tileLabel: "Payment action required",
-			tileTitle: `Complete payment authentication to keep ${computeName} active.`,
-			tileTextClass: "text-warning-muted-foreground",
 		};
 	}
 
@@ -218,9 +194,6 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			description:
 				"Top up your Wallet. Stripe will keep the invoice open while funds are short, and billing will update automatically after payment completes.",
 			ctaTarget: "top_up",
-			tileLabel: "Wallet payment past due",
-			tileTitle: "Top up your Wallet to pay the open invoice.",
-			tileTextClass: "text-warning-muted-foreground",
 		};
 	}
 
@@ -232,20 +205,5 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		title: "Payment past due",
 		description: "Update the card payment method for the open invoice.",
 		ctaTarget: "fix_payment",
-		tileLabel: "Payment past due",
-		tileTitle: "Fix the card payment method for the open invoice.",
-		tileTextClass: "text-warning-muted-foreground",
-	};
-}
-
-export function computeDunningTileStatus(
-	deployment: DunningDeployment,
-): { label: string; title: string; textClass: string } | null {
-	const state = computeDunningState(deployment);
-	if (!state) return null;
-	return {
-		label: state.tileLabel,
-		title: state.tileTitle,
-		textClass: state.tileTextClass,
 	};
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -53,9 +53,14 @@ describe("deploy wizard personalization", () => {
 		expect(wizardSource).not.toContain("deployAssistantNameAfterRuntimeChange");
 		expect(wizardSource).toContain("required");
 		expect(wizardSource).toContain("aria-invalid={nameError ? true : undefined}");
-		expect(wizardSource).toContain(
-			'aria-describedby={nameError ? "agent-name-error" : "agent-name-help"}',
-		);
+		expect(wizardSource).toContain('"agent-name-error agent-name-count"');
+		expect(wizardSource).toContain('"agent-name-help agent-name-count"');
+		expect(wizardSource).toContain('id="agent-name-count"');
+		expect(wizardSource).toContain("nameLimitReached");
+		expect(wizardSource).toContain('className="sr-only" role="status" aria-live="polite"');
+		expect(wizardSource).toContain('aria-live="polite"');
+		expect(wizardSource).toContain('" — limit reached."');
+		expect(wizardSource).toContain("Name limit reached. You can enter up to");
 		expect(wizardSource).toContain('type="submit"');
 		expect(wizardSource).toContain("submitBlockingReason");
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -526,6 +526,7 @@ export function DeployWizard() {
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
 	const trimmedAssistantName = assistantName.trim();
+	const nameLimitReached = assistantName.length >= DEPLOY_ASSISTANT_NAME_MAX_LENGTH;
 	const nameError =
 		trimmedAssistantName.length === 0
 			? "Enter a name for this agent."
@@ -1428,7 +1429,11 @@ export function DeployWizard() {
 									maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
 									required
 									aria-invalid={nameError ? true : undefined}
-									aria-describedby={nameError ? "agent-name-error" : "agent-name-help"}
+									aria-describedby={
+										nameError
+											? "agent-name-error agent-name-count"
+											: "agent-name-help agent-name-count"
+									}
 									onChange={(event) => setAssistantName(event.target.value)}
 									onBlur={() => setAssistantName((name) => name.trim())}
 								/>
@@ -1438,9 +1443,27 @@ export function DeployWizard() {
 									</p>
 								) : (
 									<p id="agent-name-help" className="text-xs text-muted-foreground">
-										{`Used to identify this agent in Clawdi. ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters maximum.`}
+										Used to identify this agent in Clawdi.
 									</p>
 								)}
+								<p
+									id="agent-name-count"
+									className={cn(
+										"text-xs",
+										nameLimitReached
+											? "font-medium text-warning-muted-foreground"
+											: "text-muted-foreground",
+									)}
+								>
+									{`${assistantName.length} / ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters${
+										nameLimitReached ? " — limit reached." : ""
+									}`}
+								</p>
+								{nameLimitReached ? (
+									<span className="sr-only" role="status" aria-live="polite">
+										{`Name limit reached. You can enter up to ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters.`}
+									</span>
+								) : null}
 							</div>
 							<div className="flex flex-col gap-1.5">
 								<label htmlFor="agent-language" className="text-sm text-muted-foreground">

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -337,7 +337,8 @@ describe("reconcileDeploymentSnapshots", () => {
 		expect(reconciledStatus.summary_state).toBe("failed");
 		expect(reconciledStatus.failure).toEqual(failure);
 		expect(deploymentFailureProjection(reconciled)).toEqual({
-			reason: "Re-quote the plan change and try again.",
+			reason:
+				"The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -449,13 +449,9 @@ export function billingRecoveryRefetchIntervalFor(
 export function useHostedDeployments({
 	enabled = true,
 	pollBillingRecoveryFor = null,
-	additionalRefetchInterval,
 }: {
 	enabled?: boolean;
 	pollBillingRecoveryFor?: string | null;
-	additionalRefetchInterval?: (
-		deployments: readonly HostedDeployment[] | undefined,
-	) => number | false;
 } = {}) {
 	const client = useBillingClient();
 	const transitionTrackersRef = useRef<ReadonlyMap<string, SettlingTracker>>(new Map());
@@ -478,8 +474,7 @@ export function useHostedDeployments({
 				q.state.data,
 				pollBillingRecoveryFor,
 			);
-			const detailInterval = additionalRefetchInterval?.(q.state.data) ?? false;
-			return shortestRefetchInterval(inventoryInterval, billingInterval, detailInterval);
+			return shortestRefetchInterval(inventoryInterval, billingInterval);
 		},
 		...HOSTED_DEPLOYMENTS_REFRESH_POLICY,
 	});

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -101,10 +101,10 @@ describe("deploymentFailureReason", () => {
 		const cases = [
 			["create", "Agent setup failed", "restart"],
 			["start", "Agent startup failed", "restart"],
-			["stop", "Compute stop failed", "none"],
-			["restart", "Compute restart failed", "restart"],
+			["stop", "Agent stop failed", "none"],
+			["restart", "Agent restart failed", "restart"],
 			["update", "Agent update failed", "none"],
-			["runtime_switch", "Runtime switch failed", "none"],
+			["runtime_switch", "Agent software change failed", "none"],
 			["rename", "Agent rename failed", "none"],
 			["delete", "Agent deletion failed", "retry_delete"],
 			["plan_change", "Plan change failed", "review_plan_change"],

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -9,7 +9,7 @@ import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("deploymentFailureReason", () => {
-	test("uses the compatibility Problem title instead of internal detail", () => {
+	test("uses client-owned copy instead of a free-form Problem title or detail", () => {
 		expect(
 			deploymentFailureReason({
 				failure: {
@@ -17,15 +17,25 @@ describe("deploymentFailureReason", () => {
 					conditionMessage: "The runtime did not become ready.",
 				},
 			}),
-		).toBe("Runtime startup failed");
+		).toBe("The Clawdi service could not complete this request.");
 	});
 
-	test("falls back to the condition message when the title is empty", () => {
+	test("does not expose internal exceptions, identifiers, or implementation vocabulary", () => {
 		expect(
 			deploymentFailureReason({
-				failure: { title: "  ", conditionMessage: "The runtime did not become ready." },
+				failure: {
+					title: "MissingGreenlet during provisioning",
+					detail:
+						"SQLAlchemy failed for operations/op-secret and hdep_internal while reconciling the runtime.",
+					conditionMessage:
+						"Agent 123e4567-e89b-42d3-a456-426614174000 failed synchronous plan confirmation.",
+					phase: "plan_change",
+					code: "operation_aborted",
+				},
 			}),
-		).toBe("The runtime did not become ready.");
+		).toBe(
+			"The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
+		);
 	});
 
 	test("projects the authoritative reason and failed verb for every tab", () => {
@@ -65,39 +75,26 @@ describe("deploymentFailureReason", () => {
 		});
 
 		expect(deploymentFailureProjection(deployment)).toEqual({
-			reason: "Top up your wallet and retry the plan change.",
+			reason:
+				"The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",
 		});
 		expect(deploymentFailurePresentation(deployment)).toEqual({
-			reason: "Top up your wallet and retry the plan change.",
+			reason:
+				"The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
 			failedVerb: "plan_change",
 			retryable: false,
 			code: "operation_aborted",
 			title: "Plan change failed",
-			description:
-				"Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying.",
+			description: "Get a fresh quote and confirm the price before trying again.",
 			remediation: {
 				kind: "review_plan_change",
-				label: "Review plan",
-				requiresWalletTopUp: true,
+				label: "Get fresh quote",
+				requiresWalletTopUp: false,
 			},
 		});
-	});
-
-	test("removes internal operation and deployment references from visible failures", () => {
-		expect(
-			deploymentFailureReason({
-				failure: {
-					title: " ",
-					phase: "plan_change",
-					detail:
-						"Try again. Operation ID: operations/op-secret. Deployment ID: hdep_internal. Agent ID: 123e4567-e89b-42d3-a456-426614174000.",
-					conditionMessage: "Plan change failed.",
-				},
-			}),
-		).toBe("Try again.");
 	});
 
 	test("maps every failed operation to a truthful safe remediation", () => {

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -2,22 +2,24 @@ import type { HostedDeployment } from "@/hosted/billing/contracts";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 
 const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
-const INTERNAL_OPERATION_REFERENCE_RE =
-	/\s*(?:operation\s+id\s*:\s*)?operations\/[A-Za-z0-9._~-]+[.!]?/gi;
-const INTERNAL_DEPLOYMENT_REFERENCE_RE =
-	/\s*(?:deployment\s+id\s*:\s*)?hdep_[A-Za-z0-9._~-]+[.!]?/gi;
-const INTERNAL_UUID_REFERENCE_RE =
-	/\s*(?:(?:agent|environment|deployment)\s+id\s*:\s*)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[.!]?/gi;
+const PLAN_CHANGE_FAILURE_REASON =
+	"The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.";
+const DEFAULT_SERVICE_FAILURE_REASON = "The Clawdi service could not complete this request.";
 
-function userFacingFailureReason(value: string): string {
-	return value
-		.replace(/\s+/g, " ")
-		.replace(INTERNAL_OPERATION_REFERENCE_RE, "")
-		.replace(INTERNAL_DEPLOYMENT_REFERENCE_RE, "")
-		.replace(INTERNAL_UUID_REFERENCE_RE, "")
-		.replace(/\s+([,.!?])/g, "$1")
-		.trim();
-}
+const CUSTOMER_FAILURE_REASONS_BY_CODE = new Map<string, string>([
+	[
+		"insufficient_balance",
+		"Your Wallet balance was too low for the Clawdi service to complete this request.",
+	],
+	[
+		"insufficient_wallet_balance",
+		"Your Wallet balance was too low for the Clawdi service to complete this request.",
+	],
+	[
+		"open_refund_debt",
+		"Your Wallet has an unsettled refund balance, so the Clawdi service could not complete this request.",
+	],
+]);
 
 export type DeploymentFailureProjection = {
 	reason: string;
@@ -38,8 +40,6 @@ export type DeploymentFailurePresentation = DeploymentFailureProjection & {
 	remediation: DeploymentFailureRemediation;
 };
 
-const WALLET_FUNDING_REASON_RE =
-	/\b(?:top[ -]?up|insufficient(?: wallet)? (?:balance|funds?)|wallet (?:balance|funds?).*(?:low|short|empty|exhausted|depleted)|refund debt)\b/i;
 const WALLET_FUNDING_CODES = new Set([
 	"insufficient_balance",
 	"insufficient_wallet_balance",
@@ -73,7 +73,7 @@ export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): 
 }
 
 function deploymentFailureNeedsWalletTopUp(failure: DeploymentFailureProjection): boolean {
-	return WALLET_FUNDING_CODES.has(failure.code) || WALLET_FUNDING_REASON_RE.test(failure.reason);
+	return WALLET_FUNDING_CODES.has(failure.code);
 }
 
 /** Shared honest copy/action decision for detail, status, and tile surfaces. */
@@ -119,11 +119,11 @@ export function deploymentFailurePresentation(
 				...failure,
 				title: `${operationLabel} failed`,
 				description: requiresWalletTopUp
-					? "Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying."
-					: "Open Compute settings to request a fresh quote and confirm the price before retrying.",
+					? "Top up your Wallet, then get a fresh quote and confirm the price before trying again."
+					: "Get a fresh quote and confirm the price before trying again.",
 				remediation: {
 					kind: "review_plan_change",
-					label: "Review plan",
+					label: "Get fresh quote",
 					requiresWalletTopUp,
 				},
 			};
@@ -159,22 +159,22 @@ export function deploymentFailureReason(
 			conditionMessage: string;
 			detail?: string;
 			phase?: string | null;
+			code?: string;
 		} | null;
 	} | null,
+	failedVerb: DeploymentOperationVerb | null = null,
 ): string | null {
 	const failure = input?.failure;
-	const candidates =
-		failure?.phase === "plan_change"
-			? [failure.detail, failure.title, failure.conditionMessage]
-			: [failure?.title, failure?.conditionMessage];
-	for (const candidate of candidates) {
-		// Backend reasons are concatenated from conditions, so they arrive with
-		// ragged padding. Collapse it once here — every label and tooltip is
-		// derived from this value.
-		const reason = userFacingFailureReason(candidate ?? "");
-		if (reason) return reason;
+	if (!failure) return null;
+
+	// Failure title/detail/conditionMessage are free-form backend strings. Even
+	// after removing identifiers they can contain exception names or service
+	// vocabulary, so none of them are customer copy. Only structured classes
+	// that the client explicitly recognizes may select a specific message.
+	if (failedVerb === "plan_change" || failure.phase === "plan_change") {
+		return PLAN_CHANGE_FAILURE_REASON;
 	}
-	return null;
+	return CUSTOMER_FAILURE_REASONS_BY_CODE.get(failure.code ?? "") ?? DEFAULT_SERVICE_FAILURE_REASON;
 }
 
 /** One tab-agnostic failure view backed by the authoritative failed snapshot. */
@@ -185,11 +185,13 @@ export function deploymentFailureProjection(
 	const status = deployment.resource.status;
 	if (status === null || status.summary_state !== "failed") return null;
 	const failure = status.failure;
-	const reason = deploymentFailureReason(status);
-	if (!failure || !reason) return null;
+	if (!failure) return null;
+	const failedVerb = deployment.accepted_operation?.metadata.verb ?? null;
+	const reason = deploymentFailureReason(status, failedVerb);
+	if (!reason) return null;
 	return {
 		reason,
-		failedVerb: deployment.accepted_operation?.metadata.verb ?? null,
+		failedVerb,
 		retryable: failure.retryable ?? null,
 		code: failure.code,
 	};

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -54,13 +54,13 @@ export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): 
 		case "start":
 			return "Agent startup";
 		case "stop":
-			return "Compute stop";
+			return "Agent stop";
 		case "restart":
-			return "Compute restart";
+			return "Agent restart";
 		case "update":
 			return "Agent update";
 		case "runtime_switch":
-			return "Runtime switch";
+			return "Agent software change";
 		case "rename":
 			return "Agent rename";
 		case "delete":
@@ -68,7 +68,7 @@ export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): 
 		case "plan_change":
 			return "Plan change";
 		case null:
-			return "Deployment operation";
+			return "Agent action";
 	}
 }
 
@@ -94,7 +94,7 @@ export function deploymentFailurePresentation(
 				title: `${operationLabel} failed`,
 				description: requiresWalletTopUp
 					? `Top up your Wallet, then retry ${operationName}.`
-					: `Restart the compute to retry ${operationName}.`,
+					: `The Clawdi service could not finish ${operationName}. Restart the agent to try again.`,
 				remediation: {
 					kind: "restart",
 					label: "Retry startup",
@@ -106,8 +106,8 @@ export function deploymentFailurePresentation(
 				...failure,
 				title: `${operationLabel} failed`,
 				description: requiresWalletTopUp
-					? "Top up your Wallet, then retry the compute restart."
-					: "Retry the compute restart after reviewing the reason below.",
+					? "The Clawdi service could not restart the agent. Top up your Wallet, then try again."
+					: "The Clawdi service could not restart the agent. Review the reason below, then try again.",
 				remediation: {
 					kind: "restart",
 					label: "Retry restart",
@@ -131,7 +131,8 @@ export function deploymentFailurePresentation(
 			return {
 				...failure,
 				title: `${operationLabel} failed`,
-				description: "The deployment was not deleted. Review the reason, then retry deletion.",
+				description:
+					"The Clawdi service did not delete the agent. Review the reason, then try again.",
 				remediation: {
 					kind: "retry_delete",
 					label: "Retry delete",

--- a/apps/web/src/hosted/deployment-status-unavailable.test.ts
+++ b/apps/web/src/hosted/deployment-status-unavailable.test.ts
@@ -19,8 +19,8 @@ test("renders an honest retryable state when deployment status is unavailable", 
 	}).not.toThrow();
 
 	expect(markup).toContain('data-testid="deployment-status-unavailable"');
-	expect(markup).toContain("Deployment status unavailable");
-	expect(markup).toContain("We can’t determine this agent’s deployment state right now.");
+	expect(markup).toContain("Agent status unavailable");
+	expect(markup).toContain("The Clawdi service can’t determine this agent’s status right now.");
 	expect(markup).toContain("Actions and live tools are paused");
 	expect(markup).toContain("Check again");
 	expect(markup).not.toContain(">Running<");

--- a/apps/web/src/hosted/deployment-status-unavailable.tsx
+++ b/apps/web/src/hosted/deployment-status-unavailable.tsx
@@ -23,8 +23,8 @@ export function DeploymentStatusUnavailableState({
 		<div data-hosted="true" data-testid="deployment-status-unavailable">
 			<EmptyState
 				icon={AlertCircle}
-				title="Deployment status unavailable"
-				description="We can’t determine this agent’s deployment state right now. Actions and live tools are paused until a status is available."
+				title="Agent status unavailable"
+				description="The Clawdi service can’t determine this agent’s status right now. Actions and live tools are paused until the status is available."
 				action={
 					<Button type="button" variant="outline" size="sm" disabled={isRetrying} onClick={onRetry}>
 						{isRetrying ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -106,7 +106,7 @@ describe("DeploymentStatus", () => {
 
 	test("labels and tones the hosted backend statuses", () => {
 		const expected = [
-			["creating", "Provisioning", "info"],
+			["creating", "Getting ready", "info"],
 			["starting", "Starting", "info"],
 			["running", "Running", "success"],
 			["stopping", "Stopping", "info"],

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -109,7 +109,7 @@ export function deploymentStatusFromResource(
 export function deploymentStatusLabel(status: DeploymentStatus): string {
 	switch (status.kind) {
 		case "creating":
-			return "Provisioning";
+			return "Getting ready";
 		case "starting":
 			return "Starting";
 		case "running":

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -64,10 +64,9 @@ export function HostedAgentsSection({
 	/**
 	 * Cloud-api environments the parent already fetched for the
 	 * self-managed grid. Passed through so hosted tiles can join
-	 * to their daemon-sync row using the stored environment id projected
-	 * by the deploy API and render the same status badge
-	 * as self-managed tiles. Empty/missing envs is harmless — the
-	 * matched-env lookup falls back to null and the tile still renders.
+	 * avatar and sort metadata using the stored environment id projected
+	 * by the deploy API. Empty/missing envs is harmless — the tile still
+	 * renders from the deployment identity.
 	 */
 	cloudEnvs: Env[];
 	showCloudDeployments?: boolean;

--- a/apps/web/src/hosted/legacy-agent-tiles.test.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.test.ts
@@ -67,9 +67,9 @@ describe("legacyConnectedAgentTiles", () => {
 		expect("runtimeLabel" in legacyConnectedAgentTiles([legacy], new Set([legacy.id]))[0]).toBe(
 			false,
 		);
-		expect(
-			legacyConnectedAgentTiles([legacy], new Set([legacy.id]))[0]?.contextLabel,
-		).toBeUndefined();
+		const [tile] = legacyConnectedAgentTiles([legacy], new Set([legacy.id]));
+		expect("contextLabel" in (tile ?? {})).toBe(false);
+		expect("statusLabel" in (tile ?? {})).toBe(false);
 	});
 
 	it("carries env so the sync badge renders (with the hosted copy variant)", () => {

--- a/apps/web/src/hosted/legacy-agent-tiles.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.ts
@@ -4,7 +4,6 @@ import { type AgentTile, isAgentActive } from "@/components/dashboard/agents-car
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
-import { relativeTime } from "@/lib/utils";
 
 type Env = components["schemas"]["AgentResponse"];
 
@@ -43,7 +42,6 @@ export function legacyConnectedAgentTiles(
 			avatarUrl: env.avatar_url,
 			sortOrder: env.sort_order,
 			agentType: env.agent_type,
-			statusLabel: env.last_seen_at ? `Active ${relativeTime(env.last_seen_at)}` : "Never seen",
 			lastSeenAt: env.last_seen_at,
 			href: agentSectionHref(env.id),
 			manageHref,

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -198,7 +198,7 @@ describe("deploymentToTiles", () => {
 		});
 	});
 
-	test("projects failed deployment reasons ahead of dunning state", () => {
+	test("projects client-owned failure copy ahead of dunning state", () => {
 		const [tile] = hostedDeploymentToTiles(
 			deployment({
 				status: "failed",
@@ -222,8 +222,8 @@ describe("deploymentToTiles", () => {
 		);
 
 		expect(tile?.secondaryStatus).toEqual({
-			label: "Failure: startup_probe_failing; restart_count=2; container failed readiness probe",
-			title: "startup_probe_failing; restart_count=2; container failed readiness probe",
+			label: "Failure: The Clawdi service could not complete this request.",
+			title: "The Clawdi service could not complete this request.",
 			textClass: "text-destructive-muted-foreground font-medium",
 		});
 	});
@@ -241,8 +241,8 @@ describe("deploymentToTiles", () => {
 			env: null,
 			contextLabel: "hosted-test",
 			secondaryStatus: {
-				label: "Failure: startup_probe_failing; restart_count=2",
-				title: failureReason,
+				label: "Failure: The Clawdi service could not complete this request.",
+				title: "The Clawdi service could not complete this request.",
 				textClass: "text-destructive-muted-foreground font-medium",
 			},
 		});
@@ -264,9 +264,10 @@ describe("deploymentToTiles", () => {
 		);
 
 		expect(tile?.secondaryStatus).toEqual({
-			label: `Plan change failed: ${reason}`,
+			label:
+				"Plan change failed: The Clawdi service could not confirm the plan change. Your plan was not c...",
 			title:
-				"Plan change failed. Open Compute settings to top up your Wallet, request a fresh quote, and confirm the price before retrying. Reason: Top up your Wallet and retry the plan change.",
+				"Plan change failed. Get a fresh quote and confirm the price before trying again. Reason: The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
 			textClass: "text-destructive-muted-foreground font-medium",
 		});
 		expect(
@@ -275,6 +276,7 @@ describe("deploymentToTiles", () => {
 		).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123#compute-plan-controls`);
 		expect(tile?.secondaryStatus?.label).not.toContain("startup");
 		expect(tile?.secondaryStatus?.label).not.toContain("restart");
+		expect(tile?.secondaryStatus?.title).not.toContain(reason);
 	});
 
 	test("keeps Start and Delete actions on a stopped tile with a retained env identity", () => {
@@ -317,8 +319,8 @@ describe("deploymentToTiles", () => {
 			href: null,
 			env: null,
 			secondaryStatus: {
-				label: "Failure: creation_interrupted",
-				title: "creation_interrupted",
+				label: "Failure: The Clawdi service could not complete this request.",
+				title: "The Clawdi service could not complete this request.",
 			},
 		});
 		expect(tile?.action).toBeDefined();
@@ -439,7 +441,7 @@ describe("hostedRuntimeStatusView", () => {
 		const creating = hostedRuntimeStatusView("creating", null);
 
 		expect(running.secondary?.label).toBe("Sync pending");
-		expect(creating.primary.label).toBe("Provisioning");
+		expect(creating.primary.label).toBe("Getting ready");
 		expect(creating.secondary).toBeNull();
 	});
 
@@ -453,8 +455,8 @@ describe("hostedRuntimeStatusView", () => {
 		expect(view.primary.label).toBe("Failed");
 		expect(view.secondary).toEqual({
 			kind: "failure_reason",
-			label: "Failure: startup_probe_failing; restart_count=2",
-			tooltip: "startup_probe_failing; restart_count=2",
+			label: "Failure: The Clawdi service could not complete this request.",
+			tooltip: "The Clawdi service could not complete this request.",
 			textClass: "text-destructive-muted-foreground font-medium",
 		});
 	});

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -53,6 +53,13 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 	);
 }
 
+function expectHostedTileHasNoStatus(tile: ReturnType<DeploymentToTiles>[number] | undefined) {
+	expect(tile).toBeDefined();
+	for (const field of ["statusLabel", "statusDot", "secondaryStatus", "contextLabel"] as const) {
+		expect(field in (tile ?? {})).toBe(false);
+	}
+}
+
 function resolveAgentDeployment(
 	deployments: readonly HostedDeployment[],
 	environmentId: string,
@@ -163,13 +170,12 @@ describe("deploymentToTiles", () => {
 
 		expect(tiles.map((tile) => tile.agentType)).toEqual(["openclaw"]);
 		expect(tiles.map((tile) => tile.id)).toEqual(["dep_123"]);
+		expect(tiles.map((tile) => tile.name)).toEqual(["hosted-test"]);
 		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi&d=dep_123`);
-		expect(tiles[0]?.manageHref).toBe(
-			`/agents/${openclawEnv.id}/settings?source=on-clawdi&d=dep_123`,
-		);
+		expectHostedTileHasNoStatus(tiles[0]);
 	});
 
-	test("projects dunning state as the hosted tile secondary status", () => {
+	test("keeps dunning state off the hosted tile", () => {
 		const [tile] = hostedDeploymentToTiles(
 			deployment({
 				computePlanSlug: "compute_basic",
@@ -191,14 +197,10 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expect(tile?.secondaryStatus).toEqual({
-			label: "Payment action required",
-			title: "Complete payment authentication to keep Basic compute active.",
-			textClass: "text-warning-muted-foreground",
-		});
+		expectHostedTileHasNoStatus(tile);
 	});
 
-	test("projects client-owned failure copy ahead of dunning state", () => {
+	test("keeps backend failure detail off the hosted tile", () => {
 		const [tile] = hostedDeploymentToTiles(
 			deployment({
 				status: "failed",
@@ -221,11 +223,7 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expect(tile?.secondaryStatus).toEqual({
-			label: "Failure: The Clawdi service could not complete this request.",
-			title: "The Clawdi service could not complete this request.",
-			textClass: "text-destructive-muted-foreground font-medium",
-		});
+		expectHostedTileHasNoStatus(tile);
 	});
 
 	test("links by deployment env identity when the cloud-api projection is missing", () => {
@@ -237,16 +235,11 @@ describe("deploymentToTiles", () => {
 		expect(tile).toMatchObject({
 			id: "dep_123",
 			source: "on-clawdi",
+			name: "hosted-test",
 			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 			env: null,
-			contextLabel: "hosted-test",
-			secondaryStatus: {
-				label: "Failure: The Clawdi service could not complete this request.",
-				title: "The Clawdi service could not complete this request.",
-				textClass: "text-destructive-muted-foreground font-medium",
-			},
 		});
-		expect(tile?.manageHref).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123`);
+		expectHostedTileHasNoStatus(tile);
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
@@ -263,20 +256,11 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expect(tile?.secondaryStatus).toEqual({
-			label:
-				"Plan change failed: The Clawdi service could not confirm the plan change. Your plan was not c...",
-			title:
-				"Plan change failed. Get a fresh quote and confirm the price before trying again. Reason: The Clawdi service could not confirm the plan change. Your plan was not changed and you were not charged.",
-			textClass: "text-destructive-muted-foreground font-medium",
-		});
+		expectHostedTileHasNoStatus(tile);
 		expect(
 			isValidElement<{ remediationHref?: string }>(tile?.action) &&
 				tile.action.props.remediationHref,
 		).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123#compute-plan-controls`);
-		expect(tile?.secondaryStatus?.label).not.toContain("startup");
-		expect(tile?.secondaryStatus?.label).not.toContain("restart");
-		expect(tile?.secondaryStatus?.title).not.toContain(reason);
 	});
 
 	test("keeps Start and Delete actions on a stopped tile with a retained env identity", () => {
@@ -291,10 +275,9 @@ describe("deploymentToTiles", () => {
 
 		expect(tile).toMatchObject({
 			name: "OpenClaw",
-			contextLabel: null,
-			statusLabel: "Stopped",
 			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 		});
+		expectHostedTileHasNoStatus(tile);
 		expect(tile?.action).toBeDefined();
 	});
 
@@ -316,13 +299,11 @@ describe("deploymentToTiles", () => {
 
 		expect(tile).toMatchObject({
 			id: "dep_123",
+			name: "hosted-test",
 			href: null,
 			env: null,
-			secondaryStatus: {
-				label: "Failure: The Clawdi service could not complete this request.",
-				title: "The Clawdi service could not complete this request.",
-			},
 		});
+		expectHostedTileHasNoStatus(tile);
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -2,18 +2,15 @@
 
 import type { components } from "@clawdi/shared/api";
 import { createElement, useMemo } from "react";
-import { agentDisplayName } from "@/components/dashboard/agent-label";
 import type { AgentTile } from "@/components/dashboard/agents-card";
 import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { statusTextVariants } from "@/components/ui/status-badge";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
-import { computeDunningTileStatus } from "@/hosted/billing/components/compute-dunning.logic";
 import type { HostedDeployment, HostedDeploymentStatus } from "@/hosted/billing/contracts";
 import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-management";
 import {
 	compactDeploymentFailureReason,
 	type DeploymentFailurePresentation,
-	deploymentFailurePresentation,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
 import {
@@ -29,7 +26,7 @@ import {
 	isHostedDeploymentMember,
 } from "@/hosted/hosted-agent-resolution";
 import { HostedDeploymentTileAction } from "@/hosted/hosted-deployment-tile-action";
-import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
+import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import { AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, agentSectionHref } from "@/lib/agent-routes";
 
@@ -111,11 +108,8 @@ export function hostedRuntimeStatusView(
  * fetches for the self-managed grid; passing it through lets each
  * hosted tile attach its matching `EnvironmentResponse` (joined via the
  * stored environment id projected by the deploy API). With the join, the same
- * `DaemonStatusBadge` that powers
- * self-managed tiles' "Synced 2m ago" label fires on hosted tiles too
- * — hosted runtimes register cloud-api envs with their own daemon, so
- * the data is the same shape; only the "Clawdi" pill distinguishes
- * hosted in the UI.
+ * agent identity can carry its avatar and sort order without making the
+ * Cloud API projection authoritative for deployment state.
  */
 export function useHostedAgentTiles({
 	cloudEnvs,
@@ -185,8 +179,8 @@ export function useHostedAgentTiles({
 
 /**
  * One deployment renders as one hosted agent tile. The selected runtime's stored
- * environment id owns the detail route. A matching projection decorates the tile
- * with daemon sync state and presentation metadata.
+ * environment id owns the detail route. Deployment state stays on the detail page;
+ * the tile projects only the agent identity and available actions.
  */
 export function deploymentToTiles(
 	d: HostedDeployment,
@@ -195,10 +189,9 @@ export function deploymentToTiles(
 ): AgentTile[] {
 	if (!isHostedDeploymentMember(d)) return [];
 	const runtime = deploymentRuntime(d);
-	const slug = deploymentDisplayName(d.resource.spec.name, runtime);
-	// Hosted deployments don't use last_seen_at; status is the freshness signal
-	// The deploy API projects the stable agent identity. The cloud-api env
-	// join only decorates the tile and may legitimately lag or be missing.
+	const name = deploymentDisplayName(d.resource.spec.name, runtime);
+	// The deploy API projects the stable agent identity. The Cloud API env join
+	// only decorates the tile and may legitimately lag or be missing.
 	const envId = runtimeEnvironmentId(d, runtime);
 	const matchedEnv = envId ? envById.get(envId.toLowerCase()) : undefined;
 	const routeQuery = {
@@ -207,24 +200,12 @@ export function deploymentToTiles(
 	};
 	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
 	const settingsHref = envId ? agentSectionHref(envId, "settings", routeQuery) : undefined;
-	const name = matchedEnv
-		? deploymentDisplayName(agentDisplayName(matchedEnv), runtime)
-		: runtimeDisplayName(runtime);
-	const contextLabel = slug !== name ? slug : null;
-	const failurePresentation = deploymentFailurePresentation(d);
-	const runtimeStatus = hostedRuntimeStatusView(
-		d.resource.status,
-		matchedEnv ?? null,
-		failurePresentation?.failedVerb ? failurePresentation : null,
-	);
+	const deploymentStatus = deploymentStatusFromResource(d.resource.status);
 	const showTileActions =
-		runtimeStatus.compute.kind === "stopped" ||
-		runtimeStatus.compute.kind === "failed" ||
-		runtimeStatus.compute.kind === "unknown" ||
+		deploymentStatus.kind === "stopped" ||
+		deploymentStatus.kind === "failed" ||
+		deploymentStatus.kind === "unknown" ||
 		!envId;
-	const dunningStatus = computeDunningTileStatus(d);
-	const failureReasonStatus =
-		runtimeStatus.secondary?.kind === "failure_reason" ? runtimeStatus.secondary : null;
 	return [
 		{
 			id: d.resource.id,
@@ -233,8 +214,6 @@ export function deploymentToTiles(
 			avatarUrl: matchedEnv?.avatar_url ?? null,
 			sortOrder: matchedEnv?.sort_order ?? null,
 			agentType: runtime,
-			contextLabel,
-			statusLabel: runtimeStatus.primary.label,
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			href: detailHref,
 			external: false,
@@ -246,27 +225,7 @@ export function deploymentToTiles(
 						onRetry: statusRetry?.onRetry,
 					})
 				: undefined,
-			manageHref: settingsHref,
-			active: runtimeStatus.active,
-			statusDot: {
-				label: runtimeStatus.primary.label,
-				tone: runtimeStatus.primary.tone,
-			},
-			secondaryStatus: failureReasonStatus
-				? {
-						label: failureReasonStatus.label,
-						title: failureReasonStatus.tooltip,
-						textClass: failureReasonStatus.textClass,
-					}
-				: dunningStatus
-					? dunningStatus
-					: runtimeStatus.secondary
-						? {
-								label: runtimeStatus.secondary.label,
-								title: runtimeStatus.secondary.tooltip,
-								textClass: runtimeStatus.secondary.textClass,
-							}
-						: null,
+			active: isRunningStatus(deploymentStatus),
 			env: matchedEnv ?? null,
 		},
 	];

--- a/apps/web/src/hosted/use-hosted-deployment-inventory.ts
+++ b/apps/web/src/hosted/use-hosted-deployment-inventory.ts
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { isDeployApiConfigured } from "@/hosted/billing/billing-client";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useHostedDeployments } from "@/hosted/billing/hooks";
 import {
 	type DeploymentFailureProjection,
@@ -14,19 +13,14 @@ import { resolveHostedInventory } from "@/hosted/hosted-agent-resolution";
 export function useHostedDeploymentInventory({
 	enabled = true,
 	pollBillingRecoveryFor = null,
-	additionalRefetchInterval,
 }: {
 	enabled?: boolean;
 	pollBillingRecoveryFor?: string | null;
-	additionalRefetchInterval?: (
-		deployments: readonly HostedDeployment[] | undefined,
-	) => number | false;
 } = {}) {
 	const configured = isDeployApiConfigured();
 	const query = useHostedDeployments({
 		enabled,
 		pollBillingRecoveryFor,
-		additionalRefetchInterval,
 	});
 	const resolution = useMemo(
 		() =>

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -55,7 +55,6 @@ describe("selectUnifiedAgentList", () => {
 			source: "on-clawdi",
 			name: "OpenClaw",
 			agentType: "openclaw",
-			statusLabel: "Failed",
 			href: null,
 			active: false,
 			env: null,
@@ -75,7 +74,6 @@ describe("selectUnifiedAgentList", () => {
 			[legacy.id, "legacy-hosted"],
 			[connected.id, "self-managed"],
 		]);
-		expect(selection.tiles[0]?.statusLabel).toBe("Failed");
 		expect(selection.tiles.some((tile) => tile.id === claimed.id)).toBe(false);
 	});
 
@@ -87,7 +85,6 @@ describe("selectUnifiedAgentList", () => {
 			source: "on-clawdi",
 			name: "OpenClaw",
 			agentType: "openclaw",
-			statusLabel: "Starting",
 			href: null,
 			active: false,
 			env: null,
@@ -134,7 +131,6 @@ describe("selectUnifiedAgentList", () => {
 			source: "on-clawdi",
 			name: "OpenClaw",
 			agentType: "openclaw",
-			statusLabel: "Running",
 			href: `/agents/${claimed.id}?source=on-clawdi&d=dep_running`,
 			active: true,
 			env: claimed,

--- a/apps/web/src/lib/use-hydrated.test.ts
+++ b/apps/web/src/lib/use-hydrated.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { useHydrated } from "@/lib/use-hydrated";
+
+test("keeps the server render on the hydration-safe snapshot", () => {
+	function Probe() {
+		return createElement("span", null, useHydrated() ? "browser" : "server");
+	}
+
+	expect(renderToStaticMarkup(createElement(Probe))).toBe("<span>server</span>");
+});

--- a/apps/web/src/lib/use-hydrated.ts
+++ b/apps/web/src/lib/use-hydrated.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => undefined;
+
+/**
+ * False for SSR and the matching hydration render, then true in the browser.
+ * Unlike an effect-backed flag, this stays false when a Suspense boundary is
+ * hydrated after effects elsewhere in the tree have already run.
+ */
+export function useHydrated(): boolean {
+	return useSyncExternalStore(
+		subscribe,
+		() => true,
+		() => false,
+	);
+}

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { lazy, type ReactNode, Suspense, useEffect, useState } from "react";
+import { lazy, type ReactNode, Suspense, useState } from "react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { BreadcrumbTitleProvider } from "@/components/breadcrumb-title";
 import { CommandPaletteProvider } from "@/components/command-palette";
@@ -14,6 +14,7 @@ import {
 } from "@/lib/agent-ownership";
 import { IS_HOSTED } from "@/lib/hosted";
 import { isDeployApiConfigured } from "@/lib/hosted-api";
+import { useHydrated } from "@/lib/use-hydrated";
 
 // Cap dashboard content at 1536px (= Tailwind's 2xl screen) and center it in
 // SidebarInset. Below that width the constraint is inert; above it (27"/4K
@@ -32,41 +33,10 @@ const HostedAgentOwnershipSensor = IS_HOSTED_BUILD
 		)
 	: null;
 
-function AppSidebarFallback() {
-	return (
-		<>
-			<div
-				aria-hidden
-				className="sticky top-0 hidden h-svh w-(--clawdi-rail-width) shrink-0 border-r bg-sidebar/95 md:block"
-			/>
-			<div
-				aria-hidden
-				data-state="expanded"
-				data-collapsible=""
-				data-variant="inset"
-				data-side="left"
-				data-slot="sidebar"
-				className="group peer hidden text-sidebar-foreground md:block"
-			>
-				<div data-slot="sidebar-gap" className="relative w-(--sidebar-width) bg-transparent" />
-				<div
-					data-slot="sidebar-container"
-					className="fixed inset-y-0 left-[var(--clawdi-rail-width)] z-10 hidden h-svh w-(--sidebar-width) p-2 md:flex"
-				>
-					<div className="flex h-full w-full flex-col bg-sidebar" />
-				</div>
-			</div>
-		</>
-	);
-}
-
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-	const [mounted, setMounted] = useState(false);
+	const hydrated = useHydrated();
 	const [ownership, setOwnership] = useState<AgentOwnership | null>(null);
-	useEffect(() => {
-		setMounted(true);
-	}, []);
-	const showOwnershipSensor = mounted && IS_HOSTED && isDeployApiConfigured();
+	const showOwnershipSensor = hydrated && IS_HOSTED && isDeployApiConfigured();
 	// `null` strictly means "resolving" (destructive actions wait on it), so
 	// the provider must decide when there is nothing to resolve: OSS builds,
 	// and hosted mirrors without a configured deploy API get resolved empty
@@ -95,9 +65,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 				) : null}
 				<CommandPaletteProvider>
 					<BreadcrumbTitleProvider>
-						<Suspense fallback={<AppSidebarFallback />}>
-							<AppSidebar variant="inset" />
-						</Suspense>
+						<AppSidebar variant="inset" />
 						{/* 1rem = SidebarInset's md:m-2 top+bottom when the sidebar uses
 						    dashboard-01's inset variant. Keep the scroll container inside
 						    the inset so the sticky SiteHeader pins correctly. */}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,6 +3,7 @@
 import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import "../../instrumentation-client";
+import { AppNotFound } from "@/components/app-not-found";
 import { AuthProvider } from "@/components/auth-provider";
 import { Providers } from "@/components/providers";
 import RootError from "@/components/root-error";
@@ -41,14 +42,7 @@ export const Route = createRootRoute({
 			<RootError error={error} reset={reset} />
 		</RootDocument>
 	),
-	notFoundComponent: () => (
-		<div className="flex min-h-dvh items-center justify-center bg-background p-6">
-			<div className="space-y-2 text-center">
-				<h1 className="font-semibold text-lg">Page not found</h1>
-				<p className="text-muted-foreground text-sm">This Clawdi page does not exist.</p>
-			</div>
-		</div>
-	),
+	notFoundComponent: AppNotFound,
 	component: RootComponent,
 });
 


### PR DESCRIPTION
## Summary

- keep backend failure detail behind client-owned customer copy; failed plan changes say the plan was unchanged, no charge moved, and a fresh quote is required
- make slow auth and both not-found surfaces escapable
- converge hosted agent detail on one honest narrative for getting ready, ready, unavailable, and failed states
- add perceivable 64-character name-limit feedback
- fix the sidebar hydration mismatch with a stable server/hydration snapshot instead of suppression
- remove unrequested automatic Runtime UI opening while preserving the manual Runtime UI path
- remove deployment/sync/dunning status from hosted agent tiles; tiles and the sidebar focus rail show the agent name, while detail remains authoritative for status
- align all hosted Playwright fixtures and expectations with the current product and USD contract

## Owner decisions preserved

- Hosted tiles intentionally no longer provide at-a-glance health. With several agents, a user opens an agent to see ready, working, unavailable, or failed state. This is deliberate.
- Runtime UI never opens automatically. The manual Runtime UI link and retryable credential flow remain.
- The deleted auto-open trigger was reachable, not dead: accepted deploy navigation uses the deployment id as the `/agents/:id` route id with `source=on-clawdi`, so the old equality could be true.
- v1/legacy/local-daemon badges and status behavior are unchanged.

## Playwright triage

Walkthrough baseline: **29/59 passed, 30/59 failed**. Reproducing after the K1 fix but before spec updates produced **37/60 passed, 23/60 failed**:

- **7 real K1 failures:** sidebar SSR/hydration timing changed active link attributes. These passed with the hydration fix alone.
- **23 stale specs:** old labels/selectors, raw backend failure expectations, credits-era money fixtures/copy, old credential controls, and the prior Runtime UI wording. Product behavior was retained; assertions and fixtures were updated.

The compatibility-overlay description in the walkthrough is imprecise: #498 removed a TypeScript read-contract overlay, not a visible UI overlay. The stale browser expectations came from several current product/contract changes, not one removed visual overlay.

Final hosted suite: **60/60 passed in 4.3m**. No test was deleted.

## Verification

- `bun run typecheck`: 4/4 package tasks passed
- `bun run lint`: 705 files checked, 0 errors
- `bun test`: 1713/1713 passed across 183 files
- `bun run --cwd apps/web e2e:hosted`: 60/60 passed in 4.3m

No production mutations. Do not merge as part of this task.
