### PR TITLE
Fix Wallet USD formatting and action layout

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3493,12 +3493,20 @@ test("pending welcome balance stops polling and offers a bounded refresh", async
 	await expect(page.getByText("Adding your welcome balance…", { exact: true })).toBeVisible();
 });
 
-test("Wallet opens the shared billing portal action", async ({ page }) => {
+test("Wallet formats its balance and opens billing from the balance actions", async ({ page }) => {
 	const portalRequests: string[] = [];
-	await stubHostedApi(page, { portalRequests });
+	await stubHostedApi(page, {
+		portalRequests,
+		walletState: { ...walletState, balance_usd: "29.4825458" },
+	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
+	const balanceCard = settingsDialog
+		.locator('[data-slot="card"]')
+		.filter({ hasText: "Wallet balance" });
+	await expect(balanceCard.getByText("$29.48", { exact: true })).toBeVisible();
+	await expect(balanceCard.getByRole("button", { name: "Top up", exact: true })).toBeVisible();
 
-	await settingsDialog.getByRole("button", { name: "Manage payment methods" }).click();
+	await balanceCard.getByRole("button", { name: "Manage payment methods" }).click();
 
 	await expect.poll(() => portalRequests.length).toBe(1);
 	await expect(page).toHaveURL(/\?portal=opened$/);

--- a/apps/web/src/hosted/billing/format.test.ts
+++ b/apps/web/src/hosted/billing/format.test.ts
@@ -2,15 +2,28 @@ import { describe, expect, test } from "bun:test";
 import { formatCents, formatUsd, formatUsdExact } from "@/hosted/billing/format";
 
 describe("USD formatting", () => {
-	test("groups decimal-string USD without rounding the quoted amount", () => {
+	test("formats normal numeric USD with exactly two decimal places", () => {
+		expect(formatUsd(29.4825458)).toBe("$29.48");
+		expect(formatUsd(12)).toBe("$12.00");
+	});
+
+	test("rounds and groups exact decimal-string USD to cents", () => {
 		expect(formatUsdExact("0123456.7800")).toBe("$123,456.78");
-		expect(formatUsdExact("12.345678")).toBe("$12.345678");
+		expect(formatUsdExact("12.344")).toBe("$12.34");
+		expect(formatUsdExact("12.345678")).toBe("$12.35");
+		expect(formatUsdExact("999.999")).toBe("$1,000.00");
+		expect(formatUsdExact("9007199254740993.995")).toBe("$9,007,199,254,740,994.00");
+		expect(formatUsdExact(" +0000012.4 ")).toBe("$12.40");
 		expect(formatUsdExact("-2500")).toBe("-$2,500.00");
+		expect(formatUsdExact("-12.345")).toBe("-$12.35");
 	});
 
 	test("keeps non-zero sub-cent values visible", () => {
 		expect(formatUsdExact("0.000001")).toBe("<$0.01");
+		expect(formatUsdExact("0.009999")).toBe("<$0.01");
+		expect(formatUsdExact("-0.000001")).toBe("-<$0.01");
 		expect(formatUsd(0.001)).toBe("<$0.01");
+		expect(formatUsd(-0.001)).toBe("-<$0.01");
 		expect(formatUsdExact("0.01")).toBe("$0.01");
 	});
 

--- a/apps/web/src/hosted/billing/format.ts
+++ b/apps/web/src/hosted/billing/format.ts
@@ -9,6 +9,20 @@ const USD = new Intl.NumberFormat("en-US", {
 
 const DECIMAL_USD = /^([+-]?)(\d+)(?:\.(\d+))?$/;
 
+function incrementDecimalDigits(digits: string): string {
+	const incremented = [...digits];
+	for (let index = incremented.length - 1; index >= 0; index -= 1) {
+		const digit = incremented[index];
+		if (digit === "9") {
+			incremented[index] = "0";
+			continue;
+		}
+		incremented[index] = String.fromCharCode(digit.charCodeAt(0) + 1);
+		return incremented.join("");
+	}
+	return `1${incremented.join("")}`;
+}
+
 /** Cents → "$19.00". */
 export function formatCents(cents: number): string {
 	return formatUsd(cents / 100);
@@ -24,24 +38,29 @@ export function formatUsd(dollars: number): string {
 }
 
 /**
- * Decimal-string USD → an exact grouped display without rounding through a
- * JavaScript number. Non-zero sub-cent values use a visible floor so usage
- * never appears as "$0.00".
+ * Decimal-string USD → an exactly rounded, grouped cents display without
+ * converting the amount to a JavaScript number. Non-zero sub-cent values use
+ * a visible floor so usage never appears as "$0.00".
  */
 export function formatUsdExact(dollars: string): string {
 	const match = DECIMAL_USD.exec(dollars.trim());
 	if (!match) return "—";
 	const [, sign, rawWhole, rawFraction] = match;
 	const whole = rawWhole.replace(/^0+(?=\d)/, "");
-	const fraction = rawFraction?.replace(/0+$/, "") ?? "";
-	const isZero = whole === "0" && !fraction;
-	const normalizedSign = isZero || sign === "+" ? "" : sign;
+	const fraction = rawFraction ?? "";
+	const isZero = whole === "0" && !/[1-9]/.test(fraction);
+	const normalizedSign = isZero || sign !== "-" ? "" : "-";
 	const firstTwoFractionDigits = fraction.slice(0, 2).padEnd(2, "0");
 	if (!isZero && whole === "0" && firstTwoFractionDigits === "00") {
 		return `${normalizedSign}<$0.01`;
 	}
-	const groupedWhole = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-	const displayFraction = fraction.padEnd(2, "0");
+
+	const unroundedCents = `${whole}${firstTwoFractionDigits}`;
+	const roundedCents =
+		(fraction[2] ?? "0") >= "5" ? incrementDecimalDigits(unroundedCents) : unroundedCents;
+	const roundedWhole = roundedCents.slice(0, -2);
+	const displayFraction = roundedCents.slice(-2);
+	const groupedWhole = roundedWhole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 	return `${normalizedSign}$${groupedWhole}.${displayFraction}`;
 }
 

--- a/apps/web/src/hosted/billing/wallet/balance-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/balance-card.tsx
@@ -3,6 +3,7 @@
 import { Coins, CreditCard, Info, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatUsdExact } from "@/hosted/billing/format";
 import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
@@ -17,15 +18,19 @@ export function BalanceCard({
 	wallet,
 	hasWalletCompute = false,
 	onTopUp,
+	onManagePaymentMethods,
+	isManagePaymentMethodsPending = false,
 }: {
 	wallet: WalletCacheSnapshot;
 	hasWalletCompute?: boolean;
 	onTopUp: () => void;
+	onManagePaymentMethods: () => void;
+	isManagePaymentMethodsPending?: boolean;
 }) {
 	const low = isLowBalance(wallet.balance_usd);
 	return (
 		<Card data-hosted="true">
-			<CardContent className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+			<CardContent className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
 				<div className="space-y-1.5">
 					<div className="flex items-center gap-1.5 text-sm text-muted-foreground">
 						<Coins className="size-4" aria-hidden />
@@ -68,9 +73,21 @@ export function BalanceCard({
 						) : null}
 					</div>
 				</div>
-				<Button onClick={onTopUp} size="lg" className="w-full sm:w-auto">
-					<CreditCard /> Top up
-				</Button>
+				<div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto lg:shrink-0">
+					<Button onClick={onTopUp} size="lg" className="w-full sm:w-auto">
+						<CreditCard /> Top up
+					</Button>
+					<Button
+						variant="outline"
+						size="lg"
+						className="w-full sm:w-auto"
+						onClick={onManagePaymentMethods}
+						disabled={isManagePaymentMethodsPending}
+						aria-busy={isManagePaymentMethodsPending}
+					>
+						{isManagePaymentMethodsPending ? <Spinner /> : <CreditCard />} Manage payment methods
+					</Button>
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { CreditCard } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
@@ -80,16 +77,6 @@ export function WalletPage() {
 		}
 	}
 
-	const portalAction = (
-		<Button
-			variant="outline"
-			onClick={() => runAction(openBillingPortal)}
-			disabled={portal.isPending}
-		>
-			{portal.isPending ? <Spinner /> : <CreditCard />} Manage payment methods
-		</Button>
-	);
-
 	useEffect(() => {
 		const topupReturn = readWalletTopupReturn(window.location.search);
 		if (!topupReturn) return;
@@ -151,7 +138,7 @@ export function WalletPage() {
 	if (wallet.isLoading) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} actions={portalAction} />
+				<PageHeader title="Wallet" description={DESCRIPTION} />
 				<WalletSkeleton />
 			</div>
 		);
@@ -160,7 +147,7 @@ export function WalletPage() {
 	if (wallet.error || !wallet.data) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} actions={portalAction} />
+				<PageHeader title="Wallet" description={DESCRIPTION} />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={wallet.error}
@@ -179,11 +166,7 @@ export function WalletPage() {
 
 	return (
 		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-			<PageHeader
-				title="Wallet"
-				description={DESCRIPTION}
-				actions={topUpOpen ? undefined : portalAction}
-			/>
+			<PageHeader title="Wallet" description={DESCRIPTION} />
 
 			<TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} presentation="inline" />
 
@@ -199,6 +182,8 @@ export function WalletPage() {
 					wallet={w}
 					hasWalletCompute={walletComputeCount > 0}
 					onTopUp={() => setTopUpOpen(true)}
+					onManagePaymentMethods={() => void runAction(openBillingPortal)}
+					isManagePaymentMethodsPending={portal.isPending}
 				/>
 
 				<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">


### PR DESCRIPTION
## Summary

- round shared hosted-billing USD displays to exactly two decimal places without converting exact decimal strings to Number
- preserve visible positive and negative non-zero sub-cent amounts
- move Manage payment methods beside Top up in the Wallet balance card with responsive and pending-state behavior
- cover the formatter contract and Wallet placement in focused unit and hosted E2E tests

## Tests

- bun test apps/web/src/hosted/billing/format.test.ts
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- bunx biome check apps/web/e2e/hosted-smoke.pw.ts
- E2E_HOSTED_PORT=43127 bun run --cwd apps/web e2e:hosted --grep "Wallet formats its balance and opens billing from the balance actions"
- git diff --check origin/main..HEAD
