### PR TITLE
feat(cli): add stable installer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The fastest way to try it is hosted Clawdi Cloud. The whole stack is also here: 
 Recommended on macOS and Linux (no Node.js required):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Clawdi-AI/clawdi/main/install.sh | sh
+curl -fsSL https://clawdi.ai/install.sh | sh
 
 clawdi auth login
 clawdi setup
@@ -227,7 +227,7 @@ Clawdi has two intended paths.
 Best for trying it in minutes.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Clawdi-AI/clawdi/main/install.sh | sh
+curl -fsSL https://clawdi.ai/install.sh | sh
 clawdi auth login
 clawdi setup
 ```

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -446,14 +446,20 @@ describe("Vite hosted flag boundary", () => {
 	});
 });
 
-describe("PostHog proxy route boundaries", () => {
-	test("vercel.json keeps PostHog first-party proxy rewrites explicit", () => {
+describe("Vercel route boundaries", () => {
+	test("keeps public redirects and PostHog proxy rewrites explicit", () => {
 		const vercelConfig = join(SRC_DIR, "..", "vercel.json");
 		expect(existsSync(vercelConfig)).toBe(true);
 
 		const config = JSON.parse(readFileSync(vercelConfig, "utf8")) as {
 			rewrites?: Array<{ source: string; destination: string }>;
+			redirects?: Array<{ source: string; destination: string; permanent: boolean }>;
 		};
+		expect(config.redirects).toContainEqual({
+			source: "/install.sh",
+			destination: "https://github.com/Clawdi-AI/clawdi/releases/latest/download/install.sh",
+			permanent: false,
+		});
 		expect(config.rewrites).toContainEqual({
 			source: "/_cdi/px/static/:path*",
 			destination: "https://us-assets.i.posthog.com/static/:path*",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -12,6 +12,11 @@
 		}
 	],
 	"redirects": [
+		{
+			"source": "/install.sh",
+			"destination": "https://github.com/Clawdi-AI/clawdi/releases/latest/download/install.sh",
+			"permanent": false
+		},
 		{ "source": "/wallet", "destination": "/?settings=billing-wallet", "permanent": false },
 		{ "source": "/subscription", "destination": "/?settings=billing-plan", "permanent": false },
 		{ "source": "/pricing", "destination": "/?settings=billing-plan", "permanent": false },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ backend + dashboard + CLI stack, use the canonical runbook in
 Recommended on macOS and Linux (no Node.js required):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Clawdi-AI/clawdi/main/install.sh | sh
+curl -fsSL https://clawdi.ai/install.sh | sh
 clawdi auth login
 clawdi setup
 clawdi doctor


### PR DESCRIPTION
## Summary

- redirect `https://clawdi.ai/install.sh` to the latest immutable CLI release installer
- use the stable URL in CLI installation documentation
- cover the redirect in the existing parsed Vercel route contract test

## Verification

- `bun test apps/web/src/hosted/oss-clean.test.ts` (15 pass)
- Biome
- `git diff --check`