### PR TITLE
Improve v2 agent onboarding choices

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1578,7 +1578,10 @@ async function gotoHostedSettingsDialog(page: Page, section: string) {
 	throw new Error("Settings dialog did not open.");
 }
 
-test("empty account offers two working first-agent paths", async ({ page }) => {
+test("empty account offers two working first-agent paths with npm setup by default", async ({
+	page,
+	context,
+}) => {
 	await stubHostedApi(page, { deployments: [], cloudAgents: [] });
 	await page.goto("/");
 
@@ -1586,15 +1589,78 @@ test("empty account offers two working first-agent paths", async ({ page }) => {
 		exact: true,
 	});
 	await expect(firstAgent).toBeVisible();
-	await expect(
-		page.getByRole("button", { name: "Deploy a hosted agent", exact: true }),
-	).toHaveAttribute("href", "/deploy");
+	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveAttribute(
+		"href",
+		"/deploy",
+	);
 
-	await page.getByRole("button", { name: "Connect via CLI", exact: true }).click();
-	await expect(page.getByText("Connect an agent you already run", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Connect an agent on your machine", exact: true }).click();
+	await expect(
+		page.getByRole("heading", { name: "Connect an agent on your machine", exact: true }),
+	).toBeVisible();
 	await expect(
 		page.getByText("Run the setup command on the machine where your agent lives."),
 	).toBeVisible();
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
+	const command = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
+	await expect(page.getByText(command, { exact: true })).toBeVisible();
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+	await page.getByRole("button", { name: "Copy", exact: true }).click();
+	await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(command);
+});
+
+test("returning users can deploy on Clawdi or connect another machine", async ({ page }) => {
+	await stubHostedApi(page, { deployments: [includedBasicDeployment], cloudAgents: [] });
+	await page.goto("/");
+
+	await expect(page.getByText("Included Basic", { exact: true }).first()).toBeVisible();
+	await expect(page.getByText("Add another agent", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveAttribute(
+		"href",
+		"/deploy",
+	);
+	await expect(
+		page.getByRole("button", { name: "Connect an agent on your machine", exact: true }),
+	).toBeVisible();
+});
+
+test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {
+	await stubHostedApi(page, {
+		canCreateCloudAgents: false,
+		deployments: [],
+		cloudAgents: [],
+	});
+	await page.goto("/");
+
+	await expect(page.getByText("Let's connect your first agent", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveCount(0);
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("npm install -g clawdi@latest && clawdi auth login && clawdi setup", {
+			exact: true,
+		}),
+	).toBeVisible();
+});
+
+test("returning accounts keep hosted management but hide new deploys when denied", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		canCreateCloudAgents: false,
+		deployments: [includedBasicDeployment],
+		cloudAgents: [],
+	});
+	await page.goto("/");
+
+	await expect(page.getByText("Included Basic", { exact: true }).first()).toBeVisible();
+	await expect(page.getByText("Add another agent", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveCount(0);
+	await expect(
+		page.getByText("Connect another agent on your machine and manage it from this dashboard.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
 });
 
 test("hosted mixed agent rail uses whole semantic buttons for context switching", async ({

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -25,13 +25,13 @@ function useOrigin() {
 
 // One paste connects the machine: install, authorize (opens the browser),
 // then auto-detect every local agent and start the sync daemons.
-const ONE_COMMAND = "bun add -g clawdi && clawdi auth login && clawdi setup";
+const ONE_COMMAND = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
 
 const CLI_STEPS = [
 	{
 		title: "Install the CLI",
-		code: "bun add -g clawdi",
-		description: "Or use npm: npm install -g clawdi",
+		code: "npm install -g clawdi@latest",
+		description: "Requires Node.js 22.5+. Prefer Bun? Use: bun add -g clawdi@latest",
 	},
 	{
 		title: "Log in",
@@ -127,6 +127,7 @@ export function AddAgentSetup() {
 					<StepNumber n={1} />
 					<span className="text-sm font-medium">Run this in a terminal on the machine</span>
 				</div>
+				<p className="mt-1.5 text-xs text-muted-foreground">Node.js 22.5+ is required.</p>
 				<div className="mt-2 rounded-lg border bg-muted/30">
 					<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
 						<span className="text-2xs uppercase tracking-wider text-muted-foreground">

--- a/apps/web/src/components/dashboard/agent-onboarding.test.ts
+++ b/apps/web/src/components/dashboard/agent-onboarding.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const onboardingSource = readFileSync(new URL("./onboarding-card.tsx", import.meta.url), "utf8");
+const setupSource = readFileSync(new URL("./add-agent-setup.tsx", import.meta.url), "utf8");
+const newAgentSource = readFileSync(new URL("./new-agent-button.tsx", import.meta.url), "utf8");
+const hostedSectionSource = readFileSync(
+	new URL("../../hosted/hosted-agents-section.tsx", import.meta.url),
+	"utf8",
+);
+const dashboardSource = readFileSync(
+	new URL("../../pages/dashboard/page.tsx", import.meta.url),
+	"utf8",
+);
+const agentsIndexSource = readFileSync(
+	new URL("../../pages/dashboard/agents/page.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("dashboard agent onboarding", () => {
+	test("passes create access to both empty and returning hosted onboarding", () => {
+		expect(dashboardSource).toContain(
+			"const cloudDeploymentManagementEnabled = Boolean(HostedAgentsSection);",
+		);
+		expect(
+			dashboardSource.match(/canDeployOnClawdi=\{hostedAccess\.canCreateCloudAgents\}/g),
+		).toHaveLength(2);
+		expect(
+			dashboardSource.match(/showCloudDeployments=\{cloudDeploymentManagementEnabled\}/g),
+		).toHaveLength(3);
+		expect(agentsIndexSource).toContain("canDeployOnClawdi={hostedAccess.canCreateCloudAgents}");
+		expect(agentsIndexSource).toContain("showCloudDeployments={cloudDeploymentManagementEnabled}");
+		expect(hostedSectionSource).toContain(
+			"<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />",
+		);
+		expect(hostedSectionSource).toContain('variant="additional-agent"');
+		expect(hostedSectionSource).toContain("canDeployOnClawdi={canDeployOnClawdi}");
+	});
+
+	test("uses one gated deploy-or-connect experience for first and additional agents", () => {
+		expect(onboardingSource).toContain("{canDeployOnClawdi ? (");
+		expect(onboardingSource).toContain("Deploy on Clawdi");
+		expect(onboardingSource).toContain("Connect an agent on your machine");
+		expect(onboardingSource).not.toContain("showHostedFirstAgentChoice");
+		expect(onboardingSource).not.toContain("Deploy a hosted agent");
+	});
+
+	test("keeps the sidebar chooser terminology and capability gate consistent", () => {
+		expect(newAgentSource).toContain(
+			"const canDeployOnClawdi = hydrated && IS_HOSTED && hostedAccess.canCreateCloudAgents;",
+		);
+		expect(newAgentSource).toContain("{canDeployOnClawdi ? (");
+		expect(newAgentSource).toContain(
+			'title={checkingDeployAccess ? "Checking deploy access" : "Deploy on Clawdi"}',
+		);
+		expect(newAgentSource).toContain('title="Connect an agent on your machine"');
+		expect(newAgentSource).not.toContain("Connect your own agent");
+		expect(newAgentSource).not.toContain("Deploy managed agent");
+	});
+});
+
+describe("connected-agent setup command", () => {
+	test("defaults the displayed and copied command to npm", () => {
+		const command = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
+		expect(setupSource).toContain(`const ONE_COMMAND = "${command}";`);
+		expect(setupSource).toContain("onClick={() => copy(ONE_COMMAND)}");
+		expect(setupSource).toContain("{ONE_COMMAND}");
+		expect(setupSource).not.toContain("npx ");
+	});
+
+	test("states the Node requirement and keeps Bun as a secondary alternative", () => {
+		expect(setupSource).toContain("Node.js 22.5+ is required.");
+		expect(setupSource).toContain("Prefer Bun? Use: bun add -g clawdi@latest");
+	});
+});

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -37,13 +37,13 @@ export function NewAgentButton({
 	const hydrated = useHydrated();
 	const [chooserOpen, setChooserOpen] = useState(false);
 	const [connectOpen, setConnectOpen] = useState(false);
-	const canDeployManagedAgent = hydrated && IS_HOSTED && hostedAccess.canCreateCloudAgents;
+	const canDeployOnClawdi = hydrated && IS_HOSTED && hostedAccess.canCreateCloudAgents;
 	const checkingDeployAccess = hydrated && IS_HOSTED && hostedAccess.isLoading;
 	const deployAccessError = hydrated && IS_HOSTED && hostedAccess.isError;
 
 	function handleClick() {
 		if (checkingDeployAccess) return;
-		if (canDeployManagedAgent || deployAccessError) {
+		if (canDeployOnClawdi || deployAccessError) {
 			setChooserOpen(true);
 			return;
 		}
@@ -56,7 +56,7 @@ export function NewAgentButton({
 	}
 
 	function chooseDeploy() {
-		if (!canDeployManagedAgent) return;
+		if (!canDeployOnClawdi) return;
 		setChooserOpen(false);
 		onNavigate?.();
 		void router.navigate({ href: "/deploy" });
@@ -97,7 +97,9 @@ export function NewAgentButton({
 					<DialogHeader>
 						<DialogTitle>New agent</DialogTitle>
 						<DialogDescription>
-							Deploy a managed agent on Clawdi, or connect an agent you already run.
+							{canDeployOnClawdi
+								? "Deploy on Clawdi, or connect an agent on your machine."
+								: "Connect an agent on your machine."}
 						</DialogDescription>
 					</DialogHeader>
 					{deployAccessError ? (
@@ -109,17 +111,18 @@ export function NewAgentButton({
 							title="Couldn't verify deploy access"
 						/>
 					) : null}
-					<div className="grid gap-3 sm:grid-cols-2">
-						<ChoiceCard
-							icon={checkingDeployAccess ? <Loader2 className="animate-spin" /> : <Rocket />}
-							title={checkingDeployAccess ? "Checking deploy access" : "Deploy managed agent"}
-							description="Clawdi-managed runtime — pick a framework and go live in minutes."
-							onClick={chooseDeploy}
-							disabled={!canDeployManagedAgent}
-						/>
+					<div className={cn("grid gap-3", canDeployOnClawdi && "sm:grid-cols-2")}>
+						{canDeployOnClawdi ? (
+							<ChoiceCard
+								icon={checkingDeployAccess ? <Loader2 className="animate-spin" /> : <Rocket />}
+								title={checkingDeployAccess ? "Checking deploy access" : "Deploy on Clawdi"}
+								description="Clawdi runs and manages it — pick a framework and go live in minutes."
+								onClick={chooseDeploy}
+							/>
+						) : null}
 						<ChoiceCard
 							icon={<TerminalSquare />}
-							title="Connect your own agent"
+							title="Connect an agent on your machine"
 							description="Claude Code, Codex, Hermes, or OpenClaw via the CLI."
 							onClick={chooseConnect}
 						/>
@@ -137,25 +140,19 @@ function ChoiceCard({
 	title,
 	description,
 	onClick,
-	disabled = false,
 }: {
 	icon: React.ReactNode;
 	title: string;
 	description: string;
 	onClick: () => void;
-	disabled?: boolean;
 }) {
 	return (
 		<Button
 			type="button"
 			data-slot="new-agent-choice"
 			onClick={onClick}
-			disabled={disabled}
 			variant="outline"
-			className={cn(
-				"h-auto min-h-32 w-full flex-col items-start justify-start gap-2 whitespace-normal p-4 text-left",
-				!disabled && "hover:border-primary/40 hover:bg-muted/50",
-			)}
+			className="h-auto min-h-32 w-full flex-col items-start justify-start gap-2 whitespace-normal p-4 text-left hover:border-primary/40 hover:bg-muted/50"
 		>
 			<IconChip size="sm" tint="bg-primary/10 text-primary" className="size-9 transition-colors">
 				{icon}

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -9,28 +9,33 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 type OnboardingCardProps = {
 	variant?: "first-agent" | "additional-agent";
-	hosted?: boolean;
+	canDeployOnClawdi?: boolean;
 };
 
 /**
  * Overview hero card for connecting a new agent. Rendered in the Overview
  * primary slot when the user has zero agents, and as a secondary
- * side-panel card once at least one agent is registered. Hosted first-agent
- * onboarding leads with deploy and reveals the shared CLI setup on demand.
+ * side-panel card once at least one agent is registered. When Cloud agent
+ * creation is available, both placements offer the same deploy-or-connect
+ * choice and reveal the shared CLI setup on demand.
  */
-export function OnboardingCard({ variant = "first-agent", hosted = false }: OnboardingCardProps) {
+export function OnboardingCard({
+	variant = "first-agent",
+	canDeployOnClawdi = false,
+}: OnboardingCardProps) {
 	const [showCliSetup, setShowCliSetup] = useState(false);
 	const isAdditionalAgent = variant === "additional-agent";
-	const showHostedFirstAgentChoice = hosted && !isAdditionalAgent;
 	const title = isAdditionalAgent
 		? "Add another agent"
-		: showHostedFirstAgentChoice
+		: canDeployOnClawdi
 			? "Get your first agent running"
 			: "Let's connect your first agent";
 	const description = isAdditionalAgent
-		? "Manage multiple agents from one place. Projects help each agent use the right skills and credentials."
-		: showHostedFirstAgentChoice
-			? "Deploy a fully hosted agent in minutes, or connect an agent you already run with the CLI."
+		? canDeployOnClawdi
+			? "Deploy another agent on Clawdi, or connect an agent on your machine."
+			: "Connect another agent on your machine and manage it from this dashboard."
+		: canDeployOnClawdi
+			? "Deploy on Clawdi in minutes, or connect an agent on your machine."
 			: "Connect an agent first. Then create a Project to organize reusable skills and credentials you can share with teammates.";
 
 	return (
@@ -43,11 +48,11 @@ export function OnboardingCard({ variant = "first-agent", hosted = false }: Onbo
 				<CardDescription>{description}</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-5">
-				{showHostedFirstAgentChoice ? (
+				{canDeployOnClawdi ? (
 					<>
-						<div className="flex flex-col gap-2 sm:flex-row">
+						<div className="flex flex-col gap-2">
 							<Button render={<Link to="/deploy" />} nativeButton={false} size="lg">
-								<Rocket data-icon="inline-start" /> Deploy a hosted agent
+								<Rocket data-icon="inline-start" /> Deploy on Clawdi
 							</Button>
 							<Button
 								type="button"
@@ -57,13 +62,13 @@ export function OnboardingCard({ variant = "first-agent", hosted = false }: Onbo
 								aria-controls={showCliSetup ? "first-agent-cli-setup" : undefined}
 								onClick={() => setShowCliSetup((visible) => !visible)}
 							>
-								<TerminalSquare data-icon="inline-start" /> Connect via CLI
+								<TerminalSquare data-icon="inline-start" /> Connect an agent on your machine
 							</Button>
 						</div>
 						{showCliSetup ? (
 							<div id="first-agent-cli-setup" className="space-y-4 border-t pt-5">
 								<div>
-									<h3 className="text-sm font-semibold">Connect an agent you already run</h3>
+									<h3 className="text-sm font-semibold">Connect an agent on your machine</h3>
 									<p className="text-sm text-muted-foreground">
 										Run the setup command on the machine where your agent lives.
 									</p>

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -23,10 +23,10 @@ import { useUnifiedAgentList } from "@/hosted/use-unified-agent-list";
 
 type Env = components["schemas"]["AgentResponse"];
 
-function HostedEmptyAccountHero() {
+function HostedEmptyAccountHero({ canDeployOnClawdi }: { canDeployOnClawdi: boolean }) {
 	return (
 		<div className="space-y-4">
-			<OnboardingCard variant="first-agent" hosted />
+			<OnboardingCard variant="first-agent" canDeployOnClawdi={canDeployOnClawdi} />
 			<WelcomeWalletCard showDeployAction={false} />
 		</div>
 	);
@@ -104,6 +104,7 @@ export function HostedAgentsSection({
 	onRetrySelfManaged,
 	selfManagedCount,
 	cloudEnvs,
+	canDeployOnClawdi,
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
@@ -119,6 +120,8 @@ export function HostedAgentsSection({
 	 * renders from the deployment identity.
 	 */
 	cloudEnvs: Env[];
+	/** Whether this account may create another Cloud agent. */
+	canDeployOnClawdi: boolean;
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
 }) {
@@ -145,7 +148,7 @@ export function HostedAgentsSection({
 		<div data-hosted="true" className="space-y-4">
 			<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 			{isEmptyState ? (
-				<HostedEmptyAccountHero />
+				<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />
 			) : (
 				<AgentsCard
 					agents={agentTiles}
@@ -178,11 +181,13 @@ export function HostedAgentsSection({
 export function HostedSecondaryCTA({
 	envsLoading,
 	cloudEnvs,
+	canDeployOnClawdi,
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
 	envsLoading: boolean;
 	cloudEnvs: Env[];
+	canDeployOnClawdi: boolean;
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
 }) {
@@ -195,7 +200,9 @@ export function HostedSecondaryCTA({
 		showLegacyAgents,
 	});
 	const hasAnyAgent = unified.tiles.length > 0;
-	if (hasAnyAgent) return <OnboardingCard variant="additional-agent" />;
+	if (hasAnyAgent) {
+		return <OnboardingCard variant="additional-agent" canDeployOnClawdi={canDeployOnClawdi} />;
+	}
 	// Loading: don't flash an empty slot then pop in. Wait for pending
 	// sources only when none has already proven there is an agent.
 	if (envsLoading || unified.isLoading) return null;
@@ -212,6 +219,7 @@ export function HostedAgentsByCompute({
 	onRetrySelfManaged,
 	selfManagedCount,
 	cloudEnvs,
+	canDeployOnClawdi,
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
@@ -220,6 +228,7 @@ export function HostedAgentsByCompute({
 	onRetrySelfManaged?: () => void;
 	selfManagedCount: number;
 	cloudEnvs: Env[];
+	canDeployOnClawdi: boolean;
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
 }) {
@@ -243,7 +252,7 @@ export function HostedAgentsByCompute({
 		return (
 			<div data-hosted="true" className="space-y-6">
 				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
-				<HostedEmptyAccountHero />
+				<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />
 			</div>
 		);
 	}

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -185,9 +185,9 @@ describe("unified list consumers", () => {
 		expect(homepage).toContain("useUnifiedAgentList({");
 		expect(homepage).not.toContain("connectedAgentTilesForHostedView");
 		expect(homepage).not.toContain("useHostedAgentTiles({");
-		expect(homepage).toContain("<HostedEmptyAccountHero />");
+		expect(homepage).toContain("<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />");
 		expect(homepage).toContain("<WelcomeWalletCard showDeployAction={false} />");
-		expect(onboarding).toContain("Deploy a hosted agent");
-		expect(onboarding).toContain("Connect via CLI");
+		expect(onboarding).toContain("Deploy on Clawdi");
+		expect(onboarding).toContain("Connect an agent on your machine");
 	});
 });

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -67,6 +67,7 @@ export default function AgentsIndexPage() {
 						}}
 						selfManagedCount={selfManagedCount}
 						cloudEnvs={environments ?? []}
+						canDeployOnClawdi={hostedAccess.canCreateCloudAgents}
 						showCloudDeployments={cloudDeploymentManagementEnabled}
 						showLegacyAgents={legacyHostedAgentsEnabled}
 					/>

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -217,6 +217,7 @@ export default function DashboardPage() {
 								}}
 								selfManagedCount={selfManagedCount}
 								cloudEnvs={environments ?? []}
+								canDeployOnClawdi={hostedAccess.canCreateCloudAgents}
 								showCloudDeployments={cloudDeploymentManagementEnabled}
 								showLegacyAgents={legacyHostedAgentsEnabled}
 							/>
@@ -310,6 +311,7 @@ export default function DashboardPage() {
 							<HostedSecondaryCTA
 								envsLoading={envsLoading}
 								cloudEnvs={environments ?? []}
+								canDeployOnClawdi={hostedAccess.canCreateCloudAgents}
 								showCloudDeployments={cloudDeploymentManagementEnabled}
 								showLegacyAgents={legacyHostedAgentsEnabled}
 							/>


### PR DESCRIPTION
## Summary

- keep Deploy on Clawdi and connected-agent onboarding available from the homepage for both new and returning users
- pass Cloud-agent creation access explicitly through hosted dashboard empty states while preserving existing deployment management
- make npm the default CLI setup path, document Node.js 22.5+, and keep Bun as a secondary option
- align sidebar terminology and add focused unit/source-contract plus hosted browser coverage

## Verification

- `scripts/test.sh web src/components/dashboard/agent-onboarding.test.ts src/hosted/use-unified-agent-list.test.ts src/lib/hosted-product-access.test.ts src/hosted/cloud-deployment-management.test.ts`
  - web typecheck passed
  - 23 focused tests passed
  - OSS production build passed
- focused hosted Playwright onboarding scenarios passed in the implementation worktree
- pre-commit Biome checks passed

No production, cluster, or tenant operations were performed.
