### PR TITLE
release(cli): prepare 0.13.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.9",
+	"version": "0.13.10",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/share/tokens.test.ts
+++ b/packages/cli/src/share/tokens.test.ts
@@ -116,6 +116,8 @@ describe("share-tokens.json", () => {
 		const [restored] = listTokens();
 		expect(restored.project_id).toBe("legacy-project");
 		expect(restored.project_name).toBe("Legacy Toolkit");
+		expect(restored).not.toHaveProperty("scope_id");
+		expect(restored).not.toHaveProperty("scope_name");
 		addToken({ ...restored, upgraded_at: "2026-05-12T11:00:00Z" });
 
 		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
@@ -123,6 +125,8 @@ describe("share-tokens.json", () => {
 		};
 		expect(raw.tokens[0].project_id).toBe("legacy-project");
 		expect(raw.tokens[0].project_name).toBe("Legacy Toolkit");
+		expect(raw.tokens[0]).not.toHaveProperty("scope_id");
+		expect(raw.tokens[0]).not.toHaveProperty("scope_name");
 		expect(raw.tokens[0].future_field).toEqual({ enabled: true });
 	});
 

--- a/packages/cli/src/share/tokens.ts
+++ b/packages/cli/src/share/tokens.ts
@@ -109,41 +109,36 @@ function nonEmptyString(value: unknown): string | undefined {
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function persistedProjectId(value: unknown): string | undefined {
-	if (typeof value !== "object" || value === null) return undefined;
-	return (
-		("project_id" in value ? nonEmptyString(value.project_id) : undefined) ??
-		("scope_id" in value ? nonEmptyString(value.scope_id) : undefined)
-	);
-}
-
-function issueLabel(value: unknown, index: number): string {
-	if (typeof value !== "object" || value === null) return `local share entry ${index + 1}`;
-	const name =
-		("project_name" in value ? nonEmptyString(value.project_name) : undefined) ??
-		("scope_name" in value ? nonEmptyString(value.scope_name) : undefined);
-	if (name) return name;
-	const projectId = persistedProjectId(value);
-	return projectId ? `Project ${projectId}` : `local share entry ${index + 1}`;
-}
-
 function normalizeToken(
 	value: unknown,
 	index: number,
-): { kind: "token"; token: ShareToken } | { kind: "issue"; issue: ShareTokenStoreIssue } {
-	const label = issueLabel(value, index);
+):
+	| { kind: "token"; token: ShareToken; projectId: string }
+	| { kind: "issue"; issue: ShareTokenStoreIssue; projectId?: string } {
 	if (typeof value !== "object" || value === null) {
-		return { kind: "issue", issue: { label, reason: "entry is not an object" } };
+		return {
+			kind: "issue",
+			issue: { label: `local share entry ${index + 1}`, reason: "entry is not an object" },
+		};
 	}
 
-	const projectId = persistedProjectId(value);
+	// `scope_id`/`scope_name` were the released version:1 names before
+	// 911c955b renamed them without bumping the persisted-file version. This is
+	// the only compatibility boundary: recognized legacy fields are read here,
+	// removed from the output, and never enter normal runtime data or writes.
+	const canonicalFields: Record<string, unknown> = { ...value };
+	const projectId =
+		nonEmptyString(canonicalFields.project_id) ?? nonEmptyString(canonicalFields.scope_id);
 	const projectName =
-		("project_name" in value ? nonEmptyString(value.project_name) : undefined) ??
-		("scope_name" in value ? nonEmptyString(value.scope_name) : undefined);
-	const ownerDisplay = "owner_display" in value ? nonEmptyString(value.owner_display) : undefined;
-	const ownerHandle = "owner_handle" in value ? nonEmptyString(value.owner_handle) : undefined;
-	const token = "token" in value ? nonEmptyString(value.token) : undefined;
-	const redeemedAt = "redeemed_at" in value ? nonEmptyString(value.redeemed_at) : undefined;
+		nonEmptyString(canonicalFields.project_name) ?? nonEmptyString(canonicalFields.scope_name);
+	delete canonicalFields.scope_id;
+	delete canonicalFields.scope_name;
+	const ownerDisplay = nonEmptyString(canonicalFields.owner_display);
+	const ownerHandle = nonEmptyString(canonicalFields.owner_handle);
+	const token = nonEmptyString(canonicalFields.token);
+	const redeemedAt = nonEmptyString(canonicalFields.redeemed_at);
+	const label =
+		projectName ?? (projectId ? `Project ${projectId}` : `local share entry ${index + 1}`);
 
 	const missing: string[] = [];
 	if (!projectId) missing.push("project id");
@@ -156,18 +151,19 @@ function normalizeToken(
 		return {
 			kind: "issue",
 			issue: { label, reason: "invalid 43-character share token" },
+			projectId,
 		};
 	}
 	if (!projectId || !projectName || !ownerDisplay || !ownerHandle || !redeemedAt || !token) {
-		return { kind: "issue", issue: { label, reason: `missing ${missing.join(", ")}` } };
+		return {
+			kind: "issue",
+			issue: { label, reason: `missing ${missing.join(", ")}` },
+			projectId,
+		};
 	}
 
-	// `scope_id`/`scope_name` were the released version:1 names before
-	// 911c955b renamed them without bumping the persisted-file version.
-	// Canonical fields are overlaid at read time while all other fields,
-	// including future fields, remain available to subsequent upserts.
 	const normalized: ShareToken & Record<string, unknown> = {
-		...value,
+		...canonicalFields,
 		project_id: projectId,
 		project_name: projectName,
 		owner_display: ownerDisplay,
@@ -185,7 +181,7 @@ function normalizeToken(
 	) {
 		delete normalized.last_seen_skill_keys;
 	}
-	return { kind: "token", token: normalized };
+	return { kind: "token", token: normalized, projectId };
 }
 
 export function readTokenStore(): {
@@ -208,7 +204,9 @@ export function listTokens(): ShareToken[] {
 
 export function addToken(token: ShareToken): void {
 	const state = loadRaw();
-	const idx = state.tokens.findIndex((value) => persistedProjectId(value) === token.project_id);
+	const idx = state.tokens.findIndex(
+		(value, index) => normalizeToken(value, index).projectId === token.project_id,
+	);
 	if (idx === -1) {
 		state.tokens.push(token);
 	} else {
@@ -223,7 +221,9 @@ export function addToken(token: ShareToken): void {
 
 export function removeToken(projectId: string): void {
 	const state = loadRaw();
-	state.tokens = state.tokens.filter((value) => persistedProjectId(value) !== projectId);
+	state.tokens = state.tokens.filter(
+		(value, index) => normalizeToken(value, index).projectId !== projectId,
+	);
 	save(state);
 }
 


### PR DESCRIPTION
## Summary

- Bump the Clawdi CLI and Bun workspace metadata from 0.13.9 to 0.13.10.
- Follow up #537 with one persistence read-boundary normalizer for released version:1 share-tokens.json records.
- Strip recognized scope_id/scope_name fields from canonical runtime data while preserving genuinely unknown fields.
- Keep normal writes project_*-only, malformed raw records recoverable, and the existing auth upgrade/404 behavior unchanged.

## Audit evidence

- Exact searches across packages/cli, .github, and scripts found no scope-sharing, shared scope, or /scope route references.
- Production scope_id/scope_name references exist only in packages/cli/src/share/tokens.ts inside normalizeToken, where they are read and deleted.
- Remaining test references are released-v1 compatibility fixtures plus one focused persistence-boundary test.
- No stale runtime scope fallback remains. addToken accepts the canonical ShareToken type; auth and business logic use project_* only.
- Removed the separate persistedProjectId and issueLabel compatibility helpers. Production tokens.ts remains 232 lines, but legacy-schema knowledge is now concentrated in one normalizer.
- Release metadata resolves to 0.13.10 in packages/cli/package.json and bun.lock. The sole 0.13.9 search hit is a historical 0.13.9-beta.0 runtime updater fixture, not publish metadata.

## Verification

- Focused token-store and auth tests: 21 passed.
- Full CLI suite: 1,227 passed.
- Docker clean runner: CLI 1,227 passed; backend 1,464 passed, 7 skipped; exit 0.
- Workspace typecheck: 4/4 packages.
- Biome check: 738 files.
- Frozen Bun lockfile install: no changes.
- Publish manifest validation: passed.
- Standalone binary: reports 0.13.10; release tarball checksum passed.
- npm pack: clawdi-0.13.10.tgz; tarball and clean installed CLI both report 0.13.10.
- git diff --check: passed.

Head commit: c7383b0ec26f7f1f729bb899df09c32301807e48

No npm publish, release workflow dispatch, production/live-cluster operation, or tenant-data access was performed.