### PR TITLE
fix(web): separate agent rail sorting from navigation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -301,6 +301,36 @@ const sharedLegacyCloudAgent = {
 	default_project_id: "project-hosted",
 };
 
+const railHostedEnvironmentId = "88888888-8888-4888-8888-888888888888";
+const railConnectedEnvironmentId = "99999999-9999-4999-8999-999999999999";
+const railHostedDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_rail_cloud",
+	name: "Rail Cloud",
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: railHostedEnvironmentId },
+	},
+};
+const railConnectedCloudAgent = {
+	...sharedLegacyCloudAgent,
+	id: railConnectedEnvironmentId,
+	name: "rail-connected",
+	default_name: "Rail Connected",
+	machine_name: "rail-connected.local",
+	display_name: "Rail Connected",
+	sort_order: 1,
+};
+const railHostedCloudAgent = {
+	...sharedLegacyCloudAgent,
+	id: railHostedEnvironmentId,
+	name: "rail-cloud",
+	default_name: "Rail Cloud",
+	machine_name: "rail-cloud.local",
+	display_name: "Rail Cloud projection",
+	sort_order: 0,
+};
+
 const interruptedIdentitylessDeployment = {
 	...includedBasicDeployment,
 	id: "hdep_creation_interrupted",
@@ -781,6 +811,7 @@ function isStubResponse(value: unknown): value is StubResponse {
 }
 
 type HostedApiStubOptions = {
+	agentOrderRequests?: string[];
 	autoReloadRequests?: string[];
 	autoReloadResponses?: StubResponse[];
 	billingHistoryRequests?: string[];
@@ -1331,6 +1362,27 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				? fulfillJson(r, options.cloudAgentsResponse.body, options.cloudAgentsResponse.status)
 				: fulfillJson(r, options.cloudAgents ?? []);
 		}
+		if (p === "/v1/agents/order" && r.request().method() === "PATCH") {
+			const postData = r.request().postData() ?? "";
+			options.agentOrderRequests?.push(postData);
+			const body: unknown = JSON.parse(postData || "{}");
+			const agentIds =
+				isRecord(body) && Array.isArray(body.agent_ids)
+					? body.agent_ids.filter((id): id is string => typeof id === "string")
+					: [];
+			const agentsById = new Map(
+				(options.cloudAgents ?? [])
+					.filter(isRecord)
+					.flatMap((agent) => (typeof agent.id === "string" ? [[agent.id, agent] as const] : [])),
+			);
+			return fulfillJson(
+				r,
+				agentIds.flatMap((id, sortOrder) => {
+					const agent = agentsById.get(id);
+					return agent ? [{ ...agent, sort_order: sortOrder }] : [];
+				}),
+			);
+		}
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
 			const response = options.cloudAgentResponses?.[id]?.shift();
@@ -1494,6 +1546,140 @@ test("empty account offers two working first-agent paths", async ({ page }) => {
 	await expect(
 		page.getByText("Run the setup command on the machine where your agent lives."),
 	).toBeVisible();
+});
+
+test("hosted mixed agent rail keeps navigation separate from sorting", async ({
+	page,
+	browser,
+	baseURL,
+}) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the hosted rail test.");
+	const agentOrderRequests: string[] = [];
+	await stubHostedApi(page, {
+		agentOrderRequests,
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
+	});
+
+	await page.goto("/agents");
+	const rail = page.getByTestId("app-sidebar-agent-rail");
+	const consoleLink = rail.getByRole("link", { name: "Console", exact: true });
+	const cloudLink = rail.getByRole("link", { name: "Rail Cloud", exact: true });
+	const connectedLink = rail.getByRole("link", { name: /Rail Connected/ });
+
+	await expect(consoleLink).toHaveAttribute("href", "/");
+	await expect(cloudLink).toHaveAttribute(
+		"href",
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=hdep_rail_cloud`,
+	);
+	await expect(connectedLink).toHaveAttribute("href", `/agents/${railConnectedEnvironmentId}`);
+
+	await consoleLink.click();
+	await expect(page).toHaveURL("/");
+	await page.goto("/");
+	await cloudLink.click();
+	await expect(page).toHaveURL(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=hdep_rail_cloud`,
+	);
+	await page.goto("/");
+	await connectedLink.click();
+	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+
+	await page.goto("/");
+	await connectedLink.focus();
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+
+	await page.goto("/");
+	const connectedHandle = rail.getByRole("button", { name: /Reorder Rail Connected/ });
+	const cloudHandle = rail.getByRole("button", { name: /Reorder .*Rail Cloud projection/ });
+	const connectedTileBox = await rail
+		.getByTestId("app-sidebar-agent-tile")
+		.filter({ hasText: "Rail Connected" })
+		.boundingBox();
+	const connectedLinkBox = await connectedLink.boundingBox();
+	const sourceBox = await connectedHandle.boundingBox();
+	const targetBox = await cloudHandle.boundingBox();
+	if (!connectedTileBox || !connectedLinkBox || !sourceBox || !targetBox) {
+		throw new Error("Hosted rail links and drag handles should render.");
+	}
+	expect(connectedTileBox.height).toBeCloseTo(72, 0);
+	expect(connectedLinkBox.height).toBeCloseTo(connectedTileBox.height, 0);
+	expect(sourceBox.x).toBeGreaterThanOrEqual(connectedLinkBox.x + connectedLinkBox.width - 0.5);
+	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+		steps: 10,
+	});
+	await page.mouse.up();
+	expect(page.url()).toBe(new URL("/", baseURL).href);
+	await connectedLink.click();
+	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+
+	await expect.poll(() => agentOrderRequests.length).toBe(1);
+	expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
+		agent_ids: [railConnectedEnvironmentId, railHostedEnvironmentId],
+	});
+	await expect(rail.getByTestId("app-sidebar-agent-tile").nth(0)).toContainText("Rail Connected");
+
+	const touchContext = await browser.newContext({
+		baseURL,
+		hasTouch: true,
+		viewport: { width: 1280, height: 720 },
+	});
+	const touchPage = await touchContext.newPage();
+	const touchOrderRequests: string[] = [];
+	try {
+		await stubHostedApi(touchPage, {
+			agentOrderRequests: touchOrderRequests,
+			deployments: [railHostedDeployment],
+			cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
+		});
+		await touchPage.goto("/");
+		const touchConnectedLink = touchPage
+			.getByTestId("app-sidebar-agent-rail")
+			.getByRole("link", { name: /Rail Connected/ });
+		await touchConnectedLink.tap();
+		await expect(touchPage).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+
+		await touchPage.goto("/");
+		const touchRail = touchPage.getByTestId("app-sidebar-agent-rail");
+		const touchSourceBox = await touchRail
+			.getByRole("button", { name: /Reorder Rail Connected/ })
+			.boundingBox();
+		const touchTargetBox = await touchRail
+			.getByRole("button", { name: /Reorder .*Rail Cloud projection/ })
+			.boundingBox();
+		if (!touchSourceBox || !touchTargetBox) {
+			throw new Error("Hosted rail touch drag handles should render.");
+		}
+		const cdp = await touchContext.newCDPSession(touchPage);
+		const source = {
+			x: touchSourceBox.x + touchSourceBox.width / 2,
+			y: touchSourceBox.y + touchSourceBox.height / 2,
+		};
+		const target = {
+			x: touchTargetBox.x + touchTargetBox.width / 2,
+			y: touchTargetBox.y + touchTargetBox.height / 2,
+		};
+		await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [source] });
+		for (let step = 1; step <= 10; step += 1) {
+			await cdp.send("Input.dispatchTouchEvent", {
+				type: "touchMove",
+				touchPoints: [
+					{
+						x: source.x + ((target.x - source.x) * step) / 10,
+						y: source.y + ((target.y - source.y) * step) / 10,
+					},
+				],
+			});
+		}
+		await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+		expect(touchPage.url()).toBe(new URL("/", baseURL).href);
+		await expect.poll(() => touchOrderRequests.length).toBe(1);
+	} finally {
+		await touchContext.close();
+	}
 });
 
 test("existing Cloud customers keep billing settings when new deploys are disabled", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -276,26 +276,22 @@ test("agent rail links support touch taps and keyboard activation", async ({
 	}
 });
 
-test("agent rail supports whole-tile sorting without drag handles", async ({ page }) => {
+test("agent rail exposes accessible keyboard sorting handles", async ({ page }) => {
 	const agentOrderRequests: string[] = [];
 	await stubDashboardApi(page, agentOrderRequests);
 	await page.goto("/");
 
 	const tiles = page.getByTestId("app-sidebar-agent-tile");
 	await expect(tiles).toHaveCount(2, { timeout: 15_000 });
-	await expect(page.getByRole("button", { name: /^Reorder / })).toHaveCount(0);
-	const source = tiles.filter({ hasText: "Smoke Codex" }).locator("a");
-	const target = tiles.filter({ hasText: "Smoke Hermes" }).locator("a");
-	const sourceBox = await source.boundingBox();
-	const targetBox = await target.boundingBox();
-	if (!sourceBox || !targetBox) throw new Error("Agent rail tiles are not draggable.");
-
-	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
-	await page.mouse.down();
-	await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
-		steps: 10,
+	const firstHandle = page.getByRole("button", {
+		name: "Reorder Smoke Codex · Codex, position 1 of 2",
+		exact: true,
 	});
-	await page.mouse.up();
+	await expect(firstHandle).toBeVisible();
+	await firstHandle.focus();
+	await page.keyboard.press("Space");
+	await page.keyboard.press("ArrowDown");
+	await page.keyboard.press("Space");
 
 	await expect(page).toHaveURL("/");
 	await expect.poll(() => agentOrderRequests.length).toBe(1);
@@ -304,8 +300,7 @@ test("agent rail supports whole-tile sorting without drag handles", async ({ pag
 	});
 	await expect(tiles.nth(0)).toContainText("Smoke Hermes");
 
-	const postDragKeyboardTarget = tiles.filter({ hasText: "Smoke Hermes" }).locator("a");
-	await postDragKeyboardTarget.focus();
-	await page.keyboard.press("Enter");
+	const postDragTarget = tiles.filter({ hasText: "Smoke Hermes" }).locator("a");
+	await postDragTarget.click();
 	await expect(page).toHaveURL("/agents/agent-smoke-2");
 });

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -6,15 +6,16 @@ import {
 	DndContext,
 	type DragEndEvent,
 	type DragOverEvent,
+	KeyboardSensor,
 	type Modifier,
-	MouseSensor,
-	TouchSensor,
+	PointerSensor,
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
 import {
 	arrayMove,
 	SortableContext,
+	sortableKeyboardCoordinates,
 	useSortable,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
@@ -26,6 +27,7 @@ import {
 	CircleHelp,
 	Cloud,
 	ExternalLink,
+	GripVertical,
 	History,
 	Layers,
 	LayoutDashboard,
@@ -752,8 +754,6 @@ function RailFocusButton({
 	caption,
 	active,
 	onNavigate,
-	onMouseDown,
-	onTouchStart,
 	showTooltip = true,
 	children,
 }: {
@@ -761,25 +761,12 @@ function RailFocusButton({
 	label: string;
 	caption?: string;
 	active: boolean;
-	onNavigate?: React.MouseEventHandler<HTMLAnchorElement>;
-	onMouseDown?: React.MouseEventHandler<HTMLAnchorElement>;
-	onTouchStart?: React.TouchEventHandler<HTMLAnchorElement>;
+	onNavigate?: () => void;
 	showTooltip?: boolean;
 	children: React.ReactNode;
 }) {
 	const hasCaption = Boolean(caption);
-	const focusTarget = href ? (
-		<Link
-			to={href}
-			draggable={false}
-			onClick={onNavigate}
-			onMouseDown={onMouseDown}
-			onTouchStart={onTouchStart}
-			className="cursor-default"
-		/>
-	) : (
-		<div aria-disabled="true" className="cursor-default" />
-	);
+	const focusTarget = href ? <Link to={href} onClick={onNavigate} /> : <div aria-disabled="true" />;
 	const button = (
 		<SidebarMenuButton
 			render={focusTarget}
@@ -810,7 +797,7 @@ function RailFocusButton({
 	return (
 		<div
 			className={cn(
-				"group/rail-focus relative flex items-center justify-center",
+				"group/rail-focus relative flex min-w-0 items-center justify-center",
 				hasCaption ? "h-[4.5rem] w-full" : "size-11",
 			)}
 		>
@@ -841,16 +828,28 @@ function RailFocusButton({
 
 function SortableAgentRailItem({
 	agent,
+	position,
+	itemCount,
 	active,
 	onNavigate,
 	showTooltip,
 }: {
 	agent: AgentTile;
+	position: number;
+	itemCount: number;
 	active: boolean;
-	onNavigate: React.MouseEventHandler<HTMLAnchorElement>;
+	onNavigate?: () => void;
 	showTooltip: boolean;
 }) {
-	const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+	const {
+		attributes,
+		listeners,
+		setActivatorNodeRef,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({
 		id: agent.id,
 		disabled: !agent.env,
 	});
@@ -872,10 +871,7 @@ function SortableAgentRailItem({
 		transition: isDragging ? undefined : transition,
 		zIndex: isDragging ? 20 : undefined,
 	};
-	const dragMouseDown: React.MouseEventHandler<HTMLAnchorElement> | undefined =
-		listeners?.onMouseDown ? (event) => listeners.onMouseDown?.(event) : undefined;
-	const dragTouchStart: React.TouchEventHandler<HTMLAnchorElement> | undefined =
-		listeners?.onTouchStart ? (event) => listeners.onTouchStart?.(event) : undefined;
+	const reorderLabel = `Reorder ${baseIdentityLabel}, position ${position} of ${itemCount}`;
 
 	return (
 		<SidebarMenuItem
@@ -883,7 +879,7 @@ function SortableAgentRailItem({
 			data-testid="app-sidebar-agent-tile"
 			style={style}
 			className={cn(
-				"group/agent-rail-item relative w-full touch-pan-y will-change-transform",
+				"group/agent-rail-item flex h-[4.5rem] w-full touch-pan-y items-end will-change-transform",
 				isDragging && "opacity-80",
 			)}
 		>
@@ -893,8 +889,6 @@ function SortableAgentRailItem({
 				caption={caption}
 				active={active}
 				onNavigate={onNavigate}
-				onMouseDown={dragMouseDown}
-				onTouchStart={dragTouchStart}
 				showTooltip={showTooltip}
 			>
 				<span className="relative inline-flex rounded-md">
@@ -916,6 +910,20 @@ function SortableAgentRailItem({
 					) : null}
 				</span>
 			</RailFocusButton>
+			<Button
+				ref={setActivatorNodeRef}
+				type="button"
+				variant="ghost"
+				size="icon-sm"
+				className="size-6 touch-none cursor-grab rounded-sm text-muted-foreground hover:text-sidebar-foreground active:cursor-grabbing"
+				disabled={!agent.env}
+				aria-label={reorderLabel}
+				title={reorderLabel}
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical aria-hidden="true" className="size-3" />
+			</Button>
 		</SidebarMenuItem>
 	);
 }
@@ -933,7 +941,6 @@ function FocusRailContent({
 }) {
 	const api = useApi();
 	const queryClient = useQueryClient();
-	const draggingRailItem = useRef(false);
 	const [railAgents, setRailAgents] = useState<AgentTile[]>(() =>
 		[...agents].sort(compareAgentTiles),
 	);
@@ -943,15 +950,16 @@ function FocusRailContent({
 		railAgentsRef.current = next;
 		setRailAgents(next);
 	};
-	// Separate mouse and touch activators so a touch pointerdown cannot claim the
-	// gesture before TouchSensor applies its long-press activation constraint.
-	// After activation, dnd-kit captures the post-drag click before it reaches the link.
+	// Drag input belongs exclusively to each tile's explicit activator button. The
+	// adjacent link remains a plain navigation target for clicks, taps, and keyboard use.
 	const sensors = useSensors(
-		useSensor(MouseSensor, { activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE } }),
-		useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+		useSensor(PointerSensor, {
+			activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE },
+		}),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
 	);
 	useEffect(() => {
-		if (!draggingRailItem.current) {
+		if (!dragStartRailAgents.current) {
 			setRailAgentsOrder([...agents].sort(compareAgentTiles));
 		}
 	}, [agents]);
@@ -985,7 +993,6 @@ function FocusRailContent({
 	});
 	const onDragEnd = (event: DragEndEvent) => {
 		const { active, over } = event;
-		draggingRailItem.current = false;
 		const initialAgents = dragStartRailAgents.current;
 		dragStartRailAgents.current = null;
 		if (!over) {
@@ -1022,10 +1029,8 @@ function FocusRailContent({
 		setRailAgentsOrder(reorderAgentTilesByIndex(current, from, to));
 	};
 	const beginRailDragGesture = () => {
-		draggingRailItem.current = true;
 		dragStartRailAgents.current = railAgentsRef.current;
 	};
-	const onRailAgentNavigate = () => onNavigate?.();
 
 	return (
 		<>
@@ -1079,7 +1084,6 @@ function FocusRailContent({
 						modifiers={RAIL_DND_MODIFIERS}
 						onDragStart={beginRailDragGesture}
 						onDragCancel={() => {
-							draggingRailItem.current = false;
 							if (dragStartRailAgents.current) {
 								setRailAgentsOrder(dragStartRailAgents.current);
 							} else {
@@ -1091,12 +1095,14 @@ function FocusRailContent({
 						onDragEnd={onDragEnd}
 					>
 						<SortableContext items={orderedAgentIds} strategy={verticalListSortingStrategy}>
-							{orderedAgents.map((agent) => (
+							{orderedAgents.map((agent, index) => (
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
+									position={index + 1}
+									itemCount={orderedAgents.length}
 									active={Boolean(activeAgentId && agentTileMatchesRouteId(agent, activeAgentId))}
-									onNavigate={onRailAgentNavigate}
+									onNavigate={onNavigate}
 									showTooltip={showTooltips}
 								/>
 							))}


### PR DESCRIPTION
## Summary

- Keep Console outside sortable ownership and keep every destination as a semantic TanStack Link.
- Move the only dnd-kit activator path to a visible sibling button using `setActivatorNodeRef`, `attributes`, and `listeners`.
- Use `PointerSensor` for the explicit handle and restore accessible `KeyboardSensor` sorting with `sortableKeyboardCoordinates`.
- Preserve the existing compact rail footprint: the Link and 24px handle are normal-flow siblings in the same 72px item, with no overlap.
- Remove link-level mouse/touch activators, activator forwarding wrappers, the rail-wide dragging ref, and the desktop no-op navigation wrapper.

Production change in `app-sidebar.tsx`: 48 lines added, 42 deleted, net **+6 lines**. There are no click-capture guards, coordinate refs, timeouts, `preventDefault`/`stopPropagation` handlers, or CSS event overlays.

## Failing before: current main

Reproduced against `origin/main` at `25ccc7a3` in an isolated hosted Playwright fixture containing Console, one joined Cloud/on-clawdi tile, and one connected/projected tile.

The instrumented current-main test failed with:

```text
same-tile drags must not activate their links
Expected: []
Received:
  /agents/77777777-7777-4777-8777-777777777777?source=on-clawdi&d=hdep_shared_newer
  /agents/88888888-8888-4888-8888-888888888888
```

The second URL is the connected tile. Its drag-end click reached document capture with `target=A` and `defaultPrevented=false`; dnd-kit then stopped propagation, but the browser still performed the anchor default navigation and full reload.

Concrete exclusions from DOM/event instrumentation:

- Console, href-bearing Cloud, and connected tiles each rendered as one composed `<a>`; ordinary isolated clicks navigated through TanStack without a document reload.
- Hit testing landed inside each anchor. No stacking, pointer-events, Tooltip wrapper, Base UI render, or TanStack Link fault was present for href-bearing tiles.
- An identityless Cloud deployment separately renders a disabled `<div>` because its hosted projection supplies `href: null`; this is a data/identity state, not the event-path defect.
- The production defect was that the anchor also owned the dnd activator. PR #516 relied on propagation suppression as if it canceled link default behavior; it does not.

## Why a drag cannot navigate after this change

The Link and activator button are siblings. Pointer and keyboard sorting begin only from the button; the Link has no dnd-kit listeners. Therefore the synthetic click at the end of a drag targets a button whose default action is not navigation, and the anchor is not in that event path. Console is outside `DndContext` entirely.

The browser geometry regression verifies the sortable item remains approximately 72px high, the Link remains the same height, and the handle begins at or after the Link right edge.

## Regression coverage

Hosted mixed fixture verifies:

- Console click navigates
- Cloud click navigates
- connected click navigates
- connected Enter activation navigates
- pointer reorder does not navigate
- click immediately after drag still navigates
- touch tap navigates
- real touch pointer sorting from the handle does not navigate
- PATCH order payload and authoritative post-response DOM order
- compact, non-overlapping 72px DOM geometry

Also restores the existing non-hosted keyboard sorting scenario: `Space → ArrowDown → Space`, followed immediately by a working Link click.

Passing verification:

- official Playwright `mcr.microsoft.com/playwright:v1.61.1-noble`, hosted mixed rail: **1 passed**
- same container, non-hosted rail focus: **3 passed**
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`: **663 passed**
- Biome on changed files
- `bun run --cwd apps/web build:oss`
- hosted production build with `VITE_CLAWDI_HOSTED=true`

No CI workflow, deployment, production cluster, or tenant data changes are included.

## Official upstream basis

- dnd-kit useSortable activator pattern: https://docs.dndkit.com/legacy/presets/sortable/use-sortable/#activator
  - When the activator differs from the draggable node, dnd-kit recommends setting the activator node ref on the activator.
- dnd-kit PointerSensor touch-action guidance: https://docs.dndkit.com/legacy/api-documentation/sensors/pointer#touch-action
  - For scrollable lists with a dedicated handle, use `touch-action: none` on the handle.
- dnd-kit sortable keyboard sensor and `sortableKeyboardCoordinates`: https://docs.dndkit.com/presets/sortable
- Installed dnd-kit 6.3.1 pointer sensor only installs a capture click `stopPropagation`: https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/pointer/AbstractPointerSensor.ts#L175-L196
- The pinned `stopPropagation` helper does not call `preventDefault`: https://github.com/clauderic/dnd-kit/blob/e9215e820798459ae036896fce7fd9a6fe855772/packages/core/src/sensors/events.ts#L11-L17
- MDN confirms `stopPropagation()` does not prevent link default behavior: https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation
