### PR TITLE
Fix v2 runtime observation cursor starvation

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -1082,6 +1082,7 @@ async def read_runtime_observations(
         .all()
     )
     matching_prefix: list[V2RuntimeObservationInbox] = []
+    skipped_mismatch_position = decoded.stream_position
     for event in events:
         if (
             event.generation != expected_apply_identity.generation
@@ -1089,11 +1090,18 @@ async def read_runtime_observations(
             or event.apply_receipt_id != expected_apply_identity.apply_receipt_id
             or event.boot_nonce != expected_apply_identity.boot_nonce
         ):
+            if matching_prefix:
+                break
+            skipped_mismatch_position = event.id
+            continue
+        # Keep the first matching event after an obsolete leading tuple for the
+        # next read, whose returned cursor can be durably ACKed first.
+        if skipped_mismatch_position != decoded.stream_position:
             break
         matching_prefix.append(event)
     has_more = len(matching_prefix) > limit
     page = matching_prefix[:limit]
-    next_position = page[-1].id if page else decoded.stream_position
+    next_position = page[-1].id if page else skipped_mismatch_position
     heads = list(
         (
             await db.execute(

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -1862,6 +1862,244 @@ async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_read_advances_over_leading_mismatch_without_crossing_matching_event(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="leading-mismatch-controller",
+    )
+    stale = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="stale-session",
+            sequence=1,
+            captured_at=base,
+        ),
+        received_at=base,
+    )
+    rotated = _rotated_identity()
+    matching = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="rotated-session",
+            sequence=1,
+            captured_at=base + timedelta(seconds=1),
+            generation=rotated.generation,
+            manifest_etag=rotated.manifest_etag,
+            apply_receipt_id=rotated.apply_receipt_id,
+            boot_nonce=rotated.boot_nonce,
+        ),
+        received_at=base + timedelta(seconds=1),
+    )
+    stale_tail = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="stale-session",
+            sequence=2,
+            captured_at=base + timedelta(seconds=2),
+        ),
+        received_at=base + timedelta(seconds=2),
+    )
+
+    skipped_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="leading-mismatch-controller",
+        expected_apply_identity=rotated,
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+
+    assert skipped_page["events"] == []
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            skipped_page["nextCursor"]
+        ).stream_position
+        == stale.stream_position
+    )
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            skipped_page["streamHighWaterCursor"]
+        ).stream_position
+        == stale_tail.stream_position
+    )
+
+    matching_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="leading-mismatch-controller",
+        expected_apply_identity=rotated,
+        after_cursor=skipped_page["nextCursor"],
+        limit=100,
+    )
+
+    assert [event["evidenceReference"]["eventId"] for event in matching_page["events"]] == [
+        matching.event_id
+    ]
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            matching_page["nextCursor"]
+        ).stream_position
+        == matching.stream_position
+    )
+
+    resumed_stale_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="leading-mismatch-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=matching_page["nextCursor"],
+        limit=100,
+    )
+    assert [event["evidenceReference"]["eventId"] for event in resumed_stale_page["events"]] == [
+        stale_tail.event_id
+    ]
+
+
+@pytest.mark.asyncio
+async def test_read_treats_same_generation_different_receipt_as_identity_mismatch(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="same-generation-receipt-controller",
+    )
+    stale = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="old-receipt-session",
+            captured_at=base,
+        ),
+        received_at=base,
+    )
+    expected = RuntimeApplyIdentity(
+        generation=1,
+        manifest_etag=_MANIFEST_ETAG,
+        apply_receipt_id="apply-receipt-00000002",
+        boot_nonce=_BOOT_NONCE,
+    )
+    matching = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="new-receipt-session",
+            captured_at=base + timedelta(seconds=1),
+            apply_receipt_id=expected.apply_receipt_id,
+            boot_nonce=expected.boot_nonce,
+        ),
+        received_at=base + timedelta(seconds=1),
+    )
+
+    skipped_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="same-generation-receipt-controller",
+        expected_apply_identity=expected,
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    assert skipped_page["events"] == []
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            skipped_page["nextCursor"]
+        ).stream_position
+        == stale.stream_position
+    )
+
+    matching_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="same-generation-receipt-controller",
+        expected_apply_identity=expected,
+        after_cursor=skipped_page["nextCursor"],
+        limit=100,
+    )
+    assert [event["evidenceReference"]["eventId"] for event in matching_page["events"]] == [
+        matching.event_id
+    ]
+
+
+@pytest.mark.asyncio
+async def test_read_advances_across_all_mismatch_physical_pages(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="all-mismatch-controller",
+    )
+    ingested = []
+    for sequence in range(1, 7):
+        ingested.append(
+            await ingest_runtime_observation(
+                db_session,
+                environment_id=environment.id,
+                value=_payload(
+                    boot_session_id="stale-page-session",
+                    sequence=sequence,
+                    captured_at=base + timedelta(seconds=sequence),
+                ),
+                received_at=base + timedelta(seconds=sequence),
+            )
+        )
+
+    cursor = registration["cursor"]
+    positions = [
+        runtime_observation_service.decode_runtime_observation_cursor(cursor).stream_position
+    ]
+    for _ in range(2):
+        page = await read_runtime_observations(
+            db_session,
+            environment_id=environment.id,
+            owner_id=seed_user.id,
+            deployment_id=_DEPLOYMENT_ID,
+            consumer_id="all-mismatch-controller",
+            expected_apply_identity=_rotated_identity(),
+            after_cursor=cursor,
+            limit=2,
+        )
+        assert page["events"] == []
+        cursor = page["nextCursor"]
+        positions.append(
+            runtime_observation_service.decode_runtime_observation_cursor(cursor).stream_position
+        )
+
+    assert positions == [0, ingested[2].stream_position, ingested[5].stream_position]
+
+
+@pytest.mark.asyncio
 async def test_short_tuple_filtered_page_does_not_skip_next_tuple_first_event(
     db_session: AsyncSession,
     seed_user,


### PR DESCRIPTION
## Summary

- advance `nextCursor` across a contiguous leading prefix whose apply identity does not match the requested v2 identity
- stop immediately before the first matching event so the next read delivers it
- preserve the existing matching-prefix tuple boundary and never cross the following mismatch
- leave `streamHighWaterCursor` independent; no high-water ACK behavior is added

This prevents replay/ACK/dedupe/normal-retention starvation after an apply-identity rotation. Readiness continues to use heads and is not described as deadlocked.

Hosted companion: Clawdi-AI/clawdi-hosted#1153

## Algorithm invariants

1. An empty page can advance only across contiguous leading mismatches already present in the bounded physical read.
2. The first matching event after skipped mismatches is not crossed or returned; it remains the first event for the next read.
3. Once a matching prefix is returned, `nextCursor` points to its last returned event and does not cross the next tuple mismatch.
4. The returned `nextCursor` remains between the requested cursor and the same-snapshot stream high-water.

## Complexity audit

The database query remains the existing bounded `limit + 1` physical read. The prefix scan is one pass over that result: `O(p)` time for `p <= limit + 1`, with `O(1)` additional state beyond the existing returned-prefix list. There are no new database queries, cursor states, or persistence paths.

## Compatibility

- no v1 changes
- no wire-field or generated-client changes
- no database-model or migration changes
- only server-returned cursors remain eligible for the existing Hosted persistence/ACK flow

## Verification

- focused cursor/tuple cases: 4 passed
- `tests/test_runtime_observation_companion.py`: 29 passed
- full backend pytest: 1511 passed, 7 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
