### PR TITLE
fix(cli): bind credentials to API origins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -156,6 +156,12 @@ clawdi push --dry-run # preview what push would upload
 stores the current short-lived access token and Clerk refresh grant in the
 existing private atomic CLI state file (0700 directory, 0600 file), refreshes
 before expiry, and rotates the persisted refresh value when Clerk returns one.
+The verified login is bound to the canonical Cloud and Hosted API origins that
+were active when the grant was created. The CLI checks the exact request origin
+before adding an Authorization header; changing either endpoint requires a new
+login. Process-injected `CLAWDI_AUTH_TOKEN` credentials retain production Cloud
+compatibility, while custom Cloud endpoints must also set the explicit
+`CLAWDI_AUTH_TOKEN_ORIGIN` binding.
 `clawdi auth logout` asks the Cloud backend to revoke the refresh grant before
 removing local state. The legacy `--manual` API-key path remains Cloud-only.
 The Clerk Public OAuth Application must allow `openid`, `profile`, `email`, and

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/agent-credentials.ts
+++ b/packages/cli/src/commands/agent-credentials.ts
@@ -428,7 +428,7 @@ export function parseAgentCredentialProfilePayload(
 async function resolveProjectOption(project?: string): Promise<string | undefined> {
 	if (!project) return undefined;
 	const { apiUrl } = getConfig();
-	return await resolveProjectId(apiUrl, await getClawdiAccessToken(), project);
+	return await resolveProjectId(apiUrl, await getClawdiAccessToken(apiUrl), project);
 }
 
 function previewFiles(

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { readJson } from "../lib/api-client";
+import { normalizeCloudApiBaseUrl } from "../lib/api-origin";
 import { openInBrowser } from "../lib/browser";
 import {
 	ClerkOAuthError,
@@ -10,6 +11,8 @@ import {
 	clearPendingClerkOAuthLogin,
 	commitClawdiCredential,
 	createClerkOAuthAuthorization,
+	createCredentialEndpointBinding,
+	describeCredentialEndpointBinding,
 	exchangeClerkOAuthCode,
 	fetchClerkOAuthClientConfig,
 	fetchClerkOAuthDiscovery,
@@ -55,12 +58,16 @@ async function verifyAndSaveLegacy(
 	apiUrl: string,
 	expectedCredential: StoredCredentialIdentity,
 ): Promise<MeResponse | null> {
-	const res = await fetch(`${apiUrl}/v1/auth/me`, {
+	const endpointBinding = createCredentialEndpointBinding(apiUrl);
+	const res = await fetch(`${endpointBinding.cloudApiOrigin}/v1/auth/me`, {
 		headers: { Authorization: `Bearer ${apiKey}` },
 	});
 	if (!res.ok) return null;
 	const me = await readJson<MeResponse>(res, "/v1/auth/me");
-	await commitClawdiCredential({ apiKey, userId: me.id, email: me.email }, expectedCredential);
+	await commitClawdiCredential(
+		{ apiKey, userId: me.id, email: me.email, endpointBinding },
+		expectedCredential,
+	);
 	return me;
 }
 
@@ -247,14 +254,23 @@ function pendingAuthExpired(pending: PendingAuth): boolean {
 
 async function startOAuthLogin(
 	apiUrl: string,
+	hostedApiUrl: string,
 	expectedCredential: StoredCredentialIdentity,
 ): Promise<PendingAuth> {
-	const clientConfig = await fetchClerkOAuthClientConfig(apiUrl);
+	const endpointBinding = createCredentialEndpointBinding(apiUrl, hostedApiUrl);
+	if (!endpointBinding.hostedApiOrigin) {
+		throw new ClerkOAuthError(
+			"invalid_credential_endpoint_binding",
+			"Hosted endpoint binding is required for OAuth login.",
+		);
+	}
+	const clientConfig = await fetchClerkOAuthClientConfig(endpointBinding.cloudApiOrigin);
 	const discovery = await fetchClerkOAuthDiscovery(clientConfig);
 	const pending = createClerkOAuthAuthorization({
 		config: clientConfig,
 		discovery,
-		apiUrl,
+		apiUrl: endpointBinding.cloudApiOrigin,
+		hostedApiUrl: endpointBinding.hostedApiOrigin,
 	});
 	await persistPendingClerkOAuthLogin(pending, expectedCredential);
 	return pending;
@@ -380,7 +396,7 @@ export async function authLogin(opts: { manual?: boolean; open?: boolean } = {})
 		p.log.info("Run `clawdi auth logout` first to switch accounts.");
 		const { apiUrl } = getConfig();
 		try {
-			await autoUpgradePendingShares(apiUrl, await getClawdiAccessToken());
+			await autoUpgradePendingShares(apiUrl, await getClawdiAccessToken(apiUrl));
 		} catch (error) {
 			reportOAuthError(error);
 		}
@@ -408,7 +424,7 @@ export async function authLogin(opts: { manual?: boolean; open?: boolean } = {})
 
 	let pending: PendingAuth;
 	try {
-		pending = await startOAuthLogin(config.apiUrl, expectedCredential);
+		pending = await startOAuthLogin(config.apiUrl, config.deployApiUrl, expectedCredential);
 	} catch (error) {
 		reportOAuthError(error);
 		return;
@@ -575,12 +591,21 @@ export async function authStatus(opts: { json?: boolean } = {}) {
 	const paths = getRuntimePaths({ mode });
 	const source = detectAuthSource();
 	const authenticated = Boolean(auth) || source === "runtime-instance-data";
+	let safeApiUrl = "<invalid>";
+	try {
+		safeApiUrl = normalizeCloudApiBaseUrl(config.apiUrl);
+	} catch {
+		// Do not echo malformed raw URLs: userinfo could contain a password.
+	}
 	const payload = {
 		schemaVersion: "clawdi.authStatus.v1",
 		authenticated,
 		source,
 		credentialType: isClerkOAuthAuth(auth) ? "clerk-oauth" : auth ? "legacy-api-key" : undefined,
-		apiUrl: config.apiUrl,
+		endpointBinding: auth
+			? describeCredentialEndpointBinding(auth, config.apiUrl, config.deployApiUrl)
+			: undefined,
+		apiUrl: safeApiUrl,
 		runtimeMode: mode,
 		user: auth ? { email: auth.email, id: auth.userId } : undefined,
 		paths: {
@@ -602,7 +627,10 @@ export async function authStatus(opts: { json?: boolean } = {}) {
 	console.log(`  Authenticated: ${authenticated ? chalk.green("yes") : chalk.red("no")}`);
 	console.log(`  Source: ${source}`);
 	if (payload.credentialType) console.log(`  Credential: ${payload.credentialType}`);
-	console.log(chalk.gray(`  API: ${config.apiUrl}`));
+	if (payload.endpointBinding) {
+		console.log(`  Endpoint binding: ${payload.endpointBinding.state}`);
+	}
+	console.log(chalk.gray(`  API: ${safeApiUrl}`));
 	if (auth?.email || auth?.userId) {
 		console.log(chalk.gray(`  User: ${auth.email || auth.userId}`));
 	}

--- a/packages/cli/src/commands/inbox.ts
+++ b/packages/cli/src/commands/inbox.ts
@@ -205,7 +205,7 @@ export async function inboxListCommand(opts: { json?: boolean }): Promise<void> 
 		);
 		return;
 	}
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 
 	const r = await fetch(`${apiUrl}/v1/me/invitations`, {
 		headers: { Authorization: `Bearer ${accessToken}` },
@@ -286,7 +286,7 @@ export async function inboxAcceptCommand(
 		await acceptAnonymousUrl(apiUrl, normalized, opts);
 		return;
 	}
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 
 	if (opts.invite) {
 		await acceptInvitation(apiUrl, accessToken, opts.invite, opts);
@@ -341,7 +341,7 @@ export async function inboxDeclineCommand(invitationId: string): Promise<void> {
 		process.exitCode = 1;
 		return;
 	}
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 	const r = await fetch(`${apiUrl}/v1/me/invitations/${invitationId}/decline`, {
 		method: "POST",
 		headers: { Authorization: `Bearer ${accessToken}` },

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -71,6 +71,7 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 			`
 Environment:
   CLAWDI_AUTH_TOKEN       Bearer token (preferred over ~/.clawdi/auth.json)
+  CLAWDI_AUTH_TOKEN_ORIGIN Explicit Cloud origin binding for the bearer token
   CLAWDI_SERVE_MODE       "container" forces polling watcher + graceful SIGTERM
   CLAWDI_STATE_DIR        Override location of queue.jsonl + health (default ~/.clawdi/serve)
   CLAWDI_DAEMON_RPC_HOST         HTTP RPC host (default 127.0.0.1)

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -64,6 +64,11 @@ function rpcPendingAuth(): PendingAuth {
 		tokenEndpoint: "https://clerk.example.test/oauth/token",
 		expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
 		apiUrl: "https://cloud.example.test",
+		endpointBinding: {
+			version: 1,
+			cloudApiOrigin: "https://cloud.example.test",
+			hostedApiOrigin: "https://deploy.example.test",
+		},
 		scopes: ["openid", "profile", "email", "offline_access"],
 	};
 }
@@ -316,6 +321,55 @@ describe("full control RPC handler surface", () => {
 					}))(),
 			).rejects.toThrow("API key verification failed with HTTP 401");
 			expect(getAuth()?.apiKey).toBe("old-key");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
+	});
+
+	it("binds a verified imported API key to its canonical custom Cloud origin", async () => {
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const originalFetch = globalThis.fetch;
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-rpc-auth-binding-"));
+		process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
+		delete process.env.CLAWDI_AUTH_TOKEN;
+		const requests: Request[] = [];
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL) => {
+				const request = input instanceof Request ? input : new Request(input);
+				requests.push(request.clone());
+				return Response.json({ id: "custom-user", email: "custom@example.test" });
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		try {
+			const [{ createControlRpcHandlers }, { getStoredAuth }] = await Promise.all([
+				import("./serve"),
+				import("../lib/config"),
+			]);
+			const handler = createControlRpcHandlers()["auth.login"];
+			if (!handler) throw new Error("missing auth.login handler");
+
+			await handler({
+				api_key: "custom-api-key-secret",
+				api_url: "https://CUSTOM.example.test:443/",
+				confirm_secret_access: true,
+			});
+			expect(requests.map((request) => request.url)).toEqual([
+				"https://custom.example.test/v1/auth/me",
+			]);
+			expect(getStoredAuth()).toMatchObject({
+				apiKey: "custom-api-key-secret",
+				endpointBinding: {
+					version: 1,
+					cloudApiOrigin: "https://custom.example.test",
+				},
+			});
 		} finally {
 			globalThis.fetch = originalFetch;
 			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -32,6 +32,7 @@ import {
 	clearPendingClerkOAuthLogin,
 	commitClawdiCredential,
 	createClerkOAuthAuthorization,
+	createCredentialEndpointBinding,
 	exchangeClerkOAuthCode,
 	fetchClerkOAuthClientConfig,
 	fetchClerkOAuthDiscovery,
@@ -1006,7 +1007,8 @@ async function authLoginRpc(params: unknown): Promise<unknown> {
 	if (existing && replace) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "auth.login replace existing auth");
 	}
-	const apiUrl = optionalStringParam(record.api_url, "api_url") ?? getConfig().apiUrl;
+	const endpointConfig = getConfig();
+	const apiUrl = optionalStringParam(record.api_url, "api_url") ?? endpointConfig.apiUrl;
 	const apiKey = optionalStringParam(record.api_key, "api_key");
 	if (existing && replace && !apiKey) {
 		throw new Error("auth.login replace requires api_key, or call auth.logout before OAuth login.");
@@ -1016,7 +1018,7 @@ async function authLoginRpc(params: unknown): Promise<unknown> {
 		const me = await verifyAndSaveRpcAuth(apiUrl, apiKey, expectedCredential);
 		return { status: "logged_in", user: me, api_url: apiUrl };
 	}
-	return startOAuthAuthRpc(apiUrl, expectedCredential);
+	return startOAuthAuthRpc(apiUrl, endpointConfig.deployApiUrl, expectedCredential);
 }
 
 async function authCompleteRpc(params: unknown): Promise<unknown> {
@@ -1151,24 +1153,38 @@ async function verifyAndSaveRpcAuth(
 	apiKey: string,
 	expectedCredential: StoredCredentialIdentity,
 ): Promise<AuthMeResponse> {
-	const response = await fetch(`${apiUrl}/v1/auth/me`, {
+	const endpointBinding = createCredentialEndpointBinding(apiUrl);
+	const response = await fetch(`${endpointBinding.cloudApiOrigin}/v1/auth/me`, {
 		headers: { Authorization: `Bearer ${apiKey}` },
 	});
 	if (!response.ok) {
 		throw new Error(`API key verification failed with HTTP ${response.status}`);
 	}
 	const me = await readJsonObject<AuthMeResponse>(response, isAuthMeResponse, "/v1/auth/me");
-	await commitClawdiCredential({ apiKey, userId: me.id, email: me.email }, expectedCredential);
+	await commitClawdiCredential(
+		{ apiKey, userId: me.id, email: me.email, endpointBinding },
+		expectedCredential,
+	);
 	return me;
 }
 
 async function startOAuthAuthRpc(
 	apiUrl: string,
+	hostedApiUrl: string,
 	expectedCredential: StoredCredentialIdentity,
 ): Promise<unknown> {
-	const config = await fetchClerkOAuthClientConfig(apiUrl);
+	const endpointBinding = createCredentialEndpointBinding(apiUrl, hostedApiUrl);
+	if (!endpointBinding.hostedApiOrigin) {
+		throw new Error("Hosted endpoint binding is required for OAuth login.");
+	}
+	const config = await fetchClerkOAuthClientConfig(endpointBinding.cloudApiOrigin);
 	const discovery = await fetchClerkOAuthDiscovery(config);
-	const pending = createClerkOAuthAuthorization({ config, discovery, apiUrl });
+	const pending = createClerkOAuthAuthorization({
+		config,
+		discovery,
+		apiUrl: endpointBinding.cloudApiOrigin,
+		hostedApiUrl: endpointBinding.hostedApiOrigin,
+	});
 	await persistPendingClerkOAuthLogin(pending, expectedCredential);
 	return {
 		status: "pending",

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -92,7 +92,11 @@ export async function skillList(opts: { json?: boolean; project?: string } = {})
 		const { resolveProjectId } = await import("../lib/project-resolver.js");
 		const { getConfig } = await import("../lib/config.js");
 		const cfg = getConfig();
-		projectId = await resolveProjectId(cfg.apiUrl, await getClawdiAccessToken(), opts.project);
+		projectId = await resolveProjectId(
+			cfg.apiUrl,
+			await getClawdiAccessToken(cfg.apiUrl),
+			opts.project,
+		);
 	}
 	const skills = await fetchAllSkills(api, projectId);
 
@@ -243,7 +247,11 @@ export async function skillAdd(
 		const { resolveProjectId } = await import("../lib/project-resolver.js");
 		const { getConfig } = await import("../lib/config.js");
 		const cfg = getConfig();
-		projectId = await resolveProjectId(cfg.apiUrl, await getClawdiAccessToken(), opts.project);
+		projectId = await resolveProjectId(
+			cfg.apiUrl,
+			await getClawdiAccessToken(cfg.apiUrl),
+			opts.project,
+		);
 	} else if (opts.agent) {
 		const envId = getEnvIdByAgent(opts.agent);
 		if (!envId) {
@@ -344,7 +352,11 @@ export async function skillInstall(
 		const { resolveProjectId } = await import("../lib/project-resolver.js");
 		const { getConfig } = await import("../lib/config.js");
 		const cfg = getConfig();
-		projectId = await resolveProjectId(cfg.apiUrl, await getClawdiAccessToken(), opts.project);
+		projectId = await resolveProjectId(
+			cfg.apiUrl,
+			await getClawdiAccessToken(cfg.apiUrl),
+			opts.project,
+		);
 		targetAgent = "__skip_local__";
 	} else if (opts.agent) {
 		const envId = getEnvIdByAgent(opts.agent);
@@ -522,7 +534,11 @@ export async function skillRm(key: string, opts: { agent?: string; project?: str
 		const { resolveProjectId } = await import("../lib/project-resolver.js");
 		const { getConfig } = await import("../lib/config.js");
 		const cfg = getConfig();
-		projectId = await resolveProjectId(cfg.apiUrl, await getClawdiAccessToken(), opts.project);
+		projectId = await resolveProjectId(
+			cfg.apiUrl,
+			await getClawdiAccessToken(cfg.apiUrl),
+			opts.project,
+		);
 	} else if (opts.agent) {
 		const envId = getEnvIdByAgent(opts.agent);
 		if (!envId) {

--- a/packages/cli/src/commands/vault-resolve.ts
+++ b/packages/cli/src/commands/vault-resolve.ts
@@ -54,7 +54,7 @@ export async function vaultResolveCommand(
 		process.exitCode = 1;
 		return;
 	}
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 	if (opts.project && opts.agent) {
 		console.error(chalk.red("Pass either --project or --agent, not both."));
 		process.exitCode = 1;

--- a/packages/cli/src/commands/vault.ts
+++ b/packages/cli/src/commands/vault.ts
@@ -155,7 +155,11 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 		const { resolveProjectId } = await import("../lib/project-resolver.js");
 		const { getConfig } = await import("../lib/config.js");
 		const cfg = getConfig();
-		projectId = await resolveProjectId(cfg.apiUrl, await getClawdiAccessToken(), opts.project);
+		projectId = await resolveProjectId(
+			cfg.apiUrl,
+			await getClawdiAccessToken(cfg.apiUrl),
+			opts.project,
+		);
 	}
 	const page = await fetchAllVaults(api, projectId);
 	const vaults = page.items;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -56,6 +56,7 @@ Examples:
 Environment:
   CLAWDI_API_URL           Override the Clawdi Cloud API endpoint
   CLAWDI_DEPLOY_API_URL    Override the Hosted deploy API endpoint
+  CLAWDI_AUTH_TOKEN_ORIGIN Explicit Cloud origin binding for CLAWDI_AUTH_TOKEN
   CLAWDI_DEBUG             Print stack traces on error
   CLAWDI_NO_UPDATE_CHECK   Suppress the non-blocking update check
   CLAWDI_NO_AUTO_UPDATE    Skip CLI/daemon background auto-update (also disables via \`config set autoUpdate false\`)

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { type components, extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient, { type Client } from "openapi-fetch";
-import { getClawdiAccessToken } from "./clerk-oauth";
+import { canonicalApiOrigin, normalizeCloudApiBaseUrl } from "./api-origin";
+import { assertCloudCredentialEndpoint, getClawdiAccessToken } from "./clerk-oauth";
 import { getAuth, getConfig } from "./config";
 import { assertValidSkillKey } from "./skill-key";
 import { getCliVersion } from "./version";
@@ -191,7 +192,8 @@ export class ApiClient {
 				hint: "Not logged in. Run `clawdi auth login` first.",
 			});
 		}
-		this.baseUrl = config.apiUrl;
+		const baseUrl = normalizeCloudApiBaseUrl(config.apiUrl);
+		this.baseUrl = baseUrl;
 		this.requireAuth = requireAuth;
 		this.abortSignal = opts.abortSignal;
 		this.client = createClient<paths>({
@@ -201,7 +203,14 @@ export class ApiClient {
 		this.client.use({
 			async onRequest({ request }) {
 				if (requireAuth) {
-					request.headers.set("Authorization", `Bearer ${await getClawdiAccessToken()}`);
+					if (new URL(request.url).origin !== canonicalApiOrigin(baseUrl)) {
+						throw new ApiError({
+							status: 0,
+							body: "",
+							hint: "Cloud request origin changed before authorization. No credential was sent.",
+						});
+					}
+					request.headers.set("Authorization", `Bearer ${await getClawdiAccessToken(baseUrl)}`);
 				}
 				request.headers.set("User-Agent", USER_AGENT);
 				// Generate a per-request correlation ID. Backend's
@@ -221,11 +230,14 @@ export class ApiClient {
 
 	/** Current bearer snapshot for compatibility helpers; requests refresh it asynchronously. */
 	get apiKey(): string {
-		return getAuth()?.apiKey ?? "";
+		const auth = getAuth();
+		if (!auth) return "";
+		assertCloudCredentialEndpoint(auth, this.baseUrl);
+		return auth.apiKey;
 	}
 
 	async getAccessToken(): Promise<string> {
-		return this.requireAuth ? getClawdiAccessToken() : "";
+		return this.requireAuth ? getClawdiAccessToken(this.baseUrl) : "";
 	}
 
 	get GET(): Client<paths>["GET"] {

--- a/packages/cli/src/lib/api-origin.ts
+++ b/packages/cli/src/lib/api-origin.ts
@@ -1,0 +1,97 @@
+const PRODUCTION_CLOUD_API_ORIGIN = "https://cloud-api.clawdi.ai";
+
+type ParsedApiBaseUrl = {
+	url: URL;
+	rawPath: string;
+};
+
+function parseApiBaseUrl(raw: string, label: string): ParsedApiBaseUrl {
+	if (typeof raw !== "string" || raw.length > 2_048) {
+		throw new Error(`${label} must be a valid absolute http:// or https:// URL.`);
+	}
+	const trimmed = raw.trim();
+	let url: URL;
+	try {
+		url = new URL(trimmed);
+	} catch {
+		throw new Error(`${label} must be a valid absolute http:// or https:// URL.`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error(`${label} must use http:// or https://.`);
+	}
+	const schemeEnd = trimmed.indexOf("://") + 3;
+	const authorityEnd = trimmed.slice(schemeEnd).search(/[/?#]/);
+	const authority =
+		authorityEnd === -1
+			? trimmed.slice(schemeEnd)
+			: trimmed.slice(schemeEnd, schemeEnd + authorityEnd);
+	if (url.username || url.password || authority.includes("@")) {
+		throw new Error(`${label} must not contain credentials.`);
+	}
+	if (
+		!url.hostname ||
+		(!url.hostname.startsWith("[") &&
+			!url.hostname
+				.split(".")
+				.every((labelPart) => /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(labelPart)))
+	) {
+		throw new Error(`${label} must contain a canonical hostname.`);
+	}
+	if (trimmed.includes("?") || trimmed.includes("#")) {
+		throw new Error(`${label} must not contain a query or fragment.`);
+	}
+
+	const pathStart = trimmed.indexOf("/", schemeEnd);
+	const rawPath = pathStart === -1 ? "" : trimmed.slice(pathStart);
+	return { url, rawPath };
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+function requireSecureTransport(url: URL, label: string): void {
+	if (url.protocol === "http:" && !isLoopbackHostname(url.hostname)) {
+		throw new Error(`${label} must use HTTPS except on loopback localhost.`);
+	}
+}
+
+/**
+ * Normalize the Cloud request base. Cloud has no compatible path-prefixed
+ * spelling: authenticated routes are always rooted at the URL origin.
+ */
+export function normalizeCloudApiBaseUrl(raw: string): string {
+	const label = "Clawdi Cloud API URL";
+	const { url, rawPath } = parseApiBaseUrl(raw, label);
+	requireSecureTransport(url, label);
+	if ((rawPath !== "" && rawPath !== "/") || url.pathname !== "/") {
+		throw new Error(`${label} must not contain a non-root path.`);
+	}
+	return url.origin;
+}
+
+/**
+ * Preserve Hosted's established `/v2` base alias, then return the exact base
+ * used to build generated-client requests. Other paths are not accepted.
+ */
+export function normalizeHostedDeployApiBaseUrl(raw: string): string {
+	const label = "Hosted deploy API URL";
+	const { url, rawPath } = parseApiBaseUrl(raw, label);
+	requireSecureTransport(url, label);
+	if (!["", "/", "/v2", "/v2/"].includes(rawPath)) {
+		throw new Error(`${label} must use the origin root or the compatible /v2 base.`);
+	}
+	if (url.pathname !== "/" && url.pathname !== "/v2" && url.pathname !== "/v2/") {
+		throw new Error(`${label} must use the origin root or the compatible /v2 base.`);
+	}
+	return url.origin;
+}
+
+/** Canonical URL origin: lower-case host, effective port, and no trailing slash. */
+export function canonicalApiOrigin(normalizedBaseUrl: string): string {
+	return new URL(normalizedBaseUrl).origin;
+}
+
+export function isProductionCloudApiOrigin(origin: string): boolean {
+	return origin === PRODUCTION_CLOUD_API_ORIGIN;
+}

--- a/packages/cli/src/lib/clerk-oauth.ts
+++ b/packages/cli/src/lib/clerk-oauth.ts
@@ -1,8 +1,15 @@
 import { createHash, randomBytes } from "node:crypto";
 import { join } from "node:path";
 import {
+	canonicalApiOrigin,
+	isProductionCloudApiOrigin,
+	normalizeCloudApiBaseUrl,
+	normalizeHostedDeployApiBaseUrl,
+} from "./api-origin";
+import {
 	type ClawdiAuth,
 	type ClerkOAuthAuth,
+	type CredentialEndpointBinding,
 	clearAuth,
 	clearPendingAuth,
 	getAuth,
@@ -48,6 +55,203 @@ export class ClerkOAuthError extends Error {
 		this.name = "ClerkOAuthError";
 		this.code = code;
 	}
+}
+
+const ENV_CREDENTIAL_ORIGIN = "CLAWDI_AUTH_TOKEN_ORIGIN";
+
+function bindingError(code: string, message: string): ClerkOAuthError {
+	return new ClerkOAuthError(code, message);
+}
+
+function canonicalStoredOrigin(raw: string, service: "Cloud" | "Hosted"): string {
+	let origin: string;
+	try {
+		const base =
+			service === "Cloud" ? normalizeCloudApiBaseUrl(raw) : normalizeHostedDeployApiBaseUrl(raw);
+		origin = canonicalApiOrigin(base);
+	} catch {
+		throw bindingError(
+			"invalid_credential_endpoint_binding",
+			"The saved credential endpoint binding is invalid. Log out and sign in again.",
+		);
+	}
+	if (raw !== origin) {
+		throw bindingError(
+			"invalid_credential_endpoint_binding",
+			"The saved credential endpoint binding is not canonical. Log out and sign in again.",
+		);
+	}
+	return origin;
+}
+
+function normalizedBinding(
+	binding: CredentialEndpointBinding | undefined,
+): CredentialEndpointBinding | null {
+	if (binding?.version !== 1 || typeof binding.cloudApiOrigin !== "string") {
+		return null;
+	}
+	const cloudApiOrigin = canonicalStoredOrigin(binding.cloudApiOrigin, "Cloud");
+	const hostedApiOrigin =
+		typeof binding.hostedApiOrigin === "string"
+			? canonicalStoredOrigin(binding.hostedApiOrigin, "Hosted")
+			: undefined;
+	return {
+		version: 1,
+		cloudApiOrigin,
+		...(hostedApiOrigin ? { hostedApiOrigin } : {}),
+	};
+}
+
+export function createCredentialEndpointBinding(
+	cloudApiUrl: string,
+	hostedApiUrl?: string,
+): CredentialEndpointBinding {
+	const cloudApiOrigin = canonicalApiOrigin(normalizeCloudApiBaseUrl(cloudApiUrl));
+	const hostedApiOrigin = hostedApiUrl
+		? canonicalApiOrigin(normalizeHostedDeployApiBaseUrl(hostedApiUrl))
+		: undefined;
+	return {
+		version: 1,
+		cloudApiOrigin,
+		...(hostedApiOrigin ? { hostedApiOrigin } : {}),
+	};
+}
+
+function unboundCredentialError(auth: ClawdiAuth, targetOrigin: string): ClerkOAuthError {
+	if (auth.authType === "clerk_oauth") {
+		return bindingError(
+			"oauth_endpoint_binding_required",
+			"This Clerk OAuth credential predates endpoint binding and cannot be used safely. Run `clawdi auth logout`, then `clawdi auth login` again for the current Cloud and Hosted endpoints.",
+		);
+	}
+	if (process.env.CLAWDI_AUTH_TOKEN) {
+		return bindingError(
+			"environment_endpoint_binding_required",
+			`CLAWDI_AUTH_TOKEN is not bound to ${targetOrigin}. Set ${ENV_CREDENTIAL_ORIGIN} to the intended Cloud origin, or remove the endpoint override.`,
+		);
+	}
+	return bindingError(
+		"legacy_endpoint_binding_required",
+		`This legacy API key is not bound to ${targetOrigin}. Run \`clawdi auth logout\`, then re-import it with \`clawdi auth login --manual\` for this Cloud origin.`,
+	);
+}
+
+function boundCloudOrigin(auth: ClawdiAuth): string | null {
+	if (process.env.CLAWDI_AUTH_TOKEN) {
+		const configured = process.env[ENV_CREDENTIAL_ORIGIN]?.trim();
+		return configured ? createCredentialEndpointBinding(configured).cloudApiOrigin : null;
+	}
+	return normalizedBinding(auth.endpointBinding)?.cloudApiOrigin ?? null;
+}
+
+/** Validate a Cloud bearer against the exact request base before returning it. */
+export function assertCloudCredentialEndpoint(auth: ClawdiAuth, cloudApiUrl: string): string {
+	const targetOrigin = canonicalApiOrigin(normalizeCloudApiBaseUrl(cloudApiUrl));
+	if (auth.authType === "clerk_oauth" && !isClerkOAuthAuth(auth)) {
+		throw bindingError(
+			"invalid_oauth_credential",
+			"The saved Clerk OAuth credential is incomplete. Log out and sign in again.",
+		);
+	}
+	const boundOrigin = boundCloudOrigin(auth);
+	if (!boundOrigin) {
+		if (auth.authType !== "clerk_oauth" && isProductionCloudApiOrigin(targetOrigin)) {
+			return targetOrigin;
+		}
+		throw unboundCredentialError(auth, targetOrigin);
+	}
+	if (boundOrigin !== targetOrigin) {
+		throw bindingError(
+			"credential_endpoint_mismatch",
+			`Credential is bound to Cloud origin ${boundOrigin}, but the request targets ${targetOrigin}. Restore the endpoint configuration or log out and sign in again.`,
+		);
+	}
+	return targetOrigin;
+}
+
+/** Validate the complete Cloud + Hosted profile used by the shared OAuth bearer. */
+export function assertClerkOAuthEndpointProfile(
+	auth: ClerkOAuthAuth,
+	cloudApiUrl: string,
+	hostedApiUrl: string,
+): void {
+	const cloudOrigin = canonicalApiOrigin(normalizeCloudApiBaseUrl(cloudApiUrl));
+	const hostedOrigin = canonicalApiOrigin(normalizeHostedDeployApiBaseUrl(hostedApiUrl));
+	const binding = normalizedBinding(auth.endpointBinding);
+	if (!binding?.hostedApiOrigin) throw unboundCredentialError(auth, cloudOrigin);
+	if (binding.cloudApiOrigin !== cloudOrigin || binding.hostedApiOrigin !== hostedOrigin) {
+		throw bindingError(
+			"credential_endpoint_mismatch",
+			`Credential is bound to Cloud ${binding.cloudApiOrigin} and Hosted ${binding.hostedApiOrigin}, but the request profile is Cloud ${cloudOrigin} and Hosted ${hostedOrigin}. Restore the endpoint configuration or log out and sign in again.`,
+		);
+	}
+}
+
+export type CredentialEndpointBindingMetadata = {
+	state: "bound" | "invalid" | "legacy-production-compatible" | "unbound";
+	cloudApiOrigin?: string;
+	hostedApiOrigin?: string;
+	currentProfileMatches?: boolean;
+};
+
+/** Non-secret endpoint metadata for `auth status`; malformed raw values stay redacted. */
+export function describeCredentialEndpointBinding(
+	auth: ClawdiAuth,
+	cloudApiUrl: string,
+	hostedApiUrl: string,
+): CredentialEndpointBindingMetadata {
+	let binding: CredentialEndpointBinding | null;
+	try {
+		if (process.env.CLAWDI_AUTH_TOKEN) {
+			const configured = process.env[ENV_CREDENTIAL_ORIGIN]?.trim();
+			binding = configured ? createCredentialEndpointBinding(configured) : null;
+		} else {
+			binding = normalizedBinding(auth.endpointBinding);
+			if (auth.endpointBinding && !binding) return { state: "invalid" };
+		}
+	} catch {
+		return { state: "invalid" };
+	}
+
+	let cloudOrigin: string | undefined;
+	let hostedOrigin: string | undefined;
+	try {
+		cloudOrigin = canonicalApiOrigin(normalizeCloudApiBaseUrl(cloudApiUrl));
+		hostedOrigin = canonicalApiOrigin(normalizeHostedDeployApiBaseUrl(hostedApiUrl));
+	} catch {
+		// Current config is reported elsewhere. Do not echo a malformed value
+		// through endpoint-binding metadata because it could contain userinfo.
+	}
+
+	if (binding) {
+		if (auth.authType === "clerk_oauth" && !binding.hostedApiOrigin) {
+			return {
+				state: "unbound",
+				cloudApiOrigin: binding.cloudApiOrigin,
+				currentProfileMatches: false,
+			};
+		}
+		return {
+			state: "bound",
+			cloudApiOrigin: binding.cloudApiOrigin,
+			...(binding.hostedApiOrigin ? { hostedApiOrigin: binding.hostedApiOrigin } : {}),
+			...(cloudOrigin
+				? {
+						currentProfileMatches:
+							binding.cloudApiOrigin === cloudOrigin &&
+							(binding.hostedApiOrigin === undefined || binding.hostedApiOrigin === hostedOrigin),
+					}
+				: {}),
+		};
+	}
+	if (auth.authType !== "clerk_oauth" && cloudOrigin && isProductionCloudApiOrigin(cloudOrigin)) {
+		return {
+			state: "legacy-production-compatible",
+			cloudApiOrigin: cloudOrigin,
+			currentProfileMatches: true,
+		};
+	}
+	return { state: "unbound", ...(cloudOrigin ? { currentProfileMatches: false } : {}) };
 }
 
 type FetchLike = (request: Request) => Promise<Response>;
@@ -369,13 +573,16 @@ export function createClerkOAuthAuthorization({
 	config,
 	discovery,
 	apiUrl,
+	hostedApiUrl,
 	now = Date.now,
 }: {
 	config: ClerkOAuthClientConfig;
 	discovery: ClerkOAuthDiscovery;
 	apiUrl: string;
+	hostedApiUrl: string;
 	now?: () => number;
 }): PendingAuth {
+	const endpointBinding = createCredentialEndpointBinding(apiUrl, hostedApiUrl);
 	const state = randomBytes(32).toString("base64url");
 	const codeVerifier = randomBytes(48).toString("base64url");
 	const challenge = createHash("sha256").update(codeVerifier).digest("base64url");
@@ -399,7 +606,8 @@ export function createClerkOAuthAuthorization({
 		authorizedParties: config.authorizedParties,
 		tokenEndpoint: discovery.tokenEndpoint,
 		expiresAt: new Date(now() + OAUTH_LOGIN_TTL_MS).toISOString(),
-		apiUrl,
+		apiUrl: endpointBinding.cloudApiOrigin,
+		endpointBinding,
 		scopes: [...REQUIRED_SCOPES],
 	};
 }
@@ -609,6 +817,20 @@ export async function exchangeClerkOAuthCode(
 			"Pending OAuth login expired. Run `clawdi auth login` again.",
 		);
 	}
+	const endpointBinding = normalizedBinding(pending.endpointBinding);
+	if (!endpointBinding?.hostedApiOrigin) {
+		throw new ClerkOAuthError(
+			"oauth_endpoint_binding_required",
+			"Pending OAuth login predates endpoint binding. Run `clawdi auth login` again.",
+		);
+	}
+	const pendingCloudOrigin = canonicalApiOrigin(normalizeCloudApiBaseUrl(pending.apiUrl));
+	if (endpointBinding.cloudApiOrigin !== pendingCloudOrigin) {
+		throw new ClerkOAuthError(
+			"invalid_credential_endpoint_binding",
+			"Pending OAuth endpoint binding does not match its Cloud URL. Run `clawdi auth login` again.",
+		);
+	}
 	const code = parseClerkOAuthCallback(pending, callbackUrl);
 	const form = new URLSearchParams({
 		grant_type: "authorization_code",
@@ -626,7 +848,7 @@ export async function exchangeClerkOAuthCode(
 		tokenEndpoint: pending.tokenEndpoint,
 		now: now(),
 	});
-	return auth;
+	return { ...auth, endpointBinding };
 }
 
 function credentialLockPath(): string {
@@ -765,7 +987,9 @@ async function revokeClerkOAuthGrant(
 	auth: ClerkOAuthAuth,
 	fetcher: FetchLike,
 ): Promise<void> {
-	const endpoint = new URL("/v1/cli/auth/oauth/revoke", `${apiUrl.replace(/\/$/, "")}/`);
+	const cloudApiBaseUrl = normalizeCloudApiBaseUrl(apiUrl);
+	assertCloudCredentialEndpoint(auth, cloudApiBaseUrl);
+	const endpoint = new URL("/v1/cli/auth/oauth/revoke", `${cloudApiBaseUrl}/`);
 	const response = await fetcher(
 		new Request(endpoint, {
 			method: "POST",
@@ -860,7 +1084,13 @@ export async function verifyAndPersistClerkOAuthLogin(
 ): Promise<ClerkOAuthCloudVerification> {
 	const fetcher = options.fetch ?? fetchWithTimeout;
 	const expected = options.expectedCredential ?? { kind: "none" };
-	const endpoint = new URL("/v1/auth/me", `${apiUrl.replace(/\/$/, "")}/`);
+	const binding = normalizedBinding(auth.endpointBinding);
+	if (!binding?.hostedApiOrigin) {
+		throw unboundCredentialError(auth, canonicalApiOrigin(normalizeCloudApiBaseUrl(apiUrl)));
+	}
+	const cloudApiBaseUrl = normalizeCloudApiBaseUrl(apiUrl);
+	assertCloudCredentialEndpoint(auth, cloudApiBaseUrl);
+	const endpoint = new URL("/v1/auth/me", `${cloudApiBaseUrl}/`);
 	let response: Response;
 	try {
 		response = await fetcher(
@@ -989,6 +1219,7 @@ async function refreshClerkOAuthGrant(
 	}
 	refreshed.email = auth.email;
 	refreshed.userId = auth.userId;
+	refreshed.endpointBinding = auth.endpointBinding;
 	return refreshed;
 }
 
@@ -1011,6 +1242,7 @@ function terminalRefreshFailure(error: unknown): boolean {
 }
 
 export async function getClawdiAccessToken(
+	cloudApiUrl: string,
 	options: ClerkOAuthNetworkOptions = {},
 ): Promise<string> {
 	const auth = getAuth();
@@ -1020,6 +1252,7 @@ export async function getClawdiAccessToken(
 			"Not logged in. Run `clawdi auth login` first.",
 		);
 	}
+	assertCloudCredentialEndpoint(auth, cloudApiUrl);
 	if (!isClerkOAuthAuth(auth)) return auth.apiKey;
 	const now = options.now ?? Date.now;
 	const expiresAt = Date.parse(auth.accessTokenExpiresAt);
@@ -1039,6 +1272,7 @@ export async function getClawdiAccessToken(
 						"Not logged in. Run `clawdi auth login` first.",
 					);
 				}
+				assertCloudCredentialEndpoint(latest, cloudApiUrl);
 				if (!isClerkOAuthAuth(latest)) return latest.apiKey;
 				const latestExpiresAt = Date.parse(latest.accessTokenExpiresAt);
 				if (
@@ -1105,6 +1339,7 @@ export async function logoutClawdiCredentials(
 			let remoteRevoked = false;
 			if (isClerkOAuthAuth(current)) {
 				try {
+					assertCloudCredentialEndpoint(current, apiUrl);
 					const expiresAt = Date.parse(current.accessTokenExpiresAt);
 					const now = options.now ?? Date.now;
 					const latest =

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -45,6 +45,13 @@ export interface LegacyClawdiAuth {
 	apiKey: string;
 	userId?: string;
 	email?: string;
+	endpointBinding?: CredentialEndpointBinding;
+}
+
+export interface CredentialEndpointBinding {
+	version: 1;
+	cloudApiOrigin: string;
+	hostedApiOrigin?: string;
 }
 
 export interface ClerkOAuthAuth {
@@ -65,6 +72,8 @@ export interface ClerkOAuthAuth {
 	/** Cloud-local user id, populated after `/v1/auth/me` succeeds. */
 	userId: string;
 	email?: string;
+	/** Exact Cloud + Hosted origins selected when this OAuth grant was created. */
+	endpointBinding?: CredentialEndpointBinding;
 }
 
 export type ClawdiAuth = LegacyClawdiAuth | ClerkOAuthAuth;
@@ -87,6 +96,7 @@ export interface PendingAuth {
 	tokenEndpoint: string;
 	expiresAt: string;
 	apiUrl: string;
+	endpointBinding?: CredentialEndpointBinding;
 	scopes: string[];
 }
 

--- a/packages/cli/src/lib/hosted-deploy-auth.ts
+++ b/packages/cli/src/lib/hosted-deploy-auth.ts
@@ -1,4 +1,8 @@
-import { getClawdiAccessToken, isClerkOAuthAuth } from "./clerk-oauth";
+import {
+	assertClerkOAuthEndpointProfile,
+	getClawdiAccessToken,
+	isClerkOAuthAuth,
+} from "./clerk-oauth";
 import { getAuth } from "./config";
 
 const ACCESS_TOKEN_EXPIRY_SKEW_MS = 5_000;
@@ -76,8 +80,15 @@ export function assertHostedDeployAccessToken(
 	return token;
 }
 
+export type HostedDeployEndpointProfile = {
+	cloudApiUrl: string;
+	hostedApiUrl: string;
+};
+
 /** Reuses the single canonical Clerk OAuth session established by `clawdi auth login`. */
-export function createHostedDeployAuthProvider(): HostedDeployAuthProvider {
+export function createHostedDeployAuthProvider(
+	profile: HostedDeployEndpointProfile,
+): HostedDeployAuthProvider {
 	return {
 		async getAccessToken() {
 			const beforeRefresh = getAuth();
@@ -87,12 +98,28 @@ export function createHostedDeployAuthProvider(): HostedDeployAuthProvider {
 					"Hosted deployment requires the canonical Clerk OAuth login. Run `clawdi auth login` without --manual.",
 				);
 			}
-			const token = await getClawdiAccessToken();
+			try {
+				assertClerkOAuthEndpointProfile(beforeRefresh, profile.cloudApiUrl, profile.hostedApiUrl);
+			} catch {
+				throw new HostedDeployAuthorizationError(
+					"hosted_endpoint_binding_mismatch",
+					"This Clerk OAuth login is not bound to the current Cloud and Hosted endpoints. Restore endpoint configuration or run `clawdi auth logout` followed by `clawdi auth login`.",
+				);
+			}
+			const token = await getClawdiAccessToken(profile.cloudApiUrl);
 			const refreshed = getAuth();
 			if (!isClerkOAuthAuth(refreshed)) {
 				throw new HostedDeployAuthorizationError(
 					"hosted_oauth_login_required",
 					"Clerk OAuth login is unavailable. Run `clawdi auth login` again.",
+				);
+			}
+			try {
+				assertClerkOAuthEndpointProfile(refreshed, profile.cloudApiUrl, profile.hostedApiUrl);
+			} catch {
+				throw new HostedDeployAuthorizationError(
+					"hosted_endpoint_binding_mismatch",
+					"The refreshed Clerk OAuth login is not bound to the current Cloud and Hosted endpoints. Run `clawdi auth login` again.",
 				);
 			}
 			return { token, expiresAt: refreshed.accessTokenExpiresAt };

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -19,10 +19,16 @@ import {
 	unwrapDeploymentList,
 } from "@clawdi/shared/api";
 import createClient, { type Client, type Middleware } from "openapi-fetch";
+import {
+	canonicalApiOrigin,
+	normalizeCloudApiBaseUrl,
+	normalizeHostedDeployApiBaseUrl,
+} from "./api-origin";
 import { getConfig } from "./config";
 import {
 	assertHostedDeployAccessToken,
 	createHostedDeployAuthProvider,
+	HostedDeployAuthorizationError,
 	type HostedDeployAuthProvider,
 } from "./hosted-deploy-auth";
 import { getCliVersion } from "./version";
@@ -44,32 +50,7 @@ export class HostedDeployApiError extends Error {
 	}
 }
 
-export function normalizeHostedDeployApiBaseUrl(raw: string): string {
-	let url: URL;
-	try {
-		url = new URL(raw);
-	} catch {
-		throw new Error("Hosted deploy API URL must be a valid http:// or https:// URL.");
-	}
-	if (url.protocol !== "http:" && url.protocol !== "https:") {
-		throw new Error("Hosted deploy API URL must use http:// or https://.");
-	}
-	const loopback =
-		url.hostname === "localhost" ||
-		url.hostname === "127.0.0.1" ||
-		url.hostname === "[::1]" ||
-		url.hostname === "::1";
-	if (url.protocol === "http:" && !loopback) {
-		throw new Error("Hosted deploy API URL must use HTTPS except on loopback localhost.");
-	}
-	if (url.username || url.password) {
-		throw new Error("Hosted deploy API URL must not contain credentials.");
-	}
-	url.pathname = url.pathname.replace(/\/+$/, "").replace(/\/v2$/, "");
-	url.search = "";
-	url.hash = "";
-	return url.toString().replace(/\/$/, "");
-}
+export { normalizeHostedDeployApiBaseUrl } from "./api-origin";
 
 async function fetchWithTimeout(request: Request): Promise<Response> {
 	const controller = new AbortController();
@@ -119,21 +100,34 @@ export class HostedDeployClient {
 	private readonly paidCheckoutSupported: boolean;
 
 	constructor(options: HostedDeployClientOptions = {}) {
-		const auth = options.auth ?? createHostedDeployAuthProvider();
+		const config = getConfig();
 		const now = options.now ?? Date.now;
 		this.paidCheckoutSupported = options.paidCheckoutSupported ?? true;
-		this.baseUrl = normalizeHostedDeployApiBaseUrl(options.baseUrl ?? getConfig().deployApiUrl);
+		this.baseUrl = normalizeHostedDeployApiBaseUrl(options.baseUrl ?? config.deployApiUrl);
+		const cloudBaseUrl = normalizeCloudApiBaseUrl(options.apiBaseUrl ?? config.apiUrl);
+		const auth =
+			options.auth ??
+			createHostedDeployAuthProvider({
+				cloudApiUrl: cloudBaseUrl,
+				hostedApiUrl: this.baseUrl,
+			});
 		const requestFetch = options.fetch ?? fetchWithTimeout;
 		this.client = createClient<DeployPaths>({
 			baseUrl: this.baseUrl,
 			fetch: requestFetch,
 		});
 		this.cloudClient = createClient<paths>({
-			baseUrl: options.apiBaseUrl ?? getConfig().apiUrl,
+			baseUrl: cloudBaseUrl,
 			fetch: requestFetch,
 		});
-		const authMiddleware: Middleware = {
+		const authMiddleware = (expectedOrigin: string): Middleware => ({
 			async onRequest({ request }) {
+				if (new URL(request.url).origin !== expectedOrigin) {
+					throw new HostedDeployAuthorizationError(
+						"hosted_request_origin_mismatch",
+						"Hosted request origin changed before authorization. No credential was sent.",
+					);
+				}
 				const credential = await auth.getAccessToken();
 				const token = assertHostedDeployAccessToken(credential, now());
 				request.headers.set("Authorization", `Bearer ${token}`);
@@ -141,9 +135,9 @@ export class HostedDeployClient {
 				request.headers.set("X-Request-ID", randomUUID());
 				return request;
 			},
-		};
-		this.client.use(authMiddleware);
-		this.cloudClient.use(authMiddleware);
+		});
+		this.client.use(authMiddleware(canonicalApiOrigin(this.baseUrl)));
+		this.cloudClient.use(authMiddleware(canonicalApiOrigin(cloudBaseUrl)));
 	}
 
 	/**

--- a/packages/cli/src/lib/project-command-utils.ts
+++ b/packages/cli/src/lib/project-command-utils.ts
@@ -11,7 +11,7 @@ export interface ProjectAuthContext {
 
 export async function requireProjectAuth(): Promise<ProjectAuthContext> {
 	const { apiUrl } = getConfig();
-	return { apiUrl, apiKey: await getClawdiAccessToken() };
+	return { apiUrl, apiKey: await getClawdiAccessToken(apiUrl) };
 }
 
 export async function projectAuthOrExit(): Promise<ProjectAuthContext | null> {

--- a/packages/cli/src/lib/secret-references.ts
+++ b/packages/cli/src/lib/secret-references.ts
@@ -218,7 +218,7 @@ async function requestClawdiReference<T extends VaultReferencePreview>(
 	}
 	const ref = parseClawdiReference(input);
 	const { apiUrl } = getConfig();
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 
 	const params = new URLSearchParams({
 		vault_slug: ref.vault,
@@ -353,7 +353,7 @@ async function requestClawdiReferenceBulk<T extends VaultReferencePreview>(
 	}
 
 	const { apiUrl } = getConfig();
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(apiUrl);
 
 	const projectIdCache = new Map<string, string>();
 	const resolveCachedProjectId = async (project: string): Promise<string> => {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -220,7 +220,7 @@ const MCP_ENDPOINT_PATH = "/v1/mcp/clawdi";
 
 async function callClawdiMcp(method: string, params?: Record<string, unknown>): Promise<unknown> {
 	const config = getConfig();
-	const accessToken = await getClawdiAccessToken();
+	const accessToken = await getClawdiAccessToken(config.apiUrl);
 	const response = await fetch(`${config.apiUrl}${MCP_ENDPOINT_PATH}`, {
 		method: "POST",
 		headers: {

--- a/packages/cli/tests/api-client.test.ts
+++ b/packages/cli/tests/api-client.test.ts
@@ -14,7 +14,12 @@ function fakeLogin(apiUrl: string) {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(
 		join(dir, "auth.json"),
-		JSON.stringify({ apiKey: "test-key", userId: "u1", email: "e" }),
+		JSON.stringify({
+			apiKey: "test-key",
+			userId: "u1",
+			email: "e",
+			endpointBinding: { version: 1, cloudApiOrigin: apiUrl },
+		}),
 	);
 	writeFileSync(join(dir, "config.json"), JSON.stringify({ apiUrl }));
 }

--- a/packages/cli/tests/clerk-oauth.test.ts
+++ b/packages/cli/tests/clerk-oauth.test.ts
@@ -31,6 +31,8 @@ import {
 
 const NOW = Date.parse("2026-07-28T00:00:00Z");
 const AUTHORIZED_PARTY = "https://accounts.clawdi.test";
+const CLOUD_API_URL = "https://cloud.example.test";
+const HOSTED_API_URL = "https://deploy.example.test";
 const CONFIG: ClerkOAuthClientConfig = {
 	issuer: "https://clerk.example.test",
 	clientId: "clawdi-cli",
@@ -74,6 +76,11 @@ function storedOAuth(overrides: Partial<ClerkOAuthAuth> = {}): ClerkOAuthAuth {
 		scopes: ["openid", "profile", "email"],
 		subject: "user_same_sub",
 		userId: "cloud-local-user",
+		endpointBinding: {
+			version: 1,
+			cloudApiOrigin: CLOUD_API_URL,
+			hostedApiOrigin: HOSTED_API_URL,
+		},
 		...overrides,
 	};
 }
@@ -91,7 +98,12 @@ function pending(): PendingAuth {
 		authorizedParties: CONFIG.authorizedParties,
 		tokenEndpoint: DISCOVERY.tokenEndpoint,
 		expiresAt: new Date(NOW + 10 * 60_000).toISOString(),
-		apiUrl: "https://cloud.example.test",
+		apiUrl: CLOUD_API_URL,
+		endpointBinding: {
+			version: 1,
+			cloudApiOrigin: CLOUD_API_URL,
+			hostedApiOrigin: HOSTED_API_URL,
+		},
 		scopes: ["openid", "profile", "email", "offline_access"],
 	};
 }
@@ -281,6 +293,7 @@ describe("Clerk public OAuth PKCE", () => {
 			config: CONFIG,
 			discovery: DISCOVERY,
 			apiUrl: "https://cloud.example.test",
+			hostedApiUrl: HOSTED_API_URL,
 			now: () => NOW,
 		});
 		const url = new URL(transaction.authorizationUrl);
@@ -505,6 +518,11 @@ describe("Clerk public OAuth PKCE", () => {
 			scopes: ["openid", "profile", "email"],
 			subject: "user_same_sub",
 			userId: "cloud-local-user",
+			endpointBinding: {
+				version: 1,
+				cloudApiOrigin: CLOUD_API_URL,
+				hostedApiOrigin: HOSTED_API_URL,
+			},
 		});
 		let refreshes = 0;
 		const fetcher = async (request: Request) => {
@@ -513,8 +531,8 @@ describe("Clerk public OAuth PKCE", () => {
 			return tokenResponse(accessToken(), "refresh-rotated");
 		};
 		const [first, second] = await Promise.all([
-			getClawdiAccessToken({ now: () => NOW, fetch: fetcher }),
-			getClawdiAccessToken({ now: () => NOW, fetch: fetcher }),
+			getClawdiAccessToken(CLOUD_API_URL, { now: () => NOW, fetch: fetcher }),
+			getClawdiAccessToken(CLOUD_API_URL, { now: () => NOW, fetch: fetcher }),
 		]);
 		expect(first).toBe(second);
 		expect(refreshes).toBe(1);
@@ -610,10 +628,15 @@ describe("Clerk public OAuth PKCE", () => {
 			scopes: ["openid", "profile", "email"],
 			subject: "user_same_sub",
 			userId: "cloud-local-user",
+			endpointBinding: {
+				version: 1,
+				cloudApiOrigin: CLOUD_API_URL,
+				hostedApiOrigin: HOSTED_API_URL,
+			},
 		});
 
 		await expect(
-			getClawdiAccessToken({
+			getClawdiAccessToken(CLOUD_API_URL, {
 				now: () => NOW,
 				fetch: async () => tokenResponse(accessToken({ sub: "user_other" })),
 			}),
@@ -627,7 +650,7 @@ describe("Clerk public OAuth PKCE", () => {
 			const authPath = join(stateDir, "auth.json");
 			const before = readFileSync(authPath, "utf8");
 			await expect(
-				getClawdiAccessToken({
+				getClawdiAccessToken(CLOUD_API_URL, {
 					now: () => NOW,
 					fetch: async () => {
 						if (failure === "network") {
@@ -653,7 +676,10 @@ describe("Clerk public OAuth PKCE", () => {
 			setAuth(storedOAuth());
 			let failure: unknown;
 			try {
-				await getClawdiAccessToken({ now: () => NOW, fetch: async () => response() });
+				await getClawdiAccessToken(CLOUD_API_URL, {
+					now: () => NOW,
+					fetch: async () => response(),
+				});
 			} catch (error) {
 				failure = error;
 			}
@@ -667,7 +693,7 @@ describe("Clerk public OAuth PKCE", () => {
 		setAuth(storedOAuth());
 		const replacement = storedOAuth({ refreshToken: "refresh-newer" });
 		await expect(
-			getClawdiAccessToken({
+			getClawdiAccessToken(CLOUD_API_URL, {
 				now: () => NOW,
 				fetch: async () => {
 					setAuth(replacement);
@@ -691,6 +717,11 @@ describe("Clerk public OAuth PKCE", () => {
 			scopes: ["openid", "profile", "email"],
 			subject: "user_same_sub",
 			userId: "cloud-local-user",
+			endpointBinding: {
+				version: 1,
+				cloudApiOrigin: CLOUD_API_URL,
+				hostedApiOrigin: HOSTED_API_URL,
+			},
 		});
 		let body = "";
 		await revokeClerkOAuthSession("https://cloud.example.test", {
@@ -714,7 +745,7 @@ describe("Clerk public OAuth PKCE", () => {
 		const refreshStarted = new Promise<void>((resolve) => {
 			markRefreshStarted = resolve;
 		});
-		const refresh = getClawdiAccessToken({
+		const refresh = getClawdiAccessToken(CLOUD_API_URL, {
 			now: () => NOW,
 			fetch: async () => {
 				markRefreshStarted?.();
@@ -754,7 +785,7 @@ describe("Clerk public OAuth PKCE", () => {
 		const refreshStarted = new Promise<void>((resolve) => {
 			markRefreshStarted = resolve;
 		});
-		const oldRefresh = getClawdiAccessToken({
+		const oldRefresh = getClawdiAccessToken(CLOUD_API_URL, {
 			now: () => NOW,
 			fetch: async () => {
 				markRefreshStarted?.();
@@ -795,7 +826,7 @@ describe("Clerk public OAuth PKCE", () => {
 		});
 		await logoutRefreshStarted;
 		let waiterFetches = 0;
-		const waitingRefresh = getClawdiAccessToken({
+		const waitingRefresh = getClawdiAccessToken(CLOUD_API_URL, {
 			now: () => NOW,
 			fetch: async () => {
 				waiterFetches += 1;
@@ -891,11 +922,16 @@ describe("Clerk public OAuth PKCE", () => {
 						issuer: origin,
 						tokenEndpoint: `${origin}/oauth/token`,
 						refreshToken: `refresh-${status}-secret`,
+						endpointBinding: {
+							version: 1,
+							cloudApiOrigin: origin,
+							hostedApiOrigin: HOSTED_API_URL,
+						},
 					}),
 				);
 				let refreshError: unknown;
 				try {
-					await getClawdiAccessToken({ now: () => NOW });
+					await getClawdiAccessToken(origin, { now: () => NOW });
 				} catch (error) {
 					refreshError = error;
 				}

--- a/packages/cli/tests/commands/agent-credentials.test.ts
+++ b/packages/cli/tests/commands/agent-credentials.test.ts
@@ -41,9 +41,15 @@ beforeEach(() => {
 	mkdirSync(join(tmpHome, ".codex"), { recursive: true });
 	mkdirSync(join(tmpHome, ".claude"), { recursive: true });
 	mkdirSync(join(tmpHome, ".config", "gh"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	delete process.env.GH_CONFIG_DIR;
 	delete process.env.XDG_CONFIG_HOME;
 });

--- a/packages/cli/tests/commands/agent-projects.test.ts
+++ b/packages/cli/tests/commands/agent-projects.test.ts
@@ -21,9 +21,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-agent-projects-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -51,8 +51,14 @@ beforeEach(() => {
 	mkdirSync(tmpHome, { recursive: true });
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	process.env.CLAWDI_API_URL = "https://api.test";
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	delete process.env.CLAWDI_HOME;
 });
 

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -48,7 +48,12 @@ function oauthPending(): PendingAuth {
 		authorizedParties: ["https://accounts.clawdi.test"],
 		tokenEndpoint: "https://clerk.example.test/oauth/token",
 		expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
-		apiUrl: "http://api.test",
+		apiUrl: "https://api.test",
+		endpointBinding: {
+			version: 1,
+			cloudApiOrigin: "https://api.test",
+			hostedApiOrigin: "http://localhost:50021",
+		},
 		scopes: ["openid", "profile", "email", "offline_access"],
 	};
 }
@@ -64,12 +69,17 @@ beforeEach(() => {
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
 	writeFileSync(
 		join(tmpHome, ".clawdi", "auth.json"),
-		JSON.stringify({ apiKey: "bob-key", userId: "bob", email: "bob@example.test" }),
+		JSON.stringify({
+			apiKey: "bob-key",
+			userId: "bob",
+			email: "bob@example.test",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
 	);
 
 	process.env.HOME = tmpHome;
 	delete process.env.CLAWDI_HOME;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	delete process.env.CLAWDI_AUTH_TOKEN;
 	process.exitCode = undefined;
 });
@@ -138,6 +148,11 @@ describe("authLogin pending share upgrade", () => {
 			const { getPendingAuth } = await import("../../src/lib/config");
 			const pending = getPendingAuth();
 			expect(pending?.authType).toBe("clerk_oauth_pkce");
+			expect(pending?.endpointBinding).toEqual({
+				version: 1,
+				cloudApiOrigin: "https://api.test",
+				hostedApiOrigin: "http://localhost:50021",
+			});
 			const authorizationUrl = new URL(pending?.authorizationUrl ?? "");
 			expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
 			expect(authorizationUrl.searchParams.has("client_secret")).toBe(false);
@@ -313,6 +328,7 @@ describe("interactive OAuth Cloud verification boundary", () => {
 						}
 					: { refreshToken: `refresh-${cloudCase}`, userId: "oauth-user" },
 			);
+			expect(getAuth()?.endpointBinding).toEqual(pending.endpointBinding);
 			expect(getPendingAuth()).toBeNull();
 			expect(captured.map((request) => `${request.method} ${request.path}`)).toEqual([
 				"POST /oauth/token",

--- a/packages/cli/tests/commands/channel.test.ts
+++ b/packages/cli/tests/commands/channel.test.ts
@@ -26,9 +26,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-channel-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	process.exitCode = 0;
 });
 

--- a/packages/cli/tests/commands/helpers.ts
+++ b/packages/cli/tests/commands/helpers.ts
@@ -127,7 +127,12 @@ export function seedAuthAndEnv(home: string, agent: string, envId = "env-test"):
 	mkdirSync(join(clawdiDir, "environments"), { recursive: true });
 	writeFileSync(
 		join(clawdiDir, "auth.json"),
-		JSON.stringify({ apiKey: "test-key", userId: "u1", email: "e@x" }),
+		JSON.stringify({
+			apiKey: "test-key",
+			userId: "u1",
+			email: "e@x",
+			endpointBinding: { version: 1, cloudApiOrigin: "http://localhost:8000" },
+		}),
 	);
 	writeFileSync(
 		join(clawdiDir, "environments", `${agent}.json`),

--- a/packages/cli/tests/commands/inbox.test.ts
+++ b/packages/cli/tests/commands/inbox.test.ts
@@ -31,11 +31,17 @@ beforeEach(() => {
 	agentHomeOverrides = snapshotAndClearAgentHomeOverrides();
 	tmpHome = join(tmpdir(), `clawdi-inbox-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
 	delete process.env.CLAWDI_HOME;
 	delete process.env.CLAWDI_AUTH_TOKEN;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/memory.test.ts
+++ b/packages/cli/tests/commands/memory.test.ts
@@ -14,9 +14,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-memory-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/project-create.test.ts
+++ b/packages/cli/tests/commands/project-create.test.ts
@@ -15,9 +15,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-project-create-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	process.exitCode = 0;
 });
 

--- a/packages/cli/tests/commands/project-list.test.ts
+++ b/packages/cli/tests/commands/project-list.test.ts
@@ -15,9 +15,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-project-list-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/project-members.test.ts
+++ b/packages/cli/tests/commands/project-members.test.ts
@@ -19,9 +19,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-project-members-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/project-sharing-owner.test.ts
+++ b/packages/cli/tests/commands/project-sharing-owner.test.ts
@@ -40,9 +40,15 @@ beforeEach(() => {
 		`clawdi-project-sharing-owner-${Date.now()}-${Math.random().toString(36)}`,
 	);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	process.exitCode = 0;
 });
 

--- a/packages/cli/tests/commands/project-show.test.ts
+++ b/packages/cli/tests/commands/project-show.test.ts
@@ -15,9 +15,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-project-show-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/read-inject.test.ts
+++ b/packages/cli/tests/commands/read-inject.test.ts
@@ -35,10 +35,16 @@ beforeEach(() => {
 	const clawdiHome = join(tmpRoot, "state");
 	mkdirSync(clawdiHome, { recursive: true });
 	mkdirSync(projectRoot, { recursive: true });
-	writeFileSync(join(clawdiHome, "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(clawdiHome, "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
 	process.env.CLAWDI_HOME = clawdiHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	process.chdir(projectRoot);
 });
 

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -33,12 +33,18 @@ beforeEach(() => {
 	projectChild = join(projectRoot, "src");
 	mkdirSync(fakeClawdiHome, { recursive: true });
 	mkdirSync(projectChild, { recursive: true });
-	writeFileSync(join(fakeClawdiHome, "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(fakeClawdiHome, "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 
 	process.env.HOME = join(tmpRoot, "home");
 	process.env.CLAWDI_HOME = fakeClawdiHome;
 	delete process.env.CLAWDI_AUTH_TOKEN;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 	process.chdir(projectChild);
 });
 

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -155,7 +155,13 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-runtime-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
 	process.env.CLAWDI_API_URL = "https://api.test";
 	process.exitCode = 0;

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
 
 	process.env.CI = "1";
 	process.env.HOME = home;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 
 	originalArgv1 = process.argv[1];
 	const fakeEntry = join(home, "clawdi-bin");
@@ -295,7 +295,12 @@ function seedAuth(): void {
 	mkdirSync(clawdiDir, { recursive: true });
 	writeFileSync(
 		join(clawdiDir, "auth.json"),
-		`${JSON.stringify({ apiKey: "test-key", userId: "u1", email: "u@example.test" })}\n`,
+		`${JSON.stringify({
+			apiKey: "test-key",
+			userId: "u1",
+			email: "u@example.test",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		})}\n`,
 		{ mode: 0o600 },
 	);
 }

--- a/packages/cli/tests/commands/vault-resolve.test.ts
+++ b/packages/cli/tests/commands/vault-resolve.test.ts
@@ -14,9 +14,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-vault-resolve-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/commands/vault.test.ts
+++ b/packages/cli/tests/commands/vault.test.ts
@@ -24,9 +24,15 @@ beforeEach(() => {
 	origApiUrl = process.env.CLAWDI_API_URL;
 	tmpHome = join(tmpdir(), `clawdi-vault-list-${Date.now()}-${Math.random().toString(36)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
-	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	writeFileSync(
+		join(tmpHome, ".clawdi", "auth.json"),
+		JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		}),
+	);
 	process.env.HOME = tmpHome;
-	process.env.CLAWDI_API_URL = "http://api.test";
+	process.env.CLAWDI_API_URL = "https://api.test";
 });
 
 afterEach(() => {

--- a/packages/cli/tests/credential-origin-binding.test.ts
+++ b/packages/cli/tests/credential-origin-binding.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { authStatus } from "../src/commands/auth";
+import { ApiClient, unwrap } from "../src/lib/api-client";
+import { normalizeCloudApiBaseUrl, normalizeHostedDeployApiBaseUrl } from "../src/lib/api-origin";
+import {
+	getClawdiAccessToken,
+	logoutClawdiCredentials,
+	revokeClerkOAuthSession,
+} from "../src/lib/clerk-oauth";
+import { type ClerkOAuthAuth, getStoredAuth, setAuth, setConfig } from "../src/lib/config";
+import { HostedDeployClient } from "../src/lib/hosted-deploy-client";
+
+const CLOUD_ORIGIN = "https://cloud.example.test";
+const HOSTED_ORIGIN = "https://hosted.example.test";
+const PRODUCTION_CLOUD_ORIGIN = "https://cloud-api.clawdi.ai";
+
+function oauthAuth(
+	endpointBinding: ClerkOAuthAuth["endpointBinding"] | null = {
+		version: 1,
+		cloudApiOrigin: CLOUD_ORIGIN,
+		hostedApiOrigin: HOSTED_ORIGIN,
+	},
+): ClerkOAuthAuth {
+	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+	const accessToken = `${encode({ alg: "RS256", typ: "at+jwt" })}.${encode({
+		exp: Math.floor(Date.now() / 1_000) + 3_600,
+		sub: "oauth-user",
+	})}.signature`;
+	return {
+		authType: "clerk_oauth",
+		apiKey: accessToken,
+		refreshToken: "oauth-refresh-secret",
+		accessTokenExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+		issuer: "https://clerk.example.test",
+		clientId: "clawdi-cli",
+		audience: "clawdi-api",
+		tokenEndpoint: "https://clerk.example.test/oauth/token",
+		scopes: ["openid", "profile", "email"],
+		subject: "oauth-user",
+		userId: "cloud-user",
+		...(endpointBinding ? { endpointBinding } : {}),
+	};
+}
+
+let priorClawdiHome: string | undefined;
+let priorApiUrl: string | undefined;
+let priorDeployApiUrl: string | undefined;
+let priorAuthToken: string | undefined;
+let priorAuthTokenOrigin: string | undefined;
+let priorFetch: typeof globalThis.fetch;
+let stateDir: string;
+
+beforeEach(() => {
+	priorClawdiHome = process.env.CLAWDI_HOME;
+	priorApiUrl = process.env.CLAWDI_API_URL;
+	priorDeployApiUrl = process.env.CLAWDI_DEPLOY_API_URL;
+	priorAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+	priorAuthTokenOrigin = process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+	priorFetch = globalThis.fetch;
+	stateDir = join(tmpdir(), `clawdi-origin-binding-${crypto.randomUUID()}`);
+	mkdirSync(stateDir, { recursive: true });
+	process.env.CLAWDI_HOME = stateDir;
+	delete process.env.CLAWDI_API_URL;
+	delete process.env.CLAWDI_DEPLOY_API_URL;
+	delete process.env.CLAWDI_AUTH_TOKEN;
+	delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+});
+
+afterEach(() => {
+	if (priorClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+	else process.env.CLAWDI_HOME = priorClawdiHome;
+	if (priorApiUrl === undefined) delete process.env.CLAWDI_API_URL;
+	else process.env.CLAWDI_API_URL = priorApiUrl;
+	if (priorDeployApiUrl === undefined) delete process.env.CLAWDI_DEPLOY_API_URL;
+	else process.env.CLAWDI_DEPLOY_API_URL = priorDeployApiUrl;
+	if (priorAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+	else process.env.CLAWDI_AUTH_TOKEN = priorAuthToken;
+	if (priorAuthTokenOrigin === undefined) delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+	else process.env.CLAWDI_AUTH_TOKEN_ORIGIN = priorAuthTokenOrigin;
+	globalThis.fetch = priorFetch;
+	rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("credential endpoint normalization", () => {
+	test("canonicalizes scheme, hostname, effective port, and trailing slash", () => {
+		expect(normalizeCloudApiBaseUrl("https://CLOUD.Example.Test:443/")).toBe(CLOUD_ORIGIN);
+		expect(normalizeCloudApiBaseUrl("http://LOCALHOST:80/")).toBe("http://localhost");
+		expect(normalizeHostedDeployApiBaseUrl("https://HOSTED.Example.Test:443/v2")).toBe(
+			HOSTED_ORIGIN,
+		);
+		expect(normalizeHostedDeployApiBaseUrl("https://hosted.example.test/v2/")).toBe(HOSTED_ORIGIN);
+	});
+
+	test("rejects unsafe components and non-compatible paths", () => {
+		const cloudInvalid = [
+			"cloud.example.test",
+			"ftp://cloud.example.test",
+			"http://cloud.example.test",
+			"https://user:secret@cloud.example.test",
+			"https://@cloud.example.test",
+			"https://cloud.example.test/v1",
+			"https://cloud.example.test?tenant=evil",
+			"https://cloud.example.test#evil",
+			"https://cloud.example.test.",
+			"https://bad_host.example.test",
+		];
+		for (const invalid of cloudInvalid) {
+			expect(() => normalizeCloudApiBaseUrl(invalid)).toThrow();
+		}
+		for (const invalid of [
+			"http://hosted.example.test",
+			"https://hosted.example.test/v1",
+			"https://hosted.example.test/v2/agents",
+			"https://hosted.example.test/v2?tenant=evil",
+			"https://user@hosted.example.test/v2",
+		]) {
+			expect(() => normalizeHostedDeployApiBaseUrl(invalid)).toThrow();
+		}
+	});
+});
+
+describe("Cloud bearer origin binding", () => {
+	test("allows canonical-equivalent config and rejects a hostile override before fetch", async () => {
+		const auth = oauthAuth();
+		setAuth(auth);
+		setConfig({
+			apiUrl: "https://CLOUD.Example.Test:443/",
+			deployApiUrl: HOSTED_ORIGIN,
+		});
+		let requests = 0;
+		let authorization = "";
+		globalThis.fetch = async (request) => {
+			requests += 1;
+			authorization = request.headers.get("authorization") ?? "";
+			return Response.json({ id: "cloud-user", email: "user@example.test" });
+		};
+		const matching = new ApiClient();
+		unwrap(await matching.GET("/v1/auth/me"));
+		expect(requests).toBe(1);
+		expect(authorization).toBe(`Bearer ${auth.apiKey}`);
+
+		process.env.CLAWDI_API_URL = "https://attacker.example.test";
+		const hostile = new ApiClient();
+		await expect(hostile.GET("/v1/auth/me")).rejects.toThrow("bound to Cloud origin");
+		expect(requests).toBe(1);
+	});
+
+	test("never auto-binds a pre-binding OAuth credential, including production defaults", async () => {
+		setAuth(oauthAuth(null));
+		setConfig({ apiUrl: PRODUCTION_CLOUD_ORIGIN, deployApiUrl: "https://api.clawdi.ai" });
+		let requests = 0;
+		globalThis.fetch = async () => {
+			requests += 1;
+			return Response.json({});
+		};
+		await expect(new ApiClient().GET("/v1/auth/me")).rejects.toThrow("predates endpoint binding");
+		expect(requests).toBe(0);
+		expect(getStoredAuth()?.endpointBinding).toBeUndefined();
+	});
+
+	test("preserves old API keys only at production Cloud and supports explicit custom binding", async () => {
+		setAuth({ apiKey: "legacy-production-secret" });
+		expect(await getClawdiAccessToken(PRODUCTION_CLOUD_ORIGIN)).toBe("legacy-production-secret");
+		await expect(getClawdiAccessToken(CLOUD_ORIGIN)).rejects.toThrow("re-import it");
+
+		setAuth({
+			apiKey: "legacy-custom-secret",
+			endpointBinding: { version: 1, cloudApiOrigin: CLOUD_ORIGIN },
+		});
+		expect(await getClawdiAccessToken("https://CLOUD.Example.Test:443/")).toBe(
+			"legacy-custom-secret",
+		);
+	});
+
+	test("requires an explicit custom origin for environment credentials", async () => {
+		process.env.CLAWDI_AUTH_TOKEN = "environment-secret";
+		expect(await getClawdiAccessToken(PRODUCTION_CLOUD_ORIGIN)).toBe("environment-secret");
+		await expect(getClawdiAccessToken(CLOUD_ORIGIN)).rejects.toThrow(
+			"CLAWDI_AUTH_TOKEN is not bound",
+		);
+		process.env.CLAWDI_AUTH_TOKEN_ORIGIN = "https://CLOUD.Example.Test:443/";
+		expect(await getClawdiAccessToken(CLOUD_ORIGIN)).toBe("environment-secret");
+		await expect(getClawdiAccessToken("https://attacker.example.test")).rejects.toThrow(
+			"bound to Cloud origin",
+		);
+	});
+
+	test("logout never revokes through a mismatched Cloud origin and still clears local secrets", async () => {
+		setAuth(oauthAuth());
+		let requests = 0;
+		const result = await logoutClawdiCredentials("https://attacker.example.test", {
+			fetch: async () => {
+				requests += 1;
+				return Response.json({ status: "revoked" });
+			},
+		});
+		expect(result).toEqual({
+			loggedOut: true,
+			remoteRevoked: false,
+			environmentCredential: false,
+		});
+		expect(requests).toBe(0);
+		expect(getStoredAuth()).toBeNull();
+	});
+
+	test("explicit revoke fails closed on mismatch without deleting the credential", async () => {
+		setAuth(oauthAuth());
+		let requests = 0;
+		await expect(
+			revokeClerkOAuthSession("https://attacker.example.test", {
+				fetch: async () => {
+					requests += 1;
+					return Response.json({});
+				},
+			}),
+		).rejects.toThrow("bound to Cloud origin");
+		expect(requests).toBe(0);
+		expect(getStoredAuth()).not.toBeNull();
+	});
+});
+
+describe("Hosted shared OAuth profile binding", () => {
+	test("rejects a bound legacy Cloud key before Hosted fetch", async () => {
+		setAuth({
+			apiKey: "clawdi_legacy_secret",
+			endpointBinding: { version: 1, cloudApiOrigin: CLOUD_ORIGIN },
+		});
+		let requests = 0;
+		const client = new HostedDeployClient({
+			apiBaseUrl: CLOUD_ORIGIN,
+			baseUrl: HOSTED_ORIGIN,
+			fetch: async () => {
+				requests += 1;
+				return Response.json([]);
+			},
+		});
+		await expect(client.getPlans()).rejects.toThrow("canonical Clerk OAuth login");
+		expect(requests).toBe(0);
+	});
+
+	test("uses constructor endpoint snapshots even if environment overrides change later", async () => {
+		setAuth(oauthAuth());
+		process.env.CLAWDI_API_URL = CLOUD_ORIGIN;
+		process.env.CLAWDI_DEPLOY_API_URL = `${HOSTED_ORIGIN}/v2`;
+		const urls: string[] = [];
+		const client = new HostedDeployClient({
+			fetch: async (request) => {
+				urls.push(request.url);
+				return Response.json([]);
+			},
+		});
+		process.env.CLAWDI_API_URL = "https://attacker-cloud.example.test";
+		process.env.CLAWDI_DEPLOY_API_URL = "https://attacker-hosted.example.test";
+		await client.getPlans();
+		expect(urls).toEqual([`${HOSTED_ORIGIN}/v2/subscription/plans`]);
+	});
+
+	test("rejects Hosted mismatch and an auth-file replacement before fetch", async () => {
+		setAuth(oauthAuth());
+		let requests = 0;
+		const mismatched = new HostedDeployClient({
+			apiBaseUrl: CLOUD_ORIGIN,
+			baseUrl: "https://attacker-hosted.example.test",
+			fetch: async () => {
+				requests += 1;
+				return Response.json([]);
+			},
+		});
+		await expect(mismatched.getPlans()).rejects.toThrow("not bound");
+		expect(requests).toBe(0);
+
+		const snapshot = new HostedDeployClient({
+			apiBaseUrl: CLOUD_ORIGIN,
+			baseUrl: HOSTED_ORIGIN,
+			fetch: async () => {
+				requests += 1;
+				return Response.json([]);
+			},
+		});
+		setAuth(
+			oauthAuth({
+				version: 1,
+				cloudApiOrigin: "https://other-cloud.example.test",
+				hostedApiOrigin: "https://other-hosted.example.test",
+			}),
+		);
+		await expect(snapshot.getPlans()).rejects.toThrow("not bound");
+		expect(requests).toBe(0);
+	});
+});
+
+describe("auth status endpoint metadata", () => {
+	test("reports only non-secret binding state in JSON", async () => {
+		setConfig({ apiUrl: CLOUD_ORIGIN, deployApiUrl: HOSTED_ORIGIN });
+		const auth = oauthAuth();
+		setAuth(auth);
+		const output: string[] = [];
+		const priorLog = console.log;
+		console.log = (...values: unknown[]) => output.push(values.map(String).join(" "));
+		try {
+			await authStatus({ json: true });
+		} finally {
+			console.log = priorLog;
+		}
+		const rendered = output.join("\n");
+		const payload: unknown = JSON.parse(rendered);
+		expect(payload).toMatchObject({
+			schemaVersion: "clawdi.authStatus.v1",
+			credentialType: "clerk-oauth",
+			endpointBinding: {
+				state: "bound",
+				cloudApiOrigin: CLOUD_ORIGIN,
+				hostedApiOrigin: HOSTED_ORIGIN,
+				currentProfileMatches: true,
+			},
+		});
+		expect(rendered).not.toContain(auth.apiKey);
+		expect(rendered).not.toContain("oauth-refresh-secret");
+	});
+
+	test("redacts malformed configured URLs that contain userinfo", async () => {
+		setAuth(oauthAuth());
+		process.env.CLAWDI_API_URL = "https://operator-password@attacker.example.test";
+		const output: string[] = [];
+		const priorLog = console.log;
+		console.log = (...values: unknown[]) => output.push(values.map(String).join(" "));
+		try {
+			await authStatus({ json: true });
+		} finally {
+			console.log = priorLog;
+		}
+		const rendered = output.join("\n");
+		expect(rendered).toContain('"apiUrl": "<invalid>"');
+		expect(rendered).not.toContain("operator-password");
+	});
+});

--- a/packages/cli/tests/e2e/ai-provider.e2e.test.ts
+++ b/packages/cli/tests/e2e/ai-provider.e2e.test.ts
@@ -221,9 +221,14 @@ function createFixture(): Fixture {
 	const clawdiHome = join(root, "clawdi-state");
 	mkdirSync(home, { recursive: true });
 	mkdirSync(clawdiHome, { recursive: true });
-	writeFileSync(join(clawdiHome, "auth.json"), `${JSON.stringify({ apiKey: "test-key" })}\n`, {
-		mode: 0o600,
-	});
+	writeFileSync(
+		join(clawdiHome, "auth.json"),
+		`${JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: "https://api.test" },
+		})}\n`,
+		{ mode: 0o600 },
+	);
 	return { root, home, clawdiHome };
 }
 
@@ -237,7 +242,7 @@ async function runCli(
 		stdout: "pipe",
 		stderr: "pipe",
 		env: {
-			CLAWDI_API_URL: "http://api.test",
+			CLAWDI_API_URL: "https://api.test",
 			CLAWDI_HOME: fixture.clawdiHome,
 			CLAWDI_NO_AUTO_UPDATE: "1",
 			CLAWDI_NO_UPDATE_CHECK: "1",

--- a/packages/cli/tests/e2e/credential-profile.e2e.test.ts
+++ b/packages/cli/tests/e2e/credential-profile.e2e.test.ts
@@ -201,9 +201,14 @@ function createFixture(): Fixture {
 	const clawdiHome = join(root, "clawdi-state");
 	mkdirSync(home, { recursive: true });
 	mkdirSync(clawdiHome, { recursive: true });
-	writeFileSync(join(clawdiHome, "auth.json"), `${JSON.stringify({ apiKey: "test-key" })}\n`, {
-		mode: 0o600,
-	});
+	writeFileSync(
+		join(clawdiHome, "auth.json"),
+		`${JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: server.url.origin },
+		})}\n`,
+		{ mode: 0o600 },
+	);
 	return { root, home, clawdiHome };
 }
 

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -342,6 +342,7 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 	return {
 		CLAWDI_API_URL: server.url.origin,
 		CLAWDI_AUTH_TOKEN: API_KEY,
+		CLAWDI_AUTH_TOKEN_ORIGIN: server.url.origin,
 		CLAWDI_ENVIRONMENT_ID: ENV_ID,
 		CLAWDI_HOME: fixture.clawdiHome,
 		CLAWDI_NO_AUTO_UPDATE: "1",

--- a/packages/cli/tests/e2e/vault-reference.e2e.test.ts
+++ b/packages/cli/tests/e2e/vault-reference.e2e.test.ts
@@ -205,9 +205,14 @@ function createFixture(): Fixture {
 	const clawdiHome = join(root, "clawdi-state");
 	mkdirSync(home, { recursive: true });
 	mkdirSync(clawdiHome, { recursive: true });
-	writeFileSync(join(clawdiHome, "auth.json"), `${JSON.stringify({ apiKey: "test-key" })}\n`, {
-		mode: 0o600,
-	});
+	writeFileSync(
+		join(clawdiHome, "auth.json"),
+		`${JSON.stringify({
+			apiKey: "test-key",
+			endpointBinding: { version: 1, cloudApiOrigin: server.url.origin },
+		})}\n`,
+		{ mode: 0o600 },
+	);
 	return { root, home, clawdiHome };
 }
 

--- a/packages/cli/tests/fixtures/oauth-refresh-worker.ts
+++ b/packages/cli/tests/fixtures/oauth-refresh-worker.ts
@@ -1,4 +1,4 @@
 import { getClawdiAccessToken } from "../../src/lib/clerk-oauth";
 
-await getClawdiAccessToken();
+await getClawdiAccessToken("https://cloud.example.test");
 process.stdout.write("ok\n");

--- a/packages/cli/tests/hosted-deploy-auth.test.ts
+++ b/packages/cli/tests/hosted-deploy-auth.test.ts
@@ -68,7 +68,10 @@ describe("Hosted deploy auth boundary", () => {
 	});
 
 	test("requires the single canonical Clerk OAuth login", async () => {
-		const provider = createHostedDeployAuthProvider();
+		const provider = createHostedDeployAuthProvider({
+			cloudApiUrl: "https://cloud.example.test",
+			hostedApiUrl: "https://deploy.example.test",
+		});
 		await expect(provider.getAccessToken()).rejects.toBeInstanceOf(HostedDeployAuthorizationError);
 	});
 
@@ -105,6 +108,11 @@ describe("Hosted deploy auth boundary", () => {
 			scopes: ["openid", "profile", "email"],
 			subject: "user_same_sub",
 			userId: "cloud-local-user",
+			endpointBinding: {
+				version: 1,
+				cloudApiOrigin: "https://cloud.example.test",
+				hostedApiOrigin: "https://deploy.example.test",
+			},
 		});
 
 		const authorizations: string[] = [];


### PR DESCRIPTION
## Summary

- bind verified Clerk OAuth credentials to canonical Cloud and Hosted API origins
- reject endpoint overrides before adding `Authorization`, including Hosted/Cloud client snapshots and logout/revoke paths
- preserve production Cloud compatibility for legacy API keys while requiring explicit custom-origin binding
- expose non-secret binding diagnostics in `clawdi auth status --json`
- bump the CLI to `0.13.4`

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun run check`
- focused OAuth/origin/deploy/auth tests: 79 passed
- `bun run --cwd packages/cli check:publish-manifest`
- `bash scripts/test.sh cli`: 1156 passed, 0 failed
- `git diff --check origin/main..HEAD`
- clean linear rebase onto `fb1b8988`; zero merge commits

## Rollout

OAuth remains disabled in production until `0.13.4` is published and deployed. No production or tenant operations are part of this PR.
