### PR TITLE
fix(cli): enforce runtime sync invariants

### DIFF
--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
-import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
+import { replaceSkillArchiveTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -333,14 +333,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const skillsDir = join(claudeDir(), "skills");
-		const targetDir = join(skillsDir, key);
-
-		if (existsSync(targetDir)) {
-			rmSync(targetDir, { recursive: true, force: true });
-		}
-		mkdirSync(targetDir, { recursive: true });
-
-		await extractTarGz(skillsDir, tarGzBytes);
+		await replaceSkillArchiveTarGz(key, skillsDir, join(skillsDir, key), tarGzBytes);
 	}
 
 	async writeSharedSkillArchive(
@@ -348,7 +341,12 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		ownerHandle: string,
 		tarGzBytes: Buffer,
 	): Promise<void> {
-		await extractSharedSkillTarGz(key, this.getSharedSkillPath(key, ownerHandle), tarGzBytes);
+		await replaceSkillArchiveTarGz(
+			key,
+			this.getSkillsRootDir(),
+			this.getSharedSkillPath(key, ownerHandle),
+			tarGzBytes,
+		);
 	}
 
 	buildRunCommand(args: string[], _env: Record<string, string>): string[] {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,8 +1,8 @@
-import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
-import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
+import { replaceSkillArchiveTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -307,13 +307,8 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
-		const targetDir = join(skillsDir(), key);
-		if (existsSync(targetDir)) {
-			rmSync(targetDir, { recursive: true, force: true });
-		}
-		mkdirSync(targetDir, { recursive: true });
-
-		await extractTarGz(skillsDir(), tarGzBytes);
+		const root = skillsDir();
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
 	}
 
 	async writeSharedSkillArchive(
@@ -321,7 +316,12 @@ export class CodexAdapter implements AgentAdapter {
 		ownerHandle: string,
 		tarGzBytes: Buffer,
 	): Promise<void> {
-		await extractSharedSkillTarGz(key, this.getSharedSkillPath(key, ownerHandle), tarGzBytes);
+		await replaceSkillArchiveTarGz(
+			key,
+			this.getSkillsRootDir(),
+			this.getSharedSkillPath(key, ownerHandle),
+			tarGzBytes,
+		);
 	}
 
 	buildRunCommand(args: string[], _env: Record<string, string>): string[] {

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { isValidSkillKey } from "../lib/skill-key";
-import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
+import { replaceSkillArchiveTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -303,14 +303,8 @@ export class HermesAdapter implements AgentAdapter {
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
-		const targetDir = join(skillsDir(), key);
-
-		if (existsSync(targetDir)) {
-			rmSync(targetDir, { recursive: true, force: true });
-		}
-		mkdirSync(targetDir, { recursive: true });
-
-		await extractTarGz(skillsDir(), tarGzBytes);
+		const root = skillsDir();
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
 	}
 
 	async writeSharedSkillArchive(
@@ -318,7 +312,12 @@ export class HermesAdapter implements AgentAdapter {
 		ownerHandle: string,
 		tarGzBytes: Buffer,
 	): Promise<void> {
-		await extractSharedSkillTarGz(key, this.getSharedSkillPath(key, ownerHandle), tarGzBytes);
+		await replaceSkillArchiveTarGz(
+			key,
+			this.getSkillsRootDir(),
+			this.getSharedSkillPath(key, ownerHandle),
+			tarGzBytes,
+		);
 	}
 
 	buildRunCommand(args: string[], _env: Record<string, string>): string[] {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
-import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
+import { replaceSkillArchiveTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -389,13 +389,8 @@ export class OpenClawAdapter implements AgentAdapter {
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
-		const targetDir = join(skillsDir(), key);
-		if (existsSync(targetDir)) {
-			rmSync(targetDir, { recursive: true, force: true });
-		}
-		mkdirSync(targetDir, { recursive: true });
-
-		await extractTarGz(skillsDir(), tarGzBytes);
+		const root = skillsDir();
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
 	}
 
 	async writeSharedSkillArchive(
@@ -403,7 +398,12 @@ export class OpenClawAdapter implements AgentAdapter {
 		ownerHandle: string,
 		tarGzBytes: Buffer,
 	): Promise<void> {
-		await extractSharedSkillTarGz(key, this.getSharedSkillPath(key, ownerHandle), tarGzBytes);
+		await replaceSkillArchiveTarGz(
+			key,
+			this.getSkillsRootDir(),
+			this.getSharedSkillPath(key, ownerHandle),
+			tarGzBytes,
+		);
 	}
 
 	buildRunCommand(args: string[], _env: Record<string, string>): string[] {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1754,7 +1754,7 @@ export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
 		manifestCache: {
 			path: paths.manifestLastGood,
 			exists: manifestCacheExists,
-			valid: errors.length === 0,
+			valid: manifestCacheExists ? errors.length === 0 : null,
 		},
 		errors,
 	};
@@ -2875,6 +2875,7 @@ export async function runtimeStatus(opts: { json?: boolean } = {}) {
 		},
 		...read,
 	};
+	if (read.error || read.status?.status === "error") process.exitCode = 1;
 
 	if (opts.json || !process.stdout.isTTY) {
 		console.log(JSON.stringify(payload, null, 2));
@@ -2889,7 +2890,6 @@ export async function runtimeStatus(opts: { json?: boolean } = {}) {
 	}
 	if (read.error) {
 		console.log(chalk.red(`  Could not read ${read.source}: ${read.error}`));
-		process.exitCode = 1;
 		return;
 	}
 	if (!read.status) {

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -50,15 +50,29 @@ function hintFor(status: number): string {
 	return "";
 }
 
-function sleep(ms: number): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("Aborted", "AbortError"));
+			return;
+		}
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new DOMException("Aborted", "AbortError"));
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
 }
 
 // GET/HEAD/PUT/DELETE are safe to retry on 5xx + network errors; POST/PATCH
 // skip retry because they may have side effects.
 const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE"]);
 
-async function retryingFetch(
+export async function retryingFetch(
 	req: Request,
 	timeoutMs: number,
 	externalSignal: AbortSignal | undefined,
@@ -89,7 +103,19 @@ async function retryingFetch(
 
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		if (attempt > 0) {
-			await sleep(RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)]);
+			try {
+				await sleep(
+					RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)],
+					externalSignal,
+				);
+			} catch {
+				throw new ApiError({
+					status: 0,
+					body: "aborted",
+					hint: "Request aborted between retries.",
+					isNetwork: true,
+				});
+			}
 			if (externalSignal?.aborted) {
 				throw new ApiError({
 					status: 0,
@@ -108,14 +134,29 @@ async function retryingFetch(
 			if (externalSignal.aborted) controller.abort();
 			else externalSignal.addEventListener("abort", onExternalAbort, { once: true });
 		}
-		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			controller.abort();
+		}, timeoutMs);
 
-		let res: Response;
+		let buffered: Response;
 		try {
-			res = await fetch(base.clone(), { signal: controller.signal });
+			const res = await fetch(base.clone(), { signal: controller.signal });
+			// Own the complete REST response lifecycle here. Returning the
+			// network-backed Response would detach the timeout and caller abort
+			// before openapi-fetch (or a hand-written caller) consumes the body.
+			// Buffering keeps cancellation effective through JSON, text, and
+			// binary bodies, including error responses that are retried below.
+			const body = await res.arrayBuffer();
+			const hasNullBody =
+				base.method === "HEAD" || res.status === 204 || res.status === 205 || res.status === 304;
+			buffered = new Response(hasNullBody ? null : body, {
+				status: res.status,
+				statusText: res.statusText,
+				headers: res.headers,
+			});
 		} catch (e: unknown) {
-			clearTimeout(timer);
-			if (externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
 			if (externalSignal?.aborted) {
 				throw new ApiError({
 					status: 0,
@@ -125,7 +166,7 @@ async function retryingFetch(
 				});
 			}
 			const err = e as { name?: string; message?: string };
-			const isTimeout = err?.name === "AbortError";
+			const isTimeout = timedOut;
 			lastErr = new ApiError({
 				status: 0,
 				body: err?.message ?? String(e),
@@ -135,21 +176,33 @@ async function retryingFetch(
 			});
 			if (retry) continue;
 			throw lastErr;
+		} finally {
+			clearTimeout(timer);
+			if (externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
 		}
-		clearTimeout(timer);
-		if (externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
 
-		if (res.ok) return res;
+		if (buffered.ok) return buffered;
 
-		if (res.status === 429 && retry && attempt < maxAttempts - 1) {
-			const retryAfter = Number(res.headers.get("retry-after"));
-			if (Number.isFinite(retryAfter) && retryAfter > 0) await sleep(retryAfter * 1000);
+		if (buffered.status === 429 && retry && attempt < maxAttempts - 1) {
+			const retryAfter = Number(buffered.headers.get("retry-after"));
+			if (Number.isFinite(retryAfter) && retryAfter > 0) {
+				try {
+					await sleep(retryAfter * 1000, externalSignal);
+				} catch {
+					throw new ApiError({
+						status: 0,
+						body: "aborted",
+						hint: "Request aborted by caller.",
+						isNetwork: true,
+					});
+				}
+			}
 			continue;
 		}
 
-		if (res.status >= 500 && retry && attempt < maxAttempts - 1) continue;
+		if (buffered.status >= 500 && retry && attempt < maxAttempts - 1) continue;
 
-		return res;
+		return buffered;
 	}
 
 	throw (

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -1,6 +1,14 @@
-import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
 import { lstat, readdir, realpath } from "node:fs/promises";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import * as tar from "tar";
 import { assertValidSkillKey } from "./skill-key";
 
@@ -86,49 +94,67 @@ export function extractTarGz(cwd: string, bytes: Buffer): Promise<void> {
 }
 
 /**
- * Extract a skill tarball into a shared-project target dir.
+ * Atomically replace a skill directory from a downloaded archive.
  *
- * Skill tarballs have `<skillKey>/...` at the top level (upload side
- * doesn't know the content will be re-served as shared). For a
- * shared skill we want the result at `<targetDir>` whose basename
- * is `<skillKey>__<ownerHandle>`, not `<skillKey>`. Extract into a
- * sibling temp dir then rename the resulting `<skillKey>` folder
- * into place. Atomic from the caller's perspective: targetDir
- * either has the prior version (on failure mid-extract) or the
- * new version (on success).
+ * Staging is a sibling of `skillsRoot`, never a child of it. This keeps
+ * temporary `<skillKey>/SKILL.md` trees and old-version trash outside the
+ * watched skills root. The explicit root also preserves nested Hermes keys:
+ * extracting `category/foo` is validated at `join(stageRoot, skillKey)`
+ * instead of inferring an extraction root from `dirname(targetDir)`.
  */
-export async function extractSharedSkillTarGz(
+export async function replaceSkillArchiveTarGz(
 	skillKey: string,
+	skillsRoot: string,
 	targetDir: string,
 	bytes: Buffer,
 ): Promise<void> {
 	assertValidSkillKey(skillKey);
-	const { dirname, basename } = await import("node:path");
-	const { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync } = await import("node:fs");
-	const parent = dirname(targetDir);
-	mkdirSync(parent, { recursive: true });
-	const tmp = mkdtempSync(`${parent}/.share-extract-${basename(targetDir)}-`);
+	const targetFromRoot = relative(skillsRoot, targetDir);
+	if (!targetFromRoot || targetFromRoot.startsWith("..") || isAbsolute(targetFromRoot)) {
+		throw new Error(`Skill target must be inside skills root: ${targetDir}`);
+	}
+	mkdirSync(skillsRoot, { recursive: true });
+	const realSkillsRoot = realpathSync(skillsRoot);
+	const skillsParent = dirname(realSkillsRoot);
+	const stageRoot = mkdtempSync(join(skillsParent, `.${basename(skillsRoot)}-stage-`));
+	const stagedSkill = join(stageRoot, skillKey);
+	const trash = join(stageRoot, ".previous");
+	let preserveStageForRecovery = false;
 	try {
-		await extractTarGz(tmp, bytes);
-		const extracted = `${tmp}/${skillKey}`;
-		if (!existsSync(extracted)) {
-			throw new Error(`Shared skill tarball did not contain expected '${skillKey}/' root entry`);
+		await extractTarGz(stageRoot, bytes);
+		if (!existsSync(stagedSkill) || !lstatSync(stagedSkill).isDirectory()) {
+			throw new Error(`Skill tarball did not contain expected '${skillKey}/' root entry`);
 		}
-		// Wipe any prior version atomically: rename old → trash, then
-		// rename new → place, then nuke trash. Two renames so an
-		// interrupted reconcile leaves either the old or the new
-		// content in place, never a partial.
-		const trash = `${parent}/.share-trash-${basename(targetDir)}-${process.pid}-${randomUUID()}`;
-		if (existsSync(targetDir)) renameSync(targetDir, trash);
+		mkdirSync(dirname(targetDir), { recursive: true });
+		let previousMoved = false;
+		if (existsSync(targetDir)) {
+			renameSync(targetDir, trash);
+			previousMoved = true;
+		}
 		try {
-			renameSync(extracted, targetDir);
-		} catch (e) {
-			if (existsSync(trash)) renameSync(trash, targetDir);
-			throw e;
+			renameSync(stagedSkill, targetDir);
+		} catch (installError) {
+			if (!previousMoved) throw installError;
+			try {
+				renameSync(trash, targetDir);
+			} catch (restoreError) {
+				preserveStageForRecovery = true;
+				const installMessage =
+					installError instanceof Error ? installError.message : String(installError);
+				const restoreMessage =
+					restoreError instanceof Error ? restoreError.message : String(restoreError);
+				throw new Error(
+					`Skill install failed: ${installMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained at ${trash}`,
+					{ cause: installError },
+				);
+			}
+			throw installError;
 		}
 		if (existsSync(trash)) rmSync(trash, { recursive: true, force: true });
 	} finally {
-		if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+		if (!preserveStageForRecovery) {
+			rmSync(stageRoot, { recursive: true, force: true });
+		}
 	}
 }
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -22,6 +22,7 @@ import {
 	releaseInFlight,
 	rememberPendingSkillUploadEcho,
 	resolveOwningSkillKey,
+	SyncHealth,
 } from "./sync-engine";
 
 describe("stable session enqueue abort fence", () => {
@@ -120,6 +121,45 @@ describe("isAuthFailure", () => {
 });
 
 describe("live-sync transient failure classification", () => {
+	it("keeps unrelated unresolved errors after transport and resource successes", () => {
+		const health = new SyncHealth();
+		health.set("pull", "skill:broken", "skill broken pull: disk busy");
+		health.set("transport", "sse", "sse_disconnect:http_502");
+		health.set("push", "session:healthy", "session upload failed");
+		health.set("transport", "auth", "auth_revoked: rejected");
+
+		expect(health.project()).toBe("auth_revoked: rejected");
+		health.clear("transport", "auth");
+
+		health.clear("transport", "sse");
+		expect(health.project()).toBe("skill broken pull: disk busy");
+
+		health.clear("push", "session:healthy");
+		expect(health.project()).toBe("skill broken pull: disk busy");
+
+		health.clear("pull", "skill:broken");
+		health.set("push", "skill:foo", "permanent: upload rejected");
+		health.setIfAbsent("push", "skill:foo", "skill foo push was not applied", true);
+		expect(health.project()).toBe("permanent: upload rejected");
+		health.set("push", "skill_scan:foo", "skill foo scan failed");
+		health.clear("push", "skill_scan:foo");
+		expect(health.project()).toBe("permanent: upload rejected");
+		health.set("push", "skills_scan", "periodic skills scan failed");
+		health.clear("push", "skills_scan");
+		expect(health.project()).toBe("permanent: upload rejected");
+		health.clear("push", "skill:foo");
+		health.setIfAbsent("push", "skill:foo", "skill foo push was not applied", true);
+		expect(health.project()).toBe("skill foo push was not applied");
+		health.clearTransient("push", "skill:foo");
+		health.set("push", "session:deleted", "deleted session failed permanently");
+		health.set("push", "session:present", "present session still failing");
+		health.clearAbsent("push", "session:", new Set(["session:present"]));
+		expect(health.project()).toBe("present session still failing");
+
+		health.clear("push", "session:present");
+		expect(health.project()).toBeNull();
+	});
+
 	it("does not surface transient SSE reconnects as last_sync_error", () => {
 		expect(
 			lastSyncErrorForSseReconnect({

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -132,6 +132,60 @@ const SKILL_UPLOAD_ECHO_TTL_MS = 2 * 60_000;
 const TRANSIENT_HEARTBEAT_FAILURES = 3;
 
 type FailureClassification = "transient" | "sustained";
+type SyncHealthArea = "transport" | "push" | "pull";
+interface SyncHealthError {
+	message: string;
+	transient: boolean;
+}
+
+/** Unresolved sync failures keyed by their owning source or resource. */
+export class SyncHealth {
+	private readonly errors: Record<SyncHealthArea, Map<string, SyncHealthError>> = {
+		transport: new Map(),
+		push: new Map(),
+		pull: new Map(),
+	};
+
+	set(area: SyncHealthArea, resource: string, message: string, transient = false): void {
+		this.errors[area].set(resource, { message, transient });
+	}
+
+	setIfAbsent(area: SyncHealthArea, resource: string, message: string, transient = false): void {
+		if (!this.errors[area].has(resource)) {
+			this.errors[area].set(resource, { message, transient });
+		}
+	}
+
+	clear(area: SyncHealthArea, resource: string): void {
+		this.errors[area].delete(resource);
+	}
+
+	clearTransient(area: SyncHealthArea, resource: string): void {
+		if (this.errors[area].get(resource)?.transient) {
+			this.errors[area].delete(resource);
+		}
+	}
+
+	clearAbsent(area: SyncHealthArea, prefix: string, presentResources: ReadonlySet<string>): void {
+		for (const resource of this.errors[area].keys()) {
+			if (resource.startsWith(prefix) && !presentResources.has(resource)) {
+				this.errors[area].delete(resource);
+			}
+		}
+	}
+
+	project(): string | null {
+		const auth = this.errors.transport.get("auth");
+		if (auth) return auth.message;
+		for (const area of ["transport", "pull", "push"] as const) {
+			const first = [...this.errors[area]]
+				.filter(([resource]) => area !== "transport" || resource !== "auth")
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))[0];
+			if (first) return first[1].message;
+		}
+		return null;
+	}
+}
 
 export type PendingSkillUploadEcho = {
 	contentHash: string;
@@ -144,6 +198,7 @@ interface StableSessionEnqueueOptions {
 	queue: Pick<RetryQueue, "enqueue">;
 	lastPushedHash: ReadonlyMap<string, string>;
 	inFlightHash: Map<string, string>;
+	onPresentSessions?: (resources: ReadonlySet<string>) => void;
 }
 
 export async function enqueueChangedSessionsAfterStability(
@@ -152,6 +207,7 @@ export async function enqueueChangedSessionsAfterStability(
 	if (opts.abort.aborted) return 0;
 	const { sessions } = await opts.collectSessions();
 	if (opts.abort.aborted) return 0;
+	opts.onPresentSessions?.(new Set(sessions.map((session) => `session:${session.localSessionId}`)));
 	let enqueued = 0;
 	for (const session of sessions) {
 		if (opts.abort.aborted) return enqueued;
@@ -306,7 +362,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	// the daemon — it could grow more components and we'd silently
 	// regress to false 304s on every change.
 	let lastListingEtag: string | null = null;
-	let lastSyncError: string | null = null;
+	const syncHealth = new SyncHealth();
 
 	// Last content hash we pushed for each session, keyed by
 	// local_session_id. Lets the sessions watcher dedup: if the
@@ -425,7 +481,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		// best-effort heartbeat (sent on the way down) carries the
 		// reason. Without this the dashboard just shows "paused" / no
 		// error and the user has no idea their key was revoked.
-		lastSyncError = "auth_revoked: api key rejected by server";
+		syncHealth.set("transport", "auth", "auth_revoked: api key rejected by server");
 		// Best-effort final heartbeat. We don't await — the abort
 		// fires on the same tick — but kicking off the POST before
 		// the abort gives the request a fighting chance to land.
@@ -447,7 +503,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 					queue_depth: queue.highWaterMark,
 					dropped_count_delta: 0,
 					last_revision_seen: lastSeenRevision,
-					last_sync_error: lastSyncError,
+					last_sync_error: syncHealth.project(),
 				},
 			})
 			.catch(() => {
@@ -489,6 +545,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			if (abort.aborted) return;
 			try {
 				const fresh = await fetchDefaultProjectId();
+				syncHealth.clear("transport", "project_refresh");
 				if (fresh !== defaultProjectId) {
 					log.info("engine.project_changed", { from: defaultProjectId, to: fresh });
 					defaultProjectId = fresh;
@@ -532,6 +589,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 					stale_project_id: defaultProjectId,
 				};
 				if (consecutiveFailures >= STALE_PROJECT_THRESHOLD) {
+					syncHealth.set("transport", "project_refresh", `project_refresh: ${toErrorMessage(e)}`);
 					log.error("engine.project_filter_stale", fields);
 				} else {
 					log.warn("engine.project_filter_refresh_failed", fields);
@@ -571,6 +629,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			(etag) => {
 				lastListingEtag = etag;
 			},
+			syncHealth,
 		);
 	} catch (e) {
 		if (isAuthFailure(e)) {
@@ -582,8 +641,6 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		}
 		throw e;
 	}
-	lastSyncError = null;
-
 	// Push side: wire watcher → enqueue.
 	const onLocalChange = (skillKey: string) => {
 		if (pullsInFlight.has(skillKey)) {
@@ -593,11 +650,15 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			// rm and extract), not user edits.
 			return;
 		}
-		void enqueueIfChanged(opts, queue, lastPushedHash, skillKey, () => defaultProjectId).catch(
-			(e) => {
+		const scanResource = `skill_scan:${skillKey}`;
+		void enqueueIfChanged(opts, queue, lastPushedHash, skillKey, () => defaultProjectId)
+			.then(() => {
+				syncHealth.clear("push", scanResource);
+			})
+			.catch((e) => {
+				syncHealth.set("push", scanResource, `skill ${skillKey} scan: ${toErrorMessage(e)}`);
 				log.warn("engine.enqueue_failed", { skill_key: skillKey, error: toErrorMessage(e) });
-			},
-		);
+			});
 	};
 
 	// Pull side: SSE event → fetch + writeSkillArchive (or rm).
@@ -658,8 +719,16 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				delete lock.skills[skillCacheKey(opts.adapter.agentType, event.skill_key)];
 				writeSkillsLock(lock);
 				log.info("engine.skill_deleted_local", { skill_key: event.skill_key });
+				syncHealth.clear("pull", `skill:${event.skill_key}`);
+				syncHealth.clear("push", `skill:${event.skill_key}`);
+				syncHealth.clear("push", `skill_scan:${event.skill_key}`);
 				applied = true;
 			} catch (e) {
+				syncHealth.set(
+					"pull",
+					`skill:${event.skill_key}`,
+					`skill ${event.skill_key} delete: ${toErrorMessage(e)}`,
+				);
 				log.warn("engine.skill_delete_failed", {
 					skill_key: event.skill_key,
 					error: toErrorMessage(e),
@@ -686,6 +755,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			event.content_hash &&
 			(lastPushedHash.get(event.skill_key) === event.content_hash || pendingEchoMatched)
 		) {
+			syncHealth.clear("pull", `skill:${event.skill_key}`);
 			log.debug("engine.sse_self_echo_suppressed", {
 				skill_key: event.skill_key,
 				content_hash: event.content_hash,
@@ -706,6 +776,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			// boundary the sweep uses to avoid wiping local-only
 			// skills, so anything we pulled needs to be in it.
 			cloudObservedKeys.add(event.skill_key);
+			syncHealth.clear("pull", `skill:${event.skill_key}`);
 			pulled = true;
 		} catch (e) {
 			// 401/403 here means the key the daemon's been using is
@@ -718,6 +789,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				triggerAuthFailureAbort("sse_skill_pull");
 				return;
 			}
+			syncHealth.set(
+				"pull",
+				`skill:${event.skill_key}`,
+				`skill ${event.skill_key} pull: ${toErrorMessage(e)}`,
+			);
 			log.warn("engine.pull_failed", {
 				skill_key: event.skill_key,
 				error: toErrorMessage(e),
@@ -744,13 +820,16 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				queue,
 				lastPushedHash: lastPushedSessionHash,
 				inFlightHash: inFlightSessionHash,
+				onPresentSessions: (resources) => syncHealth.clearAbsent("push", "session:", resources),
 			});
 			if (opts.abort.aborted) return;
+			syncHealth.clear("push", "session_scan");
 			if (enqueued > 0) {
 				log.info("engine.sessions_enqueued", { count: enqueued });
 			}
 		} catch (e) {
 			if (opts.abort.aborted) return;
+			syncHealth.set("push", "session_scan", `session scan: ${toErrorMessage(e)}`);
 			log.warn("engine.sessions_enumerate_failed", { error: toErrorMessage(e) });
 		}
 	};
@@ -805,13 +884,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			abort: opts.abort,
 			onEvent: onServerEvent,
 			onConnect: () => {
-				lastSyncError = null;
+				syncHealth.clear("transport", "sse");
 			},
 			onDisconnect: (info) => {
 				const nextError = lastSyncErrorForSseReconnect(info);
-				if (nextError !== null || lastSyncError?.startsWith("sse_disconnect:")) {
-					lastSyncError = nextError;
-				}
+				if (nextError !== null) syncHealth.set("transport", "sse", nextError);
 			},
 			onAuthFailure: () => triggerAuthFailureAbort("sse_channel"),
 		}),
@@ -824,9 +901,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			inFlightSessionHash,
 			pendingSkillUploadEchoes,
 			() => defaultProjectId,
-			(err) => {
-				lastSyncError = err;
-			},
+			syncHealth,
 			triggerAuthFailureAbort,
 		),
 		reconcileLoop(
@@ -844,11 +919,12 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			(etag) => {
 				lastListingEtag = etag;
 			},
+			syncHealth,
 			triggerAuthFailureAbort,
 		),
 		heartbeatLoop(opts, api, queue, opts.abort, () => ({
 			last_revision_seen: lastSeenRevision,
-			last_sync_error: lastSyncError,
+			last_sync_error: syncHealth.project(),
 		})),
 		refreshDefaultProjectIdLoop(opts.abort),
 		// Safety-net periodic sessions rescan. After a 4xx drop we
@@ -877,15 +953,19 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			while (!opts.abort.aborted) {
 				await sleep(5 * 60_000, opts.abort);
 				if (opts.abort.aborted) return;
-				await rescanLocalSkillsForChanges(
-					opts,
-					queue,
-					lastPushedHash,
-					pullsInFlight,
-					() => defaultProjectId,
-				).catch((e) => {
+				try {
+					await rescanLocalSkillsForChanges(
+						opts,
+						queue,
+						lastPushedHash,
+						pullsInFlight,
+						() => defaultProjectId,
+					);
+					syncHealth.clear("push", "skills_scan");
+				} catch (e) {
+					syncHealth.set("push", "skills_scan", `skills scan: ${toErrorMessage(e)}`);
 					log.warn("engine.skills_rescan_failed", { error: toErrorMessage(e) });
-				});
+				}
 			}
 		})(),
 	]);
@@ -913,9 +993,12 @@ async function enqueueIfChanged(
 		// Directory disappeared (skill deleted). v1 doesn't
 		// support push-deletes from daemon; the user does that
 		// from the dashboard. Just stop tracking it.
-		lastPushedHash.delete(skillKey);
-		log.debug("engine.skill_dir_gone", { skill_key: skillKey, error: toErrorMessage(e) });
-		return;
+		if (!existsSync(dir)) {
+			lastPushedHash.delete(skillKey);
+			log.debug("engine.skill_dir_gone", { skill_key: skillKey, error: toErrorMessage(e) });
+			return;
+		}
+		throw e;
 	}
 	if (lastPushedHash.get(skillKey) === hash) {
 		// Echo from a cloud-originated write or a no-op touch.
@@ -1034,9 +1117,11 @@ async function drainQueueLoop(
 	inFlightSessionHash: Map<string, string>,
 	pendingSkillUploadEchoes: Map<string, PendingSkillUploadEcho>,
 	getProjectId: () => string,
-	setLastError: (err: string | null) => void,
+	health: SyncHealth,
 	onAuthFailure: (origin: string) => void,
 ): Promise<void> {
+	const healthResource = (item: QueueItem): string =>
+		item.kind === "skill_push" ? `skill:${item.skill_key}` : `session:${item.local_session_id}`;
 	// Clear the in-flight stamp for a session_push item so the
 	// next watcher tick will re-enqueue if the local content
 	// hasn't already been confirmed shipped. Skill_push items have
@@ -1053,12 +1138,10 @@ async function drainQueueLoop(
 	};
 
 	// Common terminal-drop bookkeeping shared by oversized / permanent /
-	// retry-exhausted branches. `lastSyncError` is intentionally NOT
-	// touched here — each branch encodes its own UX contract (oversized
-	// preserves prior state, permanent stamps `permanent:`, retry-
-	// exhausted stamps `retry_exhausted:`), so folding setLastError in
-	// would re-introduce the C1 bug where oversized clobbered prior
-	// errors.
+	// retry-exhausted branches. Each branch owns its health contract:
+	// oversized clears only a same-resource transient, while permanent
+	// and retry-exhausted failures remain unresolved until that exact
+	// resource is later applied or disappears.
 	const dropItem = (item: QueueItem) => {
 		queue.recordPermanentDrop();
 		clearInFlight(item);
@@ -1071,7 +1154,7 @@ async function drainQueueLoop(
 			continue;
 		}
 		try {
-			await processQueueItem(
+			const outcome = await processQueueItem(
 				opts,
 				api,
 				queue,
@@ -1082,9 +1165,19 @@ async function drainQueueLoop(
 				pendingSkillUploadEchoes,
 				getProjectId(),
 			);
-			setLastError(null);
+			if (outcome === "applied" || outcome === "absent") {
+				health.clear("push", healthResource(item));
+			} else {
+				health.setIfAbsent(
+					"push",
+					healthResource(item),
+					`${item.kind === "skill_push" ? `skill ${item.skill_key}` : `session ${item.local_session_id}`} push was not applied; awaiting rescan`,
+					true,
+				);
+			}
 		} catch (e) {
 			const msg = toErrorMessage(e);
+			const resource = healthResource(item);
 			// Auth dead → daemon abort, not queue drop. Every
 			// upload from this point will fail the same way
 			// because the api key is revoked. Dropping the queue
@@ -1099,7 +1192,7 @@ async function drainQueueLoop(
 				// signal. The unified path takes over on the next
 				// poll, but this prevents the heartbeat from looking
 				// healthy in the gap.
-				setLastError(msg);
+				health.set("push", resource, msg);
 				log.error("engine.queue_auth_failure", {
 					item: redactItem(item),
 					error: msg,
@@ -1135,18 +1228,10 @@ async function drainQueueLoop(
 					item: redactItem(item),
 					error: msg,
 				});
-				// Intentionally do NOT touch `lastSyncError` here.
-				// An earlier `setLastError(null)` was wrong on two
-				// fronts: (a) if a PRIOR item had stamped a real
-				// `permanent:` / `retry_exhausted:` error, clearing
-				// it here would silently dismiss the dashboard alarm
-				// for a problem the daemon hasn't actually resolved;
-				// (b) eagerly stamping the raw 413 first then
-				// clearing also briefly poisoned the heartbeat. The
-				// dropped-events counter (`dropItem` below) is the
-				// right signal for "we skipped some content"; the
-				// heartbeat carries forward whatever real condition
-				// was previously surfaced.
+				// Oversized is terminal for this exact resource. Clear
+				// only its prior transient push failure; the dropped
+				// counter remains the user-visible oversized signal.
+				health.clearTransient("push", resource);
 				dropItem(item);
 			} else if (isPermanentUploadError(e)) {
 				// 4xx that won't change on retry — malformed body,
@@ -1168,7 +1253,7 @@ async function drainQueueLoop(
 				// a too-big skill) and re-push manually. Mirrors
 				// the existing `auth_revoked:` / `sse_disconnect:`
 				// prefix convention.
-				setLastError(`permanent: ${msg}`);
+				health.set("push", resource, `permanent: ${msg}`);
 				// `dropItem` bumps the dropped counter so the
 				// dashboard's "dropped" pill shows non-evict drops
 				// too. Pre-fix only FIFO eviction ticked the counter
@@ -1193,7 +1278,7 @@ async function drainQueueLoop(
 				// gave up retrying for now; the next sync cycle
 				// will pick this up automatically once connectivity
 				// is back."
-				setLastError(`retry_exhausted: ${msg}`);
+				health.set("push", resource, `retry_exhausted: ${msg}`);
 				dropItem(item);
 			} else {
 				log.warn("engine.queue_retry", {
@@ -1206,12 +1291,14 @@ async function drainQueueLoop(
 				// right now" while the daemon keeps retrying.
 				// Cleared on the next successful drain (top of this
 				// try block).
-				setLastError(msg);
+				health.set("push", resource, msg, true);
 				await sleep(QUEUE_RETRY_INTERVAL_MS, opts.abort);
 			}
 		}
 	}
 }
+
+type QueueProcessOutcome = "applied" | "absent" | "not_applied";
 
 async function processQueueItem(
 	opts: EngineOpts,
@@ -1223,7 +1310,7 @@ async function processQueueItem(
 	inFlightSessionHash: Map<string, string>,
 	pendingSkillUploadEchoes: Map<string, PendingSkillUploadEcho>,
 	projectId: string,
-): Promise<void> {
+): Promise<QueueProcessOutcome> {
 	if (item.kind === "skill_push") {
 		// Legacy items (no project_id stamp) inherit the current
 		// project — they were enqueued by an older binary that
@@ -1243,7 +1330,7 @@ async function processQueueItem(
 				current_project_id: projectId,
 			});
 			queue.markDoneIfVersion(item);
-			return;
+			return "not_applied";
 		}
 		await uploadSkillFromQueue(
 			opts,
@@ -1265,7 +1352,7 @@ async function processQueueItem(
 				version: item.version,
 			});
 		}
-		return;
+		return "applied";
 	}
 	if (item.kind === "session_push") {
 		const result = await uploadSessionFromQueue(opts, api, item);
@@ -1282,10 +1369,12 @@ async function processQueueItem(
 		// and drain, the live `session.messages` we just shipped
 		// has a different hash; stamping the stale value would
 		// short-circuit a future re-push on the wrong hash. When
-		// the session vanished mid-flight (`result === null`),
-		// leave the in-memory state untouched so the next watcher
+		// the session vanished or was rejected mid-flight, only an
+		// applied result updates confirmed state; the outcome below
+		// independently decides whether resource health is resolved.
+		// Leave the in-memory state untouched so the next watcher
 		// tick can decide.
-		if (result !== null) {
+		if (result.outcome === "applied") {
 			lastPushedSessionHash.set(item.local_session_id, result.actualHash);
 		}
 		const cur = inFlightSessionHash.get(item.local_session_id);
@@ -1299,10 +1388,11 @@ async function processQueueItem(
 				version: item.version,
 			});
 		}
-		return;
+		return result.outcome;
 	}
 	const _exhaustive: never = item;
 	log.warn("engine.queue_unknown_kind", { item: _exhaustive });
+	return "not_applied";
 }
 
 /** Upload a single session via the same two-step `clawdi push`
@@ -1320,7 +1410,9 @@ async function uploadSessionFromQueue(
 	opts: EngineOpts,
 	api: ApiClient,
 	item: Extract<QueueItem, { kind: "session_push" }>,
-): Promise<{ actualHash: string } | null> {
+): Promise<
+	{ outcome: "applied"; actualHash: string } | { outcome: "absent" } | { outcome: "not_applied" }
+> {
 	// Re-enumerate via the adapter so we always upload current
 	// content. Filter to the single local_session_id we were asked
 	// to push; if the user deleted the session between enqueue and
@@ -1329,7 +1421,7 @@ async function uploadSessionFromQueue(
 	const session = sessions.find((s) => s.localSessionId === item.local_session_id);
 	if (!session) {
 		log.info("engine.session_gone", { local_session_id: item.local_session_id });
-		return null;
+		return { outcome: "absent" };
 	}
 	if (session.messages.length === 0) {
 		// Session file exists but parsed empty — push the metadata
@@ -1379,22 +1471,16 @@ async function uploadSessionFromQueue(
 
 	// Server flagged this id as a cross-env race casualty (see
 	// SessionBatchResponse.rejected). Don't upload content, don't
-	// persist the lock, and crucially DON'T return the actualHash
-	// — the caller treats `{ actualHash }` as success and writes
-	// it to `lastPushedSessionHash`, which would then dedup the
-	// next watcher / rescan tick and stick the daemon at "already
-	// shipped" until restart. Returning `null` shares the same
-	// "leave in-memory state untouched" path used for vanished
-	// sessions: the queue item still gets removed, but
-	// lastPushedSessionHash stays empty for this id, so the 5min
-	// rescan re-enqueues and the next pre-fetch will see the
-	// winner's row and return a clean 409 to retry against.
+	// persist the lock, and crucially return `not_applied` without
+	// the actualHash. The queue item is removed, but confirmed state
+	// and health remain unresolved so the 5-minute rescan re-enqueues
+	// it and a later real success can clear the exact resource.
 	if (result.rejected?.includes(session.localSessionId)) {
 		log.warn("engine.session_push_rejected", {
 			local_session_id: session.localSessionId,
 			reason: "cross_env_race",
 		});
-		return null;
+		return { outcome: "not_applied" };
 	}
 
 	if (result.needs_content.includes(session.localSessionId) && session.messages.length > 0) {
@@ -1425,7 +1511,7 @@ async function uploadSessionFromQueue(
 		message_count: session.messageCount,
 		uploaded_content: result.needs_content.includes(session.localSessionId),
 	});
-	return { actualHash };
+	return { outcome: "applied", actualHash };
 }
 
 async function uploadSkillFromQueue(
@@ -1653,6 +1739,7 @@ async function initialSync(
 	projectId: string,
 	setRevision: (rev: number) => void,
 	setEtag: (etag: string | null) => void,
+	health: SyncHealth,
 ): Promise<void> {
 	const rootDir = opts.adapter.getSkillsRootDir();
 
@@ -1693,6 +1780,12 @@ async function initialSync(
 		etag,
 		complete: cloudComplete,
 	} = await listAllCloudSkills(api, projectId);
+	health.clear("pull", "listing");
+	if (cloudComplete) {
+		health.clear("pull", "reconcile");
+	} else {
+		health.set("pull", "reconcile", "reconcile: cloud skill listing was incomplete");
+	}
 	for (const s of cloudSkills) cloudObservedKeys.add(s.skill_key);
 	const cloudByKey = new Map(cloudSkills.map((s) => [s.skill_key, s]));
 
@@ -1718,8 +1811,10 @@ async function initialSync(
 			addInFlight(pullsInFlight, key);
 			try {
 				await pullSkill(opts, api, key, lastPushedHash, projectId);
+				health.clear("pull", `skill:${key}`);
 			} catch (e) {
 				allApplied = false;
+				health.set("pull", `skill:${key}`, `skill ${key} pull: ${toErrorMessage(e)}`);
 				log.warn("engine.boot_pull_failed", {
 					skill_key: key,
 					error: toErrorMessage(e),
@@ -1776,6 +1871,7 @@ async function initialSync(
 				addInFlight(pullsInFlight, key);
 				try {
 					await pullSkill(opts, api, key, lastPushedHash, projectId);
+					health.clear("pull", `skill:${key}`);
 					log.info("engine.boot_pull_diverged", {
 						skill_key: key,
 						local: localHash,
@@ -1784,6 +1880,7 @@ async function initialSync(
 					});
 				} catch (e) {
 					allApplied = false;
+					health.set("pull", `skill:${key}`, `skill ${key} pull: ${toErrorMessage(e)}`);
 					log.warn("engine.boot_pull_failed", {
 						skill_key: key,
 						error: toErrorMessage(e),
@@ -1793,6 +1890,7 @@ async function initialSync(
 				}
 			}
 		} else {
+			health.clear("pull", `skill:${key}`);
 			// Match — record so subsequent watcher events dedup
 			// AND persist to skills-lock so a daemon restart
 			// before any push/pull writes one preserves the
@@ -1859,8 +1957,12 @@ async function initialSync(
 				delete lock.skills[skillCacheKey(opts.adapter.agentType, key)];
 				writeSkillsLock(lock);
 				log.info("engine.boot_remove_cloud_deleted", { skill_key: key });
+				health.clear("pull", `skill:${key}`);
+				health.clear("push", `skill:${key}`);
+				health.clear("push", `skill_scan:${key}`);
 			} catch (e) {
 				allApplied = false;
+				health.set("pull", `skill:${key}`, `skill ${key} delete: ${toErrorMessage(e)}`);
 				log.warn("engine.boot_remove_failed", {
 					skill_key: key,
 					error: toErrorMessage(e),
@@ -1888,7 +1990,7 @@ async function initialSync(
 	// reconcile listing isn't 304'd, and the failed item is
 	// retried on the next pass instead of silently dropped until
 	// something else changes upstream.
-	if (allApplied) {
+	if (cloudComplete && allApplied) {
 		if (revision !== null) setRevision(revision);
 		setEtag(etag);
 	}
@@ -1927,6 +2029,7 @@ async function reconcileLoop(
 	getKnownEtag: () => string | null,
 	setRevision: (rev: number) => void,
 	setEtag: (etag: string | null) => void,
+	health: SyncHealth,
 	onAuthFailure: (origin: string) => void,
 ): Promise<void> {
 	while (!abort.aborted) {
@@ -1943,6 +2046,7 @@ async function reconcileLoop(
 				getKnownEtag(),
 				setRevision,
 				setEtag,
+				health,
 				onAuthFailure,
 			);
 		} catch (e) {
@@ -1954,6 +2058,7 @@ async function reconcileLoop(
 				onAuthFailure("reconcile_list");
 				return;
 			}
+			health.set("pull", "listing", `reconcile listing: ${toErrorMessage(e)}`);
 			log.warn("engine.reconcile_failed", { error: toErrorMessage(e) });
 		}
 	}
@@ -1979,6 +2084,7 @@ async function reconcileFromCloud(
 	knownEtag: string | null,
 	setRevision: (rev: number) => void,
 	setEtag: (etag: string | null) => void,
+	health: SyncHealth,
 	onAuthFailure: (origin: string) => void,
 ): Promise<void> {
 	const { skills, complete, revision, etag, notModified } = await listAllCloudSkills(
@@ -1986,7 +2092,9 @@ async function reconcileFromCloud(
 		projectId,
 		knownEtag,
 	);
+	health.clear("pull", "listing");
 	if (notModified) {
+		health.clear("pull", "reconcile");
 		// Server confirmed nothing changed since `knownEtag` —
 		// no skills to pull, no sweep work. Save the bandwidth +
 		// pagination work; the local state is already consistent
@@ -2006,11 +2114,19 @@ async function reconcileFromCloud(
 	// failed item permanently stale until some other cloud change
 	// bumps the revision.
 	let allApplied = true;
+	if (complete) {
+		health.clear("pull", "reconcile");
+	} else {
+		health.set("pull", "reconcile", "reconcile: cloud skill listing was incomplete");
+	}
 	const cloudKeys = new Set(skills.map((s) => s.skill_key));
 	for (const skill of skills) {
 		cloudObservedKeys.add(skill.skill_key);
 		const local = lastPushedHash.get(skill.skill_key);
-		if (local === skill.content_hash) continue;
+		if (local === skill.content_hash) {
+			health.clear("pull", `skill:${skill.skill_key}`);
+			continue;
+		}
 		// Skip if a cloud-pull is already mid-flight for this skill
 		// (e.g. boot initialSync still draining). Concurrent rm +
 		// tar extract on the same dir leaves it partially-extracted.
@@ -2032,7 +2148,6 @@ async function reconcileFromCloud(
 				`/v1/projects/${encodeURIComponent(projectId)}/skills/${encodeURIComponent(skill.skill_key)}/download`,
 			);
 			await opts.adapter.writeSkillArchive(skill.skill_key, tarBytes);
-			lastPushedHash.set(skill.skill_key, skill.content_hash);
 			// Persist the pulled hash to skills-lock too so a daemon
 			// restart treats this as a known-shipped skill. Without
 			// this, a cloud-side delete during a subsequent offline
@@ -2043,6 +2158,8 @@ async function reconcileFromCloud(
 				hash: skill.content_hash,
 			};
 			writeSkillsLock(lock);
+			lastPushedHash.set(skill.skill_key, skill.content_hash);
+			health.clear("pull", `skill:${skill.skill_key}`);
 			log.info("engine.skill_pulled", {
 				skill_key: skill.skill_key,
 				content_hash: skill.content_hash,
@@ -2053,6 +2170,11 @@ async function reconcileFromCloud(
 				return;
 			}
 			allApplied = false;
+			health.set(
+				"pull",
+				`skill:${skill.skill_key}`,
+				`skill ${skill.skill_key} pull: ${toErrorMessage(e)}`,
+			);
 			log.warn("engine.reconcile_pull_failed", {
 				skill_key: skill.skill_key,
 				error: toErrorMessage(e),
@@ -2094,8 +2216,12 @@ async function reconcileFromCloud(
 				delete lock.skills[skillCacheKey(opts.adapter.agentType, knownKey)];
 				writeSkillsLock(lock);
 				log.info("engine.skill_swept", { skill_key: knownKey });
+				health.clear("pull", `skill:${knownKey}`);
+				health.clear("push", `skill:${knownKey}`);
+				health.clear("push", `skill_scan:${knownKey}`);
 			} catch (e) {
 				allApplied = false;
+				health.set("pull", `skill:${knownKey}`, `skill ${knownKey} delete: ${toErrorMessage(e)}`);
 				log.warn("engine.sweep_failed", {
 					skill_key: knownKey,
 					error: toErrorMessage(e),
@@ -2114,7 +2240,7 @@ async function reconcileFromCloud(
 
 	// All-or-nothing revision + etag update. See `allApplied`
 	// comment above.
-	if (allApplied) {
+	if (complete && allApplied) {
 		if (revision !== null) setRevision(revision);
 		setEtag(etag);
 	}
@@ -2234,21 +2360,16 @@ async function pullSkill(
 	// Recompute the on-disk hash so the watcher's next tick
 	// recognizes this as our own write and skips re-uploading.
 	const dir = join(opts.adapter.getSkillsRootDir(), skillKey);
-	try {
-		const hash = await computeSkillFolderHash(dir);
-		lastPushedHash.set(skillKey, hash);
-		// Persist to skills-lock so a future daemon restart treats
-		// this as a known-shipped skill. Without this, a cloud-side
-		// delete that lands while the daemon is offline would
-		// surface at boot as "local-only, no record" → PUSH back,
-		// resurrecting the deletion. Mirrors the push-success path.
-		const lock = readSkillsLock();
-		lock.skills[skillCacheKey(opts.adapter.agentType, skillKey)] = { hash };
-		writeSkillsLock(lock);
-	} catch {
-		// Directory state weird (extraction half-done?); next
-		// reconcile fixes it.
-	}
+	const hash = await computeSkillFolderHash(dir);
+	// Persist to skills-lock so a future daemon restart treats
+	// this as a known-shipped skill. Without this, a cloud-side
+	// delete that lands while the daemon is offline would
+	// surface at boot as "local-only, no record" → PUSH back,
+	// resurrecting the deletion. Mirrors the push-success path.
+	const lock = readSkillsLock();
+	lock.skills[skillCacheKey(opts.adapter.agentType, skillKey)] = { hash };
+	writeSkillsLock(lock);
+	lastPushedHash.set(skillKey, hash);
 	log.info("engine.skill_pulled", { skill_key: skillKey });
 }
 

--- a/packages/cli/tests/api-client.test.ts
+++ b/packages/cli/tests/api-client.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ApiError } from "../src/lib/api-client";
+import { ApiError, retryingFetch } from "../src/lib/api-client";
 
 // ApiClient reads ~/.clawdi/{auth,config}.json at construction via getAuth/getConfig.
 // We redirect HOME to a tmpdir so each test gets a fresh auth/config.
@@ -190,5 +190,80 @@ describe("ApiClient error classification", () => {
 		expect(caught).toBeInstanceOf(ApiError);
 		expect((caught as ApiError).status).toBe(200);
 		expect((caught as ApiError).body).toContain("empty response");
+	});
+
+	it("keeps timeout and caller abort active while consuming non-2xx bodies", async () => {
+		const origFetch = globalThis.fetch;
+		let externalBodyStartedResolve: (() => void) | undefined;
+		const externalBodyStarted = new Promise<void>((resolve) => {
+			externalBodyStartedResolve = resolve;
+		});
+		let fetchCalls = 0;
+		globalThis.fetch = async (_input, init) => {
+			fetchCalls += 1;
+			const fetchCall = fetchCalls;
+			const signal = init?.signal;
+			if (!signal) throw new Error("expected request abort signal");
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						const abort = () => controller.error(new DOMException("Aborted", "AbortError"));
+						if (signal.aborted) abort();
+						else signal.addEventListener("abort", abort, { once: true });
+					},
+					pull() {
+						if (fetchCall === 2) externalBodyStartedResolve?.();
+						return new Promise<void>(() => {});
+					},
+				}),
+				{ status: 422 },
+			);
+		};
+
+		try {
+			await expect(
+				retryingFetch(new Request("http://127.0.0.1:0", { method: "POST" }), 10, undefined),
+			).rejects.toMatchObject({ name: "ApiError", status: 0, isTimeout: true });
+
+			const callerAbort = new AbortController();
+			const pending = retryingFetch(
+				new Request("http://127.0.0.1:0", { method: "POST" }),
+				1_000,
+				callerAbort.signal,
+			);
+			await externalBodyStarted;
+			callerAbort.abort();
+			await expect(pending).rejects.toMatchObject({
+				name: "ApiError",
+				body: "aborted",
+				isTimeout: false,
+			});
+		} finally {
+			globalThis.fetch = origFetch;
+		}
+	});
+
+	it("keeps Retry-After outside the attempt timeout but abortable by the caller", async () => {
+		const origFetch = globalThis.fetch;
+		let fetchCalls = 0;
+		globalThis.fetch = async () => {
+			fetchCalls += 1;
+			return new Response("rate limited", {
+				status: 429,
+				headers: { "retry-after": "60" },
+			});
+		};
+		const callerAbort = new AbortController();
+		const abortTimer = setTimeout(() => callerAbort.abort(), 20);
+
+		try {
+			await expect(
+				retryingFetch(new Request("http://127.0.0.1:0"), 1, callerAbort.signal),
+			).rejects.toMatchObject({ name: "ApiError", body: "aborted", isTimeout: false });
+			expect(fetchCalls).toBe(1);
+		} finally {
+			clearTimeout(abortTimer);
+			globalThis.fetch = origFetch;
+		}
 	});
 });

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -153,7 +153,28 @@ describe("CLI smoke — src entry", () => {
 		}
 	});
 
-	it("runtime init enters repair and writes boot status without datasource", async () => {
+	it("runtime verify treats a missing manifest cache as not checked", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-runtime-verify-${Date.now()}`);
+		mkdirSync(join(root, "home"), { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["runtime", "verify", "--json"], {
+				HOME: join(root, "home"),
+				CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
+				CLAWDI_RUN_DIR: join(root, "run"),
+			});
+			expect(code).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.status).toBe("ok");
+			expect(parsed.manifestCache).toMatchObject({ exists: false, valid: null });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init writes repair status and runtime status exits non-zero for it", async () => {
 		const { tmpdir } = await import("node:os");
 		const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-init-${Date.now()}`);
@@ -206,7 +227,7 @@ describe("CLI smoke — src entry", () => {
 			expect(cloudResult.v1.errors).toEqual(parsed.errors);
 
 			const status = await runCli(["runtime", "status", "--json"], env);
-			expect(status.code).toBe(0);
+			expect(status.code).toBe(1);
 			const statusParsed = JSON.parse(status.stdout);
 			expect(statusParsed.exists).toBe(true);
 			expect(statusParsed.status.mode).toBe("repair");

--- a/packages/cli/tests/tar.test.ts
+++ b/packages/cli/tests/tar.test.ts
@@ -6,11 +6,20 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as tar from "tar";
-import { extractSharedSkillTarGz, tarSingleFile, tarSkillDir } from "../src/lib/tar";
+import { replaceSkillArchiveTarGz, tarSingleFile, tarSkillDir } from "../src/lib/tar";
 
 function buildSkill(layout: Record<string, string>): { path: string; cleanup: () => void } {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-tar-test-"));
@@ -131,8 +140,9 @@ describe("tarSkillDir filter", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-shared-extract-test-"));
 		try {
 			const bytes = await tarSingleFile("safe-skill", "# safe");
+			const skillsRoot = join(root, "skills");
 			await expect(
-				extractSharedSkillTarGz("../escape", join(root, "target"), bytes),
+				replaceSkillArchiveTarGz("../escape", skillsRoot, join(skillsRoot, "target"), bytes),
 			).rejects.toThrow("Invalid skill_key");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
@@ -152,10 +162,41 @@ describe("tarSkillDir filter", () => {
 				.on("data", (chunk: Buffer) => chunks.push(chunk))
 				.promise();
 
-			const target = join(root, "target");
-			await extractSharedSkillTarGz("safe-skill", target, Buffer.concat(chunks));
+			const skillsRoot = join(root, "skills");
+			const target = join(skillsRoot, "target");
+			await replaceSkillArchiveTarGz("safe-skill", skillsRoot, target, Buffer.concat(chunks));
 			expect(existsSync(join(target, "SKILL.md"))).toBe(true);
 			expect(existsSync(join(target, "leak"))).toBe(false);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("atomically replaces a nested Hermes skill from staging outside the watched root", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-skill-replace-test-"));
+		const skillsRoot = join(root, "skills");
+		const target = join(skillsRoot, "category", "foo");
+		try {
+			mkdirSync(target, { recursive: true });
+			writeFileSync(join(target, "SKILL.md"), "# old");
+
+			const malformedRoot = join(root, "malformed");
+			mkdirSync(join(malformedRoot, "category"), { recursive: true });
+			writeFileSync(join(malformedRoot, "category", "foo"), "not a directory");
+			const chunks: Buffer[] = [];
+			await tar
+				.create({ gzip: true, cwd: malformedRoot }, ["category/foo"])
+				.on("data", (chunk: Buffer) => chunks.push(chunk))
+				.promise();
+			await expect(
+				replaceSkillArchiveTarGz("category/foo", skillsRoot, target, Buffer.concat(chunks)),
+			).rejects.toThrow("expected 'category/foo/' root entry");
+			expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# old");
+
+			const replacement = await tarSingleFile("category/foo", "# new");
+			await replaceSkillArchiveTarGz("category/foo", skillsRoot, target, replacement);
+			expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# new");
+			expect(readdirSync(root).filter((entry) => entry.startsWith(".skills-stage-"))).toEqual([]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Root cause

- The REST retry boundary released its timeout and external abort listener as soon as response headers arrived, leaving JSON, text, binary, and non-2xx body consumption uncancellable. Retry-After also shared the wrong timeout ownership.
- Each adapter replaced downloaded Cloud skill archives in place. Temporary extraction and trash could appear under the watched skills root, nested Hermes keys could resolve against the wrong boundary, and rollback failure could lose the only old copy.
- Live sync compressed unrelated transport, pull, reconcile, scan, and push failures into one mutable string, so an unrelated success could clear a still-unresolved resource failure and falsely project Live.
- Runtime status returned before setting JSON exit semantics for a recorded error, while runtime verify treated an absent manifest cache as valid instead of not checked.

## Minimal design

- Buffer each REST response inside the per-attempt fetch plus arrayBuffer cancellation scope, then classify status and retry after cleanup. Retry-After remains server-directed and outside the attempt timeout while caller abort stays immediate.
- Route all four adapters through one atomic archive helper. It stages beside the real skills root on the same filesystem, validates the expected skillKey directory including nested keys, swaps target to outside-root .previous and staged skill to target, rolls back on install failure, and preserves the exact recovery path if rollback also fails.
- Track unresolved sync health by transport, pull, and push resource. Projection is deterministic with explicit auth priority; successes clear only their matching source or resource, deletion paths clear pull plus both push keys, and scan preparation keys remain independent from upload keys.
- Make missing runtime manifest cache validity nullable and give JSON and human runtime status the same nonzero semantics for unreadable or recorded error status.

## Verification

- bun run --cwd packages/cli typecheck
- bun test packages/cli/tests/api-client.test.ts packages/cli/tests/tar.test.ts packages/cli/src/serve/sync-engine.test.ts packages/cli/tests/smoke.test.ts: 79 passed
- Biome check on all 12 affected files
- Docker clean runner: bun run test cli: 1227 passed, 0 failed
- git diff --check origin/main...HEAD
- Rebased onto origin/main at 51c6ed241f9fa092c1fe1e0f158d2d25edde8dbf before final verification and push

## Explicit exclusions

- No runtime installer pinning or versioning was added.
- Official OpenClaw and Hermes installers remain unpinned, and source=official behavior is unchanged.
- No CI or workflow changes, merge, deployment, live cluster access, tenant data access, credential access, or production setting changes.