### PR TITLE
Regenerate deploy contract and explain upgrade ineligibility

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -43,6 +43,7 @@ type DeploymentMutationFixture = {
 	status: string;
 	created_at: string;
 	upgrade_available: boolean;
+	upgrade_eligibility?: DeploymentRead["upgrade_eligibility"];
 	compute_subscription: DeploymentComputeSubscription | null;
 	config_info: {
 		compute_plan_slug: string;
@@ -694,6 +695,10 @@ function mutationDeploymentReadFixture(deployment: DeploymentMutationFixture): D
 		},
 		current_plan_slug: config.compute_plan_slug,
 		upgrade_available: deployment.upgrade_available,
+		upgrade_eligibility: deployment.upgrade_eligibility ?? {
+			eligible: deployment.upgrade_available,
+			reason: null,
+		},
 		compute_slot_occupancy: {
 			occupies_slot: backingInfrastructure === "present",
 			backing_infra: backingInfrastructure,
@@ -2592,6 +2597,34 @@ test("included Basic uses unified card quote and change without creating a secon
 	expect(subscriptionQuoteRequests).toEqual([]);
 	await expect(page.getByText("Plan changed", { exact: true })).toBeVisible();
 	expect(errors, `included Basic card upgrade: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("included Basic explains an unknown upgrade state and offers a re-check", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const deployment = {
+		...includedBasicDeployment,
+		id: "hdep_upgrade_state_unknown",
+		name: "Upgrade state unknown",
+		upgrade_available: false,
+		upgrade_eligibility: {
+			eligible: false,
+			reason: "deployment_state_unknown",
+		},
+	} satisfies DeploymentMutationFixture;
+	await stubHostedApi(page, {
+		deployments: [deployment],
+		plans: [basicPlan, performancePlan],
+	});
+
+	await gotoHostedAgentSettings(page, deployment.id, "Basic");
+	await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toBeDisabled();
+	await expect(
+		page.getByText(
+			"Clawdi couldn’t read this agent’s current state. Check again before trying to upgrade.",
+			{ exact: true },
+		),
+	).toBeVisible();
+	expect(errors, `unknown upgrade state: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("included Basic uses unified wallet quote and change with exact debit", async ({ page }) => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2919,8 +2919,9 @@ function ComputeSettingsSections({
 		deploymentStatusSupportsUpgrade:
 			isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped",
 		upgradeAvailable: deployment.upgrade_available,
+		upgradeEligibilityReason: deployment.upgrade_eligibility.reason,
 	});
-	const canUpgrade = upgradeUnavailableMessage === null;
+	const canUpgrade = deployment.upgrade_available && upgradeUnavailableMessage === null;
 	const canStartNewSubscription =
 		hostedAccess.canCreateCloudAgents && hasTerminalFallback && !!(basicPlan || perfPlan);
 	const subscriptionCreatePlanSlug = resolveSubscriptionCreatePlanSlug(

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -157,7 +157,7 @@ describe("performanceUpgradeUnavailableReason", () => {
 			],
 			[
 				"compute_subscription_not_active",
-				"This agent’s subscription is not active, so Clawdi can’t start the upgrade. Resolve the subscription status, then try again.",
+				"Clawdi can’t start this upgrade because this agent’s no-cost subscription is not active. You were not charged, and there’s nothing you need to fix. Check again later.",
 			],
 			[
 				"compute_subscription_canceling",

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -113,15 +113,16 @@ describe("performanceUpgradeUnavailableReason", () => {
 		planChangeUnavailable: null,
 		deploymentStatusSupportsUpgrade: true,
 		upgradeAvailable: true,
+		upgradeEligibilityReason: null,
 	};
 
 	test("distinguishes each upgrade block from a pending upgrade", () => {
-		expect(performanceUpgradeUnavailableReason({ ...available, isIncludedBasic: false })).toContain(
-			"only available for included Basic",
+		expect(performanceUpgradeUnavailableReason({ ...available, isIncludedBasic: false })).toBe(
+			"This upgrade is only available for Basic agents without a separate subscription. Use this agent’s subscription controls to change its plan.",
 		);
 		expect(
 			performanceUpgradeUnavailableReason({ ...available, performancePlanAvailable: false }),
-		).toBe("Performance compute is unavailable right now.");
+		).toBe("The Performance plan is unavailable right now. Try again later.");
 		expect(
 			performanceUpgradeUnavailableReason({
 				...available,
@@ -134,9 +135,71 @@ describe("performanceUpgradeUnavailableReason", () => {
 				pendingPlanSlug: "compute_performance",
 			}),
 		).toBe("An upgrade to Performance is already scheduled.");
-		expect(performanceUpgradeUnavailableReason({ ...available, upgradeAvailable: false })).toBe(
-			"This Basic agent is not currently eligible for an upgrade.",
-		);
+	});
+
+	test("gives every server ineligibility reason its matching next step", () => {
+		const cases = [
+			[
+				"deployment_deleted",
+				"This agent has been deleted, so it can’t be upgraded. Create a new agent if you need Performance.",
+			],
+			[
+				"compute_basic_required",
+				"Only agents on the Basic plan can be upgraded to Performance. No upgrade is available for this agent’s current plan.",
+			],
+			[
+				"compute_subscription_unavailable",
+				"Clawdi couldn’t read this agent’s subscription details, so it can’t safely start an upgrade. Check again in a moment.",
+			],
+			[
+				"included_basic_required",
+				"This agent’s subscription is managed separately, so it can’t be upgraded here. Use the subscription controls to change its plan instead.",
+			],
+			[
+				"compute_subscription_not_active",
+				"This agent’s subscription is not active, so Clawdi can’t start the upgrade. Resolve the subscription status, then try again.",
+			],
+			[
+				"compute_subscription_canceling",
+				"This agent’s subscription is set to cancel, so it can’t be upgraded. Resume the subscription first, then try again.",
+			],
+			[
+				"deployment_state_unknown",
+				"Clawdi couldn’t read this agent’s current state. Check again before trying to upgrade.",
+			],
+			[
+				"deployment_must_be_running_or_stopped",
+				"Wait until this agent is running or stopped before trying to upgrade again.",
+			],
+			[
+				"upgrade_already_in_progress",
+				"An upgrade to Performance is already in progress. Wait for it to finish; there is no second upgrade to start.",
+			],
+		] as const;
+
+		for (const [upgradeEligibilityReason, expected] of cases) {
+			expect(
+				performanceUpgradeUnavailableReason({
+					...available,
+					upgradeAvailable: false,
+					upgradeEligibilityReason,
+				}),
+			).toBe(expected);
+		}
+	});
+
+	test("renders an honest fallback for an absent or unrecognised reason", () => {
+		const expected =
+			"Clawdi can’t confirm why this agent can’t be upgraded right now. Check again later, or contact support if this continues.";
+		for (const upgradeEligibilityReason of [null, "new_server_reason"]) {
+			expect(
+				performanceUpgradeUnavailableReason({
+					...available,
+					upgradeAvailable: false,
+					upgradeEligibilityReason,
+				}),
+			).toBe(expected);
+		}
 	});
 
 	test("returns no reason only when every upgrade condition is met", () => {

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -25,7 +25,7 @@ const PERFORMANCE_UPGRADE_UNAVAILABLE_COPY = {
 	included_basic_required:
 		"This agent’s subscription is managed separately, so it can’t be upgraded here. Use the subscription controls to change its plan instead.",
 	compute_subscription_not_active:
-		"This agent’s subscription is not active, so Clawdi can’t start the upgrade. Resolve the subscription status, then try again.",
+		"Clawdi can’t start this upgrade because this agent’s no-cost subscription is not active. You were not charged, and there’s nothing you need to fix. Check again later.",
 	compute_subscription_canceling:
 		"This agent’s subscription is set to cancel, so it can’t be upgraded. Resume the subscription first, then try again.",
 	deployment_state_unknown:

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -1,4 +1,8 @@
-import type { ComputePlanChangeQuoteRequest, ComputePlanSlug } from "@/hosted/billing/contracts";
+import type {
+	ComputePlanChangeQuoteRequest,
+	ComputePlanSlug,
+	HostedDeployment,
+} from "@/hosted/billing/contracts";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
 export type PlanChangeSelection = Omit<ComputePlanChangeQuoteRequest, "subscription_id"> & {
@@ -6,6 +10,46 @@ export type PlanChangeSelection = Omit<ComputePlanChangeQuoteRequest, "subscript
 };
 
 const UNSIGNED_DECIMAL = /^(\d+)(?:\.(\d+))?$/;
+
+type HostedComputeUpgradeIneligibilityReason = NonNullable<
+	HostedDeployment["upgrade_eligibility"]["reason"]
+>;
+
+const PERFORMANCE_UPGRADE_UNAVAILABLE_COPY = {
+	deployment_deleted:
+		"This agent has been deleted, so it can’t be upgraded. Create a new agent if you need Performance.",
+	compute_basic_required:
+		"Only agents on the Basic plan can be upgraded to Performance. No upgrade is available for this agent’s current plan.",
+	compute_subscription_unavailable:
+		"Clawdi couldn’t read this agent’s subscription details, so it can’t safely start an upgrade. Check again in a moment.",
+	included_basic_required:
+		"This agent’s subscription is managed separately, so it can’t be upgraded here. Use the subscription controls to change its plan instead.",
+	compute_subscription_not_active:
+		"This agent’s subscription is not active, so Clawdi can’t start the upgrade. Resolve the subscription status, then try again.",
+	compute_subscription_canceling:
+		"This agent’s subscription is set to cancel, so it can’t be upgraded. Resume the subscription first, then try again.",
+	deployment_state_unknown:
+		"Clawdi couldn’t read this agent’s current state. Check again before trying to upgrade.",
+	deployment_must_be_running_or_stopped:
+		"Wait until this agent is running or stopped before trying to upgrade again.",
+	upgrade_already_in_progress:
+		"An upgrade to Performance is already in progress. Wait for it to finish; there is no second upgrade to start.",
+} satisfies Record<HostedComputeUpgradeIneligibilityReason, string>;
+
+const UNKNOWN_PERFORMANCE_UPGRADE_UNAVAILABLE_COPY =
+	"Clawdi can’t confirm why this agent can’t be upgraded right now. Check again later, or contact support if this continues.";
+
+function isHostedComputeUpgradeIneligibilityReason(
+	reason: string,
+): reason is HostedComputeUpgradeIneligibilityReason {
+	return Object.hasOwn(PERFORMANCE_UPGRADE_UNAVAILABLE_COPY, reason);
+}
+
+function performanceUpgradeEligibilityReasonCopy(reason: string | null): string {
+	return reason !== null && isHostedComputeUpgradeIneligibilityReason(reason)
+		? PERFORMANCE_UPGRADE_UNAVAILABLE_COPY[reason]
+		: UNKNOWN_PERFORMANCE_UPGRADE_UNAVAILABLE_COPY;
+}
 
 function decimalParts(value: string): { units: bigint; scale: number } | null {
 	const match = UNSIGNED_DECIMAL.exec(value.trim());
@@ -97,6 +141,7 @@ export function performanceUpgradeUnavailableReason({
 	planChangeUnavailable,
 	deploymentStatusSupportsUpgrade,
 	upgradeAvailable,
+	upgradeEligibilityReason,
 }: {
 	plansLoading: boolean;
 	canCreateCloudAgents: boolean;
@@ -106,19 +151,24 @@ export function performanceUpgradeUnavailableReason({
 	planChangeUnavailable: string | null;
 	deploymentStatusSupportsUpgrade: boolean;
 	upgradeAvailable: boolean;
+	upgradeEligibilityReason: string | null;
 }): string | null {
 	if (plansLoading) return "Checking Performance availability…";
-	if (!isIncludedBasic)
-		return "Upgrade to Performance is only available for included Basic compute.";
 	if (!canCreateCloudAgents) return "Upgrades are temporarily unavailable.";
-	if (!performancePlanAvailable) return "Performance compute is unavailable right now.";
+	if (!performancePlanAvailable)
+		return "The Performance plan is unavailable right now. Try again later.";
+	if (!upgradeAvailable) {
+		return performanceUpgradeEligibilityReasonCopy(upgradeEligibilityReason);
+	}
+	if (!isIncludedBasic) {
+		return "This upgrade is only available for Basic agents without a separate subscription. Use this agent’s subscription controls to change its plan.";
+	}
 	if (pendingPlanSlug === COMPUTE_PERFORMANCE_SLUG) {
 		return "An upgrade to Performance is already scheduled.";
 	}
 	if (planChangeUnavailable) return planChangeUnavailable;
 	if (!deploymentStatusSupportsUpgrade) {
-		return "Upgrade is available once this Basic agent is running or stopped.";
+		return "Wait until this Basic agent is running or stopped before trying to upgrade again.";
 	}
-	if (!upgradeAvailable) return "This Basic agent is not currently eligible for an upgrade.";
 	return null;
 }

--- a/apps/web/src/hosted/hosted-deployment.test-fixture.ts
+++ b/apps/web/src/hosted/hosted-deployment.test-fixture.ts
@@ -26,6 +26,7 @@ type HostedDeploymentFixtureOptions = {
 	occupiesSlot?: boolean;
 	computeSlotOccupancy?: HostedDeployment["compute_slot_occupancy"];
 	upgradeAvailable?: boolean;
+	upgradeEligibility?: HostedDeployment["upgrade_eligibility"];
 	acceptedOperation?: HostedDeployment["accepted_operation"];
 	cloudEnvironments?: HostedDeployment["clawdi_cloud_environments"];
 	aiProviderAuthKinds?: HostedDeployment["ai_provider_auth_kinds"];
@@ -43,6 +44,7 @@ export function hostedDeploymentFixture(
 	const backingInfrastructure =
 		options.backingInfrastructure ?? (occupiesSlot ? "present" : "absent");
 	const runtime = options.runtime ?? "openclaw";
+	const upgradeAvailable = options.upgradeAvailable ?? false;
 
 	return {
 		resource: {
@@ -97,7 +99,11 @@ export function hostedDeploymentFixture(
 			latest_funding_fact: options.fundingFact ?? null,
 		},
 		current_plan_slug: options.currentPlanSlug ?? "compute_basic",
-		upgrade_available: options.upgradeAvailable ?? false,
+		upgrade_available: upgradeAvailable,
+		upgrade_eligibility: options.upgradeEligibility ?? {
+			eligible: upgradeAvailable,
+			reason: null,
+		},
 		compute_slot_occupancy:
 			options.computeSlotOccupancy === undefined
 				? {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -805,7 +805,7 @@ export interface components {
             /** Detail */
             detail: string;
             /** Instance */
-            instance: string;
+            instance?: string | null;
             /** Code */
             code: string;
             /** Phase */
@@ -833,7 +833,7 @@ export interface components {
             /** Detail */
             detail: string;
             /** Instance */
-            instance: string;
+            instance?: string | null;
             /** Code */
             code: string;
             /** Phase */
@@ -866,7 +866,7 @@ export interface components {
             /** Detail */
             detail: string;
             /** Instance */
-            instance: string;
+            instance?: string | null;
             /** Code */
             code: string;
             /** Phase */

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -486,6 +486,44 @@ export interface components {
              */
             secret_references: components["schemas"]["SecretReference"][];
         };
+        /** ComputePlanChangeProgress */
+        ComputePlanChangeProgress: {
+            /**
+             * @Type
+             * @constant
+             */
+            "@type": "type.googleapis.com/clawdi.v2.ComputePlanChangeProgress";
+            /** Operationid */
+            operationId: string;
+            /** Subscriptionid */
+            subscriptionId: number;
+            /**
+             * Fundingsource
+             * @enum {string}
+             */
+            fundingSource: "stripe" | "wallet";
+            /** Sourceplanslug */
+            sourcePlanSlug: string;
+            /** Targetplanslug */
+            targetPlanSlug: string;
+            /**
+             * Targetbillingtermmonths
+             * @enum {integer}
+             */
+            targetBillingTermMonths: 1 | 12;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "quoted" | "wallet_debit_pending" | "wallet_debit_applied" | "stripe_update_pending" | "invoice_pending" | "settlement_pending" | "awaiting_payment" | "awaiting_projection" | "compensation_pending" | "reversal_pending" | "reconciliation_required" | "scheduled" | "complete" | "compensated" | "failed" | "terminated_paid_unapplied";
+            /**
+             * Effectiveat
+             * Format: date-time
+             */
+            effectiveAt: string;
+            /** Fundinginvoiceid */
+            fundingInvoiceId?: string | null;
+        };
         /** DeploymentCondition */
         DeploymentCondition: {
             /**
@@ -553,7 +591,7 @@ export interface components {
              * Verb
              * @enum {string}
              */
-            verb: "create" | "start" | "stop" | "restart" | "update" | "rename" | "delete";
+            verb: "create" | "plan_change" | "start" | "stop" | "restart" | "update" | "rename" | "delete";
             /** Targetgeneration */
             targetGeneration: number;
             /** Manifestetag */
@@ -568,6 +606,9 @@ export interface components {
              * Format: date-time
              */
             updateTime: string;
+            /** @description Acceptance-time deployment snapshot for create operations so clients can render the resource without a follow-up read. */
+            initialDeployment?: components["schemas"]["HostedDeploymentResource"] | null;
+            planChange?: components["schemas"]["ComputePlanChangeProgress"] | null;
         };
         /** DeploymentOperationResponse */
         DeploymentOperationResponse: {
@@ -613,7 +654,7 @@ export interface components {
              */
             read_only: true;
             /** Deployments */
-            deployments: components["schemas"]["HostedDeploymentResource"][];
+            deployments: components["schemas"]["V2HostedDeploymentReadResponse"][];
             /** Operations */
             operations: components["schemas"]["LongRunningOperation"][];
             /** Event Stream Cursor */
@@ -1221,36 +1262,6 @@ export interface components {
             /** Operation Id */
             operation_id: string;
         };
-        /** V2ComputePlanChangeResponse */
-        V2ComputePlanChangeResponse: {
-            /** Operation Id */
-            operation_id: string;
-            /** Subscription Id */
-            subscription_id: number;
-            /** Funding Source */
-            funding_source?: ("stripe" | "wallet") | null;
-            /** Current Plan Slug */
-            current_plan_slug: string;
-            /** Target Plan Slug */
-            target_plan_slug: string;
-            /**
-             * Target Billing Term Months
-             * @enum {integer}
-             */
-            target_billing_term_months: 1 | 12;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "awaiting_payment" | "awaiting_projection" | "scheduled" | "complete";
-            /**
-             * Effective At
-             * Format: date-time
-             */
-            effective_at: string;
-            /** Funding Invoice Id */
-            funding_invoice_id?: string | null;
-        };
         /** V2ComputePortalRequest */
         V2ComputePortalRequest: {
             /** Locale */
@@ -1500,6 +1511,13 @@ export interface components {
             /** Pending Plan Slug */
             pending_plan_slug?: string | null;
         };
+        /** V2HostedComputeUpgradeEligibility */
+        V2HostedComputeUpgradeEligibility: {
+            /** Eligible */
+            eligible: boolean;
+            /** Reason */
+            reason: ("deployment_deleted" | "compute_basic_required" | "compute_subscription_unavailable" | "included_basic_required" | "compute_subscription_not_active" | "compute_subscription_canceling" | "deployment_state_unknown" | "deployment_must_be_running_or_stopped" | "upgrade_already_in_progress") | null;
+        };
         /** V2HostedConfigRequest */
         V2HostedConfigRequest: {
             /** Primary Model */
@@ -1649,6 +1667,7 @@ export interface components {
              * @default false
              */
             upgrade_available: boolean;
+            upgrade_eligibility: components["schemas"]["V2HostedComputeUpgradeEligibility"];
             compute_slot_occupancy: components["schemas"]["V2HostedComputeSlotOccupancy"] | null;
         };
         /** V2HostedRuntimeUiCredentials */
@@ -2746,7 +2765,9 @@ export interface operations {
     change_v2_subscription_plan_v2_subscription_plan_change_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2757,12 +2778,12 @@ export interface operations {
         };
         responses: {
             /** @description Successful Response */
-            200: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["V2ComputePlanChangeResponse"];
+                    "application/json": components["schemas"]["LongRunningOperation"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- regenerate `deploy.generated.ts` from the live deployed contract after both Clawdi-AI/clawdi-hosted#1050 and Clawdi-AI/clawdi-hosted#1054, including `V2HostedComputeUpgradeEligibility` and nullable lifecycle problem `instance` fields
- replace the generic upgrade-ineligibility sentence with actionable customer copy for all nine known reasons and an honest fallback for future unknown reasons
- keep `upgrade_available` as the eligibility source of truth; use `upgrade_eligibility.reason` only to explain the disabled state
- cover every reason in unit tests and verify the unknown-state production path in hosted Playwright

## Copy decision for inactive no-cost subscriptions

The server reason groups every non-active status after confirming this is the no-cost subscription. Those statuses do not share a safe customer action, and the reason does not expose which status occurred. The UI therefore says Clawdi cannot start the upgrade, confirms that the customer was not charged and has nothing to fix, and asks them to check again later. A state-specific remedy would require splitting the server reason in a separate backend change.

## Contract verification

`LifecycleFailureOccurrence.instance`, `LifecycleProblemAny.instance`, and `LifecycleProblemDetails.instance` now generate as optional `string | null`. An independent repository search found no web product consumer of `problem.instance`; the only web source match is a test fixture `@type` string, so no runtime null-handling change is needed.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run --cwd apps/web test` (659 passed)
- `bun run --cwd apps/web e2e:hosted --retries=2` (61 passed without retries)
- `DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json DEPLOY_CONTRACT_FETCH_MODE=strict scripts/check-deploy-generated-api.sh`
- `bun run check`

## Diff

226 additions and 52 deletions: net +174 lines.