### PR TITLE
Fix stable installer release boundary

### DIFF
--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -457,7 +457,7 @@ describe("Vercel route boundaries", () => {
 		};
 		expect(config.redirects).toContainEqual({
 			source: "/install.sh",
-			destination: "https://github.com/Clawdi-AI/clawdi/releases/latest/download/install.sh",
+			destination: "https://raw.githubusercontent.com/Clawdi-AI/clawdi/main/install.sh",
 			permanent: false,
 		});
 		expect(config.rewrites).toContainEqual({

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -14,7 +14,7 @@
 	"redirects": [
 		{
 			"source": "/install.sh",
-			"destination": "https://github.com/Clawdi-AI/clawdi/releases/latest/download/install.sh",
+			"destination": "https://raw.githubusercontent.com/Clawdi-AI/clawdi/main/install.sh",
 			"permanent": false
 		},
 		{ "source": "/wallet", "destination": "/?settings=billing-wallet", "permanent": false },


### PR DESCRIPTION
## Summary

- decouple `/install.sh` from the repository-wide GitHub `latest` release pointer
- redirect to the reviewed installer on `main`, which resolves the exact CLI version from npm and verifies immutable release artifacts
- preserve the route boundary contract test

## Why

App releases and CLI releases share one GitHub repository. Publishing `clawdi-YYYY-MM-DD` as latest can otherwise make `/install.sh` resolve to an app release with no installer asset.

## Verification

- isolated Docker Web typecheck
- `oss-clean.test.ts`: 15 passed
- OSS production build
- `git diff --check`

No backend, CLI protocol, tenant, or production data changes.