### PR TITLE
Run app containers with docker init (zombie reaping)

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -53,12 +53,15 @@ servers:
     options:
       memory: 4g # embedding model (~1.6G resident) + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
+      # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
+      init: true
   channels-worker:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     proxy: false
     options:
       memory: 2g # grows with connected channel accounts
+      init: true
       ulimit: nofile=65536:65536 # per-account gateway sockets
     env:
       clear:


### PR DESCRIPTION
Same fix as the hosted repo: task/channel subprocesses that outlive their parent reparent to the container's unreaping PID 1 and become zombies. `init: true` puts tini at PID 1. Observed on the production host under the hosted worker; applied uniformly to both stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)