### PR TITLE
Align CLI release test invocation

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -168,8 +168,7 @@ jobs:
 
       - name: Test
         if: steps.check.outputs.should_release == 'true'
-        working-directory: packages/cli
-        run: bun test --isolate --max-concurrency=1
+        run: bun test --isolate --max-concurrency=1 packages/cli
 
       - name: Pack and verify immutable release artifact
         id: pack_release

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -123,7 +123,7 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain('tarball="$CLI_TARBALL_FILENAME"');
 		expect(workflow).toContain(`name: \${{ env.CLI_ARTIFACT_NAME }}`);
 		expect(workflow).toContain("run: bun run typecheck");
-		expect(workflow).toContain("run: bun test --isolate --max-concurrency=1");
+		expect(workflow).toContain("run: bun test --isolate --max-concurrency=1 packages/cli");
 		expect(workflow).toContain('npm install "$tarball_path" --ignore-scripts --no-audit --no-fund');
 		expect(workflow).toContain('sha256sum --check "$tarball.sha256"');
 		expect(workflow.match(/npm pack /g) ?? []).toHaveLength(1);


### PR DESCRIPTION
Runs the release suite from the workspace root using the same validated invocation as Client CI. This avoids Bun 1.3.14 epoll stream failures caused by the divergent package-local test entrypoint without reducing coverage or adding retries.