### PR TITLE
fix(deploy): hide system providers from saved picker

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -157,7 +157,7 @@ describe("AI provider binding fields", () => {
 		}
 	});
 
-	test("rejects a managed secondary in a saved provider pool", () => {
+	test("keeps saved primary with managed and another saved provider in the ordered pool", () => {
 		const draft = {
 			bindingMode: "configured" as const,
 			providerChoices: [oauthProvider.provider_id, MANAGED_AI_CHOICE, apiKeyProvider.provider_id],
@@ -166,13 +166,23 @@ describe("AI provider binding fields", () => {
 		};
 
 		for (const mode of ["create", "update"] as const) {
-			expect(() =>
-				buildAiBindingFields(draft, {
-					managedModels,
-					mode,
-					providers: [apiKeyProvider, oauthProvider],
-				}),
-			).toThrow("cannot be used as a saved provider");
+			const fields = buildAiBindingFields(draft, {
+				managedModels,
+				mode,
+				providers: [apiKeyProvider, oauthProvider],
+			});
+			expect(fields.provider_ids).toEqual([
+				oauthProvider.provider_id,
+				MANAGED_PROVIDER_ID,
+				apiKeyProvider.provider_id,
+			]);
+			expect(fields.primary_model).toEqual({
+				provider_id: oauthProvider.provider_id,
+				model: "gpt-custom",
+			});
+			expect(
+				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
+			).toEqual([oauthProvider.provider_id, apiKeyProvider.provider_id]);
 		}
 	});
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -157,7 +157,7 @@ describe("AI provider binding fields", () => {
 		}
 	});
 
-	test("keeps saved primary with managed and another saved provider in the ordered pool", () => {
+	test("rejects a managed secondary in a saved provider pool", () => {
 		const draft = {
 			bindingMode: "configured" as const,
 			providerChoices: [oauthProvider.provider_id, MANAGED_AI_CHOICE, apiKeyProvider.provider_id],
@@ -166,23 +166,13 @@ describe("AI provider binding fields", () => {
 		};
 
 		for (const mode of ["create", "update"] as const) {
-			const fields = buildAiBindingFields(draft, {
-				managedModels,
-				mode,
-				providers: [apiKeyProvider, oauthProvider],
-			});
-			expect(fields.provider_ids).toEqual([
-				oauthProvider.provider_id,
-				MANAGED_PROVIDER_ID,
-				apiKeyProvider.provider_id,
-			]);
-			expect(fields.primary_model).toEqual({
-				provider_id: oauthProvider.provider_id,
-				model: "gpt-custom",
-			});
-			expect(
-				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
-			).toEqual([oauthProvider.provider_id, apiKeyProvider.provider_id]);
+			expect(() =>
+				buildAiBindingFields(draft, {
+					managedModels,
+					mode,
+					providers: [apiKeyProvider, oauthProvider],
+				}),
+			).toThrow("cannot be used as a saved provider");
 		}
 	});
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.test.ts
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { CLAWDI_MANAGED_V1_PROVIDER_ID } from "@clawdi/shared";
+import type { AiProvider, AiProviderList } from "@/hosted/v2/ai-providers/types";
+
+type SelectUserAiProviders =
+	typeof import("@/hosted/v2/ai-providers/ai-providers-hooks").selectUserAiProviders;
+
+let selectUserAiProvidersImplementation: SelectUserAiProviders | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	selectUserAiProvidersImplementation = (
+		await import("@/hosted/v2/ai-providers/ai-providers-hooks")
+	).selectUserAiProviders;
+});
+
+function selectUserAiProviders(data: AiProviderList): AiProvider[] {
+	if (!selectUserAiProvidersImplementation) throw new Error("Provider selector was not loaded.");
+	return selectUserAiProvidersImplementation(data);
+}
+
+function provider(providerId: string, managedBy: AiProvider["managed_by"]): AiProvider {
+	return {
+		id: `row-${providerId}`,
+		provider_id: providerId,
+		scope: "account_global",
+		type: "openai",
+		label: providerId,
+		base_url: "https://provider.example.test/v1",
+		managed_by: managedBy,
+		auth: { type: "api_key", source: "managed" },
+		usable: true,
+		created_at: "2026-07-28T00:00:00Z",
+		updated_at: "2026-07-28T00:00:00Z",
+	};
+}
+
+describe("user AI provider query projection", () => {
+	test("keeps Web provider surfaces aligned with the shared selectable inventory", () => {
+		const userProvider = provider("openai-team", "user");
+		const inventory = {
+			providers: [
+				provider(CLAWDI_MANAGED_V1_PROVIDER_ID, "user"),
+				provider("custom-managed-id", "clawdi"),
+				userProvider,
+			],
+		} satisfies AiProviderList;
+
+		expect(selectUserAiProviders(inventory)).toEqual([userProvider]);
+		expect(inventory.providers).toHaveLength(3);
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
+import { projectUserSelectableAiProviders } from "@clawdi/shared";
 import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
@@ -14,8 +14,8 @@ import { useSensitiveAction } from "@/lib/use-sensitive-action";
 /** Typed data hooks for the AI Providers surface (cloud-api `/v1/ai-providers`). */
 
 const KEY = ["ai-providers"] as const;
-const selectUserAiProviders = (data: AiProviderList) =>
-	data.providers.filter((provider) => !isFirstPartyManagedAiProvider(provider));
+export const selectUserAiProviders = (data: AiProviderList) =>
+	projectUserSelectableAiProviders(data.providers);
 
 function aiProvidersQueryOptions(api: ReturnType<typeof useApi>) {
 	return queryOptions({

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.8",
+	"version": "0.13.9",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as p from "@clack/prompts";
+import { projectUserSelectableAiProviders } from "@clawdi/shared";
 import {
 	buildHostedAiBindingFields,
 	buildHostedDeployCheckoutRequest,
@@ -629,12 +630,13 @@ export async function runDeployFlow(
 				return [];
 			})
 		: Promise.resolve([]);
-	const [plans, deployments, managedModels, savedProviders] = await Promise.all([
+	const [plans, deployments, managedModels, savedProviderInventory] = await Promise.all([
 		dependencies.client.getPlans(),
 		dependencies.client.listDeployments(),
 		needsManagedModels ? dependencies.client.getManagedModels() : Promise.resolve([]),
 		savedProvidersPromise,
 	]);
+	const savedProviders = projectUserSelectableAiProviders(savedProviderInventory);
 
 	let runtime = parsed.runtime ?? DEFAULT_HOSTED_DEPLOY_RUNTIME;
 	if (interactive && !parsed.runtime) {

--- a/packages/cli/tests/commands/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import {
+	CLAWDI_MANAGED_PROVIDER_ID,
+	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
+} from "@clawdi/shared";
 import type {
 	HostedDeployCheckoutRequest,
 	HostedDeployCheckoutResult,
@@ -71,6 +78,7 @@ function savedProvider(
 	providerId: string,
 	options: {
 		auth?: HostedSavedAiProvider["auth"];
+		managedBy?: HostedSavedAiProvider["managed_by"];
 		models?: HostedSavedAiProvider["models"];
 		usable?: boolean;
 	} = {},
@@ -82,7 +90,7 @@ function savedProvider(
 		label: `Provider ${providerId}`,
 		base_url: "https://provider.example.test/v1",
 		api_mode: "openai_responses",
-		managed_by: "user",
+		managed_by: options.managedBy ?? "user",
 		scope: "account_global",
 		auth: options.auth ?? {
 			type: "api_key",
@@ -477,6 +485,47 @@ describe("deploy orchestration", () => {
 		expect(JSON.stringify(notes)).not.toContain("secret upstream detail");
 	});
 
+	test("interactive provider choices use the shared user-selectable projection", async () => {
+		const client = new FakeDeployGateway();
+		client.savedProviders = [
+			savedProvider(CLAWDI_MANAGED_V1_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID),
+			savedProvider(`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`),
+			savedProvider("custom-managed-id", { managedBy: "clawdi" }),
+			savedProvider("openai-team"),
+		];
+		let providerChoices: readonly string[] = [];
+		const prompts: DeployPromptAdapter = {
+			...noUnexpectedPrompts,
+			async select(message, options) {
+				if (message === "AI provider") {
+					providerChoices = options.map((option) => option.value);
+					return "openai-team";
+				}
+				if (message === "Primary model") return "gpt-saved";
+				throw new Error(`Unexpected select prompt: ${message}`);
+			},
+		};
+
+		await runDeployFlow(
+			parseDeployCommandOptions({
+				runtime: "hermes",
+				compute: "basic",
+				name: "Hermes",
+				language: "default",
+				timezone: "Etc/UTC",
+				yes: true,
+				wait: false,
+			}),
+			{ client, interactive: true, prompts },
+		);
+
+		expect(providerChoices).toEqual(["managed", "openai-team", "unmanaged"]);
+		expect(client.created?.body.ai_provider_id).toBe("openai-team");
+	});
+
 	test("exact saved provider selection fails closed when metadata cannot load", async () => {
 		const client = new FakeDeployGateway();
 		client.getSavedAiProviders = async () => {
@@ -498,6 +547,35 @@ describe("deploy orchestration", () => {
 		).rejects.toThrow("Saved AI provider metadata could not be loaded");
 		expect(client.created).toBeNull();
 		expect(client.savedProviderReads).toBe(1);
+	});
+
+	test("exact provider ids cannot bypass the user-selectable projection", async () => {
+		const managedProviders = [
+			savedProvider(CLAWDI_MANAGED_V1_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID),
+			savedProvider(CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID),
+			savedProvider(`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`),
+			savedProvider("custom-managed-id", { managedBy: "clawdi" }),
+		];
+
+		for (const provider of managedProviders) {
+			const client = new FakeDeployGateway();
+			client.savedProviders = [provider];
+			await expect(
+				runDeployFlow(
+					parseDeployCommandOptions({
+						provider: provider.provider_id,
+						model: "gpt-saved",
+						compute: "basic",
+						requestId: "123e4567-e89b-42d3-a456-426614174084",
+						yes: true,
+					}),
+					{ client, interactive: false },
+				),
+			).rejects.toMatchObject({ code: "provider_missing" });
+			expect(client.created).toBeNull();
+		}
 	});
 
 	test("binds exact saved API-key and Codex OAuth providers without credential material", async () => {

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -14,6 +14,7 @@ import {
 	isClawdiManagedV2ProviderId,
 	isFirstPartyManagedAiProvider,
 	isProviderAuthProfileId,
+	projectUserSelectableAiProviders,
 	validateAiProviderCatalog,
 } from "./ai-provider";
 import type { components } from "./api/api.generated";
@@ -422,6 +423,22 @@ describe("isFirstPartyManagedAiProvider", () => {
 		expect(isFirstPartyManagedAiProvider({ provider_id: "openai-prod", managed_by: "user" })).toBe(
 			false,
 		);
+	});
+
+	test("projects only user-selectable providers without changing the inventory", () => {
+		const userProvider = { provider_id: "openai-prod", managed_by: "user" };
+		const providers = [
+			userProvider,
+			{ provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID },
+			{ provider_id: CLAWDI_MANAGED_PROVIDER_ID },
+			{ provider_id: CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID },
+			{ provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID },
+			{ provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42` },
+			{ provider_id: "managed-with-custom-id", managed_by: "clawdi" },
+		];
+
+		expect(projectUserSelectableAiProviders(providers)).toEqual([userProvider]);
+		expect(providers).toHaveLength(7);
 	});
 });
 

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -227,6 +227,12 @@ export function isFirstPartyManagedAiProvider(provider: AiProviderManagedIdentit
 	);
 }
 
+export function projectUserSelectableAiProviders<T extends AiProviderManagedIdentity>(
+	providers: readonly T[],
+): T[] {
+	return providers.filter((provider) => !isFirstPartyManagedAiProvider(provider));
+}
+
 export function isAiProviderId(input: string): boolean {
 	return PROVIDER_ID_RE.test(input);
 }

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { CLAWDI_MANAGED_PROVIDER_ID } from "../ai-provider";
+import {
+	CLAWDI_MANAGED_PROVIDER_ID,
+	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
+} from "../ai-provider";
 import {
 	buildHostedAiBindingFields,
 	buildHostedAiProviderPoolBootstrap,
@@ -172,7 +178,7 @@ describe("shared Hosted AI provider binding", () => {
 		}
 	});
 
-	test("preserves a saved primary with managed and saved secondary providers", () => {
+	test("preserves a saved primary with another saved provider", () => {
 		for (const mode of ["create", "update"] as const) {
 			const fields = buildHostedAiBindingFields({
 				managedModels,
@@ -182,19 +188,11 @@ describe("shared Hosted AI provider binding", () => {
 					mode: "saved",
 					model: "gpt-codex",
 					primaryProviderId: codexProvider.provider_id,
-					providerIds: [
-						codexProvider.provider_id,
-						CLAWDI_MANAGED_PROVIDER_ID,
-						secondaryProvider.provider_id,
-					],
+					providerIds: [codexProvider.provider_id, secondaryProvider.provider_id],
 				},
 			});
 
-			expect(fields.provider_ids).toEqual([
-				"codex-main",
-				CLAWDI_MANAGED_PROVIDER_ID,
-				"openai-secondary",
-			]);
+			expect(fields.provider_ids).toEqual(["codex-main", "openai-secondary"]);
 			expect(fields.primary_model).toEqual({ provider_id: "codex-main", model: "gpt-codex" });
 			expect(fields.ai_provider_id).toBe("codex-main");
 			expect(fields.ai_provider_auth_kind).toBe("codex_oauth");
@@ -204,6 +202,69 @@ describe("shared Hosted AI provider binding", () => {
 				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
 			).toEqual(["codex-main", "openai-secondary"]);
 		}
+	});
+
+	test("rejects first-party managed providers anywhere in a saved provider pool", () => {
+		const managedProviders: HostedSavedAiProvider[] = [
+			{ ...apiKeyProvider, id: "row-v1", provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID },
+			{ ...apiKeyProvider, id: "row-v2", provider_id: CLAWDI_MANAGED_PROVIDER_ID },
+			{
+				...apiKeyProvider,
+				id: "row-legacy-public",
+				provider_id: CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
+			},
+			{
+				...apiKeyProvider,
+				id: "row-legacy",
+				provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+			},
+			{
+				...apiKeyProvider,
+				id: "row-deployment",
+				provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
+			},
+			{
+				...apiKeyProvider,
+				id: "row-managed-by",
+				provider_id: "custom-managed-id",
+				managed_by: "clawdi",
+			},
+		];
+
+		for (const provider of managedProviders) {
+			try {
+				buildHostedAiBindingFields({
+					managedModels,
+					mode: "create",
+					providers: [provider],
+					selection: {
+						mode: "saved",
+						providerIds: [provider.provider_id],
+						primaryProviderId: provider.provider_id,
+						model: "gpt-catalog",
+					},
+				});
+				throw new Error(`Expected ${provider.provider_id} to be rejected.`);
+			} catch (error) {
+				expect(error).toBeInstanceOf(HostedAiBindingError);
+				if (!(error instanceof HostedAiBindingError)) throw error;
+				expect(error.code).toBe("first_party_managed_provider");
+			}
+		}
+
+		expect(() =>
+			buildHostedAiBindingFields({
+				managedModels,
+				mode: "create",
+				providers: [apiKeyProvider],
+				selection: {
+					mode: "saved",
+					providerIds: [apiKeyProvider.provider_id, CLAWDI_MANAGED_PROVIDER_ID],
+					primaryProviderId: apiKeyProvider.provider_id,
+					model: "gpt-catalog",
+				},
+			}),
+		).toThrow("cannot be used as a saved provider");
 	});
 
 	test("rejects missing, unusable, and unknown managed selections", () => {

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -178,36 +178,90 @@ describe("shared Hosted AI provider binding", () => {
 		}
 	});
 
-	test("preserves a saved primary with another saved provider", () => {
-		for (const mode of ["create", "update"] as const) {
-			const fields = buildHostedAiBindingFields({
-				managedModels,
-				mode,
-				providers: [apiKeyProvider, codexProvider, secondaryProvider],
-				selection: {
-					mode: "saved",
-					model: "gpt-codex",
-					primaryProviderId: codexProvider.provider_id,
-					providerIds: [codexProvider.provider_id, secondaryProvider.provider_id],
-				},
-			});
+	test("preserves a canonical managed secondary without materializing it in saved bootstrap", () => {
+		const canonicalManagedProvider = {
+			...apiKeyProvider,
+			id: "row-managed-v2",
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+			managed_by: "clawdi",
+		} satisfies HostedSavedAiProvider;
 
-			expect(fields.provider_ids).toEqual(["codex-main", "openai-secondary"]);
-			expect(fields.primary_model).toEqual({ provider_id: "codex-main", model: "gpt-codex" });
-			expect(fields.ai_provider_id).toBe("codex-main");
-			expect(fields.ai_provider_auth_kind).toBe("codex_oauth");
-			expect(fields.ai_provider_bootstrap?.selected_provider_id).toBe("codex-main");
-			expect(fields.ai_provider_bootstrap?.auth_kind).toBe("codex_oauth");
-			expect(
-				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
-			).toEqual(["codex-main", "openai-secondary"]);
+		for (const includeCanonicalRow of [false, true]) {
+			for (const mode of ["create", "update"] as const) {
+				const fields = buildHostedAiBindingFields({
+					managedModels,
+					mode,
+					providers: [
+						apiKeyProvider,
+						codexProvider,
+						...(includeCanonicalRow ? [canonicalManagedProvider] : []),
+						secondaryProvider,
+					],
+					selection: {
+						mode: "saved",
+						model: "gpt-codex",
+						primaryProviderId: codexProvider.provider_id,
+						providerIds: [
+							codexProvider.provider_id,
+							CLAWDI_MANAGED_PROVIDER_ID,
+							secondaryProvider.provider_id,
+						],
+					},
+				});
+
+				expect(fields.provider_ids).toEqual([
+					"codex-main",
+					CLAWDI_MANAGED_PROVIDER_ID,
+					"openai-secondary",
+				]);
+				expect(fields.primary_model).toEqual({
+					provider_id: "codex-main",
+					model: "gpt-codex",
+				});
+				expect(fields.ai_provider_id).toBe("codex-main");
+				expect(fields.ai_provider_auth_kind).toBe("codex_oauth");
+				expect(fields.ai_provider_bootstrap?.selected_provider_id).toBe("codex-main");
+				expect(fields.ai_provider_bootstrap?.auth_kind).toBe("codex_oauth");
+				expect(
+					fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
+				).toEqual(["codex-main", "openai-secondary"]);
+			}
 		}
 	});
 
-	test("rejects first-party managed providers anywhere in a saved provider pool", () => {
+	test("rejects canonical managed provider as a saved primary with or without its row", () => {
+		const canonicalManagedProvider = {
+			...apiKeyProvider,
+			id: "row-managed-v2",
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+			managed_by: "clawdi",
+		} satisfies HostedSavedAiProvider;
+
+		for (const providers of [[], [canonicalManagedProvider]]) {
+			try {
+				buildHostedAiBindingFields({
+					managedModels,
+					mode: "create",
+					providers,
+					selection: {
+						mode: "saved",
+						providerIds: [CLAWDI_MANAGED_PROVIDER_ID],
+						primaryProviderId: CLAWDI_MANAGED_PROVIDER_ID,
+						model: "gpt-catalog",
+					},
+				});
+				throw new Error("Expected canonical managed provider primary to be rejected.");
+			} catch (error) {
+				expect(error).toBeInstanceOf(HostedAiBindingError);
+				if (!(error instanceof HostedAiBindingError)) throw error;
+				expect(error.code).toBe("first_party_managed_provider");
+			}
+		}
+	});
+
+	test("rejects noncanonical first-party managed providers anywhere in a saved pool", () => {
 		const managedProviders: HostedSavedAiProvider[] = [
 			{ ...apiKeyProvider, id: "row-v1", provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID },
-			{ ...apiKeyProvider, id: "row-v2", provider_id: CLAWDI_MANAGED_PROVIDER_ID },
 			{
 				...apiKeyProvider,
 				id: "row-legacy-public",
@@ -232,39 +286,29 @@ describe("shared Hosted AI provider binding", () => {
 		];
 
 		for (const provider of managedProviders) {
-			try {
-				buildHostedAiBindingFields({
-					managedModels,
-					mode: "create",
-					providers: [provider],
-					selection: {
-						mode: "saved",
-						providerIds: [provider.provider_id],
-						primaryProviderId: provider.provider_id,
-						model: "gpt-catalog",
-					},
-				});
-				throw new Error(`Expected ${provider.provider_id} to be rejected.`);
-			} catch (error) {
-				expect(error).toBeInstanceOf(HostedAiBindingError);
-				if (!(error instanceof HostedAiBindingError)) throw error;
-				expect(error.code).toBe("first_party_managed_provider");
+			for (const asPrimary of [false, true]) {
+				try {
+					buildHostedAiBindingFields({
+						managedModels,
+						mode: "create",
+						providers: [apiKeyProvider, provider],
+						selection: {
+							mode: "saved",
+							providerIds: asPrimary
+								? [provider.provider_id]
+								: [apiKeyProvider.provider_id, provider.provider_id],
+							primaryProviderId: asPrimary ? provider.provider_id : apiKeyProvider.provider_id,
+							model: "gpt-catalog",
+						},
+					});
+					throw new Error(`Expected ${provider.provider_id} to be rejected.`);
+				} catch (error) {
+					expect(error).toBeInstanceOf(HostedAiBindingError);
+					if (!(error instanceof HostedAiBindingError)) throw error;
+					expect(error.code).toBe("first_party_managed_provider");
+				}
 			}
 		}
-
-		expect(() =>
-			buildHostedAiBindingFields({
-				managedModels,
-				mode: "create",
-				providers: [apiKeyProvider],
-				selection: {
-					mode: "saved",
-					providerIds: [apiKeyProvider.provider_id, CLAWDI_MANAGED_PROVIDER_ID],
-					primaryProviderId: apiKeyProvider.provider_id,
-					model: "gpt-catalog",
-				},
-			}),
-		).toThrow("cannot be used as a saved provider");
 	});
 
 	test("rejects missing, unusable, and unknown managed selections", () => {

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -51,6 +51,31 @@ const secondaryProvider = {
 	models: [{ id: "gpt-secondary" }],
 } satisfies HostedSavedAiProvider;
 
+const noncanonicalManagedProviders: HostedSavedAiProvider[] = [
+	{ ...apiKeyProvider, id: "row-v1", provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID },
+	{
+		...apiKeyProvider,
+		id: "row-legacy-public",
+		provider_id: CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
+	},
+	{
+		...apiKeyProvider,
+		id: "row-legacy",
+		provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	},
+	{
+		...apiKeyProvider,
+		id: "row-deployment",
+		provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
+	},
+	{
+		...apiKeyProvider,
+		id: "row-managed-by",
+		provider_id: "custom-managed-id",
+		managed_by: "clawdi",
+	},
+];
+
 describe("shared Hosted AI provider binding", () => {
 	test("builds the same managed and unmanaged deployment fields for every adapter", () => {
 		expect(
@@ -178,6 +203,27 @@ describe("shared Hosted AI provider binding", () => {
 		}
 	});
 
+	test("rejects noncanonical first-party managed secondaries in a managed pool", () => {
+		for (const provider of noncanonicalManagedProviders) {
+			expect(() =>
+				buildHostedAiBindingFields({
+					managedModels,
+					mode: "create",
+					providers: [apiKeyProvider, provider],
+					selection: {
+						mode: "managed",
+						model: "gpt-managed",
+						providerIds: [
+							CLAWDI_MANAGED_PROVIDER_ID,
+							apiKeyProvider.provider_id,
+							provider.provider_id,
+						],
+					},
+				}),
+			).toThrow("cannot be used as a saved provider");
+		}
+	});
+
 	test("preserves a canonical managed secondary without materializing it in saved bootstrap", () => {
 		const canonicalManagedProvider = {
 			...apiKeyProvider,
@@ -260,32 +306,7 @@ describe("shared Hosted AI provider binding", () => {
 	});
 
 	test("rejects noncanonical first-party managed providers anywhere in a saved pool", () => {
-		const managedProviders: HostedSavedAiProvider[] = [
-			{ ...apiKeyProvider, id: "row-v1", provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID },
-			{
-				...apiKeyProvider,
-				id: "row-legacy-public",
-				provider_id: CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
-			},
-			{
-				...apiKeyProvider,
-				id: "row-legacy",
-				provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
-			},
-			{
-				...apiKeyProvider,
-				id: "row-deployment",
-				provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
-			},
-			{
-				...apiKeyProvider,
-				id: "row-managed-by",
-				provider_id: "custom-managed-id",
-				managed_by: "clawdi",
-			},
-		];
-
-		for (const provider of managedProviders) {
+		for (const provider of noncanonicalManagedProviders) {
 			for (const asPrimary of [false, true]) {
 				try {
 					buildHostedAiBindingFields({

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -1,6 +1,7 @@
 import {
 	type AiProviderCatalog,
 	CLAWDI_MANAGED_PROVIDER_ID,
+	isFirstPartyManagedAiProvider,
 	type AiProvider as RuntimeAiProvider,
 	type AiProviderAuth as RuntimeAiProviderAuth,
 	type AiProviderModel as RuntimeAiProviderModel,
@@ -38,6 +39,7 @@ export type HostedAiBindingOperationMode = "create" | "update";
 export class HostedAiBindingError extends Error {
 	readonly code:
 		| "invalid_provider_metadata"
+		| "first_party_managed_provider"
 		| "managed_model_unavailable"
 		| "model_required"
 		| "provider_missing"
@@ -165,7 +167,7 @@ export function buildHostedAiBindingFields({
 			selection.providerIds ?? [CLAWDI_MANAGED_PROVIDER_ID],
 			CLAWDI_MANAGED_PROVIDER_ID,
 		);
-		const customProviders = savedProvidersForIds(providerIds, providers);
+		const customProviders = savedProvidersForIds(providerIds, providers, "skip");
 		const fields: ReturnType<typeof buildHostedAiBindingFields> = {
 			ai_provider_auth_kind: "managed",
 			ai_provider_id: null,
@@ -190,7 +192,7 @@ export function buildHostedAiBindingFields({
 	}
 
 	const providerIds = selectedProviderIds(selection.providerIds, selection.primaryProviderId);
-	const selectedProviders = savedProvidersForIds(providerIds, providers);
+	const selectedProviders = savedProvidersForIds(providerIds, providers, "reject");
 	const primaryProvider = selectedProviders.find(
 		(provider) => provider.provider_id === selection.primaryProviderId,
 	);
@@ -220,25 +222,41 @@ function selectedProviderIds(providerIds: readonly string[], primaryProviderId: 
 function savedProvidersForIds(
 	providerIds: readonly string[],
 	providers: readonly HostedSavedAiProvider[],
+	firstPartyManaged: "reject" | "skip",
 ): HostedSavedAiProvider[] {
-	return providerIds
-		.filter((providerId) => providerId !== CLAWDI_MANAGED_PROVIDER_ID)
-		.map((providerId) => {
-			const provider = providers.find((candidate) => candidate.provider_id === providerId);
-			if (!provider) {
-				throw new HostedAiBindingError(
-					"provider_missing",
-					`Saved AI provider ${providerId} is unavailable. Refresh providers or choose another provider.`,
-				);
-			}
-			if (!provider.usable) {
-				throw new HostedAiBindingError(
-					"provider_unusable",
-					`${provider.label?.trim() || provider.provider_id} has no usable credential. Finish its setup or choose another provider.`,
-				);
-			}
-			return provider;
-		});
+	const selectedProviders: HostedSavedAiProvider[] = [];
+	for (const providerId of providerIds) {
+		if (isFirstPartyManagedAiProvider({ provider_id: providerId })) {
+			if (firstPartyManaged === "reject") throw firstPartyManagedProviderError(providerId);
+			continue;
+		}
+		const provider = providers.find((candidate) => candidate.provider_id === providerId);
+		if (!provider) {
+			throw new HostedAiBindingError(
+				"provider_missing",
+				`Saved AI provider ${providerId} is unavailable. Refresh providers or choose another provider.`,
+			);
+		}
+		if (isFirstPartyManagedAiProvider(provider)) {
+			if (firstPartyManaged === "reject") throw firstPartyManagedProviderError(providerId);
+			continue;
+		}
+		if (!provider.usable) {
+			throw new HostedAiBindingError(
+				"provider_unusable",
+				`${provider.label?.trim() || provider.provider_id} has no usable credential. Finish its setup or choose another provider.`,
+			);
+		}
+		selectedProviders.push(provider);
+	}
+	return selectedProviders;
+}
+
+function firstPartyManagedProviderError(providerId: string): HostedAiBindingError {
+	return new HostedAiBindingError(
+		"first_party_managed_provider",
+		`AI provider ${providerId} is managed by Clawdi and cannot be used as a saved provider. Choose managed AI instead.`,
+	);
 }
 
 function dedupeProviderIds(providerIds: readonly string[]): string[] {

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -192,7 +192,14 @@ export function buildHostedAiBindingFields({
 	}
 
 	const providerIds = selectedProviderIds(selection.providerIds, selection.primaryProviderId);
-	const selectedProviders = savedProvidersForIds(providerIds, providers, "reject");
+	if (selection.primaryProviderId === CLAWDI_MANAGED_PROVIDER_ID) {
+		throw firstPartyManagedProviderError(selection.primaryProviderId);
+	}
+	const selectedProviders = savedProvidersForIds(
+		providerIds.filter((providerId) => providerId !== CLAWDI_MANAGED_PROVIDER_ID),
+		providers,
+		"reject",
+	);
 	const primaryProvider = selectedProviders.find(
 		(provider) => provider.provider_id === selection.primaryProviderId,
 	);

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -167,7 +167,10 @@ export function buildHostedAiBindingFields({
 			selection.providerIds ?? [CLAWDI_MANAGED_PROVIDER_ID],
 			CLAWDI_MANAGED_PROVIDER_ID,
 		);
-		const customProviders = savedProvidersForIds(providerIds, providers, "skip");
+		const customProviders = savedProvidersForIds(
+			providerIds.filter((providerId) => providerId !== CLAWDI_MANAGED_PROVIDER_ID),
+			providers,
+		);
 		const fields: ReturnType<typeof buildHostedAiBindingFields> = {
 			ai_provider_auth_kind: "managed",
 			ai_provider_id: null,
@@ -198,7 +201,6 @@ export function buildHostedAiBindingFields({
 	const selectedProviders = savedProvidersForIds(
 		providerIds.filter((providerId) => providerId !== CLAWDI_MANAGED_PROVIDER_ID),
 		providers,
-		"reject",
 	);
 	const primaryProvider = selectedProviders.find(
 		(provider) => provider.provider_id === selection.primaryProviderId,
@@ -229,13 +231,11 @@ function selectedProviderIds(providerIds: readonly string[], primaryProviderId: 
 function savedProvidersForIds(
 	providerIds: readonly string[],
 	providers: readonly HostedSavedAiProvider[],
-	firstPartyManaged: "reject" | "skip",
 ): HostedSavedAiProvider[] {
 	const selectedProviders: HostedSavedAiProvider[] = [];
 	for (const providerId of providerIds) {
 		if (isFirstPartyManagedAiProvider({ provider_id: providerId })) {
-			if (firstPartyManaged === "reject") throw firstPartyManagedProviderError(providerId);
-			continue;
+			throw firstPartyManagedProviderError(providerId);
 		}
 		const provider = providers.find((candidate) => candidate.provider_id === providerId);
 		if (!provider) {
@@ -245,8 +245,7 @@ function savedProvidersForIds(
 			);
 		}
 		if (isFirstPartyManagedAiProvider(provider)) {
-			if (firstPartyManaged === "reject") throw firstPartyManagedProviderError(providerId);
-			continue;
+			throw firstPartyManagedProviderError(providerId);
 		}
 		if (!provider.usable) {
 			throw new HostedAiBindingError(


### PR DESCRIPTION
## Summary

- use one shared user-selectable AI-provider projection for Web and CLI deploy
- hide V1, V2, legacy, deployment-scoped, and `managed_by=clawdi` inventory rows from the saved-provider picker
- keep canonical `clawdi` only as the existing unmaterialized secondary pool member; reject it as saved primary and reject every noncanonical system identity
- bump the CLI patch release to `0.13.9`

## Compatibility

Cloud `/v1/ai-providers` remains the complete inventory. This changes only the V2 deploy selection projection. Existing managed-primary/saved-secondary and saved-primary/canonical-managed-secondary pool contracts remain intact.

## Verification

- shared focused: 50 passed
- CLI deploy: 34 passed in the isolated Docker runner, including CLI typecheck
- Web focused: 12 passed
- Shared, CLI, Web typecheck: passed
- Biome and `git diff --check`: passed

## Release impact

Merging publishes `clawdi@0.13.9` through the existing trusted-publisher workflow.
