### PR TITLE
fix(cli): recover incomplete CLI releases

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -23,10 +23,12 @@ jobs:
     permissions:
       contents: read
     outputs:
-      should_publish: ${{ steps.check.outputs.should_publish }}
+      should_release: ${{ steps.check.outputs.should_release }}
       version: ${{ steps.check.outputs.version }}
       npm_tag: ${{ steps.check.outputs.npm_tag }}
+      npm_action: ${{ steps.check.outputs.npm_action }}
       cli_tarball_filename: ${{ steps.check.outputs.cli_tarball_filename }}
+      source_commit: ${{ steps.check.outputs.source_commit }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,33 +43,110 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Check whether the exact version needs publishing
+      - name: Check whether the exact release needs completing
         id: check
         working-directory: packages/cli
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          package_name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
-          npm_tag=$(node -e "const p=require('./package.json'); console.log(p.version.includes('-') ? 'beta' : 'latest')")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
-          echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"
+          tag="clawdi-cli-v$version"
+          npm_exists=false
+          published_integrity=""
+          attestations=""
+          attestation_bundle=""
           if npm view "clawdi@$version" version >/dev/null 2>&1; then
-            echo "clawdi@$version already exists on npm"
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            npm_exists=true
+            published_integrity=$(npm view "clawdi@$version" dist.integrity)
+            attestations=$(npm view "clawdi@$version" dist.attestations --json)
+            attestation_url=$(ATTESTATIONS="$attestations" node - <<'NODE'
+          const attestations = JSON.parse(process.env.ATTESTATIONS);
+          const url = new URL(attestations.url);
+          if (url.origin !== "https://registry.npmjs.org") process.exit(1);
+          console.log(attestations.url);
+          NODE
+            )
+            attestation_bundle=$(curl --fail --silent --show-error --location "$attestation_url")
           fi
+          release_json=null
+          if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish,assets 2>/dev/null); then
+            release_json="$existing_release"
+          fi
+          tag_commit=null
+          if resolved_tag=$(git rev-list -n 1 "$tag" 2>/dev/null); then
+            tag_commit="\"$resolved_tag\""
+          fi
+          recovery_input=$(PACKAGE_NAME="$package_name" VERSION="$version" NPM_EXISTS="$npm_exists" \
+            PUBLISHED_INTEGRITY="$published_integrity" ATTESTATIONS="$attestations" \
+            ATTESTATION_BUNDLE="$attestation_bundle" RELEASE_JSON="$release_json" \
+            TAG_COMMIT="$tag_commit" node - <<'NODE'
+          const npm = process.env.NPM_EXISTS === "true"
+            ? {
+                exists: true,
+                distIntegrity: process.env.PUBLISHED_INTEGRITY,
+                attestations: JSON.parse(process.env.ATTESTATIONS),
+                attestationBundle: JSON.parse(process.env.ATTESTATION_BUNDLE),
+              }
+            : { exists: false };
+          console.log(JSON.stringify({
+            schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+            mode: "plan",
+            package: { name: process.env.PACKAGE_NAME, version: process.env.VERSION },
+            repository: {
+              url: `https://github.com/${process.env.GITHUB_REPOSITORY}`,
+              workflowPath: ".github/workflows/cli-publish.yml",
+            },
+            currentCommit: process.env.GITHUB_SHA,
+            requiredAssets: [
+              "clawdi-cli-linux-x64.tar.gz",
+              "clawdi-cli-linux-x64.tar.gz.sha256",
+            ],
+            npm,
+            github: {
+              release: JSON.parse(process.env.RELEASE_JSON),
+              tagCommit: JSON.parse(process.env.TAG_COMMIT),
+            },
+          }));
+          NODE
+          )
+          recovery=$(node scripts/release-recovery.mjs <<< "$recovery_input")
+          RECOVERY="$recovery" node - <<'NODE'
+          const fs = require("node:fs");
+          const decision = JSON.parse(process.env.RECOVERY);
+          const outputs = {
+            should_release: decision.shouldRelease,
+            version: decision.version,
+            npm_tag: decision.npmTag,
+            npm_action: decision.npmAction,
+            cli_tarball_filename: decision.tarballFilename,
+            source_commit: decision.sourceCommit,
+          };
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, Object.entries(outputs)
+            .map(([key, value]) => `${key}=${value}\n`).join(""));
+          NODE
+
+      - name: Checkout immutable CLI source
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          SOURCE_COMMIT: ${{ steps.check.outputs.source_commit }}
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          git cat-file -e "$SOURCE_COMMIT^{commit}"
+          git checkout --detach "$SOURCE_COMMIT"
+          test "$(node -p "require('./packages/cli/package.json').version")" = "$VERSION"
 
       - name: Install workspace dependencies
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         run: bun install --frozen-lockfile
 
       - name: Typecheck
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: bun run typecheck
 
       - name: Build package and standalone binary
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: |
           bun run build
@@ -76,12 +155,12 @@ jobs:
           bun run package:binary-release
 
       - name: Test
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: bun test --isolate --max-concurrency=1
 
       - name: Pack and verify immutable release artifact
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: |
           node scripts/check-publish-manifest.mjs
@@ -103,7 +182,7 @@ jobs:
           "$install_dir/node_modules/.bin/clawdi" --version
 
       - name: Upload immutable CLI release artifact
-        if: steps.check.outputs.should_publish == 'true'
+        if: steps.check.outputs.should_release == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CLI_ARTIFACT_NAME }}
@@ -112,7 +191,7 @@ jobs:
           retention-days: 7
 
   publish-immutable-artifact-with-oidc:
-    if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
+    if: needs['build-immutable-artifact'].outputs.should_release == 'true'
     needs: build-immutable-artifact
     # npm trusted publishing supports GitHub-hosted runners, not self-hosted runners.
     runs-on: ubuntu-latest
@@ -159,17 +238,103 @@ jobs:
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).name)" <<< "$manifest")" = "clawdi"
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).version)" <<< "$manifest")" = "$VERSION"
 
-      - name: Publish immutable tarball
+      - name: Publish or verify immutable tarball
+        id: publish
         env:
+          GH_TOKEN: ${{ github.token }}
           CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
           NPM_TAG: ${{ needs['build-immutable-artifact'].outputs.npm_tag }}
-        run: npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
+          NPM_ACTION: ${{ needs['build-immutable-artifact'].outputs.npm_action }}
+          VERSION: ${{ needs['build-immutable-artifact'].outputs.version }}
+          SOURCE_COMMIT: ${{ needs['build-immutable-artifact'].outputs.source_commit }}
+        run: |
+          local_integrity=$(node -e 'const { createHash }=require("node:crypto"); const { readFileSync }=require("node:fs"); console.log(`sha512-${createHash("sha512").update(readFileSync(process.argv[1])).digest("base64")}`)' "./release/$CLI_TARBALL_FILENAME")
+          local_sha512=$(node -e 'const { createHash }=require("node:crypto"); const { readFileSync }=require("node:fs"); console.log(createHash("sha512").update(readFileSync(process.argv[1])).digest("hex"))' "./release/$CLI_TARBALL_FILENAME")
+          case "$NPM_ACTION" in
+            publish)
+              npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
+              ;;
+            verify) ;;
+            *)
+              echo "unsupported npm recovery action: $NPM_ACTION" >&2
+              exit 64
+              ;;
+          esac
+          published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)
+          attestations=$(npm view "clawdi@$VERSION" dist.attestations --json)
+          attestation_url=$(ATTESTATIONS="$attestations" node - <<'NODE'
+          const attestations = JSON.parse(process.env.ATTESTATIONS);
+          const url = new URL(attestations.url);
+          if (url.origin !== "https://registry.npmjs.org") process.exit(1);
+          console.log(attestations.url);
+          NODE
+          )
+          attestation_bundle=$(curl --fail --silent --show-error --location "$attestation_url")
+          tag="clawdi-cli-v$VERSION"
+          release_json=null
+          if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish,assets 2>/dev/null); then
+            release_json="$existing_release"
+          fi
+          tag_commit=null
+          if resolved_tag=$(git rev-list -n 1 "$tag" 2>/dev/null); then
+            tag_commit="\"$resolved_tag\""
+          fi
+          recovery_input=$(PUBLISHED_INTEGRITY="$published_integrity" ATTESTATIONS="$attestations" \
+            ATTESTATION_BUNDLE="$attestation_bundle" LOCAL_INTEGRITY="$local_integrity" \
+            LOCAL_SHA512="$local_sha512" RELEASE_JSON="$release_json" TAG_COMMIT="$tag_commit" \
+            node - <<'NODE'
+          console.log(JSON.stringify({
+            schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+            mode: "complete",
+            package: { name: "clawdi", version: process.env.VERSION },
+            repository: {
+              url: `https://github.com/${process.env.GITHUB_REPOSITORY}`,
+              workflowPath: ".github/workflows/cli-publish.yml",
+            },
+            expectedSourceCommit: process.env.SOURCE_COMMIT,
+            requiredAssets: [
+              "clawdi-cli-linux-x64.tar.gz",
+              "clawdi-cli-linux-x64.tar.gz.sha256",
+            ],
+            localArtifact: {
+              integrity: process.env.LOCAL_INTEGRITY,
+              sha512: process.env.LOCAL_SHA512,
+            },
+            npm: {
+              exists: true,
+              distIntegrity: process.env.PUBLISHED_INTEGRITY,
+              attestations: JSON.parse(process.env.ATTESTATIONS),
+              attestationBundle: JSON.parse(process.env.ATTESTATION_BUNDLE),
+            },
+            github: {
+              release: JSON.parse(process.env.RELEASE_JSON),
+              tagCommit: JSON.parse(process.env.TAG_COMMIT),
+            },
+          }));
+          NODE
+          )
+          recovery=$(node packages/cli/scripts/release-recovery.mjs <<< "$recovery_input")
+          RECOVERY="$recovery" node - <<'NODE'
+          const fs = require("node:fs");
+          const decision = JSON.parse(process.env.RECOVERY);
+          const outputs = {
+            release_target: decision.releaseTarget,
+            release_action: decision.releaseAction,
+            finalize: decision.finalize,
+          };
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, Object.entries(outputs)
+            .map(([key, value]) => `${key}=${value}\n`).join(""));
+          NODE
 
       - name: Create GitHub release
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs['build-immutable-artifact'].outputs.version }}
           NPM_TAG: ${{ needs['build-immutable-artifact'].outputs.npm_tag }}
+          RELEASE_TARGET: ${{ steps.publish.outputs.release_target }}
+          RELEASE_ACTION: ${{ steps.publish.outputs.release_action }}
+          FINALIZE_RELEASE: ${{ steps.publish.outputs.finalize }}
         run: |
           tag="clawdi-cli-v$VERSION"
           previous=$(git tag --list 'clawdi-cli-v*' --sort=-version:refname | grep -Fxv "$tag" | head -n 1 || true)
@@ -187,21 +352,32 @@ jobs:
           \`clawdi-YYYY-MM-DD[-N]\` releases.
           EOF
           )
-          if gh release view "$tag" >/dev/null 2>&1; then
+          if [ "$RELEASE_ACTION" = "resume-draft" ]; then
             gh release upload "$tag" \
               release/clawdi-cli-linux-x64.tar.gz \
               release/clawdi-cli-linux-x64.tar.gz.sha256 \
               --clobber
+            if [ "$FINALIZE_RELEASE" = true ]; then
+              gh release edit "$tag" --draft=false
+            fi
             exit 0
+          fi
+          if [ "$RELEASE_ACTION" = "none" ]; then
+            exit 0
+          fi
+          if [ "$RELEASE_ACTION" != "create-draft" ]; then
+            echo "unsupported GitHub release recovery action: $RELEASE_ACTION" >&2
+            exit 64
           fi
           args=(
             release create "$tag"
             release/clawdi-cli-linux-x64.tar.gz
             release/clawdi-cli-linux-x64.tar.gz.sha256
-            --target "$GITHUB_SHA"
+            --target "$RELEASE_TARGET"
             --title "Clawdi CLI v$VERSION"
             --notes "$notes"
             --generate-notes
+            --draft
             --latest=false
           )
           case "$NPM_TAG" in
@@ -218,3 +394,6 @@ jobs:
             args+=(--notes-start-tag "$previous")
           fi
           gh "${args[@]}"
+          if [ "$FINALIZE_RELEASE" = true ]; then
+            gh release edit "$tag" --draft=false
+          fi

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -371,7 +371,15 @@ onward releases are automatic.
    one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
    from GitHub-hosted `ubuntu-latest` with
    `npm publish <tarball> --access public --provenance --ignore-scripts --tag <resolved-tag>`.
-4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
+   If npm already has the exact version but its GitHub Release is incomplete,
+   a rerun checks out the source commit recorded by npm provenance, rebuilds the
+   tarball, compares it with npm `dist.integrity`, skips the immutable npm
+   version, and completes the release assets. The workflow passes collected npm,
+   provenance, tag, and asset facts to `scripts/release-recovery.mjs`; that
+   tested decision script fails closed before the workflow performs an action.
+4. The workflow creates or completes `clawdi-cli-v<version>` as a draft,
+   uploads the verified binary assets, then finalizes the release with changelog
+   notes.
 5. Watch the Actions tab; on green,
    `npm view clawdi@<exact-version> version` reflects the new number. A
    prerelease updates `beta`; a stable release updates `latest`.
@@ -380,8 +388,8 @@ Stop here for this release workflow. Hosted rollout selects the approved exact
 version through its Cloud manifest. The `beta` tag is publication metadata;
 production and Hosted never resolve an npm dist-tag.
 
-A manual run is available under `workflow_dispatch` if the auto-run
-needs a nudge (e.g. npm was transiently unavailable).
+A manual run is available under `workflow_dispatch` if the auto-run needs a
+nudge (for example, npm succeeded but GitHub Release creation failed).
 
 ### Smoke checks before bumping the version
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -83,7 +83,12 @@ releases.
    GitHub-hosted `ubuntu-latest`, because npm trusted publishing does not support
    self-hosted or third-party GitHub Actions runners. The CLI workflow does not
    call workflows in the Hosted repository or depend on Hosted repository
-   settings.
+   settings. A rerun after npm succeeds but GitHub Release creation fails
+   checks out the source commit recorded by npm provenance, rebuilds the same
+   artifact, verifies its npm `dist.integrity`, skips republishing the immutable
+   npm version, and completes the draft release before finalization. Recovery
+   decisions come from `packages/cli/scripts/release-recovery.mjs`; the workflow
+   only gathers external facts and executes the validated action.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -98,8 +103,9 @@ releases.
      only after the deployed commit should get public app/backend/web release
      notes.
    - `.github/workflows/cli-publish.yml` runs for `packages/cli/**` and the
-     CLI publish workflow file, then publishes only when the local CLI version
-     differs from npm.
+     CLI publish workflow file. It publishes when the exact npm version is
+     absent, or rebuilds and verifies that version to complete an unfinished
+     GitHub Release.
 3. For CLI releases, verify npm after the workflow succeeds:
 
    ```bash

--- a/packages/cli/scripts/release-recovery.mjs
+++ b/packages/cli/scripts/release-recovery.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+const INPUT_SCHEMA = "clawdi.cliReleaseRecoveryInput.v1";
+const OUTPUT_SCHEMA = "clawdi.cliReleaseRecoveryOutput.v1";
+const PROVENANCE_PREDICATE = "https://slsa.dev/provenance/v1";
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const SEMVER_PATTERN =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const GITHUB_REPOSITORY_PATTERN =
+	/^https:\/\/github\.com\/[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]+$/;
+
+class ReleaseRecoveryError extends Error {
+	constructor(code, message) {
+		super(message);
+		this.code = code;
+	}
+}
+
+function fail(code, message) {
+	throw new ReleaseRecoveryError(code, message);
+}
+
+function object(value, label) {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		fail("INVALID_INPUT", `${label} must be an object`);
+	}
+	return value;
+}
+
+function string(value, label) {
+	if (typeof value !== "string" || value.length === 0) {
+		fail("INVALID_INPUT", `${label} must be a non-empty string`);
+	}
+	return value;
+}
+
+function commit(value, label) {
+	const parsed = string(value, label);
+	if (!COMMIT_PATTERN.test(parsed)) {
+		fail("INVALID_COMMIT", `${label} must be a lowercase 40-character Git commit`);
+	}
+	return parsed;
+}
+
+function packageInput(value) {
+	const parsed = object(value, "package");
+	const name = string(parsed.name, "package.name");
+	const version = string(parsed.version, "package.version");
+	if (name !== "clawdi") fail("INVALID_PACKAGE", "package.name must be clawdi");
+	if (!SEMVER_PATTERN.test(version)) {
+		fail("INVALID_VERSION", "package.version must be an exact semantic version");
+	}
+	return { name, version };
+}
+
+function repositoryInput(value) {
+	const parsed = object(value, "repository");
+	const url = string(parsed.url, "repository.url");
+	const workflowPath = string(parsed.workflowPath, "repository.workflowPath");
+	if (!GITHUB_REPOSITORY_PATTERN.test(url)) {
+		fail("INVALID_REPOSITORY", "repository.url must be a canonical GitHub HTTPS URL");
+	}
+	if (!workflowPath.startsWith(".github/workflows/") || !workflowPath.endsWith(".yml")) {
+		fail("INVALID_WORKFLOW", "repository.workflowPath must name a YAML workflow");
+	}
+	return { url, workflowPath };
+}
+
+function requiredAssetsInput(value) {
+	if (!Array.isArray(value) || value.length === 0) {
+		fail("INVALID_ASSETS", "requiredAssets must be a non-empty array");
+	}
+	const assets = value.map((entry, index) => string(entry, `requiredAssets[${index}]`));
+	if (new Set(assets).size !== assets.length) {
+		fail("DUPLICATE_ASSET", "requiredAssets contains duplicate names");
+	}
+	return assets;
+}
+
+function integrityDigest(integrity, label) {
+	const parsed = string(integrity, label);
+	const match = /^sha512-([A-Za-z0-9+/]+={0,2})$/.exec(parsed);
+	if (!match) fail("INVALID_INTEGRITY", `${label} must be a sha512 SRI value`);
+	const digest = Buffer.from(match[1], "base64");
+	if (digest.length !== 64 || digest.toString("base64") !== match[1]) {
+		fail("INVALID_INTEGRITY", `${label} must contain one canonical SHA-512 digest`);
+	}
+	return { integrity: parsed, hex: digest.toString("hex") };
+}
+
+function npmInput(value) {
+	const parsed = object(value, "npm");
+	if (typeof parsed.exists !== "boolean") {
+		fail("INVALID_INPUT", "npm.exists must be a boolean");
+	}
+	if (!parsed.exists) {
+		const extra = Object.keys(parsed).filter((key) => key !== "exists");
+		if (extra.length > 0) {
+			fail("INVALID_NPM_STATE", "npm metadata is forbidden when npm.exists is false");
+		}
+		return { exists: false };
+	}
+	return {
+		exists: true,
+		distIntegrity: string(parsed.distIntegrity, "npm.distIntegrity"),
+		attestations: object(parsed.attestations, "npm.attestations"),
+		attestationBundle: object(parsed.attestationBundle, "npm.attestationBundle"),
+	};
+}
+
+function verifyProvenance(npm, packageInfo, repository, expectedSha512) {
+	if (!npm.exists) fail("MISSING_PROVENANCE", "published npm metadata is required");
+	const published = integrityDigest(npm.distIntegrity, "npm.distIntegrity");
+	if (expectedSha512 && published.hex !== expectedSha512) {
+		fail("INTEGRITY_MISMATCH", "npm integrity does not match the local artifact");
+	}
+
+	const attestationUrl = string(npm.attestations.url, "npm.attestations.url");
+	let parsedUrl;
+	try {
+		parsedUrl = new URL(attestationUrl);
+	} catch {
+		fail("INVALID_ATTESTATION_URL", "npm attestation URL is invalid");
+	}
+	if (parsedUrl.origin !== "https://registry.npmjs.org") {
+		fail("INVALID_ATTESTATION_URL", "npm attestation URL must use the npm registry origin");
+	}
+	if (npm.attestations.provenance?.predicateType !== PROVENANCE_PREDICATE) {
+		fail("INVALID_PROVENANCE", "npm metadata does not declare SLSA provenance v1");
+	}
+
+	const entries = npm.attestationBundle.attestations;
+	if (!Array.isArray(entries)) {
+		fail("INVALID_PROVENANCE", "attestation bundle is missing attestations");
+	}
+	const matchingEntries = entries.filter((entry) => entry?.predicateType === PROVENANCE_PREDICATE);
+	if (matchingEntries.length !== 1) {
+		fail("INVALID_PROVENANCE", "attestation bundle must contain exactly one SLSA provenance entry");
+	}
+	const payload = matchingEntries[0]?.bundle?.dsseEnvelope?.payload;
+	if (typeof payload !== "string") {
+		fail("INVALID_PROVENANCE", "provenance entry is missing its DSSE payload");
+	}
+	let statement;
+	try {
+		statement = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+	} catch {
+		fail("INVALID_PROVENANCE", "provenance DSSE payload is not valid JSON");
+	}
+
+	const expectedSubject = `pkg:npm/${packageInfo.name}@${packageInfo.version}`;
+	const subjects = Array.isArray(statement.subject) ? statement.subject : [];
+	const subjectMatches = subjects.filter(
+		(subject) => subject?.name === expectedSubject && subject?.digest?.sha512 === published.hex,
+	);
+	if (subjectMatches.length !== 1) {
+		fail("SUBJECT_MISMATCH", "provenance subject does not match the published package");
+	}
+
+	const workflow = statement.predicate?.buildDefinition?.externalParameters?.workflow;
+	if (workflow?.repository !== repository.url || workflow?.path !== repository.workflowPath) {
+		fail("WORKFLOW_MISMATCH", "provenance workflow identity does not match this repository");
+	}
+	const dependencies = statement.predicate?.buildDefinition?.resolvedDependencies;
+	if (!Array.isArray(dependencies)) {
+		fail("SOURCE_COMMIT_MISSING", "provenance does not resolve repository source");
+	}
+	const prefix = `git+${repository.url}@`;
+	const sourceCommits = dependencies
+		.filter((dependency) => dependency?.uri?.startsWith(prefix))
+		.map((dependency) => dependency?.digest?.gitCommit)
+		.filter((value) => typeof value === "string");
+	const uniqueCommits = [...new Set(sourceCommits)];
+	if (uniqueCommits.length !== 1 || !COMMIT_PATTERN.test(uniqueCommits[0])) {
+		fail("SOURCE_COMMIT_INVALID", "provenance must resolve exactly one valid source commit");
+	}
+	return { sourceCommit: uniqueCommits[0], published };
+}
+
+function githubInput(value) {
+	const parsed = object(value, "github");
+	const tagCommit = parsed.tagCommit === null ? null : commit(parsed.tagCommit, "github.tagCommit");
+	if (parsed.release === null) return { release: null, tagCommit };
+	const release = object(parsed.release, "github.release");
+	if (typeof release.isDraft !== "boolean") {
+		fail("INVALID_INPUT", "github.release.isDraft must be a boolean");
+	}
+	if (!Array.isArray(release.assets)) {
+		fail("INVALID_INPUT", "github.release.assets must be an array");
+	}
+	return {
+		release: {
+			isDraft: release.isDraft,
+			targetCommitish: commit(release.targetCommitish, "github.release.targetCommitish"),
+			assets: release.assets.map((value, index) => {
+				const asset = object(value, `github.release.assets[${index}]`);
+				if (!Number.isInteger(asset.size) || asset.size < 0) {
+					fail(
+						"INVALID_ASSET",
+						`github.release.assets[${index}].size must be a non-negative integer`,
+					);
+				}
+				return {
+					name: string(asset.name, `github.release.assets[${index}].name`),
+					size: asset.size,
+				};
+			}),
+		},
+		tagCommit,
+	};
+}
+
+function releaseState(github, requiredAssets, sourceCommit) {
+	if (github.tagCommit && github.tagCommit !== sourceCommit) {
+		fail("TAG_TARGET_MISMATCH", "release tag does not match the provenance source commit");
+	}
+	if (!github.release) return "absent";
+	if (github.release.targetCommitish !== sourceCommit) {
+		fail("RELEASE_TARGET_MISMATCH", "GitHub release does not match the provenance source commit");
+	}
+
+	const assets = new Map();
+	for (const asset of github.release.assets) {
+		if (assets.has(asset.name)) {
+			fail("DUPLICATE_ASSET", `GitHub release contains duplicate asset ${asset.name}`);
+		}
+		assets.set(asset.name, asset.size);
+	}
+	const incomplete = requiredAssets.filter((name) => !assets.has(name) || assets.get(name) === 0);
+	if (github.release.isDraft) return "draft";
+	if (incomplete.length > 0) {
+		fail(
+			"PUBLISHED_RELEASE_INCOMPLETE",
+			`published release is missing complete assets: ${incomplete.join(", ")}`,
+		);
+	}
+	return "published-complete";
+}
+
+function commonInput(input) {
+	if (input.schemaVersion !== INPUT_SCHEMA) {
+		fail("INVALID_SCHEMA", `schemaVersion must be ${INPUT_SCHEMA}`);
+	}
+	if (input.mode !== "plan" && input.mode !== "complete") {
+		fail("INVALID_MODE", "mode must be plan or complete");
+	}
+	return {
+		mode: input.mode,
+		packageInfo: packageInput(input.package),
+		repository: repositoryInput(input.repository),
+		requiredAssets: requiredAssetsInput(input.requiredAssets),
+		npm: npmInput(input.npm),
+		github: githubInput(input.github),
+	};
+}
+
+function plan(input, common) {
+	const currentCommit = commit(input.currentCommit, "currentCommit");
+	const provenance = common.npm.exists
+		? verifyProvenance(common.npm, common.packageInfo, common.repository)
+		: null;
+	const sourceCommit = provenance?.sourceCommit ?? currentCommit;
+	const state = releaseState(common.github, common.requiredAssets, sourceCommit);
+	if (!common.npm.exists && state === "published-complete") {
+		fail("RELEASE_WITHOUT_PACKAGE", "published GitHub release exists without the npm package");
+	}
+	const shouldRelease = !(common.npm.exists && state === "published-complete");
+	return {
+		schemaVersion: OUTPUT_SCHEMA,
+		mode: "plan",
+		version: common.packageInfo.version,
+		npmTag: common.packageInfo.version.includes("-") ? "beta" : "latest",
+		releaseTag: `clawdi-cli-v${common.packageInfo.version}`,
+		tarballFilename: `clawdi-${common.packageInfo.version}.tgz`,
+		shouldRelease,
+		sourceCommit,
+		npmAction: shouldRelease ? (common.npm.exists ? "verify" : "publish") : "none",
+		releaseState: state,
+	};
+}
+
+function complete(input, common) {
+	if (!common.npm.exists) {
+		fail("PACKAGE_NOT_PUBLISHED", "complete mode requires the published npm package");
+	}
+	const expectedSourceCommit = commit(input.expectedSourceCommit, "expectedSourceCommit");
+	const localArtifact = object(input.localArtifact, "localArtifact");
+	const localIntegrity = integrityDigest(localArtifact.integrity, "localArtifact.integrity");
+	const localSha512 = string(localArtifact.sha512, "localArtifact.sha512");
+	if (!/^[0-9a-f]{128}$/.test(localSha512) || localSha512 !== localIntegrity.hex) {
+		fail("LOCAL_INTEGRITY_MISMATCH", "local artifact integrity and SHA-512 digest disagree");
+	}
+	const provenance = verifyProvenance(
+		common.npm,
+		common.packageInfo,
+		common.repository,
+		localSha512,
+	);
+	if (provenance.sourceCommit !== expectedSourceCommit) {
+		fail(
+			"SOURCE_COMMIT_MISMATCH",
+			"published provenance does not match the expected source commit",
+		);
+	}
+	const state = releaseState(common.github, common.requiredAssets, provenance.sourceCommit);
+	return {
+		schemaVersion: OUTPUT_SCHEMA,
+		mode: "complete",
+		version: common.packageInfo.version,
+		releaseTag: `clawdi-cli-v${common.packageInfo.version}`,
+		releaseTarget: provenance.sourceCommit,
+		releaseState: state,
+		releaseAction:
+			state === "absent" ? "create-draft" : state === "draft" ? "resume-draft" : "none",
+		finalize: state !== "published-complete",
+	};
+}
+
+async function main() {
+	const chunks = [];
+	for await (const chunk of process.stdin) chunks.push(chunk);
+	let input;
+	try {
+		input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+	} catch {
+		fail("INVALID_JSON", "stdin must contain one JSON object");
+	}
+	const parsedInput = object(input, "input");
+	const common = commonInput(parsedInput);
+	const output = common.mode === "plan" ? plan(parsedInput, common) : complete(parsedInput, common);
+	process.stdout.write(`${JSON.stringify(output)}\n`);
+}
+
+try {
+	await main();
+} catch (error) {
+	if (error instanceof ReleaseRecoveryError) {
+		process.stderr.write(`${error.code}: ${error.message}\n`);
+		process.exitCode = 1;
+	} else {
+		throw error;
+	}
+}

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowJob {
+	needs?: unknown;
+	permissions?: Record<string, string>;
+	steps?: Array<Record<string, unknown>>;
+}
+
+interface WorkflowDocument {
+	jobs: Record<string, WorkflowJob>;
+}
 
 const workflow = readFileSync(
 	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
 	"utf8",
 );
+const workflowDocument = parse(workflow) as WorkflowDocument;
 const releaseRunbookDoc = readFileSync(
 	resolve(import.meta.dir, "../../../docs/runbooks/release.md"),
 	"utf8",
@@ -26,11 +38,24 @@ const cliPackage = JSON.parse(
 	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
 ) as { version: string; publishConfig?: { access?: string; tag?: unknown } };
 
-function expectedNpmTag(version: string): string {
-	return version.includes("-") ? "beta" : "latest";
-}
-
 describe("CLI publish workflow contract", () => {
+	test("keeps recovery decisions inside the protected publish topology", () => {
+		const build = workflowDocument.jobs["build-immutable-artifact"];
+		const publish = workflowDocument.jobs["publish-immutable-artifact-with-oidc"];
+
+		expect(Object.keys(workflowDocument.jobs)).toEqual([
+			"build-immutable-artifact",
+			"publish-immutable-artifact-with-oidc",
+		]);
+		expect(build.permissions).toEqual({ contents: "read" });
+		expect(publish.needs).toBe("build-immutable-artifact");
+		expect(publish.permissions).toEqual({ contents: "write", "id-token": "write" });
+		expect(build.steps?.find((step) => step.id === "check")?.["working-directory"]).toBe(
+			"packages/cli",
+		);
+		expect(publish.steps?.map((step) => step.id).filter(Boolean)).toEqual(["publish", "release"]);
+	});
+
 	test("keeps the protected OIDC publish fully repository-local", () => {
 		const build = workflow.indexOf("  build-immutable-artifact:");
 		const publish = workflow.indexOf("  publish-immutable-artifact-with-oidc:");
@@ -44,9 +69,6 @@ describe("CLI publish workflow contract", () => {
 		);
 		expect(publishJob).toContain("runs-on: ubuntu-latest");
 		expect(publishJob).not.toContain("vars.CI_RUNNER");
-		expect(workflow).toContain(
-			'echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"',
-		);
 		expect(workflow).toContain("needs: build-immutable-artifact");
 		expect(workflow).toContain("environment: npm");
 		expect(workflow).toContain("id-token: write");
@@ -64,8 +86,6 @@ describe("CLI publish workflow contract", () => {
 		const publishCommands = workflow.match(/npm publish /g) ?? [];
 
 		expect(publishCommands).toHaveLength(1);
-		expect(workflow).toContain('echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"');
-		expect(workflow).toContain("p.version.includes('-') ? 'beta' : 'latest'");
 		expect(workflow).not.toContain("publishConfig");
 		expect(workflow).toContain(
 			`NPM_TAG: \${{ needs['build-immutable-artifact'].outputs.npm_tag }}`,
@@ -74,9 +94,6 @@ describe("CLI publish workflow contract", () => {
 			'npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
 		expect(cliPackage.version).not.toContain("-");
-		expect(expectedNpmTag(cliPackage.version)).toBe("latest");
-		expect(expectedNpmTag("1.2.3-beta.1")).toBe("beta");
-		expect(expectedNpmTag("1.2.3")).toBe("latest");
 		expect(cliPackage.publishConfig).toEqual({ access: "public" });
 		expect(publishManifestChecker).toContain(
 			'Object.hasOwn(packageJson.publishConfig ?? {}, "tag")',

--- a/packages/cli/tests/release-recovery.test.ts
+++ b/packages/cli/tests/release-recovery.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const script = resolve(import.meta.dir, "../scripts/release-recovery.mjs");
+const sourceCommit = "1".repeat(40);
+const otherCommit = "2".repeat(40);
+const sha512 = "ab".repeat(64);
+const integrity = `sha512-${Buffer.from(sha512, "hex").toString("base64")}`;
+const requiredAssets = ["clawdi-cli-linux-x64.tar.gz", "clawdi-cli-linux-x64.tar.gz.sha256"];
+
+function provenanceStatement(version = "0.13.10") {
+	return {
+		subject: [{ name: `pkg:npm/clawdi@${version}`, digest: { sha512 } }],
+		predicate: {
+			buildDefinition: {
+				externalParameters: {
+					workflow: {
+						repository: "https://github.com/Clawdi-AI/clawdi",
+						path: ".github/workflows/cli-publish.yml",
+					},
+				},
+				resolvedDependencies: [
+					{
+						uri: "git+https://github.com/Clawdi-AI/clawdi@refs/heads/main",
+						digest: { gitCommit: sourceCommit },
+					},
+				],
+			},
+		},
+	};
+}
+
+function publishedNpm(version = "0.13.10") {
+	return {
+		exists: true,
+		distIntegrity: integrity,
+		attestations: {
+			url: "https://registry.npmjs.org/-/npm/v1/attestations/clawdi@0.13.10",
+			provenance: { predicateType: "https://slsa.dev/provenance/v1" },
+		},
+		attestationBundle: {
+			attestations: [
+				{
+					predicateType: "https://slsa.dev/provenance/v1",
+					bundle: {
+						dsseEnvelope: {
+							payload: Buffer.from(JSON.stringify(provenanceStatement(version))).toString("base64"),
+						},
+					},
+				},
+			],
+		},
+	};
+}
+
+function completeRelease() {
+	return {
+		isDraft: false,
+		targetCommitish: sourceCommit,
+		assets: requiredAssets.map((name) => ({ name, size: 128 })),
+	};
+}
+
+function planFixture() {
+	return {
+		schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+		mode: "plan",
+		package: { name: "clawdi", version: "0.13.10" },
+		repository: {
+			url: "https://github.com/Clawdi-AI/clawdi",
+			workflowPath: ".github/workflows/cli-publish.yml",
+		},
+		currentCommit: otherCommit,
+		requiredAssets: [...requiredAssets],
+		npm: publishedNpm(),
+		github: { release: null, tagCommit: null },
+	};
+}
+
+function completeFixture() {
+	return {
+		...planFixture(),
+		mode: "complete",
+		expectedSourceCommit: sourceCommit,
+		localArtifact: { integrity, sha512 },
+	};
+}
+
+function runRecovery(input: unknown) {
+	const result = spawnSync(process.execPath, [script], {
+		input: JSON.stringify(input),
+		encoding: "utf8",
+		env: { ...process.env, NO_COLOR: "1" },
+	});
+	return {
+		exitCode: result.status,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}
+
+function expectDecision(input: unknown) {
+	const result = runRecovery(input);
+	if (result.exitCode !== 0) throw new Error(result.stderr);
+	return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
+describe("CLI release recovery decision", () => {
+	test("plans a first publish from the current commit", () => {
+		const fixture = { ...planFixture(), npm: { exists: false } };
+		const decision = expectDecision(fixture);
+
+		expect(decision).toMatchObject({
+			mode: "plan",
+			shouldRelease: true,
+			npmAction: "publish",
+			releaseState: "absent",
+			sourceCommit: otherCommit,
+			npmTag: "latest",
+		});
+	});
+
+	test("derives beta for a prerelease without changing recovery semantics", () => {
+		const fixture = planFixture();
+		fixture.package.version = "0.13.11-beta.1";
+		fixture.npm = publishedNpm("0.13.11-beta.1");
+		const decision = expectDecision(fixture);
+
+		expect(decision.npmTag).toBe("beta");
+		expect(decision.npmAction).toBe("verify");
+		expect(decision.sourceCommit).toBe(sourceCommit);
+	});
+
+	test("rejects non-SemVer prerelease identifiers with leading zeroes", () => {
+		const fixture = { ...planFixture(), npm: { exists: false } };
+		fixture.package.version = "1.2.3-beta.01";
+
+		const result = runRecovery(fixture);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("INVALID_VERSION");
+	});
+
+	test("rejects non-canonical GitHub repository URLs", () => {
+		for (const url of [
+			"https://github.com/Clawdi-AI/clawdi/extra",
+			"https://github.com/Clawdi-AI/clawdi?ref=main",
+			"https://github.com/Clawdi-AI/clawdi#readme",
+		]) {
+			const fixture = { ...planFixture(), npm: { exists: false } };
+			fixture.repository.url = url;
+
+			const result = runRecovery(fixture);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("INVALID_REPOSITORY");
+		}
+	});
+
+	test("skips an npm version whose published release is complete", () => {
+		const fixture = planFixture();
+		fixture.github = { release: completeRelease(), tagCommit: sourceCommit };
+		const decision = expectDecision(fixture);
+
+		expect(decision).toMatchObject({
+			shouldRelease: false,
+			npmAction: "none",
+			releaseState: "published-complete",
+		});
+	});
+
+	test("recovers a published npm version whose GitHub release is absent", () => {
+		const decision = expectDecision(planFixture());
+
+		expect(decision).toMatchObject({
+			shouldRelease: true,
+			npmAction: "verify",
+			releaseState: "absent",
+			sourceCommit,
+		});
+	});
+
+	test("resumes a draft for the verified source commit", () => {
+		const fixture = completeFixture();
+		fixture.github = {
+			release: { ...completeRelease(), isDraft: true, assets: [] },
+			tagCommit: sourceCommit,
+		};
+		const decision = expectDecision(fixture);
+
+		expect(decision).toMatchObject({
+			releaseAction: "resume-draft",
+			releaseTarget: sourceCommit,
+			finalize: true,
+		});
+	});
+
+	test("creates a draft only after validating the published artifact", () => {
+		const decision = expectDecision(completeFixture());
+
+		expect(decision).toMatchObject({
+			releaseAction: "create-draft",
+			releaseTarget: sourceCommit,
+			finalize: true,
+		});
+	});
+
+	test("fails closed on local, published, or provenance integrity drift", () => {
+		const fixtures = [completeFixture(), completeFixture(), completeFixture()];
+		fixtures[0].localArtifact.sha512 = "cd".repeat(64);
+		fixtures[1].npm.distIntegrity = `sha512-${Buffer.from("cd".repeat(64), "hex").toString("base64")}`;
+		fixtures[2].npm.attestationBundle.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(
+			JSON.stringify({ ...provenanceStatement(), subject: [] }),
+		).toString("base64");
+
+		for (const fixture of fixtures) {
+			const result = runRecovery(fixture);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toMatch(/INTEGRITY|SUBJECT/);
+		}
+	});
+
+	test("fails closed when provenance repository, workflow, or source identity drifts", () => {
+		const mutations = [
+			(statement: ReturnType<typeof provenanceStatement>) => {
+				statement.predicate.buildDefinition.externalParameters.workflow.repository =
+					"https://github.com/example/fork";
+			},
+			(statement: ReturnType<typeof provenanceStatement>) => {
+				statement.predicate.buildDefinition.externalParameters.workflow.path =
+					".github/workflows/other.yml";
+			},
+			(statement: ReturnType<typeof provenanceStatement>) => {
+				statement.predicate.buildDefinition.resolvedDependencies[0].digest.gitCommit = otherCommit;
+			},
+		];
+
+		for (const mutate of mutations) {
+			const fixture = completeFixture();
+			const statement = provenanceStatement();
+			mutate(statement);
+			fixture.npm.attestationBundle.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(
+				JSON.stringify(statement),
+			).toString("base64");
+			const result = runRecovery(fixture);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toMatch(/WORKFLOW_MISMATCH|SOURCE_COMMIT_MISMATCH/);
+		}
+	});
+
+	test("fails closed on mismatched release or tag targets", () => {
+		for (const target of ["release", "tag"] as const) {
+			const fixture = completeFixture();
+			fixture.github = {
+				release: { ...completeRelease(), isDraft: true },
+				tagCommit: sourceCommit,
+			};
+			if (target === "release") fixture.github.release.targetCommitish = otherCommit;
+			else fixture.github.tagCommit = otherCommit;
+			const result = runRecovery(fixture);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toMatch(/TARGET_MISMATCH/);
+		}
+	});
+
+	test("fails closed on incomplete or ambiguous published assets", () => {
+		const fixtures = [planFixture(), planFixture(), planFixture()];
+		fixtures[0].github = {
+			release: { ...completeRelease(), assets: completeRelease().assets.slice(0, 1) },
+			tagCommit: sourceCommit,
+		};
+		fixtures[1].github = {
+			release: {
+				...completeRelease(),
+				assets: completeRelease().assets.map((asset, index) =>
+					index === 0 ? { ...asset, size: 0 } : asset,
+				),
+			},
+			tagCommit: sourceCommit,
+		};
+		fixtures[2].github = {
+			release: {
+				...completeRelease(),
+				assets: [...completeRelease().assets, completeRelease().assets[0]],
+			},
+			tagCommit: sourceCommit,
+		};
+
+		for (const fixture of fixtures) {
+			const result = runRecovery(fixture);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toMatch(/PUBLISHED_RELEASE_INCOMPLETE|DUPLICATE_ASSET/);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- recover a GitHub CLI Release after immutable npm publication without republishing npm
- move provenance, source-commit, release completeness, and action decisions into the workflow-invoked release-recovery script
- validate exact SemVer, canonical GitHub repository identity, attestation subject, integrity, targets, and required assets with JSON subprocess fixtures

## Boundary

This is stack layer 3 of 5. The workflow is thin orchestration; new tests exercise decision behavior and parsed workflow topology rather than raw workflow command strings. It contains no daemon or native distribution changes.

## Verification

- Docker clean runner: full CLI typecheck and 1317 tests passed
- Docker Biome: 761 files passed
- workflow shell blocks passed syntax validation
- `git diff --check c2e41a4c..84dd7bca` passed

Base is Hosted runtime. Merge before daemon lifecycle and native distribution PR #556.