### PR TITLE
Wire Sentry into the production deploy (DSN + release tag)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -197,6 +197,7 @@ class Settings(BaseSettings):
     # Observability (both optional; no-op if not set)
     sentry_dsn: str = ""
     sentry_environment: str = ""  # falls back to `environment` if empty
+    sentry_release: str = ""  # deploy git SHA; ties events to releases
     sentry_traces_sample_rate: float = 0.0
     slow_request_log_ms: float = 750.0
     metrics_bearer_token: str = ""

--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -54,6 +54,7 @@ def init_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
         environment=settings.sentry_environment or settings.environment,
+        release=settings.sentry_release or None,
         traces_sample_rate=settings.sentry_traces_sample_rate,
         send_default_pii=False,
         integrations=[

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -156,6 +156,8 @@ env:
   clear:
     ENVIRONMENT: production
     DEBUG: "false"
+    # CI exports GITHUB_SHA; operator deploys without it simply go untagged.
+    SENTRY_RELEASE: <%= ENV.fetch("GITHUB_SHA", "") %>
     PUBLIC_API_URL: https://cloud-api.clawdi.ai
     WEB_ORIGIN: https://cloud.clawdi.ai
     CORS_ORIGINS: '["https://www.clawdi.ai","https://clawdi.ai","https://api.clawdi.ai","https://cloud.clawdi.ai"]'
@@ -174,6 +176,7 @@ env:
   secret:
     - ADMIN_API_KEY
     - CLERK_JWT_ISSUER
+    - SENTRY_DSN
     - CLERK_SECRET_KEY
     - COMPOSIO_API_KEY
     - DATABASE_URL


### PR DESCRIPTION
Production audit found the backend's Sentry integration fully implemented but never configured: no `SENTRY_DSN` in the deploy env, so cloud-api errors were silently dropped. This adds `SENTRY_DSN` to the Kamal secret set (value provisioned in KAMAL_SECRETS), a `sentry_release` setting + `release=` in init, and `SENTRY_RELEASE` from CI's `GITHUB_SHA` so events correlate to deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)