### PR TITLE
Inject deployment host and backup-repo internals via secrets [do not merge until secrets are provisioned]

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -213,12 +213,11 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Pin server host keys
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh
-          {
-            echo "|1|6VsutRLikG/F8Efp7xl84gwcmwo=|7R6A3maqxFauB/u3pxnpiN4DFyE= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEydrRjB+jX9/F0RAGK1E6y3VJmw6pnA4vUhFYmuWC9v"
-            echo "jump.phala.systems ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHYb1XDF9By6XWbQG++HWkIElz9+8f8hYafMokBGjdKY"
-          } >> ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Write Kamal secrets
         env:
@@ -243,6 +242,8 @@ jobs:
         env:
           CLOUDFLARE_ORIGIN_CERT: ${{ secrets.CLOUDFLARE_ORIGIN_CERT }}
           CLOUDFLARE_ORIGIN_KEY: ${{ secrets.CLOUDFLARE_ORIGIN_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_PROXY_COMMAND: ${{ secrets.DEPLOY_SSH_PROXY_COMMAND }}
         run: |
           gem install kamal -v '~> 2.12' --no-document
           kamal deploy -P --version "${{ needs.build.outputs.image_tag }}"

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -29,10 +29,10 @@ aliases:
 
 ssh:
   user: phala
-  # All deploys (CI and operator) reach the box through the jump host.
-  # -F none skips ssh config files (ownership differs inside the kamal
-  # container); auth comes from the ssh agent or default key files.
-  proxy_command: "ssh -F none -o StrictHostKeyChecking=accept-new -l phala -W %h:%p jump.phala.systems"
+  # Self-hosters connect directly unless they provide a proxy command.
+<% if ENV["DEPLOY_SSH_PROXY_COMMAND"] %>
+  proxy_command: <%= ENV["DEPLOY_SSH_PROXY_COMMAND"] %>
+<% end %>
   keys:
     - ~/.ssh/clawdi_access_ed25519
 
@@ -49,13 +49,13 @@ builder:
 servers:
   web:
     hosts:
-      - 66.220.6.123
+      - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
       memory: 4g # embedding model (~1.6G resident) + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
   channels-worker:
     hosts:
-      - 66.220.6.123
+      - <%= ENV.fetch("DEPLOY_HOST") %>
     proxy: false
     options:
       memory: 2g # grows with connected channel accounts
@@ -67,7 +67,6 @@ servers:
 proxy:
   hosts:
     - cloud-api.clawdi.ai
-    - cloud-api-next.clawdi.ai # temporary smoke-test host; remove after cutover
   app_port: 8000
   # All traffic stays behind Cloudflare (orange cloud). TLS between Cloudflare
   # and this origin uses a Cloudflare Origin CA wildcard cert — no ACME.
@@ -92,7 +91,7 @@ volumes:
 accessories:
   postgres:
     image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18 # pgvector pg18 + pgBackRest (WAL archiving to R2)
-    host: 66.220.6.123
+    host: <%= ENV.fetch("DEPLOY_HOST") %>
     options:
       ulimit: nofile=65536:65536
     # 512MB buffers (default 128MB is tiny for 16G host); idle-in-transaction
@@ -113,9 +112,6 @@ accessories:
           PGBACKREST_PG1_PATH: /var/lib/postgresql/18/docker
           PGBACKREST_PG1_SOCKET_PATH: /var/run/postgresql
           PGBACKREST_REPO1_TYPE: s3
-          PGBACKREST_REPO1_PATH: /clawdi
-          PGBACKREST_REPO1_S3_BUCKET: clawdi-db-backup
-          PGBACKREST_REPO1_S3_ENDPOINT: 1d694c298092ffa09c793cbca4587812.r2.cloudflarestorage.com
           PGBACKREST_REPO1_S3_REGION: auto
           PGBACKREST_REPO1_S3_URI_STYLE: path
           PGBACKREST_REPO1_RETENTION_FULL: "2"
@@ -125,6 +121,9 @@ accessories:
         POSTGRES_USER: clawdi
       secret:
         - POSTGRES_PASSWORD
+        - PGBACKREST_REPO1_PATH
+        - PGBACKREST_REPO1_S3_BUCKET
+        - PGBACKREST_REPO1_S3_ENDPOINT
         - PGBACKREST_REPO1_S3_KEY
         - PGBACKREST_REPO1_S3_KEY_SECRET
         - PGBACKREST_REPO1_CIPHER_PASS
@@ -133,7 +132,7 @@ accessories:
     # Scheduled pgBackRest runs (Sunday full, daily diff) against the server's
     # shared data and socket volumes. See docs/ops/postgres-backup-restore.md.
     image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18
-    host: 66.220.6.123
+    host: <%= ENV.fetch("DEPLOY_HOST") %>
     cmd: gosu postgres supercronic /etc/pgbackrest/backup-cron
     volumes:
       - /home/phala/clawdi-postgres/data:/var/lib/postgresql
@@ -143,6 +142,9 @@ accessories:
         <<: *pgbackrest-env
         PGBACKREST_LOG_LEVEL_CONSOLE: info
       secret:
+        - PGBACKREST_REPO1_PATH
+        - PGBACKREST_REPO1_S3_BUCKET
+        - PGBACKREST_REPO1_S3_ENDPOINT
         - PGBACKREST_REPO1_S3_KEY
         - PGBACKREST_REPO1_S3_KEY_SECRET
         - PGBACKREST_REPO1_CIPHER_PASS

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -30,7 +30,7 @@ aliases:
 ssh:
   user: phala
   # Self-hosters connect directly unless they provide a proxy command.
-<% if ENV["DEPLOY_SSH_PROXY_COMMAND"] %>
+<% if ENV["DEPLOY_SSH_PROXY_COMMAND"].to_s.strip != "" %>
   proxy_command: <%= ENV["DEPLOY_SSH_PROXY_COMMAND"] %>
 <% end %>
   keys:

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -190,8 +190,15 @@ releases.
 
 ## Production Deployment Checks
 
-The deployment platform is outside this repository, but every deploy should
-run these checks before traffic is considered healthy:
+### Production values
+
+[`config/deploy.yml`](../../config/deploy.yml) keeps the Kamal structure public
+while production values stay outside the repository. CI injects them from
+GitHub Actions secrets; operators keep Kamal secrets in the gitignored
+`.kamal/secrets` file and export deployment parameters before running Kamal.
+Self-hosters set `DEPLOY_HOST` to their own server.
+
+Every deploy should run these checks before traffic is considered healthy:
 
 1. Apply migrations before starting code that depends on them:
 


### PR DESCRIPTION
## Summary

- render Kamal server hosts and the optional SSH proxy command from environment variables, and remove the retired cutover hostname
- move pgBackRest repository endpoint, bucket, and path into accessory secrets; source pinned SSH host keys and deploy parameters from GitHub Actions secrets
- document that the public Kamal structure receives production values from CI secrets or an operator's local environment

## Required before merge

Create these GitHub Actions secrets:

- `SSH_KNOWN_HOSTS` → newline-separated pinned OpenSSH host-key entries, for example `<deploy-host> ssh-ed25519 <base64-host-key>` followed by `<jump-host> ssh-ed25519 <base64-host-key>` on the next line
- `DEPLOY_HOST` → a server address such as `203.0.113.10` or `server.example.com`
- `DEPLOY_SSH_PROXY_COMMAND` → a complete SSH proxy command such as `ssh -F none -o StrictHostKeyChecking=accept-new -l <user> -W %h:%p <jump-host>`

Add these entries to the existing `KAMAL_SECRETS` GitHub secret blob (they are not standalone GitHub secrets):

- `PGBACKREST_REPO1_S3_ENDPOINT=<account-id>.r2.cloudflarestorage.com`
- `PGBACKREST_REPO1_S3_BUCKET=<backup-bucket-name>`
- `PGBACKREST_REPO1_PATH=/<repository-prefix>`

## Validation

- Ruby ERB render + YAML parse with dummy `DEPLOY_HOST` and proxy command
- Ruby ERB render + YAML parse with dummy `DEPLOY_HOST` and `DEPLOY_SSH_PROXY_COMMAND` unset; asserted the key is omitted
- pgBackRest assertions confirm all three repository fields are absent from clear env and present in both accessory secret lists
- workflow YAML parse
- `actionlint` passes with only the two unchanged baseline `SC2129` warnings ignored
- `bun run check`
- `rg -n '66\.220\.6\.|jump\.phala|r2\.cloudflarestorage|1d694c298092' . --hidden --glob '!.git/**'` returns zero matches

No Kamal deployment command was run, and no production system was contacted.
