### PR TITLE
fix(cli): fence updater and local state

### DIFF
--- a/packages/cli/src/commands/inbox.ts
+++ b/packages/cli/src/commands/inbox.ts
@@ -456,7 +456,7 @@ export async function inboxJoinCommand(projectId: string, opts: JoinOpts): Promi
 	}
 
 	if (response.status === 404 || response.status === 410) {
-		removeToken(ticket.project_id, ticket.token);
+		await removeToken(ticket.project_id, ticket.token);
 		if (opts.json) {
 			console.log(
 				JSON.stringify(
@@ -482,7 +482,7 @@ export async function inboxJoinCommand(projectId: string, opts: JoinOpts): Promi
 			detail?: { error?: unknown };
 		} | null;
 		if (conflict?.detail?.error === "already_owner") {
-			removeToken(ticket.project_id, ticket.token);
+			await removeToken(ticket.project_id, ticket.token);
 			if (opts.json) {
 				console.log(
 					JSON.stringify(
@@ -531,7 +531,7 @@ export async function inboxJoinCommand(projectId: string, opts: JoinOpts): Promi
 		);
 	}
 
-	removeToken(ticket.project_id, ticket.token);
+	await removeToken(ticket.project_id, ticket.token);
 	if (opts.json) {
 		console.log(
 			JSON.stringify(
@@ -575,7 +575,7 @@ export async function inboxDeclineCommand(invitationId: string): Promise<void> {
 // inbox forget — local-only cleanup
 // ────────────────────────────────────────────────────────────────
 
-export function inboxForgetCommand(projectId: string): void {
+export async function inboxForgetCommand(projectId: string): Promise<void> {
 	const token = findToken(projectId);
 	if (!token) {
 		console.error(chalk.red(`No local share record found for project '${projectId}'.`));
@@ -606,7 +606,10 @@ export function inboxForgetCommand(projectId: string): void {
 			}
 		}
 	}
-	removeToken(token.project_id);
+	const tokenRemoved = await removeToken(token.project_id, token.token);
+	if (!tokenRemoved) {
+		throw new Error("local share changed while it was being forgotten; retry the command");
+	}
 
 	console.log(`${chalk.green("✓")} Forgot local share for "${chalk.bold(token.project_name)}".`);
 	if (removed > 0) {
@@ -714,7 +717,7 @@ async function acceptAnonymousUrl(
 		redeemed_at: new Date().toISOString(),
 		api_origin: apiOrigin,
 	};
-	addToken(record);
+	await addToken(record);
 	if (opts.json) {
 		console.log(
 			JSON.stringify(
@@ -796,7 +799,7 @@ async function acceptUrl(
 	if (r.status === 409) {
 		const detail = (await r.json().catch(() => ({})))?.detail ?? {};
 		if (detail.error === "already_owner") {
-			if (localTicket) removeToken(localTicket.project_id, localTicket.token);
+			if (localTicket) await removeToken(localTicket.project_id, localTicket.token);
 			if (opts.json) {
 				console.log(
 					JSON.stringify(
@@ -822,7 +825,7 @@ async function acceptUrl(
 		throw new ApiError({ status: r.status, body: JSON.stringify(detail), hint: "" });
 	}
 	if (r.status === 404 || r.status === 410) {
-		if (localTicket) removeToken(localTicket.project_id, localTicket.token);
+		if (localTicket) await removeToken(localTicket.project_id, localTicket.token);
 		throw new Error(
 			r.status === 404
 				? "Share link not found. Any matching local ticket was removed."
@@ -835,7 +838,7 @@ async function acceptUrl(
 	if (!body || (localTicket && localTicket.project_id !== body.project_id)) {
 		throw new Error("Clawdi returned an invalid project join response.");
 	}
-	if (localTicket) removeToken(localTicket.project_id, localTicket.token);
+	if (localTicket) await removeToken(localTicket.project_id, localTicket.token);
 	if (opts.json) {
 		console.log(
 			JSON.stringify(

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,20 +1,28 @@
 import { spawn, spawnSync } from "node:child_process";
 import {
+	accessSync,
 	closeSync,
+	constants,
 	existsSync,
 	mkdirSync,
 	openSync,
 	readFileSync,
 	realpathSync,
-	rmSync,
-	statSync,
-	writeFileSync,
 } from "node:fs";
-import { dirname, join, normalize, resolve, sep } from "node:path";
+import { delimiter, dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
+import { resolveCurrentCliInvocation } from "../lib/current-cli-invocation";
+import {
+	type PrivateDirectoryLockOptions,
+	PrivateDirectoryLockTimeoutError,
+	withPrivateDirectoryLock,
+} from "../lib/private-directory-lock";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { terminateProcessGroup } from "../lib/process-group";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { compareSemver, isValidSemver } from "../lib/semver";
+import { timedFetch } from "../lib/timed-fetch";
 import { getCliVersion } from "../lib/version";
 import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { detectRuntimeMode } from "../runtime/paths";
@@ -31,11 +39,14 @@ const REGISTRY_URL = "https://registry.npmjs.org/clawdi";
 // feel broken whenever a fix shipped.
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const DAEMON_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
-const DAEMON_UPDATE_LOCK_STALE_MS = 15 * 60 * 1000;
+const INSTALL_TIMEOUT_MS = 3 * 60_000;
+const INSTALL_TERM_GRACE_MS = 2_000;
+const INSTALL_KILL_GRACE_MS = 1_000;
 export type Installer = "bun" | "npm";
 
-interface GlobalInstallOwnership {
+export interface GlobalInstallOwnership {
 	installer: Installer;
+	installerExecutable: string;
 	executable: string;
 }
 
@@ -44,19 +55,16 @@ interface UpdateCache {
 	latest: string;
 }
 
-type BackgroundInstallContext = {
+type BackgroundWorkerRequest = {
 	current: string;
-	latest: string;
+	latest?: string;
+	channel: string;
 	logFd: number;
 };
 
 type AutoUpdateRuntime = {
 	detectOwnership?: () => GlobalInstallOwnership | null;
-	spawnBackgroundInstall?: (
-		installer: Installer,
-		args: string[],
-		context: BackgroundInstallContext,
-	) => void;
+	spawnBackgroundWorker?: (request: BackgroundWorkerRequest) => void;
 };
 
 type ForegroundUpdateRuntime = {
@@ -64,6 +72,7 @@ type ForegroundUpdateRuntime = {
 	installRunner?: (command: string, args: string[]) => number | null;
 	platform?: NodeJS.Platform;
 	versionReader?: (command: string, args: string[]) => string | null;
+	lockOptions?: PrivateDirectoryLockOptions;
 };
 
 interface CommandVector {
@@ -93,11 +102,10 @@ function readCache(channel = "latest"): UpdateCache | null {
 
 function writeCache(latest: string, channel = "latest"): void {
 	try {
-		mkdirSync(getClawdiDir(), { recursive: true });
-		writeFileSync(
+		writePrivateFileAtomic(
 			cachePath(channel),
 			`${JSON.stringify({ checkedAt: new Date().toISOString(), latest }, null, 2)}\n`,
-			{ mode: 0o600 },
+			{ mode: PRIVATE_FILE_MODE, dirMode: PRIVATE_DIR_MODE },
 		);
 	} catch {
 		// best-effort; ignore
@@ -110,18 +118,14 @@ function updateChannelForVersion(version: string): string {
 }
 
 async function fetchLatest(timeoutMs = 3000, channel = "latest"): Promise<string | null> {
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), timeoutMs);
 	try {
-		const res = await fetch(REGISTRY_URL, { signal: controller.signal });
+		const res = await timedFetch(REGISTRY_URL, {}, timeoutMs);
 		if (!res.ok) return null;
 		const data = (await res.json()) as { "dist-tags"?: Record<string, string | undefined> };
 		const resolved = data["dist-tags"]?.[channel];
 		return resolved && isValidSemver(resolved) ? resolved : null;
 	} catch {
 		return null;
-	} finally {
-		clearTimeout(timer);
 	}
 }
 
@@ -199,34 +203,46 @@ export async function update(
 	}
 
 	const { installer } = ownership;
-	const args = installArgs(installer, latest);
-	const install = installerCommandVector(installer, args, runtime.platform);
 	console.log();
 	console.log(chalk.cyan(`Installing v${latest} via ${installer}…`));
-	const status = (runtime.installRunner ?? runForegroundInstall)(install.command, install.args);
-	if (status !== 0) {
+	const result = await runUpdateInstallWorker({
+		current,
+		latest,
+		ownership,
+		output: "inherit",
+		platform: runtime.platform,
+		lockOptions: runtime.lockOptions,
+		installRunner: runtime.installRunner
+			? async (command, args) => runtime.installRunner?.(command, args) ?? null
+			: undefined,
+		versionReader: runtime.versionReader,
+	});
+	if (result.status === "locked") {
 		console.log();
-		console.log(
-			chalk.red(`Install failed (${installer} exited ${status}). Try manually:`) +
-				"\n  " +
-				chalk.white(installCommand(installer, latest)),
-		);
-		process.exitCode = status ?? 1;
-		return;
-	}
-	const smoke = executableCommandVector(ownership.executable, ["--version"], runtime.platform);
-	const installedVersion = (runtime.versionReader ?? readCommandVersion)(smoke.command, smoke.args);
-	if (installedVersion !== latest) {
-		console.log();
-		console.log(
-			chalk.red(
-				`Install verification failed: expected ${latest}, got ${installedVersion ?? "no version"}.`,
-			),
-		);
+		console.log(chalk.yellow("Another clawdi update is already running."));
 		process.exitCode = 1;
 		return;
 	}
-	writeLastVersion(current);
+	if (result.status === "disabled") {
+		console.log();
+		console.log(chalk.yellow("Local CLI updates are disabled by Hosted policy."));
+		process.exitCode = 1;
+		return;
+	}
+	if (result.status === "failed") {
+		console.log();
+		console.log(
+			chalk.red(
+				result.installedVersion === undefined
+					? `Install failed (${installer} exited ${result.exitCode}). Try manually:`
+					: `Install verification failed: expected ${latest}, got ${result.installedVersion ?? "no version"}.`,
+			) +
+				"\n  " +
+				chalk.white(installCommand(installer, latest)),
+		);
+		process.exitCode = result.exitCode ?? 1;
+		return;
+	}
 	console.log();
 	console.log(chalk.green(`✓ clawdi v${latest} installed.`));
 }
@@ -249,8 +265,10 @@ function lastVersionPath(): string {
 
 function writeLastVersion(version: string): void {
 	try {
-		mkdirSync(getClawdiDir(), { recursive: true });
-		writeFileSync(lastVersionPath(), version, { mode: 0o644 });
+		writePrivateFileAtomic(lastVersionPath(), `${version}\n`, {
+			mode: PRIVATE_FILE_MODE,
+			dirMode: PRIVATE_DIR_MODE,
+		});
 	} catch {
 		// best-effort
 	}
@@ -264,76 +282,142 @@ function detectUpdateOwnership(runtime: ForegroundUpdateRuntime): GlobalInstallO
 	return runtime.detectOwnership?.() ?? detectGlobalInstall();
 }
 
-function detectGlobalInstall(): GlobalInstallOwnership | null {
-	const bunBin = bunGlobalBinDir();
-	return detectGlobalInstallFromPaths(process.argv[1], {
-		npmBin: npmGlobalBinDir(),
-		npmRoot: npmGlobalRootDir(),
-		bunBin,
-		bunRoot: bunBin ? bunGlobalRootDir(bunBin) : null,
-	});
+export function detectGlobalInstall(): GlobalInstallOwnership | null {
+	let invokedPath: string | undefined;
+	try {
+		invokedPath = resolveCurrentCliInvocation().entryPath ?? undefined;
+	} catch {
+		return null;
+	}
+	for (const npmExecutable of absoluteExecutableCandidates("npm")) {
+		const prefix = commandOutput(executableCommandVector(npmExecutable, ["prefix", "-g"]));
+		const npmRoot = commandOutput(executableCommandVector(npmExecutable, ["root", "-g"]));
+		const npmBin = prefix
+			? process.platform === "win32"
+				? normalizePath(prefix)
+				: normalizePath(join(prefix, "bin"))
+			: null;
+		const ownership = detectUpdateOwnershipFromPaths(invokedPath, {
+			npmBin,
+			npmRoot,
+			npmExecutable,
+		});
+		if (ownership) return ownership;
+	}
+
+	for (const bunExecutable of bunExecutableCandidates()) {
+		const bunBin = commandOutput(executableCommandVector(bunExecutable, ["pm", "bin", "-g"]));
+		const ownership = detectUpdateOwnershipFromPaths(invokedPath, {
+			bunBin,
+			bunRoot: bunBin ? bunGlobalRootDir(bunBin) : null,
+			bunExecutable,
+		});
+		if (ownership) return ownership;
+	}
+	return null;
 }
 
 export function detectInstallerFromPaths(
 	invokedPath: string | undefined,
-	paths: {
-		bunBin?: string | null;
-		bunRoot?: string | null;
-		npmBin?: string | null;
-		npmRoot?: string | null;
-	},
+	paths: GlobalInstallPaths,
 ): Installer | null {
-	return detectGlobalInstallFromPaths(invokedPath, paths)?.installer ?? null;
+	return detectUpdateOwnershipFromPaths(invokedPath, paths)?.installer ?? null;
 }
 
-function detectGlobalInstallFromPaths(
+type GlobalInstallPaths = {
+	bunBin?: string | null;
+	bunRoot?: string | null;
+	bunExecutable?: string | null;
+	npmBin?: string | null;
+	npmRoot?: string | null;
+	npmExecutable?: string | null;
+};
+
+export function detectUpdateOwnershipFromPaths(
 	invokedPath: string | undefined,
-	paths: {
-		bunBin?: string | null;
-		bunRoot?: string | null;
-		npmBin?: string | null;
-		npmRoot?: string | null;
-	},
+	paths: GlobalInstallPaths,
 ): GlobalInstallOwnership | null {
 	if (!invokedPath) return null;
 
 	const candidates = normalizedPathCandidates(invokedPath);
 	const npmBin = paths.npmBin ? normalizePath(paths.npmBin) : null;
 	const npmRoot = paths.npmRoot ? normalizePath(paths.npmRoot) : null;
+	const npmExecutable = absolutePath(paths.npmExecutable);
 	const bunBin = paths.bunBin ? normalizePath(paths.bunBin) : null;
 	const bunRoot = paths.bunRoot ? normalizePath(paths.bunRoot) : null;
+	const bunExecutable = absolutePath(paths.bunExecutable);
 	if (candidates.some(isTransientPath)) return null;
 	if (
 		npmBin &&
 		npmRoot &&
+		npmExecutable &&
 		candidates.some((candidate) => pathStartsWith(candidate, join(npmRoot, "clawdi")))
 	) {
-		return { installer: "npm", executable: globalExecutable("npm", npmBin) };
+		return {
+			installer: "npm",
+			installerExecutable: npmExecutable,
+			executable: globalExecutable("npm", npmBin),
+		};
 	}
 	if (
 		bunBin &&
 		bunRoot &&
+		bunExecutable &&
 		candidates.some((candidate) => pathStartsWith(candidate, join(bunRoot, "clawdi")))
 	) {
-		return { installer: "bun", executable: globalExecutable("bun", bunBin) };
+		return {
+			installer: "bun",
+			installerExecutable: bunExecutable,
+			executable: globalExecutable("bun", bunBin),
+		};
 	}
 	return null;
 }
 
-function npmGlobalBinDir(): string | null {
-	const prefix = commandOutput(installerCommandVector("npm", ["prefix", "-g"]));
-	if (!prefix) return null;
-	return process.platform === "win32" ? normalizePath(prefix) : normalizePath(join(prefix, "bin"));
+function absolutePath(path: string | null | undefined): string | null {
+	return path && isAbsolute(path) ? normalizePath(path) : null;
 }
 
-function npmGlobalRootDir(): string | null {
-	const root = commandOutput(installerCommandVector("npm", ["root", "-g"]));
-	return root ? normalizePath(root) : null;
+function bunExecutableCandidates(): string[] {
+	const candidates: string[] = [];
+	const bunInstall = process.env.BUN_INSTALL;
+	if (bunInstall) candidates.push(join(bunInstall, "bin", bunExecutableName()));
+	const home = process.env.HOME;
+	if (home) candidates.push(join(home, ".bun", "bin", bunExecutableName()));
+	candidates.push(...absoluteExecutableCandidates("bun"));
+	return verifiedAbsoluteExecutables(candidates);
 }
 
-function bunGlobalBinDir(): string | null {
-	const bin = commandOutput(executableCommandVector("bun", ["pm", "bin", "-g"]));
-	return bin ? normalizePath(bin) : null;
+function bunExecutableName(): string {
+	return process.platform === "win32" ? "bun.exe" : "bun";
+}
+
+function absoluteExecutableCandidates(command: "bun" | "npm"): string[] {
+	const names =
+		process.platform === "win32"
+			? command === "npm"
+				? ["npm.cmd", "npm.exe", "npm"]
+				: ["bun.exe", "bun"]
+			: [command];
+	const candidates = (process.env.PATH ?? "")
+		.split(delimiter)
+		.filter(Boolean)
+		.flatMap((directory) => names.map((name) => join(directory, name)));
+	return verifiedAbsoluteExecutables(candidates);
+}
+
+function verifiedAbsoluteExecutables(candidates: string[]): string[] {
+	const verified: string[] = [];
+	for (const candidate of candidates) {
+		if (!isAbsolute(candidate)) continue;
+		try {
+			accessSync(candidate, constants.X_OK);
+			verified.push(realpathSync(candidate));
+		} catch {
+			// Only an existing executable can own an installation.
+		}
+	}
+	return [...new Set(verified)];
 }
 
 function bunGlobalRootDir(binDir: string): string {
@@ -388,13 +472,13 @@ function pathStartsWith(path: string, parent: string): boolean {
 	return normalizedPath.startsWith(prefix);
 }
 
-function detectAutoUpdateOwnership(runtime: AutoUpdateRuntime): GlobalInstallOwnership | null {
-	return runtime.detectOwnership?.() ?? detectGlobalInstall();
-}
-
 function packageSpecForVersion(version: string): string {
 	if (!isValidSemver(version)) throw new Error(`invalid clawdi update version: ${version}`);
 	return `clawdi@${version}`;
+}
+
+function detectAutoUpdateOwnership(runtime: AutoUpdateRuntime): GlobalInstallOwnership | null {
+	return runtime.detectOwnership?.() ?? detectGlobalInstall();
 }
 
 function installArgs(installer: Installer, version: string): string[] {
@@ -435,26 +519,6 @@ function executableCommandVector(
 	return { command: executable, args };
 }
 
-function installerCommandVector(
-	installer: Installer,
-	args: string[],
-	platform: NodeJS.Platform = process.platform,
-): CommandVector {
-	const executable = installer === "npm" && platform === "win32" ? "npm.cmd" : installer;
-	return executableCommandVector(executable, args, platform);
-}
-
-function runForegroundInstall(command: string, args: string[]): number | null {
-	try {
-		return spawnSync(command, args, {
-			stdio: "inherit",
-			windowsHide: true,
-		}).status;
-	} catch {
-		return null;
-	}
-}
-
 function readCommandVersion(command: string, args: string[]): string | null {
 	try {
 		const result = spawnSync(command, args, {
@@ -468,11 +532,6 @@ function readCommandVersion(command: string, args: string[]): string | null {
 	} catch {
 		return null;
 	}
-}
-
-function readExecutableVersion(executable: string): string | null {
-	const vector = executableCommandVector(executable, ["--version"]);
-	return readCommandVersion(vector.command, vector.args);
 }
 
 function isLongLivedDaemonInvocation(args = process.argv.slice(2)): boolean {
@@ -526,8 +585,7 @@ function autoUpdateDisabled(): boolean {
 	if (process.env.CLAWDI_NO_AUTO_UPDATE) return true;
 	if (process.env.CLAWDI_NO_UPDATE_CHECK) return true;
 	if (isTransientInvocation()) return true;
-	const stored = getStoredConfig() as { autoUpdate?: unknown };
-	return stored.autoUpdate === false || stored.autoUpdate === "false";
+	return getStoredConfig().autoUpdate === false;
 }
 
 async function latestFromCacheOrRegistry(channel = "latest"): Promise<string | null> {
@@ -544,68 +602,94 @@ async function latestFromCacheOrRegistry(channel = "latest"): Promise<string | n
 	return cached?.latest ?? null;
 }
 
-function acquireDaemonUpdateLock(): (() => void) | null {
-	const root = getClawdiDir();
-	const lockDir = join(root, "daemon-auto-update.lock");
-	const acquire = () => {
-		mkdirSync(root, { recursive: true });
-		mkdirSync(lockDir, { mode: 0o700 });
-		writeFileSync(join(lockDir, "pid"), `${process.pid}\n`, { mode: 0o600 });
-		return () => {
-			rmSync(lockDir, { recursive: true, force: true });
-		};
-	};
-	try {
-		return acquire();
-	} catch {
-		try {
-			const age = Date.now() - statSync(lockDir).mtimeMs;
-			if (age > DAEMON_UPDATE_LOCK_STALE_MS) {
-				rmSync(lockDir, { recursive: true, force: true });
-				return acquire();
-			}
-		} catch {
-			// If stat/remove failed, treat as locked; another daemon
-			// will retry on the next cadence.
-		}
-		return null;
-	}
-}
+type InstallerOutput = "inherit" | "log";
 
-type InstallRunner = (
-	installer: Installer,
+type ProcessInstallRunner = (
+	command: string,
 	args: string[],
-	signal?: AbortSignal,
+	options: { signal?: AbortSignal; output: InstallerOutput },
 ) => Promise<number | null>;
 
-async function runInstall(installer: Installer, args: string[], signal?: AbortSignal) {
-	if (signal?.aborted) return null;
-
+export async function runInstallerProcess(
+	command: string,
+	args: string[],
+	options: {
+		signal?: AbortSignal;
+		output?: InstallerOutput;
+		timeoutMs?: number;
+		termGraceMs?: number;
+		killGraceMs?: number;
+	} = {},
+): Promise<number | null> {
+	if (options.signal?.aborted) return null;
+	const output = options.output ?? "log";
+	const timeoutMs = options.timeoutMs ?? INSTALL_TIMEOUT_MS;
+	const termGraceMs = options.termGraceMs ?? INSTALL_TERM_GRACE_MS;
+	const killGraceMs = options.killGraceMs ?? INSTALL_KILL_GRACE_MS;
+	if (
+		!Number.isFinite(timeoutMs) ||
+		timeoutMs <= 0 ||
+		!Number.isFinite(termGraceMs) ||
+		termGraceMs < 0 ||
+		!Number.isFinite(killGraceMs) ||
+		killGraceMs < 0
+	) {
+		throw new Error("installer timeout must be positive and grace periods must be non-negative");
+	}
 	const logPath = join(getClawdiDir(), "auto-update.log");
 	let logFd: number;
-	try {
-		mkdirSync(getClawdiDir(), { recursive: true });
-		logFd = openSync(logPath, "a");
-	} catch {
+	if (output === "log") {
+		try {
+			mkdirSync(getClawdiDir(), { recursive: true });
+			logFd = openSync(logPath, "a");
+		} catch {
+			logFd = -1;
+		}
+	} else {
 		logFd = -1;
 	}
 	try {
 		return await new Promise<number | null>((resolve) => {
-			const vector = installerCommandVector(installer, args);
-			const child = spawn(vector.command, vector.args, {
-				stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+			const child = spawn(command, args, {
+				stdio: output === "inherit" ? "inherit" : logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
 				env: process.env,
+				detached: process.platform !== "win32",
 				windowsHide: true,
 			});
-			const onAbort = () => {
-				child.kill();
+			let markClosed = () => {};
+			const closed = new Promise<void>((resolveClosed) => {
+				markClosed = resolveClosed;
+			});
+			let termination: Promise<void> | null = null;
+			let settled = false;
+			const finish = (result: number | null) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeout);
+				options.signal?.removeEventListener("abort", terminate);
+				process.removeListener("SIGINT", terminate);
+				process.removeListener("SIGTERM", terminate);
+				resolve(result);
 			};
-			signal?.addEventListener("abort", onAbort, { once: true });
-			if (signal?.aborted) onAbort();
-			child.on("error", () => resolve(null));
+			function terminate() {
+				if (termination || settled) return;
+				termination = terminateProcessGroup(child, closed, {
+					termTimeoutMs: termGraceMs,
+					killTimeoutMs: killGraceMs,
+				}).then(() => finish(null));
+			}
+			const timeout = setTimeout(terminate, timeoutMs);
+			options.signal?.addEventListener("abort", terminate, { once: true });
+			process.once("SIGINT", terminate);
+			process.once("SIGTERM", terminate);
+			if (options.signal?.aborted) terminate();
+			child.on("error", () => {
+				markClosed();
+				finish(null);
+			});
 			child.on("close", (code) => {
-				signal?.removeEventListener("abort", onAbort);
-				resolve(code);
+				markClosed();
+				if (!termination) finish(code);
 			});
 		});
 	} finally {
@@ -619,6 +703,63 @@ async function runInstall(installer: Installer, args: string[], signal?: AbortSi
 	}
 }
 
+type UpdateInstallWorkerResult =
+	| { status: "installed"; installedVersion: string }
+	| { status: "failed"; exitCode: number | null; installedVersion?: undefined }
+	| { status: "failed"; exitCode?: undefined; installedVersion: string | null }
+	| { status: "locked" }
+	| { status: "disabled" };
+
+async function runUpdateInstallWorker(input: {
+	current: string;
+	latest: string;
+	ownership: GlobalInstallOwnership;
+	output: InstallerOutput;
+	signal?: AbortSignal;
+	platform?: NodeJS.Platform;
+	lockOptions?: PrivateDirectoryLockOptions;
+	installRunner?: ProcessInstallRunner;
+	versionReader?: (command: string, args: string[]) => string | null;
+}): Promise<UpdateInstallWorkerResult> {
+	if (!evaluateHostPolicyForCommand("update").allowed) return { status: "disabled" };
+	if (input.signal?.aborted) return { status: "failed", exitCode: null };
+	const install = executableCommandVector(
+		input.ownership.installerExecutable,
+		installArgs(input.ownership.installer, input.latest),
+		input.platform,
+	);
+	const smoke = executableCommandVector(input.ownership.executable, ["--version"], input.platform);
+	try {
+		return await withPrivateDirectoryLock(
+			join(getClawdiDir(), "update.lock"),
+			async (lease) => {
+				const exitCode = await (input.installRunner ?? runInstallerProcess)(
+					install.command,
+					install.args,
+					{ signal: input.signal, output: input.output },
+				);
+				lease.assertOwned();
+				if (exitCode !== 0) return { status: "failed", exitCode };
+				const installedVersion = (input.versionReader ?? readCommandVersion)(
+					smoke.command,
+					smoke.args,
+				);
+				lease.assertOwned();
+				if (installedVersion !== input.latest) {
+					return { status: "failed", installedVersion };
+				}
+				writeLastVersion(input.current);
+				lease.assertOwned();
+				return { status: "installed", installedVersion };
+			},
+			input.lockOptions,
+		);
+	} catch (error) {
+		if (error instanceof PrivateDirectoryLockTimeoutError) return { status: "locked" };
+		throw error;
+	}
+}
+
 export type DaemonAutoUpdateResult =
 	| "disabled"
 	| "no_update"
@@ -627,11 +768,17 @@ export type DaemonAutoUpdateResult =
 	| "installed"
 	| "failed";
 
+type DaemonInstallRunner = (
+	installer: Installer,
+	args: string[],
+	signal?: AbortSignal,
+) => Promise<number | null>;
+
 export async function daemonAutoUpdateOnce(
 	opts: {
 		currentVersion?: string;
 		ownership?: GlobalInstallOwnership | null;
-		installRunner?: InstallRunner;
+		installRunner?: DaemonInstallRunner;
 		versionReader?: (executable: string) => string | null;
 		ignoreDisabled?: boolean;
 		restartCoordination?: RestartCoordination;
@@ -653,42 +800,51 @@ export async function daemonAutoUpdateOnce(
 		return "unsupported";
 	}
 	const { installer } = ownership;
-
-	const release = acquireDaemonUpdateLock();
-	if (!release) return "locked";
-	try {
-		log.info("daemon.auto_update_installing", { current, latest, channel, installer });
-		const installAndValidate = async (): Promise<DaemonAutoUpdateResult> => {
-			const status = await (opts.installRunner ?? runInstall)(
-				installer,
-				installArgs(installer, latest),
-				opts.signal,
-			);
-			if (status !== 0) {
-				log.warn("daemon.auto_update_failed", { current, latest, channel, installer, status });
-				return "failed";
-			}
-			const installedVersion = (opts.versionReader ?? readExecutableVersion)(ownership.executable);
-			if (installedVersion !== latest) {
+	log.info("daemon.auto_update_installing", { current, latest, channel, installer });
+	const installAndValidate = async (): Promise<DaemonAutoUpdateResult> => {
+		const result = await runUpdateInstallWorker({
+			current,
+			latest,
+			ownership,
+			output: "log",
+			signal: opts.signal,
+			lockOptions: { timeoutMs: 0 },
+			installRunner: opts.installRunner
+				? async (_command, _args, options) =>
+						opts.installRunner?.(installer, installArgs(installer, latest), options.signal) ?? null
+				: undefined,
+			versionReader: opts.versionReader
+				? () => opts.versionReader?.(ownership.executable) ?? null
+				: undefined,
+		});
+		if (result.status === "locked") return "locked";
+		if (result.status === "disabled") return "disabled";
+		if (result.status === "failed") {
+			if (result.installedVersion !== undefined) {
 				log.warn("daemon.auto_update_validation_failed", {
 					current,
 					latest,
 					channel,
 					installer,
-					installed_version: installedVersion,
+					installed_version: result.installedVersion,
 				});
-				return "failed";
+			} else {
+				log.warn("daemon.auto_update_failed", {
+					current,
+					latest,
+					channel,
+					installer,
+					status: result.exitCode,
+				});
 			}
-			writeLastVersion(current);
-			log.info("daemon.auto_update_installed", { from: current, to: latest, channel, installer });
-			return "installed";
-		};
-		return opts.restartCoordination
-			? await opts.restartCoordination.duringUpdateInstall(installAndValidate)
-			: await installAndValidate();
-	} finally {
-		release();
-	}
+			return "failed";
+		}
+		log.info("daemon.auto_update_installed", { from: current, to: latest, channel, installer });
+		return "installed";
+	};
+	return opts.restartCoordination
+		? await opts.restartCoordination.duringUpdateInstall(installAndValidate)
+		: await installAndValidate();
 }
 
 export function startDaemonAutoUpdate(opts: {
@@ -774,46 +930,19 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 	if (!isHumanTerminal) return;
 	if (isTransientInvocation()) return;
 
-	// `clawdi config set autoUpdate false` writes the literal string "false";
-	// fall back to a boolean compare for direct mutators of config.json.
-	const stored = getStoredConfig() as { autoUpdate?: unknown };
-	if (stored.autoUpdate === false || stored.autoUpdate === "false") return;
+	if (getStoredConfig().autoUpdate === false) return;
 
 	const cached = readCache(channel);
 	const now = Date.now();
-	let latest: string | null = cached?.latest ?? null;
-
-	if (!cached) {
-		// First run on this machine — no cache to fall back on. Block briefly
-		// for a registry lookup (3 s timeout); without this the first
-		// auto-update opportunity is silently dropped, costing the user one
-		// stale invocation before the system kicks in.
-		latest = await fetchLatest(3000, channel);
-		if (latest) writeCache(latest, channel);
-	} else if (now - new Date(cached.checkedAt).getTime() > CACHE_TTL_MS) {
-		// Have stale data — use it now, refresh in the background for the
-		// next invocation. Keeps the hot path snappy after the first run.
-		fetchLatest(3000, channel)
-			.then((l) => {
-				if (l) writeCache(l, channel);
-			})
-			.catch(() => {});
-	}
-
-	if (!latest) return;
-	if (!isNewer(latest, current)) return;
-
-	const ownership = detectAutoUpdateOwnership(runtime);
-	if (!ownership) return;
-	const { installer } = ownership;
-	const args = installArgs(installer, latest);
+	const cacheFresh = cached !== null && now - new Date(cached.checkedAt).getTime() <= CACHE_TTL_MS;
+	if (cacheFresh && !isNewer(cached.latest, current)) return;
+	const latest = cacheFresh ? cached.latest : undefined;
+	if (!detectAutoUpdateOwnership(runtime)) return;
 
 	// Redirect installer output to a logfile so silent failures (network
 	// flake, perms error, npm 4xx) leave a trail. `stdio: "ignore"` would
 	// throw the diagnosis away. Append (`"a"`) instead of truncate (`"w"`)
-	// so two concurrent CLI invocations spawning their own installs (which
-	// is rare but legal — the lock is gone on purpose) don't clobber each
-	// other's logs.
+	// so concurrent discovery workers do not clobber each other's diagnostics.
 	const logPath = join(getClawdiDir(), "auto-update.log");
 	let logFd: number;
 	try {
@@ -824,10 +953,12 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 		logFd = -1;
 	}
 
-	console.log(chalk.gray(`Updating clawdi v${current} → v${latest} in background…`));
+	if (latest) {
+		console.log(chalk.gray(`Updating clawdi v${current} → v${latest} in background…`));
+	}
 	try {
-		const spawner = runtime.spawnBackgroundInstall ?? spawnBackgroundInstall;
-		spawner(installer, args, { current, latest, logFd });
+		const spawner = runtime.spawnBackgroundWorker ?? spawnBackgroundUpdateWorker;
+		spawner({ current, latest, channel, logFd });
 	} finally {
 		if (logFd >= 0) {
 			try {
@@ -839,14 +970,23 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 	}
 }
 
-function spawnBackgroundInstall(
-	installer: Installer,
-	args: string[],
-	context: BackgroundInstallContext,
-): void {
-	const vector = installerCommandVector(installer, args);
-	const child = spawn(vector.command, vector.args, {
-		stdio: context.logFd >= 0 ? ["ignore", context.logFd, context.logFd] : "ignore",
+function spawnBackgroundUpdateWorker(request: BackgroundWorkerRequest): void {
+	let invocation: ReturnType<typeof resolveCurrentCliInvocation>;
+	try {
+		invocation = resolveCurrentCliInvocation([
+			"update",
+			"--background-worker",
+			"--current-version",
+			request.current,
+			"--channel",
+			request.channel,
+			...(request.latest ? ["--latest", request.latest] : []),
+		]);
+	} catch {
+		return;
+	}
+	const child = spawn(invocation.command, invocation.args, {
+		stdio: request.logFd >= 0 ? ["ignore", request.logFd, request.logFd] : "ignore",
 		detached: true,
 		env: process.env,
 		windowsHide: true,
@@ -856,6 +996,57 @@ function spawnBackgroundInstall(
 		// `auto-update.log` if they care, and the next invocation retries.
 	});
 	child.unref();
+}
+
+export async function runBackgroundUpdateWorker(
+	opts: {
+		currentVersion: string;
+		channel: string;
+		latest?: string;
+	},
+	runtime: {
+		ownership?: GlobalInstallOwnership | null;
+		installRunner?: DaemonInstallRunner;
+		versionReader?: (executable: string) => string | null;
+		lockOptions?: PrivateDirectoryLockOptions;
+	} = {},
+): Promise<DaemonAutoUpdateResult> {
+	if (detectRuntimeMode() === "hosted") return "disabled";
+	if (autoUpdateDisabled()) return "disabled";
+	if (!isValidSemver(opts.currentVersion)) return "failed";
+	if (opts.channel !== "latest" && opts.channel !== "beta") return "failed";
+	const latest = opts.latest ?? (await latestFromCacheOrRegistry(opts.channel));
+	if (!latest || !isValidSemver(latest) || !isNewer(latest, opts.currentVersion)) {
+		return "no_update";
+	}
+	writeCache(latest, opts.channel);
+	const ownership = runtime.ownership === undefined ? detectGlobalInstall() : runtime.ownership;
+	if (!ownership) return "unsupported";
+	const result = await runUpdateInstallWorker({
+		current: opts.currentVersion,
+		latest,
+		ownership,
+		output: "log",
+		lockOptions: runtime.lockOptions ?? { timeoutMs: 0 },
+		installRunner: runtime.installRunner
+			? async (_command, _args, options) =>
+					runtime.installRunner?.(
+						ownership.installer,
+						installArgs(ownership.installer, latest),
+						options.signal,
+					) ?? null
+			: undefined,
+		versionReader: runtime.versionReader
+			? () => runtime.versionReader?.(ownership.executable) ?? null
+			: undefined,
+	});
+	return result.status === "installed"
+		? "installed"
+		: result.status === "locked"
+			? "locked"
+			: result.status === "disabled"
+				? "disabled"
+				: "failed";
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1273,8 +1273,24 @@ program
 	.description("Install the latest CLI from npm (--check to only diagnose)")
 	.option("--check", "Only check for updates, don't install")
 	.option("--json", "Output as JSON")
+	.addOption(new Option("--background-worker").hideHelp())
+	.addOption(new Option("--current-version <version>").hideHelp())
+	.addOption(new Option("--channel <channel>").hideHelp())
+	.addOption(new Option("--latest <version>").hideHelp())
 	.action(async (opts) => {
-		const { update } = await import("./commands/update.js");
+		const { runBackgroundUpdateWorker, update } = await import("./commands/update.js");
+		if (opts.backgroundWorker) {
+			if (!opts.currentVersion || !opts.channel) {
+				throw new Error("background update worker requires current version and channel");
+			}
+			const result = await runBackgroundUpdateWorker({
+				currentVersion: opts.currentVersion,
+				channel: opts.channel,
+				latest: opts.latest,
+			});
+			if (result === "failed") process.exitCode = 1;
+			return;
+		}
 		await update(opts);
 	});
 
@@ -1719,7 +1735,7 @@ inboxCmd
 	.description("Local-only: remove a share record and its cached files")
 	.action(async (projectId) => {
 		const { inboxForgetCommand } = await import("./commands/inbox.js");
-		inboxForgetCommand(projectId);
+		await inboxForgetCommand(projectId);
 	});
 
 // Auto-update tick: prints any "✓ Updated to v…" notice from a previous

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { normalizeCloudApiBaseUrl, normalizeHostedDeployApiBaseUrl } from "./api-origin";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
 
 // NOTE: these paths are computed lazily so tests can override HOME per-run
@@ -30,9 +31,9 @@ function pendingAuthFile() {
 export interface ClawdiConfig {
 	apiUrl: string;
 	deployApiUrl: string;
-	// Default-on. Set to "false" to opt out of background auto-updates.
+	// Default-on. Set to false to opt out of background auto-updates.
 	// `CLAWDI_NO_AUTO_UPDATE=1` env var has the same effect for ad-hoc opt-out.
-	autoUpdate?: "true" | "false";
+	autoUpdate?: boolean;
 }
 
 // Keys accepted by `clawdi config set/get/unset`. Add a new entry here
@@ -105,6 +106,22 @@ function readJson<T>(path: string): T | null {
 	return JSON.parse(readFileSync(path, "utf-8"));
 }
 
+type StoredConfigRecord = Partial<ClawdiConfig> & Record<string, unknown>;
+
+function readStoredConfig(): StoredConfigRecord {
+	const value = readJson<unknown>(configFile());
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+	const normalized: Record<string, unknown> = { ...value };
+	// Released CLIs persisted these two spellings; collapse them once here so
+	// every consumer sees the canonical boolean shape.
+	if (normalized.autoUpdate === "true") normalized.autoUpdate = true;
+	else if (normalized.autoUpdate === "false") normalized.autoUpdate = false;
+	else if (typeof normalized.autoUpdate !== "boolean") delete normalized.autoUpdate;
+	if (typeof normalized.apiUrl !== "string") delete normalized.apiUrl;
+	if (typeof normalized.deployApiUrl !== "string") delete normalized.deployApiUrl;
+	return normalized;
+}
+
 function writeJson(path: string, data: unknown) {
 	writePrivateFileAtomic(path, `${JSON.stringify(data, null, 2)}\n`, {
 		mode: PRIVATE_FILE_MODE,
@@ -121,7 +138,7 @@ const DEFAULT_DEPLOY_API_URL =
 export function getConfig(): ClawdiConfig {
 	// Precedence: CLAWDI_API_URL env var > ~/.clawdi/config.json > default.
 	// Env var wins so CI / scripted runs can override without writing to disk.
-	const stored = readJson<Partial<ClawdiConfig>>(configFile()) ?? {};
+	const stored = readStoredConfig();
 	return {
 		apiUrl: process.env.CLAWDI_API_URL || stored.apiUrl || DEFAULT_API_URL,
 		deployApiUrl:
@@ -132,16 +149,42 @@ export function getConfig(): ClawdiConfig {
 
 /** Raw config on disk, without env overrides. Used by `config list / get`. */
 export function getStoredConfig(): Partial<ClawdiConfig> {
-	return readJson<Partial<ClawdiConfig>>(configFile()) ?? {};
+	return readStoredConfig();
 }
 
 export function setConfig(config: Pick<ClawdiConfig, "apiUrl"> & Partial<ClawdiConfig>) {
-	writeJson(configFile(), config);
+	const normalized: Partial<ClawdiConfig> = {
+		...config,
+		apiUrl: normalizeConfigUrl("apiUrl", config.apiUrl),
+	};
+	if (config.deployApiUrl !== undefined) {
+		normalized.deployApiUrl = normalizeConfigUrl("deployApiUrl", config.deployApiUrl);
+	}
+	if (config.autoUpdate !== undefined && typeof config.autoUpdate !== "boolean") {
+		throw new Error("autoUpdate must be true or false.");
+	}
+	writeJson(configFile(), normalized);
 }
 
 export function setConfigKey(key: ConfigKey, value: string) {
+	const normalized = normalizeConfigValue(key, value);
 	const current = getStoredConfig();
-	writeJson(configFile(), { ...current, [key]: value });
+	writeJson(configFile(), { ...current, [key]: normalized });
+}
+
+function normalizeConfigValue(key: ConfigKey, value: string): string | boolean {
+	if (key === "autoUpdate") {
+		if (value === "true") return true;
+		if (value === "false") return false;
+		throw new Error("autoUpdate must be true or false.");
+	}
+	return normalizeConfigUrl(key, value);
+}
+
+function normalizeConfigUrl(key: "apiUrl" | "deployApiUrl", value: string): string {
+	return key === "apiUrl"
+		? normalizeCloudApiBaseUrl(value)
+		: normalizeHostedDeployApiBaseUrl(value);
 }
 
 export function unsetConfigKey(key: ConfigKey) {

--- a/packages/cli/src/lib/current-cli-invocation.test.ts
+++ b/packages/cli/src/lib/current-cli-invocation.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCurrentCliInvocation } from "./current-cli-invocation";
+
+const root = mkdtempSync(join(tmpdir(), "clawdi-invocation-"));
+const executable = join(root, "bun");
+const entry = join(root, "clawdi.mjs");
+writeFileSync(executable, "runtime\n");
+writeFileSync(entry, "entry\n");
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolveCurrentCliInvocation", () => {
+	it("keeps the script entrypoint for normal Node or Bun execution", () => {
+		const invocation = resolveCurrentCliInvocation(["daemon", "run"], {
+			execPath: executable,
+			argv: [executable, entry, "daemon", "install"],
+		});
+
+		expect(invocation).toEqual({
+			command: realpathSync(executable),
+			args: [realpathSync(entry), "daemon", "run"],
+			entryPath: realpathSync(entry),
+		});
+	});
+
+	it("requires a script entrypoint", () => {
+		expect(() =>
+			resolveCurrentCliInvocation([], {
+				execPath: executable,
+				argv: [executable],
+			}),
+		).toThrow("process.argv[1]");
+	});
+});

--- a/packages/cli/src/lib/current-cli-invocation.ts
+++ b/packages/cli/src/lib/current-cli-invocation.ts
@@ -1,0 +1,56 @@
+import { realpathSync } from "node:fs";
+import { isAbsolute } from "node:path";
+
+export interface CurrentCliRuntime {
+	execPath: string;
+	argv: readonly string[];
+}
+
+export interface CurrentCliInvocation {
+	command: string;
+	args: string[];
+	entryPath: string;
+}
+
+/**
+ * Resolve the current CLI process into a command that can invoke this same
+ * script installation again.
+ */
+export function resolveCurrentCliInvocation(
+	cliArgs: readonly string[] = [],
+	runtime: CurrentCliRuntime = currentCliRuntime(),
+): CurrentCliInvocation {
+	const command = resolveAbsoluteRealpath(runtime.execPath, "CLI executable");
+	const rawEntry = runtime.argv[1];
+	if (!rawEntry) {
+		throw new Error("could not resolve the current clawdi CLI script from process.argv[1]");
+	}
+	const entryPath = resolveAbsoluteRealpath(rawEntry, "CLI script");
+	return {
+		command,
+		args: [entryPath, ...cliArgs],
+		entryPath,
+	};
+}
+
+function currentCliRuntime(): CurrentCliRuntime {
+	return {
+		execPath: process.execPath,
+		argv: process.argv,
+	};
+}
+
+function resolveAbsoluteRealpath(path: string, label: string): string {
+	let resolved: string;
+	try {
+		resolved = realpathSync.native(path);
+	} catch (error) {
+		throw new Error(
+			`could not resolve ${label} path ${path}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isAbsolute(resolved)) {
+		throw new Error(`refusing to invoke a relative ${label} path: ${resolved}`);
+	}
+	return resolved;
+}

--- a/packages/cli/src/lib/private-directory-lock.ts
+++ b/packages/cli/src/lib/private-directory-lock.ts
@@ -29,6 +29,16 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_STALE_MS = 60_000;
 const DEFAULT_RETRY_MS = 50;
 
+export class PrivateDirectoryLockTimeoutError extends Error {
+	readonly lockDir: string;
+
+	constructor(lockDir: string) {
+		super(`timed out waiting for private lock at ${lockDir}`);
+		this.name = "PrivateDirectoryLockTimeoutError";
+		this.lockDir = lockDir;
+	}
+}
+
 function errno(error: unknown, code: string): boolean {
 	return error instanceof Error && "code" in error && error.code === code;
 }
@@ -282,7 +292,7 @@ export async function withPrivateDirectoryLock<T>(
 				continue;
 			}
 			if (now() - startedAt >= timeoutMs) {
-				throw new Error(`timed out waiting for private lock at ${lockDir}`);
+				throw new PrivateDirectoryLockTimeoutError(lockDir);
 			}
 			await new Promise((resolve) => setTimeout(resolve, retryMs));
 		}

--- a/packages/cli/src/lib/process-group.test.ts
+++ b/packages/cli/src/lib/process-group.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { terminateProcessGroup } from "./process-group";
+
+describe("terminateProcessGroup", () => {
+	it("bounds both waits when process close is never observed", async () => {
+		const signals: NodeJS.Signals[] = [];
+		const child = {
+			pid: undefined,
+			kill(signal: NodeJS.Signals) {
+				signals.push(signal);
+				return true;
+			},
+		};
+		const neverCloses = new Promise<void>(() => {});
+		const started = Date.now();
+
+		await terminateProcessGroup(child, neverCloses, {
+			termTimeoutMs: 20,
+			killTimeoutMs: 20,
+		});
+
+		expect(Date.now() - started).toBeLessThan(500);
+		expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+	});
+});

--- a/packages/cli/src/lib/process-group.ts
+++ b/packages/cli/src/lib/process-group.ts
@@ -1,0 +1,79 @@
+export interface ProcessTerminationOptions {
+	termTimeoutMs: number;
+	killTimeoutMs: number;
+}
+
+export interface ProcessTarget {
+	readonly pid?: number;
+	kill(signal: NodeJS.Signals): boolean;
+}
+
+export async function terminateProcessGroup(
+	child: ProcessTarget,
+	closed: Promise<void>,
+	options: ProcessTerminationOptions,
+): Promise<void> {
+	signalProcessGroup(child, "SIGTERM");
+	if (await waitForProcessExit(child, closed, options.termTimeoutMs)) return;
+	signalProcessGroup(child, "SIGKILL");
+	await waitForProcessExit(child, closed, options.killTimeoutMs);
+}
+
+function signalProcessGroup(child: ProcessTarget, signal: NodeJS.Signals): void {
+	if (process.platform !== "win32" && child.pid) {
+		try {
+			process.kill(-child.pid, signal);
+			return;
+		} catch {
+			// Fall back to signalling the direct child.
+		}
+	}
+	try {
+		child.kill(signal);
+	} catch {
+		// The process may have closed between observation and signalling.
+	}
+}
+
+async function waitForProcessExit(
+	child: ProcessTarget,
+	closed: Promise<void>,
+	timeoutMs: number,
+): Promise<boolean> {
+	const pid = child.pid;
+	if (process.platform === "win32" || !pid) return await waitForClose(closed, timeoutMs);
+	if (!processGroupExists(pid)) return true;
+
+	let poll: ReturnType<typeof setInterval> | undefined;
+	const groupClosed = new Promise<void>((resolveClosed) => {
+		poll = setInterval(() => {
+			if (!processGroupExists(pid)) resolveClosed();
+		}, 10);
+	});
+	try {
+		return await waitForClose(groupClosed, timeoutMs);
+	} finally {
+		if (poll) clearInterval(poll);
+	}
+}
+
+async function waitForClose(closed: Promise<void>, timeoutMs: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const didClose = await Promise.race([
+		closed.then(() => true),
+		new Promise<false>((resolveTimeout) => {
+			timer = setTimeout(() => resolveTimeout(false), timeoutMs);
+		}),
+	]);
+	if (timer) clearTimeout(timer);
+	return didClose;
+}
+
+function processGroupExists(pid: number): boolean {
+	try {
+		process.kill(-pid, 0);
+		return true;
+	} catch (error) {
+		return error instanceof Error && "code" in error && error.code === "EPERM";
+	}
+}

--- a/packages/cli/src/lib/timed-fetch.ts
+++ b/packages/cli/src/lib/timed-fetch.ts
@@ -1,0 +1,50 @@
+export class FetchTimeoutError extends Error {
+	readonly timeoutMs: number;
+
+	constructor(timeoutMs: number) {
+		super(`request timed out after ${timeoutMs}ms`);
+		this.name = "FetchTimeoutError";
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+export async function timedFetch(
+	input: RequestInfo | URL,
+	init: RequestInit = {},
+	timeoutMs: number,
+): Promise<Response> {
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("fetch timeout must be a positive finite number");
+	}
+	const controller = new AbortController();
+	const externalSignal = init.signal;
+	const onExternalAbort = () => controller.abort(externalSignal?.reason);
+	if (externalSignal?.aborted) controller.abort(externalSignal.reason);
+	else externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+	let timedOut = false;
+	const timer = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, timeoutMs);
+	try {
+		const response = await fetch(input, { ...init, signal: controller.signal });
+		const body = await response.arrayBuffer();
+		const method = init.method?.toUpperCase();
+		const hasNullBody =
+			method === "HEAD" ||
+			response.status === 204 ||
+			response.status === 205 ||
+			response.status === 304;
+		return new Response(hasNullBody ? null : body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	} catch (error) {
+		if (timedOut) throw new FetchTimeoutError(timeoutMs);
+		throw error;
+	} finally {
+		clearTimeout(timer);
+		externalSignal?.removeEventListener("abort", onExternalAbort);
+	}
+}

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createClawdiMcpServer, createConnectorToolDefinition, type McpTool } from "./server";
+import {
+	callClawdiMcp,
+	createClawdiMcpServer,
+	createConnectorToolDefinition,
+	type McpTool,
+} from "./server";
 
 describe("MCP connector helpers", () => {
 	it("throws instead of exiting when there is no CLI auth", async () => {
@@ -19,6 +24,46 @@ describe("MCP connector helpers", () => {
 			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
 			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
 			rmSync(clawdiHome, { recursive: true, force: true });
+		}
+	});
+
+	it("aborts a stalled MCP forwarding request at the configured deadline", async () => {
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		const previousAuthTokenOrigin = process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+		const previousApiUrl = process.env.CLAWDI_API_URL;
+		const originalFetch = globalThis.fetch;
+		process.env.CLAWDI_AUTH_TOKEN = "test-mcp-token";
+		process.env.CLAWDI_AUTH_TOKEN_ORIGIN = "http://localhost:8000";
+		process.env.CLAWDI_API_URL = "http://localhost:8000";
+		let aborted = false;
+		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					init?.signal?.addEventListener(
+						"abort",
+						() => {
+							aborted = true;
+							controller.error(new DOMException("Aborted", "AbortError"));
+						},
+						{ once: true },
+					);
+				},
+			});
+			return new Response(body, { status: 200 });
+		}) as typeof fetch;
+		try {
+			await expect(callClawdiMcp("tools/list", {}, 10)).rejects.toThrow(
+				"request timed out after 10ms",
+			);
+			expect(aborted).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+			if (previousAuthTokenOrigin === undefined) delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+			else process.env.CLAWDI_AUTH_TOKEN_ORIGIN = previousAuthTokenOrigin;
+			if (previousApiUrl === undefined) delete process.env.CLAWDI_API_URL;
+			else process.env.CLAWDI_API_URL = previousApiUrl;
 		}
 	});
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod/v3";
 import { getClawdiAccessToken } from "../lib/clerk-oauth";
 import { getConfig, isLoggedIn } from "../lib/config";
+import { timedFetch } from "../lib/timed-fetch";
 
 // Minimal shape of a JSON Schema property we care about when mapping
 // Composio tool definitions to Zod. Unknown fields are ignored.
@@ -217,18 +218,27 @@ function ensureMcpLogin(): void {
 }
 
 const MCP_ENDPOINT_PATH = "/v1/mcp/clawdi";
+const MCP_FORWARD_TIMEOUT_MS = 30_000;
 
-async function callClawdiMcp(method: string, params?: Record<string, unknown>): Promise<unknown> {
+export async function callClawdiMcp(
+	method: string,
+	params?: Record<string, unknown>,
+	timeoutMs = MCP_FORWARD_TIMEOUT_MS,
+): Promise<unknown> {
 	const config = getConfig();
 	const accessToken = await getClawdiAccessToken(config.apiUrl);
-	const response = await fetch(`${config.apiUrl}${MCP_ENDPOINT_PATH}`, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${accessToken}`,
-			"Content-Type": "application/json",
+	const response = await timedFetch(
+		`${config.apiUrl}${MCP_ENDPOINT_PATH}`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} }),
 		},
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} }),
-	});
+		timeoutMs,
+	);
 	if (!response.ok) {
 		throw new Error(`Clawdi MCP request failed (HTTP ${response.status})`);
 	}

--- a/packages/cli/src/share/tokens.test.ts
+++ b/packages/cli/src/share/tokens.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -40,49 +48,63 @@ describe("share-tokens.json", () => {
 		expect(listTokens()).toEqual([]);
 	});
 
-	it("addToken then listTokens round-trips", () => {
-		addToken(sample);
+	it("addToken then listTokens round-trips", async () => {
+		await addToken(sample);
 		expect(listTokens()).toEqual([sample]);
 	});
 
-	it("addToken upserts on project_id", () => {
-		addToken(sample);
-		addToken({ ...sample, owner_handle: "alice-9999" });
+	it("addToken upserts on project_id", async () => {
+		await addToken(sample);
+		await addToken({ ...sample, owner_handle: "alice-9999" });
 		const all = listTokens();
 		expect(all).toHaveLength(1);
 		expect(all[0].owner_handle).toBe("alice-9999");
 	});
 
-	it("removeToken by project_id", () => {
-		addToken(sample);
-		addToken({ ...sample, project_id: "def-456" });
-		removeToken("abc-123");
+	it("removeToken by project_id", async () => {
+		await addToken(sample);
+		await addToken({ ...sample, project_id: "def-456", token: "y".repeat(43) });
+		await removeToken("abc-123");
 		const all = listTokens();
 		expect(all).toHaveLength(1);
 		expect(all[0].project_id).toBe("def-456");
 	});
 
-	it("findToken by project_id", () => {
-		addToken(sample);
+	it("findToken by project_id", async () => {
+		await addToken(sample);
 		expect(findToken("abc-123")?.token).toBe(sample.token);
 		expect(findToken("ghost")).toBeUndefined();
 	});
 
-	it("writes file with 0600 perms", () => {
-		addToken(sample);
+	it("writes file with 0600 perms", async () => {
+		await addToken(sample);
 		const stat = statSync(join(tempHome, ".clawdi", "share-tokens.json"));
 		// 0o600 = mode bits 110_000_000; mask off file-type bits.
 		expect(stat.mode & 0o777).toBe(0o600);
 	});
 
-	it("survives empty / malformed file", () => {
-		const path = join(tempHome, ".clawdi", "share-tokens.json");
-		writeFileSync(path, "not-json", "utf-8");
-		expect(listTokens()).toEqual([]);
+	it("hardens existing store permissions on read", () => {
+		const dir = join(tempHome, ".clawdi");
+		const path = join(dir, "share-tokens.json");
+		writeFileSync(path, JSON.stringify({ version: 1, tokens: [sample] }), { mode: 0o666 });
+		chmodSync(dir, 0o755);
+		chmodSync(path, 0o644);
+
+		expect(listTokens()).toEqual([sample]);
+		expect(statSync(dir).mode & 0o777).toBe(0o700);
+		expect(statSync(path).mode & 0o777).toBe(0o600);
 	});
 
-	it("round-trips upgraded_at + last_seen_skill_keys", () => {
-		addToken({
+	it("reports malformed JSON without overwriting it", async () => {
+		const path = join(tempHome, ".clawdi", "share-tokens.json");
+		writeFileSync(path, "not-json", "utf-8");
+		expect(() => listTokens()).toThrow("share token store is corrupt");
+		await expect(addToken(sample)).rejects.toThrow("share token store is corrupt");
+		expect(readFileSync(path, "utf8")).toBe("not-json");
+	});
+
+	it("round-trips upgraded_at + last_seen_skill_keys", async () => {
+		await addToken({
 			...sample,
 			upgraded_at: "2026-05-12T10:00:00Z",
 			last_seen_skill_keys: ["git-tools", "k8s-helpers"],
@@ -92,7 +114,42 @@ describe("share-tokens.json", () => {
 		expect(restored.last_seen_skill_keys).toEqual(["git-tools", "k8s-helpers"]);
 	});
 
-	it("normalizes released version:1 scope fields without dropping unknown fields", () => {
+	it("serializes concurrent read-modify-write commits without losing tokens", async () => {
+		await Promise.all(
+			Array.from({ length: 12 }, (_, index) =>
+				addToken({
+					...sample,
+					project_id: `project-${index}`,
+					token: index.toString(36).padStart(43, "a"),
+				}),
+			),
+		);
+		expect(
+			listTokens()
+				.map((token) => token.project_id)
+				.sort(),
+		).toEqual(Array.from({ length: 12 }, (_, index) => `project-${index}`).sort());
+	});
+
+	it("matches an upgraded project by raw token and conditionally deletes", async () => {
+		await addToken({ ...sample, api_origin: "https://CLOUD-API.CLAWDI.AI/" });
+		expect(listTokens()[0]?.api_origin).toBe("https://cloud-api.clawdi.ai");
+		await addToken({ ...sample, project_id: "canonical-project", project_name: "Canonical" });
+		expect(listTokens()).toEqual([
+			{
+				...sample,
+				project_id: "canonical-project",
+				project_name: "Canonical",
+			},
+		]);
+
+		expect(await removeToken("canonical-project", "z".repeat(43))).toBe(false);
+		expect(findToken("canonical-project")).toBeDefined();
+		expect(await removeToken("canonical-project", sample.token)).toBe(true);
+		expect(findToken("canonical-project")).toBeUndefined();
+	});
+
+	it("normalizes released version:1 scope fields without dropping unknown fields", async () => {
 		const path = join(tempHome, ".clawdi", "share-tokens.json");
 		writeFileSync(
 			path,
@@ -118,7 +175,7 @@ describe("share-tokens.json", () => {
 		expect(restored.project_name).toBe("Legacy Toolkit");
 		expect(restored).not.toHaveProperty("scope_id");
 		expect(restored).not.toHaveProperty("scope_name");
-		addToken({ ...restored, upgraded_at: "2026-05-12T11:00:00Z" });
+		await addToken({ ...restored, upgraded_at: "2026-05-12T11:00:00Z" });
 
 		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
 			tokens: Array<Record<string, unknown>>;
@@ -130,7 +187,7 @@ describe("share-tokens.json", () => {
 		expect(raw.tokens[0].future_field).toEqual({ enabled: true });
 	});
 
-	it("skips malformed records at runtime but preserves them during unrelated writes", () => {
+	it("skips malformed records at runtime but preserves them during unrelated writes", async () => {
 		const path = join(tempHome, ".clawdi", "share-tokens.json");
 		const malformed = {
 			project_id: "broken-project",
@@ -152,7 +209,7 @@ describe("share-tokens.json", () => {
 			},
 		]);
 
-		addToken({ ...sample, owner_handle: "alice-updated" });
+		await addToken({ ...sample, owner_handle: "alice-updated" });
 		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
 			tokens: Array<Record<string, unknown>>;
 		};
@@ -161,7 +218,7 @@ describe("share-tokens.json", () => {
 		expect(raw.tokens[1].owner_handle).toBe("alice-updated");
 	});
 
-	it("preserves unknown future fields across read+write", () => {
+	it("preserves unknown future fields across read+write", async () => {
 		const path = join(tempHome, ".clawdi", "share-tokens.json");
 		writeFileSync(
 			path,
@@ -172,7 +229,7 @@ describe("share-tokens.json", () => {
 			"utf-8",
 		);
 		const [t] = listTokens();
-		addToken({ ...t, redeemed_at: "2026-05-12T11:00:00Z" });
+		await addToken({ ...t, redeemed_at: "2026-05-12T11:00:00Z" });
 		const raw = readFileSync(path, "utf-8");
 		expect(raw).toContain('"future_field"');
 		expect(raw).toContain('"x"');

--- a/packages/cli/src/share/tokens.ts
+++ b/packages/cli/src/share/tokens.ts
@@ -16,10 +16,17 @@
  * silently stripped when an older daemon writes the file back.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { normalizeCloudApiBaseUrl } from "../lib/api-origin";
+import { withPrivateDirectoryLock } from "../lib/private-directory-lock";
+import {
+	chmodBestEffort,
+	PRIVATE_DIR_MODE,
+	PRIVATE_FILE_MODE,
+	writePrivateFileAtomic,
+} from "../lib/private-file";
 
 // Use `process.env.HOME` first so test fixtures that overwrite the
 // env var pick up the new value immediately. `os.homedir()` caches
@@ -72,12 +79,29 @@ export interface ShareTokenStoreIssue {
 
 const RAW_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/;
 
+export class ShareTokenStoreCorruptionError extends Error {
+	constructor(message: string) {
+		super(`share token store is corrupt: ${message}`);
+		this.name = "ShareTokenStoreCorruptionError";
+	}
+}
+
 function filePath(): string {
 	return join(clawdiHome(), "share-tokens.json");
 }
 
+function lockPath(): string {
+	return join(clawdiHome(), "share-tokens.lock");
+}
+
+function hardenStorePermissions(path: string): void {
+	if (existsSync(clawdiHome())) chmodBestEffort(clawdiHome(), PRIVATE_DIR_MODE);
+	if (existsSync(path)) chmodBestEffort(path, PRIVATE_FILE_MODE);
+}
+
 function loadRaw(): PersistedShareTokensFile {
 	const path = filePath();
+	hardenStorePermissions(path);
 	if (!existsSync(path)) {
 		return { version: 1, tokens: [] };
 	}
@@ -92,21 +116,24 @@ function loadRaw(): PersistedShareTokensFile {
 			!("tokens" in parsed) ||
 			!Array.isArray(parsed.tokens)
 		) {
-			// Malformed file: treat as empty. Operator can re-accept
-			// any shares they care about; we don't brick the CLI
-			// over local-state corruption.
-			return { version: 1, tokens: [] };
+			throw new ShareTokenStoreCorruptionError("expected a version 1 tokens array");
 		}
 		return { version: 1, tokens: parsed.tokens };
-	} catch {
-		return { version: 1, tokens: [] };
+	} catch (error) {
+		if (error instanceof ShareTokenStoreCorruptionError) throw error;
+		if (error instanceof SyntaxError) {
+			throw new ShareTokenStoreCorruptionError("file is not valid JSON");
+		}
+		throw error;
 	}
 }
 
 function save(state: PersistedShareTokensFile): void {
 	const path = filePath();
-	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-	writeFileSync(path, JSON.stringify(state, null, 2), { mode: 0o600 });
+	writePrivateFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`, {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -155,7 +182,6 @@ function normalizeToken(
 	const redeemedAt = nonEmptyString(canonicalFields.redeemed_at);
 	const label =
 		projectName ?? (projectId ? `Project ${projectId}` : `local share entry ${index + 1}`);
-
 	const missing: string[] = [];
 	if (!projectId) missing.push("project id");
 	if (!projectName) missing.push("project name");
@@ -223,36 +249,50 @@ export function listTokens(): ShareToken[] {
 	return readTokenStore().tokens;
 }
 
-export function addToken(token: ShareToken): void {
-	const state = loadRaw();
-	const idx = state.tokens.findIndex((value, index) => {
-		const normalized = normalizeToken(value, index);
-		return (
-			normalized.projectId === token.project_id ||
-			(normalized.kind === "token" && normalized.token.token === token.token)
-		);
+async function mutateTokenStore<T>(
+	mutate: (state: PersistedShareTokensFile) => { result: T; changed: boolean },
+): Promise<T> {
+	return withPrivateDirectoryLock(lockPath(), async (lease) => {
+		const state = loadRaw();
+		const { result, changed } = mutate(state);
+		if (changed) {
+			lease.assertOwned();
+			save(state);
+			lease.assertOwned();
+		}
+		return result;
 	});
-	if (idx === -1) {
-		state.tokens.push(token);
-	} else {
-		// Upsert: replace the existing entry. The whole object is
-		// passed in by callers so they handle merging unknown
-		// fields explicitly (use `{...existing, ...patch}` pattern
-		// on the caller side to preserve fields).
-		state.tokens[idx] = token;
-	}
-	save(state);
 }
 
-export function removeToken(projectId: string, expectedToken?: string): void {
-	const state = loadRaw();
-	state.tokens = state.tokens.filter((value, index) => {
-		const normalized = normalizeToken(value, index);
-		if (normalized.projectId !== projectId) return true;
-		if (expectedToken === undefined) return false;
-		return normalized.kind !== "token" || normalized.token.token !== expectedToken;
+export async function addToken(token: ShareToken): Promise<void> {
+	await mutateTokenStore((state) => {
+		const idx = state.tokens.findIndex((value, index) => {
+			const normalized = normalizeToken(value, index);
+			return (
+				normalized.projectId === token.project_id ||
+				(normalized.kind === "token" && normalized.token.token === token.token)
+			);
+		});
+		if (idx === -1) state.tokens.push(token);
+		else state.tokens[idx] = token;
+		return { result: undefined, changed: true };
 	});
-	save(state);
+}
+
+export async function removeToken(projectId: string, expectedToken?: string): Promise<boolean> {
+	return mutateTokenStore((state) => {
+		const before = state.tokens.length;
+		state.tokens = state.tokens.filter((value, index) => {
+			const normalized = normalizeToken(value, index);
+			if (normalized.projectId !== projectId) return true;
+			return (
+				expectedToken !== undefined &&
+				(normalized.kind !== "token" || normalized.token.token !== expectedToken)
+			);
+		});
+		const changed = state.tokens.length !== before;
+		return { result: changed, changed };
+	});
 }
 
 export function findToken(projectId: string): ShareToken | undefined {

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -168,7 +168,7 @@ describe("authLogin authentication boundary", () => {
 
 describe("interactive OAuth Cloud verification boundary", () => {
 	it("persists both verified and explicitly cloud-unverified grants without fake profile data", async () => {
-		addToken({
+		await addToken({
 			project_id: "project-shared",
 			project_name: "Team Toolkit",
 			owner_display: "Alice",

--- a/packages/cli/tests/commands/inbox.test.ts
+++ b/packages/cli/tests/commands/inbox.test.ts
@@ -28,9 +28,9 @@ let agentHomeOverrides: AgentHomeOverrideSnapshot;
 
 const rawToken = "a".repeat(43);
 
-function addPendingShare(
+async function addPendingShare(
 	overrides: Partial<Parameters<typeof addToken>[0]> = {},
-): Parameters<typeof addToken>[0] {
+): Promise<Parameters<typeof addToken>[0]> {
 	const token = {
 		project_id: "project-shared",
 		project_name: "Shared Toolkit",
@@ -41,7 +41,7 @@ function addPendingShare(
 		api_origin: "https://api.test",
 		...overrides,
 	};
-	addToken(token);
+	await addToken(token);
 	return token;
 }
 
@@ -164,7 +164,7 @@ describe("inboxAcceptCommand", () => {
 		const staged = findToken("project-shared");
 		expect(staged).toBeDefined();
 		if (!staged) throw new Error("Expected staged share fixture");
-		addToken({ ...staged, upgraded_at: "2026-05-19T00:00:00.000Z" });
+		await addToken({ ...staged, upgraded_at: "2026-05-19T00:00:00.000Z" });
 		rmSync(join(tmpHome, ".clawdi", "auth.json"), { force: true });
 		const legacyFetch = mockFetch([]);
 		const legacyLines: string[] = [];
@@ -278,11 +278,11 @@ describe("inboxAcceptCommand", () => {
 	});
 
 	it("joins staged projects without pulling content and discloses ticket removal", async () => {
-		addPendingShare({ project_id: "uuid-project-shared" });
+		await addPendingShare({ project_id: "uuid-project-shared" });
 		const jsonJoinToken = "b".repeat(43);
 		const acceptToken = "c".repeat(43);
-		addPendingShare({ project_id: "uuid-project-json", token: jsonJoinToken });
-		addPendingShare({ project_id: "uuid-project-accept", token: acceptToken });
+		await addPendingShare({ project_id: "uuid-project-json", token: jsonJoinToken });
+		await addPendingShare({ project_id: "uuid-project-accept", token: acceptToken });
 		const joinedResponse = (projectId: string) =>
 			jsonResponse({
 				membership_id: `membership-${projectId}`,
@@ -399,7 +399,7 @@ describe("share ticket outcomes", () => {
 		];
 
 		for (const testCase of cases) {
-			addPendingShare({ api_origin: testCase.apiOrigin ?? "https://api.test" });
+			await addPendingShare({ api_origin: testCase.apiOrigin ?? "https://api.test" });
 			const { captured, restore } = mockFetch([
 				{
 					method: "POST",
@@ -438,8 +438,8 @@ describe("share ticket outcomes", () => {
 });
 
 describe("inboxForgetCommand", () => {
-	it("keeps local shared skill folders still referenced by another project from the same owner", () => {
-		addToken({
+	it("keeps local shared skill folders still referenced by another project from the same owner", async () => {
+		await addToken({
 			project_id: "project-a",
 			project_name: "A",
 			owner_display: "Alice",
@@ -448,7 +448,7 @@ describe("inboxForgetCommand", () => {
 			redeemed_at: "2026-05-18T00:00:00.000Z",
 			last_seen_skill_keys: ["deploy-tools"],
 		});
-		addToken({
+		await addToken({
 			project_id: "project-b",
 			project_name: "B",
 			owner_display: "Alice",
@@ -468,7 +468,7 @@ describe("inboxForgetCommand", () => {
 		const origLog = console.log;
 		console.log = () => {};
 		try {
-			inboxForgetCommand("project-a");
+			await inboxForgetCommand("project-a");
 		} finally {
 			console.log = origLog;
 		}

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	daemonAutoUpdateOnce,
+	detectGlobalInstall,
 	detectInstallerFromPaths,
+	detectUpdateOwnershipFromPaths,
 	installCommand,
 	maybeAutoUpdate,
+	runBackgroundUpdateWorker,
+	runInstallerProcess,
 	update,
 } from "../../src/commands/update";
 import {
@@ -27,6 +31,7 @@ let origExitCode: number | undefined;
 
 const npmOwnership = {
 	installer: "npm" as const,
+	installerExecutable: "/owned/npm/bin/npm",
 	executable: "/owned/npm/bin/clawdi",
 };
 
@@ -49,7 +54,7 @@ beforeEach(() => {
 	origHostPolicyPath = process.env.CLAWDI_HOST_POLICY_PATH;
 	origArgv = [...process.argv];
 	origExitCode = process.exitCode;
-	process.exitCode = undefined;
+	process.exitCode = 0;
 	delete process.env.CLAWDI_NO_UPDATE_CHECK;
 	delete process.env.CLAWDI_NO_AUTO_UPDATE;
 	delete process.env.CLAWDI_RUNTIME_MODE;
@@ -61,7 +66,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	process.argv.splice(0, process.argv.length, ...origArgv);
-	process.exitCode = origExitCode;
+	// Bun latches a non-zero exit code when it is reset to `undefined`.
+	process.exitCode = origExitCode ?? 0;
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
 	if (origNoCheck) process.env.CLAWDI_NO_UPDATE_CHECK = origNoCheck;
@@ -81,8 +87,10 @@ describe("detectInstaller", () => {
 			detectInstallerFromPaths("/home/user/.local/lib/node_modules/clawdi/bin/clawdi.mjs", {
 				npmBin: "/home/user/.local/bin",
 				npmRoot: "/home/user/.local/lib/node_modules",
+				npmExecutable: "/home/user/.local/bin/npm",
 				bunBin: "/home/user/.bun/bin",
 				bunRoot: "/home/user/.bun/install/global/node_modules",
+				bunExecutable: "/home/user/.bun/bin/bun",
 			}),
 		).toBe("npm");
 	});
@@ -94,11 +102,83 @@ describe("detectInstaller", () => {
 				{
 					npmBin: "/home/user/.local/bin",
 					npmRoot: "/home/user/.local/lib/node_modules",
+					npmExecutable: "/home/user/.local/bin/npm",
 					bunBin: "/home/user/.bun/bin",
 					bunRoot: "/home/user/.bun/install/global/node_modules",
+					bunExecutable: "/home/user/.bun/bin/bun",
 				},
 			),
 		).toBe("bun");
+	});
+
+	it("binds a Bun-owned install to its positively identified absolute Bun executable", () => {
+		expect(
+			detectUpdateOwnershipFromPaths(
+				"/home/user/.bun/install/global/node_modules/clawdi/bin/clawdi.mjs",
+				{
+					bunBin: "/home/user/.bun/bin",
+					bunRoot: "/home/user/.bun/install/global/node_modules",
+					bunExecutable: "/home/user/.bun/bin/bun",
+				},
+			),
+		).toEqual({
+			installer: "bun",
+			installerExecutable: "/home/user/.bun/bin/bun",
+			executable: "/home/user/.bun/bin/clawdi",
+		});
+		expect(
+			detectUpdateOwnershipFromPaths(
+				"/home/user/.bun/install/global/node_modules/clawdi/bin/clawdi.mjs",
+				{
+					bunBin: "/home/user/.bun/bin",
+					bunRoot: "/home/user/.bun/install/global/node_modules",
+					bunExecutable: "bun",
+				},
+			),
+		).toBeNull();
+	});
+
+	it("finds the owning absolute Bun executable outside the supervisor PATH", () => {
+		if (process.platform === "win32") return;
+		const bunExecutable = join(tmpHome, ".bun", "bin", "bun");
+		const invokedPath = join(
+			tmpHome,
+			".bun",
+			"install",
+			"global",
+			"node_modules",
+			"clawdi",
+			"bin",
+			"clawdi.mjs",
+		);
+		mkdirSync(dirname(bunExecutable), { recursive: true });
+		mkdirSync(dirname(invokedPath), { recursive: true });
+		writeFileSync(
+			bunExecutable,
+			[
+				"#!/bin/sh",
+				'if [ "$1" = pm ] && [ "$2" = bin ] && [ "$3" = -g ]; then',
+				`  printf "%s\\n" ${JSON.stringify(join(tmpHome, ".bun", "bin"))}`,
+				"  exit 0",
+				"fi",
+				"exit 1",
+			].join("\n"),
+		);
+		chmodSync(bunExecutable, 0o700);
+		writeFileSync(invokedPath, "// fixture\n");
+		const previousPath = process.env.PATH;
+		process.env.PATH = "/usr/bin:/bin";
+		process.argv[1] = invokedPath;
+		try {
+			expect(detectGlobalInstall()).toEqual({
+				installer: "bun",
+				installerExecutable: bunExecutable,
+				executable: join(tmpHome, ".bun", "bin", "clawdi"),
+			});
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
 	});
 
 	it("does not infer ownership from an executable merely being in a global bin", () => {
@@ -106,8 +186,10 @@ describe("detectInstaller", () => {
 			detectInstallerFromPaths("/home/user/.local/bin/clawdi", {
 				npmBin: "/home/user/.local/bin",
 				npmRoot: "/home/user/.local/lib/node_modules",
+				npmExecutable: "/home/user/.local/bin/npm",
 				bunBin: "/home/user/.bun/bin",
 				bunRoot: "/home/user/.bun/install/global/node_modules",
+				bunExecutable: "/home/user/.bun/bin/bun",
 			}),
 		).toBeNull();
 	});
@@ -117,6 +199,7 @@ describe("detectInstaller", () => {
 			detectInstallerFromPaths("/tmp/bunx-1000-clawdi@latest/node_modules/clawdi/bin/clawdi.mjs", {
 				bunBin: "/home/user/.bun/bin",
 				bunRoot: "/tmp/bunx-1000-clawdi@latest/node_modules",
+				bunExecutable: "/home/user/.bun/bin/bun",
 			}),
 		).toBeNull();
 		expect(
@@ -125,6 +208,7 @@ describe("detectInstaller", () => {
 				{
 					npmBin: "C:\\Users\\test\\AppData\\Roaming\\npm",
 					npmRoot: "C:\\Users\\test\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules",
+					npmExecutable: "C:\\Users\\test\\AppData\\Roaming\\npm\\npm.cmd",
 				},
 			),
 		).toBeNull();
@@ -136,6 +220,38 @@ describe("installCommand", () => {
 		expect(installCommand("npm", "1.2.3")).toBe("npm i -g clawdi@1.2.3");
 		expect(installCommand("bun", "1.2.3-beta.10")).toBe("bun add -g clawdi@1.2.3-beta.10");
 		expect(installCommand(null, "1.2.3")).toBe("npm i -g clawdi@1.2.3");
+	});
+});
+
+describe("installer process lifetime", () => {
+	it.each([
+		"timeout",
+		"abort",
+	] as const)("terminates the entire installer process group after %s", async (trigger) => {
+		if (process.platform === "win32") return;
+		const script = join(tmpHome, `installer-tree-${trigger}.sh`);
+		const descendantPidPath = join(tmpHome, `installer-descendant-${trigger}.pid`);
+		writeFileSync(
+			script,
+			[
+				"trap '' TERM",
+				'sh -c \'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done\' child "$1" &',
+				"wait",
+			].join("\n"),
+		);
+		const abort = new AbortController();
+		const running = runInstallerProcess("/bin/sh", [script, descendantPidPath], {
+			signal: abort.signal,
+			timeoutMs: trigger === "timeout" ? 200 : 5_000,
+			termGraceMs: 20,
+		});
+		await waitForPath(descendantPidPath);
+		if (trigger === "abort") abort.abort();
+		expect(await running).toBeNull();
+		const descendantPid = Number(readFileSync(descendantPidPath, "utf8").trim());
+		expect(Number.isInteger(descendantPid)).toBe(true);
+		await waitForProcessExit(descendantPid);
+		expect(processIsAlive(descendantPid)).toBe(false);
 	});
 });
 
@@ -250,6 +366,7 @@ describe("update install", () => {
 		const smokes: { command: string; args: string[] }[] = [];
 		const ownership = {
 			installer: "npm" as const,
+			installerExecutable: "C:\\Program Files\\npm\\npm.cmd",
 			executable: "C:\\Program Files\\npm\\clawdi.cmd",
 		};
 		const { restore } = mockFetch([
@@ -284,7 +401,7 @@ describe("update install", () => {
 		expect(installs).toEqual([
 			{
 				command: "cmd.exe",
-				args: ["/d", "/s", "/c", "npm.cmd", "i", "-g", "clawdi@99.0.0"],
+				args: ["/d", "/s", "/c", ownership.installerExecutable, "i", "-g", "clawdi@99.0.0"],
 			},
 		]);
 		expect(smokes).toEqual([
@@ -293,7 +410,7 @@ describe("update install", () => {
 				args: ["/d", "/s", "/c", ownership.executable, "--version"],
 			},
 		]);
-		expect(process.exitCode).toBeUndefined();
+		expect(process.exitCode).toBe(0);
 	});
 
 	it("does not claim success when the owned executable reports another version", async () => {
@@ -355,9 +472,67 @@ describe("update install", () => {
 		expect(captured).toContain("Automatic update is unsupported");
 		expect(captured).toContain("npm i -g clawdi@99.0.0");
 	});
+
+	it("uses the shared fenced update lease and never reclaims an old live owner", async () => {
+		const lockDir = join(tmpHome, ".clawdi", "update.lock");
+		mkdirSync(lockDir, { recursive: true });
+		writeFileSync(
+			join(lockDir, "owner.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.privateDirectoryLockOwner.v1",
+				pid: process.pid,
+				acquiredAt: "2000-01-01T00:00:00.000Z",
+				token: "live-update-owner",
+			}),
+		);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+			},
+		]);
+		try {
+			await withStdoutTty(() =>
+				update(
+					{},
+					{
+						detectOwnership: () => npmOwnership,
+						lockOptions: { timeoutMs: 0, staleMs: 1 },
+						installRunner: () => {
+							throw new Error("live owner must fence the manual installer");
+						},
+					},
+				),
+			);
+		} finally {
+			restore();
+		}
+		expect(process.exitCode).toBe(1);
+		expect(JSON.parse(readFileSync(join(lockDir, "owner.json"), "utf8")).token).toBe(
+			"live-update-owner",
+		);
+	});
 });
 
 describe("daemonAutoUpdateOnce", () => {
+	it("runs a startup request through exact install and owned executable validation", async () => {
+		const calls: Array<{ installer: string; args: string[] }> = [];
+		const result = await runBackgroundUpdateWorker(
+			{ currentVersion: "1.2.3", channel: "latest", latest: "1.2.4" },
+			{
+				ownership: npmOwnership,
+				installRunner: async (installer, args) => {
+					calls.push({ installer, args });
+					return 0;
+				},
+				versionReader: (executable) => (executable === npmOwnership.executable ? "1.2.4" : null),
+			},
+		);
+		expect(result).toBe("installed");
+		expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@1.2.4"] }]);
+	});
+
 	it("cannot bypass hosted update authority with ignoreDisabled", async () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const { captured, restore } = mockFetch([]);
@@ -466,7 +641,7 @@ describe("daemonAutoUpdateOnce", () => {
 		}
 	});
 
-	it("respects autoUpdate=false for daemon auto-update", async () => {
+	it("normalizes legacy autoUpdate=false for daemon auto-update", async () => {
 		writeFileSync(join(tmpHome, ".clawdi", "config.json"), JSON.stringify({ autoUpdate: "false" }));
 		const { captured: fetches, restore } = mockFetch([]);
 		try {
@@ -481,8 +656,18 @@ describe("daemonAutoUpdateOnce", () => {
 		}
 	});
 
-	it("uses a cross-daemon lock so only one daemon installs at a time", async () => {
-		mkdirSync(join(tmpHome, ".clawdi", "daemon-auto-update.lock"), { recursive: true });
+	it("uses the shared updater lock for daemon and startup workers", async () => {
+		const lockDir = join(tmpHome, ".clawdi", "update.lock");
+		mkdirSync(lockDir, { recursive: true });
+		writeFileSync(
+			join(lockDir, "owner.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.privateDirectoryLockOwner.v1",
+				pid: process.pid,
+				acquiredAt: "2000-01-01T00:00:00.000Z",
+				token: "live-update-owner",
+			}),
+		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -499,6 +684,17 @@ describe("daemonAutoUpdateOnce", () => {
 				},
 			});
 			expect(result).toBe("locked");
+			expect(
+				await runBackgroundUpdateWorker(
+					{ currentVersion: "1.2.3", channel: "latest", latest: "1.2.4" },
+					{
+						ownership: npmOwnership,
+						installRunner: async () => {
+							throw new Error("startup worker must use the same lock");
+						},
+					},
+				),
+			).toBe("locked");
 		} finally {
 			restore();
 		}
@@ -638,7 +834,7 @@ describe("maybeAutoUpdate", () => {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
 					detectOwnership: () => npmOwnership,
-					spawnBackgroundInstall: () => {
+					spawnBackgroundWorker: () => {
 						throw new Error("should not spawn hosted local self-update");
 					},
 				}),
@@ -668,7 +864,7 @@ describe("maybeAutoUpdate", () => {
 					detectOwnership: () => {
 						throw new Error("--json must skip updater ownership detection");
 					},
-					spawnBackgroundInstall: () => {
+					spawnBackgroundWorker: () => {
 						throw new Error("--json must not install");
 					},
 				}),
@@ -697,7 +893,7 @@ describe("maybeAutoUpdate", () => {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
 					detectOwnership: () => null,
-					spawnBackgroundInstall: () => {
+					spawnBackgroundWorker: () => {
 						throw new Error("unowned invocation must not install");
 					},
 				}),
@@ -733,6 +929,25 @@ describe("maybeAutoUpdate", () => {
 		expect(captured).not.toContain("Updated clawdi to");
 	});
 
+	it("delegates first-run discovery without waiting for a registry request", async () => {
+		const workers: Array<{ latest?: string; channel: string }> = [];
+		const { captured: fetches, restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectOwnership: () => npmOwnership,
+					spawnBackgroundWorker: (request) => workers.push(request),
+				}),
+			);
+		} finally {
+			restore();
+		}
+		expect(fetches).toHaveLength(0);
+		expect(workers).toHaveLength(1);
+		expect(workers[0]?.latest).toBeUndefined();
+		expect(workers[0]?.channel).toBe("latest");
+	});
+
 	it("prints `Updated clawdi to vX` when last-version differs from current", async () => {
 		// Plant an OLDER last-version so the current binary version looks fresh.
 		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
@@ -746,9 +961,7 @@ describe("maybeAutoUpdate", () => {
 		try {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
-					detectOwnership: () => {
-						throw new Error("update notices must not probe global ownership");
-					},
+					detectOwnership: () => null,
 				}),
 			);
 		} finally {
@@ -839,10 +1052,10 @@ describe("maybeAutoUpdate", () => {
 			join(tmpHome, ".clawdi", cacheFile),
 			JSON.stringify({ checkedAt: new Date().toISOString(), latest: "999.0.0" }),
 		);
-		const installs: {
-			installer: string;
-			args: string[];
-			latest: string;
+		const workers: {
+			current: string;
+			latest?: string;
+			channel: string;
 			logFd: number;
 		}[] = [];
 		const orig = console.log;
@@ -855,8 +1068,8 @@ describe("maybeAutoUpdate", () => {
 			await withStdoutTty(() =>
 				maybeAutoUpdate({
 					detectOwnership: () => npmOwnership,
-					spawnBackgroundInstall: (installer, args, context) => {
-						installs.push({ installer, args, latest: context.latest, logFd: context.logFd });
+					spawnBackgroundWorker: (request) => {
+						workers.push(request);
 					},
 				}),
 			);
@@ -867,14 +1080,12 @@ describe("maybeAutoUpdate", () => {
 		expect(captured).toContain("Updating clawdi v");
 		expect(captured).toContain("→ v999.0.0 in background");
 		expect(captured).not.toContain("Major release");
-		expect(installs).toHaveLength(1);
-		expect(installs[0]?.installer).toBe("npm");
-		expect(installs[0]?.args).toEqual(["i", "-g", "clawdi@999.0.0"]);
-		expect(installs[0]?.latest).toBe("999.0.0");
-		expect(installs[0]?.logFd ?? -1).toBeGreaterThanOrEqual(0);
+		expect(workers).toHaveLength(1);
+		expect(workers[0]?.latest).toBe("999.0.0");
+		expect(workers[0]?.logFd ?? -1).toBeGreaterThanOrEqual(0);
 	});
 
-	it("respects autoUpdate=false config — skips install path", async () => {
+	it("normalizes legacy autoUpdate=false before the startup install path", async () => {
 		writeFileSync(join(tmpHome, ".clawdi", "config.json"), JSON.stringify({ autoUpdate: "false" }));
 		// Cache says a newer version is available.
 		writeFileSync(
@@ -951,4 +1162,31 @@ function writeDaemonHealth(agent: string, version: string): void {
 		join(dir, "health"),
 		`${JSON.stringify({ timestamp: new Date().toISOString(), version })}\n`,
 	);
+}
+
+async function waitForPath(path: string): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		try {
+			readFileSync(path);
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+	}
+	throw new Error(`timed out waiting for ${path}`);
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+	for (let attempt = 0; attempt < 100 && processIsAlive(pid); attempt++) {
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
 }

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -38,7 +38,7 @@ describe("getConfig env override", () => {
 
 	it("CLAWDI_DEPLOY_API_URL env overrides stored Hosted config", async () => {
 		const { getConfig, setConfigKey } = await import("../src/lib/config");
-		setConfigKey("deployApiUrl", "http://deploy-from-disk");
+		setConfigKey("deployApiUrl", "https://deploy-from-disk.test");
 		process.env.CLAWDI_DEPLOY_API_URL = "http://deploy-from-env";
 		expect(getConfig().deployApiUrl).toBe("http://deploy-from-env");
 	});
@@ -46,20 +46,59 @@ describe("getConfig env override", () => {
 	it("preserves the stored auto-update preference", async () => {
 		const { getConfig, setConfigKey } = await import("../src/lib/config");
 		setConfigKey("autoUpdate", "false");
-		expect(getConfig().autoUpdate).toBe("false");
+		expect(getConfig().autoUpdate).toBe(false);
+	});
+
+	it("normalizes released string booleans at the config read boundary", async () => {
+		const { getConfig, getStoredConfig, setConfigKey } = await import("../src/lib/config");
+		const path = join(fakeHome, ".clawdi", "config.json");
+		mkdirSync(join(fakeHome, ".clawdi"), { recursive: true });
+		const legacy = '{"autoUpdate":"false","futureSetting":{"enabled":true}}\n';
+		writeFileSync(path, legacy);
+
+		expect(getConfig().autoUpdate).toBe(false);
+		expect(getStoredConfig()).toEqual({
+			autoUpdate: false,
+			futureSetting: { enabled: true },
+		});
+		expect(readFileSync(path, "utf8")).toBe(legacy);
+
+		setConfigKey("apiUrl", "https://cloud.example.test");
+		expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+			autoUpdate: false,
+			futureSetting: { enabled: true },
+			apiUrl: "https://cloud.example.test",
+		});
+
+		writeFileSync(path, '{"autoUpdate":"true"}\n');
+		expect(getConfig().autoUpdate).toBe(true);
+	});
+
+	it("does not coerce invalid config shapes into canonical values", async () => {
+		const { getStoredConfig } = await import("../src/lib/config");
+		const path = join(fakeHome, ".clawdi", "config.json");
+		mkdirSync(join(fakeHome, ".clawdi"), { recursive: true });
+		for (const autoUpdate of ["FALSE", 1, null, [], {}]) {
+			writeFileSync(path, JSON.stringify({ autoUpdate, futureSetting: "preserved" }));
+			expect(getStoredConfig()).toEqual({ futureSetting: "preserved" });
+		}
+		for (const invalid of [null, [], "false", 1]) {
+			writeFileSync(path, JSON.stringify(invalid));
+			expect(getStoredConfig()).toEqual({});
+		}
 	});
 
 	it("CLAWDI_API_URL env overrides stored config", async () => {
 		const { getConfig, setConfig } = await import("../src/lib/config");
-		setConfig({ apiUrl: "http://from-disk" });
+		setConfig({ apiUrl: "https://from-disk.test" });
 		process.env.CLAWDI_API_URL = "http://from-env";
 		expect(getConfig().apiUrl).toBe("http://from-env");
 	});
 
 	it("stored config used when env not set", async () => {
 		const { getConfig, setConfig } = await import("../src/lib/config");
-		setConfig({ apiUrl: "http://from-disk" });
-		expect(getConfig().apiUrl).toBe("http://from-disk");
+		setConfig({ apiUrl: "https://from-disk.test" });
+		expect(getConfig().apiUrl).toBe("https://from-disk.test");
 	});
 });
 
@@ -133,11 +172,46 @@ describe("auth persistence", () => {
 describe("config keys", () => {
 	it("setConfigKey / unsetConfigKey round-trip", async () => {
 		const { getStoredConfig, setConfigKey, unsetConfigKey } = await import("../src/lib/config");
-		setConfigKey("apiUrl", "http://x");
-		expect(getStoredConfig().apiUrl).toBe("http://x");
+		setConfigKey("apiUrl", "https://cloud.example.test");
+		expect(getStoredConfig().apiUrl).toBe("https://cloud.example.test");
 		unsetConfigKey("apiUrl");
 		expect(getStoredConfig().apiUrl).toBeUndefined();
-		setConfigKey("deployApiUrl", "http://deploy-x");
-		expect(getStoredConfig().deployApiUrl).toBe("http://deploy-x");
+		setConfigKey("deployApiUrl", "https://deploy.example.test/v2");
+		expect(getStoredConfig().deployApiUrl).toBe("https://deploy.example.test");
+	});
+
+	it("rejects invalid values before replacing the existing config", async () => {
+		const { getStoredConfig, setConfigKey } = await import("../src/lib/config");
+		setConfigKey("apiUrl", "https://cloud.example.test");
+		setConfigKey("autoUpdate", "false");
+		const path = join(fakeHome, ".clawdi", "config.json");
+		const before = readFileSync(path, "utf8");
+
+		expect(() => setConfigKey("autoUpdate", "FALSE")).toThrow("must be true or false");
+		expect(() => setConfigKey("apiUrl", "cloud.example.test")).toThrow("absolute http");
+		expect(() => setConfigKey("deployApiUrl", "ftp://deploy.example.test")).toThrow(
+			"must use http:// or https://",
+		);
+		expect(readFileSync(path, "utf8")).toBe(before);
+		expect(getStoredConfig()).toEqual({
+			apiUrl: "https://cloud.example.test",
+			autoUpdate: false,
+		});
+	});
+
+	it("exits nonzero for invalid config set input without touching the old value", () => {
+		const configPath = join(fakeHome, ".clawdi", "config.json");
+		mkdirSync(join(fakeHome, ".clawdi"), { recursive: true });
+		writeFileSync(configPath, '{"autoUpdate":false}\n');
+		const result = Bun.spawnSync(
+			["bun", join(import.meta.dir, "../src/index.ts"), "config", "set", "autoUpdate", "yes"],
+			{
+				env: { ...process.env, HOME: fakeHome, CLAWDI_HOME: join(fakeHome, ".clawdi") },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		expect(result.exitCode).not.toBe(0);
+		expect(readFileSync(configPath, "utf8")).toBe('{"autoUpdate":false}\n');
 	});
 });


### PR DESCRIPTION
## Summary

- fence local updater work with one durable lease and bounded process-group termination
- resolve the current script invocation once for updater ownership and background workers
- harden private config, share-token, inbox, and MCP state against races, corruption, and unbounded waits

## Boundary

This is stack layer 1 of 5. It contains no Hosted transaction, release recovery, daemon lifecycle, standalone, or native distribution changes.

## Verification

- Docker clean runner: full CLI typecheck and 1294 tests passed
- Docker Biome: 759 files passed
- `git diff --check origin/main..61a98713` passed

Merge order: this PR, Hosted runtime, release recovery, daemon lifecycle, then native distribution PR #556.