### PR TITLE
refactor(web): improve API key management

### DIFF
--- a/apps/web/e2e/api-keys-settings.pw.ts
+++ b/apps/web/e2e/api-keys-settings.pw.ts
@@ -1,0 +1,263 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+type ApiKeyFixture = {
+	id: string;
+	label: string;
+	key_prefix: string;
+	created_at: string;
+	last_used_at: string | null;
+	expires_at: string | null;
+	revoked_at: string | null;
+};
+
+const longLabel =
+	"Production automation key with a deliberately long descriptive name that must truncate";
+const now = "2026-07-28T12:00:00.000Z";
+
+function apiKey(id: string, label: string, overrides: Partial<ApiKeyFixture> = {}): ApiKeyFixture {
+	return {
+		id,
+		label,
+		key_prefix: `clawdi_${id}_prefix`,
+		created_at: now,
+		last_used_at: null,
+		expires_at: null,
+		revoked_at: null,
+		...overrides,
+	};
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+	await route.fulfill({
+		status,
+		contentType: "application/json",
+		body: JSON.stringify(body),
+	});
+}
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
+
+async function openApiKeySettings(page: Page) {
+	await page.goto("/");
+	await expect(page.getByTestId("app-sidebar")).toBeVisible({ timeout: 15_000 });
+	await expect(async () => {
+		await page.getByTestId("app-sidebar-settings-button").click();
+		await expect(page).toHaveURL(/[?&]settings=general/, { timeout: 1_000 });
+	}).toPass({ timeout: 15_000 });
+	const settingsDialog = page.getByTestId("settings-dialog");
+	await expect(settingsDialog).toBeVisible({ timeout: 15_000 });
+	await settingsDialog.getByRole("button", { name: /^API Keys/ }).click();
+	await expect(settingsDialog.getByRole("heading", { name: "API Keys" })).toBeVisible();
+}
+
+async function stubApiKeys(
+	page: Page,
+	options: { initialKeys?: ApiKeyFixture[]; failFirstList?: boolean } = {},
+) {
+	let keys = options.initialKeys ?? [
+		apiKey("active-long", longLabel, { last_used_at: "2026-07-27T08:00:00.000Z" }),
+		apiKey("active-short", "CI runner", { expires_at: "2026-12-31T00:00:00.000Z" }),
+		apiKey("revoked", "Revoked key from an older backend", {
+			revoked_at: "2026-07-27T10:00:00.000Z",
+		}),
+	];
+	let listRequests = 0;
+	let nextDelete:
+		| {
+				gate: ReturnType<typeof deferred>;
+				fail: boolean;
+		  }
+		| undefined;
+	const deleteRequests: string[] = [];
+
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		const method = route.request().method();
+		if (url.pathname === "/v1/auth/keys" && method === "GET") {
+			listRequests += 1;
+			if (options.failFirstList && listRequests === 1) {
+				await fulfillJson(route, { detail: "Mock list failure" }, 400);
+				return;
+			}
+			await fulfillJson(route, keys);
+			return;
+		}
+		if (url.pathname === "/v1/auth/keys" && method === "POST") {
+			const body = route.request().postDataJSON() as { label: string };
+			const created = apiKey("created", body.label);
+			keys = [created, ...keys];
+			await fulfillJson(route, { ...created, raw_key: "clawdi_created_one_time_secret" });
+			return;
+		}
+		if (url.pathname.startsWith("/v1/auth/keys/") && method === "DELETE") {
+			const keyId = url.pathname.split("/").at(-1) ?? "";
+			deleteRequests.push(keyId);
+			const pendingDelete = nextDelete;
+			if (pendingDelete) await pendingDelete.gate.promise;
+			if (pendingDelete?.fail) {
+				await fulfillJson(route, { detail: "Mock revoke failure" }, 500);
+				return;
+			}
+			keys = keys.filter((key) => key.id !== keyId);
+			await fulfillJson(route, { status: "revoked" });
+			return;
+		}
+
+		if (url.pathname === "/v1/agents") {
+			await fulfillJson(route, []);
+			return;
+		}
+		if (url.pathname === "/v1/projects") {
+			await fulfillJson(route, []);
+			return;
+		}
+		if (["/v1/sessions", "/v1/skills", "/v1/memories"].includes(url.pathname)) {
+			await fulfillJson(route, { items: [], total: 0, page: 1, page_size: 25 });
+			return;
+		}
+		if (url.pathname === "/v1/connectors/available") {
+			await fulfillJson(route, { items: [], total: 0, page: 1, page_size: 25 });
+			return;
+		}
+		if (["/v1/connectors", "/v1/vault"].includes(url.pathname)) {
+			await fulfillJson(route, []);
+			return;
+		}
+		if (url.pathname === "/v1/dashboard/stats") {
+			await fulfillJson(route, {
+				total_sessions: 0,
+				total_messages: 0,
+				total_tokens: 0,
+				active_days: 0,
+				current_streak: 0,
+				longest_streak: 0,
+				peak_hour: null,
+				favorite_model: null,
+				skills_count: 0,
+				memories_count: 0,
+				vault_count: 0,
+				vault_keys_count: 0,
+				connectors_count: 0,
+				manual_sessions_last_7_days: 0,
+				contribution: [],
+			});
+			return;
+		}
+		await fulfillJson(route, {});
+	});
+
+	return {
+		deleteRequests,
+		setNextDelete(fail: boolean) {
+			const gate = deferred();
+			nextDelete = { gate, fail };
+			return gate;
+		},
+	};
+}
+
+test("API key settings protects secrets and reconciles optimistic revokes", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.addInitScript(() => {
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: {
+				writeText: () => Promise.reject(new DOMException("Clipboard blocked")),
+			},
+		});
+	});
+	const api = await stubApiKeys(page);
+
+	await openApiKeySettings(page);
+	await expect(page.getByText("Revoked key from an older backend", { exact: true })).toHaveCount(0);
+	const desktopTable = page.getByRole("table");
+	await expect(desktopTable.getByText(longLabel, { exact: true })).toBeVisible();
+
+	const longName = desktopTable.getByText(longLabel, { exact: true });
+	const truncation = await longName.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(truncation.scrollWidth).toBeGreaterThan(truncation.clientWidth);
+	await testInfo.attach("api-keys-desktop", {
+		body: await page.screenshot(),
+		contentType: "image/png",
+	});
+
+	await page.getByRole("button", { name: "Create API key", exact: true }).first().click();
+	const createDialog = page.getByRole("dialog", { name: "Create API key" });
+	await createDialog.getByLabel("Key name").fill("Backup container");
+	await createDialog.getByRole("button", { name: "Create API key", exact: true }).click();
+
+	const secretDialog = page.getByRole("dialog", { name: "Save your API key" });
+	await expect(
+		secretDialog.getByText("clawdi_created_one_time_secret", { exact: true }),
+	).toBeVisible();
+	await expect(secretDialog.getByRole("button", { name: "Done" })).toBeDisabled();
+	await expect(secretDialog.getByRole("button", { name: "Close" })).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await expect(secretDialog).toBeVisible();
+	await secretDialog.getByRole("button", { name: "Copy" }).click();
+	await expect(
+		page.getByText("Couldn’t copy the API key — select and copy it manually.", { exact: true }),
+	).toBeVisible();
+	await secretDialog
+		.getByRole("checkbox", { name: "I have copied and stored this API key safely." })
+		.click();
+	await secretDialog.getByRole("button", { name: "Done" }).click();
+	await expect(secretDialog).toHaveCount(0);
+	await expect(desktopTable.getByText("Backup container", { exact: true })).toBeVisible();
+
+	const successfulDelete = api.setNextDelete(false);
+	await page.getByRole("button", { name: "Revoke CI runner" }).click();
+	await page.getByRole("button", { name: "Revoke key", exact: true }).click();
+	await expect(page.getByText("CI runner", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Revoke Backup container" })).toBeEnabled();
+	await expect.poll(() => api.deleteRequests).toContain("active-short");
+	successfulDelete.resolve();
+	await expect(page.getByText("API key revoked", { exact: true })).toBeVisible();
+
+	const failedDelete = api.setNextDelete(true);
+	await page.getByRole("button", { name: "Revoke Backup container" }).click();
+	await page.getByRole("button", { name: "Revoke key", exact: true }).click();
+	await expect(page.getByText("Backup container", { exact: true })).toHaveCount(0);
+	failedDelete.resolve();
+	await expect(desktopTable.getByText("Backup container", { exact: true })).toBeVisible();
+	await expect(page.getByText("Couldn’t revoke API key", { exact: true })).toBeVisible();
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.reload();
+	await expect(page.getByTestId("settings-dialog")).toBeVisible({ timeout: 15_000 });
+	const mobileCard = page.getByRole("article").filter({ hasText: longLabel });
+	await expect(mobileCard).toBeVisible();
+	const cardBox = await mobileCard.boundingBox();
+	expect(cardBox).not.toBeNull();
+	expect(cardBox?.x ?? -1).toBeGreaterThanOrEqual(0);
+	expect((cardBox?.x ?? 0) + (cardBox?.width ?? 0)).toBeLessThanOrEqual(390);
+	await expect(mobileCard.getByRole("button", { name: `Revoke ${longLabel}` })).toBeVisible();
+	await testInfo.attach("api-keys-mobile", {
+		body: await page.screenshot(),
+		contentType: "image/png",
+	});
+});
+
+test("API key list error is retryable and the active-only empty state can create a key", async ({
+	page,
+}) => {
+	await stubApiKeys(page, { initialKeys: [], failFirstList: true });
+
+	await openApiKeySettings(page);
+	await expect(page.getByText("Couldn’t load API keys", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Retry" }).click();
+	await expect(page.getByText("No active API keys", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Create API key", exact: true }).last().click();
+	await expect(page.getByRole("dialog", { name: "Create API key" })).toBeVisible();
+});

--- a/apps/web/src/components/settings/api-keys-panel.logic.ts
+++ b/apps/web/src/components/settings/api-keys-panel.logic.ts
@@ -1,0 +1,23 @@
+import type { ApiKey } from "@/lib/api-schemas";
+
+export const API_KEYS_QUERY_KEY = ["api-keys"] as const;
+
+/** Keep revoked keys out of the UI while older backends are still in a rolling deployment. */
+export function activeApiKeys(keys: readonly ApiKey[] | undefined): ApiKey[] {
+	return keys?.filter((key) => key.revoked_at === null) ?? [];
+}
+
+export function removeApiKeyFromList(
+	keys: readonly ApiKey[] | undefined,
+	keyId: string,
+): ApiKey[] | undefined {
+	return keys?.filter((key) => key.id !== keyId);
+}
+
+/** Restore only the failed optimistic removal so concurrent successful revokes stay removed. */
+export function restoreApiKeyToList(keys: readonly ApiKey[] | undefined, key: ApiKey): ApiKey[] {
+	if (keys?.some((candidate) => candidate.id === key.id)) return [...keys];
+	return [...(keys ?? []), key].sort(
+		(left, right) => Date.parse(right.created_at) - Date.parse(left.created_at),
+	);
+}

--- a/apps/web/src/components/settings/api-keys-panel.test.ts
+++ b/apps/web/src/components/settings/api-keys-panel.test.ts
@@ -1,36 +1,53 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import type { ApiKey } from "@/lib/api-schemas";
+import { activeApiKeys, removeApiKeyFromList, restoreApiKeyToList } from "./api-keys-panel.logic";
 
-const source = readFileSync(new URL("./api-keys-panel.tsx", import.meta.url), "utf8");
+function apiKey(id: string, overrides: Partial<ApiKey> = {}): ApiKey {
+	return {
+		id,
+		label: `Key ${id}`,
+		key_prefix: `clawdi_${id}`,
+		created_at: "2026-07-28T12:00:00.000Z",
+		last_used_at: null,
+		expires_at: null,
+		revoked_at: null,
+		...overrides,
+	};
+}
 
-describe("API keys query states", () => {
-	test("renders a retryable error instead of passing failed data to empty lists", () => {
-		expect(source).toMatch(/data: keys,\s+error,\s+isLoading,\s+refetch,/);
-		expect(source).toContain('title="Couldn’t load API keys"');
-		expect(source).toContain("onRetry={() => refetch()}");
-		expect(source.indexOf("{error ? (")).toBeLessThan(source.indexOf("<ApiKeysMobileList"));
-		expect(source.indexOf("{error ? (")).toBeLessThan(source.indexOf("<DataTable"));
+describe("activeApiKeys", () => {
+	test("defensively excludes revoked rows returned by an older backend", () => {
+		const active = apiKey("active");
+		const revoked = apiKey("revoked", { revoked_at: "2026-07-28T13:00:00.000Z" });
+
+		expect(activeApiKeys([revoked, active])).toEqual([active]);
+		expect(activeApiKeys(undefined)).toEqual([]);
 	});
 });
 
-describe("API key creation safeguards", () => {
-	test("trims labels and rejects whitespace-only input", () => {
-		expect(source).toContain("const normalizedNewLabel = newLabel.trim()");
-		expect(source).toContain("createKey.execute(normalizedNewLabel)");
-		expect(source).toContain("const createKey = useSensitiveAction(");
-		expect(source).toContain("disabled={!normalizedNewLabel || createKey.isPending");
+describe("optimistic API key revocation", () => {
+	test("removes the selected row immediately", () => {
+		const first = apiKey("first");
+		const second = apiKey("second");
+
+		expect(removeApiKeyFromList([first, second], first.id)).toEqual([second]);
 	});
 
-	test("does not replace an unacknowledged one-time key", () => {
-		expect(source).toContain("normalizedNewLabel && createdKey === null");
-		expect(source).toContain("createKey.isPending || createdKey !== null");
-		expect(source).toContain("onClick={() => setCreatedKey(null)}");
-		expect(source).toContain("I&apos;ve saved it");
+	test("rolls back only the failed removal when revokes overlap", () => {
+		const older = apiKey("older", { created_at: "2026-07-27T12:00:00.000Z" });
+		const newer = apiKey("newer", { created_at: "2026-07-28T12:00:00.000Z" });
+		const afterFirstRevoke = removeApiKeyFromList([newer, older], newer.id);
+		const afterSecondRevoke = removeApiKeyFromList(afterFirstRevoke, older.id);
+
+		// The newer revoke failed while the older revoke succeeded.
+		expect(restoreApiKeyToList(afterSecondRevoke, newer)).toEqual([newer]);
 	});
 
-	test("normalizes create-action and revoke-mutation errors", () => {
-		expect(source).toContain('toastApiError("Couldn\'t create key")(error)');
-		expect(source).toContain('onError: toastApiError("Couldn\'t turn off key")');
-		expect(source).not.toMatch(/onError:.*\.detail/);
+	test("restores newest-first ordering without duplicating an existing row", () => {
+		const older = apiKey("older", { created_at: "2026-07-27T12:00:00.000Z" });
+		const newer = apiKey("newer", { created_at: "2026-07-28T12:00:00.000Z" });
+
+		expect(restoreApiKeyToList([older], newer)).toEqual([newer, older]);
+		expect(restoreApiKeyToList([newer, older], newer)).toEqual([newer, older]);
 	});
 });

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -2,335 +2,534 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Check, Copy, Plus, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Check, Copy, KeyRound, Laptop, Plus, ShieldCheck, Trash2 } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import {
+	API_KEYS_QUERY_KEY,
+	activeApiKeys,
+	removeApiKeyFromList,
+	restoreApiKeyToList,
+} from "@/components/settings/api-keys-panel.logic";
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
-import { Badge } from "@/components/ui/badge";
+import { TimeTooltip } from "@/components/time-tooltip";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { DataTable } from "@/components/ui/data-table";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
+import { formatShortDate } from "@/lib/format";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
+
+const API_KEY_LABEL_MAX_LENGTH = 200;
+const REVOKE_API_KEY_MUTATION_KEY = ["revoke-api-key"] as const;
+
+type RevokeContext = {
+	removedKey?: ApiKey;
+};
 
 /** API Keys settings — CLI-facing bearer tokens. */
 export function ApiKeysPanel() {
 	const api = useApi();
 	const queryClient = useQueryClient();
+	const [createDialogOpen, setCreateDialogOpen] = useState(false);
 	const [newLabel, setNewLabel] = useState("");
 	const [createdKey, setCreatedKey] = useState<string | null>(null);
+	const [secretAcknowledged, setSecretAcknowledged] = useState(false);
 	const normalizedNewLabel = newLabel.trim();
+	const { copied, copy } = useCopyToClipboard({
+		success: "API key copied to clipboard",
+		error: "Couldn’t copy the API key — select and copy it manually.",
+	});
 
 	const {
-		data: keys,
+		data: listedKeys,
 		error,
 		isLoading,
 		refetch,
 	} = useQuery({
-		queryKey: ["api-keys"],
+		queryKey: API_KEYS_QUERY_KEY,
 		queryFn: async () => unwrap(await api.GET("/v1/auth/keys")),
 	});
+	const keys = useMemo(() => activeApiKeys(listedKeys), [listedKeys]);
 
 	const createKey = useSensitiveAction(async (label: string) => {
 		try {
 			const data = unwrap(await api.POST("/v1/auth/keys", { body: { label } }));
 			setCreatedKey(data.raw_key);
+			setSecretAcknowledged(false);
 			setNewLabel("");
-			queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+			void queryClient.invalidateQueries({ queryKey: API_KEYS_QUERY_KEY });
 			return data;
-		} catch (error) {
-			toastApiError("Couldn't create key")(error);
-			throw error;
+		} catch (actionError) {
+			toastApiError("Couldn’t create API key")(actionError);
+			throw actionError;
 		}
 	});
 
 	const revokeKey = useMutation({
+		mutationKey: REVOKE_API_KEY_MUTATION_KEY,
 		mutationFn: async (keyId: string) =>
 			unwrap(
 				await api.DELETE("/v1/auth/keys/{key_id}", {
 					params: { path: { key_id: keyId } },
 				}),
 			),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["api-keys"] });
-			toast.success("Key turned off");
+		onMutate: async (keyId): Promise<RevokeContext> => {
+			await queryClient.cancelQueries({ queryKey: API_KEYS_QUERY_KEY });
+			const currentKeys = queryClient.getQueryData<ApiKey[]>(API_KEYS_QUERY_KEY);
+			const removedKey = currentKeys?.find((key) => key.id === keyId);
+			queryClient.setQueryData<ApiKey[]>(
+				API_KEYS_QUERY_KEY,
+				removeApiKeyFromList(currentKeys, keyId),
+			);
+			return { removedKey };
 		},
-		onError: toastApiError("Couldn't turn off key"),
+		onSuccess: () => {
+			toast.success("API key revoked");
+		},
+		onError: (mutationError, _keyId, context) => {
+			const removedKey = context?.removedKey;
+			if (removedKey) {
+				queryClient.setQueryData<ApiKey[]>(API_KEYS_QUERY_KEY, (currentKeys) =>
+					restoreApiKeyToList(currentKeys, removedKey),
+				);
+			}
+			toastApiError("Couldn’t revoke API key")(mutationError);
+		},
+		onSettled: () => {
+			// Reconcile once the last overlapping revoke settles so a refetch cannot
+			// temporarily resurrect another row whose request is still in flight.
+			if (queryClient.isMutating({ mutationKey: REVOKE_API_KEY_MUTATION_KEY }) === 1) {
+				return queryClient.invalidateQueries({ queryKey: API_KEYS_QUERY_KEY });
+			}
+		},
 	});
 
-	const columns = useMemo<ColumnDef<ApiKey>[]>(
-		() => [
-			{
-				accessorKey: "label",
-				header: "Label",
-				cell: ({ row }) => (
-					<div className="flex items-center gap-2">
-						<span className="font-medium">{row.original.label}</span>
-						{row.original.revoked_at ? <Badge variant="destructive">Off</Badge> : null}
-					</div>
-				),
-			},
-			{
-				accessorKey: "key_prefix",
-				header: "Prefix",
-				cell: ({ row }) => (
-					<span className="font-mono text-xs text-muted-foreground">
-						{row.original.key_prefix}…
-					</span>
-				),
-			},
-			{
-				accessorKey: "created_at",
-				header: "Created",
-				cell: ({ row }) => (
-					<span className="text-xs text-muted-foreground">
-						{new Date(row.original.created_at).toLocaleDateString()}
-					</span>
-				),
-			},
-			{
-				accessorKey: "last_used_at",
-				header: "Last used",
-				cell: ({ row }) =>
-					row.original.last_used_at ? (
-						<span className="text-xs text-muted-foreground">
-							{new Date(row.original.last_used_at).toLocaleDateString()}
-						</span>
-					) : (
-						<span className="text-xs text-muted-foreground">—</span>
-					),
-			},
-			{
-				id: "actions",
-				header: "",
-				cell: ({ row }) =>
-					!row.original.revoked_at ? (
-						<ConfirmAction
-							title={`Turn off ${row.original.label}?`}
-							description={
-								<p>
-									If a machine is still using this key, sync will stop within a minute. Sign in
-									again from that machine to resume.
-								</p>
-							}
-							confirmLabel="Turn Off Key"
-							destructive
-							onConfirm={() => revokeKey.mutate(row.original.id)}
-						>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								disabled={revokeKey.isPending}
-								aria-label="Turn off key"
-								className="text-muted-foreground hover:text-destructive"
-							>
-								<Trash2 className="size-3.5" />
-							</Button>
-						</ConfirmAction>
-					) : null,
-				size: 40,
-			},
-		],
-		[revokeKey],
+	const handleRevoke = useCallback(
+		(keyId: string) => revokeKey.mutateAsync(keyId),
+		[revokeKey.mutateAsync],
 	);
+	const showExpiration = keys.some((key) => key.expires_at !== null);
+	const columns = useMemo(
+		() => apiKeyColumns({ showExpiration, onRevoke: handleRevoke }),
+		[handleRevoke, showExpiration],
+	);
+
+	function openCreateDialog() {
+		if (createdKey !== null) return;
+		createKey.reset();
+		setNewLabel("");
+		setSecretAcknowledged(false);
+		setCreateDialogOpen(true);
+	}
+
+	function handleCreateDialogOpenChange(nextOpen: boolean) {
+		if (!nextOpen && (createKey.isPending || createdKey !== null)) return;
+		if (!nextOpen) {
+			createKey.reset();
+			setNewLabel("");
+			setSecretAcknowledged(false);
+		}
+		setCreateDialogOpen(nextOpen);
+	}
+
+	function finishSecretReveal() {
+		if (!secretAcknowledged) return;
+		setCreatedKey(null);
+		setSecretAcknowledged(false);
+		setCreateDialogOpen(false);
+	}
 
 	return (
 		<div className="space-y-6 px-4 lg:px-6">
 			<SettingsPanelHeader
 				title="API Keys"
-				description={
-					<>
-						On a laptop,{" "}
-						<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-							clawdi auth login
-						</code>{" "}
-						handles auth automatically — you don&apos;t need to touch this. Create a key here when
-						you&apos;re setting up a server or container that can&apos;t open a browser, then paste
-						it into{" "}
-						<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
-							CLAWDI_AUTH_TOKEN
-						</code>{" "}
-						(this is the env var the CLI and{" "}
-						<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">clawdi daemon</code>{" "}
-						actually read).
-					</>
+				description="Manage bearer tokens for servers, containers, and other headless environments."
+				actions={
+					<Button type="button" onClick={openCreateDialog} className="sm:mr-8">
+						<Plus data-icon="inline-start" />
+						Create API key
+					</Button>
 				}
 			/>
 
-			{/* Create form */}
-			<form
-				className="flex flex-col gap-2 sm:flex-row"
-				onSubmit={(e) => {
-					e.preventDefault();
-					if (normalizedNewLabel && createdKey === null) {
-						void createKey.execute(normalizedNewLabel).catch(() => undefined);
-					}
-				}}
-			>
-				<Label htmlFor="new-key-label" className="sr-only">
-					New API key label
-				</Label>
-				<Input
-					id="new-key-label"
-					value={newLabel}
-					onChange={(e) => setNewLabel(e.target.value)}
-					placeholder="my-laptop…"
-					className="min-w-0 flex-1"
-					name="new-key-label"
-					autoComplete="off"
-					disabled={createdKey !== null}
-				/>
-				<Button
-					type="submit"
-					disabled={!normalizedNewLabel || createKey.isPending || createdKey !== null}
-					className="w-full sm:w-auto"
-				>
-					<Plus />
-					Create
-				</Button>
-			</form>
-
-			{/* Created key banner */}
-			{createdKey ? (
-				<div className="space-y-2 rounded-lg border border-primary/30 bg-primary/5 p-4">
-					<div className="text-sm font-medium text-primary">
-						Key created — copy it now, it won't be shown again.
-					</div>
-					<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-						<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
-							{createdKey}
-						</code>
-						<Button
-							type="button"
-							variant="ghost"
-							size="icon"
-							onClick={() => {
-								navigator.clipboard
-									.writeText(createdKey)
-									.then(() => toast.success("Copied to clipboard"))
-									.catch(() => toast.error("Couldn't copy", { description: "Copy it manually." }));
-							}}
-							aria-label="Copy key"
-						>
-							<Copy />
-						</Button>
-						<Button type="button" variant="outline" size="sm" onClick={() => setCreatedKey(null)}>
-							<Check />
-							I&apos;ve saved it
-						</Button>
-					</div>
-				</div>
-			) : null}
+			<div className="flex items-start gap-3 rounded-lg border bg-muted/20 px-4 py-3 text-sm">
+				<Laptop className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+				<p className="text-muted-foreground">
+					<span className="font-medium text-foreground">Using Clawdi on a laptop?</span> Run{" "}
+					<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">clawdi auth login</code>{" "}
+					instead; it completes sign-in without a manually managed key.
+				</p>
+			</div>
 
 			{error ? (
 				<ApiErrorPanel error={error} onRetry={() => refetch()} title="Couldn’t load API keys" />
+			) : isLoading ? (
+				<>
+					<ApiKeysMobileLoading />
+					<DataTable columns={columns} data={[]} isLoading className="hidden md:block" />
+				</>
+			) : keys.length === 0 ? (
+				<ApiKeysEmptyState onCreate={openCreateDialog} />
 			) : (
 				<>
 					<div className="md:hidden">
-						<ApiKeysMobileList
-							keys={keys ?? []}
-							isLoading={isLoading}
-							isRevoking={revokeKey.isPending}
-							onRevoke={(keyId) => revokeKey.mutate(keyId)}
-						/>
+						<ApiKeysMobileList keys={keys} onRevoke={handleRevoke} />
 					</div>
 					<DataTable
 						columns={columns}
-						data={keys ?? []}
-						isLoading={isLoading}
-						emptyMessage="No API keys yet."
+						data={keys}
 						className="hidden md:block"
+						tableContainerClassName="max-w-full"
 					/>
 				</>
 			)}
+
+			<Dialog open={createDialogOpen} onOpenChange={handleCreateDialogOpenChange}>
+				<DialogContent
+					showCloseButton={!createKey.isPending && createdKey === null}
+					className="sm:max-w-lg"
+				>
+					<DialogHeader>
+						<DialogTitle>{createdKey ? "Save your API key" : "Create API key"}</DialogTitle>
+						<DialogDescription>
+							{createdKey
+								? "Copy this key now. For your security, it won’t be available again."
+								: "Use a recognizable name so you know which client can be revoked later."}
+						</DialogDescription>
+					</DialogHeader>
+
+					{createdKey ? (
+						<div className="space-y-5">
+							<Alert className="border-primary/30 bg-primary/5">
+								<ShieldCheck aria-hidden="true" />
+								<AlertTitle>Key created</AlertTitle>
+								<AlertDescription>
+									Store it in your secret manager and set it as{" "}
+									<code className="font-mono text-xs">CLAWDI_AUTH_TOKEN</code> on the client.
+								</AlertDescription>
+							</Alert>
+
+							<div className="flex min-w-0 items-start gap-2 rounded-lg border bg-muted/30 p-2">
+								<code className="min-w-0 flex-1 select-all break-all px-1 py-1.5 font-mono text-xs leading-relaxed">
+									{createdKey}
+								</code>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => void copy(createdKey)}
+									data-copied={copied}
+								>
+									{copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+									{copied ? "Copied" : "Copy"}
+								</Button>
+							</div>
+
+							<div className="flex items-start gap-2.5">
+								<Checkbox
+									id="api-key-secret-acknowledgement"
+									checked={secretAcknowledged}
+									onCheckedChange={(checked) => setSecretAcknowledged(checked === true)}
+									className="mt-0.5"
+								/>
+								<Label
+									htmlFor="api-key-secret-acknowledgement"
+									className="text-sm leading-snug font-normal"
+								>
+									I have copied and stored this API key safely.
+								</Label>
+							</div>
+
+							<DialogFooter>
+								<Button type="button" disabled={!secretAcknowledged} onClick={finishSecretReveal}>
+									Done
+								</Button>
+							</DialogFooter>
+						</div>
+					) : (
+						<form
+							className="space-y-5"
+							onSubmit={(event) => {
+								event.preventDefault();
+								if (normalizedNewLabel && !createKey.isPending) {
+									void createKey.execute(normalizedNewLabel).catch(() => undefined);
+								}
+							}}
+						>
+							<div className="space-y-2">
+								<Label htmlFor="new-key-label">Key name</Label>
+								<Input
+									id="new-key-label"
+									value={newLabel}
+									onChange={(event) => {
+										setNewLabel(event.target.value);
+										createKey.reset();
+									}}
+									placeholder="Production server"
+									name="new-key-label"
+									autoComplete="off"
+									maxLength={API_KEY_LABEL_MAX_LENGTH}
+									required
+									disabled={createKey.isPending}
+									aria-describedby="new-key-label-help"
+								/>
+								<p id="new-key-label-help" className="text-xs text-muted-foreground">
+									For example, the server, container, or automation that will use this key.
+								</p>
+								{createKey.error ? (
+									<p role="alert" className="text-xs text-destructive">
+										The key couldn’t be created. Check the name and try again.
+									</p>
+								) : null}
+							</div>
+
+							<DialogFooter>
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => handleCreateDialogOpenChange(false)}
+									disabled={createKey.isPending}
+								>
+									Cancel
+								</Button>
+								<Button type="submit" disabled={!normalizedNewLabel || createKey.isPending}>
+									{createKey.isPending ? <Spinner /> : <Plus aria-hidden="true" />}
+									Create API key
+								</Button>
+							</DialogFooter>
+						</form>
+					)}
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}
+
+function apiKeyColumns({
+	showExpiration,
+	onRevoke,
+}: {
+	showExpiration: boolean;
+	onRevoke: (keyId: string) => Promise<unknown>;
+}): ColumnDef<ApiKey>[] {
+	const columns: ColumnDef<ApiKey>[] = [
+		{
+			accessorKey: "label",
+			header: "Name",
+			cell: ({ row }) => (
+				<span className="block min-w-0 truncate font-medium" title={row.original.label}>
+					{row.original.label}
+				</span>
+			),
+			size: 240,
+		},
+		{
+			accessorKey: "key_prefix",
+			header: "Key",
+			cell: ({ row }) => <KeyIdentifier prefix={row.original.key_prefix} />,
+			size: 170,
+		},
+		{
+			accessorKey: "created_at",
+			header: "Created",
+			cell: ({ row }) => <ApiKeyDate value={row.original.created_at} />,
+			size: 120,
+		},
+		{
+			accessorKey: "last_used_at",
+			header: "Last used",
+			cell: ({ row }) => <ApiKeyDate value={row.original.last_used_at} emptyLabel="Never" />,
+			size: 120,
+		},
+	];
+
+	if (showExpiration) {
+		columns.push({
+			accessorKey: "expires_at",
+			header: "Expires",
+			cell: ({ row }) => <ApiKeyDate value={row.original.expires_at} emptyLabel="Never" />,
+			size: 120,
+		});
+	}
+
+	columns.push({
+		id: "actions",
+		header: "",
+		cell: ({ row }) => (
+			<RevokeApiKeyAction key={row.original.id} apiKey={row.original} onRevoke={onRevoke} />
+		),
+		size: 88,
+	});
+
+	return columns;
+}
+
+function KeyIdentifier({ prefix }: { prefix: string }) {
+	return (
+		<code
+			className="block min-w-0 truncate font-mono text-xs text-muted-foreground"
+			title={`Key prefix: ${prefix}`}
+		>
+			{prefix}…
+		</code>
+	);
+}
+
+function ApiKeyDate({ value, emptyLabel = "—" }: { value: string | null; emptyLabel?: string }) {
+	if (!value) return <span className="text-xs text-muted-foreground">{emptyLabel}</span>;
+	return (
+		<TimeTooltip value={value}>
+			<span className="text-xs text-muted-foreground">{formatShortDate(value)}</span>
+		</TimeTooltip>
+	);
+}
+
+function RevokeApiKeyAction({
+	apiKey,
+	onRevoke,
+}: {
+	apiKey: ApiKey;
+	onRevoke: (keyId: string) => Promise<unknown>;
+}) {
+	return (
+		<ConfirmAction
+			title={`Revoke “${apiKey.label}”?`}
+			description={
+				<p>
+					Requests using this key will stop working. This can’t be undone; create and install a new
+					key to reconnect the client.
+				</p>
+			}
+			confirmLabel="Revoke key"
+			destructive
+			onConfirm={() => onRevoke(apiKey.id)}
+		>
+			<Button
+				type="button"
+				variant="ghost"
+				size="sm"
+				aria-label={`Revoke ${apiKey.label}`}
+				className="text-muted-foreground hover:text-destructive"
+			>
+				<Trash2 aria-hidden="true" />
+				Revoke
+			</Button>
+		</ConfirmAction>
+	);
+}
+
+function ApiKeysEmptyState({ onCreate }: { onCreate: () => void }) {
+	return (
+		<div className="rounded-lg border bg-card">
+			<Empty className="p-8 sm:p-12">
+				<EmptyHeader>
+					<EmptyMedia variant="icon">
+						<KeyRound aria-hidden="true" />
+					</EmptyMedia>
+					<EmptyTitle>No active API keys</EmptyTitle>
+					<EmptyDescription>
+						Create a key to authenticate a server, container, or other client that can’t open a
+						browser.
+					</EmptyDescription>
+				</EmptyHeader>
+				<EmptyContent>
+					<Button type="button" onClick={onCreate}>
+						<Plus aria-hidden="true" />
+						Create API key
+					</Button>
+				</EmptyContent>
+			</Empty>
+		</div>
+	);
+}
+
+function ApiKeysMobileLoading() {
+	return (
+		<div className="flex flex-col gap-3 md:hidden" role="status">
+			<span className="sr-only">Loading API keys</span>
+			{[0, 1, 2].map((index) => (
+				<div key={index} className="rounded-lg border bg-card p-4">
+					<Skeleton className="h-4 w-2/3" />
+					<Skeleton className="mt-3 h-3 w-1/2" />
+					<Skeleton className="mt-4 h-8 w-full" />
+				</div>
+			))}
 		</div>
 	);
 }
 
 function ApiKeysMobileList({
 	keys,
-	isLoading,
-	isRevoking,
 	onRevoke,
 }: {
 	keys: ApiKey[];
-	isLoading: boolean;
-	isRevoking: boolean;
-	onRevoke: (keyId: string) => void;
+	onRevoke: (keyId: string) => Promise<unknown>;
 }) {
-	if (isLoading) {
-		return (
-			<div className="flex flex-col gap-2">
-				{[0, 1, 2].map((i) => (
-					<div key={i} className="rounded-lg border bg-card p-3">
-						<Skeleton className="h-4 w-32" />
-						<Skeleton className="mt-2 h-3 w-24" />
-					</div>
-				))}
-			</div>
-		);
-	}
-
-	if (keys.length === 0) {
-		return (
-			<div className="rounded-lg border bg-card px-4 py-8 text-center text-sm text-muted-foreground">
-				No API keys yet.
-			</div>
-		);
-	}
-
 	return (
-		<div className="flex flex-col gap-2">
+		<div className="flex flex-col gap-3">
 			{keys.map((key) => (
-				<div key={key.id} className="rounded-lg border bg-card p-3">
-					<div className="flex min-w-0 items-start justify-between gap-3">
+				<article key={key.id} className="min-w-0 rounded-lg border bg-card p-4">
+					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
 						<div className="min-w-0">
-							<div className="flex min-w-0 flex-wrap items-center gap-2">
-								<span className="break-words text-sm font-medium">{key.label}</span>
-								{key.revoked_at ? <Badge variant="destructive">Off</Badge> : null}
-							</div>
-							<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-								<span className="font-mono">{key.key_prefix}…</span>
-								<span>Created {new Date(key.created_at).toLocaleDateString()}</span>
-								<span>
-									Last used{" "}
-									{key.last_used_at ? new Date(key.last_used_at).toLocaleDateString() : "—"}
-								</span>
+							<h3 className="line-clamp-2 break-all text-sm font-medium" title={key.label}>
+								{key.label}
+							</h3>
+							<div className="mt-1.5 max-w-full">
+								<KeyIdentifier prefix={key.key_prefix} />
 							</div>
 						</div>
-						{key.revoked_at ? null : (
-							<ConfirmAction
-								title={`Turn off ${key.label}?`}
-								description={
-									<p>
-										If a machine is still using this key, sync will stop within a minute. Sign in
-										again from that machine to resume.
-									</p>
-								}
-								confirmLabel="Turn Off Key"
-								destructive
-								onConfirm={() => onRevoke(key.id)}
-							>
-								<Button
-									type="button"
-									variant="ghost"
-									size="icon-sm"
-									disabled={isRevoking}
-									aria-label="Turn off key"
-									className="shrink-0 text-muted-foreground hover:text-destructive"
-								>
-									<Trash2 className="size-3.5" />
-								</Button>
-							</ConfirmAction>
-						)}
+						<RevokeApiKeyAction apiKey={key} onRevoke={onRevoke} />
 					</div>
-				</div>
+
+					<dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3 text-xs">
+						<div className="min-w-0">
+							<dt className="text-muted-foreground">Created</dt>
+							<dd className="mt-0.5 font-medium text-foreground">
+								<ApiKeyDate value={key.created_at} />
+							</dd>
+						</div>
+						<div className="min-w-0">
+							<dt className="text-muted-foreground">Last used</dt>
+							<dd className="mt-0.5 font-medium text-foreground">
+								<ApiKeyDate value={key.last_used_at} emptyLabel="Never" />
+							</dd>
+						</div>
+						{key.expires_at ? (
+							<div className="min-w-0">
+								<dt className="text-muted-foreground">Expires</dt>
+								<dd className="mt-0.5 font-medium text-foreground">
+									<ApiKeyDate value={key.expires_at} />
+								</dd>
+							</div>
+						) : null}
+					</dl>
+				</article>
 			))}
 		</div>
 	);

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -92,7 +92,11 @@ async def list_api_keys(
 ):
     result = await db.execute(
         select(ApiKey)
-        .where(ApiKey.user_id == auth.user_id, ApiKey.managed.is_(False))
+        .where(
+            ApiKey.user_id == auth.user_id,
+            ApiKey.managed.is_(False),
+            ApiKey.revoked_at.is_(None),
+        )
         .order_by(ApiKey.created_at.desc())
     )
     keys = result.scalars().all()

--- a/backend/tests/test_auth_keys.py
+++ b/backend/tests/test_auth_keys.py
@@ -95,16 +95,26 @@ async def test_me_reflects_cli_auth(cli_client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_revoke_api_key_marks_row(client: httpx.AsyncClient):
+async def test_revoke_api_key_hides_row_but_preserves_audit_record(
+    client: httpx.AsyncClient, db_session
+):
+    from sqlalchemy import select
+
+    from app.models.api_key import ApiKey
+
     created = (await client.post("/v1/auth/keys", json={"label": "to-revoke"})).json()
     r = await client.delete(f"/v1/auth/keys/{created['id']}")
     assert r.status_code == 200, r.text
     assert r.json() == {"status": "revoked"}
 
-    # After revoke, the key still shows in the list but with ``revoked_at`` set.
+    # The user-facing list is active-only, but soft revocation keeps the row for audit.
     listing = (await client.get("/v1/auth/keys")).json()
-    match = next(k for k in listing if k["id"] == created["id"])
-    assert match["revoked_at"] is not None
+    assert created["id"] not in {key["id"] for key in listing}
+
+    revoked_at = await db_session.scalar(
+        select(ApiKey.revoked_at).where(ApiKey.id == created["id"])
+    )
+    assert revoked_at is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Redesign the API key settings surface for desktop and mobile.
- Keep one-time keys out of mutation caches and require explicit save acknowledgement.
- Hide revoked keys while preserving backend audit records, with retry and concurrent optimistic revoke handling.

## Verification

- Docker web: typecheck, focused unit tests, OSS production build
- Docker backend: tests/test_auth_keys.py (12 passed) with fresh PostgreSQL migrations
- Docker lint: Biome and Ruff checks
- Docker Playwright: api-keys-settings.pw.ts (2 passed)