### PR TITLE
Fix OSS HTTP cache contracts

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from http import HTTPStatus
 from typing import Any, Literal
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
@@ -41,7 +41,11 @@ from app.routes.memories import router as memories_router
 from app.routes.metrics import router as metrics_router
 from app.routes.platform import router as platform_router
 from app.routes.projects import router as projects_router
-from app.routes.public_sessions import router as public_sessions_router
+from app.routes.public_sessions import (
+    PUBLIC_SESSION_EXPORT_CACHE_CONTROL,
+    is_public_session_export_path,
+    router as public_sessions_router,
+)
 from app.routes.runtime import router as runtime_router
 from app.routes.runtime_observation_v2 import router as runtime_observation_v2_router
 from app.routes.search import router as search_router
@@ -225,6 +229,15 @@ app.add_middleware(RequestIDMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 
 
+def _apply_public_session_export_cache_policy(
+    request: Request,
+    response: Response,
+) -> Response:
+    if is_public_session_export_path(request.url.path):
+        response.headers["Cache-Control"] = PUBLIC_SESSION_EXPORT_CACHE_CONTROL
+    return response
+
+
 @app.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(
     request: Request,
@@ -244,9 +257,12 @@ async def request_validation_exception_handler(
             request.headers.get("content-length", ""),
             _validation_errors_for_log(exc),
         )
-    return JSONResponse(
-        status_code=422,
-        content={"detail": jsonable_encoder(exc.errors())},
+    return _apply_public_session_export_cache_policy(
+        request,
+        JSONResponse(
+            status_code=422,
+            content={"detail": jsonable_encoder(exc.errors())},
+        ),
     )
 
 
@@ -307,12 +323,14 @@ async def clawdi_http_exception_handler(
     exc: StarletteHTTPException,
 ):
     if _is_bluebubbles_request(request):
-        return _bluebubbles_error_response(
+        response = _bluebubbles_error_response(
             status_code=exc.status_code,
             detail=exc.detail,
             headers=exc.headers,
         )
-    return await http_exception_handler(request, exc)
+    else:
+        response = await http_exception_handler(request, exc)
+    return _apply_public_session_export_cache_policy(request, response)
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,8 @@ from app.routes.projects import router as projects_router
 from app.routes.public_sessions import (
     PUBLIC_SESSION_EXPORT_CACHE_CONTROL,
     is_public_session_export_path,
+)
+from app.routes.public_sessions import (
     router as public_sessions_router,
 )
 from app.routes.runtime import router as runtime_router

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -17,6 +17,7 @@ Access policy:
 from __future__ import annotations
 
 import logging
+import re
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
@@ -54,6 +55,15 @@ router = APIRouter(tags=["public-sessions"])
 log = logging.getLogger(__name__)
 
 file_store = get_file_store()
+PUBLIC_SESSION_EXPORT_CACHE_CONTROL = "no-store"
+_PUBLIC_SESSION_EXPORT_PATH = re.compile(
+    r"^/(?:v1|api)/public/sessions/[^/]+/export\.(?:md|json)$"
+)
+
+
+def is_public_session_export_path(path: str) -> bool:
+    """Match canonical and compatibility export paths, including invalid ids."""
+    return _PUBLIC_SESSION_EXPORT_PATH.fullmatch(path) is not None
 
 
 async def _resolve_session_for_view(
@@ -186,7 +196,7 @@ async def export_shared_session_markdown(
     knows it's reading a Clawdi session and which agent / project it
     came from.
 
-    `Content-Type: text/markdown; charset=utf-8`. NO cache header:
+    `Content-Type: text/markdown; charset=utf-8` and `Cache-Control: no-store`:
     revoke-immediacy beats CDN saving — the
     `(file_key, content_hash)` cache in `load_session_messages`
     already absorbs the parse cost.
@@ -214,6 +224,7 @@ async def export_shared_session_markdown(
     return Response(
         content=body,
         media_type="text/markdown; charset=utf-8",
+        headers={"Cache-Control": PUBLIC_SESSION_EXPORT_CACHE_CONTROL},
     )
 
 
@@ -223,6 +234,7 @@ async def export_shared_session_markdown(
     response_model_exclude_none=True,
 )
 async def export_shared_session_json(
+    response: Response,
     session_id: UUID = Path(...),
     db: AsyncSession = Depends(get_session),
     visitor: AuthContext | None = Depends(optional_web_auth),
@@ -233,6 +245,7 @@ async def export_shared_session_json(
     machine_name, and any other field the share link is not meant
     to expose.
     """
+    response.headers["Cache-Control"] = PUBLIC_SESSION_EXPORT_CACHE_CONTROL
     session, agent_type, _ = await _resolve_session_for_view(db, session_id, visitor)
 
     if not session.file_key:

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -56,9 +56,7 @@ log = logging.getLogger(__name__)
 
 file_store = get_file_store()
 PUBLIC_SESSION_EXPORT_CACHE_CONTROL = "no-store"
-_PUBLIC_SESSION_EXPORT_PATH = re.compile(
-    r"^/(?:v1|api)/public/sessions/[^/]+/export\.(?:md|json)$"
-)
+_PUBLIC_SESSION_EXPORT_PATH = re.compile(r"^/(?:v1|api)/public/sessions/[^/]+/export\.(?:md|json)$")
 
 
 def is_public_session_export_path(path: str) -> bool:

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -22,6 +22,7 @@ from app.services.runtime_source import (
 )
 
 router = APIRouter(prefix="/runtime", tags=["runtime"])
+_RUNTIME_MANIFEST_CACHE_CONTROL = "no-store, no-transform"
 
 
 @router.get("/manifest")
@@ -61,7 +62,7 @@ async def get_runtime_manifest(
     etag = expected_runtime_bundle_v2_etag(source.source_revision)
     headers = {
         "ETag": etag,
-        "Cache-Control": "no-store",
+        "Cache-Control": _RUNTIME_MANIFEST_CACHE_CONTROL,
         "Vary": "Accept",
         "Content-Type": RUNTIME_BUNDLE_V2_MEDIA_TYPE,
     }

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -38,6 +38,7 @@ from app.core.skill_key import (
     validate_derived_skill_key,
 )
 from app.core.skill_sync_protocol import (
+    SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
     SKILL_SYNC_PROTOCOL_HEADER,
     require_agent_authoritative_skill_sync,
 )
@@ -266,7 +267,12 @@ async def list_skills(
     fast_response = _bound_api_key_skills_304_response(
         auth=auth,
         selected_project_id=project_id,
+        q=q,
+        page=page,
+        page_size=page_size,
+        include_content=include_content,
         if_none_match=if_none_match,
+        skill_sync_protocol=skill_sync_protocol,
     )
     if fast_response is not None:
         return fast_response
@@ -377,8 +383,11 @@ async def _list_skills_with_db(
         selected_project_id=selected_project_id,
         visible_project_ids=visible_project_ids,
         visible_revision_fingerprint=visible_revision_fingerprint,
+        q=q,
+        page_size=page_size,
+        include_content=include_content,
     )
-    if if_none_match_contains(if_none_match, etag):
+    if page == 1 and if_none_match_contains(if_none_match, etag):
         await db.commit()
         return Response(
             status_code=status.HTTP_304_NOT_MODIFIED,
@@ -527,7 +536,12 @@ def _bound_api_key_skills_304_response(
     *,
     auth: AuthContext,
     selected_project_id: UUID | None,
+    q: str | None,
+    page: int,
+    page_size: int,
+    include_content: bool,
     if_none_match: str | None,
+    skill_sync_protocol: str | None,
 ) -> Response | None:
     """Serve the hot daemon conditional-GET path without opening a DB session.
 
@@ -540,24 +554,28 @@ def _bound_api_key_skills_304_response(
     Dashboard JWTs and unbound CLI keys still go through the DB-backed path so
     shared-project owner revisions stay part of the ETag.
     """
-    if if_none_match is None or auth.api_key_project_id is None:
+    if (
+        if_none_match is None
+        or auth.api_key_project_id is None
+        or selected_project_id != auth.api_key_project_id
+        or q is not None
+        or page != 1
+        or page_size != 200
+        or include_content
+        or skill_sync_protocol != SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1
+    ):
         return None
 
-    if selected_project_id is not None:
-        visible_project_ids = (
-            [selected_project_id] if selected_project_id == auth.api_key_project_id else []
-        )
-    else:
-        visible_project_ids = [auth.api_key_project_id]
-
-    visible_revision_fingerprint = (
-        _auth_user_skills_revision_fingerprint(auth) if visible_project_ids else "none"
-    )
+    visible_project_ids = [auth.api_key_project_id]
+    visible_revision_fingerprint = _auth_user_skills_revision_fingerprint(auth)
     etag = _skills_collection_etag(
         revision=auth.skills_revision,
         selected_project_id=selected_project_id,
         visible_project_ids=visible_project_ids,
         visible_revision_fingerprint=visible_revision_fingerprint,
+        q=q,
+        page_size=page_size,
+        include_content=include_content,
     )
     if not if_none_match_contains(if_none_match, etag):
         return None
@@ -573,10 +591,40 @@ def _skills_collection_etag(
     selected_project_id: UUID | None,
     visible_project_ids: list[UUID],
     visible_revision_fingerprint: str,
+    q: str | None,
+    page_size: int,
+    include_content: bool,
 ) -> str:
     project_tag = str(selected_project_id) if selected_project_id is not None else "all"
     visible_fingerprint = _visible_project_fingerprint(visible_project_ids)
-    return f'"{revision}:{project_tag}:{visible_fingerprint}:{visible_revision_fingerprint}"'
+    representation_fingerprint = _skills_representation_fingerprint(
+        q=q,
+        page_size=page_size,
+        include_content=include_content,
+    )
+    return (
+        f'"{revision}:{project_tag}:{visible_fingerprint}:'
+        f'{visible_revision_fingerprint}:{representation_fingerprint}"'
+    )
+
+
+def _skills_representation_fingerprint(
+    *,
+    q: str | None,
+    page_size: int,
+    include_content: bool,
+) -> str:
+    """Bind representation-changing list options without breaking page fences.
+
+    CLI 0.13.13 requires every page in one complete inventory read to expose
+    the same strong collection ETag. Keep `page` out of this fingerprint until
+    that released cross-page contract can be versioned; conditional requests
+    are limited to page 1 separately so a page-1 validator cannot suppress a
+    page-2 body.
+    """
+    normalized_q = q or ""
+    value = f"{normalized_q}\0{page_size}\0{int(include_content)}"
+    return hashlib.sha256(value.encode()).hexdigest()[:16]
 
 
 def _visible_project_fingerprint(visible_project_ids: list[UUID]) -> str:

--- a/backend/tests/test_public_sessions.py
+++ b/backend/tests/test_public_sessions.py
@@ -209,6 +209,7 @@ async def test_public_export_md_has_front_matter_and_body(
     r = await anon_client.get(f"/v1/public/sessions/{sid}/export.md")
     assert r.status_code == 200
     assert r.headers["content-type"].startswith("text/markdown")
+    assert r.headers["cache-control"] == "no-store"
     body = r.text
 
     assert body.startswith("---\n")
@@ -232,6 +233,7 @@ async def test_public_export_json_strips_owner_fields(
 
     r = await anon_client.get(f"/v1/public/sessions/{sid}/export.json")
     assert r.status_code == 200
+    assert r.headers["cache-control"] == "no-store"
     body = r.json()
 
     assert body["summary"] == "Public test session"
@@ -285,6 +287,61 @@ async def test_link_revoke_returns_401_to_anon(
     for path_suffix in ["", "/messages", "/export.md", "/export.json"]:
         r = await anon_client.get(f"/v1/public/sessions/{sid}{path_suffix}")
         assert r.status_code == 401, f"{path_suffix} → {r.status_code}"
+        if path_suffix.startswith("/export."):
+            assert r.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", ["export.md", "export.json"])
+@pytest.mark.parametrize("prefix", ["v1", "api"])
+async def test_public_exports_disable_caching_on_validation_and_missing_session(
+    anon_client: httpx.AsyncClient,
+    suffix: str,
+    prefix: str,
+):
+    invalid = await anon_client.get(f"/{prefix}/public/sessions/not-a-uuid/{suffix}")
+    assert invalid.status_code == 422, invalid.text
+    assert invalid.headers["cache-control"] == "no-store"
+
+    missing = await anon_client.get(
+        f"/{prefix}/public/sessions/00000000-0000-0000-0000-000000000000/{suffix}"
+    )
+    assert missing.status_code == 404, missing.text
+    assert missing.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_name", "expected_status"),
+    [("missing", 404), ("invalid", 500)],
+)
+async def test_public_exports_disable_caching_on_content_errors(
+    client: httpx.AsyncClient,
+    anon_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_name: str,
+    expected_status: int,
+):
+    from app.routes import public_sessions as public_sessions_route
+    from app.services.session_content import SessionContentInvalid, SessionContentMissing
+
+    sid, _ = await _seed_session_with_content(
+        client,
+        local_session_id=f"sess-export-{failure_name}",
+    )
+    await _enable_link(client, sid)
+
+    async def _fail_content_load(*_args):
+        if failure_name == "missing":
+            raise SessionContentMissing("missing test content")
+        raise SessionContentInvalid("invalid test content")
+
+    monkeypatch.setattr(public_sessions_route, "load_session_messages", _fail_content_load)
+
+    for suffix in ("export.md", "export.json"):
+        response = await anon_client.get(f"/v1/public/sessions/{sid}/{suffix}")
+        assert response.status_code == expected_status, response.text
+        assert response.headers["cache-control"] == "no-store"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -933,7 +933,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert response.status_code == 200, response.text
     etag = response.headers.get("etag")
     assert etag is not None
-    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["cache-control"] == "no-store, no-transform"
     payload = response.json()
     manifest = payload["manifest"]
     assert manifest["schemaVersion"] == "clawdi.hosted-runtime.manifest.v1"
@@ -983,7 +983,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
 
     assert not_modified.status_code == 304
     assert not_modified.headers["etag"] == etag
-    assert not_modified.headers["cache-control"] == "no-store"
+    assert not_modified.headers["cache-control"] == "no-store, no-transform"
     assert not_modified.content == b""
 
 
@@ -3790,10 +3790,12 @@ async def test_runtime_manifest_requires_exact_v2_media_type(admin_client, db_se
         "placeholderTokenSecretRef",
     }
     assert bundle.headers["content-type"] == RUNTIME_BUNDLE_V2_MEDIA_TYPE
+    assert bundle.headers["cache-control"] == "no-store, no-transform"
     assert bundle.headers["vary"] == "Accept"
     assert bundle.headers["etag"] == expected_runtime_bundle_v2_etag(body["sourceRevision"])
     assert bundle_not_modified.status_code == 304
     assert bundle_not_modified.headers["etag"] == bundle.headers["etag"]
+    assert bundle_not_modified.headers["cache-control"] == "no-store, no-transform"
     assert bundle_not_modified.headers["vary"] == "Accept"
     assert unsupported.status_code == 406
     assert unsupported.headers["cache-control"] == "no-store"

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -793,8 +793,9 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
 
     app.dependency_overrides[get_auth_short_session] = _override_get_auth
 
+    canonical_url = f"/v1/skills?project_id={project_id}&page=1&page_size=200"
     first = await client.get(
-        f"/v1/skills?project_id={project_id}",
+        canonical_url,
         headers=AGENT_SKILL_SYNC_HEADERS,
     )
     assert first.status_code == 200, first.text
@@ -803,13 +804,38 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
     assert etag
     assert etag.startswith('"') and etag.endswith('"')
 
+    # Released CLI 0.13.13 expects one ETag across every page in a complete
+    # inventory read. Preserve that fence while preventing a page-1 validator
+    # from suppressing any non-canonical representation body.
+    query_variants = [
+        (f"{canonical_url}&q=missing", True, 304),
+        (f"/v1/skills?project_id={project_id}&page=1&page_size=25", True, 304),
+        (f"{canonical_url}&include_content=true", True, 304),
+        (f"/v1/skills?project_id={project_id}&page=2&page_size=200", False, 200),
+    ]
+    for url, etag_must_differ, replay_status in query_variants:
+        changed_shape = await client.get(
+            url,
+            headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": etag},
+        )
+        assert changed_shape.status_code == 200, (url, changed_shape.text)
+        variant_etag = changed_shape.headers.get("ETag")
+        assert variant_etag is not None
+        assert (variant_etag != etag) is etag_must_differ
+
+        replay = await client.get(
+            url,
+            headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": variant_etag},
+        )
+        assert replay.status_code == replay_status, (url, replay.text)
+
     def _fail_session_factory():
         raise AssertionError("matching bound-key skills ETag opened a DB session")
 
     monkeypatch.setattr(skills_route, "async_session_factory", _fail_session_factory)
 
     cached = await client.get(
-        f"/v1/skills?project_id={project_id}",
+        canonical_url,
         headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": etag},
     )
     assert cached.status_code == 304, cached.text
@@ -817,7 +843,7 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
     assert cached.headers.get("Cache-Control") == "no-transform"
 
     weak_cached = await client.get(
-        f"/v1/skills?project_id={project_id}",
+        canonical_url,
         headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": f"W/{etag}"},
     )
     assert weak_cached.status_code == 304, weak_cached.text

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1268,7 +1268,7 @@ export interface paths {
          *     knows it's reading a Clawdi session and which agent / project it
          *     came from.
          *
-         *     `Content-Type: text/markdown; charset=utf-8`. NO cache header:
+         *     `Content-Type: text/markdown; charset=utf-8` and `Cache-Control: no-store`:
          *     revoke-immediacy beats CDN saving — the
          *     `(file_key, content_hash)` cache in `load_session_messages`
          *     already absorbs the parse cost.


### PR DESCRIPTION
## Summary

- keep runtime manifest responses private while adding `no-transform` consistently to 200 and 304 responses
- bind Skill listing validators to `q`, `page_size`, and `include_content`, restrict conditionals to page 1, and gate the bound-key database-free 304 to the canonical daemon request shape
- set `Cache-Control: no-store` on public session Markdown/JSON export successes and handled error/validation responses on canonical and compatibility paths

## Compatibility

- preserves the #605 strong Skill ETag behavior and CLI 0.13.13 parsing
- deliberately keeps `page` out of the Skill ETag so all pages retain one collection fence; page 2 never returns 304, avoiding an incorrect empty body without breaking the released cross-page contract
- does not add a generic ETag parser
- no OpenAPI schema changed, so the generated typed client is unchanged

## Focused verification

- `scripts/test.sh backend tests/test_runtime_manifest.py::test_admin_upsert_runtime_state_and_manifest_omit_channels tests/test_runtime_manifest.py::test_runtime_manifest_requires_exact_v2_media_type` (2 passed)
- `scripts/test.sh backend tests/test_skills.py::test_list_skills_etag_binds_revision_and_project tests/test_skills.py::test_bound_api_key_matching_skills_etag_304_skips_list_db_session` (2 passed)
- `scripts/test.sh backend tests/test_public_sessions.py::test_public_export_md_has_front_matter_and_body tests/test_public_sessions.py::test_public_export_json_strips_owner_fields tests/test_public_sessions.py::test_link_revoke_returns_401_to_anon tests/test_public_sessions.py::test_public_exports_disable_caching_on_validation_and_missing_session tests/test_public_sessions.py::test_public_exports_disable_caching_on_content_errors` (9 passed)

No production or tenant state was touched.