### PR TITLE
Fix deploy-vps: create .kamal dir when installing secrets

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -324,7 +324,7 @@ jobs:
 
       - name: Kamal deploy (VPS)
         run: |
-          install -m 600 /home/phala/.kamal-secrets/clawdi.env .kamal/secrets
+          install -D -m 600 /home/phala/.kamal-secrets/clawdi.env .kamal/secrets
           docker run --rm \
             -v "$PWD":/workdir \
             -v /home/phala/.ssh:/root/.ssh \


### PR DESCRIPTION
`install -D` creates the gitignored `.kamal/` parent directory in a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)