### PR TITLE
Release CLI 0.13.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.13",
+      "version": "0.13.14",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.13",
+	"version": "0.13.14",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the immutable CLI package version to 0.13.14
- publish the reviewed cold-install MCP planning fix from #582 as a new artifact

## Verification

- CLI typecheck
- publish manifest validation
- git diff --check