### PR TITLE
fix(skills): preserve strong listing ETags

### DIFF
--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -61,6 +61,7 @@ from app.schemas.skill import (
     SkillUploadResponse,
 )
 from app.services.file_store import get_file_store
+from app.services.http_cache import if_none_match_contains
 from app.services.runtime_manifest_resources import (
     assert_project_skill_not_runtime_managed,
     project_skill_advisory_lock_key,
@@ -108,6 +109,7 @@ scope_router = APIRouter(
 log = logging.getLogger(__name__)
 
 file_store = get_file_store()
+_SKILLS_LIST_CACHE_CONTROL = "no-transform"
 
 
 def _file_key(user_id, project_id, skill_key: str) -> str:
@@ -376,9 +378,12 @@ async def _list_skills_with_db(
         visible_project_ids=visible_project_ids,
         visible_revision_fingerprint=visible_revision_fingerprint,
     )
-    if if_none_match is not None and if_none_match.strip() == etag:
+    if if_none_match_contains(if_none_match, etag):
         await db.commit()
-        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
+        return Response(
+            status_code=status.HTTP_304_NOT_MODIFIED,
+            headers={"ETag": etag, "Cache-Control": _SKILLS_LIST_CACHE_CONTROL},
+        )
 
     # Drop the `Skill.user_id == auth.user_id` filter that was here
     # pre-sharing: that would have blocked viewer members from seeing
@@ -514,7 +519,7 @@ async def _list_skills_with_db(
     return Response(
         content=response.model_dump_json(),
         media_type="application/json",
-        headers={"ETag": etag},
+        headers={"ETag": etag, "Cache-Control": _SKILLS_LIST_CACHE_CONTROL},
     )
 
 
@@ -554,9 +559,12 @@ def _bound_api_key_skills_304_response(
         visible_project_ids=visible_project_ids,
         visible_revision_fingerprint=visible_revision_fingerprint,
     )
-    if if_none_match.strip() != etag:
+    if not if_none_match_contains(if_none_match, etag):
         return None
-    return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
+    return Response(
+        status_code=status.HTTP_304_NOT_MODIFIED,
+        headers={"ETag": etag, "Cache-Control": _SKILLS_LIST_CACHE_CONTROL},
+    )
 
 
 def _skills_collection_etag(

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -681,8 +681,10 @@ async def test_list_skills_etag_binds_revision_and_project(
     # Capture project A's listing ETag.
     list_a = await client.get(f"/v1/skills?project_id={project_id}")
     assert list_a.status_code == 200, list_a.text
+    assert list_a.headers.get("Cache-Control") == "no-transform"
     etag_a = list_a.headers.get("ETag")
     assert etag_a is not None
+    assert etag_a.startswith('"') and etag_a.endswith('"')
     # ETag carries `<revision>:<project_id>`. Sanity-check both
     # components are present so a regression to plain
     # `<revision>` would fail the test.
@@ -695,6 +697,31 @@ async def test_list_skills_etag_binds_revision_and_project(
         headers={"If-None-Match": etag_a},
     )
     assert r304.status_code == 304, r304.text
+    assert r304.headers.get("ETag") == etag_a
+    assert r304.headers.get("Cache-Control") == "no-transform"
+
+    # If-None-Match uses weak comparison for GET. A weak validator exposed by
+    # an intermediary must still match the origin's strong collection ETag.
+    weak_r304 = await client.get(
+        f"/v1/skills?project_id={project_id}",
+        headers={"If-None-Match": f"W/{etag_a}"},
+    )
+    assert weak_r304.status_code == 304, weak_r304.text
+    assert weak_r304.headers.get("ETag") == etag_a
+    assert weak_r304.headers.get("Cache-Control") == "no-transform"
+
+    # The hidden compatibility alias mounts this same listing contract.
+    alias_list = await client.get(f"/api/skills?project_id={project_id}")
+    assert alias_list.status_code == 200, alias_list.text
+    assert alias_list.headers.get("ETag") == etag_a
+    assert alias_list.headers.get("Cache-Control") == "no-transform"
+    alias_304 = await client.get(
+        f"/api/skills?project_id={project_id}",
+        headers={"If-None-Match": etag_a},
+    )
+    assert alias_304.status_code == 304, alias_304.text
+    assert alias_304.headers.get("ETag") == etag_a
+    assert alias_304.headers.get("Cache-Control") == "no-transform"
 
     # Now register a SECOND project and land a skill there. Crucially,
     # the second upload bumps the user-wide skills_revision (pre-fix
@@ -771,8 +798,10 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
         headers=AGENT_SKILL_SYNC_HEADERS,
     )
     assert first.status_code == 200, first.text
+    assert first.headers.get("Cache-Control") == "no-transform"
     etag = first.headers.get("ETag")
     assert etag
+    assert etag.startswith('"') and etag.endswith('"')
 
     def _fail_session_factory():
         raise AssertionError("matching bound-key skills ETag opened a DB session")
@@ -785,6 +814,15 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
     )
     assert cached.status_code == 304, cached.text
     assert cached.headers.get("ETag") == etag
+    assert cached.headers.get("Cache-Control") == "no-transform"
+
+    weak_cached = await client.get(
+        f"/v1/skills?project_id={project_id}",
+        headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": f"W/{etag}"},
+    )
+    assert weak_cached.status_code == 304, weak_cached.text
+    assert weak_cached.headers.get("ETag") == etag
+    assert weak_cached.headers.get("Cache-Control") == "no-transform"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- send `Cache-Control: no-transform` on skills listing `200` and `304` responses so intermediaries do not weaken strong ETags during compression transforms
- reuse the existing `if_none_match_contains()` helper for GET weak comparison
- cover canonical `/v1/skills`, compatibility `/api/skills`, DB-backed responses, and the bound-key fast `304` path

## Root cause

Cloudflare can weaken a strong origin ETag when it transforms the representation for compression. Released clients use the strong skills-listing ETag as a reconciliation fence, so a transformed `W/` validator is rejected as incomplete or unfenced.

The fix uses the established HTTP cache directive rather than adding a custom ETag parser or a new client protocol. RFC 9111 §5.2.2.6 defines `no-transform`, and Cloudflare documents that the origin directive prevents compression transformations.

- https://www.rfc-editor.org/rfc/rfc9111#section-5.2.2.6
- https://developers.cloudflare.com/speed/optimization/content/compression/
- https://developers.cloudflare.com/cache/reference/etag-headers/

## Verification

```text
scripts/test.sh backend tests/test_skills.py \
  -k 'list_skills_etag_binds_revision_and_project or bound_api_key_matching_skills_etag_304_skips_list_db_session'

2 passed, 24 deselected
```

Also verified `git diff --check` against the refreshed `origin/main`.