### PR TITLE
Add Kamal service label to backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,6 +32,9 @@ RUN mkdir -p /data/files /home/app/.cache/fastembed \
 
 USER app
 
+# Kamal requires images to carry the service identity label.
+LABEL service="clawdi"
+
 EXPOSE 8000
 
 CMD ["python", "-m", "app.runtime_entrypoint"]


### PR DESCRIPTION
Kamal validates that a deployed image carries a `service` label matching the service name (`clawdi`). Images are built by CI rather than by Kamal, so the label must be baked into the Dockerfile.

One-line runtime-image change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)