### PR TITLE
fix(cli): use standard SSE and Retry-After parsers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,9 +76,6 @@
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },
-      "dependencies": {
-        "eventsource-parser": "^3.0.8",
-      },
       "devDependencies": {
         "@clack/prompts": "^1.7.0",
         "@clawdi/shared": "workspace:*",
@@ -87,6 +84,7 @@
         "@types/node": "^22.20.0",
         "chalk": "^5.4.0",
         "commander": "^15.0.0",
+        "eventsource-parser": "^3.0.8",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.19",
         "typescript": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,9 @@
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },
+      "dependencies": {
+        "eventsource-parser": "^3.0.8",
+      },
       "devDependencies": {
         "@clack/prompts": "^1.7.0",
         "@clawdi/shared": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,13 +68,11 @@
 		"@types/node": "^22.20.0",
 		"chalk": "^5.4.0",
 		"commander": "^15.0.0",
+		"eventsource-parser": "^3.0.8",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.19",
 		"typescript": "catalog:",
 		"yaml": "^2.9.0",
 		"zod": "catalog:"
-	},
-	"dependencies": {
-		"eventsource-parser": "^3.0.8"
 	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,5 +73,8 @@
 		"typescript": "catalog:",
 		"yaml": "^2.9.0",
 		"zod": "catalog:"
+	},
+	"dependencies": {
+		"eventsource-parser": "^3.0.8"
 	}
 }

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import createClient, { type Client } from "openapi-fetch";
 import { canonicalApiOrigin, normalizeCloudApiBaseUrl } from "./api-origin";
 import { assertCloudCredentialEndpoint, getClawdiAccessToken } from "./clerk-oauth";
 import { getAuth, getConfig } from "./config";
+import { parseRetryAfter } from "./retry-after";
 import { assertValidSkillKey } from "./skill-key";
 import {
 	SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
@@ -202,10 +203,10 @@ export async function retryingFetch(
 		if (buffered.ok) return buffered;
 
 		if (buffered.status === 429 && retry && attempt < maxAttempts - 1) {
-			const retryAfter = Number(buffered.headers.get("retry-after"));
-			if (Number.isFinite(retryAfter) && retryAfter > 0) {
+			const retryAfterMs = parseRetryAfter(buffered.headers.get("retry-after"));
+			if (retryAfterMs !== null) {
 				try {
-					await sleep(retryAfter * 1000, externalSignal);
+					await sleep(retryAfterMs, externalSignal);
 				} catch {
 					throw new ApiError({
 						status: 0,

--- a/packages/cli/src/lib/retry-after.test.ts
+++ b/packages/cli/src/lib/retry-after.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { parseRetryAfter } from "./retry-after";
+
+describe("parseRetryAfter", () => {
+	it("parses delta-seconds", () => {
+		expect(parseRetryAfter("42")).toBe(42_000);
+	});
+
+	it("parses HTTP-date relative to the supplied clock", () => {
+		const now = Date.parse("Wed, 21 Oct 2015 07:27:00 GMT");
+		expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT", { now })).toBe(60_000);
+	});
+
+	it("rejects expired and malformed values", () => {
+		const now = Date.parse("Wed, 21 Oct 2015 07:29:00 GMT");
+		expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT", { now })).toBeNull();
+		expect(parseRetryAfter("1.5")).toBeNull();
+		expect(parseRetryAfter("later")).toBeNull();
+	});
+
+	it("clamps excessive and overflowing delays", () => {
+		expect(parseRetryAfter("999999999999999999999")).toBe(300_000);
+		expect(parseRetryAfter("600")).toBe(300_000);
+	});
+});

--- a/packages/cli/src/lib/retry-after.ts
+++ b/packages/cli/src/lib/retry-after.ts
@@ -1,0 +1,23 @@
+const MAX_RETRY_AFTER_MS = 5 * 60 * 1000;
+
+/** Parse RFC Retry-After (delta-seconds or HTTP-date) into a bounded delay. */
+export function parseRetryAfter(
+	value: string | null,
+	options: { now?: number; maxMs?: number } = {},
+): number | null {
+	if (value === null) return null;
+	const raw = value.trim();
+	if (!raw) return null;
+
+	let delayMs: number;
+	if (/^\d+$/.test(raw)) {
+		delayMs = Number(raw) * 1000;
+	} else {
+		const timestamp = Date.parse(raw);
+		if (!Number.isFinite(timestamp)) return null;
+		delayMs = timestamp - (options.now ?? Date.now());
+	}
+
+	if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
+	return Math.min(delayMs, options.maxMs ?? MAX_RETRY_AFTER_MS);
+}

--- a/packages/cli/src/serve/sse-client.test.ts
+++ b/packages/cli/src/serve/sse-client.test.ts
@@ -38,6 +38,67 @@ describe("classifySseReconnect", () => {
 });
 
 describe("consumeSse reconnect metadata", () => {
+	it.each([
+		["LF", "\n"],
+		["CRLF", "\r\n"],
+		["CR", "\r"],
+	])("parses %s framing across arbitrary chunk boundaries", async (_name, newline) => {
+		const body = [
+			"event: skill_changed",
+			'data: {"type":"skill_changed",',
+			'data: "skill_key":"chunked","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":3}',
+			"",
+			"",
+		].join(newline);
+		const bytes = new TextEncoder().encode(body);
+		globalThis.fetch = Object.assign(
+			async () =>
+				new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							for (let index = 0; index < bytes.length; index += 3) {
+								controller.enqueue(bytes.slice(index, index + 3));
+							}
+							controller.close();
+						},
+					}),
+				),
+			{ preconnect: originalFetch.preconnect },
+		);
+		const abort = new AbortController();
+		const events: unknown[] = [];
+		await consumeSse({
+			apiUrl: "https://cloud.example",
+			apiKey: "test-key",
+			abort: abort.signal,
+			onEvent: (event) => {
+				events.push(event);
+			},
+			onDisconnect: () => abort.abort(),
+		});
+		expect(events).toEqual([expect.objectContaining({ skill_key: "chunked" })]);
+	});
+
+	it("ignores comments and malformed records while continuing the stream", async () => {
+		const body =
+			': ping\nmalformed-field\n\nevent: skill_changed\ndata: not-json\n\nevent: skill_deleted\ndata: {"type":"skill_deleted","skill_key":"valid","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":4}\n\n';
+		globalThis.fetch = Object.assign(async () => new Response(body), {
+			preconnect: originalFetch.preconnect,
+		});
+		const abort = new AbortController();
+		const events: unknown[] = [];
+		await consumeSse({
+			apiUrl: "https://cloud.example",
+			apiKey: "test-key",
+			abort: abort.signal,
+			onEvent: (event) => {
+				events.push(event);
+			},
+			onDisconnect: () => abort.abort(),
+		});
+		expect(events).toEqual([expect.objectContaining({ skill_key: "valid" })]);
+	});
+
 	it("declares the Agent-authoritative protocol on every stream", async () => {
 		const protocols: Array<string | null> = [];
 		globalThis.fetch = Object.assign(

--- a/packages/cli/src/serve/sse-client.ts
+++ b/packages/cli/src/serve/sse-client.ts
@@ -24,6 +24,8 @@
  * keep a long outage from drifting into an hour-long retry gap.
  */
 
+import { createParser, type EventSourceMessage } from "eventsource-parser";
+import { parseRetryAfter } from "../lib/retry-after";
 import {
 	SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
 	SKILL_SYNC_PROTOCOL_HEADER,
@@ -116,13 +118,18 @@ class SseConnectionError extends Error {
 	readonly reason: string;
 	readonly httpStatus?: number;
 	readonly requestId?: string;
+	readonly retryAfterMs?: number;
 
-	constructor(reason: string, fields?: { httpStatus?: number; requestId?: string | null }) {
+	constructor(
+		reason: string,
+		fields?: { httpStatus?: number; requestId?: string | null; retryAfterMs?: number | null },
+	) {
 		super(reason);
 		this.name = "SseConnectionError";
 		this.reason = reason;
 		this.httpStatus = fields?.httpStatus;
 		this.requestId = fields?.requestId ?? undefined;
+		this.retryAfterMs = fields?.retryAfterMs ?? undefined;
 	}
 }
 
@@ -173,11 +180,7 @@ export async function consumeSse(opts: Opts): Promise<void> {
 				opts.onAuthFailure?.();
 				return;
 			}
-			// Honor Retry-After on 429 rate-limit. The error message
-			// carries the value as `rate_limited:<seconds>`; parse
-			// it and use as the floor for this reconnect's wait.
-			const rateLimitMs = parseRateLimit(error.reason);
-			const wait = rateLimitMs ?? backoffMs(attempt);
+			const wait = error.retry_after_ms ?? backoffMs(attempt);
 			const info = buildReconnectInfo({
 				reason: error.reason,
 				attempt,
@@ -230,35 +233,6 @@ function pruneUndefined(fields: Record<string, unknown>): Record<string, unknown
 	return Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined));
 }
 
-function parseRateLimit(reason: string): number | null {
-	if (!reason.startsWith("rate_limited:")) return null;
-	const raw = reason.slice("rate_limited:".length).trim();
-	if (!raw) return null;
-	// RFC 7231 §7.1.3 allows two formats for Retry-After:
-	//   - delta-seconds (integer)
-	//   - HTTP-date (RFC 1123 format, e.g. "Wed, 21 Oct 2015 07:28:00 GMT")
-	// Most servers send seconds, but Cloudflare and some CDNs send
-	// dates. Try seconds first; if the value looks non-numeric, fall
-	// through to Date.parse.
-	let ms: number;
-	const asSeconds = Number.parseInt(raw, 10);
-	if (Number.isFinite(asSeconds) && /^\s*\d+\s*$/.test(raw)) {
-		ms = asSeconds * 1000;
-	} else {
-		const t = Date.parse(raw);
-		if (!Number.isFinite(t)) {
-			log.warn("sse.retry_after_unparseable", { value: raw });
-			return null;
-		}
-		ms = t - Date.now();
-	}
-	if (ms <= 0) return null;
-	// Clamp at 5 minutes — if the server says wait an hour, that's
-	// almost certainly a misbehaving proxy, and we'd rather cap the
-	// daemon's silence to keep heartbeats flowing than sleep blind.
-	return Math.min(ms, 5 * 60 * 1000);
-}
-
 async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise<void> {
 	const url = `${opts.apiUrl.replace(/\/+$/, "")}/v1/sync/events`;
 	const accessToken = opts.getAccessToken ? await opts.getAccessToken() : opts.apiKey;
@@ -280,9 +254,15 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 		});
 	}
 	if (res.status === 429) {
-		throw new SseConnectionError(`rate_limited:${res.headers.get("retry-after") ?? ""}`, {
+		const retryAfter = res.headers.get("retry-after");
+		const retryAfterMs = parseRetryAfter(retryAfter);
+		if (retryAfter !== null && retryAfterMs === null) {
+			log.warn("sse.retry_after_unparseable", { value: retryAfter });
+		}
+		throw new SseConnectionError("rate_limited", {
 			httpStatus: res.status,
 			requestId: res.headers.get("x-request-id"),
+			retryAfterMs,
 		});
 	}
 	if (!res.ok) {
@@ -300,7 +280,6 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 
 	const reader = res.body.getReader();
 	const decoder = new TextDecoder("utf-8");
-	let buffer = "";
 	let lastChunkAt = Date.now();
 	let staleDetected = false;
 
@@ -320,6 +299,17 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 	}, HEARTBEAT_HINT_MS);
 
 	let firstByteFired = false;
+	const pendingEvents: EventSourceMessage[] = [];
+	const parser = createParser({
+		onEvent: (event) => pendingEvents.push(event),
+		onError: (error) => log.warn("sse.framing_invalid", { error: toErrorMessage(error) }),
+	});
+	const drainEvents = async (): Promise<void> => {
+		while (pendingEvents.length > 0) {
+			const parsed = parseEventMessage(pendingEvents.shift());
+			if (parsed) await opts.onEvent(parsed);
+		}
+	};
 	try {
 		while (true) {
 			const { value, done } = await reader.read();
@@ -331,6 +321,12 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 				// resets to 0, and the daemon hammers the server
 				// every cycle.
 				if (staleDetected) throw new Error("stale");
+				parser.feed(decoder.decode());
+				// Resolve a trailing bare CR, which is a complete SSE line
+				// terminator but remains ambiguous to an incremental parser
+				// until either the next byte or EOF is known.
+				parser.feed("\n");
+				await drainEvents();
 				return;
 			}
 			if (!firstByteFired) {
@@ -338,18 +334,8 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 				opts.onFirstByte?.();
 			}
 			lastChunkAt = Date.now();
-			buffer += decoder.decode(value, { stream: true });
-
-			// SSE record terminator is a blank line. Process every
-			// completed record and keep the partial tail in `buffer`.
-			let split: number = buffer.indexOf("\n\n");
-			while (split !== -1) {
-				const record = buffer.slice(0, split);
-				buffer = buffer.slice(split + 2);
-				split = buffer.indexOf("\n\n");
-				const parsed = parseRecord(record);
-				if (parsed) await opts.onEvent(parsed);
-			}
+			parser.feed(decoder.decode(value, { stream: true }));
+			await drainEvents();
 		}
 	} finally {
 		clearInterval(stale);
@@ -361,32 +347,26 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
  * tests can drive synthetic byte sequences without standing up a
  * full SSE round-trip. */
 export function parseRecord(record: string): ServerEvent | null {
-	let eventType = "";
-	let dataPayload = "";
-	for (const line of record.split("\n")) {
-		if (!line || line.startsWith(":")) continue;
-		const colon = line.indexOf(":");
-		if (colon === -1) continue;
-		const field = line.slice(0, colon);
-		// SSE allows one optional space after the colon.
-		const value = line.slice(colon + 1).replace(/^ /, "");
-		if (field === "event") eventType = value;
-		else if (field === "data") dataPayload += dataPayload ? `\n${value}` : value;
-	}
-	if (!eventType || !dataPayload) return null;
+	let message: EventSourceMessage | undefined;
+	createParser({ onEvent: (event) => (message = event) }).feed(`${record}\n\n`);
+	return parseEventMessage(message);
+}
+
+function parseEventMessage(message: EventSourceMessage | undefined): ServerEvent | null {
+	if (!message?.event || !message.data) return null;
 
 	try {
-		const parsed = parseServerEvent(JSON.parse(dataPayload) as unknown);
+		const parsed = parseServerEvent(JSON.parse(message.data) as unknown);
 		if (!parsed) {
-			log.warn("sse.event_invalid", { event_type: eventType });
+			log.warn("sse.event_invalid", { event_type: message.event });
 			return null;
 		}
-		if (parsed.type !== eventType) {
-			log.warn("sse.event_type_mismatch", { header: eventType, body_type: parsed.type });
+		if (parsed.type !== message.event) {
+			log.warn("sse.event_type_mismatch", { header: message.event, body_type: parsed.type });
 		}
 		return parsed;
 	} catch (e) {
-		log.warn("sse.parse_failed", { record, error: toErrorMessage(e) });
+		log.warn("sse.parse_failed", { data: message.data, error: toErrorMessage(e) });
 		return null;
 	}
 }
@@ -430,12 +410,18 @@ function parseServerEvent(value: unknown): ServerEvent | null {
 	};
 }
 
-function errorInfo(err: unknown): { reason: string; http_status?: number; request_id?: string } {
+function errorInfo(err: unknown): {
+	reason: string;
+	http_status?: number;
+	request_id?: string;
+	retry_after_ms?: number;
+} {
 	if (err instanceof SseConnectionError) {
 		return {
 			reason: err.reason,
 			http_status: err.httpStatus,
 			request_id: err.requestId,
+			retry_after_ms: err.retryAfterMs,
 		};
 	}
 	if (!(err instanceof Error)) return { reason: "unknown" };


### PR DESCRIPTION
## Summary
- replace the CLI SSE framing loop with the maintained `eventsource-parser` package while preserving typed validation, heartbeat/stale detection, reconnect backoff, and structured logging
- share bounded RFC `Retry-After` parsing between REST and SSE for delta-seconds and HTTP-date values
- add framing coverage for CR, LF, CRLF, arbitrary chunk boundaries, multiline data, comments, and malformed records

## SemVer evaluation
Migration to npm `semver` is deferred. The existing CLI contract deliberately compares valid SemVer numeric identifiers beyond JavaScript's safe-integer range without precision loss (`9007199254740992` vs `9007199254740993`). npm `semver` rejects core identifiers above `MAX_SAFE_INTEGER`, so replacing the helper would be an incompatible behavior change. No SemVer dependency or code change is included.

## Verification
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test -- src/serve/sse-client.test.ts src/lib/retry-after.test.ts tests/api-client.test.ts` (44 passed)
- `bun run --cwd packages/cli test` (1419 passed, 4 skipped, 0 failed)
- `bun run check`
- `git diff --check origin/main..HEAD`

No production or tenant operations were performed. This PR does not touch skills, ETag, or runtime-owned files.