### PR TITLE
fix(web): remove cloud badge from agent tab headers

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("hosted agent detail header", () => {
+	test("keeps the agent source badge out of tab page headers", () => {
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		const sidebarSource = readFileSync(
+			new URL("../../components/app-sidebar.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(detailSource).not.toContain("AgentSourceBadge");
+		expect(sidebarSource).toContain("AgentSourceBadge");
+	});
+});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -29,7 +29,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
+import { agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
 import type { DetailSectionMeta } from "@/components/detail/layout";
@@ -549,7 +549,6 @@ export function HostedAgentDetail({
 						title={activeTabLabel}
 						description={activeNavItem.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
-						status={<AgentSourceBadge source="hosted" compact />}
 						actions={headerActions}
 					/>
 				)}


### PR DESCRIPTION
## Summary
- remove the hosted-agent source badge from the shared agent tab page header
- preserve source badges in navigation and agent list surfaces
- add a focused regression test for the intended placement boundary

## Verification
- `bun run test web src/hosted/agents/hosted-agent-detail.test.ts` (Docker-isolated; includes web typecheck and OSS production build)