### PR TITLE
fix(web): restore v2 agent live sync status

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -65,7 +65,7 @@ import {
 	compareAgentTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
-import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
+import { DaemonStatusBadge, type DaemonStatusSource } from "@/components/dashboard/daemon-status";
 import { NewAgentButton } from "@/components/dashboard/new-agent-button";
 import { IconChip } from "@/components/icon-chip";
 import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
@@ -1155,6 +1155,14 @@ function agentHeaderMeta(
 	return { visibleLabel: visible.join(" · "), detailLabel: detail.join(" · "), activityLabel };
 }
 
+export function focusHeaderSyncSource(
+	kind: AgentChromeKind,
+	hasEnvironment: boolean,
+): DaemonStatusSource | null {
+	if (!hasEnvironment || kind === "unresolved") return null;
+	return kind === "connected" ? "self-managed" : "on-clawdi";
+}
+
 function FocusHeader({
 	activeAgent,
 	activeAgentTile,
@@ -1207,19 +1215,14 @@ function FocusHeader({
 	const name =
 		activeAgentTile?.name ?? (activeAgent ? agentDisplayName(activeAgent) : "Clawdi Cloud agent");
 	const displayName = displayMachineName(name);
-	const meta =
-		activeAgentKind !== "cloud" && activeAgent
-			? agentHeaderMeta(activeAgent, activeAgentKind)
-			: null;
+	const meta = activeAgent ? agentHeaderMeta(activeAgent, activeAgentKind) : null;
 	const activityLabel = meta?.activityLabel ?? "Agent details unavailable";
 	const visibleLabel = meta?.visibleLabel;
 	const detailLabel = meta?.detailLabel;
-	const title =
-		activeAgentKind === "cloud"
-			? name
-			: [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
+	const title = [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
 	const manageHref =
 		activeAgentKind === "legacy" ? (legacyHostedDashboardUrl() ?? undefined) : undefined;
+	const syncSource = focusHeaderSyncSource(activeAgentKind, Boolean(activeAgent));
 	return (
 		<div className="min-w-0 text-left">
 			<div className="flex min-w-0 items-center gap-2" title={title}>
@@ -1243,24 +1246,24 @@ function FocusHeader({
 					{visibleLabel}
 				</div>
 			) : null}
-			{activeAgentKind !== "cloud" ? (
+			{activeAgent && syncSource ? (
 				<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
-					{/* Legacy agents use hosted daemon copy and keep remediation in
-					 * the legacy v1 dashboard when that URL is configured. */}
-					{activeAgent ? (
-						<DaemonStatusBadge
-							env={activeAgent}
-							source={activeAgentKind === "legacy" ? "on-clawdi" : "self-managed"}
-							manageHref={manageHref}
-							compact
-							tooltipDetail={detailLabel}
-						/>
-					) : (
-						<FocusStatusFallback />
-					)}
+					{/* Cloud and legacy agents use supervised-runtime copy. Legacy
+					 * remediation stays in v1 when that dashboard is configured. */}
+					<DaemonStatusBadge
+						env={activeAgent}
+						source={syncSource}
+						manageHref={manageHref}
+						compact
+						tooltipDetail={detailLabel}
+					/>
 					<span className="min-w-0 truncate text-muted-foreground" title={activityLabel}>
 						{activityLabel}
 					</span>
+				</div>
+			) : activeAgentKind !== "cloud" ? (
+				<div className="mt-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
+					<FocusStatusFallback />
 				</div>
 			) : null}
 		</div>

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -1,13 +1,25 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import type { components } from "@clawdi/shared/api";
 import {
 	type AgentTile,
+	agentTileCardProjection,
 	agentTileMatchesRouteId,
 	fleetSummaryFromTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
 
+type FocusHeaderSyncSource = typeof import("@/components/app-sidebar").focusHeaderSyncSource;
+
 type Env = components["schemas"]["AgentResponse"];
+
+let getFocusHeaderSyncSource: FocusHeaderSyncSource | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const sidebar = await import("@/components/app-sidebar");
+	getFocusHeaderSyncSource = sidebar.focusHeaderSyncSource;
+});
 
 function env(overrides: Partial<Env> = {}): Env {
 	return {
@@ -62,6 +74,91 @@ describe("selfManagedAgentTiles", () => {
 		});
 		expect("statusLabel" in tile).toBe(false);
 		expect("runtimeLabel" in tile).toBe(false);
+	});
+});
+
+describe("agentTileCardProjection", () => {
+	it("shows real v2 hosted live sync and retains useful card metadata", () => {
+		const projected = env({
+			last_seen_at: new Date(Date.now() - 30_000).toISOString(),
+			last_sync_at: new Date().toISOString(),
+			sync_enabled: true,
+		});
+		const tile: AgentTile = {
+			id: "hdep_live",
+			source: "on-clawdi",
+			name: "Research agent",
+			agentType: "openclaw",
+			lastSeenAt: projected.last_seen_at,
+			href: `/agents/${projected.id}`,
+			active: true,
+			env: projected,
+		};
+
+		const projection = agentTileCardProjection(tile);
+
+		expect(projection.statusVisual).toMatchObject({
+			kind: "live",
+			label: "Live",
+			tooltip: "Sync is live.",
+		});
+		expect(projection.meta[0]).toBe("OpenClaw");
+		expect(projection.meta).toHaveLength(2);
+	});
+
+	it("does not manufacture hosted sync status without an environment projection", () => {
+		const tile: AgentTile = {
+			id: "hdep_pending_projection",
+			source: "on-clawdi",
+			name: "Research agent",
+			agentType: "openclaw",
+			lastSeenAt: null,
+			href: "/agents/env_pending",
+			active: true,
+			env: null,
+		};
+
+		expect(agentTileCardProjection(tile)).toEqual({
+			meta: ["OpenClaw"],
+			statusVisual: null,
+		});
+	});
+
+	it("keeps self-managed setup and legacy live-sync semantics", () => {
+		const selfManaged: AgentTile = {
+			id: "self",
+			source: "self-managed",
+			name: "Workstation",
+			agentType: "codex",
+			href: "/agents/self",
+			active: false,
+			env: env(),
+		};
+		const legacy: AgentTile = {
+			...selfManaged,
+			id: "legacy",
+			source: "legacy-hosted",
+			env: env({ last_sync_at: new Date().toISOString(), sync_enabled: true }),
+		};
+
+		expect(agentTileCardProjection(selfManaged).statusVisual?.kind).toBe("set-up");
+		expect(agentTileCardProjection(legacy).statusVisual?.kind).toBe("live");
+	});
+});
+
+describe("focused sidebar sync projection", () => {
+	it("shows Cloud sync only after the environment projection exists", () => {
+		if (!getFocusHeaderSyncSource) throw new Error("focusHeaderSyncSource was not loaded");
+
+		expect(getFocusHeaderSyncSource("cloud", true)).toBe("on-clawdi");
+		expect(getFocusHeaderSyncSource("cloud", false)).toBeNull();
+	});
+
+	it("preserves connected and legacy status copy", () => {
+		if (!getFocusHeaderSyncSource) throw new Error("focusHeaderSyncSource was not loaded");
+
+		expect(getFocusHeaderSyncSource("connected", true)).toBe("self-managed");
+		expect(getFocusHeaderSyncSource("legacy", true)).toBe("on-clawdi");
 	});
 });
 

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -259,18 +259,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	) : legacyHosted ? (
 		<LegacyAgentBadge iconOnly />
 	) : null;
-	const identity = agentIdentity({
-		name: tile.name,
-		machine_name: tile.name,
-		agent_type: tile.agentType,
-	});
-	const activityLabel = agentTileActivityLabel(tile);
-	const meta = onClawdi
-		? []
-		: [identity.secondaryLabel, activityLabel].filter((value): value is string => Boolean(value));
-	const statusVisual = onClawdi
-		? null
-		: daemonStatusVisual(tile.env, legacyHosted ? "on-clawdi" : "self-managed");
+	const { meta, statusVisual } = agentTileCardProjection(tile);
 	const linkLabel = statusVisual
 		? `Open ${tile.name}. Status: ${statusVisual.label}`
 		: `Open ${tile.name}`;
@@ -279,12 +268,11 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		<div
 			className={cn(
 				ENTITY_CARD_BASE,
-				"group relative z-0 h-full transition-colors hover:bg-muted/50",
+				"group relative z-0 h-full p-3 transition-colors hover:bg-muted/50",
 			)}
 			title={tile.href ? undefined : tile.name}
 		>
 			<EntityHeader
-				align="start"
 				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
 				title={
 					<span className="flex min-w-0 items-center gap-1.5">
@@ -328,11 +316,40 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 
 function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
 	return (
-		<span title={visual.label} className="inline-flex shrink-0 items-center">
+		<span
+			title={`Status: ${visual.label}. ${visual.tooltip}`}
+			className="inline-flex shrink-0 items-center"
+		>
 			<span aria-hidden className={cn("size-1.5 rounded-full", visual.dotClass)} />
 			<span className="sr-only">{visual.label}</span>
 		</span>
 	);
+}
+
+/**
+ * The compact card projects sync only from a real Cloud API environment.
+ * A v2 deployment can exist before that projection arrives; rendering the
+ * daemon's null-env "pending" state there would turn missing data into a
+ * reassuring status. Self-managed and legacy tiles retain their established
+ * setup status because their environment record is their source of truth.
+ */
+export function agentTileCardProjection(tile: AgentTile): {
+	meta: string[];
+	statusVisual: DaemonStatusVisual | null;
+} {
+	const identity = agentIdentity({
+		name: tile.name,
+		machine_name: tile.name,
+		agent_type: tile.agentType,
+	});
+	const meta = [identity.secondaryLabel, agentTileActivityLabel(tile)].filter(
+		(value): value is string => Boolean(value),
+	);
+	const statusVisual =
+		tile.source === "on-clawdi" && !tile.env
+			? null
+			: daemonStatusVisual(tile.env, tile.source === "self-managed" ? "self-managed" : "on-clawdi");
+	return { meta, statusVisual };
 }
 
 function agentTileActivityLabel(tile: AgentTile): string | null {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -172,6 +172,7 @@ describe("deploymentToTiles", () => {
 		expect(tiles.map((tile) => tile.id)).toEqual(["dep_123"]);
 		expect(tiles.map((tile) => tile.name)).toEqual(["hosted-test"]);
 		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi&d=dep_123`);
+		expect(tiles[0]?.env).toBe(openclawEnv);
 		expectHostedTileHasNoStatus(tiles[0]);
 	});
 
@@ -239,6 +240,7 @@ describe("deploymentToTiles", () => {
 			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 			env: null,
 		});
+		expect(tile?.env).toBeNull();
 		expectHostedTileHasNoStatus(tile);
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");


### PR DESCRIPTION
## Summary

- restore env-backed live-sync status on v2 Cloud agent cards without duplicating compute state
- compact the shared agent card into a calmer identity row plus agent type/activity row while preserving source badges, actions, and whole-card links
- show the same truthful live-sync badge in the focused sidebar when a Cloud API environment is available; keep it absent while the projection is missing
- preserve the detail page's compute-first hierarchy and existing self-managed/legacy behavior

## Root cause

`AgentTileView` explicitly returned no status and no metadata for every `source === "on-clawdi"` tile, even though `useHostedAgentTiles` already joins the matching Cloud API environment into `tile.env`. The sidebar independently excluded all Cloud agents from `DaemonStatusBadge`.

## Status surface matrix

| Surface | Self-managed / legacy | v2 Cloud with matched env | v2 Cloud without env |
| --- | --- | --- | --- |
| Compact grid card | Live-sync status | Live-sync status only | No sync status |
| Focused sidebar | Live-sync badge | Live-sync badge | No sync status |
| Hosted detail Overview | Existing behavior | Compute primary; degraded sync secondary; healthy sync quiet | Compute primary; existing pending/degraded handling |
| Homepage/deployment choice | Existing compute semantics | Compute status | Compute status |

Grid cards intentionally do not project deployment compute status.

## Verification

- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src`
- `bun run --cwd apps/web test` (all web tests pass)
- `bun run --cwd apps/web test src/hosted/oss-clean.test.ts` (15 pass)
- `bun run --cwd apps/web build:oss`
- focused card/hosted/sidebar projection tests (31 pass across the two focused files)
- `git diff --check origin/main..HEAD`

The pure card/sidebar projection tests provide a deterministic component-level check without requiring host mutations or live services.
