### PR TITLE
fix(cli): harden daemon invocation and shutdown

### DIFF
--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -28,6 +28,7 @@ import { rejectUnsupportedOpts, runDaemonWorkers } from "./serve";
  */
 
 const captured = {
+	stdout: [] as string[],
 	stderr: [] as string[],
 	exitCode: null as number | null,
 };
@@ -76,19 +77,25 @@ function rpcPendingAuth(): PendingAuth {
 let restoreExit: (() => void) | null = null;
 
 beforeEach(() => {
+	captured.stdout = [];
 	captured.stderr = [];
 	captured.exitCode = null;
 	const origExit = process.exit;
+	const origLog = console.log;
 	const origErr = console.error;
 	process.exit = ((code?: number) => {
 		captured.exitCode = code ?? 0;
 		throw new ExitCalled(code ?? 0);
 	}) as typeof process.exit;
+	console.log = (...args: unknown[]) => {
+		captured.stdout.push(args.map(String).join(" "));
+	};
 	console.error = (...args: unknown[]) => {
 		captured.stderr.push(args.map(String).join(" "));
 	};
 	restoreExit = () => {
 		process.exit = origExit;
+		console.log = origLog;
 		console.error = origErr;
 	};
 });
@@ -228,6 +235,56 @@ describe("subcommand handler rejects parent-leaked options", () => {
 			ExitCalled,
 		);
 		expect(captured.stderr.join("\n")).toMatch(/daemon doctor.*--agent/);
+	});
+});
+
+describe("daemon install activation failure", () => {
+	it("preserves the unit, prints no success, and exits non-zero", async () => {
+		if (process.platform !== "linux") return;
+		const originalHome = process.env.HOME;
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalPath = process.env.PATH;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const originalArgv1 = process.argv[1];
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-daemon-install-failure-"));
+		const stubBin = join(tmpHome, "bin");
+		const fakeEntry = join(tmpHome, "clawdi-bin");
+		const unit = join(tmpHome, ".config", "systemd", "user", "clawdi-serve.service");
+		try {
+			process.env.HOME = tmpHome;
+			delete process.env.CLAWDI_HOME;
+			process.env.CLAWDI_AUTH_TOKEN = "clawdi_test_token";
+			mkdirSync(join(tmpHome, ".clawdi", "environments"), { recursive: true });
+			writeFileSync(
+				join(tmpHome, ".clawdi", "environments", "codex.json"),
+				`${JSON.stringify({ id: "env-codex", agentType: "codex" })}\n`,
+			);
+			mkdirSync(stubBin, { recursive: true });
+			writeExecutable(join(stubBin, "systemctl"), "#!/bin/sh\nexit 1\n");
+			process.env.PATH = `${stubBin}:${originalPath ?? ""}`;
+			writeExecutable(fakeEntry, "#!/bin/sh\nexit 0\n");
+			process.argv[1] = fakeEntry;
+
+			const { serveInstall } = await import("./serve");
+			await expect(serveInstall({})).rejects.toThrow(ExitCalled);
+
+			expect(captured.exitCode).toBe(1);
+			expect(existsSync(unit)).toBe(true);
+			expect(captured.stderr.join("\n")).toContain("systemctl activation failed");
+			expect(captured.stderr.join("\n")).toContain("systemctl --user daemon-reload");
+			expect(captured.stdout.join("\n")).not.toContain("singleton daemon unit");
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			process.argv[1] = originalArgv1 ?? "";
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -281,7 +281,16 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		});
 	} catch (e) {
 		log.error("serve.fatal", { error: toErrorMessage(e) });
-		process.exit(1);
+		process.exitCode = 1;
+	} finally {
+		abort.abort();
+		const cleanup = await Promise.allSettled([operationManager.shutdownAll(), rpc.close()]);
+		activeControlRpcHttp = null;
+		for (const result of cleanup) {
+			if (result.status === "fulfilled") continue;
+			log.error("serve.shutdown_failed", { error: toErrorMessage(result.reason) });
+			process.exitCode = 1;
+		}
 	}
 
 	// Preserve any non-zero exitCode the engine set (e.g. auth

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -192,6 +192,7 @@ function installDaemonForAllRegisteredAgents() {
 	} catch (e) {
 		console.log(chalk.yellow(`⚠ Could not install daemon: ${errMessage(e)}`));
 		console.log(chalk.gray("  Run manually: clawdi daemon install"));
+		process.exitCode = 1;
 	}
 }
 

--- a/packages/cli/src/serve/auto-restart.ts
+++ b/packages/cli/src/serve/auto-restart.ts
@@ -7,6 +7,7 @@
  */
 import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { resolveCurrentCliInvocation } from "../lib/current-cli-invocation";
 import { log } from "./log";
 
 export interface RestartCoordination {
@@ -42,28 +43,33 @@ interface AutoRestartOpts {
 }
 
 /**
- * Resolve the JS file the daemon is actually executing. Returns
- * null when we can't figure it out (e.g. running tests with no
- * argv[1]) — the caller treats that as "skip this feature" rather
- * than throwing, since the daemon is otherwise functional without
- * auto-restart.
+ * Resolve the file the daemon is actually executing. Script installs prefer
+ * the bundled JS behind the stable bin wrapper. Returns null when resolution
+ * fails because the daemon is otherwise functional without auto-restart.
  *
  * Resolution order:
- *   1. `argv[1]` if it ends in `.js`/`.mjs` and is a real file.
- *   2. `<argv[1]_dir>/../dist/index.js` — the bun/npm install
+ *   1. `<entry_dir>/../dist/index.js` — the bun/npm install
  *      layout where `bin/clawdi.mjs` is a thin wrapper that
  *      imports the bundled file. The wrapper rarely changes,
  *      but the bundled file gets rewritten on every update.
+ *   2. The current script entry.
  */
 async function resolveEntryFile(): Promise<string | null> {
-	const arg = process.argv[1];
-	if (!arg) return null;
+	let invocation: ReturnType<typeof resolveCurrentCliInvocation>;
+	try {
+		invocation = resolveCurrentCliInvocation();
+	} catch {
+		return null;
+	}
 
-	// `argv[1]` = `.../node_modules/clawdi/bin/clawdi.mjs` for an
+	// The script entry is `.../node_modules/clawdi/bin/clawdi.mjs` for an
 	// installed CLI. The bundled JS sits at `.../dist/index.js`.
 	// We prefer the bundled file because that's what gets rewritten
 	// on `npm i -g`; the .mjs wrapper is stable across versions.
-	const candidates = [join(dirname(dirname(arg)), "dist", "index.js"), arg];
+	const candidates = [
+		join(dirname(dirname(invocation.entryPath)), "dist", "index.js"),
+		invocation.entryPath,
+	];
 	for (const c of candidates) {
 		try {
 			const s = await stat(c);

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -9,6 +9,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { request } from "node:http";
+import { createServer as createTcpServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -55,6 +56,43 @@ if (process.platform !== "win32") {
 				const result = await callControlRpc("echo", { via: "http" }, rpcClient(server));
 
 				expect(result).toEqual({ params: { via: "http" } });
+			});
+		});
+
+		it("returns the in-flight server close promise to every shutdown caller", async () => {
+			await withRpcFixture(async ({ start }) => {
+				const server = await start({});
+
+				const firstClose = server.close();
+				expect(server.close()).toBe(firstClose);
+				await firstClose;
+			});
+		});
+
+		it("times out when a socket accepts the request but never finishes a response", async () => {
+			await withHangingTcpServer(async (port) => {
+				await expect(
+					callControlRpc("ping", {}, { port, token: "test-token", timeoutMs: 50 }),
+				).rejects.toThrow("Control RPC timed out after 50ms");
+			});
+		});
+
+		it("aborts an in-flight request with the caller's AbortSignal reason", async () => {
+			await withHangingTcpServer(async (port) => {
+				const abort = new AbortController();
+				const call = callControlRpc(
+					"ping",
+					{},
+					{
+						port,
+						token: "test-token",
+						timeoutMs: 5_000,
+						signal: abort.signal,
+					},
+				);
+				setTimeout(() => abort.abort(new Error("caller cancelled RPC")), 25);
+
+				await expect(call).rejects.toThrow("caller cancelled RPC");
 			});
 		});
 
@@ -226,6 +264,26 @@ function rpcClient(server: RpcServer): { host: string; port: number; token: stri
 
 function readServerToken(server: RpcServer): string {
 	return readFileSync(server.tokenPath, "utf-8").trim();
+}
+
+async function withHangingTcpServer<T>(run: (port: number) => Promise<T>): Promise<T> {
+	const sockets = new Set<Socket>();
+	const server = createTcpServer((socket) => {
+		sockets.add(socket);
+		socket.on("close", () => sockets.delete(socket));
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("expected TCP test port");
+	try {
+		return await run(address.port);
+	} finally {
+		for (const socket of sockets) socket.destroy();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
 }
 
 function postWithoutToken(

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,6 +1,7 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import {
+	type ClientRequest,
 	createServer,
 	type IncomingMessage,
 	request,
@@ -12,6 +13,7 @@ import { dirname, join } from "node:path";
 import { getDaemonControlDir, getDaemonControlTokenPath } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
+export const DEFAULT_CONTROL_RPC_TIMEOUT_MS = 10_000;
 export const DEFAULT_CONTROL_RPC_HOST = "127.0.0.1";
 export const DEFAULT_CONTROL_RPC_PORT = 17654;
 
@@ -30,6 +32,8 @@ export interface ControlRpcClientConfig {
 	host?: string;
 	port?: number;
 	token?: string;
+	timeoutMs?: number;
+	signal?: AbortSignal;
 }
 
 interface JsonRpcRequest {
@@ -80,11 +84,10 @@ export async function startControlRpcServer(
 		host,
 		port: typeof address === "object" && address ? address.port : port,
 	};
-	let closed = false;
+	let closePromise: Promise<void> | null = null;
 	const close = () => {
-		if (closed) return Promise.resolve();
-		closed = true;
-		return closeServer(httpServer);
+		closePromise ??= closeServer(httpServer);
+		return closePromise;
 	};
 	abort.addEventListener(
 		"abort",
@@ -113,8 +116,39 @@ export async function callControlRpc(
 		method,
 		params: params ?? {},
 	});
+	const timeoutMs = config.timeoutMs ?? DEFAULT_CONTROL_RPC_TIMEOUT_MS;
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("Control RPC timeout must be a positive number.");
+	}
 	const response = await new Promise<string>((resolve, reject) => {
-		const req = createServerlessRequest(body, token, config, resolve, reject);
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const finish = (result: { value: string } | { error: unknown }) => {
+			if (settled) return;
+			settled = true;
+			if (timer) clearTimeout(timer);
+			config.signal?.removeEventListener("abort", onAbort);
+			if ("error" in result) reject(result.error);
+			else resolve(result.value);
+		};
+		const resolveResponse = (value: string) => finish({ value });
+		const rejectResponse = (error: unknown) => finish({ error });
+		const req = createServerlessRequest(body, token, config, resolveResponse, rejectResponse);
+		const onAbort = () => {
+			const error = controlRpcAbortError(config.signal);
+			rejectResponse(error);
+			req.destroy(error);
+		};
+		if (config.signal?.aborted) {
+			onAbort();
+			return;
+		}
+		config.signal?.addEventListener("abort", onAbort, { once: true });
+		timer = setTimeout(() => {
+			const error = new Error(`Control RPC timed out after ${timeoutMs}ms.`);
+			rejectResponse(error);
+			req.destroy(error);
+		}, timeoutMs);
 		req.write(body);
 		req.end();
 	});
@@ -134,7 +168,7 @@ function createServerlessRequest(
 	config: ControlRpcClientConfig,
 	resolve: (value: string) => void,
 	reject: (reason?: unknown) => void,
-) {
+): ClientRequest {
 	const req = request(
 		{
 			hostname: config.host ?? DEFAULT_CONTROL_RPC_HOST,
@@ -160,10 +194,19 @@ function createServerlessRequest(
 				}
 				resolve(chunks);
 			});
+			res.on("aborted", () => reject(new Error("Control RPC response was aborted.")));
+			res.on("error", reject);
 		},
 	);
 	req.on("error", reject);
 	return req;
+}
+
+function controlRpcAbortError(signal: AbortSignal | undefined): Error {
+	if (signal?.reason instanceof Error) return signal.reason;
+	const error = new Error("Control RPC call aborted.");
+	error.name = "AbortError";
+	return error;
 }
 
 function resolveControlTokenPaths(config: ControlRpcListenConfig): ControlRpcTokenPaths {

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -281,6 +281,43 @@ describe("installer.install (Linux systemd)", () => {
 			process.env.PATH = oldPath;
 		}
 	});
+
+	it("preserves the unit and throws an actionable error when activation fails", async () => {
+		const os = await import("node:os");
+		if (os.platform() !== "linux") return;
+
+		const stubBin = join(process.env.HOME ?? tmp, "stub-bin");
+		mkdirSync(stubBin, { recursive: true });
+		const stubSystemctl = join(stubBin, "systemctl");
+		writeFileSync(stubSystemctl, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+		chmodSync(stubSystemctl, 0o755);
+		const oldPath = process.env.PATH;
+		process.env.PATH = `${stubBin}:${oldPath}`;
+
+		try {
+			const { install } = await import("./installer");
+			let error: unknown;
+			try {
+				install();
+			} catch (caught) {
+				error = caught;
+			}
+			const unit = join(
+				process.env.HOME ?? "",
+				".config",
+				"systemd",
+				"user",
+				"clawdi-serve.service",
+			);
+			expect(existsSync(unit)).toBe(true);
+			if (!(error instanceof Error)) throw new Error("expected activation error");
+			expect(error.message).toContain("systemctl activation failed");
+			expect(error.message).toContain("systemctl --user daemon-reload");
+			expect(error.message).toContain("enable --now clawdi-serve.service");
+		} finally {
+			process.env.PATH = oldPath;
+		}
+	});
 });
 
 describe("installer.readHealth", () => {

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -28,13 +28,16 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
-	realpathSync,
 	statSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir, platform } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { join } from "node:path";
+import {
+	type CurrentCliInvocation,
+	resolveCurrentCliInvocation,
+} from "../lib/current-cli-invocation";
 
 interface InstallOpts {
 	/** Internal migration hook for removing pre-singleton per-agent units. */
@@ -164,40 +167,16 @@ function upsertCapturedEnv(
 	out.push({ key, value });
 }
 
-/** Path to the currently-running clawdi entry point. Both paths
- * are resolved via `realpathSync.native` so a malicious shim or
- * unstable symlink earlier in $PATH doesn't end up baked into
- * the launchd plist / systemd unit — the supervisor would happily
- * exec that shim on every boot for as long as the unit lives.
- *
- * We bake the absolute realpath into the unit because referencing
- * `clawdi` from $PATH would silently change what's actually
- * running on `npm i -g <other-version>`. */
-function currentClawdiCommand(): string[] {
-	// `process.argv[0]` is the node binary; `process.argv[1]`
-	// is the bundled CLI entry. If the user invoked us via a
-	// shell wrapper (`clawdi`), argv[1] resolves to the linked
-	// JS file inside the npm install — exactly what we want.
-	const rawNode = process.execPath;
-	const rawEntry = process.argv[1] ?? "";
-	if (!rawEntry) {
-		throw new Error("could not resolve clawdi entry point from process.argv[1]");
-	}
-	let node: string;
-	let entry: string;
+/** Resolve this exact CLI installation for a supervisor-owned daemon. */
+function currentDaemonInvocation(opts: InstallOpts): CurrentCliInvocation {
+	let invocation: CurrentCliInvocation;
 	try {
-		node = realpathSync.native(rawNode);
-		entry = realpathSync.native(rawEntry);
-	} catch (e) {
+		invocation = resolveCurrentCliInvocation(daemonProgramArgs(opts));
+	} catch (error) {
 		throw new Error(
-			`could not resolve absolute path for daemon binary: ${(e as Error).message}. ` +
-				"Reinstall the CLI (npm i -g clawdi) and try again.",
-		);
-	}
-	if (!isAbsolute(node) || !isAbsolute(entry)) {
-		throw new Error(
-			`refusing to install a daemon unit with a relative path ` +
-				`(node=${node}, entry=${entry}). Reinstall the CLI from a clean shell.`,
+			`could not resolve the current CLI for daemon installation: ${
+				error instanceof Error ? error.message : String(error)
+			}. Reinstall the CLI and try again.`,
 		);
 	}
 	// Reject TypeScript source paths. A common dev-mode footgun:
@@ -208,15 +187,15 @@ function currentClawdiCommand(): string[] {
 	// TypeScript — daemon crashes silently in a respawn loop and
 	// the user has no idea what's wrong because `launchctl load`
 	// itself succeeded. Fail loudly at install time instead.
-	if (/\.tsx?$/.test(entry)) {
+	if (invocation.entryPath && /\.tsx?$/.test(invocation.entryPath)) {
 		throw new Error(
 			"refusing to install a daemon unit with a TypeScript source path " +
-				`(entry=${entry}). The OS supervisor can't run .ts files. ` +
+				`(entry=${invocation.entryPath}). The OS supervisor can't run .ts files. ` +
 				"Build a JS bundle first (npm i -g clawdi or bun run build) " +
 				"and re-run install from the installed binary.",
 		);
 	}
-	return [node, entry];
+	return invocation;
 }
 
 export function install(opts: InstallOpts = {}): {
@@ -324,7 +303,7 @@ function installLaunchd(opts: InstallOpts): {
 	replaced: boolean;
 } {
 	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
-	const [node, entry] = currentClawdiCommand();
+	const invocation = currentDaemonInvocation(opts);
 	const logDir = join(clawdiRoot(), "serve", "logs");
 	if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true });
 
@@ -334,8 +313,7 @@ function installLaunchd(opts: InstallOpts): {
 	// stderr (where we emit JSON logs) lands in a rotating
 	// file the user can `tail`.
 	//
-	const args = daemonProgramArgs(opts);
-	const programArgs = [node, entry, ...args]
+	const programArgs = [invocation.command, ...invocation.args]
 		.map((arg) => `    <string>${escapeXml(arg)}</string>`)
 		.join("\n");
 	const plist = `<?xml version="1.0" encoding="UTF-8"?>
@@ -399,10 +377,14 @@ ${programArgs}
 	// reload to pick up edits.
 	tryRun(["launchctl", "unload", path]);
 	const loaded = tryRun(["launchctl", "load", "-w", path]);
+	if (!loaded) {
+		throw new Error(
+			`Wrote daemon unit to ${path}, but launchctl activation failed. ` +
+				`The unit was preserved. Try: launchctl load -w "${path}"`,
+		);
+	}
 
-	const instructions = loaded
-		? `Loaded ${label}. Tail logs with: tail -f ${join(logDir, `${opts.agent ?? "daemon"}.stderr.log`)}`
-		: `Wrote plist to ${path}, but launchctl load failed (try: launchctl load -w "${path}").`;
+	const instructions = `Loaded ${label}. Tail logs with: tail -f ${join(logDir, `${opts.agent ?? "daemon"}.stderr.log`)}`;
 	return { unit: path, instructions, replaced };
 }
 
@@ -485,10 +467,9 @@ function installSystemd(opts: InstallOpts): {
 	instructions: string;
 	replaced: boolean;
 } {
-	const [node, entry] = currentClawdiCommand();
+	const invocation = currentDaemonInvocation(opts);
 	const path = unitPath(opts.agent);
 	const replaced = existsSync(path);
-	const args = daemonProgramArgs(opts);
 
 	// systemd `Environment="KEY=VALUE"` parses backslash + double-
 	// quote inside the value. A $HOME containing `"` could close
@@ -545,7 +526,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${[node, entry, ...args].map(shellEscape).join(" ")}
+ExecStart=${[invocation.command, ...invocation.args].map(shellEscape).join(" ")}
 Restart=always
 RestartSec=10
 RestartPreventExitStatus=2
@@ -568,12 +549,18 @@ WantedBy=default.target
 	} catch {
 		/* best effort */
 	}
-	tryRun(["systemctl", "--user", "daemon-reload"]);
-	const enabled = tryRun(["systemctl", "--user", "enable", "--now", unitFileName(opts.agent)]);
+	const activated =
+		tryRun(["systemctl", "--user", "daemon-reload"]) &&
+		tryRun(["systemctl", "--user", "enable", "--now", unitFileName(opts.agent)]);
+	if (!activated) {
+		throw new Error(
+			`Wrote daemon unit to ${path}, but systemctl activation failed. ` +
+				"The unit was preserved. Try: " +
+				`systemctl --user daemon-reload && systemctl --user enable --now ${unitFileName(opts.agent)}`,
+		);
+	}
 
-	const instructions = enabled
-		? `Enabled and started ${unitFileName(opts.agent)}. Tail logs with: journalctl --user -u ${unitFileName(opts.agent)} -f`
-		: `Wrote ${path} but systemctl enable failed. Try: systemctl --user enable --now ${unitFileName(opts.agent)}`;
+	const instructions = `Enabled and started ${unitFileName(opts.agent)}. Tail logs with: journalctl --user -u ${unitFileName(opts.agent)} -f`;
 	return { unit: path, instructions, replaced };
 }
 
@@ -614,7 +601,7 @@ function statusSystemd(opts: InstallOpts): string[] {
 
 function tryRun(argv: string[]): boolean {
 	try {
-		execFileSync(argv[0], argv.slice(1), { stdio: "ignore" });
+		execFileSync(argv[0], argv.slice(1), { env: process.env, stdio: "ignore" });
 		return true;
 	} catch {
 		return false;
@@ -629,6 +616,7 @@ function tryRunCapture(argv: string[]): string | null {
 		// `daemon restart`'s liveness probe.
 		return execFileSync(argv[0], argv.slice(1), {
 			encoding: "utf-8",
+			env: process.env,
 			stdio: ["ignore", "pipe", "ignore"],
 		});
 	} catch {

--- a/packages/cli/src/serve/operation-runner.test.ts
+++ b/packages/cli/src/serve/operation-runner.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CurrentCliInvocation } from "../lib/current-cli-invocation";
+import {
+	OperationManager,
+	type OperationShutdownOptions,
+	runCliCommandImmediate,
+} from "./operation-runner";
+
+const root = mkdtempSync(join(tmpdir(), "clawdi-operation-runner-"));
+const worker = join(root, "worker.ts");
+writeFileSync(
+	worker,
+	[
+		'import { spawn } from "node:child_process";',
+		'import { writeFileSync } from "node:fs";',
+		'const mode = process.argv[2] ?? "";',
+		'const marker = process.argv[3] ?? "";',
+		'if (mode === "grandchild") {',
+		'  process.on("SIGTERM", () => {});',
+		"  setInterval(() => {}, 1_000);",
+		'} else if (mode === "stubborn" || mode === "orphaning") {',
+		'  process.on("SIGTERM", () => { if (mode === "orphaning") process.exit(0); });',
+		'  const grandchild = spawn(process.execPath, [process.argv[1] ?? "", "grandchild", marker], { stdio: "ignore" });',
+		"  writeFileSync(marker, String(grandchild.pid));",
+		'  console.log("ready");',
+		"  setInterval(() => {}, 1_000);",
+		"} else {",
+		'  process.on("SIGTERM", () => {',
+		"    setTimeout(() => {",
+		'      writeFileSync(marker, "closed");',
+		"      process.exit(0);",
+		"    }, 75);",
+		"  });",
+		'  console.log("ready");',
+		"  setInterval(() => {}, 1_000);",
+		"}",
+	].join("\n"),
+);
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+if (process.platform !== "win32") {
+	describe("operation process-group cleanup", () => {
+		it("waits for operation close after TERM and keeps cancellation status", async () => {
+			const marker = join(root, "graceful-marker");
+			const manager = createManager();
+			const operation = manager.start({ name: "graceful", args: ["graceful", marker] });
+			await waitForOperationReady(manager, operation.id);
+
+			const started = Date.now();
+			await manager.shutdownAll({ termTimeoutMs: 1_000 });
+
+			expect(Date.now() - started).toBeGreaterThanOrEqual(50);
+			expect(readFileSync(marker, "utf-8")).toBe("closed");
+			expect(manager.get(operation.id)).toMatchObject({
+				status: "cancelled",
+				exit_code: 0,
+				signal: null,
+			});
+			expect(() => manager.start({ name: "late", args: ["graceful", marker] })).toThrow(
+				"daemon is shutting down",
+			);
+		});
+
+		it("escalates to KILL for the entire operation process group", async () => {
+			const pidFile = join(root, "grandchild-pid");
+			const manager = createManager();
+			const operation = manager.start({ name: "stubborn", args: ["stubborn", pidFile] });
+			await waitForOperationReady(manager, operation.id);
+			await waitFor(() => existsSync(pidFile));
+			const grandchildPid = Number(readFileSync(pidFile, "utf-8"));
+
+			await manager.shutdownAll({ termTimeoutMs: 50 });
+
+			expect(manager.get(operation.id)).toMatchObject({
+				status: "cancelled",
+				signal: "SIGKILL",
+			});
+			await waitFor(() => !processExists(grandchildPid));
+		});
+
+		it("escalates cancellation so stubborn descendants do not survive", async () => {
+			const pidFile = join(root, "cancel-grandchild-pid");
+			const manager = createManager({ termTimeoutMs: 50, killTimeoutMs: 100 });
+			const operation = manager.start({ name: "cancel", args: ["orphaning", pidFile] });
+			await waitForOperationReady(manager, operation.id);
+			await waitFor(() => existsSync(pidFile));
+			const grandchildPid = Number(readFileSync(pidFile, "utf-8"));
+
+			expect(manager.cancel(operation.id)?.status).toBe("cancelled");
+			await waitFor(() => !processExists(grandchildPid));
+			expect(manager.get(operation.id)?.status).toBe("cancelled");
+		});
+
+		it("keeps a cancelled exclusive operation active until its process closes", async () => {
+			const manager = createManager();
+			const operation = manager.start({
+				name: "first",
+				args: ["graceful", join(root, "exclusive-first-marker")],
+				exclusiveKey: "sync",
+			});
+			await waitForOperationReady(manager, operation.id);
+
+			expect(manager.cancel(operation.id)?.status).toBe("cancelled");
+			expect(() =>
+				manager.start({
+					name: "overlap",
+					args: ["graceful", join(root, "exclusive-overlap-marker")],
+					exclusiveKey: "sync",
+				}),
+			).toThrow("Another sync operation is already running");
+			await waitFor(() => manager.get(operation.id)?.exit_code === 0);
+
+			const replacement = manager.start({
+				name: "replacement",
+				args: ["graceful", join(root, "exclusive-replacement-marker")],
+				exclusiveKey: "sync",
+			});
+			await waitForOperationReady(manager, replacement.id);
+			await manager.shutdownAll();
+		});
+
+		it("cleans the process group before resolving an immediate timeout", async () => {
+			const pidFile = join(root, "immediate-grandchild-pid");
+
+			const result = await runCliCommandImmediate(
+				{ name: "immediate", args: ["orphaning", pidFile], timeoutMs: 100 },
+				workerInvocation,
+			);
+
+			expect(result).toMatchObject({ exit_code: null, signal: "SIGTERM" });
+			expect(result.stderr).toContain("Command timed out after 100ms");
+			const grandchildPid = Number(readFileSync(pidFile, "utf-8"));
+			await waitFor(() => !processExists(grandchildPid));
+		});
+	});
+}
+
+function createManager(options: OperationShutdownOptions = {}): OperationManager {
+	return new OperationManager(workerInvocation, options);
+}
+
+function workerInvocation(args: readonly string[]): CurrentCliInvocation {
+	return {
+		command: process.execPath,
+		args: [worker, ...args],
+		entryPath: worker,
+	};
+}
+
+async function waitForOperationReady(manager: OperationManager, id: string): Promise<void> {
+	await waitFor(() => manager.logs(id)?.stdout.includes("ready") === true);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("timed out waiting for operation test condition");
+}
+
+function processExists(pid: number): boolean {
+	// A container runtime without an init process may leave the killed orphan as
+	// a zombie briefly. It is already terminated even though kill(pid, 0) still
+	// finds its process-table entry.
+	if (process.platform === "linux") {
+		try {
+			const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+			const stateOffset = stat.lastIndexOf(") ") + 2;
+			if (stateOffset > 1 && stat[stateOffset] === "Z") return false;
+		} catch {
+			// Fall through to the portable existence probe.
+		}
+	}
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/cli/src/serve/operation-runner.ts
+++ b/packages/cli/src/serve/operation-runner.ts
@@ -1,12 +1,19 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
+import {
+	type CurrentCliInvocation,
+	resolveCurrentCliInvocation,
+} from "../lib/current-cli-invocation";
+import { type ProcessTerminationOptions, terminateProcessGroup } from "../lib/process-group";
 import { stripTerminalEscapes } from "../lib/sanitize";
 
 const MAX_OUTPUT_LINES = 1000;
 const MAX_OPERATIONS = 100;
 const MAX_RUNNING_OPERATIONS = 4;
 const DEFAULT_IMMEDIATE_TIMEOUT_MS = 60_000;
+const DEFAULT_SHUTDOWN_TERM_TIMEOUT_MS = 5_000;
+const DEFAULT_SHUTDOWN_KILL_TIMEOUT_MS = 1_000;
 
 export type OperationStatus = "running" | "succeeded" | "failed" | "cancelled";
 
@@ -34,6 +41,9 @@ export interface OperationSnapshot {
 
 interface OperationRecord extends OperationSnapshot {
 	child: ChildProcess;
+	closed: Promise<void>;
+	closeObserved: boolean;
+	termination: Promise<void> | null;
 }
 
 export interface CommandOperationOptions {
@@ -49,18 +59,39 @@ export interface ImmediateCommandOptions extends CommandOperationOptions {
 	timeoutMs?: number;
 }
 
-class OperationManager {
+export interface OperationShutdownOptions {
+	termTimeoutMs?: number;
+	killTimeoutMs?: number;
+}
+
+type CliInvocationResolver = (args: readonly string[]) => CurrentCliInvocation;
+
+export class OperationManager {
 	private operations = new Map<string, OperationRecord>();
+	private shuttingDown = false;
+	private shutdownPromise: Promise<void> | null = null;
+	private readonly terminationOptions: ProcessTerminationOptions;
+
+	constructor(
+		private readonly invocationResolver: CliInvocationResolver = resolveCurrentCliInvocation,
+		terminationOptions: OperationShutdownOptions = {},
+	) {
+		this.terminationOptions = resolveTerminationOptions(terminationOptions);
+	}
 
 	start(options: CommandOperationOptions): OperationSnapshot {
 		this.assertCanStart(options);
-		const invocation = buildCliInvocation(options.args);
+		const invocation = this.invocationResolver(options.args);
 		const cwd = resolveOperationCwd(options.cwd);
 		const child = spawn(invocation.command, invocation.args, {
 			cwd,
 			env: nestedCliEnv(),
 			detached: process.platform !== "win32",
 			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let markClosed = () => {};
+		const closed = new Promise<void>((resolveClosed) => {
+			markClosed = resolveClosed;
 		});
 		const operation: OperationRecord = {
 			id: randomUUID(),
@@ -76,6 +107,9 @@ class OperationManager {
 			stdout: [],
 			stderr: [],
 			child,
+			closed,
+			closeObserved: false,
+			termination: null,
 		};
 		this.operations.set(operation.id, operation);
 		this.prune();
@@ -87,12 +121,14 @@ class OperationManager {
 			appendLines(operation.stderr, error.message);
 		});
 		child.on("close", (code, signal) => {
+			operation.closeObserved = true;
 			operation.exit_code = code;
 			operation.signal = signal;
 			operation.finished_at = new Date().toISOString();
 			if (operation.status !== "cancelled") {
 				operation.status = code === 0 ? "succeeded" : "failed";
 			}
+			markClosed();
 		});
 		if (options.stdin !== undefined) {
 			child.stdin?.end(options.stdin);
@@ -124,23 +160,45 @@ class OperationManager {
 		const operation = this.operations.get(id);
 		if (!operation) return null;
 		if (operation.status === "running") {
-			operation.status = "cancelled";
-			operation.finished_at = new Date().toISOString();
-			terminateChild(operation.child);
+			markOperationCancelled(operation);
+			void this.terminate(operation, this.terminationOptions);
 		}
 		return snapshotOperation(operation);
 	}
 
+	/** Stop every operation process group before the daemon exits. */
+	shutdownAll(options: OperationShutdownOptions = {}): Promise<void> {
+		if (this.shutdownPromise) return this.shutdownPromise;
+		const terminationOptions = resolveTerminationOptions(options, this.terminationOptions);
+		this.shuttingDown = true;
+		this.shutdownPromise = this.shutdownRunningOperations(terminationOptions);
+		return this.shutdownPromise;
+	}
+
+	private async shutdownRunningOperations(options: ProcessTerminationOptions): Promise<void> {
+		const open = [...this.operations.values()].filter((operation) => !operation.closeObserved);
+		for (const operation of open) {
+			if (operation.status === "running") markOperationCancelled(operation);
+		}
+		await Promise.all(open.map((operation) => this.terminate(operation, options)));
+	}
+
+	private terminate(operation: OperationRecord, options: ProcessTerminationOptions): Promise<void> {
+		operation.termination ??= terminateProcessGroup(operation.child, operation.closed, options);
+		return operation.termination;
+	}
+
 	private assertCanStart(options: CommandOperationOptions): void {
-		const running = [...this.operations.values()].filter(
-			(operation) => operation.status === "running",
-		);
-		if (running.length >= MAX_RUNNING_OPERATIONS) {
+		if (this.shuttingDown) {
+			throw new Error("The daemon is shutting down and cannot start new operations.");
+		}
+		const open = [...this.operations.values()].filter((operation) => !operation.closeObserved);
+		if (open.length >= MAX_RUNNING_OPERATIONS) {
 			throw new Error(`Too many running daemon operations (max ${MAX_RUNNING_OPERATIONS}).`);
 		}
 		if (
 			options.exclusiveKey &&
-			running.some((operation) => operation.exclusive_key === options.exclusiveKey)
+			open.some((operation) => operation.exclusive_key === options.exclusiveKey)
 		) {
 			throw new Error(`Another ${options.exclusiveKey} operation is already running.`);
 		}
@@ -151,7 +209,7 @@ class OperationManager {
 		if (overflow <= 0) return;
 		for (const operation of this.operations.values()) {
 			if (overflow <= 0) break;
-			if (operation.status === "running") continue;
+			if (!operation.closeObserved) continue;
 			this.operations.delete(operation.id);
 			overflow -= 1;
 		}
@@ -162,19 +220,28 @@ export const operationManager = new OperationManager();
 
 export async function runCliCommandImmediate(
 	options: ImmediateCommandOptions,
+	invocationResolver: CliInvocationResolver = resolveCurrentCliInvocation,
 ): Promise<CommandResult> {
-	const invocation = buildCliInvocation(options.args);
+	const invocation = invocationResolver(options.args);
 	const cwd = resolveOperationCwd(options.cwd);
 	const timeoutMs = options.timeoutMs ?? DEFAULT_IMMEDIATE_TIMEOUT_MS;
+	if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("Immediate command timeout must be a positive number.");
+	}
 	return await new Promise<CommandResult>((resolveResult) => {
 		let stdout = "";
 		let stderr = "";
 		let settled = false;
+		let timedOut = false;
 		const child = spawn(invocation.command, invocation.args, {
 			cwd,
 			env: nestedCliEnv(),
 			detached: process.platform !== "win32",
 			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let markClosed = () => {};
+		const closed = new Promise<void>((resolveClosed) => {
+			markClosed = resolveClosed;
 		});
 		const finish = (result: CommandResult) => {
 			if (settled) return;
@@ -187,12 +254,17 @@ export async function runCliCommandImmediate(
 			});
 		};
 		const timer = setTimeout(() => {
-			terminateChild(child);
-			finish({
-				exit_code: null,
-				signal: "SIGTERM",
-				stdout,
-				stderr: `${stderr}${stderr ? "\n" : ""}Command timed out after ${timeoutMs}ms.`,
+			timedOut = true;
+			void terminateProcessGroup(child, closed, {
+				termTimeoutMs: Math.min(timeoutMs, DEFAULT_SHUTDOWN_TERM_TIMEOUT_MS),
+				killTimeoutMs: DEFAULT_SHUTDOWN_KILL_TIMEOUT_MS,
+			}).then(() => {
+				finish({
+					exit_code: null,
+					signal: "SIGTERM",
+					stdout,
+					stderr: `${stderr}${stderr ? "\n" : ""}Command timed out after ${timeoutMs}ms.`,
+				});
 			});
 		}, timeoutMs);
 		child.stdout?.setEncoding("utf8");
@@ -207,7 +279,8 @@ export async function runCliCommandImmediate(
 			stderr += `${stderr ? "\n" : ""}${error.message}`;
 		});
 		child.on("close", (code, signal) => {
-			finish({ exit_code: code, signal, stdout, stderr });
+			markClosed();
+			if (!timedOut) finish({ exit_code: code, signal, stdout, stderr });
 		});
 		if (options.stdin !== undefined) {
 			child.stdin?.end(options.stdin);
@@ -246,17 +319,6 @@ function appendLines(target: string[], chunk: string): void {
 
 function tail(lines: string[], limit: number): string[] {
 	return lines.slice(Math.max(0, lines.length - limit));
-}
-
-function buildCliInvocation(args: string[]): { command: string; args: string[] } {
-	const entrypoint = process.argv[1];
-	if (!entrypoint) {
-		throw new Error("Cannot resolve the current clawdi CLI entrypoint for RPC operation.");
-	}
-	return {
-		command: process.execPath,
-		args: [entrypoint, ...args],
-	};
 }
 
 function resolveOperationCwd(cwd: string | undefined): string {
@@ -312,14 +374,29 @@ function nestedCliEnv(): NodeJS.ProcessEnv {
 	return env;
 }
 
-function terminateChild(child: ChildProcess): void {
-	if (process.platform !== "win32" && child.pid) {
-		try {
-			process.kill(-child.pid, "SIGTERM");
-			return;
-		} catch {
-			// Fall back to signalling the direct child.
+function markOperationCancelled(operation: OperationRecord): void {
+	operation.status = "cancelled";
+	operation.finished_at = new Date().toISOString();
+}
+
+function resolveTerminationOptions(
+	options: OperationShutdownOptions,
+	fallback: ProcessTerminationOptions = {
+		termTimeoutMs: DEFAULT_SHUTDOWN_TERM_TIMEOUT_MS,
+		killTimeoutMs: DEFAULT_SHUTDOWN_KILL_TIMEOUT_MS,
+	},
+): ProcessTerminationOptions {
+	const resolved = {
+		termTimeoutMs: options.termTimeoutMs ?? fallback.termTimeoutMs,
+		killTimeoutMs: options.killTimeoutMs ?? fallback.killTimeoutMs,
+	};
+	for (const [label, timeoutMs] of [
+		["TERM", resolved.termTimeoutMs],
+		["KILL", resolved.killTimeoutMs],
+	] as const) {
+		if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+			throw new Error(`Operation shutdown ${label} timeout must be a non-negative number.`);
 		}
 	}
-	child.kill("SIGTERM");
+	return resolved;
 }

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -46,6 +46,7 @@ let restoreFetch: (() => void) | null = null;
 let restoreConsole: (() => void) | null = null;
 let originalArgv1: string | undefined;
 let home = "";
+let consoleOutput: string[] = [];
 
 afterAll(() => {
 	rmSync(tmpRoot, { recursive: true, force: true });
@@ -84,8 +85,13 @@ beforeEach(() => {
 	seedAuth();
 	const originalLog = console.log;
 	const originalError = console.error;
-	console.log = () => {};
-	console.error = () => {};
+	consoleOutput = [];
+	console.log = (...args: unknown[]) => {
+		consoleOutput.push(args.map(String).join(" "));
+	};
+	console.error = (...args: unknown[]) => {
+		consoleOutput.push(args.map(String).join(" "));
+	};
 	restoreConsole = () => {
 		console.log = originalLog;
 		console.error = originalError;
@@ -213,6 +219,22 @@ describe("setup daemon install", () => {
 
 		expect(readFileSync(join(target, "SKILL.md"), "utf-8")).toBe("# Future user Clawdi\n");
 		expect(managedSkillReservationState(target, "clawdi")).toBe("unreserved");
+	});
+
+	it("sets a failing exit code without printing install success when service activation fails", async () => {
+		if (process.platform !== "linux") return;
+		installEnvironmentMock("env-codex");
+		writeExecutable(join(home, "bin", "systemctl"), "#!/bin/sh\nexit 1\n");
+
+		await setup({ agent: "codex", yes: true });
+
+		expect(process.exitCode).toBe(1);
+		process.exitCode = 0;
+		expect(daemonUnitExists("daemon")).toBe(true);
+		const output = consoleOutput.join("\n");
+		expect(output).toContain("systemctl activation failed");
+		expect(output).toContain("systemctl --user daemon-reload");
+		expect(output).not.toContain("Singleton daemon installed");
 	});
 });
 


### PR DESCRIPTION
## Summary

- make serve wait for operation and RPC shutdown ownership
- bound and abort control RPC calls and preserve one in-flight close promise
- terminate daemon operations as process groups and install reproducible script/npm daemon invocations

## Boundary

This is stack layer 4 of 5. It consumes current-cli-invocation and process-group primitives owned by layer 1. It does not add or rewrite those primitives and contains no standalone marker, native build support, native E2E, package script, or workflow transition.

## Verification

- Docker clean runner: full CLI typecheck and 1328 tests passed
- Docker Biome: 762 files passed
- `git diff --check 84dd7bca..aca95169` passed

Base is release recovery. Merge before native distribution PR #556.