### PR TITLE
fix(cli): repair cached mitmproxy directory permissions

### DIFF
--- a/packages/cli/src/runtime/mitmproxy-fetch.ts
+++ b/packages/cli/src/runtime/mitmproxy-fetch.ts
@@ -54,6 +54,7 @@ export function ensureRuntimeMitmproxy(
 		const cacheDir = join(paths.egressEngineMaintainedRoot, pin.version, normalizedSha);
 		const binaryPath = join(cacheDir, "mitmdump");
 		if (isExecutableFile(binaryPath)) {
+			rootOwnedBestEffort(dirname(paths.egressEngineMaintainedRoot));
 			return ready(pin, cacheDir, binaryPath);
 		}
 

--- a/packages/cli/tests/runtime-mitmproxy-fetch.test.ts
+++ b/packages/cli/tests/runtime-mitmproxy-fetch.test.ts
@@ -70,6 +70,52 @@ describe("runtime egress engine maintained fetch", () => {
 		expect(second.binaryPath).toBe(first.binaryPath);
 	});
 
+	it("repairs legacy egress engine directory permissions on a cache hit", () => {
+		const paths = runtimePaths();
+		const pin = {
+			type: "mitmproxy" as const,
+			version: "12.2.3",
+			url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+			sha256: "a".repeat(64),
+		};
+		const egressEngineRoot = dirname(paths.egressEngineMaintainedRoot);
+		const versionRoot = join(paths.egressEngineMaintainedRoot, pin.version);
+		const cacheDir = join(versionRoot, pin.sha256);
+		const binaryPath = join(cacheDir, "mitmdump");
+		const unrelatedPrivateDir = join(paths.maintainedRoot, "private");
+		const unrelatedPrivateFile = join(unrelatedPrivateDir, "secret");
+
+		mkdirSync(cacheDir, { recursive: true, mode: 0o755 });
+		writeFileSync(binaryPath, "cached mitmdump", { mode: 0o755 });
+		chmodSync(binaryPath, 0o755);
+		mkdirSync(unrelatedPrivateDir, { mode: 0o700 });
+		writeFileSync(unrelatedPrivateFile, "private", { mode: 0o600 });
+		chmodSync(unrelatedPrivateDir, 0o700);
+		chmodSync(unrelatedPrivateFile, 0o600);
+		chmodSync(egressEngineRoot, 0o700);
+		expect(statSync(egressEngineRoot).mode & 0o777).toBe(0o700);
+
+		const result = ensureRuntimeMitmproxy(pin, paths, {
+			downloadCommand: "missing-curl-for-cache-hit",
+		});
+
+		expect(result.status).toBe("ready");
+		if (result.status !== "ready") throw new Error(result.error);
+		expect(result.binaryPath).toBe(binaryPath);
+		expect(statSync(egressEngineRoot).mode & 0o777).toBe(0o755);
+		for (const path of [
+			egressEngineRoot,
+			paths.egressEngineMaintainedRoot,
+			versionRoot,
+			cacheDir,
+		]) {
+			expect(statSync(path).mode & 0o005).toBe(0o005);
+		}
+		expect(statSync(binaryPath).mode & 0o005).toBe(0o005);
+		expect(statSync(unrelatedPrivateDir).mode & 0o777).toBe(0o700);
+		expect(statSync(unrelatedPrivateFile).mode & 0o777).toBe(0o600);
+	});
+
 	it("degrades instead of installing on checksum mismatch", () => {
 		const { archive } = makeMitmproxyArchive();
 		const paths = runtimePaths();


### PR DESCRIPTION
## Summary

- converge the public, regenerable `maintained/egress-engine` directory to `0755` before returning a valid mitmproxy cache hit
- add regression coverage for a persisted legacy cache with a `0700` ancestor and an existing executable
- verify traversal/read bits for the unprivileged egress process while unrelated private directory and file modes remain unchanged

## Root cause

`ensureRuntimeMitmproxy()` returned immediately when the pinned `mitmdump` executable already existed. Permission convergence only ran after a fresh download, so a persistent cache created by an older runtime could retain `maintained/egress-engine` as `0700`. After the egress sidecar began dropping mitmproxy to UID 10002, that UID could not traverse the ancestor and read the official PyInstaller binary archive.

## Tests

- `scripts/test.sh cli tests/runtime-mitmproxy-fetch.test.ts` (Docker clean runner; CLI TypeScript typecheck passed, 6 tests passed)
- `node_modules/.bin/biome check packages/cli/src/runtime/mitmproxy-fetch.ts packages/cli/tests/runtime-mitmproxy-fetch.test.ts`
- `git diff --check`

## Safety

No hosted-repo changes, production or tenant operations, releases, or merges were performed.