### PR TITLE
fix(web): make the whole agent tile draggable

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1548,7 +1548,7 @@ test("empty account offers two working first-agent paths", async ({ page }) => {
 	).toBeVisible();
 });
 
-test("hosted mixed agent rail keeps navigation separate from sorting", async ({
+test("hosted mixed agent rail uses whole semantic buttons for context switching", async ({
 	page,
 	browser,
 	baseURL,
@@ -1564,63 +1564,44 @@ test("hosted mixed agent rail keeps navigation separate from sorting", async ({
 	await page.goto("/agents");
 	const rail = page.getByTestId("app-sidebar-agent-rail");
 	const consoleLink = rail.getByRole("link", { name: "Console", exact: true });
-	const cloudLink = rail.getByRole("link", { name: "Rail Cloud", exact: true });
-	const connectedLink = rail.getByRole("link", { name: /Rail Connected/ });
+	const cloudButton = rail.getByRole("button", { name: "Rail Cloud", exact: true });
+	const connectedButton = rail.getByRole("button", { name: /Rail Connected/ });
 
 	await expect(consoleLink).toHaveAttribute("href", "/");
-	await expect(cloudLink).toHaveAttribute(
-		"href",
-		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=hdep_rail_cloud`,
-	);
-	await expect(connectedLink).toHaveAttribute("href", `/agents/${railConnectedEnvironmentId}`);
+	await expect(cloudButton).toHaveAttribute("type", "button");
+	await expect(connectedButton).toHaveAttribute("type", "button");
+	await expect(rail.getByRole("button", { name: /^Reorder / })).toHaveCount(0);
+	await expect(rail.getByTitle(/^Reorder /)).toHaveCount(0);
 
-	await consoleLink.click();
-	await expect(page).toHaveURL("/");
-	await page.goto("/");
-	await cloudLink.click();
-	await expect(page).toHaveURL(
-		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=hdep_rail_cloud`,
-	);
-	await page.goto("/");
-	await connectedLink.click();
-	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
-
-	await page.goto("/");
-	await connectedLink.focus();
-	await page.keyboard.press("Enter");
-	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
-
-	await page.goto("/");
-	const connectedHandle = rail.getByRole("button", { name: /Reorder Rail Connected/ });
-	const cloudHandle = rail.getByRole("button", { name: /Reorder .*Rail Cloud projection/ });
 	const connectedTileBox = await rail
 		.getByTestId("app-sidebar-agent-tile")
 		.filter({ hasText: "Rail Connected" })
 		.boundingBox();
-	const connectedLinkBox = await connectedLink.boundingBox();
-	const sourceBox = await connectedHandle.boundingBox();
-	const targetBox = await cloudHandle.boundingBox();
-	if (!connectedTileBox || !connectedLinkBox || !sourceBox || !targetBox) {
-		throw new Error("Hosted rail links and drag handles should render.");
+	const connectedButtonBox = await connectedButton.boundingBox();
+	if (!connectedTileBox || !connectedButtonBox) {
+		throw new Error("Hosted rail agent tile should be a whole interactive button.");
 	}
 	expect(connectedTileBox.height).toBeCloseTo(72, 0);
-	expect(connectedLinkBox.height).toBeCloseTo(connectedTileBox.height, 0);
-	expect(sourceBox.x).toBeGreaterThanOrEqual(connectedLinkBox.x + connectedLinkBox.width - 0.5);
-	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
-	await page.mouse.down();
-	await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
-		steps: 10,
-	});
-	await page.mouse.up();
-	expect(page.url()).toBe(new URL("/", baseURL).href);
-	await connectedLink.click();
+	expect(connectedButtonBox.x).toBeCloseTo(connectedTileBox.x, 0);
+	expect(connectedButtonBox.y).toBeCloseTo(connectedTileBox.y, 0);
+	expect(connectedButtonBox.height).toBeCloseTo(connectedTileBox.height, 0);
+	expect(connectedButtonBox.width).toBeCloseTo(connectedTileBox.width, 0);
+
+	await consoleLink.click();
+	await expect(page).toHaveURL("/");
+	await page.goto("/");
+	await cloudButton.click();
+	await expect(page).toHaveURL(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=hdep_rail_cloud`,
+	);
+	await page.goto("/");
+	await connectedButton.click();
 	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
 
-	await expect.poll(() => agentOrderRequests.length).toBe(1);
-	expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
-		agent_ids: [railConnectedEnvironmentId, railHostedEnvironmentId],
-	});
-	await expect(rail.getByTestId("app-sidebar-agent-tile").nth(0)).toContainText("Rail Connected");
+	await page.goto("/");
+	await connectedButton.focus();
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
 
 	const touchContext = await browser.newContext({
 		baseURL,
@@ -1636,33 +1617,113 @@ test("hosted mixed agent rail keeps navigation separate from sorting", async ({
 			cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
 		});
 		await touchPage.goto("/");
-		const touchConnectedLink = touchPage
+		const touchConnectedButton = touchPage
 			.getByTestId("app-sidebar-agent-rail")
-			.getByRole("link", { name: /Rail Connected/ });
-		await touchConnectedLink.tap();
+			.getByRole("button", { name: /Rail Connected/ });
+		await touchConnectedButton.tap();
 		await expect(touchPage).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+	} finally {
+		await touchContext.close();
+	}
+	expect(agentOrderRequests).toEqual([]);
+	expect(touchOrderRequests).toEqual([]);
+});
 
-		await touchPage.goto("/");
-		const touchRail = touchPage.getByTestId("app-sidebar-agent-rail");
-		const touchSourceBox = await touchRail
-			.getByRole("button", { name: /Reorder Rail Connected/ })
-			.boundingBox();
-		const touchTargetBox = await touchRail
-			.getByRole("button", { name: /Reorder .*Rail Cloud projection/ })
-			.boundingBox();
-		if (!touchSourceBox || !touchTargetBox) {
-			throw new Error("Hosted rail touch drag handles should render.");
-		}
-		const cdp = await touchContext.newCDPSession(touchPage);
+test("whole agent tile mouse drag reorders without navigation", async ({ page, baseURL }) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the hosted rail test.");
+	const agentOrderRequests: string[] = [];
+	await stubHostedApi(page, {
+		agentOrderRequests,
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
+	});
+	await page.goto("/");
+
+	const rail = page.getByTestId("app-sidebar-agent-rail");
+	const connectedButton = rail.getByRole("button", { name: /Rail Connected/ });
+	const cloudButton = rail.getByRole("button", { name: "Rail Cloud", exact: true });
+	const sourceBox = await connectedButton.boundingBox();
+	const targetBox = await cloudButton.boundingBox();
+	if (!sourceBox || !targetBox) throw new Error("Hosted rail agent buttons should render.");
+
+	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+		steps: 10,
+	});
+	await page.mouse.up();
+	expect(page.url()).toBe(new URL("/", baseURL).href);
+
+	await connectedButton.click();
+	await expect(page).toHaveURL(`/agents/${railConnectedEnvironmentId}`);
+	await expect.poll(() => agentOrderRequests.length).toBe(1);
+	expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
+		agent_ids: [railConnectedEnvironmentId, railHostedEnvironmentId],
+	});
+	await expect(rail.getByTestId("app-sidebar-agent-tile").nth(0)).toContainText("Rail Connected");
+});
+
+test("whole agent tile preserves touch scroll intent and supports long-press drag", async ({
+	browser,
+	baseURL,
+}) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the hosted rail test.");
+	const context = await browser.newContext({
+		baseURL,
+		hasTouch: true,
+		viewport: { width: 1280, height: 360 },
+	});
+	const page = await context.newPage();
+	const agentOrderRequests: string[] = [];
+	try {
+		await stubHostedApi(page, {
+			agentOrderRequests,
+			deployments: [railHostedDeployment],
+			cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
+		});
+		await page.goto("/");
+
+		const rail = page.getByTestId("app-sidebar-agent-rail");
+		const scrollContainer = rail.locator('[data-slot="sidebar-content"]');
+		const cloudButton = rail.getByRole("button", { name: "Rail Cloud", exact: true });
+		const connectedButton = rail.getByRole("button", { name: /Rail Connected/ });
+		const scrollSourceBox = await cloudButton.boundingBox();
+		if (!scrollSourceBox) throw new Error("Hosted rail cloud button should render.");
+		const cdp = await context.newCDPSession(page);
+		const scrollStart = await scrollContainer.evaluate((element) => element.scrollTop);
+		const scrollSource = {
+			x: scrollSourceBox.x + scrollSourceBox.width / 2,
+			y: scrollSourceBox.y + scrollSourceBox.height / 2,
+		};
+		await cdp.send("Input.dispatchTouchEvent", {
+			type: "touchStart",
+			touchPoints: [scrollSource],
+		});
+		await cdp.send("Input.dispatchTouchEvent", {
+			type: "touchMove",
+			touchPoints: [{ x: scrollSource.x, y: scrollSource.y - 40 }],
+		});
+		await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+		expect(page.url()).toBe(new URL("/", baseURL).href);
+		expect(agentOrderRequests).toEqual([]);
+		await expect
+			.poll(() => scrollContainer.evaluate((element) => element.scrollTop))
+			.toBeGreaterThan(scrollStart);
+
+		await page.reload();
+		const sourceBox = await connectedButton.boundingBox();
+		const targetBox = await cloudButton.boundingBox();
+		if (!sourceBox || !targetBox) throw new Error("Hosted rail agent buttons should render.");
 		const source = {
-			x: touchSourceBox.x + touchSourceBox.width / 2,
-			y: touchSourceBox.y + touchSourceBox.height / 2,
+			x: sourceBox.x + sourceBox.width / 2,
+			y: sourceBox.y + sourceBox.height / 2,
 		};
 		const target = {
-			x: touchTargetBox.x + touchTargetBox.width / 2,
-			y: touchTargetBox.y + touchTargetBox.height / 2,
+			x: targetBox.x + targetBox.width / 2,
+			y: targetBox.y + targetBox.height / 2,
 		};
 		await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [source] });
+		await expect(connectedButton).toHaveAttribute("aria-pressed", "true");
 		for (let step = 1; step <= 10; step += 1) {
 			await cdp.send("Input.dispatchTouchEvent", {
 				type: "touchMove",
@@ -1675,10 +1736,13 @@ test("hosted mixed agent rail keeps navigation separate from sorting", async ({
 			});
 		}
 		await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
-		expect(touchPage.url()).toBe(new URL("/", baseURL).href);
-		await expect.poll(() => touchOrderRequests.length).toBe(1);
+		expect(page.url()).toBe(new URL("/", baseURL).href);
+		await expect.poll(() => agentOrderRequests.length).toBe(1);
+		expect(JSON.parse(agentOrderRequests[0] ?? "{}")).toEqual({
+			agent_ids: [railConnectedEnvironmentId, railHostedEnvironmentId],
+		});
 	} finally {
-		await touchContext.close();
+		await context.close();
 	}
 });
 

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -190,7 +190,7 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await expect(agentTile).toHaveCount(1, { timeout: 15_000 });
 	await expectNoBrowserErrors(page, browserErrors, "dashboard render");
 
-	await agentTile.locator("a").hover();
+	await agentTile.locator("button").hover();
 	await expect(
 		page.locator('[data-slot="tooltip-content"]').filter({ hasText: "Smoke Codex" }),
 	).toBeVisible();
@@ -219,24 +219,24 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await expectNoBrowserErrors(page, browserErrors, "settings select");
 });
 
-test("every agent rail tile navigates on click", async ({ page }) => {
+test("every agent rail tile button navigates on click", async ({ page }) => {
 	await stubDashboardApi(page);
 
 	for (const agent of agents) {
 		await page.goto("/");
-		const tileLink = page
+		const tileButton = page
 			.getByTestId("app-sidebar-agent-tile")
 			.filter({ hasText: agent.display_name })
-			.locator("a");
-		await expect(tileLink).toBeVisible({ timeout: 15_000 });
-		await expect(tileLink).toHaveAttribute("href", `/agents/${agent.id}`);
+			.locator("button");
+		await expect(tileButton).toBeVisible({ timeout: 15_000 });
+		await expect(tileButton).toHaveAttribute("type", "button");
 
-		await tileLink.click();
+		await tileButton.click();
 		await expect(page).toHaveURL(`/agents/${agent.id}`);
 	}
 });
 
-test("agent rail links support touch taps and keyboard activation", async ({
+test("agent rail tile buttons support touch taps and Enter activation", async ({
 	browser,
 	baseURL,
 }) => {
@@ -256,7 +256,7 @@ test("agent rail links support touch taps and keyboard activation", async ({
 		const touchTarget = page
 			.getByTestId("app-sidebar-agent-tile")
 			.filter({ hasText: firstAgent.display_name })
-			.locator("a");
+			.locator("button");
 		await expect(touchTarget).toBeVisible({ timeout: 15_000 });
 		await touchTarget.tap();
 		await expect(page).toHaveURL(`/agents/${firstAgent.id}`);
@@ -265,7 +265,7 @@ test("agent rail links support touch taps and keyboard activation", async ({
 		const keyboardTarget = page
 			.getByTestId("app-sidebar-agent-tile")
 			.filter({ hasText: secondAgent.display_name })
-			.locator("a");
+			.locator("button");
 		await expect(keyboardTarget).toBeVisible({ timeout: 15_000 });
 		await keyboardTarget.focus();
 		await expect(keyboardTarget).toBeFocused();
@@ -276,22 +276,45 @@ test("agent rail links support touch taps and keyboard activation", async ({
 	}
 });
 
-test("agent rail exposes accessible keyboard sorting handles", async ({ page }) => {
+test("agent rail uses each whole tile for Space keyboard sorting", async ({ page }) => {
 	const agentOrderRequests: string[] = [];
 	await stubDashboardApi(page, agentOrderRequests);
 	await page.goto("/");
 
 	const tiles = page.getByTestId("app-sidebar-agent-tile");
 	await expect(tiles).toHaveCount(2, { timeout: 15_000 });
-	const firstHandle = page.getByRole("button", {
-		name: "Reorder Smoke Codex · Codex, position 1 of 2",
-		exact: true,
-	});
-	await expect(firstHandle).toBeVisible();
-	await firstHandle.focus();
-	await page.keyboard.press("Space");
+	await expect(page.getByRole("button", { name: /^Reorder / })).toHaveCount(0);
+	const firstTile = tiles.filter({ hasText: "Smoke Codex" });
+	const firstButton = firstTile.locator("button");
+	const firstTileBox = await firstTile.boundingBox();
+	const firstButtonBox = await firstButton.boundingBox();
+	if (!firstTileBox || !firstButtonBox) throw new Error("Agent rail tile should be interactive.");
+	expect(firstTileBox.height).toBeCloseTo(72, 0);
+	expect(firstButtonBox.height).toBeCloseTo(firstTileBox.height, 0);
+	expect(firstButtonBox.width).toBeCloseTo(firstTileBox.width, 0);
+
+	await firstButton.focus();
+	await page.keyboard.down("Space");
+	await expect(firstButton).toHaveAttribute("aria-pressed", "true");
+	await page.keyboard.up("Space");
 	await page.keyboard.press("ArrowDown");
-	await page.keyboard.press("Space");
+	await page.keyboard.press("Escape");
+	await expect(firstButton).not.toHaveAttribute("aria-pressed", "true");
+	await expect(page).toHaveURL("/");
+	expect(agentOrderRequests).toEqual([]);
+	await expect(tiles.nth(0)).toContainText("Smoke Codex");
+
+	await firstButton.focus();
+	await page.keyboard.down("Space");
+	await expect(firstButton).toHaveAttribute("aria-pressed", "true");
+	await expect(page).toHaveURL("/");
+	await page.keyboard.up("Space");
+	await expect(page).toHaveURL("/");
+	await page.keyboard.press("ArrowDown");
+	await page.keyboard.down("Space");
+	await expect(firstButton).not.toHaveAttribute("aria-pressed", "true");
+	await expect(page).toHaveURL("/");
+	await page.keyboard.up("Space");
 
 	await expect(page).toHaveURL("/");
 	await expect.poll(() => agentOrderRequests.length).toBe(1);
@@ -300,7 +323,7 @@ test("agent rail exposes accessible keyboard sorting handles", async ({ page }) 
 	});
 	await expect(tiles.nth(0)).toContainText("Smoke Hermes");
 
-	const postDragTarget = tiles.filter({ hasText: "Smoke Hermes" }).locator("a");
+	const postDragTarget = tiles.filter({ hasText: "Smoke Hermes" }).locator("button");
 	await postDragTarget.click();
 	await expect(page).toHaveURL("/agents/agent-smoke-2");
 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -276,6 +276,31 @@ test("agent rail tile buttons support touch taps and Enter activation", async ({
 	}
 });
 
+test("Enter drops an active keyboard sort before navigating when inactive", async ({ page }) => {
+	const agentOrderRequests: string[] = [];
+	await stubDashboardApi(page, agentOrderRequests);
+	await page.goto("/");
+
+	const tiles = page.getByTestId("app-sidebar-agent-tile");
+	await expect(tiles).toHaveCount(2, { timeout: 15_000 });
+	const firstButton = tiles.filter({ hasText: "Smoke Codex" }).locator("button");
+	await firstButton.focus();
+	await page.keyboard.down("Space");
+	await expect(firstButton).toHaveAttribute("aria-pressed", "true");
+	await page.keyboard.up("Space");
+	await page.keyboard.press("ArrowDown");
+	await page.keyboard.press("Enter");
+
+	await expect(firstButton).not.toHaveAttribute("aria-pressed", "true");
+	await expect(page).toHaveURL("/");
+	await expect.poll(() => agentOrderRequests.length).toBe(1);
+	await expect(tiles.nth(0)).toContainText("Smoke Hermes");
+	await expect(firstButton).toBeFocused();
+
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL("/agents/agent-smoke-1");
+});
+
 test("agent rail uses each whole tile for Space keyboard sorting", async ({ page }) => {
 	const agentOrderRequests: string[] = [];
 	await stubDashboardApi(page, agentOrderRequests);

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -278,7 +278,7 @@ const RAIL_DRAG_ACTIVATION_DISTANCE = 10;
 const RAIL_KEYBOARD_CODES = {
 	start: [KeyboardCode.Space],
 	cancel: [KeyboardCode.Esc],
-	end: [KeyboardCode.Space],
+	end: [KeyboardCode.Space, KeyboardCode.Enter, KeyboardCode.Tab],
 };
 
 const restrictRailDragToVerticalAxis: Modifier = ({ transform }) => ({

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -6,9 +6,11 @@ import {
 	DndContext,
 	type DragEndEvent,
 	type DragOverEvent,
+	KeyboardCode,
 	KeyboardSensor,
 	type Modifier,
-	PointerSensor,
+	MouseSensor,
+	TouchSensor,
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
@@ -21,13 +23,12 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
 	BookOpen,
 	CircleHelp,
 	Cloud,
 	ExternalLink,
-	GripVertical,
 	History,
 	Layers,
 	LayoutDashboard,
@@ -274,6 +275,11 @@ type AgentSectionDefinition = {
 };
 
 const RAIL_DRAG_ACTIVATION_DISTANCE = 10;
+const RAIL_KEYBOARD_CODES = {
+	start: [KeyboardCode.Space],
+	cancel: [KeyboardCode.Esc],
+	end: [KeyboardCode.Space],
+};
 
 const restrictRailDragToVerticalAxis: Modifier = ({ transform }) => ({
 	...transform,
@@ -749,27 +755,26 @@ function FocusNavigationPane({
 }
 
 function RailFocusButton({
-	href,
+	render,
 	label,
 	caption,
 	active,
-	onNavigate,
+	className,
 	showTooltip = true,
 	children,
 }: {
-	href: string | null;
+	render: React.ReactElement;
 	label: string;
 	caption?: string;
 	active: boolean;
-	onNavigate?: () => void;
+	className?: string;
 	showTooltip?: boolean;
 	children: React.ReactNode;
 }) {
 	const hasCaption = Boolean(caption);
-	const focusTarget = href ? <Link to={href} onClick={onNavigate} /> : <div aria-disabled="true" />;
 	const button = (
 		<SidebarMenuButton
-			render={focusTarget}
+			render={render}
 			size="lg"
 			isActive={active}
 			aria-label={label}
@@ -777,6 +782,7 @@ function RailFocusButton({
 				hasCaption
 					? "h-[4.5rem] w-full flex-col justify-center gap-1 rounded-lg px-1 py-1"
 					: "size-11 justify-center rounded-lg p-0",
+				className,
 			)}
 		>
 			{children}
@@ -828,19 +834,16 @@ function RailFocusButton({
 
 function SortableAgentRailItem({
 	agent,
-	position,
-	itemCount,
 	active,
 	onNavigate,
 	showTooltip,
 }: {
 	agent: AgentTile;
-	position: number;
-	itemCount: number;
 	active: boolean;
 	onNavigate?: () => void;
 	showTooltip: boolean;
 }) {
+	const router = useRouter();
 	const {
 		attributes,
 		listeners,
@@ -871,7 +874,11 @@ function SortableAgentRailItem({
 		transition: isDragging ? undefined : transition,
 		zIndex: isDragging ? 20 : undefined,
 	};
-	const reorderLabel = `Reorder ${baseIdentityLabel}, position ${position} of ${itemCount}`;
+	const activateAgent = () => {
+		if (!agent.href) return;
+		onNavigate?.();
+		void router.navigate({ href: agent.href });
+	};
 
 	return (
 		<SidebarMenuItem
@@ -879,16 +886,28 @@ function SortableAgentRailItem({
 			data-testid="app-sidebar-agent-tile"
 			style={style}
 			className={cn(
-				"group/agent-rail-item flex h-[4.5rem] w-full touch-pan-y items-end will-change-transform",
+				"group/agent-rail-item relative h-[4.5rem] w-full touch-pan-y will-change-transform",
 				isDragging && "opacity-80",
 			)}
 		>
 			<RailFocusButton
-				href={agent.href}
+				render={
+					<button
+						ref={setActivatorNodeRef}
+						type="button"
+						disabled={!agent.href}
+						onClick={activateAgent}
+						{...attributes}
+						aria-disabled={agent.href ? undefined : true}
+						aria-describedby={agent.env ? attributes["aria-describedby"] : undefined}
+						aria-roledescription={agent.env ? attributes["aria-roledescription"] : undefined}
+						{...listeners}
+					/>
+				}
 				label={label}
 				caption={caption}
 				active={active}
-				onNavigate={onNavigate}
+				className="touch-pan-y cursor-grab active:cursor-grabbing"
 				showTooltip={showTooltip}
 			>
 				<span className="relative inline-flex rounded-md">
@@ -910,20 +929,6 @@ function SortableAgentRailItem({
 					) : null}
 				</span>
 			</RailFocusButton>
-			<Button
-				ref={setActivatorNodeRef}
-				type="button"
-				variant="ghost"
-				size="icon-sm"
-				className="size-6 touch-none cursor-grab rounded-sm text-muted-foreground hover:text-sidebar-foreground active:cursor-grabbing"
-				disabled={!agent.env}
-				aria-label={reorderLabel}
-				title={reorderLabel}
-				{...attributes}
-				{...listeners}
-			>
-				<GripVertical aria-hidden="true" className="size-3" />
-			</Button>
 		</SidebarMenuItem>
 	);
 }
@@ -950,13 +955,17 @@ function FocusRailContent({
 		railAgentsRef.current = next;
 		setRailAgents(next);
 	};
-	// Drag input belongs exclusively to each tile's explicit activator button. The
-	// adjacent link remains a plain navigation target for clicks, taps, and keyboard use.
+	// Mouse and touch sensors keep scrolling distinct from drag activation. Enter
+	// remains ordinary button activation; Space follows dnd-kit's screen-reader instructions.
 	const sensors = useSensors(
-		useSensor(PointerSensor, {
+		useSensor(MouseSensor, {
 			activationConstraint: { distance: RAIL_DRAG_ACTIVATION_DISTANCE },
 		}),
-		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+		useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+			keyboardCodes: RAIL_KEYBOARD_CODES,
+		}),
 	);
 	useEffect(() => {
 		if (!dragStartRailAgents.current) {
@@ -1061,11 +1070,10 @@ function FocusRailContent({
 				<SidebarMenu className="items-center">
 					<SidebarMenuItem>
 						<RailFocusButton
-							href="/"
+							render={<Link to="/" onClick={onNavigate} />}
 							label="Console"
 							caption="Console"
 							active={!activeAgentId}
-							onNavigate={onNavigate}
 							showTooltip={showTooltips}
 						>
 							<IconChip size="sm" tint={RESOURCE_TINT_CLASSES.overview}>
@@ -1095,12 +1103,10 @@ function FocusRailContent({
 						onDragEnd={onDragEnd}
 					>
 						<SortableContext items={orderedAgentIds} strategy={verticalListSortingStrategy}>
-							{orderedAgents.map((agent, index) => (
+							{orderedAgents.map((agent) => (
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
-									position={index + 1}
-									itemCount={orderedAgents.length}
 									active={Boolean(activeAgentId && agentTileMatchesRouteId(agent, activeAgentId))}
 									onNavigate={onNavigate}
 									showTooltip={showTooltips}


### PR DESCRIPTION
## Summary

- remove the PR #517 reorder handle and make each compact 72px agent tile a single semantic button
- use that same full button as dnd-kit's sole mouse, touch, and keyboard activator
- navigate ordinary clicks, touch taps, and Enter programmatically through TanStack Router
- retain Console as an independent link
- use a 10px mouse threshold, touch long-press with movement tolerance, and Space-only keyboard drag start; Space, Enter, and Tab end an active drag, while inactive Enter remains button activation

## Root cause

PR #517 separated an anchor from a drag handle because dnd-kit's post-drag `stopPropagation()` cannot cancel an anchor's browser default navigation. That fixed accidental navigation by shrinking drag initiation to the handle, but it broke the requested Discord-style whole-tile interaction.

This change removes the anchor default action from agent tiles entirely. The tile is a real button whose only navigation action is its React `onClick`; once a pointer drag activates, dnd-kit's document capture listener suppresses the generated click before that handler runs. A later real click is independent and navigates normally. No click guard, drag-history flag, coordinate ref, overlay, timeout, propagation patch, duplicate activator, hidden control, or handle is added.

## Upstream validation

- [`@dnd-kit/core@6.3.1` pointer sensor source](https://github.com/clauderic/dnd-kit/blob/%40dnd-kit/core%406.3.1/packages/core/src/sensors/pointer/AbstractPointerSensor.ts) installs the capture click listener only after activation.
- [`@dnd-kit/core@6.3.1` keyboard defaults](https://github.com/clauderic/dnd-kit/blob/%40dnd-kit/core%406.3.1/packages/core/src/sensors/keyboard/defaults.ts) include Enter by default, while its [screen-reader instructions](https://github.com/clauderic/dnd-kit/blob/%40dnd-kit/core%406.3.1/packages/core/src/components/Accessibility/defaults.ts) specify Space/Arrow/Space and Escape. The rail therefore limits drag start to Space while retaining Space, Enter, and Tab as safe active-drag end codes.
- [TanStack Router navigation guidance](https://tanstack.com/router/latest/docs/framework/react/guide/navigation) supports imperative navigation from an event handler; this follows the repository's existing `router.navigate({ href })` convention.

## Evidence

Failing before against `origin/main` (`604d112b`), with only the new assertions applied:

- OSS ordinary tile-button click stayed at `/` instead of navigating to `/agents/agent-smoke-1`.
- Hosted mixed rail could not find a `Rail Cloud` semantic button because current main rendered an anchor plus a Reorder button.

Passing after:

- official `mcr.microsoft.com/playwright:v1.61.1-noble`: focused OSS rail tests, 3 passed
- official `mcr.microsoft.com/playwright:v1.61.1-noble`: focused hosted mixed/click/mouse/touch rail tests, 3 passed
- `bunx biome check apps/web/src apps/web/e2e/sidebar-runtime-smoke.pw.ts apps/web/e2e/hosted-smoke.pw.ts`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test src/hosted/oss-clean.test.ts` (15 passed)
- `bun run --cwd apps/web build:oss`

The E2E coverage includes Console/Cloud/connected activation, touch tap, Enter, no handle, exact full-tile bounds, mouse drag without navigation, immediate click after drag, touch scroll intent, touch long-press drag, Space keyboard sorting, Enter active-drag termination followed by inactive Enter navigation, and Escape cancellation.

## Safety

Code and tests only. No live/production cluster, tenant data, deployment, merge, CI/workflow, or hosted-reference-repository changes.

