### PR TITLE
ci: harden production image deployment boundary

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -116,10 +116,12 @@ jobs:
         run: uv run deptry app
       - name: Generated OpenAPI client is current
         run: uv run python scripts/check_generated_api.py
-      - name: Coolify deploy contract sanity
+      - name: Coolify deploy and release contract sanity
         run: |
           python3 -m py_compile ../infra/deploy/coolify/*.py
           python3 -m json.tool ../infra/deploy/coolify/production-stack.json >/dev/null
+          uv run pytest -q --confcutdir=tests/workflow_contracts \
+            tests/workflow_contracts/test_image_release_workflow_contract.py
 
   test:
     needs: changes

--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build. Defaults to the workflow SHA."
+        description: "Git ref to publish. Production deploys must resolve to the current main workflow SHA."
         required: false
       deploy:
         description: "Update and deploy the Coolify Applications after publishing."
@@ -47,10 +47,9 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
-  group: clawdi-image-release-production
+  group: clawdi-image-release
   cancel-in-progress: false
 
 env:
@@ -58,13 +57,21 @@ env:
   WEB_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-web
 
 jobs:
-  build:
+  publish:
+    name: Publish immutable images
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       github.event.workflow_run.repository.full_name == github.repository)
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_tag: ${{ steps.rev.outputs.sha }}
       build_required: ${{ steps.runtime-changes.outputs.build }}
@@ -73,40 +80,87 @@ jobs:
     steps:
       - name: Resolve source ref
         id: source-ref
+        env:
+          DISPATCH_REF: ${{ inputs.ref }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
-            ref="${{ github.event.workflow_run.head_sha }}"
-          else
-            ref="${{ inputs.ref }}"
-            if [ -z "$ref" ]; then
-              ref="${GITHUB_SHA}"
-            fi
-          fi
+          case "$GITHUB_EVENT_NAME" in
+            workflow_run)
+              ref="$WORKFLOW_RUN_HEAD_SHA"
+              if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "workflow_run head_sha must be a full git SHA." >&2
+                exit 1
+              fi
+              ;;
+            workflow_dispatch)
+              ref="${DISPATCH_REF:-$GITHUB_SHA}"
+              if ! git check-ref-format --allow-onelevel "$ref" >/dev/null 2>&1; then
+                echo "ref must be a full git SHA or valid git ref." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported image release event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.source-ref.outputs.ref }}
           fetch-depth: 2
+          persist-credentials: false
 
       - id: rev
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          sha="$(git rev-parse --verify HEAD^{commit})"
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Resolved source must be a full git commit SHA." >&2
+            exit 1
+          fi
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve deploy mode
         id: deploy-mode
         env:
           AUTO_DEPLOY: ${{ vars.CLAWDI_COOLIFY_AUTO_DEPLOY }}
+          DISPATCH_DEPLOY: ${{ inputs.deploy }}
+          DISPATCH_DEPLOY_SCOPE: ${{ inputs.deploy_scope }}
+          SOURCE_SHA: ${{ steps.rev.outputs.sha }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           should_deploy=false
-          deploy_scope="${{ inputs.deploy_scope }}"
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
-            deploy_scope=all
-            if [ "${AUTO_DEPLOY}" = "true" ]; then
-              should_deploy=true
-            fi
-          elif [ "${{ inputs.deploy }}" = "true" ]; then
-            should_deploy=true
-          fi
+          deploy_scope="$DISPATCH_DEPLOY_SCOPE"
+          case "$GITHUB_EVENT_NAME" in
+            workflow_run)
+              if [ "$SOURCE_SHA" != "$WORKFLOW_RUN_HEAD_SHA" ]; then
+                echo "Resolved source does not match the trusted workflow_run commit." >&2
+                exit 1
+              fi
+              deploy_scope=all
+              if [ "$AUTO_DEPLOY" = "true" ]; then
+                should_deploy=true
+              fi
+              ;;
+            workflow_dispatch)
+              if [ "$DISPATCH_DEPLOY" = "true" ]; then
+                if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+                  echo "Production deploys may only be dispatched from main." >&2
+                  exit 1
+                fi
+                if [ "$SOURCE_SHA" != "$GITHUB_SHA" ]; then
+                  echo "Production deploy ref must resolve to the current main workflow SHA." >&2
+                  exit 1
+                fi
+                should_deploy=true
+              fi
+              ;;
+            *)
+              echo "Unsupported image release event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
           if [ -z "$deploy_scope" ]; then
             deploy_scope=api-only
           fi
@@ -115,6 +169,8 @@ jobs:
 
       - name: Detect backend image changes
         id: runtime-changes
+        env:
+          SOURCE_SHA: ${{ steps.rev.outputs.sha }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "build=true" >> "$GITHUB_OUTPUT"
@@ -122,7 +178,7 @@ jobs:
             exit 0
           fi
 
-          changed_files="$(git diff-tree --no-commit-id --name-only -r -m --first-parent "${{ steps.rev.outputs.sha }}")"
+          changed_files="$(git diff-tree --no-commit-id --name-only -r -m --first-parent "$SOURCE_SHA")"
           printf '%s\n' "$changed_files"
 
           build=false
@@ -218,42 +274,55 @@ jobs:
 
       - name: Print image summary
         if: steps.runtime-changes.outputs.build == 'true'
+        env:
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE_NAME }}
+          BUILD_WEB: ${{ inputs.build_web }}
+          SOURCE_SHA: ${{ steps.rev.outputs.sha }}
+          WEB_IMAGE: ${{ env.WEB_IMAGE_NAME }}
         run: |
           echo "### Clawdi Images" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Backend: \`${{ env.BACKEND_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ inputs.build_web }}" = "true" ]; then
-            echo "- Web: \`${{ env.WEB_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Backend: \`${BACKEND_IMAGE}:${SOURCE_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$BUILD_WEB" = "true" ]; then
+            echo "- Web: \`${WEB_IMAGE}:${SOURCE_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Web: skipped" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Print skipped image summary
         if: steps.runtime-changes.outputs.build != 'true'
+        env:
+          BUILD_REASON: ${{ steps.runtime-changes.outputs.reason }}
+          SOURCE_SHA: ${{ steps.rev.outputs.sha }}
         run: |
           echo "### Clawdi Images" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Backend image build: skipped" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reason: \`${{ steps.runtime-changes.outputs.reason }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Ref: \`${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Reason: \`${BUILD_REASON}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Ref: \`${SOURCE_SHA}\`" >> "$GITHUB_STEP_SUMMARY"
 
-  deploy:
-    needs: build
-    if: needs.build.outputs.build_required == 'true' && needs.build.outputs.should_deploy == 'true'
+  deploy-production:
+    name: Deploy production
+    needs: publish
+    if: needs.publish.outputs.build_required == 'true' && needs.publish.outputs.should_deploy == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 30
+    environment: production
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.build.outputs.image_tag }}
+          ref: ${{ needs.publish.outputs.image_tag }}
+          persist-credentials: false
 
       - name: Deploy Coolify Applications
         env:
           COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
           CLAWDI_BACKEND_RUNTIME_IMAGE: ${{ env.BACKEND_IMAGE_NAME }}
-          CLAWDI_BACKEND_RUNTIME_TAG: ${{ needs.build.outputs.image_tag }}
-          CLAWDI_DEPLOY_SCOPE: ${{ needs.build.outputs.deploy_scope }}
+          CLAWDI_BACKEND_RUNTIME_TAG: ${{ needs.publish.outputs.image_tag }}
+          CLAWDI_DEPLOY_SCOPE: ${{ needs.publish.outputs.deploy_scope }}
           CLAWDI_WAIT_FOR_DEPLOY: ${{ inputs.wait }}
         run: |
           if [ -z "$COOLIFY_API_URL" ] || [ -z "$COOLIFY_TOKEN" ]; then
@@ -272,8 +341,8 @@ jobs:
         env:
           COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
-          CLAWDI_BACKEND_RUNTIME_TAG: ${{ needs.build.outputs.image_tag }}
-          CLAWDI_DEPLOY_SCOPE: ${{ needs.build.outputs.deploy_scope }}
+          CLAWDI_BACKEND_RUNTIME_TAG: ${{ needs.publish.outputs.image_tag }}
+          CLAWDI_DEPLOY_SCOPE: ${{ needs.publish.outputs.deploy_scope }}
           CLAWDI_EXPECT_FILE_STORE_TYPE: ${{ vars.CLAWDI_COOLIFY_FILE_STORE_TYPE }}
         run: |
           if [ "$CLAWDI_DEPLOY_SCOPE" = "api-only" ]; then
@@ -286,15 +355,20 @@ jobs:
             --phase "$phase" \
             --expect-commit "$CLAWDI_BACKEND_RUNTIME_TAG"
 
-  audit:
-    needs: build
-    if: needs.build.outputs.build_required != 'true' && needs.build.outputs.should_deploy == 'true'
+  audit-production:
+    name: Audit production
+    needs: publish
+    if: needs.publish.outputs.build_required != 'true' && needs.publish.outputs.should_deploy == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.build.outputs.image_tag }}
+          ref: ${{ needs.publish.outputs.image_tag }}
+          persist-credentials: false
 
       - name: Audit Coolify Applications
         env:

--- a/backend/tests/workflow_contracts/test_image_release_workflow_contract.py
+++ b/backend/tests/workflow_contracts/test_image_release_workflow_contract.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "clawdi-image-release.yml"
+WORKFLOW_TEXT = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def load_workflow() -> dict[str, Any]:
+    workflow = yaml.load(WORKFLOW_TEXT, Loader=yaml.BaseLoader)
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    for step in job["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"Missing workflow step: {name}")
+
+
+def test_workflow_run_requires_successful_same_repository_main_push() -> None:
+    workflow = load_workflow()
+    workflow_run = workflow["on"]["workflow_run"]
+    assert workflow_run["workflows"] == ["Backend CI"]
+    assert workflow_run["types"] == ["completed"]
+    assert workflow_run["branches"] == ["main"]
+
+    publish_gate = workflow["jobs"]["publish"]["if"]
+    for required_check in (
+        "github.event_name == 'workflow_run'",
+        "github.event.workflow_run.conclusion == 'success'",
+        "github.event.workflow_run.event == 'push'",
+        "github.event.workflow_run.head_branch == 'main'",
+        "github.event.workflow_run.head_repository.full_name == github.repository",
+        "github.event.workflow_run.repository.full_name == github.repository",
+    ):
+        assert required_check in publish_gate
+
+
+def test_manual_production_deploy_requires_current_main_commit() -> None:
+    publish = load_workflow()["jobs"]["publish"]
+    source_step = named_step(publish, "Resolve source ref")
+    assert source_step["env"]["DISPATCH_REF"] == "${{ inputs.ref }}"
+    assert 'git check-ref-format --allow-onelevel "$ref"' in source_step["run"]
+    assert '[[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]' in source_step["run"]
+
+    deploy_mode = named_step(publish, "Resolve deploy mode")
+    assert deploy_mode["env"]["DISPATCH_DEPLOY"] == "${{ inputs.deploy }}"
+    assert deploy_mode["env"]["SOURCE_SHA"] == "${{ steps.rev.outputs.sha }}"
+    assert '[ "$GITHUB_REF" != "refs/heads/main" ]' in deploy_mode["run"]
+    assert '[ "$SOURCE_SHA" != "$GITHUB_SHA" ]' in deploy_mode["run"]
+    assert '[ "$SOURCE_SHA" != "$WORKFLOW_RUN_HEAD_SHA" ]' in deploy_mode["run"]
+
+
+@pytest.mark.parametrize(
+    ("event_env", "expected_output"),
+    (
+        (
+            {
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_REF": "refs/heads/main",
+                "DISPATCH_DEPLOY": "true",
+            },
+            "deploy_scope=api-only\nshould_deploy=true\n",
+        ),
+        (
+            {
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_REF": "refs/heads/feature",
+                "DISPATCH_DEPLOY": "true",
+            },
+            None,
+        ),
+        (
+            {
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_REF": "refs/heads/main",
+                "DISPATCH_DEPLOY": "true",
+                "SOURCE_SHA": "b" * 40,
+            },
+            None,
+        ),
+        (
+            {
+                "GITHUB_EVENT_NAME": "workflow_run",
+                "AUTO_DEPLOY": "true",
+            },
+            "deploy_scope=all\nshould_deploy=true\n",
+        ),
+        (
+            {
+                "GITHUB_EVENT_NAME": "workflow_run",
+                "AUTO_DEPLOY": "true",
+                "WORKFLOW_RUN_HEAD_SHA": "b" * 40,
+            },
+            None,
+        ),
+    ),
+)
+def test_deploy_mode_fails_closed(
+    tmp_path: Path,
+    event_env: dict[str, str],
+    expected_output: str | None,
+) -> None:
+    publish = load_workflow()["jobs"]["publish"]
+    deploy_mode = named_step(publish, "Resolve deploy mode")
+    output_path = tmp_path / "github-output"
+    trusted_sha = "a" * 40
+    env = {
+        "AUTO_DEPLOY": "false",
+        "DISPATCH_DEPLOY": "false",
+        "DISPATCH_DEPLOY_SCOPE": "api-only",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_OUTPUT": str(output_path),
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_SHA": trusted_sha,
+        "SOURCE_SHA": trusted_sha,
+        "WORKFLOW_RUN_HEAD_SHA": trusted_sha,
+        **event_env,
+    }
+
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", deploy_mode["run"]],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    if expected_output is None:
+        assert result.returncode != 0
+        return
+    assert result.returncode == 0, result.stderr
+    assert output_path.read_text(encoding="utf-8") == expected_output
+
+
+def test_publish_and_production_jobs_have_separate_authority() -> None:
+    workflow = load_workflow()
+    jobs = workflow["jobs"]
+    publish = jobs["publish"]
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert publish["permissions"] == {"contents": "read", "packages": "write"}
+    assert "environment" not in publish
+    assert "COOLIFY_API_URL" not in str(publish)
+    assert "COOLIFY_TOKEN" not in str(publish)
+
+    for job_name in ("deploy-production", "audit-production"):
+        production_job = jobs[job_name]
+        assert production_job["needs"] == "publish"
+        assert production_job["environment"] == "production"
+        assert production_job["permissions"] == {"contents": "read"}
+        assert "needs.publish.outputs.should_deploy == 'true'" in production_job["if"]
+
+    secret_names = set(re.findall(r"secrets\.([A-Z0-9_]+)", WORKFLOW_TEXT))
+    assert secret_names == {"COOLIFY_API_URL", "COOLIFY_TOKEN"}
+    assert WORKFLOW_TEXT.count("packages: write") == 1
+
+
+def test_shell_steps_receive_expressions_through_environment() -> None:
+    workflow = load_workflow()
+    for job_name, job in workflow["jobs"].items():
+        for step in job["steps"]:
+            run = step.get("run")
+            if run is not None:
+                assert "${{" not in run, f"{job_name}/{step.get('name', step.get('id'))}"
+                syntax = subprocess.run(
+                    ["bash", "--noprofile", "--norc", "-n", "-c", run],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                assert syntax.returncode == 0, syntax.stderr
+
+
+def test_production_jobs_do_not_control_tenants_or_business_apis() -> None:
+    workflow = load_workflow()
+    jobs = workflow["jobs"]
+    deploy_run = named_step(jobs["deploy-production"], "Deploy Coolify Applications")["run"]
+    audit_runs = [
+        step["run"]
+        for job_name in ("deploy-production", "audit-production")
+        for step in jobs[job_name]["steps"]
+        if step.get("name") == "Audit Coolify Applications"
+    ]
+
+    assert "infra/deploy/coolify/deploy_ghcr_runtime.py" in deploy_run
+    assert all("infra/deploy/coolify/audit_stack.py" in run for run in audit_runs)
+    for forbidden in (
+        "repository_dispatch",
+        "workflow_call",
+        "CLAWDI_AUTH_TOKEN",
+        "ADMIN_API_KEY",
+        "/v1/admin",
+        "tenant",
+    ):
+        assert forbidden not in WORKFLOW_TEXT

--- a/infra/deploy/coolify/README.md
+++ b/infra/deploy/coolify/README.md
@@ -234,3 +234,34 @@ ignored local overlay with the real destination and storage values.
 The API role runs `alembic upgrade head` before Uvicorn starts. Keep migrations
 backward-compatible and short enough for the API health-check startup budget, or
 run long data migrations manually before deploying the image.
+
+### GitHub production boundary
+
+Image publication and production deployment are separate jobs. The publish job
+has GHCR write access but no production environment or Coolify secrets. A manual
+production deploy fails unless the workflow was dispatched from `main` and the
+published ref resolves to that run's current `main` commit. The automatic path
+accepts only a successful same-repository `push` run of `Backend CI` on `main`.
+Production deploy and audit jobs reference the dedicated `production`
+environment and can call only the repository's Coolify deploy/audit helpers.
+Administrators must configure that environment as the protected boundary; the
+workflow reference alone does not prove that protection rules exist. These jobs
+must not carry tenant, admin, or other business-control-plane credentials.
+
+Repository administrators must complete these GitHub-side controls separately
+from the code change:
+
+1. Create or update the `production` environment. Restrict deployment branches
+   to `main`, require reviewers, and prevent self-review when the repository plan
+   supports it.
+2. Rotate the Coolify API token, store the replacement as the environment secret
+   `COOLIFY_TOKEN`, and store `COOLIFY_API_URL` in the same environment. Remove
+   repository-level copies after an environment-protected run succeeds, and
+   revoke the replaced token at its issuer.
+3. Inventory repository and environment secrets, then delete every obsolete
+   production deploy or admin API secret that this workflow no longer
+   references. Revoke or rotate the underlying credentials; deleting only the
+   GitHub secret is not sufficient.
+4. Keep `CLAWDI_COOLIFY_AUTO_DEPLOY` disabled until environment protection and
+   secret migration are complete. It may then be enabled as a repository
+   variable for same-repository successful `main` pushes only.


### PR DESCRIPTION
## Scope

This is the Clawdi-side security-boundary change. It is independent from the Hermes readiness fix in Clawdi-AI/clawdi-hosted#1090.

## Changes

- Split image publishing from production Coolify deployment authority.
- Require successful same-repository main push provenance for automatic production deployment.
- Require an explicit current-main commit for manual production deployment.
- Restrict production credentials to production environment jobs.
- Add hermetic fail-closed workflow contracts and document administrator-side follow-up.

## Verification

- Workflow contract suite: 10 passed.
- Workflow YAML, shell syntax, formatting, and git diff checks passed.

No production API, tenant, rollout, restart, reconcile, dispatch, merge, or deployment operation was performed. GitHub environment protection and repository secret deletion or rotation remain administrator actions.