### PR TITLE
Also normalize double-escaped PEM newlines

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -115,7 +115,7 @@ class Settings(BaseSettings):
         deployment that passes the key through one delivers `\n` as two
         characters, which no PEM parser accepts.
         """
-        return value.replace("\\n", "\n")
+        return value.replace("\\\\n", "\n").replace("\\n", "\n")
 
     @field_validator("clerk_jwt_issuer")
     @classmethod


### PR DESCRIPTION
Follow-up: kamal's env-file serialization delivers two backslashes + n; handle both encodings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)