### PR TITLE
fix(cli): make hosted rollback identity truthful

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -2214,7 +2214,7 @@ async function runtimeWatchTickLocked(
 			systemdApplyResult.userUnitsChanged.length > 0;
 		if (errors.length > 0) {
 			const cliRollback = maybeRollbackFailedCliUpgrade(paths, manifestIdentity, errors);
-			if (cliRollback.status === "rolled_back") selfReexec = false;
+			if (cliRollback.status === "rolled_back") selfReexec = true;
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -244,8 +244,27 @@ describe("full control RPC handler surface", () => {
 		expect(methodsResult?.methods).toContain("sync.pull");
 		expect(methodsResult?.methods).toContain("vault.resolve");
 		expect(methodsResult?.methods).toContain("auth.login");
+		expect(methodsResult?.methods).toContain("update.check");
 		expect(methodsResult?.methods).toContain("update.install");
 		expect(methodsResult?.methods).toContain("operation.status");
+	});
+
+	it("removes local CLI update RPCs when hosted policy owns updates", async () => {
+		const previousRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		try {
+			const { createControlRpcHandlers } = await import("./serve");
+			const handlers = createControlRpcHandlers();
+			const methodsResult = (await handlers.methods?.({})) as { methods?: string[] } | undefined;
+
+			expect(methodsResult?.methods).not.toContain("update.check");
+			expect(methodsResult?.methods).not.toContain("update.install");
+			expect(handlers["update.check"]).toBeUndefined();
+			expect(handlers["update.install"]).toBeUndefined();
+		} finally {
+			if (previousRuntimeMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+			else process.env.CLAWDI_RUNTIME_MODE = previousRuntimeMode;
+		}
 	});
 
 	it("requires an explicit cwd, project, or all=true for sync.push", async () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -45,6 +45,7 @@ import {
 import { getAuth, getClawdiDir, getConfig, getPendingAuth, isLoggedIn } from "../lib/config";
 import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
+import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { runRuntimeObservationProducer } from "../runtime/observation-producer";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
@@ -653,8 +654,10 @@ export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): C
 	handlers["auth.login"] = (params) => authLoginRpc(params);
 	handlers["auth.complete"] = (params) => authCompleteRpc(params);
 	handlers["auth.logout"] = (params) => authLogoutRpc(params);
-	handlers["update.check"] = (params) => updateCheckRpc(params);
-	handlers["update.install"] = (params) => updateInstallRpc(params, opts.abortController);
+	if (evaluateHostPolicyForCommand("update").allowed) {
+		handlers["update.check"] = (params) => updateCheckRpc(params);
+		handlers["update.install"] = (params) => updateInstallRpc(params, opts.abortController);
+	}
 	return handlers;
 }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -15,6 +15,7 @@ import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
+import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { detectRuntimeMode } from "../runtime/paths";
 import { isSingletonDaemonInstalled, listInstalledAgents, readHealth } from "../serve/installer";
 import { log } from "../serve/log";
@@ -536,6 +537,7 @@ export async function daemonAutoUpdateOnce(
 		signal?: AbortSignal;
 	} = {},
 ): Promise<DaemonAutoUpdateResult> {
+	if (!evaluateHostPolicyForCommand("update").allowed) return "disabled";
 	if (!opts.ignoreDisabled && autoUpdateDisabled()) return "disabled";
 	if (opts.signal?.aborted) return "disabled";
 
@@ -576,6 +578,7 @@ export function startDaemonAutoUpdate(opts: {
 	intervalMs?: number;
 	initialDelayMs?: number;
 }): boolean {
+	if (!evaluateHostPolicyForCommand("update").allowed) return false;
 	if (autoUpdateDisabled()) return false;
 	const intervalMs = opts.intervalMs ?? DAEMON_UPDATE_INTERVAL_MS;
 	const initialDelayMs =

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -47,6 +47,13 @@ interface RuntimeCliBootstrapStatus {
 	version?: string;
 }
 
+type RuntimeCliInstallIdentity = Required<
+	Pick<
+		RuntimeCliBootstrapStatus,
+		"packageSpec" | "registry" | "npmPrefix" | "activeTarget" | "version"
+	>
+>;
+
 interface RuntimeCliBadVersion {
 	packageSpec: string;
 	registry: string | null;
@@ -159,10 +166,20 @@ export function applyRuntimeCliDesiredState(
 		});
 	}
 
-	const previousActiveTarget = current?.activeTarget ?? activeLinkTarget(paths.cliManagedBin);
-	const previousActivePrefix = previousActiveTarget
-		? prefixForActiveTarget(previousActiveTarget)
-		: null;
+	const previousIdentity = verifiedActiveCliIdentity(paths, current);
+	if (
+		previousIdentity &&
+		(current?.status !== "installed" ||
+			current.source !== "npm" ||
+			current.packageSpec !== previousIdentity.packageSpec ||
+			(current.registry ?? null) !== previousIdentity.registry ||
+			current.npmPrefix !== previousIdentity.npmPrefix ||
+			current.activePath !== paths.cliManagedBin ||
+			current.activeTarget !== previousIdentity.activeTarget ||
+			current.version !== previousIdentity.version)
+	) {
+		writeCliBootstrapStatus(paths, previousIdentity);
+	}
 	const installed = installCliPackage(paths, packageSpec, registry);
 	swapActiveCli(paths.cliManagedBin, installed.activeTarget);
 	removeLegacyManagedCliLink(paths, installed.activeTarget);
@@ -177,11 +194,10 @@ export function applyRuntimeCliDesiredState(
 		packageSpec,
 		registry,
 		installed,
-		previousStatus: current,
-		previousActiveTarget,
+		previousIdentity,
 		manifestIdentity: opts.manifestIdentity,
 	});
-	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousActivePrefix]);
+	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousIdentity?.npmPrefix ?? null]);
 	return baseResult("installed", paths, {
 		packageSpec,
 		registry,
@@ -404,10 +420,60 @@ function isCurrentCliInstall(
 	if (status.activePath !== paths.cliManagedBin) return false;
 	if (!status.activeTarget) return false;
 	if (!isManagedCliTarget(paths, status.activeTarget)) return false;
+	if (activeLinkTarget(paths.cliManagedBin) !== status.activeTarget) return false;
+	if (
+		!status.npmPrefix ||
+		resolve(status.npmPrefix) !== resolve(prefixForActiveTarget(status.activeTarget))
+	) {
+		return false;
+	}
 	if (!isExecutable(status.activeTarget)) return false;
+	if (!status.version) return false;
 	const exactVersion = exactNpmPackageVersion(packageSpec);
 	if (exactVersion && status.version !== exactVersion) return false;
 	return isExecutable(paths.cliManagedBin);
+}
+
+function verifiedActiveCliIdentity(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliInstallIdentity | null {
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	if (!activeTarget || !isManagedCliTarget(paths, activeTarget)) return null;
+	const npmPrefix = prefixForActiveTarget(activeTarget);
+	if (!isManagedCliPrefix(paths, npmPrefix)) return null;
+	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
+
+	try {
+		hardenManagedCliInstall(paths, activeTarget, npmPrefix);
+		const version = smokeCliVersion(activeTarget);
+		const inferredPackageSpec = `clawdi@${version}`;
+		if (!hostedCliPackageSpecSchema.safeParse(inferredPackageSpec).success) return null;
+		const statusPackageSpec = status?.packageSpec;
+		const statusRegistry = status?.registry ?? null;
+		const exactStatusVersion = statusPackageSpec ? exactNpmPackageVersion(statusPackageSpec) : null;
+		const statusMatches =
+			status?.status === "installed" &&
+			status.source === "npm" &&
+			status.activePath === paths.cliManagedBin &&
+			status.activeTarget === activeTarget &&
+			status.npmPrefix !== undefined &&
+			resolve(status.npmPrefix) === resolve(npmPrefix) &&
+			status.version === version &&
+			statusPackageSpec !== undefined &&
+			hostedFixtureCliPackageSpecSchema.safeParse(statusPackageSpec).success &&
+			(exactStatusVersion === null || exactStatusVersion === version) &&
+			(statusRegistry === null || statusRegistry === "https://registry.npmjs.org");
+		return {
+			packageSpec: statusMatches && statusPackageSpec ? statusPackageSpec : inferredPackageSpec,
+			registry: statusMatches ? statusRegistry : null,
+			npmPrefix,
+			activeTarget,
+			version,
+		};
+	} catch {
+		return null;
+	}
 }
 
 function recoverCurrentCliInstallFromActiveLink(
@@ -547,7 +613,7 @@ function prefixForActiveTarget(activeTarget: string): string {
 
 function activeLinkTarget(activePath: string): string | null {
 	try {
-		return readlinkSync(activePath);
+		return resolve(dirname(activePath), readlinkSync(activePath));
 	} catch {
 		return null;
 	}
@@ -723,28 +789,33 @@ export function rollbackPendingRuntimeCliUpgrade(
 			previousActiveTarget: pending.previousActiveTarget,
 		};
 	}
-	if (!pending.previousActiveTarget || !isExecutable(pending.previousActiveTarget)) {
+	const previousIdentity = verifiedPendingRollbackIdentity(paths, pending);
+	if (!previousIdentity) {
 		return {
 			status: "error",
 			version: pending.version,
 			previousVersion: pending.previousVersion,
 			activeTarget: pending.activeTarget,
 			previousActiveTarget: pending.previousActiveTarget,
-			error: "previous clawdi CLI target is missing or not executable",
+			error: "previous clawdi CLI identity is missing, inconsistent, or not executable",
+		};
+	}
+	if (activeLinkTarget(paths.cliManagedBin) !== pending.activeTarget) {
+		return {
+			status: "error",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+			error: "pending clawdi CLI target is no longer active",
 		};
 	}
 	try {
-		swapActiveCli(paths.cliManagedBin, pending.previousActiveTarget);
-		if (pending.previousStatus?.packageSpec && pending.previousStatus.activeTarget) {
-			writeCliBootstrapStatus(paths, {
-				packageSpec: pending.previousStatus.packageSpec,
-				registry: pending.previousStatus.registry ?? null,
-				npmPrefix:
-					pending.previousStatus.npmPrefix ?? prefixForActiveTarget(pending.previousActiveTarget),
-				activeTarget: pending.previousActiveTarget,
-				version: pending.previousStatus.version ?? pending.previousVersion ?? "unknown",
-			});
+		swapActiveCli(paths.cliManagedBin, previousIdentity.activeTarget);
+		if (activeLinkTarget(paths.cliManagedBin) !== previousIdentity.activeTarget) {
+			throw new Error("restored clawdi CLI link does not match the verified previous target");
 		}
+		writeCliBootstrapStatus(paths, previousIdentity);
 		const nextState = normalizeCliUpgradeState(state);
 		nextState.pendingUpgrade = null;
 		nextState.badVersions = upsertBadVersion(nextState.badVersions ?? [], {
@@ -755,7 +826,7 @@ export function rollbackPendingRuntimeCliUpgrade(
 			markedAt: new Date().toISOString(),
 		});
 		writeCliUpgradeState(paths, nextState);
-		pruneCliPackagePrefixes(paths, [pending.previousNpmPrefix]);
+		pruneCliPackagePrefixes(paths, [previousIdentity.npmPrefix]);
 		return {
 			status: "rolled_back",
 			version: pending.version,
@@ -797,30 +868,81 @@ function markPendingCliUpgrade(
 		packageSpec: string;
 		registry: string | null;
 		installed: { npmPrefix: string; activeTarget: string; version: string };
-		previousStatus: RuntimeCliBootstrapStatus | null;
-		previousActiveTarget: string | null;
+		previousIdentity: RuntimeCliInstallIdentity | null;
 		manifestIdentity?: RuntimeCliManifestIdentity;
 	},
 ): void {
 	const state = normalizeCliUpgradeState(readCliUpgradeState(paths));
+	const previousStatus = input.previousIdentity
+		? {
+				status: "installed",
+				source: "npm",
+				...input.previousIdentity,
+				activePath: paths.cliManagedBin,
+			}
+		: null;
 	state.pendingUpgrade = {
 		packageSpec: input.packageSpec,
 		registry: input.registry,
 		version: input.installed.version,
 		npmPrefix: input.installed.npmPrefix,
 		activeTarget: input.installed.activeTarget,
-		previousStatus: input.previousStatus,
-		previousActiveTarget: input.previousActiveTarget,
-		previousNpmPrefix: input.previousActiveTarget
-			? prefixForActiveTarget(input.previousActiveTarget)
-			: null,
-		previousVersion: input.previousStatus?.version ?? null,
+		previousStatus,
+		previousActiveTarget: input.previousIdentity?.activeTarget ?? null,
+		previousNpmPrefix: input.previousIdentity?.npmPrefix ?? null,
+		previousVersion: input.previousIdentity?.version ?? null,
 		manifestGeneration: input.manifestIdentity?.generation ?? null,
 		manifestEtag: input.manifestIdentity?.etag ?? null,
-		rollbackEligible: input.manifestIdentity?.previouslyApplied === true,
+		rollbackEligible:
+			input.manifestIdentity?.previouslyApplied === true && input.previousIdentity !== null,
 		installedAt: new Date().toISOString(),
 	};
 	writeCliUpgradeState(paths, state);
+}
+
+function verifiedPendingRollbackIdentity(
+	paths: RuntimePaths,
+	pending: RuntimeCliPendingUpgrade,
+): RuntimeCliInstallIdentity | null {
+	const status = pending.previousStatus;
+	const activeTarget = pending.previousActiveTarget;
+	const npmPrefix = pending.previousNpmPrefix;
+	const version = pending.previousVersion;
+	if (
+		!status ||
+		!activeTarget ||
+		!npmPrefix ||
+		!version ||
+		status.status !== "installed" ||
+		status.source !== "npm" ||
+		status.activePath !== paths.cliManagedBin ||
+		status.activeTarget !== activeTarget ||
+		status.npmPrefix !== npmPrefix ||
+		status.version !== version ||
+		!status.packageSpec ||
+		!hostedFixtureCliPackageSpecSchema.safeParse(status.packageSpec).success ||
+		(status.registry != null && status.registry !== "https://registry.npmjs.org") ||
+		!isManagedCliTarget(paths, activeTarget) ||
+		!isManagedCliPrefix(paths, npmPrefix) ||
+		resolve(prefixForActiveTarget(activeTarget)) !== resolve(npmPrefix) ||
+		!isExecutable(activeTarget)
+	) {
+		return null;
+	}
+	const exactVersion = exactNpmPackageVersion(status.packageSpec);
+	if (exactVersion && exactVersion !== version) return null;
+	try {
+		if (smokeCliVersion(activeTarget) !== version) return null;
+		return {
+			packageSpec: status.packageSpec,
+			registry: status.registry ?? null,
+			npmPrefix,
+			activeTarget,
+			version,
+		};
+	} catch {
+		return null;
+	}
 }
 
 function isBadCliVersion(

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -198,6 +198,25 @@ describe("update --json", () => {
 });
 
 describe("daemonAutoUpdateOnce", () => {
+	it("cannot bypass hosted update authority with ignoreDisabled", async () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		const { captured, restore } = mockFetch([]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				installer: "npm",
+				ignoreDisabled: true,
+				installRunner: async () => {
+					throw new Error("hosted policy must prevent local CLI installation");
+				},
+			});
+			expect(result).toBe("disabled");
+			expect(captured).toHaveLength(0);
+		} finally {
+			restore();
+		}
+	});
+
 	it("installs updates and leaves last-version for the next human CLI notice", async () => {
 		const calls: { installer: string; args: string[] }[] = [];
 		const { restore } = mockFetch([

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -34,7 +34,10 @@ import {
 	applyRuntimeBundleChannelsToManifestLoad,
 	applyRuntimeChannelsToManifestLoad,
 } from "../src/runtime/channels";
-import { applyRuntimeCliDesiredState } from "../src/runtime/cli-update";
+import {
+	applyRuntimeCliDesiredState,
+	rollbackPendingRuntimeCliUpgrade,
+} from "../src/runtime/cli-update";
 import {
 	deniedCommandReason,
 	evaluateHostPolicyForCommand,
@@ -8675,7 +8678,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.cliUpdate.status).toBe("installed");
 			expect(event.cliRollback.status).toBe("rolled_back");
 			expect(event.cliRollback.version).toBe("0.13.5-beta.0");
-			expect(event.selfReexec).toBe(false);
+			expect(event.selfReexec).toBe(true);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
 			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
 			expect(upgradeState.pendingUpgrade).toBeNull();
@@ -9228,6 +9231,132 @@ chmod +x "$prefix/bin/clawdi"
 			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 			expect(status.packageSpec).toBe("clawdi@0.13.6-beta.0");
 			expect(status.activeTarget).toBe(readlinkSync(paths.cliManagedBin));
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("preserves the real last-good CLI across a status-missing rollback and later upgrade", () => {
+		const home = join(root, "home-cli-rollback-lifecycle", "clawdi");
+		const state = join(root, "state-cli-rollback-lifecycle");
+		const run = join(root, "run-cli-rollback-lifecycle");
+		const bin = join(root, "bin-cli-rollback-lifecycle");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+package=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  case "$1" in clawdi@*) package="$1" ;; esac
+  shift
+done
+version="\${package#clawdi@}"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<SH
+#!/usr/bin/env bash
+if [ "\\\${1:-}" = "--version" ]; then
+  echo "$version"
+  exit 0
+fi
+if [ "\\\${1:-} \\\${2:-} \\\${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		const paths = getRuntimePaths();
+		const manifestIdentity = {
+			generation: 1,
+			etag: '"etag-cli-rollback-lifecycle"',
+			previouslyApplied: true,
+		};
+		const manifestFor = (version: string): RuntimeManifest => ({
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_cli_rollback_lifecycle",
+			environmentId: "env_cli_rollback_lifecycle",
+			instanceId: "iid_cli_rollback_lifecycle",
+			generation: 1,
+			issuedAt: "2026-07-29T00:00:00Z",
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			clawdiCli: { source: "npm:clawdi", packageSpec: `clawdi@${version}` },
+			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			recovery: {},
+		});
+
+		try {
+			const first = applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.0"), paths, {
+				manifestIdentity,
+			});
+			if (!first.activeTarget) throw new Error("first CLI install has no active target");
+			const lastGoodTarget = first.activeTarget;
+			const lastGoodPrefix = first.npmPrefix;
+			const firstState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			expect(firstState.pendingUpgrade.rollbackEligible).toBe(false);
+
+			rmSync(paths.cliBootstrapStatus, { force: true });
+			const failed = applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.1"), paths, {
+				manifestIdentity,
+			});
+			if (!failed.activeTarget) throw new Error("failed CLI install has no active target");
+			const failedTarget = failed.activeTarget;
+			const failedState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			expect(failedState.pendingUpgrade).toMatchObject({
+				rollbackEligible: true,
+				previousActiveTarget: lastGoodTarget,
+				previousNpmPrefix: lastGoodPrefix,
+				previousVersion: "0.13.20-beta.0",
+			});
+
+			const firstRollback = rollbackPendingRuntimeCliUpgrade(
+				paths,
+				"injected first converge failure",
+				manifestIdentity,
+			);
+			expect(firstRollback.status).toBe("rolled_back");
+			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);
+			expect(existsSync(lastGoodPrefix)).toBe(true);
+			expect(existsSync(dirname(dirname(failedTarget)))).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+				packageSpec: "clawdi@0.13.20-beta.0",
+				npmPrefix: lastGoodPrefix,
+				activeTarget: lastGoodTarget,
+				version: "0.13.20-beta.0",
+			});
+
+			applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.2"), paths, {
+				manifestIdentity,
+			});
+			const secondState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			expect(secondState.pendingUpgrade.previousActiveTarget).toBe(lastGoodTarget);
+			expect(secondState.pendingUpgrade.previousActiveTarget).not.toBe(failedTarget);
+			expect(existsSync(lastGoodPrefix)).toBe(true);
+
+			const secondRollback = rollbackPendingRuntimeCliUpgrade(
+				paths,
+				"injected second converge failure",
+				manifestIdentity,
+			);
+			expect(secondRollback.status).toBe("rolled_back");
+			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);
+			expect(existsSync(lastGoodPrefix)).toBe(true);
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;


### PR DESCRIPTION
## Summary

- make the hosted runtime manifest updater the only CLI update authority by removing update.check and update.install RPC handlers under built-in hosted policy, and by making daemon auto-update refuse hosted mode even when ignoreDisabled is requested
- derive rollback identity from the resolved managed active symlink and a successful version smoke check; reuse bootstrap metadata only when it agrees with that observed identity, and persist repaired canonical status before activation when needed
- mark rollback eligible only when an already-applied manifest has a verified previous identity; revalidate the persisted identity and active failed target before restoring both the link and bootstrap status
- request immediate watcher re-exec after successful rollback and cover the status-missing rollback followed by a second upgrade, including last-good prefix retention

## Guarantees

- hosted daemon RPC and daemon auto-update cannot bypass the built-in system-managed CLI policy
- successful rollback means the expected failed target was active, the previous managed target still passed its version smoke check, and both active link and bootstrap status were restored
- a missing or stale bootstrap status cannot override the actual active link when choosing last-good identity
- a later upgrade cannot select the deleted failed target as previous or prune the real last-good prefix

## Deferred hardening

This change deliberately does not add a transaction journal across the active symlink, bootstrap status, and upgrade-state files. Each individual write remains atomic, but crash recovery across interruptions between those separate writes is deferred to a dedicated transactional hardening change.

## Verification

- scripts/test.sh cli: 1230 passed
- CLI TypeScript typecheck passed in the isolated Docker runner
- Biome check passed for all changed files
- git diff --check passed

No release bump, package publish, workflow dispatch, or production operation is included.