### PR TITLE
Complete the capacity plan: launch-sized memory caps

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -51,12 +51,14 @@ servers:
     hosts:
       - 66.220.6.123
     options:
+      memory: 4g # embedding model (~1.6G resident) + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
   channels-worker:
     hosts:
       - 66.220.6.123
     proxy: false
     options:
+      memory: 2g # grows with connected channel accounts
       ulimit: nofile=65536:65536 # per-account gateway sockets
     env:
       clear:


### PR DESCRIPTION
Closes the one asymmetry left: hosted roles carry ceilings, clawdi roles didn't. Launch-sized (web 4g, channels-worker 2g) so a runaway OOMs the offender, never the databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)