### PR TITLE
Raise accessory file-descriptor limits for launch load

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -93,6 +93,8 @@ accessories:
   postgres:
     image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18 # pgvector pg18 + pgBackRest (WAL archiving to R2)
     host: 66.220.6.123
+    options:
+      ulimit: nofile=65536:65536
     # 512MB buffers (default 128MB is tiny for 16G host); idle-in-transaction
     # timeout guards against the connection-pile-up-behind-locks failure mode.
     cmd: >-


### PR DESCRIPTION
Adversarial config review found the data-plane containers at docker's default `nofile=1024` (the app roles were already raised). Postgres/redis → 65536; ClickHouse → its documented 262144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)