### PR TITLE
fix(web): clean up accepted deploy transition

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -851,6 +851,7 @@ type HostedApiStubOptions = {
 	failedDeleteRetryability?: Map<string, boolean>;
 	deleteResponses?: StubResponse[];
 	deploymentListRequests?: string[];
+	deploymentListResponses?: unknown[][];
 	deploymentRequestReads?: string[];
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
@@ -1008,6 +1009,17 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
 			options.deploymentListRequests?.push(p);
+			const deploymentListResponse = options.deploymentListResponses?.shift();
+			if (deploymentListResponse) {
+				return fulfillJson(
+					r,
+					deploymentListResponse.map((deployment) =>
+						isDeploymentMutationFixture(deployment)
+							? readDeploymentFixture(deployment)
+							: deployment,
+					),
+				);
+			}
 			if (options.deploymentsResponse) {
 				if (options.deploymentsResponse.delayMs) {
 					await new Promise((resolve) => setTimeout(resolve, options.deploymentsResponse?.delayMs));
@@ -1922,16 +1934,16 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 		},
 		"create",
 	);
+	const startingDeployment = {
+		...includedBasicDeployment,
+		id: "hdep_included_created",
+		name: "Created included Basic",
+		status: "creating",
+	};
 	await stubHostedApi(page, {
 		plans: [basicPlan],
-		deployments: [
-			{
-				...includedBasicDeployment,
-				id: "hdep_included_created",
-				name: "Created included Basic",
-				status: "creating",
-			},
-		],
+		deployments: [startingDeployment],
+		deploymentListResponses: [[], [startingDeployment]],
 		createDeploymentResponse: {
 			status: 202,
 			body: { ...acceptedCreate, done: false, response: null },
@@ -1943,6 +1955,8 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 	await page.getByRole("button", { name: "Deploy agent" }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
 	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
+	await expect(page.getByText("Agent not found", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
 	await expect(page.getByText("Agent actions", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Delete", exact: true })).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1924,7 +1924,14 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 	);
 	await stubHostedApi(page, {
 		plans: [basicPlan],
-		deployments: [],
+		deployments: [
+			{
+				...includedBasicDeployment,
+				id: "hdep_included_created",
+				name: "Created included Basic",
+				status: "creating",
+			},
+		],
 		createDeploymentResponse: {
 			status: 202,
 			body: { ...acceptedCreate, done: false, response: null },
@@ -1935,9 +1942,10 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 
 	await page.getByRole("button", { name: "Deploy agent" }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
-	await expect.poll(() => new URL(page.url()).searchParams.get("setup")).toBe("accepted");
-	await expect(page.getByTestId("accepted-agent-setup")).toBeVisible();
-	await expect(page.getByText("Starting your agent", { exact: true })).toHaveCount(2);
+	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
+	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByText("Agent actions", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Delete", exact: true })).toHaveCount(0);
 	await expect(page.getByText("Agent unavailable", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
 	await expect(page.locator("body")).not.toContainText("hdep_included_created");

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -96,6 +96,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { StatusDot } from "@/components/ui/status-badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { UserMenuItems } from "@/components/user-menu";
+import { useUnresolvedHostedRouteGrace } from "@/hosted/agents/unresolved-hosted-route";
 import {
 	type AgentOwnershipKind,
 	agentOwnershipKindFromId,
@@ -1173,6 +1174,15 @@ function FocusHeader({
 	activeAgentKind: AgentChromeKind;
 	activeAgentId: string | null;
 }) {
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const awaitingAcceptedDeployment = useUnresolvedHostedRouteGrace(
+		activeAgentId &&
+			!activeAgent &&
+			!activeAgentTile &&
+			new URLSearchParams(searchStr).get("source") === "on-clawdi"
+			? activeAgentId
+			: null,
+	);
 	if (!activeAgent && !activeAgentId) {
 		return (
 			<div className="min-w-0">
@@ -1184,7 +1194,7 @@ function FocusHeader({
 		);
 	}
 
-	if (activeAgentKind === "unresolved") {
+	if (activeAgentKind === "unresolved" || awaitingAcceptedDeployment) {
 		return (
 			<div className="min-w-0 space-y-2" role="status" aria-label="Agent ownership loading">
 				<Skeleton className="h-4 w-32" />

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -107,7 +107,6 @@ import {
 	agentDeploymentSelector,
 	agentSectionHref,
 	agentSectionLabel,
-	isAcceptedHostedAgentRoute,
 	parseAgentPathname,
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
@@ -1174,10 +1173,6 @@ function FocusHeader({
 	activeAgentKind: AgentChromeKind;
 	activeAgentId: string | null;
 }) {
-	const searchStr = useLocation({ select: (location) => location.searchStr });
-	const acceptedSetupRoute = Boolean(
-		activeAgentId && isAcceptedHostedAgentRoute(activeAgentId, searchStr),
-	);
 	if (!activeAgent && !activeAgentId) {
 		return (
 			<div className="min-w-0">
@@ -1202,11 +1197,9 @@ function FocusHeader({
 	if (!activeAgent && !activeAgentTile) {
 		return (
 			<div className="min-w-0">
-				<div className="truncate text-sm font-semibold leading-5">
-					{acceptedSetupRoute ? "Starting your agent" : "Agent not found"}
-				</div>
+				<div className="truncate text-sm font-semibold leading-5">Agent not found</div>
 				<div className="truncate text-xs leading-4 text-muted-foreground">
-					{acceptedSetupRoute ? "This usually takes a few minutes" : "No details are available"}
+					No details are available
 				</div>
 			</div>
 		);

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -23,6 +23,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
+import { useUnresolvedHostedRouteGrace } from "@/hosted/agents/unresolved-hosted-route";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { deploymentStatusFromResource, deploymentStatusLabel } from "@/hosted/deployment-status";
 import { defaultDeploymentRuntime, isHostedRuntime } from "@/hosted/runtimes";
@@ -82,6 +83,9 @@ export function AgentHome({
 		requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading;
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
+	const awaitingAcceptedDeployment = useUnresolvedHostedRouteGrace(
+		unresolvedHostedAgent && requestedFromCloudRedirect ? environmentId : null,
+	);
 	const isFetchingRef = useRef(isFetching);
 	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
 	const hostedSection = HOSTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
@@ -233,6 +237,10 @@ export function AgentHome({
 				onRetry={handleCheckAgain}
 			/>
 		);
+	}
+
+	if (awaitingAcceptedDeployment) {
+		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
 	if (deployment) {

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -2,7 +2,7 @@
 
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { AlertCircle, ChevronRight, RefreshCw } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -36,7 +36,6 @@ import {
 	bindAgentDeploymentSearch,
 	CONNECTED_AGENT_SECTION_IDS,
 	HOSTED_AGENT_SECTION_IDS,
-	isAcceptedHostedAgentRoute,
 } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -77,7 +76,6 @@ export function AgentHome({
 	} = useAgentDeployment(environmentId, deploymentSelector);
 	const isCloudEnvironmentId = isCloudEnvId(environmentId);
 	const requestedFromCloudRedirect = routeSearch.source === "on-clawdi";
-	const acceptedSetupRoute = isAcceptedHostedAgentRoute(environmentId, routeSearch);
 	const requestedHostedAgent =
 		requestedFromCloudRedirect || Boolean(deploymentSelector) || !isCloudEnvironmentId;
 	const unresolvedHostedAgent =
@@ -85,7 +83,6 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
-	const [acceptedSetupStatusTimedOut, setAcceptedSetupStatusTimedOut] = useState(false);
 	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
 	const hostedSection = HOSTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
 	const connectedSection = CONNECTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
@@ -153,10 +150,6 @@ export function AgentHome({
 	}, [isFetching]);
 
 	useEffect(() => {
-		setAcceptedSetupStatusTimedOut(false);
-	}, [environmentId, deploymentSelector]);
-
-	useEffect(() => {
 		if (!shouldAutoRefetchUnresolvedHostedAgent || typeof window === "undefined") return;
 
 		let attempts = 0;
@@ -168,14 +161,13 @@ export function AgentHome({
 
 			if (attempts >= UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS) {
 				window.clearInterval(intervalId);
-				if (acceptedSetupRoute) setAcceptedSetupStatusTimedOut(true);
 			}
 		}, UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS);
 
 		return () => {
 			window.clearInterval(intervalId);
 		};
-	}, [acceptedSetupRoute, refetch, shouldAutoRefetchUnresolvedHostedAgent]);
+	}, [refetch, shouldAutoRefetchUnresolvedHostedAgent]);
 
 	const handleCheckAgain = () => {
 		if (isFetchingRef.current) return;
@@ -203,18 +195,12 @@ export function AgentHome({
 				</div>
 			);
 		}
-		if (acceptedSetupRoute) {
-			return <AcceptedAgentSetupState />;
-		}
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
-		if (acceptedSetupRoute) {
-			return <AcceptedAgentSetupState />;
-		}
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
@@ -272,16 +258,6 @@ export function AgentHome({
 		);
 	}
 
-	if (acceptedSetupRoute) {
-		return (
-			<AcceptedAgentSetupState
-				isChecking={isFetching}
-				onCheckAgain={handleCheckAgain}
-				statusTimedOut={acceptedSetupStatusTimedOut}
-			/>
-		);
-	}
-
 	if (requestedHostedAgent) {
 		return (
 			<div
@@ -307,48 +283,6 @@ export function AgentHome({
 			section={section}
 			routeSearch={routeSearch}
 		/>
-	);
-}
-
-export function AcceptedAgentSetupState({
-	statusTimedOut = false,
-	isChecking = false,
-	onCheckAgain,
-}: {
-	statusTimedOut?: boolean;
-	isChecking?: boolean;
-	onCheckAgain?: () => void;
-}) {
-	return (
-		<div
-			data-hosted="true"
-			data-testid="accepted-agent-setup"
-			className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
-		>
-			<EmptyState
-				icon={statusTimedOut ? AlertCircle : <Spinner className="size-5" />}
-				title={statusTimedOut ? "Agent status is unavailable" : "Starting your agent"}
-				description={
-					statusTimedOut
-						? "Clawdi accepted your request, but couldn’t load a progress update within two minutes. Startup may still be continuing."
-						: "Your request was accepted. Clawdi is preparing your agent now. This usually takes a few minutes."
-				}
-				action={
-					statusTimedOut && onCheckAgain ? (
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							disabled={isChecking}
-							onClick={onCheckAgain}
-						>
-							{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw />}
-							Check again
-						</Button>
-					) : null
-				}
-			/>
-		</div>
 	);
 }
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -132,6 +132,18 @@ describe("deployment failure remediation rendering", () => {
 });
 
 describe("deployment transition timeout rendering", () => {
+	test("keeps startup overview actions hidden until startup and projection resolve", () => {
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(detailSource).toContain('projection.status === "resolved" &&');
+		expect(detailSource).toContain("!isStartingStatus(deploymentStatus)");
+		expect(detailSource).not.toContain(
+			'showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}',
+		);
+	});
+
 	test("replaces the automatic-update promise with an honest timeout and check action", () => {
 		if (!overviewReadinessPanel) throw new Error("agent detail was not loaded");
 		const deployment = hostedDeploymentFixture({ status: "creating" });
@@ -225,8 +237,6 @@ describe("hosted agent customer language", () => {
 		}
 		expect(detailSource).toContain("Starting your agent…");
 		expect(detailSource).toContain("Your agent is running");
-		expect(agentHomeSource).toContain('"Starting your agent"');
-		expect(sidebarSource).toContain('"Starting your agent"');
 		expect(wizardSource).toContain("After your agent is running");
 	});
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -585,7 +585,11 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
-							showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}
+							showDeploymentActions={
+								projection.status === "resolved" &&
+								!deploymentRunning &&
+								!isStartingStatus(deploymentStatus)
+							}
 							onDeleteAccepted={onDeleteAccepted}
 							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}

--- a/apps/web/src/hosted/agents/unresolved-hosted-route.ts
+++ b/apps/web/src/hosted/agents/unresolved-hosted-route.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const UNRESOLVED_HOSTED_ROUTE_GRACE_MS = 2 * 60_000;
+
+/** Keep an accepted hosted route in neutral loading chrome while inventory converges. */
+export function useUnresolvedHostedRouteGrace(routeKey: string | null): boolean {
+	const [graceState, setGraceState] = useState<{ expired: boolean; routeKey: string | null }>({
+		expired: false,
+		routeKey,
+	});
+
+	useEffect(() => {
+		setGraceState({ expired: false, routeKey });
+		if (!routeKey || typeof window === "undefined") return;
+		const timeoutId = window.setTimeout(
+			() => setGraceState({ expired: true, routeKey }),
+			UNRESOLVED_HOSTED_ROUTE_GRACE_MS,
+		);
+		return () => window.clearTimeout(timeoutId);
+	}, [routeKey]);
+
+	return Boolean(routeKey && (graceState.routeKey !== routeKey || !graceState.expired));
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -154,7 +154,13 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
 	});
 
-	test("keeps setup progress on the destination and bounds the payment-only notice", () => {
+	test("routes accepted creates directly by canonical deployment selector", () => {
+		expect(wizardSource).toContain(
+			'agentSectionHref(deploymentId, "overview", "source=on-clawdi")',
+		);
+		expect(wizardSource).not.toContain("setup=accepted");
+		expect(wizardSource).not.toContain("waitForRuntime");
+		expect(wizardSource).not.toContain("getDeployment(created.deploymentId)");
 		expect(wizardSource).not.toContain("Agent deployment started");
 		expect(wizardSource).not.toContain("agent is getting ready now");
 		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
@@ -271,6 +277,18 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain(
 			"router.navigate(acceptedDeploymentNavigation(outcome.deploymentId))",
 		);
+	});
+
+	test("funnels every accepted create and activation through the same immediate navigation", () => {
+		for (const acceptedId of [
+			"resolved.deploymentId",
+			"deploymentId",
+			"outcome.deploymentId",
+			"created.deploymentId",
+		]) {
+			expect(wizardSource).toContain(`acceptedDeploymentNavigation(${acceptedId}`);
+		}
+		expect(wizardSource).not.toContain("setup=accepted");
 	});
 
 	test("shows a scoped honest busy state and keeps a persistent actionable failure", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -184,7 +184,7 @@ const DEPLOY_MANAGED_AI_LABEL = "Managed AI";
 
 function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
 	return {
-		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi&setup=accepted"),
+		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
 		replace,
 	};
 }

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -16,7 +16,6 @@ import {
 	bindAgentDeploymentSearch,
 	CONNECTED_AGENT_SECTION_IDS,
 	HOSTED_AGENT_SECTION_IDS,
-	isAcceptedHostedAgentRoute,
 	legacyAgentRoute,
 	parseAgentPathname,
 	parseAgentSectionSegment,
@@ -135,26 +134,6 @@ describe("agent routes", () => {
 			params: { id: "agent 1", section: "channel-links" },
 			search: { d: "hdep_1" },
 		});
-	});
-
-	it("distinguishes a freshly accepted hosted route from normal and unknown routes", () => {
-		expect(isAcceptedHostedAgentRoute("hdep_accepted", "source=on-clawdi&setup=accepted")).toBe(
-			true,
-		);
-		expect(isAcceptedHostedAgentRoute("hdep_unknown", "source=on-clawdi")).toBe(false);
-		expect(
-			isAcceptedHostedAgentRoute(
-				"9f6e5c8f-5af3-55fe-97ab-c9eb3cd7859d",
-				"source=on-clawdi&setup=accepted",
-			),
-		).toBe(false);
-		expect(
-			isAcceptedHostedAgentRoute(
-				"hdep_accepted",
-				"source=on-clawdi&setup=accepted&d=hdep_accepted",
-			),
-		).toBe(false);
-		expect(isAcceptedHostedAgentRoute("hdep_unknown", undefined)).toBe(false);
 	});
 
 	it("parses only canonical section segments", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -15,7 +15,6 @@ export type RouteSearchParamsRecord = Record<string, string | string[] | undefin
 export type AgentRouteSearch = Record<string, unknown> & {
 	source?: string;
 	d?: string;
-	setup?: string;
 	tab?: string;
 	project?: string;
 };
@@ -28,7 +27,6 @@ export type AgentRouteQuery =
 	| undefined;
 
 export const AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY = "d";
-const AGENT_ACCEPTED_SETUP_QUERY_KEY = "setup";
 
 export const CONNECTED_AGENT_SECTION_IDS = [
 	"overview",
@@ -201,7 +199,6 @@ export function validateAgentRouteSearch(search: Record<string, unknown>): Agent
 		...search,
 		source: optionalSearchString(search.source),
 		d: optionalSearchString(search.d),
-		setup: optionalSearchString(search.setup),
 		tab: optionalSearchString(search.tab),
 		project: optionalSearchString(search.project),
 	};
@@ -241,21 +238,6 @@ export function legacyAgentRoute(
 export function agentDeploymentSelector(query?: AgentRouteQuery): string | null {
 	const selector = agentRouteSearchParams(query).get(AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY)?.trim();
 	return selector || null;
-}
-
-/**
- * The create flow initially routes by the accepted deployment id because the
- * stable agent id does not exist yet. Once inventory catches up, normal hosted
- * links carry a separate deployment selector and use the stable agent id.
- */
-export function isAcceptedHostedAgentRoute(agentId: string, query?: AgentRouteQuery): boolean {
-	const params = agentRouteSearchParams(query);
-	return (
-		agentId.toLowerCase().startsWith("hdep_") &&
-		params.get("source") === "on-clawdi" &&
-		params.get(AGENT_ACCEPTED_SETUP_QUERY_KEY) === "accepted" &&
-		agentDeploymentSelector(params) === null
-	);
 }
 
 export function agentDeploymentRouteQuery(


### PR DESCRIPTION
## Summary
- Navigate immediately after the deploy API accepts creation with HTTP 202, without a special accepted/setup page.
- Keep unresolved post-acceptance inventory lag in existing neutral loading chrome.
- Hide overview Agent actions and Delete while startup or projection resolution is incomplete.

## Verification
- Focused Bun tests: 51 passed.
- Biome on all changed Web files: passed.
- Web TypeScript typecheck: passed.
- Hosted Playwright acceptance race scenario: 1 passed.
- Git diff check against origin/main: passed.

No production or tenant operations were performed.