### PR TITLE
fix: restore Skill resource boundaries

### DIFF
--- a/apps/web/src/components/dashboard/agent-skills-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-tab.test.ts
@@ -9,5 +9,6 @@ describe("agent Skills resource boundary", () => {
 		expect(source).toContain("Deployment-managed Skills");
 		expect(source).toContain("cleanupOnlySkillCheck");
 		expect(source).not.toMatch(/managed_resources|mcp_server|MCP servers/i);
+		expect(source).not.toMatch(/has_mcp|Deployment MCP/i);
 	});
 });

--- a/apps/web/src/components/dashboard/agent-skills-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-tab.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("agent Skills resource boundary", () => {
+	test("renders managed Skills without MCP-derived UI", () => {
+		const source = readFileSync(new URL("./agent-skills-tab.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("managed_skills");
+		expect(source).toContain("Deployment-managed Skills");
+		expect(source).toContain("cleanupOnlySkillCheck");
+		expect(source).not.toMatch(/managed_resources|mcp_server|MCP servers/i);
+	});
+});

--- a/apps/web/src/components/dashboard/agent-skills-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-tab.test.ts
@@ -8,6 +8,9 @@ describe("agent Skills resource boundary", () => {
 		expect(source).toContain("managed_skills");
 		expect(source).toContain("Deployment-managed Skills");
 		expect(source).toContain("cleanupOnlySkillCheck");
+		expect(source).toMatch(
+			/const managedSkills = hostedManaged\s+\? \(runtimeObserved\.data\?\.desired\?\.managed_skills \?\? \[\]\)\s+: \[\]/,
+		);
 		expect(source).not.toMatch(/managed_resources|mcp_server|MCP servers/i);
 		expect(source).not.toMatch(/has_mcp|Deployment MCP/i);
 	});

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -7,6 +7,7 @@ import { isProjectOwner } from "@/components/projects/project-metadata";
 import { SkillCardGrid } from "@/components/skills/skill-card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { useAgentRuntimeObserved } from "@/hooks/use-agent-runtime-observed";
 import { type AgentRouteSearch, agentSkillDetailLink } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
@@ -64,16 +65,7 @@ export function AgentSkillsTab({
 	hostedManaged?: boolean;
 }) {
 	const api = useApi();
-	const runtimeObserved = useQuery({
-		queryKey: ["runtime-observed", agentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}/runtime-observed", {
-					params: { path: { agent_id: agentId } },
-				}),
-			),
-		enabled: hostedManaged,
-	});
+	const runtimeObserved = useAgentRuntimeObserved(agentId, hostedManaged);
 	const { data: projects } = useQuery({
 		queryKey: ["projects"],
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -94,22 +94,9 @@ export function AgentSkillsTab({
 		refetch: refetchSkills,
 	} = useAgentProjectSkills(agentProjectId);
 	const uninstallSkill = useUninstallAgentSkill();
-	const managedResources = runtimeObserved.data?.desired?.managed_resources ?? [];
-	const managedSkills = managedResources.filter((resource) => resource.kind === "skill");
-	const managedMcpServers = managedResources.filter((resource) => resource.kind === "mcp_server");
-	const reservedSkillIds = new Set(
-		managedSkills.filter((skill) => skill.enabled).map((skill) => skill.id),
-	);
+	const managedSkills = runtimeObserved.data?.desired?.managed_skills ?? [];
+	const reservedSkillIds = new Set(managedSkills.map((skill) => skill.id));
 	const conflictingSkills = (skills ?? []).filter((skill) => reservedSkillIds.has(skill.skill_key));
-	const desiredGeneration = runtimeObserved.data?.desired?.desired_config_generation ?? null;
-	const observedGeneration = runtimeObserved.data?.observed?.observed_config_generation ?? null;
-	const desiredSource = runtimeObserved.data?.desired?.desired_source_revision ?? null;
-	const observedSource = runtimeObserved.data?.observed?.observed_source_revision ?? null;
-	const isApplied =
-		runtimeObserved.data?.health.status === "ok" &&
-		desiredGeneration !== null &&
-		desiredGeneration === observedGeneration &&
-		(desiredSource === null || desiredSource === observedSource);
 
 	if (skillsError) {
 		return (
@@ -126,58 +113,26 @@ export function AgentSkillsTab({
 	return (
 		<div className="flex flex-col gap-6">
 			{hostedManaged && runtimeObserved.isLoading ? (
-				<p className="text-sm text-muted-foreground">Loading deployment-managed capabilities…</p>
+				<p className="text-sm text-muted-foreground">Loading deployment-managed Skills…</p>
 			) : null}
 			{hostedManaged && runtimeObserved.error ? (
 				<Alert>
-					<AlertTitle>Managed capability status is unavailable</AlertTitle>
+					<AlertTitle>Deployment-managed Skills are unavailable</AlertTitle>
 					<AlertDescription>Your Cloud Skills remain available below.</AlertDescription>
 				</Alert>
 			) : null}
-			{runtimeObserved.data ? (
-				<section className="rounded-xl border p-4" aria-label="Deployment-managed capabilities">
-					<div className="flex flex-wrap items-center justify-between gap-2">
-						<h2 className="font-medium">Deployment-managed capabilities</h2>
-						<Badge variant={isApplied ? "secondary" : "outline"}>
-							{isApplied ? "Applied" : "Not applied"}
-						</Badge>
-					</div>
+			{managedSkills.length > 0 ? (
+				<section className="rounded-xl border p-4" aria-label="Deployment-managed Skills">
+					<h2 className="font-medium">Deployment-managed Skills</h2>
 					<p className="mt-1 text-sm text-muted-foreground">
-						Desired generation {runtimeObserved.data.desired?.desired_config_generation ?? "—"} ·
-						Observed generation {runtimeObserved.data.observed?.observed_config_generation ?? "—"}
+						These Skills are read-only and follow the deployment manifest.
 					</p>
-					<p className="mt-1 text-xs text-muted-foreground">
-						Health {runtimeObserved.data.health.status} · Source{" "}
-						{(observedSource ?? desiredSource ?? "Not reported").slice(0, 12)}
-						{runtimeObserved.data.observed?.observed_manifest_etag ? " · Manifest observed" : ""}
-					</p>
-					<div className="mt-4 grid gap-4 md:grid-cols-2">
-						<div>
-							<h3 className="text-sm font-medium">Skills</h3>
-							<div className="mt-2 flex flex-wrap gap-2">
-								{managedSkills.map((skill) => (
-									<Badge key={skill.id} variant="secondary">
-										{skill.id} · v{skill.version} · {skill.enabled ? "enabled" : "disabled"}
-									</Badge>
-								))}
-								{managedSkills.length === 0 ? (
-									<span className="text-sm text-muted-foreground">None</span>
-								) : null}
-							</div>
-						</div>
-						<div>
-							<h3 className="text-sm font-medium">MCP servers</h3>
-							<div className="mt-2 flex flex-wrap gap-2">
-								{managedMcpServers.map((server) => (
-									<Badge key={server.id} variant="secondary">
-										{server.id}
-									</Badge>
-								))}
-								{managedMcpServers.length === 0 ? (
-									<span className="text-sm text-muted-foreground">None</span>
-								) : null}
-							</div>
-						</div>
+					<div className="mt-3 flex flex-wrap gap-2">
+						{managedSkills.map((skill) => (
+							<Badge key={skill.id} variant="secondary">
+								{skill.id} · v{skill.version}
+							</Badge>
+						))}
 					</div>
 				</section>
 			) : null}

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -86,7 +86,7 @@ export function AgentSkillsTab({
 		refetch: refetchSkills,
 	} = useAgentProjectSkills(agentProjectId);
 	const uninstallSkill = useUninstallAgentSkill();
-	const managedSkills = runtimeObserved.data?.desired?.managed_skills ?? [];
+	const managedSkills = hostedManaged ? (runtimeObserved.data?.desired?.managed_skills ?? []) : [];
 	const reservedSkillIds = new Set(managedSkills.map((skill) => skill.id));
 	const conflictingSkills = (skills ?? []).filter((skill) => reservedSkillIds.has(skill.skill_key));
 

--- a/apps/web/src/hooks/use-agent-runtime-observed.test.ts
+++ b/apps/web/src/hooks/use-agent-runtime-observed.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { deploymentManagedMcpValue } from "./use-agent-runtime-observed";
+
+describe("deployment-managed MCP inventory", () => {
+	test("reports the manifest-managed state when it is known", () => {
+		expect(deploymentManagedMcpValue({ has_mcp: true }, false)).toBe("Managed");
+		expect(deploymentManagedMcpValue({ has_mcp: false }, false)).toBe("Not managed");
+	});
+
+	test("does not turn mixed-version or failed reads into an empty inventory", () => {
+		expect(deploymentManagedMcpValue({}, false)).toBe("—");
+		expect(deploymentManagedMcpValue(undefined, false)).toBe("—");
+		expect(deploymentManagedMcpValue({ has_mcp: false }, true)).toBe("—");
+	});
+
+	test("renders the summary only in the existing Hosted Overview inventory", () => {
+		const overview = readFileSync(
+			new URL("../hosted/agents/hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(overview).toContain('label="Deployment MCP"');
+		expect(overview).toContain("deploymentManagedMcpValue(");
+		expect(overview).not.toMatch(/mcp_server|managed_resources|desired_config_generation/);
+	});
+});

--- a/apps/web/src/hooks/use-agent-runtime-observed.test.ts
+++ b/apps/web/src/hooks/use-agent-runtime-observed.test.ts
@@ -21,6 +21,7 @@ describe("deployment-managed MCP inventory", () => {
 		);
 		expect(overview).toContain('label="Deployment MCP"');
 		expect(overview).toContain("deploymentManagedMcpValue(");
+		expect(overview).toContain("!projectionAvailable || runtimeObserved.isLoading");
 		expect(overview).not.toMatch(/mcp_server|managed_resources|desired_config_generation/);
 	});
 });

--- a/apps/web/src/hooks/use-agent-runtime-observed.ts
+++ b/apps/web/src/hooks/use-agent-runtime-observed.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { unwrap, useApi } from "@/lib/api";
+
+export function useAgentRuntimeObserved(agentId: string, enabled = true) {
+	const api = useApi();
+	return useQuery({
+		queryKey: ["runtime-observed", agentId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/agents/{agent_id}/runtime-observed", {
+					params: { path: { agent_id: agentId } },
+				}),
+			),
+		enabled,
+	});
+}
+
+export function deploymentManagedMcpValue(
+	desired: { has_mcp?: boolean } | null | undefined,
+	unavailable: boolean,
+): "Managed" | "Not managed" | "—" {
+	if (unavailable || typeof desired?.has_mcp !== "boolean") return "—";
+	return desired.has_mcp ? "Managed" : "Not managed";
+}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -67,6 +67,10 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
+import {
+	deploymentManagedMcpValue,
+	useAgentRuntimeObserved,
+} from "@/hooks/use-agent-runtime-observed";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -582,6 +586,7 @@ export function HostedAgentDetail({
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{deploymentStatus.known && activeTab === "overview" ? (
 						<OverviewTab
+							environmentId={environmentId}
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
@@ -1089,6 +1094,7 @@ export function OverviewFailedPanel({
 }
 
 function OverviewTab({
+	environmentId,
 	deployment,
 	agent,
 	isPerformance,
@@ -1106,6 +1112,7 @@ function OverviewTab({
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
+	environmentId: string;
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	isPerformance: boolean;
@@ -1126,6 +1133,7 @@ function OverviewTab({
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
+	const runtimeObserved = useAgentRuntimeObserved(environmentId, projectionAvailable);
 	const spec = deployment.resource.spec;
 	const providers = useUserAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
@@ -1154,6 +1162,10 @@ function OverviewTab({
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
+	const managedMcpValue = deploymentManagedMcpValue(
+		runtimeObserved.data?.desired,
+		runtimeObserved.isLoading || runtimeObserved.isError,
+	);
 	return (
 		<div className="flex flex-col gap-5">
 			{showReadinessPanel ? (
@@ -1178,7 +1190,7 @@ function OverviewTab({
 			<div
 				className={cn(
 					"grid gap-2 sm:grid-cols-2",
-					showReadinessPanel ? "lg:grid-cols-3" : "lg:grid-cols-4",
+					showReadinessPanel ? "lg:grid-cols-4" : "lg:grid-cols-5",
 				)}
 			>
 				{showReadinessPanel ? null : (
@@ -1189,6 +1201,7 @@ function OverviewTab({
 				)}
 				<StatCard label="Compute" value={isPerformance ? "Performance" : "Basic"} />
 				<StatCard label="Model" value={model} />
+				<StatCard label="Deployment MCP" value={managedMcpValue} />
 				<StatCard
 					label="Resources"
 					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)}`}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1164,7 +1164,7 @@ function OverviewTab({
 		: "Sessions appear once your agent is running.";
 	const managedMcpValue = deploymentManagedMcpValue(
 		runtimeObserved.data?.desired,
-		runtimeObserved.isLoading || runtimeObserved.isError,
+		!projectionAvailable || runtimeObserved.isLoading || runtimeObserved.isError,
 	);
 	return (
 		<div className="flex flex-col gap-5">

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -36,11 +36,7 @@ from app.models.session_permission import (
     SessionPermission,
 )
 from app.schemas.common import Paginated
-from app.schemas.runtime import (
-    HostedRuntimeMcp,
-    PersistedHostedRuntimeSkills,
-    validate_hosted_runtime_desired_state,
-)
+from app.schemas.runtime import PersistedHostedRuntimeSkills, validate_hosted_runtime_desired_state
 from app.schemas.runtime_observed import (
     HostedRuntimeObserved,
     HostedRuntimeObservedProviderPayload,
@@ -56,8 +52,6 @@ from app.schemas.session import (
     EnvironmentReorderRequest,
     EnvironmentResponse,
     EnvironmentUpdate,
-    RuntimeManagedMcpServerSummary,
-    RuntimeManagedResourceSummary,
     RuntimeManagedSkillSummary,
     RuntimeObservedDesiredResponse,
     RuntimeObservedHealthResponse,
@@ -894,29 +888,7 @@ async def get_agent_runtime_observed(
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedResponse:
     """Canonical Agent-identity route for runtime desired/observed summaries."""
-    response = await get_environment_runtime_observed(agent_id, auth, db)
-    state = await db.get(HostedRuntimeState, agent_id)
-    desired = response.desired
-    if desired is None and state is None:
-        return response
-    if (
-        desired is None
-        or state is None
-        or desired.deployment_id != state.deployment_id
-        or desired.instance_id != state.instance_id
-        or desired.desired_config_generation != state.generation
-    ):
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE,
-            "Runtime desired state changed while it was being read; retry the request.",
-        )
-    return response.model_copy(
-        update={
-            "desired": desired.model_copy(
-                update={"managed_resources": _runtime_managed_resource_summaries(state)}
-            )
-        }
-    )
+    return await get_environment_runtime_observed(agent_id, auth, db)
 
 
 @router.get("/assets/{asset_key:path}", include_in_schema=False)
@@ -1056,38 +1028,30 @@ def _runtime_observed_desired(
         enabled_runtimes=_enabled_runtime_names(state.runtimes),
         has_mcp=state.mcp is not None,
         has_tools=state.tools is not None,
+        managed_skills=_runtime_managed_skill_summaries(state),
         updated_at=state.updated_at,
     )
 
 
-def _runtime_managed_resource_summaries(
+def _runtime_managed_skill_summaries(
     state: HostedRuntimeState,
-) -> list[RuntimeManagedResourceSummary]:
-    resources: list[RuntimeManagedResourceSummary] = []
+) -> list[RuntimeManagedSkillSummary]:
+    managed_skills: list[RuntimeManagedSkillSummary] = []
     if state.skills is not None:
         try:
             skills = PersistedHostedRuntimeSkills.model_validate(state.skills)
         except ValueError:
             skills = None
         if skills is not None:
-            resources.extend(
+            managed_skills.extend(
                 RuntimeManagedSkillSummary(
                     id=skill_id,
-                    enabled=entry.enabled,
                     version=entry.version or 1,
                 )
                 for skill_id, entry in sorted(skills.entries.items())
+                if entry.enabled
             )
-    if state.mcp is not None:
-        try:
-            mcp = HostedRuntimeMcp.model_validate(state.mcp)
-        except ValueError:
-            mcp = None
-        if mcp is not None:
-            resources.extend(
-                RuntimeManagedMcpServerSummary(id=server_id) for server_id in sorted(mcp.servers)
-            )
-    return resources
+    return managed_skills
 
 
 def _runtime_observed_health(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -47,6 +47,8 @@ from app.schemas.runtime_observed import (
 from app.schemas.session import (
     AgentReorderRequest,
     AgentResponse,
+    AgentRuntimeObservedDesiredResponse,
+    AgentRuntimeObservedResponse,
     EnvironmentCreate,
     EnvironmentCreatedResponse,
     EnvironmentReorderRequest,
@@ -880,15 +882,46 @@ async def get_environment_runtime_observed(
 
 @router.get(
     "/agents/{agent_id}/runtime-observed",
-    response_model=RuntimeObservedResponse,
+    response_model=AgentRuntimeObservedResponse,
 )
 async def get_agent_runtime_observed(
     agent_id: UUID,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
-) -> RuntimeObservedResponse:
+) -> AgentRuntimeObservedResponse:
     """Canonical Agent-identity route for runtime desired/observed summaries."""
-    return await get_environment_runtime_observed(agent_id, auth, db)
+    response = await get_environment_runtime_observed(agent_id, auth, db)
+    state = await db.get(HostedRuntimeState, agent_id)
+    desired = response.desired
+    if desired is None and state is None:
+        return AgentRuntimeObservedResponse(
+            environment=response.environment,
+            desired=None,
+            observed=response.observed,
+            health=response.health,
+            provider_health=response.provider_health,
+        )
+    if (
+        desired is None
+        or state is None
+        or desired.deployment_id != state.deployment_id
+        or desired.instance_id != state.instance_id
+        or desired.desired_config_generation != state.generation
+    ):
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Runtime desired state changed while it was being read; retry the request.",
+        )
+    agent_desired = AgentRuntimeObservedDesiredResponse.model_validate(desired.model_dump())
+    return AgentRuntimeObservedResponse(
+        environment=response.environment,
+        desired=agent_desired.model_copy(
+            update={"managed_skills": _runtime_managed_skill_summaries(state)}
+        ),
+        observed=response.observed,
+        health=response.health,
+        provider_health=response.provider_health,
+    )
 
 
 @router.get("/assets/{asset_key:path}", include_in_schema=False)
@@ -1028,7 +1061,6 @@ def _runtime_observed_desired(
         enabled_runtimes=_enabled_runtime_names(state.runtimes),
         has_mcp=state.mcp is not None,
         has_tools=state.tools is not None,
-        managed_skills=_runtime_managed_skill_summaries(state),
         updated_at=state.updated_at,
     )
 
@@ -1041,16 +1073,18 @@ def _runtime_managed_skill_summaries(
         try:
             skills = PersistedHostedRuntimeSkills.model_validate(state.skills)
         except ValueError:
-            skills = None
-        if skills is not None:
-            managed_skills.extend(
-                RuntimeManagedSkillSummary(
-                    id=skill_id,
-                    version=entry.version or 1,
-                )
-                for skill_id, entry in sorted(skills.entries.items())
-                if entry.enabled
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Managed Skill inventory is temporarily unavailable.",
+            ) from None
+        managed_skills.extend(
+            RuntimeManagedSkillSummary(
+                id=skill_id,
+                version=entry.version or 1,
             )
+            for skill_id, entry in sorted(skills.entries.items())
+            if entry.enabled
+        )
     return managed_skills
 
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -313,8 +313,11 @@ class RuntimeObservedDesiredResponse(BaseModel):
     enabled_runtimes: list[str]
     has_mcp: bool = False
     has_tools: bool = False
-    managed_skills: list[RuntimeManagedSkillSummary] = Field(default_factory=list)
     updated_at: datetime | None = None
+
+
+class AgentRuntimeObservedDesiredResponse(RuntimeObservedDesiredResponse):
+    managed_skills: list[RuntimeManagedSkillSummary] = Field(default_factory=list)
 
 
 class RuntimeObservedHealthResponse(BaseModel):
@@ -337,6 +340,10 @@ class RuntimeObservedResponse(BaseModel):
     observed: RuntimeObservedConfigResponse | None = None
     health: RuntimeObservedHealthResponse
     provider_health: list[RuntimeObservedProviderHealthResponse] = []
+
+
+class AgentRuntimeObservedResponse(RuntimeObservedResponse):
+    desired: AgentRuntimeObservedDesiredResponse | None = None
 
 
 class RuntimeObservedSummaryCountsResponse(BaseModel):

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -300,23 +300,8 @@ class EnvironmentResponse(AgentResponse):
 class RuntimeManagedSkillSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    kind: Literal["skill"] = "skill"
     id: str
-    enabled: bool
     version: int = Field(ge=1)
-
-
-class RuntimeManagedMcpServerSummary(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    kind: Literal["mcp_server"] = "mcp_server"
-    id: str
-
-
-RuntimeManagedResourceSummary = Annotated[
-    RuntimeManagedSkillSummary | RuntimeManagedMcpServerSummary,
-    Field(discriminator="kind"),
-]
 
 
 class RuntimeObservedDesiredResponse(BaseModel):
@@ -328,7 +313,7 @@ class RuntimeObservedDesiredResponse(BaseModel):
     enabled_runtimes: list[str]
     has_mcp: bool = False
     has_tools: bool = False
-    managed_resources: list[RuntimeManagedResourceSummary] = Field(default_factory=list)
+    managed_skills: list[RuntimeManagedSkillSummary] = Field(default_factory=list)
     updated_at: datetime | None = None
 
 

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -540,7 +540,12 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         recovery={"cacheManifest": True, "allowOfflineBoot": True},
         runtimes=_test_runtimes(),
         mcp={"servers": {"clawdi": {"command": "clawdi", "args": ["mcp"]}}},
-        skills={"entries": {"clawdi": {"enabled": True, "version": 1}}},
+        skills={
+            "entries": {
+                "clawdi": {"enabled": True, "version": 1},
+                "removed": {"enabled": False, "version": 2},
+            }
+        },
         tools={**CANONICAL_CODEX_TOOLS, "catalog": "clawdi-default"},
     )
     db_session.add(state)
@@ -576,15 +581,12 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         "enabled_runtimes": ["openclaw"],
         "has_mcp": True,
         "has_tools": True,
-        "managed_resources": [],
+        "managed_skills": [{"id": "clawdi", "version": 1}],
         "updated_at": payload["desired"]["updated_at"],
     }
     canonical = await client.get(f"/v1/agents/{env_id}/runtime-observed")
     assert canonical.status_code == 200, canonical.text
-    assert canonical.json()["desired"]["managed_resources"] == [
-        {"kind": "skill", "id": "clawdi", "enabled": True, "version": 1},
-        {"kind": "mcp_server", "id": "clawdi"},
-    ]
+    assert canonical.json() == payload
     serialized = canonical.text.lower()
     assert "secretref" not in serialized
     assert '"headers"' not in serialized

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -31,6 +31,8 @@ from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation
+from app.routes import sessions as session_routes
+from app.schemas.session import RuntimeObservedResponse
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
@@ -581,12 +583,11 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         "enabled_runtimes": ["openclaw"],
         "has_mcp": True,
         "has_tools": True,
-        "managed_skills": [{"id": "clawdi", "version": 1}],
         "updated_at": payload["desired"]["updated_at"],
     }
     canonical = await client.get(f"/v1/agents/{env_id}/runtime-observed")
     assert canonical.status_code == 200, canonical.text
-    assert canonical.json() == payload
+    assert canonical.json()["desired"]["managed_skills"] == [{"id": "clawdi", "version": 1}]
     serialized = canonical.text.lower()
     assert "secretref" not in serialized
     assert '"headers"' not in serialized
@@ -608,6 +609,96 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     assert payload["health"]["status"] == "ok"
     assert payload["health"]["reasons"] == []
     assert payload["health"]["observed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_observed_schema_is_enriched_without_environment_v1_drift(
+    client: httpx.AsyncClient,
+):
+    openapi = (await client.get("/openapi.json")).json()
+    environment_schema = openapi["paths"]["/v1/environments/{environment_id}/runtime-observed"][
+        "get"
+    ]["responses"]["200"]["content"]["application/json"]["schema"]
+    agent_schema = openapi["paths"]["/v1/agents/{agent_id}/runtime-observed"]["get"]["responses"][
+        "200"
+    ]["content"]["application/json"]["schema"]
+    assert environment_schema["$ref"].endswith("/RuntimeObservedResponse")
+    assert agent_schema["$ref"].endswith("/AgentRuntimeObservedResponse")
+    desired = openapi["components"]["schemas"]["RuntimeObservedDesiredResponse"]
+    agent_desired = openapi["components"]["schemas"]["AgentRuntimeObservedDesiredResponse"]
+    assert "managed_skills" not in desired["properties"]
+    assert "managed_skills" in agent_desired["properties"]
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_observed_fails_closed_across_generation_race(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    env_id = await _create_env(client)
+    state = canonical_hosted_runtime_state(
+        environment_id=uuid.UUID(env_id),
+        deployment_id="dep-race",
+        instance_id="iid-race",
+        generation=2,
+        cli_package_spec=_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC,
+        locale=_TEST_LOCALE,
+        system=_TEST_SYSTEM,
+        live_sync={"enabled": False, "agents": []},
+        recovery={"cacheManifest": True, "allowOfflineBoot": True},
+        runtimes=_test_runtimes(),
+        skills={"entries": {"clawdi": {"enabled": True, "version": 1}}},
+        tools={**CANONICAL_CODEX_TOOLS, "catalog": "clawdi-default"},
+    )
+    db_session.add(state)
+    await db_session.commit()
+    stale_payload = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
+    stale_payload["desired"]["desired_config_generation"] = 1
+
+    async def stale_environment_response(*_args, **_kwargs) -> RuntimeObservedResponse:
+        return RuntimeObservedResponse.model_validate(stale_payload)
+
+    monkeypatch.setattr(
+        session_routes, "get_environment_runtime_observed", stale_environment_response
+    )
+    response = await client.get(f"/v1/agents/{env_id}/runtime-observed")
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Runtime desired state changed while it was being read; retry the request."
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_managed_skill_inventory_fails_closed_on_invalid_persisted_state(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    env_id = await _create_env(client)
+    state = canonical_hosted_runtime_state(
+        environment_id=uuid.UUID(env_id),
+        deployment_id="dep-invalid-skills",
+        instance_id="iid-invalid-skills",
+        generation=1,
+        cli_package_spec=_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC,
+        locale=_TEST_LOCALE,
+        system=_TEST_SYSTEM,
+        live_sync={"enabled": False, "agents": []},
+        recovery={"cacheManifest": True, "allowOfflineBoot": True},
+        runtimes=_test_runtimes(),
+        skills={"entries": {"clawdi": {"enabled": True, "version": 1}}},
+        tools={**CANONICAL_CODEX_TOOLS, "catalog": "clawdi-default"},
+    )
+    state.skills = {"entries": []}
+    db_session.add(state)
+    await db_session.commit()
+
+    environment = await client.get(f"/v1/environments/{env_id}/runtime-observed")
+    assert environment.status_code == 200
+    assert "managed_skills" not in environment.json()["desired"]
+    agent = await client.get(f"/v1/agents/{env_id}/runtime-observed")
+    assert agent.status_code == 503
+    assert agent.json() == {"detail": "Managed Skill inventory is temporarily unavailable."}
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -271,6 +271,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
+			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			const dirPath = join(skillsDir, entry.name);
 			if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
@@ -322,6 +323,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		const out: string[] = [];
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
+			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			if (shouldIgnoreUserSkill(join(skillsDir, entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir, entry.name, "SKILL.md");

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -5,8 +5,8 @@ import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
-	assertUserSkillTargetMutable,
 	migrateLegacyLocalSetupSkill,
+	mutateUserSkillTarget,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -341,15 +341,16 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(claudeDir(), "skills", key);
-		assertUserSkillTargetMutable(dir, key);
-		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		mutateUserSkillTarget(dir, key, () => {
+			if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		});
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const skillsDir = join(claudeDir(), "skills");
-		assertUserSkillTargetMutable(join(skillsDir, key), key);
-		await replaceSkillArchiveTarGz(key, skillsDir, join(skillsDir, key), tarGzBytes, () =>
-			assertUserSkillTargetMutable(join(skillsDir, key), key),
+		const targetDir = join(skillsDir, key);
+		await replaceSkillArchiveTarGz(key, skillsDir, targetDir, tarGzBytes, undefined, (mutation) =>
+			mutateUserSkillTarget(targetDir, key, mutation),
 		);
 	}
 

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -264,8 +264,6 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			// Upgrade bridge for local setup installs created before the ownership ledger.
-			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir, entry.name);
 			if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 			const skillMd = join(dirPath, "SKILL.md");
@@ -311,7 +309,6 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			if (entry.name === "clawdi") continue;
 			if (shouldIgnoreUserSkill(join(skillsDir, entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir, entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -3,8 +3,10 @@ import { basename, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	assertUserSkillTargetMutable,
+	migrateLegacyLocalSetupSkill,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -257,6 +259,12 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 	async collectSkills(): Promise<RawSkill[]> {
 		const skillsDir = join(claudeDir(), "skills");
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir, "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir)) return [];
 
 		const skills: RawSkill[] = [];
@@ -304,6 +312,12 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		// rescan returns the same set the bulk push would consider
 		// — otherwise nested or skip-listed dirs would diverge.
 		const skillsDir = join(claudeDir(), "skills");
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir, "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir)) return [];
 		const out: string[] = [];
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -247,8 +247,6 @@ export class CodexAdapter implements AgentAdapter {
 			// Skip dot-dirs (e.g. `.system/` holds Codex's built-in skills, not user-authored ones).
 			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			// Upgrade bridge for local setup installs created before the ownership ledger.
-			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir(), entry.name);
 			if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 			const skillMd = join(dirPath, "SKILL.md");
@@ -282,7 +280,6 @@ export class CodexAdapter implements AgentAdapter {
 			if (!entry.isDirectory()) continue;
 			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			if (entry.name === "clawdi") continue;
 			if (shouldIgnoreUserSkill(join(skillsDir(), entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir(), entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -3,8 +3,10 @@ import { join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	assertUserSkillTargetMutable,
+	migrateLegacyLocalSetupSkill,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -239,6 +241,12 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir())) return [];
 
 		const skills: RawSkill[] = [];
@@ -274,6 +282,12 @@ export class CodexAdapter implements AgentAdapter {
 	async listSkillKeys(): Promise<string[]> {
 		// Flat layout. Mirrors `collectSkills` filtering so the
 		// daemon's rescan and the bulk push see the same set.
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir())) return [];
 		const out: string[] = [];
 		for (const entry of readdirSync(skillsDir(), { withFileTypes: true })) {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -5,8 +5,8 @@ import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
-	assertUserSkillTargetMutable,
 	migrateLegacyLocalSetupSkill,
+	mutateUserSkillTarget,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -319,15 +319,16 @@ export class CodexAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
-		assertUserSkillTargetMutable(dir, key);
-		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		mutateUserSkillTarget(dir, key, () => {
+			if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		});
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		assertUserSkillTargetMutable(join(root, key), key);
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
-			assertUserSkillTargetMutable(join(root, key), key),
+		const targetDir = join(root, key);
+		await replaceSkillArchiveTarGz(key, root, targetDir, tarGzBytes, undefined, (mutation) =>
+			mutateUserSkillTarget(targetDir, key, mutation),
 		);
 	}
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -4,8 +4,10 @@ import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { isValidSkillKey } from "../lib/skill-key";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	assertUserSkillTargetMutable,
+	migrateLegacyLocalSetupSkill,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -203,6 +205,12 @@ export class HermesAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir())) return [];
 
 		const skills: RawSkill[] = [];
@@ -268,6 +276,12 @@ export class HermesAdapter implements AgentAdapter {
 		// place under `getSkillsRootDir()`. Without this method,
 		// the generic flat-walk used to silently drop nested
 		// Hermes skills from sync.
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir())) return [];
 		const out: string[] = [];
 		const walk = (dir: string): void => {

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -6,8 +6,8 @@ import { isValidSkillKey } from "../lib/skill-key";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
-	assertUserSkillTargetMutable,
 	migrateLegacyLocalSetupSkill,
+	mutateUserSkillTarget,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -312,15 +312,16 @@ export class HermesAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
-		assertUserSkillTargetMutable(dir, key);
-		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		mutateUserSkillTarget(dir, key, () => {
+			if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		});
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		assertUserSkillTargetMutable(join(root, key), key);
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
-			assertUserSkillTargetMutable(join(root, key), key),
+		const targetDir = join(root, key);
+		await replaceSkillArchiveTarGz(key, root, targetDir, tarGzBytes, undefined, (mutation) =>
+			mutateUserSkillTarget(targetDir, key, mutation),
 		);
 	}
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -218,8 +218,6 @@ export class HermesAdapter implements AgentAdapter {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (shouldSkipHermesSkillDir(entry.name)) continue;
-			// Upgrade bridge for local setup installs created before the ownership ledger.
-			if (dir === skillsDir() && entry.name === "clawdi") continue;
 			const fullPath = join(dir, entry.name);
 			const skillMd = join(fullPath, "SKILL.md");
 
@@ -276,7 +274,6 @@ export class HermesAdapter implements AgentAdapter {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
 				if (shouldSkipHermesSkillDir(entry.name)) continue;
-				if (dir === skillsDir() && entry.name === "clawdi") continue;
 				const fullPath = join(dir, entry.name);
 				if (existsSync(join(fullPath, "SKILL.md"))) {
 					const skillKey = hermesSkillKeyFromPath(fullPath);

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -3,8 +3,10 @@ import { isAbsolute, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	assertUserSkillTargetMutable,
+	migrateLegacyLocalSetupSkill,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -295,6 +297,12 @@ export class OpenClawAdapter implements AgentAdapter {
 	async collectSkills(): Promise<RawSkill[]> {
 		const skills: RawSkill[] = [];
 		const seen = new Map<string, string>(); // skillKey → first-winning agentDir
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 
 		// Skills can live under any `agents/<id>/skills/` — iterate every
 		// agent the user has on disk so a deployment with multiple
@@ -305,6 +313,12 @@ export class OpenClawAdapter implements AgentAdapter {
 		// user can rename or pick an explicit OPENCLAW_AGENT_ID.
 		for (const agentRoot of listAgentDirs()) {
 			const dir = join(agentRoot, "skills");
+			migrateLegacyLocalSetupSkill({
+				targetDir: join(dir, "clawdi"),
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			});
 			if (!existsSync(dir)) continue;
 
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -364,6 +378,12 @@ export class OpenClawAdapter implements AgentAdapter {
 		// silently dropping those skills. Pre-fix the cross-agent
 		// enumerator silently lost OpenClaw skills under any
 		// agent other than the active one.
+		migrateLegacyLocalSetupSkill({
+			targetDir: join(skillsDir(), "clawdi"),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		if (!existsSync(skillsDir())) return [];
 		const out: string[] = [];
 		for (const entry of readdirSync(skillsDir(), { withFileTypes: true })) {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -310,8 +310,6 @@ export class OpenClawAdapter implements AgentAdapter {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
 				if (SKIP_DIRS.has(entry.name)) continue;
-				// Upgrade bridge for local setup installs created before the ownership ledger.
-				if (entry.name === "clawdi") continue;
 				const dirPath = join(dir, entry.name);
 				if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
 				const skillMd = join(dirPath, "SKILL.md");
@@ -371,7 +369,6 @@ export class OpenClawAdapter implements AgentAdapter {
 		for (const entry of readdirSync(skillsDir(), { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
-			if (entry.name === "clawdi") continue;
 			if (shouldIgnoreUserSkill(join(skillsDir(), entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir(), entry.name, "SKILL.md");
 			if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -5,8 +5,8 @@ import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
-	assertUserSkillTargetMutable,
 	migrateLegacyLocalSetupSkill,
+	mutateUserSkillTarget,
 	shouldIgnoreUserSkill,
 } from "../runtime/managed-skill-reservation";
 import type {
@@ -407,15 +407,16 @@ export class OpenClawAdapter implements AgentAdapter {
 
 	async removeLocalSkill(key: string): Promise<void> {
 		const dir = join(skillsDir(), key);
-		assertUserSkillTargetMutable(dir, key);
-		if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		mutateUserSkillTarget(dir, key, () => {
+			if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+		});
 	}
 
 	async writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void> {
 		const root = skillsDir();
-		assertUserSkillTargetMutable(join(root, key), key);
-		await replaceSkillArchiveTarGz(key, root, join(root, key), tarGzBytes, () =>
-			assertUserSkillTargetMutable(join(root, key), key),
+		const targetDir = join(root, key);
+		await replaceSkillArchiveTarGz(key, root, targetDir, tarGzBytes, undefined, (mutation) =>
+			mutateUserSkillTarget(targetDir, key, mutation),
 		);
 	}
 

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -323,6 +323,7 @@ export class OpenClawAdapter implements AgentAdapter {
 
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
+				if (entry.name.startsWith(".")) continue;
 				if (SKIP_DIRS.has(entry.name)) continue;
 				const dirPath = join(dir, entry.name);
 				if (shouldIgnoreUserSkill(dirPath, entry.name)) continue;
@@ -388,6 +389,7 @@ export class OpenClawAdapter implements AgentAdapter {
 		const out: string[] = [];
 		for (const entry of readdirSync(skillsDir(), { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
+			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
 			if (shouldIgnoreUserSkill(join(skillsDir(), entry.name), entry.name)) continue;
 			const skillMd = join(skillsDir(), entry.name, "SKILL.md");

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -23,6 +23,7 @@ import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	installReservedManagedSkill,
 	managedSkillReservationState,
+	migrateLegacyLocalSetupSkill,
 	replaceManagedSkillDirectoryAtomic,
 } from "../runtime/managed-skill-reservation";
 import {
@@ -262,6 +263,12 @@ async function installBuiltinSkill(agentType: AgentType) {
 
 	try {
 		const sourceDigest = managedSkillDirectoryDigest(sourceDir);
+		migrateLegacyLocalSetupSkill({
+			targetDir,
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
 		const reservationState = managedSkillReservationState(targetDir);
 		if (
 			existsSync(targetDir) &&

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { cpSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { join, resolve } from "node:path";
 import * as p from "@clack/prompts";
@@ -21,8 +21,9 @@ import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
+	installReservedManagedSkill,
 	managedSkillReservationState,
-	reserveManagedSkill,
+	replaceManagedSkillDirectoryAtomic,
 } from "../runtime/managed-skill-reservation";
 import {
 	install as installDaemonService,
@@ -269,24 +270,21 @@ async function installBuiltinSkill(agentType: AgentType) {
 		) {
 			throw new Error(`refusing to replace unmanaged Skill at ${targetDir}`);
 		}
-		reserveManagedSkill({
-			targetDir,
-			id: "clawdi",
-			version: 1,
-			digest: sourceDigest,
-			manager: "local-setup",
-		});
-		mkdirSync(targetDir, { recursive: true });
-		// Always overwrite — the bundled skill content evolves with each CLI
-		// release (better trigger language, new tool descriptions), and users
-		// who ran setup once should get those improvements on re-run without
-		// having to manually delete the old copy.
-		cpSync(sourceDir, targetDir, { recursive: true, force: true });
+		installReservedManagedSkill(
+			{
+				targetDir,
+				id: "clawdi",
+				version: 1,
+				digest: sourceDigest,
+				manager: "local-setup",
+			},
+			() => replaceManagedSkillDirectoryAtomic(sourceDir, targetDir),
+		);
 		console.log(
 			chalk.green(`✓ Clawdi skill ${alreadyInstalled ? "updated" : "installed"} in ${label}`),
 		);
-	} catch {
-		console.log(chalk.yellow("⚠ Could not install Clawdi skill."));
+	} catch (error) {
+		console.log(chalk.yellow(`⚠ Could not install Clawdi skill (${errMessage(error)}).`));
 	}
 }
 

--- a/packages/cli/src/commands/teardown.ts
+++ b/packages/cli/src/commands/teardown.ts
@@ -15,7 +15,11 @@ import { errMessage } from "../lib/errors";
 import { askMulti, askYesNo } from "../lib/prompts";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
-import { releaseManagedSkill } from "../runtime/managed-skill-reservation";
+import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
+import {
+	migrateLegacyLocalSetupSkill,
+	releaseManagedSkill,
+} from "../runtime/managed-skill-reservation";
 
 export async function teardown(opts: {
 	agent?: string;
@@ -132,21 +136,29 @@ async function teardownOne(agentType: AgentType, opts: { keepSkill: boolean; kee
 	//    needs to add that endpoint first.
 
 	// 3. Bundled skill
-	if (!opts.keepSkill) {
-		const skillDir = builtinSkillTargetDir(agentType);
-		if (skillDir) {
-			try {
-				const result = releaseManagedSkill({
-					targetDir: skillDir,
-					id: "clawdi",
-					manager: "local-setup",
-					removeTarget: () => rmSync(skillDir, { recursive: true, force: true }),
-				});
+	const skillDir = builtinSkillTargetDir(agentType);
+	if (skillDir) {
+		try {
+			migrateLegacyLocalSetupSkill({
+				targetDir: skillDir,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			});
+			const result = releaseManagedSkill({
+				targetDir: skillDir,
+				id: "clawdi",
+				manager: "local-setup",
+				removeTarget: () => {
+					if (!opts.keepSkill) rmSync(skillDir, { recursive: true, force: true });
+				},
+			});
+			if (!opts.keepSkill) {
 				if (result === "absent") throw new Error("Skill is not owned by local setup");
 				p.log.success(`${label}: removed bundled skill (${skillDir})`);
-			} catch (e) {
-				p.log.warn(`${label}: could not remove skill (${errMessage(e)})`);
 			}
+		} catch (e) {
+			p.log.warn(`${label}: could not remove skill (${errMessage(e)})`);
 		}
 	}
 

--- a/packages/cli/src/lib/private-directory-lock.ts
+++ b/packages/cli/src/lib/private-directory-lock.ts
@@ -152,6 +152,84 @@ function releaseOwnedLock(lockDir: string, token: string): void {
 	rmSync(lockDir, { recursive: true, force: true });
 }
 
+function sleepSync(milliseconds: number): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+export function withPrivateDirectoryLockSync<T>(
+	lockDir: string,
+	fn: (lease: PrivateDirectoryLockLease) => T,
+	options: PrivateDirectoryLockOptions = {},
+): T {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+	const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+	const now = options.now ?? Date.now;
+	const alive = options.isProcessAlive ?? processIsAlive;
+	const parent = dirname(lockDir);
+	mkdirSync(parent, { recursive: true, mode: PRIVATE_DIR_MODE });
+	try {
+		chmodSync(parent, PRIVATE_DIR_MODE);
+	} catch {
+		// Best effort on platforms that do not implement POSIX permissions.
+	}
+
+	const startedAt = now();
+	const token = randomUUID();
+	for (;;) {
+		try {
+			mkdirSync(lockDir, { mode: PRIVATE_DIR_MODE });
+			try {
+				writePrivateFileAtomic(
+					ownerPath(lockDir),
+					`${JSON.stringify({
+						schemaVersion: "clawdi.privateDirectoryLockOwner.v1",
+						pid: process.pid,
+						acquiredAt: new Date(now()).toISOString(),
+						token,
+					})}\n`,
+					{ mode: PRIVATE_FILE_MODE, dirMode: PRIVATE_DIR_MODE },
+				);
+			} catch (error) {
+				rmSync(lockDir, { recursive: true, force: true });
+				throw error;
+			}
+			break;
+		} catch (error) {
+			if (!errno(error, "EEXIST")) throw error;
+			if (
+				reclaimStaleLock(lockDir, {
+					staleMs,
+					now,
+					isProcessAlive: alive,
+					beforeReclaimRename: options.beforeReclaimRename,
+				})
+			) {
+				continue;
+			}
+			if (now() - startedAt >= timeoutMs) {
+				throw new Error(`timed out waiting for private lock at ${lockDir}`);
+			}
+			sleepSync(retryMs);
+		}
+	}
+
+	const lease: PrivateDirectoryLockLease = {
+		token,
+		assertOwned() {
+			if (readOwner(lockDir)?.token !== token) {
+				throw new Error(`lost ownership of private lock at ${lockDir}`);
+			}
+		},
+	};
+	try {
+		lease.assertOwned();
+		return fn(lease);
+	} finally {
+		releaseOwnedLock(lockDir, token);
+	}
+}
+
 export async function withPrivateDirectoryLock<T>(
 	lockDir: string,
 	fn: (lease: PrivateDirectoryLockLease) => Promise<T>,

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -112,6 +112,7 @@ export async function replaceSkillArchiveTarGz(
 	targetDir: string,
 	bytes: Buffer,
 	beforeActivate?: () => void,
+	commitMutation: (mutation: () => void) => void = (mutation) => mutation(),
 ): Promise<void> {
 	assertValidSkillKey(skillKey);
 	const targetFromRoot = relative(skillsRoot, targetDir);
@@ -131,32 +132,34 @@ export async function replaceSkillArchiveTarGz(
 			throw new Error(`Skill tarball did not contain expected '${skillKey}/' root entry`);
 		}
 		mkdirSync(dirname(targetDir), { recursive: true });
-		let previousMoved = false;
-		if (existsSync(targetDir)) {
-			renameSync(targetDir, trash);
-			previousMoved = true;
-		}
-		try {
-			beforeActivate?.();
-			renameSync(stagedSkill, targetDir);
-		} catch (installError) {
-			if (!previousMoved) throw installError;
-			try {
-				renameSync(trash, targetDir);
-			} catch (restoreError) {
-				preserveStageForRecovery = true;
-				const installMessage =
-					installError instanceof Error ? installError.message : String(installError);
-				const restoreMessage =
-					restoreError instanceof Error ? restoreError.message : String(restoreError);
-				throw new Error(
-					`Skill install failed: ${installMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained at ${trash}`,
-					{ cause: installError },
-				);
+		commitMutation(() => {
+			let previousMoved = false;
+			if (existsSync(targetDir)) {
+				renameSync(targetDir, trash);
+				previousMoved = true;
 			}
-			throw installError;
-		}
-		if (existsSync(trash)) rmSync(trash, { recursive: true, force: true });
+			try {
+				beforeActivate?.();
+				renameSync(stagedSkill, targetDir);
+			} catch (installError) {
+				if (!previousMoved) throw installError;
+				try {
+					renameSync(trash, targetDir);
+				} catch (restoreError) {
+					preserveStageForRecovery = true;
+					const installMessage =
+						installError instanceof Error ? installError.message : String(installError);
+					const restoreMessage =
+						restoreError instanceof Error ? restoreError.message : String(restoreError);
+					throw new Error(
+						`Skill install failed: ${installMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained at ${trash}`,
+						{ cause: installError },
+					);
+				}
+				throw installError;
+			}
+			if (existsSync(trash)) rmSync(trash, { recursive: true, force: true });
+		});
 	} finally {
 		if (!preserveStageForRecovery) {
 			rmSync(stageRoot, { recursive: true, force: true });

--- a/packages/cli/src/runtime/converge-lock.ts
+++ b/packages/cli/src/runtime/converge-lock.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { RuntimePaths } from "./paths";
+
+function ownerPath(lockDir: string): string {
+	return join(lockDir, "owner.json");
+}
+
+function writeFileAtomic(path: string, content: string, mode: number): void {
+	const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
+	let renamed = false;
+	try {
+		writeFileSync(tmp, content, { mode });
+		renameSync(tmp, path);
+		renamed = true;
+	} finally {
+		if (!renamed) rmSync(tmp, { force: true });
+	}
+}
+
+function writeOwner(lockDir: string): void {
+	writeFileAtomic(
+		ownerPath(lockDir),
+		`${JSON.stringify({
+			schemaVersion: "clawdi.runtimeConvergeLockOwner.v1",
+			pid: process.pid,
+			acquiredAt: new Date().toISOString(),
+		})}\n`,
+		0o600,
+	);
+}
+
+function readOwnerPid(lockDir: string): number | null {
+	try {
+		const raw = JSON.parse(readFileSync(ownerPath(lockDir), "utf-8")) as unknown;
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+		const pid = (raw as Record<string, unknown>).pid;
+		return typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : null;
+	} catch {
+		return null;
+	}
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ESRCH") return false;
+		return true;
+	}
+}
+
+function reclaimStale(lockDir: string, timeoutMs: number): boolean {
+	const ownerPid = readOwnerPid(lockDir);
+	if (ownerPid === null) {
+		let mtimeMs: number;
+		try {
+			mtimeMs = statSync(lockDir).mtimeMs;
+		} catch (error) {
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+			throw error;
+		}
+		if (Date.now() - mtimeMs <= 2 * timeoutMs) return false;
+	} else if (processIsAlive(ownerPid)) {
+		return false;
+	}
+	const staleDir = `${lockDir}.stale.${process.pid}.${Date.now()}.${Math.random()
+		.toString(36)
+		.slice(2)}`;
+	try {
+		renameSync(lockDir, staleDir);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+		throw error;
+	}
+	rmSync(staleDir, { recursive: true, force: true });
+	return true;
+}
+
+function sleepSync(ms: number): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function lockPath(paths: RuntimePaths): string {
+	const lockRoot = join(paths.runRoot, "locks");
+	mkdirSync(lockRoot, { recursive: true });
+	return join(lockRoot, "converge.lock");
+}
+
+function tryAcquire(lockDir: string, timeoutMs: number, startedAt: number): boolean {
+	try {
+		mkdirSync(lockDir);
+		try {
+			writeOwner(lockDir);
+		} catch (error) {
+			rmSync(lockDir, { recursive: true, force: true });
+			throw error;
+		}
+		return true;
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+		if (reclaimStale(lockDir, timeoutMs)) return false;
+		if (Date.now() - startedAt > timeoutMs) {
+			throw new Error(`timed out waiting for runtime converge lock at ${lockDir}`);
+		}
+		return false;
+	}
+}
+
+export function withRuntimeConvergeLock<T>(
+	paths: RuntimePaths,
+	fn: () => T,
+	opts: { timeoutMs?: number } = {},
+): T {
+	const timeoutMs = opts.timeoutMs ?? 300_000;
+	const lockDir = lockPath(paths);
+	const startedAt = Date.now();
+	while (!tryAcquire(lockDir, timeoutMs, startedAt)) sleepSync(100);
+	try {
+		return fn();
+	} finally {
+		rmSync(lockDir, { recursive: true, force: true });
+	}
+}
+
+export async function withRuntimeConvergeLockAsync<T>(
+	paths: RuntimePaths,
+	fn: () => Promise<T>,
+	opts: { timeoutMs?: number } = {},
+): Promise<T> {
+	const timeoutMs = opts.timeoutMs ?? 300_000;
+	const lockDir = lockPath(paths);
+	const startedAt = Date.now();
+	while (!tryAcquire(lockDir, timeoutMs, startedAt)) {
+		await new Promise<void>((resolve) => setTimeout(resolve, 100));
+	}
+	try {
+		return await fn();
+	} finally {
+		rmSync(lockDir, { recursive: true, force: true });
+	}
+}

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -19,9 +19,15 @@ import {
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
+import {
+	installReservedManagedSkill,
+	managedSkillReservationState,
+} from "./managed-skill-reservation";
 
 const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
 const bundledSourceDir = resolve(import.meta.dir, "../../skills/hosted-versions/1/clawdi");
+const originalRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
+const originalServiceStateDir = process.env.CLAWDI_SERVICE_STATE_DIR;
 
 describe("hosted bundled skill reconciliation", () => {
 	let root: string;
@@ -34,14 +40,22 @@ describe("hosted bundled skill reconciliation", () => {
 
 	afterEach(() => {
 		rmSync(root, { recursive: true, force: true });
+		if (originalRuntimeMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+		else process.env.CLAWDI_RUNTIME_MODE = originalRuntimeMode;
+		if (originalServiceStateDir === undefined) delete process.env.CLAWDI_SERVICE_STATE_DIR;
+		else process.env.CLAWDI_SERVICE_STATE_DIR = originalServiceStateDir;
 	});
 
-	function reconcile(sourceDir = bundledSourceDir) {
+	function reconcile(
+		sourceDir = bundledSourceDir,
+		activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
+	) {
 		return reconcileHostedBundledSkill({
 			skillId: "clawdi",
 			version: 1,
 			sourceDir,
 			targetDir,
+			activation,
 		});
 	}
 
@@ -99,6 +113,39 @@ describe("hosted bundled skill reconciliation", () => {
 			digest: catalogEntry.digest,
 		});
 		expect(readdirSync(join(root, "target"))).toEqual(["clawdi"]);
+	});
+
+	it("treats activation as committed before best-effort previous-target cleanup", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		const install = (
+			activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
+		) =>
+			installReservedManagedSkill(
+				{
+					targetDir,
+					id: "clawdi",
+					version: 1,
+					digest: catalogEntry.digest,
+					manager: "hosted-manifest",
+				},
+				() => reconcile(bundledSourceDir, activation),
+			);
+		expect(install()).toBe("replaced");
+		writeFileSync(join(targetDir, "SKILL.md"), "tampered\n");
+
+		expect(
+			install({
+				beforeCleanup: () => {
+					throw new Error("cleanup failed");
+				},
+			}),
+		).toBe("replaced");
+		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
+			readFileSync(join(bundledSourceDir, "SKILL.md")),
+		);
+		expect(managedSkillReservationState(targetDir, "clawdi")).toBe("reserved");
+		expect(readdirSync(join(root, "target")).some((entry) => entry.includes("-trash-"))).toBe(true);
 	});
 
 	it("adopts an old marker only when catalog identity and live content match exactly", () => {

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -8,7 +8,6 @@ import {
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
-	renameSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -18,6 +17,10 @@ import {
 	computeManagedBundleHash,
 	type ManagedBundleHashEntry,
 } from "./managed-bundle-hash";
+import {
+	activateManagedSkillDirectory,
+	type ManagedSkillDirectoryActivationOptions,
+} from "./managed-skill-reservation";
 
 const HOSTED_BUNDLED_SKILL_MARKER = ".clawdi-managed.json";
 const HOSTED_BUNDLED_SKILL_MARKER_SCHEMA = "clawdi.hostedBundledSkillMarker.v1";
@@ -66,6 +69,8 @@ export interface ReconcileHostedBundledSkillInput {
 	targetDir: string;
 	/** A root-owned reservation for this exact target authorizes replacement. */
 	reserved?: boolean;
+	/** Deterministic failure hooks for the shared activation contract. */
+	activation?: ManagedSkillDirectoryActivationOptions;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -313,14 +318,12 @@ export function reconcileHostedBundledSkill(
 			`${JSON.stringify(marker, null, 2)}\n`,
 			{ mode: 0o600 },
 		);
-		if (targetExists) renameSync(input.targetDir, trash);
-		try {
-			renameSync(stagedTarget, input.targetDir);
-		} catch (error) {
-			if (existsSync(trash)) renameSync(trash, input.targetDir);
-			throw error;
-		}
-		if (existsSync(trash)) rmSync(trash, { recursive: true, force: true });
+		activateManagedSkillDirectory({
+			stagedTarget,
+			targetDir: input.targetDir,
+			previousTarget: trash,
+			options: input.activation,
+		});
 	} finally {
 		rmSync(stagingRoot, { recursive: true, force: true });
 	}

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	installReservedManagedSkill,
 	managedSkillReservationState,
 	releaseManagedSkill,
+	replaceManagedSkillDirectoryAtomic,
 	reserveManagedSkill,
+	shouldIgnoreUserSkill,
 } from "./managed-skill-reservation";
 
 const originalHome = process.env.HOME;
@@ -129,5 +132,139 @@ describe("managed Skill reservations", () => {
 			}),
 		).toThrow("identity is invalid");
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("reports malformed ownership state instead of silently hiding Skills", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const path = target();
+		const ledger = join(root, ".clawdi", "managed-resources", "managed-skills.json");
+		mkdirSync(join(ledger, ".."), { recursive: true });
+		writeFileSync(ledger, "not-json\n");
+
+		expect(managedSkillReservationState(path, "example")).toBe("indeterminate");
+		expect(() => shouldIgnoreUserSkill(path, "example")).toThrow(
+			"managed Skill ownership state is invalid",
+		);
+	});
+
+	it("atomically replaces stale files under an active reservation", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const source = join(root, "source");
+		const path = target();
+		mkdirSync(source, { recursive: true });
+		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
+		writeFileSync(join(path, "removed.txt"), "stale\n");
+
+		installReservedManagedSkill(
+			{
+				targetDir: path,
+				id: "example",
+				version: 2,
+				digest: "e".repeat(64),
+				manager: "local-setup",
+			},
+			() => replaceManagedSkillDirectoryAtomic(source, path),
+		);
+
+		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Updated\n");
+		expect(existsSync(join(path, "removed.txt"))).toBe(false);
+		expect(managedSkillReservationState(path, "example")).toBe("reserved");
+	});
+
+	it("restores target and ownership when activation fails", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const source = join(root, "source");
+		const path = target();
+		mkdirSync(source, { recursive: true });
+		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
+
+		expect(() =>
+			installReservedManagedSkill(
+				{
+					targetDir: path,
+					id: "example",
+					version: 2,
+					digest: "f".repeat(64),
+					manager: "local-setup",
+				},
+				() =>
+					replaceManagedSkillDirectoryAtomic(source, path, {
+						beforeActivate: () => {
+							throw new Error("injected activation failure");
+						},
+					}),
+			),
+		).toThrow("injected activation failure");
+
+		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Example\n");
+		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("serializes local writers so rollback cannot lose a concurrent reservation", async () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		const firstTarget = join(root, "skills", "first");
+		const secondTarget = join(root, "skills", "second");
+		const ready = join(root, "first-ready");
+		const moduleUrl = new URL("./managed-skill-reservation.ts", import.meta.url).href;
+		const childEnv = {
+			...process.env,
+			HOME: root,
+			CLAWDI_RUNTIME_MODE: "",
+			CLAWDI_SERVICE_STATE_DIR: "",
+		};
+		const first = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`import { writeFileSync } from "node:fs";
+const { installReservedManagedSkill } = await import(${JSON.stringify(moduleUrl)});
+try {
+  installReservedManagedSkill(${JSON.stringify({
+		targetDir: firstTarget,
+		id: "first",
+		version: 1,
+		digest: "1".repeat(64),
+		manager: "local-setup",
+	})}, () => {
+    writeFileSync(${JSON.stringify(ready)}, "ready");
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+    throw new Error("rollback");
+  });
+} catch (error) {
+  if (!(error instanceof Error) || error.message !== "rollback") throw error;
+}`,
+			],
+			{ env: childEnv, stdout: "pipe", stderr: "pipe" },
+		);
+		for (let attempt = 0; attempt < 200 && !existsSync(ready); attempt += 1) {
+			await Bun.sleep(10);
+		}
+		expect(existsSync(ready)).toBe(true);
+		const second = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`const { reserveManagedSkill } = await import(${JSON.stringify(moduleUrl)});
+reserveManagedSkill(${JSON.stringify({
+					targetDir: secondTarget,
+					id: "second",
+					version: 1,
+					digest: "2".repeat(64),
+					manager: "local-setup",
+				})});`,
+			],
+			{ env: childEnv, stdout: "pipe", stderr: "pipe" },
+		);
+
+		expect(await first.exited).toBe(0);
+		expect(await second.exited).toBe(0);
+		process.env.HOME = root;
+		delete process.env.CLAWDI_RUNTIME_MODE;
+		delete process.env.CLAWDI_SERVICE_STATE_DIR;
+		expect(managedSkillReservationState(firstTarget, "first")).toBe("unreserved");
+		expect(managedSkillReservationState(secondTarget, "second")).toBe("reserved");
 	});
 });

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
 	installReservedManagedSkill,
 	managedSkillReservationState,
+	migrateLegacyLocalSetupSkill,
 	releaseManagedSkill,
 	replaceManagedSkillDirectoryAtomic,
 	reserveManagedSkill,
@@ -148,6 +157,46 @@ describe("managed Skill reservations", () => {
 		);
 	});
 
+	it("records legacy migration independently for each canonical target", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const existing = join(root, "one", "skills", "clawdi");
+		const absent = join(root, "two", "skills", "clawdi");
+		mkdirSync(existing, { recursive: true });
+		writeFileSync(join(existing, "SKILL.md"), "# Old bundled Skill\n");
+		const digest = () => "a".repeat(64);
+
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: existing,
+				id: "clawdi",
+				version: 1,
+				digest,
+			}),
+		).toBe("adopted");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: absent,
+				id: "clawdi",
+				version: 1,
+				digest,
+			}),
+		).toBe("absent");
+		expect(managedSkillReservationState(existing, "clawdi")).toBe("reserved");
+
+		mkdirSync(absent, { recursive: true });
+		writeFileSync(join(absent, "SKILL.md"), "# Future user Skill\n");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: absent,
+				id: "clawdi",
+				version: 1,
+				digest,
+			}),
+		).toBe("already_migrated");
+		expect(managedSkillReservationState(absent, "clawdi")).toBe("unreserved");
+	});
+
 	it("atomically replaces stale files under an active reservation", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.HOME = root;
@@ -201,6 +250,78 @@ describe("managed Skill reservations", () => {
 
 		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Example\n");
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("preserves the previous target when activation and restore both fail", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const source = join(root, "source");
+		const path = target();
+		mkdirSync(source, { recursive: true });
+		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
+
+		expect(() =>
+			installReservedManagedSkill(
+				{
+					targetDir: path,
+					id: "example",
+					version: 2,
+					digest: "3".repeat(64),
+					manager: "local-setup",
+				},
+				() =>
+					replaceManagedSkillDirectoryAtomic(source, path, {
+						beforeActivate: () => {
+							throw new Error("activation failed");
+						},
+						beforeRestore: () => {
+							throw new Error("restore failed");
+						},
+					}),
+			),
+		).toThrow(
+			/activation failed.*restore failed.*previous version retained as a recovery artifact/,
+		);
+
+		expect(existsSync(path)).toBe(false);
+		const recovery = readdirSync(dirname(path)).find((entry) =>
+			entry.startsWith(`.${basename(path)}-previous-`),
+		);
+		expect(recovery).toBeDefined();
+		if (!recovery) throw new Error("expected recovery artifact");
+		expect(readFileSync(join(dirname(path), recovery, "SKILL.md"), "utf8")).toBe("# Example\n");
+		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+	});
+
+	it("keeps committed ownership when previous-target cleanup fails", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const source = join(root, "source");
+		const path = target();
+		mkdirSync(source, { recursive: true });
+		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
+
+		installReservedManagedSkill(
+			{
+				targetDir: path,
+				id: "example",
+				version: 2,
+				digest: "4".repeat(64),
+				manager: "local-setup",
+			},
+			() =>
+				replaceManagedSkillDirectoryAtomic(source, path, {
+					beforeCleanup: () => {
+						throw new Error("cleanup failed");
+					},
+				}),
+		);
+
+		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Updated\n");
+		expect(managedSkillReservationState(path, "example")).toBe("reserved");
+		expect(
+			readdirSync(dirname(path)).some((entry) => entry.startsWith(`.${basename(path)}-previous-`)),
+		).toBe(true);
 	});
 
 	it("serializes local writers so rollback cannot lose a concurrent reservation", async () => {

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+	cpSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -9,11 +10,13 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
+import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import {
 	installReservedManagedSkill,
 	managedSkillReservationState,
 	migrateLegacyLocalSetupSkill,
+	mutateUserSkillTarget,
 	releaseManagedSkill,
 	replaceManagedSkillDirectoryAtomic,
 	reserveManagedSkill,
@@ -162,16 +165,14 @@ describe("managed Skill reservations", () => {
 		process.env.HOME = root;
 		const existing = join(root, "one", "skills", "clawdi");
 		const absent = join(root, "two", "skills", "clawdi");
-		mkdirSync(existing, { recursive: true });
-		writeFileSync(join(existing, "SKILL.md"), "# Old bundled Skill\n");
-		const digest = () => "a".repeat(64);
+		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), existing, { recursive: true });
 
 		expect(
 			migrateLegacyLocalSetupSkill({
 				targetDir: existing,
 				id: "clawdi",
 				version: 1,
-				digest,
+				digest: managedSkillDirectoryDigest,
 			}),
 		).toBe("adopted");
 		expect(
@@ -179,7 +180,7 @@ describe("managed Skill reservations", () => {
 				targetDir: absent,
 				id: "clawdi",
 				version: 1,
-				digest,
+				digest: managedSkillDirectoryDigest,
 			}),
 		).toBe("absent");
 		expect(managedSkillReservationState(existing, "clawdi")).toBe("reserved");
@@ -191,10 +192,36 @@ describe("managed Skill reservations", () => {
 				targetDir: absent,
 				id: "clawdi",
 				version: 1,
-				digest,
+				digest: managedSkillDirectoryDigest,
 			}),
 		).toBe("already_migrated");
 		expect(managedSkillReservationState(absent, "clawdi")).toBe("unreserved");
+	});
+
+	it("records custom same-name content as unmanaged instead of adopting it", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const custom = join(root, "one", "skills", "clawdi");
+		mkdirSync(custom, { recursive: true });
+		writeFileSync(join(custom, "SKILL.md"), "---\nname: clawdi\ndescription: User Skill\n---\n");
+
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: custom,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("unmanaged");
+		expect(managedSkillReservationState(custom, "clawdi")).toBe("unreserved");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: custom,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("already_migrated");
 	});
 
 	it("atomically replaces stale files under an active reservation", () => {
@@ -387,5 +414,69 @@ reserveManagedSkill(${JSON.stringify({
 		delete process.env.CLAWDI_SERVICE_STATE_DIR;
 		expect(managedSkillReservationState(firstTarget, "first")).toBe("unreserved");
 		expect(managedSkillReservationState(secondTarget, "second")).toBe("reserved");
+	});
+
+	it("linearizes user target commits after a concurrent reservation install", async () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		const path = join(root, "skills", "example");
+		const ready = join(root, "reservation-ready");
+		const moduleUrl = new URL("./managed-skill-reservation.ts", import.meta.url).href;
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`import { mkdirSync, writeFileSync } from "node:fs";
+const { installReservedManagedSkill } = await import(${JSON.stringify(moduleUrl)});
+installReservedManagedSkill(${JSON.stringify({
+					targetDir: path,
+					id: "example",
+					version: 1,
+					digest: "5".repeat(64),
+					manager: "local-setup",
+				})}, () => {
+  mkdirSync(${JSON.stringify(path)}, { recursive: true });
+  writeFileSync(${JSON.stringify(join(path, "SKILL.md"))}, "# Managed\\n");
+  writeFileSync(${JSON.stringify(ready)}, "ready");
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+});`,
+			],
+			{
+				env: {
+					...process.env,
+					HOME: root,
+					CLAWDI_RUNTIME_MODE: "",
+					CLAWDI_SERVICE_STATE_DIR: "",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		for (let attempt = 0; attempt < 200 && !existsSync(ready); attempt += 1) {
+			await Bun.sleep(10);
+		}
+		expect(existsSync(ready)).toBe(true);
+		process.env.HOME = root;
+		delete process.env.CLAWDI_RUNTIME_MODE;
+		delete process.env.CLAWDI_SERVICE_STATE_DIR;
+
+		expect(() =>
+			mutateUserSkillTarget(path, "example", () => rmSync(path, { recursive: true, force: true })),
+		).toThrow("reserved by a managed Skill owner");
+		expect(await child.exited).toBe(0);
+		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Managed\n");
+		expect(() =>
+			mutateUserSkillTarget(path, "example", () =>
+				writeFileSync(join(path, "SKILL.md"), "# Overwritten\n"),
+			),
+		).toThrow("reserved by a managed Skill owner");
+
+		releaseManagedSkill({
+			targetDir: path,
+			id: "example",
+			manager: "local-setup",
+			removeTarget: () => undefined,
+		});
+		mutateUserSkillTarget(path, "example", () => writeFileSync(join(path, "SKILL.md"), "# User\n"));
+		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# User\n");
 	});
 });

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -7,6 +7,7 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -204,6 +205,33 @@ describe("managed Skill reservations", () => {
 		const custom = join(root, "one", "skills", "clawdi");
 		mkdirSync(custom, { recursive: true });
 		writeFileSync(join(custom, "SKILL.md"), "---\nname: clawdi\ndescription: User Skill\n---\n");
+
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: custom,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("unmanaged");
+		expect(managedSkillReservationState(custom, "clawdi")).toBe("unreserved");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: custom,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("already_migrated");
+	});
+
+	it("completes legacy migration when custom same-name content cannot be digested", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const custom = join(root, "one", "skills", "clawdi");
+		mkdirSync(custom, { recursive: true });
+		writeFileSync(join(custom, "SKILL.md"), "# User Skill\n");
+		symlinkSync("SKILL.md", join(custom, "unsupported-link"));
 
 		expect(
 			migrateLegacyLocalSetupSkill({

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -1,6 +1,17 @@
-import { existsSync, lstatSync, readFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	cpSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { getClawdiDir } from "../lib/config";
+import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
 
 const LEDGER_FILE = "managed-skills.json";
@@ -47,13 +58,11 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 		const stat = lstatSync(path);
 		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
 		value = JSON.parse(readFileSync(path, "utf8"));
-	} catch (error) {
-		throw new Error(
-			`managed Skill reservation ledger is invalid: ${error instanceof Error ? error.message : String(error)}`,
-		);
+	} catch {
+		throw new Error("managed Skill ownership state is invalid");
 	}
 	if (!isRecord(value) || value.schemaVersion !== LEDGER_SCHEMA || !isRecord(value.reservations)) {
-		throw new Error("managed Skill reservation ledger has an unsupported schema");
+		throw new Error("managed Skill ownership state is invalid");
 	}
 	const reservations: Record<string, ManagedSkillReservation> = {};
 	for (const [target, raw] of Object.entries(value.reservations)) {
@@ -71,7 +80,7 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 			!SHA256_PATTERN.test(raw.digest) ||
 			(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
 		) {
-			throw new Error("managed Skill reservation ledger contains an invalid reservation");
+			throw new Error("managed Skill ownership state is invalid");
 		}
 		reservations[target] = {
 			target,
@@ -89,6 +98,16 @@ function writeLedger(path: string, ledger: ManagedSkillReservationLedger): void 
 		mode: 0o644,
 		dirMode: 0o755,
 	});
+}
+
+function withLedgerWriteLock<T>(manager: ManagedSkillReservationManager, write: () => T): T {
+	// Hosted writers already run under the global runtime converge lock. Local
+	// setup and teardown use a private user-state lock so concurrent commands
+	// cannot lose reservations without chmod'ing the hosted projection parent.
+	if (manager === "hosted-manifest") return write();
+	return withPrivateDirectoryLockSync(join(getClawdiDir(), "locks", "managed-skills.lock"), () =>
+		write(),
+	);
 }
 
 export function managedSkillReservationState(
@@ -113,7 +132,11 @@ export function managedSkillReservationOwner(
 }
 
 export function shouldIgnoreUserSkill(targetDir: string, skillId = basename(targetDir)): boolean {
-	return managedSkillReservationState(targetDir, skillId) !== "unreserved";
+	const state = managedSkillReservationState(targetDir, skillId);
+	if (state === "indeterminate") {
+		throw new Error("managed Skill ownership state is invalid");
+	}
+	return state === "reserved";
 }
 
 export function assertUserSkillTargetMutable(
@@ -143,21 +166,99 @@ export function reserveManagedSkill(input: {
 	) {
 		throw new Error("managed Skill reservation identity is invalid");
 	}
-	const ledger = readLedger(path);
-	const previous = ledger.reservations[target];
-	const manager = input.manager;
-	if (previous && previous.manager !== manager) {
-		throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+	return withLedgerWriteLock(input.manager, () => {
+		const ledger = readLedger(path);
+		const previous = ledger.reservations[target];
+		const manager = input.manager;
+		if (previous && previous.manager !== manager) {
+			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+		}
+		ledger.reservations[target] = {
+			target,
+			id: input.id,
+			version: input.version,
+			digest: input.digest,
+			manager,
+		};
+		writeLedger(path, ledger);
+		return previous ? "existing" : "created";
+	});
+}
+
+export function installReservedManagedSkill<T>(
+	input: {
+		targetDir: string;
+		id: string;
+		version: number;
+		digest: string;
+		manager: ManagedSkillReservationManager;
+	},
+	install: () => T,
+): T {
+	const path = ledgerPath();
+	const target = resolve(input.targetDir);
+	if (
+		basename(target) !== input.id ||
+		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
+		!Number.isSafeInteger(input.version) ||
+		input.version <= 0 ||
+		!SHA256_PATTERN.test(input.digest)
+	) {
+		throw new Error("managed Skill reservation identity is invalid");
 	}
-	ledger.reservations[target] = {
-		target,
-		id: input.id,
-		version: input.version,
-		digest: input.digest,
-		manager,
-	};
-	writeLedger(path, ledger);
-	return previous ? "existing" : "created";
+	return withLedgerWriteLock(input.manager, () => {
+		const ledger = readLedger(path);
+		const previous = ledger.reservations[target];
+		if (previous && previous.manager !== input.manager) {
+			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+		}
+		ledger.reservations[target] = {
+			target,
+			id: input.id,
+			version: input.version,
+			digest: input.digest,
+			manager: input.manager,
+		};
+		writeLedger(path, ledger);
+		try {
+			return install();
+		} catch (error) {
+			if (previous) ledger.reservations[target] = previous;
+			else delete ledger.reservations[target];
+			writeLedger(path, ledger);
+			throw error;
+		}
+	});
+}
+
+export function replaceManagedSkillDirectoryAtomic(
+	sourceDir: string,
+	targetDir: string,
+	options: { beforeActivate?: () => void } = {},
+): void {
+	const parent = dirname(targetDir);
+	mkdirSync(parent, { recursive: true });
+	const stagingRoot = mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
+	const stagedTarget = join(stagingRoot, basename(targetDir));
+	const previousTarget = join(
+		parent,
+		`.${basename(targetDir)}-previous-${process.pid}-${randomUUID()}`,
+	);
+	try {
+		cpSync(sourceDir, stagedTarget, { recursive: true });
+		const hadPrevious = existsSync(targetDir);
+		if (hadPrevious) renameSync(targetDir, previousTarget);
+		try {
+			options.beforeActivate?.();
+			renameSync(stagedTarget, targetDir);
+		} catch (error) {
+			if (hadPrevious) renameSync(previousTarget, targetDir);
+			throw error;
+		}
+		if (hadPrevious) rmSync(previousTarget, { recursive: true, force: true });
+	} finally {
+		rmSync(stagingRoot, { recursive: true, force: true });
+	}
 }
 
 export function releaseManagedSkill(input: {
@@ -168,16 +269,18 @@ export function releaseManagedSkill(input: {
 }): "absent" | "removed" {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
-	const ledger = readLedger(path);
-	const reservation = ledger.reservations[target];
-	if (!reservation) return "absent";
-	if (reservation.id !== input.id || reservation.manager !== input.manager) {
-		throw new Error("managed Skill reservation identity mismatch");
-	}
-	input.removeTarget();
-	delete ledger.reservations[target];
-	writeLedger(path, ledger);
-	return "removed";
+	return withLedgerWriteLock(input.manager, () => {
+		const ledger = readLedger(path);
+		const reservation = ledger.reservations[target];
+		if (!reservation) return "absent";
+		if (reservation.id !== input.id || reservation.manager !== input.manager) {
+			throw new Error("managed Skill reservation identity mismatch");
+		}
+		input.removeTarget();
+		delete ledger.reservations[target];
+		writeLedger(path, ledger);
+		return "removed";
+	});
 }
 
 export function isReservedSkillArchivePath(path: string): boolean {

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -221,11 +221,18 @@ export function migrateLegacyLocalSetupSkill(input: {
 		const existing = ledger.reservations[target];
 		let outcome: "adopted" | "absent" | "unmanaged" = "absent";
 		if (!existing && existsSync(target)) {
-			const digest = input.digest(target);
-			if (!SHA256_PATTERN.test(digest)) {
+			let digest: string | undefined;
+			try {
+				digest = input.digest(target);
+			} catch {
+				// Unsupported entries cannot prove legacy bundled identity. Complete
+				// migration without claiming user-owned content so scans can proceed.
+				outcome = "unmanaged";
+			}
+			if (digest !== undefined && !SHA256_PATTERN.test(digest)) {
 				throw new Error("managed Skill migration digest is invalid");
 			}
-			if (LEGACY_LOCAL_SETUP_SKILL_DIGESTS.has(digest)) {
+			if (digest !== undefined && LEGACY_LOCAL_SETUP_SKILL_DIGESTS.has(digest)) {
 				ledger.reservations[target] = {
 					target,
 					id: input.id,
@@ -234,7 +241,7 @@ export function migrateLegacyLocalSetupSkill(input: {
 					manager: "local-setup",
 				};
 				outcome = "adopted";
-			} else {
+			} else if (digest !== undefined) {
 				outcome = "unmanaged";
 			}
 		}

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -32,6 +32,7 @@ interface ManagedSkillReservation {
 interface ManagedSkillReservationLedger {
 	schemaVersion: typeof LEDGER_SCHEMA;
 	reservations: Record<string, ManagedSkillReservation>;
+	localSetupMigrations: Record<string, { target: string; id: string }>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -48,7 +49,7 @@ function ledgerPath(): string {
 }
 
 function emptyLedger(): ManagedSkillReservationLedger {
-	return { schemaVersion: LEDGER_SCHEMA, reservations: {} };
+	return { schemaVersion: LEDGER_SCHEMA, reservations: {}, localSetupMigrations: {} };
 }
 
 function readLedger(path: string): ManagedSkillReservationLedger {
@@ -61,7 +62,12 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 	} catch {
 		throw new Error("managed Skill ownership state is invalid");
 	}
-	if (!isRecord(value) || value.schemaVersion !== LEDGER_SCHEMA || !isRecord(value.reservations)) {
+	if (
+		!isRecord(value) ||
+		value.schemaVersion !== LEDGER_SCHEMA ||
+		!isRecord(value.reservations) ||
+		(value.localSetupMigrations !== undefined && !isRecord(value.localSetupMigrations))
+	) {
 		throw new Error("managed Skill ownership state is invalid");
 	}
 	const reservations: Record<string, ManagedSkillReservation> = {};
@@ -90,7 +96,21 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 			manager: raw.manager,
 		};
 	}
-	return { schemaVersion: LEDGER_SCHEMA, reservations };
+	const localSetupMigrations: Record<string, { target: string; id: string }> = {};
+	for (const [target, raw] of Object.entries(value.localSetupMigrations ?? {})) {
+		if (
+			!isRecord(raw) ||
+			raw.target !== target ||
+			resolve(target) !== target ||
+			typeof raw.id !== "string" ||
+			basename(target) !== raw.id ||
+			!MANAGED_SKILL_ID_PATTERN.test(raw.id)
+		) {
+			throw new Error("managed Skill ownership state is invalid");
+		}
+		localSetupMigrations[target] = { target, id: raw.id };
+	}
+	return { schemaVersion: LEDGER_SCHEMA, reservations, localSetupMigrations };
 }
 
 function writeLedger(path: string, ledger: ManagedSkillReservationLedger): void {
@@ -144,8 +164,51 @@ export function assertUserSkillTargetMutable(
 	skillId = basename(targetDir),
 ): void {
 	if (shouldIgnoreUserSkill(targetDir, skillId)) {
-		throw new Error(`Skill ${skillId} is reserved by the hosted runtime manifest`);
+		throw new Error(`Skill ${skillId} is reserved by a managed Skill owner`);
 	}
+}
+
+export function migrateLegacyLocalSetupSkill(input: {
+	targetDir: string;
+	id: string;
+	version: number;
+	digest: (targetDir: string) => string;
+}): "adopted" | "already_migrated" | "absent" | "hosted" {
+	if (process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted") return "hosted";
+	if (process.env.CLAWDI_SERVICE_STATE_DIR?.trim()) return "hosted";
+	const path = ledgerPath();
+	const target = resolve(input.targetDir);
+	if (
+		basename(target) !== input.id ||
+		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
+		!Number.isSafeInteger(input.version) ||
+		input.version <= 0
+	) {
+		throw new Error("managed Skill migration identity is invalid");
+	}
+	return withLedgerWriteLock("local-setup", () => {
+		const ledger = readLedger(path);
+		if (ledger.localSetupMigrations[target]) return "already_migrated";
+		const existing = ledger.reservations[target];
+		let outcome: "adopted" | "absent" = "absent";
+		if (!existing && existsSync(target)) {
+			const digest = input.digest(target);
+			if (!SHA256_PATTERN.test(digest)) {
+				throw new Error("managed Skill migration digest is invalid");
+			}
+			ledger.reservations[target] = {
+				target,
+				id: input.id,
+				version: input.version,
+				digest,
+				manager: "local-setup",
+			};
+			outcome = "adopted";
+		}
+		ledger.localSetupMigrations[target] = { target, id: input.id };
+		writeLedger(path, ledger);
+		return outcome;
+	});
 }
 
 export function reserveManagedSkill(input: {
@@ -234,7 +297,7 @@ export function installReservedManagedSkill<T>(
 export function replaceManagedSkillDirectoryAtomic(
 	sourceDir: string,
 	targetDir: string,
-	options: { beforeActivate?: () => void } = {},
+	options: ManagedSkillDirectoryActivationOptions = {},
 ): void {
 	const parent = dirname(targetDir);
 	mkdirSync(parent, { recursive: true });
@@ -246,18 +309,56 @@ export function replaceManagedSkillDirectoryAtomic(
 	);
 	try {
 		cpSync(sourceDir, stagedTarget, { recursive: true });
-		const hadPrevious = existsSync(targetDir);
-		if (hadPrevious) renameSync(targetDir, previousTarget);
-		try {
-			options.beforeActivate?.();
-			renameSync(stagedTarget, targetDir);
-		} catch (error) {
-			if (hadPrevious) renameSync(previousTarget, targetDir);
-			throw error;
-		}
-		if (hadPrevious) rmSync(previousTarget, { recursive: true, force: true });
+		activateManagedSkillDirectory({ stagedTarget, targetDir, previousTarget, options });
 	} finally {
 		rmSync(stagingRoot, { recursive: true, force: true });
+	}
+}
+
+export interface ManagedSkillDirectoryActivationOptions {
+	beforeActivate?: () => void;
+	beforeRestore?: () => void;
+	beforeCleanup?: () => void;
+}
+
+export function activateManagedSkillDirectory(input: {
+	stagedTarget: string;
+	targetDir: string;
+	previousTarget: string;
+	options?: ManagedSkillDirectoryActivationOptions;
+}): void {
+	const hadPrevious = existsSync(input.targetDir);
+	if (hadPrevious) renameSync(input.targetDir, input.previousTarget);
+	try {
+		input.options?.beforeActivate?.();
+		renameSync(input.stagedTarget, input.targetDir);
+	} catch (activationError) {
+		if (!hadPrevious) throw activationError;
+		try {
+			input.options?.beforeRestore?.();
+			renameSync(input.previousTarget, input.targetDir);
+		} catch (restoreError) {
+			const activationMessage =
+				activationError instanceof Error ? activationError.message : String(activationError);
+			const restoreMessage =
+				restoreError instanceof Error ? restoreError.message : String(restoreError);
+			throw new Error(
+				`Skill activation failed: ${activationMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained as a recovery artifact`,
+				{ cause: activationError },
+			);
+		}
+		throw activationError;
+	}
+
+	// Renaming the staged target is the commit point. Cleanup is GC only and
+	// must never make callers roll back ownership after the new target is live.
+	if (hadPrevious) {
+		try {
+			input.options?.beforeCleanup?.();
+			rmSync(input.previousTarget, { recursive: true, force: true });
+		} catch {
+			// Best effort. The uniquely named sibling is safe to collect later.
+		}
 	}
 }
 

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -13,11 +13,24 @@ import { basename, dirname, join, resolve } from "node:path";
 import { getClawdiDir } from "../lib/config";
 import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { withRuntimeConvergeLock } from "./converge-lock";
+import { getRuntimePaths } from "./paths";
 
 const LEDGER_FILE = "managed-skills.json";
 const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
 const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+// Exact local bundled Skill trees shipped by published CLI releases before the
+// ownership ledger. Pre-ledger installs had no marker, so content is the only
+// durable identity proof available for one-time adoption.
+const LEGACY_LOCAL_SETUP_SKILL_DIGESTS = new Set([
+	"954d8b81e67138cb59385353490679d191451d5d36bfe461571f91db43fb4bb4",
+	"b89cad1fa72e8b90b65b579e86e3fe57730b0d349710b13b192794d3862010bf",
+	"5719cc8e5dbdf4f3b7ff732589d3b23883fbead713652434a5e765c17308708a",
+	"2bb89a1ba5b546ea75cbc07351908aabdd19e3abc6fa4f3af0e83bb7fbda36d6",
+	"c8ce517615d7d8919d6149afee7b5702c39e157c5684b94b6fb365e3fc9644e7",
+	"ed7f4415a7a024990b7ce4d94040ce06621c5182ac42434b6eb6a19abefd5043",
+]);
 
 export type ManagedSkillReservationManager = "hosted-manifest" | "local-setup";
 
@@ -168,17 +181,33 @@ export function assertUserSkillTargetMutable(
 	}
 }
 
+/** Linearize a user-owned target commit with reservation/install/release commits. */
+export function mutateUserSkillTarget<T>(targetDir: string, skillId: string, mutation: () => T): T {
+	const commit = () => {
+		assertUserSkillTargetMutable(targetDir, skillId);
+		return mutation();
+	};
+	if (
+		process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted" ||
+		process.env.CLAWDI_SERVICE_STATE_DIR?.trim()
+	) {
+		return withRuntimeConvergeLock(getRuntimePaths({ mode: "hosted" }), commit);
+	}
+	return withPrivateDirectoryLockSync(join(getClawdiDir(), "locks", "managed-skills.lock"), commit);
+}
+
 export function migrateLegacyLocalSetupSkill(input: {
 	targetDir: string;
 	id: string;
 	version: number;
 	digest: (targetDir: string) => string;
-}): "adopted" | "already_migrated" | "absent" | "hosted" {
+}): "adopted" | "already_migrated" | "absent" | "unmanaged" | "hosted" {
 	if (process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted") return "hosted";
 	if (process.env.CLAWDI_SERVICE_STATE_DIR?.trim()) return "hosted";
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
 	if (
+		input.id !== "clawdi" ||
 		basename(target) !== input.id ||
 		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
 		!Number.isSafeInteger(input.version) ||
@@ -190,20 +219,24 @@ export function migrateLegacyLocalSetupSkill(input: {
 		const ledger = readLedger(path);
 		if (ledger.localSetupMigrations[target]) return "already_migrated";
 		const existing = ledger.reservations[target];
-		let outcome: "adopted" | "absent" = "absent";
+		let outcome: "adopted" | "absent" | "unmanaged" = "absent";
 		if (!existing && existsSync(target)) {
 			const digest = input.digest(target);
 			if (!SHA256_PATTERN.test(digest)) {
 				throw new Error("managed Skill migration digest is invalid");
 			}
-			ledger.reservations[target] = {
-				target,
-				id: input.id,
-				version: input.version,
-				digest,
-				manager: "local-setup",
-			};
-			outcome = "adopted";
+			if (LEGACY_LOCAL_SETUP_SKILL_DIGESTS.has(digest)) {
+				ledger.reservations[target] = {
+					target,
+					id: input.id,
+					version: input.version,
+					digest,
+					manager: "local-setup",
+				};
+				outcome = "adopted";
+			} else {
+				outcome = "unmanaged";
+			}
 		}
 		ledger.localSetupMigrations[target] = { target, id: input.id };
 		writeLedger(path, ledger);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -13,9 +13,7 @@ import {
 	readdirSync,
 	readFileSync,
 	readlinkSync,
-	renameSync,
 	rmSync,
-	statSync,
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -62,6 +60,9 @@ import {
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
+
+export { withRuntimeConvergeLock, withRuntimeConvergeLockAsync } from "./converge-lock";
+
 import {
 	isClawdiManagedProviderProjection,
 	managedMcpHeaderPlaceholder,
@@ -4008,191 +4009,6 @@ function revisionHash(value: unknown): string {
 		.update(JSON.stringify(canonicalize(value)))
 		.digest("hex")
 		.slice(0, 32);
-}
-
-function sleepSync(ms: number): void {
-	const signal = new Int32Array(new SharedArrayBuffer(4));
-	Atomics.wait(signal, 0, 0, ms);
-}
-
-function convergeLockOwnerPath(lockDir: string): string {
-	return join(lockDir, "owner.json");
-}
-
-function writeConvergeFileAtomic(path: string, content: string, mode: number): void {
-	const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
-	let renamed = false;
-	try {
-		writeFileSync(tmp, content, { mode });
-		renameSync(tmp, path);
-		renamed = true;
-	} finally {
-		if (!renamed) rmSync(tmp, { force: true });
-	}
-}
-
-function writeConvergeLockOwner(lockDir: string): void {
-	writeConvergeFileAtomic(
-		convergeLockOwnerPath(lockDir),
-		`${JSON.stringify({
-			schemaVersion: "clawdi.runtimeConvergeLockOwner.v1",
-			pid: process.pid,
-			acquiredAt: new Date().toISOString(),
-		})}\n`,
-		0o600,
-	);
-}
-
-function readConvergeLockOwnerPid(lockDir: string): number | null {
-	try {
-		const raw = JSON.parse(readFileSync(convergeLockOwnerPath(lockDir), "utf-8")) as unknown;
-		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-		const pid = (raw as Record<string, unknown>).pid;
-		return typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : null;
-	} catch {
-		return null;
-	}
-}
-
-function processIsAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			(error as NodeJS.ErrnoException).code === "ESRCH"
-		) {
-			return false;
-		}
-		return true;
-	}
-}
-
-function reclaimStaleConvergeLock(lockDir: string, timeoutMs: number): boolean {
-	const ownerPid = readConvergeLockOwnerPid(lockDir);
-	if (ownerPid === null) {
-		let mtimeMs: number;
-		try {
-			mtimeMs = statSync(lockDir).mtimeMs;
-		} catch (error) {
-			if (
-				error instanceof Error &&
-				"code" in error &&
-				(error as NodeJS.ErrnoException).code === "ENOENT"
-			) {
-				return true;
-			}
-			throw error;
-		}
-		if (Date.now() - mtimeMs <= 2 * timeoutMs) return false;
-	} else if (processIsAlive(ownerPid)) {
-		return false;
-	}
-	const staleDir = `${lockDir}.stale.${process.pid}.${Date.now()}.${Math.random()
-		.toString(36)
-		.slice(2)}`;
-	try {
-		renameSync(lockDir, staleDir);
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			(error as NodeJS.ErrnoException).code === "ENOENT"
-		) {
-			return true;
-		}
-		throw error;
-	}
-	rmSync(staleDir, { recursive: true, force: true });
-	return true;
-}
-
-export function withRuntimeConvergeLock<T>(
-	paths: RuntimePaths,
-	fn: () => T,
-	opts: { timeoutMs?: number } = {},
-): T {
-	const timeoutMs = opts.timeoutMs ?? 300_000;
-	const lockRoot = join(paths.runRoot, "locks");
-	const lockDir = join(lockRoot, "converge.lock");
-	const startedAt = Date.now();
-	mkdirSync(lockRoot, { recursive: true });
-	for (;;) {
-		try {
-			mkdirSync(lockDir);
-			try {
-				writeConvergeLockOwner(lockDir);
-			} catch (error) {
-				rmSync(lockDir, { recursive: true, force: true });
-				throw error;
-			}
-			break;
-		} catch (error) {
-			if (
-				!(error instanceof Error) ||
-				!("code" in error) ||
-				(error as NodeJS.ErrnoException).code !== "EEXIST"
-			) {
-				throw error;
-			}
-			if (reclaimStaleConvergeLock(lockDir, timeoutMs)) {
-				continue;
-			}
-			if (Date.now() - startedAt > timeoutMs) {
-				throw new Error(`timed out waiting for runtime converge lock at ${lockDir}`);
-			}
-			sleepSync(100);
-		}
-	}
-	try {
-		return fn();
-	} finally {
-		rmSync(lockDir, { recursive: true, force: true });
-	}
-}
-
-export async function withRuntimeConvergeLockAsync<T>(
-	paths: RuntimePaths,
-	fn: () => Promise<T>,
-	opts: { timeoutMs?: number } = {},
-): Promise<T> {
-	const timeoutMs = opts.timeoutMs ?? 300_000;
-	const lockRoot = join(paths.runRoot, "locks");
-	const lockDir = join(lockRoot, "converge.lock");
-	const startedAt = Date.now();
-	mkdirSync(lockRoot, { recursive: true });
-	for (;;) {
-		try {
-			mkdirSync(lockDir);
-			try {
-				writeConvergeLockOwner(lockDir);
-			} catch (error) {
-				rmSync(lockDir, { recursive: true, force: true });
-				throw error;
-			}
-			break;
-		} catch (error) {
-			if (
-				!(error instanceof Error) ||
-				!("code" in error) ||
-				(error as NodeJS.ErrnoException).code !== "EEXIST"
-			) {
-				throw error;
-			}
-			if (reclaimStaleConvergeLock(lockDir, timeoutMs)) continue;
-			if (Date.now() - startedAt > timeoutMs) {
-				throw new Error(`timed out waiting for runtime converge lock at ${lockDir}`);
-			}
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		}
-	}
-	try {
-		return await fn();
-	} finally {
-		rmSync(lockDir, { recursive: true, force: true });
-	}
 }
 
 export function runtimeProgramRevision(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -73,6 +73,7 @@ import {
 	resolveManagedPrimaryModel,
 } from "./managed-model-resolution";
 import {
+	installReservedManagedSkill,
 	managedSkillReservationOwner,
 	releaseManagedSkill,
 	reserveManagedSkill,
@@ -3353,20 +3354,23 @@ function applyHostedBundledSkills(
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
 		}
 		const bundled = catalogEntry;
-		reserveManagedSkill({
-			targetDir,
-			id: skillName,
-			manager: "hosted-manifest",
-			version: desired.version,
-			digest: bundled.digest,
-		});
-		const result = reconcileHostedBundledSkill({
-			skillId: skillName,
-			version: desired.version,
-			sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
-			targetDir,
-			reserved: true,
-		});
+		const result = installReservedManagedSkill(
+			{
+				targetDir,
+				id: skillName,
+				manager: "hosted-manifest",
+				version: desired.version,
+				digest: bundled.digest,
+			},
+			() =>
+				reconcileHostedBundledSkill({
+					skillId: skillName,
+					version: desired.version,
+					sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
+					targetDir,
+					reserved: true,
+				}),
+		);
 		if (result === "unchanged") continue;
 		makeRuntimeUserOwnedAncestors(targetDir);
 		makeRuntimeUserOwned(targetDir);

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -4,10 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CollectSessionsResult } from "../adapters/base";
 import { ApiError } from "../lib/api-client";
+import { readSkillsLock, skillCacheKey, writeSkillsLock } from "../lib/skills-lock";
+import { releaseManagedSkill, reserveManagedSkill } from "../runtime/managed-skill-reservation";
 import type { PendingSkillUploadEcho } from "./sync-engine";
 import {
 	addInFlight,
 	classifyHeartbeatFailure,
+	clearReservedSkillHashes,
 	consumePendingSkillUploadEcho,
 	enqueueChangedSessionsAfterStability,
 	filterValidSkillKeysForSync,
@@ -88,6 +91,75 @@ describe("reserved Skill reconcile listing", () => {
 		const observed = new Set(["managed"]);
 		const pulled = new Map([["managed", "current-cloud-hash"]]);
 		expect(shouldForceFullSkillListing(observed, pulled, () => false)).toBe(false);
+	});
+});
+
+describe("reserved Skill boot cache cleanup", () => {
+	it("clears only reserved hashes even when Cloud has no matching key", () => {
+		const root = mkdtempSync(join(tmpdir(), "reserved-skill-cache-"));
+		const originalHome = process.env.HOME;
+		const originalMode = process.env.CLAWDI_RUNTIME_MODE;
+		const originalStateDir = process.env.CLAWDI_SERVICE_STATE_DIR;
+		try {
+			process.env.HOME = root;
+			delete process.env.CLAWDI_RUNTIME_MODE;
+			delete process.env.CLAWDI_SERVICE_STATE_DIR;
+			const skillsRoot = join(root, ".claude", "skills");
+			const managed = join(skillsRoot, "managed");
+			mkdirSync(managed, { recursive: true });
+			writeFileSync(join(managed, "SKILL.md"), "# Managed\n");
+			reserveManagedSkill({
+				targetDir: managed,
+				id: "managed",
+				version: 1,
+				digest: "a".repeat(64),
+				manager: "local-setup",
+			});
+			const managedCacheKey = skillCacheKey("claude_code", "managed");
+			const unrelatedCacheKey = skillCacheKey("claude_code", "unrelated");
+			writeSkillsLock({
+				version: 2,
+				skills: {
+					[managedCacheKey]: { hash: "same-content-hash" },
+					[unrelatedCacheKey]: { hash: "unrelated-hash" },
+					[skillCacheKey("codex", "managed")]: { hash: "other-agent-hash" },
+				},
+			});
+			const pushed = new Map([
+				["managed", "same-content-hash"],
+				["unrelated", "unrelated-hash"],
+			]);
+
+			clearReservedSkillHashes(
+				{ agentType: "claude_code", getSkillsRootDir: () => skillsRoot },
+				pushed,
+				false,
+			);
+
+			expect(pushed.has("managed")).toBe(false);
+			expect(pushed.get("unrelated")).toBe("unrelated-hash");
+			const persisted = readSkillsLock().skills;
+			expect(persisted[managedCacheKey]).toBeUndefined();
+			expect(persisted[unrelatedCacheKey]?.hash).toBe("unrelated-hash");
+			expect(persisted[skillCacheKey("codex", "managed")]?.hash).toBe("other-agent-hash");
+
+			releaseManagedSkill({
+				targetDir: managed,
+				id: "managed",
+				manager: "local-setup",
+				removeTarget: () => undefined,
+			});
+			// A future user Skill with identical bytes is no longer suppressed by the old hash.
+			expect(pushed.get("managed")).toBeUndefined();
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+			else process.env.CLAWDI_RUNTIME_MODE = originalMode;
+			if (originalStateDir === undefined) delete process.env.CLAWDI_SERVICE_STATE_DIR;
+			else process.env.CLAWDI_SERVICE_STATE_DIR = originalStateDir;
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -330,6 +330,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				}
 			}
 		}
+		clearReservedSkillHashes(opts.adapter, lastPushedHash, registeredAgents.length <= 1);
 		log.info("engine.skills_lock_loaded", { skill_count: lastPushedHash.size });
 	}
 	// Skills currently being written by a pull (boot initialSync,
@@ -2427,6 +2428,29 @@ function deferReservedSkill(
 	const hadPersistentHash = key in lock.skills;
 	if (hadPersistentHash) delete lock.skills[key];
 	if (hadMemoryHash || hadPersistentHash) writeSkillsLock(lock);
+}
+
+export function clearReservedSkillHashes(
+	adapter: Pick<AgentAdapter, "agentType" | "getSkillsRootDir">,
+	lastPushedHash: Map<string, string>,
+	clearLegacyFlatKeys = listRegisteredAgentTypes().length <= 1,
+): void {
+	const lock = readSkillsLock();
+	let changed = false;
+	for (const skillKey of [...lastPushedHash.keys()]) {
+		if (!shouldIgnoreUserSkill(join(adapter.getSkillsRootDir(), skillKey), skillKey)) continue;
+		lastPushedHash.delete(skillKey);
+		const partitioned = skillCacheKey(adapter.agentType, skillKey);
+		if (partitioned in lock.skills) {
+			delete lock.skills[partitioned];
+			changed = true;
+		}
+		if (clearLegacyFlatKeys && skillKey in lock.skills) {
+			delete lock.skills[skillKey];
+			changed = true;
+		}
+	}
+	if (changed) writeSkillsLock(lock);
 }
 
 export function shouldForceFullSkillListing(

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -306,6 +306,18 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 		expect(demo.filePath).toContain("/.claude/skills/demo/SKILL.md");
 	});
 
+	it("does not scan a hidden managed Skill recovery directory", async () => {
+		const recovery = join(tmpHome, ".claude", "skills", ".clawdi-previous-test");
+		mkdirSync(recovery, { recursive: true });
+		writeFileSync(join(recovery, "SKILL.md"), "# Managed recovery artifact\n");
+
+		const adapter = new ClaudeCodeAdapter();
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain(
+			".clawdi-previous-test",
+		);
+		expect(await adapter.listSkillKeys()).not.toContain(".clawdi-previous-test");
+	});
+
 	it("adopts a pre-ledger bundled clawdi target without uploading it", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
 		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), legacy, { recursive: true });

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -305,13 +305,13 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 		expect(demo.filePath).toContain("/.claude/skills/demo/SKILL.md");
 	});
 
-	it("does not upload a pre-ledger local setup Skill after upgrade", async () => {
+	it("does not reserve the clawdi name without ownership", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
 		mkdirSync(legacy, { recursive: true });
 		writeFileSync(join(legacy, "SKILL.md"), "# Legacy bundled Skill\n");
 		const adapter = new ClaudeCodeAdapter();
-		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain("clawdi");
-		expect(await adapter.listSkillKeys()).not.toContain("clawdi");
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).toContain("clawdi");
+		expect(await adapter.listSkillKeys()).toContain("clawdi");
 	});
 });
 
@@ -352,6 +352,8 @@ describe("ClaudeCodeAdapter.writeSkillArchive + getSkillPath", () => {
 		await adapter.writeSkillArchive("demo", bytes);
 
 		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toContain("name: demo");
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).toContain("demo");
+		expect(await adapter.listSkillKeys()).toContain("demo");
 	});
 
 	it("getSkillPath returns skills/<key>/SKILL.md under Claude home", () => {

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { ClaudeCodeAdapter } from "../../src/adapters/claude-code";
 import { tarSkillDir } from "../../src/lib/tar";
 import {
+	managedSkillReservationState,
 	releaseManagedSkill,
 	reserveManagedSkill,
 } from "../../src/runtime/managed-skill-reservation";
@@ -305,13 +306,35 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 		expect(demo.filePath).toContain("/.claude/skills/demo/SKILL.md");
 	});
 
-	it("does not reserve the clawdi name without ownership", async () => {
+	it("adopts a pre-ledger bundled clawdi target without uploading it", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
 		mkdirSync(legacy, { recursive: true });
 		writeFileSync(join(legacy, "SKILL.md"), "# Legacy bundled Skill\n");
 		const adapter = new ClaudeCodeAdapter();
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain("clawdi");
+		expect(await adapter.listSkillKeys()).not.toContain("clawdi");
+		expect(managedSkillReservationState(legacy, "clawdi")).toBe("reserved");
+
+		releaseManagedSkill({
+			targetDir: legacy,
+			id: "clawdi",
+			manager: "local-setup",
+			removeTarget: () => undefined,
+		});
 		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).toContain("clawdi");
 		expect(await adapter.listSkillKeys()).toContain("clawdi");
+	});
+
+	it("does not adopt a future clawdi Skill after an absent migration", async () => {
+		const adapter = new ClaudeCodeAdapter();
+		const target = join(tmpHome, ".claude", "skills", "clawdi");
+		expect(await adapter.listSkillKeys()).not.toContain("clawdi");
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "# User Skill\n");
+
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).toContain("clawdi");
+		expect(await adapter.listSkillKeys()).toContain("clawdi");
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 });
 

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { ClaudeCodeAdapter } from "../../src/adapters/claude-code";
 import { tarSkillDir } from "../../src/lib/tar";
 import {
@@ -308,8 +308,7 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 
 	it("adopts a pre-ledger bundled clawdi target without uploading it", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
-		mkdirSync(legacy, { recursive: true });
-		writeFileSync(join(legacy, "SKILL.md"), "# Legacy bundled Skill\n");
+		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), legacy, { recursive: true });
 		const adapter = new ClaudeCodeAdapter();
 		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain("clawdi");
 		expect(await adapter.listSkillKeys()).not.toContain("clawdi");

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -235,6 +235,25 @@ describe("OpenClawAdapter.collectSkills", () => {
 		expect(skills.map((s) => s.skillKey)).toEqual(["demo"]);
 	});
 
+	it("does not scan a hidden managed Skill recovery directory", async () => {
+		const recovery = join(
+			tmpHome,
+			".openclaw",
+			"agents",
+			"main",
+			"skills",
+			".clawdi-previous-test",
+		);
+		mkdirSync(recovery, { recursive: true });
+		writeFileSync(join(recovery, "SKILL.md"), "# Managed recovery artifact\n");
+
+		const adapter = new OpenClawAdapter();
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).not.toContain(
+			".clawdi-previous-test",
+		);
+		expect(await adapter.listSkillKeys()).not.toContain(".clawdi-previous-test");
+	});
+
 	it("unions skills across agents/<id>/skills/ dirs (issue #28)", async () => {
 		addFinancialAgent(join(tmpHome, ".openclaw"));
 		const a = new OpenClawAdapter();

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -158,6 +158,18 @@ describe("setup daemon install", () => {
 		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
 	});
 
+	it("reconciles the bundled Skill as an exact directory replacement", async () => {
+		installEnvironmentMock("env-codex");
+		await setup({ agent: "codex", yes: true, daemon: false });
+		const target = join(home, ".codex", "skills", "clawdi");
+		writeFileSync(join(target, "removed-by-upgrade.txt"), "stale\n");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		expect(existsSync(join(target, "removed-by-upgrade.txt"))).toBe(false);
+		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+	});
+
 	it("does not claim or overwrite an unmanaged Skill collision", async () => {
 		const target = join(home, ".codex", "skills", "clawdi");
 		mkdirSync(target, { recursive: true });

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
 	chmodSync,
+	cpSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -9,7 +10,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { setup } from "../../src/commands/setup";
 import {
 	managedSkillReservationState,
@@ -175,14 +176,24 @@ describe("setup daemon install", () => {
 
 	it("adopts a pre-ledger clawdi target under the previous exclusion contract", async () => {
 		const target = join(home, ".codex", "skills", "clawdi");
+		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), target, { recursive: true });
+		installEnvironmentMock("env-codex");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+	});
+
+	it("refuses to replace a custom pre-ledger same-name Skill", async () => {
+		const target = join(home, ".codex", "skills", "clawdi");
 		mkdirSync(target, { recursive: true });
 		writeFileSync(join(target, "SKILL.md"), "# User-owned Clawdi\n");
 		installEnvironmentMock("env-codex");
 
 		await setup({ agent: "codex", yes: true, daemon: false });
 
-		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).not.toBe("# User-owned Clawdi\n");
-		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# User-owned Clawdi\n");
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 
 	it("does not reclaim a future user clawdi target after migration and release", async () => {

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -11,7 +11,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { setup } from "../../src/commands/setup";
-import { managedSkillReservationState } from "../../src/runtime/managed-skill-reservation";
+import {
+	managedSkillReservationState,
+	releaseManagedSkill,
+} from "../../src/runtime/managed-skill-reservation";
 import {
 	type AgentHomeOverrideSnapshot,
 	jsonResponse,
@@ -170,7 +173,7 @@ describe("setup daemon install", () => {
 		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
 	});
 
-	it("does not claim or overwrite an unmanaged Skill collision", async () => {
+	it("adopts a pre-ledger clawdi target under the previous exclusion contract", async () => {
 		const target = join(home, ".codex", "skills", "clawdi");
 		mkdirSync(target, { recursive: true });
 		writeFileSync(join(target, "SKILL.md"), "# User-owned Clawdi\n");
@@ -178,7 +181,26 @@ describe("setup daemon install", () => {
 
 		await setup({ agent: "codex", yes: true, daemon: false });
 
-		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# User-owned Clawdi\n");
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).not.toBe("# User-owned Clawdi\n");
+		expect(managedSkillReservationState(target, "clawdi")).toBe("reserved");
+	});
+
+	it("does not reclaim a future user clawdi target after migration and release", async () => {
+		installEnvironmentMock("env-codex");
+		await setup({ agent: "codex", yes: true, daemon: false });
+		const target = join(home, ".codex", "skills", "clawdi");
+		releaseManagedSkill({
+			targetDir: target,
+			id: "clawdi",
+			manager: "local-setup",
+			removeTarget: () => rmSync(target, { recursive: true, force: true }),
+		});
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "# Future user Clawdi\n");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# Future user Clawdi\n");
 		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 });

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { teardown } from "../../src/commands/teardown";
 import {
 	managedSkillReservationState,
+	migrateLegacyLocalSetupSkill,
 	reserveManagedSkill,
 } from "../../src/runtime/managed-skill-reservation";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
@@ -59,6 +60,12 @@ function setup(agent: AgentKey): {
 		version: 1,
 		digest: "a".repeat(64),
 		manager: "local-setup",
+	});
+	migrateLegacyLocalSetupSkill({
+		targetDir: dirname(skillPath),
+		id: "clawdi",
+		version: 1,
+		digest: () => "a".repeat(64),
 	});
 
 	return { envPath, skillPath };
@@ -166,6 +173,17 @@ describe("teardown — flag behavior", () => {
 
 		await teardown({ agent: "codex", yes: true, keepMcp: true });
 
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "# Future user Skill\n");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: target,
+				id: "clawdi",
+				version: 1,
+				digest: () => "b".repeat(64),
+			}),
+		).toBe("already_migrated");
 		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
 	});
 

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import {
+	chmodSync,
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { ClaudeCodeAdapter } from "../../src/adapters/claude-code";
 import { teardown } from "../../src/commands/teardown";
+import { managedSkillDirectoryDigest } from "../../src/runtime/hosted-bundled-skill";
 import {
 	managedSkillReservationState,
 	migrateLegacyLocalSetupSkill,
@@ -30,7 +40,10 @@ let origPathSet = false;
 let origHomeOverrides: AgentHomeOverrideSnapshot = {};
 let origIsTTY: boolean | undefined;
 
-function setup(agent: AgentKey): {
+function setup(
+	agent: AgentKey,
+	options: { managed?: boolean } = {},
+): {
 	envPath: string;
 	skillPath: string;
 } {
@@ -54,19 +67,21 @@ function setup(agent: AgentKey): {
 	}
 	mkdirSync(join(skillPath, ".."), { recursive: true });
 	writeFileSync(skillPath, "---\nname: clawdi\ndescription: bundled\n---\n");
-	reserveManagedSkill({
-		targetDir: dirname(skillPath),
-		id: "clawdi",
-		version: 1,
-		digest: "a".repeat(64),
-		manager: "local-setup",
-	});
-	migrateLegacyLocalSetupSkill({
-		targetDir: dirname(skillPath),
-		id: "clawdi",
-		version: 1,
-		digest: () => "a".repeat(64),
-	});
+	if (options.managed !== false) {
+		reserveManagedSkill({
+			targetDir: dirname(skillPath),
+			id: "clawdi",
+			version: 1,
+			digest: "a".repeat(64),
+			manager: "local-setup",
+		});
+		migrateLegacyLocalSetupSkill({
+			targetDir: dirname(skillPath),
+			id: "clawdi",
+			version: 1,
+			digest: managedSkillDirectoryDigest,
+		});
+	}
 
 	return { envPath, skillPath };
 }
@@ -160,9 +175,64 @@ describe("teardown — basic round-trip per agent", () => {
 describe("teardown — flag behavior", () => {
 	it("--keep-skill leaves the bundled skill in place", async () => {
 		const { envPath, skillPath } = setup("claude-code");
+		const target = dirname(skillPath);
 		await teardown({ agent: "claude_code", yes: true, keepMcp: true, keepSkill: true });
 		expect(existsSync(envPath)).toBe(false);
 		expect(existsSync(skillPath)).toBe(true);
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+
+		seedAuthAndEnv(tmpHome, "claude_code");
+		writeFileSync(skillPath, "# User-edited retained Skill\n");
+		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
+		expect(readFileSync(skillPath, "utf8")).toBe("# User-edited retained Skill\n");
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+	});
+
+	it("adopts and removes a genuine pre-ledger bundle on direct teardown only once", async () => {
+		const { skillPath } = setup("claude-code", { managed: false });
+		const target = dirname(skillPath);
+		rmSync(target, { recursive: true, force: true });
+		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), target, { recursive: true });
+
+		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
+
+		expect(existsSync(target)).toBe(false);
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: target,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("already_migrated");
+
+		seedAuthAndEnv(tmpHome, "claude_code");
+		mkdirSync(target, { recursive: true });
+		writeFileSync(skillPath, "---\nname: clawdi\ndescription: User Skill\n---\n");
+		const adapter = new ClaudeCodeAdapter();
+		expect((await adapter.collectSkills()).map((skill) => skill.skillKey)).toContain("clawdi");
+		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
+		expect(existsSync(skillPath)).toBe(true);
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+	});
+
+	it("preserves an unproven custom same-name Skill on direct teardown", async () => {
+		const { skillPath } = setup("claude-code", { managed: false });
+		const target = dirname(skillPath);
+		writeFileSync(skillPath, "---\nname: clawdi\ndescription: Custom Skill\n---\n");
+
+		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
+
+		expect(existsSync(skillPath)).toBe(true);
+		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+		expect(
+			migrateLegacyLocalSetupSkill({
+				targetDir: target,
+				id: "clawdi",
+				version: 1,
+				digest: managedSkillDirectoryDigest,
+			}),
+		).toBe("already_migrated");
 	});
 
 	it("releases a stale reservation even when the managed target is already absent", async () => {
@@ -181,7 +251,7 @@ describe("teardown — flag behavior", () => {
 				targetDir: target,
 				id: "clawdi",
 				version: 1,
-				digest: () => "b".repeat(64),
+				digest: managedSkillDirectoryDigest,
 			}),
 		).toBe("already_migrated");
 		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2880,6 +2880,47 @@ export interface components {
             /** Default Project Id */
             default_project_id: string;
         };
+        /** AgentRuntimeObservedDesiredResponse */
+        AgentRuntimeObservedDesiredResponse: {
+            /** Deployment Id */
+            deployment_id: string;
+            /** Instance Id */
+            instance_id: string;
+            /** Desired Config Generation */
+            desired_config_generation: number;
+            /** Desired Source Revision */
+            desired_source_revision?: string | null;
+            /** Provider Id */
+            provider_id?: string | null;
+            /** Enabled Runtimes */
+            enabled_runtimes: string[];
+            /**
+             * Has Mcp
+             * @default false
+             */
+            has_mcp: boolean;
+            /**
+             * Has Tools
+             * @default false
+             */
+            has_tools: boolean;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Managed Skills */
+            managed_skills?: components["schemas"]["RuntimeManagedSkillSummary"][];
+        };
+        /** AgentRuntimeObservedResponse */
+        AgentRuntimeObservedResponse: {
+            environment: components["schemas"]["EnvironmentResponse"];
+            desired?: components["schemas"]["AgentRuntimeObservedDesiredResponse"] | null;
+            observed?: components["schemas"]["RuntimeObservedConfigResponse"] | null;
+            health: components["schemas"]["RuntimeObservedHealthResponse"];
+            /**
+             * Provider Health
+             * @default []
+             */
+            provider_health: components["schemas"]["RuntimeObservedProviderHealthResponse"][];
+        };
         /** AiProviderAcceptRequest */
         AiProviderAcceptRequest: {
             provider: components["schemas"]["AiProviderUpsert"];
@@ -5966,8 +6007,6 @@ export interface components {
              * @default false
              */
             has_tools: boolean;
-            /** Managed Skills */
-            managed_skills?: components["schemas"]["RuntimeManagedSkillSummary"][];
             /** Updated At */
             updated_at?: string | null;
         };
@@ -9188,7 +9227,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RuntimeObservedResponse"];
+                    "application/json": components["schemas"]["AgentRuntimeObservedResponse"];
                 };
             };
             /** @description Validation Error */

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5676,27 +5676,10 @@ export interface components {
             /** Finalsessionhighwatermarks */
             finalSessionHighWaterMarks: components["schemas"]["RuntimeSessionHighWaterMark"][];
         };
-        /** RuntimeManagedMcpServerSummary */
-        RuntimeManagedMcpServerSummary: {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            kind: "mcp_server";
-            /** Id */
-            id: string;
-        };
         /** RuntimeManagedSkillSummary */
         RuntimeManagedSkillSummary: {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            kind: "skill";
             /** Id */
             id: string;
-            /** Enabled */
-            enabled: boolean;
             /** Version */
             version: number;
         };
@@ -5983,8 +5966,8 @@ export interface components {
              * @default false
              */
             has_tools: boolean;
-            /** Managed Resources */
-            managed_resources?: (components["schemas"]["RuntimeManagedSkillSummary"] | components["schemas"]["RuntimeManagedMcpServerSummary"])[];
+            /** Managed Skills */
+            managed_skills?: components["schemas"]["RuntimeManagedSkillSummary"][];
             /** Updated At */
             updated_at?: string | null;
         };


### PR DESCRIPTION
## Summary

- keep the Skills surface Skill-only: remove MCP cards, capability wording, and raw runtime generation/source/health diagnostics
- replace the UI-only `managed_resources` union with enabled-only `managed_skills` inventory; build it once from the existing runtime state snapshot and keep `/v1/agents/{id}/runtime-observed` as a thin alias
- make local managed-Skill setup exact and transactional with sibling staging, target rollback, reservation rollback, and a private local writer lock
- remove permanent `clawdi` name exceptions from all adapters so ownership release restores normal sync
- surface malformed ownership ledgers as diagnostic failures instead of silently hiding every Skill

## Ownership lifecycle audit

Reviewed PR #550 across manifest create/update/version replacement, disable/delete, drift repair, runtime switch, Cloud upload/install/delete, local setup/teardown, legacy marker adoption, SSE/pull/reconcile, and release.

Kept:

- the root-owned central ledger as ownership authority; co-located markers remain migration/content evidence only
- exact-target and manager-aware reservations
- backend advisory locking between manifest reservation changes and Cloud Skill writes
- cleanup-only conflict cards and deferred Cloud reconcile while a target is reserved

Fixed:

- setup used reserve-then-in-place-copy, which could leave stale ownership after failure and retained files removed from newer bundles
- local ledger writers could lose updates; local setup/teardown now serialize under a private `~/.clawdi` lock, while hosted writers continue to use the existing global runtime converge lock (no chmod of hosted projection parents)
- hosted install reservation changes now roll back if staged reconcile fails
- adapter scans permanently treated the name `clawdi` as reserved even after ownership release
- malformed ledgers were silently interpreted as reserved during scans

No MCP ownership/reconcile mechanism was changed: its runtime projection and ledger have independent consumers and resource boundaries outside the Skills UI.

## API rollout

`managed_resources` was introduced by #550 and had no consumers beyond the erroneous Skills UI and its test. The generated client is regenerated with `managed_skills`.

Web/backend deployment order is safe in either direction because both fields are optional and the Web falls back to an empty list. A mixed-version window only omits the read-only managed-Skill section; Cloud Skill inventory remains available and backend reservation enforcement remains authoritative. No compatibility dual-write is added.

## Verification

Isolated Docker:

- Web typecheck, `agent-skills-tab.test.ts`, and OSS production build
- CLI typecheck plus 253 focused runtime/setup/teardown/adapter/sync tests
- CLI ownership suite again with the concurrent rollback/lost-update test: 9 passed
- backend migrated PostgreSQL: `test_skills.py` plus focused runtime-observed test: 28 passed
- final focused runtime-observed test: 1 passed

Local read-only/focused checks:

- Web and CLI typecheck
- Biome on all touched TS/TSX
- Ruff lint and format checks on touched backend files
- generated API freshness check
- `git diff --check`

No production, tenant, secret, deploy, or release operations were performed.

## Review follow-up

- added a durable, per-target local pre-ledger migration: an existing legacy bundled `clawdi` target is adopted once, while an absent target records migration completion so a future user-created same-name Skill remains user-owned
- shared one atomic directory activation contract between local setup and hosted bundled reconcile; the staged-to-live rename is the commit point
- activation failures restore the previous target; restore failures preserve a uniquely named recovery artifact and report a combined diagnostic without exposing its path
- post-commit cleanup failures are best-effort GC only, so the live target and reservation remain committed for both local and hosted managers
- made reservation errors manager-neutral

Additional isolated Docker verification after review: CLI typecheck and 270 focused tests passed; Web typecheck/test/OSS build passed; backend migrated PostgreSQL focused suite passed (28 tests). The only residual operational risk is that a failed best-effort cleanup leaves a uniquely named sibling recovery artifact for later/manual collection; it does not affect the live target or ownership ledger.

## Blocking review follow-up (final)

- direct teardown now performs the same per-target one-time migration as setup and daemon scans before release
- `--keep-skill` retains the directory but releases `local-setup` ownership; the durable migration-complete record prevents later re-adoption
- local legacy adoption is content-proven against the six unique managed-bundle digests shipped across 93 published `clawdi-cli-v*` tags; absent or unproven same-name targets are marked migrated and remain user-owned
- user Skill delete/archive activation and managed reservation/install/release commits are linearized through the ownership commit lock; hosted mutations and manifest convergence now share the extracted existing global converge-lock implementation without changing its path or permissions
- daemon boot clears reserved keys from only the current agent’s in-memory and persisted Skill hash cache, including the safe single-agent legacy fallback
- byte-frozen environment runtime-observation symbols remain unchanged; only the agent route uses an agent-specific response schema with enabled-only `managed_skills`, identity/generation fencing, and fail-closed invalid persisted-state handling

Final isolated Docker verification after rebasing current `origin/main`:

- Web typecheck, 16 focused/boundary tests, and OSS production build
- CLI typecheck and 135 focused tests; shared converge/ownership suites additionally 15 passed
- backend migrated PostgreSQL focused suite: 32 passed, including the byte-freeze test
- generated API client freshness check
- Biome, Ruff, and diff-check

A mixed Web/backend rollout remains safe: the agent-only field has a default, so older backend/newer Web or newer backend/older Web only temporarily omits the read-only managed section. The environment v1 response and OpenAPI schema do not gain the field.