### PR TITLE
fix(cli): migrate legacy pending share tokens

### DIFF
--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import * as p from "@clack/prompts";
+import type { components } from "@clawdi/shared/api";
 import chalk from "chalk";
 import { readJson } from "../lib/api-client";
 import { normalizeCloudApiBaseUrl } from "../lib/api-origin";
@@ -47,6 +48,15 @@ interface MeResponse {
 	name: string;
 }
 
+type ShareUpgradeResponse = components["schemas"]["ShareUpgradeResponse"];
+
+function shareDisplayName(token: ShareToken): string {
+	const name = typeof token.project_name === "string" ? token.project_name.trim() : "";
+	if (name) return name;
+	const projectId = typeof token.project_id === "string" ? token.project_id.trim() : "";
+	return projectId ? `Project ${projectId}` : "local share";
+}
+
 /**
  * Open a URL in the default browser. Best-effort: on headless machines or
  * when no opener is installed, the spawn silently no-ops and the user just
@@ -84,12 +94,20 @@ function postLoginHint() {
  * until done so a subsequent `clawdi project list` shows the new
  * project memberships deterministically.
  *
- * Per-token failures don't abort the loop; they print a reason and
- * the token stays in share-tokens.json for manual cleanup.
+ * Per-token failures don't abort the loop. Local entries stay available
+ * for retry or explicit `clawdi inbox forget` cleanup because the file
+ * does not record which API origin issued a token, so even a 404 from the
+ * current API cannot prove that the credential is globally stale.
  */
 async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise<void> {
-	const { listTokens, addToken } = await import("../share/tokens");
-	const tokens = listTokens().filter((t) => !t.upgraded_at);
+	const { readTokenStore, addToken } = await import("../share/tokens");
+	const store = readTokenStore();
+	for (const issue of store.issues) {
+		p.log.warn(
+			`Skipped malformed local share "${issue.label}": ${issue.reason} (entry kept for recovery)`,
+		);
+	}
+	const tokens = store.tokens.filter((t) => !t.upgraded_at);
 	if (tokens.length === 0) return;
 
 	// Parallel network round-trips, sequential disk writes. addToken
@@ -104,8 +122,9 @@ async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise
 
 	const outcomes = await Promise.all(
 		tokens.map(async (t): Promise<Outcome> => {
+			const name = shareDisplayName(t);
 			try {
-				const r = await fetch(`${apiUrl}/v1/share/${t.token}/upgrade`, {
+				const r = await fetch(`${apiUrl}/v1/share/${encodeURIComponent(t.token)}/upgrade`, {
 					method: "POST",
 					headers: {
 						Authorization: `Bearer ${apiKey}`,
@@ -114,8 +133,19 @@ async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise
 					},
 					body: "{}",
 				});
+				if (r.status === 404) {
+					return {
+						kind: "fail",
+						name,
+						reason: "share link not found on this API (local token kept)",
+					};
+				}
 				if (r.status === 410) {
-					return { kind: "fail", name: t.project_name, reason: "revoked by owner" };
+					return {
+						kind: "fail",
+						name,
+						reason: "share link was revoked, expired, or removed (local token kept)",
+					};
 				}
 				if (r.status === 409) {
 					const body = (await r.json().catch(() => ({}))) as {
@@ -124,7 +154,7 @@ async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise
 					if (body?.detail?.error === "mount_target_ambiguous") {
 						return {
 							kind: "fail",
-							name: t.project_name,
+							name,
 							reason: "needs manual project review",
 						};
 					}
@@ -133,27 +163,32 @@ async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise
 					}
 					return {
 						kind: "fail",
-						name: t.project_name,
-						reason: `409 ${body.detail?.error}`,
+						name,
+						reason: body.detail?.error ? `conflict: ${body.detail.error}` : "HTTP 409 conflict",
 					};
 				}
 				if (!r.ok) {
-					return { kind: "fail", name: t.project_name, reason: `HTTP ${r.status}` };
+					return { kind: "fail", name, reason: `HTTP ${r.status}` };
 				}
-				const body = await readJson<{
-					project_id?: string;
-					resolved_owner_handle?: string;
-				}>(r, "share upgrade");
+				const body = await readJson<ShareUpgradeResponse>(r, "share upgrade");
+				if (
+					typeof body.project_id !== "string" ||
+					!body.project_id.trim() ||
+					typeof body.resolved_owner_handle !== "string" ||
+					!body.resolved_owner_handle.trim()
+				) {
+					throw new Error("share upgrade returned an invalid response");
+				}
 				return {
 					kind: "ok",
 					token: t,
-					projectId: body.project_id ?? t.project_id,
-					ownerHandle: body.resolved_owner_handle ?? t.owner_handle,
+					projectId: body.project_id,
+					ownerHandle: body.resolved_owner_handle,
 				};
 			} catch (e) {
 				return {
 					kind: "fail",
-					name: t.project_name,
+					name,
 					reason: e instanceof Error ? e.message : "network error",
 				};
 			}
@@ -164,11 +199,16 @@ async function autoUpgradePendingShares(apiUrl: string, apiKey: string): Promise
 	const results: Array<{ name: string; alias?: string; pulled?: number; reason?: string }> = [];
 	for (const o of outcomes) {
 		if (o.kind === "ok") {
-			addToken({ ...o.token, upgraded_at: new Date().toISOString() });
+			addToken({
+				...o.token,
+				project_id: o.projectId,
+				owner_handle: o.ownerHandle,
+				upgraded_at: new Date().toISOString(),
+			});
 			const pulled = await pullSharedSkills(apiUrl, apiKey, o.projectId, o.ownerHandle).catch(
 				() => 0,
 			);
-			results.push({ name: o.token.project_name, alias: o.alias, pulled });
+			results.push({ name: shareDisplayName(o.token), alias: o.alias, pulled });
 		} else if (o.kind === "already_owner") {
 			addToken({ ...o.token, upgraded_at: new Date().toISOString() });
 		} else {

--- a/packages/cli/src/share/tokens.test.ts
+++ b/packages/cli/src/share/tokens.test.ts
@@ -3,7 +3,14 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { addToken, findToken, listTokens, removeToken, type ShareToken } from "./tokens";
+import {
+	addToken,
+	findToken,
+	listTokens,
+	readTokenStore,
+	removeToken,
+	type ShareToken,
+} from "./tokens";
 
 const ORIG_HOME = process.env.HOME;
 let tempHome: string;
@@ -83,6 +90,71 @@ describe("share-tokens.json", () => {
 		const [restored] = listTokens();
 		expect(restored.upgraded_at).toBe("2026-05-12T10:00:00Z");
 		expect(restored.last_seen_skill_keys).toEqual(["git-tools", "k8s-helpers"]);
+	});
+
+	it("normalizes released version:1 scope fields without dropping unknown fields", () => {
+		const path = join(tempHome, ".clawdi", "share-tokens.json");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				version: 1,
+				tokens: [
+					{
+						scope_id: "legacy-project",
+						scope_name: "Legacy Toolkit",
+						owner_display: "Alice",
+						owner_handle: "alice-a3b4",
+						token: "l".repeat(43),
+						redeemed_at: "2026-05-12T10:00:00Z",
+						future_field: { enabled: true },
+					},
+				],
+			}),
+			"utf-8",
+		);
+
+		const [restored] = listTokens();
+		expect(restored.project_id).toBe("legacy-project");
+		expect(restored.project_name).toBe("Legacy Toolkit");
+		addToken({ ...restored, upgraded_at: "2026-05-12T11:00:00Z" });
+
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
+			tokens: Array<Record<string, unknown>>;
+		};
+		expect(raw.tokens[0].project_id).toBe("legacy-project");
+		expect(raw.tokens[0].project_name).toBe("Legacy Toolkit");
+		expect(raw.tokens[0].future_field).toEqual({ enabled: true });
+	});
+
+	it("skips malformed records at runtime but preserves them during unrelated writes", () => {
+		const path = join(tempHome, ".clawdi", "share-tokens.json");
+		const malformed = {
+			project_id: "broken-project",
+			project_name: "Broken Toolkit",
+			owner_display: "Alice",
+			owner_handle: "alice-a3b4",
+			token: "undefined",
+			redeemed_at: "2026-05-12T10:00:00Z",
+			future_field: "keep-me",
+		};
+		writeFileSync(path, JSON.stringify({ version: 1, tokens: [malformed, sample] }), "utf-8");
+
+		const store = readTokenStore();
+		expect(store.tokens).toEqual([sample]);
+		expect(store.issues).toEqual([
+			{
+				label: "Broken Toolkit",
+				reason: "invalid 43-character share token",
+			},
+		]);
+
+		addToken({ ...sample, owner_handle: "alice-updated" });
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
+			tokens: Array<Record<string, unknown>>;
+		};
+		expect(raw.tokens).toHaveLength(2);
+		expect(raw.tokens[0]).toEqual(malformed);
+		expect(raw.tokens[1].owner_handle).toBe("alice-updated");
 	});
 
 	it("preserves unknown future fields across read+write", () => {

--- a/packages/cli/src/share/tokens.ts
+++ b/packages/cli/src/share/tokens.ts
@@ -54,48 +54,161 @@ export interface ShareToken {
 	last_seen_skill_keys?: string[];
 }
 
-interface ShareTokensFile {
+interface PersistedShareTokensFile {
 	version: 1;
-	tokens: ShareToken[];
+	tokens: unknown[];
 }
+
+export interface ShareTokenStoreIssue {
+	label: string;
+	reason: string;
+}
+
+const RAW_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/;
 
 function filePath(): string {
 	return join(clawdiHome(), "share-tokens.json");
 }
 
-function loadRaw(): ShareTokensFile {
+function loadRaw(): PersistedShareTokensFile {
 	const path = filePath();
 	if (!existsSync(path)) {
 		return { version: 1, tokens: [] };
 	}
 	try {
 		const text = readFileSync(path, "utf-8");
-		const parsed = JSON.parse(text) as ShareTokensFile;
-		if (parsed.version !== 1 || !Array.isArray(parsed.tokens)) {
+		const parsed: unknown = JSON.parse(text);
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			!("version" in parsed) ||
+			parsed.version !== 1 ||
+			!("tokens" in parsed) ||
+			!Array.isArray(parsed.tokens)
+		) {
 			// Malformed file: treat as empty. Operator can re-accept
-			// any shares they care about; we don't bricks the CLI
+			// any shares they care about; we don't brick the CLI
 			// over local-state corruption.
 			return { version: 1, tokens: [] };
 		}
-		return parsed;
+		return { version: 1, tokens: parsed.tokens };
 	} catch {
 		return { version: 1, tokens: [] };
 	}
 }
 
-function save(state: ShareTokensFile): void {
+function save(state: PersistedShareTokensFile): void {
 	const path = filePath();
 	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
 	writeFileSync(path, JSON.stringify(state, null, 2), { mode: 0o600 });
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function persistedProjectId(value: unknown): string | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	return (
+		("project_id" in value ? nonEmptyString(value.project_id) : undefined) ??
+		("scope_id" in value ? nonEmptyString(value.scope_id) : undefined)
+	);
+}
+
+function issueLabel(value: unknown, index: number): string {
+	if (typeof value !== "object" || value === null) return `local share entry ${index + 1}`;
+	const name =
+		("project_name" in value ? nonEmptyString(value.project_name) : undefined) ??
+		("scope_name" in value ? nonEmptyString(value.scope_name) : undefined);
+	if (name) return name;
+	const projectId = persistedProjectId(value);
+	return projectId ? `Project ${projectId}` : `local share entry ${index + 1}`;
+}
+
+function normalizeToken(
+	value: unknown,
+	index: number,
+): { kind: "token"; token: ShareToken } | { kind: "issue"; issue: ShareTokenStoreIssue } {
+	const label = issueLabel(value, index);
+	if (typeof value !== "object" || value === null) {
+		return { kind: "issue", issue: { label, reason: "entry is not an object" } };
+	}
+
+	const projectId = persistedProjectId(value);
+	const projectName =
+		("project_name" in value ? nonEmptyString(value.project_name) : undefined) ??
+		("scope_name" in value ? nonEmptyString(value.scope_name) : undefined);
+	const ownerDisplay = "owner_display" in value ? nonEmptyString(value.owner_display) : undefined;
+	const ownerHandle = "owner_handle" in value ? nonEmptyString(value.owner_handle) : undefined;
+	const token = "token" in value ? nonEmptyString(value.token) : undefined;
+	const redeemedAt = "redeemed_at" in value ? nonEmptyString(value.redeemed_at) : undefined;
+
+	const missing: string[] = [];
+	if (!projectId) missing.push("project id");
+	if (!projectName) missing.push("project name");
+	if (!ownerDisplay) missing.push("owner display");
+	if (!ownerHandle) missing.push("owner handle");
+	if (!redeemedAt) missing.push("redeemed timestamp");
+	if (!token) missing.push("share token");
+	if (token && !RAW_TOKEN_RE.test(token)) {
+		return {
+			kind: "issue",
+			issue: { label, reason: "invalid 43-character share token" },
+		};
+	}
+	if (!projectId || !projectName || !ownerDisplay || !ownerHandle || !redeemedAt || !token) {
+		return { kind: "issue", issue: { label, reason: `missing ${missing.join(", ")}` } };
+	}
+
+	// `scope_id`/`scope_name` were the released version:1 names before
+	// 911c955b renamed them without bumping the persisted-file version.
+	// Canonical fields are overlaid at read time while all other fields,
+	// including future fields, remain available to subsequent upserts.
+	const normalized: ShareToken & Record<string, unknown> = {
+		...value,
+		project_id: projectId,
+		project_name: projectName,
+		owner_display: ownerDisplay,
+		owner_handle: ownerHandle,
+		token,
+		redeemed_at: redeemedAt,
+	};
+	if ("upgraded_at" in value && typeof value.upgraded_at !== "string") {
+		delete normalized.upgraded_at;
+	}
+	if (
+		"last_seen_skill_keys" in value &&
+		(!Array.isArray(value.last_seen_skill_keys) ||
+			!value.last_seen_skill_keys.every((key) => typeof key === "string"))
+	) {
+		delete normalized.last_seen_skill_keys;
+	}
+	return { kind: "token", token: normalized };
+}
+
+export function readTokenStore(): {
+	tokens: ShareToken[];
+	issues: ShareTokenStoreIssue[];
+} {
+	const tokens: ShareToken[] = [];
+	const issues: ShareTokenStoreIssue[] = [];
+	for (const [index, value] of loadRaw().tokens.entries()) {
+		const normalized = normalizeToken(value, index);
+		if (normalized.kind === "issue") issues.push(normalized.issue);
+		else tokens.push(normalized.token);
+	}
+	return { tokens, issues };
+}
+
 export function listTokens(): ShareToken[] {
-	return loadRaw().tokens;
+	return readTokenStore().tokens;
 }
 
 export function addToken(token: ShareToken): void {
 	const state = loadRaw();
-	const idx = state.tokens.findIndex((t) => t.project_id === token.project_id);
+	const idx = state.tokens.findIndex((value) => persistedProjectId(value) === token.project_id);
 	if (idx === -1) {
 		state.tokens.push(token);
 	} else {
@@ -110,7 +223,7 @@ export function addToken(token: ShareToken): void {
 
 export function removeToken(projectId: string): void {
 	const state = loadRaw();
-	state.tokens = state.tokens.filter((t) => t.project_id !== projectId);
+	state.tokens = state.tokens.filter((value) => persistedProjectId(value) !== projectId);
 	save(state);
 }
 

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as p from "@clack/prompts";
 
 import { authLogin, browserOpenCommand, finishOAuthLogin } from "../../src/commands/auth";
 import {
@@ -218,6 +219,178 @@ describe("authLogin pending share upgrade", () => {
 		const [token] = listTokens();
 		expect(token.upgraded_at).toBeString();
 		expect(token.last_seen_skill_keys).toEqual(["deploy-helper"]);
+	});
+
+	it("upgrades a released version:1 scope record and persists its normalized fields", async () => {
+		const legacyToken = "b".repeat(43);
+		const tokenPath = join(tmpHome, ".clawdi", "share-tokens.json");
+		writeFileSync(
+			tokenPath,
+			JSON.stringify({
+				version: 1,
+				tokens: [
+					{
+						scope_id: "legacy-project",
+						scope_name: "Legacy Toolkit",
+						owner_display: "Alice",
+						owner_handle: "alice-legacy",
+						token: legacyToken,
+						redeemed_at: "2026-05-12T10:00:00Z",
+						future_field: "preserved",
+					},
+				],
+			}),
+		);
+		const { captured, restore } = mockFetch([
+			{
+				method: "POST",
+				path: `/v1/share/${legacyToken}/upgrade`,
+				response: () =>
+					jsonResponse({
+						project_id: "legacy-project",
+						resolved_owner_handle: "alice-legacy",
+					}),
+			},
+			{
+				method: "GET",
+				path: "/v1/skills",
+				response: () => jsonResponse({ items: [] }),
+			},
+		]);
+
+		try {
+			await authLogin();
+		} finally {
+			restore();
+		}
+
+		expect(captured.map((request) => `${request.method} ${request.path}`)).toEqual([
+			`POST /v1/share/${legacyToken}/upgrade`,
+			"GET /v1/skills?project_id=legacy-project&page=1&page_size=200",
+		]);
+		const [normalized] = listTokens();
+		expect(normalized.project_id).toBe("legacy-project");
+		expect(normalized.project_name).toBe("Legacy Toolkit");
+		expect(normalized.upgraded_at).toBeString();
+		const persisted = JSON.parse(readFileSync(tokenPath, "utf-8")) as {
+			tokens: Array<Record<string, unknown>>;
+		};
+		expect(persisted.tokens[0].future_field).toBe("preserved");
+		expect(persisted.tokens[0].project_name).toBe("Legacy Toolkit");
+	});
+
+	it("keeps a valid legacy token after 404 and names the failure without undefined", async () => {
+		writeFileSync(
+			join(tmpHome, ".clawdi", "share-tokens.json"),
+			JSON.stringify({
+				version: 1,
+				tokens: [
+					{
+						scope_id: "project-stale",
+						scope_name: "Stale Toolkit",
+						owner_display: "Alice",
+						owner_handle: "alice-example",
+						token: rawToken,
+						redeemed_at: "2026-05-12T10:00:00Z",
+					},
+				],
+			}),
+		);
+		const warn = spyOn(p.log, "warn").mockImplementation(() => {});
+		const { captured, restore } = mockFetch([
+			{
+				method: "POST",
+				path: `/v1/share/${rawToken}/upgrade`,
+				response: () => jsonResponse({ detail: "share link not found" }, 404),
+			},
+		]);
+		let messages: string[] = [];
+
+		try {
+			await authLogin();
+			messages = warn.mock.calls.map(([message]) => String(message));
+		} finally {
+			restore();
+			warn.mockRestore();
+		}
+
+		expect(captured.map((request) => `${request.method} ${request.path}`)).toEqual([
+			`POST /v1/share/${rawToken}/upgrade`,
+		]);
+		const [retained] = listTokens();
+		expect(retained.project_id).toBe("project-stale");
+		expect(retained.upgraded_at).toBeUndefined();
+		expect(messages).toContain(
+			'Could not upgrade "Stale Toolkit": share link not found on this API (local token kept)',
+		);
+		expect(messages.join("\n")).not.toContain("undefined");
+	});
+
+	it("leaves a pending token untouched when a successful response is malformed", async () => {
+		addToken({
+			project_id: "project-shared",
+			project_name: "Team Toolkit",
+			owner_display: "Alice",
+			owner_handle: "alice-example",
+			token: rawToken,
+			redeemed_at: "2026-05-12T10:00:00Z",
+		});
+		const warn = spyOn(p.log, "warn").mockImplementation(() => {});
+		const { captured, restore } = mockFetch([
+			{
+				method: "POST",
+				path: `/v1/share/${rawToken}/upgrade`,
+				response: () => jsonResponse({ project_id: "project-shared" }),
+			},
+		]);
+		let messages: string[] = [];
+
+		try {
+			await authLogin();
+			messages = warn.mock.calls.map(([message]) => String(message));
+		} finally {
+			restore();
+			warn.mockRestore();
+		}
+
+		expect(captured).toHaveLength(1);
+		expect(listTokens()[0].upgraded_at).toBeUndefined();
+		expect(messages).toContain(
+			'Could not upgrade "Team Toolkit": share upgrade returned an invalid response',
+		);
+		expect(messages.join("\n")).not.toContain("undefined");
+	});
+
+	it("uses a defined diagnostic for a conflict response without an error code", async () => {
+		addToken({
+			project_id: "project-shared",
+			project_name: "Team Toolkit",
+			owner_display: "Alice",
+			owner_handle: "alice-example",
+			token: rawToken,
+			redeemed_at: "2026-05-12T10:00:00Z",
+		});
+		const warn = spyOn(p.log, "warn").mockImplementation(() => {});
+		const { restore } = mockFetch([
+			{
+				method: "POST",
+				path: `/v1/share/${rawToken}/upgrade`,
+				response: () => jsonResponse({}, 409),
+			},
+		]);
+		let messages: string[] = [];
+
+		try {
+			await authLogin();
+			messages = warn.mock.calls.map(([message]) => String(message));
+		} finally {
+			restore();
+			warn.mockRestore();
+		}
+
+		expect(listTokens()[0].upgraded_at).toBeUndefined();
+		expect(messages).toContain('Could not upgrade "Team Toolkit": HTTP 409 conflict');
+		expect(messages.join("\n")).not.toContain("undefined");
 	});
 
 	it("skips invalid server skill keys during eager pull", async () => {


### PR DESCRIPTION
## Root cause

This warning is emitted by the post-login pending-share upgrade in `packages/cli/src/commands/auth.ts`, not by the CLI updater in `commands/update.ts`.

The original version:1 token store used `scope_id` and `scope_name`. Commit `911c955b` renamed the TypeScript interface and upsert key to `project_id` and `project_name` without bumping the persisted version or migrating existing files. The read path cast JSON directly to `ShareToken`, so old entries retained a usable raw token but rendered `project_name` as `undefined`.

The accompanying 404 has separate server semantics: `require_share_token` returns 404 only when the token hash has no share-link row on the current API. A link may be stale/deleted, but the local record does not retain its issuing API origin, so a 404 after changing endpoints cannot safely trigger automatic credential deletion.

## Fix

- Normalize released v1 `scope_*` records to canonical `project_*` fields at the read boundary while preserving unknown fields.
- Runtime-validate persisted records before interpolating tokens into requests; malformed entries are skipped and retained for recovery instead of being fetched or silently discarded.
- Keep valid 404 records pending and emit a current-API-specific diagnostic with a stable display name.
- Use the generated share-upgrade response type and validate required response identity fields before marking a token upgraded.
- Remove all `undefined` fallbacks from conflict and per-share diagnostics.

## Tests

- `bun test --isolate --max-concurrency=1 src/share/tokens.test.ts tests/commands/auth.test.ts` (21 pass)
- `bun run --cwd packages/cli test` (pass)
- `bun run --cwd packages/cli typecheck` (pass)
- `bunx biome check src/share/tokens.ts src/share/tokens.test.ts src/commands/auth.ts tests/commands/auth.test.ts` (pass)
- `git diff --check` (pass)

No production or tenant operations were performed.