### PR TITLE
fix(web): polish checkout and accepted delete flows

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -568,6 +568,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function checkoutDeployRequestId(requestBody: string): string | null {
+	const request: unknown = JSON.parse(requestBody);
+	if (!isRecord(request) || !isRecord(request.deploy_config)) return null;
+	return typeof request.deploy_config.deploy_request_id === "string"
+		? request.deploy_config.deploy_request_id
+		: null;
+}
+
 function isDeploymentMutationFixture(value: unknown): value is DeploymentMutationFixture {
 	return (
 		isRecord(value) &&
@@ -806,6 +814,20 @@ function failedDeletionReadFixture(
 					observedGeneration: 2,
 				},
 			},
+		},
+	};
+}
+
+function acceptedDeletionReadFixture(deployment: DeploymentMutationFixture): DeploymentRead {
+	const read = mutationDeploymentReadFixture({ ...deployment, status: "deleting" });
+	const operation = completedDeploymentOperation(deployment, "delete");
+	return {
+		...read,
+		accepted_operation: { ...operation, done: false, response: null },
+		compute_slot_occupancy: {
+			occupies_slot: false,
+			backing_infra: "present",
+			reason: "delete_accepted",
 		},
 	};
 }
@@ -1051,7 +1073,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 										deployment,
 										options.failedDeleteRetryability.get(deployment.id) ?? false,
 									)
-								: readDeploymentFixture({ ...deployment, status: "deleting" })
+								: acceptedDeletionReadFixture(deployment)
 							: readDeploymentFixture(deployment),
 					),
 			);
@@ -1407,7 +1429,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			);
 			if (!deployment) return fulfillJson(r, { detail: "Deployment not found" }, 404);
 			acceptedDeleteIds.add(deployment.id);
-			return fulfillJson(r, completedDeploymentOperation(deployment, "delete"), 202);
+			const operation = completedDeploymentOperation(deployment, "delete");
+			return fulfillJson(r, { ...operation, done: false, response: null }, 202);
 		}
 		return fulfillJson(r, {});
 	});
@@ -2050,6 +2073,62 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
 });
 
+test("failed checkout start stays contextual and retries without duplicate or internal errors", async ({
+	page,
+}) => {
+	const checkoutRequests: string[] = [];
+	await page.setViewportSize({ width: 390, height: 844 });
+	await stubCompletedStripeCheckout(page);
+	await stubHostedApi(page, {
+		checkoutRequests,
+		checkoutResponses: [
+			{
+				status: 503,
+				body: { detail: "stripe_proxy_internal tenant=usr_secret upstream=acct_live" },
+			},
+			{
+				status: 200,
+				body: {
+					flow_type: "checkout_session",
+					funding_source: "stripe",
+					action_url: null,
+					checkout_url: "https://checkout.stripe.test/retry",
+					client_secret: "cs_test_checkout_retry",
+				},
+			},
+		],
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan],
+	});
+	await page.goto("/deploy");
+
+	await page.getByRole("button", { name: "Continue to checkout" }).click();
+	const error = page.getByTestId("deploy-submit-error");
+	await expect(error.getByText("Checkout didn’t open", { exact: true })).toBeVisible();
+	await expect(error).toContainText("Secure checkout is temporarily unavailable.");
+	await expect(error).toContainText("No payment was submitted.");
+	await expect(error).not.toContainText("stripe_proxy_internal");
+	await expect(error).not.toContainText("usr_secret");
+	await expect(error).toBeInViewport();
+	const errorBounds = await error.boundingBox();
+	if (!errorBounds) throw new Error("Expected the compact checkout alert to have layout bounds");
+	expect(errorBounds.x).toBeGreaterThanOrEqual(0);
+	expect(errorBounds.x + errorBounds.width).toBeLessThanOrEqual(390);
+	await expect(
+		page.getByText("The billing service is having trouble", { exact: false }),
+	).toHaveCount(0);
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await expect(checkoutRequests).toHaveLength(1);
+
+	await error.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect(checkoutRequests).toHaveLength(2);
+	await expect(page.getByRole("dialog", { name: /Complete .* checkout/ })).toBeVisible();
+	const initialDeployRequestId = checkoutDeployRequestId(checkoutRequests[0] ?? "{}");
+	const retryDeployRequestId = checkoutDeployRequestId(checkoutRequests[1] ?? "{}");
+	expect(initialDeployRequestId).not.toBeNull();
+	expect(retryDeployRequestId).toBe(initialDeployRequestId);
+});
+
 test("accepted detail delete dismisses immediately while teardown finishes in the background", async ({
 	page,
 }) => {
@@ -2064,6 +2143,7 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 		deploymentListRequests,
 	});
 	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+	const historyLengthBeforeDelete = await page.evaluate(() => window.history.length);
 
 	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
 	await page
@@ -2072,20 +2152,58 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
-	await expect(page).toHaveURL(/\/agents\/?$/);
+	await expect.poll(() => new URL(page.url()).pathname).toBe("/");
+	await expect
+		.poll(() => page.evaluate(() => window.history.length))
+		.toBe(historyLengthBeforeDelete);
 	await expect(page.getByText("Agent removed", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("Cleanup continues in the background.", { exact: true }),
+	).toBeVisible();
 	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
 	await expect(page.getByTestId("app-sidebar-agent-tiles").getByLabel("Basic")).toHaveCount(0);
 	// The deployment is still in the stubbed inventory as `deleting`; dismissal
 	// therefore precedes teardown rather than waiting for a completed list read.
 	expect(completedDeleteIds.has("hdep_included")).toBe(false);
+	await page.goto("/deploy");
+	await expect(page.getByRole("button", { name: "Deploy agent", exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Continue to checkout" })).toHaveCount(0);
+	expect(completedDeleteIds.has("hdep_included")).toBe(false);
 
 	const readsBeforeCompletion = deploymentListRequests.length;
 	completedDeleteIds.add("hdep_included");
-	await expect
-		.poll(() => deploymentListRequests.length, { timeout: 10_000 })
-		.toBeGreaterThan(readsBeforeCompletion);
+	await page.reload();
+	await expect.poll(() => deploymentListRequests.length).toBeGreaterThan(readsBeforeCompletion);
 	await expect(page.getByRole("link", { name: "Open Basic", exact: true })).toHaveCount(0);
+});
+
+test("rejected detail delete stays on the current agent without accepted cleanup feedback", async ({
+	page,
+}) => {
+	const deleteRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+		deleteRequests,
+		deleteResponses: [
+			{ status: 422, body: { detail: "internal delete coordinator rejected tenant usr_secret" } },
+		],
+	});
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	const dialog = page.getByRole("alertdialog");
+	await dialog.getByRole("button", { name: "Delete agent", exact: true }).click();
+
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
+	await expect(page).toHaveURL(/\/agents\/hdep_included\/settings/);
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Delete agent", exact: true })).toBeEnabled();
+	await expect(page.getByText("Agent removed", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Cleanup continues in the background.", { exact: true })).toHaveCount(
+		0,
+	);
+	await expect(page.getByText("internal delete coordinator", { exact: false })).toHaveCount(0);
 });
 
 test("managed model picker lists the curated catalog without Custom or image models", async ({
@@ -2804,6 +2922,7 @@ test("identity-less interrupted deployment tile exposes delete", async ({ page }
 	});
 
 	await page.goto("/agents");
+	const historyLengthBeforeDelete = await page.evaluate(() => window.history.length);
 	const deleteAction = page.getByRole("button", { name: "Delete Interrupted deployment" });
 	await expect(deleteAction).toBeVisible();
 	await deleteAction.click();
@@ -2812,6 +2931,10 @@ test("identity-less interrupted deployment tile exposes delete", async ({ page }
 		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_creation_interrupted"]);
+	await expect.poll(() => new URL(page.url()).pathname).toBe("/");
+	await expect
+		.poll(() => page.evaluate(() => window.history.length))
+		.toBe(historyLengthBeforeDelete);
 	await expect(deleteAction).toHaveCount(0);
 
 	failedDeleteRetryability.set("hdep_creation_interrupted", false);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -891,7 +891,6 @@ type HostedApiStubOptions = {
 	ledgerRequests?: string[];
 	ledgerResponses?: unknown[];
 	legacyAgentEnvironmentIds?: readonly string[];
-	missingDeploymentRequests?: boolean;
 	managedModels?: typeof managedModelCatalog;
 	planRequests?: string[];
 	mutationOrder?: string[];
@@ -1150,9 +1149,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				name: "Created Basic",
 				status: "running",
 			};
-			if (deployRequestId && !options.missingDeploymentRequests) {
-				deploymentRequests.set(deployRequestId, createdDeployment);
-			}
+			if (deployRequestId) deploymentRequests.set(deployRequestId, createdDeployment);
 			const response =
 				options.checkoutResponses?.shift() ??
 				(request.funding_source === "wallet"
@@ -2074,46 +2071,6 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	expect(deploymentRequestReads).toHaveLength(1);
 	expect(operationPollRequests).toEqual([]);
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
-});
-
-test("post-payment uncertainty blocks a second checkout behind toast-only recovery", async ({
-	page,
-}) => {
-	const checkoutRequests: string[] = [];
-	await stubCompletedStripeCheckout(page);
-	await stubHostedApi(page, {
-		checkoutRequests,
-		checkoutResponses: [
-			{
-				status: 200,
-				body: {
-					flow_type: "checkout_session",
-					funding_source: "stripe",
-					action_url: null,
-					checkout_url: "https://checkout.stripe.test/session",
-					client_secret: "cs_test_paid_checkout",
-				},
-			},
-		],
-		deployments: [includedBasicDeployment],
-		missingDeploymentRequests: true,
-		plans: [basicPlan],
-	});
-	await page.goto("/deploy");
-
-	const submit = page.getByRole("button", { name: "Continue to checkout" });
-	await submit.click();
-	const checkoutDialog = page.getByRole("dialog", { name: /Complete .* checkout/ });
-	await checkoutDialog.getByRole("button", { name: "Subscribe", exact: true }).click();
-
-	const recovery = page.locator("[data-sonner-toast]").filter({
-		hasText: "Payment succeeded; your agent is not visible yet",
-	});
-	await expect(recovery).toBeVisible();
-	await expect(recovery.getByRole("button", { name: "View agents" })).toBeVisible();
-	await expect(submit).toBeDisabled();
-	expect(checkoutRequests).toHaveLength(1);
-	await expect(page.getByTestId("deploy-submit-error")).toHaveCount(0);
 });
 
 test("failed checkout start stays contextual and retries without duplicate or internal errors", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -891,6 +891,7 @@ type HostedApiStubOptions = {
 	ledgerRequests?: string[];
 	ledgerResponses?: unknown[];
 	legacyAgentEnvironmentIds?: readonly string[];
+	missingDeploymentRequests?: boolean;
 	managedModels?: typeof managedModelCatalog;
 	planRequests?: string[];
 	mutationOrder?: string[];
@@ -1149,7 +1150,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				name: "Created Basic",
 				status: "running",
 			};
-			if (deployRequestId) deploymentRequests.set(deployRequestId, createdDeployment);
+			if (deployRequestId && !options.missingDeploymentRequests) {
+				deploymentRequests.set(deployRequestId, createdDeployment);
+			}
 			const response =
 				options.checkoutResponses?.shift() ??
 				(request.funding_source === "wallet"
@@ -2071,6 +2074,46 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	expect(deploymentRequestReads).toHaveLength(1);
 	expect(operationPollRequests).toEqual([]);
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
+});
+
+test("post-payment uncertainty blocks a second checkout behind toast-only recovery", async ({
+	page,
+}) => {
+	const checkoutRequests: string[] = [];
+	await stubCompletedStripeCheckout(page);
+	await stubHostedApi(page, {
+		checkoutRequests,
+		checkoutResponses: [
+			{
+				status: 200,
+				body: {
+					flow_type: "checkout_session",
+					funding_source: "stripe",
+					action_url: null,
+					checkout_url: "https://checkout.stripe.test/session",
+					client_secret: "cs_test_paid_checkout",
+				},
+			},
+		],
+		deployments: [includedBasicDeployment],
+		missingDeploymentRequests: true,
+		plans: [basicPlan],
+	});
+	await page.goto("/deploy");
+
+	const submit = page.getByRole("button", { name: "Continue to checkout" });
+	await submit.click();
+	const checkoutDialog = page.getByRole("dialog", { name: /Complete .* checkout/ });
+	await checkoutDialog.getByRole("button", { name: "Subscribe", exact: true }).click();
+
+	const recovery = page.locator("[data-sonner-toast]").filter({
+		hasText: "Payment succeeded; your agent is not visible yet",
+	});
+	await expect(recovery).toBeVisible();
+	await expect(recovery.getByRole("button", { name: "View agents" })).toBeVisible();
+	await expect(submit).toBeDisabled();
+	expect(checkoutRequests).toHaveLength(1);
+	await expect(page.getByTestId("deploy-submit-error")).toHaveCount(0);
 });
 
 test("failed checkout start stays contextual and retries without duplicate or internal errors", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2103,7 +2103,7 @@ test("failed checkout start stays contextual and retries without duplicate or in
 	await page.goto("/deploy");
 
 	await page.getByRole("button", { name: "Continue to checkout" }).click();
-	const error = page.getByTestId("deploy-submit-error");
+	const error = page.locator("[data-sonner-toast]").filter({ hasText: "Checkout didn’t open" });
 	await expect(error.getByText("Checkout didn’t open", { exact: true })).toBeVisible();
 	await expect(error).toContainText("Secure checkout is temporarily unavailable.");
 	await expect(error).toContainText("No payment was submitted.");
@@ -2111,13 +2111,13 @@ test("failed checkout start stays contextual and retries without duplicate or in
 	await expect(error).not.toContainText("usr_secret");
 	await expect(error).toBeInViewport();
 	const errorBounds = await error.boundingBox();
-	if (!errorBounds) throw new Error("Expected the compact checkout alert to have layout bounds");
+	if (!errorBounds) throw new Error("Expected the checkout error toast to have layout bounds");
 	expect(errorBounds.x).toBeGreaterThanOrEqual(0);
 	expect(errorBounds.x + errorBounds.width).toBeLessThanOrEqual(390);
 	await expect(
 		page.getByText("The billing service is having trouble", { exact: false }),
 	).toHaveCount(0);
-	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(1);
 	await expect(checkoutRequests).toHaveLength(1);
 
 	await error.getByRole("button", { name: "Retry", exact: true }).click();

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -250,7 +250,7 @@ export function AgentHome({
 				runtime={runtime}
 				section={section}
 				routeSearch={deploymentRouteSearch}
-				onDeleteAccepted={() => router.navigate({ href: "/agents", replace: true })}
+				onDeleteAccepted={() => router.navigate({ href: "/", replace: true })}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 				isCheckingDeployment={isFetching}
 				onCheckDeploymentAgain={handleCheckAgain}

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "@tanstack/react-router";
 import { type ReactElement, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -34,6 +35,7 @@ export function HostedDeploymentDeleteAction({
 	deployment: HostedDeployment;
 	onAccepted?: () => Promise<void> | void;
 }) {
+	const router = useRouter();
 	const deleteDeployment = useDeleteDeployment();
 	const [open, setOpen] = useState(false);
 	const [choice, setChoice] =
@@ -51,19 +53,26 @@ export function HostedDeploymentDeleteAction({
 		if (locked.current) return;
 		locked.current = true;
 		setPending(true);
-		let deletionAccepted = false;
 		try {
-			await deleteDeployment.mutateAsync({
-				id: deployment.resource.id,
-				request: {
-					subscription_choice: offerChoice ? choice : "keep_subscription",
-				},
-			});
-			deletionAccepted = true;
+			try {
+				await deleteDeployment.mutateAsync({
+					id: deployment.resource.id,
+					request: {
+						subscription_choice: offerChoice ? choice : "keep_subscription",
+					},
+				});
+			} catch {
+				// The mutation owns failure feedback. Keep this detail page in place.
+				return;
+			}
 			setOpen(false);
-			await onAccepted?.();
-		} catch {
-			if (deletionAccepted) {
+			try {
+				if (onAccepted) {
+					await onAccepted();
+				} else {
+					await router.navigate({ href: "/", replace: true });
+				}
+			} catch {
 				toast.error("Agent removed, but navigation failed", {
 					description: "Use Agents in the sidebar to check its status.",
 				});

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -334,6 +334,22 @@ describe("deployment mutation settlement", () => {
 		expect(settlementInvalidations).toHaveLength(4);
 	});
 
+	test("describes accepted deletion as background cleanup and replace-navigates detail", () => {
+		const hooksSource = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
+		const homeSource = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
+		const actionSource = readFileSync(
+			new URL("./deployment-delete-action.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(hooksSource).toContain('toast.message("Agent removed", {');
+		expect(hooksSource).toContain('description: "Cleanup continues in the background."');
+		expect(homeSource).toContain(
+			'onDeleteAccepted={() => router.navigate({ href: "/", replace: true })}',
+		);
+		expect(actionSource).toContain('await router.navigate({ href: "/", replace: true });');
+	});
+
 	test("retires old runtime windows only after restart, access reset, or delete is accepted", () => {
 		const source = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
 

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -246,7 +246,9 @@ export function useDeleteDeployment() {
 		onSuccess: (accepted) => {
 			projectAcceptedDeploymentTransition(qc, accepted);
 			retireRuntimeWindows(accepted.deploymentId);
-			toast.message("Agent removed");
+			toast.message("Agent removed", {
+				description: "Cleanup continues in the background.",
+			});
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -96,7 +96,8 @@ describe("deploy wizard product copy and flow", () => {
 	});
 
 	test("links unresolved post-payment recovery to the agents list", () => {
-		expect(wizardSource).toContain("submitError.blocksRetry");
+		expect(wizardSource).toContain('id: "deploy-post-payment-error"');
+		expect(wizardSource).toContain("duration: Number.POSITIVE_INFINITY");
 		expect(wizardSource).toContain("View agents");
 		expect(wizardSource).toContain('router.navigate({ href: "/agents" })');
 	});
@@ -294,17 +295,18 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).not.toContain("setup=accepted");
 	});
 
-	test("shows a scoped honest busy state and keeps a persistent actionable failure", () => {
+	test("shows a scoped honest busy state and reports failures only through actionable toasts", () => {
 		expect(wizardSource).toContain("setSubmitBusyLabel(");
 		expect(wizardSource).toContain('"Confirming payment & creating agent…"');
 		expect(wizardSource).toContain('"Opening secure checkout…"');
 		expect(wizardSource).toContain('"Creating agent…"');
 		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');
 		expect(wizardSource).toContain("{submitting ? submitBusyLabel : deployLabel}");
-		expect(wizardSource).toContain('data-testid="deploy-submit-error"');
-		expect(wizardSource).toContain('className="max-w-md border-destructive/25 bg-card');
-		expect(wizardSource).toContain('submitError.blocksRetry ? "View agents" : "Retry"');
+		expect(wizardSource).toContain('id: "deploy-submit-error"');
+		expect(wizardSource).toContain('label: "Retry"');
 		expect(wizardSource).toContain("deploySubmissionErrorPresentation(");
+		expect(wizardSource).not.toContain('data-testid="deploy-submit-error"');
+		expect(wizardSource).not.toContain("submitError");
 		expect(wizardSource).not.toContain('toast.error("Couldn’t deploy"');
 		expect(wizardSource).not.toContain('toast.error("Couldn’t create agent"');
 		expect(wizardSource).not.toContain('submitting ? "Working…"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -301,8 +301,12 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain('"Creating agent…"');
 		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');
 		expect(wizardSource).toContain("{submitting ? submitBusyLabel : deployLabel}");
-		expect(wizardSource).toContain('role="alert"');
-		expect(wizardSource).toContain("Your choices are unchanged; review them and try again.");
+		expect(wizardSource).toContain('data-testid="deploy-submit-error"');
+		expect(wizardSource).toContain('className="max-w-md border-destructive/25 bg-card');
+		expect(wizardSource).toContain('submitError.blocksRetry ? "View agents" : "Retry"');
+		expect(wizardSource).toContain("deploySubmissionErrorPresentation(");
+		expect(wizardSource).not.toContain('toast.error("Couldn’t deploy"');
+		expect(wizardSource).not.toContain('toast.error("Couldn’t create agent"');
 		expect(wizardSource).not.toContain('submitting ? "Working…"');
 	});
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -409,6 +409,7 @@ export function DeployWizard() {
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
+	const [postPaymentBlocked, setPostPaymentBlocked] = useState(false);
 	const [submitTakingLong, setSubmitTakingLong] = useState(false);
 	const [submitBusyLabel, setSubmitBusyLabel] = useState("Creating agent…");
 	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState(
@@ -584,7 +585,7 @@ export function DeployWizard() {
 		}
 		return null;
 	})();
-	const canSubmit = !submitting && submitBlockingReason === null;
+	const canSubmit = !submitting && !postPaymentBlocked && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
@@ -637,6 +638,7 @@ export function DeployWizard() {
 	}
 
 	function showPostPaymentError(title: string, description: string) {
+		setPostPaymentBlocked(true);
 		toast.error(title, {
 			id: "deploy-post-payment-error",
 			description,

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -89,8 +89,8 @@ import {
 import {
 	billingErrorNormalizer,
 	DeploymentRequestTerminalError,
+	deploySubmissionErrorPresentation,
 	isIdempotencyKeyReusedError,
-	isNetworkError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import {
@@ -704,7 +704,6 @@ export function DeployWizard() {
 							title: "Payment succeeded, but the agent could not be started",
 							description: `${normalized} Don’t submit another payment; check Agents for the latest state.`,
 						});
-						toast.error("Couldn’t create agent", { description: normalized });
 						return;
 					}
 					// Stripe may complete before its deployment request is visible. Fall back
@@ -900,23 +899,20 @@ export function DeployWizard() {
 			includedCreateAttemptRef.current = null;
 			acceptDeployment(created.deploymentId);
 		} catch (e) {
-			const normalized = normalizeBillingError(e);
-			setSubmitError(
-				isNetworkError(e)
-					? {
-							title: "We couldn’t confirm this attempt",
-							description: `${normalized} Your choices are unchanged; retry to safely check the same payment attempt.`,
-						}
-					: {
-							title: "Your agent wasn’t created",
-							description: `${normalized} Your choices are unchanged; review them and try again.`,
-						},
-			);
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();
 				if (walletTopUp.handleFundingError(e)) return;
 			}
-			toast.error("Couldn’t deploy", { description: normalized });
+			setSubmitError(
+				deploySubmissionErrorPresentation(
+					e,
+					paidSelection
+						? paymentMethod === "wallet"
+							? "wallet_creation"
+							: "card_checkout"
+						: "included_creation",
+				),
+			);
 		} finally {
 			setSubmitting(false);
 			setSubmitTakingLong(false);
@@ -1468,41 +1464,55 @@ export function DeployWizard() {
 						<p className="min-w-0 max-w-full truncate text-xs text-muted-foreground sm:text-sm">
 							{summaryLine}
 						</p>
-						<div className="flex flex-col gap-1 sm:items-end">
-							<Button
-								type="submit"
-								size="lg"
-								disabled={!canSubmit}
-								aria-describedby={submitBlockingReason ? "deploy-blocking-reason" : undefined}
-								className="w-full sm:w-auto"
-							>
-								{submitting ? (
-									<Spinner data-icon="inline-start" />
-								) : (
-									<Rocket data-icon="inline-start" />
-								)}
-								{submitting ? submitBusyLabel : deployLabel}
-							</Button>
-							{submitError ? (
-								<div className="max-w-sm text-xs text-destructive sm:text-right" role="alert">
-									<p className="font-medium">{submitError.title}</p>
-									<p>{submitError.description}</p>
-									{submitError.blocksRetry ? (
-										<Button
-											type="button"
-											variant="link"
-											className="h-auto px-0 text-destructive"
-											onClick={() => void router.navigate({ href: "/agents" })}
-										>
-											View agents
-										</Button>
-									) : null}
-								</div>
-							) : submitTakingLong ? (
+						<div className="flex min-w-0 flex-col gap-1 sm:items-end">
+							<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+								{submitError ? (
+									<Alert
+										data-testid="deploy-submit-error"
+										className="max-w-md border-destructive/25 bg-card px-3 py-2 shadow-xs"
+									>
+										<TriangleAlert className="text-destructive" />
+										<AlertTitle>{submitError.title}</AlertTitle>
+										<AlertDescription className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
+											<span className="min-w-0 flex-1">{submitError.description}</span>
+											<Button
+												type="button"
+												size="sm"
+												variant="outline"
+												onClick={() => {
+													if (submitError.blocksRetry) {
+														void router.navigate({ href: "/agents" });
+														return;
+													}
+													if (canSubmit) void runAction(onDeploy);
+												}}
+											>
+												{submitError.blocksRetry ? null : <RefreshCw data-icon="inline-start" />}
+												{submitError.blocksRetry ? "View agents" : "Retry"}
+											</Button>
+										</AlertDescription>
+									</Alert>
+								) : null}
+								<Button
+									type="submit"
+									size="lg"
+									disabled={!canSubmit}
+									aria-describedby={submitBlockingReason ? "deploy-blocking-reason" : undefined}
+									className="w-full shrink-0 sm:w-auto"
+								>
+									{submitting ? (
+										<Spinner data-icon="inline-start" />
+									) : (
+										<Rocket data-icon="inline-start" />
+									)}
+									{submitting ? submitBusyLabel : deployLabel}
+								</Button>
+							</div>
+							{!submitError && submitTakingLong ? (
 								<p className="max-w-sm text-xs text-muted-foreground sm:text-right" role="status">
 									{submitTakingLongCopy}
 								</p>
-							) : submitBlockingReason ? (
+							) : !submitError && submitBlockingReason ? (
 								<p
 									id="deploy-blocking-reason"
 									className={cn(

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -410,11 +410,6 @@ export function DeployWizard() {
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
 	const [submitTakingLong, setSubmitTakingLong] = useState(false);
-	const [submitError, setSubmitError] = useState<{
-		blocksRetry?: boolean;
-		description: string;
-		title: string;
-	} | null>(null);
 	const [submitBusyLabel, setSubmitBusyLabel] = useState("Creating agent…");
 	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState(
 		"Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
@@ -589,7 +584,7 @@ export function DeployWizard() {
 		}
 		return null;
 	})();
-	const canSubmit = !submitting && !submitError?.blocksRetry && submitBlockingReason === null;
+	const canSubmit = !submitting && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
@@ -641,6 +636,39 @@ export function DeployWizard() {
 		}
 	}
 
+	function showPostPaymentError(title: string, description: string) {
+		toast.error(title, {
+			id: "deploy-post-payment-error",
+			description,
+			duration: Number.POSITIVE_INFINITY,
+			action: {
+				label: "View agents",
+				onClick: () => void router.navigate({ href: "/agents" }),
+			},
+		});
+	}
+
+	function showDeploySubmissionError(error: unknown) {
+		const presentation = deploySubmissionErrorPresentation(
+			error,
+			paidSelection
+				? paymentMethod === "wallet"
+					? "wallet_creation"
+					: "card_checkout"
+				: "included_creation",
+		);
+		toast.error(presentation.title, {
+			id: "deploy-submit-error",
+			description: presentation.description,
+			action: {
+				label: "Retry",
+				onClick: () => {
+					if (canSubmit) void runAction(onDeploy);
+				},
+			},
+		});
+	}
+
 	function buildDeployRequest(
 		aiFields: DeployAiFields,
 		computePlanSlug: ComputePlanSlug,
@@ -674,7 +702,6 @@ export function DeployWizard() {
 		request: SubscriptionCreateRequestView | null,
 	) {
 		setCheckoutSession(null);
-		setSubmitError(null);
 		setSubmitTakingLong(false);
 		setSubmitBusyLabel("Creating agent…");
 		setSubmitTakingLongCopy(
@@ -699,11 +726,10 @@ export function DeployWizard() {
 						forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 						checkoutAttemptRef.current = null;
 						const normalized = normalizeBillingError(error);
-						setSubmitError({
-							blocksRetry: true,
-							title: "Payment succeeded, but the agent could not be started",
-							description: `${normalized} Don’t submit another payment; check Agents for the latest state.`,
-						});
+						showPostPaymentError(
+							"Payment succeeded, but the agent could not be started",
+							`${normalized} Don’t submit another payment; check Agents for the latest state.`,
+						);
 						return;
 					}
 					// Stripe may complete before its deployment request is visible. Fall back
@@ -714,22 +740,18 @@ export function DeployWizard() {
 			try {
 				refreshedDeployments = await refreshCheckoutReturn();
 			} catch {
-				setSubmitError({
-					blocksRetry: true,
-					title: "Payment succeeded; agent status is unavailable",
-					description:
-						"We couldn’t refresh your agent list. Don’t submit another payment; open Agents and check again in a moment.",
-				});
+				showPostPaymentError(
+					"Payment succeeded; agent status is unavailable",
+					"We couldn’t refresh your agent list. Don’t submit another payment; open Agents and check again in a moment.",
+				);
 				return;
 			}
 			const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
 			if (!deploymentId) {
-				setSubmitError({
-					blocksRetry: true,
-					title: "Payment succeeded; your agent is not visible yet",
-					description:
-						"Don’t submit another payment. Open Agents and check again in a moment while the accepted request appears.",
-				});
+				showPostPaymentError(
+					"Payment succeeded; your agent is not visible yet",
+					"Don’t submit another payment. Open Agents and check again in a moment while the accepted request appears.",
+				);
 				return;
 			}
 			if (requestFingerprint) {
@@ -745,7 +767,6 @@ export function DeployWizard() {
 
 	async function onDeploy() {
 		if (!canSubmit) return;
-		setSubmitError(null);
 		setSubmitTakingLong(false);
 		setSubmitBusyLabel(
 			paidSelection
@@ -903,16 +924,7 @@ export function DeployWizard() {
 				void subscriptionCreateQuote.refetch();
 				if (walletTopUp.handleFundingError(e)) return;
 			}
-			setSubmitError(
-				deploySubmissionErrorPresentation(
-					e,
-					paidSelection
-						? paymentMethod === "wallet"
-							? "wallet_creation"
-							: "card_checkout"
-						: "included_creation",
-				),
-			);
+			showDeploySubmissionError(e);
 		} finally {
 			setSubmitting(false);
 			setSubmitTakingLong(false);
@@ -1466,33 +1478,6 @@ export function DeployWizard() {
 						</p>
 						<div className="flex min-w-0 flex-col gap-1 sm:items-end">
 							<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
-								{submitError ? (
-									<Alert
-										data-testid="deploy-submit-error"
-										className="max-w-md border-destructive/25 bg-card px-3 py-2 shadow-xs"
-									>
-										<TriangleAlert className="text-destructive" />
-										<AlertTitle>{submitError.title}</AlertTitle>
-										<AlertDescription className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
-											<span className="min-w-0 flex-1">{submitError.description}</span>
-											<Button
-												type="button"
-												size="sm"
-												variant="outline"
-												onClick={() => {
-													if (submitError.blocksRetry) {
-														void router.navigate({ href: "/agents" });
-														return;
-													}
-													if (canSubmit) void runAction(onDeploy);
-												}}
-											>
-												{submitError.blocksRetry ? null : <RefreshCw data-icon="inline-start" />}
-												{submitError.blocksRetry ? "View agents" : "Retry"}
-											</Button>
-										</AlertDescription>
-									</Alert>
-								) : null}
 								<Button
 									type="submit"
 									size="lg"
@@ -1508,11 +1493,11 @@ export function DeployWizard() {
 									{submitting ? submitBusyLabel : deployLabel}
 								</Button>
 							</div>
-							{!submitError && submitTakingLong ? (
+							{submitTakingLong ? (
 								<p className="max-w-sm text-xs text-muted-foreground sm:text-right" role="status">
 									{submitTakingLongCopy}
 								</p>
-							) : !submitError && submitBlockingReason ? (
+							) : submitBlockingReason ? (
 								<p
 									id="deploy-blocking-reason"
 									className={cn(

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -3,6 +3,7 @@ import {
 	BillingApiError,
 	BillingNetworkError,
 	billingQueryRetry,
+	deploySubmissionErrorPresentation,
 	isAuthError,
 	isForbiddenError,
 	isInsufficientBalanceError,
@@ -102,7 +103,7 @@ describe("normalizeBillingError", () => {
 
 	test("5xx → transient service message, not the raw detail", () => {
 		const msg = normalizeBillingError(new BillingApiError(503, "upstream connect error"));
-		expect(msg).toMatch(/having trouble/i);
+		expect(msg).toMatch(/couldn’t be completed/i);
 		expect(msg).not.toMatch(/upstream connect error/);
 	});
 
@@ -139,5 +140,61 @@ describe("normalizeBillingError", () => {
 
 	test("unknown shapes get a safe message", () => {
 		expect(normalizeBillingError(null)).toMatch(/something went wrong/i);
+	});
+});
+
+describe("deploySubmissionErrorPresentation", () => {
+	test("makes a failed card checkout start explicit, charge-safe, and retryable", () => {
+		const presentation = deploySubmissionErrorPresentation(
+			new BillingApiError(503, "stripe_proxy_internal tenant=usr_secret"),
+			"card_checkout",
+		);
+
+		expect(presentation.title).toBe("Checkout didn’t open");
+		expect(presentation.description).toContain("No payment was submitted");
+		expect(presentation.description).toContain("Retry");
+		expect(presentation.description).not.toContain("stripe_proxy_internal");
+		expect(presentation.description).not.toContain("usr_secret");
+		expect(presentation.description).not.toContain("billing service is having trouble");
+	});
+
+	test("handles card network failures without pretending checkout opened", () => {
+		const presentation = deploySubmissionErrorPresentation(
+			new BillingNetworkError("offline"),
+			"card_checkout",
+		);
+
+		expect(presentation.title).toBe("Checkout didn’t open");
+		expect(presentation.description).toContain("connection dropped");
+		expect(presentation.description).toContain("No payment was submitted");
+	});
+
+	test("keeps ambiguous wallet and create failures on the idempotent retry path", () => {
+		const wallet = deploySubmissionErrorPresentation(
+			new BillingNetworkError("timeout"),
+			"wallet_creation",
+		);
+		const included = deploySubmissionErrorPresentation(
+			new BillingApiError(502, "raw deployment driver failure"),
+			"included_creation",
+		);
+
+		expect(wallet.title).toBe("We couldn’t confirm this attempt");
+		expect(wallet.description).toContain("safely resume the same attempt");
+		expect(wallet.description).not.toContain("No Wallet payment was made");
+		expect(included.title).toBe("We couldn’t confirm agent creation");
+		expect(included.description).toContain("safely resume the same attempt");
+		expect(included.description).not.toContain("raw deployment driver failure");
+	});
+
+	test("states when an explicit wallet rejection did not start payment", () => {
+		const presentation = deploySubmissionErrorPresentation(
+			new BillingApiError(422, "internal validation trace"),
+			"wallet_creation",
+		);
+
+		expect(presentation.title).toBe("Payment and creation didn’t start");
+		expect(presentation.description).toContain("No Wallet payment was made");
+		expect(presentation.description).not.toContain("internal validation trace");
 	});
 });

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -131,7 +131,7 @@ export function isServerError(error: unknown): boolean {
 }
 
 /** True when the request never reached the server (offline / DNS / timeout). */
-export function isNetworkError(error: unknown): boolean {
+export function isNetworkError(error: unknown): error is BillingNetworkError {
 	return error instanceof BillingNetworkError;
 }
 
@@ -142,6 +142,105 @@ export function isNetworkError(error: unknown): boolean {
  */
 export function isRetryableError(error: unknown): boolean {
 	return isNetworkError(error) || isServerError(error);
+}
+
+export type DeploySubmissionContext = "card_checkout" | "included_creation" | "wallet_creation";
+
+export type DeploySubmissionErrorPresentation = {
+	description: string;
+	title: string;
+};
+
+function isDefinitiveBillingRejection(error: unknown): boolean {
+	return (
+		error instanceof BillingApiError &&
+		error.status >= 400 &&
+		error.status < 500 &&
+		error.status !== 429
+	);
+}
+
+/** Only return copy backed by a known public billing condition. */
+function knownBillingRecovery(error: unknown): string | null {
+	if (error instanceof DeploymentConflictError) return DEPLOYMENT_CONFLICT_MESSAGE;
+	if (isInsufficientBalanceError(error)) return normalizeBillingError(error);
+	if (isAuthError(error)) return "Your session expired before this request could start.";
+	if (!(error instanceof BillingApiError)) return null;
+
+	const code = billingErrorDetail(error)?.code;
+	if (code === "open_refund_debt") {
+		return "Top up your Wallet before trying again.";
+	}
+	if (code === "deploy_request_funding_conflict") {
+		return "This agent request is already linked to a different payment flow.";
+	}
+	if (code === "idempotency_key_reused") {
+		return "This attempt could not be matched to the earlier request.";
+	}
+	if (error.detail === "payment_method_required") {
+		return "Add a payment method before trying again.";
+	}
+	return null;
+}
+
+/**
+ * Contextual, non-sensitive copy for the Deploy CTA. Card checkout has not
+ * collected payment until its checkout UI opens, while wallet and create
+ * transport failures can be ambiguous and must resume the same idempotent
+ * attempt instead of claiming that nothing happened.
+ */
+export function deploySubmissionErrorPresentation(
+	error: unknown,
+	context: DeploySubmissionContext,
+): DeploySubmissionErrorPresentation {
+	const knownRecovery = knownBillingRecovery(error);
+	if (context === "card_checkout") {
+		const reason = isNetworkError(error)
+			? error.kind === "timeout"
+				? "The request timed out while opening secure checkout."
+				: "The connection dropped while opening secure checkout."
+			: isServerError(error)
+				? "Secure checkout is temporarily unavailable."
+				: (knownRecovery ?? "We couldn’t open secure checkout.");
+		return {
+			title: "Checkout didn’t open",
+			description: `${reason} No payment was submitted. Retry when you’re ready.`,
+		};
+	}
+
+	if (context === "wallet_creation") {
+		if (isDefinitiveBillingRejection(error)) {
+			return {
+				title: "Payment and creation didn’t start",
+				description: `${knownRecovery ?? "The request was rejected before it was accepted."} No Wallet payment was made. Review your choices and retry.`,
+			};
+		}
+		const reason = isNetworkError(error)
+			? error.kind === "timeout"
+				? "The request timed out before payment and creation were confirmed."
+				: "The connection dropped before payment and creation were confirmed."
+			: "The service didn’t confirm payment and creation.";
+		return {
+			title: "We couldn’t confirm this attempt",
+			description: `${reason} Retry to safely resume the same attempt.`,
+		};
+	}
+
+	if (isDefinitiveBillingRejection(error)) {
+		return {
+			title: "Agent creation didn’t start",
+			description: `${knownRecovery ?? "The request was rejected before it was accepted."} Your choices are unchanged; review them and retry.`,
+		};
+	}
+	const reason = isNetworkError(error)
+		? error.kind === "timeout"
+			? "The request timed out before agent creation was confirmed."
+			: "The connection dropped before agent creation was confirmed."
+		: "The service didn’t confirm agent creation.";
+	return {
+		title: "We couldn’t confirm agent creation",
+		description: `${reason} Retry to safely resume the same attempt.`,
+	};
 }
 
 /**
@@ -196,7 +295,7 @@ export function normalizeBillingError(error: unknown): string {
 		return "Your session has expired. Please sign in again to continue.";
 	}
 	if (isServerError(error)) {
-		return "The billing service is having trouble right now. Please try again in a moment.";
+		return "The billing request couldn’t be completed right now. Try again in a moment.";
 	}
 	if (error instanceof BillingApiError) {
 		const code = billingErrorDetail(error)?.code;

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -60,14 +60,17 @@ function subscriptionAction(cancelAtPeriodEnd: boolean): ComputeSubscriptionActi
 	};
 }
 
-function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
+function acceptedOperation(
+	verb: DeploymentOperationVerb,
+	targetGeneration = 2,
+): DeploymentOperation {
 	return {
 		name: `operations/${verb}-failure`,
 		metadata: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
 			deploymentId: "hdep_failure",
 			verb: verb as DeploymentOperation["metadata"]["verb"],
-			targetGeneration: 2,
+			targetGeneration,
 			manifestETag: "manifest-failure",
 			createTime: "2026-07-25T00:00:00Z",
 			updateTime: "2026-07-25T00:01:00Z",
@@ -368,12 +371,19 @@ describe("reconcileDeploymentSnapshots", () => {
 		expect(reconciled?.accepted_operation?.done).toBe(true);
 		expect(reconciled?.accepted_operation?.error?.code).toBe(1);
 
-		const laterStartOperation = acceptedOperation("start");
+		const laterStartOperation = acceptedOperation("start", 4);
 		const laterServerSnapshot = hostedDeploymentFixture({
 			id: "hdep_delete",
 			status: "starting",
 			acceptedOperation: laterStartOperation,
 		});
+		laterServerSnapshot.resource.metadata.generation = 4;
+		const [directlyAfterCancellation] = reconcileDeploymentSnapshots(
+			[optimistic],
+			[laterServerSnapshot],
+		);
+		expect(directlyAfterCancellation?.accepted_operation).toEqual(laterStartOperation);
+
 		const [afterCancellation] = reconcileDeploymentSnapshots(
 			[restoredServerSnapshot],
 			[laterServerSnapshot],

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -320,6 +320,65 @@ describe("reconcileDeploymentSnapshots", () => {
 
 		expect(reconciled?.resource.status?.summary_state).toBe("running");
 		expect(reconciled?.accepted_operation).toEqual(accepted);
+
+		const [reconciledWithoutOperation] = reconcileDeploymentSnapshots(
+			[optimistic],
+			[
+				hostedDeploymentFixture({
+					id: "hdep_delete",
+					status: "running",
+					acceptedOperation: null,
+				}),
+			],
+		);
+		expect(reconciledWithoutOperation?.accepted_operation).toEqual(accepted);
+	});
+
+	test("converges a delete when the same operation becomes terminal and cancelled", () => {
+		const accepted = acceptedOperation("delete");
+		const optimistic = hostedDeploymentFixture({
+			id: "hdep_delete",
+			status: "deleting",
+			acceptedOperation: accepted,
+		});
+		const cancelledOperation: DeploymentOperation = {
+			...accepted,
+			done: true,
+			error: {
+				code: 1,
+				message: "Delete was cancelled before teardown.",
+				details: [],
+			},
+			response: null,
+		};
+		const restoredServerSnapshot = hostedDeploymentFixture({
+			id: "hdep_delete",
+			status: "running",
+			acceptedOperation: cancelledOperation,
+			computeSlotOccupancy: {
+				occupies_slot: true,
+				backing_infra: "present",
+				reason: "backing_infra_present",
+			},
+		});
+
+		const [reconciled] = reconcileDeploymentSnapshots([optimistic], [restoredServerSnapshot]);
+
+		expect(reconciled).toEqual(restoredServerSnapshot);
+		expect(reconciled?.accepted_operation?.done).toBe(true);
+		expect(reconciled?.accepted_operation?.error?.code).toBe(1);
+
+		const laterStartOperation = acceptedOperation("start");
+		const laterServerSnapshot = hostedDeploymentFixture({
+			id: "hdep_delete",
+			status: "starting",
+			acceptedOperation: laterStartOperation,
+		});
+		const [afterCancellation] = reconcileDeploymentSnapshots(
+			[restoredServerSnapshot],
+			[laterServerSnapshot],
+		);
+		expect(afterCancellation?.accepted_operation).toEqual(laterStartOperation);
 	});
 
 	test("lets a failed server snapshot override optimistic pending state and retain its verb", () => {

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -365,7 +365,8 @@ export function reconcileDeploymentSnapshots(
 	);
 	const reconciled = incoming.map((deployment) => {
 		const acceptedOperation = previousById.get(deployment.resource.id)?.accepted_operation;
-		if (acceptedOperation?.metadata.verb === "delete") {
+		if (acceptedOperation?.metadata.verb === "delete" && !acceptedOperation.done) {
+			if (deployment.accepted_operation?.name === acceptedOperation.name) return deployment;
 			return { ...deployment, accepted_operation: acceptedOperation };
 		}
 		if (deployment.accepted_operation) return deployment;

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -366,7 +366,12 @@ export function reconcileDeploymentSnapshots(
 	const reconciled = incoming.map((deployment) => {
 		const acceptedOperation = previousById.get(deployment.resource.id)?.accepted_operation;
 		if (acceptedOperation?.metadata.verb === "delete" && !acceptedOperation.done) {
-			if (deployment.accepted_operation?.name === acceptedOperation.name) return deployment;
+			if (
+				deployment.accepted_operation?.name === acceptedOperation.name ||
+				deployment.resource.metadata.generation > acceptedOperation.metadata.targetGeneration
+			) {
+				return deployment;
+			}
 			return { ...deployment, accepted_operation: acceptedOperation };
 		}
 		if (deployment.accepted_operation) return deployment;

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -45,6 +45,19 @@ function acceptedDelete(deploymentId: string): DeploymentOperation {
 	};
 }
 
+function cancelledDelete(deploymentId: string): DeploymentOperation {
+	return {
+		...acceptedDelete(deploymentId),
+		done: true,
+		error: {
+			code: 1,
+			message: "Delete was cancelled before teardown.",
+			details: [],
+		},
+		response: null,
+	};
+}
+
 describe("hosted inventory resolution matrix", () => {
 	test("distinguishes a successful empty snapshot from loading", () => {
 		expect(
@@ -139,7 +152,7 @@ describe("hosted detail projection resolution", () => {
 		expect(resolveAgentDeployment([deleting], environmentId, deploymentId).match).toBeNull();
 	});
 
-	test("does not resurrect a dismissed agent when background deletion fails", () => {
+	test("keeps a dismissed agent hidden across a failed snapshot while delete remains pending", () => {
 		const deploymentId = "hdep_delete_failed";
 		const failed = hostedDeploymentFixture({
 			id: deploymentId,
@@ -149,6 +162,40 @@ describe("hosted detail projection resolution", () => {
 
 		expect(isHostedDeploymentVisible(failed)).toBe(false);
 		expect(resolveAgentDeployment([failed], deploymentId).match).toBeNull();
+	});
+
+	test("restores a running agent when its accepted delete is cancelled", () => {
+		const deploymentId = "hdep_delete_cancelled";
+		const restored = hostedDeploymentFixture({
+			id: deploymentId,
+			status: "running",
+			acceptedOperation: cancelledDelete(deploymentId),
+			computeSlotOccupancy: {
+				occupies_slot: true,
+				backing_infra: "present",
+				reason: "backing_infra_present",
+			},
+		});
+
+		expect(isHostedDeploymentVisible(restored)).toBe(true);
+		expect(resolveAgentDeployment([restored], deploymentId).match?.deployment).toBe(restored);
+	});
+
+	test("keeps an agent hidden while occupancy authoritatively reports delete accepted", () => {
+		const deploymentId = "hdep_delete_accepted";
+		const deleting = hostedDeploymentFixture({
+			id: deploymentId,
+			status: "running",
+			acceptedOperation: null,
+			computeSlotOccupancy: {
+				occupies_slot: false,
+				backing_infra: "present",
+				reason: "delete_accepted",
+			},
+		});
+
+		expect(isHostedDeploymentVisible(deleting)).toBe(false);
+		expect(resolveAgentDeployment([deleting], deploymentId).match).toBeNull();
 	});
 
 	test("keeps a selected stopped deployment addressable after its projection is removed", () => {

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -123,12 +123,12 @@ describe("hosted inventory resolution matrix", () => {
 });
 
 describe("hosted detail projection resolution", () => {
-	test("dismisses an accepted delete without releasing its hosted ownership claim", () => {
+	test("suppresses stale detail as soon as delete is accepted without releasing ownership", () => {
 		const environmentId = "55555555-5555-4555-8555-555555555555";
 		const deploymentId = "hdep_user_deleted";
 		const deleting = hostedDeploymentFixture({
 			id: deploymentId,
-			status: "deleting",
+			status: "running",
 			cloudEnvironments: { openclaw: environmentId },
 			acceptedOperation: acceptedDelete(deploymentId),
 		});

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -42,13 +42,15 @@ export function isHostedDeploymentMember(deployment: HostedDeployment): boolean 
 	return deploymentStatusFromResource(deployment.resource.status).kind !== "deleted";
 }
 
-/** Accepted deletion dismisses the agent while its deployment remains observable for cleanup. */
+/** Pending or authoritatively accepted deletion dismisses the agent during cleanup. */
 export function isHostedDeploymentVisible(deployment: HostedDeployment): boolean {
 	const status = deploymentStatusFromResource(deployment.resource.status);
+	const acceptedOperation = deployment.accepted_operation;
 	return (
 		status.kind !== "deleting" &&
 		status.kind !== "deleted" &&
-		deployment.accepted_operation?.metadata.verb !== "delete"
+		!(acceptedOperation?.metadata.verb === "delete" && !acceptedOperation.done) &&
+		deployment.compute_slot_occupancy?.reason !== "delete_accepted"
 	);
 }
 

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -218,7 +218,6 @@ describe("hosted deploy compute and payment contract", () => {
 
 	test("honors delete_accepted occupancy while backing infrastructure remains", () => {
 		const deleting = includedDeployment(false);
-		deleting.accepted_operation = acceptedDeleteOperation();
 		deleting.compute_slot_occupancy = {
 			occupies_slot: false,
 			backing_infra: "present",
@@ -234,6 +233,23 @@ describe("hosted deploy compute and payment contract", () => {
 
 		expect(usesHostedDeployIncludedBasicSlot([deleting])).toBe(false);
 		expect(usesHostedDeployIncludedBasicSlot([deleting, includedDeployment(true)])).toBe(true);
+	});
+
+	test("restores included Basic occupancy when an accepted delete is cancelled", () => {
+		const restored = includedDeployment(true);
+		const acceptedDelete = acceptedDeleteOperation();
+		restored.accepted_operation = {
+			...acceptedDelete,
+			done: true,
+			error: {
+				code: 1,
+				message: "Delete was cancelled before teardown.",
+				details: [],
+			},
+			response: null,
+		};
+
+		expect(usesHostedDeployIncludedBasicSlot([restored])).toBe(true);
 	});
 
 	test("requires an explicit Basic offer once the free slot is occupied", () => {

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -100,6 +100,23 @@ function includedDeployment(occupiesSlot: boolean | null): HostedDeployDeploymen
 	};
 }
 
+function acceptedDeleteOperation(): NonNullable<HostedDeployDeployment["accepted_operation"]> {
+	return {
+		name: "operations/delete-hdep_test",
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "hdep_test",
+			verb: "delete",
+			targetGeneration: 2,
+			manifestETag: "manifest-delete",
+			createTime: "2026-07-28T00:01:00Z",
+			updateTime: "2026-07-28T00:01:00Z",
+		},
+		done: false,
+		response: null,
+	};
+}
+
 describe("hosted deploy request contract", () => {
 	test("keeps the browser-compatible persona mirror and managed provider reference", () => {
 		const result = validateAndBuildHostedDeployRequest(
@@ -197,6 +214,26 @@ describe("hosted deploy compute and payment contract", () => {
 		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(true)])).toBe(true);
 		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(false)])).toBe(false);
 		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(null)])).toBeNull();
+	});
+
+	test("honors delete_accepted occupancy while backing infrastructure remains", () => {
+		const deleting = includedDeployment(false);
+		deleting.accepted_operation = acceptedDeleteOperation();
+		deleting.compute_slot_occupancy = {
+			occupies_slot: false,
+			backing_infra: "present",
+			reason: "delete_accepted",
+		};
+
+		expect(usesHostedDeployIncludedBasicSlot([deleting])).toBe(false);
+	});
+
+	test("optimistically releases the included Basic slot as soon as delete is accepted", () => {
+		const deleting = includedDeployment(true);
+		deleting.accepted_operation = acceptedDeleteOperation();
+
+		expect(usesHostedDeployIncludedBasicSlot([deleting])).toBe(false);
+		expect(usesHostedDeployIncludedBasicSlot([deleting, includedDeployment(true)])).toBe(true);
 	});
 
 	test("requires an explicit Basic offer once the free slot is occupied", () => {

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -280,7 +280,13 @@ export function usesHostedDeployIncludedBasicSlot(
 	let occupancyUnavailable = false;
 	for (const deployment of deployments ?? []) {
 		if (!hasIncludedBasicSubscription(deployment)) continue;
-		if (deployment.accepted_operation?.metadata.verb === "delete") continue;
+		const acceptedOperation = deployment.accepted_operation;
+		if (
+			(acceptedOperation?.metadata.verb === "delete" && !acceptedOperation.done) ||
+			deployment.compute_slot_occupancy?.reason === "delete_accepted"
+		) {
+			continue;
+		}
 		const occupancy = deployment.compute_slot_occupancy;
 		if (occupancy === null) {
 			occupancyUnavailable = true;

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -280,6 +280,7 @@ export function usesHostedDeployIncludedBasicSlot(
 	let occupancyUnavailable = false;
 	for (const deployment of deployments ?? []) {
 		if (!hasIncludedBasicSubscription(deployment)) continue;
+		if (deployment.accepted_operation?.metadata.verb === "delete") continue;
 		const occupancy = deployment.compute_slot_occupancy;
 		if (occupancy === null) {
 			occupancyUnavailable = true;

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1541,7 +1541,7 @@ export interface components {
              * Reason
              * @enum {string}
              */
-            reason: "backing_infra_present" | "backing_infra_unknown" | "observed_stopped" | "observed_deleted" | "authoritative_absence";
+            reason: "backing_infra_present" | "backing_infra_unknown" | "observed_stopped" | "observed_deleted" | "authoritative_absence" | "delete_accepted";
         };
         /** V2HostedComputeSubscriptionInfo */
         V2HostedComputeSubscriptionInfo: {


### PR DESCRIPTION
## Summary
- report deploy and checkout failures only through contextual toasts with Retry or View agents actions
- suppress duplicate error surfaces and raw backend detail while keeping idempotent retry semantics
- immediately treat an accepted free-slot deletion as available
- navigate with replace to the application dashboard `/` after delete acceptance
- keep rejected or failed deletes on the detail page

## Verification
- focused web tests: 43 passed after the toast-only follow-up
- web typecheck and Biome
- hosted Chromium toast scenario passed at 390x844, including no overflow, exactly one error toast, safe raw-detail suppression, and retry with the same deploy_request_id
- prior delete-navigation and free-slot browser scenarios: 3 passed
- shared deploy contract tests: 12 passed
- generated deploy client checked against the paired hosted OpenAPI
- `git diff --check origin/main..HEAD`

## Coordination
Paired backend and schema change: Clawdi-AI/clawdi-hosted#1092. Keep this PR unmerged until the migration rollout is deliberately coordinated. No deployment or production operation was performed.