### PR TITLE
feat: reserve manifest-managed skills

### DIFF
--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { isProjectOwner } from "@/components/projects/project-metadata";
 import { SkillCardGrid } from "@/components/skills/skill-card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { type AgentRouteSearch, agentSkillDetailLink } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
@@ -52,14 +54,26 @@ export function AgentSkillsTab({
 	routeSearch,
 	isResolvingAgentProject = false,
 	writableProjectIds,
+	hostedManaged = false,
 }: {
 	agentId: string;
 	agentProjectId: string | null | undefined;
 	routeSearch: AgentRouteSearch;
 	isResolvingAgentProject?: boolean;
 	writableProjectIds?: ReadonlySet<string> | null;
+	hostedManaged?: boolean;
 }) {
 	const api = useApi();
+	const runtimeObserved = useQuery({
+		queryKey: ["runtime-observed", agentId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/agents/{agent_id}/runtime-observed", {
+					params: { path: { agent_id: agentId } },
+				}),
+			),
+		enabled: hostedManaged,
+	});
 	const { data: projects } = useQuery({
 		queryKey: ["projects"],
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
@@ -80,6 +94,22 @@ export function AgentSkillsTab({
 		refetch: refetchSkills,
 	} = useAgentProjectSkills(agentProjectId);
 	const uninstallSkill = useUninstallAgentSkill();
+	const managedResources = runtimeObserved.data?.desired?.managed_resources ?? [];
+	const managedSkills = managedResources.filter((resource) => resource.kind === "skill");
+	const managedMcpServers = managedResources.filter((resource) => resource.kind === "mcp_server");
+	const reservedSkillIds = new Set(
+		managedSkills.filter((skill) => skill.enabled).map((skill) => skill.id),
+	);
+	const conflictingSkills = (skills ?? []).filter((skill) => reservedSkillIds.has(skill.skill_key));
+	const desiredGeneration = runtimeObserved.data?.desired?.desired_config_generation ?? null;
+	const observedGeneration = runtimeObserved.data?.observed?.observed_config_generation ?? null;
+	const desiredSource = runtimeObserved.data?.desired?.desired_source_revision ?? null;
+	const observedSource = runtimeObserved.data?.observed?.observed_source_revision ?? null;
+	const isApplied =
+		runtimeObserved.data?.health.status === "ok" &&
+		desiredGeneration !== null &&
+		desiredGeneration === observedGeneration &&
+		(desiredSource === null || desiredSource === observedSource);
 
 	if (skillsError) {
 		return (
@@ -94,19 +124,86 @@ export function AgentSkillsTab({
 	}
 
 	return (
-		<SkillCardGrid
-			skills={skills ?? []}
-			isLoading={isResolvingAgentProject || skillsLoading}
-			emptyMessage="No skills installed on this agent yet."
-			readOnlySkillCheck={(s) =>
-				!s.project_id || !(derivedWritableProjectIds?.has(s.project_id) ?? false)
-			}
-			onUninstall={(skillKey, projectId) => uninstallSkill.mutate({ skillKey, projectId })}
-			uninstallPending={uninstallSkill.isPending}
-			skillLink={(skill) =>
-				agentSkillDetailLink(agentId, skill.skill_key, skill.project_id, routeSearch)
-			}
-		/>
+		<div className="flex flex-col gap-6">
+			{hostedManaged && runtimeObserved.isLoading ? (
+				<p className="text-sm text-muted-foreground">Loading deployment-managed capabilities…</p>
+			) : null}
+			{hostedManaged && runtimeObserved.error ? (
+				<Alert>
+					<AlertTitle>Managed capability status is unavailable</AlertTitle>
+					<AlertDescription>Your Cloud Skills remain available below.</AlertDescription>
+				</Alert>
+			) : null}
+			{runtimeObserved.data ? (
+				<section className="rounded-xl border p-4" aria-label="Deployment-managed capabilities">
+					<div className="flex flex-wrap items-center justify-between gap-2">
+						<h2 className="font-medium">Deployment-managed capabilities</h2>
+						<Badge variant={isApplied ? "secondary" : "outline"}>
+							{isApplied ? "Applied" : "Not applied"}
+						</Badge>
+					</div>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Desired generation {runtimeObserved.data.desired?.desired_config_generation ?? "—"} ·
+						Observed generation {runtimeObserved.data.observed?.observed_config_generation ?? "—"}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Health {runtimeObserved.data.health.status} · Source{" "}
+						{(observedSource ?? desiredSource ?? "Not reported").slice(0, 12)}
+						{runtimeObserved.data.observed?.observed_manifest_etag ? " · Manifest observed" : ""}
+					</p>
+					<div className="mt-4 grid gap-4 md:grid-cols-2">
+						<div>
+							<h3 className="text-sm font-medium">Skills</h3>
+							<div className="mt-2 flex flex-wrap gap-2">
+								{managedSkills.map((skill) => (
+									<Badge key={skill.id} variant="secondary">
+										{skill.id} · v{skill.version} · {skill.enabled ? "enabled" : "disabled"}
+									</Badge>
+								))}
+								{managedSkills.length === 0 ? (
+									<span className="text-sm text-muted-foreground">None</span>
+								) : null}
+							</div>
+						</div>
+						<div>
+							<h3 className="text-sm font-medium">MCP servers</h3>
+							<div className="mt-2 flex flex-wrap gap-2">
+								{managedMcpServers.map((server) => (
+									<Badge key={server.id} variant="secondary">
+										{server.id}
+									</Badge>
+								))}
+								{managedMcpServers.length === 0 ? (
+									<span className="text-sm text-muted-foreground">None</span>
+								) : null}
+							</div>
+						</div>
+					</div>
+				</section>
+			) : null}
+			{conflictingSkills.length > 0 ? (
+				<Alert>
+					<AlertTitle>Cloud Skill conflicts with deployment-managed Skill</AlertTitle>
+					<AlertDescription>
+						You can uninstall the Cloud copy below; the managed copy is read-only.
+					</AlertDescription>
+				</Alert>
+			) : null}
+			<SkillCardGrid
+				skills={skills ?? []}
+				isLoading={isResolvingAgentProject || skillsLoading}
+				emptyMessage="No skills installed on this agent yet."
+				readOnlySkillCheck={(s) =>
+					!s.project_id || !(derivedWritableProjectIds?.has(s.project_id) ?? false)
+				}
+				cleanupOnlySkillCheck={(skill) => reservedSkillIds.has(skill.skill_key)}
+				onUninstall={(skillKey, projectId) => uninstallSkill.mutate({ skillKey, projectId })}
+				uninstallPending={uninstallSkill.isPending}
+				skillLink={(skill) =>
+					agentSkillDetailLink(agentId, skill.skill_key, skill.project_id, routeSearch)
+				}
+			/>
+		</div>
 	);
 }
 

--- a/apps/web/src/components/skills/skill-card.tsx
+++ b/apps/web/src/components/skills/skill-card.tsx
@@ -31,6 +31,7 @@ type SkillLinkBuilder = (skill: SkillSummary) => SkillLinkOptions;
 export function SkillCard({
 	skill,
 	readOnly = false,
+	cleanupOnly = false,
 	onUninstall,
 	uninstallPending = false,
 	selectMode = false,
@@ -41,6 +42,7 @@ export function SkillCard({
 }: {
 	skill: SkillSummary;
 	readOnly?: boolean;
+	cleanupOnly?: boolean;
 	onUninstall?: (skillKey: string, projectId: string) => void;
 	uninstallPending?: boolean;
 	selectMode?: boolean;
@@ -62,7 +64,7 @@ export function SkillCard({
 		<HeroCard
 			className="min-h-28 gap-2"
 			selected={selectMode && selected}
-			interactive={!selectMode}
+			interactive={!selectMode && !cleanupOnly}
 			icon={
 				<IconChip size="sm" tint={id.colorClasses} className="rounded-lg text-base">
 					{id.emoji}
@@ -79,6 +81,7 @@ export function SkillCard({
 							Shared
 						</Badge>
 					) : null}
+					{cleanupOnly ? <Badge variant="destructive">Conflict</Badge> : null}
 				</>
 			}
 			description={skill.description}
@@ -109,7 +112,7 @@ export function SkillCard({
 					/>
 				) : (
 					<div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
-						{skill.project_id ? <SendSkillDialog skills={[skill]} /> : null}
+						{skill.project_id && !cleanupOnly ? <SendSkillDialog skills={[skill]} /> : null}
 						{canUninstall ? (
 							<ConfirmAction
 								title={`Uninstall ${skill.name}?`}
@@ -134,8 +137,8 @@ export function SkillCard({
 					</div>
 				)
 			}
-			link={selectMode ? undefined : detailLink}
-			ariaLabel={`Open ${skill.name}`}
+			link={selectMode || cleanupOnly ? undefined : detailLink}
+			ariaLabel={cleanupOnly ? skill.name : `Open ${skill.name}`}
 		>
 			{selectMode ? (
 				<button
@@ -159,6 +162,7 @@ export function SkillCardGrid({
 	emptyMessage,
 	emptyVariant = "page",
 	readOnlySkillCheck,
+	cleanupOnlySkillCheck,
 	onUninstall,
 	uninstallPending,
 	selectMode = false,
@@ -173,6 +177,8 @@ export function SkillCardGrid({
 	emptyVariant?: EmptyStateVariant;
 	/** Returns true when the current user cannot uninstall this skill. */
 	readOnlySkillCheck?: (skill: SkillSummary) => boolean;
+	/** Conflict copies may only be removed; detail and send actions are disabled. */
+	cleanupOnlySkillCheck?: (skill: SkillSummary) => boolean;
 	onUninstall?: (skillKey: string, projectId: string) => void;
 	uninstallPending?: boolean;
 	selectMode?: boolean;
@@ -202,6 +208,7 @@ export function SkillCardGrid({
 					key={skillSelectionKey(skill)}
 					skill={skill}
 					readOnly={readOnlySkillCheck?.(skill) ?? false}
+					cleanupOnly={cleanupOnlySkillCheck?.(skill) ?? false}
 					onUninstall={onUninstall}
 					uninstallPending={uninstallPending}
 					selectMode={selectMode}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -635,6 +635,7 @@ export function HostedAgentDetail({
 								agentProjectId={agent?.default_project_id}
 								routeSearch={routeSearch}
 								isResolvingAgentProject={false}
+								hostedManaged
 							/>
 						) : (
 							<ProjectionDependentUnavailable label="Skills" />

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -117,6 +117,10 @@ from app.services.managed_ai_provider import (
     lock_deployment_managed_provider_mutation,
     upsert_clawdi_managed_provider,
 )
+from app.services.runtime_manifest_resources import (
+    enabled_runtime_manifest_skill_ids,
+    lock_runtime_manifest_skill_reservations,
+)
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
@@ -1414,6 +1418,16 @@ async def _admin_upsert_runtime_state(
         )
     ).scalar_one_or_none()
     existing_state = state
+    old_skill_ids = enabled_runtime_manifest_skill_ids(state.skills if state is not None else None)
+    new_skill_ids = enabled_runtime_manifest_skill_ids(
+        body.skills.model_dump(mode="json") if body.skills is not None else None
+    )
+    await lock_runtime_manifest_skill_reservations(
+        db,
+        user_id=target_user_id,
+        project_id=env.default_project_id,
+        skill_ids=old_skill_ids | new_skill_ids,
+    )
     previous_generation = state.generation if state is not None else None
     desired_state = _runtime_state_values(body)
     changed_fields = _runtime_state_changed_fields(existing_state, desired_state)
@@ -1674,7 +1688,7 @@ def _runtime_state_values(body: AdminRuntimeStateUpsert) -> dict[str, Any]:
         "live_sync": body.live_sync.model_dump(mode="json"),
         "recovery": body.recovery.model_dump(mode="json"),
         "egress_profiles": optional_wire_value("egress_profiles"),
-        "mcp": body.mcp,
+        "mcp": optional_wire_value("mcp"),
         "skills": optional_wire_value("skills"),
         "tools": (
             body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -52,6 +52,10 @@ from app.services.platform_workload_auth import (
     issue_platform_workload_token,
     require_platform_mutation_auth,
 )
+from app.services.runtime_manifest_resources import (
+    enabled_runtime_manifest_skill_ids,
+    lock_runtime_manifest_skill_reservations,
+)
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_runtime_manifest_changed,
@@ -714,6 +718,18 @@ async def platform_upsert_runtime_state(
             .with_for_update()
         )
     ).scalar_one_or_none()
+    old_skill_ids = enabled_runtime_manifest_skill_ids(
+        runtime_state.skills if runtime_state is not None else None
+    )
+    new_skill_ids = enabled_runtime_manifest_skill_ids(
+        body.skills.model_dump(mode="json") if body.skills is not None else None
+    )
+    await lock_runtime_manifest_skill_reservations(
+        db,
+        user_id=owner.id,
+        project_id=agent.default_project_id,
+        skill_ids=old_skill_ids | new_skill_ids,
+    )
     previous_generation = runtime_state.generation if runtime_state is not None else None
     changed_fields = _runtime_state_changed_fields(runtime_state, body)
     if runtime_state is not None and body.generation <= runtime_state.generation:
@@ -1047,7 +1063,7 @@ def _assign_runtime_state(
     state.live_sync = body.live_sync.model_dump(mode="json")
     state.recovery = body.recovery.model_dump(mode="json")
     state.egress_profiles = _optional_runtime_model(body.egress_profiles)
-    state.mcp = body.mcp
+    state.mcp = _optional_runtime_model(body.mcp)
     state.skills = _optional_runtime_model(body.skills)
     state.tools = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
 
@@ -1091,7 +1107,7 @@ def _runtime_state_changed_fields(
                 name: runtime.model_dump(exclude_none=True, mode="json")
                 for name, runtime in body.runtimes.items()
             }
-        elif field in {"egress_engine", "egress_profiles", "skills"}:
+        elif field in {"egress_engine", "egress_profiles", "mcp", "skills"}:
             body_value = _optional_runtime_model(getattr(body, field))
         elif field in {"live_sync", "recovery"}:
             body_value = getattr(body, field).model_dump(mode="json")

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -810,12 +810,46 @@ async def upload_environment_avatar(
 @router.get(
     "/environments/{environment_id}/runtime-observed",
     response_model=RuntimeObservedResponse,
+    response_model_exclude={"desired": {"managed_resources"}},
     deprecated=True,
 )
 async def get_environment_runtime_observed(
     environment_id: UUID,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
+) -> RuntimeObservedResponse:
+    return await _get_runtime_observed(
+        environment_id,
+        auth,
+        db,
+        include_managed_resources=False,
+    )
+
+
+@router.get(
+    "/agents/{agent_id}/runtime-observed",
+    response_model=RuntimeObservedResponse,
+)
+async def get_agent_runtime_observed(
+    agent_id: UUID,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservedResponse:
+    """Canonical Agent-identity route for runtime desired/observed summaries."""
+    return await _get_runtime_observed(
+        agent_id,
+        auth,
+        db,
+        include_managed_resources=True,
+    )
+
+
+async def _get_runtime_observed(
+    environment_id: UUID,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    include_managed_resources: bool,
 ) -> RuntimeObservedResponse:
     bound_env = _bound_env_id(auth)
     if bound_env is not None and environment_id != bound_env:
@@ -864,13 +898,18 @@ async def get_environment_runtime_observed(
             )
         )
     ).scalar_one_or_none()
+    desired = (
+        _runtime_observed_desired(state, source_revision=source_revision)
+        if state is not None
+        else None
+    )
+    if desired is not None and include_managed_resources:
+        desired = desired.model_copy(
+            update={"managed_resources": _runtime_managed_resource_summaries(state)}
+        )
     return RuntimeObservedResponse(
         environment=_env_to_response(env, state),
-        desired=(
-            _runtime_observed_desired(state, source_revision=source_revision)
-            if state is not None
-            else None
-        ),
+        desired=desired,
         observed=_runtime_observed_response(observation),
         health=_runtime_observed_health(
             env,
@@ -881,31 +920,6 @@ async def get_environment_runtime_observed(
             desired_cli_package_spec=desired_cli_package_spec,
         ),
         provider_health=_runtime_observed_provider_health(state, observation),
-    )
-
-
-@router.get(
-    "/agents/{agent_id}/runtime-observed",
-    response_model=RuntimeObservedResponse,
-)
-async def get_agent_runtime_observed(
-    agent_id: UUID,
-    auth: AuthContext = Depends(get_auth),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeObservedResponse:
-    """Canonical Agent-identity route for runtime desired/observed summaries."""
-    response = await get_environment_runtime_observed(agent_id, auth, db)
-    if response.desired is None:
-        return response
-    state = await db.get(HostedRuntimeState, agent_id)
-    if state is None:
-        return response
-    return response.model_copy(
-        update={
-            "desired": response.desired.model_copy(
-                update={"managed_resources": _runtime_managed_resource_summaries(state)}
-            )
-        }
     )
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -810,46 +810,12 @@ async def upload_environment_avatar(
 @router.get(
     "/environments/{environment_id}/runtime-observed",
     response_model=RuntimeObservedResponse,
-    response_model_exclude={"desired": {"managed_resources"}},
     deprecated=True,
 )
 async def get_environment_runtime_observed(
     environment_id: UUID,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
-) -> RuntimeObservedResponse:
-    return await _get_runtime_observed(
-        environment_id,
-        auth,
-        db,
-        include_managed_resources=False,
-    )
-
-
-@router.get(
-    "/agents/{agent_id}/runtime-observed",
-    response_model=RuntimeObservedResponse,
-)
-async def get_agent_runtime_observed(
-    agent_id: UUID,
-    auth: AuthContext = Depends(get_auth),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeObservedResponse:
-    """Canonical Agent-identity route for runtime desired/observed summaries."""
-    return await _get_runtime_observed(
-        agent_id,
-        auth,
-        db,
-        include_managed_resources=True,
-    )
-
-
-async def _get_runtime_observed(
-    environment_id: UUID,
-    auth: AuthContext,
-    db: AsyncSession,
-    *,
-    include_managed_resources: bool,
 ) -> RuntimeObservedResponse:
     bound_env = _bound_env_id(auth)
     if bound_env is not None and environment_id != bound_env:
@@ -898,18 +864,13 @@ async def _get_runtime_observed(
             )
         )
     ).scalar_one_or_none()
-    desired = (
-        _runtime_observed_desired(state, source_revision=source_revision)
-        if state is not None
-        else None
-    )
-    if desired is not None and include_managed_resources:
-        desired = desired.model_copy(
-            update={"managed_resources": _runtime_managed_resource_summaries(state)}
-        )
     return RuntimeObservedResponse(
         environment=_env_to_response(env, state),
-        desired=desired,
+        desired=(
+            _runtime_observed_desired(state, source_revision=source_revision)
+            if state is not None
+            else None
+        ),
         observed=_runtime_observed_response(observation),
         health=_runtime_observed_health(
             env,
@@ -920,6 +881,41 @@ async def _get_runtime_observed(
             desired_cli_package_spec=desired_cli_package_spec,
         ),
         provider_health=_runtime_observed_provider_health(state, observation),
+    )
+
+
+@router.get(
+    "/agents/{agent_id}/runtime-observed",
+    response_model=RuntimeObservedResponse,
+)
+async def get_agent_runtime_observed(
+    agent_id: UUID,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservedResponse:
+    """Canonical Agent-identity route for runtime desired/observed summaries."""
+    response = await get_environment_runtime_observed(agent_id, auth, db)
+    state = await db.get(HostedRuntimeState, agent_id)
+    desired = response.desired
+    if desired is None and state is None:
+        return response
+    if (
+        desired is None
+        or state is None
+        or desired.deployment_id != state.deployment_id
+        or desired.instance_id != state.instance_id
+        or desired.desired_config_generation != state.generation
+    ):
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Runtime desired state changed while it was being read; retry the request.",
+        )
+    return response.model_copy(
+        update={
+            "desired": desired.model_copy(
+                update={"managed_resources": _runtime_managed_resource_summaries(state)}
+            )
+        }
     )
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -36,7 +36,11 @@ from app.models.session_permission import (
     SessionPermission,
 )
 from app.schemas.common import Paginated
-from app.schemas.runtime import validate_hosted_runtime_desired_state
+from app.schemas.runtime import (
+    HostedRuntimeMcp,
+    PersistedHostedRuntimeSkills,
+    validate_hosted_runtime_desired_state,
+)
 from app.schemas.runtime_observed import (
     HostedRuntimeObserved,
     HostedRuntimeObservedProviderPayload,
@@ -52,6 +56,9 @@ from app.schemas.session import (
     EnvironmentReorderRequest,
     EnvironmentResponse,
     EnvironmentUpdate,
+    RuntimeManagedMcpServerSummary,
+    RuntimeManagedResourceSummary,
+    RuntimeManagedSkillSummary,
     RuntimeObservedDesiredResponse,
     RuntimeObservedHealthResponse,
     RuntimeObservedProviderHealthResponse,
@@ -877,6 +884,31 @@ async def get_environment_runtime_observed(
     )
 
 
+@router.get(
+    "/agents/{agent_id}/runtime-observed",
+    response_model=RuntimeObservedResponse,
+)
+async def get_agent_runtime_observed(
+    agent_id: UUID,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservedResponse:
+    """Canonical Agent-identity route for runtime desired/observed summaries."""
+    response = await get_environment_runtime_observed(agent_id, auth, db)
+    if response.desired is None:
+        return response
+    state = await db.get(HostedRuntimeState, agent_id)
+    if state is None:
+        return response
+    return response.model_copy(
+        update={
+            "desired": response.desired.model_copy(
+                update={"managed_resources": _runtime_managed_resource_summaries(state)}
+            )
+        }
+    )
+
+
 @router.get("/assets/{asset_key:path}", include_in_schema=False)
 async def get_public_asset(asset_key: str) -> Response:
     if not _AGENT_AVATAR_KEY_RE.match(asset_key):
@@ -1016,6 +1048,36 @@ def _runtime_observed_desired(
         has_tools=state.tools is not None,
         updated_at=state.updated_at,
     )
+
+
+def _runtime_managed_resource_summaries(
+    state: HostedRuntimeState,
+) -> list[RuntimeManagedResourceSummary]:
+    resources: list[RuntimeManagedResourceSummary] = []
+    if state.skills is not None:
+        try:
+            skills = PersistedHostedRuntimeSkills.model_validate(state.skills)
+        except ValueError:
+            skills = None
+        if skills is not None:
+            resources.extend(
+                RuntimeManagedSkillSummary(
+                    id=skill_id,
+                    enabled=entry.enabled,
+                    version=entry.version or 1,
+                )
+                for skill_id, entry in sorted(skills.entries.items())
+            )
+    if state.mcp is not None:
+        try:
+            mcp = HostedRuntimeMcp.model_validate(state.mcp)
+        except ValueError:
+            mcp = None
+        if mcp is not None:
+            resources.extend(
+                RuntimeManagedMcpServerSummary(id=server_id) for server_id in sorted(mcp.servers)
+            )
+    return resources
 
 
 def _runtime_observed_health(

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -49,6 +49,10 @@ from app.schemas.skill import (
     SkillUploadResponse,
 )
 from app.services.file_store import get_file_store
+from app.services.runtime_manifest_resources import (
+    assert_project_skill_not_runtime_managed,
+    project_skill_advisory_lock_key,
+)
 from app.services.sync_events import bump_skills_revision
 from app.services.tar_utils import (
     TarValidationError,
@@ -142,26 +146,6 @@ _SKILL_HASH_EXCLUDE = {
     ".claude",
     ".codex",
 }
-
-
-def _advisory_lock_key(user_id, project_id, skill_key: str) -> int:
-    """Stable 64-bit signed int derived from (user_id, project_id,
-    skill_key) for `pg_advisory_xact_lock`. Postgres takes a
-    bigint (signed int64) so we mask the SHA digest into that
-    range.
-
-    Lock identity matches the partial unique constraint
-    (`uq_skills_active_user_project_skill_key`) so the lock
-    serializes exactly the same logical resource the constraint
-    enforces.
-    """
-    h = hashlib.sha256(f"skill:{user_id}:{project_id}:{skill_key}".encode()).digest()
-    n = int.from_bytes(h[:8], "big", signed=False)
-    # Map to signed int64 via two's-complement wrap. PG accepts
-    # any int64; this keeps the cast deterministic.
-    if n >= 1 << 63:
-        n -= 1 << 64
-    return n
 
 
 def _compute_file_tree_hash(tar_bytes: bytes, skill_key: str | None = None) -> str:
@@ -1046,8 +1030,11 @@ async def _do_upload_skill(
     # the partial unique index. Two projects can hold the same
     # skill_key in parallel; the lock is per-(user,project,key) so
     # they don't block each other.
-    lock_key = _advisory_lock_key(auth.user_id, project_id, skill_key)
+    lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, skill_key)
     await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})
+    await assert_project_skill_not_runtime_managed(
+        db, user_id=auth.user_id, project_id=project_id, skill_key=skill_key
+    )
 
     # Pre-fetch existing row so we can skip both file_store.put AND the
     # upsert when the bytes are identical to what's already stored. Saves
@@ -1408,7 +1395,7 @@ async def _do_delete_skill(
     # Advisory lock matches the partial unique index identity, so
     # this delete serializes with any concurrent write to the
     # same (user, project, skill_key).
-    lock_key = _advisory_lock_key(auth.user_id, project_id, skill_key)
+    lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, skill_key)
     await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})
 
     # `is_active` filter + ORDER BY + LIMIT 1: third call site of
@@ -1516,6 +1503,17 @@ async def _do_install_skill(
         )
         raise HTTPException(status.HTTP_404_NOT_FOUND, "skill not found in repository") from None
 
+    try:
+        validate_tar(fetched.tar_bytes)
+    except TarValidationError as e:
+        log.warning(
+            "skill_install_validation_failed repo=%s path=%s error=%s",
+            _sanitize_log(body.repo),
+            _sanitize_log(body.path),
+            _sanitize_log(e),
+        )
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "archive validation failed") from None
+
     content_hash = _compute_file_tree_hash(fetched.tar_bytes)
     # The `name` comes from the marketplace SKILL.md frontmatter
     # which the user controls. A malicious `name: "../etc/passwd"`
@@ -1531,8 +1529,11 @@ async def _do_install_skill(
     # (user, project, key) matches the partial unique index, so the
     # serialization is precisely scoped — different projects don't
     # block each other.
-    lock_key = _advisory_lock_key(auth.user_id, project_id, skill_key)
+    lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, skill_key)
     await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})
+    await assert_project_skill_not_runtime_managed(
+        db, user_id=auth.user_id, project_id=project_id, skill_key=skill_key
+    )
 
     await file_store.put(fk, fetched.tar_bytes)
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -30,12 +30,12 @@ from app.schemas.runtime import (
     HostedRuntimeDesiredState,
     HostedRuntimeLiveSync,
     HostedRuntimeLocale,
+    HostedRuntimeMcp,
     HostedRuntimeRecovery,
     HostedRuntimeSkills,
     HostedRuntimeSystem,
     HostedRuntimeTools,
     validate_clawdi_cli_package_spec,
-    validate_hosted_runtime_mcp_desired_state,
 )
 
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
@@ -144,7 +144,7 @@ class AdminRuntimeStateUpsert(BaseModel):
     live_sync: HostedRuntimeLiveSync
     recovery: HostedRuntimeRecovery
     egress_profiles: HostedEgressProfiles | None = None
-    mcp: dict[str, Any] | None = None
+    mcp: HostedRuntimeMcp | None = None
     skills: HostedRuntimeSkills | None = None
     tools: HostedRuntimeTools
 
@@ -169,11 +169,6 @@ class AdminRuntimeStateUpsert(BaseModel):
         if len(value) != 1:
             raise ValueError("runtimes must contain exactly one enabled runtime")
         return value
-
-    @field_validator("mcp")
-    @classmethod
-    def _validate_mcp(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        return validate_hosted_runtime_mcp_desired_state(value)
 
 
 class AdminRuntimeStateResponse(BaseModel):

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -12,12 +12,12 @@ from app.schemas.runtime import (
     HostedRuntimeDesiredState,
     HostedRuntimeLiveSync,
     HostedRuntimeLocale,
+    HostedRuntimeMcp,
     HostedRuntimeRecovery,
     HostedRuntimeSkills,
     HostedRuntimeSystem,
     HostedRuntimeTools,
     validate_clawdi_cli_package_spec,
-    validate_hosted_runtime_mcp_desired_state,
 )
 
 PlatformOwnerKind = Literal["clerk", "partner_tenant"]
@@ -93,7 +93,7 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
     live_sync: HostedRuntimeLiveSync
     recovery: HostedRuntimeRecovery
     egress_profiles: HostedEgressProfiles | None = None
-    mcp: dict[str, Any] | None = None
+    mcp: HostedRuntimeMcp | None = None
     skills: HostedRuntimeSkills | None = None
     tools: HostedRuntimeTools
 
@@ -118,11 +118,6 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
         if len(value) != 1:
             raise ValueError("runtimes must contain exactly one enabled runtime")
         return value
-
-    @field_validator("mcp")
-    @classmethod
-    def _validate_mcp(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
-        return validate_hosted_runtime_mcp_desired_state(value)
 
 
 class PlatformRuntimeStateResponse(BaseModel):

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -297,6 +297,28 @@ class EnvironmentResponse(AgentResponse):
     )
 
 
+class RuntimeManagedSkillSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["skill"] = "skill"
+    id: str
+    enabled: bool
+    version: int = Field(ge=1)
+
+
+class RuntimeManagedMcpServerSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["mcp_server"] = "mcp_server"
+    id: str
+
+
+RuntimeManagedResourceSummary = Annotated[
+    RuntimeManagedSkillSummary | RuntimeManagedMcpServerSummary,
+    Field(discriminator="kind"),
+]
+
+
 class RuntimeObservedDesiredResponse(BaseModel):
     deployment_id: str
     instance_id: str
@@ -306,6 +328,7 @@ class RuntimeObservedDesiredResponse(BaseModel):
     enabled_runtimes: list[str]
     has_mcp: bool = False
     has_tools: bool = False
+    managed_resources: list[RuntimeManagedResourceSummary] = Field(default_factory=list)
     updated_at: datetime | None = None
 
 

--- a/backend/app/services/runtime_manifest_resources.py
+++ b/backend/app/services/runtime_manifest_resources.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.session import AgentEnvironment
+from app.schemas.runtime import PersistedHostedRuntimeSkills
+
+
+async def runtime_manifest_reserved_skill_ids(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    project_id: UUID,
+) -> set[str]:
+    """Return enabled desired Skill IDs for the hosted agent's default project."""
+    result = await db.execute(
+        select(HostedRuntimeState.skills)
+        .join(
+            AgentEnvironment,
+            AgentEnvironment.id == HostedRuntimeState.environment_id,
+        )
+        .where(
+            AgentEnvironment.user_id == user_id,
+            AgentEnvironment.default_project_id == project_id,
+        )
+    )
+    reserved: set[str] = set()
+    for raw in result.scalars():
+        if raw is None:
+            continue
+        try:
+            skills = PersistedHostedRuntimeSkills.model_validate(raw)
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "runtime_manifest_skill_reservation_indeterminate",
+                    "message": "Runtime-managed Skill reservations are temporarily unavailable.",
+                },
+            ) from exc
+        reserved.update(
+            skill_id for skill_id, entry in skills.entries.items() if entry.enabled is True
+        )
+    return reserved
+
+
+def enabled_runtime_manifest_skill_ids(raw: object | None) -> set[str]:
+    if raw is None:
+        return set()
+    try:
+        skills = PersistedHostedRuntimeSkills.model_validate(raw)
+    except ValueError as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "runtime_manifest_skill_reservation_indeterminate",
+                "message": "Runtime-managed Skill reservations are temporarily unavailable.",
+            },
+        ) from exc
+    return {skill_id for skill_id, entry in skills.entries.items() if entry.enabled is True}
+
+
+def project_skill_advisory_lock_key(
+    user_id: UUID,
+    project_id: UUID,
+    skill_key: str,
+) -> int:
+    digest = hashlib.sha256(f"skill:{user_id}:{project_id}:{skill_key}".encode()).digest()
+    value = int.from_bytes(digest[:8], "big", signed=False)
+    return value - (1 << 64) if value >= 1 << 63 else value
+
+
+async def lock_runtime_manifest_skill_reservations(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    project_id: UUID | None,
+    skill_ids: set[str],
+) -> None:
+    if project_id is None:
+        return
+    for skill_id in sorted(skill_ids):
+        await db.execute(
+            text("SELECT pg_advisory_xact_lock(:k)"),
+            {"k": project_skill_advisory_lock_key(user_id, project_id, skill_id)},
+        )
+
+
+async def assert_project_skill_not_runtime_managed(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    project_id: UUID,
+    skill_key: str,
+) -> None:
+    if skill_key not in await runtime_manifest_reserved_skill_ids(
+        db,
+        user_id=user_id,
+        project_id=project_id,
+    ):
+        return
+    raise HTTPException(
+        status.HTTP_409_CONFLICT,
+        detail={
+            "code": "runtime_manifest_managed_skill",
+            "message": "This Skill key is reserved by the hosted runtime manifest.",
+            "skill_key": skill_key,
+        },
+    )

--- a/backend/app/services/tar_utils.py
+++ b/backend/app/services/tar_utils.py
@@ -75,6 +75,10 @@ def validate_tar(data: bytes) -> int:
                 parts = PurePosixPath(member.name).parts
                 if ".." in parts:
                     raise TarValidationError(f"Path traversal not allowed: {member.name}")
+                if any(part.lower().startswith(".clawdi-managed") for part in parts):
+                    raise TarValidationError(
+                        f"Reserved management metadata not allowed: {member.name}"
+                    )
 
                 if member.isfile():
                     file_count += 1

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -549,6 +549,13 @@ async def test_platform_runtime_state_enforces_generation_contract(
     )
     assert initial.status_code == 200, initial.text
 
+    same_generation = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("generation-same-mcp-model"),
+        json=initial_body,
+    )
+    assert same_generation.status_code == 200, same_generation.text
+
     stale = await platform_client.put(
         f"/v1/platform/agents/{agent_id}/runtime-state",
         headers=_headers("generation-stale"),

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -15,6 +15,7 @@ import uuid
 import httpx
 import pytest
 
+from app.services.skill_installer import SkillPackage
 from app.services.tar_utils import tar_from_content
 
 pytestmark = pytest.mark.committed_db
@@ -264,6 +265,62 @@ async def test_skill_upload_rejects_path_traversal(client: httpx.AsyncClient, pr
     # Negative contract: body must NOT echo the attacker-supplied
     # member name — that would be an uncontrolled reflection vector.
     assert "../evil" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_rejects_reserved_management_metadata(
+    client: httpx.AsyncClient, project_id: str
+):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, payload in (
+            ("example/SKILL.md", b"# Example\n"),
+            ("example/.clawdi-managed.json", b"{}\n"),
+        ):
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    response = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "example"},
+        files={"file": ("example.tar.gz", buf.getvalue(), "application/gzip")},
+    )
+    assert response.status_code == 400, response.text
+    assert "archive validation failed" in response.text.lower()
+    assert ".clawdi-managed" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_marketplace_install_rejects_reserved_management_metadata(
+    client: httpx.AsyncClient, project_id: str, monkeypatch: pytest.MonkeyPatch
+):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, payload in (
+            ("example/SKILL.md", b"# Example\n"),
+            ("example/.clawdi-managed.json", b"{}\n"),
+        ):
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+    async def fake_fetch(_repo: str, _path: str | None = None) -> SkillPackage:
+        return SkillPackage(
+            name="example",
+            description="example",
+            tar_bytes=buf.getvalue(),
+            file_count=2,
+            repo="owner/repo",
+        )
+
+    monkeypatch.setattr("app.services.skill_installer.fetch_skill_from_github", fake_fetch)
+    response = await client.post(
+        f"/v1/projects/{project_id}/skills/install",
+        json={"repo": "owner/repo", "path": "example"},
+    )
+    assert response.status_code == 400, response.text
+    assert "archive validation failed" in response.text.lower()
+    assert ".clawdi-managed" not in response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -14,7 +14,9 @@ import uuid
 
 import httpx
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.hosted_runtime import HostedRuntimeState
 from app.services.skill_installer import SkillPackage
 from app.services.tar_utils import tar_from_content
 
@@ -134,6 +136,69 @@ async def test_dashboard_edit_without_content_hash_is_last_write_wins(
     assert r.status_code == 200, r.text
     after = await client.get(f"/v1/projects/{project_id}/skills/lww")
     assert "# Edited" in after.json().get("content", "")
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_skill_reservation_is_cleanup_only_until_disabled(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    environment_project,
+):
+    project_id = str(environment_project.id)
+    content = "---\nname: managed\ndescription: cloud copy\n---\n# Cloud copy\n"
+    tar_bytes, _ = tar_from_content("managed", content)
+
+    seed = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "managed"},
+        files={"file": ("managed.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert seed.status_code == 200, seed.text
+
+    state = HostedRuntimeState(
+        environment_id=environment_project.origin_environment_id,
+        deployment_id="dep-skill-reservation",
+        instance_id="iid-skill-reservation",
+        generation=1,
+        cli_package_spec="clawdi@0.13.10",
+        locale={"language": "en", "timezone": "UTC"},
+        system={},
+        runtimes={},
+        live_sync={"enabled": False, "agents": []},
+        recovery={"cacheManifest": True, "allowOfflineBoot": True},
+        skills={"entries": {"managed": {"enabled": True, "version": 1}}},
+        tools={},
+    )
+    db_session.add(state)
+    await db_session.commit()
+
+    update = await client.put(
+        f"/v1/projects/{project_id}/skills/managed/content",
+        json={"content": f"{content}\nUpdated\n"},
+    )
+    assert update.status_code == 409, update.text
+    assert update.json()["detail"]["code"] == "runtime_manifest_managed_skill"
+
+    cleanup = await client.delete(f"/v1/projects/{project_id}/skills/managed")
+    assert cleanup.status_code == 200, cleanup.text
+
+    recreate_while_reserved = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "managed"},
+        files={"file": ("managed.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert recreate_while_reserved.status_code == 409, recreate_while_reserved.text
+
+    state.skills = {"entries": {"managed": {"enabled": False, "version": 1}}}
+    state.generation = 2
+    await db_session.commit()
+
+    recreate_after_disable = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "managed"},
+        files={"file": ("managed.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert recreate_after_disable.status_code == 200, recreate_after_disable.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -576,9 +576,9 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         "enabled_runtimes": ["openclaw"],
         "has_mcp": True,
         "has_tools": True,
-        "managed_resources": [],
         "updated_at": payload["desired"]["updated_at"],
     }
+    assert "managed_resources" not in payload["desired"]
     canonical = await client.get(f"/v1/agents/{env_id}/runtime-observed")
     assert canonical.status_code == 200, canonical.text
     assert canonical.json()["desired"]["managed_resources"] == [

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -576,9 +576,9 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         "enabled_runtimes": ["openclaw"],
         "has_mcp": True,
         "has_tools": True,
+        "managed_resources": [],
         "updated_at": payload["desired"]["updated_at"],
     }
-    assert "managed_resources" not in payload["desired"]
     canonical = await client.get(f"/v1/agents/{env_id}/runtime-observed")
     assert canonical.status_code == 200, canonical.text
     assert canonical.json()["desired"]["managed_resources"] == [

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -576,8 +576,19 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         "enabled_runtimes": ["openclaw"],
         "has_mcp": True,
         "has_tools": True,
+        "managed_resources": [],
         "updated_at": payload["desired"]["updated_at"],
     }
+    canonical = await client.get(f"/v1/agents/{env_id}/runtime-observed")
+    assert canonical.status_code == 200, canonical.text
+    assert canonical.json()["desired"]["managed_resources"] == [
+        {"kind": "skill", "id": "clawdi", "enabled": True, "version": 1},
+        {"kind": "mcp_server", "id": "clawdi"},
+    ]
+    serialized = canonical.text.lower()
+    assert "secretref" not in serialized
+    assert '"headers"' not in serialized
+    assert '"url"' not in serialized
     observed_at = datetime.fromisoformat(payload["observed"]["observed_at"].replace("Z", "+00:00"))
     assert received_at_lower_bound <= observed_at <= received_at_upper_bound
     assert datetime.fromisoformat(

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -3,6 +3,10 @@ import { basename, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import {
+	assertUserSkillTargetMutable,
+	shouldIgnoreUserSkill,
+} from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -260,13 +264,10 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			// Bundled by `clawdi setup` — not user-authored content. Without
-			// this filter every user's `clawdi push --modules skills` would
-			// upload the bundled skill to their cloud account, and pulling
-			// on another machine would re-download it on top of what
-			// `clawdi setup` already installs there.
+			// Upgrade bridge for local setup installs created before the ownership ledger.
 			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir, entry.name);
+			if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 
@@ -311,6 +312,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			if (entry.name === "clawdi") continue;
+			if (shouldIgnoreUserSkill(join(skillsDir, entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir, entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 			out.push(entry.name);
@@ -328,12 +330,16 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(claudeDir(), "skills", key);
+		assertUserSkillTargetMutable(dir, key);
 		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const skillsDir = join(claudeDir(), "skills");
-		await replaceSkillArchiveTarGz(key, skillsDir, join(skillsDir, key), tarGzBytes);
+		assertUserSkillTargetMutable(join(skillsDir, key), key);
+		await replaceSkillArchiveTarGz(key, skillsDir, join(skillsDir, key), tarGzBytes, () =>
+			assertUserSkillTargetMutable(join(skillsDir, key), key),
+		);
 	}
 
 	async writeSharedSkillArchive(

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import {
+	assertUserSkillTargetMutable,
+	shouldIgnoreUserSkill,
+} from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -243,10 +247,10 @@ export class CodexAdapter implements AgentAdapter {
 			// Skip dot-dirs (e.g. `.system/` holds Codex's built-in skills, not user-authored ones).
 			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
-			// for the full reasoning.
+			// Upgrade bridge for local setup installs created before the ownership ledger.
 			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir(), entry.name);
+			if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 
@@ -279,6 +283,7 @@ export class CodexAdapter implements AgentAdapter {
 			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			if (entry.name === "clawdi") continue;
+			if (shouldIgnoreUserSkill(join(skillsDir(), entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir(), entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 			out.push(entry.name);
@@ -303,12 +308,16 @@ export class CodexAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
+		assertUserSkillTargetMutable(dir, key);
 		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
+		assertUserSkillTargetMutable(join(root, key), key);
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
+			assertUserSkillTargetMutable(join(root, key), key),
+		);
 	}
 
 	async writeSharedSkillArchive(

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -4,6 +4,10 @@ import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { isValidSkillKey } from "../lib/skill-key";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import {
+	assertUserSkillTargetMutable,
+	shouldIgnoreUserSkill,
+} from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -214,10 +218,7 @@ export class HermesAdapter implements AgentAdapter {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (shouldSkipHermesSkillDir(entry.name)) continue;
-			// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
-			// for the full reasoning. Hermes only filters at the top level
-			// — nested skills with the literal name "clawdi" deeper in the
-			// tree are an unlikely edge case not worth handling.
+			// Upgrade bridge for local setup installs created before the ownership ledger.
 			if (dir === skillsDir() && entry.name === "clawdi") continue;
 			const fullPath = join(dir, entry.name);
 			const skillMd = join(fullPath, "SKILL.md");
@@ -226,6 +227,7 @@ export class HermesAdapter implements AgentAdapter {
 				const content = readFileSync(skillMd, "utf-8");
 				const skillKey = hermesSkillKeyFromPath(fullPath);
 				if (!skillKey) continue;
+				if (shouldIgnoreUserSkill(fullPath, skillKey)) continue;
 				const fileCount = readdirSync(fullPath, { recursive: true }).length;
 
 				results.push({
@@ -278,7 +280,7 @@ export class HermesAdapter implements AgentAdapter {
 				const fullPath = join(dir, entry.name);
 				if (existsSync(join(fullPath, "SKILL.md"))) {
 					const skillKey = hermesSkillKeyFromPath(fullPath);
-					if (skillKey) out.push(skillKey);
+					if (skillKey && !shouldIgnoreUserSkill(fullPath, skillKey)) out.push(skillKey);
 				} else {
 					walk(fullPath);
 				}
@@ -299,12 +301,16 @@ export class HermesAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
+		assertUserSkillTargetMutable(dir, key);
 		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
+		assertUserSkillTargetMutable(join(root, key), key);
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
+			assertUserSkillTargetMutable(join(root, key), key),
+		);
 	}
 
 	async writeSharedSkillArchive(

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -3,6 +3,10 @@ import { isAbsolute, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import {
+	assertUserSkillTargetMutable,
+	shouldIgnoreUserSkill,
+} from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
 	CollectSessionsOptions,
@@ -306,10 +310,10 @@ export class OpenClawAdapter implements AgentAdapter {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
 				if (SKIP_DIRS.has(entry.name)) continue;
-				// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
-				// for the full reasoning.
+				// Upgrade bridge for local setup installs created before the ownership ledger.
 				if (entry.name === "clawdi") continue;
 				const dirPath = join(dir, entry.name);
+				if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 				const skillMd = join(dirPath, "SKILL.md");
 				if (!existsSync(skillMd)) continue;
 
@@ -368,6 +372,7 @@ export class OpenClawAdapter implements AgentAdapter {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			if (entry.name === "clawdi") continue;
+			if (shouldIgnoreUserSkill(join(skillsDir(), entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir(), entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 			out.push(entry.name);
@@ -385,12 +390,16 @@ export class OpenClawAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
+		assertUserSkillTargetMutable(dir, key);
 		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes);
+		assertUserSkillTargetMutable(join(root, key), key);
+		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
+			assertUserSkillTargetMutable(join(root, key), key),
+		);
 	}
 
 	async writeSharedSkillArchive(

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -19,6 +19,11 @@ import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
+import {
+	managedSkillReservationState,
+	reserveManagedSkill,
+} from "../runtime/managed-skill-reservation";
 import {
 	install as installDaemonService,
 	listInstalledAgents,
@@ -255,6 +260,22 @@ async function installBuiltinSkill(agentType: AgentType) {
 	const alreadyInstalled = existsSync(join(targetDir, "SKILL.md"));
 
 	try {
+		const sourceDigest = managedSkillDirectoryDigest(sourceDir);
+		const reservationState = managedSkillReservationState(targetDir);
+		if (
+			existsSync(targetDir) &&
+			reservationState !== "reserved" &&
+			managedSkillDirectoryDigest(targetDir) !== sourceDigest
+		) {
+			throw new Error(`refusing to replace unmanaged Skill at ${targetDir}`);
+		}
+		reserveManagedSkill({
+			targetDir,
+			id: "clawdi",
+			version: 1,
+			digest: sourceDigest,
+			manager: "local-setup",
+		});
 		mkdirSync(targetDir, { recursive: true });
 		// Always overwrite — the bundled skill content evolves with each CLI
 		// release (better trigger language, new tool descriptions), and users

--- a/packages/cli/src/commands/teardown.ts
+++ b/packages/cli/src/commands/teardown.ts
@@ -15,6 +15,7 @@ import { errMessage } from "../lib/errors";
 import { askMulti, askYesNo } from "../lib/prompts";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
+import { releaseManagedSkill } from "../runtime/managed-skill-reservation";
 
 export async function teardown(opts: {
 	agent?: string;
@@ -133,9 +134,15 @@ async function teardownOne(agentType: AgentType, opts: { keepSkill: boolean; kee
 	// 3. Bundled skill
 	if (!opts.keepSkill) {
 		const skillDir = builtinSkillTargetDir(agentType);
-		if (skillDir && existsSync(skillDir)) {
+		if (skillDir) {
 			try {
-				rmSync(skillDir, { recursive: true, force: true });
+				const result = releaseManagedSkill({
+					targetDir: skillDir,
+					id: "clawdi",
+					manager: "local-setup",
+					removeTarget: () => rmSync(skillDir, { recursive: true, force: true }),
+				});
+				if (result === "absent") throw new Error("Skill is not owned by local setup");
 				p.log.success(`${label}: removed bundled skill (${skillDir})`);
 			} catch (e) {
 				p.log.warn(`${label}: could not remove skill (${errMessage(e)})`);

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -10,6 +10,7 @@ import {
 import { lstat, readdir, realpath } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import * as tar from "tar";
+import { isReservedSkillArchivePath } from "../runtime/managed-skill-reservation";
 import { assertValidSkillKey } from "./skill-key";
 
 /**
@@ -83,6 +84,9 @@ export function extractTarGz(cwd: string, bytes: Buffer): Promise<void> {
 			gzip: true,
 			filter: (path, entry) => {
 				if (path.includes("..") || path.startsWith("/")) return false;
+				if (isReservedSkillArchivePath(path)) {
+					throw new Error("Skill archive contains reserved management metadata");
+				}
 				const type = "type" in entry ? entry.type : undefined;
 				return type !== "SymbolicLink" && type !== "Link";
 			},
@@ -107,6 +111,7 @@ export async function replaceSkillArchiveTarGz(
 	skillsRoot: string,
 	targetDir: string,
 	bytes: Buffer,
+	beforeActivate?: () => void,
 ): Promise<void> {
 	assertValidSkillKey(skillKey);
 	const targetFromRoot = relative(skillsRoot, targetDir);
@@ -132,6 +137,7 @@ export async function replaceSkillArchiveTarGz(
 			previousMoved = true;
 		}
 		try {
+			beforeActivate?.();
 			renameSync(stagedSkill, targetDir);
 		} catch (installError) {
 			if (!previousMoved) throw installError;
@@ -342,6 +348,9 @@ export async function tarSkillDir(
 				// legitimately named `dist`/`build`/`out` (or whose category dir
 				// is) doesn't get packaged as an empty tarball.
 				filter: (path) => {
+					if (isReservedSkillArchivePath(path)) {
+						throw new Error("Skill contains reserved management metadata");
+					}
 					const segments = path.split("/").slice(components.length);
 					return !segments.some((seg) => SKILL_TAR_EXCLUDE.has(seg));
 				},

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -14,7 +14,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { reconcileHostedBundledSkill, resolveHostedBundledSkill } from "./hosted-bundled-skill";
+import {
+	adoptableLegacyHostedBundledSkill,
+	reconcileHostedBundledSkill,
+	resolveHostedBundledSkill,
+} from "./hosted-bundled-skill";
 
 const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
 const bundledSourceDir = resolve(import.meta.dir, "../../skills/hosted-versions/1/clawdi");
@@ -95,6 +99,17 @@ describe("hosted bundled skill reconciliation", () => {
 			digest: catalogEntry.digest,
 		});
 		expect(readdirSync(join(root, "target"))).toEqual(["clawdi"]);
+	});
+
+	it("adopts an old marker only when catalog identity and live content match exactly", () => {
+		expect(reconcile()).toBe("replaced");
+		writeFileSync(
+			join(targetDir, ".clawdi-managed.json"),
+			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
+		);
+		expect(adoptableLegacyHostedBundledSkill(targetDir, "clawdi")).toEqual(catalogEntry);
+		writeFileSync(join(targetDir, "SKILL.md"), "tampered\n");
+		expect(adoptableLegacyHostedBundledSkill(targetDir, "clawdi")).toBeNull();
 	});
 
 	it("detects target symlink tampering without following or modifying its destination", () => {

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -64,6 +64,8 @@ export interface ReconcileHostedBundledSkillInput {
 	version: number;
 	sourceDir: string;
 	targetDir: string;
+	/** A root-owned reservation for this exact target authorizes replacement. */
+	reserved?: boolean;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -170,6 +172,36 @@ function hostedBundledSkillDigest(
 	return computeManagedBundleHash(files);
 }
 
+export function managedSkillDirectoryDigest(directory: string): string {
+	return hostedBundledSkillDigest(directory, false);
+}
+
+export function adoptableLegacyHostedBundledSkill(
+	targetDir: string,
+	skillId: string,
+): HostedBundledSkillCatalogEntry | null {
+	const marker = readHostedBundledSkillMarker(targetDir);
+	if (!marker) return null;
+	const current = isCurrentManagedMarker(marker, skillId);
+	const legacy = isLegacyManagedMarker(marker, skillId);
+	if (!current && !legacy) return null;
+	const version = current ? (marker.version as number) : 1;
+	let catalogEntry: HostedBundledSkillCatalogEntry;
+	try {
+		catalogEntry = resolveHostedBundledSkill(skillId, version);
+	} catch {
+		return null;
+	}
+	if (current && marker.digest !== catalogEntry.digest) return null;
+	try {
+		return hostedBundledSkillDigest(targetDir, true, true) === catalogEntry.digest
+			? catalogEntry
+			: null;
+	} catch {
+		return null;
+	}
+}
+
 function normalizeHostedBundledSkillModes(currentDir: string): void {
 	chmodSync(currentDir, HOSTED_BUNDLED_SKILL_DIRECTORY_MODE);
 	for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
@@ -247,7 +279,11 @@ export function reconcileHostedBundledSkill(
 		digest: catalogEntry.digest,
 	};
 	const targetExists = existsSync(input.targetDir);
-	if (targetExists && !isManagedHostedBundledSkill(input.targetDir, catalogEntry.id)) {
+	if (
+		targetExists &&
+		!input.reserved &&
+		!isManagedHostedBundledSkill(input.targetDir, catalogEntry.id)
+	) {
 		throw new Error(`refusing to replace unmanaged ${catalogEntry.id} skill at ${input.targetDir}`);
 	}
 	if (targetExists && markerMatches(readHostedBundledSkillMarker(input.targetDir), marker)) {

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	managedSkillReservationState,
+	releaseManagedSkill,
+	reserveManagedSkill,
+} from "./managed-skill-reservation";
+
+const originalHome = process.env.HOME;
+const originalMode = process.env.CLAWDI_RUNTIME_MODE;
+const originalState = process.env.CLAWDI_SERVICE_STATE_DIR;
+let root = "";
+
+function target(parent = "one"): string {
+	const path = join(root, parent, "skills", "example");
+	mkdirSync(path, { recursive: true });
+	writeFileSync(join(path, "SKILL.md"), "# Example\n");
+	return path;
+}
+
+afterEach(() => {
+	if (root) rmSync(root, { recursive: true, force: true });
+	root = "";
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	if (originalMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+	else process.env.CLAWDI_RUNTIME_MODE = originalMode;
+	if (originalState === undefined) delete process.env.CLAWDI_SERVICE_STATE_DIR;
+	else process.env.CLAWDI_SERVICE_STATE_DIR = originalState;
+});
+
+describe("managed Skill reservations", () => {
+	it("reserves the exact target path rather than every matching id", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		delete process.env.CLAWDI_RUNTIME_MODE;
+		delete process.env.CLAWDI_SERVICE_STATE_DIR;
+		const first = target("one");
+		const second = target("two");
+		reserveManagedSkill({
+			targetDir: first,
+			id: "example",
+			version: 1,
+			digest: "a".repeat(64),
+			manager: "local-setup",
+		});
+		expect(managedSkillReservationState(first, "example")).toBe("reserved");
+		expect(managedSkillReservationState(second, "example")).toBe("unreserved");
+	});
+
+	it("does not treat a forged co-located marker as authority", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const path = target();
+		writeFileSync(join(path, ".clawdi-managed.json"), '{"id":"example"}\n');
+		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("persists authority before target mutation and releases only after cleanup", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		const path = target();
+		reserveManagedSkill({
+			targetDir: path,
+			id: "example",
+			manager: "hosted-manifest",
+			version: 2,
+			digest: "b".repeat(64),
+		});
+		expect(managedSkillReservationState(path, "example")).toBe("reserved");
+		releaseManagedSkill({
+			targetDir: path,
+			id: "example",
+			manager: "hosted-manifest",
+			removeTarget: () => {
+				expect(managedSkillReservationState(path, "example")).toBe("reserved");
+				rmSync(path, { recursive: true, force: true });
+			},
+		});
+		expect(existsSync(path)).toBe(false);
+		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("does not let another manager replace or release ownership", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const path = target();
+		reserveManagedSkill({
+			targetDir: path,
+			id: "example",
+			manager: "local-setup",
+			version: 1,
+			digest: "c".repeat(64),
+		});
+		expect(() =>
+			reserveManagedSkill({
+				targetDir: path,
+				id: "example",
+				manager: "hosted-manifest",
+				version: 1,
+				digest: "c".repeat(64),
+			}),
+		).toThrow("different manager");
+		expect(() =>
+			releaseManagedSkill({
+				targetDir: path,
+				id: "example",
+				manager: "hosted-manifest",
+				removeTarget: () => rmSync(path, { recursive: true, force: true }),
+			}),
+		).toThrow("identity mismatch");
+		expect(existsSync(path)).toBe(true);
+	});
+});

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -114,4 +114,20 @@ describe("managed Skill reservations", () => {
 		).toThrow("identity mismatch");
 		expect(existsSync(path)).toBe(true);
 	});
+
+	it("rejects an invalid identity before it can poison the ledger", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const path = target();
+		expect(() =>
+			reserveManagedSkill({
+				targetDir: path,
+				id: "example",
+				manager: "local-setup",
+				version: 1,
+				digest: "not-a-sha256",
+			}),
+		).toThrow("identity is invalid");
+		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
 });

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -1,0 +1,177 @@
+import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { getClawdiDir } from "../lib/config";
+import { writePrivateFileAtomic } from "../lib/private-file";
+
+export const MANAGED_SKILL_MARKER_FILE = ".clawdi-managed.json";
+const LEDGER_FILE = "managed-skills.json";
+const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
+
+interface ManagedSkillReservation {
+	target: string;
+	id: string;
+	version: number;
+	digest: string;
+	manager: "hosted-manifest" | "local-setup";
+}
+
+interface ManagedSkillReservationLedger {
+	schemaVersion: typeof LEDGER_SCHEMA;
+	reservations: Record<string, ManagedSkillReservation>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function ledgerPath(): string {
+	const root = process.env.CLAWDI_SERVICE_STATE_DIR?.trim();
+	const mode = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase();
+	if (mode === "hosted" || root) {
+		return join(root || "/var/lib/clawdi", "config", "projections", LEDGER_FILE);
+	}
+	return join(getClawdiDir(), "managed-resources", LEDGER_FILE);
+}
+
+function emptyLedger(): ManagedSkillReservationLedger {
+	return { schemaVersion: LEDGER_SCHEMA, reservations: {} };
+}
+
+function readLedger(path: string): ManagedSkillReservationLedger {
+	if (!existsSync(path)) return emptyLedger();
+	let value: unknown;
+	try {
+		const stat = lstatSync(path);
+		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
+		value = JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		throw new Error(
+			`managed Skill reservation ledger is invalid: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isRecord(value) || value.schemaVersion !== LEDGER_SCHEMA || !isRecord(value.reservations)) {
+		throw new Error("managed Skill reservation ledger has an unsupported schema");
+	}
+	const reservations: Record<string, ManagedSkillReservation> = {};
+	for (const [target, raw] of Object.entries(value.reservations)) {
+		if (
+			!isRecord(raw) ||
+			raw.target !== target ||
+			resolve(target) !== target ||
+			typeof raw.id !== "string" ||
+			basename(target) !== raw.id ||
+			typeof raw.version !== "number" ||
+			!Number.isSafeInteger(raw.version) ||
+			raw.version <= 0 ||
+			typeof raw.digest !== "string" ||
+			!/^[a-f0-9]{64}$/.test(raw.digest) ||
+			(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
+		) {
+			throw new Error("managed Skill reservation ledger contains an invalid reservation");
+		}
+		reservations[target] = {
+			target,
+			id: raw.id,
+			version: raw.version,
+			digest: raw.digest,
+			manager: raw.manager,
+		};
+	}
+	return { schemaVersion: LEDGER_SCHEMA, reservations };
+}
+
+function writeLedger(path: string, ledger: ManagedSkillReservationLedger): void {
+	writePrivateFileAtomic(path, `${JSON.stringify(ledger, null, 2)}\n`, {
+		mode: 0o644,
+		dirMode: 0o755,
+	});
+}
+
+export function managedSkillReservationState(
+	targetDir: string,
+	skillId = basename(targetDir),
+): "unreserved" | "reserved" | "indeterminate" {
+	const path = ledgerPath();
+	if (!path) return "unreserved";
+	try {
+		const reservation = readLedger(path).reservations[resolve(targetDir)];
+		return reservation?.id === skillId ? "reserved" : "unreserved";
+	} catch {
+		return "indeterminate";
+	}
+}
+
+export function shouldIgnoreUserSkill(targetDir: string, skillId = basename(targetDir)): boolean {
+	return managedSkillReservationState(targetDir, skillId) !== "unreserved";
+}
+
+export function assertUserSkillTargetMutable(
+	targetDir: string,
+	skillId = basename(targetDir),
+): void {
+	if (shouldIgnoreUserSkill(targetDir, skillId)) {
+		throw new Error(`Skill ${skillId} is reserved by the hosted runtime manifest`);
+	}
+}
+
+export function reserveManagedSkill(input: {
+	targetDir: string;
+	id: string;
+	version: number;
+	digest: string;
+	manager: "hosted-manifest" | "local-setup";
+}): "created" | "existing" {
+	const path = ledgerPath();
+	const target = resolve(input.targetDir);
+	if (basename(target) !== input.id || !Number.isSafeInteger(input.version) || input.version <= 0) {
+		throw new Error("managed Skill reservation identity is invalid");
+	}
+	const ledger = readLedger(path);
+	const previous = ledger.reservations[target];
+	const manager = input.manager;
+	if (previous && previous.manager !== manager) {
+		throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+	}
+	ledger.reservations[target] = {
+		target,
+		id: input.id,
+		version: input.version,
+		digest: input.digest,
+		manager,
+	};
+	writeLedger(path, ledger);
+	return previous ? "existing" : "created";
+}
+
+export function releaseManagedSkill(input: {
+	targetDir: string;
+	id: string;
+	manager: "hosted-manifest" | "local-setup";
+	removeTarget: () => void;
+}): "absent" | "removed" {
+	const path = ledgerPath();
+	const target = resolve(input.targetDir);
+	const ledger = readLedger(path);
+	const reservation = ledger.reservations[target];
+	if (!reservation) return "absent";
+	if (reservation.id !== input.id || reservation.manager !== input.manager) {
+		throw new Error("managed Skill reservation identity mismatch");
+	}
+	input.removeTarget();
+	delete ledger.reservations[target];
+	writeLedger(path, ledger);
+	return "removed";
+}
+
+export function removeReservedUserSkillTarget(
+	targetDir: string,
+	skillId = basename(targetDir),
+): "protected" | "removed" {
+	if (shouldIgnoreUserSkill(targetDir, skillId)) return "protected";
+	if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
+	return "removed";
+}
+
+export function isReservedSkillArchivePath(path: string): boolean {
+	return path.split(/[\\/]/).some((segment) => segment.toLowerCase().startsWith(".clawdi-managed"));
+}

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -1,18 +1,21 @@
-import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { getClawdiDir } from "../lib/config";
 import { writePrivateFileAtomic } from "../lib/private-file";
 
-export const MANAGED_SKILL_MARKER_FILE = ".clawdi-managed.json";
 const LEDGER_FILE = "managed-skills.json";
 const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
+const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export type ManagedSkillReservationManager = "hosted-manifest" | "local-setup";
 
 interface ManagedSkillReservation {
 	target: string;
 	id: string;
 	version: number;
 	digest: string;
-	manager: "hosted-manifest" | "local-setup";
+	manager: ManagedSkillReservationManager;
 }
 
 interface ManagedSkillReservationLedger {
@@ -60,11 +63,12 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 			resolve(target) !== target ||
 			typeof raw.id !== "string" ||
 			basename(target) !== raw.id ||
+			!MANAGED_SKILL_ID_PATTERN.test(raw.id) ||
 			typeof raw.version !== "number" ||
 			!Number.isSafeInteger(raw.version) ||
 			raw.version <= 0 ||
 			typeof raw.digest !== "string" ||
-			!/^[a-f0-9]{64}$/.test(raw.digest) ||
+			!SHA256_PATTERN.test(raw.digest) ||
 			(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
 		) {
 			throw new Error("managed Skill reservation ledger contains an invalid reservation");
@@ -91,11 +95,18 @@ export function managedSkillReservationState(
 	targetDir: string,
 	skillId = basename(targetDir),
 ): "unreserved" | "reserved" | "indeterminate" {
+	const owner = managedSkillReservationOwner(targetDir, skillId);
+	return owner === "unreserved" || owner === "indeterminate" ? owner : "reserved";
+}
+
+export function managedSkillReservationOwner(
+	targetDir: string,
+	skillId = basename(targetDir),
+): ManagedSkillReservationManager | "unreserved" | "indeterminate" {
 	const path = ledgerPath();
-	if (!path) return "unreserved";
 	try {
 		const reservation = readLedger(path).reservations[resolve(targetDir)];
-		return reservation?.id === skillId ? "reserved" : "unreserved";
+		return reservation?.id === skillId ? reservation.manager : "unreserved";
 	} catch {
 		return "indeterminate";
 	}
@@ -119,11 +130,17 @@ export function reserveManagedSkill(input: {
 	id: string;
 	version: number;
 	digest: string;
-	manager: "hosted-manifest" | "local-setup";
+	manager: ManagedSkillReservationManager;
 }): "created" | "existing" {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
-	if (basename(target) !== input.id || !Number.isSafeInteger(input.version) || input.version <= 0) {
+	if (
+		basename(target) !== input.id ||
+		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
+		!Number.isSafeInteger(input.version) ||
+		input.version <= 0 ||
+		!SHA256_PATTERN.test(input.digest)
+	) {
 		throw new Error("managed Skill reservation identity is invalid");
 	}
 	const ledger = readLedger(path);
@@ -146,7 +163,7 @@ export function reserveManagedSkill(input: {
 export function releaseManagedSkill(input: {
 	targetDir: string;
 	id: string;
-	manager: "hosted-manifest" | "local-setup";
+	manager: ManagedSkillReservationManager;
 	removeTarget: () => void;
 }): "absent" | "removed" {
 	const path = ledgerPath();
@@ -160,15 +177,6 @@ export function releaseManagedSkill(input: {
 	input.removeTarget();
 	delete ledger.reservations[target];
 	writeLedger(path, ledger);
-	return "removed";
-}
-
-export function removeReservedUserSkillTarget(
-	targetDir: string,
-	skillId = basename(targetDir),
-): "protected" | "removed" {
-	if (shouldIgnoreUserSkill(targetDir, skillId)) return "protected";
-	if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
 	return "removed";
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -56,9 +56,9 @@ import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
 import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
 import { ensureRuntimeAuthTokenFile } from "./auth-token";
 import {
+	adoptableLegacyHostedBundledSkill,
 	assertHostedBundledSkillCatalogDigest,
 	hostedBundledSkillIds,
-	isManagedHostedBundledSkill,
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
@@ -72,6 +72,11 @@ import {
 	extractManagedLiveModels,
 	resolveManagedPrimaryModel,
 } from "./managed-model-resolution";
+import {
+	managedSkillReservationState,
+	releaseManagedSkill,
+	reserveManagedSkill,
+} from "./managed-skill-reservation";
 import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 import {
 	type HostedMcpServerDesiredState,
@@ -3290,7 +3295,11 @@ function validateHostedBundledSkillsPlan(
 		if (!targetDir || !runtimeEnabled || desired.enabled !== true) continue;
 		const sourceDir = hostedBundledSkillSourceDir(bundled.assetDirectory);
 		assertHostedBundledSkillCatalogDigest(bundled, sourceDir);
-		if (existsSync(targetDir) && !isManagedHostedBundledSkill(targetDir, skillName)) {
+		if (
+			existsSync(targetDir) &&
+			managedSkillReservationState(targetDir, skillName) !== "reserved" &&
+			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
+		) {
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
 		}
 	}
@@ -3311,21 +3320,49 @@ function applyHostedBundledSkills(
 		const desired = manifest.projection?.skills?.entries[skillName];
 		const runtimeEnabled = manifest.runtimes[name]?.enabled === true;
 		if (!installEnabled || !runtimeEnabled || desired?.enabled !== true) {
-			if (isManagedHostedBundledSkill(targetDir, skillName)) {
-				rmSync(targetDir, { recursive: true, force: true });
+			if (!installEnabled) continue;
+			const legacy = adoptableLegacyHostedBundledSkill(targetDir, skillName);
+			if (legacy && managedSkillReservationState(targetDir, skillName) === "unreserved") {
+				reserveManagedSkill({
+					targetDir,
+					id: skillName,
+					manager: "hosted-manifest",
+					version: legacy.version,
+					digest: legacy.digest,
+				});
 			}
+			releaseManagedSkill({
+				targetDir,
+				id: skillName,
+				manager: "hosted-manifest",
+				removeTarget: () => rmSync(targetDir, { recursive: true, force: true }),
+			});
 			continue;
 		}
 		if (!observation?.enabled || observation.status === "install_failed") continue;
-		if (existsSync(targetDir) && !isManagedHostedBundledSkill(targetDir, skillName)) {
+		const catalogEntry = resolveHostedBundledSkill(skillName, desired.version);
+		const reservationState = managedSkillReservationState(targetDir, skillName);
+		if (
+			existsSync(targetDir) &&
+			reservationState !== "reserved" &&
+			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
+		) {
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
 		}
-		const bundled = resolveHostedBundledSkill(skillName, desired.version);
+		const bundled = catalogEntry;
+		reserveManagedSkill({
+			targetDir,
+			id: skillName,
+			manager: "hosted-manifest",
+			version: desired.version,
+			digest: bundled.digest,
+		});
 		const result = reconcileHostedBundledSkill({
 			skillId: skillName,
 			version: desired.version,
 			sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
 			targetDir,
+			reserved: true,
 		});
 		if (result === "unchanged") continue;
 		makeRuntimeUserOwnedAncestors(targetDir);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -73,7 +73,7 @@ import {
 	resolveManagedPrimaryModel,
 } from "./managed-model-resolution";
 import {
-	managedSkillReservationState,
+	managedSkillReservationOwner,
 	releaseManagedSkill,
 	reserveManagedSkill,
 } from "./managed-skill-reservation";
@@ -3295,9 +3295,10 @@ function validateHostedBundledSkillsPlan(
 		if (!targetDir || !runtimeEnabled || desired.enabled !== true) continue;
 		const sourceDir = hostedBundledSkillSourceDir(bundled.assetDirectory);
 		assertHostedBundledSkillCatalogDigest(bundled, sourceDir);
+		const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
 		if (
 			existsSync(targetDir) &&
-			managedSkillReservationState(targetDir, skillName) !== "reserved" &&
+			reservationOwner !== "hosted-manifest" &&
 			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
 		) {
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
@@ -3320,9 +3321,11 @@ function applyHostedBundledSkills(
 		const desired = manifest.projection?.skills?.entries[skillName];
 		const runtimeEnabled = manifest.runtimes[name]?.enabled === true;
 		if (!installEnabled || !runtimeEnabled || desired?.enabled !== true) {
-			if (!installEnabled) continue;
+			const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
 			const legacy = adoptableLegacyHostedBundledSkill(targetDir, skillName);
-			if (legacy && managedSkillReservationState(targetDir, skillName) === "unreserved") {
+			if (reservationOwner === "local-setup") continue;
+			if (!installEnabled && reservationOwner === "unreserved" && !legacy) continue;
+			if (legacy && reservationOwner === "unreserved") {
 				reserveManagedSkill({
 					targetDir,
 					id: skillName,
@@ -3341,10 +3344,10 @@ function applyHostedBundledSkills(
 		}
 		if (!observation?.enabled || observation.status === "install_failed") continue;
 		const catalogEntry = resolveHostedBundledSkill(skillName, desired.version);
-		const reservationState = managedSkillReservationState(targetDir, skillName);
+		const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
 		if (
 			existsSync(targetDir) &&
-			reservationState !== "reserved" &&
+			reservationOwner !== "hosted-manifest" &&
 			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
 		) {
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -23,6 +23,7 @@ import {
 	rememberPendingSkillUploadEcho,
 	resolveOwningSkillKey,
 	SyncHealth,
+	shouldForceFullSkillListing,
 } from "./sync-engine";
 
 describe("stable session enqueue abort fence", () => {
@@ -68,6 +69,19 @@ describe("stable session enqueue abort fence", () => {
 		expect(await running).toBe(0);
 		expect(queued).toEqual([]);
 		expect(inFlight.size).toBe(0);
+	});
+});
+
+describe("reserved Skill reconcile listing", () => {
+	it("forces a full listing despite a pre-reservation pushed hash", () => {
+		const observed = new Set(["managed"]);
+		const pushed = new Map([["managed", "old-cloud-hash"]]);
+		expect(shouldForceFullSkillListing(observed, pushed, (key) => key === "managed")).toBe(true);
+	});
+
+	it("keeps one full pass after release when the deferred hash was cleared", () => {
+		const observed = new Set(["managed"]);
+		expect(shouldForceFullSkillListing(observed, new Map(), () => false)).toBe(true);
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -83,6 +83,12 @@ describe("reserved Skill reconcile listing", () => {
 		const observed = new Set(["managed"]);
 		expect(shouldForceFullSkillListing(observed, new Map(), () => false)).toBe(true);
 	});
+
+	it("returns to conditional listings after the released Skill is pulled", () => {
+		const observed = new Set(["managed"]);
+		const pulled = new Map([["managed", "current-cloud-hash"]]);
+		expect(shouldForceFullSkillListing(observed, pulled, () => false)).toBe(false);
+	});
 });
 
 describe("daemon SSE routing", () => {

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -65,6 +65,7 @@ import {
 } from "../lib/skills-lock";
 import { tarSkillDir } from "../lib/tar";
 import { getCliVersion } from "../lib/version";
+import { shouldIgnoreUserSkill } from "../runtime/managed-skill-reservation";
 import { readHostedRuntimeObserved } from "../runtime/observed";
 
 export { isSafelyTerminalRuntimeObservationFailure } from "../runtime/observation-producer";
@@ -706,6 +707,12 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		// until some unrelated cloud change next bumped the
 		// revision.
 		if (event.type === "skill_deleted") {
+			if (isReservedSkill(opts, event.skill_key)) {
+				deferReservedSkill(opts, event.skill_key, lastPushedHash);
+				syncHealth.clear("pull", `skill:${event.skill_key}`);
+				lastSeenRevision = event.skills_revision;
+				return;
+			}
 			addInFlight(pullsInFlight, event.skill_key);
 			let applied = false;
 			try {
@@ -767,7 +774,12 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		addInFlight(pullsInFlight, event.skill_key);
 		let pulled = false;
 		try {
-			await pullSkill(opts, api, event.skill_key, lastPushedHash, defaultProjectId);
+			const outcome = await pullSkill(opts, api, event.skill_key, lastPushedHash, defaultProjectId);
+			if (outcome === "deferred") {
+				cloudObservedKeys.add(event.skill_key);
+				syncHealth.clear("pull", `skill:${event.skill_key}`);
+				return;
+			}
 			// Track the SSE-pulled skill in cloudObservedKeys so the
 			// reconcile sweep can later remove it if its delete event
 			// is missed. Without this, an SSE-installed skill that
@@ -980,6 +992,7 @@ async function enqueueIfChanged(
 	skillKey: string,
 	getProjectId: () => string,
 ): Promise<void> {
+	if (isReservedSkill(opts, skillKey)) return;
 	if (!isValidSkillKey(skillKey)) {
 		lastPushedHash.delete(skillKey);
 		log.warn("engine.invalid_skill_key_skipped", { skill_key: skillKey });
@@ -1522,6 +1535,10 @@ async function uploadSkillFromQueue(
 	pendingSkillUploadEchoes: Map<string, PendingSkillUploadEcho>,
 	projectId: string,
 ): Promise<void> {
+	if (isReservedSkill(opts, item.skill_key)) {
+		lastPushedHash.delete(item.skill_key);
+		return;
+	}
 	const dir = join(opts.adapter.getSkillsRootDir(), item.skill_key);
 	// Recompute the hash from the live directory at upload time
 	// rather than trusting `item.new_hash`. The watcher's hash
@@ -1940,6 +1957,10 @@ async function initialSync(
 			continue;
 		}
 		if (lastShipped !== undefined) {
+			if (isReservedSkill(opts, key)) {
+				health.clear("pull", `skill:${key}`);
+				continue;
+			}
 			// We shipped this before, cloud doesn't have it now.
 			// Treat as cloud-side delete + remove the local copy.
 			// (Fine to delete: the user's intent — when they
@@ -2087,10 +2108,13 @@ async function reconcileFromCloud(
 	health: SyncHealth,
 	onAuthFailure: (origin: string) => void,
 ): Promise<void> {
+	const forceFullListing = shouldForceFullSkillListing(cloudObservedKeys, lastPushedHash, (key) =>
+		isReservedSkill(opts, key),
+	);
 	const { skills, complete, revision, etag, notModified } = await listAllCloudSkills(
 		api,
 		projectId,
-		knownEtag,
+		forceFullListing ? null : knownEtag,
 	);
 	health.clear("pull", "listing");
 	if (notModified) {
@@ -2122,6 +2146,11 @@ async function reconcileFromCloud(
 	const cloudKeys = new Set(skills.map((s) => s.skill_key));
 	for (const skill of skills) {
 		cloudObservedKeys.add(skill.skill_key);
+		if (isReservedSkill(opts, skill.skill_key)) {
+			deferReservedSkill(opts, skill.skill_key, lastPushedHash);
+			health.clear("pull", `skill:${skill.skill_key}`);
+			continue;
+		}
 		const local = lastPushedHash.get(skill.skill_key);
 		if (local === skill.content_hash) {
 			health.clear("pull", `skill:${skill.skill_key}`);
@@ -2193,6 +2222,11 @@ async function reconcileFromCloud(
 	if (complete) {
 		for (const knownKey of [...cloudObservedKeys]) {
 			if (cloudKeys.has(knownKey)) continue;
+			if (isReservedSkill(opts, knownKey)) {
+				cloudObservedKeys.delete(knownKey);
+				health.clear("pull", `skill:${knownKey}`);
+				continue;
+			}
 			// Skip if a pull for this key is in flight. Without this,
 			// the sweep can rm the directory while the pull is mid-
 			// extract, and the pull's writeSkillArchive resurrects
@@ -2352,7 +2386,11 @@ async function pullSkill(
 	skillKey: string,
 	lastPushedHash: Map<string, string>,
 	projectId: string,
-): Promise<void> {
+): Promise<"applied" | "deferred"> {
+	if (isReservedSkill(opts, skillKey)) {
+		deferReservedSkill(opts, skillKey, lastPushedHash);
+		return "deferred";
+	}
 	const tarBytes = await api.getBytes(
 		`/v1/projects/${encodeURIComponent(projectId)}/skills/${encodeURIComponent(skillKey)}/download`,
 	);
@@ -2371,6 +2409,32 @@ async function pullSkill(
 	writeSkillsLock(lock);
 	lastPushedHash.set(skillKey, hash);
 	log.info("engine.skill_pulled", { skill_key: skillKey });
+	return "applied";
+}
+
+function isReservedSkill(opts: EngineOpts, skillKey: string): boolean {
+	return shouldIgnoreUserSkill(join(opts.adapter.getSkillsRootDir(), skillKey), skillKey);
+}
+
+function deferReservedSkill(
+	opts: EngineOpts,
+	skillKey: string,
+	lastPushedHash: Map<string, string>,
+): void {
+	const hadMemoryHash = lastPushedHash.delete(skillKey);
+	const lock = readSkillsLock();
+	const key = skillCacheKey(opts.adapter.agentType, skillKey);
+	const hadPersistentHash = key in lock.skills;
+	if (hadPersistentHash) delete lock.skills[key];
+	if (hadMemoryHash || hadPersistentHash) writeSkillsLock(lock);
+}
+
+export function shouldForceFullSkillListing(
+	cloudObservedKeys: ReadonlySet<string>,
+	lastPushedHash: ReadonlyMap<string, string>,
+	isReserved: (skillKey: string) => boolean,
+): boolean {
+	return [...cloudObservedKeys].some((key) => isReserved(key) || !lastPushedHash.has(key));
 }
 
 /** Heartbeat sender. Fires immediately on boot then every

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ClaudeCodeAdapter } from "../../src/adapters/claude-code";
 import { tarSkillDir } from "../../src/lib/tar";
+import {
+	releaseManagedSkill,
+	reserveManagedSkill,
+} from "../../src/runtime/managed-skill-reservation";
 import { cleanupTmp, copyFixtureToTmp } from "./helpers";
 
 let tmpHome: string;
@@ -322,6 +326,32 @@ describe("ClaudeCodeAdapter.writeSkillArchive + getSkillPath", () => {
 		const extracted = join(tmpHome, ".claude", "skills", "demo", "SKILL.md");
 		expect(existsSync(extracted)).toBe(true);
 		expect(readFileSync(extracted, "utf-8")).toContain("name: demo");
+	});
+
+	it("blocks Cloud writes while reserved and permits the same write after release", async () => {
+		const target = join(tmpHome, ".claude", "skills", "demo");
+		const bytes = await tarSkillDir(target);
+		reserveManagedSkill({
+			targetDir: target,
+			id: "demo",
+			version: 1,
+			digest: "d".repeat(64),
+			manager: "local-setup",
+		});
+		const adapter = new ClaudeCodeAdapter();
+
+		await expect(adapter.writeSkillArchive("demo", bytes)).rejects.toThrow("reserved");
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain("demo");
+
+		releaseManagedSkill({
+			targetDir: target,
+			id: "demo",
+			manager: "local-setup",
+			removeTarget: () => rmSync(target, { recursive: true, force: true }),
+		});
+		await adapter.writeSkillArchive("demo", bytes);
+
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toContain("name: demo");
 	});
 
 	it("getSkillPath returns skills/<key>/SKILL.md under Claude home", () => {

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -300,6 +300,15 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 		expect(demo.content).toContain("description: A demo skill");
 		expect(demo.filePath).toContain("/.claude/skills/demo/SKILL.md");
 	});
+
+	it("does not upload a pre-ledger local setup Skill after upgrade", async () => {
+		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
+		mkdirSync(legacy, { recursive: true });
+		writeFileSync(join(legacy, "SKILL.md"), "# Legacy bundled Skill\n");
+		const adapter = new ClaudeCodeAdapter();
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain("clawdi");
+		expect(await adapter.listSkillKeys()).not.toContain("clawdi");
+	});
 });
 
 describe("ClaudeCodeAdapter.writeSkillArchive + getSkillPath", () => {

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { setup } from "../../src/commands/setup";
+import { managedSkillReservationState } from "../../src/runtime/managed-skill-reservation";
 import {
 	type AgentHomeOverrideSnapshot,
 	jsonResponse,
@@ -29,6 +30,8 @@ const ENV_KEYS = [
 	"CLAWDI_AUTH_TOKEN",
 	"CLAWDI_ENVIRONMENT_ID",
 	"CLAWDI_STATE_DIR",
+	"CLAWDI_SERVICE_STATE_DIR",
+	"CLAWDI_RUNTIME_MODE",
 	"CLAWDI_SERVE_MODE",
 	"CLAWDI_SERVE_DEBUG",
 ] as const;
@@ -143,6 +146,28 @@ describe("setup daemon install", () => {
 		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(false);
 		expect(daemonUnitExists("daemon")).toBe(false);
 		expect(daemonUnitExists("codex")).toBe(false);
+	});
+
+	it("installs the bundled Skill with explicit local-setup ownership", async () => {
+		installEnvironmentMock("env-codex");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		const target = join(home, ".codex", "skills", "clawdi");
+		expect(existsSync(join(target, "SKILL.md"))).toBe(true);
+		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+	});
+
+	it("does not claim or overwrite an unmanaged Skill collision", async () => {
+		const target = join(home, ".codex", "skills", "clawdi");
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "# User-owned Clawdi\n");
+		installEnvironmentMock("env-codex");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# User-owned Clawdi\n");
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 });
 

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { teardown } from "../../src/commands/teardown";
+import { reserveManagedSkill } from "../../src/runtime/managed-skill-reservation";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
 import {
 	type AgentHomeOverrideSnapshot,
@@ -49,6 +50,13 @@ function setup(agent: AgentKey): {
 	}
 	mkdirSync(join(skillPath, ".."), { recursive: true });
 	writeFileSync(skillPath, "---\nname: clawdi\ndescription: bundled\n---\n");
+	reserveManagedSkill({
+		targetDir: dirname(skillPath),
+		id: "clawdi",
+		version: 1,
+		digest: "a".repeat(64),
+		manager: "local-setup",
+	});
 
 	return { envPath, skillPath };
 }

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { teardown } from "../../src/commands/teardown";
-import { reserveManagedSkill } from "../../src/runtime/managed-skill-reservation";
+import {
+	managedSkillReservationState,
+	reserveManagedSkill,
+} from "../../src/runtime/managed-skill-reservation";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
 import {
 	type AgentHomeOverrideSnapshot,
@@ -153,6 +156,17 @@ describe("teardown — flag behavior", () => {
 		await teardown({ agent: "claude_code", yes: true, keepMcp: true, keepSkill: true });
 		expect(existsSync(envPath)).toBe(false);
 		expect(existsSync(skillPath)).toBe(true);
+	});
+
+	it("releases a stale reservation even when the managed target is already absent", async () => {
+		const { skillPath } = setup("codex");
+		const target = dirname(skillPath);
+		rmSync(target, { recursive: true, force: true });
+		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+
+		await teardown({ agent: "codex", yes: true, keepMcp: true });
+
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 
 	it("--all tears down every registered agent", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -47,6 +47,7 @@ import {
 	hostedManifestEgressProfiles,
 	managedMcpHeaderPlaceholder,
 } from "../src/runtime/hosted-egress-profiles";
+import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	convergeRuntimeManifest,
 	loadRuntimeManifest,
@@ -11430,6 +11431,28 @@ exit 64
 		).toThrow("no bundled hosted skill clawdi version 2 is registered");
 		expect(existsSync(ledgerPath)).toBe(false);
 
+		const openclawSkill = join(home, ".openclaw", "agents", "main", "skills", "clawdi");
+		mkdirSync(openclawSkill, { recursive: true });
+		writeFileSync(join(openclawSkill, "SKILL.md"), "local setup skill\n");
+		reserveManagedSkill({
+			targetDir: openclawSkill,
+			id: "clawdi",
+			version: 1,
+			digest: "a".repeat(64),
+			manager: "local-setup",
+		});
+		expect(() =>
+			convergeRuntimeManifest(load(1, "openclaw", initialServers), getRuntimePaths()),
+		).toThrow(`refusing to replace unmanaged clawdi skill at ${openclawSkill}`);
+		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).toBe("local setup skill\n");
+		expect(existsSync(ledgerPath)).toBe(false);
+		releaseManagedSkill({
+			targetDir: openclawSkill,
+			id: "clawdi",
+			manager: "local-setup",
+			removeTarget: () => rmSync(openclawSkill, { recursive: true, force: true }),
+		});
+
 		const initial = convergeRuntimeManifest(load(1, "openclaw", initialServers), getRuntimePaths());
 		expect(initial.installErrors).toEqual([]);
 		expect(readOpenClawMcpServers(home).clawdi).toEqual(initialServers.clawdi);
@@ -11441,7 +11464,6 @@ exit 64
 		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
 			openclaw: initialServers,
 		});
-		const openclawSkill = join(home, ".openclaw", "agents", "main", "skills", "clawdi");
 		expect(existsSync(join(openclawSkill, ".clawdi-managed.json"))).toBe(true);
 
 		const updated = convergeRuntimeManifest(load(2, "openclaw", updatedServers), getRuntimePaths());

--- a/packages/cli/tests/tar.test.ts
+++ b/packages/cli/tests/tar.test.ts
@@ -323,4 +323,23 @@ describe("tarSkillDir filter", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("rechecks ownership at the activation boundary and restores the previous target", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-tar-test-"));
+		try {
+			const skillsRoot = join(root, "skills");
+			const target = join(skillsRoot, "example");
+			mkdirSync(target, { recursive: true });
+			writeFileSync(join(target, "SKILL.md"), "old\n");
+			const archive = await tarSingleFile("example", "new\n");
+			await expect(
+				replaceSkillArchiveTarGz("example", skillsRoot, target, archive, () => {
+					throw new Error("reservation appeared");
+				}),
+			).rejects.toThrow("reservation appeared");
+			expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("old\n");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -902,6 +902,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/agents/{agent_id}/runtime-observed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Agent Runtime Observed
+         * @description Canonical Agent-identity route for runtime desired/observed summaries.
+         */
+        get: operations["get_agent_runtime_observed_v1_agents__agent_id__runtime_observed_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/agents/{agent_id}/sync-heartbeat": {
         parameters: {
             query?: never;
@@ -4802,6 +4822,23 @@ export interface components {
             /** Timezone */
             timezone: string;
         };
+        /** HostedRuntimeMcp */
+        HostedRuntimeMcp: {
+            /** Servers */
+            servers: {
+                [key: string]: components["schemas"]["HostedRuntimeStdioMcpServer"] | components["schemas"]["HostedRuntimeRemoteMcpServer"];
+            };
+        };
+        /** HostedRuntimeMcpSecretHeader */
+        HostedRuntimeMcpSecretHeader: {
+            /** Secretref */
+            secretRef: string;
+            /**
+             * Prefix
+             * @default
+             */
+            prefix: string;
+        };
         /** HostedRuntimeObservedAppliedV2 */
         HostedRuntimeObservedAppliedV2: {
             /** Etag */
@@ -4969,6 +5006,20 @@ export interface components {
             /** Allowofflineboot */
             allowOfflineBoot: boolean;
         };
+        /** HostedRuntimeRemoteMcpServer */
+        HostedRuntimeRemoteMcpServer: {
+            /** Url */
+            url: string;
+            /**
+             * Transport
+             * @enum {string}
+             */
+            transport: "streamable-http" | "sse";
+            /** Headers */
+            headers?: {
+                [key: string]: string | components["schemas"]["HostedRuntimeMcpSecretHeader"];
+            };
+        };
         /** HostedRuntimeRunSettings */
         HostedRuntimeRunSettings: {
             /** Command */
@@ -5001,6 +5052,13 @@ export interface components {
             entries: {
                 [key: string]: components["schemas"]["HostedRuntimeSkillEntry"];
             };
+        };
+        /** HostedRuntimeStdioMcpServer */
+        HostedRuntimeStdioMcpServer: {
+            /** Command */
+            command: string;
+            /** Args */
+            args: string[];
         };
         /** HostedRuntimeSystem */
         HostedRuntimeSystem: {
@@ -5395,10 +5453,7 @@ export interface components {
             live_sync: components["schemas"]["HostedRuntimeLiveSync"];
             recovery: components["schemas"]["HostedRuntimeRecovery"];
             egress_profiles?: components["schemas"]["HostedEgressProfiles"] | null;
-            /** Mcp */
-            mcp?: {
-                [key: string]: unknown;
-            } | null;
+            mcp?: components["schemas"]["HostedRuntimeMcp"] | null;
             skills?: components["schemas"]["HostedRuntimeSkills"] | null;
             tools: components["schemas"]["HostedRuntimeTools"];
         };
@@ -5614,6 +5669,30 @@ export interface components {
             finalCursor: string;
             /** Finalsessionhighwatermarks */
             finalSessionHighWaterMarks: components["schemas"]["RuntimeSessionHighWaterMark"][];
+        };
+        /** RuntimeManagedMcpServerSummary */
+        RuntimeManagedMcpServerSummary: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "mcp_server";
+            /** Id */
+            id: string;
+        };
+        /** RuntimeManagedSkillSummary */
+        RuntimeManagedSkillSummary: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "skill";
+            /** Id */
+            id: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Version */
+            version: number;
         };
         /** RuntimeObservationApplyIdentityResponse */
         RuntimeObservationApplyIdentityResponse: {
@@ -5898,6 +5977,8 @@ export interface components {
              * @default false
              */
             has_tools: boolean;
+            /** Managed Resources */
+            managed_resources?: (components["schemas"]["RuntimeManagedSkillSummary"] | components["schemas"]["RuntimeManagedMcpServerSummary"])[];
             /** Updated At */
             updated_at?: string | null;
         };
@@ -9076,6 +9157,37 @@ export interface operations {
             header?: never;
             path: {
                 environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_agent_runtime_observed_v1_agents__agent_id__runtime_observed_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
             };
             cookie?: never;
         };


### PR DESCRIPTION
## Summary

- expose read-only manifest-managed Skill and MCP summaries on the canonical Agent runtime-observed API and hosted Skills UI
- reserve manifest-managed Skill targets across backend writes, guest adapters, sync, setup, teardown, drift repair, disable, and runtime switches
- preserve cleanup-only deletion for pre-existing Cloud conflicts and force a full Cloud pull after ownership release
- keep MCP desired state strict and reject management metadata at archive boundaries

## Safety

- UI/API expose only resource ids, enabled/version state, convergence generations, and health; no URL, headers, secret refs, or raw manifest
- ownership is exact-target and manager-aware; unmanaged or cross-manager collisions fail closed
- legacy adoption requires marker identity, catalog digest, and live content to match
- no hosted repository, deployment, App Settings, production, or tenant mutation is included

## Verification

- CLI full suite: 1260 passed
- final runtime-focused CLI suite: 154 passed
- backend full suite: 1467 passed, 7 skipped
- final runtime-observed focused backend test: 1 passed
- web typecheck, tests, and OSS production build passed
- workspace typecheck, Biome, Ruff, generated API drift, and git diff checks passed
