### PR TITLE
fix(web): polish Runtime UI access controls

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2502,12 +2502,16 @@ test("deployment detail stays put, becomes running, and keeps manual Runtime UI 
 		"https://runtime.example/hermes",
 	);
 	await expect(main.getByRole("button", { name: "Access Hermes Dashboard" })).toBeVisible();
+	await expect(
+		main.getByRole("button", { name: "Open Hermes Dashboard in new window" }),
+	).toBeVisible();
 });
 
-test("Runtime UI Access masks both Hermes fields and submits one declarative reset", async ({
+test("Runtime UI Access shows Hermes username, masks password, and submits one declarative reset", async ({
 	context,
 	page,
 }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
 	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 	const runtimeUiRedemptionRequests: string[] = [];
 	const runtimeUiResetRequests: Array<{ idempotencyKey: string | null; ifMatch: string | null }> =
@@ -2526,9 +2530,11 @@ test("Runtime UI Access masks both Hermes fields and submits one declarative res
 	const dialog = page.getByRole("dialog", { name: "Runtime UI access" });
 	await expect(dialog).toBeVisible();
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
-	await expect(dialog.locator("code")).toHaveText(["••••••••••••", "••••••••••••"]);
-	await dialog.getByRole("button", { name: "Show Username" }).click();
+	await expect(dialog.locator("code")).toHaveText(["admin", "••••••••••••"]);
 	await expect(dialog.getByText("admin", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Show Username" })).toHaveCount(0);
+	await dialog.getByRole("button", { name: "Copy Username" }).click();
+	await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("admin");
 	await dialog.getByRole("button", { name: "Copy Password" }).click();
 	await expect
 		.poll(() => page.evaluate(() => navigator.clipboard.readText()))
@@ -2586,7 +2592,7 @@ test("Runtime UI credential failure renders a retryable error instead of a perma
 	await expect(
 		dialog.getByText("Couldn't load Hermes Dashboard access", { exact: true }),
 	).toHaveCount(0);
-	await expect(dialog.locator("code")).toHaveText(["••••••••••••", "••••••••••••"]);
+	await expect(dialog.locator("code")).toHaveText(["admin", "••••••••••••"]);
 	await dialog.getByRole("button", { name: "Show Password", exact: true }).click();
 	await expect(dialog.getByText("recovered-password", { exact: true })).toBeVisible();
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(2);
@@ -2621,6 +2627,14 @@ test("OpenClaw Console opens through the direct gateway token handoff", async ({
 		"https://runtime.example/openclaw/#token=gateway-token",
 	);
 	await expect(main.getByText("gateway-token", { exact: false })).toHaveCount(0);
+	await expect(
+		main.getByRole("button", { name: "Open OpenClaw Control UI in new window" }),
+	).toBeVisible();
+	const toolbarPopupPromise = page.waitForEvent("popup");
+	await main.getByRole("button", { name: "Open OpenClaw Control UI in new window" }).click();
+	const toolbarPopup = await toolbarPopupPromise;
+	expect(toolbarPopup).toBeDefined();
+	await toolbarPopup.close();
 	await main.getByRole("button", { name: "Access OpenClaw Control UI" }).click();
 	const dialog = page.getByRole("dialog", { name: "Runtime UI access" });
 	expect(runtimeUiRedemptionRequests).toHaveLength(1);
@@ -2630,8 +2644,11 @@ test("OpenClaw Console opens through the direct gateway token handoff", async ({
 		"https://runtime.example/openclaw/#token=gateway-token",
 	);
 	await expect(dialog.locator("code")).toHaveText("••••••••••••");
+	await dialog.getByRole("button", { name: "Copy Token" }).click();
 	await dialog.getByRole("button", { name: "Show Token" }).click();
 	await expect(dialog.getByText("gateway-token", { exact: true })).toBeVisible();
+	await dialog.getByRole("button", { name: "Hide Token" }).click();
+	await expect(dialog.getByText("gateway-token", { exact: true })).toHaveCount(0);
 	const popupPromise = page.waitForEvent("popup");
 	await dialog.getByRole("button", { name: "Open in new window", exact: true }).click();
 	const popup = await popupPromise;

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -268,14 +268,17 @@ describe("hosted agent customer language", () => {
 		expect(detailSource.match(/getRuntimeUiCredentials/g)).toHaveLength(1);
 		expect(detailSource).toContain("openSecureRuntimeWindow");
 		expect(detailSource).toContain("resolveRuntimeUiCredentials");
+		expect(detailSource).toContain("runtimeUiLaunchTarget");
 		expect(detailSource).toContain("RuntimeUiAccessDialog");
 		expect(detailSource).toContain("Runtime UI access");
 		expect(detailSource).toContain("<iframe");
 		expect(detailSource).toContain('allow="clipboard-read; clipboard-write"');
-		expect(detailSource).toContain("credentials.handoff_url");
-		expect(detailSource).toContain('<TokenReveal label="Username"');
-		expect(detailSource).toContain('<TokenReveal label="Password"');
-		expect(detailSource).toContain('<TokenReveal label="Token"');
+		expect(detailSource).toContain("Open in new window");
+		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Username"');
+		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Password"');
+		expect(detailSource).toContain(
+			'<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />',
+		);
 		expect(detailSource).not.toContain("reconciliationRequired");
 	});
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -6,9 +6,13 @@ import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
 	Bot,
+	Check,
 	CircleCheck,
+	Copy,
 	Cpu,
 	ExternalLink,
+	Eye,
+	EyeOff,
 	Info,
 	LifeBuoy,
 	Link2,
@@ -59,9 +63,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
 import {
@@ -80,6 +86,7 @@ import {
 import {
 	openSecureRuntimeWindow,
 	resolveRuntimeUiCredentials,
+	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
 import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import { useBillingClient } from "@/hosted/billing/billing-client";
@@ -1372,7 +1379,7 @@ function ConsoleTab({
 	const iframeUrl =
 		runtime === "openclaw"
 			? credentials?.runtime === "openclaw"
-				? credentials.handoff_url
+				? runtimeUiLaunchTarget(credentials)
 				: "about:blank"
 			: url;
 
@@ -1398,6 +1405,60 @@ function ConsoleTab({
 				allow="clipboard-read; clipboard-write"
 			/>
 		</LiveToolFrame>
+	);
+}
+
+const MASKED_RUNTIME_UI_CREDENTIAL = "••••••••••••";
+
+function RuntimeUiCredentialRow({
+	label,
+	value,
+	secret = false,
+}: {
+	label: string;
+	value: string;
+	secret?: boolean;
+}) {
+	const [revealed, setRevealed] = useState(!secret);
+	const { copied, copy } = useCopyToClipboard({
+		success: `${label} copied`,
+		error: `Couldn't copy ${label.toLowerCase()}`,
+	});
+	const visibleValue = secret && !revealed ? MASKED_RUNTIME_UI_CREDENTIAL : value;
+
+	return (
+		<div className="grid min-w-0 grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2.5">
+			<span className="text-xs font-medium text-muted-foreground">{label}</span>
+			<code
+				className="block min-w-0 truncate font-mono text-sm font-medium"
+				title={secret && !revealed ? undefined : value}
+			>
+				{visibleValue}
+			</code>
+			<div className="flex items-center gap-0.5">
+				{secret ? (
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-xs"
+						onClick={() => setRevealed((visible) => !visible)}
+						aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
+						aria-pressed={revealed}
+					>
+						{revealed ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+					</Button>
+				) : null}
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					onClick={() => copy(value)}
+					aria-label={`Copy ${label}`}
+				>
+					{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+				</Button>
+			</div>
+		</div>
 	);
 }
 
@@ -1432,20 +1493,23 @@ function RuntimeUiAccessDialog({
 		setIsLoading(false);
 	}, [onCredentialsChange]);
 
-	const loadCredentials = useCallback(async () => {
+	const loadCredentials = useCallback(async (): Promise<RuntimeUiCredentials | null> => {
 		const requestVersion = requestVersionRef.current + 1;
 		requestVersionRef.current = requestVersion;
 		setIsLoading(true);
 		setCredentialError(null);
 		try {
 			const resolved = await requestCredentials();
-			if (requestVersionRef.current === requestVersion) onCredentialsChange(resolved);
+			if (requestVersionRef.current !== requestVersion) return null;
+			onCredentialsChange(resolved);
+			return resolved;
 		} catch (error) {
 			if (requestVersionRef.current === requestVersion) {
 				setCredentialError(
 					error instanceof Error ? error : new Error("Runtime UI credential request failed"),
 				);
 			}
+			return null;
 		} finally {
 			if (requestVersionRef.current === requestVersion) setIsLoading(false);
 		}
@@ -1467,8 +1531,7 @@ function RuntimeUiAccessDialog({
 		[credentials, isLoading, loadCredentials],
 	);
 
-	const openRuntime = useCallback(() => {
-		if (!credentials) return;
+	const openRuntime = useCallback(async () => {
 		const popup = openSecureRuntimeWindow(window.open.bind(window));
 		if (!popup) {
 			toast.error(`Couldn't open ${label}`, {
@@ -1478,11 +1541,36 @@ function RuntimeUiAccessDialog({
 			});
 			return;
 		}
-		popup.location.replace(
-			credentials.runtime === "openclaw" ? credentials.handoff_url : credentials.url,
-		);
-		trackRuntimeWindow(deployment.resource.id, popup);
-	}, [credentials, deployment.resource.id, label]);
+
+		const launchCredentials = credentials ?? (await loadCredentials());
+		if (!launchCredentials) {
+			try {
+				popup.close();
+			} catch {
+				// Browser isolation may have severed the WindowProxy.
+			}
+			toast.error(`Couldn't open ${label}`, {
+				id: RUNTIME_UI_LAUNCH_TOAST_ID,
+				description: "Runtime UI access couldn't be loaded. Open Access to retry.",
+			});
+			return;
+		}
+
+		try {
+			popup.location.replace(runtimeUiLaunchTarget(launchCredentials));
+			trackRuntimeWindow(deployment.resource.id, popup);
+		} catch {
+			try {
+				popup.close();
+			} catch {
+				// Browser isolation may have severed the WindowProxy.
+			}
+			toast.error(`Couldn't open ${label}`, {
+				id: RUNTIME_UI_LAUNCH_TOAST_ID,
+				description: "The new window couldn't be connected. Try again.",
+			});
+		}
+	}, [credentials, deployment.resource.id, label, loadCredentials]);
 
 	const acceptReset = useCallback(async () => {
 		await reset.mutateAsync({ id: deployment.resource.id });
@@ -1492,16 +1580,34 @@ function RuntimeUiAccessDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<Button
-				ref={triggerRef}
-				type="button"
-				variant="outline"
-				size="sm"
-				onClick={() => handleOpenChange(true)}
-				aria-label={`Access ${label}`}
-			>
-				Access
-			</Button>
+			<div className="flex items-center gap-1.5">
+				<Button
+					ref={triggerRef}
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => handleOpenChange(true)}
+					aria-label={`Access ${label}`}
+				>
+					Access
+				</Button>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					disabled={isLoading}
+					onClick={() => void openRuntime()}
+					aria-label={`Open ${label} in new window`}
+				>
+					{isLoading && !credentials ? (
+						<Spinner className="size-3.5" />
+					) : (
+						<ExternalLink className="size-3.5" />
+					)}
+					<span className="hidden sm:inline">Open in new window</span>
+					<span className="sm:hidden">Open</span>
+				</Button>
+			</div>
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
@@ -1511,8 +1617,8 @@ function RuntimeUiAccessDialog({
 				<DialogHeader>
 					<DialogTitle>Runtime UI access</DialogTitle>
 					<DialogDescription>
-						Reveal or copy the current {label} sign-in details. Reset rotates the same access
-						material through the normal agent rollout.
+						View or copy the current {label} access details. Reset rotates the same access material
+						through the normal agent rollout.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -1536,14 +1642,17 @@ function RuntimeUiAccessDialog({
 				) : null}
 
 				{credentials?.runtime === "hermes" ? (
-					<div className="space-y-3">
-						<TokenReveal label="Username" value={credentials.username} />
-						<TokenReveal label="Password" value={credentials.password} />
+					<div className="overflow-hidden rounded-lg border bg-card/60">
+						<RuntimeUiCredentialRow label="Username" value={credentials.username} />
+						<Separator />
+						<RuntimeUiCredentialRow label="Password" value={credentials.password} secret />
 					</div>
 				) : null}
 
 				{credentials?.runtime === "openclaw" ? (
-					<TokenReveal label="Token" value={credentials.token} />
+					<div className="overflow-hidden rounded-lg border bg-card/60">
+						<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />
+					</div>
 				) : null}
 
 				<div className="flex flex-wrap justify-end gap-2">
@@ -1564,7 +1673,11 @@ function RuntimeUiAccessDialog({
 							Reset access
 						</Button>
 					</ConfirmAction>
-					<Button type="button" disabled={!credentials || isLoading} onClick={openRuntime}>
+					<Button
+						type="button"
+						disabled={!credentials || isLoading}
+						onClick={() => void openRuntime()}
+					>
 						Open in new window
 						<ExternalLink className="size-3.5" />
 					</Button>

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
 	openSecureRuntimeWindow,
 	resolveRuntimeUiCredentials,
+	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
 
 describe("runtime UI credential targeting", () => {
@@ -34,6 +35,7 @@ describe("runtime UI credential targeting", () => {
 			resolveRuntimeUiCredentials(credentials, "https://runtime.example/hermes", "rv-current"),
 		).toEqual(credentials);
 		expect(credentials.url).not.toContain(credentials.password ?? "");
+		expect(runtimeUiLaunchTarget(credentials)).toBe(credentials.url);
 	});
 
 	test("rejects credentials targeting a different published endpoint", () => {
@@ -73,6 +75,8 @@ describe("runtime UI credential targeting", () => {
 		expect(
 			resolveRuntimeUiCredentials(credentials, "https://runtime.example/openclaw/", "rv-current"),
 		).toEqual(credentials);
+		expect(runtimeUiLaunchTarget(credentials)).toBe(credentials.handoff_url);
+		expect(runtimeUiLaunchTarget(credentials)).not.toBe(credentials.url);
 	});
 
 	test("rejects a stale rollout or a handoff without the exact token fragment", () => {

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -58,3 +58,7 @@ export function resolveRuntimeUiCredentials(
 	}
 	return credentials;
 }
+
+export function runtimeUiLaunchTarget(credentials: RuntimeUiCredentials): string {
+	return credentials.runtime === "openclaw" ? credentials.handoff_url : credentials.url;
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -103,14 +103,16 @@ describe("deploy wizard product copy and flow", () => {
 });
 
 describe("hosted agent security and copy", () => {
-	test("masks every Runtime UI access field behind reveal and copy controls", () => {
+	test("shows the Hermes username and masks Hermes and OpenClaw secrets", () => {
 		expect(agentDetailSource).toContain(
-			'<TokenReveal label="Username" value={credentials.username} />',
+			'<RuntimeUiCredentialRow label="Username" value={credentials.username} />',
 		);
 		expect(agentDetailSource).toContain(
-			'<TokenReveal label="Password" value={credentials.password} />',
+			'<RuntimeUiCredentialRow label="Password" value={credentials.password} secret />',
 		);
-		expect(agentDetailSource).toContain('<TokenReveal label="Token" value={credentials.token} />');
+		expect(agentDetailSource).toContain(
+			'<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />',
+		);
 		expect(agentDetailSource).not.toContain("hermes-password-");
 		expect(agentDetailSource).not.toContain("openclaw-token-");
 	});


### PR DESCRIPTION
## Summary

- replace the bulky credential cards with one standard shadcn-style credential row composition
- keep the Hermes username visible by default while masking Hermes passwords and OpenClaw tokens
- expose the secure new-window action in the Runtime UI toolbar and keep it in the access dialog
- preserve the validated OpenClaw fragment handoff without logging or rendering the token outside the reveal control

## Verification

- `scripts/test.sh web src/hosted/agents/runtime-ui-credentials.test.ts src/hosted/agents/deployment-hooks.test.ts src/hosted/billing/deploy/deploy-wizard.test.ts` (Docker-isolated: typecheck, 40 tests, OSS production build)
- `bunx biome check` on all 6 changed files
- focused Chromium hosted-stub e2e: 3 passed
- desktop and 390x844 Chromium visual review
- `git diff --check origin/main..HEAD`

No production, tenant, rollout, restart, reconcile, or workflow-dispatch operations were performed.
