### PR TITLE
fix: make dashboard status and metrics truthful

### DIFF
--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -6,6 +6,7 @@ import { Bot, Check, Copy, Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AgentLabel, AgentSourceBadgeForEnvironment } from "@/components/dashboard/agent-label";
+import { agentRegistrationDescription } from "@/components/dashboard/agent-registration-status";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { unwrap, useApi } from "@/lib/api";
@@ -157,7 +158,7 @@ export function AddAgentSetup() {
 						</span>
 					) : null}
 					<span className="text-sm font-medium">
-						{newAgents.length > 0 ? "Agent connected" : "Watch for your agent"}
+						{newAgents.length > 0 ? "Agent registered" : "Watch for your agent"}
 					</span>
 				</div>
 				{newAgents.length > 0 ? (
@@ -185,7 +186,7 @@ export function AddAgentSetup() {
 							</div>
 						))}
 						<p className="text-xs text-success-muted-foreground">
-							Sessions from this machine sync automatically from now on.
+							{agentRegistrationDescription(newAgents)}
 						</p>
 					</div>
 				) : (

--- a/apps/web/src/components/dashboard/agent-registration-status.test.ts
+++ b/apps/web/src/components/dashboard/agent-registration-status.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import type { components } from "@clawdi/shared/api";
+import { agentRegistrationDescription } from "@/components/dashboard/agent-registration-status";
+
+type Env = components["schemas"]["AgentResponse"];
+
+function env(overrides: Partial<Env> = {}): Env {
+	return {
+		id: "11111111-1111-4111-8111-111111111111",
+		name: "workstation",
+		default_name: "workstation",
+		machine_name: "workstation",
+		agent_type: "codex",
+		agent_version: null,
+		os: "linux",
+		last_seen_at: new Date().toISOString(),
+		last_sync_at: null,
+		last_sync_error: null,
+		last_revision_seen: null,
+		sort_order: 0,
+		queue_depth_high_water: 0,
+		dropped_count: 0,
+		sync_enabled: true,
+		default_project_id: "22222222-2222-4222-8222-222222222222",
+		...overrides,
+	} as Env;
+}
+
+describe("agentRegistrationDescription", () => {
+	test("does not promise automatic session sync from registration alone", () => {
+		expect(agentRegistrationDescription([env()])).toBe(
+			"Registration is complete. Waiting for the first successful sync.",
+		);
+	});
+
+	test("confirms automatic flow only after a fresh successful sync", () => {
+		expect(agentRegistrationDescription([env({ last_sync_at: new Date().toISOString() })])).toBe(
+			"Live sync confirmed. New sessions can now appear here automatically.",
+		);
+	});
+});

--- a/apps/web/src/components/dashboard/agent-registration-status.ts
+++ b/apps/web/src/components/dashboard/agent-registration-status.ts
@@ -1,0 +1,12 @@
+import type { components } from "@clawdi/shared/api";
+import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
+
+type Env = components["schemas"]["AgentResponse"];
+
+export function agentRegistrationDescription(environments: readonly Env[]): string {
+	const hasFreshSyncEvidence =
+		environments.length > 0 && environments.every((env) => daemonStatusVisual(env).kind === "live");
+	return hasFreshSyncEvidence
+		? "Live sync confirmed. New sessions can now appear here automatically."
+		: "Registration is complete. Waiting for the first successful sync.";
+}

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -89,9 +89,7 @@ describe("agentTileCardProjection", () => {
 			source: "on-clawdi",
 			name: "Research agent",
 			agentType: "openclaw",
-			lastSeenAt: projected.last_seen_at,
 			href: `/agents/${projected.id}`,
-			active: true,
 			env: projected,
 		};
 
@@ -103,7 +101,7 @@ describe("agentTileCardProjection", () => {
 			tooltip: "Sync is live.",
 		});
 		expect(projection.meta[0]).toBe("OpenClaw");
-		expect(projection.meta).toHaveLength(2);
+		expect(projection.meta[1]).toStartWith("Synced ");
 	});
 
 	it("does not manufacture hosted sync status without an environment projection", () => {
@@ -112,9 +110,7 @@ describe("agentTileCardProjection", () => {
 			source: "on-clawdi",
 			name: "Research agent",
 			agentType: "openclaw",
-			lastSeenAt: null,
 			href: "/agents/env_pending",
-			active: true,
 			env: null,
 		};
 
@@ -131,7 +127,6 @@ describe("agentTileCardProjection", () => {
 			name: "Workstation",
 			agentType: "codex",
 			href: "/agents/self",
-			active: false,
 			env: env(),
 		};
 		const legacy: AgentTile = {
@@ -141,8 +136,16 @@ describe("agentTileCardProjection", () => {
 			env: env({ last_sync_at: new Date().toISOString(), sync_enabled: true }),
 		};
 
-		expect(agentTileCardProjection(selfManaged).statusVisual?.kind).toBe("set-up");
-		expect(agentTileCardProjection(legacy).statusVisual?.kind).toBe("live");
+		expect(agentTileCardProjection(selfManaged).statusVisual?.label).toBe("Setup");
+		expect(agentTileCardProjection(legacy).statusVisual?.label).toBe("Live");
+	});
+
+	it("labels last-seen fallback explicitly when no sync timestamp exists", () => {
+		const [tile] = selfManagedAgentTiles([
+			env({ last_seen_at: new Date().toISOString(), last_sync_at: null }),
+		]);
+
+		expect(agentTileCardProjection(tile).meta[1]).toStartWith("Seen ");
 	});
 });
 
@@ -171,7 +174,6 @@ describe("agentTileMatchesRouteId", () => {
 			name: "Hosted agent",
 			agentType: "openclaw",
 			href: `/agents/${projected.id}?source=on-clawdi&d=hdep_paid`,
-			active: true,
 			env: projected,
 		};
 
@@ -189,14 +191,12 @@ describe("agentTileMatchesRouteId", () => {
 			name: "Selected deployment",
 			agentType: "openclaw",
 			href: `/agents/${projected.id}?source=on-clawdi&d=hdep_selected`,
-			active: false,
 			env: null,
 		};
 		const replacement: AgentTile = {
 			...selected,
 			id: "hdep_replacement",
 			name: "Replacement deployment",
-			active: true,
 			env: projected,
 		};
 
@@ -207,12 +207,10 @@ describe("agentTileMatchesRouteId", () => {
 });
 
 describe("fleetSummaryFromTiles", () => {
-	it("counts active tiles instead of requiring a fresh cloud-api last-seen timestamp", () => {
-		const freshSeenAt = new Date().toISOString();
-		const newestSeenAt = new Date(Date.now() + 1000).toISOString();
+	it("summarizes inventory without inventing an activity clock", () => {
 		const selfManaged = selfManagedAgentTiles([
 			env({
-				last_seen_at: freshSeenAt,
+				last_seen_at: new Date().toISOString(),
 			}),
 		]);
 		const hostedRunningWithoutEnv: AgentTile = {
@@ -220,9 +218,7 @@ describe("fleetSummaryFromTiles", () => {
 			source: "on-clawdi",
 			name: "Codex",
 			agentType: "codex",
-			lastSeenAt: null,
 			href: "/agents/dep_123",
-			active: true,
 			env: null,
 		};
 		const hostedStoppedWithFreshEnv: AgentTile = {
@@ -230,18 +226,12 @@ describe("fleetSummaryFromTiles", () => {
 			source: "on-clawdi",
 			name: "Stopped Codex",
 			agentType: "codex",
-			lastSeenAt: newestSeenAt,
 			href: "/agents/dep_456",
-			active: true,
-			env: null,
+			env: env({ last_seen_at: new Date().toISOString() }),
 		};
 
 		expect(
 			fleetSummaryFromTiles([...selfManaged, hostedRunningWithoutEnv, hostedStoppedWithFreshEnv]),
-		).toEqual({
-			activeCount: 3,
-			total: 3,
-			lastActive: newestSeenAt,
-		});
+		).toEqual({ total: 3 });
 	});
 });

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -28,14 +28,6 @@ import { cn, relativeTime } from "@/lib/utils";
 
 type Env = components["schemas"]["AgentResponse"];
 
-// Freshness threshold — "active" means the agent pinged us in the last 5 minutes.
-const ACTIVE_WINDOW_MS = 5 * 60 * 1000;
-
-export function isAgentActive(lastSeenAt: string | null | undefined): boolean {
-	if (!lastSeenAt) return false;
-	return Date.now() - new Date(lastSeenAt).getTime() < ACTIVE_WINDOW_MS;
-}
-
 /**
  * Build self-managed AgentTiles from cloud-api environments. Shared by the
  * Overview grid and the `/agents` index so the tile shape stays identical
@@ -49,11 +41,17 @@ export function selfManagedAgentTiles(environments: Env[] | undefined): AgentTil
 		avatarUrl: env.avatar_url,
 		sortOrder: env.sort_order,
 		agentType: env.agent_type,
-		lastSeenAt: env.last_seen_at,
 		href: agentSectionHref(env.id),
-		active: isAgentActive(env.last_seen_at),
 		env,
 	}));
+}
+
+export type AgentCardStatusVisual = Pick<DaemonStatusVisual, "label" | "tooltip" | "dotClass">;
+
+export interface AgentCardStatusProjection {
+	visual: AgentCardStatusVisual;
+	/** Explicit status labels rendered in the compact card metadata. */
+	labels: string[];
 }
 
 /**
@@ -69,8 +67,6 @@ export interface AgentTile {
 	avatarUrl?: string | null;
 	sortOrder?: number | null;
 	agentType: string | null;
-	/** Used to compute the "N active now" count in the card description. */
-	lastSeenAt?: string | null;
 	/** Primary click target. Points at the in-app env detail page
 	 * (`/agents/{env_id}`). Hosted tiles derive this identity from deployment
 	 * config even while the cloud-api projection is absent. A hosted deployment
@@ -81,8 +77,9 @@ export interface AgentTile {
 	action?: ReactNode;
 	/** Optional remediation target for legacy status dialogs. */
 	manageHref?: string;
-	/** Counted in the "N active now" header line. */
-	active: boolean;
+	/** Hosted integrations can project compute-first status without making the
+	 * generic card import hosted lifecycle types. */
+	cardStatus?: AgentCardStatusProjection;
 	/** Self-managed envs carry the full EnvironmentResponse so the
 	 * tile can render a sync indicator. Hosted tiles join their
 	 * cloud-api env via `clawdi_cloud_environments` and end up with
@@ -105,21 +102,11 @@ export function agentTileMatchesRouteId(
 }
 
 export interface AgentFleetSummary {
-	activeCount: number;
 	total: number;
-	lastActive: string | null;
 }
 
 export function fleetSummaryFromTiles(agents: readonly AgentTile[]): AgentFleetSummary {
-	return {
-		activeCount: agents.filter((agent) => agent.active).length,
-		total: agents.length,
-		lastActive:
-			agents
-				.map((agent) => agent.lastSeenAt)
-				.filter((value): value is string => Boolean(value))
-				.sort((a, b) => b.localeCompare(a))[0] ?? null,
-	};
+	return { total: agents.length };
 }
 
 export function AgentsCard({
@@ -152,7 +139,7 @@ export function AgentsCard({
 	const hiddenCount = ordered.length - visible.length;
 
 	// No section header: the greeting directly above already carries the
-	// fleet summary ("N agents connected · last active …"), and a bare
+	// fleet summary ("N agents"), and a bare
 	// text header here pushed the tile wall below the right rail's card
 	// top — the two columns read as misaligned (Marvin's screenshot).
 	// Tiles start flush with the column, level with the cards on the right.
@@ -314,7 +301,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	);
 }
 
-function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
+function AgentStatusDot({ visual }: { visual: AgentCardStatusVisual }) {
 	return (
 		<span
 			title={`Status: ${visual.label}. ${visual.tooltip}`}
@@ -335,25 +322,29 @@ function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
  */
 export function agentTileCardProjection(tile: AgentTile): {
 	meta: string[];
-	statusVisual: DaemonStatusVisual | null;
+	statusVisual: AgentCardStatusVisual | null;
 } {
 	const identity = agentIdentity({
 		name: tile.name,
 		machine_name: tile.name,
 		agent_type: tile.agentType,
 	});
-	const meta = [identity.secondaryLabel, agentTileActivityLabel(tile)].filter(
-		(value): value is string => Boolean(value),
-	);
-	const statusVisual =
-		tile.source === "on-clawdi" && !tile.env
+	const meta = [
+		identity.secondaryLabel,
+		...(tile.cardStatus?.labels ?? []),
+		agentTileActivityLabel(tile),
+	].filter((value): value is string => Boolean(value));
+	const statusVisual = tile.cardStatus
+		? tile.cardStatus.visual
+		: tile.source === "on-clawdi" && !tile.env
 			? null
 			: daemonStatusVisual(tile.env, tile.source === "self-managed" ? "self-managed" : "on-clawdi");
 	return { meta, statusVisual };
 }
 
 function agentTileActivityLabel(tile: AgentTile): string | null {
-	if (tile.lastSeenAt) return relativeTime(tile.lastSeenAt);
+	if (tile.env?.last_sync_at) return `Synced ${relativeTime(tile.env.last_sync_at)}`;
+	if (tile.env?.last_seen_at) return `Seen ${relativeTime(tile.env.last_seen_at)}`;
 	return null;
 }
 

--- a/apps/web/src/components/dashboard/contribution-graph.test.ts
+++ b/apps/web/src/components/dashboard/contribution-graph.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+	buildWeeks,
+	computeMonthLabels,
+	parseCalendarDate,
+} from "@/components/dashboard/contribution-graph";
+
+const originalTimezone = process.env.TZ;
+
+beforeAll(() => {
+	process.env.TZ = "America/Los_Angeles";
+});
+
+afterAll(() => {
+	if (originalTimezone === undefined) {
+		delete process.env.TZ;
+	} else {
+		process.env.TZ = originalTimezone;
+	}
+});
+
+describe("contribution calendar dates", () => {
+	test("keeps a date-only value on its calendar day in a negative-offset timezone", () => {
+		const date = parseCalendarDate("2026-07-01");
+
+		expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe("America/Los_Angeles");
+		expect(date?.getFullYear()).toBe(2026);
+		expect(date?.getMonth()).toBe(6);
+		expect(date?.getDate()).toBe(1);
+		expect(date?.getDay()).toBe(3);
+	});
+
+	test("aligns weeks and month labels from local calendar parts", () => {
+		const weeks = buildWeeks([
+			{ date: "2026-07-01", count: 1, level: 1 },
+			{ date: "2026-07-02", count: 2, level: 2 },
+		]);
+
+		expect(weeks[0]?.findIndex((day) => day.date === "2026-07-01")).toBe(3);
+		expect(computeMonthLabels(weeks)).toEqual(["Jul"]);
+	});
+});

--- a/apps/web/src/components/dashboard/contribution-graph.tsx
+++ b/apps/web/src/components/dashboard/contribution-graph.tsx
@@ -29,11 +29,24 @@ function clampLevel(level: number): number {
 
 /** Chunk chronological days into weeks (columns), padding the first week so
  * day[0] of the first column lines up with Sunday. */
-function buildWeeks(data: ContributionDay[]): ContributionDay[][] {
+export function parseCalendarDate(value: string): Date | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const monthIndex = Number(match[2]) - 1;
+	const day = Number(match[3]);
+	const date = new Date(year, monthIndex, day);
+	if (date.getFullYear() !== year || date.getMonth() !== monthIndex || date.getDate() !== day) {
+		return null;
+	}
+	return date;
+}
+
+export function buildWeeks(data: ContributionDay[]): ContributionDay[][] {
 	if (!data.length) return [];
 	const weeks: ContributionDay[][] = [];
 	let current: ContributionDay[] = [];
-	const startPad = new Date(data[0].date).getDay();
+	const startPad = parseCalendarDate(data[0].date)?.getDay() ?? 0;
 	for (let i = 0; i < startPad; i++) {
 		current.push({ date: "", count: 0, level: 0 });
 	}
@@ -51,15 +64,17 @@ function buildWeeks(data: ContributionDay[]): ContributionDay[][] {
 /** For each week column, return the month short-name if that week is the
  * first one to contain a day from a new month (so we draw one label per
  * month, like GitHub). Returns null for columns that shouldn't label. */
-function computeMonthLabels(weeks: ContributionDay[][]): (string | null)[] {
+export function computeMonthLabels(weeks: ContributionDay[][]): (string | null)[] {
 	let prevMonth = -1;
 	return weeks.map((week) => {
 		const firstReal = week.find((d) => d.date);
 		if (!firstReal) return null;
-		const month = new Date(firstReal.date).getMonth();
+		const date = parseCalendarDate(firstReal.date);
+		if (!date) return null;
+		const month = date.getMonth();
 		if (month === prevMonth) return null;
 		prevMonth = month;
-		return new Date(firstReal.date).toLocaleString("en-US", { month: "short" });
+		return date.toLocaleString("en-US", { month: "short" });
 	});
 }
 

--- a/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
+++ b/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { agentGreetingSummary } from "@/components/dashboard/greeting";
+import { ThisWeekCard } from "@/components/dashboard/this-week-card";
+import type { DashboardStats } from "@/lib/api-schemas";
+import { getProjectResourceDefinition, projectResourceCount } from "@/lib/project-resource-model";
+
+function stats(overrides: Partial<DashboardStats> = {}): DashboardStats {
+	return {
+		total_sessions: 40,
+		total_messages: 100,
+		total_tokens: 1_000,
+		active_days: 8,
+		current_streak: 2,
+		longest_streak: 5,
+		peak_hour: 10,
+		favorite_model: "all-time-model",
+		skills_count: 4,
+		memories_count: 6,
+		vault_count: 2,
+		vault_keys_count: 99,
+		connectors_count: 3,
+		manual_sessions_last_7_days: 7,
+		automated_sessions_last_7_days: 11,
+		top_model_last_7_days: "weekly-model",
+		sessions_today: 5,
+		contribution: [],
+		...overrides,
+	};
+}
+
+describe("dashboard data contracts", () => {
+	test("uses the visible Vault inventory count rather than its number of keys", () => {
+		expect(projectResourceCount(getProjectResourceDefinition("vaults"), stats(), 1)).toBe(2);
+	});
+
+	test("renders direct seven-day fields without deriving them from contribution data", () => {
+		const markup = renderToStaticMarkup(createElement(ThisWeekCard, { stats: stats() }));
+
+		expect(markup).toContain("Last 7 days");
+		expect(markup).toContain("weekly-model");
+		expect(markup).not.toContain("all-time-model");
+		expect(markup).toContain("+ 11 automated");
+		expect(markup).toContain(">7<");
+		expect(markup).toContain(">5<");
+	});
+
+	test("does not show first-agent empty copy while membership is unresolved", () => {
+		expect(agentGreetingSummary(0, "loading")).toBe("Loading agent status…");
+		expect(agentGreetingSummary(0, "resolved")).toBe("Connect your first agent to start syncing.");
+		expect(agentGreetingSummary(0, "error")).toBe("Agent status is unavailable right now.");
+	});
+});

--- a/apps/web/src/components/dashboard/greeting.ts
+++ b/apps/web/src/components/dashboard/greeting.ts
@@ -1,0 +1,9 @@
+export type AgentGreetingState = "loading" | "resolved" | "error";
+
+export function agentGreetingSummary(total: number, state: AgentGreetingState): string {
+	if (state === "loading") return "Loading agent status…";
+	if (state === "error") return "Agent status is unavailable right now.";
+	return total === 0
+		? "Connect your first agent to start syncing."
+		: `${total} agent${total === 1 ? "" : "s"}`;
+}

--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -4,13 +4,12 @@ import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DashboardStats } from "@/lib/api-schemas";
 import {
 	getProjectResourceDefinition,
-	PROJECT_CANONICAL_DEFINITION,
 	PROJECT_RESOURCE_GROUPS,
 	PROJECT_RESOURCE_NAV_IDS,
 	type ProjectResourceDefinition,
@@ -34,7 +33,6 @@ export type ProjectTypeCounts = {
 	agent: number;
 };
 
-const FIRST_PATH_STEPS = ["Create Project", "Add Skills or Vaults"];
 const RESOURCE_ROUTES = {
 	projects: "/projects",
 	skills: "/skills",
@@ -71,7 +69,6 @@ export function ResourcesCard({
 	projectCountLoading = false,
 	projectCountError,
 	onRetryProjectCount,
-	hasConnectedAgent,
 }: {
 	stats: DashboardStats | undefined;
 	statsError?: unknown;
@@ -81,28 +78,16 @@ export function ResourcesCard({
 	projectCountLoading?: boolean;
 	projectCountError?: unknown;
 	onRetryProjectCount?: () => void;
-	hasConnectedAgent?: boolean;
 }) {
 	const projectCountUnavailable = Boolean(projectCountError && projectCount === undefined);
 	const ready =
 		stats &&
 		!statsError &&
 		(!projectCountLoading || projectCount !== undefined || projectCountUnavailable);
-	const waitingForAgent = hasConnectedAgent === false;
-	const finalStep = waitingForAgent ? "Ready to Add to agent" : "Add to agent";
-	// The "First path" walkthrough is onboarding — once the user has
-	// created a custom Project they've walked the path, and the banner
-	// is just permanent noise above their real counts. Hide it then.
-	const established = (projectTypeCounts?.custom ?? 0) > 0;
-	const showFirstPath = !projectCountUnavailable && !established;
 	return (
 		<Card className="gap-0 pb-0">
 			<CardHeader className="border-b">
 				<CardTitle>Resources</CardTitle>
-				<CardDescription>
-					{PROJECT_CANONICAL_DEFINITION} Agents run on your machines. Account resources (Sessions,
-					Memories, Connectors) apply across all Projects.
-				</CardDescription>
 			</CardHeader>
 			<CardContent className="p-0">
 				{statsError ? (
@@ -124,32 +109,6 @@ export function ResourcesCard({
 								/>
 							</div>
 						) : null}
-						{showFirstPath ? (
-							<div className="grid gap-3 border-b bg-muted/15 px-6 py-4 text-xs">
-								<div className="flex flex-wrap items-center gap-2">
-									<span className="font-medium text-foreground">
-										{waitingForAgent ? "After connecting an agent" : "First path"}
-									</span>
-									{[...FIRST_PATH_STEPS, finalStep].map((step, index) => (
-										<span
-											key={step}
-											className={cn(
-												"inline-flex items-center gap-1 rounded-sm border bg-background px-2 py-1 text-muted-foreground",
-												waitingForAgent && index === 2 && "border-dashed opacity-60",
-											)}
-										>
-											<span className="font-medium tabular-nums text-foreground">{index + 1}.</span>
-											{step}
-										</span>
-									))}
-								</div>
-								<p className="text-muted-foreground">
-									Create Projects to share with teammates. Use the Global Project for defaults.
-									Agent Projects stay private to one agent. Skills and Vaults live in Projects;
-									Sessions, Memories, and Connectors apply account-wide.
-								</p>
-							</div>
-						) : null}
 						<div className="divide-y">
 							{ready ? (
 								<ProjectResourceGroups
@@ -162,7 +121,9 @@ export function ResourcesCard({
 							) : (
 								PROJECT_RESOURCE_GROUPS.map((group) => (
 									<div key={group.id}>
-										<ResourceGroupLabel label={group.label} />
+										{group.resourceIds.length > 1 ? (
+											<ResourceGroupLabel label={group.label} />
+										) : null}
 										{group.resourceIds.map((id) => (
 											<ResourceRowSkeleton key={id} />
 										))}
@@ -189,7 +150,7 @@ function ProjectResourceGroups({
 		<>
 			{PROJECT_RESOURCE_GROUPS.map((group) => (
 				<div key={group.id}>
-					<ResourceGroupLabel label={group.label} />
+					{group.resourceIds.length > 1 ? <ResourceGroupLabel label={group.label} /> : null}
 					{projectResourceDefinitionsForGroup(group.id).map((definition) => {
 						const resource = byId.get(definition.id);
 						return resource ? (

--- a/apps/web/src/components/dashboard/this-week-card.tsx
+++ b/apps/web/src/components/dashboard/this-week-card.tsx
@@ -3,38 +3,30 @@
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { ContributionDay, DashboardStats } from "@/lib/api-schemas";
+import type { DashboardStats } from "@/lib/api-schemas";
 import { formatModelLabel } from "@/lib/format";
 import { formatNumber } from "@/lib/utils";
 
-function sessionsInLastDays(contribution: ContributionDay[] | undefined, days: number): number {
-	if (!contribution) return 0;
-	return contribution.slice(-days).reduce((sum, d) => sum + d.count, 0);
-}
-
 export function ThisWeekCard({
 	stats,
-	contribution,
 	error,
 	onRetry,
 }: {
 	stats: DashboardStats | undefined;
-	contribution: ContributionDay[] | undefined;
 	error?: unknown;
 	onRetry?: () => void;
 }) {
 	const ready = !!stats;
-	const weekSessions = sessionsInLastDays(contribution, 7);
-	const todaySessions = sessionsInLastDays(contribution, 1);
-	const topModel = formatModelLabel(stats?.favorite_model) || null;
+	const todaySessions = stats?.sessions_today;
+	const topModel = formatModelLabel(stats?.top_model_last_7_days) || null;
 	const manualWeek = stats?.manual_sessions_last_7_days;
-	const automatedWeek = manualWeek === undefined ? null : Math.max(0, weekSessions - manualWeek);
+	const automatedWeek = stats?.automated_sessions_last_7_days;
 
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>This week</CardTitle>
-				<CardDescription>Last 7 days of agent activity.</CardDescription>
+				<CardTitle>Last 7 days</CardTitle>
+				<CardDescription>Agent activity, measured in UTC.</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-5">
 				{error ? (
@@ -48,9 +40,9 @@ export function ThisWeekCard({
 							{ready && manualWeek !== undefined ? (
 								<>
 									<div className="text-3xl font-semibold tabular-nums leading-none">
-										{formatNumber(Math.min(manualWeek, weekSessions))}
+										{formatNumber(manualWeek)}
 									</div>
-									{automatedWeek !== null && automatedWeek > 0 ? (
+									{automatedWeek !== undefined && automatedWeek > 0 ? (
 										<div className="mt-1 text-xs text-muted-foreground tabular-nums">
 											+ {formatNumber(automatedWeek)} automated (cron, heartbeat)
 										</div>
@@ -63,7 +55,10 @@ export function ThisWeekCard({
 
 						{/* Secondary stats — smaller, grouped. */}
 						<dl className="grid grid-cols-3 gap-3 text-sm">
-							<SecondaryStat label="Today" value={ready ? formatNumber(todaySessions) : null} />
+							<SecondaryStat
+								label="Today"
+								value={ready && todaySessions !== undefined ? formatNumber(todaySessions) : null}
+							/>
 							<SecondaryStat label="Streak" value={ready ? `${stats.current_streak}d` : null} />
 							<SecondaryStat label="Top model" value={ready ? (topModel ?? "—") : null} small />
 						</dl>

--- a/apps/web/src/components/ui/status-badge.tsx
+++ b/apps/web/src/components/ui/status-badge.tsx
@@ -96,4 +96,10 @@ function StatusDot({
 }
 
 export type { StatusTone };
-export { StatusBadge, StatusDot, statusBadgeVariants, statusTextVariants };
+export {
+	dotVariants as statusDotVariants,
+	StatusBadge,
+	StatusDot,
+	statusBadgeVariants,
+	statusTextVariants,
+};

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -24,10 +24,6 @@ const modelBindingPickerSource = readFileSync(
 	new URL("../../v2/ai-providers/model-binding-picker.tsx", import.meta.url),
 	"utf8",
 );
-const welcomeWalletSource = readFileSync(
-	new URL("../subscription/welcome-wallet-card.tsx", import.meta.url),
-	"utf8",
-);
 const runtimesSource = readFileSync(new URL("../../runtimes.ts", import.meta.url), "utf8");
 const addProviderDialogSource = readFileSync(
 	new URL("../../v2/ai-providers/add-provider-dialog.tsx", import.meta.url),
@@ -213,13 +209,9 @@ describe("deploy provider choice", () => {
 	});
 
 	test("explains that the welcome balance is used before added Wallet funds", () => {
-		expect(welcomeWalletSource).toContain(
-			"welcome balance covers Managed AI first; after that, usage draws from your Wallet.",
-		);
 		expect(wizardSource).toContain(
 			"Your welcome balance covers usage first; after that, it draws from your Wallet.",
 		);
-		expect(welcomeWalletSource).not.toContain("managed AI is on us to start");
 		expect(wizardSource).not.toContain("Managed-AI usage paid directly from your Wallet");
 	});
 

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { welcomeWalletDescription } from "@/hosted/billing/subscription/welcome-wallet-card.logic";
+
+describe("welcomeWalletDescription", () => {
+	test("explains the funding order when deployment is available", () => {
+		expect(
+			welcomeWalletDescription({
+				grantApplied: true,
+				grantPending: false,
+				grantCheckTimedOut: false,
+				grantAmount: "$5.00",
+				showDeployAction: true,
+			}),
+		).toContain(
+			"welcome balance covers Managed AI first; after that, usage draws from your Wallet.",
+		);
+	});
+
+	test("does not advertise deployment when the account has no deploy action", () => {
+		const unavailable = welcomeWalletDescription({
+			grantApplied: false,
+			grantPending: false,
+			grantCheckTimedOut: false,
+			grantAmount: "$5.00",
+			showDeployAction: false,
+		});
+		const pending = welcomeWalletDescription({
+			grantApplied: false,
+			grantPending: true,
+			grantCheckTimedOut: false,
+			grantAmount: "$5.00",
+			showDeployAction: false,
+		});
+
+		expect(unavailable).toBe("Your Wallet is ready.");
+		expect(pending).toBe("Your $5.00 welcome balance is on the way.");
+		expect(`${unavailable} ${pending}`).not.toContain("deploy");
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
@@ -1,0 +1,36 @@
+export function welcomeWalletDescription({
+	grantApplied,
+	grantPending,
+	grantCheckTimedOut,
+	grantAmount,
+	showDeployAction,
+}: {
+	grantApplied: boolean;
+	grantPending: boolean;
+	grantCheckTimedOut: boolean;
+	grantAmount: string | null;
+	showDeployAction: boolean;
+}): string {
+	if (grantApplied) {
+		if (!showDeployAction) {
+			return grantAmount
+				? `Your ${grantAmount} welcome balance is available in your Wallet.`
+				: "Your welcome balance is available in your Wallet.";
+		}
+		return grantAmount
+			? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Managed AI first; after that, usage draws from your Wallet.`
+			: "Your free Basic compute is ready. Managed AI usage draws from your Wallet.";
+	}
+	if (grantPending) {
+		if (grantCheckTimedOut) return "It hasn’t appeared yet. Refresh to check again.";
+		const balance = grantAmount
+			? `Your ${grantAmount} welcome balance is on the way.`
+			: "Your welcome balance is on the way.";
+		return showDeployAction
+			? `${balance} You can deploy now; it’ll be ready in a moment.`
+			: balance;
+	}
+	return showDeployAction
+		? "Your free Basic compute slot is ready. Deploy your first agent to get going."
+		: "Your Wallet is ready.";
+}

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -12,6 +12,7 @@ import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useHostedDeployments, usePlans, useWalletLedger } from "@/hosted/billing/hooks";
 import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
+import { welcomeWalletDescription } from "@/hosted/billing/subscription/welcome-wallet-card.logic";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 
 const WELCOME_GRANT_RECHECK_INTERVAL_MS = 5_000;
@@ -138,6 +139,13 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 		: configuredSignupGrantUsd
 			? formatUsdExact(configuredSignupGrantUsd)
 			: null;
+	const description = welcomeWalletDescription({
+		grantApplied,
+		grantPending,
+		grantCheckTimedOut,
+		grantAmount,
+		showDeployAction,
+	});
 
 	return (
 		<Card data-hosted="true" className="border-primary/30 bg-primary/5">
@@ -156,17 +164,7 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 										: "Adding your welcome balance…"
 									: "Welcome to Clawdi"}
 						</p>
-						<p className="text-sm text-muted-foreground">
-							{grantApplied
-								? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Managed AI first; after that, usage draws from your Wallet.`
-								: grantPending
-									? grantCheckTimedOut
-										? "It hasn’t appeared yet. Refresh to check again."
-										: grantAmount
-											? `Your ${grantAmount} welcome balance is on the way. You can deploy now; it’ll be ready in a moment.`
-											: "Your welcome balance is on the way. You can deploy now; it’ll be ready in a moment."
-									: "Your free Basic compute slot is ready. Deploy your first agent to get going."}
-						</p>
+						<p className="text-sm text-muted-foreground">{description}</p>
 					</div>
 				</div>
 				{grantPending || showDeployAction ? (

--- a/apps/web/src/hosted/legacy-agent-tiles.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.ts
@@ -1,6 +1,6 @@
 import type { components } from "@clawdi/shared/api";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
-import { type AgentTile, isAgentActive } from "@/components/dashboard/agents-card";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
@@ -42,10 +42,8 @@ export function legacyConnectedAgentTiles(
 			avatarUrl: env.avatar_url,
 			sortOrder: env.sort_order,
 			agentType: env.agent_type,
-			lastSeenAt: env.last_seen_at,
 			href: agentSectionHref(env.id),
 			manageHref,
-			active: isAgentActive(env.last_seen_at),
 			env,
 		}));
 }

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -53,11 +53,13 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 	);
 }
 
-function expectHostedTileHasNoStatus(tile: ReturnType<DeploymentToTiles>[number] | undefined) {
+function expectHostedTileStatus(
+	tile: ReturnType<DeploymentToTiles>[number] | undefined,
+	label: string,
+) {
 	expect(tile).toBeDefined();
-	for (const field of ["statusLabel", "statusDot", "secondaryStatus", "contextLabel"] as const) {
-		expect(field in (tile ?? {})).toBe(false);
-	}
+	expect(tile?.cardStatus?.visual.label).toBe(label);
+	expect(tile?.cardStatus?.labels[0]).toBe(label);
 }
 
 function resolveAgentDeployment(
@@ -173,7 +175,7 @@ describe("deploymentToTiles", () => {
 		expect(tiles.map((tile) => tile.name)).toEqual(["hosted-test"]);
 		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi&d=dep_123`);
 		expect(tiles[0]?.env).toBe(openclawEnv);
-		expectHostedTileHasNoStatus(tiles[0]);
+		expectHostedTileStatus(tiles[0], "Running");
 	});
 
 	test("keeps dunning state off the hosted tile", () => {
@@ -198,7 +200,7 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Running");
 	});
 
 	test("keeps backend failure detail off the hosted tile", () => {
@@ -224,7 +226,7 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Failed");
 	});
 
 	test("links by deployment env identity when the cloud-api projection is missing", () => {
@@ -241,7 +243,7 @@ describe("deploymentToTiles", () => {
 			env: null,
 		});
 		expect(tile?.env).toBeNull();
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Failed");
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
@@ -258,7 +260,7 @@ describe("deploymentToTiles", () => {
 			}),
 		);
 
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Failed");
 		expect(
 			isValidElement<{ remediationHref?: string }>(tile?.action) &&
 				tile.action.props.remediationHref,
@@ -279,8 +281,28 @@ describe("deploymentToTiles", () => {
 			name: "OpenClaw",
 			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 		});
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Stopped");
 		expect(tile?.action).toBeDefined();
+	});
+
+	test("keeps non-running compute primary when the joined environment has fresh sync", () => {
+		for (const [status, label] of [
+			["stopped", "Stopped"],
+			["failed", "Failed"],
+			[null, "Status unavailable"],
+		] as const) {
+			const environmentId = `env-${status ?? "unknown"}-with-fresh-sync`;
+			const joinedEnv = env({
+				id: environmentId,
+				last_seen_at: new Date().toISOString(),
+				last_sync_at: new Date().toISOString(),
+			});
+			const [tile] = hostedDeploymentToTiles(deployment({ status, environmentId }), [joinedEnv]);
+
+			expectHostedTileStatus(tile, label);
+			expect(tile?.cardStatus?.labels).not.toContain("Live");
+			expect(tile?.cardStatus?.visual.dotClass).not.toContain("bg-success");
+		}
 	});
 
 	test("removes deleted deployments from tiles and detail membership", () => {
@@ -313,7 +335,7 @@ describe("deploymentToTiles", () => {
 			href: null,
 			env: null,
 		});
-		expectHostedTileHasNoStatus(tile);
+		expectHostedTileStatus(tile, "Failed");
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -2,9 +2,9 @@
 
 import type { components } from "@clawdi/shared/api";
 import { createElement, useMemo } from "react";
-import type { AgentTile } from "@/components/dashboard/agents-card";
+import type { AgentCardStatusProjection, AgentTile } from "@/components/dashboard/agents-card";
 import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
-import { statusTextVariants } from "@/components/ui/status-badge";
+import { statusDotVariants, statusTextVariants } from "@/components/ui/status-badge";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import type { HostedDeployment, HostedDeploymentStatus } from "@/hosted/billing/contracts";
 import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-management";
@@ -215,6 +215,18 @@ export function deploymentToTiles(
 	const providerSettingsHref = envId ? agentSectionHref(envId, "ai", routeQuery) : undefined;
 	const deploymentStatus = deploymentStatusFromResource(d.resource.status);
 	const failure = deploymentFailurePresentation(d);
+	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv ?? null, failure);
+	const cardStatus: AgentCardStatusProjection = {
+		visual: {
+			label: runtimeStatus.primary.label,
+			tooltip: `Compute status: ${runtimeStatus.primary.label}.`,
+			dotClass: statusDotVariants({ status: runtimeStatus.primary.tone }),
+		},
+		labels: [
+			runtimeStatus.primary.label,
+			...(runtimeStatus.secondary ? [runtimeStatus.secondary.label] : []),
+		],
+	};
 	const showTileActions =
 		Boolean(failure) ||
 		deploymentStatus.kind === "stopped" ||
@@ -229,7 +241,6 @@ export function deploymentToTiles(
 			avatarUrl: matchedEnv?.avatar_url ?? null,
 			sortOrder: matchedEnv?.sort_order ?? null,
 			agentType: runtime,
-			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			href: detailHref,
 			external: false,
 			action: showTileActions
@@ -245,7 +256,7 @@ export function deploymentToTiles(
 						onRetry: statusRetry?.onRetry,
 					})
 				: undefined,
-			active: isRunningStatus(deploymentStatus),
+			cardStatus,
 			env: matchedEnv ?? null,
 		},
 	];

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -56,7 +56,6 @@ describe("selectUnifiedAgentList", () => {
 			name: "OpenClaw",
 			agentType: "openclaw",
 			href: null,
-			active: false,
 			env: null,
 		};
 
@@ -86,7 +85,6 @@ describe("selectUnifiedAgentList", () => {
 			name: "OpenClaw",
 			agentType: "openclaw",
 			href: null,
-			active: false,
 			env: null,
 		};
 
@@ -132,7 +130,6 @@ describe("selectUnifiedAgentList", () => {
 			name: "OpenClaw",
 			agentType: "openclaw",
 			href: `/agents/${claimed.id}?source=on-clawdi&d=dep_running`,
-			active: true,
 			env: claimed,
 		};
 		const selection = selectUnifiedAgentList({

--- a/apps/web/src/lib/project-resource-model.ts
+++ b/apps/web/src/lib/project-resource-model.ts
@@ -82,8 +82,8 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		projectScope: "project-managed",
 		pathSegments: ["Projects", "Selected Project", "Vaults"],
 		projectQueryParam: "project",
-		statsKey: "vault_keys_count",
-		countLabel: "keys",
+		statsKey: "vault_count",
+		countLabel: "vaults",
 	},
 	{
 		id: "sessions",

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
 import { ContributionGraph } from "@/components/dashboard/contribution-graph";
+import { type AgentGreetingState, agentGreetingSummary } from "@/components/dashboard/greeting";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { type ProjectTypeCounts, ResourcesCard } from "@/components/dashboard/resources-card";
 import { ThisWeekCard } from "@/components/dashboard/this-week-card";
@@ -140,11 +141,6 @@ export default function DashboardPage() {
 	const sessions = sessionsPage?.items.slice(0, RECENT_SESSIONS_LIMIT);
 	const contribution = stats?.contribution;
 
-	const streakLine =
-		stats && stats.current_streak > 0
-			? `Current streak: ${stats.current_streak} day${stats.current_streak === 1 ? "" : "s"}`
-			: null;
-
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
 	const selfManagedFleetSummary = useMemo(
 		() => fleetSummaryFromTiles(selfManagedTiles),
@@ -170,16 +166,21 @@ export default function DashboardPage() {
 		HostedAgentsSection && hostedAccess.canUseLegacyHostedDashboard,
 	);
 	const hostedSectionEnabled = cloudDeploymentManagementEnabled || legacyHostedAgentsEnabled;
-	const greeting = renderGreeting(selfManagedFleetSummary, {
-		agentStatusUnavailable: Boolean(envsError),
-	});
+	const greetingState: AgentGreetingState =
+		hostedAccessLoading || envsLoading
+			? "loading"
+			: envsError || hostedAccess.isError
+				? "error"
+				: "resolved";
+	const greeting = renderGreeting(selfManagedFleetSummary, { state: greetingState });
+	const loadingGreeting = renderGreeting(selfManagedFleetSummary, { state: "loading" });
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			{hostedAccessLoading ? (
-				greeting
+				loadingGreeting
 			) : hostedSectionEnabled && HostedFleetSummary ? (
-				<Suspense fallback={greeting}>
+				<Suspense fallback={loadingGreeting}>
 					<HostedFleetSummary
 						cloudEnvs={environments ?? []}
 						showCloudDeployments={cloudDeploymentManagementEnabled}
@@ -187,8 +188,12 @@ export default function DashboardPage() {
 					>
 						{(summary, state) =>
 							renderGreeting(summary, {
-								agentStatusUnavailable:
-									Boolean(envsError) || !state.membershipResolved || Boolean(state.error),
+								state:
+									envsError || hostedAccess.isError || state.error
+										? "error"
+										: envsLoading || state.isLoading || !state.membershipResolved
+											? "loading"
+											: "resolved",
 							})
 						}
 					</HostedFleetSummary>
@@ -238,10 +243,7 @@ export default function DashboardPage() {
 					<Card>
 						<CardHeader>
 							<CardTitle>Activity</CardTitle>
-							<CardDescription>
-								Sessions per day in the last 12 months
-								{streakLine ? ` · ${streakLine}` : ""}
-							</CardDescription>
+							<CardDescription>Sessions per day in the last 12 months</CardDescription>
 						</CardHeader>
 						<CardContent>
 							{statsError ? (
@@ -262,14 +264,9 @@ export default function DashboardPage() {
 
 					<section className="space-y-2">
 						<div className="flex items-end justify-between">
-							<div>
-								<h2 className="text-base font-semibold">Recent sessions</h2>
-								<p className="text-sm text-muted-foreground">
-									Your latest work — automated runs live under View all.
-								</p>
-							</div>
+							<h2 className="text-base font-semibold">Recent sessions</h2>
 							<Button
-								render={<Link to="/sessions" search={{ automated: false }} />}
+								render={<Link to="/sessions" />}
 								nativeButton={false}
 								variant="ghost"
 								size="sm"
@@ -292,7 +289,7 @@ export default function DashboardPage() {
 								sessions={sessions ?? []}
 								isLoading={sessionsLoading}
 								grouped={false}
-								emptyMessage="No sessions yet. Once your agent starts a conversation, it'll show up here."
+								emptyMessage="No manual sessions yet. Once you start a conversation, it'll show up here."
 								emptyVariant="inset"
 							/>
 						)}
@@ -332,15 +329,9 @@ export default function DashboardPage() {
 						onRetryProjectCount={() => {
 							void refetchProjects();
 						}}
-						hasConnectedAgent={
-							hostedAccessLoading || hostedSectionEnabled || envsLoading || envsError
-								? undefined
-								: hasAgents
-						}
 					/>
 					<ThisWeekCard
 						stats={stats}
-						contribution={contribution}
 						error={statsError}
 						onRetry={() => {
 							void refetchStats();
@@ -352,11 +343,8 @@ export default function DashboardPage() {
 	);
 }
 
-function renderGreeting(
-	summary: AgentFleetSummary,
-	options: { agentStatusUnavailable?: boolean } = {},
-) {
-	return <Greeting total={summary.total} agentStatusUnavailable={options.agentStatusUnavailable} />;
+function renderGreeting(summary: AgentFleetSummary, options: { state?: AgentGreetingState } = {}) {
+	return <Greeting total={summary.total} state={options.state} />;
 }
 
 function ActivityGraphSkeleton() {
@@ -412,10 +400,7 @@ function ConnectAnotherCard() {
 	return (
 		<Card className="py-4">
 			<CardContent className="flex items-center justify-between gap-3 px-4">
-				<div className="min-w-0">
-					<div className="text-sm font-medium">Connect another machine</div>
-					<p className="mt-0.5 text-xs text-muted-foreground">Follow the Clawdi CLI steps.</p>
-				</div>
+				<div className="min-w-0 text-sm font-medium">Connect another machine</div>
 				<Button size="sm" variant="outline" onClick={() => setOpen(true)}>
 					Add agent
 				</Button>
@@ -431,24 +416,14 @@ function currentDaypart(): "morning" | "afternoon" | "evening" {
 	return hour < 5 ? "evening" : hour < 12 ? "morning" : hour < 18 ? "afternoon" : "evening";
 }
 
-function Greeting({
-	total,
-	agentStatusUnavailable = false,
-}: {
-	total: number;
-	agentStatusUnavailable?: boolean;
-}) {
+function Greeting({ total, state = "resolved" }: { total: number; state?: AgentGreetingState }) {
 	const { user } = useCurrentUser();
 	const [daypart, setDaypart] = useState<ReturnType<typeof currentDaypart> | null>(null);
 	useEffect(() => {
 		setDaypart(currentDaypart());
 	}, []);
 	const firstName = user?.fullName?.split(" ")[0];
-	const summary = agentStatusUnavailable
-		? "Agent status is unavailable right now."
-		: total === 0
-			? "Connect your first agent to start syncing."
-			: `${total} agent${total === 1 ? "" : "s"}`;
+	const summary = agentGreetingSummary(total, state);
 	return (
 		<div>
 			<h1 className="text-2xl font-semibold tracking-tight">

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -47,14 +47,41 @@ async def get_stats(
     now = datetime.now(UTC)
     since = now - timedelta(days=days)
     current_floor = now.date() - timedelta(days=1)
-    manual_since = now - timedelta(days=7)
+    weekly_since = now - timedelta(days=7)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
     result = await db.execute(
         text(
             """
-            WITH session_window AS (
+            WITH visible_projects AS (
+                SELECT id
+                FROM projects
+                WHERE user_id = :user_id
+                UNION
+                SELECT project_id
+                FROM project_memberships
+                WHERE member_user_id = :user_id
+            ),
+            visible_vaults AS (
+                SELECT vaults.id
+                FROM vaults
+                WHERE vaults.user_id = :user_id
+                   OR EXISTS (
+                       SELECT 1
+                       FROM vault_project_attachments
+                       WHERE vault_project_attachments.vault_id = vaults.id
+                         AND vault_project_attachments.project_id IN (
+                             SELECT id FROM visible_projects
+                         )
+                   )
+            ),
+            all_session_count AS (
+                SELECT count(*)::integer AS total_sessions
+                FROM sessions
+                WHERE user_id = :user_id
+            ),
+            session_window AS (
                 SELECT
-                    count(*)::integer AS total_sessions,
                     COALESCE(sum(message_count), 0)::bigint AS total_messages,
                     COALESCE(sum(input_tokens + output_tokens), 0)::bigint AS total_tokens
                 FROM sessions
@@ -63,12 +90,12 @@ async def get_stats(
             ),
             day_counts AS (
                 SELECT
-                    CAST(started_at AS date) AS day,
+                    CAST(started_at AT TIME ZONE 'UTC' AS date) AS day,
                     count(*)::integer AS count
                 FROM sessions
                 WHERE user_id = :user_id
                   AND started_at >= :since
-                GROUP BY CAST(started_at AS date)
+                GROUP BY CAST(started_at AT TIME ZONE 'UTC' AS date)
             ),
             favorite_model AS (
                 SELECT model
@@ -88,7 +115,7 @@ async def get_stats(
                 LIMIT 1
             ),
             days AS (
-                SELECT DISTINCT CAST(started_at AS date) AS day
+                SELECT DISTINCT CAST(started_at AT TIME ZONE 'UTC' AS date) AS day
                 FROM sessions
                 WHERE user_id = :user_id
             ),
@@ -119,30 +146,45 @@ async def get_stats(
                 SELECT
                     (SELECT count(*)::integer
                      FROM skills
-                     WHERE user_id = :user_id AND is_active) AS skills_count,
+                     WHERE is_active
+                       AND project_id IN (SELECT id FROM visible_projects)) AS skills_count,
                     (SELECT count(*)::integer
                      FROM memories
                      WHERE user_id = :user_id) AS memories_count,
                     (SELECT count(*)::integer
-                     FROM vaults
-                     WHERE user_id = :user_id) AS vault_count,
+                     FROM visible_vaults) AS vault_count,
                     (SELECT count(*)::integer
                      FROM vault_items
-                     JOIN vaults ON vaults.id = vault_items.vault_id
-                     WHERE vaults.user_id = :user_id) AS vault_keys_count
+                     WHERE vault_id IN (SELECT id FROM visible_vaults)) AS vault_keys_count
             ),
-            manual_recent AS (
-                SELECT count(*)::integer AS manual_sessions_last_7_days
+            weekly_sessions AS (
+                SELECT
+                    count(*) FILTER (
+                        WHERE summary IS NULL
+                           OR (summary NOT LIKE 'Cron:%' AND summary NOT LIKE '[%')
+                    )::integer AS manual_sessions_last_7_days,
+                    count(*) FILTER (
+                        WHERE summary LIKE 'Cron:%' OR summary LIKE '[%'
+                    )::integer AS automated_sessions_last_7_days,
+                    count(*) FILTER (
+                        WHERE started_at >= :today_start
+                    )::integer AS sessions_today
                 FROM sessions
                 WHERE user_id = :user_id
-                  AND last_activity_at >= :manual_since
-                  AND (
-                      summary IS NULL
-                      OR (summary NOT LIKE 'Cron:%' AND summary NOT LIKE '[%')
-                  )
+                  AND started_at >= :weekly_since
+            ),
+            weekly_top_model AS (
+                SELECT model
+                FROM sessions
+                WHERE user_id = :user_id
+                  AND started_at >= :weekly_since
+                  AND model IS NOT NULL
+                GROUP BY model
+                ORDER BY count(*) DESC, model
+                LIMIT 1
             )
             SELECT
-                session_window.total_sessions,
+                all_session_count.total_sessions,
                 session_window.total_messages,
                 session_window.total_tokens,
                 (SELECT count(*)::integer FROM day_counts) AS active_days,
@@ -154,13 +196,17 @@ async def get_stats(
                 resource_counts.memories_count,
                 resource_counts.vault_count,
                 resource_counts.vault_keys_count,
-                manual_recent.manual_sessions_last_7_days,
+                weekly_sessions.manual_sessions_last_7_days,
+                weekly_sessions.automated_sessions_last_7_days,
+                weekly_sessions.sessions_today,
+                (SELECT model FROM weekly_top_model) AS top_model_last_7_days,
                 day_counts.day AS contribution_day,
                 day_counts.count AS contribution_count
             FROM session_window
+            CROSS JOIN all_session_count
             CROSS JOIN streaks
             CROSS JOIN resource_counts
-            CROSS JOIN manual_recent
+            CROSS JOIN weekly_sessions
             LEFT JOIN day_counts ON true
             ORDER BY day_counts.day
             """
@@ -169,7 +215,8 @@ async def get_stats(
             "user_id": auth.user_id,
             "since": since,
             "current_floor": current_floor,
-            "manual_since": manual_since,
+            "weekly_since": weekly_since,
+            "today_start": today_start,
         },
     )
     rows = result.mappings().all()
@@ -197,6 +244,9 @@ async def get_stats(
         vault_keys_count=int(row["vault_keys_count"] or 0),
         connectors_count=connectors_count,
         manual_sessions_last_7_days=int(row["manual_sessions_last_7_days"] or 0),
+        automated_sessions_last_7_days=int(row["automated_sessions_last_7_days"] or 0),
+        top_model_last_7_days=row["top_model_last_7_days"],
+        sessions_today=int(row["sessions_today"] or 0),
         contribution=_build_contribution_graph(
             day_map,
             since_date=since.date(),

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -24,4 +24,7 @@ class DashboardStatsResponse(BaseModel):
     vault_keys_count: int
     connectors_count: int
     manual_sessions_last_7_days: int
+    automated_sessions_last_7_days: int
+    top_model_last_7_days: str | None
+    sessions_today: int
     contribution: list[ContributionDayResponse]

--- a/backend/tests/test_dashboard_performance.py
+++ b/backend/tests/test_dashboard_performance.py
@@ -14,11 +14,11 @@ from app.models.project_membership import ProjectMembership
 from app.models.session import Session
 from app.models.skill import Skill
 from app.models.user import User
-from app.models.vault import Vault, VaultItem
+from app.models.vault import Vault, VaultItem, VaultProjectAttachment
 
 
-async def _seed_dashboard_sessions(db_session: AsyncSession, user_id) -> None:
-    now = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+async def _seed_dashboard_sessions(db_session: AsyncSession, user_id) -> datetime:
+    now = datetime.now(UTC).replace(microsecond=0)
     day_offsets = [0, 1, 2, 5, 6, 7, 8]
     sessions = [
         Session(
@@ -35,6 +35,7 @@ async def _seed_dashboard_sessions(db_session: AsyncSession, user_id) -> None:
     ]
     db_session.add_all(sessions)
     await db_session.commit()
+    return now
 
 
 @pytest.mark.asyncio
@@ -47,7 +48,7 @@ async def test_dashboard_stats_uses_bounded_database_round_trips(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(settings, "composio_api_key", "")
-    await _seed_dashboard_sessions(db_session, seed_user.id)
+    seeded_now = await _seed_dashboard_sessions(db_session, seed_user.id)
     skill = Skill(
         user_id=seed_user.id,
         project_id=seed_project.id,
@@ -95,7 +96,7 @@ async def test_dashboard_stats_uses_bounded_database_round_trips(
     assert data["total_sessions"] == 7
     assert data["active_days"] == 7
     assert data["favorite_model"] == "gpt-4o-mini"
-    assert data["peak_hour"] == 12
+    assert data["peak_hour"] == seeded_now.hour
     assert data["current_streak"] == 3
     assert data["longest_streak"] == 4
     assert data["skills_count"] == 1
@@ -103,10 +104,140 @@ async def test_dashboard_stats_uses_bounded_database_round_trips(
     assert data["vault_count"] == 1
     assert data["vault_keys_count"] == 1
     assert data["manual_sessions_last_7_days"] >= 1
+    assert data["automated_sessions_last_7_days"] == 0
+    assert data["top_model_last_7_days"] == "claude-sonnet"
     contribution_by_date = {entry["date"]: entry["count"] for entry in data["contribution"]}
     assert contribution_by_date[str(datetime.now(UTC).date())] == 1
     assert len(data["contribution"]) >= 365
     assert len(statements) <= 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_matches_visible_inventory_and_one_week_started_at_window(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    seed_project,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "composio_api_key", "")
+    now = datetime.now(UTC).replace(microsecond=0)
+    owner = User(
+        clerk_id=f"dashboard-owner-{seed_user.id}",
+        email=f"dashboard-owner-{seed_user.id}@clawdi.local",
+        name="Dashboard Owner",
+    )
+    db_session.add(owner)
+    await db_session.flush()
+    shared_project = Project(
+        user_id=owner.id,
+        name="Shared Dashboard Project",
+        slug="shared-dashboard-project",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(shared_project)
+    await db_session.flush()
+    db_session.add(
+        ProjectMembership(
+            project_id=shared_project.id,
+            member_user_id=seed_user.id,
+            role="viewer",
+            joined_via="invite",
+            joined_at=now,
+            resolved_owner_handle="dashboard-owner",
+        )
+    )
+    db_session.add_all(
+        [
+            Skill(
+                user_id=seed_user.id,
+                project_id=seed_project.id,
+                skill_key="owned-active",
+                name="Owned Active",
+                content_hash="owned-active",
+                is_active=True,
+            ),
+            Skill(
+                user_id=owner.id,
+                project_id=shared_project.id,
+                skill_key="shared-active",
+                name="Shared Active",
+                content_hash="shared-active",
+                is_active=True,
+            ),
+            Skill(
+                user_id=owner.id,
+                project_id=shared_project.id,
+                skill_key="shared-archived",
+                name="Shared Archived",
+                content_hash="shared-archived",
+                is_active=False,
+            ),
+        ]
+    )
+    owned_vault = Vault(user_id=seed_user.id, slug="owned", name="Owned")
+    shared_vault = Vault(user_id=owner.id, slug="shared", name="Shared")
+    hidden_vault = Vault(user_id=owner.id, slug="hidden", name="Hidden")
+    db_session.add_all([owned_vault, shared_vault, hidden_vault])
+    await db_session.flush()
+    db_session.add(VaultProjectAttachment(vault_id=shared_vault.id, project_id=shared_project.id))
+    db_session.add_all(
+        [
+            Session(
+                user_id=seed_user.id,
+                local_session_id="weekly-manual-1",
+                started_at=now - timedelta(days=6, hours=20),
+                last_activity_at=now - timedelta(days=30),
+                summary="Manual work",
+                model="weekly-model",
+            ),
+            Session(
+                user_id=seed_user.id,
+                local_session_id="weekly-manual-2",
+                started_at=now - timedelta(days=1),
+                last_activity_at=now - timedelta(days=30),
+                summary=None,
+                model="weekly-model",
+            ),
+            Session(
+                user_id=seed_user.id,
+                local_session_id="weekly-automated",
+                started_at=now - timedelta(minutes=1),
+                last_activity_at=now - timedelta(days=30),
+                summary="Cron: health check",
+                model="automation-model",
+            ),
+            Session(
+                user_id=seed_user.id,
+                local_session_id="stale-but-recently-active",
+                started_at=now - timedelta(days=8),
+                last_activity_at=now,
+                summary="Old manual work",
+                model="stale-model",
+            ),
+            Session(
+                user_id=seed_user.id,
+                local_session_id="historical-inventory-session",
+                started_at=now - timedelta(days=400),
+                last_activity_at=now - timedelta(days=400),
+                summary="Historical work",
+                model="historical-model",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get("/v1/dashboard/stats")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total_sessions"] == 5
+    assert data["manual_sessions_last_7_days"] == 2
+    assert data["automated_sessions_last_7_days"] == 1
+    assert data["top_model_last_7_days"] == "weekly-model"
+    assert data["sessions_today"] == 1
+    assert data["skills_count"] == 2
+    assert data["vault_count"] == 2
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4311,6 +4311,12 @@ export interface components {
             connectors_count: number;
             /** Manual Sessions Last 7 Days */
             manual_sessions_last_7_days: number;
+            /** Automated Sessions Last 7 Days */
+            automated_sessions_last_7_days: number;
+            /** Top Model Last 7 Days */
+            top_model_last_7_days: string | null;
+            /** Sessions Today */
+            sessions_today: number;
             /** Contribution */
             contribution: components["schemas"]["ContributionDayResponse"][];
         };


### PR DESCRIPTION
## Summary

- project Cloud agent cards from the existing compute-first runtime status so stopped, failed, and unavailable deployments cannot appear Live from stale joined daemon data
- align dashboard counts with linked inventory contracts, including all-time sessions and shared Project Skills and Vaults, and regenerate the shared API client
- return direct UTC Last 7 days manual, automated, top-model, and today metrics from `started_at`, then consume them without client-side mixed-window math
- make greeting, recent-session, sync-recency, onboarding, wallet, and hosted empty states explicit and truthful
- fix date-only contribution rendering in negative-offset timezones and remove the audited actionless or duplicate homepage copy
- remove dead agent activity projection plumbing while retaining the hosted runtime active contract

## Behavior tests

- covers non-running Cloud compute with fresh joined sync, explicit Synced and Seen metadata, and direct dashboard metric rendering
- covers all-time session inventory, one consistent 7-day `started_at` window, shared Project Skills and Vaults, and active-only Skill behavior
- covers America/Los_Angeles contribution calendar dates, registration before first sync, loading greeting states, and no-deploy Wallet copy

## Verification

- `bun run test web` — 702 passed; includes web typecheck and OSS client/SSR/Nitro build
- `bun run test backend tests/test_dashboard_performance.py` — 5 passed against migrated throwaway PostgreSQL in the Docker clean runner
- `bun run typecheck` — 4 workspace packages passed
- `bunx biome check apps/web/src` — 459 files passed
- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && uv run python -m compileall app scripts tests alembic`
- `cd backend && CLERK_JWT_ISSUER=https://clerk.example uv run python scripts/check_generated_api.py`
- `git diff --check origin/main..HEAD`

## Notes

No dashboard bitmap or image reference was changed because no truthful local browser fixture capture was available. No hosted repository, production environment, live cluster, tenant data, or deployment operation was touched.