### PR TITLE
Backend runtime: Python 3.13; fix fastembed cache mount

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
       - uses: ./.github/actions/setup-bun-ci
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
       - run: uv sync --frozen --no-install-project

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM python:3.12-slim AS runtime
+FROM python:3.13-slim AS runtime
 
 ARG APP_UID=1000
 ARG APP_GID=1000

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - "${API_HOST:-127.0.0.1}:${API_PORT:-8000}:8000"
     volumes:
       - files:/data/files
-      - fastembed_cache:/home/app/.cache/fastembed
+      - fastembed_cache:/tmp/fastembed_cache
     healthcheck:
       test:
         [
@@ -100,7 +100,7 @@ services:
     environment: *backend-env
     volumes:
       - files:/data/files
-      - fastembed_cache:/home/app/.cache/fastembed
+      - fastembed_cache:/tmp/fastembed_cache
     command: ["python", "-m", "app.workers.channels"]
     healthcheck:
       test:


### PR DESCRIPTION
- `python:3.12-slim` → `python:3.13-slim`; backend CI to 3.13 (lockfile already permits `>=3.12`).
- fastembed stores models under `/tmp/fastembed_cache` (its default), not `~/.cache/fastembed` — the self-host compose mounted the wrong path, so every container recreation re-downloaded the ~1.1GB ONNX embedding model. Point the volume at the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)