### PR TITLE
Right-size workers and memory caps for actual load

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -51,12 +51,14 @@ servers:
     hosts:
       - 66.220.6.123
     options:
+      memory: 3g # local embedding model (~1.6G resident) plus headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
   channels-worker:
     hosts:
       - 66.220.6.123
     proxy: false
     options:
+      memory: 1g
       ulimit: nofile=65536:65536 # per-account gateway sockets
     env:
       clear:


### PR DESCRIPTION
De-anchoring from old-production parity per owner: celery concurrency 16→4 (~1GB freed, parallelism kept), worker caps 6g/4cpu→3g/2cpu; clawdi web gains a 3g cap (embedding model + headroom) and channels-worker 1g so runaway memory OOMs the offender, not the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)