### PR TITLE
Backend runtime: Python 3.14

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
       - uses: ./.github/actions/setup-bun-ci
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
       - run: uv sync --frozen --no-install-project

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM python:3.13-slim AS runtime
+FROM python:3.14-slim AS runtime
 
 ARG APP_UID=1000
 ARG APP_GID=1000


### PR DESCRIPTION
`python:3.13-slim` → `python:3.14-slim`; backend CI matrix to 3.14. Lockfile constraints already permit `>=3.12`; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)