### PR TITLE
Toolcache prep: use the real uid, not $USER

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -344,7 +344,7 @@ jobs:
           chmod 600 .kamal/secrets
 
       - name: Prepare toolcache
-        run: sudo mkdir -p /opt/hostedtoolcache && sudo chown -R "$USER" /opt/hostedtoolcache
+        run: sudo install -d -o "$(id -u)" -g "$(id -g)" /opt/hostedtoolcache
 
       - name: Install Kamal
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
`chown -R \"$USER\"` succeeded but ruby/setup-ruby still got EACCES — $USER doesn't match the executing uid on this runner. `install -d -o $(id -u)` targets the actual identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)