### PR TITLE
fix(cli): make local auto-updates exact and owned

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -47,7 +47,11 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { runRuntimeObservationProducer } from "../runtime/observation-producer";
-import { startAutoRestart } from "../serve/auto-restart";
+import {
+	createRestartCoordination,
+	type RestartCoordination,
+	startAutoRestart,
+} from "../serve/auto-restart";
 import {
 	type ControlRpcClientConfig,
 	type ControlRpcHandlers,
@@ -224,6 +228,7 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 	});
 
 	const abort = new AbortController();
+	const restartCoordination = createRestartCoordination(abort);
 	const triggerShutdown = (signal: string) => {
 		log.info("serve.signal", { signal });
 		abort.abort();
@@ -248,17 +253,17 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 	// Skip in container mode — k8s rolls pods on its own schedule
 	// and self-restart inside a pod fights the orchestrator.
 	if (!isContainer) {
-		const watching = await startAutoRestart({ abort });
+		const watching = await startAutoRestart({ abort, restart: restartCoordination });
 		if (watching) {
 			log.info("serve.auto_restart_armed", { entry: watching });
 		}
-		if (startDaemonAutoUpdate({ abort })) {
+		if (startDaemonAutoUpdate({ abort, restart: restartCoordination })) {
 			log.info("serve.auto_update_armed", {});
 		}
 	}
 
 	const rpc = await startControlRpcServer(
-		createControlRpcHandlers({ abortController: abort }),
+		createControlRpcHandlers({ abortController: abort, restartCoordination }),
 		abort.signal,
 		rpcListen,
 	);
@@ -604,6 +609,7 @@ function rpcMethodCommandName(method: string): string {
 
 interface ControlRpcHandlerOptions {
 	abortController?: AbortController;
+	restartCoordination?: RestartCoordination;
 }
 
 export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): ControlRpcHandlers {
@@ -656,7 +662,8 @@ export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): C
 	handlers["auth.logout"] = (params) => authLogoutRpc(params);
 	if (evaluateHostPolicyForCommand("update").allowed) {
 		handlers["update.check"] = (params) => updateCheckRpc(params);
-		handlers["update.install"] = (params) => updateInstallRpc(params, opts.abortController);
+		handlers["update.install"] = (params) =>
+			updateInstallRpc(params, opts.abortController, opts.restartCoordination);
 	}
 	return handlers;
 }
@@ -1083,6 +1090,7 @@ function updateCheckRpc(params: unknown): Promise<unknown> {
 async function updateInstallRpc(
 	params: unknown,
 	abortController: AbortController | undefined,
+	restartCoordination: RestartCoordination | undefined,
 ): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(record, new Set(["confirm"]));
@@ -1090,12 +1098,14 @@ async function updateInstallRpc(
 	const result = await daemonAutoUpdateOnce({
 		currentVersion: getCliVersion(),
 		ignoreDisabled: true,
+		restartCoordination,
 	});
 	const restartScheduled = result === "installed" && abortController !== undefined;
 	if (restartScheduled) {
 		setTimeout(() => {
 			log.info("daemon.update_install_restart_scheduled", {});
-			abortController.abort();
+			if (restartCoordination) restartCoordination.requestRestart();
+			else abortController.abort();
 		}, CONTROL_ACTION_DELAY_MS);
 	}
 	return {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -14,9 +14,11 @@ import { dirname, join, normalize, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
+import { compareSemver, isValidSemver } from "../lib/semver";
 import { getCliVersion } from "../lib/version";
 import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { detectRuntimeMode } from "../runtime/paths";
+import type { RestartCoordination } from "../serve/auto-restart";
 import { isSingletonDaemonInstalled, listInstalledAgents, readHealth } from "../serve/installer";
 import { log } from "../serve/log";
 import { getServeStateDir } from "../serve/paths";
@@ -32,6 +34,11 @@ const DAEMON_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 const DAEMON_UPDATE_LOCK_STALE_MS = 15 * 60 * 1000;
 export type Installer = "bun" | "npm";
 
+interface GlobalInstallOwnership {
+	installer: Installer;
+	executable: string;
+}
+
 interface UpdateCache {
 	checkedAt: string;
 	latest: string;
@@ -44,13 +51,25 @@ type BackgroundInstallContext = {
 };
 
 type AutoUpdateRuntime = {
-	detectInstaller?: () => Installer | null;
+	detectOwnership?: () => GlobalInstallOwnership | null;
 	spawnBackgroundInstall?: (
 		installer: Installer,
 		args: string[],
 		context: BackgroundInstallContext,
 	) => void;
 };
+
+type ForegroundUpdateRuntime = {
+	detectOwnership?: () => GlobalInstallOwnership | null;
+	installRunner?: (command: string, args: string[]) => number | null;
+	platform?: NodeJS.Platform;
+	versionReader?: (command: string, args: string[]) => string | null;
+};
+
+interface CommandVector {
+	command: string;
+	args: string[];
+}
 
 function cachePath(channel = "latest"): string {
 	return join(getClawdiDir(), channel === "latest" ? "update.json" : `update-${channel}.json`);
@@ -60,7 +79,13 @@ function readCache(channel = "latest"): UpdateCache | null {
 	try {
 		const p = cachePath(channel);
 		if (!existsSync(p)) return null;
-		return JSON.parse(readFileSync(p, "utf-8")) as UpdateCache;
+		const parsed = JSON.parse(readFileSync(p, "utf-8")) as Partial<UpdateCache>;
+		const latest = parsed.latest;
+		if (typeof parsed.checkedAt !== "string" || typeof latest !== "string") {
+			return null;
+		}
+		if (!isValidSemver(latest)) return null;
+		return { checkedAt: parsed.checkedAt, latest };
 	} catch {
 		return null;
 	}
@@ -80,10 +105,8 @@ function writeCache(latest: string, channel = "latest"): void {
 }
 
 function updateChannelForVersion(version: string): string {
-	const pre = parseVersion(version).pre;
-	if (!pre) return "latest";
-	const channel = pre.split(".", 1)[0]?.trim() ?? "";
-	return /^[A-Za-z0-9._-]+$/.test(channel) ? channel : "latest";
+	if (!isValidSemver(version)) return "latest";
+	return version.split("+", 1)[0]?.includes("-") ? "beta" : "latest";
 }
 
 async function fetchLatest(timeoutMs = 3000, channel = "latest"): Promise<string | null> {
@@ -93,7 +116,8 @@ async function fetchLatest(timeoutMs = 3000, channel = "latest"): Promise<string
 		const res = await fetch(REGISTRY_URL, { signal: controller.signal });
 		if (!res.ok) return null;
 		const data = (await res.json()) as { "dist-tags"?: Record<string, string | undefined> };
-		return data["dist-tags"]?.[channel] ?? null;
+		const resolved = data["dist-tags"]?.[channel];
+		return resolved && isValidSemver(resolved) ? resolved : null;
 	} catch {
 		return null;
 	} finally {
@@ -101,27 +125,8 @@ async function fetchLatest(timeoutMs = 3000, channel = "latest"): Promise<string
 	}
 }
 
-// Parse an npm version string ("1.2.3" or "1.2.3-beta.4") into comparable
-// parts. The numeric triple dominates; the pre-release suffix is a tiebreaker
-// where a stable version beats any `-pre`-tagged build at the same triple
-// (npm semver: `1.2.3 > 1.2.3-beta.4`).
-function parseVersion(v: string): { triple: [number, number, number]; pre: string | null } {
-	const [core, pre] = v.split("-", 2);
-	const [a = 0, b = 0, c = 0] = (core ?? "").split(".").map((n) => Number.parseInt(n, 10) || 0);
-	return { triple: [a, b, c], pre: pre ?? null };
-}
-
 function isNewer(latest: string, current: string): boolean {
-	const L = parseVersion(latest);
-	const C = parseVersion(current);
-	for (let i = 0; i < 3; i++) {
-		if (L.triple[i] !== C.triple[i]) return L.triple[i] > C.triple[i];
-	}
-	// Same numeric triple: stable (no pre) > pre-release; otherwise string cmp.
-	if (L.pre === C.pre) return false;
-	if (L.pre === null) return true;
-	if (C.pre === null) return false;
-	return L.pre > C.pre;
+	return isValidSemver(latest) && isValidSemver(current) && compareSemver(latest, current) > 0;
 }
 
 /**
@@ -131,7 +136,10 @@ function isNewer(latest: string, current: string): boolean {
  * behavior. JSON / non-TTY runs always stay diagnose-only because piping
  * into a script and silently mutating the global install would surprise.
  */
-export async function update(opts: { json?: boolean; check?: boolean } = {}) {
+export async function update(
+	opts: { json?: boolean; check?: boolean } = {},
+	runtime: ForegroundUpdateRuntime = {},
+) {
 	const current = getCliVersion();
 	const channel = updateChannelForVersion(current);
 	const latest = await fetchLatest(3000, channel);
@@ -169,45 +177,68 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 	// `--check` keeps the old display-only behavior for users who scripted
 	// against it (CI guards, custom dashboards). Default is now to install.
 	if (opts.check) {
-		const installer = detectInstaller();
+		const ownership = detectUpdateOwnership(runtime);
 		console.log();
-		console.log(
-			chalk.cyan(`A newer version is available. Install with:`) +
-				"\n  " +
-				chalk.white(installCommand(installer, channel)),
-		);
+		if (ownership) {
+			console.log(
+				chalk.cyan("A newer version is available. Install with:") +
+					"\n  " +
+					chalk.white(installCommand(ownership.installer, latest)),
+			);
+		} else {
+			printUnsupportedInstall(latest);
+		}
 		return;
 	}
 
-	const installer = detectInstaller();
-	if (!installer) {
+	const ownership = detectUpdateOwnership(runtime);
+	if (!ownership) {
 		console.log();
-		console.log(
-			chalk.yellow("Neither bun nor npm is on PATH; install manually:") +
-				"\n  " +
-				chalk.white(installCommand(null, channel)),
-		);
+		printUnsupportedInstall(latest);
 		return;
 	}
 
-	const args = installArgs(installer, channel);
+	const { installer } = ownership;
+	const args = installArgs(installer, latest);
+	const install = installerCommandVector(installer, args, runtime.platform);
 	console.log();
 	console.log(chalk.cyan(`Installing v${latest} via ${installer}…`));
-	const result = spawnSync(installer, args, { stdio: "inherit" });
-	if (result.status !== 0) {
+	const status = (runtime.installRunner ?? runForegroundInstall)(install.command, install.args);
+	if (status !== 0) {
 		console.log();
 		console.log(
-			chalk.red(`Install failed (${installer} exited ${result.status}). Try manually:`) +
+			chalk.red(`Install failed (${installer} exited ${status}). Try manually:`) +
 				"\n  " +
-				chalk.white(installCommand(installer)),
+				chalk.white(installCommand(installer, latest)),
 		);
-		process.exitCode = result.status ?? 1;
+		process.exitCode = status ?? 1;
 		return;
 	}
-	// Update last-version so the post-install run prints "Updated to v…".
+	const smoke = executableCommandVector(ownership.executable, ["--version"], runtime.platform);
+	const installedVersion = (runtime.versionReader ?? readCommandVersion)(smoke.command, smoke.args);
+	if (installedVersion !== latest) {
+		console.log();
+		console.log(
+			chalk.red(
+				`Install verification failed: expected ${latest}, got ${installedVersion ?? "no version"}.`,
+			),
+		);
+		process.exitCode = 1;
+		return;
+	}
 	writeLastVersion(current);
 	console.log();
 	console.log(chalk.green(`✓ clawdi v${latest} installed.`));
+}
+
+function printUnsupportedInstall(version: string): void {
+	console.log(
+		chalk.yellow("Automatic update is unsupported for this invocation.") +
+			"\n" +
+			chalk.gray("Update the installation that launched clawdi, or install the exact release:") +
+			"\n  " +
+			chalk.white(installCommand(null, version)),
+	);
 }
 
 const LAST_VERSION_FILE = "last-version";
@@ -226,91 +257,97 @@ function writeLastVersion(version: string): void {
 }
 
 export function detectInstaller(): Installer | null {
-	const available = {
-		bun: commandExists("bun"),
-		npm: commandExists("npm"),
-	};
-	if (!available.bun && !available.npm) return null;
-
-	const current = installerForCurrentInvocation(available);
-	if (current) return current;
-
-	// npm is the documented install path and is the safer default when the
-	// current executable cannot be mapped to a global install. If the current
-	// executable is Bun-managed, installerForCurrentInvocation catches it first.
-	if (available.npm) return "npm";
-	return available.bun ? "bun" : null;
+	return detectGlobalInstall()?.installer ?? null;
 }
 
-function commandExists(command: string): boolean {
-	try {
-		const r = spawnSync(command, ["--version"], { stdio: "ignore" });
-		return r.status === 0;
-	} catch {
-		return false;
-	}
+function detectUpdateOwnership(runtime: ForegroundUpdateRuntime): GlobalInstallOwnership | null {
+	return runtime.detectOwnership?.() ?? detectGlobalInstall();
 }
 
-function installerForCurrentInvocation(available: Record<Installer, boolean>): Installer | null {
-	return detectInstallerFromPaths(process.argv[1], {
-		npmBin: available.npm ? npmGlobalBinDir() : null,
-		npmRoot: available.npm ? npmGlobalRootDir() : null,
-		bunBin: available.bun ? bunGlobalBinDir() : null,
+function detectGlobalInstall(): GlobalInstallOwnership | null {
+	const bunBin = bunGlobalBinDir();
+	return detectGlobalInstallFromPaths(process.argv[1], {
+		npmBin: npmGlobalBinDir(),
+		npmRoot: npmGlobalRootDir(),
+		bunBin,
+		bunRoot: bunBin ? bunGlobalRootDir(bunBin) : null,
 	});
 }
 
 export function detectInstallerFromPaths(
 	invokedPath: string | undefined,
-	paths: { bunBin?: string | null; npmBin?: string | null; npmRoot?: string | null },
+	paths: {
+		bunBin?: string | null;
+		bunRoot?: string | null;
+		npmBin?: string | null;
+		npmRoot?: string | null;
+	},
 ): Installer | null {
+	return detectGlobalInstallFromPaths(invokedPath, paths)?.installer ?? null;
+}
+
+function detectGlobalInstallFromPaths(
+	invokedPath: string | undefined,
+	paths: {
+		bunBin?: string | null;
+		bunRoot?: string | null;
+		npmBin?: string | null;
+		npmRoot?: string | null;
+	},
+): GlobalInstallOwnership | null {
 	if (!invokedPath) return null;
 
 	const candidates = normalizedPathCandidates(invokedPath);
 	const npmBin = paths.npmBin ? normalizePath(paths.npmBin) : null;
 	const npmRoot = paths.npmRoot ? normalizePath(paths.npmRoot) : null;
 	const bunBin = paths.bunBin ? normalizePath(paths.bunBin) : null;
-
-	if (npmBin && candidates.some((candidate) => samePath(dirname(candidate), npmBin))) {
-		return "npm";
-	}
-	if (bunBin && candidates.some((candidate) => samePath(dirname(candidate), bunBin))) {
-		return "bun";
-	}
+	const bunRoot = paths.bunRoot ? normalizePath(paths.bunRoot) : null;
+	if (candidates.some(isTransientPath)) return null;
 	if (
+		npmBin &&
 		npmRoot &&
 		candidates.some((candidate) => pathStartsWith(candidate, join(npmRoot, "clawdi")))
 	) {
-		return "npm";
+		return { installer: "npm", executable: globalExecutable("npm", npmBin) };
 	}
 	if (
-		candidates.some((candidate) =>
-			candidate.includes(`${sep}.bun${sep}install${sep}global${sep}node_modules${sep}clawdi${sep}`),
-		)
+		bunBin &&
+		bunRoot &&
+		candidates.some((candidate) => pathStartsWith(candidate, join(bunRoot, "clawdi")))
 	) {
-		return "bun";
+		return { installer: "bun", executable: globalExecutable("bun", bunBin) };
 	}
 	return null;
 }
 
 function npmGlobalBinDir(): string | null {
-	const prefix = commandOutput("npm", ["prefix", "-g"]);
+	const prefix = commandOutput(installerCommandVector("npm", ["prefix", "-g"]));
 	if (!prefix) return null;
 	return process.platform === "win32" ? normalizePath(prefix) : normalizePath(join(prefix, "bin"));
 }
 
 function npmGlobalRootDir(): string | null {
-	const root = commandOutput("npm", ["root", "-g"]);
+	const root = commandOutput(installerCommandVector("npm", ["root", "-g"]));
 	return root ? normalizePath(root) : null;
 }
 
 function bunGlobalBinDir(): string | null {
-	const bin = commandOutput("bun", ["pm", "bin", "-g"]);
+	const bin = commandOutput(executableCommandVector("bun", ["pm", "bin", "-g"]));
 	return bin ? normalizePath(bin) : null;
 }
 
-function commandOutput(command: string, args: string[]): string | null {
+function bunGlobalRootDir(binDir: string): string {
+	// Bun 1.3.14 keeps global packages under the install root that owns
+	// the authoritative `bun pm bin -g` directory.
+	return normalizePath(join(dirname(binDir), "install", "global", "node_modules"));
+}
+
+function commandOutput(vector: CommandVector): string | null {
 	try {
-		const result = spawnSync(command, args, { encoding: "utf-8" });
+		const result = spawnSync(vector.command, vector.args, {
+			encoding: "utf-8",
+			windowsHide: true,
+		});
 		if (result.status !== 0) return null;
 		const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
 		return stdout || null;
@@ -351,37 +388,91 @@ function pathStartsWith(path: string, parent: string): boolean {
 	return normalizedPath.startsWith(prefix);
 }
 
-function detectAutoUpdateInstaller(runtime: AutoUpdateRuntime): Installer | null {
-	return runtime.detectInstaller?.() ?? detectInstaller();
+function detectAutoUpdateOwnership(runtime: AutoUpdateRuntime): GlobalInstallOwnership | null {
+	return runtime.detectOwnership?.() ?? detectGlobalInstall();
 }
 
-function packageSpecForChannel(channel: string): string {
-	return channel === "latest" ? "clawdi@latest" : `clawdi@${channel}`;
+function packageSpecForVersion(version: string): string {
+	if (!isValidSemver(version)) throw new Error(`invalid clawdi update version: ${version}`);
+	return `clawdi@${version}`;
 }
 
-function installArgs(installer: Installer, channel = "latest"): string[] {
-	const spec = packageSpecForChannel(channel);
+function installArgs(installer: Installer, version: string): string[] {
+	const spec = packageSpecForVersion(version);
 	return installer === "bun" ? ["add", "-g", spec] : ["i", "-g", spec];
 }
 
-export function installCommand(installer: Installer | null, channel = "latest"): string {
-	const spec = packageSpecForChannel(channel);
+export function installCommand(installer: Installer | null, version: string): string {
+	const spec = packageSpecForVersion(version);
 	return installer === "bun" ? `bun add -g ${spec}` : `npm i -g ${spec}`;
 }
 
-// `npx clawdi …` and `bunx clawdi …` install the package into a per-call
-// temp dir. Running `npm i -g clawdi` from that temp invocation would put a
-// global binary on the user's PATH that they didn't ask for. Detect those
-// paths and skip auto-update — the next npx call will fetch latest anyway.
-//
-// Normalise backslashes first so Windows `C:\Users\…\_npx\…` matches the
-// same regex; otherwise the guard quietly fails open and a Windows npx
-// invocation tries to globally install itself. The patterns are anchored
-// to a leading slash to avoid false positives on legit paths that happen
-// to contain `npx` somewhere.
 function isTransientInvocation(): boolean {
-	const argv1 = (process.argv[1] ?? "").replace(/\\/g, "/");
-	return /\/_npx\/|\/\.bunx-|\/bun\/install\/cache\//.test(argv1);
+	return isTransientPath(process.argv[1] ?? "");
+}
+
+function isTransientPath(path: string): boolean {
+	const normalized = path.replace(/\\/g, "/");
+	return /\/_npx\/|\/bunx-[^/]+\/|\/\.bunx-|\/bun\/install\/cache\//.test(normalized);
+}
+
+function globalExecutable(installer: Installer, binDir: string): string {
+	const extension = process.platform === "win32" ? (installer === "npm" ? ".cmd" : ".exe") : "";
+	return join(binDir, `clawdi${extension}`);
+}
+
+function executableCommandVector(
+	executable: string,
+	args: string[],
+	platform: NodeJS.Platform = process.platform,
+): CommandVector {
+	if (platform === "win32" && /\.(?:cmd|bat)$/i.test(executable)) {
+		return {
+			command: "cmd.exe",
+			args: ["/d", "/s", "/c", executable, ...args],
+		};
+	}
+	return { command: executable, args };
+}
+
+function installerCommandVector(
+	installer: Installer,
+	args: string[],
+	platform: NodeJS.Platform = process.platform,
+): CommandVector {
+	const executable = installer === "npm" && platform === "win32" ? "npm.cmd" : installer;
+	return executableCommandVector(executable, args, platform);
+}
+
+function runForegroundInstall(command: string, args: string[]): number | null {
+	try {
+		return spawnSync(command, args, {
+			stdio: "inherit",
+			windowsHide: true,
+		}).status;
+	} catch {
+		return null;
+	}
+}
+
+function readCommandVersion(command: string, args: string[]): string | null {
+	try {
+		const result = spawnSync(command, args, {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
+		});
+		if (result.status !== 0 || typeof result.stdout !== "string") return null;
+		const version = result.stdout.trim();
+		return isValidSemver(version) ? version : null;
+	} catch {
+		return null;
+	}
+}
+
+function readExecutableVersion(executable: string): string | null {
+	const vector = executableCommandVector(executable, ["--version"]);
+	return readCommandVersion(vector.command, vector.args);
 }
 
 function isLongLivedDaemonInvocation(args = process.argv.slice(2)): boolean {
@@ -409,6 +500,10 @@ function isInformationalInvocation(args = process.argv.slice(2)): boolean {
 	return args.some(
 		(arg) => arg === "--version" || arg === "-V" || arg === "--help" || arg === "-h",
 	);
+}
+
+function isMachineReadableInvocation(args = process.argv.slice(2)): boolean {
+	return args.includes("--json");
 }
 
 function outdatedDaemonAgents(current: string): string[] {
@@ -485,6 +580,7 @@ type InstallRunner = (
 
 async function runInstall(installer: Installer, args: string[], signal?: AbortSignal) {
 	if (signal?.aborted) return null;
+
 	const logPath = join(getClawdiDir(), "auto-update.log");
 	let logFd: number;
 	try {
@@ -495,14 +591,17 @@ async function runInstall(installer: Installer, args: string[], signal?: AbortSi
 	}
 	try {
 		return await new Promise<number | null>((resolve) => {
-			const child = spawn(installer, args, {
+			const vector = installerCommandVector(installer, args);
+			const child = spawn(vector.command, vector.args, {
 				stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
 				env: process.env,
+				windowsHide: true,
 			});
 			const onAbort = () => {
 				child.kill();
 			};
 			signal?.addEventListener("abort", onAbort, { once: true });
+			if (signal?.aborted) onAbort();
 			child.on("error", () => resolve(null));
 			child.on("close", (code) => {
 				signal?.removeEventListener("abort", onAbort);
@@ -523,7 +622,7 @@ async function runInstall(installer: Installer, args: string[], signal?: AbortSi
 export type DaemonAutoUpdateResult =
 	| "disabled"
 	| "no_update"
-	| "no_installer"
+	| "unsupported"
 	| "locked"
 	| "installed"
 	| "failed";
@@ -531,9 +630,11 @@ export type DaemonAutoUpdateResult =
 export async function daemonAutoUpdateOnce(
 	opts: {
 		currentVersion?: string;
-		installer?: Installer | null;
+		ownership?: GlobalInstallOwnership | null;
 		installRunner?: InstallRunner;
+		versionReader?: (executable: string) => string | null;
 		ignoreDisabled?: boolean;
+		restartCoordination?: RestartCoordination;
 		signal?: AbortSignal;
 	} = {},
 ): Promise<DaemonAutoUpdateResult> {
@@ -546,28 +647,45 @@ export async function daemonAutoUpdateOnce(
 	const latest = await latestFromCacheOrRegistry(channel);
 	if (!latest || !isNewer(latest, current)) return "no_update";
 
-	const installer = opts.installer === undefined ? detectInstaller() : opts.installer;
-	if (!installer) {
-		log.warn("daemon.auto_update_no_installer", { current, latest, channel });
-		return "no_installer";
+	const ownership = opts.ownership === undefined ? detectGlobalInstall() : opts.ownership;
+	if (!ownership) {
+		log.warn("daemon.auto_update_unsupported", { current, latest, channel });
+		return "unsupported";
 	}
+	const { installer } = ownership;
 
 	const release = acquireDaemonUpdateLock();
 	if (!release) return "locked";
 	try {
 		log.info("daemon.auto_update_installing", { current, latest, channel, installer });
-		const status = await (opts.installRunner ?? runInstall)(
-			installer,
-			installArgs(installer, channel),
-			opts.signal,
-		);
-		if (status !== 0) {
-			log.warn("daemon.auto_update_failed", { current, latest, channel, installer, status });
-			return "failed";
-		}
-		writeLastVersion(current);
-		log.info("daemon.auto_update_installed", { from: current, to: latest, channel, installer });
-		return "installed";
+		const installAndValidate = async (): Promise<DaemonAutoUpdateResult> => {
+			const status = await (opts.installRunner ?? runInstall)(
+				installer,
+				installArgs(installer, latest),
+				opts.signal,
+			);
+			if (status !== 0) {
+				log.warn("daemon.auto_update_failed", { current, latest, channel, installer, status });
+				return "failed";
+			}
+			const installedVersion = (opts.versionReader ?? readExecutableVersion)(ownership.executable);
+			if (installedVersion !== latest) {
+				log.warn("daemon.auto_update_validation_failed", {
+					current,
+					latest,
+					channel,
+					installer,
+					installed_version: installedVersion,
+				});
+				return "failed";
+			}
+			writeLastVersion(current);
+			log.info("daemon.auto_update_installed", { from: current, to: latest, channel, installer });
+			return "installed";
+		};
+		return opts.restartCoordination
+			? await opts.restartCoordination.duringUpdateInstall(installAndValidate)
+			: await installAndValidate();
 	} finally {
 		release();
 	}
@@ -575,6 +693,7 @@ export async function daemonAutoUpdateOnce(
 
 export function startDaemonAutoUpdate(opts: {
 	abort: AbortController;
+	restart: RestartCoordination;
 	intervalMs?: number;
 	initialDelayMs?: number;
 }): boolean {
@@ -587,9 +706,12 @@ export function startDaemonAutoUpdate(opts: {
 	void (async () => {
 		await sleep(initialDelayMs, opts.abort.signal);
 		while (!opts.abort.signal.aborted) {
-			const result = await daemonAutoUpdateOnce({ signal: opts.abort.signal });
+			const result = await daemonAutoUpdateOnce({
+				restartCoordination: opts.restart,
+				signal: opts.abort.signal,
+			});
 			if (result === "installed") {
-				opts.abort.abort();
+				opts.restart.requestRestart();
 				return;
 			}
 			await sleep(intervalMs, opts.abort.signal);
@@ -606,8 +728,8 @@ export function startDaemonAutoUpdate(opts: {
  * Default-on auto-updater. On startup:
  *   1. If the binary version differs from `last-version` on disk, print a
  *      one-line "updated to v…" notice (the previous run's spawn finished).
- *   2. If a newer release exists in the cache, kick off a detached
- *      `npm/bun add -g clawdi@<channel>` so the next invocation gets it.
+ *   2. If a newer release exists in the cache, install that exact version
+ *      in the background so the next invocation gets it.
  *
  * Opt-out: `CLAWDI_NO_AUTO_UPDATE=1` env, `clawdi config set autoUpdate
  * false`, non-TTY (CI), or running via npx/bunx.
@@ -617,22 +739,16 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 	if (
 		isLongLivedDaemonInvocation() ||
 		isAutoUpdateControlInvocation() ||
-		isInformationalInvocation()
+		isInformationalInvocation() ||
+		isMachineReadableInvocation()
 	) {
 		return;
 	}
-
 	const current = getCliVersion();
 	const isHumanTerminal = !!process.stdout.isTTY;
 
-	// Notify on the FIRST run after a successful background install — the
-	// new binary's `getCliVersion()` no longer matches what we wrote last
-	// time. After-the-fact is the only honest signal we have, since the
-	// detached spawn can't write a marker that the parent reliably sees.
-	//
-	// Keep this notice out of piped / scripted output. `clawdi --version`,
-	// `--json` commands, and shell completions need stdout to stay machine-
-	// parseable even on the first run after an update.
+	// Notify when this CLI is newer than the last version seen. Scripted and
+	// JSON invocations return above so their stdout remains machine-readable.
 	const lastFile = lastVersionPath();
 	try {
 		if (existsSync(lastFile)) {
@@ -687,21 +803,10 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 	if (!latest) return;
 	if (!isNewer(latest, current)) return;
 
-	const installer = detectAutoUpdateInstaller(runtime);
-	if (!installer) return;
-
-	// No single-flight lock. Two concurrent CLIs both spawning an npm install
-	// for the same package spec serialize on npm's own per-package install lock —
-	// at worst one waits, both end up at the same target version. The
-	// previous mkdir-based lock added stale-recovery complexity for a
-	// non-correctness gain (saving one redundant spawn + a duplicate
-	// "Updating…" line); not worth it.
-	//
-	// Installing the dist-tag (not the pinned cache version) keeps installs
-	// idempotent — a newer release landing between cache write and now is
-	// picked up automatically, and `last-version` on next invocation detects
-	// the change.
-	const args = installArgs(installer, channel);
+	const ownership = detectAutoUpdateOwnership(runtime);
+	if (!ownership) return;
+	const { installer } = ownership;
+	const args = installArgs(installer, latest);
 
 	// Redirect installer output to a logfile so silent failures (network
 	// flake, perms error, npm 4xx) leave a trail. `stdio: "ignore"` would
@@ -739,13 +844,12 @@ function spawnBackgroundInstall(
 	args: string[],
 	context: BackgroundInstallContext,
 ): void {
-	const child = spawn(installer, args, {
+	const vector = installerCommandVector(installer, args);
+	const child = spawn(vector.command, vector.args, {
 		stdio: context.logFd >= 0 ? ["ignore", context.logFd, context.logFd] : "ignore",
 		detached: true,
-		// Pass env explicitly so a future change to spawn defaults can't
-		// strip NPM_CONFIG_PREFIX / BUN_INSTALL and silently install into
-		// the wrong global location.
 		env: process.env,
+		windowsHide: true,
 	});
 	child.on("error", () => {
 		// Installer missing / crashed — silent skip; the user still sees

--- a/packages/cli/src/lib/semver.test.ts
+++ b/packages/cli/src/lib/semver.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { compareSemver, isValidSemver } from "./semver";
+
+describe("compareSemver", () => {
+	it.each([
+		["1.0.0-beta.9", "1.0.0-beta.10"],
+		["1.0.0-rc.2", "1.0.0-rc.10"],
+	])("orders %s before %s", (current, next) => {
+		expect(compareSemver(current, next)).toBe(-1);
+		expect(compareSemver(next, current)).toBe(1);
+	});
+
+	it("compares numeric identifiers without Number precision loss", () => {
+		expect(
+			compareSemver(
+				"9007199254740992.0.0-rc.9007199254740992",
+				"9007199254740993.0.0-rc.9007199254740993",
+			),
+		).toBe(-1);
+	});
+});
+
+describe("isValidSemver", () => {
+	it("rejects numeric prerelease identifiers with leading zeroes", () => {
+		expect(isValidSemver("1.0.0-rc.01")).toBe(false);
+	});
+});

--- a/packages/cli/src/lib/semver.ts
+++ b/packages/cli/src/lib/semver.ts
@@ -1,12 +1,14 @@
 interface ParsedSemver {
-	major: number;
-	minor: number;
-	patch: number;
+	major: string;
+	minor: string;
+	patch: string;
 	pre: string[];
 }
 
 const SEMVER_RE =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+const NUMERIC_IDENTIFIER_RE = /^\d+$/;
+const IDENTIFIER_RE = /^[0-9A-Za-z-]+$/;
 
 export function isValidSemver(value: string): boolean {
 	return parseSemver(value) !== null;
@@ -19,7 +21,8 @@ export function compareSemver(a: string, b: string): number {
 		throw new Error(`invalid semver comparison: ${a} <=> ${b}`);
 	}
 	for (const key of ["major", "minor", "patch"] as const) {
-		if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1;
+		const compared = compareNumericIdentifier(left[key], right[key]);
+		if (compared !== 0) return compared;
 	}
 	if (left.pre.length === 0 && right.pre.length === 0) return 0;
 	if (left.pre.length === 0) return 1;
@@ -31,11 +34,11 @@ export function compareSemver(a: string, b: string): number {
 		if (l === undefined) return -1;
 		if (r === undefined) return 1;
 		if (l === r) continue;
-		const lNum = numericIdentifier(l);
-		const rNum = numericIdentifier(r);
-		if (lNum !== null && rNum !== null) return lNum < rNum ? -1 : 1;
-		if (lNum !== null) return -1;
-		if (rNum !== null) return 1;
+		const lNumeric = NUMERIC_IDENTIFIER_RE.test(l);
+		const rNumeric = NUMERIC_IDENTIFIER_RE.test(r);
+		if (lNumeric && rNumeric) return compareNumericIdentifier(l, r);
+		if (lNumeric) return -1;
+		if (rNumeric) return 1;
 		return l < r ? -1 : 1;
 	}
 	return 0;
@@ -46,19 +49,30 @@ export function isSemverLessThan(a: string, b: string): boolean {
 }
 
 function parseSemver(value: string): ParsedSemver | null {
-	const match = SEMVER_RE.exec(value.trim());
+	const match = SEMVER_RE.exec(value);
 	if (!match) return null;
 	const [, major, minor, patch, pre] = match;
 	if (!major || !minor || !patch) return null;
+	const prerelease = pre ? pre.split(".") : [];
+	const build = value.includes("+") ? value.slice(value.indexOf("+") + 1).split(".") : [];
+	if (![...prerelease, ...build].every((part) => IDENTIFIER_RE.test(part))) return null;
+	if (
+		prerelease.some(
+			(part) => NUMERIC_IDENTIFIER_RE.test(part) && part.length > 1 && part.startsWith("0"),
+		)
+	) {
+		return null;
+	}
 	return {
-		major: Number.parseInt(major, 10),
-		minor: Number.parseInt(minor, 10),
-		patch: Number.parseInt(patch, 10),
-		pre: pre ? pre.split(".") : [],
+		major,
+		minor,
+		patch,
+		pre: prerelease,
 	};
 }
 
-function numericIdentifier(value: string): number | null {
-	if (!/^(0|[1-9]\d*)$/.test(value)) return null;
-	return Number.parseInt(value, 10);
+function compareNumericIdentifier(left: string, right: string): number {
+	if (left.length !== right.length) return left.length < right.length ? -1 : 1;
+	if (left === right) return 0;
+	return left < right ? -1 : 1;
 }

--- a/packages/cli/src/serve/auto-restart.ts
+++ b/packages/cli/src/serve/auto-restart.ts
@@ -1,43 +1,43 @@
 /**
- * Self-restart on binary update.
- *
- * Problem: when `npm i -g clawdi` (or `bun add -g`, or a local
- * `bun run build:dev`) rewrites the daemon's own JS file, the
- * already-running process stays on the old in-memory code forever.
- * Users had no way to pick up a fix short of `launchctl kickstart`
- * or rebooting.
- *
- * Solution: snapshot the entry JS file's mtime at boot, poll
- * periodically, and exit cleanly when the file changes. The OS
- * supervisor (launchd `KeepAlive=true` on macOS, systemd
- * `Restart=always` on Linux) respawns the daemon, which loads the
- * new code at process start. Net effect: any update path
- * propagates to a running daemon within `pollMs` of the file
- * being rewritten.
- *
- * Why mtime + poll instead of `fs.watch`: npm and bun both replace
- * files atomically (write to temp + rename), and `fs.watch`
- * semantics across platforms differ on rename events (macOS sends
- * `rename`, Linux sends `change`, Windows behavior varies). Polling
- * mtime is dumb but works the same everywhere and the daemon's
- * baseline cost is trivial — one stat() per poll interval.
+ * Watches the loaded CLI entry by mtime and asks the service supervisor for a
+ * clean restart when it changes. A daemon-owned global install holds the small
+ * coordination barrier below through installer close and version validation;
+ * watcher events observed inside that interval are deferred while the updater
+ * validates the new bytes, while entry changes outside it restart immediately.
  */
-
 import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { log } from "./log";
 
+export interface RestartCoordination {
+	duringUpdateInstall<T>(work: () => Promise<T>): Promise<T>;
+	requestRestart(): boolean;
+}
+
+export function createRestartCoordination(abort: AbortController): RestartCoordination {
+	let installsInFlight = 0;
+
+	return {
+		async duringUpdateInstall<T>(work: () => Promise<T>): Promise<T> {
+			installsInFlight += 1;
+			try {
+				return await work();
+			} finally {
+				installsInFlight -= 1;
+			}
+		},
+		requestRestart(): boolean {
+			if (installsInFlight > 0) return false;
+			abort.abort();
+			return true;
+		},
+	};
+}
+
 interface AutoRestartOpts {
-	/** Caller's abort controller. We call `.abort()` when the entry
-	 * file changes so the engine's main loop drains and exits. */
 	abort: AbortController;
-	/** Polling cadence. Defaults to 60s — fast enough that a user
-	 * who just ran `clawdi update` sees behavior change inside one
-	 * coffee break, slow enough to not be visible in `top`. */
+	restart: RestartCoordination;
 	pollMs?: number;
-	/** Override the entry-file resolver. Tests pass an explicit
-	 * path; production callers omit it and we derive from
-	 * `process.argv[1]`. */
 	entryPath?: string;
 }
 
@@ -90,9 +90,9 @@ export async function startAutoRestart(opts: AutoRestartOpts): Promise<string | 
 	const entry = opts.entryPath ?? (await resolveEntryFile());
 	if (!entry) return null;
 
-	let initial: number;
+	let previous: number;
 	try {
-		initial = (await stat(entry)).mtimeMs;
+		previous = (await stat(entry)).mtimeMs;
 	} catch {
 		// Entry vanished between resolveEntryFile and stat — bail
 		// silently rather than throwing; the daemon is fine without
@@ -107,17 +107,14 @@ export async function startAutoRestart(opts: AutoRestartOpts): Promise<string | 
 			if (opts.abort.signal.aborted) return;
 			try {
 				const now = (await stat(entry)).mtimeMs;
-				if (now !== initial) {
+				if (now !== previous) {
 					log.info("serve.binary_updated", {
 						entry,
-						initial_mtime: initial,
+						initial_mtime: previous,
 						current_mtime: now,
 					});
-					// Graceful shutdown — the engine's drain loop
-					// notices the abort and exits, then launchd /
-					// systemd respawns us with the new code.
-					opts.abort.abort();
-					return;
+					previous = now;
+					if (opts.restart.requestRestart()) return;
 				}
 			} catch (e) {
 				// Atomic replace momentarily makes the path miss; one

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -9,6 +9,11 @@ import {
 	maybeAutoUpdate,
 	update,
 } from "../../src/commands/update";
+import {
+	createRestartCoordination,
+	type RestartCoordination,
+	startAutoRestart,
+} from "../../src/serve/auto-restart";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -18,6 +23,12 @@ let origNoAuto: string | undefined;
 let origRuntimeMode: string | undefined;
 let origHostPolicyPath: string | undefined;
 let origArgv: string[];
+let origExitCode: number | undefined;
+
+const npmOwnership = {
+	installer: "npm" as const,
+	executable: "/owned/npm/bin/clawdi",
+};
 
 async function withStdoutTty<T>(fn: () => Promise<T>): Promise<T> {
 	const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
@@ -37,6 +48,8 @@ beforeEach(() => {
 	origRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
 	origHostPolicyPath = process.env.CLAWDI_HOST_POLICY_PATH;
 	origArgv = [...process.argv];
+	origExitCode = process.exitCode;
+	process.exitCode = undefined;
 	delete process.env.CLAWDI_NO_UPDATE_CHECK;
 	delete process.env.CLAWDI_NO_AUTO_UPDATE;
 	delete process.env.CLAWDI_RUNTIME_MODE;
@@ -48,6 +61,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	process.argv.splice(0, process.argv.length, ...origArgv);
+	process.exitCode = origExitCode;
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
 	if (origNoCheck) process.env.CLAWDI_NO_UPDATE_CHECK = origNoCheck;
@@ -62,55 +76,66 @@ afterEach(() => {
 });
 
 describe("detectInstaller", () => {
-	it("uses npm when the running clawdi binary is in npm's global bin even if bun is available", () => {
-		expect(
-			detectInstallerFromPaths("/home/user/.local/bin/clawdi", {
-				npmBin: "/home/user/.local/bin",
-				npmRoot: "/home/user/.local/lib/node_modules",
-				bunBin: "/home/user/.bun/bin",
-			}),
-		).toBe("npm");
-	});
-
-	it("uses bun when the running clawdi binary is in bun's global bin", () => {
-		expect(
-			detectInstallerFromPaths("/home/user/.bun/bin/clawdi", {
-				npmBin: "/home/user/.local/bin",
-				npmRoot: "/home/user/.local/lib/node_modules",
-				bunBin: "/home/user/.bun/bin",
-			}),
-		).toBe("bun");
-	});
-
-	it("uses npm when the resolved clawdi package path is inside npm's global root", () => {
+	it("uses npm when the resolved entry is inside npm's global package root", () => {
 		expect(
 			detectInstallerFromPaths("/home/user/.local/lib/node_modules/clawdi/bin/clawdi.mjs", {
 				npmBin: "/home/user/.local/bin",
 				npmRoot: "/home/user/.local/lib/node_modules",
 				bunBin: "/home/user/.bun/bin",
+				bunRoot: "/home/user/.bun/install/global/node_modules",
 			}),
 		).toBe("npm");
 	});
 
-	it("uses bun when the resolved clawdi package path is inside Bun's global install", () => {
+	it("uses bun when the resolved entry is inside Bun's global package root", () => {
 		expect(
 			detectInstallerFromPaths(
 				"/home/user/.bun/install/global/node_modules/clawdi/bin/clawdi.mjs",
 				{
 					npmBin: "/home/user/.local/bin",
 					npmRoot: "/home/user/.local/lib/node_modules",
+					bunBin: "/home/user/.bun/bin",
+					bunRoot: "/home/user/.bun/install/global/node_modules",
 				},
 			),
 		).toBe("bun");
 	});
+
+	it("does not infer ownership from an executable merely being in a global bin", () => {
+		expect(
+			detectInstallerFromPaths("/home/user/.local/bin/clawdi", {
+				npmBin: "/home/user/.local/bin",
+				npmRoot: "/home/user/.local/lib/node_modules",
+				bunBin: "/home/user/.bun/bin",
+				bunRoot: "/home/user/.bun/install/global/node_modules",
+			}),
+		).toBeNull();
+	});
+
+	it("rejects Bun 1.3.14 bunx and npm npx cache ownership", () => {
+		expect(
+			detectInstallerFromPaths("/tmp/bunx-1000-clawdi@latest/node_modules/clawdi/bin/clawdi.mjs", {
+				bunBin: "/home/user/.bun/bin",
+				bunRoot: "/tmp/bunx-1000-clawdi@latest/node_modules",
+			}),
+		).toBeNull();
+		expect(
+			detectInstallerFromPaths(
+				"C:\\Users\\test\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\clawdi\\bin\\clawdi.mjs",
+				{
+					npmBin: "C:\\Users\\test\\AppData\\Roaming\\npm",
+					npmRoot: "C:\\Users\\test\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules",
+				},
+			),
+		).toBeNull();
+	});
 });
 
 describe("installCommand", () => {
-	it("prints the installer-specific manual command", () => {
-		expect(installCommand("npm")).toBe("npm i -g clawdi@latest");
-		expect(installCommand("bun")).toBe("bun add -g clawdi@latest");
-		expect(installCommand(null)).toBe("npm i -g clawdi@latest");
-		expect(installCommand("npm", "beta")).toBe("npm i -g clawdi@beta");
+	it("prints the installer-specific exact command", () => {
+		expect(installCommand("npm", "1.2.3")).toBe("npm i -g clawdi@1.2.3");
+		expect(installCommand("bun", "1.2.3-beta.10")).toBe("bun add -g clawdi@1.2.3-beta.10");
+		expect(installCommand(null, "1.2.3")).toBe("npm i -g clawdi@1.2.3");
 	});
 });
 
@@ -195,6 +220,141 @@ describe("update --json", () => {
 		expect(result.latest).toBeNull();
 		expect(result.upgradeAvailable).toBe(false);
 	});
+
+	it("rejects a registry dist-tag value that is not an exact semver", async () => {
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured = args.map(String).join(" ");
+		};
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "latest" } }),
+			},
+		]);
+		try {
+			await update({ json: true });
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect((JSON.parse(captured) as { latest: string | null }).latest).toBeNull();
+	});
+});
+
+describe("update install", () => {
+	it("uses safe Windows command vectors for exact npm install and owned executable smoke", async () => {
+		const installs: { command: string; args: string[] }[] = [];
+		const smokes: { command: string; args: string[] }[] = [];
+		const ownership = {
+			installer: "npm" as const,
+			executable: "C:\\Program Files\\npm\\clawdi.cmd",
+		};
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+			},
+		]);
+		try {
+			await withStdoutTty(() =>
+				update(
+					{},
+					{
+						detectOwnership: () => ownership,
+						installRunner: (command, args) => {
+							installs.push({ command, args });
+							return 0;
+						},
+						platform: "win32",
+						versionReader: (command, args) => {
+							smokes.push({ command, args });
+							return "99.0.0";
+						},
+					},
+				),
+			);
+		} finally {
+			restore();
+		}
+
+		expect(installs).toEqual([
+			{
+				command: "cmd.exe",
+				args: ["/d", "/s", "/c", "npm.cmd", "i", "-g", "clawdi@99.0.0"],
+			},
+		]);
+		expect(smokes).toEqual([
+			{
+				command: "cmd.exe",
+				args: ["/d", "/s", "/c", ownership.executable, "--version"],
+			},
+		]);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("does not claim success when the owned executable reports another version", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+			},
+		]);
+		try {
+			await withStdoutTty(() =>
+				update(
+					{},
+					{
+						detectOwnership: () => npmOwnership,
+						installRunner: () => 0,
+						versionReader: () => "98.0.0",
+					},
+				),
+			);
+		} finally {
+			restore();
+		}
+
+		expect(process.exitCode).toBe(1);
+		expect(() => readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8")).toThrow();
+	});
+
+	it("reports an exact manual command without installing when ownership is unknown", async () => {
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured += `${args.map(String).join(" ")}\n`;
+		};
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+			},
+		]);
+		try {
+			await withStdoutTty(() =>
+				update(
+					{},
+					{
+						detectOwnership: () => null,
+						installRunner: () => {
+							throw new Error("unowned invocation must not install");
+						},
+					},
+				),
+			);
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect(captured).toContain("Automatic update is unsupported");
+		expect(captured).toContain("npm i -g clawdi@99.0.0");
+	});
 });
 
 describe("daemonAutoUpdateOnce", () => {
@@ -204,7 +364,6 @@ describe("daemonAutoUpdateOnce", () => {
 		try {
 			const result = await daemonAutoUpdateOnce({
 				currentVersion: "1.2.3",
-				installer: "npm",
 				ignoreDisabled: true,
 				installRunner: async () => {
 					throw new Error("hosted policy must prevent local CLI installation");
@@ -229,15 +388,16 @@ describe("daemonAutoUpdateOnce", () => {
 		try {
 			const result = await daemonAutoUpdateOnce({
 				currentVersion: "1.2.3",
-				installer: "npm",
+				ownership: npmOwnership,
 				installRunner: async (installer, args) => {
 					calls.push({ installer, args });
 					return 0;
 				},
+				versionReader: (executable) => (executable === npmOwnership.executable ? "1.2.4" : null),
 			});
 
 			expect(result).toBe("installed");
-			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@latest"] }]);
+			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@1.2.4"] }]);
 			expect(readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8").trim()).toBe("1.2.3");
 		} finally {
 			restore();
@@ -256,20 +416,24 @@ describe("daemonAutoUpdateOnce", () => {
 		try {
 			const result = await daemonAutoUpdateOnce({
 				currentVersion: "1.9.9",
-				installer: "npm",
+				ownership: npmOwnership,
 				installRunner: async (installer, args) => {
 					calls.push({ installer, args });
 					return 0;
 				},
+				versionReader: () => "2.0.0",
 			});
 			expect(result).toBe("installed");
-			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@latest"] }]);
+			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@2.0.0"] }]);
 		} finally {
 			restore();
 		}
 	});
 
-	it("follows the beta dist-tag when the daemon is running a beta build", async () => {
+	it.each([
+		["rc", "0.12.10-rc.2", "0.12.10-rc.10"],
+		["alpha", "0.12.11-alpha.1", "0.12.11-alpha.2"],
+	])("routes %s prereleases through the beta dist-tag", async (tag, current, next) => {
 		const calls: { installer: string; args: string[] }[] = [];
 		const { restore } = mockFetch([
 			{
@@ -277,21 +441,26 @@ describe("daemonAutoUpdateOnce", () => {
 				path: "/clawdi",
 				response: () =>
 					jsonResponse({
-						"dist-tags": { latest: "0.12.9", beta: "0.12.10-beta.27" },
+						"dist-tags": {
+							latest: "0.12.9",
+							beta: next,
+							[tag]: `99.0.0-${tag}.1`,
+						},
 					}),
 			},
 		]);
 		try {
 			const result = await daemonAutoUpdateOnce({
-				currentVersion: "0.12.10-beta.26",
-				installer: "npm",
+				currentVersion: current,
+				ownership: npmOwnership,
 				installRunner: async (installer, args) => {
 					calls.push({ installer, args });
 					return 0;
 				},
+				versionReader: () => next,
 			});
 			expect(result).toBe("installed");
-			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@beta"] }]);
+			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", `clawdi@${next}`] }]);
 		} finally {
 			restore();
 		}
@@ -303,7 +472,7 @@ describe("daemonAutoUpdateOnce", () => {
 		try {
 			const result = await daemonAutoUpdateOnce({
 				currentVersion: "1.2.3",
-				installer: "npm",
+				ownership: npmOwnership,
 			});
 			expect(result).toBe("disabled");
 			expect(fetches).toHaveLength(0);
@@ -324,7 +493,7 @@ describe("daemonAutoUpdateOnce", () => {
 		try {
 			const result = await daemonAutoUpdateOnce({
 				currentVersion: "1.2.3",
-				installer: "npm",
+				ownership: npmOwnership,
 				installRunner: async () => {
 					throw new Error("should not install while locked");
 				},
@@ -333,6 +502,131 @@ describe("daemonAutoUpdateOnce", () => {
 		} finally {
 			restore();
 		}
+	});
+
+	it("fails validation when the owned executable is not the resolved version", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "1.2.4" } }),
+			},
+		]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				ownership: npmOwnership,
+				installRunner: async () => 0,
+				versionReader: () => "1.2.5",
+			});
+
+			expect(result).toBe("failed");
+			expect(() => readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8")).toThrow();
+		} finally {
+			restore();
+		}
+	});
+
+	it("returns unsupported without installing from an unowned invocation", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "1.2.4" } }),
+			},
+		]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				ownership: null,
+				installRunner: async () => {
+					throw new Error("unsupported invocation must not install");
+				},
+			});
+			expect(result).toBe("unsupported");
+		} finally {
+			restore();
+		}
+	});
+
+	it("defers an mtime restart until a slow install closes and validates", async () => {
+		const entry = join(tmpHome, "owned-entry.js");
+		writeFileSync(entry, "old\n");
+		const abort = new AbortController();
+		const baseRestart = createRestartCoordination(abort);
+		let observeWatcherRequest: (() => void) | undefined;
+		const watcherRequested = new Promise<void>((resolve) => {
+			observeWatcherRequest = resolve;
+		});
+		const restart: RestartCoordination = {
+			duringUpdateInstall: (work) => baseRestart.duringUpdateInstall(work),
+			requestRestart: () => {
+				observeWatcherRequest?.();
+				return baseRestart.requestRestart();
+			},
+		};
+		await startAutoRestart({ abort, restart, entryPath: entry, pollMs: 5 });
+
+		let finishInstall: (() => void) | undefined;
+		const installGate = new Promise<void>((resolve) => {
+			finishInstall = resolve;
+		});
+		const lifecycle: string[] = [];
+		abort.signal.addEventListener("abort", () => lifecycle.push("restart"), { once: true });
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "1.2.4" } }),
+			},
+		]);
+		try {
+			const updatePromise = daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				ownership: npmOwnership,
+				restartCoordination: restart,
+				installRunner: async () => {
+					lifecycle.push("install-start");
+					const changed = new Date(Date.now() + 10_000);
+					utimesSync(entry, changed, changed);
+					await installGate;
+					lifecycle.push("installer-close");
+					return 0;
+				},
+				versionReader: () => {
+					lifecycle.push("validated");
+					return "1.2.4";
+				},
+			});
+
+			await watcherRequested;
+			expect(abort.signal.aborted).toBe(false);
+			finishInstall?.();
+			expect(await updatePromise).toBe("installed");
+			expect(abort.signal.aborted).toBe(false);
+			restart.requestRestart();
+			expect(abort.signal.aborted).toBe(true);
+			expect(lifecycle).toEqual(["install-start", "installer-close", "validated", "restart"]);
+		} finally {
+			finishInstall?.();
+			abort.abort();
+			restore();
+		}
+	});
+
+	it("restarts immediately for an entry change outside an update install", async () => {
+		const entry = join(tmpHome, "external-entry.js");
+		writeFileSync(entry, "old\n");
+		const abort = new AbortController();
+		const restart = createRestartCoordination(abort);
+		await startAutoRestart({ abort, restart, entryPath: entry, pollMs: 5 });
+		const restarted = new Promise<void>((resolve) => {
+			abort.signal.addEventListener("abort", () => resolve(), { once: true });
+		});
+		const changed = new Date(Date.now() + 10_000);
+		utimesSync(entry, changed, changed);
+		await restarted;
+		expect(abort.signal.aborted).toBe(true);
 	});
 });
 
@@ -343,7 +637,7 @@ describe("maybeAutoUpdate", () => {
 		try {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
-					detectInstaller: () => "npm",
+					detectOwnership: () => npmOwnership,
 					spawnBackgroundInstall: () => {
 						throw new Error("should not spawn hosted local self-update");
 					},
@@ -355,6 +649,67 @@ describe("maybeAutoUpdate", () => {
 		expect(captured).toHaveLength(0);
 	});
 
+	it("leaves TTY stdout untouched for every --json invocation", async () => {
+		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
+		writeFileSync(
+			join(tmpHome, ".clawdi", "update.json"),
+			JSON.stringify({ checkedAt: new Date().toISOString(), latest: "999.0.0" }),
+		);
+		process.argv.splice(2, process.argv.length - 2, "status", "--json");
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured += `${args.map(String).join(" ")}\n`;
+		};
+		const { captured: fetches, restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectOwnership: () => {
+						throw new Error("--json must skip updater ownership detection");
+					},
+					spawnBackgroundInstall: () => {
+						throw new Error("--json must not install");
+					},
+				}),
+			);
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect(captured).toBe("");
+		expect(fetches).toHaveLength(0);
+		expect(readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8").trim()).toBe("0.0.1");
+	});
+
+	it("silently skips background update for an unowned invocation", async () => {
+		writeFileSync(
+			join(tmpHome, ".clawdi", "update.json"),
+			JSON.stringify({ checkedAt: new Date().toISOString(), latest: "999.0.0" }),
+		);
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured += `${args.map(String).join(" ")}\n`;
+		};
+		const { captured: fetches, restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectOwnership: () => null,
+					spawnBackgroundInstall: () => {
+						throw new Error("unowned invocation must not install");
+					},
+				}),
+			);
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect(captured).toBe("");
+		expect(fetches).toHaveLength(0);
+	});
+
 	it("writes last-version on first run; no notice", async () => {
 		const orig = console.log;
 		let captured = "";
@@ -363,7 +718,11 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await maybeAutoUpdate();
+			await maybeAutoUpdate({
+				detectOwnership: () => {
+					throw new Error("startup without a newer version must not probe global ownership");
+				},
+			});
 		} finally {
 			console.log = orig;
 			restore();
@@ -385,7 +744,13 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await withStdoutTty(() => maybeAutoUpdate());
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectOwnership: () => {
+						throw new Error("update notices must not probe global ownership");
+					},
+				}),
+			);
 		} finally {
 			console.log = orig;
 			restore();
@@ -406,7 +771,7 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await withStdoutTty(() => maybeAutoUpdate());
+			await withStdoutTty(() => maybeAutoUpdate({ detectOwnership: () => npmOwnership }));
 		} finally {
 			console.log = orig;
 			restore();
@@ -425,7 +790,7 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await maybeAutoUpdate();
+			await maybeAutoUpdate({ detectOwnership: () => npmOwnership });
 		} finally {
 			console.log = orig;
 			restore();
@@ -446,7 +811,7 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { captured: fetches, restore } = mockFetch([]);
 		try {
-			await withStdoutTty(() => maybeAutoUpdate());
+			await withStdoutTty(() => maybeAutoUpdate({ detectOwnership: () => npmOwnership }));
 		} finally {
 			console.log = orig;
 			delete process.env.CLAWDI_NO_AUTO_UPDATE;
@@ -468,7 +833,6 @@ describe("maybeAutoUpdate", () => {
 			? (current.split("-", 2)[1]?.split(".", 1)[0] ?? "latest")
 			: "latest";
 		const cacheFile = channel === "latest" ? "update.json" : `update-${channel}.json`;
-		const expectedSpec = channel === "latest" ? "clawdi@latest" : `clawdi@${channel}`;
 		// Plant cache with a version way higher than package.json so this
 		// remains a major-bump test regardless of the fixture version.
 		writeFileSync(
@@ -490,7 +854,7 @@ describe("maybeAutoUpdate", () => {
 		try {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
-					detectInstaller: () => "npm",
+					detectOwnership: () => npmOwnership,
 					spawnBackgroundInstall: (installer, args, context) => {
 						installs.push({ installer, args, latest: context.latest, logFd: context.logFd });
 					},
@@ -505,7 +869,7 @@ describe("maybeAutoUpdate", () => {
 		expect(captured).not.toContain("Major release");
 		expect(installs).toHaveLength(1);
 		expect(installs[0]?.installer).toBe("npm");
-		expect(installs[0]?.args).toEqual(["i", "-g", expectedSpec]);
+		expect(installs[0]?.args).toEqual(["i", "-g", "clawdi@999.0.0"]);
 		expect(installs[0]?.latest).toBe("999.0.0");
 		expect(installs[0]?.logFd ?? -1).toBeGreaterThanOrEqual(0);
 	});
@@ -524,7 +888,7 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await maybeAutoUpdate();
+			await maybeAutoUpdate({ detectOwnership: () => npmOwnership });
 		} finally {
 			console.log = orig;
 			restore();


### PR DESCRIPTION
## Summary

- use the hardened shared SemVer comparator, including precision-safe numeric prerelease ordering
- resolve channels to one exact registry version, then install only `clawdi@<exact-version>`
- require positive npm or Bun global ownership before any local updater writes
- smoke the owned executable after foreground and daemon installs before reporting success or restarting
- coordinate daemon-owned installs with the mtime watcher through one in-flight restart barrier
- route Windows `.cmd` launches through `cmd.exe` argv vectors while keeping detached windows hidden
- preserve JSON stdout and Hosted update authority guards

## Simplified model

The release channel is used only to select the registry dist-tag and cache. Stable builds use `latest`; every prerelease uses `beta`. The resolved value must be one exact valid SemVer. Ownership proof gates the write, the exact owned-executable smoke gates success, and one restart coordination primitive spans installer close plus validation.

## Verification

- `bun test --timeout 15000 packages/cli/src/lib/semver.test.ts packages/cli/tests/commands/update.test.ts` (39 pass)
- `scripts/test.sh cli` in Docker isolation (1245 pass, 0 fail, 89 files)
- `bun run --cwd packages/cli typecheck`
- `bun run check`
- `git diff --check`

No host global installation was touched.

## Explicitly deferred audit items

- standalone updater/downloader support
- retry or backoff policy
- full updater lock redesign
- broader updater and release-pipeline audit beyond the scoped prerelease tag contract
