### PR TITLE
fix(deploy): declare Clerk backend secret

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -139,6 +139,12 @@ def test_production_stack_assigns_runtime_roles():
         assert app_env == {"CLAWDI_PROCESS_ROLE": role}, app_name
 
 
+def test_coolify_env_manifest_declares_optional_clerk_secret():
+    module = _load_audit_module()
+
+    assert "CLERK_SECRET_KEY" in module.parse_env_manifest(COOLIFY_DIR / ".env.example")
+
+
 def test_audit_env_accepts_shared_manifest_and_application_env(monkeypatch):
     module = _load_audit_module()
 

--- a/infra/deploy/coolify/.env.example
+++ b/infra/deploy/coolify/.env.example
@@ -6,6 +6,7 @@
 
 ADMIN_API_KEY=
 CLERK_PEM_PUBLIC_KEY=replace-with-clerk-pem
+CLERK_SECRET_KEY=
 COMPOSIO_API_KEY=
 CORS_ORIGINS=["https://app.example.com"]
 DATABASE_URL=postgresql+asyncpg://<user>:<password>@host.docker.internal:5432/<database>


### PR DESCRIPTION
## Summary

- declare the existing optional Clerk backend secret in the Coolify shared environment contract
- add regression coverage for the manifest key
- keep the secret value entirely in Coolify; no value is committed or exposed

## Root cause

The production applications already had the valid runtime-only shared `CLERK_SECRET_KEY`, but `infra/deploy/coolify/.env.example` did not declare it. Post-deploy audit therefore reported the healthy, correct-revision applications as drift.

## Verification

- `bash scripts/test.sh backend tests/test_coolify_runtime_deploy.py` — 18 passed
- prior failed deployment audit confirmed both applications healthy and on expected commit; only the undeclared key failed
