### PR TITLE
fix: correct post-standards cache and parser regressions

### DIFF
--- a/apps/web/src/pages/public-share/session-export-route.test.ts
+++ b/apps/web/src/pages/public-share/session-export-route.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { publicSessionExportErrorMessage } from "./session-export-route";
+import { GET, publicSessionExportErrorMessage } from "./session-export-route";
+
+const VALID_SESSION_ID = "123e4567-e89b-42d3-a456-426614174000";
+const REQUEST = new Request(`http://localhost/s/${VALID_SESSION_ID}.md`);
+
+async function withFetchResponse(response: Response, run: () => Promise<void>): Promise<void> {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = Object.assign(async () => response, {
+		preconnect: originalFetch.preconnect,
+	});
+
+	try {
+		await run();
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
 
 describe("public session export errors", () => {
 	test("maps known public access statuses without leaking backend details", () => {
@@ -16,5 +32,47 @@ describe("public session export errors", () => {
 			"The service is having trouble right now. Please try again in a moment.",
 		);
 		expect(publicSessionExportErrorMessage(418)).toBe("Unable to export this shared session.");
+	});
+});
+
+describe("public session export response headers", () => {
+	test("prevents caching local validation errors", async () => {
+		for (const params of [
+			{ id: VALID_SESSION_ID, format: "txt" },
+			{ id: "not-a-uuid", format: "md" },
+		]) {
+			const response = await GET(REQUEST, params);
+
+			expect(response.status).toBe(404);
+			expect(response.headers.get("cache-control")).toBe("no-store");
+			expect(await response.text()).toBe("Not found");
+		}
+	});
+
+	test("prevents caching sanitized upstream errors", async () => {
+		await withFetchResponse(
+			new Response("sensitive upstream detail", { status: 503 }),
+			async () => {
+				const response = await GET(REQUEST, { id: VALID_SESSION_ID, format: "md" });
+
+				expect(response.status).toBe(503);
+				expect(response.headers.get("cache-control")).toBe("no-store");
+				expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+				expect(await response.text()).toBe(
+					"The service is having trouble right now. Please try again in a moment.",
+				);
+			},
+		);
+	});
+
+	test("prevents caching successful exports", async () => {
+		await withFetchResponse(new Response("# Shared session", { status: 200 }), async () => {
+			const response = await GET(REQUEST, { id: VALID_SESSION_ID, format: "md" });
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("cache-control")).toBe("no-store");
+			expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+			expect(await response.text()).toBe("# Shared session");
+		});
 	});
 });

--- a/apps/web/src/pages/public-share/session-export-route.ts
+++ b/apps/web/src/pages/public-share/session-export-route.ts
@@ -29,6 +29,8 @@ const FORMAT_MEDIA_TYPE: Record<string, string> = {
 	json: "application/json; charset=utf-8",
 };
 
+const NO_STORE_HEADERS = { "cache-control": "no-store" };
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function publicSessionExportErrorMessage(status: number): string {
@@ -54,10 +56,10 @@ export async function GET(
 	{ id, format }: { id: string; format: string },
 ): Promise<Response> {
 	if (!ALLOWED_FORMATS.has(format)) {
-		return new Response("Not found", { status: 404 });
+		return new Response("Not found", { status: 404, headers: NO_STORE_HEADERS });
 	}
 	if (!UUID_RE.test(id)) {
-		return new Response("Not found", { status: 404 });
+		return new Response("Not found", { status: 404, headers: NO_STORE_HEADERS });
 	}
 
 	const api = createClient<paths>({ baseUrl: env.VITE_CLAWDI_API_URL });
@@ -77,14 +79,17 @@ export async function GET(
 	if (result.error !== undefined) {
 		return new Response(publicSessionExportErrorMessage(result.response.status), {
 			status: result.response.status,
-			headers: { "content-type": "text/plain; charset=utf-8" },
+			headers: {
+				...NO_STORE_HEADERS,
+				"content-type": "text/plain; charset=utf-8",
+			},
 		});
 	}
 
-	// NO cache-control — revocation / permission-toggle must take effect immediately.
 	return new Response(result.data, {
 		status: 200,
 		headers: {
+			...NO_STORE_HEADERS,
 			"content-type": FORMAT_MEDIA_TYPE[format],
 		},
 	});

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -240,7 +240,6 @@ def _apply_public_session_export_cache_policy(
     return response
 
 
-@app.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(
     request: Request,
     exc: RequestValidationError,

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import logging
 import tarfile
 from uuid import UUID
@@ -38,7 +39,6 @@ from app.core.skill_key import (
     validate_derived_skill_key,
 )
 from app.core.skill_sync_protocol import (
-    SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
     SKILL_SYNC_PROTOCOL_HEADER,
     require_agent_authoritative_skill_sync,
 )
@@ -71,6 +71,7 @@ from app.services.sync_events import (
     AGENT_SKILL_CHANGED_EVENT,
     AGENT_SKILL_DELETED_EVENT,
     bump_skills_revision,
+    get_skills_revision,
 )
 from app.services.tar_utils import (
     TarValidationError,
@@ -111,6 +112,7 @@ log = logging.getLogger(__name__)
 
 file_store = get_file_store()
 _SKILLS_LIST_CACHE_CONTROL = "no-transform"
+_SKILLS_ETAG_VERSION = "skills-v2"
 
 
 def _file_key(user_id, project_id, skill_key: str) -> str:
@@ -264,19 +266,6 @@ async def list_skills(
         and auth.api_key.environment_id is not None
     ):
         require_agent_authoritative_skill_sync(skill_sync_protocol)
-    fast_response = _bound_api_key_skills_304_response(
-        auth=auth,
-        selected_project_id=project_id,
-        q=q,
-        page=page,
-        page_size=page_size,
-        include_content=include_content,
-        if_none_match=if_none_match,
-        skill_sync_protocol=skill_sync_protocol,
-    )
-    if fast_response is not None:
-        return fast_response
-
     async with async_session_factory() as db:
         return await _list_skills_with_db(
             auth=auth,
@@ -303,6 +292,17 @@ async def _list_skills_with_db(
     if_none_match: str | None,
     skill_sync_protocol: str | None,
 ) -> Paginated[SkillSummaryResponse]:
+    # Keep every query that contributes to the strong collection ETag and its
+    # response body in one snapshot. Cross-page consistency remains fenced by
+    # the shared collection revision because released CLI 0.13.13 performs a
+    # separate request for each page.
+    await db.connection(
+        execution_options={
+            "isolation_level": "REPEATABLE READ",
+            "postgresql_readonly": True,
+        }
+    )
+
     # Collection-level ETag short-circuit: when the daemon's last-seen
     # revision matches current, return 304 with no body so periodic complete
     # Agent-Project inventory catch-up costs nothing on quiet accounts.
@@ -326,33 +326,19 @@ async def _list_skills_with_db(
     # it can't write to). When the caller pins `project_id`,
     # intersect with what they're allowed to see — an ID
     # outside that set yields a deliberately-empty listing.
-    revision = auth.skills_revision
     selected_project_id = project_id
     if selected_project_id is not None:
         if auth.api_key_project_id is not None:
             visible_project_ids = (
                 [selected_project_id] if selected_project_id == auth.api_key_project_id else []
             )
-            visible_revision_fingerprint = await _visible_skills_revision_fingerprint(
-                db,
-                auth,
-                visible_project_ids,
-            )
         elif auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
             bound_project_id = await resolve_default_write_project(db, auth)
             visible_project_ids = (
                 [selected_project_id] if selected_project_id == bound_project_id else []
             )
-            visible_revision_fingerprint = await _visible_skills_revision_fingerprint(
-                db,
-                auth,
-                visible_project_ids,
-            )
         else:
-            (
-                visible_project_ids,
-                visible_revision_fingerprint,
-            ) = await _selected_project_visibility_and_revision_fingerprint(
+            visible_project_ids = await _selected_project_visibility(
                 db,
                 auth,
                 selected_project_id,
@@ -360,22 +346,22 @@ async def _list_skills_with_db(
     else:
         # Unscoped read: full inventory across owned + shared projects.
         visible_project_ids = await project_ids_visible_to(db, auth)
-        visible_revision_fingerprint = await _visible_skills_revision_fingerprint(
-            db,
-            auth,
-            visible_project_ids,
-        )
+
+    # Do not trust `auth.skills_revision` here. API-key authentication caches
+    # that snapshot for longer than the daemon polling interval, so it can lag
+    # a committed Skill mutation. Both the caller revision (kept as the first
+    # ETag segment for CLI 0.13.13) and every visible owner's revision come
+    # from this database snapshot before a 304 is considered.
+    revision = await get_skills_revision(db, auth.user_id)
+    (
+        visible_revision_fingerprint,
+        metadata_fingerprint,
+        project_meta,
+    ) = await _visible_skills_etag_state(db, visible_project_ids)
     if (auth.is_cli or auth.oauth_cli) and visible_project_ids:
-        has_agent_project = (
-            await db.execute(
-                select(func.count())
-                .select_from(Project)
-                .where(
-                    Project.id.in_(visible_project_ids),
-                    Project.kind == PROJECT_KIND_ENVIRONMENT,
-                )
-            )
-        ).scalar_one()
+        has_agent_project = any(
+            meta["kind"] == PROJECT_KIND_ENVIRONMENT for meta in project_meta.values()
+        )
         if has_agent_project:
             require_agent_authoritative_skill_sync(skill_sync_protocol)
     etag = _skills_collection_etag(
@@ -383,11 +369,15 @@ async def _list_skills_with_db(
         selected_project_id=selected_project_id,
         visible_project_ids=visible_project_ids,
         visible_revision_fingerprint=visible_revision_fingerprint,
+        metadata_fingerprint=metadata_fingerprint,
         q=q,
         page_size=page_size,
         include_content=include_content,
     )
-    if page == 1 and if_none_match_contains(if_none_match, etag):
+    # Inline content depends on object storage after the DB snapshot closes.
+    # Always render that shape so a transient prior failure cannot turn its
+    # partial `content=None` body into a reusable 304 validator.
+    if page == 1 and not include_content and if_none_match_contains(if_none_match, etag):
         await db.commit()
         return Response(
             status_code=status.HTTP_304_NOT_MODIFIED,
@@ -405,7 +395,7 @@ async def _list_skills_with_db(
             Skill.is_active,
             Skill.project_id.in_(visible_project_ids),
         )
-        .order_by(Skill.skill_key)
+        .order_by(Skill.skill_key, Skill.project_id, Skill.id)
     )
     if q:
         needle = like_needle(q)
@@ -422,45 +412,6 @@ async def _list_skills_with_db(
     skills = (
         (await db.execute(base.limit(page_size).offset((page - 1) * page_size))).scalars().all()
     )
-
-    # Bulk-fetch the project + machine metadata for the visible
-    # skills in one query each (vs N+1). Two indexed lookups
-    # against `projects.id` and `agent_environments.id`.
-    project_ids_in_listing = {s.project_id for s in skills if s.project_id is not None}
-    project_meta: dict = {}
-    if project_ids_in_listing:
-        project_rows = (
-            await db.execute(
-                select(
-                    Project.id,
-                    Project.name,
-                    Project.kind,
-                    Project.origin_environment_id,
-                ).where(Project.id.in_(project_ids_in_listing))
-            )
-        ).all()
-        env_ids_in_listing = {
-            sid_row.origin_environment_id
-            for sid_row in project_rows
-            if sid_row.origin_environment_id is not None
-        }
-        env_meta: dict = {}
-        if env_ids_in_listing:
-            env_rows = (
-                await db.execute(
-                    select(AgentEnvironment.id, AgentEnvironment.machine_name).where(
-                        AgentEnvironment.id.in_(env_ids_in_listing)
-                    )
-                )
-            ).all()
-            env_meta = {row.id: row.machine_name for row in env_rows}
-        for sid_row in project_rows:
-            project_meta[sid_row.id] = {
-                "name": sid_row.name,
-                "kind": sid_row.kind,
-                "environment_id": sid_row.origin_environment_id,
-                "machine_name": env_meta.get(sid_row.origin_environment_id),
-            }
 
     items: list[SkillSummaryResponse] = []
     content_fetches: list[tuple[int, UUID, str]] = []
@@ -522,66 +473,16 @@ async def _list_skills_with_db(
     response = Paginated[SkillSummaryResponse](
         items=items, total=total, page=page, page_size=page_size
     )
-    # Attach the same project-bound ETag the 304 path would have
-    # echoed; daemons cache the full string and replay it on the
-    # next request.
+    headers = {"Cache-Control": _SKILLS_LIST_CACHE_CONTROL}
+    if not include_content:
+        # Metadata-only pages expose one shared collection fence. Inline
+        # content depends on fallible object storage and deliberately has no
+        # reusable strong validator, whether every fetch succeeded or not.
+        headers["ETag"] = etag
     return Response(
         content=response.model_dump_json(),
         media_type="application/json",
-        headers={"ETag": etag, "Cache-Control": _SKILLS_LIST_CACHE_CONTROL},
-    )
-
-
-def _bound_api_key_skills_304_response(
-    *,
-    auth: AuthContext,
-    selected_project_id: UUID | None,
-    q: str | None,
-    page: int,
-    page_size: int,
-    include_content: bool,
-    if_none_match: str | None,
-    skill_sync_protocol: str | None,
-) -> Response | None:
-    """Serve the hot daemon conditional-GET path without opening a DB session.
-
-    Env-bound API keys are already narrowed by the auth snapshot to exactly one
-    Agent Project (`auth.api_key_project_id`) and never see shared projects.
-    Their visible-owner revision is therefore the authenticated user's cached
-    `skills_revision`. That makes the 304 ETag fully derivable from the auth
-    context and query parameters.
-
-    Dashboard JWTs and unbound CLI keys still go through the DB-backed path so
-    shared-project owner revisions stay part of the ETag.
-    """
-    if (
-        if_none_match is None
-        or auth.api_key_project_id is None
-        or selected_project_id != auth.api_key_project_id
-        or q is not None
-        or page != 1
-        or page_size != 200
-        or include_content
-        or skill_sync_protocol != SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1
-    ):
-        return None
-
-    visible_project_ids = [auth.api_key_project_id]
-    visible_revision_fingerprint = _auth_user_skills_revision_fingerprint(auth)
-    etag = _skills_collection_etag(
-        revision=auth.skills_revision,
-        selected_project_id=selected_project_id,
-        visible_project_ids=visible_project_ids,
-        visible_revision_fingerprint=visible_revision_fingerprint,
-        q=q,
-        page_size=page_size,
-        include_content=include_content,
-    )
-    if not if_none_match_contains(if_none_match, etag):
-        return None
-    return Response(
-        status_code=status.HTTP_304_NOT_MODIFIED,
-        headers={"ETag": etag, "Cache-Control": _SKILLS_LIST_CACHE_CONTROL},
+        headers=headers,
     )
 
 
@@ -591,6 +492,7 @@ def _skills_collection_etag(
     selected_project_id: UUID | None,
     visible_project_ids: list[UUID],
     visible_revision_fingerprint: str,
+    metadata_fingerprint: str,
     q: str | None,
     page_size: int,
     include_content: bool,
@@ -603,8 +505,9 @@ def _skills_collection_etag(
         include_content=include_content,
     )
     return (
-        f'"{revision}:{project_tag}:{visible_fingerprint}:'
-        f'{visible_revision_fingerprint}:{representation_fingerprint}"'
+        f'"{revision}:{_SKILLS_ETAG_VERSION}:{project_tag}:{visible_fingerprint}:'
+        f"{visible_revision_fingerprint}:{metadata_fingerprint}:"
+        f'{representation_fingerprint}"'
     )
 
 
@@ -636,28 +539,21 @@ def _visible_project_fingerprint(visible_project_ids: list[UUID]) -> str:
     ).hexdigest()[:16]
 
 
-def _auth_user_skills_revision_fingerprint(auth: AuthContext) -> str:
-    return hashlib.sha256(f"{auth.user_id}:{auth.skills_revision}".encode()).hexdigest()[:16]
-
-
-async def _selected_project_visibility_and_revision_fingerprint(
+async def _selected_project_visibility(
     db: AsyncSession,
     auth: AuthContext,
     selected_project_id: UUID,
-) -> tuple[list[UUID], str]:
-    """Validate one selected project and fetch its owner revision in one query.
+) -> list[UUID]:
+    """Validate one selected project without loading the full visible set.
 
     The daemon always calls `/v1/skills?project_id=<env-project>`. For unbound
-    CLI keys and dashboard JWTs, the old path loaded the caller's full visible
-    project set and then ran a second owner-revision query even though the
-    representation is scoped to one project. This keeps the same read policy
-    (owned OR shared membership) but collapses the hot conditional-GET path to
-    one indexed lookup.
+    CLI keys and dashboard JWTs this keeps the same read policy (owned OR
+    shared membership) with one indexed lookup. Current owner revisions and
+    response-visible metadata are loaded separately for every caller shape.
     """
-    row = (
+    project = (
         await db.execute(
-            select(Project.user_id, User.skills_revision)
-            .join(User, User.id == Project.user_id)
+            select(Project.id)
             .outerjoin(
                 ProjectMembership,
                 and_(
@@ -673,17 +569,8 @@ async def _selected_project_visibility_and_revision_fingerprint(
                 ),
             )
         )
-    ).first()
-    if row is None:
-        return [], "none"
-    return [selected_project_id], _owner_skills_revision_fingerprint(
-        row.user_id,
-        row.skills_revision,
-    )
-
-
-def _owner_skills_revision_fingerprint(owner_id: UUID, skills_revision: int | None) -> str:
-    return hashlib.sha256(f"{owner_id}:{int(skills_revision or 0)}".encode()).hexdigest()[:16]
+    ).scalar_one_or_none()
+    return [project] if project is not None else []
 
 
 async def _resolve_legacy_skill(
@@ -712,38 +599,76 @@ async def _resolve_legacy_skill(
     return skill
 
 
-async def _visible_skills_revision_fingerprint(
+async def _visible_skills_etag_state(
     db: AsyncSession,
-    auth: AuthContext,
-    visible_project_ids: list,
-) -> str:
-    """Fingerprint skill revisions for every owner represented in
-    the caller's visible project set.
+    visible_project_ids: list[UUID],
+) -> tuple[str, str, dict]:
+    """Load current owner revisions and all response-visible metadata.
 
     `users.skills_revision` is bumped on the owner account when a skill
     changes. For shared projects, the recipient's own revision does not
-    move, so an ETag based only on `auth.user_id` would incorrectly 304
-    after the owner updated shared content. Hashing the visible projects'
-    owner revisions keeps conditional GETs correct without adding a new
-    project-level revision table in this PR.
+    move. Project and Agent metadata have no shared revision counter, so hash
+    their actual projected values. Both fingerprints cover the full visible
+    set and therefore remain identical across pages.
     """
     if not visible_project_ids:
-        return "none"
-
-    if auth.api_key_project_id is not None and set(visible_project_ids) == {
-        auth.api_key_project_id
-    }:
-        return _auth_user_skills_revision_fingerprint(auth)
+        return "none", "none", {}
 
     rows = (
         await db.execute(
-            select(Project.user_id, User.skills_revision)
+            select(
+                Project.id,
+                Project.user_id,
+                User.skills_revision,
+                Project.name,
+                Project.kind,
+                Project.origin_environment_id,
+                AgentEnvironment.machine_name,
+            )
             .join(User, User.id == Project.user_id)
+            .outerjoin(
+                AgentEnvironment,
+                AgentEnvironment.id == Project.origin_environment_id,
+            )
             .where(Project.id.in_(visible_project_ids))
         )
     ).all()
-    parts = sorted(f"{owner_id}:{int(revision or 0)}" for owner_id, revision in rows)
-    return hashlib.sha256(":".join(parts).encode()).hexdigest()[:16]
+    owner_revisions = {row.user_id: int(row.skills_revision or 0) for row in rows}
+    owner_parts = sorted(f"{owner_id}:{revision}" for owner_id, revision in owner_revisions.items())
+    visible_revision_fingerprint = hashlib.sha256(":".join(owner_parts).encode()).hexdigest()[:16]
+
+    rows_by_project_id = {row.id: row for row in rows}
+    metadata_values = []
+    project_meta: dict = {}
+    for project_id in sorted(set(visible_project_ids), key=str):
+        row = rows_by_project_id.get(project_id)
+        if row is None:
+            metadata_values.append([str(project_id), None, None, None, None])
+            continue
+        environment_id = row.origin_environment_id
+        metadata_values.append(
+            [
+                str(project_id),
+                row.name,
+                row.kind,
+                str(environment_id) if environment_id is not None else None,
+                row.machine_name,
+            ]
+        )
+        project_meta[project_id] = {
+            "name": row.name,
+            "kind": row.kind,
+            "environment_id": environment_id,
+            "machine_name": row.machine_name,
+        }
+    metadata_fingerprint = hashlib.sha256(
+        json.dumps(
+            metadata_values,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()[:16]
+    return visible_revision_fingerprint, metadata_fingerprint, project_meta
 
 
 async def _build_skill_detail(skill: Skill, db: AsyncSession | None = None) -> SkillDetailResponse:

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -685,11 +685,25 @@ async def test_list_skills_etag_binds_revision_and_project(
     etag_a = list_a.headers.get("ETag")
     assert etag_a is not None
     assert etag_a.startswith('"') and etag_a.endswith('"')
-    # ETag carries `<revision>:<project_id>`. Sanity-check both
-    # components are present so a regression to plain
-    # `<revision>` would fail the test.
-    assert ":" in etag_a.strip('"'), f"expected revision:project tag, got {etag_a}"
+    # Keep the numeric revision first for CLI 0.13.13 parsing, then salt the
+    # corrected ordering/metadata identity so pre-fix validators cannot mask
+    # the new representation.
+    etag_parts = etag_a.strip('"').split(":")
+    assert etag_parts[0].isdigit()
+    assert etag_parts[1] == "skills-v2"
     assert project_id in etag_a, f"project_id missing from ETag {etag_a}"
+
+    legacy_etag = (
+        '"'
+        + ":".join([etag_parts[0], etag_parts[2], etag_parts[3], etag_parts[4], etag_parts[6]])
+        + '"'
+    )
+    legacy_replay = await client.get(
+        f"/v1/skills?project_id={project_id}",
+        headers={"If-None-Match": legacy_etag},
+    )
+    assert legacy_replay.status_code == 200, legacy_replay.text
+    assert legacy_replay.headers["etag"] == etag_a
 
     # Replaying the same ETag against the same project returns 304.
     r304 = await client.get(
@@ -763,33 +777,29 @@ async def test_list_skills_etag_binds_revision_and_project(
 
 
 @pytest.mark.asyncio
-async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
+async def test_bound_api_key_skills_etag_reads_current_db_revision(
     client: httpx.AsyncClient,
+    db_session,
     seed_user,
     project_id: str,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    """Hot daemon reconcile path: a matching bound-key ETag should not open
-    the list handler's DB session.
+    """A bound key must not 304 from its TTL-cached auth revision snapshot."""
+    from sqlalchemy import update
 
-    Auth has already resolved the env-bound API key to exactly one Agent
-    Project. For that caller shape the collection ETag is derivable from the
-    auth snapshot, so the 304 path should avoid the DB-backed project
-    visibility and listing work entirely.
-    """
     from app.core.auth import AuthContext, get_auth_short_session
     from app.main import app
     from app.models.api_key import ApiKey
-    from app.routes import skills as skills_route
+    from app.models.user import User
 
     project_uuid = uuid.UUID(project_id)
+    stale_auth = AuthContext(
+        user=seed_user,
+        api_key=ApiKey(user_id=seed_user.id, environment_id=uuid.uuid4()),
+        api_key_project_id=project_uuid,
+    )
 
     async def _override_get_auth() -> AuthContext:
-        return AuthContext(
-            user=seed_user,
-            api_key=ApiKey(user_id=seed_user.id, environment_id=uuid.uuid4()),
-            api_key_project_id=project_uuid,
-        )
+        return stale_auth
 
     app.dependency_overrides[get_auth_short_session] = _override_get_auth
 
@@ -803,6 +813,9 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
     etag = first.headers.get("ETag")
     assert etag
     assert etag.startswith('"') and etag.endswith('"')
+    first_revision, etag_version, *_ = etag.strip('"').split(":")
+    assert int(first_revision) == stale_auth.skills_revision
+    assert etag_version == "skills-v2"
 
     # Released CLI 0.13.13 expects one ETag across every page in a complete
     # inventory read. Preserve that fence while preventing a page-1 validator
@@ -810,7 +823,6 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
     query_variants = [
         (f"{canonical_url}&q=missing", True, 304),
         (f"/v1/skills?project_id={project_id}&page=1&page_size=25", True, 304),
-        (f"{canonical_url}&include_content=true", True, 304),
         (f"/v1/skills?project_id={project_id}&page=2&page_size=200", False, 200),
     ]
     for url, etag_must_differ, replay_status in query_variants:
@@ -829,26 +841,144 @@ async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
         )
         assert replay.status_code == replay_status, (url, replay.text)
 
-    def _fail_session_factory():
-        raise AssertionError("matching bound-key skills ETag opened a DB session")
+    inline = await client.get(
+        f"{canonical_url}&include_content=true",
+        headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": etag},
+    )
+    assert inline.status_code == 200, inline.text
+    assert inline.headers.get("etag") is None
+    inline_replay = await client.get(
+        f"{canonical_url}&include_content=true",
+        headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": etag},
+    )
+    assert inline_replay.status_code == 200, inline_replay.text
+    assert inline_replay.headers.get("etag") is None
 
-    monkeypatch.setattr(skills_route, "async_session_factory", _fail_session_factory)
+    # Simulate the API-key auth cache retaining its old user snapshot while a
+    # Skill mutation commits a newer revision in PostgreSQL.
+    await db_session.execute(
+        update(User)
+        .where(User.id == seed_user.id)
+        .values(skills_revision=User.skills_revision + 1)
+        .execution_options(synchronize_session=False)
+    )
+    await db_session.commit()
+    assert stale_auth.skills_revision == int(first_revision)
 
-    cached = await client.get(
+    changed = await client.get(
         canonical_url,
         headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": etag},
     )
-    assert cached.status_code == 304, cached.text
-    assert cached.headers.get("ETag") == etag
-    assert cached.headers.get("Cache-Control") == "no-transform"
+    assert changed.status_code == 200, changed.text
+    changed_etag = changed.headers["etag"]
+    assert changed_etag != etag
+    assert int(changed_etag.strip('"').split(":", 1)[0]) == int(first_revision) + 1
 
-    weak_cached = await client.get(
-        canonical_url,
-        headers={**AGENT_SKILL_SYNC_HEADERS, "If-None-Match": f"W/{etag}"},
+
+@pytest.mark.asyncio
+async def test_list_skills_order_and_etag_are_stable_across_pages(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    project_id: str,
+    workspace_project,
+):
+    """Duplicate cross-project keys sort by project id with one page fence."""
+    from app.models.skill import Skill
+
+    project_ids = [uuid.UUID(project_id), workspace_project.id]
+    rows = [
+        Skill(
+            id=uuid.uuid4(),
+            user_id=seed_user.id,
+            project_id=current_project_id,
+            skill_key="same-key",
+            name=f"Skill {current_project_id}",
+            content_hash=str(index) * 64,
+        )
+        for index, current_project_id in enumerate(project_ids, start=1)
+    ]
+    db_session.add_all(reversed(rows))
+    await db_session.commit()
+
+    first = await client.get("/v1/skills", params={"page": 1, "page_size": 1})
+    second = await client.get("/v1/skills", params={"page": 2, "page_size": 1})
+    assert first.status_code == second.status_code == 200
+    assert first.headers["etag"] == second.headers["etag"]
+    listed_project_ids = [
+        first.json()["items"][0]["project_id"],
+        second.json()["items"][0]["project_id"],
+    ]
+    assert listed_project_ids == sorted(str(project) for project in project_ids)
+
+    # Compatibility debt: page 2 returns its body even when sent page 1's
+    # validator, and echoes the same collection ETag.
+    page_two_replay = await client.get(
+        "/v1/skills",
+        params={"page": 2, "page_size": 1},
+        headers={"If-None-Match": first.headers["etag"]},
     )
-    assert weak_cached.status_code == 304, weak_cached.text
-    assert weak_cached.headers.get("ETag") == etag
-    assert weak_cached.headers.get("Cache-Control") == "no-transform"
+    assert page_two_replay.status_code == 200, page_two_replay.text
+    assert page_two_replay.headers["etag"] == first.headers["etag"]
+
+
+@pytest.mark.asyncio
+async def test_list_skills_etag_covers_project_and_machine_metadata(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    environment_project,
+):
+    """Metadata-only mutations must invalidate the strong list validator."""
+    from app.models.project import PROJECT_KIND_WORKSPACE
+    from app.models.session import AgentEnvironment
+    from app.models.skill import Skill
+
+    skill = Skill(
+        user_id=seed_user.id,
+        project_id=environment_project.id,
+        skill_key="metadata",
+        name="Metadata",
+        content_hash="a" * 64,
+    )
+    db_session.add(skill)
+    await db_session.commit()
+
+    url = f"/v1/skills?project_id={environment_project.id}"
+    first = await client.get(url)
+    assert first.status_code == 200, first.text
+    first_etag = first.headers["etag"]
+    revision = first_etag.strip('"').split(":", 1)[0]
+
+    environment = await db_session.get(
+        AgentEnvironment,
+        environment_project.origin_environment_id,
+    )
+    assert environment is not None
+    environment.machine_name = "Renamed machine"
+    environment_project.name = "Renamed project"
+    await db_session.commit()
+
+    renamed = await client.get(url, headers={"If-None-Match": first_etag})
+    assert renamed.status_code == 200, renamed.text
+    renamed_item = renamed.json()["items"][0]
+    assert renamed_item["project_name"] == "Renamed project"
+    assert renamed_item["machine_name"] == "Renamed machine"
+    assert renamed.headers["etag"] != first_etag
+    assert renamed.headers["etag"].strip('"').split(":", 1)[0] == revision
+
+    renamed_etag = renamed.headers["etag"]
+    environment_project.kind = PROJECT_KIND_WORKSPACE
+    environment_project.origin_environment_id = None
+    await db_session.commit()
+    detached = await client.get(url, headers={"If-None-Match": renamed_etag})
+    assert detached.status_code == 200, detached.text
+    detached_item = detached.json()["items"][0]
+    assert detached_item["project_kind"] == PROJECT_KIND_WORKSPACE
+    assert detached_item["environment_id"] is None
+    assert detached_item["machine_name"] is None
+    assert detached.headers["etag"] != renamed_etag
+    assert detached.headers["etag"].strip('"').split(":", 1)[0] == revision
 
 
 @pytest.mark.asyncio
@@ -889,6 +1019,60 @@ async def test_list_skills_releases_db_transaction_before_inline_content_fetch(
     assert listing.status_code == 200, listing.text
     item = next(item for item in listing.json()["items"] if item["skill_key"] == "inline")
     assert item["content"] == content
+    assert listing.headers.get("etag") is None
+
+
+@pytest.mark.asyncio
+async def test_list_skills_inline_content_failure_is_unfenced_and_retried(
+    client: httpx.AsyncClient,
+    project_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A transient object-store failure must not become a reusable 304."""
+    from app.routes import skills as skills_route
+
+    content = "---\nname: retry-inline\ndescription: retry storage\n---\n# Retry\n"
+    tar_bytes, _ = tar_from_content("retry-inline", content)
+    upload = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "retry-inline"},
+        files={"file": ("retry-inline.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    metadata = await client.get(f"/v1/skills?project_id={project_id}")
+    assert metadata.status_code == 200, metadata.text
+    metadata_etag = metadata.headers["etag"]
+    real_file_store = skills_route.file_store
+
+    class FailingFileStore:
+        async def get(self, key: str) -> bytes:
+            raise RuntimeError(f"temporary read failure for {key}")
+
+    monkeypatch.setattr(skills_route, "file_store", FailingFileStore())
+    failed = await client.get(
+        f"/v1/skills?project_id={project_id}&include_content=true",
+        headers={"If-None-Match": metadata_etag},
+    )
+    assert failed.status_code == 200, failed.text
+    assert failed.headers.get("etag") is None
+    assert failed.headers["cache-control"] == "no-transform"
+    failed_item = next(
+        item for item in failed.json()["items"] if item["skill_key"] == "retry-inline"
+    )
+    assert failed_item["content"] is None
+
+    monkeypatch.setattr(skills_route, "file_store", real_file_store)
+    recovered = await client.get(
+        f"/v1/skills?project_id={project_id}&include_content=true",
+        headers={"If-None-Match": metadata_etag},
+    )
+    assert recovered.status_code == 200, recovered.text
+    assert recovered.headers.get("etag") is None
+    recovered_item = next(
+        item for item in recovered.json()["items"] if item["skill_key"] == "retry-inline"
+    )
+    assert recovered_item["content"] == content
 
 
 @pytest.mark.asyncio

--- a/docs/clawdi-daemon-test-guide.md
+++ b/docs/clawdi-daemon-test-guide.md
@@ -178,6 +178,15 @@ The daemon log shows an SSE invalidation followed by a local scan and
 projection upload. `cmp` stays silent and exits 0. If SSE was disconnected,
 the five-minute strong-ETag complete Agent-Project listing catches the missed
 revision; failed, truncated, or unfenced listings never authorize cleanup.
+The backend reads current caller and visible-owner revisions from PostgreSQL
+before returning 304, including for Agent-bound keys whose authentication
+snapshot may still be cached. The ETag keeps the numeric revision first for
+CLI 0.13.13, then binds the deterministic cross-project order and the complete
+visible set's Project name/kind/origin-Agent and machine-name metadata. Every
+metadata-only page retains the same ETag, and page 2 always returns its body.
+Requests with `include_content=true` ignore conditional validators and return
+200 without ETag because transient object-storage reads can produce partial
+`content=null` results; such responses are never valid cleanup evidence.
 Deleting the local `test-skill` directory then removes the Cloud projection;
 no Cloud event may recreate the directory.
 

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -4,7 +4,7 @@ import createClient, { type Client } from "openapi-fetch";
 import { canonicalApiOrigin, normalizeCloudApiBaseUrl } from "./api-origin";
 import { assertCloudCredentialEndpoint, getClawdiAccessToken } from "./clerk-oauth";
 import { getAuth, getConfig } from "./config";
-import { parseRetryAfter } from "./retry-after";
+import { MAX_SAFE_RETRY_AFTER_MS, parseRetryAfter } from "./retry-after";
 import { assertValidSkillKey } from "./skill-key";
 import {
 	SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
@@ -19,6 +19,10 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 const RETRY_DELAYS_MS = [100, 400, 1600] as const;
 const USER_AGENT = `clawdi-cli/${getCliVersion()}`;
+// Node-compatible timers cannot safely schedule a single delay above this
+// value. Longer Retry-After waits are split into chunks without changing the
+// server-requested REST delay.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /** Error thrown by ApiClient. Carries HTTP status and a human-facing hint. */
 export class ApiError extends Error {
@@ -75,15 +79,26 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 			reject(new DOMException("Aborted", "AbortError"));
 			return;
 		}
+		let remainingMs = ms;
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		const onAbort = () => {
-			clearTimeout(timer);
+			if (timer !== undefined) clearTimeout(timer);
 			reject(new DOMException("Aborted", "AbortError"));
 		};
-		const timer = setTimeout(() => {
-			signal?.removeEventListener("abort", onAbort);
-			resolve();
-		}, ms);
+		const scheduleNextChunk = () => {
+			if (remainingMs <= 0) {
+				signal?.removeEventListener("abort", onAbort);
+				resolve();
+				return;
+			}
+			const chunkMs = Math.min(remainingMs, MAX_TIMER_DELAY_MS);
+			timer = setTimeout(() => {
+				remainingMs -= chunkMs;
+				scheduleNextChunk();
+			}, chunkMs);
+		};
 		signal?.addEventListener("abort", onAbort, { once: true });
+		scheduleNextChunk();
 	});
 }
 
@@ -203,7 +218,9 @@ export async function retryingFetch(
 		if (buffered.ok) return buffered;
 
 		if (buffered.status === 429 && retry && attempt < maxAttempts - 1) {
-			const retryAfterMs = parseRetryAfter(buffered.headers.get("retry-after"));
+			const retryAfterMs = parseRetryAfter(buffered.headers.get("retry-after"), {
+				maxMs: MAX_SAFE_RETRY_AFTER_MS,
+			});
 			if (retryAfterMs !== null) {
 				try {
 					await sleep(retryAfterMs, externalSignal);

--- a/packages/cli/src/lib/retry-after.test.ts
+++ b/packages/cli/src/lib/retry-after.test.ts
@@ -1,25 +1,40 @@
 import { describe, expect, it } from "bun:test";
-import { parseRetryAfter } from "./retry-after";
+import { MAX_SAFE_RETRY_AFTER_MS, parseRetryAfter } from "./retry-after";
 
 describe("parseRetryAfter", () => {
-	it("parses delta-seconds", () => {
+	it("parses non-negative delta-seconds, including zero", () => {
 		expect(parseRetryAfter("42")).toBe(42_000);
+		expect(parseRetryAfter("0")).toBe(0);
 	});
 
-	it("parses HTTP-date relative to the supplied clock", () => {
-		const now = Date.parse("Wed, 21 Oct 2015 07:27:00 GMT");
-		expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT", { now })).toBe(60_000);
+	it.each([
+		"Sun, 06 Nov 1994 08:49:37 GMT",
+		"Sunday, 06-Nov-94 08:49:37 GMT",
+		"Sun Nov  6 08:49:37 1994",
+	])("parses the standard HTTP-date form %s", (value) => {
+		const now = Date.parse("Sun, 06 Nov 1994 08:48:37 GMT");
+		expect(parseRetryAfter(value, { now })).toBe(60_000);
 	});
 
-	it("rejects expired and malformed values", () => {
+	it("treats current and expired HTTP-date values as zero delay", () => {
 		const now = Date.parse("Wed, 21 Oct 2015 07:29:00 GMT");
-		expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT", { now })).toBeNull();
+		expect(parseRetryAfter("Wed, 21 Oct 2015 07:29:00 GMT", { now })).toBe(0);
+		expect(parseRetryAfter("Wed, 21 Oct 2015 07:28:00 GMT", { now })).toBe(0);
+	});
+
+	it("rejects malformed and non-HTTP date values", () => {
 		expect(parseRetryAfter("1.5")).toBeNull();
 		expect(parseRetryAfter("later")).toBeNull();
+		expect(parseRetryAfter("2015-10-21T07:28:00Z")).toBeNull();
 	});
 
-	it("clamps excessive and overflowing delays", () => {
-		expect(parseRetryAfter("999999999999999999999")).toBe(300_000);
-		expect(parseRetryAfter("600")).toBe(300_000);
+	it("has no hidden five-minute policy", () => {
+		expect(parseRetryAfter("600")).toBe(600_000);
+	});
+
+	it("safely saturates arbitrarily large digit strings at an explicit bound", () => {
+		const hugeDelta = "9".repeat(10_000);
+		expect(parseRetryAfter(hugeDelta)).toBe(MAX_SAFE_RETRY_AFTER_MS);
+		expect(parseRetryAfter(hugeDelta, { maxMs: 300_000 })).toBe(300_000);
 	});
 });

--- a/packages/cli/src/lib/retry-after.ts
+++ b/packages/cli/src/lib/retry-after.ts
@@ -1,6 +1,13 @@
-const MAX_RETRY_AFTER_MS = 5 * 60 * 1000;
+/** Largest millisecond delay that can be represented as an exact JavaScript integer. */
+export const MAX_SAFE_RETRY_AFTER_MS = Number.MAX_SAFE_INTEGER;
 
-/** Parse RFC Retry-After (delta-seconds or HTTP-date) into a bounded delay. */
+const HTTP_DATE_PATTERN = new RegExp(
+	"^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \\d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} GMT|" +
+		"(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \\d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2} \\d{2}:\\d{2}:\\d{2} GMT|" +
+		"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?:\\d{2}| \\d) \\d{2}:\\d{2}:\\d{2} \\d{4})$",
+);
+
+/** Parse RFC Retry-After (delta-seconds or HTTP-date) into milliseconds. */
 export function parseRetryAfter(
 	value: string | null,
 	options: { now?: number; maxMs?: number } = {},
@@ -8,16 +15,23 @@ export function parseRetryAfter(
 	if (value === null) return null;
 	const raw = value.trim();
 	if (!raw) return null;
-
-	let delayMs: number;
-	if (/^\d+$/.test(raw)) {
-		delayMs = Number(raw) * 1000;
-	} else {
-		const timestamp = Date.parse(raw);
-		if (!Number.isFinite(timestamp)) return null;
-		delayMs = timestamp - (options.now ?? Date.now());
+	const maxMs = options.maxMs ?? MAX_SAFE_RETRY_AFTER_MS;
+	if (!Number.isSafeInteger(maxMs) || maxMs < 0) {
+		throw new RangeError("Retry-After maxMs must be a non-negative safe integer");
 	}
 
-	if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
-	return Math.min(delayMs, options.maxMs ?? MAX_RETRY_AFTER_MS);
+	if (/^\d+$/.test(raw)) {
+		// Parse as bigint so an arbitrarily large but valid delta never becomes
+		// Infinity or gets mistaken for a malformed header. The caller-supplied
+		// bound (or exact-integer representation limit) is applied afterwards.
+		const delayMs = BigInt(raw) * 1000n;
+		return delayMs > BigInt(maxMs) ? maxMs : Number(delayMs);
+	}
+
+	if (!HTTP_DATE_PATTERN.test(raw)) return null;
+	const timestamp = Date.parse(raw);
+	if (!Number.isFinite(timestamp)) return null;
+	const delayMs = timestamp - (options.now ?? Date.now());
+	if (!Number.isFinite(delayMs)) return null;
+	return Math.min(Math.max(0, delayMs), maxMs);
 }

--- a/packages/cli/src/serve/sse-client.test.ts
+++ b/packages/cli/src/serve/sse-client.test.ts
@@ -25,6 +25,36 @@ afterEach(() => {
 	globalThis.fetch = originalFetch;
 });
 
+function responseFromChunks(chunks: string[]): Response {
+	const encoder = new TextEncoder();
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+				controller.close();
+			},
+		}),
+	);
+}
+
+async function consumeChunks(chunks: string[]): Promise<unknown[]> {
+	globalThis.fetch = Object.assign(async () => responseFromChunks(chunks), {
+		preconnect: originalFetch.preconnect,
+	});
+	const abort = new AbortController();
+	const events: unknown[] = [];
+	await consumeSse({
+		apiUrl: "https://cloud.example",
+		apiKey: "test-key",
+		abort: abort.signal,
+		onEvent: (event) => {
+			events.push(event);
+		},
+		onDisconnect: () => abort.abort(),
+	});
+	return events;
+}
+
 describe("classifySseReconnect", () => {
 	it("treats the first few reconnects as transient churn", () => {
 		expect(classifySseReconnect(1)).toBe("transient");
@@ -77,6 +107,37 @@ describe("consumeSse reconnect metadata", () => {
 			onDisconnect: () => abort.abort(),
 		});
 		expect(events).toEqual([expect.objectContaining({ skill_key: "chunked" })]);
+	});
+
+	it.each([
+		["no final line terminator", "\n", ""],
+		["a single final LF", "\n", "\n"],
+		["a final CRLF without a blank line", "\r\n", "\r\n"],
+		["a final bare CR without a blank line", "\r", "\r"],
+	])("discards an incomplete event at EOF with %s", async (_name, newline, suffix) => {
+		const body = [
+			"event: skill_changed",
+			'data: {"type":"skill_changed","skill_key":"incomplete","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":3}',
+		].join(newline);
+		expect(await consumeChunks([body + suffix])).toEqual([]);
+	});
+
+	it.each([
+		["LF", "\n"],
+		["CRLF", "\r\n"],
+		["bare CR", "\r"],
+	])("dispatches a complete %s-framed event at EOF", async (_name, newline) => {
+		const body =
+			[
+				"event: skill_changed",
+				'data: {"type":"skill_changed","skill_key":"complete","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":4}',
+			].join(newline) +
+			newline +
+			newline;
+		// One-character chunks force every CRLF pair across a chunk boundary.
+		expect(await consumeChunks([...body])).toEqual([
+			expect.objectContaining({ skill_key: "complete" }),
+		]);
 	});
 
 	it("ignores comments and malformed records while continuing the stream", async () => {
@@ -156,6 +217,32 @@ describe("consumeSse reconnect metadata", () => {
 				request_id: "req-sse-502",
 			},
 		]);
+	});
+
+	it.each([
+		["zero", "0", 0],
+		["a value above the SSE policy", "600", 300_000],
+		["an arbitrarily large value", "9".repeat(1_000), 300_000],
+	])("applies the explicit five-minute SSE cap to %s Retry-After", async (_name, value, waitMs) => {
+		globalThis.fetch = Object.assign(
+			async () => new Response(null, { status: 429, headers: { "retry-after": value } }),
+			{ preconnect: originalFetch.preconnect },
+		);
+		const abort = new AbortController();
+		const disconnects: Array<{ wait_ms: number }> = [];
+
+		await consumeSse({
+			apiUrl: "https://cloud.example",
+			apiKey: "test-key",
+			abort: abort.signal,
+			onEvent: () => {},
+			onDisconnect: (info) => {
+				disconnects.push(info);
+				abort.abort();
+			},
+		});
+
+		expect(disconnects).toEqual([expect.objectContaining({ wait_ms: waitMs })]);
 	});
 
 	it("starts unstable close failure counts at one", async () => {

--- a/packages/cli/src/serve/sse-client.ts
+++ b/packages/cli/src/serve/sse-client.ts
@@ -80,6 +80,7 @@ const STALE_MS = 60_000;
 const HEARTBEAT_HINT_MS = 25_000;
 const BASE_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 60_000;
+const MAX_SSE_RETRY_AFTER_MS = 5 * 60 * 1000;
 
 interface Opts {
 	apiUrl: string;
@@ -255,7 +256,7 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 	}
 	if (res.status === 429) {
 		const retryAfter = res.headers.get("retry-after");
-		const retryAfterMs = parseRetryAfter(retryAfter);
+		const retryAfterMs = parseRetryAfter(retryAfter, { maxMs: MAX_SSE_RETRY_AFTER_MS });
 		if (retryAfter !== null && retryAfterMs === null) {
 			log.warn("sse.retry_after_unparseable", { value: retryAfter });
 		}
@@ -299,6 +300,7 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 	}, HEARTBEAT_HINT_MS);
 
 	let firstByteFired = false;
+	let trailingBareCr = false;
 	const pendingEvents: EventSourceMessage[] = [];
 	const parser = createParser({
 		onEvent: (event) => pendingEvents.push(event),
@@ -309,6 +311,11 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 			const parsed = parseEventMessage(pendingEvents.shift());
 			if (parsed) await opts.onEvent(parsed);
 		}
+	};
+	const feedDecodedChunk = (chunk: string): void => {
+		if (chunk.length === 0) return;
+		trailingBareCr = chunk.endsWith("\r");
+		parser.feed(chunk);
 	};
 	try {
 		while (true) {
@@ -321,11 +328,16 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 				// resets to 0, and the daemon hammers the server
 				// every cycle.
 				if (staleDetected) throw new Error("stale");
-				parser.feed(decoder.decode());
-				// Resolve a trailing bare CR, which is a complete SSE line
-				// terminator but remains ambiguous to an incremental parser
-				// until either the next byte or EOF is known.
-				parser.feed("\n");
+				feedDecodedChunk(decoder.decode());
+				// A CR at the true end of the decoded stream is a complete line
+				// terminator, but the incremental parser holds it in case an LF
+				// arrives in the next chunk. Resolve only that ambiguity: adding
+				// an LF after any other ending would synthesize an empty line and
+				// incorrectly dispatch an incomplete final event.
+				if (trailingBareCr) parser.feed("\n");
+				// WHATWG requires pending event data to be discarded at EOF when
+				// no final empty line was received.
+				parser.reset();
 				await drainEvents();
 				return;
 			}
@@ -334,7 +346,7 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 				opts.onFirstByte?.();
 			}
 			lastChunkAt = Date.now();
-			parser.feed(decoder.decode(value, { stream: true }));
+			feedDecodedChunk(decoder.decode(value, { stream: true }));
 			await drainEvents();
 		}
 	} finally {

--- a/packages/cli/tests/api-client.test.ts
+++ b/packages/cli/tests/api-client.test.ts
@@ -247,14 +247,17 @@ describe("ApiClient error classification", () => {
 		}
 	});
 
-	it("keeps Retry-After outside the attempt timeout but abortable by the caller", async () => {
+	it.each([
+		["ordinary", "60"],
+		["arbitrarily large", "9".repeat(1_000)],
+	])("keeps %s Retry-After outside the attempt timeout but abortable", async (_name, retryAfter) => {
 		const origFetch = globalThis.fetch;
 		let fetchCalls = 0;
 		globalThis.fetch = async () => {
 			fetchCalls += 1;
 			return new Response("rate limited", {
 				status: 429,
-				headers: { "retry-after": "60" },
+				headers: { "retry-after": retryAfter },
 			});
 		};
 		const callerAbort = new AbortController();
@@ -267,6 +270,37 @@ describe("ApiClient error classification", () => {
 			expect(fetchCalls).toBe(1);
 		} finally {
 			clearTimeout(abortTimer);
+			globalThis.fetch = origFetch;
+		}
+	});
+
+	it("does not apply the five-minute SSE policy to REST Retry-After", async () => {
+		const origFetch = globalThis.fetch;
+		const origSetTimeout = globalThis.setTimeout;
+		const scheduledDelays: number[] = [];
+		let fetchCalls = 0;
+		globalThis.fetch = async () => {
+			fetchCalls += 1;
+			return fetchCalls === 1
+				? new Response("rate limited", {
+						status: 429,
+						headers: { "retry-after": "600" },
+					})
+				: new Response("ok");
+		};
+		globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+			scheduledDelays.push(delay ?? 0);
+			return origSetTimeout(callback, 0, ...args);
+		}) as typeof setTimeout;
+
+		try {
+			const response = await retryingFetch(new Request("http://127.0.0.1:0"), 30_000, undefined);
+			expect(response.status).toBe(200);
+			expect(fetchCalls).toBe(2);
+			expect(scheduledDelays).toContain(600_000);
+			expect(scheduledDelays).not.toContain(300_000);
+		} finally {
+			globalThis.setTimeout = origSetTimeout;
 			globalThis.fetch = origFetch;
 		}
 	});


### PR DESCRIPTION
## Summary

- send `Cache-Control: no-store` from the web public-session export wrapper on local validation failures, upstream HTTP failures, and successful exports
- remove the DB-free Skills 304 path, read current caller and visible-owner revisions inside one read-only repeatable snapshot, stabilize cross-project ordering, and version metadata-aware collection validators
- preserve the released CLI 0.13.13 cross-page fence while making `include_content=true` fail open to 200 without a reusable strong ETag
- discard incomplete final SSE events at EOF without regressing LF, CRLF, or bare-CR framing
- parse standard Retry-After delta-seconds and HTTP-date values without a hidden policy cap; apply the five-minute cap explicitly to SSE and preserve long abortable REST waits safely
- remove the duplicate `RequestValidationError` decorator registration

## Compatibility

- keeps `eventsource-parser` in CLI devDependencies
- keeps the existing weak `If-None-Match` helper and Skills `no-transform` behavior
- keeps runtime `no-store, no-transform` and backend public-export `no-store` behavior unchanged
- keeps the numeric Skills revision as the first ETag segment and emits the same validator on every metadata-only page; page 2 still always returns a body
- salts corrected validators as `skills-v2`, so an old validator causes one intentional 200 after rollout
- makes no OpenAPI schema change; the generated client remains unchanged and passes its consistency check

## Protocol references

- WHATWG SSE EOF behavior: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
- eventsource-parser v3.0.8 parsing source: https://github.com/rexxars/eventsource-parser/blob/v3.0.8/src/parse.ts
- RFC 9110 Retry-After: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3

## Verification

- `bun run typecheck`
- `bun run --cwd packages/cli test:internal src/serve/sse-client.test.ts src/lib/retry-after.test.ts tests/api-client.test.ts` (60 passed)
- `bun run --cwd packages/cli test` in the clean Docker runner (1435 passed, 4 skipped)
- `bun run --cwd packages/cli check:publish-manifest`
- `bun run --cwd apps/web test:internal` (passed)
- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src`
- `bun run --cwd apps/web build:oss`
- `scripts/test.sh backend tests/test_skills.py tests/test_skill_authority.py tests/test_project_isolation.py tests/test_public_sessions.py` (82 passed)
- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && uv run python -m compileall app scripts tests alembic`
- `cd backend && uv run python scripts/check_generated_api.py`
- `bun run check`
- `git diff --check origin/main..HEAD`

No production, cluster, deployment, or tenant-data operations were performed. This PR is intentionally left unmerged for review.
