### PR TITLE
Fix hosted runtime CA activation ordering

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1615,8 +1615,9 @@ function applySystemdRuntimeUpdate(
 		: allUser;
 	const systemUnitsChanged = [...system.added, ...system.changed].sort();
 	const userUnitsChanged = [...user.added, ...user.changed].sort();
-	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter((unit) =>
-		after.system.has(unit),
+	const scopedSystemUnits = opts.activationScope ? new Set(opts.activationScope.systemUnits) : null;
+	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter(
+		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
 	);
 	const recoverFailedUnits = opts.recoverFailedUnits !== false;
 	const activationChanged =
@@ -1855,6 +1856,27 @@ function runtimeUserSystemctlResult(
 		]);
 	}
 	return runCommandResult(systemctlPath(), ["--user", ...args]);
+}
+
+function assertRuntimeUserCanRead(path: string): void {
+	const runtimeUser = runtimeUserName();
+	const runtimeUid = Number.parseInt(commandOutput("id", ["-u", runtimeUser]).trim(), 10);
+	if (!Number.isSafeInteger(runtimeUid) || runtimeUid < 0) {
+		throw new Error(`could not resolve runtime uid for ${runtimeUser}`);
+	}
+	const proof = buildRuntimeUserReadCommand(process.getuid?.(), runtimeUid, runtimeUser, path);
+	runCommand(proof.command, proof.args);
+}
+
+export function buildRuntimeUserReadCommand(
+	currentUid: number | undefined,
+	runtimeUid: number,
+	runtimeUser: string,
+	path: string,
+): { command: string; args: string[] } {
+	return currentUid === runtimeUid
+		? { command: "test", args: ["-r", path] }
+		: { command: "gosu", args: [runtimeUser, "test", "-r", path] };
 }
 
 function commandOutput(command: string, args: string[]): string {
@@ -2573,7 +2595,7 @@ function applyRuntimeDesiredState(
 						},
 					);
 					if (prerequisite.applied) {
-						accessSync(paths.egressSystemCaFile, constants.R_OK);
+						assertRuntimeUserCanRead(paths.egressSystemCaFile);
 						egressPrerequisiteActivated = true;
 					}
 					return prerequisite;

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1660,6 +1660,7 @@ function applySystemdRuntimeUpdate(
 	if (restartSystemUnits.length > 0) systemctl(["restart", ...restartSystemUnits]);
 
 	const changedUserUnits = new Set(user.changed);
+	const addedUserUnits = new Set(user.added);
 	const resetFailedUserUnits: string[] = [];
 	const startUserUnits: string[] = [];
 	const enableUserUnits: string[] = [];
@@ -1681,7 +1682,11 @@ function applySystemdRuntimeUpdate(
 		}
 		if (state.activeState !== "active") continue;
 		if (!enabled) enableUserUnits.push(unit);
-		if (changedUserUnits.has(unit)) restartUserUnits.push(unit);
+		// Official runtime installers may create and start their user unit after
+		// the pre-convergence snapshot. Treat that already-running added unit like
+		// a changed unit so it is restarted after system services (including the
+		// Type=notify transparent-egress sidecar) have reached readiness.
+		if (addedUserUnits.has(unit) || changedUserUnits.has(unit)) restartUserUnits.push(unit);
 	}
 	if (resetFailedUserUnits.length > 0) {
 		runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]);

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1586,10 +1586,33 @@ function applySystemdRuntimeUpdate(
 	opts: {
 		forceRestartSystemUnits?: readonly string[];
 		recoverFailedUnits?: boolean;
+		activationScope?: {
+			systemUnits: readonly string[];
+			userUnits: readonly string[];
+		};
+		skipActivatedSystemUnits?: readonly string[];
 	} = {},
 ): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
-	const system = changedSystemdUnits(before.system, after.system);
-	const user = changedSystemdUnits(before.user, after.user);
+	const allSystem = changedSystemdUnits(before.system, after.system);
+	const allUser = changedSystemdUnits(before.user, after.user);
+	const filterChanges = (
+		changes: ReturnType<typeof changedSystemdUnits>,
+		units: readonly string[],
+	): ReturnType<typeof changedSystemdUnits> => {
+		const selected = new Set(units);
+		return {
+			added: changes.added.filter((unit) => selected.has(unit)),
+			changed: changes.changed.filter((unit) => selected.has(unit)),
+			removed: changes.removed.filter((unit) => selected.has(unit)),
+			present: changes.present.filter((unit) => selected.has(unit)),
+		};
+	};
+	const system = opts.activationScope
+		? filterChanges(allSystem, opts.activationScope.systemUnits)
+		: allSystem;
+	const user = opts.activationScope
+		? filterChanges(allUser, opts.activationScope.userUnits)
+		: allUser;
 	const systemUnitsChanged = [...system.added, ...system.changed].sort();
 	const userUnitsChanged = [...user.added, ...user.changed].sort();
 	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter((unit) =>
@@ -1629,11 +1652,13 @@ function applySystemdRuntimeUpdate(
 	const addedSystemUnits = new Set(system.added);
 	const changedSystemUnits = new Set(system.changed);
 	const forcedRestartUnits = new Set(forcedSystemRestarts);
+	const skipActivatedSystemUnits = new Set(opts.skipActivatedSystemUnits ?? []);
 	const resetFailedSystemUnits: string[] = [];
 	const startSystemUnits: string[] = [];
 	const restartSystemUnits: string[] = [];
 	for (const unit of system.present) {
 		const state = systemdUnitManagerState(paths, "system", unit);
+		if (skipActivatedSystemUnits.has(unit)) continue;
 		if (state.activeState === "failed" && recoverFailedUnits) {
 			resetFailedSystemUnits.push(unit);
 			startSystemUnits.push(unit);
@@ -1660,7 +1685,6 @@ function applySystemdRuntimeUpdate(
 	if (restartSystemUnits.length > 0) systemctl(["restart", ...restartSystemUnits]);
 
 	const changedUserUnits = new Set(user.changed);
-	const addedUserUnits = new Set(user.added);
 	const resetFailedUserUnits: string[] = [];
 	const startUserUnits: string[] = [];
 	const enableUserUnits: string[] = [];
@@ -1682,11 +1706,7 @@ function applySystemdRuntimeUpdate(
 		}
 		if (state.activeState !== "active") continue;
 		if (!enabled) enableUserUnits.push(unit);
-		// Official runtime installers may create and start their user unit after
-		// the pre-convergence snapshot. Treat that already-running added unit like
-		// a changed unit so it is restarted after system services (including the
-		// Type=notify transparent-egress sidecar) have reached readiness.
-		if (addedUserUnits.has(unit) || changedUserUnits.has(unit)) restartUserUnits.push(unit);
+		if (changedUserUnits.has(unit)) restartUserUnits.push(unit);
 	}
 	if (resetFailedUserUnits.length > 0) {
 		runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]);
@@ -2526,6 +2546,7 @@ function applyRuntimeDesiredState(
 		systemUnitsChanged: [] as string[],
 		userUnitsChanged: [] as string[],
 	};
+	let egressPrerequisiteActivated = false;
 	const convergence = convergeRuntimeManifest(load, paths, {
 		cacheLastGood: false,
 		commitAuthority: (committedConvergence, authority) => {
@@ -2535,7 +2556,38 @@ function applyRuntimeDesiredState(
 			opts.authorityCommit?.(committedConvergence, authority);
 		},
 		systemdApply: {
+			activateEgressPrerequisite: ({ restartEgressSidecar }) => {
+				failedSystemdUnits = readSystemdUnitSnapshot(paths);
+				try {
+					const prerequisite = applySystemdRuntimeUpdate(
+						paths,
+						previousSystemdUnits,
+						failedSystemdUnits,
+						{
+							activationScope: {
+								systemUnits: [RUNTIME_SIDECAR_SYSTEM_UNIT],
+								userUnits: [],
+							},
+							forceRestartSystemUnits: restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
+							recoverFailedUnits: opts.recoverFailedSystemdUnits,
+						},
+					);
+					if (prerequisite.applied) {
+						accessSync(paths.egressSystemCaFile, constants.R_OK);
+						egressPrerequisiteActivated = true;
+					}
+					return prerequisite;
+				} catch (error) {
+					throw new Error(
+						`transparent-egress prerequisite activation failed: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				}
+			},
 			activate: ({ restartEgressSidecar }) => {
+				// Official installers run after the prerequisite phase and add their
+				// base units, so final reconciliation must observe a fresh rendered state.
 				failedSystemdUnits = readSystemdUnitSnapshot(paths);
 				try {
 					systemdApply = applySystemdRuntimeUpdate(
@@ -2545,6 +2597,9 @@ function applyRuntimeDesiredState(
 						{
 							forceRestartSystemUnits: restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
 							recoverFailedUnits: opts.recoverFailedSystemdUnits,
+							skipActivatedSystemUnits: egressPrerequisiteActivated
+								? [RUNTIME_SIDECAR_SYSTEM_UNIT]
+								: [],
 						},
 					);
 					return systemdApply;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -48,6 +48,12 @@ import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { normalizeSecretValues } from "./secret-values";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
+const successfulPrerequisiteActivation = () => ({
+	applied: true,
+	systemUnitsChanged: [],
+	userUnitsChanged: [],
+});
+
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
@@ -2403,6 +2409,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						);
 					},
 					systemdApply: {
+						activateEgressPrerequisite: successfulPrerequisiteActivation,
 						activate: ({ restartEgressSidecar }) => {
 							signals.push(restartEgressSidecar);
 							return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
@@ -2564,6 +2571,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				revisionA = authority.egressSidecarSecretRevision;
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
 				rollback: () => {},
 			},
@@ -2584,6 +2592,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commit("000001", revisionB);
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					recoverySignals.push(restartEgressSidecar);
 					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
@@ -2613,6 +2622,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("restart failure must not commit authority");
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					throw new Error("injected sidecar restart failure");
@@ -2641,6 +2651,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("injected authority commit failure");
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
@@ -2671,6 +2682,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commit("000002", revisionC);
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					mixedSnapshotActivations++;
@@ -2701,6 +2713,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				mixedFailureCommits++;
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					throw new Error("injected mixed-snapshot restart failure");
@@ -2743,6 +2756,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				legacyFailureCommits++;
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					expect(readFileSync(secretFile, "utf-8")).toContain(legacyDesired);
@@ -2782,6 +2796,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				legacyMissingCacheRestartCommits++;
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					expect(readFileSync(secretFile, "utf-8")).toContain(legacyDesired);
@@ -2820,6 +2835,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("injected legacy authority commit failure");
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					legacyMissingCacheActivationSecrets.push(readFileSync(secretFile, "utf-8"));
@@ -2900,6 +2916,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		const legacyEnvBaseline = convergeRuntimeManifest(legacyEnvLoad(), paths, {
 			cacheLastGood: false,
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
 				rollback: () => {},
 			},
@@ -2919,6 +2936,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				legacyEnvRestartFailureCommits++;
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					expect(readFileSync(secretFile, "utf-8")).toContain("legacy-env-c");
@@ -2950,6 +2968,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("injected legacy env authority commit failure");
 			},
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
 					expect(readFileSync(secretFile, "utf-8")).toContain("legacy-env-c");
@@ -2984,6 +3003,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commitAuthority: (_convergence, authority) =>
 					writeAuthority("000001", authority.egressSidecarSecretRevision),
 				systemdApply: {
+					activateEgressPrerequisite: successfulPrerequisiteActivation,
 					activate: ({ restartEgressSidecar }) => {
 						legacySignals.push(restartEgressSidecar);
 						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
@@ -3205,6 +3225,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		let rollbackCalls = 0;
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-patch-failure"), paths, {
 			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => {
 					activateCalls += 1;
 					throw new Error("injected systemd activation failure");

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -106,6 +106,7 @@ EOF
 	printf '%s %s\\n' '${input.runtime}' "$*" >> '${input.logPath}'
 	${input.failUninstall ? "exit 42" : `rm -f '${input.unitPath}'`}
 	;;
+  "config patch --stdin") cat >/dev/null ;;
   *)
     printf 'unexpected ${input.runtime} command: %s\\n' "$*" >&2
     exit 64
@@ -1000,6 +1001,8 @@ describe("runtime manifest services", () => {
 			recovery: {},
 		};
 
+		let prerequisiteActivations = 0;
+		let finalActivations = 0;
 		const result = convergeRuntimeManifest(
 			{
 				manifest,
@@ -1008,9 +1011,24 @@ describe("runtime manifest services", () => {
 				offline: false,
 			},
 			paths,
+			{
+				systemdApply: {
+					activateEgressPrerequisite: () => {
+						prerequisiteActivations += 1;
+						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					activate: () => {
+						finalActivations += 1;
+						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					rollback: () => {},
+				},
+			},
 		);
 
 		expect(result.installErrors).toEqual([]);
+		expect(prerequisiteActivations).toBe(0);
+		expect(finalActivations).toBe(1);
 		expect(readFileSync(logPath, "utf8").trim().split("\n")).toEqual([
 			"systemctl --user daemon-reload",
 			"systemctl --user reset-failed hermes-gateway.service",
@@ -1293,6 +1311,7 @@ cat > '${logPath}'
 		expect(result.installErrors).toEqual([]);
 		expect(JSON.parse(readFileSync(logPath, "utf8"))).toEqual({
 			agents: { defaults: { userTimezone: "UTC" } },
+			gateway: { mode: "local" },
 		});
 	});
 
@@ -1342,13 +1361,33 @@ cat > '${logPath}'
 			unitPath,
 			failInstall: true,
 		});
-		const failedFirstInstall = convergeRuntimeManifest(load("inline-install-failure", 1), paths);
+		let authorityCommits = 0;
+		let finalActivations = 0;
+		const failedFirstInstall = convergeRuntimeManifest(load("inline-install-failure", 1), paths, {
+			commitAuthority: () => {
+				authorityCommits += 1;
+			},
+			systemdApply: {
+				activateEgressPrerequisite: () => ({
+					applied: true,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				}),
+				activate: () => {
+					finalActivations += 1;
+					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+				},
+				rollback: () => {},
+			},
+		});
 		expect(failedFirstInstall.installErrors.join("\n")).toContain(
 			"official openclaw-gateway service install failed",
 		);
 		expect(existsSync(paths.managedConfig)).toBe(false);
 		expect(existsSync(manifest.workspaceRoot ?? "")).toBe(false);
 		expect(existsSync(dropInPath)).toBe(true);
+		expect(authorityCommits).toBe(0);
+		expect(finalActivations).toBe(0);
 		expect(
 			failedFirstInstall.outputs.systemdUserUnits.map((path) => path.split("/").at(-1)),
 		).not.toContain("openclaw-gateway.service");

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -204,6 +204,7 @@ interface RuntimeSystemdApplySignal {
 }
 
 interface RuntimeSystemdApplyHooks {
+	activateEgressPrerequisite: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 	activate: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 	rollback: (signal: RuntimeSystemdApplySignal) => void;
 }
@@ -2881,9 +2882,10 @@ function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, u
 					},
 				}
 			: {}),
-		...(gatewayToken || allowedOrigins.length > 0
-			? {
-					gateway: {
+		gateway: {
+			mode: "local",
+			...(gatewayToken || allowedOrigins.length > 0
+				? {
 						...(nativeAuth ? { port: 18789, bind: "lan" } : {}),
 						...(gatewayToken
 							? {
@@ -2908,9 +2910,9 @@ function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, u
 									},
 								}
 							: {}),
-					},
-				}
-			: {}),
+					}
+				: {}),
+		},
 	};
 }
 
@@ -5169,7 +5171,9 @@ function officialRuntimeSystemdPrograms(
 		const serviceName = officialRuntimeSystemdProgramName(program);
 		if (serviceName) byServiceName.set(serviceName, program);
 	}
-	return [...byServiceName.values()];
+	return [...byServiceName.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([, program]) => program);
 }
 
 function writeSystemdUnits(
@@ -6203,40 +6207,6 @@ export function convergeRuntimeManifest(
 			);
 		}
 		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(load.sourcePath, paths);
-		if (shouldInstallOfficialRuntimeServices()) {
-			for (const program of officialRuntimeSystemdPrograms(runtimeSystemdUserPrograms)) {
-				writeRuntimeSystemdUserProgram({
-					program,
-					commonEnvironment: commonSystemdEnvironment,
-					manifest,
-					paths,
-					secretValues,
-					providerProjectionRevisions,
-				});
-				const serviceName = runtimeSystemdProgramName(program);
-				const key = systemdUnitFileName(serviceName);
-				const desiredRevision = officialServiceDesiredRevision({
-					program,
-				});
-				const currentRevision = () => officialServiceCurrentRevision(program, paths);
-				const verifiedCurrentRevision = verifiedReceiptCurrentRevision(
-					previousInstallReceipts?.officialServices[key],
-					desiredRevision,
-					currentRevision,
-				);
-				const target: RuntimeInstallReceiptTarget = {
-					desiredRevision,
-					currentRevision,
-					expectedCurrentRevision: verifiedCurrentRevision,
-				};
-				installReceiptTargets.officialServices.set(key, target);
-				if (verifiedCurrentRevision !== null) continue;
-				reloadRuntimeUserManager(paths, paths.userHome);
-				const error = installOfficialRuntimeUserService({ ...program, cwd: paths.userHome }, paths);
-				if (error) throw new Error(error);
-				target.expectedCurrentRevision = currentRevision();
-			}
-		}
 		try {
 			const codexProjection = applyHostedCodexManagedProviderProjection(
 				manifest,
@@ -6482,6 +6452,52 @@ export function convergeRuntimeManifest(
 					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
 				}
 			}
+		}
+		const pendingOfficialServiceInstalls: Array<{
+			program: RuntimeSystemdUserProgram;
+			target: RuntimeInstallReceiptTarget;
+		}> = [];
+		if (shouldInstallOfficialRuntimeServices()) {
+			for (const program of officialRuntimeSystemdPrograms(runtimeSystemdUserPrograms)) {
+				const serviceName = runtimeSystemdProgramName(program);
+				const key = systemdUnitFileName(serviceName);
+				const desiredRevision = officialServiceDesiredRevision({ program });
+				const currentRevision = () => officialServiceCurrentRevision(program, paths);
+				const verifiedCurrentRevision = verifiedReceiptCurrentRevision(
+					previousInstallReceipts?.officialServices[key],
+					desiredRevision,
+					currentRevision,
+				);
+				const target: RuntimeInstallReceiptTarget = {
+					desiredRevision,
+					currentRevision,
+					expectedCurrentRevision: verifiedCurrentRevision,
+				};
+				installReceiptTargets.officialServices.set(key, target);
+				if (verifiedCurrentRevision === null) {
+					pendingOfficialServiceInstalls.push({ program, target });
+				}
+			}
+		}
+		if (
+			pendingOfficialServiceInstalls.length > 0 &&
+			systemdUnits.egressSidecarActive &&
+			opts.systemdApply
+		) {
+			systemdActivationAttempted = true;
+			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
+				restartEgressSidecar,
+			});
+			if (!prerequisite.applied) {
+				throw new Error("transparent-egress system prerequisites did not reach readiness");
+			}
+		}
+
+		for (const { program, target } of pendingOfficialServiceInstalls) {
+			reloadRuntimeUserManager(paths, paths.userHome);
+			const error = installOfficialRuntimeUserService({ ...program, cwd: paths.userHome }, paths);
+			if (error) throw new Error(error);
+			target.expectedCurrentRevision = target.currentRevision();
 		}
 
 		const bootFinished = join(instanceRoot, "boot-finished");

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import {
 	assertCurrentEgressIdentity,
 	buildEgressEngineSpawnCommand,
+	buildRuntimeUserReadCommand,
 	publishEgressSystemCaBundle,
 	runtimeApplyCommand,
 	runtimePlanCommand,
@@ -26,6 +27,13 @@ let origHome: string | undefined;
 let origApiUrl: string | undefined;
 
 describe("runtime sidecar egress privilege drop", () => {
+	it("checks the CA as the runtime user when convergence runs as root", () => {
+		expect(buildRuntimeUserReadCommand(0, 10001, "clawdi", "/run/clawdi/egress/ca.pem")).toEqual({
+			command: "gosu",
+			args: ["clawdi", "test", "-r", "/run/clawdi/egress/ca.pem"],
+		});
+	});
+
 	it("prefers setpriv with an explicit non-root numeric identity", () => {
 		expect(
 			buildEgressEngineSpawnCommand(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -14,7 +14,7 @@ import {
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
-import { tmpdir, userInfo } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
@@ -7675,7 +7675,7 @@ exit 64
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "1";
-		process.env.CLAWDI_RUNTIME_USER = userInfo().username;
+		process.env.CLAWDI_RUNTIME_USER = String(process.getuid?.() ?? 0);
 		const paths = getRuntimePaths();
 		writeFakeSystemdManager({
 			path: join(bin, "systemctl"),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -14,7 +14,7 @@ import {
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
@@ -7675,7 +7675,7 @@ exit 64
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "1";
-		process.env.CLAWDI_RUNTIME_USER = "root";
+		process.env.CLAWDI_RUNTIME_USER = userInfo().username;
 		const paths = getRuntimePaths();
 		writeFakeSystemdManager({
 			path: join(bin, "systemctl"),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -139,6 +139,8 @@ function writeFakeSystemdManager(input: {
 	stateRoot: string;
 	failNextSidecarRestart?: string;
 	failNextSidecarStop?: string;
+	sidecarReadyPath?: string;
+	staleEarlyProcessPath?: string;
 }): void {
 	mkdirSync(input.stateRoot, { recursive: true });
 	mkdirSync(dirname(input.path), { recursive: true });
@@ -178,7 +180,11 @@ case "$command" in
     fi
     ;;
   start)
-    for unit in "$@"; do rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; done
+    for unit in "$@"; do
+      rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"
+      touch "$(state_path "$unit" active)"
+      if [ "$unit" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.sidecarReadyPath ?? ""}' ]; then touch '${input.sidecarReadyPath ?? ""}'; fi
+    done
     ;;
   restart)
     if [ "$*" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.failNextSidecarRestart ?? ""}' ] && [ -f '${input.failNextSidecarRestart ?? ""}' ]; then
@@ -186,7 +192,15 @@ case "$command" in
       printf 'injected sidecar restart failure\\n' >&2
       exit 42
     fi
-    for unit in "$@"; do rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; done
+    for unit in "$@"; do
+      if [ "$scope" = "user" ] && [ "$unit" = "openclaw-gateway.service" ] && [ -n '${input.staleEarlyProcessPath ?? ""}' ]; then
+        test -r '${input.sidecarReadyPath ?? ""}'
+        rm -f '${input.staleEarlyProcessPath ?? ""}'
+      fi
+      rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"
+      touch "$(state_path "$unit" active)"
+      if [ "$unit" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.sidecarReadyPath ?? ""}' ]; then touch '${input.sidecarReadyPath ?? ""}'; fi
+    done
     ;;
   stop)
     if [ "$*" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.failNextSidecarStop ?? ""}' ] && [ -f '${input.failNextSidecarStop ?? ""}' ]; then
@@ -7615,6 +7629,97 @@ exit 64
 		expect(statSync(activeTarget).mode & 0o777).toBe(0o700);
 		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
 		expect(statSync(legacyImageShim).mode & 0o777).toBe(0o700);
+	});
+
+	it("restarts an OpenClaw service started by the official installer after egress CA readiness", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const systemctlLog = join(root, "systemctl-cold-openclaw.log");
+		const systemctlStateRoot = join(root, "systemctl-cold-openclaw-state");
+		const staleEarlyProcess = join(root, "openclaw-started-before-ca");
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		const openclawUnit = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+		const previousLog = console.log;
+		const previousUmask = process.umask(0o022);
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "1";
+		process.env.CLAWDI_RUNTIME_USER = "root";
+		const paths = getRuntimePaths();
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			sidecarReadyPath: paths.egressSystemCaFile,
+			staleEarlyProcessPath: staleEarlyProcess,
+		});
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ "$*" = "gateway install --force --json" ]; then
+  mkdir -p '${dirname(openclawUnit)}' '${systemctlStateRoot}'
+  printf '[Service]\\nExecStart=openclaw gateway run\\n' > '${openclawUnit}'
+  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "active")}'
+  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "enabled")}'
+  touch '${staleEarlyProcess}'
+fi
+exit 0
+`,
+		);
+		chmodSync(openclawBin, 0o700);
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		const mitmproxy = seedMitmproxyCache(paths);
+		console.log = (value?: unknown) => logs.push(String(value));
+		const runtimeFetch = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () =>
+					hostedRuntimeBundleResponse(
+						hostedEgressSecretRotationPayload(home, mitmproxy, "cold-home-secret"),
+						{ etag: '"cold-home-egress"' },
+					),
+			},
+		]);
+
+		try {
+			await runtimeWatch({ once: true, json: true });
+		} finally {
+			runtimeFetch.restore();
+			console.log = previousLog;
+			process.umask(previousUmask);
+		}
+
+		if (process.exitCode !== undefined && process.exitCode !== 0) {
+			throw new Error(logs.join("\n"));
+		}
+		expect(JSON.parse(logs.at(-1) ?? "{}").status).toBe("applied");
+		expect(existsSync(staleEarlyProcess)).toBe(false);
+		expect(existsSync(paths.egressSystemCaFile)).toBe(true);
+		const calls = readFileSync(systemctlLog, "utf8").trim().split("\n");
+		const sidecarActivation = calls.findIndex((call) =>
+			/^(start|restart) .*clawdi-runtime-sidecar\.service/.test(call),
+		);
+		const openclawRestart = calls.indexOf("--user restart openclaw-gateway.service");
+		expect(sidecarActivation).toBeGreaterThanOrEqual(0);
+		expect(openclawRestart).toBeGreaterThan(sidecarActivation);
+		expect(readRuntimeAppliedState(paths)).toMatchObject({
+			generation: 41,
+			etag: '"cold-home-egress"',
+		});
 	});
 
 	it("keeps public sidecar artifacts stable while forcing private egress secret restarts", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -140,7 +140,6 @@ function writeFakeSystemdManager(input: {
 	failNextSidecarRestart?: string;
 	failNextSidecarStop?: string;
 	sidecarReadyPath?: string;
-	staleEarlyProcessPath?: string;
 }): void {
 	mkdirSync(input.stateRoot, { recursive: true });
 	mkdirSync(dirname(input.path), { recursive: true });
@@ -193,10 +192,6 @@ case "$command" in
       exit 42
     fi
     for unit in "$@"; do
-      if [ "$scope" = "user" ] && [ "$unit" = "openclaw-gateway.service" ] && [ -n '${input.staleEarlyProcessPath ?? ""}' ]; then
-        test -r '${input.sidecarReadyPath ?? ""}'
-        rm -f '${input.staleEarlyProcessPath ?? ""}'
-      fi
       rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"
       touch "$(state_path "$unit" active)"
       if [ "$unit" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.sidecarReadyPath ?? ""}' ]; then touch '${input.sidecarReadyPath ?? ""}'; fi
@@ -711,12 +706,13 @@ function hostedEgressSecretRotationPayload(
 	home: string,
 	egressEngine: typeof TEST_EGRESS_ENGINE_PIN,
 	secret: string,
+	runtime: "openclaw" | "hermes" = "openclaw",
 ): HostedRuntimeResponseFixture {
 	return {
 		manifest: {
 			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
 			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
-			runtime: "openclaw",
+			runtime,
 			deploymentId: "dep_watch_egress_secret_rotation",
 			environmentId: "env_watch_egress_secret_rotation",
 			...hostedRequiredState(),
@@ -724,7 +720,7 @@ function hostedEgressSecretRotationPayload(
 			generation: 41,
 			issuedAt: "2026-07-28T00:00:00Z",
 			locale: TEST_HOSTED_LOCALE,
-			system: hostedSystemFixture(home),
+			system: runtime === "openclaw" ? hostedSystemFixture(home) : hostedHermesSystemFixture(home),
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			egressEngine,
 			clawdiCli: {
@@ -732,7 +728,10 @@ function hostedEgressSecretRotationPayload(
 				packageSpec: "clawdi@0.13.0-test",
 				registry: "https://registry.npmjs.org",
 			},
-			runtimes: { openclaw: hostedOpenClawRuntime() },
+			runtimes:
+				runtime === "openclaw"
+					? { openclaw: hostedOpenClawRuntime() }
+					: { hermes: hostedHermesRuntime() },
 			providers: {
 				default: {
 					kind: "openai-compatible",
@@ -2981,6 +2980,7 @@ chmod +x "$HOME/.local/bin/hermes"
 				},
 			},
 			gateway: {
+				mode: "local",
 				auth: {
 					mode: "token",
 					token: "gateway-token",
@@ -4110,7 +4110,7 @@ exit 0
 		expect(hermesProviders["byok-b"]).toBeDefined();
 	});
 
-	it("applies OpenClaw hosted config after the official gateway installer", () => {
+	it("projects complete OpenClaw gateway config before the official service installer", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -4204,12 +4204,13 @@ exit 0
 
 		expect(convergence.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
-			"gateway install --force --json",
 			"config patch --stdin",
 			'config patch --stdin --replace-path models.providers["default"].models',
+			"gateway install --force --json",
 		]);
 		expect(JSON.parse(readFileSync(join(root, "openclaw-patch-1.json"), "utf-8"))).toEqual({
 			gateway: {
+				mode: "local",
 				auth: {
 					mode: "token",
 					token: "gateway-token",
@@ -5374,6 +5375,11 @@ exit 64
 						models: [{ id: "gpt-test" }],
 					}),
 					systemdApply: {
+						activateEgressPrerequisite: () => ({
+							applied: true,
+							systemUnitsChanged: [],
+							userUnitsChanged: [],
+						}),
 						activate: () => ({
 							applied: true,
 							systemUnitsChanged: [],
@@ -6326,7 +6332,6 @@ fi
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
-			expect(process.exitCode ?? 0).toBe(0);
 			expect(captured).toHaveLength(2);
 			expect(captured[0].headers.authorization).toBe("Bearer file-runtime-token");
 			expect(captured[0].headers.accept).toBe(HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE);
@@ -7631,21 +7636,36 @@ exit 64
 		expect(statSync(legacyImageShim).mode & 0o777).toBe(0o700);
 	});
 
-	it("restarts an OpenClaw service started by the official installer after egress CA readiness", async () => {
+	it.each([
+		{ runtime: "openclaw" as const, publishCa: true },
+		{ runtime: "hermes" as const, publishCa: true },
+		{ runtime: "openclaw" as const, publishCa: false },
+	])("orders the cold $runtime installer after egress (publishCa=$publishCa)", async ({
+		runtime,
+		publishCa,
+	}) => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
 		const systemctlLog = join(root, "systemctl-cold-openclaw.log");
 		const systemctlStateRoot = join(root, "systemctl-cold-openclaw-state");
-		const staleEarlyProcess = join(root, "openclaw-started-before-ca");
-		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
-		const openclawUnit = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+		const installerLog = join(root, `${runtime}-installer-order.log`);
+		const runtimeBin =
+			runtime === "openclaw"
+				? join(home, ".openclaw", "bin", "openclaw")
+				: join(home, ".local", "bin", "hermes");
+		const serviceName = `${runtime}-gateway`;
+		const runtimeUnit = join(home, ".config", "systemd", "user", `${serviceName}.service`);
+		const installArgs =
+			runtime === "openclaw" ? "gateway install --force --json" : "gateway install --force";
 		const previousLog = console.log;
 		const previousUmask = process.umask(0o022);
+		const previousExitCode = process.exitCode;
+		let runtimeExitCode: number | undefined;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(dirname(runtimeBin), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -7661,24 +7681,27 @@ exit 64
 			path: join(bin, "systemctl"),
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
-			sidecarReadyPath: paths.egressSystemCaFile,
-			staleEarlyProcessPath: staleEarlyProcess,
+			sidecarReadyPath: publishCa ? paths.egressSystemCaFile : undefined,
 		});
 		writeFileSync(
-			openclawBin,
+			runtimeBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
-if [ "$*" = "gateway install --force --json" ]; then
-  mkdir -p '${dirname(openclawUnit)}' '${systemctlStateRoot}'
-  printf '[Service]\\nExecStart=openclaw gateway run\\n' > '${openclawUnit}'
-  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "active")}'
-  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "enabled")}'
-  touch '${staleEarlyProcess}'
+printf '%s\n' "$*" >> '${installerLog}'
+if [ "$*" = "${installArgs}" ]; then
+  printf '%s\n' 'official ${runtime} installer' >> '${systemctlLog}'
+  test -r '${paths.egressSystemCaFile}'
+  test -s '${join(paths.systemdEnvRoot, `${serviceName}.service.env`)}'
+  test -s '${join(paths.systemdUserRoot, `${serviceName}.service.d`, "10-clawdi-hosted.conf")}'
+  mkdir -p '${dirname(runtimeUnit)}' '${systemctlStateRoot}'
+  printf '[Service]\\nExecStart=${runtime} gateway run\\n' > '${runtimeUnit}'
+  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", `${serviceName}.service`, "active")}'
+  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", `${serviceName}.service`, "enabled")}'
 fi
 exit 0
 `,
 		);
-		chmodSync(openclawBin, 0o700);
+		chmodSync(runtimeBin, 0o700);
 		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const mitmproxy = seedMitmproxyCache(paths);
@@ -7689,7 +7712,7 @@ exit 0
 				path: "/v1/runtime/manifest",
 				response: () =>
 					hostedRuntimeBundleResponse(
-						hostedEgressSecretRotationPayload(home, mitmproxy, "cold-home-secret"),
+						hostedEgressSecretRotationPayload(home, mitmproxy, "cold-home-secret", runtime),
 						{ etag: '"cold-home-egress"' },
 					),
 			},
@@ -7697,25 +7720,49 @@ exit 0
 
 		try {
 			await runtimeWatch({ once: true, json: true });
+			runtimeExitCode = process.exitCode;
 		} finally {
 			runtimeFetch.restore();
 			console.log = previousLog;
 			process.umask(previousUmask);
+			process.exitCode = previousExitCode;
 		}
 
-		if (process.exitCode !== undefined && process.exitCode !== 0) {
+		if (!publishCa) {
+			const event = JSON.parse(logs.at(-1) ?? "{}");
+			expect(event.status).toBe("error");
+			expect(event.error).toContain("prerequisite activation failed");
+			expect(readRuntimeAppliedState(paths)).toBeNull();
+			expect(readFileSync(installerLog, "utf8")).not.toContain(installArgs);
+			expect(readFileSync(systemctlLog, "utf8")).not.toContain("clawdi-daemon.service");
+			return;
+		}
+		if (runtimeExitCode !== undefined && runtimeExitCode !== 0) {
 			throw new Error(logs.join("\n"));
 		}
 		expect(JSON.parse(logs.at(-1) ?? "{}").status).toBe("applied");
-		expect(existsSync(staleEarlyProcess)).toBe(false);
 		expect(existsSync(paths.egressSystemCaFile)).toBe(true);
 		const calls = readFileSync(systemctlLog, "utf8").trim().split("\n");
 		const sidecarActivation = calls.findIndex((call) =>
 			/^(start|restart) .*clawdi-runtime-sidecar\.service/.test(call),
 		);
-		const openclawRestart = calls.indexOf("--user restart openclaw-gateway.service");
+		const officialInstaller = calls.indexOf(`official ${runtime} installer`);
+		const finalSystemActivation = calls.findIndex(
+			(call) => call.startsWith("start") && call.includes("clawdi-daemon.service"),
+		);
 		expect(sidecarActivation).toBeGreaterThanOrEqual(0);
-		expect(openclawRestart).toBeGreaterThan(sidecarActivation);
+		expect(officialInstaller).toBeGreaterThan(sidecarActivation);
+		expect(finalSystemActivation).toBeGreaterThan(officialInstaller);
+		expect(calls).not.toContain(`--user restart ${serviceName}.service`);
+		const installerCalls = readFileSync(installerLog, "utf8").trim().split("\n");
+		const installIndex = installerCalls.indexOf(installArgs);
+		if (runtime === "openclaw") {
+			expect(installIndex).toBeGreaterThan(0);
+			expect(installerCalls.slice(installIndex + 1)).not.toContain("config patch --stdin");
+		} else {
+			expect(installIndex).toBe(0);
+			expect(existsSync(join(home, ".hermes", "config.yaml"))).toBe(true);
+		}
 		expect(readRuntimeAppliedState(paths)).toMatchObject({
 			generation: 41,
 			etag: '"cold-home-egress"',


### PR DESCRIPTION
## Summary
- restart installer-started user runtime units after system services reach readiness
- ensure transparent-egress CA publication precedes the accepted OpenClaw process
- add a cold-home official-installer regression proving authority commits only after the stale process is replaced

## Design
The existing systemd reconciliation already activates system units before user units. The transparent-egress sidecar is Type=notify and sends READY only after the CA bundle is published and nft rules are installed. This change treats an already-active, newly-added user unit like a changed unit, causing one deterministic restart after that readiness boundary. No sleep, retry loop, new journal, runtime-image change, or installer-specific workaround is added.

## Verification
- focused cold-home regression
- manifest service tests
- CLI typecheck
- Biome
- full CLI suite: 1409 pass, 4 skip
- git diff --check