### PR TITLE
Fix v2 arrival and runtime UI convergence

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1547,6 +1547,11 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 
 	await page.getByRole("button", { name: "Deploy agent" }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
+	await expect(page.getByTestId("accepted-agent-setup")).toBeVisible();
+	await expect(page.getByText("Setting up your agent", { exact: true }).first()).toBeVisible();
+	await expect(page.getByText("Agent unavailable", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
+	await expect(page.locator("body")).not.toContainText("hdep_included_created");
 	expect(convergencePollRequests).toEqual([]);
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
 	expect(createDeploymentRequests).toHaveLength(1);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1836,7 +1836,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
 
@@ -1947,7 +1947,7 @@ test("failed deployment with a retained projection keeps status-authoritative na
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
 
 	expect(restartRequests).toEqual([]);
@@ -1975,7 +1975,7 @@ test("missing live projection recovers on Check again without losing deployment 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect(main.getByText("Some agent details are not ready", { exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await main.getByRole("button", { name: "Check again", exact: true }).click();
 	await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(0);
@@ -1997,7 +1997,7 @@ test("projection service errors stay visible while deployment tools remain avail
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect(main.getByText("Couldn’t load all agent details", { exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	const renderErrors = errors.filter(
 		(error) => error.includes("Maximum update depth") || error.includes("Too many re-renders"),
@@ -2048,7 +2048,7 @@ test("deployment detail stays put, becomes ready, and keeps manual Runtime UI ac
 	expect(runtimeUiRedemptionRequests).toEqual([]);
 	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveCount(0);
 
-	await page.getByRole("link", { name: "Runtime UI", exact: true }).click();
+	await page.getByRole("link", { name: "Agent Interface", exact: true }).click();
 	await expect(page).toHaveURL(
 		(url) =>
 			url.pathname === `/agents/${pendingRuntimeUiDeployment.id}/console` &&
@@ -2190,7 +2190,7 @@ test("shared legacy environment routes an older tile's actions to its deployment
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_shared_older"]);
 });
 
-test("shared legacy environment direct route asks the user to choose a deployment", async ({
+test("shared legacy environment direct route asks the user to choose an agent", async ({
 	page,
 }) => {
 	await stubHostedApi(page, {
@@ -2199,7 +2199,7 @@ test("shared legacy environment direct route asks the user to choose a deploymen
 
 	await page.goto(`/agents/${sharedLegacyEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByRole("heading", { name: "Choose a deployment" })).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Choose an agent" })).toBeVisible();
 	const newerChoice = main.getByRole("link", { name: "Open Newer twin" });
 	const olderChoice = main.getByRole("link", { name: "Open Older twin" });
 	await expect(newerChoice).toContainText("Running");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2055,10 +2055,9 @@ test("deployment detail stays put, becomes ready, and keeps manual Runtime UI ac
 			url.searchParams.get("source") === "on-clawdi" &&
 			url.searchParams.get("d") === pendingRuntimeUiDeployment.id,
 	);
-	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
-		"src",
-		"https://runtime.example/hermes",
-	);
+	await expect(main.locator("iframe")).toHaveCount(0);
+	await expect(main.getByText("Open in a new window", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Open Hermes Dashboard" })).toBeVisible();
 });
 
 test("Runtime UI credential failure renders a retryable error instead of a permanent spinner", async ({
@@ -2085,16 +2084,20 @@ test("Runtime UI credential failure renders a retryable error instead of a perma
 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
-		"src",
-		"https://runtime.example/hermes",
-	);
-	await expect(main.getByRole("button", { name: "Open in new window", exact: true })).toBeVisible();
-	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
+	await expect(main.locator("iframe")).toHaveCount(0);
+	const failedPopupPromise = page.waitForEvent("popup");
+	await main.getByRole("button", { name: "Open Hermes Dashboard" }).click();
+	await failedPopupPromise;
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
-	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toBeVisible();
-	await main.getByRole("button", { name: "Retry", exact: true }).click();
-	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Couldn't open Hermes Dashboard", { exact: true })).toBeVisible();
+	await expect(page.getByText("credentials temporarily unavailable", { exact: true })).toHaveCount(
+		0,
+	);
+	const recoveredPopupPromise = page.waitForEvent("popup");
+	await page.getByRole("button", { name: "Try again", exact: true }).click();
+	await recoveredPopupPromise;
+	await expect(page.getByText("Couldn't open Hermes Dashboard", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Hermes sign-in details", { exact: true })).toBeVisible();
 	const passwordValue = main.locator("code");
 	await expect(passwordValue).toHaveText("••••••••••••");
 	await expect(passwordValue).not.toContainText("recovered-password");
@@ -2123,20 +2126,13 @@ test("OpenClaw Console opens through the direct gateway token handoff", async ({
 
 	await page.goto("/agents/hdep_openclaw_included/console?source=on-clawdi");
 	const main = page.locator("main");
-	await expect(main.locator('iframe[title="OpenClaw Control UI"]')).toHaveAttribute(
-		"src",
-		"https://runtime.example/openclaw/#token=gateway-token",
-	);
-	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
-	const tokenValue = main.locator("code");
-	await expect(tokenValue).toHaveText("••••••••••••");
-	await expect(tokenValue).not.toContainText("gateway-token");
-	await main.getByRole("button", { name: "Show Token", exact: true }).click();
-	await expect(tokenValue).toHaveText("gateway-token");
+	await expect(main.locator("iframe")).toHaveCount(0);
+	await expect(main.getByText("gateway-token", { exact: false })).toHaveCount(0);
 	const popupPromise = page.waitForEvent("popup");
 	await main.getByRole("button", { name: "Open OpenClaw Control UI" }).click();
 	const popup = await popupPromise;
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
+	await expect(main.getByText("gateway-token", { exact: false })).toHaveCount(0);
 	expect(popup).toBeDefined();
 });
 

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1547,6 +1547,7 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 
 	await page.getByRole("button", { name: "Deploy agent" }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
+	await expect.poll(() => new URL(page.url()).searchParams.get("setup")).toBe("accepted");
 	await expect(page.getByTestId("accepted-agent-setup")).toBeVisible();
 	await expect(page.getByText("Setting up your agent", { exact: true }).first()).toBeVisible();
 	await expect(page.getByText("Agent unavailable", { exact: true })).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2290,7 +2290,7 @@ test("entitled card subscription activation opens the accepted deployment withou
 	await page.getByRole("button", { name: "Continue to checkout" }).click();
 	await expect.poll(() => checkoutRequests.length).toBe(1);
 	await expect(page).toHaveURL(/\/agents\/hdep_included(?:\?|\/)/);
-	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
+	await expect(page.getByText("Agent deployment started", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("dialog", { name: /Complete .* checkout/ })).toHaveCount(0);
 	await expect(page.getByText("Mock secure payment form", { exact: true })).toHaveCount(0);
 	expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
@@ -2424,12 +2424,10 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 		},
 	});
 	await expect(page).toHaveURL(/\/agents\/hdep_wallet_created(?:\?|\/)/);
-	await expect(page.getByText("Agent deployment started", { exact: true })).toBeVisible();
-	await expect(
-		page.getByText("Your Basic agent is getting ready now. $100.00 was paid from Wallet.", {
-			exact: true,
-		}),
-	).toBeVisible();
+	await expect(page.getByText("Wallet payment confirmed", { exact: true })).toBeVisible();
+	await expect(page.getByText("$100.00 was paid from Wallet.", { exact: true })).toBeVisible();
+	await page.waitForTimeout(8_500);
+	await expect(page.getByText("Wallet payment confirmed", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Agent deployed", { exact: true })).toHaveCount(0);
 	expect(errors, `wallet annual deploy: ${errors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -108,6 +108,7 @@ import {
 	agentDeploymentRouteQuery,
 	agentSectionHref,
 	agentSectionLabel,
+	isAcceptedHostedAgentRoute,
 	parseAgentPathname,
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
@@ -1242,6 +1243,10 @@ function FocusHeader({
 	activeAgentKind: AgentChromeKind;
 	activeAgentId: string | null;
 }) {
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const acceptedSetupRoute = Boolean(
+		activeAgentId && isAcceptedHostedAgentRoute(activeAgentId, searchStr),
+	);
 	if (!activeAgent && !activeAgentId) {
 		return (
 			<div className="min-w-0">
@@ -1266,9 +1271,11 @@ function FocusHeader({
 	if (!activeAgent && !activeAgentTile) {
 		return (
 			<div className="min-w-0">
-				<div className="truncate text-sm font-semibold leading-5">Agent unavailable</div>
+				<div className="truncate text-sm font-semibold leading-5">
+					{acceptedSetupRoute ? "Setting up your agent" : "Agent not found"}
+				</div>
 				<div className="truncate text-xs leading-4 text-muted-foreground">
-					{activeAgentId ? activeAgentId.slice(0, 8) : "Loading navigation"}
+					{acceptedSetupRoute ? "This usually takes a few minutes" : "No details are available"}
 				</div>
 			</div>
 		);

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -34,6 +34,7 @@ import {
 	agentDeploymentRouteQuery,
 	agentDeploymentSelector,
 	agentSectionHref,
+	isAcceptedHostedAgentRoute,
 } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -80,6 +81,7 @@ export function AgentHome({
 	} = useAgentDeployment(environmentId, deploymentSelector);
 	const isCloudEnvironmentId = isCloudEnvId(environmentId);
 	const requestedFromCloudRedirect = searchParams.get("source") === "on-clawdi";
+	const acceptedSetupRoute = isAcceptedHostedAgentRoute(environmentId, searchParams);
 	const requestedHostedAgent =
 		requestedFromCloudRedirect || Boolean(deploymentSelector) || !isCloudEnvironmentId;
 	const unresolvedHostedAgent =
@@ -87,6 +89,7 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
+	const [acceptedSetupStatusTimedOut, setAcceptedSetupStatusTimedOut] = useState(false);
 	const [userDeleteIntent, setUserDeleteIntent] = useState<UserDeleteNavigationIntent | null>(null);
 	const deleteIntentStillOwnsRoute =
 		userDeleteIntent?.environmentId === environmentId &&
@@ -117,6 +120,10 @@ export function AgentHome({
 	}, [isFetching]);
 
 	useEffect(() => {
+		setAcceptedSetupStatusTimedOut(false);
+	}, [environmentId, deploymentSelector]);
+
+	useEffect(() => {
 		if (!deletedDeploymentGone) return;
 		setUserDeleteIntent(null);
 		toast.success("Agent deleted");
@@ -135,13 +142,14 @@ export function AgentHome({
 
 			if (attempts >= UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS) {
 				window.clearInterval(intervalId);
+				if (acceptedSetupRoute) setAcceptedSetupStatusTimedOut(true);
 			}
 		}, UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS);
 
 		return () => {
 			window.clearInterval(intervalId);
 		};
-	}, [refetch, shouldAutoRefetchUnresolvedHostedAgent]);
+	}, [acceptedSetupRoute, refetch, shouldAutoRefetchUnresolvedHostedAgent]);
 
 	const handleCheckAgain = () => {
 		if (isFetchingRef.current) return;
@@ -169,12 +177,18 @@ export function AgentHome({
 				</div>
 			);
 		}
+		if (acceptedSetupRoute) {
+			return <AcceptedAgentSetupState />;
+		}
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
+		if (acceptedSetupRoute) {
+			return <AcceptedAgentSetupState />;
+		}
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
@@ -232,6 +246,16 @@ export function AgentHome({
 		);
 	}
 
+	if (acceptedSetupRoute) {
+		return (
+			<AcceptedAgentSetupState
+				isChecking={isFetching}
+				onCheckAgain={handleCheckAgain}
+				statusTimedOut={acceptedSetupStatusTimedOut}
+			/>
+		);
+	}
+
 	if (requestedHostedAgent) {
 		return (
 			<div
@@ -252,6 +276,48 @@ export function AgentHome({
 	}
 
 	return <ConnectedAgentDetail environmentId={environmentId} section={section} />;
+}
+
+export function AcceptedAgentSetupState({
+	statusTimedOut = false,
+	isChecking = false,
+	onCheckAgain,
+}: {
+	statusTimedOut?: boolean;
+	isChecking?: boolean;
+	onCheckAgain?: () => void;
+}) {
+	return (
+		<div
+			data-hosted="true"
+			data-testid="accepted-agent-setup"
+			className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
+		>
+			<EmptyState
+				icon={statusTimedOut ? AlertCircle : <Spinner className="size-5" />}
+				title={statusTimedOut ? "Agent setup status is unavailable" : "Setting up your agent"}
+				description={
+					statusTimedOut
+						? "Clawdi accepted your request, but couldn’t load a progress update within two minutes. Setup may still be continuing."
+						: "Your request was accepted. Clawdi is preparing your agent now. This usually takes a few minutes."
+				}
+				action={
+					statusTimedOut && onCheckAgain ? (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={isChecking}
+							onClick={onCheckAgain}
+						>
+							{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw />}
+							Check again
+						</Button>
+					) : null
+				}
+			/>
+		</div>
+	);
 }
 
 function DeploymentChooser({

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -344,15 +344,15 @@ function DeploymentChooser({
 			className={`${CENTERED_PAGE_WIDTH_CLASS.page} flex flex-col gap-4 px-4 py-2 lg:px-6`}
 		>
 			<PageHeader
-				title="Choose a deployment"
-				description="Multiple legacy deployments share this agent identity. Choose the deployment you want to manage."
+				title="Choose an agent"
+				description="More than one older agent shares this identity. Choose the one you want to manage."
 			/>
 			{hasUnknownStatus ? (
 				<Alert data-hosted="true">
 					<AlertCircle />
-					<AlertTitle>Some deployment statuses are unavailable</AlertTitle>
+					<AlertTitle>Some agent statuses are unavailable</AlertTitle>
 					<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-						<span>We can’t determine every deployment state right now.</span>
+						<span>We can’t determine every agent state right now.</span>
 						<Button
 							type="button"
 							variant="outline"

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -223,6 +223,19 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain("title={`Agent status: ");
 		expect(sidebarSource).toContain('"Agent details unavailable"');
 	});
+
+	test("uses one top-level credential handover path and no embedded sign-in surface", () => {
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(detailSource.match(/getRuntimeUiCredentials/g)).toHaveLength(1);
+		expect(detailSource).toContain("openSecureRuntimeWindow");
+		expect(detailSource).toContain("resolveRuntimeUiCredentials");
+		expect(detailSource).not.toContain("<iframe");
+		expect(detailSource).not.toContain("Show credentials");
+	});
 });
 
 function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -65,11 +65,8 @@ import {
 } from "@/hosted/agents/hosted-terminal-panel";
 import {
 	type HermesUiCredentials,
-	hermesUiCredentials,
-	type OpenClawUiCredentials,
-	openClawUiCredentials,
-	openClawUiUrl,
 	openSecureRuntimeWindow,
+	resolveRuntimeUiCredentials,
 } from "@/hosted/agents/runtime-ui-credentials";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
@@ -523,6 +520,7 @@ export function HostedAgentDetail({
 				deployment={deployment}
 				endpointUrl={consoleUrl}
 				label={runtimeBrowserUiLabel(runtime)}
+				runtime={runtime}
 				variant="outline"
 				size="sm"
 			>
@@ -1217,11 +1215,14 @@ function OverviewDeploymentActions({
 
 // ── Runtime UI ───────────────────────────────────────────────────────────────
 
+const RUNTIME_UI_LAUNCH_TOAST_ID = "runtime-ui-launch";
+
 function RuntimeUiOpenButton({
 	deployment,
 	endpointUrl,
-	resolvedUrl,
 	label,
+	runtime,
+	onHermesCredentials,
 	children,
 	className,
 	disabled = false,
@@ -1230,8 +1231,9 @@ function RuntimeUiOpenButton({
 }: {
 	deployment: HostedDeployment;
 	endpointUrl: string;
-	resolvedUrl?: string;
 	label: string;
+	runtime: Runtime;
+	onHermesCredentials?: (credentials: HermesUiCredentials) => void;
 	children: React.ReactNode;
 	className?: string;
 	disabled?: boolean;
@@ -1240,31 +1242,57 @@ function RuntimeUiOpenButton({
 }) {
 	const client = useBillingClient();
 	const [isPending, setIsPending] = useState(false);
-	const openUi = useCallback(async () => {
-		const popup = openSecureRuntimeWindow(window.open.bind(window));
-		if (!popup) {
-			toast.error("Couldn't open agent interface", {
-				description: "Your browser blocked the new window.",
-			});
-			return;
-		}
-		if (resolvedUrl) {
-			popup.location.replace(resolvedUrl);
-			return;
-		}
-		setIsPending(true);
-		try {
-			const credentials = await client.getRuntimeUiCredentials(deployment.resource.id);
-			const url = openClawUiUrl(credentials, endpointUrl);
-			if (!url) throw new Error("Runtime UI credential response was invalid");
-			popup.location.replace(url);
-		} catch {
-			popup.close();
-			toast.error("Couldn't open agent interface", { description: "Please try again." });
-		} finally {
-			setIsPending(false);
-		}
-	}, [client, deployment.resource.id, endpointUrl, resolvedUrl]);
+	const requestVersionRef = useRef(0);
+	useEffect(
+		() => () => {
+			requestVersionRef.current += 1;
+		},
+		[],
+	);
+	const openUi = useCallback(
+		async function openUi() {
+			const popup = openSecureRuntimeWindow(window.open.bind(window));
+			if (!popup) {
+				toast.error(`Couldn't open ${label}`, {
+					id: RUNTIME_UI_LAUNCH_TOAST_ID,
+					description:
+						"Your browser blocked the new window. Allow pop-ups for Clawdi, then try again.",
+					action: { label: "Try again", onClick: () => void openUi() },
+				});
+				return;
+			}
+			const requestVersion = requestVersionRef.current + 1;
+			requestVersionRef.current = requestVersion;
+			setIsPending(true);
+			try {
+				const credentials = await client.getRuntimeUiCredentials(deployment.resource.id);
+				const resolved = resolveRuntimeUiCredentials(credentials, endpointUrl);
+				if (requestVersionRef.current !== requestVersion) {
+					popup.close();
+					return;
+				}
+				if (!resolved || resolved.runtime !== runtime) {
+					throw new Error("Runtime UI credential response was invalid");
+				}
+				toast.dismiss(RUNTIME_UI_LAUNCH_TOAST_ID);
+				if (resolved.runtime === "hermes") onHermesCredentials?.(resolved.value);
+				popup.location.replace(resolved.value.url);
+			} catch {
+				popup.close();
+				if (requestVersionRef.current === requestVersion) {
+					toast.error(`Couldn't open ${label}`, {
+						id: RUNTIME_UI_LAUNCH_TOAST_ID,
+						description:
+							"Clawdi couldn’t load valid sign-in details. Your agent was not changed. Try again.",
+						action: { label: "Try again", onClick: () => void openUi() },
+					});
+				}
+			} finally {
+				if (requestVersionRef.current === requestVersion) setIsPending(false);
+			}
+		},
+		[client, deployment.resource.id, endpointUrl, label, onHermesCredentials, runtime],
+	);
 
 	return (
 		<Button
@@ -1282,15 +1310,10 @@ function RuntimeUiOpenButton({
 	);
 }
 
-type ResolvedRuntimeUiCredentials =
-	| { runtime: "hermes"; value: HermesUiCredentials }
-	| { runtime: "openclaw"; value: OpenClawUiCredentials };
-
 /**
- * Live agent browser UI embedded inline. The deployment's selected runtime UI
- * URL points at owner-only exposure. When the runtime
- * allows dashboard framing, the bridge cookie + WS work in-frame; otherwise
- * the full-screen link is the alternate path.
+ * Native agent interfaces authenticate in a top-level browser window. Keeping
+ * this tab as the single launch surface avoids presenting an embedded sign-in
+ * form whose session cannot survive third-party cookie restrictions.
  */
 function ConsoleTab({
 	deployment,
@@ -1313,88 +1336,11 @@ function ConsoleTab({
 	const label = runtimeDisplayName(runtime);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
-	const client = useBillingClient();
-	const [credentials, setCredentials] = useState<ResolvedRuntimeUiCredentials | null>(null);
-	const [showCredentials, setShowCredentials] = useState(false);
-	const [credentialError, setCredentialError] = useState<Error | null>(null);
-	const [isLoadingCredentials, setIsLoadingCredentials] = useState(false);
-	const credentialRequestRef = useRef(0);
-	const automaticCredentialKeyRef = useRef<string | null>(null);
 	const credentialIdentity = `${deployment.resource.id}\0${deployment.resource.metadata.generation}\0${runtime}\0${url ?? ""}`;
-	const [syncedCredentialIdentity, setSyncedCredentialIdentity] = useState(credentialIdentity);
-	if (credentialIdentity !== syncedCredentialIdentity) {
-		setSyncedCredentialIdentity(credentialIdentity);
-		credentialRequestRef.current += 1;
-		setCredentials(null);
-		setShowCredentials(false);
-		setCredentialError(null);
-		setIsLoadingCredentials(false);
-	}
-	const loadCredentials = useCallback(
-		async (reveal: boolean) => {
-			if (!url) return;
-			const requestId = credentialRequestRef.current + 1;
-			credentialRequestRef.current = requestId;
-			setIsLoadingCredentials(true);
-			setCredentialError(null);
-			try {
-				const response = await client.getRuntimeUiCredentials(deployment.resource.id);
-				let resolved: ResolvedRuntimeUiCredentials | null;
-				if (runtime === "hermes") {
-					const value = hermesUiCredentials(response, url);
-					resolved = value ? { runtime: "hermes", value } : null;
-				} else {
-					const value = openClawUiCredentials(response, url);
-					resolved = value ? { runtime: "openclaw", value } : null;
-				}
-				if (!resolved) throw new Error("Runtime UI credential response was invalid");
-				if (credentialRequestRef.current !== requestId) return;
-				setCredentials(resolved);
-				setShowCredentials(reveal);
-			} catch (error) {
-				if (credentialRequestRef.current !== requestId) return;
-				setCredentialError(error instanceof Error ? error : new Error("Credential request failed"));
-			} finally {
-				if (credentialRequestRef.current === requestId) setIsLoadingCredentials(false);
-			}
-		},
-		[client, deployment.resource.id, runtime, url],
-	);
+	const [hermesCredentials, setHermesCredentials] = useState<HermesUiCredentials | null>(null);
 	useEffect(() => {
-		const automaticCredentialKey = `${credentialIdentity}\0openclaw`;
-		if (
-			!isRunning ||
-			!url ||
-			runtime !== "openclaw" ||
-			credentials?.runtime === "openclaw" ||
-			credentialError ||
-			isLoadingCredentials ||
-			automaticCredentialKeyRef.current === automaticCredentialKey
-		) {
-			return;
-		}
-		automaticCredentialKeyRef.current = automaticCredentialKey;
-		void loadCredentials(false);
-	}, [
-		credentialIdentity,
-		credentialError,
-		credentials,
-		isLoadingCredentials,
-		isRunning,
-		loadCredentials,
-		runtime,
-		url,
-	]);
-
-	const toggleCredentials = () => {
-		if (showCredentials) {
-			setShowCredentials(false);
-			if (runtime === "hermes") setCredentials(null);
-			return;
-		}
-		if (credentials?.runtime === runtime) setShowCredentials(true);
-		else void loadCredentials(true);
-	};
+		setHermesCredentials(null);
+	}, [credentialIdentity]);
 
 	if (status.kind === "stopped") {
 		return <StoppedAgentState deployment={deployment} />;
@@ -1479,99 +1425,60 @@ function ConsoleTab({
 			/>
 		);
 	}
-	const frameUrl =
-		runtime === "hermes"
-			? url
-			: credentials?.runtime === "openclaw"
-				? credentials.value.url
-				: undefined;
-	const runtimeActions = (
-		<>
-			<Button
-				type="button"
-				variant="outline"
-				size="sm"
-				disabled={isLoadingCredentials}
-				onClick={toggleCredentials}
-			>
-				{isLoadingCredentials ? <Spinner className="size-3.5" /> : null}
-				{showCredentials ? "Hide credentials" : "Show credentials"}
-			</Button>
-			{runtime === "openclaw" ? (
-				<RuntimeUiOpenButton
-					deployment={deployment}
-					endpointUrl={url}
-					resolvedUrl={credentials?.runtime === "openclaw" ? credentials.value.url : undefined}
-					label={browserUiLabel}
-					disabled={isLoadingCredentials}
-				>
-					Open in new window
-					<ExternalLink className="size-3.5" />
-				</RuntimeUiOpenButton>
-			) : (
-				<Button
-					render={<a href={url} target="_blank" rel="noopener noreferrer" />}
-					nativeButton={false}
-					variant="outline"
-					size="sm"
-				>
-					Open in new window
-					<ExternalLink className="size-3.5" />
-				</Button>
-			)}
-		</>
-	);
-
 	return (
-		<LiveToolFrame icon={MonitorPlay} title={browserUiLabel} action={runtimeActions}>
-			{showCredentials ? (
-				<div className="grid shrink-0 gap-3 border-y bg-muted/20 p-4 sm:grid-cols-2 lg:px-6">
-					{credentials?.runtime === "hermes" ? (
-						<>
+		<LiveToolFrame icon={MonitorPlay} title={browserUiLabel}>
+			<div className="flex min-h-[420px] flex-1 items-center justify-center p-6">
+				<div className="w-full max-w-xl space-y-5 text-center">
+					<div className="space-y-2">
+						<h2 className="text-lg font-semibold">Open in a new window</h2>
+						<p className="text-sm text-muted-foreground">
+							{runtime === "hermes"
+								? "Hermes signs you in only in its own browser window. Open it here, then return to copy the sign-in details."
+								: "OpenClaw signs you in securely in its own browser window."}
+						</p>
+					</div>
+					<RuntimeUiOpenButton
+						key={credentialIdentity}
+						deployment={deployment}
+						endpointUrl={url}
+						label={browserUiLabel}
+						runtime={runtime}
+						onHermesCredentials={runtime === "hermes" ? setHermesCredentials : undefined}
+					>
+						Open {browserUiLabel}
+						<ExternalLink className="size-3.5" />
+					</RuntimeUiOpenButton>
+					{runtime === "hermes" && hermesCredentials ? (
+						<div className="space-y-3 rounded-lg border bg-muted/20 p-4 text-left">
+							<div className="flex items-start justify-between gap-3">
+								<div>
+									<h3 className="text-sm font-medium">Hermes sign-in details</h3>
+									<p className="text-xs text-muted-foreground">
+										Use these in the Hermes window that just opened.
+									</p>
+								</div>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={() => setHermesCredentials(null)}
+								>
+									Hide
+								</Button>
+							</div>
 							<div className="space-y-1.5">
 								<Label htmlFor={`hermes-username-${deployment.resource.id}`}>Username</Label>
 								<Input
 									id={`hermes-username-${deployment.resource.id}`}
 									readOnly
-									value={credentials.value.username}
+									value={hermesCredentials.username}
 								/>
 							</div>
-							<TokenReveal label="Password" value={credentials.value.password} />
-						</>
-					) : credentials?.runtime === "openclaw" ? (
-						<div className="sm:col-span-2">
-							<TokenReveal label="Token" value={credentials.value.token} />
+							<TokenReveal label="Password" value={hermesCredentials.password} />
 						</div>
 					) : null}
 				</div>
-			) : null}
-			{credentialError ? (
-				<div
-					className={cn("p-4 lg:px-6", frameUrl ? "shrink-0" : "flex min-h-[420px] items-center")}
-				>
-					<div className="w-full">
-						<ApiErrorPanel
-							error={credentialError}
-							onRetry={() => void loadCredentials(runtime === "hermes")}
-							normalizer={billingErrorNormalizer}
-							title={`Couldn't load ${label} credentials`}
-						/>
-					</div>
-				</div>
-			) : null}
-			{frameUrl ? (
-				<iframe
-					key={`${runtime}:${frameUrl}`}
-					src={frameUrl}
-					title={browserUiLabel}
-					className="min-h-[420px] flex-1 border-0 bg-background"
-					allow="clipboard-read; clipboard-write"
-				/>
-			) : credentialError ? null : (
-				<div className="flex min-h-[420px] flex-1 items-center justify-center bg-background">
-					<Spinner className="size-4 text-muted-foreground" />
-				</div>
-			)}
+			</div>
 		</LiveToolFrame>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1872,7 +1872,7 @@ function AiProviderTab({
 						{bindingMode === "unmanaged" ? <Badge variant="secondary">Current</Badge> : null}
 					</div>
 					<p className="mt-0.5 text-sm text-muted-foreground">
-						Remove the hosted provider binding and configure model access inside the runtime.
+						Use provider settings inside the agent instead of connecting them through Clawdi.
 					</p>
 				</button>
 				<button
@@ -1961,8 +1961,8 @@ function AiProviderTab({
 
 			{bindingMode === "unmanaged" ? (
 				<p className="text-sm text-muted-foreground">
-					This runtime now carries no hosted provider binding. Configure models inside the agent
-					after it starts.
+					This agent has no Clawdi provider connection. Configure models inside the agent after it
+					starts.
 				</p>
 			) : (
 				<ModelBindingPicker
@@ -2655,7 +2655,7 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="default">Runtime default</SelectItem>
+								<SelectItem value="default">Agent default</SelectItem>
 								{LANGUAGE_OPTIONS.map((option) => (
 									<SelectItem key={option.code} value={option.code}>
 										{option.label}
@@ -2819,7 +2819,7 @@ function ComputeSettingsSections({
 				status: currentSubscription.status,
 				subscriptionId,
 			})
-		: "Start a new subscription to change this deployment’s paid compute.";
+		: "Start a new subscription to change this agent’s paid compute.";
 	const upgradeUnavailableMessage = performanceUpgradeUnavailableReason({
 		plansLoading: plans.isLoading,
 		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
@@ -2948,8 +2948,8 @@ function ComputeSettingsSections({
 				description: res.current_period_end
 					? `Cancellation takes effect ${formatShortDate(
 							res.current_period_end,
-						)}. The deployment then falls back to included Basic funding if available; otherwise, it stops.`
-					: "The deployment falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
+						)}. The agent then falls back to included Basic funding if available; otherwise, it stops.`
+					: "The agent falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
 			});
 		} catch (error) {
 			toast.error("Couldn’t cancel subscription", { description: normalizeBillingError(error) });
@@ -3036,7 +3036,7 @@ function ComputeSettingsSections({
 						</div>
 						<p className="mt-1 text-xs text-muted-foreground">
 							Basic includes one free active slot per user. Paid Basic and Performance each use one
-							subscription per deployment.
+							subscription per agent.
 						</p>
 						{isPaidCompute && currentSubscription ? (
 							<div className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
@@ -3151,8 +3151,8 @@ function ComputeSettingsSections({
 											title={`Cancel ${tierLabel} subscription?`}
 											description={
 												<p>
-													Cancellation takes effect {subscriptionPeriodLabel}. The deployment then
-													falls back to included Basic funding if available; otherwise, it stops.
+													Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls
+													back to included Basic funding if available; otherwise, it stops.
 												</p>
 											}
 											confirmLabel="Cancel at period end"

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
-	hermesUiCredentials,
-	openClawUiCredentials,
-	openClawUiUrl,
 	openSecureRuntimeWindow,
+	resolveRuntimeUiCredentials,
 } from "@/hosted/agents/runtime-ui-credentials";
 
 describe("runtime UI credential targeting", () => {
@@ -31,10 +29,13 @@ describe("runtime UI credential targeting", () => {
 			username: "admin",
 			password: "deployment-password",
 		};
-		expect(hermesUiCredentials(credentials, "https://runtime.example/hermes")).toEqual({
-			url: "https://runtime.example/hermes",
-			username: "admin",
-			password: "deployment-password",
+		expect(resolveRuntimeUiCredentials(credentials, "https://runtime.example/hermes")).toEqual({
+			runtime: "hermes",
+			value: {
+				url: "https://runtime.example/hermes",
+				username: "admin",
+				password: "deployment-password",
+			},
 		});
 		expect(credentials.url).not.toContain(credentials.password ?? "");
 	});
@@ -52,8 +53,8 @@ describe("runtime UI credential targeting", () => {
 			auth_mode: "openclaw_device",
 			url: "https://other.example/openclaw/#token=deployment-token",
 		};
-		expect(hermesUiCredentials(hermes, "https://runtime.example/hermes")).toBeNull();
-		expect(openClawUiUrl(openclaw, "https://runtime.example/openclaw/")).toBeNull();
+		expect(resolveRuntimeUiCredentials(hermes, "https://runtime.example/hermes")).toBeNull();
+		expect(resolveRuntimeUiCredentials(openclaw, "https://runtime.example/openclaw/")).toBeNull();
 	});
 
 	test("preserves the exact official OpenClaw token fragment URL", () => {
@@ -62,10 +63,12 @@ describe("runtime UI credential targeting", () => {
 			auth_mode: "openclaw_device",
 			url: "https://runtime.example/openclaw/#token=deployment-token",
 		};
-		expect(openClawUiUrl(credentials, "https://runtime.example/openclaw/")).toBe(credentials.url);
-		expect(openClawUiCredentials(credentials, "https://runtime.example/openclaw/")).toEqual({
-			url: credentials.url,
-			token: "deployment-token",
+		expect(resolveRuntimeUiCredentials(credentials, "https://runtime.example/openclaw/")).toEqual({
+			runtime: "openclaw",
+			value: {
+				url: credentials.url,
+				token: "deployment-token",
+			},
 		});
 	});
 
@@ -75,6 +78,6 @@ describe("runtime UI credential targeting", () => {
 			auth_mode: "openclaw_device",
 			url: "https://runtime.example/openclaw/",
 		};
-		expect(openClawUiCredentials(credentials, credentials.url)).toBeNull();
+		expect(resolveRuntimeUiCredentials(credentials, credentials.url)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -11,6 +11,10 @@ export interface OpenClawUiCredentials {
 	token: string;
 }
 
+export type ResolvedRuntimeUiCredentials =
+	| { runtime: "hermes"; value: HermesUiCredentials }
+	| { runtime: "openclaw"; value: OpenClawUiCredentials };
+
 type RuntimeWindow = {
 	close(): void;
 	location: { replace(url: string | URL): void };
@@ -41,7 +45,7 @@ function targetsPublishedEndpoint(credentialUrl: string, endpointUrl: string): b
 	}
 }
 
-export function hermesUiCredentials(
+function hermesUiCredentials(
 	credentials: RuntimeUiCredentials,
 	endpointUrl: string,
 ): HermesUiCredentials | null {
@@ -61,7 +65,7 @@ export function hermesUiCredentials(
 	};
 }
 
-export function openClawUiCredentials(
+function openClawUiCredentials(
 	credentials: RuntimeUiCredentials,
 	endpointUrl: string,
 ): OpenClawUiCredentials | null {
@@ -89,9 +93,14 @@ export function openClawUiCredentials(
 	}
 }
 
-export function openClawUiUrl(
+export function resolveRuntimeUiCredentials(
 	credentials: RuntimeUiCredentials,
 	endpointUrl: string,
-): string | null {
-	return openClawUiCredentials(credentials, endpointUrl)?.url ?? null;
+): ResolvedRuntimeUiCredentials | null {
+	if (credentials.runtime === "hermes") {
+		const value = hermesUiCredentials(credentials, endpointUrl);
+		return value ? { runtime: "hermes", value } : null;
+	}
+	const value = openClawUiCredentials(credentials, endpointUrl);
+	return value ? { runtime: "openclaw", value } : null;
 }

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -183,7 +183,7 @@ describe("declarative deployment mutations", () => {
 		});
 		expect(() =>
 			acceptDeclarativeOperation({ operation: operation({ done: false, deploymentId: "" }) }),
-		).toThrow("The deployment service completed creation without a deployment.");
+		).toThrow("The agent service completed creation without returning the agent.");
 	});
 
 	it("releases a checkout deployment request as soon as its LRO is accepted", async () => {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -105,7 +105,7 @@ function operationIdFromName(name: string): string {
 	const prefix = "operations/";
 	const operationId = name.startsWith(prefix) ? name.slice(prefix.length) : "";
 	if (!operationId) {
-		throw new BillingApiError(502, "The deployment service returned an invalid operation name.");
+		throw new BillingApiError(502, "The agent service returned an invalid operation name.");
 	}
 	return operationId;
 }
@@ -124,7 +124,7 @@ export function acceptDeclarativeOperation<T extends DeploymentOperation | null>
 		operation: T;
 		deploymentId?: string | null;
 	},
-	missingDeploymentMessage = "The deployment service completed creation without a deployment.",
+	missingDeploymentMessage = "The agent service completed creation without returning the agent.",
 ): {
 	deploymentId: string;
 	operation: T;
@@ -147,7 +147,7 @@ function strongResourceEtag(deployment: HostedDeployment): string {
 			return code >= 0x21 && code <= 0x7e && character !== '"' && character !== "\\";
 		});
 	if (!valid) {
-		throw new BillingApiError(502, "The deployment service returned an invalid resource ETag.");
+		throw new BillingApiError(502, "The agent service returned an invalid resource version.");
 	}
 	return `"${resourceVersion}"`;
 }
@@ -160,8 +160,8 @@ function terminalDeployRequestError(status: HostedDeployRequestStatus): BillingA
 	return new DeploymentRequestTerminalError(
 		409,
 		status.request_status === "superseded"
-			? "This deployment request was superseded by a newer attempt."
-			: "The deployment request could not be completed.",
+			? "This agent creation was superseded by a newer attempt."
+			: "The agent could not be created.",
 		status,
 	);
 }

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -61,12 +61,12 @@ export function useCheckoutReturnHandler({
 				const deploymentId = checkoutReturnDeploymentId(searchStr);
 				if (deploymentId && onNavigate(deploymentId) !== false) return;
 				toast.message("Checkout status refreshed", {
-					description: "We checked your deployments, subscription, and wallet.",
+					description: "We checked your agents, subscription, and wallet.",
 				});
 			})
 			.catch(() => {
 				toast.error("Couldn’t refresh checkout status", {
-					description: "Refresh the page to check your deployments, subscription, and wallet.",
+					description: "Refresh the page to check your agents, subscription, and wallet.",
 				});
 			});
 	}, [onCancelCopy, onNavigate, refreshCheckoutReturn, searchStr]);

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -97,8 +97,8 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 					{hostedAccess.isLoading ? null : !hostedAccess.canCreateCloudAgents &&
 						state.ctaTarget === "start_new" ? (
 						<span className="text-xs text-muted-foreground">
-							Starting a new subscription is temporarily unavailable. This deployment remains
-							visible and manageable.
+							Starting a new subscription is temporarily unavailable. This agent remains visible and
+							manageable.
 						</span>
 					) : state.ctaTarget === "top_up" ? (
 						<Button

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -208,7 +208,7 @@ describe("computeDunningState", () => {
 			}),
 		);
 		expect(unavailable?.description).toContain(
-			"can’t determine whether this deployment stopped or is using included Basic",
+			"can’t determine whether this agent stopped or is using included Basic",
 		);
 		expect(unavailable?.description).not.toContain("is now using included Basic");
 	});

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -122,10 +122,10 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fundingSource: fallback.funding_source,
 		recoveryAction: "start_new",
 		description: statusUnavailable
-			? "We can’t determine whether this deployment stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
+			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
 			: stopped
-				? "No included Basic slot was available, so this deployment stopped. Start a new subscription to restore paid compute."
-				: "This deployment is now using included Basic. Start a new subscription to restore paid compute.",
+				? "No included Basic slot was available, so this agent stopped. Start a new subscription to restore paid compute."
+				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
 		invoiceUrl: null,
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
@@ -167,7 +167,7 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			tone: "destructive",
 			title: "Compute subscription ended",
 			description:
-				"This paid subscription is terminal. Start a new subscription for the fallback deployment to restore paid compute.",
+				"This paid subscription ended. Start a new subscription for this agent to restore paid compute.",
 			ctaTarget: "start_new",
 		};
 	}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -100,13 +100,11 @@ describe("deploy wizard product copy and flow", () => {
 });
 
 describe("hosted agent security and copy", () => {
-	test("renders runtime secrets through the shared masked token control", () => {
+	test("masks the required Hermes password and keeps the OpenClaw token out of the page", () => {
 		expect(agentDetailSource).toContain(
-			'<TokenReveal label="Password" value={credentials.value.password} />',
+			'<TokenReveal label="Password" value={hermesCredentials.password} />',
 		);
-		expect(agentDetailSource).toContain(
-			'<TokenReveal label="Token" value={credentials.value.token} />',
-		);
+		expect(agentDetailSource).not.toContain('<TokenReveal label="Token"');
 		expect(agentDetailSource).not.toContain("hermes-password-");
 		expect(agentDetailSource).not.toContain("openclaw-token-");
 	});
@@ -150,6 +148,13 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).toContain("acceptedDeploymentNavigation(created.deploymentId)");
 		expect(wizardSource).toContain("acceptedDeploymentNavigation(outcome.deploymentId)");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
+	});
+
+	test("keeps setup progress on the destination and bounds the payment-only notice", () => {
+		expect(wizardSource).not.toContain("Agent deployment started");
+		expect(wizardSource).not.toContain("agent is getting ready now");
+		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
+		expect(wizardSource).toContain("toast.dismiss(WALLET_PAYMENT_TOAST_ID)");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -32,6 +32,10 @@ const addProviderDialogSource = readFileSync(
 	new URL("../../v2/ai-providers/add-provider-dialog.tsx", import.meta.url),
 	"utf8",
 );
+const addProviderDialogLogicSource = readFileSync(
+	new URL("../../v2/ai-providers/add-provider-dialog.logic.ts", import.meta.url),
+	"utf8",
+);
 const aiProviderHooksSource = readFileSync(
 	new URL("../../v2/ai-providers/ai-providers-hooks.ts", import.meta.url),
 	"utf8",
@@ -83,7 +87,7 @@ describe("deploy wizard product copy and flow", () => {
 		expect(wizardSource).toContain('<Badge variant="secondary">Recommended</Badge>');
 		expect(wizardSource).toContain("Agent software can’t be changed later");
 		expect(wizardSource).toContain(
-			"To switch after deployment, you must delete this agent and deploy a new one.",
+			"To switch after creation, you must delete this agent and create a new one.",
 		);
 		expect(runtimesSource).toContain("Chat with and manage your agent in the Hermes Dashboard.");
 		expect(runtimesSource).toContain("already use OpenClaw and want its Control UI and workflows.");
@@ -155,6 +159,18 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("agent is getting ready now");
 		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
 		expect(wizardSource).toContain("toast.dismiss(WALLET_PAYMENT_TOAST_ID)");
+	});
+
+	test("keeps infrastructure vocabulary out of customer copy", () => {
+		expect(planComparisonSource).toContain("Always-on agent with TEE protection");
+		expect(planComparisonSource).toContain("Public ports for agent services");
+		expect(planComparisonSource).not.toContain("hosted runtime");
+		expect(planComparisonSource).not.toContain("runtime-owned services");
+		expect(addProviderDialogSource).toContain("Agent environment variable");
+		expect(addProviderDialogSource).not.toContain("Runtime mapping");
+		expect(addProviderDialogSource).not.toContain("Runtime env var");
+		expect(addProviderDialogLogicSource).not.toContain("manifest secret");
+		expect(addProviderDialogLogicSource).not.toContain("hosted runtime");
 	});
 });
 
@@ -228,7 +244,7 @@ describe("billing-read gates", () => {
 		expect(wizardSource).toContain("activeIncludedBasicSlot === null");
 		expect(wizardSource).toContain("Free Basic agent availability is unknown");
 		expect(wizardSource).toContain("No free agent is assumed.");
-		expect(wizardSource).toContain('title="Couldn\'t check deployment inventory"');
+		expect(wizardSource).toContain('title="Couldn\'t check existing agents"');
 		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
 		expect(wizardSource).toContain('title="Couldn\'t load your Wallet balance"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -185,6 +185,21 @@ function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
 	return { href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace };
 }
 
+const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";
+const WALLET_PAYMENT_TOAST_DURATION_MS = 8_000;
+
+function showWalletPaymentConfirmation(amount: string) {
+	toast.success("Wallet payment confirmed", {
+		id: WALLET_PAYMENT_TOAST_ID,
+		description: `${amount} was paid from Wallet.`,
+		duration: Number.POSITIVE_INFINITY,
+	});
+	globalThis.setTimeout(
+		() => toast.dismiss(WALLET_PAYMENT_TOAST_ID),
+		WALLET_PAYMENT_TOAST_DURATION_MS,
+	);
+}
+
 const aiProviderErrorNormalizer: ApiErrorNormalizer = {
 	isAuthError: isApiAuthError,
 	normalizeError: (error) => `${normalizeApiError(error)} Managed AI still works.`,
@@ -632,15 +647,10 @@ export function DeployWizard() {
 
 	function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
 		setCheckoutSession(null);
-		toast.success("Agent deployment started", {
-			description:
-				"Your active subscription was reused without another charge. Your agent is getting ready now.",
-		});
 		void router.navigate(acceptedDeploymentNavigation(deploymentId));
 	}
 	async function handleCheckoutComplete(
 		previousDeploymentIds: readonly string[],
-		tierLabel: "Basic" | "Performance",
 		request: SubscriptionCreateRequestView | null,
 	) {
 		setCheckoutSession(null);
@@ -662,9 +672,6 @@ export function DeployWizard() {
 					const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
 					forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 					checkoutAttemptRef.current = null;
-					toast.success("Agent deployment started", {
-						description: `Your ${tierLabel} agent is getting ready now.`,
-					});
 					void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
 					return;
 				} catch (error) {
@@ -710,9 +717,6 @@ export function DeployWizard() {
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
 			}
-			toast.success("Agent deployment started", {
-				description: `Your ${tierLabel} agent is getting ready now.`,
-			});
 			void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
 		} finally {
 			setSubmitting(false);
@@ -788,9 +792,11 @@ export function DeployWizard() {
 					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
-					toast.success("Agent deployment started", {
-						description: `Your ${paidSelection.tierLabel} agent is getting ready now. ${walletDebit ? formatUsdExact(walletDebit.debitAmountUsd) : formatCents(paidSelection.offer.price_cents)} was paid from Wallet.`,
-					});
+					showWalletPaymentConfirmation(
+						walletDebit
+							? formatUsdExact(walletDebit.debitAmountUsd)
+							: formatCents(paidSelection.offer.price_cents),
+					);
 					void router.navigate(acceptedDeploymentNavigation(outcome.deploymentId));
 					return;
 				}
@@ -872,9 +878,6 @@ export function DeployWizard() {
 				});
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
-			toast.success("Agent deployment started", {
-				description: "Your first Basic agent is getting ready now for free.",
-			});
 			void router.navigate(acceptedDeploymentNavigation(created.deploymentId));
 		} catch (e) {
 			const normalized = normalizeBillingError(e);
@@ -1591,7 +1594,6 @@ export function DeployWizard() {
 				onComplete={() =>
 					void handleCheckoutComplete(
 						checkoutSession?.previousDeploymentIds ?? [],
-						checkoutSession?.tierLabel ?? "Basic",
 						checkoutSession?.request ?? null,
 					)
 				}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1029,7 +1029,7 @@ export function DeployWizard() {
 						<TriangleAlert />
 						<AlertTitle>Agent software can’t be changed later</AlertTitle>
 						<AlertDescription>
-							To switch after deployment, you must delete this agent and deploy a new one.
+							To switch after creation, you must delete this agent and create a new one.
 						</AlertDescription>
 					</Alert>
 				</SettingsSection>
@@ -1189,7 +1189,7 @@ export function DeployWizard() {
 									normalizer={billingErrorNormalizer}
 									error={deployments.error}
 									onRetry={() => void deployments.refetch()}
-									title="Couldn't check deployment inventory"
+									title="Couldn't check existing agents"
 								/>
 							) : (
 								<p className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
@@ -1308,7 +1308,7 @@ export function DeployWizard() {
 								<div>
 									<div className="text-sm font-medium">Payment method</div>
 									<p className="text-xs text-muted-foreground">
-										Choose how this deployment renews. You can review the charge before paying.
+										Choose how this agent’s compute renews. You can review the charge before paying.
 									</p>
 								</div>
 								<div className="grid gap-2 sm:grid-cols-2">

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -182,7 +182,10 @@ const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 const DEPLOY_MANAGED_AI_LABEL = "Managed AI";
 
 function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
-	return { href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace };
+	return {
+		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi&setup=accepted"),
+		replace,
+	};
 }
 
 const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -143,7 +143,7 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Always-on hosted runtime + TEE</FeatureRow>
+							<FeatureRow>Always-on agent with TEE protection</FeatureRow>
 							<FeatureRow>
 								Burstable compute
 								{basicResources
@@ -226,7 +226,7 @@ export function PlanComparison({
 								{performance ? ` (${performance.vcpu} vCPU / ${performance.ram_gb} GB)` : ""}
 							</FeatureRow>
 							<FeatureRow>One subscription per Performance agent</FeatureRow>
-							<FeatureRow>Public-port entitlement for runtime-owned services</FeatureRow>
+							<FeatureRow>Public ports for agent services</FeatureRow>
 							<FeatureRow>
 								Larger disk{performance ? ` (${performance.disk_size} GB)` : ""}
 							</FeatureRow>

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -130,7 +130,7 @@ describe("subscription creation adapter", () => {
 			entitledUntil: "2027-07-16T00:00:00Z",
 		});
 		expect(() => subscriptionCreateOutcome({ ...activation, deployment_id: null })).toThrow(
-			"Wallet activation did not accept a deployment target.",
+			"Wallet activation did not return an agent.",
 		);
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -137,7 +137,7 @@ export function subscriptionCreateOutcome(result: CheckoutResult): SubscriptionC
 		flowType: "subscription_activation",
 		deploymentId: acceptDeclarativeOperation(
 			{ deploymentId: result.deployment_id, operation: null },
-			"Wallet activation did not accept a deployment target.",
+			"Wallet activation did not return an agent.",
 		).deploymentId,
 		deployRequestId: result.deploy_request_id ?? null,
 		currentPeriodEnd: result.current_period_end ?? null,

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -282,7 +282,7 @@ function apiKeyHelpText(kind: ApiKeyKeepKind | undefined): string {
 	if (kind === "managed") {
 		return "Leave blank to keep the current managed key. Enter a key to replace it.";
 	}
-	return "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again.";
+	return "Clawdi stores this key encrypted and securely gives it to your agent. The dashboard will not show it again.";
 }
 
 function normalizeLabel(value: string | null | undefined): string | null {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -864,7 +864,7 @@ export function AddProviderDialog({
 														? `Preset mapping · ${API_MODE_LABEL[apiMode]} · primary ${selectedPreset.suggested_primary_model}`
 														: authMethod === "oauth"
 															? `ChatGPT/Codex mapping · ${catalogSummary || "No catalog models"}`
-															: `Runtime mapping · ${API_MODE_LABEL[apiMode]} · ${catalogSummary || "No catalog models"}`}
+															: `Custom mapping · ${API_MODE_LABEL[apiMode]} · ${catalogSummary || "No catalog models"}`}
 												</p>
 												<p className="mt-1 break-all font-mono text-xs text-muted-foreground">
 													{baseUrl}
@@ -1001,7 +1001,7 @@ export function AddProviderDialog({
 
 												{showRuntimeEnvField ? (
 													<div className="flex flex-col gap-1.5">
-														<Label htmlFor="provider-env">Runtime env var</Label>
+														<Label htmlFor="provider-env">Agent environment variable</Label>
 														<Input
 															id="provider-env"
 															name="provider-env"

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -831,7 +831,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 				title={WHATSAPP_LINKING_READY ? "Link a WhatsApp number" : "WhatsApp is coming soon"}
 			>
 				{WHATSAPP_LINKING_READY
-					? "WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by scanning it in WhatsApp -> Linked devices. The credential is handed to the agent runtime to complete pairing."
+					? "WhatsApp uses no bot token. Create secure access for an agent, then finish the link by scanning it in WhatsApp → Linked devices. The agent uses that access to complete pairing."
 					: WHATSAPP_COMING_SOON_MESSAGE}
 			</InfoCard>
 
@@ -1187,7 +1187,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 						<TokenReveal
 							label="Agent token"
 							value={visibleAgentToken}
-							note="Copy it now. It won't be shown again. The agent runtime uses this to send and receive on this channel."
+							note="Copy it now. It won't be shown again. The agent uses it to send and receive on this channel."
 						/>
 					) : null}
 				</div>
@@ -1465,7 +1465,7 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 					) : sync.data ? (
 						<EmptyState
 							variant="inset"
-							description="Command sync completed. The runtime returned no commands to publish."
+							description="Command sync completed. The agent returned no commands to publish."
 						/>
 					) : null}
 				</>

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -5,6 +5,9 @@ const agentChannels = readFileSync(
 	new URL("../../agents/hosted-agent-detail.tsx", import.meta.url),
 	"utf8",
 );
+const channelDetail = readFileSync(new URL("./channel-detail-page.tsx", import.meta.url), "utf8");
+const channelHooks = readFileSync(new URL("./channels-hooks.ts", import.meta.url), "utf8");
+const linkAgentDialog = readFileSync(new URL("./link-agent-dialog.tsx", import.meta.url), "utf8");
 
 describe("hosted-agent channel finish line", () => {
 	test("assembles the existing live health query into an honest automatic activity state", () => {
@@ -44,5 +47,16 @@ describe("hosted-agent channel finish line", () => {
 		expect(agentChannels).toContain("Choose a channel while you wait");
 		expect(agentChannels).not.toContain("minting its cloud agent id");
 		expect(agentChannels).not.toContain("shared-pool");
+	});
+
+	test("describes channel setup without infrastructure vocabulary", () => {
+		const customerCopy = `${channelDetail}\n${channelHooks}\n${linkAgentDialog}`;
+		expect(customerCopy).toContain("Open the agent’s Channels page");
+		expect(channelDetail).not.toContain("Mint a device credential");
+		expect(channelDetail).not.toContain("The agent runtime uses");
+		expect(channelDetail).not.toContain("The runtime returned");
+		expect(channelHooks).not.toContain('description: "Finish pairing from the agent runtime');
+		expect(linkAgentDialog).not.toContain("Finish device pairing from the agent runtime");
+		expect(linkAgentDialog).not.toContain("self-managed runtime that asks for it");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -310,7 +310,7 @@ export function useCreateWhatsappTenantCred(accountId: string) {
 			);
 			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
 			toast.success("WhatsApp access is ready", {
-				description: "Finish pairing from the agent runtime to link the number.",
+				description: "Open the agent’s Channels page to finish pairing the number.",
 			});
 		} catch (error) {
 			toastApiError("Couldn't link WhatsApp device")(error);

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -126,7 +126,7 @@ export function LinkAgentDialog({
 					setWhatsappCredentialMinted(true);
 				} else {
 					toast.success("Agent linked", {
-						description: `${accountName} is linked. Finish device pairing from the agent runtime.`,
+						description: `${accountName} is linked. Open the agent’s Channels page to finish device pairing.`,
 					});
 				}
 				return;
@@ -208,7 +208,7 @@ export function LinkAgentDialog({
 									<TokenReveal
 										label="Agent token"
 										value={token}
-										note="Hosted agents configure this automatically. Only copy it for a self-managed runtime that asks for it."
+										note="Clawdi agents configure this automatically. Only copy it for a self-managed agent that asks for it."
 									/>
 								</div>
 							</details>
@@ -217,7 +217,7 @@ export function LinkAgentDialog({
 				) : whatsappCredentialMinted ? (
 					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
 						<CircleCheck className="size-4 shrink-0" />
-						WhatsApp access is ready. Finish linking the number from the agent runtime.
+						WhatsApp access is ready. Open the agent’s Channels page to finish linking the number.
 					</div>
 				) : envs.isLoading ? (
 					<Skeleton className="h-10 w-full rounded-md" />

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -61,11 +61,20 @@ describe("agent routes", () => {
 	});
 
 	it("distinguishes a freshly accepted hosted route from normal and unknown routes", () => {
-		expect(isAcceptedHostedAgentRoute("hdep_accepted", "source=on-clawdi")).toBe(true);
+		expect(isAcceptedHostedAgentRoute("hdep_accepted", "source=on-clawdi&setup=accepted")).toBe(
+			true,
+		);
+		expect(isAcceptedHostedAgentRoute("hdep_unknown", "source=on-clawdi")).toBe(false);
 		expect(
 			isAcceptedHostedAgentRoute(
 				"9f6e5c8f-5af3-55fe-97ab-c9eb3cd7859d",
-				"source=on-clawdi&d=hdep_accepted",
+				"source=on-clawdi&setup=accepted",
+			),
+		).toBe(false);
+		expect(
+			isAcceptedHostedAgentRoute(
+				"hdep_accepted",
+				"source=on-clawdi&setup=accepted&d=hdep_accepted",
 			),
 		).toBe(false);
 		expect(isAcceptedHostedAgentRoute("hdep_unknown", undefined)).toBe(false);

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -12,6 +12,7 @@ import {
 	CONNECTED_AGENT_SECTION_IDS,
 	HOSTED_AGENT_SECTION_IDS,
 	hasAgentTabQuery,
+	isAcceptedHostedAgentRoute,
 	parseAgentPathname,
 	parseAgentSectionSegment,
 } from "./agent-routes";
@@ -57,6 +58,17 @@ describe("agent routes", () => {
 		expect(agentSectionHref("agent 1", "settings", agentDeploymentRouteQuery(query))).toBe(
 			"/agents/agent%201/settings?source=on-clawdi&d=dep_older",
 		);
+	});
+
+	it("distinguishes a freshly accepted hosted route from normal and unknown routes", () => {
+		expect(isAcceptedHostedAgentRoute("hdep_accepted", "source=on-clawdi")).toBe(true);
+		expect(
+			isAcceptedHostedAgentRoute(
+				"9f6e5c8f-5af3-55fe-97ab-c9eb3cd7859d",
+				"source=on-clawdi&d=hdep_accepted",
+			),
+		).toBe(false);
+		expect(isAcceptedHostedAgentRoute("hdep_unknown", undefined)).toBe(false);
 	});
 
 	it("parses only canonical section segments", () => {

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -86,7 +86,9 @@ describe("agent routes", () => {
 
 	it("keeps labels and URL segments in one route table", () => {
 		expect(agentSectionLabel("projects")).toBe("Project Access");
+		expect(agentSectionLabel("console")).toBe("Agent Interface");
 		expect(agentSectionLabelFromSegment("project-access")).toBe("Project Access");
+		expect(agentSectionLabelFromSegment("console")).toBe("Agent Interface");
 		expect(agentSectionLabelFromSegment("model-provider")).toBe("Model Provider");
 		expect(agentSectionLabelFromSegment("settings")).toBe("Settings");
 		expect(agentSectionLabelFromSegment("bad")).toBeNull();

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -13,6 +13,7 @@ export type RouteSearchParamsRecord = Record<string, string | string[] | undefin
 export type AgentRouteQuery = string | URLSearchParams | RouteSearchParamsRecord | null | undefined;
 
 export const AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY = "d";
+const AGENT_ACCEPTED_SETUP_QUERY_KEY = "setup";
 
 export const CONNECTED_AGENT_SECTION_IDS = [
 	"overview",
@@ -142,6 +143,7 @@ export function isAcceptedHostedAgentRoute(agentId: string, query?: AgentRouteQu
 	return (
 		agentId.toLowerCase().startsWith("hdep_") &&
 		params.get("source") === "on-clawdi" &&
+		params.get(AGENT_ACCEPTED_SETUP_QUERY_KEY) === "accepted" &&
 		agentDeploymentSelector(params) === null
 	);
 }

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -132,6 +132,20 @@ export function agentDeploymentSelector(query?: AgentRouteQuery): string | null 
 	return selector || null;
 }
 
+/**
+ * The create flow initially routes by the accepted deployment id because the
+ * stable agent id does not exist yet. Once inventory catches up, normal hosted
+ * links carry a separate deployment selector and use the stable agent id.
+ */
+export function isAcceptedHostedAgentRoute(agentId: string, query?: AgentRouteQuery): boolean {
+	const params = agentRouteSearchParams(query);
+	return (
+		agentId.toLowerCase().startsWith("hdep_") &&
+		params.get("source") === "on-clawdi" &&
+		agentDeploymentSelector(params) === null
+	);
+}
+
 export function agentDeploymentRouteQuery(
 	query?: AgentRouteQuery,
 ): RouteSearchParamsRecord | undefined {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -50,7 +50,7 @@ const AGENT_SECTION_LABELS = {
 	sessions: "Sessions",
 	skills: "Skills",
 	projects: "Project Access",
-	console: "Runtime UI",
+	console: "Agent Interface",
 	terminal: "Terminal",
 	ai: "Model Provider",
 	channels: "Channel Links",


### PR DESCRIPTION
## Summary

- mark successful create navigation as an explicitly accepted setup route, so the first detail frame says `Setting up your agent` without exposing `hdep_…`
- keep accepted setup polling bounded and distinguish loading, accepted work, unknown agents, and load failures
- remove the embedded runtime iframe and converge Hermes/OpenClaw access on one no-`opener` top-level window credential handoff
- remove stale setup toasts, retain only the actual Wallet payment confirmation, and force that notice to expire after eight seconds
- replace remaining customer-facing deployment/runtime/sync vocabulary in the touched hosted surfaces

## Runtime UI decision

The iframe is removed. Hermes authentication only persists in its own first-party window, so leaving the login form embedded would preserve a known silent failure. Both runtimes now fetch and validate credentials through one production call site before navigating the pre-opened secure window. Hermes username/password are revealed in component memory after launch so the user can sign in; the OpenClaw token never renders in the Clawdi DOM. Popup and credential failures close the empty window and provide safe retry guidance without backend detail.

## Already handled by #500

Current `main` already removed hosted tile/sidebar status noise and `autoOpenRuntimeUi`, changed `Provisioning` to customer language, removed `Sync record unavailable` and related synced-data/hosted-compute copy, made `Your agent is ready` persist on Overview, fixed the sidebar hydration cause, and protected hosted failure copy from raw exception detail. This PR does not duplicate those fixes.

## URL assessment

The address bar still exposes the deployment id during initial convergence and the environment UUID on canonical agent routes. Fixing that safely needs a stable customer-safe agent handle plus coordinated route/API lookup, deep-link, redirect, and compatibility behavior. This PR deliberately does not half-migrate route identity; a focused follow-up should own that design. The new `setup=accepted` value is a non-sensitive state marker, not an identifier fix.

## Verification

- current `main` hosted Playwright baseline: **60/60**
- branch hosted Playwright: **60/60** (4.7m)
- `bun run typecheck`: **4/4**
- `bun run lint`: **705 files**
- `bun test`: **1718/1718**, 183 files, 6969 assertions
- `bun run test` clean runner: web **1018/1018**; backend **1353 passed, 7 skipped**
- focused accepted-arrival Playwright: **1/1**
- protected deploy contract files unchanged; no v1 web behavior changed
- worktree clean; remote branch HEAD equals local HEAD

One earlier hosted Playwright attempt was 59/60 because Vite failed to dynamically import its own client entry while the dev server was starting. The failed case passed on the clean full rerun above.

## Scope correction

The named `backend/app/core/config.py:227` default and `backend/scripts/v2_declarative_real_e2e_smoke.py` do not exist in current `clawdi`. The web reads `signup_grant_usd` from the plans API; the hosted fixture and browser coverage show `$5.00`. No grant logic changed. The observed raw `HTTP 403` came from the external Hermes Dashboard, not Clawdi customer copy; Clawdi already maps its own insufficient-balance 402/403 responses to Wallet/top-up guidance.