### PR TITLE
Unify connect-agent onboarding dialog

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1578,10 +1578,13 @@ async function gotoHostedSettingsDialog(page: Page, section: string) {
 	throw new Error("Settings dialog did not open.");
 }
 
-test("empty account offers two working first-agent paths with npm setup by default", async ({
+test("empty account opens the shared Add agent dialog with peer setup tabs", async ({
 	page,
 	context,
+	baseURL,
 }) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the onboarding test.");
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 	await stubHostedApi(page, { deployments: [], cloudAgents: [] });
 	await page.goto("/");
 
@@ -1593,20 +1596,41 @@ test("empty account offers two working first-agent paths with npm setup by defau
 		"href",
 		"/deploy",
 	);
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toHaveCount(0);
 
 	await page.getByRole("button", { name: "Connect an agent on your machine", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Add agent" });
+	await expect(dialog).toBeVisible();
+	const commandTab = dialog.getByRole("tab", { name: "Run commands", exact: true });
+	const promptTab = dialog.getByRole("tab", { name: "Ask your agent", exact: true });
+	await expect(commandTab).toHaveAttribute("aria-selected", "true");
+	await expect(promptTab).toHaveAttribute("aria-selected", "false");
+	await expect(dialog.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
 	await expect(
-		page.getByRole("heading", { name: "Connect an agent on your machine", exact: true }),
-	).toBeVisible();
-	await expect(
-		page.getByText("Run the setup command on the machine where your agent lives."),
-	).toBeVisible();
-	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
-	const command = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
-	await expect(page.getByText(command, { exact: true })).toBeVisible();
-	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-	await page.getByRole("button", { name: "Copy", exact: true }).click();
-	await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(command);
+		dialog.getByText("npm install -g clawdi@latest && clawdi auth login && clawdi setup", {
+			exact: true,
+		}),
+	).toHaveCount(0);
+
+	const commands = [
+		{ label: "Copy Install the CLI command", value: "npm install -g clawdi@latest" },
+		{ label: "Copy Log in command", value: "clawdi auth login" },
+		{ label: "Copy Connect and enable sync command", value: "clawdi setup" },
+	];
+	for (const command of commands) {
+		await expect(dialog.getByText(command.value, { exact: true })).toBeVisible();
+		await dialog.getByRole("button", { name: command.label, exact: true }).click();
+		await expect
+			.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+			.toBe(command.value);
+	}
+
+	await promptTab.click();
+	await expect(promptTab).toHaveAttribute("aria-selected", "true");
+	const prompt = `Set up Clawdi on this machine. Fetch ${new URL(baseURL).origin}/skill.md, and follow the skills to set it up. Finally, confirm the installation with \`clawdi doctor\`.`;
+	await expect(dialog.getByText(prompt, { exact: true })).toBeVisible();
+	await dialog.getByRole("button", { name: "Copy prompt", exact: true }).click();
+	await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(prompt);
 });
 
 test("returning users can deploy on Clawdi or connect another machine", async ({ page }) => {
@@ -1622,6 +1646,8 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 	await expect(
 		page.getByRole("button", { name: "Connect an agent on your machine", exact: true }),
 	).toBeVisible();
+	await page.getByRole("button", { name: "Connect an agent on your machine", exact: true }).click();
+	await expect(page.getByRole("dialog", { name: "Add agent" })).toBeVisible();
 });
 
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {
@@ -1634,12 +1660,14 @@ test("empty accounts without deploy access only get the connected-agent path", a
 
 	await expect(page.getByText("Let's connect your first agent", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveCount(0);
-	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
-	await expect(
-		page.getByText("npm install -g clawdi@latest && clawdi auth login && clawdi setup", {
-			exact: true,
-		}),
-	).toBeVisible();
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toHaveCount(0);
+	await page.getByRole("button", { name: "Connect an agent on your machine", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Add agent" });
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("tab", { name: "Run commands", exact: true })).toHaveAttribute(
+		"aria-selected",
+		"true",
+	);
 });
 
 test("returning accounts keep hosted management but hide new deploys when denied", async ({
@@ -1660,7 +1688,9 @@ test("returning accounts keep hosted management but hide new deploys when denied
 			exact: true,
 		}),
 	).toBeVisible();
-	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toBeVisible();
+	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toHaveCount(0);
+	await page.getByRole("button", { name: "Connect an agent on your machine", exact: true }).click();
+	await expect(page.getByRole("dialog", { name: "Add agent" })).toBeVisible();
 });
 
 test("hosted mixed agent rail uses whole semantic buttons for context switching", async ({

--- a/apps/web/src/components/dashboard/add-agent-dialog.tsx
+++ b/apps/web/src/components/dashboard/add-agent-dialog.tsx
@@ -10,18 +10,16 @@ import {
 } from "@/components/ui/dialog";
 
 /**
- * Modal variant of the "Add an agent" flow. Opened from the sidebar's
- * Quick Create button. Same Tabs body as the Overview `OnboardingCard`
- * so users see one consistent UI for connecting a new agent.
+ * The shared "Add an agent" flow opened from the sidebar and homepage.
  */
 export function AddAgentDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
 	return (
 		<Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-			<DialogContent className="max-w-2xl sm:max-w-2xl">
+			<DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>Add agent</DialogTitle>
 					<DialogDescription>
-						Connect another machine or agent — Claude Code, Codex, Hermes, or OpenClaw.
+						Connect an agent on your machine — Claude Code, Codex, Hermes, or OpenClaw.
 					</DialogDescription>
 				</DialogHeader>
 				<AddAgentSetup />

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -2,11 +2,12 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Check, ChevronDown, Copy } from "lucide-react";
+import { Bot, Check, Copy, Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AgentLabel, AgentSourceBadgeForEnvironment } from "@/components/dashboard/agent-label";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { unwrap, useApi } from "@/lib/api";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -23,20 +24,16 @@ function useOrigin() {
 	return origin;
 }
 
-// One paste connects the machine: install, authorize (opens the browser),
-// then auto-detect every local agent and start the sync daemons.
-const ONE_COMMAND = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
-
 const CLI_STEPS = [
 	{
 		title: "Install the CLI",
 		code: "npm install -g clawdi@latest",
-		description: "Requires Node.js 22.5+. Prefer Bun? Use: bun add -g clawdi@latest",
+		description: "Install the latest Clawdi CLI globally.",
 	},
 	{
 		title: "Log in",
 		code: "clawdi auth login",
-		description: "Opens your browser to authorize this machine.",
+		description: "Complete browser authorization before continuing to the next step.",
 	},
 	{
 		title: "Connect and enable sync",
@@ -44,6 +41,9 @@ const CLI_STEPS = [
 		description:
 			"Detects Claude Code / Codex / Hermes / OpenClaw, registers each one with your account, and installs the background daemon by default.",
 	},
+];
+
+const AFTER_SETUP_STEPS = [
 	{
 		title: "Check live sync",
 		code: "clawdi daemon status",
@@ -71,7 +71,15 @@ function useCopy(duration = 2000) {
 	return { copied, copy };
 }
 
-function CopyButton({ text, className }: { text: string; className?: string }) {
+function CopyButton({
+	text,
+	label,
+	className,
+}: {
+	text: string;
+	label: string;
+	className?: string;
+}) {
 	const { copied, copy } = useCopy();
 	return (
 		<Button
@@ -79,7 +87,7 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
 			size="icon-xs"
 			onClick={() => copy(text)}
 			className={cn("text-muted-foreground hover:text-foreground", className)}
-			aria-label="Copy"
+			aria-label={label}
 		>
 			{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
 		</Button>
@@ -87,19 +95,13 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
 }
 
 /**
- * Connect-an-agent wizard (journey J7). One primary path — copy one
- * command — plus two quieter alternatives (send a prompt to the agent
- * itself, or step-by-step commands). While open it watches for newly
- * registered environments and flips into an explicit success card the
- * moment the agent checks in, so the win is designed rather than implied.
- *
- * Shared between `OnboardingCard` (Overview hero when no agents exist)
- * and `AddAgentDialog` (sidebar Quick Create).
+ * Shared setup body for every `AddAgentDialog`. Commands and the agent
+ * hand-off prompt are peer paths; while the dialog is open, the setup also
+ * watches for newly registered agents and surfaces an explicit success state.
  */
 export function AddAgentSetup() {
 	const api = useApi();
 	const origin = useOrigin();
-	const { copied, copy } = useCopy();
 	const prompt = `Set up Clawdi on this machine. Fetch ${origin}/skill.md, and follow the skills to set it up. Finally, confirm the installation with \`clawdi doctor\`.`;
 
 	// Live success detection: snapshot the env ids on first load, then poll
@@ -121,53 +123,64 @@ export function AddAgentSetup() {
 
 	return (
 		<div className="space-y-4">
-			{/* Step 1 — the one command */}
-			<div>
-				<div className="flex items-center gap-2">
-					<StepNumber n={1} />
-					<span className="text-sm font-medium">Run this in a terminal on the machine</span>
-				</div>
-				<p className="mt-1.5 text-xs text-muted-foreground">Node.js 22.5+ is required.</p>
-				<div className="mt-2 rounded-lg border bg-muted/30">
-					<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
-						<span className="text-2xs uppercase tracking-wider text-muted-foreground">
-							One command
-						</span>
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => copy(ONE_COMMAND)}
-							className="h-7 gap-1.5 px-2 text-xs"
-						>
-							{copied ? (
-								<>
-									<Check className="size-3.5" />
-									Copied
-								</>
-							) : (
-								<>
-									<Copy className="size-3.5" />
-									Copy
-								</>
-							)}
-						</Button>
+			<Tabs defaultValue="commands">
+				<TabsList className="w-full sm:w-auto">
+					<TabsTrigger value="commands">
+						<Terminal data-icon="inline-start" /> Run commands
+					</TabsTrigger>
+					<TabsTrigger value="prompt">
+						<Bot data-icon="inline-start" /> Ask your agent
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="commands" className="mt-2 space-y-4">
+					<div>
+						<p className="text-sm font-medium">Run these commands in order on the machine</p>
+						<p className="mt-1 text-xs text-muted-foreground">Node.js 22.5+ is required.</p>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							Prefer Bun? Use: bun add -g clawdi@latest
+						</p>
 					</div>
-					<pre className="overflow-x-auto whitespace-pre-wrap p-3 font-mono text-sm leading-relaxed">
-						{ONE_COMMAND}
-					</pre>
-				</div>
-				<p className="mt-1.5 text-xs text-muted-foreground">
-					Installs the CLI, opens your browser to authorize, then finds Claude Code / Codex / Hermes
-					/ OpenClaw on the machine and turns on live sync.
-				</p>
-			</div>
+					<CommandSteps steps={CLI_STEPS} numbered />
+					<div className="space-y-3 border-t pt-4">
+						<div>
+							<p className="text-sm font-medium">After setup</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								These checks are optional and can be run after the agent connects.
+							</p>
+						</div>
+						<CommandSteps steps={AFTER_SETUP_STEPS} />
+					</div>
+				</TabsContent>
+				<TabsContent value="prompt" className="mt-2 space-y-3">
+					<div>
+						<p className="text-sm font-medium">Ask your agent to set up Clawdi</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Paste this prompt into Claude Code, Codex, Hermes, or OpenClaw on the machine.
+						</p>
+					</div>
+					<div className="rounded-lg border bg-muted/30">
+						<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
+							<span className="text-2xs uppercase tracking-wider text-muted-foreground">
+								Setup prompt
+							</span>
+							<CopyButton text={prompt} label="Copy prompt" />
+						</div>
+						<pre className="whitespace-pre-wrap p-3 font-mono text-xs leading-relaxed">
+							{prompt}
+						</pre>
+					</div>
+				</TabsContent>
+			</Tabs>
 
-			{/* Step 2 — designed win moment */}
-			<div>
+			<div className="border-t pt-4">
 				<div className="flex items-center gap-2">
-					<StepNumber n={2} done={newAgents.length > 0} />
+					{newAgents.length > 0 ? (
+						<span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-success text-success-foreground">
+							<Check className="size-3.5" />
+						</span>
+					) : null}
 					<span className="text-sm font-medium">
-						{newAgents.length > 0 ? "Agent connected" : "Watch it appear here"}
+						{newAgents.length > 0 ? "Agent connected" : "Watch for your agent"}
 					</span>
 				</div>
 				{newAgents.length > 0 ? (
@@ -208,70 +221,40 @@ export function AddAgentSetup() {
 					</div>
 				)}
 			</div>
+		</div>
+	);
+}
 
-			{/* Quieter alternatives */}
-			<Disclosure summary="Prefer to let the AI set itself up? Send it this prompt">
-				<div className="rounded-lg border bg-muted/30">
-					<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
-						<span className="text-2xs uppercase tracking-wider text-muted-foreground">Prompt</span>
-						<CopyButton text={prompt} />
-					</div>
-					<pre className="whitespace-pre-wrap p-3 font-mono text-xs leading-relaxed">{prompt}</pre>
-				</div>
-			</Disclosure>
-
-			<Disclosure summary="Step-by-step commands">
-				<div className="space-y-3">
-					{CLI_STEPS.map((step, i) => (
-						<div key={step.title} className="flex gap-3">
-							<StepNumber n={i + 1} />
-							<div className="min-w-0 flex-1">
-								<div className="text-sm font-medium">{step.title}</div>
-								<div className="mt-1 flex items-center gap-1.5 rounded-md border bg-muted/30 px-3 py-1.5">
-									<code className="flex-1 font-mono text-xs">{step.code}</code>
-									<CopyButton text={step.code} />
-								</div>
-								{step.description ? (
-									<p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
-								) : null}
-							</div>
+function CommandSteps({
+	steps,
+	numbered = false,
+}: {
+	steps: ReadonlyArray<{ title: string; code: string; description: string }>;
+	numbered?: boolean;
+}) {
+	return (
+		<div className="space-y-3">
+			{steps.map((step, index) => (
+				<div key={step.title} className="flex gap-3">
+					{numbered ? <StepNumber n={index + 1} /> : null}
+					<div className="min-w-0 flex-1">
+						<div className="text-sm font-medium">{step.title}</div>
+						<div className="mt-1 flex items-center gap-1.5 rounded-md border bg-muted/30 px-3 py-1.5">
+							<code className="min-w-0 flex-1 overflow-x-auto font-mono text-xs">{step.code}</code>
+							<CopyButton text={step.code} label={`Copy ${step.title} command`} />
 						</div>
-					))}
+						<p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
+					</div>
 				</div>
-			</Disclosure>
+			))}
 		</div>
 	);
 }
 
-function StepNumber({ n, done = false }: { n: number; done?: boolean }) {
+function StepNumber({ n }: { n: number }) {
 	return (
-		<span
-			className={cn(
-				"flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold",
-				done ? "bg-success text-success-foreground" : "bg-primary/10 text-primary",
-			)}
-		>
-			{done ? <Check className="size-3.5" /> : n}
+		<span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+			{n}
 		</span>
-	);
-}
-
-function Disclosure({ summary, children }: { summary: string; children: React.ReactNode }) {
-	const [open, setOpen] = useState(false);
-	return (
-		<div>
-			<button
-				type="button"
-				onClick={() => setOpen((v) => !v)}
-				aria-expanded={open}
-				className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-			>
-				<ChevronDown
-					className={cn("size-3.5 transition-transform duration-150", !open && "-rotate-90")}
-				/>
-				{summary}
-			</button>
-			{open ? <div className="mt-2">{children}</div> : null}
-		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-onboarding.test.ts
+++ b/apps/web/src/components/dashboard/agent-onboarding.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 const onboardingSource = readFileSync(new URL("./onboarding-card.tsx", import.meta.url), "utf8");
 const setupSource = readFileSync(new URL("./add-agent-setup.tsx", import.meta.url), "utf8");
+const dialogSource = readFileSync(new URL("./add-agent-dialog.tsx", import.meta.url), "utf8");
 const newAgentSource = readFileSync(new URL("./new-agent-button.tsx", import.meta.url), "utf8");
 const hostedSectionSource = readFileSync(
 	new URL("../../hosted/hosted-agents-section.tsx", import.meta.url),
@@ -41,6 +42,12 @@ describe("dashboard agent onboarding", () => {
 		expect(onboardingSource).toContain("{canDeployOnClawdi ? (");
 		expect(onboardingSource).toContain("Deploy on Clawdi");
 		expect(onboardingSource).toContain("Connect an agent on your machine");
+		expect(onboardingSource).toContain("<AddAgentDialog");
+		expect(onboardingSource).toContain("onClick={() => setConnectOpen(true)}");
+		expect(onboardingSource).not.toContain("AddAgentSetup");
+		expect(dialogSource).toContain("<AddAgentSetup />");
+		expect(newAgentSource).toContain("<AddAgentDialog");
+		expect(dashboardSource).toContain("<AddAgentDialog");
 		expect(onboardingSource).not.toContain("showHostedFirstAgentChoice");
 		expect(onboardingSource).not.toContain("Deploy a hosted agent");
 	});
@@ -59,13 +66,30 @@ describe("dashboard agent onboarding", () => {
 	});
 });
 
-describe("connected-agent setup command", () => {
-	test("defaults the displayed and copied command to npm", () => {
-		const command = "npm install -g clawdi@latest && clawdi auth login && clawdi setup";
-		expect(setupSource).toContain(`const ONE_COMMAND = "${command}";`);
-		expect(setupSource).toContain("onClick={() => copy(ONE_COMMAND)}");
-		expect(setupSource).toContain("{ONE_COMMAND}");
+describe("connected-agent setup paths", () => {
+	test("defaults to sequential npm commands with per-step copy controls", () => {
+		expect(setupSource).toContain('<Tabs defaultValue="commands">');
+		expect(setupSource).toContain('<TabsTrigger value="commands">');
+		expect(setupSource).toContain("Run commands");
+		for (const command of ["npm install -g clawdi@latest", "clawdi auth login", "clawdi setup"]) {
+			expect(setupSource).toContain(`code: "${command}"`);
+		}
+		expect(setupSource).toContain("<CopyButton text={step.code} label={`Copy ");
+		expect(setupSource).toContain("command`} />");
+		expect(setupSource).not.toContain("ONE_COMMAND");
+		expect(setupSource).not.toContain(
+			"npm install -g clawdi@latest && clawdi auth login && clawdi setup",
+		);
+		expect(setupSource).not.toContain("One command");
 		expect(setupSource).not.toContain("npx ");
+	});
+
+	test("keeps the agent prompt as a peer tab with its own copy action", () => {
+		expect(setupSource).toContain('<TabsTrigger value="prompt">');
+		expect(setupSource).toContain("Ask your agent");
+		expect(setupSource).toContain('<TabsContent value="prompt"');
+		expect(setupSource).toContain('label="Copy prompt"');
+		expect(setupSource).not.toContain("<Disclosure");
 	});
 
 	test("states the Node requirement and keeps Bun as a secondary alternative", () => {

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -527,9 +527,8 @@ function SyncHelpDialog({
 }
 
 /** Install-tutorial body for the help dialog. Two modes mirroring
- * `<AddAgentSetup>` on the onboarding card so the user reads the
- * same Tabs (Send to agent / Manual setup) pattern everywhere a
- * Clawdi setup is offered. */
+ * `<AddAgentSetup>` in the Add-agent dialog so the user sees the
+ * same prompt / manual setup pattern everywhere setup is offered. */
 function SyncSetupSnippet({ env }: { env: Env }) {
 	return (
 		<Tabs defaultValue="agent">

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -3,7 +3,7 @@
 import { Link } from "@tanstack/react-router";
 import { Rocket, TerminalSquare } from "lucide-react";
 import { useState } from "react";
-import { AddAgentSetup } from "@/components/dashboard/add-agent-setup";
+import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -17,13 +17,13 @@ type OnboardingCardProps = {
  * primary slot when the user has zero agents, and as a secondary
  * side-panel card once at least one agent is registered. When Cloud agent
  * creation is available, both placements offer the same deploy-or-connect
- * choice and reveal the shared CLI setup on demand.
+ * choice. Every connect action opens the same dialog used by the sidebar.
  */
 export function OnboardingCard({
 	variant = "first-agent",
 	canDeployOnClawdi = false,
 }: OnboardingCardProps) {
-	const [showCliSetup, setShowCliSetup] = useState(false);
+	const [connectOpen, setConnectOpen] = useState(false);
 	const isAdditionalAgent = variant === "additional-agent";
 	const title = isAdditionalAgent
 		? "Add another agent"
@@ -39,48 +39,34 @@ export function OnboardingCard({
 			: "Connect an agent first. Then create a Project to organize reusable skills and credentials you can share with teammates.";
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle className="flex items-center gap-2">
-					<Rocket className="size-5 text-primary" />
-					{title}
-				</CardTitle>
-				<CardDescription>{description}</CardDescription>
-			</CardHeader>
-			<CardContent className="space-y-5">
-				{canDeployOnClawdi ? (
-					<>
-						<div className="flex flex-col gap-2">
+		<>
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Rocket className="size-5 text-primary" />
+						{title}
+					</CardTitle>
+					<CardDescription>{description}</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<div className="flex flex-col gap-2">
+						{canDeployOnClawdi ? (
 							<Button render={<Link to="/deploy" />} nativeButton={false} size="lg">
 								<Rocket data-icon="inline-start" /> Deploy on Clawdi
 							</Button>
-							<Button
-								type="button"
-								variant="outline"
-								size="lg"
-								aria-expanded={showCliSetup}
-								aria-controls={showCliSetup ? "first-agent-cli-setup" : undefined}
-								onClick={() => setShowCliSetup((visible) => !visible)}
-							>
-								<TerminalSquare data-icon="inline-start" /> Connect an agent on your machine
-							</Button>
-						</div>
-						{showCliSetup ? (
-							<div id="first-agent-cli-setup" className="space-y-4 border-t pt-5">
-								<div>
-									<h3 className="text-sm font-semibold">Connect an agent on your machine</h3>
-									<p className="text-sm text-muted-foreground">
-										Run the setup command on the machine where your agent lives.
-									</p>
-								</div>
-								<AddAgentSetup />
-							</div>
 						) : null}
-					</>
-				) : (
-					<AddAgentSetup />
-				)}
-			</CardContent>
-		</Card>
+						<Button
+							type="button"
+							variant={canDeployOnClawdi ? "outline" : "default"}
+							size="lg"
+							onClick={() => setConnectOpen(true)}
+						>
+							<TerminalSquare data-icon="inline-start" /> Connect an agent on your machine
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+			<AddAgentDialog open={connectOpen} onClose={() => setConnectOpen(false)} />
+		</>
 	);
 }

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -421,7 +421,7 @@ function ConnectAnotherCard() {
 			<CardContent className="flex items-center justify-between gap-3 px-4">
 				<div className="min-w-0">
 					<div className="text-sm font-medium">Connect another machine</div>
-					<p className="mt-0.5 text-xs text-muted-foreground">One command in a terminal.</p>
+					<p className="mt-0.5 text-xs text-muted-foreground">Follow the Clawdi CLI steps.</p>
 				</div>
 				<Button size="sm" variant="outline" onClick={() => setOpen(true)}>
 					Add agent


### PR DESCRIPTION
## Summary

- make every homepage connect CTA open the existing shared Add agent dialog instead of embedding setup UI
- replace the unreliable universal “One command” promise with explicit sequential install, login, and setup steps
- present “Run commands” and “Ask your agent” as peer tabs with focused copy actions
- preserve Cloud creation gating and existing deployment management behavior
- update hosted browser coverage for first/returning and allowed/denied account paths

## Why the chained command was removed

Interactive local OAuth normally blocks until the browser callback completes, but SSH/non-interactive login can persist pending authorization and return before authentication is complete. A chained `&& clawdi setup` is therefore not a reliable universal onboarding path.

## Verification

- `scripts/test.sh web src/components/dashboard/agent-onboarding.test.ts src/hosted/use-unified-agent-list.test.ts src/lib/hosted-product-access.test.ts src/hosted/cloud-deployment-management.test.ts`
  - web typecheck passed
  - 24 focused tests passed
  - OSS production build passed
- focused hosted Chromium onboarding scenarios: 4 passed
- pre-commit Biome checks passed

No production, cluster, or tenant operations were performed.
