### PR TITLE
Test CLI before release matrix build

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -152,6 +152,10 @@ jobs:
         working-directory: packages/cli
         run: bun run typecheck
 
+      - name: Test
+        if: steps.check.outputs.should_release == 'true'
+        run: bun test --isolate --max-concurrency=1 packages/cli
+
       - name: Build package and native release matrix
         id: build_native_release
         if: steps.check.outputs.should_release == 'true'
@@ -165,10 +169,6 @@ jobs:
             bun test \
               tests/e2e/native-installer.e2e.test.ts \
               tests/e2e/native-daemon.e2e.test.ts
-
-      - name: Test
-        if: steps.check.outputs.should_release == 'true'
-        run: bun test --isolate --max-concurrency=1 packages/cli
 
       - name: Pack and verify immutable release artifact
         id: pack_release

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -124,6 +124,9 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain(`name: \${{ env.CLI_ARTIFACT_NAME }}`);
 		expect(workflow).toContain("run: bun run typecheck");
 		expect(workflow).toContain("run: bun test --isolate --max-concurrency=1 packages/cli");
+		expect(workflow.indexOf("- name: Test")).toBeLessThan(
+			workflow.indexOf("- name: Build package and native release matrix"),
+		);
 		expect(workflow).toContain('npm install "$tarball_path" --ignore-scripts --no-audit --no-fund');
 		expect(workflow).toContain('sha256sum --check "$tarball.sha256"');
 		expect(workflow.match(/npm pack /g) ?? []).toHaveLength(1);


### PR DESCRIPTION
Runs the full immutable-source suite before constructing the six-platform native matrix. Coverage and artifact verification remain unchanged, while the test process no longer inherits the release-matrix build side effects that reproducibly triggered Bun epoll stream failures.