### PR TITLE
fix(cli): recover Hosted CLI upgrades durably

### DIFF
--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -23,35 +23,7 @@ interface Capabilities {
 	providerApply: { available: true; command: "clawdi ai-provider apply" };
 }
 
-const COMMANDS = [
-	"auth",
-	"status",
-	"config",
-	"setup",
-	"teardown",
-	"push",
-	"pull",
-	"daemon",
-	"serve",
-	"ai-provider",
-	"vault",
-	"read",
-	"inject",
-	"skill",
-	"session",
-	"memory",
-	"doctor",
-	"update",
-	"mcp",
-	"run",
-	"project",
-	"agent",
-	"inbox",
-	"runtime",
-	"capabilities",
-];
-
-function buildCapabilities(): Capabilities {
+function buildCapabilities(commands: string[]): Capabilities {
 	const runtimeMode = detectRuntimeMode();
 	const hostPolicy = readHostPolicy();
 	const cliUpdateMode = hostPolicy.policy?.cliUpdateMode;
@@ -66,7 +38,7 @@ function buildCapabilities(): Capabilities {
 		fullCliSurface: true,
 		runtimeMode,
 		updateMode,
-		commands: COMMANDS,
+		commands,
 		restrictedByHostedPolicy: normalizeDeniedCommands(hostPolicy.policy),
 		hostPolicy: {
 			source: hostPolicy.source,
@@ -81,8 +53,8 @@ function buildCapabilities(): Capabilities {
 	};
 }
 
-export async function capabilitiesCommand(opts: { json?: boolean } = {}) {
-	const capabilities = buildCapabilities();
+export async function capabilitiesCommand(opts: { json?: boolean }, commands: string[]) {
+	const capabilities = buildCapabilities(commands);
 	if (opts.json || !process.stdout.isTTY) {
 		console.log(JSON.stringify(capabilities, null, 2));
 		return;

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -38,8 +38,10 @@ import { applyRuntimeBundleChannelsToManifestLoad } from "../runtime/channels";
 import {
 	applyRuntimeCliDesiredState,
 	completePendingRuntimeCliUpgrade,
+	type RuntimeCliReconciliationResult,
 	type RuntimeCliRollbackResult,
 	type RuntimeCliUpdateResult,
+	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../runtime/cli-update";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
@@ -2098,6 +2100,31 @@ async function runtimeWatchTickLocked(
 	paths: ReturnType<typeof getRuntimePaths>,
 	opts: { forceRefresh: boolean; deferCliInstall?: boolean; deferCliInstallReason?: string },
 ): Promise<Record<string, unknown>> {
+	let reconciliation: RuntimeCliReconciliationResult;
+	try {
+		reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			schemaVersion: "clawdi.runtimeWatchEvent.v1",
+			status: "error",
+			stage: "cli-update",
+			errors: [message],
+			error: message,
+			selfReexec: false,
+		};
+	}
+	const event = await runtimeWatchTickAfterCliReconciliation(paths, opts);
+	return {
+		...event,
+		selfReexec: reconciliation.selfReexec || event.selfReexec === true,
+	};
+}
+
+async function runtimeWatchTickAfterCliReconciliation(
+	paths: ReturnType<typeof getRuntimePaths>,
+	opts: { forceRefresh: boolean; deferCliInstall?: boolean; deferCliInstallReason?: string },
+): Promise<Record<string, unknown>> {
 	const activeAppliedState = readRuntimeAppliedState(paths);
 	const manifestEtag = opts.forceRefresh ? undefined : (activeAppliedState?.etag ?? undefined);
 	const manifestLoad = await loadRemoteRuntimeManifest(paths, { ifNoneMatch: manifestEtag });
@@ -2119,6 +2146,7 @@ async function runtimeWatchTickLocked(
 		activeAppliedState !== null &&
 		activeAppliedState.etag === responseManifestEtag
 	) {
+		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "not_modified",
@@ -2127,6 +2155,7 @@ async function runtimeWatchTickLocked(
 			sourceRevision: activeAppliedState.sourceRevision,
 			generation: activeAppliedState.generation,
 			instanceId: activeAppliedState.instanceId,
+			selfReexec: completion.selfReexec,
 		};
 	}
 
@@ -2175,7 +2204,7 @@ async function runtimeWatchTickLocked(
 				rejectedGeneration: loaded.manifest.generation,
 				instanceId: activeAppliedState?.instanceId ?? null,
 				cliUpdate: applyResult.cliUpdate,
-				selfReexec: false,
+				selfReexec: shouldSelfReexecForCliUpdate(applyResult.cliUpdate),
 				systemdUnitsChanged: false,
 				systemdApply: {
 					applied: false,
@@ -2213,7 +2242,7 @@ async function runtimeWatchTickLocked(
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
 			systemdApplyResult.userUnitsChanged.length > 0;
 		if (errors.length > 0) {
-			const cliRollback = maybeRollbackFailedCliUpgrade(paths, manifestIdentity, errors);
+			const cliRollback = maybeRollbackFailedCliUpgrade(paths, errors);
 			if (cliRollback.status === "rolled_back") selfReexec = true;
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			return {
@@ -2233,7 +2262,8 @@ async function runtimeWatchTickLocked(
 				convergence: convergence.outputs,
 			};
 		}
-		completePendingRuntimeCliUpgrade(paths, getCliVersion(), manifestIdentity);
+		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		selfReexec = selfReexec || completion.selfReexec;
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "applied",
@@ -2270,7 +2300,8 @@ function applyRuntimeDesiredState(
 		cliUpdate = applyRuntimeCliDesiredState(load.manifest, paths, {
 			deferInstall: opts.deferCliInstall,
 			deferReason: opts.deferCliInstallReason,
-			manifestIdentity: opts.manifestIdentity,
+			rollbackEligible: opts.manifestIdentity?.previouslyApplied,
+			runningVersion: getCliVersion(),
 		});
 	} catch (error) {
 		if (!opts.continueOnCliUpdateError) throw error;
@@ -2278,6 +2309,9 @@ function applyRuntimeDesiredState(
 			kind: "cli_update_failed",
 			cliUpdate: runtimeCliUpdateError(load.manifest, paths, error),
 		};
+	}
+	if (cliUpdate.selfReexec) {
+		return { kind: "cli_update_failed", cliUpdate };
 	}
 	const gate = minimumCliVersionGate(load.manifest, paths);
 	if (gate) {
@@ -2360,11 +2394,13 @@ function runtimeCliUpdateError(
 		activePath: paths.cliManagedBin,
 		activeTarget: null,
 		version: null,
+		selfReexec: false,
 		error: error instanceof Error ? error.message : String(error),
 	};
 }
 
 function shouldSelfReexecForCliUpdate(cliUpdate: RuntimeCliUpdateResult): boolean {
+	if (cliUpdate.selfReexec) return true;
 	if (cliUpdate.status === "installed") return true;
 	if (!cliUpdate.version || !cliUpdate.activeTarget) return false;
 	return cliUpdate.version !== getCliVersion();
@@ -2385,13 +2421,11 @@ function runtimeManifestIdentityForWatch(
 
 function maybeRollbackFailedCliUpgrade(
 	paths: RuntimePaths,
-	manifestIdentity: RuntimeManifestIdentity,
 	errors: string[],
 ): RuntimeCliRollbackResult {
 	const rollback = rollbackPendingRuntimeCliUpgrade(
 		paths,
 		`first converge after CLI upgrade failed: ${errors[0] ?? "unknown error"}`,
-		manifestIdentity,
 	);
 	if (rollback.status === "rolled_back") {
 		errors.push(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1265,7 +1265,10 @@ program
 	.option("--json", "Output as JSON")
 	.action(async (opts: { json?: boolean }) => {
 		const { capabilitiesCommand } = await import("./commands/capabilities.js");
-		await capabilitiesCommand(opts);
+		await capabilitiesCommand(
+			opts,
+			program.commands.map((command) => command.name()),
+		);
 	});
 
 program

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -13,9 +13,11 @@ import {
 	readlinkSync,
 	renameSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { z } from "zod";
 import { chmodBestEffort, writePrivateFileAtomic } from "../lib/private-file";
 import {
 	hostedCliPackageSpecSchema,
@@ -33,6 +35,7 @@ export interface RuntimeCliUpdateResult {
 	activePath: string;
 	activeTarget: string | null;
 	version: string | null;
+	selfReexec: boolean;
 	error?: string | null;
 }
 
@@ -45,6 +48,7 @@ interface RuntimeCliBootstrapStatus {
 	activePath?: string;
 	activeTarget?: string;
 	version?: string;
+	verification?: RuntimeCliVerification;
 }
 
 type RuntimeCliInstallIdentity = Required<
@@ -62,7 +66,33 @@ interface RuntimeCliBadVersion {
 	markedAt: string;
 }
 
-interface RuntimeCliPendingUpgrade {
+interface RuntimeCliVerification {
+	verifiedAt: string;
+	device: number;
+	inode: number;
+	size: number;
+	modifiedAtMs: number;
+}
+
+interface RuntimeCliUpgradeTransaction {
+	phase: "prepared" | "activated";
+	previousIdentity: RuntimeCliInstallIdentity | null;
+	newIdentity: RuntimeCliInstallIdentity;
+	rollbackEligible: boolean;
+	installedAt: string;
+	rollback: { reason: string; markedAt: string } | null;
+}
+
+interface RuntimeCliUpgradeState {
+	schemaVersion?: string;
+	transaction?: RuntimeCliUpgradeTransaction | null;
+	badVersions?: RuntimeCliBadVersion[];
+	migratedFromV1?: boolean;
+	// Read only during the compact v1 migration.
+	pendingUpgrade?: RuntimeCliPendingUpgradeV1 | null;
+}
+
+interface RuntimeCliPendingUpgradeV1 {
 	packageSpec: string;
 	registry: string | null;
 	version: string;
@@ -72,16 +102,8 @@ interface RuntimeCliPendingUpgrade {
 	previousActiveTarget: string | null;
 	previousNpmPrefix: string | null;
 	previousVersion: string | null;
-	manifestGeneration: number | null;
-	manifestEtag: string | null;
 	rollbackEligible: boolean;
 	installedAt: string;
-}
-
-interface RuntimeCliUpgradeState {
-	schemaVersion?: string;
-	pendingUpgrade?: RuntimeCliPendingUpgrade | null;
-	badVersions?: RuntimeCliBadVersion[];
 }
 
 export interface RuntimeCliRollbackResult {
@@ -96,12 +118,90 @@ export interface RuntimeCliRollbackResult {
 const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const VERSION_SMOKE_TIMEOUT_MS = 20_000;
 const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
+const CLI_VERIFY_CACHE_MAX_AGE_MS = 300_000;
 
-interface RuntimeCliManifestIdentity {
-	generation?: number | null;
-	etag?: string | null;
-	previouslyApplied?: boolean;
+interface RuntimeCliReconciliationOptions {
+	runningVersion?: string;
 }
+
+export interface RuntimeCliReconciliationResult {
+	status: "unchanged" | "activated" | "rolled_back";
+	selfReexec: boolean;
+}
+
+const cliInstallIdentityStateSchema = z
+	.object({
+		packageSpec: z.string().min(1),
+		registry: z.string().min(1).nullable(),
+		npmPrefix: z.string().min(1),
+		activeTarget: z.string().min(1),
+		version: z.string().min(1),
+	})
+	.strict();
+
+const cliBadVersionStateSchema = z
+	.object({
+		packageSpec: z.string().min(1),
+		registry: z.string().min(1).nullable(),
+		version: z.string().min(1),
+		reason: z.string(),
+		markedAt: z.string().min(1),
+	})
+	.strict();
+
+const cliUpgradeTransactionStateSchema = z
+	.object({
+		phase: z.enum(["prepared", "activated"]),
+		previousIdentity: cliInstallIdentityStateSchema.nullable(),
+		newIdentity: cliInstallIdentityStateSchema,
+		rollbackEligible: z.boolean(),
+		installedAt: z.string().min(1),
+		rollback: z
+			.object({ reason: z.string(), markedAt: z.string().min(1) })
+			.strict()
+			.nullable(),
+	})
+	.strict();
+
+const cliUpgradeStateV2Schema = z
+	.object({
+		schemaVersion: z.literal("clawdi.cliUpgradeState.v2"),
+		transaction: cliUpgradeTransactionStateSchema.nullable(),
+		badVersions: z.array(cliBadVersionStateSchema),
+	})
+	.strict();
+
+const cliPendingUpgradeV1StateSchema = z
+	.object({
+		packageSpec: z.string().min(1),
+		registry: z.string().min(1).nullable(),
+		version: z.string().min(1),
+		npmPrefix: z.string().min(1),
+		activeTarget: z.string().min(1),
+		previousStatus: z
+			.object({
+				packageSpec: z.string().min(1).optional(),
+				registry: z.string().min(1).nullable().optional(),
+			})
+			.passthrough()
+			.nullable(),
+		previousActiveTarget: z.string().min(1).nullable(),
+		previousNpmPrefix: z.string().min(1).nullable(),
+		previousVersion: z.string().min(1).nullable(),
+		manifestGeneration: z.number().int().nullable().optional(),
+		manifestEtag: z.string().nullable().optional(),
+		rollbackEligible: z.boolean(),
+		installedAt: z.string().min(1),
+	})
+	.strict();
+
+const cliUpgradeStateV1Schema = z
+	.object({
+		schemaVersion: z.literal("clawdi.cliUpgradeState.v1"),
+		pendingUpgrade: cliPendingUpgradeV1StateSchema.nullable().optional(),
+		badVersions: z.array(cliBadVersionStateSchema).optional(),
+	})
+	.strict();
 
 export function applyRuntimeCliDesiredState(
 	manifest: RuntimeManifest,
@@ -109,9 +209,27 @@ export function applyRuntimeCliDesiredState(
 	opts: {
 		deferInstall?: boolean;
 		deferReason?: string;
-		manifestIdentity?: RuntimeCliManifestIdentity;
+		rollbackEligible?: boolean;
+		runningVersion?: string;
 	} = {},
 ): RuntimeCliUpdateResult {
+	const reconciliation = reconcileCliUpgradeTransaction(paths, opts);
+	if (reconciliation.selfReexec) {
+		const status = readBootstrapStatus(paths.cliBootstrapStatus);
+		return baseResult(
+			"deferred",
+			paths,
+			{
+				packageSpec: manifest.clawdiCli?.packageSpec?.trim() || null,
+				registry: status?.registry ?? null,
+				npmPrefix: status?.npmPrefix ?? paths.cliNpmPrefix,
+				activeTarget: status?.activeTarget ?? null,
+				version: status?.version ?? null,
+				error: `CLI transaction recovery ${reconciliation.status}; re-exec is required`,
+			},
+			true,
+		);
+	}
 	const packageSpec = manifest.clawdiCli?.packageSpec?.trim();
 	if (!packageSpec) {
 		return baseResult("not_requested", paths, {
@@ -140,13 +258,17 @@ export function applyRuntimeCliDesiredState(
 	}
 	const recovered = recoverCurrentCliInstallFromActiveLink(paths, packageSpec);
 	if (recovered) {
-		writeCliBootstrapStatus(paths, {
-			packageSpec,
-			registry,
-			npmPrefix: recovered.npmPrefix,
-			activeTarget: recovered.activeTarget,
-			version: recovered.version,
-		});
+		writeCliBootstrapStatus(
+			paths,
+			{
+				packageSpec,
+				registry,
+				npmPrefix: recovered.npmPrefix,
+				activeTarget: recovered.activeTarget,
+				version: recovered.version,
+			},
+			recovered.verification,
+		);
 		return baseResult("current", paths, {
 			packageSpec,
 			registry,
@@ -166,9 +288,10 @@ export function applyRuntimeCliDesiredState(
 		});
 	}
 
-	const previousIdentity = verifiedActiveCliIdentity(paths, current);
+	const previousIdentity = lastGoodCliIdentity(paths, current);
 	if (
 		previousIdentity &&
+		activeLinkTarget(paths.cliManagedBin) === previousIdentity.activeTarget &&
 		(current?.status !== "installed" ||
 			current.source !== "npm" ||
 			current.packageSpec !== previousIdentity.packageSpec ||
@@ -178,25 +301,36 @@ export function applyRuntimeCliDesiredState(
 			current.activeTarget !== previousIdentity.activeTarget ||
 			current.version !== previousIdentity.version)
 	) {
-		writeCliBootstrapStatus(paths, previousIdentity);
+		const verification = verifyStoredCliIdentity(paths, previousIdentity);
+		if (!verification) throw new Error("active clawdi CLI changed during verification");
+		writeCliBootstrapStatus(paths, previousIdentity, verification);
 	}
 	const installed = installCliPackage(paths, packageSpec, registry);
+	prepareCliUpgradeTransaction(paths, {
+		newIdentity: {
+			packageSpec,
+			registry,
+			npmPrefix: installed.npmPrefix,
+			activeTarget: installed.activeTarget,
+			version: installed.version,
+		},
+		previousIdentity,
+		rollbackEligible: opts.rollbackEligible === true && previousIdentity !== null,
+	});
 	swapActiveCli(paths.cliManagedBin, installed.activeTarget);
 	removeLegacyManagedCliLink(paths, installed.activeTarget);
-	writeCliBootstrapStatus(paths, {
-		packageSpec,
-		registry,
-		npmPrefix: installed.npmPrefix,
-		activeTarget: installed.activeTarget,
-		version: installed.version,
-	});
-	markPendingCliUpgrade(paths, {
-		packageSpec,
-		registry,
-		installed,
-		previousIdentity,
-		manifestIdentity: opts.manifestIdentity,
-	});
+	writeCliBootstrapStatus(
+		paths,
+		{
+			packageSpec,
+			registry,
+			npmPrefix: installed.npmPrefix,
+			activeTarget: installed.activeTarget,
+			version: installed.version,
+		},
+		installed.verification,
+	);
+	activateCliUpgradeTransaction(paths);
 	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousIdentity?.npmPrefix ?? null]);
 	return baseResult("installed", paths, {
 		packageSpec,
@@ -217,6 +351,7 @@ function baseResult(
 	status: RuntimeCliUpdateResult["status"],
 	paths: RuntimePaths,
 	values: RuntimeCliResultValues,
+	selfReexec = false,
 ): RuntimeCliUpdateResult {
 	return {
 		status,
@@ -224,6 +359,7 @@ function baseResult(
 		npmPrefix: values.npmPrefix ?? paths.cliNpmPrefix,
 		npmCache: values.npmCache ?? paths.cliNpmCache,
 		activePath: paths.cliManagedBin,
+		selfReexec,
 	};
 }
 
@@ -431,7 +567,36 @@ function isCurrentCliInstall(
 	if (!status.version) return false;
 	const exactVersion = exactNpmPackageVersion(packageSpec);
 	if (exactVersion && status.version !== exactVersion) return false;
-	return isExecutable(paths.cliManagedBin);
+	if (!isExecutable(paths.cliManagedBin)) return false;
+	const fileIdentity = cliVerificationIdentity(status.activeTarget);
+	if (
+		fileIdentity &&
+		status.verification &&
+		verificationIdentityMatches(status.verification, fileIdentity) &&
+		verificationIsFresh(status.verification)
+	) {
+		return true;
+	}
+	if (!fileIdentity) return false;
+	try {
+		if (smokeCliVersion(status.activeTarget) !== status.version) return false;
+		verifyCliRuntime(status.activeTarget);
+		const verification = finishCliVerification(status.activeTarget, fileIdentity);
+		writeCliBootstrapStatus(
+			paths,
+			{
+				packageSpec,
+				registry,
+				npmPrefix: status.npmPrefix,
+				activeTarget: status.activeTarget,
+				version: status.version,
+			},
+			verification,
+		);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function verifiedActiveCliIdentity(
@@ -446,7 +611,11 @@ function verifiedActiveCliIdentity(
 
 	try {
 		hardenManagedCliInstall(paths, activeTarget, npmPrefix);
+		const before = cliVerificationIdentity(activeTarget);
+		if (!before) return null;
 		const version = smokeCliVersion(activeTarget);
+		verifyCliRuntime(activeTarget);
+		finishCliVerification(activeTarget, before);
 		const inferredPackageSpec = `clawdi@${version}`;
 		if (!hostedCliPackageSpecSchema.safeParse(inferredPackageSpec).success) return null;
 		const statusPackageSpec = status?.packageSpec;
@@ -476,10 +645,36 @@ function verifiedActiveCliIdentity(
 	}
 }
 
+function lastGoodCliIdentity(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliInstallIdentity | null {
+	const activeIdentity = verifiedActiveCliIdentity(paths, status);
+	if (!activeIdentity) return null;
+	const transaction = readCliUpgradeState(paths).transaction;
+	if (
+		transaction?.phase !== "activated" ||
+		transaction.rollback ||
+		!transaction.rollbackEligible ||
+		!transaction.previousIdentity ||
+		transaction.newIdentity.activeTarget !== activeIdentity.activeTarget
+	) {
+		return activeIdentity;
+	}
+	return verifyStoredCliIdentity(paths, transaction.previousIdentity)
+		? transaction.previousIdentity
+		: activeIdentity;
+}
+
 function recoverCurrentCliInstallFromActiveLink(
 	paths: RuntimePaths,
 	packageSpec: string,
-): { npmPrefix: string; activeTarget: string; version: string } | null {
+): {
+	npmPrefix: string;
+	activeTarget: string;
+	version: string;
+	verification: RuntimeCliVerification;
+} | null {
 	const desiredVersion = exactNpmPackageVersion(packageSpec);
 	if (!desiredVersion) return null;
 	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
@@ -488,12 +683,17 @@ function recoverCurrentCliInstallFromActiveLink(
 	if (!isManagedCliTarget(paths, activeTarget)) return null;
 	hardenManagedCliInstall(paths, activeTarget, npmPrefix);
 	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
+	const before = cliVerificationIdentity(activeTarget);
+	if (!before) return null;
 	const version = smokeCliVersion(activeTarget);
 	if (version !== desiredVersion) return null;
+	verifyCliRuntime(activeTarget);
+	const verification = finishCliVerification(activeTarget, before);
 	return {
 		npmPrefix: prefixForActiveTarget(activeTarget),
 		activeTarget,
 		version,
+		verification,
 	};
 }
 
@@ -506,7 +706,12 @@ function installCliPackage(
 	paths: RuntimePaths,
 	packageSpec: string,
 	registry: string | null,
-): { npmPrefix: string; activeTarget: string; version: string } {
+): {
+	npmPrefix: string;
+	activeTarget: string;
+	version: string;
+	verification: RuntimeCliVerification;
+} {
 	const installPlan = cliInstallPlan(paths, packageSpec, registry);
 	if (isBadCliVersion(paths, packageSpec, registry, installPlan.version)) {
 		throw new Error(
@@ -565,6 +770,9 @@ function installCliPackage(
 		throw new Error(`npm install completed but clawdi bin is missing: ${activeTarget}`);
 	}
 	hardenManagedCliInstall(paths, activeTarget, npmPrefix);
+	const before = cliVerificationIdentity(activeTarget);
+	if (!before)
+		throw new Error(`installed clawdi bin disappeared before verification: ${activeTarget}`);
 	const version = smokeCliVersion(activeTarget);
 	const exactVersion = exactNpmPackageVersion(packageSpec);
 	if (exactVersion && version !== exactVersion) {
@@ -573,7 +781,8 @@ function installCliPackage(
 		);
 	}
 	verifyCliRuntime(activeTarget);
-	return { npmPrefix, activeTarget, version };
+	const verification = finishCliVerification(activeTarget, before);
+	return { npmPrefix, activeTarget, version, verification };
 }
 
 function cliInstallPlan(
@@ -609,6 +818,51 @@ function cliPackagePrefix(paths: RuntimePaths, version: string): string {
 
 function prefixForActiveTarget(activeTarget: string): string {
 	return dirname(dirname(activeTarget));
+}
+
+function cliVerificationIdentity(
+	activeTarget: string,
+): Omit<RuntimeCliVerification, "verifiedAt"> | null {
+	try {
+		const stat = statSync(activeTarget);
+		return {
+			device: stat.dev,
+			inode: stat.ino,
+			size: stat.size,
+			modifiedAtMs: stat.mtimeMs,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function verificationIdentityMatches(
+	verification: Omit<RuntimeCliVerification, "verifiedAt">,
+	identity: Omit<RuntimeCliVerification, "verifiedAt">,
+): boolean {
+	return (
+		verification.device === identity.device &&
+		verification.inode === identity.inode &&
+		verification.size === identity.size &&
+		verification.modifiedAtMs === identity.modifiedAtMs
+	);
+}
+
+function verificationIsFresh(verification: RuntimeCliVerification): boolean {
+	const verifiedAt = Date.parse(verification.verifiedAt);
+	const ageMs = Date.now() - verifiedAt;
+	return Number.isFinite(verifiedAt) && ageMs >= 0 && ageMs < CLI_VERIFY_CACHE_MAX_AGE_MS;
+}
+
+function finishCliVerification(
+	activeTarget: string,
+	before: Omit<RuntimeCliVerification, "verifiedAt">,
+): RuntimeCliVerification {
+	const after = cliVerificationIdentity(activeTarget);
+	if (!after || !verificationIdentityMatches(before, after)) {
+		throw new Error(`clawdi CLI target changed during verification: ${activeTarget}`);
+	}
+	return { verifiedAt: new Date().toISOString(), ...after };
 }
 
 function activeLinkTarget(activePath: string): string | null {
@@ -730,7 +984,15 @@ function writeCliBootstrapStatus(
 		activeTarget: string;
 		version: string;
 	},
+	verification?: RuntimeCliVerification,
 ): void {
+	const currentIdentity = cliVerificationIdentity(input.activeTarget);
+	if (
+		verification &&
+		(!currentIdentity || !verificationIdentityMatches(verification, currentIdentity))
+	) {
+		throw new Error(`clawdi CLI target changed after verification: ${input.activeTarget}`);
+	}
 	writePrivateFileAtomic(
 		paths.cliBootstrapStatus,
 		`${JSON.stringify(
@@ -746,6 +1008,7 @@ function writeCliBootstrapStatus(
 				activePath: paths.cliManagedBin,
 				activeTarget: input.activeTarget,
 				version: input.version,
+				verification,
 				error: null,
 			},
 			null,
@@ -758,11 +1021,17 @@ function writeCliBootstrapStatus(
 export function rollbackPendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	reason: string,
-	manifestIdentity: RuntimeCliManifestIdentity = {},
 ): RuntimeCliRollbackResult {
+	let transaction: RuntimeCliUpgradeTransaction | null = null;
+	try {
+		transaction = readCliUpgradeState(paths).transaction ?? null;
+		reconcileCliUpgradeTransaction(paths);
+	} catch (error) {
+		return rollbackErrorResult(transaction, error);
+	}
 	const state = readCliUpgradeState(paths);
-	const pending = state.pendingUpgrade ?? null;
-	if (!pending) {
+	transaction = state.transaction ?? null;
+	if (!transaction) {
 		return {
 			status: "not_pending",
 			version: null,
@@ -771,178 +1040,328 @@ export function rollbackPendingRuntimeCliUpgrade(
 			previousActiveTarget: null,
 		};
 	}
-	if (!pending.rollbackEligible) {
+	if (!transaction.rollbackEligible || !transaction.previousIdentity) {
 		return {
 			status: "not_pending",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
+			version: transaction.newIdentity.version,
+			previousVersion: transaction.previousIdentity?.version ?? null,
+			activeTarget: transaction.newIdentity.activeTarget,
+			previousActiveTarget: transaction.previousIdentity?.activeTarget ?? null,
 		};
 	}
-	if (!pendingMatchesManifestIdentity(pending, manifestIdentity)) {
-		return {
-			status: "not_pending",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
-		};
-	}
-	const previousIdentity = verifiedPendingRollbackIdentity(paths, pending);
-	if (!previousIdentity) {
+	if (!verifyStoredCliIdentity(paths, transaction.previousIdentity)) {
 		return {
 			status: "error",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
+			version: transaction.newIdentity.version,
+			previousVersion: transaction.previousIdentity.version,
+			activeTarget: transaction.newIdentity.activeTarget,
+			previousActiveTarget: transaction.previousIdentity.activeTarget,
 			error: "previous clawdi CLI identity is missing, inconsistent, or not executable",
 		};
 	}
-	if (activeLinkTarget(paths.cliManagedBin) !== pending.activeTarget) {
+	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
 		return {
 			status: "error",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
+			version: transaction.newIdentity.version,
+			previousVersion: transaction.previousIdentity.version,
+			activeTarget: transaction.newIdentity.activeTarget,
+			previousActiveTarget: transaction.previousIdentity.activeTarget,
 			error: "pending clawdi CLI target is no longer active",
 		};
 	}
 	try {
-		swapActiveCli(paths.cliManagedBin, previousIdentity.activeTarget);
-		if (activeLinkTarget(paths.cliManagedBin) !== previousIdentity.activeTarget) {
-			throw new Error("restored clawdi CLI link does not match the verified previous target");
-		}
-		writeCliBootstrapStatus(paths, previousIdentity);
-		const nextState = normalizeCliUpgradeState(state);
-		nextState.pendingUpgrade = null;
-		nextState.badVersions = upsertBadVersion(nextState.badVersions ?? [], {
-			packageSpec: pending.packageSpec,
-			registry: pending.registry,
-			version: pending.version,
-			reason,
-			markedAt: new Date().toISOString(),
-		});
-		writeCliUpgradeState(paths, nextState);
-		pruneCliPackagePrefixes(paths, [previousIdentity.npmPrefix]);
+		const rollbackTransaction: RuntimeCliUpgradeTransaction = {
+			...transaction,
+			rollback: { reason, markedAt: new Date().toISOString() },
+		};
+		writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
+		finishCliRollback(paths, rollbackTransaction);
 		return {
 			status: "rolled_back",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
+			version: transaction.newIdentity.version,
+			previousVersion: transaction.previousIdentity.version,
+			activeTarget: transaction.newIdentity.activeTarget,
+			previousActiveTarget: transaction.previousIdentity.activeTarget,
 			error: null,
 		};
 	} catch (error) {
-		return {
-			status: "error",
-			version: pending.version,
-			previousVersion: pending.previousVersion,
-			activeTarget: pending.activeTarget,
-			previousActiveTarget: pending.previousActiveTarget,
-			error: error instanceof Error ? error.message : String(error),
-		};
+		return rollbackErrorResult(transaction, error);
 	}
 }
 
 export function completePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	currentVersion: string,
-	manifestIdentity: RuntimeCliManifestIdentity = {},
-): void {
+): RuntimeCliReconciliationResult {
+	const reconciliation = reconcileCliUpgradeTransaction(paths, {
+		runningVersion: currentVersion,
+	});
+	if (reconciliation.selfReexec) return reconciliation;
 	const state = readCliUpgradeState(paths);
-	const pending = state.pendingUpgrade ?? null;
-	if (!pending) return;
-	if (pending.version !== currentVersion) return;
-	if (!pendingMatchesManifestIdentity(pending, manifestIdentity)) return;
+	const transaction = state.transaction ?? null;
+	if (transaction?.phase !== "activated" || transaction.rollback) return reconciliation;
+	if (transaction.newIdentity.version !== currentVersion) return reconciliation;
+	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
+		return reconciliation;
+	}
+	if (!verifyStoredCliIdentity(paths, transaction.newIdentity)) return reconciliation;
 	const nextState = normalizeCliUpgradeState(state);
-	nextState.pendingUpgrade = null;
+	nextState.transaction = null;
 	writeCliUpgradeState(paths, nextState);
+	pruneCliPackagePrefixes(paths, [transaction.newIdentity.npmPrefix]);
+	return reconciliation;
 }
 
-function markPendingCliUpgrade(
+export function reconcilePendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	runningVersion: string,
+): RuntimeCliReconciliationResult {
+	return reconcileCliUpgradeTransaction(paths, { runningVersion });
+}
+
+function prepareCliUpgradeTransaction(
 	paths: RuntimePaths,
 	input: {
-		packageSpec: string;
-		registry: string | null;
-		installed: { npmPrefix: string; activeTarget: string; version: string };
+		newIdentity: RuntimeCliInstallIdentity;
 		previousIdentity: RuntimeCliInstallIdentity | null;
-		manifestIdentity?: RuntimeCliManifestIdentity;
+		rollbackEligible: boolean;
 	},
 ): void {
 	const state = normalizeCliUpgradeState(readCliUpgradeState(paths));
-	const previousStatus = input.previousIdentity
-		? {
-				status: "installed",
-				source: "npm",
-				...input.previousIdentity,
-				activePath: paths.cliManagedBin,
-			}
-		: null;
-	state.pendingUpgrade = {
-		packageSpec: input.packageSpec,
-		registry: input.registry,
-		version: input.installed.version,
-		npmPrefix: input.installed.npmPrefix,
-		activeTarget: input.installed.activeTarget,
-		previousStatus,
-		previousActiveTarget: input.previousIdentity?.activeTarget ?? null,
-		previousNpmPrefix: input.previousIdentity?.npmPrefix ?? null,
-		previousVersion: input.previousIdentity?.version ?? null,
-		manifestGeneration: input.manifestIdentity?.generation ?? null,
-		manifestEtag: input.manifestIdentity?.etag ?? null,
-		rollbackEligible:
-			input.manifestIdentity?.previouslyApplied === true && input.previousIdentity !== null,
+	state.transaction = {
+		phase: "prepared",
+		previousIdentity: input.previousIdentity,
+		newIdentity: input.newIdentity,
+		rollbackEligible: input.rollbackEligible,
 		installedAt: new Date().toISOString(),
+		rollback: null,
 	};
 	writeCliUpgradeState(paths, state);
 }
 
-function verifiedPendingRollbackIdentity(
+function activateCliUpgradeTransaction(paths: RuntimePaths): void {
+	const state = readCliUpgradeState(paths);
+	const transaction = state.transaction;
+	if (transaction?.phase !== "prepared") {
+		throw new Error("prepared clawdi CLI upgrade transaction is missing");
+	}
+	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
+		throw new Error("prepared clawdi CLI target is not active");
+	}
+	writeCliUpgradeState(paths, {
+		...state,
+		transaction: { ...transaction, phase: "activated" },
+	});
+}
+
+function reconcileCliUpgradeTransaction(
 	paths: RuntimePaths,
-	pending: RuntimeCliPendingUpgrade,
-): RuntimeCliInstallIdentity | null {
-	const status = pending.previousStatus;
-	const activeTarget = pending.previousActiveTarget;
-	const npmPrefix = pending.previousNpmPrefix;
-	const version = pending.previousVersion;
+	opts: RuntimeCliReconciliationOptions = {},
+): RuntimeCliReconciliationResult {
+	const state = readCliUpgradeState(paths);
+	if (state.migratedFromV1) writeCliUpgradeState(paths, state);
+	const transaction = state.transaction ?? null;
+	if (!transaction) return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
+	if (transaction.rollback) {
+		finishCliRollback(paths, transaction);
+		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+	}
+
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	const previousTarget = transaction.previousIdentity?.activeTarget ?? null;
+	if (transaction.phase === "prepared") {
+		if (activeTarget === transaction.newIdentity.activeTarget) {
+			const verification = verifyStoredCliIdentity(paths, transaction.newIdentity);
+			if (!verification) {
+				rollBackInvalidTransaction(paths, transaction);
+				return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+			}
+			writeCliBootstrapStatus(paths, transaction.newIdentity, verification);
+			activateCliUpgradeTransaction(paths);
+			pruneCliPackagePrefixes(paths, [
+				transaction.newIdentity.npmPrefix,
+				transaction.previousIdentity?.npmPrefix ?? null,
+			]);
+			return cliReconciliationResult(paths, "activated", opts.runningVersion);
+		}
+		if (activeTarget === previousTarget) {
+			if (transaction.previousIdentity) {
+				const verification = verifyStoredCliIdentity(paths, transaction.previousIdentity);
+				if (!verification) {
+					throw new Error("prepared clawdi CLI transaction has an invalid previous identity");
+				}
+				writeCliBootstrapStatus(paths, transaction.previousIdentity, verification);
+			}
+			writeCliUpgradeState(paths, { ...state, transaction: null });
+			pruneCliPackagePrefixes(paths, [transaction.previousIdentity?.npmPrefix ?? null]);
+			return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
+		}
+		rollBackInvalidTransaction(paths, transaction);
+		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+	}
+
+	if (activeTarget === transaction.newIdentity.activeTarget) {
+		if (!verifyStoredCliIdentity(paths, transaction.newIdentity)) {
+			rollBackInvalidTransaction(paths, transaction);
+			return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+		}
+		return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
+	}
+	if (transaction.previousIdentity && activeTarget === previousTarget) {
+		const rollbackTransaction = withRecoveryRollback(transaction);
+		writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
+		finishCliRollback(paths, rollbackTransaction);
+		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+	}
+	rollBackInvalidTransaction(paths, transaction);
+	return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
+}
+
+function cliReconciliationResult(
+	paths: RuntimePaths,
+	status: RuntimeCliReconciliationResult["status"],
+	runningVersion: string | undefined,
+): RuntimeCliReconciliationResult {
+	const bootstrap = readBootstrapStatus(paths.cliBootstrapStatus);
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	const activeVersion = bootstrap?.activeTarget === activeTarget ? bootstrap.version : undefined;
+	return {
+		status,
+		selfReexec:
+			status !== "unchanged" &&
+			runningVersion !== undefined &&
+			activeVersion !== undefined &&
+			activeVersion !== runningVersion,
+	};
+}
+
+function rollBackInvalidTransaction(
+	paths: RuntimePaths,
+	transaction: RuntimeCliUpgradeTransaction,
+): void {
 	if (
-		!status ||
-		!activeTarget ||
-		!npmPrefix ||
-		!version ||
-		status.status !== "installed" ||
-		status.source !== "npm" ||
-		status.activePath !== paths.cliManagedBin ||
-		status.activeTarget !== activeTarget ||
-		status.npmPrefix !== npmPrefix ||
-		status.version !== version ||
-		!status.packageSpec ||
-		!hostedFixtureCliPackageSpecSchema.safeParse(status.packageSpec).success ||
-		(status.registry != null && status.registry !== "https://registry.npmjs.org") ||
-		!isManagedCliTarget(paths, activeTarget) ||
-		!isManagedCliPrefix(paths, npmPrefix) ||
-		resolve(prefixForActiveTarget(activeTarget)) !== resolve(npmPrefix) ||
-		!isExecutable(activeTarget)
+		!transaction.previousIdentity ||
+		!verifyStoredCliIdentity(paths, transaction.previousIdentity)
+	) {
+		throw new Error("clawdi CLI transaction cannot restore a verified previous identity");
+	}
+	const rollbackTransaction = withRecoveryRollback(transaction);
+	const state = readCliUpgradeState(paths);
+	writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
+	finishCliRollback(paths, rollbackTransaction);
+}
+
+function withRecoveryRollback(
+	transaction: RuntimeCliUpgradeTransaction,
+): RuntimeCliUpgradeTransaction {
+	return {
+		...transaction,
+		rollback: {
+			reason: "recovered interrupted or inconsistent clawdi CLI transaction",
+			markedAt: new Date().toISOString(),
+		},
+	};
+}
+
+function finishCliRollback(paths: RuntimePaths, transaction: RuntimeCliUpgradeTransaction): void {
+	const previousIdentity = transaction.previousIdentity;
+	if (!transaction.rollback || !previousIdentity) {
+		throw new Error("clawdi CLI rollback transaction is incomplete");
+	}
+	const verification = verifyStoredCliIdentity(paths, previousIdentity);
+	if (!verification) {
+		throw new Error("previous clawdi CLI identity failed rollback verification");
+	}
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	if (activeTarget !== previousIdentity.activeTarget) {
+		swapActiveCli(paths.cliManagedBin, previousIdentity.activeTarget);
+	}
+	writeCliBootstrapStatus(paths, previousIdentity, verification);
+	const state = readCliUpgradeState(paths);
+	writeCliUpgradeState(paths, {
+		...state,
+		transaction: null,
+		badVersions: upsertBadVersion(state.badVersions ?? [], {
+			packageSpec: transaction.newIdentity.packageSpec,
+			registry: transaction.newIdentity.registry,
+			version: transaction.newIdentity.version,
+			reason: transaction.rollback.reason,
+			markedAt: transaction.rollback.markedAt,
+		}),
+	});
+	pruneCliPackagePrefixes(paths, [previousIdentity.npmPrefix]);
+}
+
+function verifyStoredCliIdentity(
+	paths: RuntimePaths,
+	identity: RuntimeCliInstallIdentity,
+): RuntimeCliVerification | null {
+	if (
+		!hostedFixtureCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
+		(identity.registry !== null && identity.registry !== "https://registry.npmjs.org") ||
+		!isManagedCliTarget(paths, identity.activeTarget) ||
+		!isManagedCliPrefix(paths, identity.npmPrefix) ||
+		resolve(prefixForActiveTarget(identity.activeTarget)) !== resolve(identity.npmPrefix) ||
+		!isExecutable(identity.activeTarget)
 	) {
 		return null;
 	}
-	const exactVersion = exactNpmPackageVersion(status.packageSpec);
-	if (exactVersion && exactVersion !== version) return null;
+	const exactVersion = exactNpmPackageVersion(identity.packageSpec);
+	if (exactVersion && exactVersion !== identity.version) return null;
+	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	const fileIdentity = cliVerificationIdentity(identity.activeTarget);
+	if (
+		statusMatchesIdentity(status, paths, identity) &&
+		fileIdentity &&
+		status?.verification &&
+		verificationIdentityMatches(status.verification, fileIdentity) &&
+		verificationIsFresh(status.verification)
+	) {
+		return status.verification;
+	}
+	if (!fileIdentity) return null;
 	try {
-		if (smokeCliVersion(activeTarget) !== version) return null;
-		return {
-			packageSpec: status.packageSpec,
-			registry: status.registry ?? null,
-			npmPrefix,
-			activeTarget,
-			version,
-		};
+		if (smokeCliVersion(identity.activeTarget) !== identity.version) return null;
+		verifyCliRuntime(identity.activeTarget);
+		const verification = finishCliVerification(identity.activeTarget, fileIdentity);
+		if (activeLinkTarget(paths.cliManagedBin) === identity.activeTarget) {
+			writeCliBootstrapStatus(paths, identity, verification);
+		}
+		return verification;
 	} catch {
 		return null;
 	}
+}
+
+function statusMatchesIdentity(
+	status: RuntimeCliBootstrapStatus | null,
+	paths: RuntimePaths,
+	identity: RuntimeCliInstallIdentity,
+): boolean {
+	return (
+		status?.status === "installed" &&
+		status.source === "npm" &&
+		status.packageSpec === identity.packageSpec &&
+		(status.registry ?? null) === identity.registry &&
+		status.npmPrefix === identity.npmPrefix &&
+		status.activePath === paths.cliManagedBin &&
+		status.activeTarget === identity.activeTarget &&
+		status.version === identity.version
+	);
+}
+
+function rollbackErrorResult(
+	transaction: RuntimeCliUpgradeTransaction | null,
+	error: unknown,
+): RuntimeCliRollbackResult {
+	return {
+		status: "error",
+		version: transaction?.newIdentity.version ?? null,
+		previousVersion: transaction?.previousIdentity?.version ?? null,
+		activeTarget: transaction?.newIdentity.activeTarget ?? null,
+		previousActiveTarget: transaction?.previousIdentity?.activeTarget ?? null,
+		error: error instanceof Error ? error.message : String(error),
+	};
 }
 
 function isBadCliVersion(
@@ -961,16 +1380,44 @@ function isBadCliVersion(
 }
 
 function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {
-	if (!existsSync(paths.cliUpgradeState)) return { schemaVersion: "clawdi.cliUpgradeState.v1" };
+	if (!existsSync(paths.cliUpgradeState)) return emptyCliUpgradeState();
+	let parsed: unknown;
 	try {
-		const parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
-		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-			return { schemaVersion: "clawdi.cliUpgradeState.v1" };
-		}
-		return parsed as RuntimeCliUpgradeState;
-	} catch {
-		return { schemaVersion: "clawdi.cliUpgradeState.v1" };
+		parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
+	} catch (error) {
+		throw new Error(
+			`invalid clawdi CLI upgrade transaction JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
+	const schemaVersion =
+		typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>).schemaVersion
+			: undefined;
+	if (schemaVersion === "clawdi.cliUpgradeState.v2") {
+		const result = cliUpgradeStateV2Schema.safeParse(parsed);
+		if (!result.success) {
+			throw new Error(`invalid clawdi CLI upgrade transaction: ${result.error.issues[0]?.message}`);
+		}
+		return result.data;
+	}
+	if (schemaVersion === "clawdi.cliUpgradeState.v1") {
+		const result = cliUpgradeStateV1Schema.safeParse(parsed);
+		if (!result.success) {
+			throw new Error(
+				`invalid legacy clawdi CLI upgrade state: ${result.error.issues[0]?.message}`,
+			);
+		}
+		return {
+			schemaVersion: "clawdi.cliUpgradeState.v2",
+			transaction: migrateV1PendingUpgrade(
+				paths,
+				(result.data.pendingUpgrade as RuntimeCliPendingUpgradeV1 | null | undefined) ?? null,
+			),
+			badVersions: result.data.badVersions ?? [],
+			migratedFromV1: true,
+		};
+	}
+	throw new Error(`unsupported clawdi CLI upgrade transaction schema: ${String(schemaVersion)}`);
 }
 
 function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState): void {
@@ -983,9 +1430,76 @@ function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState
 
 function normalizeCliUpgradeState(state: RuntimeCliUpgradeState): RuntimeCliUpgradeState {
 	return {
-		schemaVersion: "clawdi.cliUpgradeState.v1",
-		pendingUpgrade: state.pendingUpgrade ?? null,
+		schemaVersion: "clawdi.cliUpgradeState.v2",
+		transaction: state.transaction ?? null,
 		badVersions: state.badVersions ?? [],
+	};
+}
+
+function emptyCliUpgradeState(): RuntimeCliUpgradeState {
+	return {
+		schemaVersion: "clawdi.cliUpgradeState.v2",
+		transaction: null,
+		badVersions: [],
+	};
+}
+
+function migrateV1PendingUpgrade(
+	paths: RuntimePaths,
+	pending: RuntimeCliPendingUpgradeV1 | null,
+): RuntimeCliUpgradeTransaction | null {
+	if (!pending) return null;
+	const previousStatus = pending.previousStatus;
+	const previousIdentity =
+		previousStatus?.packageSpec &&
+		pending.previousNpmPrefix &&
+		pending.previousActiveTarget &&
+		pending.previousVersion
+			? {
+					packageSpec: previousStatus.packageSpec,
+					registry: previousStatus.registry ?? null,
+					npmPrefix: pending.previousNpmPrefix,
+					activeTarget: pending.previousActiveTarget,
+					version: pending.previousVersion,
+				}
+			: null;
+	const newIdentity: RuntimeCliInstallIdentity = {
+		packageSpec: pending.packageSpec,
+		registry: pending.registry ?? null,
+		npmPrefix: pending.npmPrefix,
+		activeTarget: pending.activeTarget,
+		version: pending.version,
+	};
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	let phase: RuntimeCliUpgradeTransaction["phase"];
+	if (activeTarget === newIdentity.activeTarget) {
+		if (!verifyStoredCliIdentity(paths, newIdentity)) {
+			if (!previousIdentity || !verifyStoredCliIdentity(paths, previousIdentity)) {
+				throw new Error("legacy clawdi CLI upgrade has no verified recoverable identity");
+			}
+		}
+		if (
+			pending.rollbackEligible &&
+			(!previousIdentity || !verifyStoredCliIdentity(paths, previousIdentity))
+		) {
+			throw new Error("legacy clawdi CLI upgrade has an unverified previous identity");
+		}
+		phase = "activated";
+	} else if (previousIdentity && activeTarget === previousIdentity.activeTarget) {
+		if (!verifyStoredCliIdentity(paths, previousIdentity)) {
+			throw new Error("legacy clawdi CLI upgrade previous identity failed verification");
+		}
+		phase = "prepared";
+	} else {
+		throw new Error("legacy clawdi CLI upgrade does not match the real active link");
+	}
+	return {
+		phase,
+		previousIdentity,
+		newIdentity,
+		rollbackEligible: pending.rollbackEligible && previousIdentity !== null,
+		installedAt: pending.installedAt,
+		rollback: null,
 	};
 }
 
@@ -1001,28 +1515,6 @@ function upsertBadVersion(
 	);
 	next.push(entry);
 	return next;
-}
-
-function pendingMatchesManifestIdentity(
-	pending: RuntimeCliPendingUpgrade,
-	manifestIdentity: RuntimeCliManifestIdentity,
-): boolean {
-	if (
-		pending.manifestEtag &&
-		manifestIdentity.etag &&
-		pending.manifestEtag !== manifestIdentity.etag
-	) {
-		return false;
-	}
-	if (
-		pending.manifestGeneration !== null &&
-		manifestIdentity.generation !== undefined &&
-		manifestIdentity.generation !== null &&
-		pending.manifestGeneration !== manifestIdentity.generation
-	) {
-		return false;
-	}
-	return true;
 }
 
 function isExecutable(path: string): boolean {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -36,6 +36,8 @@ import {
 } from "../src/runtime/channels";
 import {
 	applyRuntimeCliDesiredState,
+	completePendingRuntimeCliUpgrade,
+	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../src/runtime/cli-update";
 import {
@@ -170,6 +172,10 @@ if [ "\${1:-}" = "--version" ]; then
   echo "${version}"
   exit 0
 fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
 echo "seeded clawdi"
 `,
 	);
@@ -193,6 +199,194 @@ echo "seeded clawdi"
 			error: null,
 		}),
 	);
+}
+
+interface RuntimeCliFixtureIdentity {
+	packageSpec: string;
+	registry: string | null;
+	npmPrefix: string;
+	activeTarget: string;
+	version: string;
+}
+
+function currentCliFixtureIdentity(
+	paths: RuntimePaths,
+	version: string,
+): RuntimeCliFixtureIdentity {
+	return {
+		packageSpec: `clawdi@${version}`,
+		registry: null,
+		npmPrefix: paths.cliNpmPrefix,
+		activeTarget: join(paths.cliNpmPrefix, "bin", "clawdi"),
+		version,
+	};
+}
+
+function createVersionedCliFixture(
+	paths: RuntimePaths,
+	version: string,
+): RuntimeCliFixtureIdentity {
+	const npmPrefix = join(paths.cliNpmPrefix, "packages", version);
+	const activeTarget = join(npmPrefix, "bin", "clawdi");
+	mkdirSync(dirname(activeTarget), { recursive: true });
+	writeFileSync(
+		activeTarget,
+		`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${version}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+`,
+		{ mode: 0o700 },
+	);
+	chmodSync(activeTarget, 0o700);
+	return {
+		packageSpec: `clawdi@${version}`,
+		registry: null,
+		npmPrefix,
+		activeTarget,
+		version,
+	};
+}
+
+function pointManagedCliAt(paths: RuntimePaths, identity: RuntimeCliFixtureIdentity): void {
+	mkdirSync(dirname(paths.cliManagedBin), { recursive: true });
+	rmSync(paths.cliManagedBin, { force: true });
+	symlinkSync(identity.activeTarget, paths.cliManagedBin);
+}
+
+function writeCliBootstrapFixture(paths: RuntimePaths, identity: RuntimeCliFixtureIdentity): void {
+	mkdirSync(dirname(paths.cliBootstrapStatus), { recursive: true });
+	writeFileSync(
+		paths.cliBootstrapStatus,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+			generatedAt: "2026-07-29T00:00:00.000Z",
+			status: "installed",
+			source: "npm",
+			packageSpec: identity.packageSpec,
+			registry: identity.registry,
+			npmPrefix: identity.npmPrefix,
+			npmCache: paths.cliNpmCache,
+			activePath: paths.cliManagedBin,
+			activeTarget: identity.activeTarget,
+			version: identity.version,
+			error: null,
+		})}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+function writeCliTransactionFixture(
+	paths: RuntimePaths,
+	input: {
+		phase: "prepared" | "activated";
+		previousIdentity: RuntimeCliFixtureIdentity;
+		newIdentity: RuntimeCliFixtureIdentity;
+		rollbackReason?: string;
+		badVersions?: Array<{ version: string; reason: string }>;
+	},
+): void {
+	mkdirSync(dirname(paths.cliUpgradeState), { recursive: true });
+	writeFileSync(
+		paths.cliUpgradeState,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.cliUpgradeState.v2",
+			transaction: {
+				phase: input.phase,
+				previousIdentity: input.previousIdentity,
+				newIdentity: input.newIdentity,
+				rollbackEligible: true,
+				installedAt: "2026-07-29T00:00:00.000Z",
+				rollback: input.rollbackReason
+					? {
+							reason: input.rollbackReason,
+							markedAt: "2026-07-29T00:01:00.000Z",
+						}
+					: null,
+			},
+			badVersions: (input.badVersions ?? []).map((entry) => ({
+				packageSpec: input.newIdentity.packageSpec,
+				registry: input.newIdentity.registry,
+				version: entry.version,
+				reason: entry.reason,
+				markedAt: "2026-07-29T00:02:00.000Z",
+			})),
+		})}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+function seedCliRecoveryFixture(state: string, run: string) {
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_SERVICE_STATE_DIR = state;
+	process.env.CLAWDI_RUN_DIR = run;
+	seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+	const paths = getRuntimePaths();
+	return {
+		paths,
+		previousIdentity: currentCliFixtureIdentity(paths, "0.13.30"),
+		newIdentity: createVersionedCliFixture(paths, "0.13.31"),
+	};
+}
+
+function installVersionedCliNpmStub(bin: string): void {
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(
+		join(bin, "npm"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+package=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  case "$1" in clawdi@*) package="$1" ;; esac
+  shift
+done
+version="\${package#clawdi@}"
+test -n "$prefix"
+test -n "$version"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<SH
+#!/usr/bin/env bash
+if [ "\\\${1:-}" = "--version" ]; then
+  echo "$version"
+  exit 0
+fi
+if [ "\\\${1:-} \\\${2:-} \\\${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+	);
+	chmodSync(join(bin, "npm"), 0o700);
+}
+
+function cliManifest(version: string): RuntimeManifest {
+	return {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "dep_cli_transaction",
+		environmentId: "env_cli_transaction",
+		instanceId: "iid_cli_transaction",
+		generation: 1,
+		issuedAt: "2026-07-29T00:00:00Z",
+		controlPlane: { apiUrl: "https://cloud-api.test" },
+		clawdiCli: { source: "npm:clawdi", packageSpec: `clawdi@${version}` },
+		runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+		recovery: {},
+	};
 }
 
 const TEST_EGRESS_ENGINE_PIN = {
@@ -7274,7 +7468,11 @@ chmod +x "$prefix/bin/clawdi"
 		mkdirSync(dirname(legacyImageShim), { recursive: true });
 		writeFileSync(
 			activeTarget,
-			`#!/usr/bin/env bash\nif [ "\${1:-}" = "--version" ]; then echo "${version}"; exit 0; fi\nexit 64\n`,
+			`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo "${version}"; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
 		);
 		writeFileSync(legacyImageShim, "#!/usr/bin/env bash\nexit 0\n");
 		chmodSync(activeTarget, 0o755);
@@ -7937,6 +8135,365 @@ chmod +x "$prefix/bin/clawdi"
 			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("cancels a prepared CLI transaction while the previous target is still active", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-prepared-previous"),
+			join(root, "run-cli-prepared-previous"),
+		);
+		pointManagedCliAt(paths, previousIdentity);
+		writeCliBootstrapFixture(paths, previousIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "prepared",
+			previousIdentity,
+			newIdentity,
+		});
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
+
+		expect(recovered).toEqual({ status: "unchanged", selfReexec: false });
+		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
+		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")).transaction).toBeNull();
+		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
+	});
+
+	it("activates a prepared CLI transaction whose valid new target is already active", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-prepared-new"),
+			join(root, "run-cli-prepared-new"),
+		);
+		pointManagedCliAt(paths, newIdentity);
+		writeCliBootstrapFixture(paths, previousIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "prepared",
+			previousIdentity,
+			newIdentity,
+		});
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
+		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		expect(recovered).toEqual({ status: "activated", selfReexec: true });
+		expect(transactionState.transaction).toMatchObject({
+			phase: "activated",
+			newIdentity,
+		});
+		expect(bootstrap).toMatchObject({
+			activeTarget: newIdentity.activeTarget,
+			version: newIdentity.version,
+		});
+		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
+	});
+
+	it("rolls back an activated CLI transaction whose new target is invalid", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-activated-invalid"),
+			join(root, "run-cli-activated-invalid"),
+		);
+		pointManagedCliAt(paths, newIdentity);
+		writeCliBootstrapFixture(paths, newIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity,
+		});
+		writeFileSync(newIdentity.activeTarget, "#!/usr/bin/env bash\nexit 1\n", { mode: 0o700 });
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
+		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+
+		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
+		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
+		expect(transactionState.transaction).toBeNull();
+		expect(transactionState.badVersions).toContainEqual(
+			expect.objectContaining({ version: newIdentity.version }),
+		);
+	});
+
+	it("finishes a durable rollback intent while the new target is still active", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-rollback-new"),
+			join(root, "run-cli-rollback-new"),
+		);
+		pointManagedCliAt(paths, newIdentity);
+		writeCliBootstrapFixture(paths, newIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity,
+			rollbackReason: "fixture convergence failure",
+		});
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
+		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+
+		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
+		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
+		expect(transactionState.transaction).toBeNull();
+		expect(transactionState.badVersions).toContainEqual(
+			expect.objectContaining({
+				version: newIdentity.version,
+				reason: "fixture convergence failure",
+			}),
+		);
+		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
+	});
+
+	it("finishes rollback journal, status, and pruning when the previous target is active", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-rollback-previous"),
+			join(root, "run-cli-rollback-previous"),
+		);
+		pointManagedCliAt(paths, previousIdentity);
+		writeCliBootstrapFixture(paths, newIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity,
+			rollbackReason: "fixture convergence failure",
+		});
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
+		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
+		expect(transactionState.transaction).toBeNull();
+		expect(bootstrap).toMatchObject({
+			activeTarget: previousIdentity.activeTarget,
+			version: previousIdentity.version,
+		});
+		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
+	});
+
+	it("re-verifies a current CLI periodically and whenever its file identity drifts", () => {
+		const state = join(root, "state-cli-verification-cache");
+		const run = join(root, "run-cli-verification-cache");
+		const commandLog = join(root, "cli-verification-cache.log");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		writeFileSync(
+			activeTarget,
+			`#!/usr/bin/env bash
+printf '%s\\n' "$*" >> '${commandLog}'
+if [ "\${1:-}" = "--version" ]; then echo '0.13.30'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+		);
+		chmodSync(activeTarget, 0o700);
+		const manifest = cliManifest("0.13.30");
+
+		applyRuntimeCliDesiredState(manifest, paths);
+		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(2);
+		applyRuntimeCliDesiredState(manifest, paths);
+		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(2);
+
+		const driftedAt = new Date(Date.now() + 1_000);
+		utimesSync(activeTarget, driftedAt, driftedAt);
+		applyRuntimeCliDesiredState(manifest, paths);
+		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(4);
+
+		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		status.verification.verifiedAt = "2020-01-01T00:00:00.000Z";
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(status));
+		applyRuntimeCliDesiredState(manifest, paths);
+		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(6);
+	});
+
+	it("does not cache a changed target as the verified desired CLI", () => {
+		const state = join(root, "state-cli-verification-race");
+		const run = join(root, "run-cli-verification-race");
+		const bin = join(root, "bin-cli-verification-race");
+		const previousPath = process.env.PATH;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\nexit 97\n");
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		writeFileSync(
+			activeTarget,
+			`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  cat > "$0" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo '0.13.29'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+SH
+  chmod +x "$0"
+  echo '0.13.30'
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+		);
+		chmodSync(activeTarget, 0o700);
+
+		try {
+			expect(() => applyRuntimeCliDesiredState(cliManifest("0.13.30"), paths)).toThrow(
+				/npm install/,
+			);
+			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+			expect(status.packageSpec).toBe("clawdi@0.13.29");
+			expect(status.version).toBe("0.13.29");
+			expect(status.verification).toBeDefined();
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("fails closed on a corrupt CLI transaction journal before install or prune", () => {
+		const state = join(root, "state-cli-corrupt-journal");
+		const run = join(root, "run-cli-corrupt-journal");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const lastGood = join(paths.cliNpmPrefix, "packages", "0.13.29", "bin", "clawdi");
+		mkdirSync(dirname(lastGood), { recursive: true });
+		writeFileSync(lastGood, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(lastGood, 0o700);
+		writeFileSync(paths.cliUpgradeState, "{broken journal");
+
+		expect(() => applyRuntimeCliDesiredState(cliManifest("0.13.31"), paths)).toThrow(
+			/invalid clawdi CLI upgrade transaction JSON/,
+		);
+		expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+		expect(existsSync(lastGood)).toBe(true);
+		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe("{broken journal");
+	});
+
+	it("migrates v1 pending state and confirms by CLI identity across manifest changes", () => {
+		const state = join(root, "state-cli-v1-migration");
+		const run = join(root, "run-cli-v1-migration");
+		const bin = join(root, "bin-cli-v1-migration");
+		const previousPath = process.env.PATH;
+		installVersionedCliNpmStub(bin);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+		const paths = getRuntimePaths();
+
+		try {
+			applyRuntimeCliDesiredState(cliManifest("0.13.31"), paths, { rollbackEligible: true });
+			const v2 = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			const transaction = v2.transaction;
+			writeFileSync(
+				paths.cliUpgradeState,
+				JSON.stringify({
+					schemaVersion: "clawdi.cliUpgradeState.v1",
+					pendingUpgrade: {
+						...transaction.newIdentity,
+						previousStatus: {
+							status: "installed",
+							source: "npm",
+							activePath: paths.cliManagedBin,
+							...transaction.previousIdentity,
+						},
+						previousActiveTarget: transaction.previousIdentity.activeTarget,
+						previousNpmPrefix: transaction.previousIdentity.npmPrefix,
+						previousVersion: transaction.previousIdentity.version,
+						manifestGeneration: 1,
+						manifestEtag: '"obsolete-etag"',
+						rollbackEligible: true,
+						installedAt: transaction.installedAt,
+					},
+					badVersions: [],
+				}),
+			);
+
+			completePendingRuntimeCliUpgrade(paths, "0.13.30");
+			const migrated = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			expect(migrated.schemaVersion).toBe("clawdi.cliUpgradeState.v2");
+			expect(migrated.transaction.newIdentity.version).toBe("0.13.31");
+
+			completePendingRuntimeCliUpgrade(paths, "0.13.31");
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")).transaction).toBeNull();
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("fails closed when a v1 rollback identity does not verify", () => {
+		const state = join(root, "state-cli-v1-invalid-identity");
+		const run = join(root, "run-cli-v1-invalid-identity");
+		const bin = join(root, "bin-cli-v1-invalid-identity");
+		const previousPath = process.env.PATH;
+		installVersionedCliNpmStub(bin);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.30", "0.13.30");
+		const paths = getRuntimePaths();
+
+		try {
+			applyRuntimeCliDesiredState(cliManifest("0.13.31"), paths, { rollbackEligible: true });
+			const v2 = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			const transaction = v2.transaction;
+			writeFileSync(
+				transaction.previousIdentity.activeTarget,
+				`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo '0.13.29'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			);
+			chmodSync(transaction.previousIdentity.activeTarget, 0o700);
+			writeFileSync(
+				paths.cliUpgradeState,
+				JSON.stringify({
+					schemaVersion: "clawdi.cliUpgradeState.v1",
+					pendingUpgrade: {
+						...transaction.newIdentity,
+						previousStatus: {
+							status: "installed",
+							source: "npm",
+							activePath: paths.cliManagedBin,
+							...transaction.previousIdentity,
+						},
+						previousActiveTarget: transaction.previousIdentity.activeTarget,
+						previousNpmPrefix: transaction.previousIdentity.npmPrefix,
+						previousVersion: transaction.previousIdentity.version,
+						manifestGeneration: 1,
+						manifestEtag: '"obsolete-etag"',
+						rollbackEligible: true,
+						installedAt: transaction.installedAt,
+					},
+					badVersions: [],
+				}),
+			);
+
+			expect(() => completePendingRuntimeCliUpgrade(paths, "0.13.31")).toThrow(
+				/unverified previous identity/,
+			);
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")).schemaVersion).toBe(
+				"clawdi.cliUpgradeState.v1",
+			);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(transaction.newIdentity.activeTarget);
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
@@ -8682,7 +9239,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.selfReexec).toBe(true);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
 			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(upgradeState.pendingUpgrade).toBeNull();
+			expect(upgradeState.transaction).toBeNull();
 			expect(upgradeState.badVersions).toContainEqual(
 				expect.objectContaining({
 					packageSpec: "clawdi@0.13.5-beta.0",
@@ -9304,32 +9861,33 @@ chmod +x "$prefix/bin/clawdi"
 
 		try {
 			const first = applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.0"), paths, {
-				manifestIdentity,
+				rollbackEligible: manifestIdentity.previouslyApplied,
 			});
 			if (!first.activeTarget) throw new Error("first CLI install has no active target");
 			const lastGoodTarget = first.activeTarget;
 			const lastGoodPrefix = first.npmPrefix;
 			const firstState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(firstState.pendingUpgrade.rollbackEligible).toBe(false);
+			expect(firstState.transaction.rollbackEligible).toBe(false);
 
 			rmSync(paths.cliBootstrapStatus, { force: true });
 			const failed = applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.1"), paths, {
-				manifestIdentity,
+				rollbackEligible: manifestIdentity.previouslyApplied,
 			});
 			if (!failed.activeTarget) throw new Error("failed CLI install has no active target");
 			const failedTarget = failed.activeTarget;
 			const failedState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(failedState.pendingUpgrade).toMatchObject({
+			expect(failedState.transaction).toMatchObject({
 				rollbackEligible: true,
-				previousActiveTarget: lastGoodTarget,
-				previousNpmPrefix: lastGoodPrefix,
-				previousVersion: "0.13.20-beta.0",
+				previousIdentity: {
+					activeTarget: lastGoodTarget,
+					npmPrefix: lastGoodPrefix,
+					version: "0.13.20-beta.0",
+				},
 			});
 
 			const firstRollback = rollbackPendingRuntimeCliUpgrade(
 				paths,
 				"injected first converge failure",
-				manifestIdentity,
 			);
 			expect(firstRollback.status).toBe("rolled_back");
 			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);
@@ -9343,17 +9901,16 @@ chmod +x "$prefix/bin/clawdi"
 			});
 
 			applyRuntimeCliDesiredState(manifestFor("0.13.20-beta.2"), paths, {
-				manifestIdentity,
+				rollbackEligible: manifestIdentity.previouslyApplied,
 			});
 			const secondState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(secondState.pendingUpgrade.previousActiveTarget).toBe(lastGoodTarget);
-			expect(secondState.pendingUpgrade.previousActiveTarget).not.toBe(failedTarget);
+			expect(secondState.transaction.previousIdentity.activeTarget).toBe(lastGoodTarget);
+			expect(secondState.transaction.previousIdentity.activeTarget).not.toBe(failedTarget);
 			expect(existsSync(lastGoodPrefix)).toBe(true);
 
 			const secondRollback = rollbackPendingRuntimeCliUpgrade(
 				paths,
 				"injected second converge failure",
-				manifestIdentity,
 			);
 			expect(secondRollback.status).toBe("rolled_back");
 			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -85,6 +85,8 @@ describe("CLI smoke — src entry", () => {
 			const parsed = JSON.parse(stdout);
 			expect(parsed.schemaVersion).toBe("clawdi.capabilities.v1");
 			expect(parsed.commands).toContain("runtime");
+			expect(parsed.commands).toContain("deploy");
+			expect(parsed.commands).toContain("channel");
 			expect(parsed.updateMode).toBe("local-self-update");
 		} finally {
 			rmSync(fakeHome, { recursive: true, force: true });
@@ -305,7 +307,14 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 `,
 		);
 		chmodSync(installer, 0o700);
-		writeFileSync(managedCliTarget, "#!/usr/bin/env sh\nexit 0\n");
+		writeFileSync(
+			managedCliTarget,
+			`#!/usr/bin/env sh
+if [ "\${1:-}" = "--version" ]; then echo '0.12.10-beta.57'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+		);
 		chmodSync(managedCliTarget, 0o700);
 		symlinkSync(managedCliTarget, managedCli);
 		writeFileSync(


### PR DESCRIPTION
## Summary

- make Hosted exact-version CLI upgrades a durable prepared/activated transaction
- reconcile observable on-disk phases, verification status, rollback intent, and v1 state
- derive the capability command catalog from the registered CLI surface

## Boundary

This is stack layer 2 of 5. Recovery tests construct durable journal, link, prefix, and status fixtures directly. Production has no faultInjection, mutation-point hook, environment test mode, or native behavior.

## Verification

- Docker clean runner: full CLI typecheck and 1304 tests passed
- Docker Biome: 759 files passed
- `git diff --check 61a98713..c2e41a4c` passed

Base is stack layer 1. Merge before release recovery, daemon lifecycle, and native distribution PR #556.