### PR TITLE
Fix Hermes credentials dialog

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2171,6 +2171,73 @@ test("deployment detail stays put, becomes running, and keeps manual Runtime UI 
 	await expect(main.getByRole("button", { name: "Open Hermes Dashboard" })).toBeVisible();
 });
 
+test("Hermes credentials use an accessible dialog without expanding the embedded dashboard", async ({
+	context,
+	page,
+}) => {
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+	const runtimeUiRedemptionRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		runtimeUiRedemptionRequests,
+	});
+
+	await page.goto(`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi`);
+	const main = page.locator("main");
+	const dashboard = main.locator('iframe[title="Hermes Dashboard"]');
+	await expect(dashboard).toHaveAttribute("src", "https://runtime.example/hermes");
+	await expect(
+		page.getByText(
+			"If Hermes returns to sign-in after you submit, use Open in new window. Some browser session policies do not work inside an embedded page.",
+			{ exact: true },
+		),
+	).toHaveCount(0);
+	const dashboardBoxBefore = await dashboard.boundingBox();
+	expect(dashboardBoxBefore).not.toBeNull();
+
+	const showCredentials = main.getByRole("button", { name: "Show credentials", exact: true });
+	await expect(showCredentials).toBeVisible();
+	await expect(main.getByRole("button", { name: "Open Hermes Dashboard" })).toBeVisible();
+	await showCredentials.click();
+
+	const dialog = page.getByRole("dialog", { name: "Hermes sign-in credentials" });
+	await expect(dialog).toBeVisible();
+	await expect
+		.poll(() => dialog.evaluate((element) => element.contains(document.activeElement)))
+		.toBe(true);
+	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
+	await expect(dialog.getByLabel("Username", { exact: true })).toHaveValue("admin");
+	await expect(main.getByLabel("Username", { exact: true })).toHaveCount(0);
+	const passwordValue = dialog.locator("code");
+	await expect(passwordValue).toHaveText("••••••••••••");
+	await expect(passwordValue).not.toContainText("test-password");
+
+	await dialog.getByRole("button", { name: "Copy Username", exact: true }).click();
+	await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("admin");
+	await dialog.getByRole("button", { name: "Copy Password", exact: true }).click();
+	await expect
+		.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+		.toBe("test-password");
+	await dialog.getByRole("button", { name: "Show Password", exact: true }).click();
+	await expect(passwordValue).toHaveText("test-password");
+
+	const dashboardBoxWhileOpen = await dashboard.boundingBox();
+	expect(dashboardBoxWhileOpen).toEqual(dashboardBoxBefore);
+	await page.keyboard.press("Escape");
+	await expect(dialog).toHaveCount(0);
+	await expect(showCredentials).toBeFocused();
+	await expect(page.locator('input[value="admin"]')).toHaveCount(0);
+	await expect(page.getByText("test-password", { exact: true })).toHaveCount(0);
+
+	const popupPromise = page.waitForEvent("popup");
+	await main.getByRole("button", { name: "Open Hermes Dashboard" }).click();
+	const popup = await popupPromise;
+	await expect(dialog).toBeVisible();
+	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(2);
+	expect(popup).toBeDefined();
+	await popup.close();
+});
+
 test("Runtime UI credential failure renders a retryable error instead of a permanent spinner", async ({
 	page,
 }) => {
@@ -2200,17 +2267,22 @@ test("Runtime UI credential failure renders a retryable error instead of a perma
 		"https://runtime.example/hermes",
 	);
 	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Hermes sign-in credentials" });
+	await expect(dialog).toBeVisible();
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
-	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Couldn't load Hermes credentials", { exact: true })).toBeVisible();
+	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("credentials temporarily unavailable", { exact: true })).toHaveCount(
 		0,
 	);
-	await main.getByRole("button", { name: "Retry", exact: true }).click();
-	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toHaveCount(0);
-	const passwordValue = main.locator("code");
+	await dialog.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect(dialog.getByText("Couldn't load Hermes credentials", { exact: true })).toHaveCount(
+		0,
+	);
+	const passwordValue = dialog.locator("code");
 	await expect(passwordValue).toHaveText("••••••••••••");
 	await expect(passwordValue).not.toContainText("recovered-password");
-	await main.getByRole("button", { name: "Show Password", exact: true }).click();
+	await dialog.getByRole("button", { name: "Show Password", exact: true }).click();
 	await expect(passwordValue).toHaveText("recovered-password");
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(2);
 });

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -259,7 +259,7 @@ describe("hosted agent customer language", () => {
 		expect(sidebarSource).toContain('"Agent details unavailable"');
 	});
 
-	test("keeps one credential handover path and restores the Hermes embedded interface", () => {
+	test("keeps one credential handover path and uses a Hermes credential dialog", () => {
 		const detailSource = readFileSync(
 			new URL("./hosted-agent-detail.tsx", import.meta.url),
 			"utf8",
@@ -271,6 +271,9 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain("<iframe");
 		expect(detailSource).toContain('allow="clipboard-read; clipboard-write"');
 		expect(detailSource).toContain("Show credentials");
+		expect(detailSource).toContain("Hermes sign-in credentials");
+		expect(detailSource).toContain("Copy Username");
+		expect(detailSource).not.toContain("If Hermes returns to sign-in after you submit");
 		expect(detailSource).toContain("OpenClaw protects its interface from embedding");
 	});
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -44,6 +44,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { DataTablePagination } from "@/components/ui/data-table-pagination";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -73,6 +80,7 @@ import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
+import { CopyButton } from "@/hosted/billing/components/copy-button";
 import type {
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeQuoteResponse,
@@ -1376,14 +1384,15 @@ function ConsoleTab({
 	const requestCredentials = useRuntimeUiCredentialRequest(deployment, url ?? "", runtime);
 	const credentialIdentity = `${deployment.resource.id}\0${deployment.resource.metadata.generation}\0${runtime}\0${url ?? ""}`;
 	const [credentials, setCredentials] = useState<ResolvedRuntimeUiCredentials | null>(null);
-	const [showCredentials, setShowCredentials] = useState(false);
+	const [isCredentialsDialogOpen, setIsCredentialsDialogOpen] = useState(false);
 	const [credentialError, setCredentialError] = useState<Error | null>(null);
 	const [isLoadingCredentials, setIsLoadingCredentials] = useState(false);
 	const credentialRequestRef = useRef(0);
+	const showCredentialsButtonRef = useRef<HTMLButtonElement>(null);
 	useEffect(() => {
 		credentialRequestRef.current += 1;
 		setCredentials(null);
-		setShowCredentials(false);
+		setIsCredentialsDialogOpen(false);
 		setCredentialError(null);
 		setIsLoadingCredentials(false);
 	}, [credentialIdentity]);
@@ -1400,7 +1409,6 @@ function ConsoleTab({
 				throw new Error("Runtime UI credential response was invalid");
 			}
 			setCredentials(resolved);
-			setShowCredentials(true);
 		} catch (error) {
 			if (credentialRequestRef.current !== requestId) return;
 			setCredentialError(error instanceof Error ? error : new Error("Credential request failed"));
@@ -1409,14 +1417,19 @@ function ConsoleTab({
 		}
 	}, [requestCredentials, runtime, url]);
 
-	const toggleHermesCredentials = () => {
-		if (showCredentials) {
-			setShowCredentials(false);
+	const handleCredentialsDialogOpenChange = (open: boolean) => {
+		setIsCredentialsDialogOpen(open);
+		if (!open) {
+			credentialRequestRef.current += 1;
 			setCredentials(null);
-			return;
+			setCredentialError(null);
+			setIsLoadingCredentials(false);
 		}
-		if (credentials?.runtime === "hermes") setShowCredentials(true);
-		else void loadHermesCredentials();
+	};
+
+	const showHermesCredentials = () => {
+		setIsCredentialsDialogOpen(true);
+		if (credentials?.runtime !== "hermes") void loadHermesCredentials();
 	};
 
 	if (status.kind === "stopped") {
@@ -1507,14 +1520,15 @@ function ConsoleTab({
 		<>
 			{runtime === "hermes" ? (
 				<Button
+					ref={showCredentialsButtonRef}
 					type="button"
 					variant="outline"
 					size="sm"
 					disabled={isLoadingCredentials}
-					onClick={toggleHermesCredentials}
+					onClick={showHermesCredentials}
 				>
 					{isLoadingCredentials ? <Spinner className="size-3.5" /> : null}
-					{showCredentials ? "Hide credentials" : "Show credentials"}
+					Show credentials
 				</Button>
 			) : null}
 			<RuntimeUiOpenButton
@@ -1529,7 +1543,7 @@ function ConsoleTab({
 						? (value) => {
 								setCredentialError(null);
 								setCredentials({ runtime: "hermes", value });
-								setShowCredentials(true);
+								setIsCredentialsDialogOpen(true);
 							}
 						: undefined
 				}
@@ -1541,36 +1555,9 @@ function ConsoleTab({
 	);
 
 	return (
-		<LiveToolFrame icon={MonitorPlay} title={browserUiLabel} action={runtimeActions}>
-			{runtime === "hermes" ? (
-				<>
-					<div className="shrink-0 border-y bg-muted/20 px-4 py-2 text-xs text-muted-foreground lg:px-6">
-						If Hermes returns to sign-in after you submit, use Open in new window. Some browser
-						session policies do not work inside an embedded page.
-					</div>
-					{showCredentials && hermesCredentials ? (
-						<div className="grid shrink-0 gap-3 border-b bg-muted/20 p-4 sm:grid-cols-2 lg:px-6">
-							<div className="space-y-1.5">
-								<Label htmlFor={`hermes-username-${deployment.resource.id}`}>Username</Label>
-								<Input
-									id={`hermes-username-${deployment.resource.id}`}
-									readOnly
-									value={hermesCredentials.username}
-								/>
-							</div>
-							<TokenReveal label="Password" value={hermesCredentials.password} />
-						</div>
-					) : null}
-					{credentialError ? (
-						<div className="shrink-0 p-4 lg:px-6">
-							<ApiErrorPanel
-								error={credentialError}
-								onRetry={() => void loadHermesCredentials()}
-								normalizer={billingErrorNormalizer}
-								title={`Couldn't load ${label} credentials`}
-							/>
-						</div>
-					) : null}
+		<>
+			<LiveToolFrame icon={MonitorPlay} title={browserUiLabel} action={runtimeActions}>
+				{runtime === "hermes" ? (
 					<iframe
 						key={`${runtime}:${url}`}
 						src={url}
@@ -1578,18 +1565,78 @@ function ConsoleTab({
 						className="min-h-[420px] flex-1 border-0 bg-background"
 						allow="clipboard-read; clipboard-write"
 					/>
-				</>
-			) : (
-				<div className="flex min-h-[420px] flex-1 items-center justify-center p-6">
-					<div className="max-w-xl space-y-2 text-center">
-						<h2 className="text-lg font-semibold">Open in a new window</h2>
-						<p className="text-sm text-muted-foreground">
-							OpenClaw protects its interface from embedding. Use the secure window to sign in.
-						</p>
+				) : (
+					<div className="flex min-h-[420px] flex-1 items-center justify-center p-6">
+						<div className="max-w-xl space-y-2 text-center">
+							<h2 className="text-lg font-semibold">Open in a new window</h2>
+							<p className="text-sm text-muted-foreground">
+								OpenClaw protects its interface from embedding. Use the secure window to sign in.
+							</p>
+						</div>
 					</div>
-				</div>
-			)}
-		</LiveToolFrame>
+				)}
+			</LiveToolFrame>
+
+			{runtime === "hermes" ? (
+				<Dialog open={isCredentialsDialogOpen} onOpenChange={handleCredentialsDialogOpenChange}>
+					<DialogContent
+						data-hosted="true"
+						data-v2="true"
+						className="sm:max-w-md"
+						finalFocus={showCredentialsButtonRef}
+					>
+						<DialogHeader>
+							<DialogTitle>Hermes sign-in credentials</DialogTitle>
+							<DialogDescription>
+								Use these credentials to sign in to the Hermes Dashboard. They disappear when you
+								close this dialog.
+							</DialogDescription>
+						</DialogHeader>
+
+						{isLoadingCredentials ? (
+							<div
+								role="status"
+								className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground"
+							>
+								<Spinner className="size-4" />
+								Loading sign-in credentials…
+							</div>
+						) : null}
+
+						{credentialError ? (
+							<ApiErrorPanel
+								error={credentialError}
+								onRetry={() => void loadHermesCredentials()}
+								normalizer={billingErrorNormalizer}
+								title={`Couldn't load ${label} credentials`}
+							/>
+						) : null}
+
+						{hermesCredentials ? (
+							<div className="space-y-4">
+								<div className="space-y-1.5">
+									<Label htmlFor={`hermes-username-${deployment.resource.id}`}>Username</Label>
+									<div className="flex items-center gap-1">
+										<Input
+											id={`hermes-username-${deployment.resource.id}`}
+											className="font-mono"
+											readOnly
+											value={hermesCredentials.username}
+										/>
+										<CopyButton
+											value={hermesCredentials.username}
+											label="Copy Username"
+											toastMessage="Username copied to clipboard"
+										/>
+									</div>
+								</div>
+								<TokenReveal label="Password" value={hermesCredentials.password} />
+							</div>
+						) : null}
+					</DialogContent>
+				</Dialog>
+			) : null}
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary

- remove the obsolete Hermes embedded-session policy sentence and keep the dashboard frame unchanged
- move Hermes username/password loading, retry, reveal, and copy behavior into the existing design-system Dialog
- clear credential state on close, restore keyboard focus to the trigger, and preserve the secure Open in new window flow
- add focused source and Chromium regressions for modal-only rendering, clipboard behavior, password masking/reveal, Escape close/focus restoration, external window launch, and retry recovery

## Verification

- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test
- bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts
- bun run --cwd apps/web build:oss
- bun run --cwd apps/web e2e:hosted --grep "Hermes credentials use|Runtime UI credential failure" --trace on
- bun run test (Docker clean runner: workspace typechecks, 1020 JS/TS tests, 1353 backend tests passed; 7 skipped)

Browser verification used an isolated Chromium context with fully stubbed hosted APIs. It verified that the dialog has an accessible name and trapped focus, credentials never render inline, the iframe bounding box does not change, username/password clipboard actions work, the password starts masked and can be revealed, Escape clears credentials and returns focus, Open in new window still launches a popup, and credential failures remain retryable inside the dialog.

No production services, live clusters, tenant data, or billing were accessed. backend/app/v1/** was not changed.