### PR TITLE
ci: drop net-negative Bun cache, consolidate client CI jobs

### DIFF
--- a/.github/actions/setup-bun-ci/action.yml
+++ b/.github/actions/setup-bun-ci/action.yml
@@ -1,7 +1,14 @@
-# Reusable composite action: set up Bun + install workspace dependencies
-# with a shared cache. Used by JS-dependent CI jobs so caching is consistent.
+# Reusable composite action: set up Bun + install workspace dependencies.
+# Used by JS-dependent CI jobs so setup is consistent.
+#
+# Deliberately uncached: a cold `bun install --frozen-lockfile` for this
+# workspace takes ~3s, while restoring the ~1.1GB `~/.bun/install/cache`
+# entry took ~100s in every job. The cache also grew without bound —
+# `restore-keys` prefix-matched the previous entry, bun appended newly
+# resolved versions, and the save wrote back a strictly larger union until
+# the repo blew past its cache quota. Do not reintroduce it.
 name: Setup Bun CI
-description: Install Bun and run `bun install --frozen-lockfile` with Bun download cache
+description: Install Bun and run `bun install --frozen-lockfile`
 
 inputs:
   node-version:
@@ -25,14 +32,6 @@ runs:
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: ${{ inputs.bun-version }}
-
-    - name: Cache Bun package downloads
-      uses: actions/cache@v5
-      with:
-        path: ~/.bun/install/cache
-        key: bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-${{ hashFiles('bun.lock') }}
-        restore-keys: |
-          bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -88,8 +88,15 @@ jobs:
               - "apps/web/package.json"
               - ".github/workflows/client-ci.yml"
 
-  # Lint + format check across the whole JS/TS tree in one fast job.
-  lint:
+  # Lint, typecheck, build, and CLI tests in one job.
+  #
+  # These are seconds of work each (Biome ~2s, each typecheck 1-4s, web build
+  # ~6s). Splitting them across five jobs plus a matrix meant paying job setup
+  # five times and holding five runner slots for ~35s of actual work, which is
+  # what drove this workflow's queueing. Turbo already resolves the task graph
+  # and skips unaffected packages, so the per-target guard logic these jobs
+  # carried was redundant with it.
+  verify:
     needs: changes
     if: >-
       github.event_name != 'schedule' && (
@@ -99,7 +106,12 @@ jobs:
         needs.changes.outputs.infra == 'true'
       )
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    timeout-minutes: 10
+    timeout-minutes: 20
+    env:
+      # Required for web typecheck/build — CI doesn't need real values
+      VITE_CLERK_PUBLISHABLE_KEY: pk_test_dummy
+      VITE_CLAWDI_API_URL: http://localhost:8000
+      CLERK_SECRET_KEY: sk_test_dummy
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-bun-ci
@@ -107,120 +119,20 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - name: Biome check
         run: bun run check
-
-  typecheck:
-    needs: changes
-    if: >-
-      github.event_name != 'schedule' && (
-        needs.changes.outputs.web == 'true' ||
-        needs.changes.outputs.cli == 'true' ||
-        needs.changes.outputs.shared == 'true' ||
-        needs.changes.outputs.infra == 'true'
-      )
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: web
-            filter: "web"
-          - target: cli
-            filter: "clawdi"
-          - target: shared
-            filter: "@clawdi/shared"
-    steps:
-      - name: Guard — run only if this target changed
-        id: guard
-        env:
-          TARGET: ${{ matrix.target }}
-          WEB: ${{ needs.changes.outputs.web }}
-          CLI: ${{ needs.changes.outputs.cli }}
-          SHARED: ${{ needs.changes.outputs.shared }}
-          INFRA: ${{ needs.changes.outputs.infra }}
-        run: |
-          run=false
-          if [ "$INFRA" = "true" ]; then
-            run=true
-          elif [ "$TARGET" = "web" ] && { [ "$WEB" = "true" ] || [ "$SHARED" = "true" ]; }; then
-            run=true
-          elif [ "$TARGET" = "cli" ] && { [ "$CLI" = "true" ] || [ "$SHARED" = "true" ]; }; then
-            run=true
-          elif [ "$TARGET" = "shared" ] && [ "$SHARED" = "true" ]; then
-            run=true
-          fi
-
-          if [ "$run" = "true" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.guard.outputs.run == 'true'
-        uses: actions/checkout@v6
-      - if: steps.guard.outputs.run == 'true'
-        uses: ./.github/actions/setup-bun-ci
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - if: steps.guard.outputs.run == 'true'
-        name: Typecheck
-        env:
-          # Required for web typecheck/build — CI doesn't need real values
-          VITE_CLERK_PUBLISHABLE_KEY: pk_test_dummy
-          VITE_CLAWDI_API_URL: http://localhost:8000
-        run: bunx turbo typecheck --filter=${{ matrix.filter }}
-
-  cli-test:
-    needs: changes
-    if: >-
-      github.event_name != 'schedule' && (
-        needs.changes.outputs.cli == 'true' ||
-        needs.changes.outputs.shared == 'true' ||
-        needs.changes.outputs.infra == 'true'
-      )
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-bun-ci
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      # Smoke tests exercise the compiled bin wrapper, so build before testing.
-      - name: Build CLI
-        run: bun run --cwd packages/cli build
+      - name: Typecheck and build
+        run: >-
+          bunx turbo typecheck build
+          --filter=web --filter=clawdi --filter=@clawdi/shared
+          --output-logs=errors-only
+      # Smoke tests exercise the compiled bin wrapper, built above by Turbo.
       - name: Build standalone CLI binary
         run: bun run --cwd packages/cli build:binary
       - name: Smoke standalone CLI binary
-        run: |
-          packages/cli/dist-bin/clawdi --version
+        run: packages/cli/dist-bin/clawdi --version
       - name: Validate CLI publish payload
-        run: |
-          bun run --cwd packages/cli check:publish-manifest
+        run: bun run --cwd packages/cli check:publish-manifest
       - name: Test CLI
         run: bun test --isolate --max-concurrency=1 packages/cli
-
-  build:
-    # This job starts from its own checkout and consumes no typecheck artifact,
-    # so build and typecheck are independent required gates.
-    needs: changes
-    if: >-
-      github.event_name != 'schedule' && (
-        needs.changes.outputs.web == 'true' ||
-        needs.changes.outputs.shared == 'true' ||
-        needs.changes.outputs.infra == 'true'
-      )
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-bun-ci
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - name: Build web
-        env:
-          VITE_CLERK_PUBLISHABLE_KEY: pk_test_dummy
-          VITE_CLAWDI_API_URL: http://localhost:8000
-          CLERK_SECRET_KEY: sk_test_dummy
-        run: bunx turbo build --filter=web
 
   deploy-contract-drift:
     needs: changes

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -6,6 +6,7 @@ const repoRoot = resolve(import.meta.dir, "../../..");
 const readRepoFile = (path: string): string => readFileSync(resolve(repoRoot, path), "utf8");
 const clientWorkflow = readRepoFile(".github/workflows/client-ci.yml");
 const cleanRunnerWorkflow = readRepoFile(".github/workflows/clean-test-runner-ci.yml");
+const setupBunAction = readRepoFile(".github/actions/setup-bun-ci/action.yml");
 const outerRunner = readRepoFile("scripts/test.sh");
 const innerRunner = readRepoFile("docker/test-runner.sh");
 const compose = readRepoFile("docker-compose.test.yml");
@@ -46,32 +47,32 @@ function calledCompositionFunctions(shellFunction: string): string[] {
 }
 
 describe("client workflow contract", () => {
-	test("keeps build and typecheck as independent required gates", () => {
-		const typecheckJob = section(clientWorkflow, "  typecheck:\n", "  cli-test:\n");
-		const buildJob = section(clientWorkflow, "  build:\n", "  deploy-contract-drift:\n");
+	// Lint, typecheck, build, and the CLI tests run in a single `verify` job.
+	// The invariant worth protecting is that typecheck and build stay
+	// independent gates — neither serialized behind the other, neither
+	// consuming the other's output as an artifact. A single Turbo graph
+	// satisfies that more directly than separate jobs did, so assert the
+	// property rather than the job layout.
+	test("keeps build and typecheck as independent gates", () => {
+		const verifyJob = section(clientWorkflow, "  verify:\n", "  deploy-contract-drift:\n");
 
-		expect(typecheckJob).toContain("needs: changes");
-		expect(buildJob).toContain("needs: changes");
-		expect(buildJob).not.toMatch(/needs:.*typecheck/);
-		for (const job of [typecheckJob, buildJob]) {
-			expect(job).toContain("uses: actions/checkout@v6");
-			expect(job).not.toContain("actions/upload-artifact");
-			expect(job).not.toContain("actions/download-artifact");
-		}
+		expect(verifyJob).toContain("needs: changes");
+		expect(verifyJob).toContain("uses: actions/checkout@v6");
+		expect(clientWorkflow).not.toContain("actions/upload-artifact");
+		expect(clientWorkflow).not.toContain("actions/download-artifact");
+
 		const typecheckTask = section(turboConfig, '\t\t"typecheck": {\n', '\t\t"lint": {\n');
 		expect(typecheckTask).toContain('"outputs": []');
 
-		expect(typecheckJob).toContain(`bunx turbo typecheck --filter=\${{ matrix.filter }}`);
-		expect(typecheckJob).toContain("target: web");
-		expect(typecheckJob).toContain("target: cli");
-		expect(typecheckJob).toContain("target: shared");
-		expect(buildJob).toContain("bunx turbo build --filter=web");
+		expect(verifyJob).toContain("bunx turbo typecheck build");
+		for (const filter of ["--filter=web", "--filter=clawdi", "--filter=@clawdi/shared"]) {
+			expect(verifyJob).toContain(filter);
+		}
 	});
 
 	test("retains the existing client build and test commands", () => {
 		for (const command of [
 			"bun run check",
-			"bun run --cwd packages/cli build",
 			"bun run --cwd packages/cli build:binary",
 			"packages/cli/dist-bin/clawdi --version",
 			"bun run --cwd packages/cli check:publish-manifest",
@@ -79,6 +80,14 @@ describe("client workflow contract", () => {
 		]) {
 			expect(clientWorkflow).toContain(command);
 		}
+	});
+
+	// Restoring the ~1.1GB `~/.bun/install/cache` entry cost ~100s in every
+	// job that used this action, to save a ~3s cold `bun install`. The cache
+	// also grew without bound via its `restore-keys` prefix match.
+	test("does not cache the Bun install directory", () => {
+		expect(setupBunAction).not.toContain("actions/cache");
+		expect(setupBunAction).toContain("bun install --frozen-lockfile");
 	});
 });
 


### PR DESCRIPTION
## Problem

Client CI wall-clock had grown to ~16 min for ~40s of actual work.

Step-level timings from a representative run (job: `lint`, total 390s):

| step | time |
|---|---|
| checkout | 4s |
| restore `~/.bun/install/cache` (~1.1GB) | **110s** |
| Biome check (the actual work) | **3s** |
| save cache back (~1.1GB) | **266s** |

Every JS job paid ~350s of cache traffic. The save fired on every run because `restore-keys` prefix-matches the previous entry whenever `bun.lock` changes, so the exact key misses and `actions/cache` re-saves a strictly larger union — the repo sat at 66 entries / >10GB (over quota). A cold `bun install --frozen-lockfile` for this workspace takes **~3s** (1435 packages, measured with an isolated `BUN_INSTALL_CACHE_DIR`), so the cache was net-negative by two orders of magnitude.

Six jobs (lint, typecheck×3, build, cli-test) each held a runner slot for this; recent runs show jobs queueing up to 488s behind it.

## Change

- `setup-bun-ci`: drop the cache step entirely; comment explains why so it is not reintroduced.
- `client-ci.yml`: lint + typecheck matrix + build + cli-test become one `verify` job driving a single Turbo graph (`turbo typecheck build --filter=web --filter=clawdi --filter=@clawdi/shared`). Turbo already resolves the dependency graph; the 60-line per-target guard script is deleted with the matrix.
- `clean-test-runner.test.ts`: the workflow-contract test pinned the old job layout by literal section markers. Rewritten to assert the invariants it was protecting: typecheck and build stay independent gates (no `upload/download-artifact` anywhere, `typecheck.outputs == []` in turbo.json), all original commands retained, and — new — the Bun install dir is never cached.

## Verification

- `bun test --isolate --max-concurrency=1 packages/cli`: 1142 pass / 0 fail
- `bun run check`: clean
- Full verify sequence executed locally end-to-end: install 1.2s, Biome 3.4s, `turbo typecheck build` 7.3s (5/5 tasks), binary build + smoke + manifest + CLI tests all green

Expected effect: JS jobs go from ~6 min each to well under 1 min, runner-slot usage per push drops 7→4, queueing pressure drops accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)