### PR TITLE
fix(cli): align Clawdi connector skill with Composio Tool Router

### DIFF
--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -247,6 +247,123 @@ async def test_clawdi_mcp_initializes_and_lists_native_tools(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_clawdi_mcp_preserves_future_composio_tool_contract(monkeypatch):
+    from app.core.auth import AuthContext, get_auth
+    from app.core.database import get_session
+    from app.models.user import User
+    from app.routes import mcp_bridge
+    from app.services.composio import ComposioMcpSession
+
+    expected_tool = {
+        "name": "COMPOSIO_FUTURE_META_TOOL",
+        "description": "A future schema-driven meta-tool",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                }
+            },
+            "required": ["target"],
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {"redirect_url": {"type": ["string", "null"]}},
+        },
+        "annotations": {"openWorldHint": True},
+    }
+    expected_arguments = {"target": {"id": "recipient_123"}, "preserve": [1, {"x": True}]}
+    expected_result = {
+        "content": [
+            {
+                "type": "text",
+                "text": '{"status":"initiated","redirect_url":"https://connect.test/link"}',
+            }
+        ],
+        "structuredContent": {
+            "status": "initiated",
+            "redirect_url": "https://connect.test/link",
+        },
+        "isError": False,
+        "_meta": {"future": {"preserved": True}},
+    }
+    forwarded: list[dict] = []
+
+    async def fake_auth() -> AuthContext:
+        return AuthContext(
+            user=User(
+                email="mcp-passthrough-test@clawdi.local",
+                name="MCP Passthrough Test",
+                clerk_id="clerk_mcp_passthrough",
+            )
+        )
+
+    async def fake_db_session():
+        yield None
+
+    async def fake_composio_session(user_id: str) -> ComposioMcpSession:
+        assert user_id == "clerk_mcp_passthrough"
+        return ComposioMcpSession(
+            url="https://composio.test/mcp",
+            headers={},
+            expires_at=datetime.now(UTC) + timedelta(minutes=30),
+        )
+
+    async def fake_forward(session: ComposioMcpSession, payload: dict):
+        forwarded.append(payload)
+        if payload["method"] == "tools/list":
+            return {
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {"tools": [expected_tool]},
+            }
+        return {"jsonrpc": "2.0", "id": payload["id"], "result": expected_result}
+
+    monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_session", fake_composio_session)
+    monkeypatch.setattr(mcp_bridge, "_forward_composio_mcp_request", fake_forward)
+    monkeypatch.setattr(mcp_bridge, "_connector_tools_cache", {})
+    app.dependency_overrides[get_auth] = fake_auth
+    app.dependency_overrides[get_session] = fake_db_session
+    try:
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            listed = await ac.post(
+                "/v1/mcp/clawdi",
+                json={"jsonrpc": "2.0", "id": 10, "method": "tools/list", "params": {}},
+            )
+            called = await ac.post(
+                "/v1/mcp/clawdi",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 11,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "COMPOSIO_FUTURE_META_TOOL",
+                        "arguments": expected_arguments,
+                    },
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_auth, None)
+
+    listed_tools = listed.json()["result"]["tools"]
+    listed_composio_tool = next(
+        tool for tool in listed_tools if tool["name"] == expected_tool["name"]
+    )
+    assert listed_composio_tool == expected_tool
+    assert called.json() == {"jsonrpc": "2.0", "id": 11, "result": expected_result}
+    assert forwarded[1] == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "COMPOSIO_FUTURE_META_TOOL", "arguments": expected_arguments},
+    }
+
+
+@pytest.mark.asyncio
 async def test_clawdi_mcp_memory_search_respects_env_bound_api_key(
     db_session,
     seed_user,

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -273,6 +273,7 @@ async def test_clawdi_mcp_preserves_future_composio_tool_contract(monkeypatch):
             "properties": {"redirect_url": {"type": ["string", "null"]}},
         },
         "annotations": {"openWorldHint": True},
+        "_meta": {"composio": {"future_contract": True}},
     }
     expected_arguments = {"target": {"id": "recipient_123"}, "preserve": [1, {"x": True}]}
     expected_result = {

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -89,11 +89,12 @@ Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
 3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
    exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
    authentication link. Say that authentication is pending, ask the user to complete it,
-   and do not claim it is complete. Never request or expose OAuth credentials, API keys, or
-   tokens.
-4. After the user reports completing authentication, re-run `COMPOSIO_SEARCH_TOOLS` or use a
-   connection-status operation only when the exposed schema provides one. Verify that the
-   connection is active, then retry the interrupted workflow.
+   and do not claim it is complete. Return only the authorization link supplied by the tool;
+   never ask for or copy OAuth credentials, API keys, or tokens into the conversation.
+4. Use a connection wait or status operation when the MCP server exposes one; otherwise stop
+   and wait for the user to report completing authentication. Then re-run
+   `COMPOSIO_SEARCH_TOOLS` or use the exposed status operation, verify that the connection is
+   active, and retry the interrupted workflow.
 5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
    inputs. Batch only independent actions; preserve dependencies between steps.
 6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -79,32 +79,36 @@ When the user's request is **conceptual** ("how do I usually do X"), prefer `mem
 
 ## Connectors
 
-Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
+Use the Composio Tool Router meta-tools returned by `tools/list` on the `clawdi` MCP server.
+Treat their live names and schemas as authoritative; never assume a fixed meta-tool set.
 
-1. Start every external-app task with `COMPOSIO_SEARCH_TOOLS`. Describe each intended app
-   action using the tool's exposed input schema, and split cross-app workflows into atomic
-   searches when useful.
-2. Use the tool schemas returned by search. If a complete schema is missing, call
-   `COMPOSIO_GET_TOOL_SCHEMAS`. Never invent tool slugs, field names, or inputs.
-3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
-   exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
-   authentication link. Say that authentication is pending, ask the user to complete it,
-   and do not claim it is complete. Return only the authorization link supplied by the tool;
-   never ask for or copy OAuth credentials, API keys, or tokens into the conversation.
-4. Use a connection wait or status operation when the MCP server exposes one; otherwise stop
-   and wait for the user to report completing authentication. Then re-run
-   `COMPOSIO_SEARCH_TOOLS` or use the exposed status operation, verify that the connection is
-   active, and retry the interrupted workflow.
-5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
-   inputs. Batch only independent actions; preserve dependencies between steps.
-6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,
-   bulk, or remote-file results. Process ordinary inline results directly.
-7. Follow returned file metadata when downloading signed file URLs. Follow only exposed
-   pagination fields and termination signals, and select among multiple accounts only when
-   the schema exposes account selection; do not invent fields or assume an account.
-8. Before an externally visible or destructive action, get user confirmation unless the
-   user's exact instruction already authorizes that exact action. Do not ask for redundant
-   confirmation.
+1. Start each external-app workflow with `COMPOSIO_SEARCH_TOOLS`. Follow its exposed
+   `queries` and `session` schema, reuse the returned session ID throughout that workflow,
+   and use only the exact toolkit and tool slugs it returns. If a required schema is absent
+   or incomplete, call `COMPOSIO_GET_TOOL_SCHEMAS`; never invent fields or inputs.
+2. Before a side effect, require a complete target identity and all schema-required inputs.
+   Explicit intent authorizes the exact requested action and target, but never authorizes
+   guessing a missing recipient, account, resource, or other target. Ask only for what is
+   missing, and do not request redundant confirmation once the exact action is authorized.
+3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
+   exposed schema and interpret only the fields it returns. For an initiated connection,
+   present the returned `redirect_url` as a clickable authentication link with a concise
+   explanation that authorization is pending. The link URL must be exactly that value; never
+   construct a substitute or ask for OAuth credentials, API keys, or tokens. If initiation
+   returns no `redirect_url`, report that terminal failure instead of suggesting an
+   out-of-band fallback.
+4. Use a wait or status operation only when `tools/list` exposes one. Follow its actual schema
+   and status values without inventing polling arguments. Continue only when it reports an
+   active connection; keep waiting only for a non-terminal status its schema defines, and
+   report any terminal failure. If none is exposed, stop until the user reports completing
+   authorization, then re-run search to verify the active connection before continuing.
+5. Execute exact returned slugs through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
+   arguments. Batch only independent calls. Keep ordinary results inline; set
+   `sync_response_to_workbench` or use `COMPOSIO_REMOTE_WORKBENCH` /
+   `COMPOSIO_REMOTE_BASH_TOOL` only for large, bulk, or remote-file results.
+6. Preserve dependencies and returned semantics. Follow signed-file metadata, pagination
+   fields, and termination signals exactly as exposed. Select an account only when the schema
+   supports it, and use additional or future meta-tools only according to their live schemas.
 
 ## Vault CLI
 

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -91,11 +91,12 @@ Treat their live names and schemas as authoritative; never assume a fixed meta-t
    guessing a missing recipient, account, resource, or other target. Ask only for what is
    missing, and do not request redundant confirmation once the exact action is authorized.
 3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
-   exposed schema and interpret only the fields it returns. For an initiated connection,
-   present the returned `redirect_url` as a clickable authentication link with a concise
-   explanation that authorization is pending. The link URL must be exactly that value; never
-   construct a substitute or ask for OAuth credentials, API keys, or tokens. If initiation
-   returns no `redirect_url`, report that terminal failure instead of suggesting an
+   exposed schema and interpret only the fields it returns. Continue on `active`. On
+   `initiated`, present its non-empty `redirect_url` as a clickable authentication link with
+   a concise explanation that authorization is pending; the link URL must be exactly that
+   value. If `initiated` has no non-empty `redirect_url`, report that authorization cannot
+   continue and stop. On `failed`, report the returned error and stop. Never construct a
+   substitute link, ask for OAuth credentials, API keys, or tokens, or suggest an
    out-of-band fallback.
 4. Use a wait or status operation only when `tools/list` exposes one. Follow its actual schema
    and status values without inventing polling arguments. Continue only when it reports an
@@ -103,9 +104,10 @@ Treat their live names and schemas as authoritative; never assume a fixed meta-t
    report any terminal failure. If none is exposed, stop until the user reports completing
    authorization, then re-run search to verify the active connection before continuing.
 5. Execute exact returned slugs through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
-   arguments. Batch only independent calls. Keep ordinary results inline; set
-   `sync_response_to_workbench` or use `COMPOSIO_REMOTE_WORKBENCH` /
-   `COMPOSIO_REMOTE_BASH_TOOL` only for large, bulk, or remote-file results.
+   arguments. Batch only independent calls. Keep ordinary results inline. Set
+   `sync_response_to_workbench` only when a result may be large or needs later remote
+   processing; use `COMPOSIO_REMOTE_WORKBENCH` / `COMPOSIO_REMOTE_BASH_TOOL` only for large
+   responses saved remotely or remote artifacts.
 6. Preserve dependencies and returned semantics. Follow signed-file metadata, pagination
    fields, and termination signals exactly as exposed. Select an account only when the schema
    supports it, and use additional or future meta-tools only according to their live schemas.

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -79,12 +79,31 @@ When the user's request is **conceptual** ("how do I usually do X"), prefer `mem
 
 ## Connectors
 
-Connected service tools (Gmail, GitHub, Notion, etc.) are dynamically registered from the user's Clawdi Cloud dashboard. They appear as individual tools like `gmail_fetch_emails`, `github_list_issues`, etc.
+Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
 
-- These tools are already authenticated — no OAuth needed at runtime
-- If a tool call fails with "No connected account", tell the user to connect the service in the Clawdi Cloud dashboard
-- File downloads from connectors return signed URLs — download them with `curl` or `fetch` before processing
-- Confirm with the user before side-effecting operations (sending email, creating issues, etc.)
+1. Start every external-app task with `COMPOSIO_SEARCH_TOOLS`. Describe each intended app
+   action using the tool's exposed input schema, and split cross-app workflows into atomic
+   searches when useful.
+2. Use the tool schemas returned by search. If a complete schema is missing, call
+   `COMPOSIO_GET_TOOL_SCHEMAS`. Never invent tool slugs, field names, or inputs.
+3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
+   exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
+   authentication link. Say that authentication is pending, ask the user to complete it,
+   and do not claim it is complete. Never request or expose OAuth credentials, API keys, or
+   tokens.
+4. After the user reports completing authentication, re-run `COMPOSIO_SEARCH_TOOLS` or use a
+   connection-status operation only when the exposed schema provides one. Verify that the
+   connection is active, then retry the interrupted workflow.
+5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
+   inputs. Batch only independent actions; preserve dependencies between steps.
+6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,
+   bulk, or remote-file results. Process ordinary inline results directly.
+7. Follow returned file metadata when downloading signed file URLs. Follow only exposed
+   pagination fields and termination signals, and select among multiple accounts only when
+   the schema exposes account selection; do not invent fields or assume an account.
+8. Before an externally visible or destructive action, get user confirmation unless the
+   user's exact instruction already authorizes that exact action. Do not ask for redundant
+   confirmation.
 
 ## Vault CLI
 

--- a/packages/cli/skills/hosted/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted/clawdi/SKILL.md
@@ -18,12 +18,28 @@ session. Do not use a generic web fetcher for Clawdi share URLs.
 
 ## Connectors
 
-Connected-service tools are registered dynamically from the user's Clawdi Cloud account.
-They can include Gmail, GitHub, Notion, Drive, Calendar, and other services.
+Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
 
-- Treat the tools as already authenticated for this runtime.
-- If a call reports that no account is connected, ask the user to connect that service in
-  the Clawdi Cloud dashboard.
-- Download files returned as signed URLs before processing them.
-- Confirm with the user before side-effecting actions such as sending mail or creating an
-  issue.
+1. Start every external-app task with `COMPOSIO_SEARCH_TOOLS`. Describe each intended app
+   action using the tool's exposed input schema, and split cross-app workflows into atomic
+   searches when useful.
+2. Use the tool schemas returned by search. If a complete schema is missing, call
+   `COMPOSIO_GET_TOOL_SCHEMAS`. Never invent tool slugs, field names, or inputs.
+3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
+   exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
+   authentication link. Say that authentication is pending, ask the user to complete it,
+   and do not claim it is complete. Never request or expose OAuth credentials, API keys, or
+   tokens.
+4. After the user reports completing authentication, re-run `COMPOSIO_SEARCH_TOOLS` or use a
+   connection-status operation only when the exposed schema provides one. Verify that the
+   connection is active, then retry the interrupted workflow.
+5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
+   inputs. Batch only independent actions; preserve dependencies between steps.
+6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,
+   bulk, or remote-file results. Process ordinary inline results directly.
+7. Follow returned file metadata when downloading signed file URLs. Follow only exposed
+   pagination fields and termination signals, and select among multiple accounts only when
+   the schema exposes account selection; do not invent fields or assume an account.
+8. Before an externally visible or destructive action, get user confirmation unless the
+   user's exact instruction already authorizes that exact action. Do not ask for redundant
+   confirmation.

--- a/packages/cli/skills/hosted/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted/clawdi/SKILL.md
@@ -28,11 +28,12 @@ Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
 3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
    exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
    authentication link. Say that authentication is pending, ask the user to complete it,
-   and do not claim it is complete. Never request or expose OAuth credentials, API keys, or
-   tokens.
-4. After the user reports completing authentication, re-run `COMPOSIO_SEARCH_TOOLS` or use a
-   connection-status operation only when the exposed schema provides one. Verify that the
-   connection is active, then retry the interrupted workflow.
+   and do not claim it is complete. Return only the authorization link supplied by the tool;
+   never ask for or copy OAuth credentials, API keys, or tokens into the conversation.
+4. Use a connection wait or status operation when the MCP server exposes one; otherwise stop
+   and wait for the user to report completing authentication. Then re-run
+   `COMPOSIO_SEARCH_TOOLS` or use the exposed status operation, verify that the connection is
+   active, and retry the interrupted workflow.
 5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
    inputs. Batch only independent actions; preserve dependencies between steps.
 6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,

--- a/packages/cli/skills/hosted/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted/clawdi/SKILL.md
@@ -18,29 +18,33 @@ session. Do not use a generic web fetcher for Clawdi share URLs.
 
 ## Connectors
 
-Use the Composio Tool Router meta-tools exposed through the `clawdi` MCP server.
+Use the Composio Tool Router meta-tools returned by `tools/list` on the `clawdi` MCP server.
+Treat their live names and schemas as authoritative; never assume a fixed meta-tool set.
 
-1. Start every external-app task with `COMPOSIO_SEARCH_TOOLS`. Describe each intended app
-   action using the tool's exposed input schema, and split cross-app workflows into atomic
-   searches when useful.
-2. Use the tool schemas returned by search. If a complete schema is missing, call
-   `COMPOSIO_GET_TOOL_SCHEMAS`. Never invent tool slugs, field names, or inputs.
-3. If search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` exactly as its
-   exposed schema requires. Present its returned `redirect_url` as a clickable Markdown
-   authentication link. Say that authentication is pending, ask the user to complete it,
-   and do not claim it is complete. Return only the authorization link supplied by the tool;
-   never ask for or copy OAuth credentials, API keys, or tokens into the conversation.
-4. Use a connection wait or status operation when the MCP server exposes one; otherwise stop
-   and wait for the user to report completing authentication. Then re-run
-   `COMPOSIO_SEARCH_TOOLS` or use the exposed status operation, verify that the connection is
-   active, and retry the interrupted workflow.
-5. Execute discovered app tools through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
-   inputs. Batch only independent actions; preserve dependencies between steps.
-6. Use `COMPOSIO_REMOTE_BASH_TOOL` or `COMPOSIO_REMOTE_WORKBENCH` only for justified large,
-   bulk, or remote-file results. Process ordinary inline results directly.
-7. Follow returned file metadata when downloading signed file URLs. Follow only exposed
-   pagination fields and termination signals, and select among multiple accounts only when
-   the schema exposes account selection; do not invent fields or assume an account.
-8. Before an externally visible or destructive action, get user confirmation unless the
-   user's exact instruction already authorizes that exact action. Do not ask for redundant
-   confirmation.
+1. Start each external-app workflow with `COMPOSIO_SEARCH_TOOLS`. Follow its exposed
+   `queries` and `session` schema, reuse the returned session ID throughout that workflow,
+   and use only the exact toolkit and tool slugs it returns. If a required schema is absent
+   or incomplete, call `COMPOSIO_GET_TOOL_SCHEMAS`; never invent fields or inputs.
+2. Before a side effect, require a complete target identity and all schema-required inputs.
+   Explicit intent authorizes the exact requested action and target, but never authorizes
+   guessing a missing recipient, account, resource, or other target. Ask only for what is
+   missing, and do not request redundant confirmation once the exact action is authorized.
+3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
+   exposed schema and interpret only the fields it returns. For an initiated connection,
+   present the returned `redirect_url` as a clickable authentication link with a concise
+   explanation that authorization is pending. The link URL must be exactly that value; never
+   construct a substitute or ask for OAuth credentials, API keys, or tokens. If initiation
+   returns no `redirect_url`, report that terminal failure instead of suggesting an
+   out-of-band fallback.
+4. Use a wait or status operation only when `tools/list` exposes one. Follow its actual schema
+   and status values without inventing polling arguments. Continue only when it reports an
+   active connection; keep waiting only for a non-terminal status its schema defines, and
+   report any terminal failure. If none is exposed, stop until the user reports completing
+   authorization, then re-run search to verify the active connection before continuing.
+5. Execute exact returned slugs through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
+   arguments. Batch only independent calls. Keep ordinary results inline; set
+   `sync_response_to_workbench` or use `COMPOSIO_REMOTE_WORKBENCH` /
+   `COMPOSIO_REMOTE_BASH_TOOL` only for large, bulk, or remote-file results.
+6. Preserve dependencies and returned semantics. Follow signed-file metadata, pagination
+   fields, and termination signals exactly as exposed. Select an account only when the schema
+   supports it, and use additional or future meta-tools only according to their live schemas.

--- a/packages/cli/skills/hosted/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted/clawdi/SKILL.md
@@ -30,11 +30,12 @@ Treat their live names and schemas as authoritative; never assume a fixed meta-t
    guessing a missing recipient, account, resource, or other target. Ask only for what is
    missing, and do not request redundant confirmation once the exact action is authorized.
 3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
-   exposed schema and interpret only the fields it returns. For an initiated connection,
-   present the returned `redirect_url` as a clickable authentication link with a concise
-   explanation that authorization is pending. The link URL must be exactly that value; never
-   construct a substitute or ask for OAuth credentials, API keys, or tokens. If initiation
-   returns no `redirect_url`, report that terminal failure instead of suggesting an
+   exposed schema and interpret only the fields it returns. Continue on `active`. On
+   `initiated`, present its non-empty `redirect_url` as a clickable authentication link with
+   a concise explanation that authorization is pending; the link URL must be exactly that
+   value. If `initiated` has no non-empty `redirect_url`, report that authorization cannot
+   continue and stop. On `failed`, report the returned error and stop. Never construct a
+   substitute link, ask for OAuth credentials, API keys, or tokens, or suggest an
    out-of-band fallback.
 4. Use a wait or status operation only when `tools/list` exposes one. Follow its actual schema
    and status values without inventing polling arguments. Continue only when it reports an
@@ -42,9 +43,10 @@ Treat their live names and schemas as authoritative; never assume a fixed meta-t
    report any terminal failure. If none is exposed, stop until the user reports completing
    authorization, then re-run search to verify the active connection before continuing.
 5. Execute exact returned slugs through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
-   arguments. Batch only independent calls. Keep ordinary results inline; set
-   `sync_response_to_workbench` or use `COMPOSIO_REMOTE_WORKBENCH` /
-   `COMPOSIO_REMOTE_BASH_TOOL` only for large, bulk, or remote-file results.
+   arguments. Batch only independent calls. Keep ordinary results inline. Set
+   `sync_response_to_workbench` only when a result may be large or needs later remote
+   processing; use `COMPOSIO_REMOTE_WORKBENCH` / `COMPOSIO_REMOTE_BASH_TOOL` only for large
+   responses saved remotely or remote artifacts.
 6. Preserve dependencies and returned semantics. Follow signed-file metadata, pagination
    fields, and termination signals exactly as exposed. Select an account only when the schema
    supports it, and use additional or future meta-tools only according to their live schemas.

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -25,10 +25,14 @@ describe("bundled Clawdi skill connector contract", () => {
 
 	it("uses Composio meta-tools with schema-driven discovery and execution", () => {
 		for (const connectors of [genericConnectors, hostedConnectors]) {
-			expect(connectors).toContain("Start every external-app task with `COMPOSIO_SEARCH_TOOLS`");
+			expect(connectors).toContain("Start each external-app workflow with `COMPOSIO_SEARCH_TOOLS`");
+			expect(connectors).toContain("`queries` and `session` schema");
+			expect(connectors).toContain("reuse the returned session ID");
+			expect(connectors).toContain("exact toolkit and tool slugs");
 			expect(connectors).toContain("`COMPOSIO_GET_TOOL_SCHEMAS`");
-			expect(connectors).toContain("Never invent tool slugs, field names, or inputs");
+			expect(connectors).toContain("never invent fields or inputs");
 			expect(connectors).toContain("`COMPOSIO_MULTI_EXECUTE_TOOL`");
+			expect(connectors).toContain("Batch only independent calls");
 			expect(connectors).not.toMatch(
 				/dynamically registered|individual tools|already authenticated/i,
 			);
@@ -37,28 +41,38 @@ describe("bundled Clawdi skill connector contract", () => {
 
 	it("documents a schema-driven auth-link handshake", () => {
 		for (const connectors of [genericConnectors, hostedConnectors]) {
-			expect(connectors).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
-			expect(connectors).toContain("returned `redirect_url` as a clickable Markdown");
-			expect(connectors).toContain("authentication is pending");
-			expect(connectors).toContain("do not claim it is complete");
-			expect(connectors).toContain("connection wait or status operation when");
-			expect(connectors).toContain("otherwise stop");
-			expect(connectors).toContain("`COMPOSIO_SEARCH_TOOLS`");
-			expect(connectors).toMatch(/connection is\s+active, and retry the interrupted workflow/);
-			expect(connectors).toContain("never ask for or copy OAuth credentials, API keys, or tokens");
+			const compact = connectors.replace(/\s+/g, " ");
+			// ComposioHQ/composio@a84d05f exposes active|initiated|failed and nullable redirect_url.
+			expect(compact).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
+			expect(compact).toContain("returned `redirect_url` as a clickable authentication link");
+			expect(compact).toContain("authorization is pending");
+			expect(compact).toContain("link URL must be exactly that value");
+			expect(compact).toContain("returns no `redirect_url`, report that terminal failure");
+			expect(compact).toContain("only when `tools/list` exposes one");
+			expect(compact).toContain("without inventing polling arguments");
+			expect(compact).toContain("Continue only when it reports an active connection");
+			expect(compact).toContain("non-terminal status its schema defines");
+			expect(compact).toContain("report any terminal failure");
+			expect(compact).toContain("re-run search to");
+			expect(compact).toContain("never construct a substitute or ask for OAuth credentials");
+			expect(connectors).not.toContain("COMPOSIO_WAIT_FOR_CONNECTIONS");
+			expect(connectors).not.toContain("Return only the authorization link");
 			expect(connectors).not.toMatch(/dashboard/i);
 		}
 	});
 
-	it("keeps result handling and confirmation conditional on the exposed contract", () => {
+	it("requires complete targets and keeps result handling conditional", () => {
 		for (const connectors of [genericConnectors, hostedConnectors]) {
-			expect(connectors).toContain("`COMPOSIO_REMOTE_BASH_TOOL`");
-			expect(connectors).toContain("`COMPOSIO_REMOTE_WORKBENCH`");
-			expect(connectors).toContain("signed file URLs");
-			expect(connectors).toContain("pagination fields and termination signals");
-			expect(connectors).toContain("multiple accounts only when");
-			expect(connectors).toContain("user's exact instruction already authorizes that exact action");
-			expect(connectors).toContain("Do not ask for redundant");
+			const compact = connectors.replace(/\s+/g, " ");
+			expect(compact).toContain("`COMPOSIO_REMOTE_BASH_TOOL`");
+			expect(compact).toContain("`COMPOSIO_REMOTE_WORKBENCH`");
+			expect(compact).toContain("`sync_response_to_workbench`");
+			expect(compact).toContain("complete target identity");
+			expect(compact).toContain("never authorizes guessing a missing recipient");
+			expect(compact).toContain("do not request redundant confirmation");
+			expect(compact).toContain("signed-file metadata, pagination fields");
+			expect(compact).toContain("Select an account only when the schema");
+			expect(compact).toContain("additional or future meta-tools");
 		}
 	});
 

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -35,16 +35,17 @@ describe("bundled Clawdi skill connector contract", () => {
 		}
 	});
 
-	it("documents the auth-link handshake without requiring a seventh meta-tool", () => {
+	it("documents a schema-driven auth-link handshake", () => {
 		for (const connectors of [genericConnectors, hostedConnectors]) {
 			expect(connectors).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
 			expect(connectors).toContain("returned `redirect_url` as a clickable Markdown");
 			expect(connectors).toContain("authentication is pending");
 			expect(connectors).toContain("do not claim it is complete");
-			expect(connectors).toContain("re-run `COMPOSIO_SEARCH_TOOLS`");
-			expect(connectors).toContain("connection is active, then retry the interrupted workflow");
-			expect(connectors).toContain("Never request or expose OAuth credentials, API keys, or");
-			expect(connectors).not.toContain("COMPOSIO_WAIT_FOR_CONNECTIONS");
+			expect(connectors).toContain("connection wait or status operation when");
+			expect(connectors).toContain("otherwise stop");
+			expect(connectors).toContain("`COMPOSIO_SEARCH_TOOLS`");
+			expect(connectors).toMatch(/connection is\s+active, and retry the interrupted workflow/);
+			expect(connectors).toContain("never ask for or copy OAuth credentials, API keys, or tokens");
 			expect(connectors).not.toMatch(/dashboard/i);
 		}
 	});

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const cliRoot = resolve(import.meta.dir, "../..");
+const genericSkill = readFileSync(resolve(cliRoot, "skills/clawdi/SKILL.md"), "utf-8");
+const hostedSkill = readFileSync(resolve(cliRoot, "skills/hosted/clawdi/SKILL.md"), "utf-8");
+
+function section(content: string, heading: string): string {
+	const marker = `## ${heading}`;
+	const start = content.indexOf(marker);
+	if (start === -1) throw new Error(`missing ${marker}`);
+	const bodyStart = start + marker.length;
+	const nextHeading = content.indexOf("\n## ", bodyStart);
+	return content.slice(start, nextHeading === -1 ? content.length : nextHeading).trim();
+}
+
+describe("bundled Clawdi skill connector contract", () => {
+	const genericConnectors = section(genericSkill, "Connectors");
+	const hostedConnectors = section(hostedSkill, "Connectors");
+
+	it("keeps the generic and hosted connector workflows aligned", () => {
+		expect(hostedConnectors).toBe(genericConnectors);
+	});
+
+	it("uses Composio meta-tools with schema-driven discovery and execution", () => {
+		for (const connectors of [genericConnectors, hostedConnectors]) {
+			expect(connectors).toContain("Start every external-app task with `COMPOSIO_SEARCH_TOOLS`");
+			expect(connectors).toContain("`COMPOSIO_GET_TOOL_SCHEMAS`");
+			expect(connectors).toContain("Never invent tool slugs, field names, or inputs");
+			expect(connectors).toContain("`COMPOSIO_MULTI_EXECUTE_TOOL`");
+			expect(connectors).not.toMatch(
+				/dynamically registered|individual tools|already authenticated/i,
+			);
+		}
+	});
+
+	it("documents the auth-link handshake without requiring a seventh meta-tool", () => {
+		for (const connectors of [genericConnectors, hostedConnectors]) {
+			expect(connectors).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
+			expect(connectors).toContain("returned `redirect_url` as a clickable Markdown");
+			expect(connectors).toContain("authentication is pending");
+			expect(connectors).toContain("do not claim it is complete");
+			expect(connectors).toContain("re-run `COMPOSIO_SEARCH_TOOLS`");
+			expect(connectors).toContain("connection is active, then retry the interrupted workflow");
+			expect(connectors).toContain("Never request or expose OAuth credentials, API keys, or");
+			expect(connectors).not.toContain("COMPOSIO_WAIT_FOR_CONNECTIONS");
+			expect(connectors).not.toMatch(/dashboard/i);
+		}
+	});
+
+	it("keeps result handling and confirmation conditional on the exposed contract", () => {
+		for (const connectors of [genericConnectors, hostedConnectors]) {
+			expect(connectors).toContain("`COMPOSIO_REMOTE_BASH_TOOL`");
+			expect(connectors).toContain("`COMPOSIO_REMOTE_WORKBENCH`");
+			expect(connectors).toContain("signed file URLs");
+			expect(connectors).toContain("pagination fields and termination signals");
+			expect(connectors).toContain("multiple accounts only when");
+			expect(connectors).toContain("user's exact instruction already authorizes that exact action");
+			expect(connectors).toContain("Do not ask for redundant");
+		}
+	});
+
+	it("keeps hosted-only guidance free of local Clawdi capabilities", () => {
+		expect(hostedSkill).not.toMatch(/\bMemory\b|memory_(?:search|add|extract)/i);
+		expect(hostedSkill).not.toMatch(
+			/\bVault\b|\bAI Provider\b|\bCLI\b|\bconfig(?:uration)?\b|\bsetup\b/i,
+		);
+		expect(hostedSkill).not.toMatch(/dashboard/i);
+		expect(genericSkill).toContain("## Memory");
+		expect(genericSkill).toContain("## Vault CLI");
+		expect(genericSkill).toContain("## AI Provider CLI");
+	});
+});

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -42,19 +42,24 @@ describe("bundled Clawdi skill connector contract", () => {
 	it("documents a schema-driven auth-link handshake", () => {
 		for (const connectors of [genericConnectors, hostedConnectors]) {
 			const compact = connectors.replace(/\s+/g, " ");
-			// ComposioHQ/composio@a84d05f exposes active|initiated|failed and nullable redirect_url.
+			// ComposioHQ/composio@a84d05fc99f00c2d77d7f25ba6553805d7d28b92
+			// exposes active|initiated|failed and a nullable redirect_url.
 			expect(compact).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
-			expect(compact).toContain("returned `redirect_url` as a clickable authentication link");
+			expect(compact).toContain("Continue on `active`");
+			expect(compact).toContain("On `initiated`");
+			expect(compact).toContain("non-empty `redirect_url` as a clickable authentication link");
 			expect(compact).toContain("authorization is pending");
 			expect(compact).toContain("link URL must be exactly that value");
-			expect(compact).toContain("returns no `redirect_url`, report that terminal failure");
+			expect(compact).toContain("has no non-empty `redirect_url`");
+			expect(compact).toContain("authorization cannot continue and stop");
+			expect(compact).toContain("On `failed`, report the returned error and stop");
 			expect(compact).toContain("only when `tools/list` exposes one");
 			expect(compact).toContain("without inventing polling arguments");
 			expect(compact).toContain("Continue only when it reports an active connection");
 			expect(compact).toContain("non-terminal status its schema defines");
 			expect(compact).toContain("report any terminal failure");
 			expect(compact).toContain("re-run search to");
-			expect(compact).toContain("never construct a substitute or ask for OAuth credentials");
+			expect(compact).toContain("Never construct a substitute link, ask for OAuth credentials");
 			expect(connectors).not.toContain("COMPOSIO_WAIT_FOR_CONNECTIONS");
 			expect(connectors).not.toContain("Return only the authorization link");
 			expect(connectors).not.toMatch(/dashboard/i);
@@ -67,6 +72,8 @@ describe("bundled Clawdi skill connector contract", () => {
 			expect(compact).toContain("`COMPOSIO_REMOTE_BASH_TOOL`");
 			expect(compact).toContain("`COMPOSIO_REMOTE_WORKBENCH`");
 			expect(compact).toContain("`sync_response_to_workbench`");
+			expect(compact).toContain("only when a result may be large or needs later remote processing");
+			expect(compact).toContain("only for large responses saved remotely or remote artifacts");
 			expect(compact).toContain("complete target identity");
 			expect(compact).toContain("never authorizes guessing a missing recipient");
 			expect(compact).toContain("do not request redundant confirmation");


### PR DESCRIPTION
## Summary

- teach both bundled Clawdi skills the schema-driven Composio Tool Router workflow
- keep hosted guidance limited to the single `clawdi` MCP server and exclude local-only capabilities
- assert future Composio tool definitions, nested arguments, structured results, redirect URLs, and metadata pass through the existing aggregate bridge unchanged

No separate Composio MCP server, endpoint, egress profile, secret, or skill is introduced.

## Verification

- `scripts/test.sh cli src/runtime/bundled-clawdi-skill.test.ts`
- `scripts/test.sh backend tests/test_settings_and_mcp.py::test_clawdi_mcp_preserves_future_composio_tool_contract`
- `quick_validate.py packages/cli/skills/clawdi`
- `quick_validate.py packages/cli/skills/hosted/clawdi`
