### PR TITLE
fix(cli): retain hosted runtime secrets for manifest watch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.5",
+	"version": "0.13.6",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -131,6 +131,7 @@ describe("runtime manifest services", () => {
 	test("renders systemd runtime services without creating user command shims", () => {
 		const paths = tempRuntimePaths();
 		process.env.PATH = `${dirname(paths.cliManagedBin)}:${process.env.PATH ?? ""}`;
+		process.env.BYOK_RUNTIME_SECRET = "stale-watcher-value";
 		const manifest: RuntimeManifest = {
 			schemaVersion: "clawdi.runtimeDesiredState.v1",
 			deploymentId: "hdep_test",
@@ -143,21 +144,28 @@ describe("runtime manifest services", () => {
 			runtimes: {
 				openclaw: {
 					enabled: true,
-					run: runSettings("openclaw", ["gateway", "run"]),
+					run: {
+						...runSettings("openclaw", ["gateway", "run"]),
+						env: { NON_SECRET_RUNTIME_SETTING: "public-value" },
+						secretEnv: { BYOK_RUNTIME_SECRET: "secret://runtime/openclaw" },
+					},
 					services: {},
 				},
 				hermes: {
 					enabled: true,
 					run: runSettings("hermes", ["gateway", "run"]),
 					services: {
-						dashboard: runSettings("hermes", [
-							"dashboard",
-							"--host",
-							"127.0.0.1",
-							"--port",
-							"9119",
-							"--no-open",
-						]),
+						dashboard: {
+							...runSettings("hermes", [
+								"dashboard",
+								"--host",
+								"127.0.0.1",
+								"--port",
+								"9119",
+								"--no-open",
+							]),
+							secretEnv: { BYOK_SERVICE_SECRET: "secret://service/hermes-dashboard" },
+						},
 					},
 				},
 			},
@@ -168,6 +176,10 @@ describe("runtime manifest services", () => {
 			source: "fixture-file",
 			sourcePath: "inline-test",
 			offline: false,
+			secretValues: {
+				"secret://runtime/openclaw": "runtime-byok-value",
+				"secret://service/hermes-dashboard": "service-byok-value",
+			},
 		};
 
 		const previousUmask = process.umask(0o077);
@@ -224,8 +236,16 @@ describe("runtime manifest services", () => {
 			join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
 			"utf8",
 		);
+		const runtimeWatchEnv = readFileSync(
+			join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
+			"utf8",
+		);
 		expect(runtimeWatchUnit).toContain(`ExecStart="${paths.cliManagedBin}" "runtime" "watch"`);
 		expect(runtimeWatchUnit).not.toContain("ConditionPathExists=");
+		expect(runtimeWatchEnv).toContain('BYOK_RUNTIME_SECRET="runtime-byok-value"');
+		expect(runtimeWatchEnv).toContain('BYOK_SERVICE_SECRET="service-byok-value"');
+		expect(runtimeWatchEnv).not.toContain("stale-watcher-value");
+		expect(runtimeWatchEnv).not.toContain("NON_SECRET_RUNTIME_SETTING");
 		for (const unit of [hermesUnit, dashboardUnit, openclawUnit]) {
 			expect(unit).not.toContain("clawdi run --");
 			expect(unit).not.toContain("supervisord");
@@ -353,12 +373,18 @@ describe("runtime manifest services", () => {
 			join(paths.systemdEnvRoot, "clawdi-hermes-dashboard.service.env"),
 			"utf8",
 		);
+		const watchEnv = readFileSync(
+			join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
+			"utf8",
+		);
 		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME="admin"');
 		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="dashboard-password"');
 		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="dashboard-session-secret"');
 		expect(dashboardEnv).toContain(
 			'HERMES_DASHBOARD_PUBLIC_URL="https://agent.example.test/hermes"',
 		);
+		expect(watchEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="dashboard-password"');
+		expect(watchEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="dashboard-session-secret"');
 		const hermesConfig = readFileSync(join(paths.userHome, ".hermes", "config.yaml"), "utf8");
 		expect(hermesConfig).toContain("basic_auth:");
 		expect(hermesConfig).toContain("username: admin");
@@ -369,6 +395,89 @@ describe("runtime manifest services", () => {
 		expect(hermesConfig).not.toContain("dashboard-password");
 		expect(hermesConfig).not.toContain("dashboard-session-secret");
 		expect(existsSync(runtimeRunConfigPath("openclaw", paths))).toBe(false);
+	});
+
+	test("merges watcher secret environments deterministically and fails closed on conflicts", () => {
+		const converge = (
+			runtimeOrder: Array<"hermes" | "openclaw">,
+			secretValues: Record<string, string>,
+		) => {
+			const paths = tempRuntimePaths();
+			process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+			const runtimeSettings: RuntimeManifest["runtimes"] = {
+				hermes: {
+					enabled: true,
+					run: {
+						...runSettings("hermes", ["gateway", "run"]),
+						secretEnv: { SHARED_RUNTIME_SECRET: "secret://runtime/hermes" },
+					},
+					services: {},
+				},
+				openclaw: {
+					enabled: true,
+					run: {
+						...runSettings("openclaw", ["gateway", "run"]),
+						secretEnv: { SHARED_RUNTIME_SECRET: "secret://runtime/openclaw" },
+					},
+					services: {},
+				},
+			};
+			const runtimes = Object.fromEntries(
+				runtimeOrder.map((runtime) => [runtime, runtimeSettings[runtime]]),
+			) as RuntimeManifest["runtimes"];
+			const manifest: RuntimeManifest = {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "hdep_conflicting_watch_secrets",
+				environmentId: "env_conflicting_watch_secrets",
+				instanceId: "hri_conflicting_watch_secrets",
+				generation: 1,
+				issuedAt: "2026-07-01T00:00:00.000Z",
+				workspaceRoot: join(paths.userHome, "clawdi"),
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes,
+				recovery: {},
+			};
+			return {
+				paths,
+				result: convergeRuntimeManifest(
+					{
+						manifest,
+						source: "fixture-file",
+						sourcePath: "inline-conflicting-watch-secrets",
+						offline: false,
+						secretValues,
+					},
+					paths,
+				),
+			};
+		};
+
+		const conflictingValues = {
+			"secret://runtime/hermes": "hermes-secret",
+			"secret://runtime/openclaw": "openclaw-secret",
+		};
+		const forward = converge(["hermes", "openclaw"], conflictingValues).result;
+		const reverse = converge(["openclaw", "hermes"], conflictingValues).result;
+		const expectedError =
+			"runtime apply failed: Runtime watch secret environment SHARED_RUNTIME_SECRET conflicts between hermes-gateway and openclaw-gateway.";
+
+		expect(forward.installErrors).toEqual([expectedError]);
+		expect(reverse.installErrors).toEqual([expectedError]);
+		expect(forward.outputs.systemdSystemUnits).toEqual([]);
+		expect(reverse.outputs.systemdSystemUnits).toEqual([]);
+		expect(expectedError).not.toContain("hermes-secret");
+		expect(expectedError).not.toContain("openclaw-secret");
+
+		const deduplicated = converge(["openclaw", "hermes"], {
+			"secret://runtime/hermes": "shared-secret",
+			"secret://runtime/openclaw": "shared-secret",
+		});
+		expect(deduplicated.result.installErrors).toEqual([]);
+		const watchEnv = readFileSync(
+			join(deduplicated.paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
+			"utf8",
+		);
+		expect(watchEnv.match(/^SHARED_RUNTIME_SECRET="shared-secret"$/gm)).toHaveLength(1);
 	});
 
 	test("converges official service state before installers restart units", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -225,6 +225,7 @@ function writeLastGoodManifest(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	secretValues: Record<string, string> | undefined,
+	secretScopeManifest: RuntimeManifest = manifest,
 ): string | null {
 	if (manifest.recovery.cacheManifest === false) {
 		rmSync(paths.manifestLastGood, { force: true });
@@ -232,7 +233,7 @@ function writeLastGoodManifest(
 		return null;
 	}
 	writeJsonFile(paths.manifestLastGood, manifest);
-	writeLastGoodSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(manifest));
+	writeLastGoodSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(secretScopeManifest));
 	return paths.manifestLastGood;
 }
 
@@ -4045,6 +4046,7 @@ interface RuntimeSystemdUserProgram {
 	args: string[];
 	cwd: string;
 	env: Record<string, string>;
+	resolvedSecretEnv: Record<string, string>;
 }
 
 interface RuntimeEgressSystemdProgram {
@@ -4106,12 +4108,14 @@ function buildRuntimeSystemdUserProgram(input: {
 		...input.config.env,
 		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
 	};
+	const resolvedSecretEnv: Record<string, string> = {};
 	for (const [envName, ref] of Object.entries(input.config.secretEnv)) {
 		const value = runtimeSecretValue(input.secretValues ?? {}, ref);
 		if (!value) {
 			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
 		}
 		env[envName] = value;
+		resolvedSecretEnv[envName] = value;
 	}
 	if (input.egress) {
 		applyEgressTransparentRuntimeEnv(env, { caFile: input.egress.systemCaBundle });
@@ -4129,6 +4133,7 @@ function buildRuntimeSystemdUserProgram(input: {
 		args: input.config.defaultArgs,
 		cwd: input.config.cwd ?? input.paths.workspaceRoot,
 		env,
+		resolvedSecretEnv,
 	};
 }
 
@@ -4774,16 +4779,26 @@ function runtimeSystemdCommonEnvironment(
 }
 
 function runtimeWatchSecretEnvironment(
-	manifest: RuntimeManifest,
-	secretValues: Record<string, string> | undefined,
+	programs: RuntimeSystemdUserProgram[],
 ): Record<string, string> {
-	const tokenRef = manifest.runtimes.openclaw?.run?.secretEnv?.[OPENCLAW_GATEWAY_TOKEN_ENV];
-	if (!tokenRef) return {};
-	const token = resolveRuntimeSecretValue(secretValues ?? {}, tokenRef);
-	if (!token) {
-		throw new Error(`Runtime secret ${tokenRef} for ${OPENCLAW_GATEWAY_TOKEN_ENV} is unavailable.`);
+	const retained = new Map<string, { value: string; program: string }>();
+	for (const program of [...programs].sort((a, b) =>
+		runtimeSystemdProgramName(a).localeCompare(runtimeSystemdProgramName(b)),
+	)) {
+		const programName = runtimeSystemdProgramName(program);
+		for (const [envName, value] of Object.entries(program.resolvedSecretEnv).sort(([a], [b]) =>
+			a.localeCompare(b),
+		)) {
+			const existing = retained.get(envName);
+			if (existing && existing.value !== value) {
+				throw new Error(
+					`Runtime watch secret environment ${envName} conflicts between ${existing.program} and ${programName}.`,
+				);
+			}
+			retained.set(envName, { value, program: existing?.program ?? programName });
+		}
 	}
-	return { [OPENCLAW_GATEWAY_TOKEN_ENV]: token };
+	return Object.fromEntries([...retained].map(([envName, entry]) => [envName, entry.value]));
 }
 
 function writeRuntimeSystemdUserProgram(input: {
@@ -4876,7 +4891,7 @@ function writeSystemdUnits(
 				env: {
 					...commonEnvironment,
 					...applyIdentityEnvironment,
-					...runtimeWatchSecretEnvironment(manifest, secretValues),
+					...runtimeWatchSecretEnvironment(runtimePrograms),
 					CLAWDI_AUTH_TOKEN: "",
 				},
 			}),
@@ -6127,6 +6142,7 @@ export function convergeRuntimeManifest(
 				load.sourceManifest ?? manifest,
 				paths,
 				load.secretValues,
+				manifest,
 			);
 		}
 

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
@@ -271,6 +279,8 @@ describe("hosted runtime bundle v2", () => {
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const openclawBin = join(paths.userHome, ".openclaw", "bin", "openclaw");
 		const channelPatchPath = join(root, "openclaw-channel-patch.json");
+		const mcpSecretRef = "secret://mcp/sidecar-only/token";
+		const mcpSecret = "mcp-sidecar-only-secret";
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -288,7 +298,27 @@ describe("hosted runtime bundle v2", () => {
 		);
 		chmodSync(openclawBin, 0o700);
 
-		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as unknown;
+		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
+			manifest: Record<string, unknown>;
+			secretValues: Record<string, string>;
+			sourceRevision: string;
+		};
+		raw.manifest = {
+			...raw.manifest,
+			mcp: {
+				servers: {
+					"sidecar-only": {
+						url: "https://mcp.test/v1/service",
+						transport: "streamable-http",
+						headers: {
+							Authorization: { secretRef: mcpSecretRef, prefix: "Bearer " },
+						},
+					},
+				},
+			},
+		};
+		raw.secretValues = { ...raw.secretValues, [mcpSecretRef]: mcpSecret };
+		raw.sourceRevision = "f".repeat(64);
 		const projected = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(raw));
 		const openclaw = structuredClone(projected.manifest.runtimes.openclaw);
 		openclaw.providerMode = "unmanaged";
@@ -322,10 +352,20 @@ describe("hosted runtime bundle v2", () => {
 		const watchEnvPath = join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env");
 		expect(watchUnit).toContain(`EnvironmentFile=${watchEnvPath}`);
 		const gatewayTokenLine = 'OPENCLAW_GATEWAY_TOKEN="gateway-token"';
-		expect(readFileSync(watchEnvPath, "utf-8")).toContain(gatewayTokenLine);
+		const watchEnv = readFileSync(watchEnvPath, "utf-8");
+		expect(watchEnv).toContain(gatewayTokenLine);
+		expect(statSync(watchEnvPath).mode & 0o777).toBe(0o600);
+		const sidecarOnlySecrets = ["sk-provider-golden", "123456789:telegram-agent-golden", mcpSecret];
+		for (const secret of sidecarOnlySecrets) expect(watchEnv).not.toContain(secret);
+		expect(watchEnv).toContain("999999999:9ded1453047ec0a48ec3b735075f7448");
 		expect(
 			readFileSync(join(paths.systemdEnvRoot, "openclaw-gateway.service.env"), "utf-8"),
 		).toContain(gatewayTokenLine);
+		const persistentLastGood = [
+			readFileSync(paths.manifestLastGood, "utf-8"),
+			readFileSync(paths.managedSecretCacheFile, "utf-8"),
+		].join("\n");
+		for (const secret of sidecarOnlySecrets) expect(persistentLastGood).not.toContain(secret);
 		expect(JSON.parse(readFileSync(channelPatchPath, "utf-8"))).toMatchObject({
 			channels: {
 				telegram: {


### PR DESCRIPTION
## Summary

- retain only resolved `secretEnv` values required by planned runtime user programs in the root-owned runtime watcher environment
- fail closed on conflicting values for the same environment key while deterministically deduplicating identical values
- keep managed MCP/provider/channel credentials sidecar-only and exclude their effective projected refs from the persistent last-good secret cache
- publish the fix as exact CLI version `0.13.6`

## Why

Hosted Hermes dashboard credentials are delivered through `env://` references. Initial convergence materialized them into the runtime user service, but the watcher retained only the OpenClaw gateway token. Later manifest refreshes therefore failed before MCP/Skill reconciliation with an unavailable Hermes secret.

## Security boundary

The watcher receives only the secret values already resolved for enabled `RuntimeSystemdUserProgram` instances. It does not infer secrets from ordinary environment values or generated files. Managed MCP, managed provider, and native-channel real credentials remain in the root/egress sidecar boundary; runtime and watcher retain only public placeholders where applicable. Ephemeral watcher env files remain mode `0600`, and sidecar-only secrets are excluded from persistent last-good cache.

## Verification

- full CLI suite: 1193 pass, 0 fail
- focused runtime/bundle tests: 43 pass, 0 fail
- CLI typecheck
- repository Biome check (731 files)
- CLI publish workflow contract tests
- publish manifest check, CLI build, npm pack, installed tarball `clawdi --version` = `0.13.6`
- `git diff --check`

## Release impact

CLI publish required. This is a CLI-only release; the existing digest-pinned Hosted runtime image should be reused and validated through the standard validate-only pairing lane before controlled canary promotion.
