### PR TITLE
fix(web): simplify dashboard summaries

### DIFF
--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -2,10 +2,8 @@
 
 import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
-import { CheckCircle2 } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
-import { ProjectResourcePath } from "@/components/project-resource-path";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -279,22 +277,6 @@ function ResourceRow({
 			</span>
 			<div className="min-w-0 flex-1">
 				<div className="text-sm font-medium">{definition.label}</div>
-				<div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-					<ProjectResourcePath resource={definition} />
-					{isProjectRow && projectTypeCounts ? (
-						<ProjectTypeBreakdown counts={projectTypeCounts} />
-					) : null}
-					{empty ? (
-						<span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
-							{isProjectRow ? "Start here" : `Start: ${definition.emptyCta}`}
-						</span>
-					) : (
-						<span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
-							<CheckCircle2 className="size-3" />
-							Active
-						</span>
-					)}
-				</div>
 			</div>
 			{isProjectRow && projectTypeCounts ? (
 				<Tooltip>
@@ -305,28 +287,5 @@ function ResourceRow({
 				countCluster
 			)}
 		</Link>
-	);
-}
-
-function ProjectTypeBreakdown({ counts }: { counts: ProjectTypeCounts }) {
-	const items = [
-		{ label: "Custom", count: counts.custom },
-		{ label: "Global", count: counts.global },
-		{ label: "Agent", count: counts.agent },
-	];
-	return (
-		<span
-			className="inline-flex min-w-0 flex-wrap items-center gap-1"
-			title={`Project types: ${formatProjectTypeCounts(counts)}`}
-		>
-			{items.map((item) => (
-				<span
-					key={item.label}
-					className="rounded-sm border bg-background px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
-				>
-					<span className="tabular-nums">{formatNumber(item.count)}</span> {item.label}
-				</span>
-			))}
-		</span>
 	);
 }

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -25,7 +25,7 @@ import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
-import { cn, relativeTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 const RECENT_SESSIONS_LIMIT = 15;
 const RECENT_SESSIONS_CACHE_PAGE_SIZE = 25;
@@ -356,14 +356,7 @@ function renderGreeting(
 	summary: AgentFleetSummary,
 	options: { agentStatusUnavailable?: boolean } = {},
 ) {
-	return (
-		<Greeting
-			activeCount={summary.activeCount}
-			total={summary.total}
-			lastActive={summary.lastActive}
-			agentStatusUnavailable={options.agentStatusUnavailable}
-		/>
-	);
+	return <Greeting total={summary.total} agentStatusUnavailable={options.agentStatusUnavailable} />;
 }
 
 function ActivityGraphSkeleton() {
@@ -439,16 +432,10 @@ function currentDaypart(): "morning" | "afternoon" | "evening" {
 }
 
 function Greeting({
-	activeCount,
 	total,
-	lastActive,
 	agentStatusUnavailable = false,
 }: {
-	activeCount: number;
 	total: number;
-	/** Most recent last-seen timestamp across the fleet — the one fact the
-	 * old AgentsCard header carried that the greeting didn't. */
-	lastActive?: string | null;
 	agentStatusUnavailable?: boolean;
 }) {
 	const { user } = useCurrentUser();
@@ -461,9 +448,7 @@ function Greeting({
 		? "Agent status is unavailable right now."
 		: total === 0
 			? "Connect your first agent to start syncing."
-			: activeCount > 0
-				? `${activeCount} of ${total} agents active right now.`
-				: `${total} agents connected${lastActive ? ` · last active ${relativeTime(lastActive)}` : ""}.`;
+			: `${total} agent${total === 1 ? "" : "s"}`;
 	return (
 		<div>
 			<h1 className="text-2xl font-semibold tracking-tight">


### PR DESCRIPTION
## Summary
- remove redundant paths, Active badges, and project-type chips from resource rows
- replace the ambiguous active-agent ratio with the total agent count only
- keep resource names, counts, status dots, and the empty Projects creation action

## Verification
- `scripts/test.sh web src/lib/project-resource-model.test.ts`
- pre-commit Biome checks