### PR TITLE
Install Ruby system deps on the minimal runner image

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -343,8 +343,11 @@ jobs:
           printf '%s\n' "$KAMAL_SECRETS" > .kamal/secrets
           chmod 600 .kamal/secrets
 
-      - name: Prepare toolcache
-        run: sudo install -d -o "$(id -u)" -g "$(id -g)" /opt/hostedtoolcache
+      - name: Prepare runner for Ruby
+        run: |
+          sudo install -d -o "$(id -u)" -g "$(id -g)" /opt/hostedtoolcache
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends libyaml-0-2 build-essential
 
       - name: Install Kamal
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The custom runner image lacks `libyaml` (Ruby psych) and a compiler (kamal's ed25519 native ext). Consider baking these into the runner image later; for now the deploy job provisions them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)