### PR TITLE
Fix v2 provider honesty and recovery

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2023,6 +2023,52 @@ test("failed deployment with a retained projection keeps status-authoritative na
 		.toEqual(["/v2/deployments/hdep_failed_retained_projection"]);
 });
 
+test("terminal provider failure replaces Starting with provider recovery", async ({ page }) => {
+	const starting = {
+		...includedBasicDeployment,
+		id: "hdep_provider_failed",
+		name: "Provider recovery",
+		status: "starting",
+	};
+	const deployment = mutationDeploymentReadFixture(starting);
+	deployment.accepted_operation = {
+		...completedDeploymentOperation(starting, "create"),
+		done: true,
+		response: null,
+		error: {
+			code: 5,
+			message: "provider unavailable",
+			details: [
+				{
+					"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails",
+					type: "https://api.clawdi.ai/problems/provider-not-found",
+					title: "Provider not found",
+					status: 404,
+					detail: "Provider unavailable",
+					code: "provider_not_found",
+					retryable: false,
+					conditionReason: "ProviderNotFound",
+					conditionMessage: "Provider unavailable",
+					observedGeneration: 1,
+				},
+			],
+		},
+	};
+	await stubHostedApi(page, { deployments: [deployment] });
+
+	await page.goto(`/agents/${starting.id}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText("Provider configuration failed", { exact: true })).toBeVisible();
+	await expect(
+		main.getByText("The selected provider is no longer available in your Clawdi account.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(main.getByText("Starting your agent…", { exact: true })).toHaveCount(0);
+	await main.getByRole("button", { name: "Fix provider", exact: true }).click();
+	await expect(page).toHaveURL(new RegExp(`/agents/${starting.id}/model-provider`));
+});
+
 test("missing live projection recovers on Check again without losing deployment tools", async ({
 	page,
 }) => {
@@ -3219,9 +3265,7 @@ test("paid Performance exposes subscription actions without a direct Basic switc
 	expect(errors, `paid Performance actions: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("occupied included Basic start surfaces the backend slot entitlement error", async ({
-	page,
-}) => {
+test("occupied included Basic start explains the slot entitlement recovery", async ({ page }) => {
 	const startRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [stoppedIncludedBasicDeployment, includedBasicDeployment],
@@ -3243,9 +3287,12 @@ test("occupied included Basic start surfaces the backend slot entitlement error"
 	await expect.poll(() => startRequests.length).toBe(1);
 	await expect(page.getByText("Couldn't update lifecycle", { exact: true })).toBeVisible();
 	await expect(
-		page.getByText("The Compute Basic free slot allows only one active deployment.", {
-			exact: true,
-		}),
+		page.getByText(
+			"Your free Basic compute slot is already in use. Stop that agent or choose paid compute, then try again.",
+			{
+				exact: true,
+			},
+		),
 	).toBeVisible();
 	expect(errors.length, `included Basic start entitlement: ${errors.join(" | ")}`).toBeGreaterThan(
 		0,

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -92,6 +92,7 @@ describe("deployment failure remediation rendering", () => {
 			createElement(overviewFailedPanel, {
 				deployment,
 				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
 				onDeleteAccepted: () => undefined,
 			}),
 		);
@@ -116,6 +117,7 @@ describe("deployment failure remediation rendering", () => {
 			createElement(overviewFailedPanel, {
 				deployment: hostedDeploymentFixture({ status: "failed" }),
 				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
 				onDeleteAccepted: () => undefined,
 			}),
 		);

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -10,12 +10,7 @@ import type {
 	HostedDeployment,
 	HostedDeploymentStatus,
 } from "@/hosted/billing/contracts";
-import {
-	DeploymentConflictError,
-	isNetworkError,
-	normalizeBillingError,
-	toastBillingError,
-} from "@/hosted/billing/errors";
+import { DeploymentConflictError, isNetworkError } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/hooks";
 import {
 	forgetIdempotencyAttempt,
@@ -23,6 +18,7 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
+import { deploymentMutationErrorMessage } from "@/hosted/deployment-failure";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
@@ -106,7 +102,7 @@ async function runStableDeploymentIntent<T>(
 
 function toastDeploymentConflict(error: unknown): boolean {
 	if (!(error instanceof DeploymentConflictError)) return false;
-	toast.error("Agent state changed", { description: normalizeBillingError(error) });
+	toast.error("Agent state changed", { description: deploymentMutationErrorMessage(error) });
 	return true;
 }
 
@@ -171,7 +167,8 @@ export function useCreateTerminalSession() {
 	const client = useBillingClient();
 	return useMutation({
 		mutationFn: (vars: { id: string }) => client.createTerminalSession(vars.id),
-		onError: toastBillingError("Couldn't open terminal"),
+		onError: (error) =>
+			toast.error("Couldn't open terminal", { description: deploymentMutationErrorMessage(error) }),
 	});
 }
 
@@ -205,7 +202,9 @@ export function useDeploymentLifecycle() {
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;
-			toast.error("Couldn't update lifecycle", { description: normalizeBillingError(error) });
+			toast.error("Couldn't update lifecycle", {
+				description: deploymentMutationErrorMessage(error),
+			});
 		},
 		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
@@ -226,7 +225,9 @@ export function useDeleteDeployment() {
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;
-			toastBillingError("Couldn't delete agent")(error);
+			toast.error("Couldn't delete agent", {
+				description: deploymentMutationErrorMessage(error),
+			});
 		},
 		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
@@ -247,7 +248,7 @@ export function useUpdateDeployment() {
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;
 			toast.error("Couldn't update agent settings", {
-				description: normalizeBillingError(error),
+				description: deploymentMutationErrorMessage(error),
 			});
 		},
 		onSettled: () => invalidateDeploymentSnapshots(qc),

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -481,6 +481,7 @@ export function HostedAgentDetail({
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const terminalHref = agentSectionHref(environmentId, "terminal", searchStr);
 	const planChangeHref = `${agentSectionHref(environmentId, "settings", searchStr)}#compute-plan-controls`;
+	const providerSettingsHref = agentSectionHref(environmentId, "ai", searchStr);
 
 	const scopedSessionLink = (sessionId: string) => ({
 		to: "/agents/$id/sessions/$sessionId" as const,
@@ -584,6 +585,7 @@ export function HostedAgentDetail({
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
 							planChangeHref={planChangeHref}
+							providerSettingsHref={providerSettingsHref}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							isCheckingDeployment={isCheckingDeployment}
 							onCheckDeploymentAgain={onCheckDeploymentAgain}
@@ -949,11 +951,13 @@ function OverviewFailureAction({
 	deployment,
 	failure,
 	planChangeHref,
+	providerSettingsHref,
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
 	failure: DeploymentFailurePresentation;
 	planChangeHref: string;
+	providerSettingsHref: string;
 	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const remediation = failure.remediation;
@@ -972,6 +976,15 @@ function OverviewFailureAction({
 			) : null}
 			{remediation.kind === "restart" ? (
 				<RestartComputeAction deployment={deployment} label={remediation.label} />
+			) : remediation.kind === "review_provider" ? (
+				<Button
+					render={<a href={providerSettingsHref} />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+				>
+					{remediation.label}
+				</Button>
 			) : remediation.kind === "review_plan_change" ? (
 				<Button
 					render={<a href={planChangeHref} />}
@@ -995,10 +1008,12 @@ function OverviewFailureAction({
 export function OverviewFailedPanel({
 	deployment,
 	planChangeHref,
+	providerSettingsHref,
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
 	planChangeHref: string;
+	providerSettingsHref: string;
 	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
@@ -1019,6 +1034,7 @@ export function OverviewFailedPanel({
 						deployment={deployment}
 						failure={failure}
 						planChangeHref={planChangeHref}
+						providerSettingsHref={providerSettingsHref}
 						onDeleteAccepted={onDeleteAccepted}
 					/>
 				</AlertDescription>
@@ -1068,6 +1084,7 @@ function OverviewTab({
 	onRetrySessions,
 	sessionLink,
 	planChangeHref,
+	providerSettingsHref,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
@@ -1087,6 +1104,7 @@ function OverviewTab({
 		params: { id: string; sessionId: string };
 	};
 	planChangeHref: string;
+	providerSettingsHref: string;
 	deploymentTransitionTimedOut: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
@@ -1109,11 +1127,13 @@ function OverviewTab({
 		),
 	);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
+	const deploymentFailure = deploymentFailurePresentation(deployment);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const showReadinessPanel =
-		deploymentTransitionTimedOut ||
-		isStartingStatus(deploymentStatus) ||
-		deploymentStatus.kind === "running";
+		!deploymentFailure &&
+		(deploymentTransitionTimedOut ||
+			isStartingStatus(deploymentStatus) ||
+			deploymentStatus.kind === "running");
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
@@ -1127,10 +1147,11 @@ function OverviewTab({
 					onCheckDeploymentAgain={onCheckDeploymentAgain}
 				/>
 			) : null}
-			{deploymentStatus.kind === "failed" ? (
+			{deploymentFailure || deploymentStatus.kind === "failed" ? (
 				<OverviewFailedPanel
 					deployment={deployment}
 					planChangeHref={planChangeHref}
+					providerSettingsHref={providerSettingsHref}
 					onDeleteAccepted={onDeleteAccepted}
 				/>
 			) : null}

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -13,6 +13,7 @@ function entry(overrides: Partial<WalletLedgerEntry> = {}): WalletLedgerEntry {
 		description: "Wallet top-up",
 		amount_usd: "1",
 		status: "applied",
+		payment_reference: null,
 		receipt_url: null,
 		created_at: "2026-07-01T00:00:00Z",
 		applied_at: "2026-07-01T00:00:00Z",

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
+import { BillingApiError, BillingNetworkError } from "@/hosted/billing/errors";
 import {
 	deploymentFailurePresentation,
 	deploymentFailureProjection,
 	deploymentFailureReason,
+	deploymentMutationErrorMessage,
 } from "@/hosted/deployment-failure";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -148,13 +150,101 @@ describe("deploymentFailureReason", () => {
 	});
 
 	test("does not expose a stale failure outside the authoritative failed state", () => {
-		const deployment = hostedDeploymentFixture({ status: "starting" });
+		const deployment = hostedDeploymentFixture({
+			status: "starting",
+			failure: {
+				type: "https://api.clawdi.ai/problems/old_failure",
+				title: "Old failure",
+				status: 409,
+				detail: "Old failure",
+				code: "old_failure",
+				retryable: false,
+				conditionReason: "OldFailure",
+				conditionMessage: "Old failure",
+				observedGeneration: 0,
+			},
+		});
 		expect(deploymentFailureProjection(deployment)).toBeNull();
+	});
+
+	test("surfaces a terminal provider operation before the resource summary catches up", () => {
+		const operation: DeploymentOperation = {
+			name: "operations/provider-failed",
+			metadata: {
+				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+				deploymentId: "hdep_provider_failed",
+				verb: "create",
+				targetGeneration: 1,
+				manifestETag: "manifest-provider-failed",
+				createTime: "2026-07-27T00:00:00Z",
+				updateTime: "2026-07-27T00:01:00Z",
+			},
+			done: true,
+			error: {
+				code: 5,
+				message: "provider unavailable",
+				details: [
+					{
+						"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails",
+						type: "https://api.clawdi.ai/problems/provider-not-found",
+						title: "Provider not found",
+						status: 404,
+						detail: "Provider unavailable",
+						code: "provider_not_found",
+						retryable: false,
+						conditionReason: "ProviderNotFound",
+						conditionMessage: "Provider unavailable",
+						observedGeneration: 1,
+					},
+				],
+			},
+			response: null,
+		};
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_provider_failed",
+			status: "starting",
+			acceptedOperation: operation,
+		});
+
+		expect(deploymentFailurePresentation(deployment)).toMatchObject({
+			title: "Provider configuration failed",
+			reason: "The selected provider is no longer available in your Clawdi account.",
+			remediation: { kind: "review_provider", label: "Fix provider" },
+		});
 	});
 
 	test("does not classify unavailable status as a failure", () => {
 		const deployment = hostedDeploymentFixture({ status: null });
 		expect(deploymentFailureReason(deployment.resource.status)).toBeNull();
 		expect(deploymentFailureProjection(deployment)).toBeNull();
+	});
+});
+
+describe("deploymentMutationErrorMessage", () => {
+	test("maps provider failures to provider recovery instead of billing copy", () => {
+		const error = new BillingApiError(404, "provider_not_found", {
+			detail: { code: "provider_not_found" },
+		});
+		const message = deploymentMutationErrorMessage(error);
+
+		expect(message).toContain("selected provider is no longer available");
+		expect(message).toContain("Choose Managed by Clawdi");
+		expect(message).not.toContain("billing");
+	});
+
+	test("keeps an unconfirmed timeout distinct from a rejection", () => {
+		expect(deploymentMutationErrorMessage(new BillingNetworkError("timeout"))).toContain(
+			"couldn’t confirm whether the agent service accepted this change",
+		);
+	});
+
+	test("maps the Basic slot entitlement to its actual recovery", () => {
+		expect(
+			deploymentMutationErrorMessage(
+				new BillingApiError(403, "The Compute Basic free slot allows only one active deployment."),
+			),
+		).toBe(
+			"Your free Basic compute slot is already in use. Stop that agent or choose paid compute, then try again.",
+		);
 	});
 });

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -1,4 +1,10 @@
 import type { HostedDeployment } from "@/hosted/billing/contracts";
+import {
+	BillingApiError,
+	BillingNetworkError,
+	billingErrorDetail,
+	DeploymentConflictError,
+} from "@/hosted/billing/errors";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 
 const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
@@ -7,6 +13,8 @@ const PLAN_CHANGE_FAILURE_REASON =
 const DEFAULT_SERVICE_FAILURE_REASON = "The Clawdi service could not complete this request.";
 
 const CUSTOMER_FAILURE_REASONS_BY_CODE = new Map<string, string>([
+	["provider_not_found", "The selected provider is no longer available in your Clawdi account."],
+	["invalid_managed_provider_id", "Managed by Clawdi cannot be combined with a saved provider."],
 	[
 		"insufficient_balance",
 		"Your Wallet balance was too low for the Clawdi service to complete this request.",
@@ -31,6 +39,7 @@ export type DeploymentFailureProjection = {
 export type DeploymentFailureRemediation =
 	| { kind: "restart"; label: string; requiresWalletTopUp: boolean }
 	| { kind: "review_plan_change"; label: string; requiresWalletTopUp: boolean }
+	| { kind: "review_provider"; label: string; requiresWalletTopUp: false }
 	| { kind: "retry_delete"; label: string; requiresWalletTopUp: false }
 	| { kind: "none"; label: null; requiresWalletTopUp: boolean };
 
@@ -45,6 +54,45 @@ const WALLET_FUNDING_CODES = new Set([
 	"insufficient_wallet_balance",
 	"open_refund_debt",
 ]);
+const PROVIDER_CONFIGURATION_CODES = new Set(["provider_not_found", "invalid_managed_provider_id"]);
+
+/** Customer-safe copy for declarative agent mutations handled by the deploy API. */
+export function deploymentMutationErrorMessage(error: unknown): string {
+	if (error instanceof DeploymentConflictError) return error.message;
+	if (error instanceof BillingNetworkError) {
+		return error.kind === "timeout"
+			? "Clawdi couldn’t confirm whether the agent service accepted this change. Check the latest status, then try again."
+			: "Clawdi couldn’t reach the agent service. Check your connection, then try again.";
+	}
+	if (error instanceof BillingApiError) {
+		const code = billingErrorDetail(error)?.code;
+		if (
+			error.status === 403 &&
+			error.detail === "The Compute Basic free slot allows only one active deployment."
+		) {
+			return "Your free Basic compute slot is already in use. Stop that agent or choose paid compute, then try again.";
+		}
+		if (code === "provider_not_found") {
+			return "The selected provider is no longer available in your Clawdi account. Choose Managed by Clawdi or save the provider again, then retry.";
+		}
+		if (code === "invalid_managed_provider_id") {
+			return "Managed by Clawdi can’t be combined with a saved provider. Choose Managed alone or choose a saved provider, then retry.";
+		}
+		if (error.status === 401) {
+			return "Your session has expired. Sign in again before changing this agent.";
+		}
+		if (error.status === 403) {
+			return "Your Clawdi account can’t change this agent. Ask the agent owner to update it.";
+		}
+		if (error.status === 404) {
+			return "This agent is no longer available. Return to Agents and refresh the list.";
+		}
+		if (error.status >= 500 || error.status === 429) {
+			return "The Clawdi agent service couldn’t complete this change. Check the latest status, then try again in a moment.";
+		}
+	}
+	return "Clawdi couldn’t apply this agent change. Check the latest status and settings, then try again.";
+}
 
 /** Stable product name for every operation verb; never render the wire value. */
 export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): string {
@@ -85,6 +133,19 @@ export function deploymentFailurePresentation(
 	const operationLabel = deploymentOperationLabel(failure.failedVerb);
 	const operationName = operationLabel.toLocaleLowerCase();
 	const requiresWalletTopUp = deploymentFailureNeedsWalletTopUp(failure);
+	if (PROVIDER_CONFIGURATION_CODES.has(failure.code)) {
+		return {
+			...failure,
+			title: "Provider configuration failed",
+			description:
+				"The current provider settings could not start this agent. Fix or switch the provider, then save the agent settings.",
+			remediation: {
+				kind: "review_provider",
+				label: "Fix provider",
+				requiresWalletTopUp: false,
+			},
+		};
+	}
 
 	switch (failure.failedVerb) {
 		case "create":
@@ -184,17 +245,25 @@ export function deploymentFailureProjection(
 ): DeploymentFailureProjection | null {
 	if (!deployment) return null;
 	const status = deployment.resource.status;
-	if (status === null || status.summary_state !== "failed") return null;
-	const failure = status.failure;
-	if (!failure) return null;
-	const failedVerb = deployment.accepted_operation?.metadata.verb ?? null;
-	const reason = deploymentFailureReason(status, failedVerb);
+	const operation = deployment.accepted_operation;
+	const operationFailed = operation?.done === true && operation.error != null;
+	const failure =
+		status?.summary_state === "failed" && status.failure
+			? status.failure
+			: operationFailed
+				? operation.error?.details[0]
+				: null;
+	if (!failure && !operationFailed) return null;
+	const failedVerb = operation?.metadata.verb ?? null;
+	const reason = failure
+		? deploymentFailureReason({ failure }, failedVerb)
+		: DEFAULT_SERVICE_FAILURE_REASON;
 	if (!reason) return null;
 	return {
 		reason,
 		failedVerb,
-		retryable: failure.retryable ?? null,
-		code: failure.code,
+		retryable: failure?.retryable ?? null,
+		code: failure?.code ?? "operation_failed",
 	};
 }
 

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -247,6 +247,20 @@ describe("DeploymentStatus", () => {
 		});
 	});
 
+	test("stops convergence polling when the accepted operation has failed", () => {
+		const operation = acceptedOperation("create");
+		operation.done = true;
+		operation.error = { code: 5, message: "provider unavailable", details: [] };
+		const failed = deploymentPollingState(
+			[hostedDeploymentFixture({ status: "starting", acceptedOperation: operation })],
+			new Map(),
+			Date.parse("2026-07-27T00:00:00Z"),
+		);
+
+		expect(failed.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
+		expect(failed.transitions.size).toBe(0);
+	});
+
 	test("drops fast plan-change polling immediately when it reaches a terminal state", () => {
 		const nowMs = Date.parse("2026-07-25T00:00:00Z");
 		const operation = acceptedOperation("plan_change");

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -385,6 +385,7 @@ export function deploymentPollingState(
 	let refetchInterval: number | false = false;
 
 	for (const deployment of deployments ?? []) {
+		if (deployment.accepted_operation?.done && deployment.accepted_operation.error) continue;
 		const status = deploymentStatusFromResource(deployment.resource.status);
 		if (!isTransitionalStatus(status)) continue;
 

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -71,7 +71,8 @@ export function HostedDeploymentTileAction({
 					Open Wallet
 				</Button>
 			) : null}
-			{remediation?.kind === "review_plan_change" && remediationHref ? (
+			{(remediation?.kind === "review_plan_change" || remediation?.kind === "review_provider") &&
+			remediationHref ? (
 				<Button
 					render={<a href={remediationHref} />}
 					nativeButton={false}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -11,6 +11,7 @@ import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-managemen
 import {
 	compactDeploymentFailureReason,
 	type DeploymentFailurePresentation,
+	deploymentFailurePresentation,
 	deploymentFailureProjection,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
@@ -211,8 +212,11 @@ export function deploymentToTiles(
 	};
 	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
 	const settingsHref = envId ? agentSectionHref(envId, "settings", routeQuery) : undefined;
+	const providerSettingsHref = envId ? agentSectionHref(envId, "ai", routeQuery) : undefined;
 	const deploymentStatus = deploymentStatusFromResource(d.resource.status);
+	const failure = deploymentFailurePresentation(d);
 	const showTileActions =
+		Boolean(failure) ||
 		deploymentStatus.kind === "stopped" ||
 		deploymentStatus.kind === "failed" ||
 		deploymentStatus.kind === "unknown" ||
@@ -231,7 +235,12 @@ export function deploymentToTiles(
 			action: showTileActions
 				? createElement(HostedDeploymentTileAction, {
 						deployment: d,
-						remediationHref: settingsHref ? `${settingsHref}#compute-plan-controls` : undefined,
+						remediationHref:
+							failure?.remediation.kind === "review_provider"
+								? providerSettingsHref
+								: settingsHref
+									? `${settingsHref}#compute-plan-controls`
+									: undefined,
 						isRetrying: statusRetry?.isRetrying,
 						onRetry: statusRetry?.onRetry,
 					})

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -108,9 +108,9 @@ describe("AI provider binding fields", () => {
 	test("uses one auth mapping and selection order for create and update bootstraps", () => {
 		const draft = {
 			bindingMode: "configured" as const,
-			providerChoices: [MANAGED_AI_CHOICE, oauthProvider.provider_id, apiKeyProvider.provider_id],
-			primaryProviderChoice: MANAGED_AI_CHOICE,
-			primaryModel: "gpt-managed",
+			providerChoices: [oauthProvider.provider_id, apiKeyProvider.provider_id],
+			primaryProviderChoice: oauthProvider.provider_id,
+			primaryModel: "gpt-custom",
 		};
 
 		for (const mode of ["create", "update"] as const) {
@@ -120,11 +120,7 @@ describe("AI provider binding fields", () => {
 				providers: [apiKeyProvider, oauthProvider],
 			});
 
-			expect(fields.provider_ids).toEqual([
-				MANAGED_PROVIDER_ID,
-				oauthProvider.provider_id,
-				apiKeyProvider.provider_id,
-			]);
+			expect(fields.provider_ids).toEqual([oauthProvider.provider_id, apiKeyProvider.provider_id]);
 			expect(fields.ai_provider_bootstrap?.selected_provider_id).toBe(oauthProvider.provider_id);
 			expect(fields.ai_provider_bootstrap?.auth_kind).toBe("codex_oauth");
 			expect(
@@ -181,6 +177,30 @@ describe("AI provider binding draft transitions", () => {
 		).toEqual([apiKeyProvider.provider_id]);
 	});
 
+	test("replaces a BYO provider with a managed-only update request", () => {
+		const managed = toggleAiBindingProvider(
+			{
+				bindingMode: "configured",
+				providerChoices: [apiKeyProvider.provider_id],
+				primaryProviderChoice: apiKeyProvider.provider_id,
+				primaryModel: "gpt-custom",
+			},
+			MANAGED_AI_CHOICE,
+			{ managedModels, operationMode: "update", providers: [apiKeyProvider] },
+		);
+
+		expect(managed.providerChoices).toEqual([MANAGED_AI_CHOICE]);
+		expect(buildAiBindingFields(managed, { managedModels, mode: "update", providers: [] })).toEqual(
+			{
+				ai_provider_auth_kind: "managed",
+				ai_provider_id: null,
+				provider_ids: [MANAGED_PROVIDER_ID],
+				primary_model: { provider_id: MANAGED_PROVIDER_ID, model: "gpt-managed" },
+				ai_provider_bootstrap: null,
+			},
+		);
+	});
+
 	test("preserves the create and update model-fallback difference", () => {
 		const draft = {
 			bindingMode: "configured" as const,
@@ -205,7 +225,7 @@ describe("AI provider binding draft transitions", () => {
 		).toBe("   ");
 	});
 
-	test("keeps unresolved providers visible only for update and replaces them with managed", () => {
+	test("keeps unresolved providers visible until the user replaces them", () => {
 		const unresolved = updateProviderChoiceFromRef("deleted-provider", []);
 		expect(unresolved).toBe(unresolvedProviderChoice("deleted-provider"));
 		expect(unresolved && isUnresolvedProviderChoice(unresolved)).toBe(true);
@@ -222,17 +242,9 @@ describe("AI provider binding draft transitions", () => {
 			operationMode: "update",
 			providers: [],
 		});
-		const createDraft = toggleAiBindingProvider(draft, MANAGED_AI_CHOICE, {
-			managedModels,
-			operationMode: "create",
-			providers: [],
-		});
-
 		expect(updateDraft.providerChoices).toEqual([MANAGED_AI_CHOICE]);
 		expect(updateDraft.primaryProviderChoice).toBe(MANAGED_AI_CHOICE);
 		expect(updateDraft.primaryModel).toBe("gpt-managed");
-		expect(createDraft.providerChoices).toEqual([unresolved, MANAGED_AI_CHOICE]);
-		expect(createDraft.primaryProviderChoice).toBe(unresolved);
 		expect(() =>
 			buildAiBindingFields(draft, { managedModels, mode: "update", providers: [] }),
 		).toThrow(AiBindingBuildError);

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
@@ -24,10 +24,11 @@ describe("ProviderUsabilityBadge", () => {
 		expect(providerPageSource).toContain("<RemoveProviderAction provider={provider}");
 	});
 
-	test("badges a credential-backed provider as connected", () => {
+	test("badges a credential-backed provider as saved without claiming connectivity", () => {
 		const markup = renderToStaticMarkup(createElement(ProviderUsabilityBadge, { usable: true }));
 
-		expect(markup).toContain("Connected");
+		expect(markup).toContain("Saved");
+		expect(markup).not.toContain("Connected");
 		expect(markup).toContain('data-status="success"');
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -53,7 +53,7 @@ export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
 export function ProviderUsabilityBadge({ usable }: { usable: boolean }) {
 	return (
 		<StatusBadge status={usable ? "success" : "warning"} withDot>
-			{usable ? "Connected" : "Needs setup"}
+			{usable ? "Saved" : "Needs setup"}
 		</StatusBadge>
 	);
 }

--- a/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
-import {
-	type AiBindingMode,
-	type AiBindingOperationMode,
-	type AiProviderBindingDraft,
-	isUnresolvedProviderChoice,
+import type {
+	AiBindingMode,
+	AiBindingOperationMode,
+	AiProviderBindingDraft,
 } from "@/hosted/v2/ai-providers/ai-provider-binding";
 import {
 	dedupeProviderIds,
@@ -54,7 +53,13 @@ export function changeAiBindingPrimaryProvider(
 	return {
 		...draft,
 		bindingMode: "configured",
-		providerChoices: normalizeSelectedProviderIds(draft.providerChoices, choice),
+		providerChoices:
+			choice === MANAGED_AI_CHOICE
+				? [MANAGED_AI_CHOICE]
+				: normalizeSelectedProviderIds(
+						draft.providerChoices.filter((item) => item !== MANAGED_AI_CHOICE),
+						choice,
+					),
 		primaryProviderChoice: choice,
 		primaryModel,
 	};
@@ -67,9 +72,7 @@ export function toggleAiBindingProvider(
 ): AiProviderBindingDraft {
 	const selected = draft.providerChoices.includes(choice);
 	let choices =
-		context.operationMode === "update" &&
-		choice === MANAGED_AI_CHOICE &&
-		draft.providerChoices.some(isUnresolvedProviderChoice)
+		choice === MANAGED_AI_CHOICE
 			? [MANAGED_AI_CHOICE]
 			: selected
 				? draft.providerChoices.filter((item) => item !== choice)

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1401,6 +1401,16 @@ export interface components {
              */
             deployment_id: string;
         };
+        /** V2DeleteDeploymentRequest */
+        V2DeleteDeploymentRequest: {
+            /**
+             * Subscription Choice
+             * @description Whether deletion keeps the paid subscription available for reuse or cancels it at the provider. Omission safely keeps the subscription.
+             * @default keep_subscription
+             * @enum {string}
+             */
+            subscription_choice: "keep_subscription" | "cancel_subscription";
+        };
         /** V2DeploymentTerminalSessionResponse */
         V2DeploymentTerminalSessionResponse: {
             /**
@@ -1869,6 +1879,11 @@ export interface components {
             amount_usd: string;
             /** Status */
             status: string;
+            /**
+             * Payment Reference
+             * @description Reference for matching a card payment to this wallet entry
+             */
+            payment_reference: string | null;
             /** Receipt Url */
             receipt_url?: string | null;
             /** Created At */
@@ -2167,7 +2182,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["V2DeleteDeploymentRequest"];
+            };
+        };
         responses: {
             /** @description The declarative spec change was accepted. */
             202: {


### PR DESCRIPTION
## Summary

- Label credential-backed BYO providers as Saved, without claiming endpoint or credential validation.
- Keep Managed by Clawdi selections representable by replacing BYO choices in the draft and emitting a Managed-only update request.
- Route deployment mutations through deployment-specific error copy, including provider and Basic-slot recovery.
- Surface terminal accepted_operation.error failures through the existing deployment failure panel and link provider failures to provider settings.

## Contract and scope notes

The dead-end root was not a stale status.failure. The live generated contract exposes the terminal failure in accepted_operation.error while summary_state may still be starting, so this change treats that completed operation error as authoritative and stops convergence polling.

No stronger connectivity fact exists in AiProviderResponse: usable only confirms that required credential material was saved. Saved is therefore the strongest supported claim.

The test-harness account identity split is intentionally unchanged. No v1 or clawdi-hosted code changed.

The live deployed OpenAPI had advanced beyond origin/main, so the deploy client was regenerated from api.clawdi.ai. The generated delta includes the delete subscription choice request and wallet payment_reference field required by the current live contract.

The billing normalizer is already reused outside billing for hosted inventory, terminal and runtime credential UI, provider reads, and managed-model reads. This PR moves deployment mutations only; broader convergence should be handled separately instead of adding more vocabularies here.

## Line delta

- Total: 352 additions, 61 deletions, net +291
- Handwritten non-test code: net +105
- Tests: net +167
- Generated contract: net +19

## Verification

- bun run lint
- bun run typecheck
- bun run --cwd apps/web test — 665 passed
- bun run --cwd apps/web e2e:hosted — 62 passed
- DEPLOY_CONTRACT_FETCH_MODE=strict scripts/check-deploy-generated-api.sh
- git diff --check
