### PR TITLE
fix(cli): fail closed when v2 egress engine is unavailable

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -13,6 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { commitRuntimeAppliedState } from "../commands/runtime";
 import {
 	readRuntimeAppliedState,
 	runtimeContentSha256,
@@ -85,7 +87,9 @@ function hostedSystemFixture(overrides: Record<string, unknown> = {}): Record<st
 	};
 }
 
-function hostedOpenClawNativeAuth(publicUrl = "https://agent.example.test/control") {
+function hostedOpenClawNativeAuth(
+	publicUrl = "https://agent.example.test/control",
+): NonNullable<RuntimeManifest["openclawGatewayAuth"]> {
 	void publicUrl;
 	return {
 		mode: "token",
@@ -148,6 +152,164 @@ function baseManifest(
 		recovery: {},
 		...overrides,
 	};
+}
+
+function testEgressEnginePin(
+	version: string,
+	sha256: string,
+): NonNullable<RuntimeManifest["egressEngine"]> {
+	return {
+		type: "mitmproxy",
+		version,
+		url: `https://downloads.mitmproxy.org/${version}/mitmproxy-${version}-linux-x86_64.tar.gz`,
+		sha256,
+	};
+}
+
+function installCachedTestEgressEngine(paths: RuntimePaths, version: string) {
+	const engine = testEgressEnginePin(version, "a".repeat(64));
+	const binaryPath = join(paths.egressEngineMaintainedRoot, version, engine.sha256, "mitmdump");
+	mkdirSync(dirname(binaryPath), { recursive: true });
+	writeFileSync(binaryPath, "#!/usr/bin/env sh\nexit 0\n");
+	chmodSync(binaryPath, 0o755);
+	return engine;
+}
+
+function writeTestMitmproxyArchive(
+	paths: RuntimePaths,
+	name: string,
+	kind: "ready" | "missing-mitmdump" | "corrupt",
+): { path: string; sha256: string } {
+	const fixtureRoot = join(dirname(paths.serviceStateRoot), "egress-engine-fixtures", name);
+	const archivePath = join(fixtureRoot, `${name}.tar.gz`);
+	mkdirSync(fixtureRoot, { recursive: true });
+	if (kind === "corrupt") {
+		writeFileSync(archivePath, "not a tar.gz archive\n");
+	} else {
+		const sourceRoot = join(fixtureRoot, "source", `mitmproxy-${name}`);
+		mkdirSync(sourceRoot, { recursive: true });
+		if (kind === "ready") {
+			const binaryPath = join(sourceRoot, "mitmdump");
+			writeFileSync(binaryPath, "#!/usr/bin/env sh\nexit 0\n");
+			chmodSync(binaryPath, 0o755);
+		} else {
+			writeFileSync(join(sourceRoot, "README.txt"), "mitmdump intentionally absent\n");
+		}
+		execFileSync("tar", ["-czf", archivePath, "-C", join(fixtureRoot, "source"), "."]);
+	}
+	return {
+		path: archivePath,
+		sha256: createHash("sha256").update(readFileSync(archivePath)).digest("hex"),
+	};
+}
+
+function installTestMitmproxyCurl(
+	paths: RuntimePaths,
+	artifactPath: string | null,
+): { commandPath: string; markerPath: string } {
+	const binRoot = join(dirname(paths.serviceStateRoot), "egress-engine-test-bin");
+	const curlPath = join(binRoot, "curl");
+	const markerPath = join(binRoot, "curl-invoked");
+	mkdirSync(binRoot, { recursive: true });
+	writeFileSync(
+		curlPath,
+		artifactPath
+			? [
+					"#!/usr/bin/env bash",
+					"set -euo pipefail",
+					`printf invoked > ${JSON.stringify(markerPath)}`,
+					`cp -- ${JSON.stringify(artifactPath)} "$5"`,
+					"",
+				].join("\n")
+			: [
+					"#!/usr/bin/env bash",
+					"set -euo pipefail",
+					`printf invoked > ${JSON.stringify(markerPath)}`,
+					"printf 'artifact endpoint unavailable: test-token\\n' >&2",
+					"exit 22",
+					"",
+				].join("\n"),
+	);
+	chmodSync(curlPath, 0o700);
+	return { commandPath: curlPath, markerPath };
+}
+
+function egressRuntimeManifest(
+	paths: RuntimePaths,
+	input: {
+		generation: number;
+		engine?: RuntimeManifest["egressEngine"];
+		profile: "enabled" | "disabled" | "absent";
+	},
+): RuntimeManifest {
+	process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
+	const commandPath = join(paths.userHome, ".openclaw", "bin", "openclaw");
+	mkdirSync(dirname(commandPath), { recursive: true });
+	writeFileSync(commandPath, "#!/usr/bin/env sh\nexit 0\n");
+	chmodSync(commandPath, 0o700);
+	return baseManifest(
+		paths,
+		{
+			openclaw: {
+				enabled: true,
+				run: runSettings(commandPath, ["gateway", "run"]),
+				services: {},
+			},
+		},
+		{
+			generation: input.generation,
+			issuedAt: `2026-07-01T00:0${input.generation}:00.000Z`,
+			openclawGatewayAuth: hostedOpenClawNativeAuth(),
+			projection: {
+				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+				system: hostedSystemFixture(),
+			},
+			...(input.engine ? { egressEngine: input.engine } : {}),
+			...(input.profile === "absent"
+				? {}
+				: {
+						egressProfiles: {
+							profiles: [
+								{
+									id: "required-egress",
+									enabled: input.profile === "enabled",
+									kind: "http" as const,
+									match: {
+										scheme: "https" as const,
+										host: "api.example.test",
+										headers: {},
+										query: {},
+									},
+									rewrite: {
+										upstreamBaseUrl: "https://upstream.example.test",
+										preservePath: true,
+										setHeaders: {},
+									},
+									logging: { redactHeaders: [], redactUrlPatterns: [] },
+									priority: 100,
+								},
+							],
+						},
+					}),
+		},
+	);
+}
+
+function commitTestRuntimeAuthority(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	convergence: ReturnType<typeof convergeRuntimeManifest>,
+	authority: { egressSidecarSecretRevision?: string },
+): void {
+	commitRuntimeAppliedState({
+		load,
+		paths,
+		etag: `"generation-${load.manifest.generation}"`,
+		sourceRevision: runtimeContentSha256({ generation: load.manifest.generation }),
+		convergence,
+		applyIdentity: null,
+		egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
+	});
 }
 
 function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -1047,7 +1209,10 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 			}),
 		);
-		const normalized = hostedManifestToRuntimeManifest(hosted);
+		const normalized: RuntimeManifest = {
+			...hostedManifestToRuntimeManifest(hosted),
+			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-control-ui"),
+		};
 		expect(normalized.projection?.system).toEqual(hosted.system);
 
 		const result = convergeRuntimeManifest(
@@ -1095,6 +1260,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		const projected = hostedManifestToRuntimeManifest(hosted);
 		const normalized: RuntimeManifest = {
 			...projected,
+			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-native-auth"),
 			projection: {
 				...projected.projection,
 				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
@@ -1139,7 +1305,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			"utf8",
 		);
 		expect(gatewayEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token"');
-		expect(result.outputs.systemdSystemUnits.map((path) => path.split("/").at(-1))).not.toContain(
+		expect(result.outputs.systemdSystemUnits.map((path) => path.split("/").at(-1))).toContain(
 			"clawdi-runtime-sidecar.service",
 		);
 	});
@@ -2312,6 +2478,233 @@ describe("runtime manifest reconciliation invariants", () => {
 		const sidecarRevision = runtimeSidecarProgramRevision(manifest);
 		expect(runtimeSidecarProgramRevision(egressManifest)).not.toBe(sidecarRevision);
 		expect(runtimeSidecarProgramRevision(metadataOnlyChange)).not.toBe(sidecarRevision);
+	});
+
+	test.each([
+		["network", "failed to download mitmproxy"],
+		["sha-mismatch", "checksum mismatch"],
+		["corrupt-archive", "tar failed to extract mitmproxy"],
+		["missing-mitmdump", "archive did not contain mitmdump"],
+		["activation", "injected egress activation failure"],
+	] as const)("fails closed and preserves authority on first-install and upgrade %s failure", (failure, expectedError) => {
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const prepareFailure = (paths: RuntimePaths, phase: "first" | "upgrade") => {
+			const version = `12.2.3-test-${failure}-${phase}`;
+			if (failure === "network") {
+				const curl = installTestMitmproxyCurl(paths, null);
+				return {
+					engine: testEgressEnginePin(version, "a".repeat(64)),
+					downloadCommand: curl.commandPath,
+				};
+			}
+			const kind =
+				failure === "corrupt-archive"
+					? "corrupt"
+					: failure === "missing-mitmdump"
+						? "missing-mitmdump"
+						: "ready";
+			const artifact = writeTestMitmproxyArchive(paths, `${failure}-${phase}`, kind);
+			const curl = installTestMitmproxyCurl(paths, artifact.path);
+			return {
+				engine: testEgressEnginePin(
+					version,
+					failure === "sha-mismatch" ? "0".repeat(64) : artifact.sha256,
+				),
+				downloadCommand: curl.commandPath,
+			};
+		};
+		const hooks = (rollback: () => void, failActivation: boolean) => ({
+			activateEgressPrerequisite: successfulPrerequisiteActivation,
+			activate: () => {
+				if (failActivation) throw new Error("injected egress activation failure");
+				return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+			},
+			rollback,
+		});
+		const managedStatePaths = (paths: RuntimePaths) => [
+			paths.managedConfig,
+			paths.syncState,
+			paths.egressEngineStatus,
+			paths.manifestLastGood,
+			paths.managedSecretCacheFile,
+			paths.appliedState,
+			paths.egressProfileBundle,
+			join(paths.managedSecretRoot, "egress-secrets.json"),
+			paths.egressAddon,
+			paths.egressTransparentEnv,
+			paths.egressSystemCaFile,
+			join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"),
+			join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
+			runtimeRunConfigPath("openclaw", paths),
+		];
+		const capture = (paths: readonly string[]) =>
+			new Map(paths.map((path) => [path, existsSync(path) ? readFileSync(path, "utf-8") : null]));
+		const expectSnapshot = (snapshot: Map<string, string | null>) => {
+			for (const [path, expected] of snapshot) {
+				if (expected === null) expect(existsSync(path)).toBe(false);
+				else expect(readFileSync(path, "utf-8")).toBe(expected);
+			}
+		};
+
+		const firstPaths = tempRuntimePaths();
+		const firstSnapshot = capture(managedStatePaths(firstPaths));
+		const firstFailure = prepareFailure(firstPaths, "first");
+		const firstManifest = egressRuntimeManifest(firstPaths, {
+			generation: 1,
+			engine: firstFailure.engine,
+			profile: "enabled",
+		});
+		const firstLoad = manifestLoad(firstManifest, `inline-egress-${failure}-first`);
+		let firstCommits = 0;
+		const failedFirstInstall = convergeRuntimeManifest(firstLoad, firstPaths, {
+			cacheLastGood: false,
+			commitAuthority: (convergence, authority) => {
+				firstCommits += 1;
+				commitTestRuntimeAuthority(firstLoad, firstPaths, convergence, authority);
+			},
+			egressEngineEnsureOptions: { downloadCommand: firstFailure.downloadCommand },
+			systemdApply: hooks(() => {}, failure === "activation"),
+		});
+		const firstErrors = failedFirstInstall.installErrors.join("\n");
+		expect(firstErrors).toContain(expectedError);
+		if (failure !== "activation") {
+			expect(firstErrors).toStartWith(
+				"runtime apply failed: required egress engine is not ready: ",
+			);
+		}
+		expect(firstErrors).not.toContain("test-token");
+		expect(firstCommits).toBe(0);
+		expectSnapshot(firstSnapshot);
+		expect(existsSync(firstPaths.manifestLastGood)).toBe(false);
+		expect(existsSync(firstPaths.appliedState)).toBe(false);
+
+		const upgradePaths = tempRuntimePaths();
+		const baselineArtifact = writeTestMitmproxyArchive(
+			upgradePaths,
+			`baseline-${failure}`,
+			"ready",
+		);
+		const baselineCurl = installTestMitmproxyCurl(upgradePaths, baselineArtifact.path);
+		const baselineManifest = egressRuntimeManifest(upgradePaths, {
+			generation: 1,
+			engine: testEgressEnginePin(`12.2.3-test-baseline-${failure}`, baselineArtifact.sha256),
+			profile: "enabled",
+		});
+		const baselineLoad = manifestLoad(baselineManifest, `inline-egress-${failure}-baseline`);
+		const baseline = convergeRuntimeManifest(baselineLoad, upgradePaths, {
+			cacheLastGood: false,
+			commitAuthority: (convergence, authority) =>
+				commitTestRuntimeAuthority(baselineLoad, upgradePaths, convergence, authority),
+			egressEngineEnsureOptions: { downloadCommand: baselineCurl.commandPath },
+			systemdApply: hooks(() => {}, false),
+		});
+		expect(baseline.installErrors).toEqual([]);
+		expect(baseline.outputs.egressEngine?.status).toBe("ready");
+		const sidecarUnit = join(upgradePaths.systemdSystemRoot, "clawdi-runtime-sidecar.service");
+		expect(existsSync(sidecarUnit)).toBe(true);
+		const previous = capture(managedStatePaths(upgradePaths));
+
+		const upgradeFailure = prepareFailure(upgradePaths, "upgrade");
+		const upgradeManifest = egressRuntimeManifest(upgradePaths, {
+			generation: 2,
+			engine: upgradeFailure.engine,
+			profile: "enabled",
+		});
+		const upgradeLoad = manifestLoad(upgradeManifest, `inline-egress-${failure}-upgrade`);
+		let upgradeCommits = 0;
+		let rollbackCalls = 0;
+		const failedUpgrade = convergeRuntimeManifest(upgradeLoad, upgradePaths, {
+			cacheLastGood: false,
+			commitAuthority: (convergence, authority) => {
+				upgradeCommits += 1;
+				commitTestRuntimeAuthority(upgradeLoad, upgradePaths, convergence, authority);
+			},
+			egressEngineEnsureOptions: { downloadCommand: upgradeFailure.downloadCommand },
+			systemdApply: hooks(() => {
+				rollbackCalls += 1;
+			}, failure === "activation"),
+		});
+		const upgradeErrors = failedUpgrade.installErrors.join("\n");
+		expect(upgradeErrors).toContain(expectedError);
+		if (failure !== "activation") {
+			expect(upgradeErrors).toStartWith(
+				"runtime apply failed: required egress engine is not ready: ",
+			);
+		}
+		expect(upgradeErrors).not.toContain("test-token");
+		expect(upgradeCommits).toBe(0);
+		expect(rollbackCalls).toBe(failure === "activation" ? 1 : 0);
+		expectSnapshot(previous);
+		expect(readRuntimeAppliedState(upgradePaths)?.generation).toBe(1);
+		expect(JSON.parse(readFileSync(upgradePaths.manifestLastGood, "utf-8"))).toMatchObject({
+			generation: 1,
+		});
+	});
+
+	test("converges enabled egress when the pinned engine is ready", () => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const artifact = writeTestMitmproxyArchive(paths, "ready-success", "ready");
+		const curl = installTestMitmproxyCurl(paths, artifact.path);
+		const manifest = egressRuntimeManifest(paths, {
+			generation: 1,
+			engine: testEgressEnginePin("12.2.3-test-success", artifact.sha256),
+			profile: "enabled",
+		});
+		const load = manifestLoad(manifest, "inline-egress-success");
+		let commits = 0;
+		const result = convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			commitAuthority: (convergence, authority) => {
+				commits += 1;
+				commitTestRuntimeAuthority(load, paths, convergence, authority);
+			},
+			egressEngineEnsureOptions: { downloadCommand: curl.commandPath },
+			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
+				activate: successfulPrerequisiteActivation,
+				rollback: () => {},
+			},
+		});
+
+		expect(result.installErrors).toEqual([]);
+		expect(result.outputs.egressEngine).toEqual(expect.objectContaining({ status: "ready" }));
+		expect(commits).toBe(1);
+		expect(readRuntimeAppliedState(paths)?.generation).toBe(1);
+		expect(existsSync(paths.manifestLastGood)).toBe(true);
+		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(true);
+	});
+
+	test.each([
+		"disabled",
+		"absent",
+	] as const)("does not require the egress engine when profiles are %s", (profile) => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const curl = installTestMitmproxyCurl(paths, null);
+		const manifest = egressRuntimeManifest(paths, {
+			generation: 1,
+			engine: testEgressEnginePin(`12.2.3-test-${profile}`, "a".repeat(64)),
+			profile,
+		});
+		const load = manifestLoad(manifest, `inline-egress-${profile}`);
+		let commits = 0;
+		const result = convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			commitAuthority: (convergence, authority) => {
+				commits += 1;
+				commitTestRuntimeAuthority(load, paths, convergence, authority);
+			},
+			egressEngineEnsureOptions: { downloadCommand: curl.commandPath },
+		});
+
+		expect(result.installErrors).toEqual([]);
+		expect(commits).toBe(1);
+		expect(existsSync(curl.markerPath)).toBe(false);
+		expect(result.outputs.egressEngine).toBeNull();
+		expect(existsSync(paths.egressProfileBundle)).toBe(false);
+		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(false);
+		expect(readRuntimeAppliedState(paths)?.generation).toBe(1);
 	});
 
 	test("restarts only active sidecars for committed egress secret lifecycle changes", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -124,7 +124,11 @@ import {
 	manifestSecretRefs,
 	type RuntimeManifestLoad,
 } from "./manifest-source";
-import { ensureRuntimeMitmproxy, type RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
+import {
+	type EnsureRuntimeMitmproxyOptions,
+	ensureRuntimeMitmproxy,
+	type RuntimeMitmproxyEnsureResult,
+} from "./mitmproxy-fetch";
 import type { RuntimePaths } from "./paths";
 import { detectRuntimeMode } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
@@ -4081,6 +4085,22 @@ function writeEgressEngineStatus(
 	return result;
 }
 
+function requireV2EgressEngineReady(
+	manifest: RuntimeManifest,
+	profileBundlePath: string | null,
+	engine: RuntimeMitmproxyEnsureResult | null,
+): void {
+	if (
+		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		profileBundlePath &&
+		engine?.status !== "ready"
+	) {
+		throw new Error(
+			`required egress engine is not ready: ${engine?.error ?? "status unavailable"}`,
+		);
+	}
+}
+
 function writeEgressAddon(paths: RuntimePaths): { path: string; sha256: string } {
 	const source = resolvePackagedEgressAddon();
 	const content = readFileSync(source, "utf-8");
@@ -5870,6 +5890,7 @@ export function convergeRuntimeManifest(
 			authority: RuntimePrivateAppliedAuthority,
 		) => void;
 		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+		egressEngineEnsureOptions?: EnsureRuntimeMitmproxyOptions;
 		systemdApply?: RuntimeSystemdApplyHooks;
 	} = {},
 ): RuntimeConvergenceResult {
@@ -6137,9 +6158,12 @@ export function convergeRuntimeManifest(
 			? writeEgressProfileBundle(egressProfileBundle, paths)
 			: clearEgressProfileBundle(paths);
 		const egressEngine = writeEgressEngineStatus(
-			egressProfileBundlePath ? ensureRuntimeMitmproxy(manifest.egressEngine, paths) : null,
+			egressProfileBundlePath
+				? ensureRuntimeMitmproxy(manifest.egressEngine, paths, opts.egressEngineEnsureOptions)
+				: null,
 			paths,
 		);
+		requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
 		const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
 		const daemonAuthTokenFile = writeDaemonAuthToken(paths);
 		writeSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(manifest));

--- a/packages/cli/src/runtime/mitmproxy-fetch.ts
+++ b/packages/cli/src/runtime/mitmproxy-fetch.ts
@@ -35,10 +35,20 @@ export interface RuntimeMitmproxyDegraded {
 
 export type RuntimeMitmproxyEnsureResult = RuntimeMitmproxyReady | RuntimeMitmproxyDegraded;
 
-interface EnsureRuntimeMitmproxyOptions {
+export interface EnsureRuntimeMitmproxyOptions {
 	allowFileUrls?: boolean;
 	downloadCommand?: string;
 }
+
+const SAFE_MITMPROXY_ERRORS = new Set([
+	"egress engine must use mitmproxy",
+	"mitmproxy version contains unsafe characters",
+	"mitmproxy sha256 must be 64 hex characters",
+	"mitmproxy URL must use https",
+	"mitmproxy URL must use official mitmproxy downloads",
+	"mitmproxy URL must use the pinned linux x86_64 release archive",
+	"mitmproxy archive did not contain mitmdump",
+]);
 
 export function ensureRuntimeMitmproxy(
 	pin: EgressEnginePin | null | undefined,
@@ -87,8 +97,19 @@ export function ensureRuntimeMitmproxy(
 			rmSync(tempRoot, { recursive: true, force: true });
 		}
 	} catch (error) {
-		return degraded(pin, error instanceof Error ? error.message : String(error));
+		return degraded(pin, safeMitmproxyError(error));
 	}
+}
+
+function safeMitmproxyError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	if (SAFE_MITMPROXY_ERRORS.has(message)) return message;
+	if (/^failed to download mitmproxy \(exit (?:[0-9]+|unknown)\)$/.test(message)) return message;
+	if (/^tar failed to extract mitmproxy \(exit (?:[0-9]+|unknown)\)$/.test(message)) return message;
+	if (/^mitmproxy checksum mismatch: expected [a-f0-9]{64}, got [a-f0-9]{64}$/.test(message)) {
+		return message;
+	}
+	return "mitmproxy preparation failed";
 }
 
 function validateMitmproxyPin(pin: EgressEnginePin, options: EnsureRuntimeMitmproxyOptions): void {
@@ -131,8 +152,7 @@ function fetchArtifact(
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 	if (result.status !== 0) {
-		const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-		throw new Error(`${command} failed to download mitmproxy${detail ? `\n${detail}` : ""}`);
+		throw new Error(`failed to download mitmproxy (exit ${result.status ?? "unknown"})`);
 	}
 }
 
@@ -142,8 +162,7 @@ function extractTarGz(archivePath: string, destination: string): void {
 		stdio: ["ignore", "pipe", "pipe"],
 	});
 	if (result.status !== 0) {
-		const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-		throw new Error(`tar failed to extract mitmproxy${detail ? `\n${detail}` : ""}`);
+		throw new Error(`tar failed to extract mitmproxy (exit ${result.status ?? "unknown"})`);
 	}
 }
 

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -88,7 +88,7 @@ describe("hosted runtime bundle v2", () => {
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
 
 		expect(projected.sourceRevision).toBe(
-			"f7aecccd700e4c6e3fa21cd8f7935b95bdcc9de1540c5aa9ff41c2984bcac6f5",
+			"12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9",
 		);
 		expect(projected.manifest.runtimes.openclaw.run?.secretEnv).toMatchObject({
 			OPENCLAW_GATEWAY_TOKEN: "env://OPENCLAW_GATEWAY_TOKEN",
@@ -913,7 +913,7 @@ describe("hosted runtime bundle v2", () => {
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
 		expect(loaded.etag).toBe('"bundle-golden"');
 		expect(loaded.sourceRevision).toBe(
-			"f7aecccd700e4c6e3fa21cd8f7935b95bdcc9de1540c5aa9ff41c2984bcac6f5",
+			"12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9",
 		);
 		expect(loaded.channelBindings).toHaveLength(1);
 	});
@@ -967,6 +967,19 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_EGRESS_GID = "10002";
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
 		const paths = getRuntimePaths({ mode: "hosted" });
+		const goldenRaw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
+			manifest: { egressEngine: { version: string; sha256: string } };
+		};
+		const goldenEngine = goldenRaw.manifest.egressEngine;
+		const goldenMitmdump = join(
+			paths.egressEngineMaintainedRoot,
+			goldenEngine.version,
+			goldenEngine.sha256,
+			"mitmdump",
+		);
+		mkdirSync(dirname(goldenMitmdump), { recursive: true });
+		writeFileSync(goldenMitmdump, "#!/usr/bin/env sh\nexit 0\n");
+		chmodSync(goldenMitmdump, 0o755);
 		const openclawBin = join(paths.userHome, ".openclaw", "bin", "openclaw");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(openclawBin, "#!/usr/bin/env sh\ncat >/dev/null || true\nexit 0\n");

--- a/packages/cli/tests/runtime-mitmproxy-fetch.test.ts
+++ b/packages/cli/tests/runtime-mitmproxy-fetch.test.ts
@@ -171,6 +171,23 @@ describe("runtime egress engine maintained fetch", () => {
 		expect(result.error).toContain("pinned linux x86_64 release archive");
 	});
 
+	it("redacts unexpected engine preparation diagnostics", () => {
+		const result = ensureRuntimeMitmproxy(
+			{
+				type: "mitmproxy" as const,
+				version: "12.2.3",
+				url: "not-a-url-test-token",
+				sha256: "a".repeat(64),
+			},
+			runtimePaths(),
+		);
+
+		expect(result.status).toBe("degraded");
+		if (result.status !== "degraded") throw new Error("expected degraded");
+		expect(result.error).toBe("mitmproxy preparation failed");
+		expect(result.error).not.toContain("test-token");
+	});
+
 	it("degrades cleanly when the manifest has no pin", () => {
 		const result = ensureRuntimeMitmproxy(null, runtimePaths());
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -122,6 +122,7 @@ const ENV_KEYS = [
 type EnvKey = (typeof ENV_KEYS)[number];
 
 let originalEnv: Partial<Record<EnvKey, string>>;
+let originalUmask: number;
 let root: string;
 
 function fakeSystemdStatePath(
@@ -138,7 +139,6 @@ function writeFakeSystemdManager(input: {
 	logPath: string;
 	stateRoot: string;
 	failNextSidecarRestart?: string;
-	failNextSidecarStop?: string;
 	sidecarReadyPath?: string;
 }): void {
 	mkdirSync(input.stateRoot, { recursive: true });
@@ -198,11 +198,6 @@ case "$command" in
     done
     ;;
   stop)
-    if [ "$*" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.failNextSidecarStop ?? ""}' ] && [ -f '${input.failNextSidecarStop ?? ""}' ]; then
-      rm -f '${input.failNextSidecarStop ?? ""}'
-      printf 'injected sidecar stop failure\\n' >&2
-      exit 43
-    fi
     for unit in "$@"; do rm -f "$(state_path "$unit" active)" "$(state_path "$unit" failed)"; touch "$(state_path "$unit" not-found)"; done
     ;;
   enable)
@@ -227,6 +222,7 @@ esac
 }
 
 beforeEach(() => {
+	originalUmask = process.umask(0o022);
 	originalEnv = {};
 	process.exitCode = undefined;
 	for (const key of ENV_KEYS) {
@@ -244,6 +240,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	process.umask(originalUmask);
 	for (const key of ENV_KEYS) delete process.env[key];
 	for (const [key, value] of Object.entries(originalEnv)) {
 		process.env[key as EnvKey] = value;
@@ -527,6 +524,7 @@ const TEST_HOSTED_CODEX_TERMINAL_TOOLING = {
 
 function hostedRequiredState() {
 	return {
+		egressEngine: TEST_EGRESS_ENGINE_PIN,
 		providers: {
 			default: {
 				kind: "openai-compatible",
@@ -625,6 +623,7 @@ function hostedRuntimeBundleResponse(
 	payload: HostedRuntimeResponseFixture,
 	options: { etag?: string; sourceRevision?: string } = {},
 ): Response {
+	seedMitmproxyCache();
 	const runtime = payload.manifest.runtime;
 	if (runtime === "openclaw") {
 		process.env.OPENCLAW_GATEWAY_TOKEN ??= "test-openclaw-gateway-token";
@@ -2669,7 +2668,7 @@ chmod +x "$HOME/.local/bin/hermes"
 			const hermesEnv = readSystemdEnvFile(paths, "hermes-gateway");
 			const hermesDashboardEnv = readSystemdEnvFile(paths, "clawdi-hermes-dashboard");
 
-			expect(convergence.outputs.systemdSystemUnits).not.toContain(
+			expect(convergence.outputs.systemdSystemUnits).toContain(
 				join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"),
 			);
 			expect(hermesEnv).not.toContain("CLAWDI_MANAGED_OPENAI_API_KEY");
@@ -5952,7 +5951,7 @@ exit 64
 		]);
 	});
 
-	it("runtime watch wakes on its own manifest SSE signal and restarts only the runtime unit", async () => {
+	it("runtime watch restarts changed runtime and egress units without restarting itself", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6051,7 +6050,9 @@ exit 0
 			expect(systemctlCalls).toContain("--user restart openclaw-gateway.service");
 			expect(systemctlCalls.some((call) => call.includes("reset-failed"))).toBe(false);
 			expect(systemctlCalls.some((call) => call.includes("enable --now"))).toBe(false);
-			expect(systemctlCalls).toContain("restart clawdi-daemon.service");
+			expect(systemctlCalls).toContain(
+				"restart clawdi-daemon.service clawdi-runtime-sidecar.service",
+			);
 			expect(systemctlCalls.some((call) => call.includes("restart clawdi-runtime-watch"))).toBe(
 				false,
 			);
@@ -6237,6 +6238,7 @@ fi
 			logs.push(String(value));
 		};
 		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
+		seedMitmproxyCache();
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -6357,7 +6359,11 @@ fi
 			expect(event.systemdUnitsChanged).toBe(true);
 			expect(event.systemdApply).toEqual({
 				applied: true,
-				systemUnitsChanged: ["clawdi-daemon.service", "clawdi-runtime-watch.service"],
+				systemUnitsChanged: [
+					"clawdi-daemon.service",
+					"clawdi-runtime-sidecar.service",
+					"clawdi-runtime-watch.service",
+				],
 				userUnitsChanged: [],
 			});
 			const watchStatus = JSON.parse(
@@ -7559,7 +7565,11 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.systemdUnitsChanged).toBe(true);
 			expect(event.systemdApply).toEqual({
 				applied: false,
-				systemUnitsChanged: ["clawdi-daemon.service", "clawdi-runtime-watch.service"],
+				systemUnitsChanged: [
+					"clawdi-daemon.service",
+					"clawdi-runtime-sidecar.service",
+					"clawdi-runtime-watch.service",
+				],
 				userUnitsChanged: ["openclaw-gateway.service"],
 			});
 		} finally {
@@ -7769,7 +7779,7 @@ exit 0
 		});
 	});
 
-	it("keeps public sidecar artifacts stable while forcing private egress secret restarts", async () => {
+	it("keeps public sidecar artifacts stable and rejects required engine degradation", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7777,7 +7787,6 @@ exit 0
 		const systemctlLog = join(root, "systemctl-egress-rotation.log");
 		const systemctlStateRoot = join(root, "systemctl-egress-state");
 		const failNextSidecarRestart = join(root, "fail-next-sidecar-restart");
-		const failNextSidecarStop = join(root, "fail-next-sidecar-stop");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
@@ -7789,7 +7798,6 @@ exit 0
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
 			failNextSidecarRestart,
-			failNextSidecarStop,
 		});
 		writeFileSync(
 			fakeSystemdStatePath(
@@ -7826,7 +7834,7 @@ exit 0
 			const initialSecret = "000000";
 			const rotatedSecret = "000001";
 			const rejectedSecret = "000002";
-			const missingSidecarSecret = "000003";
+			const invalidEngineSecret = "000003";
 			const initialFetch = mockFetch([
 				{
 					method: "GET",
@@ -8066,8 +8074,7 @@ exit 0
 			writeFileSync(systemctlLog, "");
 			logs.length = 0;
 			process.exitCode = undefined;
-			writeFileSync(failNextSidecarStop, "fail\n");
-			const missingSidecarFetch = mockFetch([
+			const invalidEngineFetch = mockFetch([
 				{
 					method: "GET",
 					path: "/v1/runtime/manifest",
@@ -8079,7 +8086,7 @@ exit 0
 									...mitmproxy,
 									url: "https://invalid.example.test/mitmproxy.tar.gz",
 								},
-								missingSidecarSecret,
+								invalidEngineSecret,
 							),
 							{ etag: '"egress-secret-revision-d"' },
 						),
@@ -8087,37 +8094,26 @@ exit 0
 			]);
 			try {
 				await runtimeWatch({ once: true, json: true });
-				expect(process.exitCode).toBe(1);
-				const removalRejectedEvent = JSON.parse(logs.at(-1) ?? "{}");
-				expect(removalRejectedEvent.status).toBe("error");
-				expect(removalRejectedEvent.error).toContain("injected sidecar stop failure");
-				expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(
-					true,
-				);
-				writeFileSync(systemctlLog, "");
-				logs.length = 0;
-				process.exitCode = undefined;
-				await runtimeWatch({ once: true, json: true });
 			} finally {
-				missingSidecarFetch.restore();
+				invalidEngineFetch.restore();
 			}
-			expect(process.exitCode ?? 0).toBe(0);
-			const missingSidecarEvent = JSON.parse(logs.at(-1) ?? "{}");
-			expect(missingSidecarEvent.status).toBe("applied");
-			expect(missingSidecarEvent.systemdApply.systemUnitsChanged).toEqual([]);
+			expect(process.exitCode).toBe(1);
+			const invalidEngineEvent = JSON.parse(logs.at(-1) ?? "{}");
+			expect(invalidEngineEvent.status).toBe("error");
+			expect(invalidEngineEvent.error).toContain(
+				"required egress engine is not ready: mitmproxy URL must use official mitmproxy downloads",
+			);
+			expect(JSON.stringify(invalidEngineEvent)).not.toContain(invalidEngineSecret);
 			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(
-				false,
+				true,
 			);
 			expect(JSON.parse(readFileSync(egressSecretFile, "utf-8"))).toMatchObject({
-				"secret://provider.default.apiKey": missingSidecarSecret,
+				"secret://provider.default.apiKey": rotatedSecret,
 			});
-			const missingSidecarSystemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
-			expect(
-				missingSidecarSystemctlCalls.filter(
-					(call) => call === "restart clawdi-runtime-sidecar.service",
-				),
-			).toHaveLength(0);
-			expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBeUndefined();
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedAppliedState);
+			expect(readFileSync(paths.manifestLastGood, "utf-8")).toBe(committedLastGood);
+			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
 		} finally {
 			console.log = previousLog;
 			process.exitCode = previousExitCode;
@@ -10633,6 +10629,7 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		const paths = getRuntimePaths();
 
 		const load: RuntimeManifestLoad = {
 			manifest: {
@@ -10645,6 +10642,7 @@ exit 64
 				issuedAt: "2026-07-07T00:00:00Z",
 				workspaceRoot: workspace,
 				controlPlane: { apiUrl: "https://cloud-api.test/" },
+				egressEngine: seedMitmproxyCache(paths),
 				runtimes: {
 					hermes: {
 						enabled: true,
@@ -10714,7 +10712,6 @@ exit 64
 			etag: '"hermes-channels"',
 		};
 
-		const paths = getRuntimePaths();
 		const projected = applyRuntimeChannelsToManifestLoad(load, channels, paths);
 		const convergence = convergeRuntimeManifest(projected, paths);
 

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -285,6 +285,7 @@ describe("CLI smoke — src entry", () => {
 			"node:fs"
 		);
 		const root = join(tmpdir(), `clawdi-smoke-runtime-strict-${Date.now()}`);
+		const previousUmask = process.umask(0o022);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -292,6 +293,21 @@ describe("CLI smoke — src entry", () => {
 		const installer = join(root, "install-openclaw.sh");
 		const managedCli = join(state, "bin", "clawdi");
 		const managedCliTarget = join(state, "npm", "bin", "clawdi");
+		const egressEngine = {
+			type: "mitmproxy",
+			version: "12.2.3",
+			url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+			sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
+		} as const;
+		const mitmdump = join(
+			state,
+			"maintained",
+			"egress-engine",
+			"mitmproxy",
+			egressEngine.version,
+			egressEngine.sha256,
+			"mitmdump",
+		);
 		mkdirSync(home, { recursive: true });
 		mkdirSync(dirname(installer), { recursive: true });
 		mkdirSync(dirname(managedCli), { recursive: true });
@@ -317,6 +333,9 @@ exit 64
 		);
 		chmodSync(managedCliTarget, 0o700);
 		symlinkSync(managedCliTarget, managedCli);
+		mkdirSync(dirname(mitmdump), { recursive: true });
+		writeFileSync(mitmdump, "#!/usr/bin/env sh\nexit 0\n");
+		chmodSync(mitmdump, 0o755);
 		writeFileSync(
 			join(state, "status", "cli-bootstrap.json"),
 			JSON.stringify({
@@ -356,6 +375,7 @@ exit 64
 						},
 					},
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					egressEngine,
 					clawdiCli: {
 						source: "npm:clawdi",
 						packageSpec: "clawdi@0.12.10-beta.57",
@@ -431,6 +451,7 @@ exit 64
 			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(true);
 			expect(existsSync(join(state, "cache", "manifest.last-good.json"))).toBe(true);
 		} finally {
+			process.umask(previousUmask);
 			rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -18,6 +18,12 @@
 		},
 		"deploymentId": "dep_test",
 		"environmentId": "20000000-0000-0000-0000-000000000002",
+		"egressEngine": {
+			"sha256": "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
+			"type": "mitmproxy",
+			"url": "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+			"version": "12.2.3"
+		},
 		"generation": 7,
 		"instanceId": "hri_test",
 		"issuedAt": "2026-07-13T00:00:00+00:00",
@@ -128,5 +134,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "f7aecccd700e4c6e3fa21cd8f7935b95bdcc9de1540c5aa9ff41c2984bcac6f5"
+	"sourceRevision": "12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9"
 }


### PR DESCRIPTION
## Summary

- enforce one convergence invariant for strict OSS CLI v2 bundles: any enabled egress profile requires the egress engine to be ready
- raise invariant failures inside the existing live-snapshot transaction, before sidecar/unit and last-good/applied authority commit
- retain current behavior for disabled or absent egress profiles and keep diagnostics useful but redacted

## Control-flow premise correction

Artifact download, SHA, archive, and missing-`mitmdump` failures previously returned a degraded engine result. Reconciliation then omitted/removed the sidecar but could still commit last-good/applied authority. Activation and authority-commit exceptions already used the existing snapshot rollback. The missing behavior was therefore a single guard that turns a required degraded engine into a convergence error before any authority commit.

## Transaction design

The guard is centralized after engine status is written and before addon/secrets/unit/authority mutation. It applies only when the projection is a strict v2 runtime bundle and at least one enabled egress profile requires the engine. All failure paths reuse the existing workspace, live snapshot, and systemd rollback. No sidecar transaction layer, parallel state machine, Hosted/v1 change, or production operation is introduced.

Errors use the common prefix `required egress engine is not ready:` followed by a safe stage diagnostic. Raw curl/tar output, URLs, filesystem internals, and unknown exceptions are not exposed.

## Tests

Coverage includes first-install and upgrade failures for:

- network download failure
- SHA mismatch
- corrupt archive
- missing `mitmdump`
- activation failure

Assertions verify that authority commit is not called, first install creates no last-good/applied state, upgrades retain the prior sidecar/unit/env/config/secret and authority, and activation failure invokes the existing systemd rollback. Additional cases cover enabled-profile success, disabled and absent profiles, strict-v2 runtime/watch/smoke/golden fixtures, and a diagnostic redaction canary.

Verification completed on the rebased commit:

- focused CLI tests: 164 passed, 0 failed
- Docker-backed CLI clean suite: 1444 passed, 4 skipped, 0 failed
- `bun run --cwd packages/cli typecheck`
- targeted Biome check across all 8 changed files
- `bun run --cwd packages/cli build`
- `git diff --check origin/main...HEAD`

## Complexity audit

- total diff: +548 / -58
- product code: +51 / -8 (`manifest.ts` +26/-2, `mitmproxy-fetch.ts` +25/-6)
- remaining diff: failure matrix, rollback assertions, and strict-v2 fixture/golden updates

There is no smaller behavioral placement that preserves the required transaction semantics: the named invariant must run after the live snapshot is captured and engine preparation returns, but before authority commit, so every error automatically uses the existing full rollback. The small download-command injection is needed for deterministic network/SHA/archive tests under Bun, where temporary PATH replacement is not reliable. The diagnostic whitelist is required to preserve actionable errors without leaking command output or internal values. Exception wording is unified under one invariant prefix, with only safe stage-specific details appended.
