### PR TITLE
fix(cli): await tar extraction stream closure

### DIFF
--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -64,9 +64,9 @@ export const SKILL_TAR_EXCLUDE = new Set([
  *
  * Use this instead of `tar.extract({...}).end(bytes)` — `.end()` returns the
  * stream (not a promise), so `await tar.extract(...).end(bytes)` resolves
- * before extraction actually completes, leaving callers in a race with the
- * filesystem. tar's Unpack contract emits `close` once it is done writing to
- * the filesystem, including closing the entry WriteStreams.
+ * immediately, before extraction completes. tar's public Unpack completion
+ * boundary is `close`, emitted in a finalization microtask after `finish` and
+ * `end`; waiting for `finish` lets the caller resume before that finalization.
  */
 export function extractTarGz(cwd: string, bytes: Buffer): Promise<void> {
 	return new Promise((resolvePromise, reject) => {

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -65,8 +65,8 @@ export const SKILL_TAR_EXCLUDE = new Set([
  * Use this instead of `tar.extract({...}).end(bytes)` — `.end()` returns the
  * stream (not a promise), so `await tar.extract(...).end(bytes)` resolves
  * before extraction actually completes, leaving callers in a race with the
- * filesystem. This helper listens for `finish` so the promise resolves only
- * after every entry has been written to disk.
+ * filesystem. tar's Unpack contract emits `close` once it is done writing to
+ * the filesystem, including closing the entry WriteStreams.
  */
 export function extractTarGz(cwd: string, bytes: Buffer): Promise<void> {
 	return new Promise((resolvePromise, reject) => {
@@ -79,7 +79,7 @@ export function extractTarGz(cwd: string, bytes: Buffer): Promise<void> {
 				return type !== "SymbolicLink" && type !== "Link";
 			},
 		});
-		stream.on("finish", () => resolvePromise());
+		stream.on("close", () => resolvePromise());
 		stream.on("error", reject);
 		stream.end(bytes);
 	});


### PR DESCRIPTION
## Summary

- wait for `tar` Unpack's public `close` completion boundary instead of `finish`
- prevent callers from resuming during Unpack's `finish`/`end` to `close` finalization window
- keep Bun, CI workflow, lockfile, sync behavior, and adapter behavior unchanged

## Evidence and precise conclusion

In the exact installed `tar@7.5.19` source:

- an entry file's successful internal `fs.close` callback calls `UNPEND` ([source](https://github.com/isaacs/node-tar/blob/v7.5.19/src/unpack.ts#L530-L539));
- Unpack emits `prefinish`, `finish`, and `end` only after `ENDED && PENDING === 0` ([source](https://github.com/isaacs/node-tar/blob/v7.5.19/src/unpack.ts#L244-L250));
- Parser's `end` listener queues `close` in a microtask ([listener](https://github.com/isaacs/node-tar/blob/v7.5.19/src/parse.ts#L159-L161), [queue](https://github.com/isaacs/node-tar/blob/v7.5.19/src/parse.ts#L281-L283)).

The exact-version probe produced:

```text
event:finish
event:end
caller:after-await-finish
event:close
```

FD count and Bun active handles were unchanged at every sampled point. This PR therefore does **not** claim that entry file descriptors or entry WriteStreams remain open after `finish`. It establishes the narrower issue: resolving at `finish` resumes the caller before Unpack's `close`/finalization microtask, while `tar@7.5.19` documents `close` as its completed-filesystem-work boundary ([public contract](https://github.com/isaacs/node-tar/blob/v7.5.19/README.md#class-unpack)).

The GitHub failures occur around these tar extraction tests and Bun 1.3.14/Linux reports `EEXIST: file already exists, epoll_ctl`. Bun propagates `epoll_ctl` registration errors ([source](https://github.com/oven-sh/bun/blob/e532ad91f306eecb3bd1619779daca3a739135c2/src/io/posix_event_loop.rs#L692-L703)). The probe does not independently prove that this finalization window is sufficient to cause EEXIST; it proves a repository lifecycle mismatch compatible with the observed low-frequency runtime race. Bun 1.3.14 remains the latest published release, so no released upgrade supersedes this lifecycle correction.

## Baseline vs after

The identical focused command ran for 100 consecutive iterations on each revision under Bun 1.3.14 with `--isolate --max-concurrency=1`:

| Revision | Iterations | Tests | Failures |
| --- | ---: | ---: | ---: |
| `origin/main` baseline (`finish`) | 100 | 6,800 | 0 (0%) |
| PR (`close`) | 100 | 6,800 | 0 (0%) |

The GitHub-runner flake did not reproduce on this host. The after-only green result is not statistical proof; the change is justified by matching tar's documented completion boundary.

Additional verification:

- exact Client CI command: 1,193 passed
- isolated Docker clean CLI suite, including typecheck: 1,193 passed
- focused suite after comment correction: 68 passed
- pre-commit Biome check: passed

## Why not `sync: true`

A probe used a 25,176,889-byte incompressible archive, close to the service's 25 MB archive limit:

| Mode | Extraction time (3 runs) | Zero-delay timer observed at |
| --- | --- | --- |
| async, await `close` | 300 / 198 / 148 ms | 47 / 34 / 31 ms |
| `sync: true` | 66 / 62 / 47 ms | 67 / 62 / 47 ms |

`sync: true` is simpler, retained the same filter, and was faster in this probe. However, it blocks the event loop for the full filesystem operation; this helper is also used by daemon/sync flows, and compressed archive size does not tightly bound extracted filesystem work. Awaiting async `close` preserves the Promise interface and avoids introducing synchronous disk I/O into those paths.
