### PR TITLE
Fix sidebar agent tile navigation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2281,9 +2281,19 @@ test("shared legacy environment routes an older tile's actions to its deployment
 	await expect(newerTile.locator("..").getByText("Running", { exact: true })).toHaveCount(0);
 	await expect(olderTile.locator("..").getByText("Stopped", { exact: true })).toHaveCount(0);
 	const rail = page.getByTestId("app-sidebar-agent-tiles");
-	await expect(rail.getByLabel("Newer twin", { exact: true })).toBeVisible();
-	await expect(rail.getByLabel("Older twin", { exact: true })).toBeVisible();
-	await olderTile.click();
+	const newerRailTile = rail.getByLabel("Newer twin", { exact: true });
+	const olderRailTile = rail.getByLabel("Older twin", { exact: true });
+	await expect(newerRailTile).toBeVisible();
+	await expect(olderRailTile).toBeVisible();
+	await newerRailTile.click();
+	await expect(page).toHaveURL(
+		new RegExp(`/agents/${sharedLegacyEnvironmentId}(?:\\?|/).*d=hdep_shared_newer`),
+	);
+	await page.goto("/agents");
+	await olderRailTile.click();
+	await expect(page).toHaveURL(
+		new RegExp(`/agents/${sharedLegacyEnvironmentId}(?:\\?|/).*d=hdep_shared_older`),
+	);
 	await page.getByRole("link", { name: "Settings", exact: true }).click();
 	await expect(page).toHaveURL(
 		new RegExp(`/agents/${sharedLegacyEnvironmentId}/settings\\?.*d=hdep_shared_older`),

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -219,6 +219,63 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await expectNoBrowserErrors(page, browserErrors, "settings select");
 });
 
+test("every agent rail tile navigates on click", async ({ page }) => {
+	await stubDashboardApi(page);
+
+	for (const agent of agents) {
+		await page.goto("/");
+		const tileLink = page
+			.getByTestId("app-sidebar-agent-tile")
+			.filter({ hasText: agent.display_name })
+			.locator("a");
+		await expect(tileLink).toBeVisible({ timeout: 15_000 });
+		await expect(tileLink).toHaveAttribute("href", `/agents/${agent.id}`);
+
+		await tileLink.click();
+		await expect(page).toHaveURL(`/agents/${agent.id}`);
+	}
+});
+
+test("agent rail links support touch taps and keyboard activation", async ({
+	browser,
+	baseURL,
+}) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the sidebar smoke test.");
+	const [firstAgent, secondAgent] = agents;
+	if (!firstAgent || !secondAgent) throw new Error("Two sidebar agent fixtures are required.");
+	const context = await browser.newContext({
+		baseURL,
+		hasTouch: true,
+		viewport: { width: 1280, height: 720 },
+	});
+	const page = await context.newPage();
+
+	try {
+		await stubDashboardApi(page);
+		await page.goto("/");
+		const touchTarget = page
+			.getByTestId("app-sidebar-agent-tile")
+			.filter({ hasText: firstAgent.display_name })
+			.locator("a");
+		await expect(touchTarget).toBeVisible({ timeout: 15_000 });
+		await touchTarget.tap();
+		await expect(page).toHaveURL(`/agents/${firstAgent.id}`);
+
+		await page.goto("/");
+		const keyboardTarget = page
+			.getByTestId("app-sidebar-agent-tile")
+			.filter({ hasText: secondAgent.display_name })
+			.locator("a");
+		await expect(keyboardTarget).toBeVisible({ timeout: 15_000 });
+		await keyboardTarget.focus();
+		await expect(keyboardTarget).toBeFocused();
+		await page.keyboard.press("Enter");
+		await expect(page).toHaveURL(`/agents/${secondAgent.id}`);
+	} finally {
+		await context.close();
+	}
+});
+
 test("agent rail supports whole-tile sorting without drag handles", async ({ page }) => {
 	const agentOrderRequests: string[] = [];
 	await stubDashboardApi(page, agentOrderRequests);
@@ -240,9 +297,15 @@ test("agent rail supports whole-tile sorting without drag handles", async ({ pag
 	});
 	await page.mouse.up();
 
+	await expect(page).toHaveURL("/");
 	await expect.poll(() => agentOrderRequests.length).toBe(1);
 	expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
 		agent_ids: ["agent-smoke-2", "agent-smoke-1"],
 	});
 	await expect(tiles.nth(0)).toContainText("Smoke Hermes");
+
+	const postDragKeyboardTarget = tiles.filter({ hasText: "Smoke Hermes" }).locator("a");
+	await postDragKeyboardTarget.focus();
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL("/agents/agent-smoke-2");
 });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -7,7 +7,7 @@ import {
 	type DragEndEvent,
 	type DragOverEvent,
 	type Modifier,
-	PointerSensor,
+	MouseSensor,
 	TouchSensor,
 	useSensor,
 	useSensors,
@@ -752,10 +752,7 @@ function RailFocusButton({
 	caption,
 	active,
 	onNavigate,
-	onClickCapture,
-	onPointerDownCapture,
-	onPointerDown,
-	onTouchStartCapture,
+	onMouseDown,
 	onTouchStart,
 	showTooltip = true,
 	children,
@@ -765,10 +762,7 @@ function RailFocusButton({
 	caption?: string;
 	active: boolean;
 	onNavigate?: React.MouseEventHandler<HTMLAnchorElement>;
-	onClickCapture?: React.MouseEventHandler<HTMLAnchorElement>;
-	onPointerDownCapture?: React.PointerEventHandler<HTMLAnchorElement>;
-	onPointerDown?: React.PointerEventHandler<HTMLAnchorElement>;
-	onTouchStartCapture?: React.TouchEventHandler<HTMLAnchorElement>;
+	onMouseDown?: React.MouseEventHandler<HTMLAnchorElement>;
 	onTouchStart?: React.TouchEventHandler<HTMLAnchorElement>;
 	showTooltip?: boolean;
 	children: React.ReactNode;
@@ -778,11 +772,8 @@ function RailFocusButton({
 		<Link
 			to={href}
 			draggable={false}
-			onClickCapture={onClickCapture}
 			onClick={onNavigate}
-			onPointerDownCapture={onPointerDownCapture}
-			onPointerDown={onPointerDown}
-			onTouchStartCapture={onTouchStartCapture}
+			onMouseDown={onMouseDown}
 			onTouchStart={onTouchStart}
 			className="cursor-default"
 		/>
@@ -852,17 +843,11 @@ function SortableAgentRailItem({
 	agent,
 	active,
 	onNavigate,
-	onClickCapture,
-	onPointerDownCapture,
-	onTouchStartCapture,
 	showTooltip,
 }: {
 	agent: AgentTile;
 	active: boolean;
 	onNavigate: React.MouseEventHandler<HTMLAnchorElement>;
-	onClickCapture: React.MouseEventHandler<HTMLAnchorElement>;
-	onPointerDownCapture: React.PointerEventHandler<HTMLAnchorElement>;
-	onTouchStartCapture: React.TouchEventHandler<HTMLAnchorElement>;
 	showTooltip: boolean;
 }) {
 	const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -887,8 +872,8 @@ function SortableAgentRailItem({
 		transition: isDragging ? undefined : transition,
 		zIndex: isDragging ? 20 : undefined,
 	};
-	const dragPointerDown: React.PointerEventHandler<HTMLAnchorElement> | undefined =
-		listeners?.onPointerDown ? (event) => listeners.onPointerDown?.(event) : undefined;
+	const dragMouseDown: React.MouseEventHandler<HTMLAnchorElement> | undefined =
+		listeners?.onMouseDown ? (event) => listeners.onMouseDown?.(event) : undefined;
 	const dragTouchStart: React.TouchEventHandler<HTMLAnchorElement> | undefined =
 		listeners?.onTouchStart ? (event) => listeners.onTouchStart?.(event) : undefined;
 
@@ -908,10 +893,7 @@ function SortableAgentRailItem({
 				caption={caption}
 				active={active}
 				onNavigate={onNavigate}
-				onClickCapture={onClickCapture}
-				onPointerDownCapture={onPointerDownCapture}
-				onPointerDown={dragPointerDown}
-				onTouchStartCapture={onTouchStartCapture}
+				onMouseDown={dragMouseDown}
 				onTouchStart={dragTouchStart}
 				showTooltip={showTooltip}
 			>
@@ -952,8 +934,6 @@ function FocusRailContent({
 	const api = useApi();
 	const queryClient = useQueryClient();
 	const draggingRailItem = useRef(false);
-	const railPointerStart = useRef<{ x: number; y: number } | null>(null);
-	const suppressCurrentRailPointerClick = useRef(false);
 	const [railAgents, setRailAgents] = useState<AgentTile[]>(() =>
 		[...agents].sort(compareAgentTiles),
 	);
@@ -963,8 +943,11 @@ function FocusRailContent({
 		railAgentsRef.current = next;
 		setRailAgents(next);
 	};
+	// Separate mouse and touch activators so a touch pointerdown cannot claim the
+	// gesture before TouchSensor applies its long-press activation constraint.
+	// After activation, dnd-kit captures the post-drag click before it reaches the link.
 	const sensors = useSensors(
-		useSensor(PointerSensor, { activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE } }),
+		useSensor(MouseSensor, { activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE } }),
 		useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
 	);
 	useEffect(() => {
@@ -1041,52 +1024,8 @@ function FocusRailContent({
 	const beginRailDragGesture = () => {
 		draggingRailItem.current = true;
 		dragStartRailAgents.current = railAgentsRef.current;
-		suppressCurrentRailPointerClick.current = true;
 	};
-	const recordRailPointerStart: React.PointerEventHandler<HTMLAnchorElement> = (event) => {
-		suppressCurrentRailPointerClick.current = false;
-		if (event.pointerType === "mouse" && event.button !== 0) {
-			railPointerStart.current = null;
-			return;
-		}
-		railPointerStart.current = { x: event.clientX, y: event.clientY };
-	};
-	const recordRailTouchStart: React.TouchEventHandler<HTMLAnchorElement> = (event) => {
-		suppressCurrentRailPointerClick.current = false;
-		const touch = event.touches.item(0);
-		railPointerStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
-	};
-	const railClickMovedPastDragThreshold = (event: React.MouseEvent<HTMLAnchorElement>) => {
-		const start = railPointerStart.current;
-		if (!start) return false;
-		const dx = event.clientX - start.x;
-		const dy = event.clientY - start.y;
-		return Math.hypot(dx, dy) >= RAIL_DRAG_ACTIVATION_DISTANCE;
-	};
-	const shouldSuppressRailClick = (event: React.MouseEvent<HTMLAnchorElement>) =>
-		draggingRailItem.current ||
-		suppressCurrentRailPointerClick.current ||
-		railClickMovedPastDragThreshold(event);
-	const suppressRailNavigation = (event: React.MouseEvent<HTMLAnchorElement>) => {
-		event.preventDefault();
-		event.stopPropagation();
-		suppressCurrentRailPointerClick.current = false;
-		railPointerStart.current = null;
-	};
-	const onRailAgentClickCapture: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
-		if (shouldSuppressRailClick(event)) {
-			suppressRailNavigation(event);
-		}
-	};
-	const onRailAgentNavigate: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
-		if (event.defaultPrevented) return;
-		if (shouldSuppressRailClick(event)) {
-			suppressRailNavigation(event);
-		} else {
-			railPointerStart.current = null;
-			onNavigate?.();
-		}
-	};
+	const onRailAgentNavigate = () => onNavigate?.();
 
 	return (
 		<>
@@ -1158,9 +1097,6 @@ function FocusRailContent({
 									agent={agent}
 									active={Boolean(activeAgentId && agentTileMatchesRouteId(agent, activeAgentId))}
 									onNavigate={onRailAgentNavigate}
-									onClickCapture={onRailAgentClickCapture}
-									onPointerDownCapture={recordRailPointerStart}
-									onTouchStartCapture={recordRailTouchStart}
 									showTooltip={showTooltips}
 								/>
 							))}


### PR DESCRIPTION
## Summary

- keep each agent tile as a semantic link while preserving Discord-style whole-tile reordering
- replace competing PointerSensor + TouchSensor activation with disjoint MouseSensor + TouchSensor constraints
- remove the rail-wide custom click-capture state and let dnd-kit suppress clicks only after a drag actually activates
- cover connected and Hosted tiles, touch tap, Enter activation, reorder-without-navigation, and activation after a completed drag

## Root cause

PR #502 restored whole-tile dragging by wiring dnd-kit activators back onto each agent link, but the rail still carried its own shared pointer-coordinate and click-capture guard. Navigation was therefore suppressed in two places and could depend on stale rail-wide gesture state. The same setup registered PointerSensor before TouchSensor, so a touch pointerdown could claim the draggable before the delayed touch sensor got a chance to enforce its long-press tolerance.

The fix uses MouseSensor with a 10px distance constraint and TouchSensor with a 200ms delay / 8px tolerance. Ordinary mouse clicks, taps, Enter, and native link behaviors do not go through an app-level preventDefault guard. Once a real drag activates, dnd-kit itself captures the following click before it reaches the link.

This behavior is based on the exact installed @dnd-kit/core 6.3.1 upstream tag (commit e9215e8), not inferred internals:

- [DndContext accepts only the first sensor that claims an event](https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/components/DndContext/DndContext.tsx#L483-L515)
- [AbstractPointerSensor applies activation constraints and captures click only after activation](https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/pointer/AbstractPointerSensor.ts#L103-L149)
- [Activated drags stop the subsequent click in document capture](https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/pointer/AbstractPointerSensor.ts#L174-L188)
- [MouseSensor and TouchSensor use separate mouse/touch activators](https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/mouse/MouseSensor.ts#L24-L44) / [TouchSensor](https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/touch/TouchSensor.ts#L21-L45)

## Verification

All commands ran inside mcr.microsoft.com/playwright:v1.61.1-noble with a clean Bun 1.3.14 install; no host or live services were used.

- bun x biome check apps/web/src/components/app-sidebar.tsx apps/web/e2e/sidebar-runtime-smoke.pw.ts apps/web/e2e/hosted-smoke.pw.ts — passed
- bun run --cwd apps/web typecheck — passed
- bun run --cwd apps/web e2e sidebar-runtime-smoke.pw.ts — 4 passed
- bun run --cwd apps/web e2e:hosted --grep "shared legacy environment routes" — 1 passed

No deployment, merge, production, cluster, or tenant-data operation was performed.