### PR TITLE
Delete dismisses the agent immediately; teardown runs behind it

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -706,7 +706,7 @@ function mutationDeploymentReadFixture(deployment: DeploymentMutationFixture): D
 function completedDeploymentOperation(
 	deployment: DeploymentMutationFixture,
 	verb: "create" | "start" | "stop" | "restart" | "delete" | "update",
-) {
+): NonNullable<DeploymentRead["accepted_operation"]> {
 	const resource = mutationDeploymentReadFixture(deployment).resource;
 	return {
 		name: `operations/e2e-${verb}-${resource.id}`,
@@ -723,6 +723,38 @@ function completedDeploymentOperation(
 		response: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationResponse",
 			deployment: resource,
+		},
+	};
+}
+
+function failedDeletionReadFixture(
+	deployment: DeploymentMutationFixture,
+	retryable: boolean,
+): DeploymentRead {
+	const read = mutationDeploymentReadFixture({ ...deployment, status: "failed" });
+	const status = read.resource.status;
+	if (status === null) throw new Error("Failed deletion fixture requires deployment status");
+	return {
+		...read,
+		accepted_operation: completedDeploymentOperation(deployment, "delete"),
+		resource: {
+			...read.resource,
+			status: {
+				...status,
+				failure: {
+					type: "https://api.clawdi.ai/problems/deployment-delete-failed",
+					title: "Deployment deletion failed",
+					status: 409,
+					detail: "The deployment could not be deleted.",
+					instance: deployment.id,
+					code: "deployment_delete_failed",
+					phase: "delete",
+					retryable,
+					conditionReason: "DeploymentDeleteFailed",
+					conditionMessage: "The deployment could not be deleted.",
+					observedGeneration: 2,
+				},
+			},
 		},
 	};
 }
@@ -766,6 +798,7 @@ type HostedApiStubOptions = {
 	createDeploymentRequests?: Array<{ body: string; idempotencyKey: string | null }>;
 	deleteRequests?: string[];
 	completedDeleteIds?: Set<string>;
+	failedDeleteRetryability?: Map<string, boolean>;
 	deleteResponses?: StubResponse[];
 	deploymentListRequests?: string[];
 	deploymentRequestReads?: string[];
@@ -927,7 +960,12 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					)
 					.map((deployment) =>
 						isDeploymentMutationFixture(deployment) && acceptedDeleteIds.has(deployment.id)
-							? readDeploymentFixture({ ...deployment, status: "deleting" })
+							? options.failedDeleteRetryability?.has(deployment.id)
+								? failedDeletionReadFixture(
+										deployment,
+										options.failedDeleteRetryability.get(deployment.id) ?? false,
+									)
+								: readDeploymentFixture({ ...deployment, status: "deleting" })
 							: readDeploymentFixture(deployment),
 					),
 			);
@@ -1618,16 +1656,18 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
 });
 
-test("accepted detail delete navigates after deployment membership disappears", async ({
+test("accepted detail delete dismisses immediately while teardown finishes in the background", async ({
 	page,
 }) => {
 	const deleteRequests: string[] = [];
+	const deploymentListRequests: string[] = [];
 	const completedDeleteIds = new Set<string>();
 	await stubHostedApi(page, {
 		deployments: [includedBasicDeployment],
 		plans: [basicPlan, performancePlan],
 		completedDeleteIds,
 		deleteRequests,
+		deploymentListRequests,
 	});
 	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
 
@@ -1638,14 +1678,48 @@ test("accepted detail delete navigates after deployment membership disappears", 
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
-	await expect(page).toHaveURL(/\/agents\/hdep_included\/settings/);
-	await expect(
-		page.locator("main").getByRole("button", { name: "Delete", exact: true }),
-	).toBeDisabled();
-
-	completedDeleteIds.add("hdep_included");
 	await expect(page).toHaveURL(/\/agents\/?$/);
-	await expect(page.getByText("Agent deleted", { exact: true })).toBeVisible();
+	await expect(page.getByText("Agent removed", { exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
+	await expect(page.getByTestId("app-sidebar-agent-tiles").getByLabel("Basic")).toHaveCount(0);
+	// The deployment is still in the stubbed inventory as `deleting`; dismissal
+	// therefore precedes teardown rather than waiting for a completed list read.
+	expect(completedDeleteIds.has("hdep_included")).toBe(false);
+
+	const readsBeforeCompletion = deploymentListRequests.length;
+	completedDeleteIds.add("hdep_included");
+	await expect
+		.poll(() => deploymentListRequests.length, { timeout: 10_000 })
+		.toBeGreaterThan(readsBeforeCompletion);
+	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
+});
+
+test("failed background deletion stays dismissed and surfaces an honest recovery action", async ({
+	page,
+}) => {
+	const failedDeleteRetryability = new Map<string, boolean>();
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+		failedDeleteRetryability,
+	});
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete agent", exact: true })
+		.click();
+	await expect(page).toHaveURL(/\/agents\/?$/);
+
+	failedDeleteRetryability.set("hdep_included", false);
+	await expect(
+		page.getByText("Cleanup for Included Basic needs attention", { exact: true }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Contact support", exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Retry cleanup", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
+	await expect(page.getByTestId("app-sidebar-agent-tiles").getByLabel("Basic")).toHaveCount(0);
 });
 
 test("managed model picker lists the curated catalog without Custom or image models", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1694,34 +1694,6 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
 });
 
-test("failed background deletion stays dismissed and surfaces an honest recovery action", async ({
-	page,
-}) => {
-	const failedDeleteRetryability = new Map<string, boolean>();
-	await stubHostedApi(page, {
-		deployments: [includedBasicDeployment],
-		plans: [basicPlan, performancePlan],
-		failedDeleteRetryability,
-	});
-	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
-
-	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
-	await page
-		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete agent", exact: true })
-		.click();
-	await expect(page).toHaveURL(/\/agents\/?$/);
-
-	failedDeleteRetryability.set("hdep_included", false);
-	await expect(
-		page.getByText("Cleanup for Included Basic needs attention", { exact: true }),
-	).toBeVisible();
-	await expect(page.getByRole("button", { name: "Contact support", exact: true })).toBeVisible();
-	await expect(page.getByRole("button", { name: "Retry cleanup", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
-	await expect(page.getByTestId("app-sidebar-agent-tiles").getByLabel("Basic")).toHaveCount(0);
-});
-
 test("managed model picker lists the curated catalog without Custom or image models", async ({
 	page,
 }) => {
@@ -2291,9 +2263,11 @@ test("shared legacy environment direct route asks the user to choose an agent", 
 
 test("identity-less interrupted deployment tile exposes delete", async ({ page }) => {
 	const deleteRequests: string[] = [];
+	const failedDeleteRetryability = new Map<string, boolean>();
 	await stubHostedApi(page, {
 		deployments: [interruptedIdentitylessDeployment],
 		deleteRequests,
+		failedDeleteRetryability,
 	});
 
 	await page.goto("/agents");
@@ -2305,6 +2279,15 @@ test("identity-less interrupted deployment tile exposes delete", async ({ page }
 		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_creation_interrupted"]);
+	await expect(deleteAction).toHaveCount(0);
+
+	failedDeleteRetryability.set("hdep_creation_interrupted", false);
+	await expect(
+		page.getByText("Cleanup for Interrupted deployment needs attention", { exact: true }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Contact support", exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Retry cleanup", exact: true })).toHaveCount(0);
+	await expect(deleteAction).toHaveCount(0);
 });
 
 test("Basic create always follows the wizard-selected funding path", async ({ page }) => {

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -3,7 +3,6 @@
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { AlertCircle, ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -26,7 +25,6 @@ import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/d
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { deploymentStatusFromResource, deploymentStatusLabel } from "@/hosted/deployment-status";
-import { userInitiatedDeploymentDeleteCompleted } from "@/hosted/hosted-agent-resolution";
 import { defaultDeploymentRuntime, isHostedRuntime } from "@/hosted/runtimes";
 import {
 	AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY,
@@ -41,12 +39,6 @@ import { cn } from "@/lib/utils";
 
 const UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS = 5_000;
 const UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS = 24;
-
-type UserDeleteNavigationIntent = {
-	deploymentId: string;
-	environmentId: string;
-	deploymentSelector: string | null;
-};
 
 /**
  * Agent home for hosted builds. An agent backed by a hosted deployment renders
@@ -68,7 +60,6 @@ export function AgentHome({
 	const deploymentSelector = agentDeploymentSelector(searchParams);
 	const {
 		deployment,
-		inventoryDeployments,
 		environmentId: resolvedEnvId,
 		matchedRuntime,
 		ambiguousMatches,
@@ -90,16 +81,6 @@ export function AgentHome({
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
 	const [acceptedSetupStatusTimedOut, setAcceptedSetupStatusTimedOut] = useState(false);
-	const [userDeleteIntent, setUserDeleteIntent] = useState<UserDeleteNavigationIntent | null>(null);
-	const deleteIntentStillOwnsRoute =
-		userDeleteIntent?.environmentId === environmentId &&
-		(userDeleteIntent.deploymentSelector === deploymentSelector ||
-			(userDeleteIntent.deploymentSelector === null &&
-				deploymentSelector?.toLowerCase() === userDeleteIntent.deploymentId.toLowerCase()));
-	const deletedDeploymentGone = userInitiatedDeploymentDeleteCompleted(
-		inventoryDeployments,
-		deleteIntentStillOwnsRoute ? userDeleteIntent.deploymentId : null,
-	);
 
 	// Canonicalize a resolved hosted route with its deployment selector before
 	// Stop removes the env mapping. The selector is then sufficient to retain
@@ -122,13 +103,6 @@ export function AgentHome({
 	useEffect(() => {
 		setAcceptedSetupStatusTimedOut(false);
 	}, [environmentId, deploymentSelector]);
-
-	useEffect(() => {
-		if (!deletedDeploymentGone) return;
-		setUserDeleteIntent(null);
-		toast.success("Agent deleted");
-		void router.navigate({ href: "/agents", replace: true });
-	}, [deletedDeploymentGone, router]);
 
 	useEffect(() => {
 		if (!shouldAutoRefetchUnresolvedHostedAgent || typeof window === "undefined") return;
@@ -236,9 +210,7 @@ export function AgentHome({
 				deployment={deployment}
 				runtime={runtime}
 				section={section}
-				onDeleteAccepted={(deploymentId) =>
-					setUserDeleteIntent({ deploymentId, environmentId, deploymentSelector })
-				}
+				onDeleteAccepted={() => router.navigate({ href: "/agents", replace: true })}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 				isCheckingDeployment={isFetching}
 				onCheckDeploymentAgain={handleCheckAgain}

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -31,11 +31,11 @@ import { cn } from "@/lib/utils";
 export function HostedDeploymentDeleteAction({
 	children,
 	deployment,
-	onDeleted,
+	onAccepted,
 }: {
 	children: ReactElement;
 	deployment: HostedDeployment;
-	onDeleted?: () => Promise<void> | void;
+	onAccepted?: () => Promise<void> | void;
 }) {
 	const deleteDeployment = useDeleteDeployment();
 	const cancelSubscription = useCancelSubscription();
@@ -56,7 +56,7 @@ export function HostedDeploymentDeleteAction({
 			recorded: boolean;
 			result: ComputeSubscriptionActionResult | null;
 		} = { recorded: false, result: null };
-		let deletionCompleted = false;
+		let deletionAccepted = false;
 		try {
 			await deleteDeploymentWithSubscriptionChoice({
 				choice: offerChoice ? choice : "keep_subscription",
@@ -68,7 +68,7 @@ export function HostedDeploymentDeleteAction({
 				},
 				deleteDeployment: async () => {
 					await deleteDeployment.mutateAsync(deployment.resource.id);
-					deletionCompleted = true;
+					deletionAccepted = true;
 				},
 			});
 			if (cancellationState.recorded) {
@@ -81,10 +81,10 @@ export function HostedDeploymentDeleteAction({
 				});
 			}
 			setOpen(false);
-			await onDeleted?.();
+			await onAccepted?.();
 		} catch (error) {
-			if (deletionCompleted) {
-				toast.error("Agent deleted, but navigation failed", {
+			if (deletionAccepted) {
+				toast.error("Agent removed, but navigation failed", {
 					description: "Refresh the page to update the agent list.",
 				});
 			} else if (offerChoice && choice === "cancel_subscription") {

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -217,7 +217,9 @@ export function useDeleteDeployment() {
 			),
 		onSuccess: (accepted) => {
 			projectAcceptedDeploymentTransition(qc, accepted);
-			toast.message("Deleting…");
+			toast.message("Agent removed", {
+				description: "Cleanup continues in the background.",
+			});
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -355,7 +355,7 @@ function DeleteComputeAction({
 	return (
 		<HostedDeploymentDeleteAction
 			deployment={deployment}
-			onDeleted={() => onDeleteAccepted(deployment.resource.id)}
+			onAccepted={() => onDeleteAccepted(deployment.resource.id)}
 		>
 			<Button type="button" variant={variant} size="sm" className={className} disabled={!canDelete}>
 				<Trash2 />

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -303,6 +303,25 @@ describe("hosted deployment refresh policy", () => {
 });
 
 describe("reconcileDeploymentSnapshots", () => {
+	test("retains accepted delete intent across stale reads so a dismissed agent cannot reappear", () => {
+		const accepted = acceptedOperation("delete");
+		const optimistic = hostedDeploymentFixture({
+			id: "hdep_delete",
+			status: "deleting",
+			acceptedOperation: accepted,
+		});
+		const staleServerSnapshot = hostedDeploymentFixture({
+			id: "hdep_delete",
+			status: "running",
+			acceptedOperation: acceptedOperation("start"),
+		});
+
+		const [reconciled] = reconcileDeploymentSnapshots([optimistic], [staleServerSnapshot]);
+
+		expect(reconciled?.resource.status?.summary_state).toBe("running");
+		expect(reconciled?.accepted_operation).toEqual(accepted);
+	});
+
 	test("lets a failed server snapshot override optimistic pending state and retain its verb", () => {
 		const optimistic = hostedDeploymentFixture({
 			id: "hdep_failure",

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -403,8 +403,11 @@ export function reconcileDeploymentSnapshots(
 		(previous ?? []).map((deployment) => [deployment.resource.id, deployment]),
 	);
 	const reconciled = incoming.map((deployment) => {
-		if (deployment.accepted_operation) return deployment;
 		const acceptedOperation = previousById.get(deployment.resource.id)?.accepted_operation;
+		if (acceptedOperation?.metadata.verb === "delete") {
+			return { ...deployment, accepted_operation: acceptedOperation };
+		}
+		if (deployment.accepted_operation) return deployment;
 		if (!acceptedOperation) return deployment;
 
 		const resourceStatus = deployment.resource.status;

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import type { HostedDeploymentStatus } from "@/hosted/billing/contracts";
+import type { DeploymentOperation, HostedDeploymentStatus } from "@/hosted/billing/contracts";
 import { BillingApiError, BillingNetworkError } from "@/hosted/billing/errors";
 import { deploymentStatusFromResource, parseDeploymentStatus } from "@/hosted/deployment-status";
 import {
 	canOpenHostedRuntimeUi,
+	claimedEnvIdsFromDeployments,
 	hostedDeploymentMembers,
+	isHostedDeploymentVisible,
 	missingProjectionRefetchInterval,
 	resolveAgentDeployment,
 	resolveHostedAgentProjection,
 	resolveHostedInventory,
-	userInitiatedDeploymentDeleteCompleted,
 } from "@/hosted/hosted-agent-resolution";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 import { ApiError } from "@/lib/api-errors";
@@ -25,6 +26,23 @@ function deployment(
 		createdAt: "2026-07-16T00:00:00Z",
 		endpoints: [{ name: "openclaw", url: "https://runtime.example/ui" }],
 	});
+}
+
+function acceptedDelete(deploymentId: string): DeploymentOperation {
+	return {
+		name: `operations/delete-${deploymentId}`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId,
+			verb: "delete",
+			targetGeneration: 2,
+			manifestETag: "manifest-delete",
+			createTime: "2026-07-27T00:00:00Z",
+			updateTime: "2026-07-27T00:00:00Z",
+		},
+		done: false,
+		response: null,
+	};
 }
 
 describe("hosted inventory resolution matrix", () => {
@@ -105,18 +123,32 @@ describe("hosted inventory resolution matrix", () => {
 });
 
 describe("hosted detail projection resolution", () => {
-	test("redirects only when the user-deleted deployment leaves authoritative membership", () => {
-		const deleting = deployment("deleting", "hdep_user_deleted");
-		const failed = deployment("failed", "hdep_user_deleted");
-		const deleted = deployment("deleted", "hdep_user_deleted");
-		const unrelated = deployment("running", "hdep_unrelated");
+	test("dismisses an accepted delete without releasing its hosted ownership claim", () => {
+		const environmentId = "55555555-5555-4555-8555-555555555555";
+		const deploymentId = "hdep_user_deleted";
+		const deleting = hostedDeploymentFixture({
+			id: deploymentId,
+			status: "deleting",
+			cloudEnvironments: { openclaw: environmentId },
+			acceptedOperation: acceptedDelete(deploymentId),
+		});
 
-		expect(userInitiatedDeploymentDeleteCompleted([deleting], "hdep_user_deleted")).toBe(false);
-		expect(userInitiatedDeploymentDeleteCompleted([failed], "hdep_user_deleted")).toBe(false);
-		expect(userInitiatedDeploymentDeleteCompleted([deleted], "hdep_user_deleted")).toBe(true);
-		expect(userInitiatedDeploymentDeleteCompleted([unrelated], "hdep_user_deleted")).toBe(true);
-		expect(userInitiatedDeploymentDeleteCompleted([], null)).toBe(false);
-		expect(userInitiatedDeploymentDeleteCompleted(null, "hdep_user_deleted")).toBe(false);
+		expect(isHostedDeploymentVisible(deleting)).toBe(false);
+		expect(hostedDeploymentMembers([deleting])).toEqual([deleting]);
+		expect(claimedEnvIdsFromDeployments([deleting])).toEqual(new Set([environmentId]));
+		expect(resolveAgentDeployment([deleting], environmentId, deploymentId).match).toBeNull();
+	});
+
+	test("does not resurrect a dismissed agent when background deletion fails", () => {
+		const deploymentId = "hdep_delete_failed";
+		const failed = hostedDeploymentFixture({
+			id: deploymentId,
+			status: "failed",
+			acceptedOperation: acceptedDelete(deploymentId),
+		});
+
+		expect(isHostedDeploymentVisible(failed)).toBe(false);
+		expect(resolveAgentDeployment([failed], deploymentId).match).toBeNull();
 	});
 
 	test("keeps a selected stopped deployment addressable after its projection is removed", () => {

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -42,27 +42,20 @@ export function isHostedDeploymentMember(deployment: HostedDeployment): boolean 
 	return deploymentStatusFromResource(deployment.resource.status).kind !== "deleted";
 }
 
+/** Accepted deletion dismisses the agent while its deployment remains observable for cleanup. */
+export function isHostedDeploymentVisible(deployment: HostedDeployment): boolean {
+	const status = deploymentStatusFromResource(deployment.resource.status);
+	return (
+		status.kind !== "deleting" &&
+		status.kind !== "deleted" &&
+		deployment.accepted_operation?.metadata.verb !== "delete"
+	);
+}
+
 export function hostedDeploymentMembers(
 	deployments: readonly HostedDeployment[],
 ): HostedDeployment[] {
 	return deployments.filter(isHostedDeploymentMember);
-}
-
-/**
- * A detail-page delete is complete only after the accepted deployment leaves
- * authoritative inventory membership. Cloud-agent projection misses are not
- * part of this decision and therefore cannot redirect an unrelated detail.
- */
-export function userInitiatedDeploymentDeleteCompleted(
-	deployments: readonly HostedDeployment[] | null,
-	deploymentId: string | null,
-): boolean {
-	if (!deploymentId || deployments === null) return false;
-	const target = deploymentId.toLowerCase();
-	return !deployments.some(
-		(deployment) =>
-			isHostedDeploymentMember(deployment) && deployment.resource.id.toLowerCase() === target,
-	);
 }
 
 /** One claimed-id set shared by list deduplication and ownership chrome. */
@@ -94,7 +87,7 @@ export function resolveAgentDeployment(
 	environmentId: string,
 	deploymentSelector?: string | null,
 ): AgentDeploymentResolution {
-	const members = hostedDeploymentMembers(deployments);
+	const members = deployments.filter(isHostedDeploymentVisible);
 	const target = environmentId.toLowerCase();
 	const direct = members.find((deployment) => deployment.resource.id.toLowerCase() === target);
 	if (direct) {

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
+import { AlertCircle, LifeBuoy } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentSourceBadge } from "@/components/dashboard/agent-label";
 import {
@@ -10,8 +11,14 @@ import {
 } from "@/components/dashboard/agents-card";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
+import { deploymentFailurePresentation } from "@/hosted/deployment-failure";
 import { useUnifiedAgentList } from "@/hosted/use-unified-agent-list";
 
 type Env = components["schemas"]["AgentResponse"];
@@ -21,6 +28,49 @@ function HostedEmptyAccountHero() {
 		<div className="space-y-4">
 			<OnboardingCard variant="first-agent" hosted />
 			<WelcomeWalletCard showDeployAction={false} />
+		</div>
+	);
+}
+
+function HostedDeletionFailureNotices({ deployments }: { deployments: HostedDeployment[] }) {
+	if (deployments.length === 0) return null;
+	return (
+		<div className="space-y-3">
+			{deployments.map((deployment) => {
+				const failure = deploymentFailurePresentation(deployment);
+				if (failure?.failedVerb !== "delete") return null;
+				const name = deploymentDisplayName(deployment.resource.spec.name);
+				const retrySafe = failure.retryable !== false;
+				return (
+					<Alert key={deployment.resource.id} variant="destructive">
+						<AlertCircle />
+						<AlertTitle>{`Cleanup for ${name} needs attention`}</AlertTitle>
+						<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+							<span>
+								The agent stays out of your list, but the Clawdi service couldn’t finish releasing
+								its resources.{" "}
+								{retrySafe ? "Retry cleanup." : "Contact support before trying again."}
+							</span>
+							{retrySafe ? (
+								<HostedDeploymentDeleteAction deployment={deployment}>
+									<Button type="button" variant="outline" size="sm">
+										Retry cleanup
+									</Button>
+								</HostedDeploymentDeleteAction>
+							) : (
+								<Button
+									render={<a href="mailto:support@clawdi.ai" />}
+									nativeButton={false}
+									variant="outline"
+									size="sm"
+								>
+									<LifeBuoy data-icon="inline-start" /> Contact support
+								</Button>
+							)}
+						</AlertDescription>
+					</Alert>
+				);
+			})}
 		</div>
 	);
 }
@@ -92,7 +142,8 @@ export function HostedAgentsSection({
 		!unified.isLoading &&
 		!unified.error;
 	return (
-		<div data-hosted="true">
+		<div data-hosted="true" className="space-y-4">
+			<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 			{isEmptyState ? (
 				<HostedEmptyAccountHero />
 			) : (
@@ -190,7 +241,8 @@ export function HostedAgentsByCompute({
 		!unified.error;
 	if (isEmptyState) {
 		return (
-			<div data-hosted="true">
+			<div data-hosted="true" className="space-y-6">
+				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<HostedEmptyAccountHero />
 			</div>
 		);
@@ -202,7 +254,8 @@ export function HostedAgentsByCompute({
 		connectedTiles.length === 0
 	) {
 		return (
-			<div data-hosted="true">
+			<div data-hosted="true" className="space-y-6">
+				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<AgentsCard agents={[]} isLoading />
 			</div>
 		);
@@ -210,6 +263,7 @@ export function HostedAgentsByCompute({
 
 	return (
 		<div data-hosted="true" className="space-y-6">
+			<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 			{hostedTiles.length > 0 ? (
 				<section className="space-y-2">
 					<SectionLabel

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -289,6 +289,14 @@ describe("deploymentToTiles", () => {
 		expect(resolveAgentDeployment([deleted], environmentId).match).toBeNull();
 	});
 
+	test("removes an accepted delete from tiles before teardown completes", () => {
+		const environmentId = "env-deleting-openclaw";
+		const deleting = deployment({ status: "deleting", failedVerb: "delete", environmentId });
+
+		expect(hostedDeploymentToTiles(deleting)).toEqual([]);
+		expect(resolveAgentDeployment([deleting], environmentId).match).toBeNull();
+	});
+
 	test("keeps a deployment without an env identity non-navigable but exposes delete", () => {
 		const hostedDeployment = deployment({
 			status: "failed",

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -11,6 +11,7 @@ import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-managemen
 import {
 	compactDeploymentFailureReason,
 	type DeploymentFailurePresentation,
+	deploymentFailureProjection,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
 import {
@@ -23,7 +24,7 @@ import {
 } from "@/hosted/deployment-status";
 import {
 	claimedEnvIdsFromDeployments,
-	isHostedDeploymentMember,
+	isHostedDeploymentVisible,
 } from "@/hosted/hosted-agent-resolution";
 import { HostedDeploymentTileAction } from "@/hosted/hosted-deployment-tile-action";
 import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
@@ -164,6 +165,15 @@ export function useHostedAgentTiles({
 		if (!includeDeployments) return new Set<string>();
 		return claimedEnvIdsFromDeployments(deployments);
 	}, [deployments, includeDeployments]);
+	const deletionFailures = useMemo(
+		() =>
+			includeDeployments
+				? deployments.filter(
+						(deployment) => deploymentFailureProjection(deployment)?.failedVerb === "delete",
+					)
+				: [],
+		[deployments, includeDeployments],
+	);
 
 	return {
 		inventoryStatus: inventory.status,
@@ -171,6 +181,7 @@ export function useHostedAgentTiles({
 			includeDeployments && hasExistingCloudDeployments(inventory.deployments),
 		tiles,
 		claimedEnvIds,
+		deletionFailures,
 		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
 		error: inventory.error,
 		refetch: inventory.refetch,
@@ -187,7 +198,7 @@ export function deploymentToTiles(
 	envById: Map<string, Env>,
 	statusRetry?: { isRetrying: boolean; onRetry: () => void },
 ): AgentTile[] {
-	if (!isHostedDeploymentMember(d)) return [];
+	if (!isHostedDeploymentVisible(d)) return [];
 	const runtime = deploymentRuntime(d);
 	const name = deploymentDisplayName(d.resource.spec.name, runtime);
 	// The deploy API projects the stable agent identity. The Cloud API env join

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -122,6 +122,7 @@ export function useUnifiedAgentList({
 	return {
 		...selection,
 		hasExistingDeployments: hosted.hasExistingDeployments,
+		deletionFailures: hosted.deletionFailures,
 		inventoryStatus: hosted.inventoryStatus,
 		isLoading:
 			(showCloudDeployments && hosted.isLoading) ||


### PR DESCRIPTION
The user should not wait on our teardown. Owner instruction.

## What was actually wrong

The DELETE contract already returns `202 Accepted` with an LRO and does not block on teardown. **The waiting was purely a UI choice** — this is a web-only change, no backend work needed.

Previously the tile stopped rendering only once the deployment vanished from an authoritative list read, and the detail page waited for the same thing.

## Now

On a real `202`:

- the agent leaves the main list, the sidebar and the detail route immediately
- the accepted delete intent survives stale list reads, so an old projection cannot resurrect the tile
- "hidden from the user" is kept distinct from "still owned by hosted", so a stale `/v1/agents` projection is not rendered as a self-managed agent
- the toast says **"Agent removed / Cleanup continues in the background."**

The UI is only dismissed after a genuine accepted response. A failed request does not produce optimistic fake success.

## Teardown failure

A failure does not bring the tile back. The Hosted agents section shows a cleanup alert: **Retry cleanup** when `retryable=true`, **Contact support** only when `retryable=false` — so `clawdi-hosted#1047`'s honest `409 retryable=false` semantics for `manual_reconcile_required` are preserved and no empty success is reintroduced.

## Not changed

No teardown, settlement, subscription cancellation, credential, Kubernetes or provider cleanup step was modified, weakened or reordered. This is presentation only.

**Known remaining wait:** subscription cancellation is *not* inside the DELETE LRO. The web waits for a separate subscription-cancel mutation to return a real answer before sending DELETE. That was left alone deliberately — it is a money operation and the standard requires waiting for one real answer. The user now waits on two fast accepts instead of on teardown convergence. Moving cancellation into the LRO would be a separate hosted lifecycle change.

## Verification

- `bun run typecheck`: 4/4
- `bun run lint`: 705 files
- `bun test`: 1721/1721
- hosted Playwright: 60/60

Regression coverage: the agent leaves detail, list and sidebar before teardown completes; teardown still runs to completion; a failed teardown does not resurrect the tile and offers the correct non-retryable support action; stale reads do not restore an accepted-delete agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)