### PR TITLE
Auto-deploy to the VPS on main via Kamal

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -308,3 +308,27 @@ jobs:
           fi
 
           python3 infra/deploy/coolify/audit_stack.py --phase live
+
+  deploy-vps:
+    needs: build
+    if: needs.build.outputs.build_required == 'true' && needs.build.outputs.should_deploy == 'true'
+    runs-on: clawdi-box
+    timeout-minutes: 15
+    concurrency:
+      group: kamal-deploy-clawdi
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.build.outputs.image_tag }}
+
+      - name: Kamal deploy (VPS)
+        run: |
+          install -m 600 /home/phala/.kamal-secrets/clawdi.env .kamal/secrets
+          docker run --rm \
+            -v "$PWD":/workdir \
+            -v /home/phala/.ssh:/root/.ssh \
+            -v /home/phala/.clawdi-ops:/home/phala/.clawdi-ops:ro \
+            -e KAMAL_LOCAL_DEPLOY=1 \
+            -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='*' \
+            ghcr.io/basecamp/kamal:latest deploy -P --version "${{ needs.build.outputs.image_tag }}"

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -29,9 +29,12 @@ aliases:
 
 ssh:
   user: phala
-  # -F none: skip ssh config files (ownership differs when kamal runs in a
-  # container with the operator's ~/.ssh bind-mounted).
+  <%# Deploys from the box itself (CI runner) connect directly; operator
+      deploys from outside go through the jump host. -F none: skip ssh config
+      files (ownership differs inside the kamal container). %>
+  <% unless ENV["KAMAL_LOCAL_DEPLOY"] %>
   proxy_command: "ssh -F none -o StrictHostKeyChecking=accept-new -i ~/.ssh/id_ed25519 -l phala -W %h:%p jump.phala.systems"
+  <% end %>
   keys:
     - ~/.ssh/clawdi_access_ed25519
 


### PR DESCRIPTION
Vercel-style flow: merge to main → image release → `deploy-vps` on the box-local self-hosted runner runs `kamal deploy -P --version=<sha>` (health-gated rolling). Mirrors the existing deploy job's gates; Coolify deploy untouched during transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)