### PR TITLE
fix(cli): resolve hosted auth ref for egress sidecar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.6",
+      "version": "0.13.7",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.6",
+	"version": "0.13.7",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -3,6 +3,7 @@ import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../
 import type { RuntimePaths } from "./paths";
 
 export const RUNTIME_AUTH_TOKEN_ENV = "CLAWDI_AUTH_TOKEN";
+export const RUNTIME_AUTH_TOKEN_SECRET_REF = `env://${RUNTIME_AUTH_TOKEN_ENV}`;
 export const RUNTIME_AUTH_ENV_SELECTOR = "CLAWDI_RUNTIME_AUTH_ENV";
 
 export function runtimeAuthEnvName(): string {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -54,7 +54,11 @@ import {
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState } from "./applied-state";
 import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
-import { ensureRuntimeAuthTokenFile } from "./auth-token";
+import {
+	ensureRuntimeAuthTokenFile,
+	RUNTIME_AUTH_TOKEN_SECRET_REF,
+	readRuntimeAuthToken,
+} from "./auth-token";
 import {
 	assertHostedBundledSkillCatalogDigest,
 	hostedBundledSkillIds,
@@ -623,14 +627,23 @@ function writeScopedSecretValues(
 	refs: readonly string[],
 	paths: RuntimePaths,
 	owner: "root" | "runtime-user" | "egress-identity",
-	options: { resolveEnv?: boolean } = {},
+	options: ScopedSecretValuesOptions = {},
 ): string | null {
 	const scoped = scopedSecretValues(secretValues, refs, options);
-	if (Object.keys(scoped).length === 0) {
+	return writeResolvedSecretValues(path, scoped, paths, owner);
+}
+
+function writeResolvedSecretValues(
+	path: string,
+	resolvedSecretValues: Readonly<Record<string, string>>,
+	paths: RuntimePaths,
+	owner: "root" | "runtime-user" | "egress-identity",
+): string | null {
+	if (Object.keys(resolvedSecretValues).length === 0) {
 		rmSync(path, { force: true });
 		return null;
 	}
-	writePrivateFileAtomic(path, `${JSON.stringify(scoped, null, 2)}\n`, {
+	writePrivateFileAtomic(path, `${JSON.stringify(resolvedSecretValues, null, 2)}\n`, {
 		mode: 0o600,
 		dirMode: 0o700,
 	});
@@ -657,16 +670,21 @@ function writeScopedSecretValues(
 	return path;
 }
 
+interface ScopedSecretValuesOptions {
+	resolveEnv?: boolean;
+	explicitValues?: Readonly<Record<string, string>>;
+}
+
 function scopedSecretValues(
 	secretValues: Record<string, string> | undefined,
 	refs: readonly string[],
-	options: { resolveEnv?: boolean } = {},
+	options: ScopedSecretValuesOptions = {},
 ): Record<string, string> {
 	const normalizedValues = normalizeSecretValues(secretValues);
 	const scoped: Record<string, string> = {};
 	for (const ref of refs) {
 		if (isEnvSecretRef(ref) && !options.resolveEnv) continue;
-		const value = resolveRuntimeSecretValue(normalizedValues, ref);
+		const value = options.explicitValues?.[ref] ?? resolveRuntimeSecretValue(normalizedValues, ref);
 		if (!value) continue;
 		scoped[ref] = value;
 		const normalized = normalizeSecretRef(ref);
@@ -1931,18 +1949,31 @@ function egressSecretFilePath(paths: RuntimePaths): string {
 }
 
 function writeEgressSecretFile(
+	resolvedSecretValues: Readonly<Record<string, string>>,
+	paths: RuntimePaths,
+): string | null {
+	return writeResolvedSecretValues(
+		egressSecretFilePath(paths),
+		resolvedSecretValues,
+		paths,
+		"egress-identity",
+	);
+}
+
+function resolveEgressSecretValues(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	paths: RuntimePaths,
-): string | null {
-	return writeScopedSecretValues(
-		egressSecretFilePath(paths),
-		secretValues,
-		egressSecretRefs(manifest),
-		paths,
-		"egress-identity",
-		{ resolveEnv: true },
-	);
+): Record<string, string> {
+	const runtimeAuthToken = readRuntimeAuthToken(paths);
+	// The hosted watcher deliberately clears CLAWDI_AUTH_TOKEN and authenticates
+	// through this root-owned file. Resolve only the canonical sidecar ref here.
+	return scopedSecretValues(secretValues, egressSecretRefs(manifest), {
+		resolveEnv: true,
+		explicitValues: runtimeAuthToken
+			? { [RUNTIME_AUTH_TOKEN_SECRET_REF]: runtimeAuthToken }
+			: undefined,
+	});
 }
 
 function egressSecretRefs(manifest: RuntimeManifest): string[] {
@@ -4150,6 +4181,7 @@ export function runtimeSidecarProgramRevision(
 	secretValues: Record<string, string>,
 	egressProgram: RuntimeEgressSystemdProgram | null = null,
 	egressIdentity: RuntimeEgressIdentity | null = null,
+	resolvedEgressSecretValues?: Readonly<Record<string, string>>,
 ): string {
 	if (egressProgram && !egressIdentity) {
 		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
@@ -4160,7 +4192,8 @@ export function runtimeSidecarProgramRevision(
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
 		egressProfiles: manifest.egressProfiles ?? null,
-		egressSecrets: scopedSecretValues(secretValues, egressSecretRefs(manifest)),
+		egressSecrets:
+			resolvedEgressSecretValues ?? scopedSecretValues(secretValues, egressSecretRefs(manifest)),
 		egress: egressProgram
 			? {
 					transparentPort: egressProgram.transparentPort,
@@ -4866,6 +4899,7 @@ function writeSystemdUnits(
 	workspaceRoot: string,
 	daemonAuthTokenFile: string | null,
 	secretValues: Record<string, string> | undefined,
+	resolvedEgressSecretValues: Readonly<Record<string, string>>,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
 	commonEnvironment: Record<string, string>,
 ): { systemUnits: string[]; userUnits: string[] } {
@@ -4939,6 +4973,7 @@ function writeSystemdUnits(
 						secretValues ?? {},
 						activeEgressProgram,
 						activeEgressIdentity,
+						resolvedEgressSecretValues,
 					),
 				},
 				serviceType: "notify",
@@ -5843,7 +5878,8 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		const egressSecretFile = writeEgressSecretFile(manifest, secretValues, paths);
+		const resolvedEgressSecretValues = resolveEgressSecretValues(manifest, secretValues, paths);
+		const egressSecretFile = writeEgressSecretFile(resolvedEgressSecretValues, paths);
 		const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 		const egressSystemdProgram = runtimeEgressSystemdProgram(
 			manifest,
@@ -6125,6 +6161,7 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			daemonAuthTokenFile,
 			secretValues,
+			resolvedEgressSecretValues,
 			providerProjectionRevisions,
 			commonSystemdEnvironment,
 		);

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import {
 	chmodSync,
+	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	statSync,
@@ -31,6 +35,39 @@ const goldenPath = resolve(
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];
+
+function readFileTree(root: string): string {
+	if (!existsSync(root)) return "";
+	const stat = lstatSync(root);
+	if (stat.isSymbolicLink()) return "";
+	if (stat.isFile()) return readFileSync(root, "utf-8");
+	if (!stat.isDirectory()) return "";
+	return readdirSync(root)
+		.sort()
+		.map((entry) => readFileTree(join(root, entry)))
+		.join("\n");
+}
+
+function validateGeneratedEgressConfig(addonPath: string, envFilePath: string): void {
+	execFileSync(
+		"python3",
+		[
+			"-c",
+			[
+				"import importlib.util",
+				"import sys",
+				"spec = importlib.util.spec_from_file_location('clawdi_egress_addon_test', sys.argv[1])",
+				"module = importlib.util.module_from_spec(spec)",
+				"spec.loader.exec_module(module)",
+				"addon = module.ClawdiEgressAddon()",
+				"addon.reload_from_environment({'CLAWDI_EGRESS_ENV_FILE': sys.argv[2]})",
+			].join("\n"),
+			addonPath,
+			envFilePath,
+		],
+		{ stdio: "pipe" },
+	);
+}
 
 afterEach(() => {
 	process.env = { ...originalEnv };
@@ -262,7 +299,7 @@ describe("hosted runtime bundle v2", () => {
 		).toBe(3);
 	});
 
-	test("keeps live-sync channel bindings applicable from the runtime watch service", () => {
+	test("resolves canonical auth for fresh boot and watcher reconcile without widening secret scope", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-watch-"));
 		roots.push(root);
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
@@ -271,16 +308,33 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 		process.env.CLAWDI_HOME = join(root, "clawdi-home");
 		process.env.HOME = process.env.CLAWDI_RUNTIME_HOME;
-		process.env.CLAWDI_AUTH_TOKEN = "test-token";
-		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
+		process.env.CLAWDI_AUTH_TOKEN = "";
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_BOOTSTRAP_AUTH_TOKEN";
+		process.env.CLAWDI_BOOTSTRAP_AUTH_TOKEN = "deployment-auth-token";
 		process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const openclawBin = join(paths.userHome, ".openclaw", "bin", "openclaw");
+		const openclawConfigPath = join(paths.userHome, ".openclaw", "openclaw.json");
 		const channelPatchPath = join(root, "openclaw-channel-patch.json");
 		const mcpSecretRef = "secret://mcp/sidecar-only/token";
 		const mcpSecret = "mcp-sidecar-only-secret";
+		const egressEngine = {
+			type: "mitmproxy",
+			version: "12.2.3",
+			url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+			sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
+		} as const;
+		const mitmdump = join(
+			paths.egressEngineMaintainedRoot,
+			egressEngine.version,
+			egressEngine.sha256,
+			"mitmdump",
+		);
+		mkdirSync(dirname(mitmdump), { recursive: true });
+		writeFileSync(mitmdump, "#!/usr/bin/env sh\nexit 0\n");
+		chmodSync(mitmdump, 0o755);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -292,11 +346,23 @@ describe("hosted runtime bundle v2", () => {
 				`  if [[ "$payload" == *'"channels"'* && "$payload" == *'"telegram"'* ]]; then`,
 				`    printf '%s\\n' "$payload" > '${channelPatchPath}'`,
 				"  fi",
+				'elif [[ "$1 $2" == "mcp set" ]]; then',
+				`  python3 - "$3" "$4" '${openclawConfigPath}' <<'PY'`,
+				"import json",
+				"import sys",
+				"name, payload, path = sys.argv[1:]",
+				"with open(path, encoding='utf-8') as handle:",
+				"    config = json.load(handle)",
+				"config.setdefault('mcp', {}).setdefault('servers', {})[name] = json.loads(payload)",
+				"with open(path, 'w', encoding='utf-8') as handle:",
+				"    json.dump(config, handle)",
+				"PY",
 				"fi",
 				"",
 			].join("\n"),
 		);
 		chmodSync(openclawBin, 0o700);
+		writeFileSync(openclawConfigPath, '{"mcp":{"servers":{}}}\n');
 
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
 			manifest: Record<string, unknown>;
@@ -305,8 +371,19 @@ describe("hosted runtime bundle v2", () => {
 		};
 		raw.manifest = {
 			...raw.manifest,
+			egressEngine,
 			mcp: {
 				servers: {
+					clawdi: {
+						url: "https://cloud-api.test/v1/mcp/clawdi",
+						transport: "streamable-http",
+						headers: {
+							Authorization: {
+								secretRef: "env://CLAWDI_AUTH_TOKEN",
+								prefix: "Bearer ",
+							},
+						},
+					},
 					"sidecar-only": {
 						url: "https://mcp.test/v1/service",
 						transport: "streamable-http",
@@ -345,6 +422,36 @@ describe("hosted runtime bundle v2", () => {
 		});
 
 		expect(result.installErrors).toEqual([]);
+		const egressSecretPath = join(paths.managedSecretRoot, "egress-secrets.json");
+		const profileBundle = JSON.parse(readFileSync(paths.egressProfileBundle, "utf-8")) as {
+			profiles: Array<{
+				id: string;
+				rewrite?: { setHeaders?: Record<string, { secretRef?: string }> };
+			}>;
+		};
+		const managedClawdiProfile = profileBundle.profiles.find(
+			(profile) => profile.id === "managed-mcp-clawdi",
+		);
+		const managedClawdiSecretRef =
+			managedClawdiProfile?.rewrite?.setHeaders?.Authorization?.secretRef;
+		expect(managedClawdiSecretRef).toBe("env://CLAWDI_AUTH_TOKEN");
+		const initialEgressSecrets = JSON.parse(readFileSync(egressSecretPath, "utf-8")) as Record<
+			string,
+			string
+		>;
+		expect(initialEgressSecrets[managedClawdiSecretRef ?? ""]).toBe("deployment-auth-token");
+		validateGeneratedEgressConfig(paths.egressAddon, paths.egressTransparentEnv);
+		const nativeMcpConfig = JSON.parse(readFileSync(openclawConfigPath, "utf-8")) as {
+			mcp: { servers: Record<string, unknown> };
+		};
+		expect(nativeMcpConfig.mcp.servers.clawdi).toEqual({
+			url: "https://cloud-api.test/v1/mcp/clawdi",
+			transport: "streamable-http",
+			headers: {
+				Authorization: `Bearer ${managedMcpHeaderPlaceholder("clawdi", "Authorization")}`,
+			},
+		});
+		expect(JSON.stringify(nativeMcpConfig)).not.toContain("deployment-auth-token");
 		const watchUnit = readFileSync(
 			join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
 			"utf-8",
@@ -355,7 +462,12 @@ describe("hosted runtime bundle v2", () => {
 		const watchEnv = readFileSync(watchEnvPath, "utf-8");
 		expect(watchEnv).toContain(gatewayTokenLine);
 		expect(statSync(watchEnvPath).mode & 0o777).toBe(0o600);
-		const sidecarOnlySecrets = ["sk-provider-golden", "123456789:telegram-agent-golden", mcpSecret];
+		const sidecarOnlySecrets = [
+			"deployment-auth-token",
+			"sk-provider-golden",
+			"123456789:telegram-agent-golden",
+			mcpSecret,
+		];
 		for (const secret of sidecarOnlySecrets) expect(watchEnv).not.toContain(secret);
 		expect(watchEnv).toContain("999999999:9ded1453047ec0a48ec3b735075f7448");
 		expect(
@@ -366,6 +478,19 @@ describe("hosted runtime bundle v2", () => {
 			readFileSync(paths.managedSecretCacheFile, "utf-8"),
 		].join("\n");
 		for (const secret of sidecarOnlySecrets) expect(persistentLastGood).not.toContain(secret);
+		for (const secret of sidecarOnlySecrets)
+			expect(readFileTree(paths.userHome)).not.toContain(secret);
+		const authTokenStat = statSync(paths.daemonAuthToken);
+		const egressSecretStat = statSync(egressSecretPath);
+		expect(authTokenStat.mode & 0o777).toBe(0o600);
+		expect(egressSecretStat.mode & 0o777).toBe(0o600);
+		expect(statSync(paths.managedSecretRoot).mode & 0o777).toBe(0o711);
+		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			expect(authTokenStat.uid).toBe(0);
+			expect(authTokenStat.gid).toBe(0);
+			expect(egressSecretStat.uid).toBe(10_002);
+			expect(egressSecretStat.gid).toBe(10_002);
+		}
 		expect(JSON.parse(readFileSync(channelPatchPath, "utf-8"))).toMatchObject({
 			channels: {
 				telegram: {
@@ -382,6 +507,49 @@ describe("hosted runtime bundle v2", () => {
 				},
 			},
 		});
+
+		const initialSidecarEnv = readFileSync(
+			join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
+			"utf-8",
+		);
+		const initialSidecarRevision = initialSidecarEnv.match(/^CLAWDI_RUNTIME_REV="([^"]+)"$/m)?.[1];
+		expect(initialSidecarRevision).toBeTruthy();
+		writeFileSync(paths.daemonAuthToken, "deployment-auth-token-rotated\n", { mode: 0o600 });
+		delete process.env.CLAWDI_BOOTSTRAP_AUTH_TOKEN;
+		const watched = convergeRuntimeManifest(load, paths, {
+			managedGatewayModelListFetcher: ({ baseUrl }) => ({
+				status: "ok",
+				endpoint: `${baseUrl}/models`,
+				models: [{ id: "gpt-test" }],
+			}),
+		});
+		expect(watched.installErrors).toEqual([]);
+		const reconciledEgressSecrets = JSON.parse(readFileSync(egressSecretPath, "utf-8")) as Record<
+			string,
+			string
+		>;
+		expect(reconciledEgressSecrets["env://CLAWDI_AUTH_TOKEN"]).toBe(
+			"deployment-auth-token-rotated",
+		);
+		validateGeneratedEgressConfig(paths.egressAddon, paths.egressTransparentEnv);
+		const reconciledSidecarEnv = readFileSync(
+			join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
+			"utf-8",
+		);
+		const reconciledSidecarRevision = reconciledSidecarEnv.match(
+			/^CLAWDI_RUNTIME_REV="([^"]+)"$/m,
+		)?.[1];
+		expect(reconciledSidecarRevision).toBeTruthy();
+		expect(reconciledSidecarRevision).not.toBe(initialSidecarRevision);
+		expect(reconciledSidecarEnv).not.toContain("deployment-auth-token-rotated");
+		expect(readFileSync(paths.daemonAuthToken, "utf-8")).toBe("deployment-auth-token-rotated\n");
+		const reconciledPersistentState = [
+			readFileSync(paths.manifestLastGood, "utf-8"),
+			readFileSync(paths.managedSecretCacheFile, "utf-8"),
+			readFileTree(paths.userHome),
+		].join("\n");
+		expect(reconciledPersistentState).not.toContain("deployment-auth-token");
+		expect(reconciledPersistentState).not.toContain("deployment-auth-token-rotated");
 	});
 
 	test("rejects unknown fields and dormant providers", () => {


### PR DESCRIPTION
## Summary

- resolve the canonical `env://CLAWDI_AUTH_TOKEN` egress ref from the root-owned runtime auth-token file at the sidecar materialization boundary
- hash the exact resolved egress secret map in the sidecar program revision so credential rotation restarts the addon
- preserve watcher-retained runtime `secretEnv` while keeping managed MCP, provider, and channel credentials out of watcher env and persistent caches
- bump the CLI patch version to 0.13.7

## Root cause

`runtimeSecretValue()` intentionally resolves `env://` refs only from `process.env`. Hosted bootstrap writes the deployment-selected credential to `/run/clawdi/secrets/auth-token`, while the runtime watcher explicitly clears `CLAWDI_AUTH_TOKEN` and uses that file for manifest fetches. Egress materialization used `resolveEnv: true` but had no explicit file-backed input, so the canonical managed MCP ref was omitted from `egress-secrets.json` on fresh boot and watcher reconcile.

The fix resolves only the canonical auth ref from the root-owned file and feeds that explicit value through the existing generic profile-ref scoping. The same resolved map is written to the sidecar-only bundle and hashed for the sidecar revision. Other egress refs retain their existing datasource or process-environment resolution.

## Verification

- `bun test --isolate --max-concurrency=1 src/runtime/runtime-bundle-v2.test.ts src/runtime/manifest-services.test.ts src/runtime/manifest-reconciliation.test.ts` (191 pass)
- focused runtime datasource tests for canonical file fetch, MCP projection, and sidecar-only provider secrets (4 pass)
- Python egress addon unit tests (17 pass)
- CLI `tsc --noEmit`
- focused Biome check
- publish manifest check

The new bundle-v2 regression exercises initial convergence and a watcher-style reconcile with `CLAWDI_AUTH_TOKEN` cleared, validates the generated bundle through the actual Python addon, verifies placeholder-only native config, checks cache and HOME exclusion, verifies file modes and root/egress ownership when running as root, and proves token rotation changes the sidecar revision.
