### PR TITLE
fix(runtime): separate v2 apply and checkpoint generations

### DIFF
--- a/backend/alembic/versions/7c2e9a4b6d1f_add_hosted_runtime_apply_generation.py
+++ b/backend/alembic/versions/7c2e9a4b6d1f_add_hosted_runtime_apply_generation.py
@@ -1,0 +1,38 @@
+"""Add hosted runtime apply generation.
+
+Revision ID: 7c2e9a4b6d1f
+Revises: 5d2a9c7e4b18
+Create Date: 2026-07-30 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "7c2e9a4b6d1f"
+down_revision: str | Sequence[str] | None = "5d2a9c7e4b18"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hosted_runtime_states",
+        sa.Column("apply_generation", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_hosted_runtime_states_apply_generation",
+        "hosted_runtime_states",
+        "apply_generation IS NULL OR apply_generation >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_hosted_runtime_states_apply_generation",
+        "hosted_runtime_states",
+        type_="check",
+    )
+    op.drop_column("hosted_runtime_states", "apply_generation")

--- a/backend/app/models/hosted_runtime.py
+++ b/backend/app/models/hosted_runtime.py
@@ -12,6 +12,12 @@ from app.models.session import AgentEnvironment  # noqa: F401 - register FK targ
 
 class HostedRuntimeState(Base, TimestampMixin):
     __tablename__ = "hosted_runtime_states"
+    __table_args__ = (
+        CheckConstraint(
+            "apply_generation IS NULL OR apply_generation >= 1",
+            name="ck_hosted_runtime_states_apply_generation",
+        ),
+    )
 
     environment_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -21,6 +27,7 @@ class HostedRuntimeState(Base, TimestampMixin):
     deployment_id: Mapped[str] = mapped_column(String(200), nullable=False)
     instance_id: Mapped[str] = mapped_column(String(200), nullable=False)
     generation: Mapped[int] = mapped_column(Integer, nullable=False)
+    apply_generation: Mapped[int | None] = mapped_column(Integer)
     cli_package_spec: Mapped[str] = mapped_column(String(200), nullable=False)
     locale: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
     system: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -122,6 +122,10 @@ from app.services.managed_ai_provider import (
     lock_deployment_managed_provider_mutation,
     upsert_clawdi_managed_provider,
 )
+from app.services.runtime_generation import (
+    RuntimeApplyGenerationUpdateError,
+    resolve_runtime_apply_generation_update,
+)
 from app.services.runtime_manifest_resources import (
     enabled_runtime_manifest_skill_ids,
     lock_runtime_manifest_skill_reservations,
@@ -1442,20 +1446,39 @@ async def _admin_upsert_runtime_state(
         skill_ids=old_skill_ids | new_skill_ids,
     )
     previous_generation = state.generation if state is not None else None
-    desired_state = _runtime_state_values(body)
-    changed_fields = _runtime_state_changed_fields(existing_state, desired_state)
-    if existing_state is not None and body.generation <= existing_state.generation:
+    previous_apply_generation = state.apply_generation if state is not None else None
+    if existing_state is not None and body.generation < existing_state.generation:
         current_generation = existing_state.generation
-        if body.generation < current_generation:
-            await db.rollback()
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "stale_generation",
-                    "current_generation": current_generation,
-                },
-            )
-        material_changes = [field for field in changed_fields if field != "generation"]
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "stale_generation",
+                "current_generation": current_generation,
+            },
+        )
+    try:
+        apply_generation = resolve_runtime_apply_generation_update(
+            current=previous_apply_generation,
+            requested=body.apply_generation,
+            explicitly_set="apply_generation" in body.model_fields_set,
+        )
+    except RuntimeApplyGenerationUpdateError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": exc.code,
+                "current_apply_generation": exc.current_apply_generation,
+            },
+        ) from exc
+    desired_state = _runtime_state_values(body, apply_generation=apply_generation)
+    changed_fields = _runtime_state_changed_fields(existing_state, desired_state)
+    if existing_state is not None and body.generation == existing_state.generation:
+        current_generation = existing_state.generation
+        material_changes = [
+            field for field in changed_fields if field not in {"generation", "apply_generation"}
+        ]
         if material_changes:
             await db.rollback()
             raise HTTPException(
@@ -1465,13 +1488,15 @@ async def _admin_upsert_runtime_state(
                     "current_generation": current_generation,
                 },
             )
-        await db.commit()
-        return AdminRuntimeStateResponse(
-            environment_id=environment_id,
-            deployment_id=body.deployment_id,
-            instance_id=body.instance_id,
-            generation=body.generation,
-        )
+        if not changed_fields:
+            await db.commit()
+            return AdminRuntimeStateResponse(
+                environment_id=environment_id,
+                deployment_id=body.deployment_id,
+                instance_id=body.instance_id,
+                generation=body.generation,
+                apply_generation=apply_generation,
+            )
     if state is None:
         state = HostedRuntimeState(environment_id=environment_id)
         db.add(state)
@@ -1492,6 +1517,8 @@ async def _admin_upsert_runtime_state(
             "instance_id": body.instance_id,
             "generation": body.generation,
             "previous_generation": previous_generation,
+            "apply_generation": apply_generation,
+            "previous_apply_generation": previous_apply_generation,
             "cli_package_spec": body.cli_package_spec,
             "locale": body.locale.model_dump(),
             "enabled_runtimes": _enabled_runtime_names(desired_state["runtimes"]),
@@ -1517,6 +1544,7 @@ async def _admin_upsert_runtime_state(
         deployment_id=body.deployment_id,
         instance_id=body.instance_id,
         generation=body.generation,
+        apply_generation=apply_generation,
     )
 
 
@@ -1679,7 +1707,11 @@ def _enabled_runtime_names(runtimes: dict[str, object]) -> list[str]:
     )
 
 
-def _runtime_state_values(body: AdminRuntimeStateUpsert) -> dict[str, Any]:
+def _runtime_state_values(
+    body: AdminRuntimeStateUpsert,
+    *,
+    apply_generation: int | None = None,
+) -> dict[str, Any]:
     def optional_wire_value(field: str) -> Any:
         value = getattr(body, field)
         if value is None:
@@ -1690,6 +1722,7 @@ def _runtime_state_values(body: AdminRuntimeStateUpsert) -> dict[str, Any]:
         "deployment_id": body.deployment_id,
         "instance_id": body.instance_id,
         "generation": body.generation,
+        "apply_generation": apply_generation,
         "cli_package_spec": body.cli_package_spec,
         "locale": body.locale.model_dump(mode="json"),
         "system": body.system.model_dump(exclude_none=True, mode="json"),
@@ -1718,7 +1751,8 @@ def _runtime_state_changed_fields(
     return [
         field
         for field, value in desired_state.items()
-        if state is None or getattr(state, field) != value
+        if (state is None and (field != "apply_generation" or value is not None))
+        or (state is not None and getattr(state, field) != value)
     ]
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -57,6 +57,10 @@ from app.services.platform_workload_auth import (
     issue_platform_workload_token,
     require_platform_mutation_auth,
 )
+from app.services.runtime_generation import (
+    RuntimeApplyGenerationUpdateError,
+    resolve_runtime_apply_generation_update,
+)
 from app.services.runtime_manifest_resources import (
     enabled_runtime_manifest_skill_ids,
     lock_runtime_manifest_skill_reservations,
@@ -703,7 +707,10 @@ async def platform_upsert_runtime_state(
         db,
         operation="runtime_state.upsert",
         idempotency_key=idempotency_key,
-        request_payload={"agent_id": str(agent_id), **body.model_dump(mode="json")},
+        request_payload={
+            "agent_id": str(agent_id),
+            **_runtime_state_idempotency_payload(body),
+        },
         owner=body.owner,
         owner_user_id=owner.id,
         resource_type="hosted_runtime_state",
@@ -749,36 +756,70 @@ async def platform_upsert_runtime_state(
         skill_ids=old_skill_ids | new_skill_ids,
     )
     previous_generation = runtime_state.generation if runtime_state is not None else None
-    changed_fields = _runtime_state_changed_fields(runtime_state, body)
-    if runtime_state is not None and body.generation <= runtime_state.generation:
+    previous_apply_generation = (
+        runtime_state.apply_generation if runtime_state is not None else None
+    )
+    if runtime_state is not None and body.generation < runtime_state.generation:
         current_generation = runtime_state.generation
-        if body.generation < current_generation:
-            await _reject(
-                db,
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "stale_generation",
-                    "current_generation": current_generation,
-                },
-                result="stale_generation",
-                owner=body.owner,
-                owner_user_id=owner.id,
-                resource_type="hosted_runtime_state",
-                resource_id=str(agent_id),
-                action=action,
-                request=request,
-                idempotency_key=idempotency_key,
-                environment_id=agent_id,
-            )
-            raise AssertionError("unreachable")
-        material_changes = [field for field in changed_fields if field != "generation"]
+        await _reject(
+            db,
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "stale_generation",
+                "current_generation": current_generation,
+            },
+            result="stale_generation",
+            owner=body.owner,
+            owner_user_id=owner.id,
+            resource_type="hosted_runtime_state",
+            resource_id=str(agent_id),
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+            environment_id=agent_id,
+        )
+        raise AssertionError("unreachable")
+    try:
+        apply_generation = resolve_runtime_apply_generation_update(
+            current=previous_apply_generation,
+            requested=body.apply_generation,
+            explicitly_set="apply_generation" in body.model_fields_set,
+        )
+    except RuntimeApplyGenerationUpdateError as exc:
+        await _reject(
+            db,
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": exc.code,
+                "current_apply_generation": exc.current_apply_generation,
+            },
+            result=exc.code,
+            owner=body.owner,
+            owner_user_id=owner.id,
+            resource_type="hosted_runtime_state",
+            resource_id=str(agent_id),
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+            environment_id=agent_id,
+        )
+        raise AssertionError("unreachable")
+    changed_fields = _runtime_state_changed_fields(
+        runtime_state,
+        body,
+        apply_generation=apply_generation,
+    )
+    if runtime_state is not None and body.generation == runtime_state.generation:
+        material_changes = [
+            field for field in changed_fields if field not in {"generation", "apply_generation"}
+        ]
         if material_changes:
             await _reject(
                 db,
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "code": "generation_conflict",
-                    "current_generation": current_generation,
+                    "current_generation": runtime_state.generation,
                 },
                 result="generation_conflict",
                 owner=body.owner,
@@ -794,7 +835,7 @@ async def platform_upsert_runtime_state(
     if runtime_state is None:
         runtime_state = HostedRuntimeState(environment_id=agent_id)
         db.add(runtime_state)
-    _assign_runtime_state(runtime_state, body)
+    _assign_runtime_state(runtime_state, body, apply_generation=apply_generation)
     if changed_fields:
         queue_runtime_manifest_changed(db, agent.user_id, agent_id)
     response = PlatformRuntimeStateResponse(
@@ -802,6 +843,7 @@ async def platform_upsert_runtime_state(
         deployment_id=body.deployment_id,
         instance_id=body.instance_id,
         generation=body.generation,
+        apply_generation=apply_generation,
     )
     await _complete_mutation(
         db,
@@ -821,6 +863,8 @@ async def platform_upsert_runtime_state(
             "deployment_id": body.deployment_id,
             "generation": body.generation,
             "previous_generation": previous_generation,
+            "apply_generation": apply_generation,
+            "previous_apply_generation": previous_apply_generation,
             "changed_fields": changed_fields,
         },
     )
@@ -1066,10 +1110,13 @@ async def platform_revoke_api_key(
 def _assign_runtime_state(
     state: HostedRuntimeState,
     body: PlatformRuntimeStateUpsert,
+    *,
+    apply_generation: int | None,
 ) -> None:
     state.deployment_id = body.deployment_id
     state.instance_id = body.instance_id
     state.generation = body.generation
+    state.apply_generation = apply_generation
     state.cli_package_spec = body.cli_package_spec
     state.locale = body.locale.model_dump()
     state.system = body.system.model_dump(exclude_none=True, mode="json")
@@ -1086,6 +1133,13 @@ def _assign_runtime_state(
     state.tools = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
 
 
+def _runtime_state_idempotency_payload(body: PlatformRuntimeStateUpsert) -> dict[str, Any]:
+    payload = body.model_dump(mode="json")
+    if "apply_generation" not in body.model_fields_set:
+        payload.pop("apply_generation", None)
+    return payload
+
+
 def _optional_runtime_model(value: BaseModel | None) -> dict[str, Any] | None:
     if value is None:
         return None
@@ -1095,11 +1149,14 @@ def _optional_runtime_model(value: BaseModel | None) -> dict[str, Any] | None:
 def _runtime_state_changed_fields(
     state: HostedRuntimeState | None,
     body: PlatformRuntimeStateUpsert,
+    *,
+    apply_generation: int | None,
 ) -> list[str]:
     fields = [
         "deployment_id",
         "instance_id",
         "generation",
+        "apply_generation",
         "cli_package_spec",
         "locale",
         "system",
@@ -1113,10 +1170,14 @@ def _runtime_state_changed_fields(
         "tools",
     ]
     if state is None:
-        return fields
+        return [
+            field for field in fields if field != "apply_generation" or apply_generation is not None
+        ]
     changed: list[str] = []
     for field in fields:
-        if field == "locale":
+        if field == "apply_generation":
+            body_value = apply_generation
+        elif field == "locale":
             body_value = body.locale.model_dump()
         elif field == "system":
             body_value = body.system.model_dump(exclude_none=True, mode="json")

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -93,6 +93,7 @@ from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_extraction import extract_memories_from_session
 from app.services.memory_provider import get_memory_provider
+from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_source import (
     RuntimeSourceError,
     expected_runtime_bundle_v2_etag,
@@ -1192,11 +1193,30 @@ def _agent_runtime_observed_health(
         reasons.append("runtime_applied_missing")
     elif diagnostics.applied.instance_id != state.instance_id:
         reasons.append("applied_instance_id_mismatch")
+
+    observed_generation = (
+        observation.observed_config_generation if observation is not None else None
+    )
+    if observed_generation is not None:
+        generation_matches = observed_generation == resolve_runtime_apply_generation(
+            generation=state.generation,
+            apply_generation=state.apply_generation,
+        )
+        if generation_matches:
+            reasons = [reason for reason in reasons if reason != "config_generation_mismatch"]
+        elif "config_generation_mismatch" not in reasons:
+            reasons.append("config_generation_mismatch")
     if reasons == health.reasons:
         return health
+
+    status_value = health.status
+    if reasons and status_value == "ok":
+        status_value = "unknown"
+    elif not reasons and status_value == "unknown" and diagnostics.status == "ok":
+        status_value = "ok"
     return health.model_copy(
         update={
-            "status": "unknown" if health.status == "ok" else health.status,
+            "status": status_value,
             "reasons": reasons,
         }
     )

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -136,6 +136,7 @@ class AdminRuntimeStateUpsert(BaseModel):
     deployment_id: str = Field(min_length=1, max_length=200)
     instance_id: str = Field(min_length=1, max_length=200)
     generation: int = Field(ge=0)
+    apply_generation: int | None = Field(default=None, ge=1)
     cli_package_spec: str = Field(min_length=1, max_length=200)
     locale: HostedRuntimeLocale
     system: HostedRuntimeSystem
@@ -176,6 +177,7 @@ class AdminRuntimeStateResponse(BaseModel):
     deployment_id: str
     instance_id: str
     generation: int
+    apply_generation: int | None = None
 
 
 class AdminManagedAiProviderUpsert(BaseModel):

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -85,6 +85,7 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
     deployment_id: str = Field(min_length=1, max_length=200)
     instance_id: str = Field(min_length=1, max_length=200)
     generation: int = Field(ge=0)
+    apply_generation: int | None = Field(default=None, ge=1)
     cli_package_spec: str = Field(min_length=1, max_length=200)
     locale: HostedRuntimeLocale
     system: HostedRuntimeSystem
@@ -125,3 +126,4 @@ class PlatformRuntimeStateResponse(BaseModel):
     deployment_id: str
     instance_id: str
     generation: int
+    apply_generation: int | None = None

--- a/backend/app/services/runtime_generation.py
+++ b/backend/app/services/runtime_generation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+
+class RuntimeApplyGenerationUpdateError(ValueError):
+    def __init__(self, code: str, current_apply_generation: int | None) -> None:
+        self.code = code
+        self.current_apply_generation = current_apply_generation
+        super().__init__(code)
+
+
+def resolve_runtime_apply_generation(
+    *,
+    generation: int,
+    apply_generation: int | None,
+) -> int:
+    """Resolve explicit apply identity with the released checkpoint fallback."""
+    return apply_generation if apply_generation is not None else generation
+
+
+def resolve_runtime_apply_generation_update(
+    *,
+    current: int | None,
+    requested: int | None,
+    explicitly_set: bool,
+) -> int | None:
+    """Preserve omission while rejecting an explicit clear or regression."""
+    if explicitly_set and requested is None:
+        raise RuntimeApplyGenerationUpdateError(
+            "apply_generation_conflict",
+            current,
+        )
+    if current is None:
+        return requested
+    if requested is not None and requested < current:
+        raise RuntimeApplyGenerationUpdateError(
+            "stale_apply_generation",
+            current,
+        )
+    return current if requested is None else requested

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -97,6 +97,7 @@ class RenderedRuntimeSource:
     channel_bindings: list[dict[str, str]]
     secret_values: dict[str, str]
     source_revision: str
+    apply_generation: int | None
 
 
 @dataclass(frozen=True)
@@ -463,18 +464,29 @@ def render_runtime_source(
         "channelBindings": bindings,
         "secretSources": secret_sources,
     }
+    if state.apply_generation is not None:
+        descriptor["applyGeneration"] = state.apply_generation
     source_revision = hashlib.sha256(_canonical(descriptor).encode()).hexdigest()
-    return RenderedRuntimeSource(manifest, bindings, secrets, source_revision)
+    return RenderedRuntimeSource(
+        manifest=manifest,
+        channel_bindings=bindings,
+        secret_values=secrets,
+        source_revision=source_revision,
+        apply_generation=state.apply_generation,
+    )
 
 
 def render_runtime_bundle(source: RenderedRuntimeSource) -> dict[str, Any]:
-    return {
+    bundle = {
         "schemaVersion": RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
         "sourceRevision": source.source_revision,
         "manifest": source.manifest,
         "channelBindings": source.channel_bindings,
         "secretValues": source.secret_values,
     }
+    if source.apply_generation is not None:
+        bundle["applyGeneration"] = source.apply_generation
+    return bundle
 
 
 def vault_key_identity(value: str) -> str:

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 REVISION = "d8f2a1c4b6e9"
 APP_SETTINGS_REVISION = "3e7a9c1d5b82"
 SKILL_AUTHORITY_REVISION = "5d2a9c7e4b18"
+APPLY_GENERATION_REVISION = "7c2e9a4b6d1f"
 HEAD_REVISION = "f4c8a1d7e2b9"
 RUNTIME_SCOPE_REVISION_DOWN_REVISION = "e2a7c9f4b6d1"
 SKILLS_REVISION_DOWN_REVISION = "b7e4d2a9c6f1"
@@ -44,7 +45,8 @@ def test_agent_v2_runtime_contract_migration_precedes_config_observation_migrati
     config.set_main_option("script_location", str(backend_dir / "alembic"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == [SKILL_AUTHORITY_REVISION]
+    assert scripts.get_heads() == [APPLY_GENERATION_REVISION]
+    assert scripts.get_revision(APPLY_GENERATION_REVISION).down_revision == SKILL_AUTHORITY_REVISION
     assert scripts.get_revision(SKILL_AUTHORITY_REVISION).down_revision == APP_SETTINGS_REVISION
     assert scripts.get_revision(APP_SETTINGS_REVISION).down_revision == HEAD_REVISION
     assert scripts.get_revision(HEAD_REVISION).down_revision == RUNTIME_SCOPE_REVISION_DOWN_REVISION

--- a/backend/tests/test_hosted_runtime_apply_generation_migration.py
+++ b/backend/tests/test_hosted_runtime_apply_generation_migration.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+REVISION = "7c2e9a4b6d1f"
+MIGRATION_FILENAME = f"{REVISION}_add_hosted_runtime_apply_generation.py"
+
+
+def _load_migration():
+    migration_path = Path(__file__).parents[1] / "alembic" / "versions" / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location("hosted_runtime_apply_generation", migration_path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def test_hosted_runtime_apply_generation_migration_is_additive_and_constrained(
+    engine: AsyncEngine,
+) -> None:
+    migration = _load_migration()
+    schema = f"hosted_runtime_apply_generation_{uuid.uuid4().hex}"
+    environment_id = uuid.uuid4()
+    sync_engine = create_engine(engine.url.set(drivername="postgresql+psycopg2"))
+    old_op = migration.op
+    try:
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET search_path TO "{schema}"'))
+            connection.execute(
+                sa.text(
+                    """
+                    CREATE TABLE hosted_runtime_states (
+                        environment_id uuid PRIMARY KEY,
+                        generation integer NOT NULL
+                    )
+                    """
+                )
+            )
+            connection.execute(
+                sa.text(
+                    "INSERT INTO hosted_runtime_states (environment_id, generation) "
+                    "VALUES (:environment_id, 2)"
+                ),
+                {"environment_id": environment_id},
+            )
+            migration.op = Operations(MigrationContext.configure(connection))
+
+            migration.upgrade()
+
+            columns = {
+                column["name"]: column
+                for column in inspect(connection).get_columns("hosted_runtime_states")
+            }
+            assert columns["apply_generation"]["nullable"] is True
+            assert (
+                connection.scalar(
+                    sa.text(
+                        "SELECT apply_generation FROM hosted_runtime_states "
+                        "WHERE environment_id = :environment_id"
+                    ),
+                    {"environment_id": environment_id},
+                )
+                is None
+            )
+
+            connection.execute(
+                sa.text(
+                    "UPDATE hosted_runtime_states SET apply_generation = 1 "
+                    "WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": environment_id},
+            )
+            assert (
+                connection.scalar(
+                    sa.text(
+                        "SELECT apply_generation FROM hosted_runtime_states "
+                        "WHERE environment_id = :environment_id"
+                    ),
+                    {"environment_id": environment_id},
+                )
+                == 1
+            )
+
+            connection.execute(
+                sa.text(
+                    "UPDATE hosted_runtime_states SET apply_generation = 3 "
+                    "WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": environment_id},
+            )
+            assert (
+                connection.scalar(
+                    sa.text(
+                        "SELECT apply_generation FROM hosted_runtime_states "
+                        "WHERE environment_id = :environment_id"
+                    ),
+                    {"environment_id": environment_id},
+                )
+                == 3
+            )
+
+            for invalid in (0, -1):
+                with pytest.raises(sa.exc.IntegrityError), connection.begin_nested():
+                    connection.execute(
+                        sa.text(
+                            "UPDATE hosted_runtime_states SET apply_generation = :invalid "
+                            "WHERE environment_id = :environment_id"
+                        ),
+                        {"invalid": invalid, "environment_id": environment_id},
+                    )
+
+            migration.downgrade()
+            assert "apply_generation" not in {
+                column["name"]
+                for column in inspect(connection).get_columns("hosted_runtime_states")
+            }
+    finally:
+        migration.op = old_op
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        sync_engine.dispose()

--- a/backend/tests/test_hosted_runtime_config_observation_migration.py
+++ b/backend/tests/test_hosted_runtime_config_observation_migration.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 REVISION = "f1a7c3d9e2b4"
 APP_SETTINGS_REVISION = "3e7a9c1d5b82"
 SKILL_AUTHORITY_REVISION = "5d2a9c7e4b18"
+APPLY_GENERATION_REVISION = "7c2e9a4b6d1f"
 HEAD_REVISION = "f4c8a1d7e2b9"
 RUNTIME_SCOPE_REVISION_DOWN_REVISION = "e2a7c9f4b6d1"
 SKILLS_REVISION_DOWN_REVISION = "b7e4d2a9c6f1"
@@ -63,7 +64,8 @@ def test_agent_v2_final_schema_migration_is_single_head() -> None:
     config.set_main_option("script_location", str(backend_dir / "alembic"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == [SKILL_AUTHORITY_REVISION]
+    assert scripts.get_heads() == [APPLY_GENERATION_REVISION]
+    assert scripts.get_revision(APPLY_GENERATION_REVISION).down_revision == SKILL_AUTHORITY_REVISION
     assert scripts.get_revision(SKILL_AUTHORITY_REVISION).down_revision == APP_SETTINGS_REVISION
     assert scripts.get_revision(APP_SETTINGS_REVISION).down_revision == HEAD_REVISION
     assert scripts.get_revision(HEAD_REVISION).down_revision == RUNTIME_SCOPE_REVISION_DOWN_REVISION

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -20,7 +20,8 @@ from app.models.platform_idempotency import PlatformMutationIdempotency
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_AGENT_SYNC, SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
-from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES
+from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES, PlatformRuntimeStateUpsert
+from app.services.platform_contract import platform_request_hash, store_platform_response
 from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
 from tests.conftest import create_env_with_project
 
@@ -577,6 +578,135 @@ async def test_platform_runtime_state_enforces_generation_contract(
     assert state is not None
     assert state.generation == 2
     assert state.instance_id == initial_body["instance_id"]
+
+
+@pytest.mark.asyncio
+async def test_platform_runtime_state_advances_apply_generation_without_weakening_checkpoint(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key="apply-generation-agent-create",
+    )
+    assert created.status_code == 200, created.text
+    body = {
+        **_runtime_body(owner, agent_id),
+        "generation": 2,
+        "apply_generation": 1,
+    }
+    invalid = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("apply-generation-invalid"),
+        json={**body, "apply_generation": 0},
+    )
+    assert invalid.status_code == 422, invalid.text
+
+    initial = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("apply-generation-initial"),
+        json=body,
+    )
+    assert initial.status_code == 200, initial.text
+    assert initial.json()["apply_generation"] == 1
+
+    advanced = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("apply-generation-advanced"),
+        json={**body, "apply_generation": 2},
+    )
+    assert advanced.status_code == 200, advanced.text
+    assert advanced.json()["apply_generation"] == 2
+
+    independent_advance = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("apply-generation-independent-advance"),
+        json={**body, "apply_generation": 3},
+    )
+    assert independent_advance.status_code == 200, independent_advance.text
+    assert independent_advance.json()["generation"] == 2
+    assert independent_advance.json()["apply_generation"] == 3
+
+    for key, apply_generation, code in (
+        ("apply-generation-regression", 2, "stale_apply_generation"),
+        ("apply-generation-clear", None, "apply_generation_conflict"),
+    ):
+        rejected = await platform_client.put(
+            f"/v1/platform/agents/{agent_id}/runtime-state",
+            headers=_headers(key),
+            json={**body, "apply_generation": apply_generation},
+        )
+        assert rejected.status_code == 409, rejected.text
+        assert rejected.json()["detail"]["code"] == code
+        assert rejected.json()["detail"]["current_apply_generation"] == 3
+
+    checkpoint_only = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("apply-generation-checkpoint-only"),
+        json={**_runtime_body(owner, agent_id), "generation": 4},
+    )
+    assert checkpoint_only.status_code == 200, checkpoint_only.text
+    assert checkpoint_only.json()["apply_generation"] == 3
+
+    state = await db_session.get(HostedRuntimeState, agent_id)
+    assert state is not None
+    assert state.generation == 4
+    assert state.apply_generation == 3
+
+
+@pytest.mark.asyncio
+async def test_platform_runtime_state_replays_pre_apply_generation_idempotency_shape(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key="idempotency-shape-agent-create",
+    )
+    assert created.status_code == 200, created.text
+    body = _runtime_body(owner, agent_id)
+    parsed = PlatformRuntimeStateUpsert.model_validate(body)
+    legacy_payload = {"agent_id": str(agent_id), **parsed.model_dump(mode="json")}
+    legacy_payload.pop("apply_generation")
+    idempotency_key = "runtime-state-before-apply-generation"
+    replay_body = {
+        "environment_id": str(agent_id),
+        "deployment_id": body["deployment_id"],
+        "instance_id": body["instance_id"],
+        "generation": body["generation"],
+    }
+    store_platform_response(
+        db_session,
+        operation="runtime_state.upsert",
+        idempotency_key=idempotency_key,
+        request_hash=platform_request_hash(legacy_payload),
+        owner_user_id=seed_user.id,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        response_status=200,
+        response_body=replay_body,
+    )
+    await db_session.commit()
+
+    replay = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers(idempotency_key),
+        json=body,
+    )
+
+    assert replay.status_code == 200, replay.text
+    assert replay.json() == replay_body
+    assert await db_session.get(HostedRuntimeState, agent_id) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_generation.py
+++ b/backend/tests/test_runtime_generation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.runtime_generation import (
+    RuntimeApplyGenerationUpdateError,
+    resolve_runtime_apply_generation,
+    resolve_runtime_apply_generation_update,
+)
+
+
+def test_runtime_apply_generation_resolver_names_the_legacy_checkpoint_fallback() -> None:
+    assert resolve_runtime_apply_generation(generation=2, apply_generation=1) == 1
+    assert resolve_runtime_apply_generation(generation=2, apply_generation=None) == 2
+
+
+def test_runtime_apply_generation_update_preserves_omission_and_binds_once() -> None:
+    assert (
+        resolve_runtime_apply_generation_update(
+            current=None,
+            requested=None,
+            explicitly_set=False,
+        )
+        is None
+    )
+    assert (
+        resolve_runtime_apply_generation_update(
+            current=None,
+            requested=1,
+            explicitly_set=True,
+        )
+        == 1
+    )
+    assert (
+        resolve_runtime_apply_generation_update(
+            current=2,
+            requested=3,
+            explicitly_set=True,
+        )
+        == 3
+    )
+
+
+@pytest.mark.parametrize(
+    ("current", "requested", "code"),
+    [
+        (None, None, "apply_generation_conflict"),
+        (1, None, "apply_generation_conflict"),
+        (2, 1, "stale_apply_generation"),
+    ],
+)
+def test_runtime_apply_generation_update_rejects_explicit_null_and_regression(
+    current: int | None,
+    requested: int | None,
+    code: str,
+) -> None:
+    with pytest.raises(RuntimeApplyGenerationUpdateError) as exc_info:
+        resolve_runtime_apply_generation_update(
+            current=current,
+            requested=requested,
+            explicitly_set=True,
+        )
+
+    assert exc_info.value.code == code
+    assert exc_info.value.current_apply_generation == current

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -1148,6 +1148,102 @@ async def test_equal_generation_material_conflict_returns_current_generation_wit
 
 
 @pytest.mark.asyncio
+async def test_admin_runtime_state_binds_and_advances_apply_generation_at_same_checkpoint(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-apply-generation-{uuid4().hex[:8]}",
+        machine_name="Runtime apply generation",
+        agent_type="openclaw",
+    )
+    body = _runtime_state_body(str(env.id), generation=2)
+    environment_id = env.id
+    invalid = await admin_client.put(
+        f"/v1/admin/environments/{environment_id}/runtime-state",
+        headers=_AUTH,
+        json={**body, "apply_generation": 0},
+    )
+    assert invalid.status_code == 422, invalid.text
+
+    initial = await admin_client.put(
+        f"/v1/admin/environments/{environment_id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+    assert initial.status_code == 200, initial.text
+    assert initial.json()["apply_generation"] is None
+
+    explicit_null = await admin_client.put(
+        f"/v1/admin/environments/{environment_id}/runtime-state",
+        headers=_AUTH,
+        json={**body, "apply_generation": None},
+    )
+    assert explicit_null.status_code == 409, explicit_null.text
+    assert explicit_null.json() == {
+        "detail": {
+            "code": "apply_generation_conflict",
+            "current_apply_generation": None,
+        }
+    }
+
+    for apply_generation in (1, 2, 3):
+        bound = await admin_client.put(
+            f"/v1/admin/environments/{environment_id}/runtime-state",
+            headers=_AUTH,
+            json={**body, "apply_generation": apply_generation},
+        )
+        assert bound.status_code == 200, bound.text
+        assert bound.json()["generation"] == 2
+        assert bound.json()["apply_generation"] == apply_generation
+
+    for apply_generation, code in (
+        (2, "stale_apply_generation"),
+        (None, "apply_generation_conflict"),
+    ):
+        rejected = await admin_client.put(
+            f"/v1/admin/environments/{environment_id}/runtime-state",
+            headers=_AUTH,
+            json={**body, "apply_generation": apply_generation},
+        )
+        assert rejected.status_code == 409, rejected.text
+        assert rejected.json() == {
+            "detail": {
+                "code": code,
+                "current_apply_generation": 3,
+            }
+        }
+
+    checkpoint_runtimes = _runtime_state()
+    checkpoint_runtimes["openclaw"]["primary_model"]["model"] = "gpt-checkpoint-next"
+    checkpoint_only = await admin_client.put(
+        f"/v1/admin/environments/{environment_id}/runtime-state",
+        headers=_AUTH,
+        json={
+            **body,
+            "generation": 4,
+            "cli_package_spec": "clawdi@0.12.10-beta.58",
+            "runtimes": checkpoint_runtimes,
+            "mcp": {"servers": {"clawdi": {"command": "clawdi", "args": ["mcp"]}}},
+            "skills": {"entries": {"clawdi": {"enabled": True, "version": 2}}},
+        },
+    )
+    assert checkpoint_only.status_code == 200, checkpoint_only.text
+    assert checkpoint_only.json()["apply_generation"] == 3
+    state = await db_session.get(HostedRuntimeState, environment_id)
+    assert state is not None
+    assert state.generation == 4
+    assert state.apply_generation == 3
+    assert state.cli_package_spec == "clawdi@0.12.10-beta.58"
+    assert state.runtimes["openclaw"]["primary_model"]["model"] == "gpt-checkpoint-next"
+    assert state.mcp == {"servers": {"clawdi": {"command": "clawdi", "args": ["mcp"]}}}
+    assert state.skills == {"entries": {"clawdi": {"enabled": True, "version": 2}}}
+
+
+@pytest.mark.asyncio
 async def test_concurrent_same_generation_runtime_state_updates_allow_one_winner(
     admin_client,
     db_session,
@@ -3800,6 +3896,40 @@ async def test_runtime_manifest_requires_exact_v2_media_type(admin_client, db_se
     assert unsupported.status_code == 406
     assert unsupported.headers["cache-control"] == "no-store"
     assert unsupported.headers["vary"] == "Accept"
+
+
+@pytest.mark.asyncio
+async def test_runtime_bundle_emits_explicit_apply_generation_and_revalidates_apply_only_change(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env, _, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    state = await db_session.get(HostedRuntimeState, env.id)
+    assert state is not None
+    state.apply_generation = 1
+    await db_session.commit()
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="bundle-apply-generation")
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get("/v1/runtime/manifest")
+        initial_body = initial.json()
+        state.apply_generation = 3
+        await db_session.commit()
+        advanced = await client.get(
+            "/v1/runtime/manifest",
+            headers={"If-None-Match": initial.headers["etag"]},
+        )
+    app.dependency_overrides.clear()
+
+    assert initial.status_code == 200, initial.text
+    assert initial_body["applyGeneration"] == 1
+    assert initial_body["manifest"]["generation"] == state.generation
+    assert advanced.status_code == 200, advanced.text
+    assert advanced.json()["applyGeneration"] == 3
+    assert advanced.json()["manifest"]["generation"] == state.generation
+    assert advanced.json()["sourceRevision"] != initial_body["sourceRevision"]
+    assert advanced.headers["etag"] != initial.headers["etag"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -46,7 +46,12 @@ def test_runtime_bundle_v2_etag_is_derived_from_source_revision() -> None:
 
 
 def _batch(
-    *, provider_label: str = "Primary", channel_name: str = "Bot", token: bytes = b"token"
+    *,
+    provider_label: str = "Primary",
+    channel_name: str = "Bot",
+    token: bytes = b"token",
+    generation: int = 2,
+    apply_generation: int | None = 1,
 ) -> RuntimeSourceBatch:
     now = datetime(2026, 7, 13, tzinfo=UTC)
     environment = AgentEnvironment(id=ENV_ID, user_id=USER_ID)
@@ -54,7 +59,8 @@ def _batch(
         environment_id=ENV_ID,
         deployment_id="dep_test",
         instance_id="hri_test",
-        generation=7,
+        generation=generation,
+        apply_generation=apply_generation,
         cli_package_spec="clawdi@0.12.10-beta.57",
         locale={"language": "en", "timezone": "UTC"},
         system={
@@ -68,6 +74,12 @@ def _batch(
                     "capability": "openclaw-native-auth-v1",
                 },
             },
+        },
+        egress_engine={
+            "type": "mitmproxy",
+            "version": "12.2.3",
+            "url": "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+            "sha256": "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
         },
         runtimes={
             "openclaw": {
@@ -280,6 +292,40 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
             ),
         }
     ]
+
+
+def test_runtime_bundle_omits_legacy_apply_generation_and_tracks_explicit_apply_only_changes() -> (
+    None
+):
+    legacy = render_runtime_source(
+        _batch(apply_generation=None),
+        environment_id=ENV_ID,
+        public_api_url="https://cloud.test/",
+        vault_key_identity="vault-key-generation-1",
+        decrypt_secrets=False,
+    )
+    apply_one = render_runtime_source(
+        _batch(apply_generation=1),
+        environment_id=ENV_ID,
+        public_api_url="https://cloud.test/",
+        vault_key_identity="vault-key-generation-1",
+        decrypt_secrets=False,
+    )
+    apply_three = render_runtime_source(
+        _batch(apply_generation=3),
+        environment_id=ENV_ID,
+        public_api_url="https://cloud.test/",
+        vault_key_identity="vault-key-generation-1",
+        decrypt_secrets=False,
+    )
+
+    legacy_bundle = render_runtime_bundle(legacy)
+    assert "applyGeneration" not in legacy_bundle
+    assert legacy_bundle["manifest"]["generation"] == 2
+    assert apply_one.manifest == apply_three.manifest
+    assert apply_one.source_revision != apply_three.source_revision
+    assert render_runtime_bundle(apply_one)["applyGeneration"] == 1
+    assert render_runtime_bundle(apply_three)["applyGeneration"] == 3
 
 
 def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs(

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -1104,7 +1104,7 @@ async def test_v2_health_requires_expected_etag_and_exact_source_provider_set(
 
 
 @pytest.mark.asyncio
-async def test_runtime_observed_health_uses_typed_config_generation(
+async def test_runtime_observed_health_uses_explicit_apply_generation(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
 ):
@@ -1114,6 +1114,62 @@ async def test_runtime_observed_health_uses_typed_config_generation(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-config-convergence",
             instance_id="iid-config-convergence",
+            generation=2,
+            apply_generation=3,
+            cli_package_spec=_TEST_CLI_PACKAGE_SPEC,
+            locale=_TEST_LOCALE,
+            system=_TEST_SYSTEM,
+            live_sync={"enabled": False, "agents": []},
+            recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            runtimes=_test_runtimes(),
+        )
+    )
+    await db_session.commit()
+
+    heartbeat = await client.post(
+        f"/v1/agents/{env_id}/sync-heartbeat",
+        json={"runtime_observed": _runtime_observed(applied_generation=3)},
+    )
+    assert heartbeat.status_code == 204, heartbeat.text
+
+    observation = await db_session.get(HostedRuntimeConfigObservation, uuid.UUID(env_id))
+    assert observation is not None
+    diagnostics = observation.diagnostics
+    assert isinstance(diagnostics, dict)
+    applied = diagnostics["applied"]
+    assert isinstance(applied, dict)
+    observation.diagnostics = {
+        **diagnostics,
+        "applied": {**applied, "generation": 2},
+    }
+    await db_session.commit()
+
+    response = await client.get(f"/v1/agents/{env_id}/runtime-observed")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["desired"]["desired_config_generation"] == 2
+    assert payload["observed"]["observed_config_generation"] == 3
+    assert "config_generation_mismatch" not in payload["health"]["reasons"]
+
+    deprecated = await client.get(f"/v1/environments/{env_id}/runtime-observed")
+    assert deprecated.status_code == 200, deprecated.text
+    deprecated_payload = deprecated.json()
+    assert deprecated_payload["desired"]["desired_config_generation"] == 2
+    assert deprecated_payload["observed"]["observed_config_generation"] == 3
+    assert "config_generation_mismatch" in deprecated_payload["health"]["reasons"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_observed_health_falls_back_to_legacy_checkpoint_generation(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    env_id = await _create_env(client)
+    db_session.add(
+        canonical_hosted_runtime_state(
+            environment_id=uuid.UUID(env_id),
+            deployment_id="dep-legacy-config-convergence",
+            instance_id="iid-legacy-config-convergence",
             generation=5,
             cli_package_spec=_TEST_CLI_PACKAGE_SPEC,
             locale=_TEST_LOCALE,
@@ -1131,24 +1187,9 @@ async def test_runtime_observed_health_uses_typed_config_generation(
     )
     assert heartbeat.status_code == 204, heartbeat.text
 
-    observation = await db_session.get(HostedRuntimeConfigObservation, uuid.UUID(env_id))
-    assert observation is not None
-    diagnostics = observation.diagnostics
-    assert isinstance(diagnostics, dict)
-    applied = diagnostics["applied"]
-    assert isinstance(applied, dict)
-    observation.diagnostics = {
-        **diagnostics,
-        "applied": {**applied, "generation": 5},
-    }
-    await db_session.commit()
-
-    response = await client.get(f"/v1/environments/{env_id}/runtime-observed")
-    assert response.status_code == 200, response.text
-    payload = response.json()
+    payload = (await client.get(f"/v1/agents/{env_id}/runtime-observed")).json()
     assert payload["desired"]["desired_config_generation"] == 5
     assert payload["observed"]["observed_config_generation"] == 4
-    assert payload["health"]["status"] == "unknown"
     assert "config_generation_mismatch" in payload["health"]["reasons"]
 
 

--- a/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
+++ b/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
@@ -1,6 +1,6 @@
 # ADR-0003: Runtime Bundle Media Type Is the Render Contract
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-07-30)
 **Date:** 2026-07-13
 **Deciders:** Clawdi maintainers
 
@@ -20,8 +20,9 @@ one strict `clawdi.hosted-runtime.bundle.v2` response containing the hosted
 manifest, sanitized Telegram and Discord channel bindings, merged secret
 values, and a deterministic `sourceRevision`.
 
-The v2 renderer and canonical JSON encoding are frozen. A response-affecting
-behavior change requires a new media type and schema version. An unsupported
+The v2 renderer and canonical JSON encoding are frozen except for the narrow
+consumer-first amendment below. Any other response-affecting behavior change
+requires a new media type and schema version. An unsupported
 or missing media type returns `406`; the CLI does not fall back to a legacy
 manifest representation or a separate `/v1/channels` flow. Agent v2 had no
 released client, so the endpoint has no unpublished compatibility response.
@@ -55,6 +56,56 @@ heartbeat reports the source-level set, while health requires exact equality
 with current desired provider IDs. SSE invalidation only reduces latency;
 conditional polling and the applied ETag/sourceRevision preserve correctness.
 
+### 2026-07-30 generation identity amendment
+
+The inner manifest `generation` permanently remains the checkpoint/content
+generation. The bundle root may additionally contain positive
+`applyGeneration` as the deployment Apply identity. The checkpoint and Apply
+sequences are independently positive and monotonic; there is no ordering
+relationship between their values.
+When runtime state has no explicit Apply generation, the backend omits the root
+field and preserves the previously released bundle bytes, `sourceRevision`, and
+ETag. When present, `applyGeneration` participates in `sourceRevision`, so an
+Apply-only advance cannot receive an incorrect `304`.
+
+This is a one-field amendment to correct an identity conflation, not a second
+renderer or state machine. The CLI uses one named compatibility resolver:
+explicit `applyGeneration` wins, otherwise legacy state falls back to
+`generation`. The same rule governs bundle Apply validation, durable applied
+state, offline recovery, observation tuples, and backend health. Durable
+`runtime-applied.json` retains checkpoint `generation` and optional
+`applyGeneration` separately.
+
+Previously released CLI schemas reject unknown bundle fields. Therefore the
+activation gate is the nullable persisted `apply_generation` itself: it is
+default-closed and the renderer omits the wire field while it is null. This OSS
+consumer release must be deployed before any Hosted producer writes a non-null
+value. Hosted activation is permitted only after the compatible CLI is present
+on every targeted runtime.
+
+Existing split identities require an ordered pre-activation rollout. For the
+concrete metadata/apply `1`, checkpoint `2` case, the Hosted producer remains
+off while the existing accepted
+`POST /v2/deployments/{deployment_id}/restart` path increments only its
+desired-state `rollout_nonce`; the legacy checkpoint floor then aligns the pair
+to `2/2` without changing runtime-state content. Only after that equality may
+the exact CLI pin and its ordinary controlled rollout advance both sequences to
+`3/3`.
+Pinning the CLI directly from `1/2` would instead produce `2/3`, which the old
+single-generation fallback rejects. The rollout must then verify the online
+bundle, durable applied state, last-good cache, offline boot, observation tuple,
+and canonical Agent health before the Hosted producer gate is enabled. This is
+a release-order constraint over the existing restart and desired-state paths,
+not another state machine.
+
+This compatibility phase is temporary. After all active CLIs accept the field
+and all persisted runtime/applied states carry explicit Apply generation, a
+follow-up contract release can remove nullable field shapes, the legacy
+fallback, the null-as-omission activation gate, rollout notes, and legacy
+fallback tests. That release must either introduce the next media type or amend
+this ADR again before making the v2 field required; it must not leave a
+permanent dual-track protocol.
+
 ## Consequences
 
 - There is one network representation, validator, apply operation, and applied
@@ -67,5 +118,7 @@ conditional polling and the applied ETag/sourceRevision preserve correctness.
 - Offline recovery caches the effective projected manifest. Secret persistence
   remains limited to the existing root-only, reference-scoped secret cache; the
   plaintext bundle is never persisted as a whole.
+- Checkpoint/content generation and deployment Apply generation remain distinct
+  through rendering, cache, applied state, and observation.
 - A future renderer change adds a new exact media type; clients never negotiate
   by fallback.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -346,6 +346,14 @@ The v2 strong ETag is `"sha256:<sourceRevision>"`; the immutable renderer and
 the revision's effective public and secret-source identity make it a strong
 validator without decrypting secrets in the health summary.
 
+The bundle root optionally carries `applyGeneration`, the deployment Apply
+identity. The inner manifest `generation` remains checkpoint/content identity.
+`applyGeneration` is omitted while persisted runtime state is null, preserving
+the legacy bundle bytes and validator; once explicit, it is included in
+`sourceRevision`. It must be positive. Checkpoint and Apply generations are
+independent monotonic sequences, with no ordering relationship between their
+values.
+
 The CLI normalizes these wire contracts into the desired-state shape:
 
 - `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
@@ -365,7 +373,8 @@ Normalization maps hosted fields into the internal shape:
 
 | Hosted field | Internal purpose |
 | --- | --- |
-| `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
+| `deploymentId`, `environmentId`, `instanceId`, `generation` | Deployment/instance identity and checkpoint/content generation for cache and content state |
+| Bundle root `applyGeneration` | Optional deployment Apply identity; legacy bundles resolve it from checkpoint `generation` through one named compatibility rule |
 | `runtime` | Required selected compute runtime; exactly one enabled `openclaw` or `hermes` entry must match it |
 | `locale.language`, `locale.timezone` | Required supported language and valid IANA timezone |
 | `system.openclawControlUiAllowedOrigins` | Strict-v2 OpenClaw public origin allowlist |
@@ -556,7 +565,8 @@ source behind `POST /v1/mcp/clawdi`; neither appears
 as a separate MCP row. No URL, header, secret reference, command, argument, or
 environment value is projected to the browser.
 
-Manifest `generation` is part of the remote manifest ETag. The CLI applies any
+Manifest `generation` is the checkpoint/content identity and is part of the
+remote manifest ETag. The CLI applies any
 non-304 manifest without monotonic generation gating, while treating generation
 as the desired intent sequence and the ETag as effective content identity. A
 generation-only control-plane bump therefore produces a new ETag so `runtime
@@ -571,10 +581,12 @@ records unchanged.
 The last-good manifest and scoped secret cache are each replaced atomically,
 then `runtime-applied.json` is replaced atomically as the final commit record.
 After a crash, strict-v2 offline load requires that final record to match the
-cached generation, instance, manifest, and canonical secret union exactly, so
+cached checkpoint generation, resolved Apply generation, instance, manifest,
+and canonical secret union exactly, so
 a partially advanced cache fails closed instead of becoming mixed authority.
 Last-good remains an offline recovery cache; `runtime-applied.json` is the
-online record of the applied instance, config generation, content identity,
+online record of the applied instance, checkpoint generation, optional Apply
+generation, content identity,
 source manifest provider IDs, and the target-specific projected provider ID map
 needed for stale deletion. The record is committed only after Apply succeeds.
 
@@ -733,7 +745,19 @@ At the boundary:
 - the CLI owns local validation, projection, diagnostics, and command launch;
 - the runtime process owns normal agent behavior after launch.
 
-For Agent v2, `generation` remains the Hosted intent/CAS sequence.
+For Agent v2, `generation` remains the Hosted checkpoint/content intent and CAS
+sequence. Optional bundle-root `applyGeneration` is the deployment Apply
+identity. The only compatibility resolution is `applyGeneration` when explicit,
+otherwise legacy `generation`; cache, applied-state, offline, observation, and
+health paths all use that named boundary rule rather than inferring one identity
+from the other.
+The canonical `/v1/agents/{agent_id}/runtime-observed` response intentionally
+keeps `desired.desired_config_generation` as the checkpoint and
+`observed.observed_config_generation` as the Apply identity; only its health
+comparison resolves the explicit Apply generation or named legacy fallback.
+The deprecated `/v1/environments/{environment_id}/runtime-observed` v1 route
+retains its byte-frozen checkpoint comparison and is not changed by this
+amendment.
 `sourceRevision` is a deterministic SHA-256 identity of the effective public
 descriptor and the selected encrypted secret-source identities, keyed by
 secret reference. For the immutable v2 renderer, the strong ETag is derived as
@@ -741,13 +765,15 @@ secret reference. For the immutable v2 renderer, the strong ETag is derived as
 loader and pure materializer inside a read-only repeatable-read snapshot; the
 summary path does not decrypt secrets.
 
-The manifest wire field remains `generation`, but it is specifically the
-desired config generation. Cloud API records daemon convergence separately as
+The inner manifest wire field remains `generation`, but it is specifically the
+desired checkpoint/content generation. Cloud API records daemon convergence separately as
 `observed_at`, `observed_config_generation`, and `observed_manifest_etag`, plus
 validated diagnostics JSONB. Agent v2 diagnostics report applied ETag,
 `sourceRevision`, and the source-level applied provider ID set only from
-`runtime-applied.json`; target-specific projected IDs remain local stale-deletion
-state. Health compares the v2 ETag with the validator derived from current
+`runtime-applied.json`; its observation tuple reports resolved Apply generation,
+not checkpoint generation. Target-specific projected IDs remain local stale-deletion
+state. Health compares observed config generation to explicit Apply generation,
+with the same named checkpoint fallback for legacy state, and compares the v2 ETag with the validator derived from current
 `sourceRevision` and requires exact provider-set equality, reporting missing and
 extra sets separately. Legacy provider-set authority remains unknown.
 `observed_at` is the server receipt time for the accepted heartbeat; the
@@ -766,7 +792,7 @@ outputs include:
 | `cache/manifest.last-good.json` | Last successfully applied effective, channel-projected manifest for offline recovery |
 | `cache/runtime-secrets.last-good.json` | Root-only `0600` canonical union of active non-`env://` secret refs required to reproduce last-good |
 | `cache/manifest.etag`, `cache/channels.etag` | Legacy v1 cache validators; not Agent v2 authority |
-| `status/runtime-applied.json` | Root-only `0600` Agent v2 authority for one ETag, source revision, instance, generation, private recoverability content identity, source provider IDs, and target-specific projected provider IDs |
+| `status/runtime-applied.json` | Root-only `0600` Agent v2 authority for one ETag, source revision, instance, checkpoint `generation`, optional `applyGeneration`, private recoverability content identity, source provider IDs, and target-specific projected provider IDs |
 | `install-inventory/<runtime>.json` | Install/verify observation |
 | `managed-cli/bin/clawdi` | Root-only active managed CLI link used by system services |
 | `npm/` | Root-only managed CLI package prefixes and active targets |
@@ -1054,11 +1080,44 @@ responses. Both include `current_generation`. Equal identical state is an
 idempotent `200`, while higher generations apply. Rejected and idempotent writes
 do not create duplicate state, audit events, or manifest invalidation.
 
+`apply_generation` is a separate nullable persistence/API field constrained to
+positive values. Omission preserves the current value;
+explicit null is rejected so null remains legacy/gated state only. An unbound
+row may bind a positive value once, and Apply generation may advance at an
+unchanged checkpoint when no other material field changes. Apply-generation
+regression, explicit clear, and any same-checkpoint material change are
+rejected. Checkpoint-only model, Skill, MCP, or CLI pin changes preserve the
+existing Apply generation. Each sequence is monotonic on its own; neither is
+ordered relative to the other, and no cross-sequence upper bound applies.
+
 Additive manifest capabilities roll out consumer first: publish and select a
 CLI version that understands the new fields, then advance existing deployments
 through ordinary higher-generation runtime-state reconciliation. Database
 migrations backfill stored authority where required; operators do not patch
 individual production rows to advance deployments.
+
+For the optional v2 `applyGeneration` amendment, strict older consumers reject
+the new root field. This OSS consumer release must deploy before Hosted producer
+activation. The nullable database field is the default-closed receiving edge;
+Hosted must not write it until compatible CLI deployment is confirmed.
+
+The pre-activation sequence uses existing Hosted desired-state behavior. If a
+deployment is at metadata/apply `1` and checkpoint `2`, first leave the CLI pin
+unchanged and accept the existing
+`POST /v2/deployments/{deployment_id}/restart` mutation, whose desired-state
+change increments only `rollout_nonce`; while the producer gate is off, the
+legacy checkpoint floor aligns the deployment to `2/2` without a runtime-state
+content change. Next, select the exact compatible CLI and use its ordinary
+controlled rollout to advance metadata and the CLI-pin checkpoint together to
+`3/3`. A direct CLI pin from `1/2` would produce `2/3`, so it is not an
+alignment mechanism. Verify the online bundle, `runtime-applied.json`,
+last-good cache, offline boot, observation tuple, and canonical Agent health
+before enabling the Hosted producer gate. No direct database, Cloud state, Pod
+cache, or tenant filesystem mutation is part of this protocol.
+
+After every active CLI and stored applied state has explicit Apply identity, a
+narrow follow-up contract release removes the optionality, legacy fallback,
+null omission gate, temporary rollout text, and legacy compatibility tests.
 
 Bundled-Skill versioning follows expand, migrate, contract ordering. During
 expand, the CLI accepts the prior enabled-only Skill entry and canonicalizes

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -28,6 +28,7 @@ import {
 import {
 	type RuntimeApplyIdentity,
 	readRuntimeApplyIdentityFromEnv,
+	resolveRuntimeApplyGeneration,
 } from "../runtime/apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
@@ -1310,10 +1311,10 @@ export function commitRuntimeAppliedState(input: {
 }): void {
 	if (
 		input.applyIdentity &&
-		input.applyIdentity.generation !== input.convergence.manifest.generation
+		input.applyIdentity.generation !== resolveRuntimeApplyGeneration(input.convergence.manifest)
 	) {
 		throw new Error(
-			`runtime apply identity generation ${input.applyIdentity.generation} does not match applied manifest generation ${input.convergence.manifest.generation}`,
+			`runtime apply identity generation ${input.applyIdentity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(input.convergence.manifest)}`,
 		);
 	}
 	const providerIds = runtimeSourceProviderIds(input.load.manifest);
@@ -1326,6 +1327,9 @@ export function commitRuntimeAppliedState(input: {
 			etag: input.etag,
 			sourceRevision: input.sourceRevision,
 			generation: input.convergence.manifest.generation,
+			...(input.convergence.manifest.applyGeneration === undefined
+				? {}
+				: { applyGeneration: input.convergence.manifest.applyGeneration }),
 			...(input.applyIdentity
 				? {
 						manifestETag: input.applyIdentity.manifestETag,

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -74,7 +74,7 @@ describe("runtime applied state", () => {
 		).toBe(false);
 	});
 
-	test("accepts the frozen apply identity only as a complete bounded tuple", () => {
+	test("reads old state through the named fallback and preserves explicit apply generation", () => {
 		const state = {
 			...appliedStateFixture(),
 			egressSidecarSecretRevision: "e".repeat(64),
@@ -91,6 +91,36 @@ describe("runtime applied state", () => {
 			manifestETag: '"manifest-generation-7"',
 			applyReceiptId: "apply-receipt-0007",
 			bootNonce: "boot-nonce-000007",
+		});
+		const splitGeneration = runtimeAppliedStateSchema.parse({
+			...complete,
+			generation: 2,
+			applyGeneration: 1,
+			manifestETag: '"manifest-generation-1"',
+			applyReceiptId: "apply-receipt-0001",
+			bootNonce: "boot-nonce-000001",
+		});
+		expect(splitGeneration.generation).toBe(2);
+		expect(splitGeneration.applyGeneration).toBe(1);
+		expect(runtimeAppliedApplyIdentity(splitGeneration)).toEqual({
+			generation: 1,
+			manifestETag: '"manifest-generation-1"',
+			applyReceiptId: "apply-receipt-0001",
+			bootNonce: "boot-nonce-000001",
+		});
+		const independentlyAdvancedApply = runtimeAppliedStateSchema.parse({
+			...complete,
+			generation: 2,
+			applyGeneration: 3,
+			manifestETag: '"manifest-generation-3"',
+			applyReceiptId: "apply-receipt-0003",
+			bootNonce: "boot-nonce-000003",
+		});
+		expect(runtimeAppliedApplyIdentity(independentlyAdvancedApply)).toEqual({
+			generation: 3,
+			manifestETag: '"manifest-generation-3"',
+			applyReceiptId: "apply-receipt-0003",
+			bootNonce: "boot-nonce-000003",
 		});
 		expect(runtimeAppliedApplyIdentity(runtimeAppliedStateSchema.parse(state))).toBeNull();
 		expect(

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { chmodSync, chownSync, existsSync, readFileSync, statSync } from "node:fs";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { type RuntimeApplyIdentity, runtimeApplyIdentitySchema } from "./apply-identity";
+import {
+	type RuntimeApplyIdentity,
+	resolveRuntimeApplyGeneration,
+	runtimeApplyIdentitySchema,
+} from "./apply-identity";
 import type { RuntimePaths } from "./paths";
 
 const appliedContentSourceSchema = z
@@ -33,6 +37,7 @@ export const runtimeAppliedStateSchema = z
 		etag: z.string().min(1),
 		sourceRevision: z.string().regex(/^[a-f0-9]{64}$/),
 		generation: z.number().int().nonnegative(),
+		applyGeneration: z.number().int().positive().safe().optional(),
 		manifestETag: z.string().min(1).max(128).optional(),
 		applyReceiptId: z.string().min(16).max(128).optional(),
 		bootNonce: z.string().min(16).max(128).optional(),
@@ -55,7 +60,7 @@ export const runtimeAppliedStateSchema = z
 				path: ["manifestETag"],
 			});
 		}
-		if (present === applyFields.length && state.generation < 1) {
+		if (present === applyFields.length && resolveRuntimeApplyGeneration(state) < 1) {
 			ctx.addIssue({
 				code: "custom",
 				message: "apply identity generation must be at least 1",
@@ -80,7 +85,7 @@ export function runtimeAppliedApplyIdentity(
 		return null;
 	}
 	const parsed = runtimeApplyIdentitySchema.safeParse({
-		generation: state.generation,
+		generation: resolveRuntimeApplyGeneration(state),
 		manifestETag: state.manifestETag,
 		applyReceiptId: state.applyReceiptId,
 		bootNonce: state.bootNonce,

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
+import {
+	readRuntimeApplyIdentityFromEnv,
+	resolveRuntimeApplyGeneration,
+	runtimeApplyIdentityEnvironment,
+} from "./apply-identity";
 
 const completeEnvironment = {
 	CLAWDI_RUNTIME_GENERATION: "7",
@@ -9,6 +13,29 @@ const completeEnvironment = {
 };
 
 describe("runtime apply identity environment", () => {
+	test("resolves explicit apply identity with one named legacy checkpoint fallback", () => {
+		expect(resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 1 })).toBe(1);
+		expect(resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 3 })).toBe(3);
+		expect(resolveRuntimeApplyGeneration({ generation: 2 })).toBe(2);
+	});
+
+	test("projects apply identity independently of checkpoint generation", () => {
+		const generation = resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 3 });
+		expect(
+			runtimeApplyIdentityEnvironment({
+				generation,
+				manifestETag: '"manifest-3"',
+				applyReceiptId: "apply-receipt-0003",
+				bootNonce: "boot-nonce-000003",
+			}),
+		).toEqual({
+			CLAWDI_RUNTIME_GENERATION: "3",
+			CLAWDI_RUNTIME_MANIFEST_ETAG: '"manifest-3"',
+			CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0003",
+			CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000003",
+		});
+	});
+
 	test("returns null when the entire tuple is absent", () => {
 		expect(readRuntimeApplyIdentityFromEnv({})).toBeNull();
 	});

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -11,6 +11,15 @@ export const runtimeApplyIdentitySchema = z
 
 export type RuntimeApplyIdentity = z.infer<typeof runtimeApplyIdentitySchema>;
 
+export interface RuntimeGenerationIdentity {
+	generation: number;
+	applyGeneration?: number;
+}
+
+export function resolveRuntimeApplyGeneration(identity: RuntimeGenerationIdentity): number {
+	return identity.applyGeneration ?? identity.generation;
+}
+
 export const RUNTIME_APPLY_IDENTITY_ENV = {
 	generation: "CLAWDI_RUNTIME_GENERATION",
 	manifestETag: "CLAWDI_RUNTIME_MANIFEST_ETAG",

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -96,6 +96,37 @@ function blockAtomicWrite(path: string): () => void {
 }
 
 describe("hosted runtime heartbeat observation", () => {
+	test("emits the exact apply tuple when checkpoint and apply generations differ", () => {
+		const paths = tempRuntimePaths();
+		writeRuntimeAppliedState(
+			{
+				...companionAppliedState(1),
+				generation: 2,
+				applyGeneration: 1,
+			},
+			paths,
+		);
+		const session = new HostedRuntimeHeartbeatSession({
+			environmentId: "env_split_generation",
+			paths,
+			now: clockSequence(["2026-07-16T01:00:00.000Z"]),
+			createId: idSequence(["boot-session-split", "event-split-000001"]),
+		});
+
+		const event = session.nextEvent()?.event;
+		expect(event).toMatchObject({
+			applyReceiptId: "apply-receipt-0001",
+			bootNonce: "boot-nonce-000001",
+			bootSessionId: "boot-session-split",
+			sequence: 1,
+			eventId: "event-split-000001",
+			applied: {
+				generation: 1,
+				etag: '"frozen-manifest-1"',
+			},
+		});
+	});
+
 	test("captures one immutable apply identity for the entire boot session", () => {
 		const paths = tempRuntimePaths();
 		writeRuntimeAppliedState(companionAppliedState(7), paths);

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -228,6 +228,7 @@ const runtimeDesiredStateShape = {
 	environmentId: z.string().min(1),
 	instanceId: z.string().min(1),
 	generation: z.number().int().nonnegative(),
+	applyGeneration: z.number().int().positive().safe().optional(),
 	minimumCliVersion: semverSchema.optional(),
 	issuedAt: z.string().min(1),
 	expiresAt: z.string().min(1).optional(),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -996,6 +996,28 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["bridge"] }));
 	});
 
+	test("accepts independent positive checkpoint and apply generations at the shared boundary", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				run: runSettings("openclaw", ["gateway", "run"]),
+				services: {},
+			},
+		});
+
+		const result = manifestSchema.safeParse({
+			...manifest,
+			generation: 2,
+			applyGeneration: 3,
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) throw result.error;
+		expect(result.data.generation).toBe(2);
+		expect(result.data.applyGeneration).toBe(3);
+	});
+
 	test.each([
 		"system.user",
 		"system.home",

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -6,6 +6,7 @@ import {
 	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
 } from "./applied-state";
+import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
@@ -71,6 +72,7 @@ const hostedRuntimeBundleV2Schema = z
 		schemaVersion: z.literal("clawdi.hosted-runtime.bundle.v2"),
 		sourceRevision: z.string().regex(/^[a-f0-9]{64}$/),
 		manifest: hostedRuntimeBundleV2ManifestSchema,
+		applyGeneration: z.number().int().positive().safe().optional(),
 		channelBindings: z.array(runtimeBundleChannelBindingSchema),
 		secretValues: z.record(z.string(), z.string()),
 	})
@@ -95,7 +97,9 @@ const hostedRuntimeBundleV2Schema = z
 export function normalizeHostedRuntimeBundleV2(value: unknown): RuntimeManifestLoad {
 	const bundle = hostedRuntimeBundleV2Schema.parse(value);
 	return {
-		manifest: markHostedRuntimeBundleV2(hostedManifestToRuntimeManifest(bundle.manifest)),
+		manifest: markHostedRuntimeBundleV2(
+			hostedManifestToRuntimeManifest(bundle.manifest, bundle.applyGeneration),
+		),
 		source: "remote-datasource",
 		sourcePath: "https://fixture.invalid/v1/runtime/manifest",
 		offline: false,
@@ -254,7 +258,9 @@ function normalizeRemoteManifestPayload(
 	if (paths.mode !== "hosted") return normalizeManifestPayload(value);
 	const hostedResponse = hostedRuntimeBundleV2Schema.parse(value);
 	return {
-		manifest: markHostedRuntimeBundleV2(hostedManifestToRuntimeManifest(hostedResponse.manifest)),
+		manifest: markHostedRuntimeBundleV2(
+			hostedManifestToRuntimeManifest(hostedResponse.manifest, hostedResponse.applyGeneration),
+		),
 		secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		channelBindings: hostedResponse.channelBindings,
 		sourceRevision: hostedResponse.sourceRevision,
@@ -485,7 +491,10 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 	return error instanceof RuntimeAuthError ? "auth" : "network";
 }
 
-export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
+export function hostedManifestToRuntimeManifest(
+	hosted: HostedRuntimeManifest,
+	applyGeneration?: number,
+): RuntimeManifest {
 	const paths = getRuntimePaths({ mode: "hosted" });
 	const workspaceRoot = paths.workspaceRoot;
 	const selectedRuntime = hosted.runtime;
@@ -496,6 +505,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		environmentId: hosted.environmentId,
 		instanceId: hosted.instanceId,
 		generation: hosted.generation,
+		...(applyGeneration === undefined ? {} : { applyGeneration }),
 		minimumCliVersion: hosted.minimumCliVersion,
 		issuedAt: hosted.issuedAt,
 		expiresAt: hosted.expiresAt,
@@ -959,6 +969,7 @@ function loadLastGoodManifest(
 			(strictV2Cache || cachedApplyIdentity || opts.requireAppliedAuthority) &&
 			appliedState &&
 			(appliedState?.generation !== manifest.generation ||
+				resolveRuntimeApplyGeneration(appliedState) !== resolveRuntimeApplyGeneration(manifest) ||
 				appliedState.instanceId !== manifest.instanceId ||
 				appliedState.contentIdentity.sha256 !==
 					runtimeContentSha256({ manifest, secretValues: cached.secretValues }))

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -99,6 +99,45 @@ async function observationSchedule(
 }
 
 describe("hosted runtime observation producer", () => {
+	test("accepts apply generation three at checkpoint two and submits its exact identity", async () => {
+		const paths = tempRuntimePaths();
+		setApplyIdentityEnvironment(3);
+		writeRuntimeAppliedState(
+			{
+				...appliedState(3),
+				generation: 2,
+				applyGeneration: 3,
+			},
+			paths,
+		);
+		let submitted: components["schemas"]["RuntimeObservationEventV2"] | null = null;
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			submit: async (_environmentId, event) => {
+				submitted = event;
+				return "accepted";
+			},
+			sessionFactory: (environmentId, sessionPaths) =>
+				new HostedRuntimeHeartbeatSession({
+					environmentId,
+					paths: sessionPaths,
+					createId: () => "event-or-boot-identity",
+					now: () => new Date("2026-07-22T00:01:00.000Z"),
+				}),
+		});
+
+		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(submitted).toMatchObject({
+			bootSessionId: "event-or-boot-identity",
+			sequence: 1,
+			eventId: "event-or-boot-identity",
+			applyReceiptId: "apply-receipt-0003",
+			bootNonce: "boot-nonce-000003",
+			applied: { generation: 3, etag: '"manifest-3"' },
+		});
+	});
+
 	test("re-reads the applied tuple after rotation and emits a new boot identity", async () => {
 		const paths = tempRuntimePaths();
 		setApplyIdentityEnvironment(1);

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getCliVersion } from "../lib/version";
-import { writeRuntimeAppliedState } from "./applied-state";
+import { readRuntimeAppliedState, writeRuntimeAppliedState } from "./applied-state";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths } from "./paths";
 
@@ -33,7 +33,8 @@ describe("hosted runtime observed v2", () => {
 				applyReceiptId: "apply-receipt-observed-v2",
 				bootNonce: "boot-nonce-observed-v2-01",
 				sourceRevision: "a".repeat(64),
-				generation: 9,
+				generation: 2,
+				applyGeneration: 1,
 				contentIdentity: {
 					sourcePath: "https://runtime.test/v1/runtime/manifest",
 					sha256: "b".repeat(64),
@@ -52,7 +53,18 @@ describe("hosted runtime observed v2", () => {
 		expect(observed?.applied).toEqual({
 			etag: '"bundle-applied"',
 			sourceRevision: "a".repeat(64),
-			generation: 9,
+			generation: 1,
+			instanceId: "hri_observed",
+			appliedProviderIds: ["managed"],
+		});
+		const companion = readHostedRuntimeObserved(paths, {
+			reportedAt: "2026-07-13T06:01:00.000Z",
+			appliedState: readRuntimeAppliedState(paths),
+		});
+		expect(companion?.applied).toEqual({
+			etag: '"frozen-companion-manifest"',
+			sourceRevision: "a".repeat(64),
+			generation: 1,
 			instanceId: "hri_observed",
 			appliedProviderIds: ["managed"],
 		});

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { getCliVersion } from "../lib/version";
 import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-state";
+import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { runtimeSecretValue } from "./secret-values";
 import { type RuntimeBootStatus, readRuntimeBootStatus } from "./state";
@@ -48,7 +49,7 @@ export function readHostedRuntimeObserved(
 						? appliedState.etag
 						: (appliedState.manifestETag ?? appliedState.etag),
 				sourceRevision: appliedState.sourceRevision,
-				generation: appliedState.generation,
+				generation: resolveRuntimeApplyGeneration(appliedState),
 				instanceId: appliedState.instanceId,
 				appliedProviderIds: [...appliedState.providerIds],
 			}

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -17,6 +17,7 @@ import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { commitRuntimeAppliedState, runtimeAppliedContentIdentity } from "../commands/runtime";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
+import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import { applyRuntimeBundleChannelsToManifestLoad } from "./channels";
 import {
 	hostedManifestEgressProfiles,
@@ -79,6 +80,18 @@ afterEach(() => {
 });
 
 describe("hosted runtime bundle v2", () => {
+	test("reads an old bundle by falling back from omitted apply generation to checkpoint", () => {
+		const raw = z
+			.record(z.string(), z.unknown())
+			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
+		delete raw.applyGeneration;
+		const load = normalizeHostedRuntimeBundleV2(raw);
+
+		expect(load.manifest.generation).toBe(2);
+		expect(load.manifest.applyGeneration).toBeUndefined();
+		expect(resolveRuntimeApplyGeneration(load.manifest)).toBe(2);
+	});
+
 	test("accepts the hosted-emitted gateway secret contract before projecting channels", () => {
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as unknown;
 		const load = normalizeHostedRuntimeBundleV2(raw);
@@ -88,7 +101,7 @@ describe("hosted runtime bundle v2", () => {
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
 
 		expect(projected.sourceRevision).toBe(
-			"12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9",
+			"da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1",
 		);
 		expect(projected.manifest.runtimes.openclaw.run?.secretEnv).toMatchObject({
 			OPENCLAW_GATEWAY_TOKEN: "env://OPENCLAW_GATEWAY_TOKEN",
@@ -804,14 +817,17 @@ describe("hosted runtime bundle v2", () => {
 		).toThrow(`runtime bundle is missing ${canonicalAgentRef}`);
 	});
 
-	test("rejects response-carried apply identity and keeps the inner manifest v1-only", () => {
+	test("accepts root apply generation while keeping the inner manifest v1-only and strict", () => {
 		const raw = z
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		expect(normalizeHostedRuntimeBundleV2(raw).manifest.projection?.sourceSchemaVersion).toBe(
+		const normalized = normalizeHostedRuntimeBundleV2(raw);
+		expect(normalized.manifest.projection?.sourceSchemaVersion).toBe(
 			"clawdi.hosted-runtime.manifest.v1",
 		);
+		expect(normalized.manifest.generation).toBe(2);
+		expect(normalized.manifest.applyGeneration).toBe(1);
 		expect(() =>
 			normalizeHostedRuntimeBundleV2({
 				...raw,
@@ -824,6 +840,14 @@ describe("hosted runtime bundle v2", () => {
 				},
 			}),
 		).toThrow();
+		expect(() => normalizeHostedRuntimeBundleV2({ ...raw, unexpectedApplyField: 1 })).toThrow();
+		const independentGenerations = normalizeHostedRuntimeBundleV2({
+			...raw,
+			applyGeneration: 3,
+		});
+		expect(independentGenerations.manifest.generation).toBe(2);
+		expect(independentGenerations.manifest.applyGeneration).toBe(3);
+		expect(resolveRuntimeApplyGeneration(independentGenerations.manifest)).toBe(3);
 	});
 
 	test("negotiates the exact media type and uses one conditional validator", async () => {
@@ -913,7 +937,7 @@ describe("hosted runtime bundle v2", () => {
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
 		expect(loaded.etag).toBe('"bundle-golden"');
 		expect(loaded.sourceRevision).toBe(
-			"12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9",
+			"da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1",
 		);
 		expect(loaded.channelBindings).toHaveLength(1);
 	});
@@ -1023,10 +1047,10 @@ describe("hosted runtime bundle v2", () => {
 			sourceRevision,
 			convergence: onlineConvergence,
 			applyIdentity: {
-				generation: onlineLoad.manifest.generation,
-				manifestETag: '"manifest-golden-7"',
-				applyReceiptId: "apply-receipt-golden-0007",
-				bootNonce: "boot-nonce-golden-000007",
+				generation: 1,
+				manifestETag: '"manifest-golden-1"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
 			},
 		});
 
@@ -1054,6 +1078,8 @@ describe("hosted runtime bundle v2", () => {
 
 		const applied = readRuntimeAppliedState(paths);
 		if (!applied) throw new Error("online apply did not commit durable authority");
+		expect(applied.generation).toBe(2);
+		expect(applied.applyGeneration).toBe(1);
 		const appliedStateText = readFileSync(paths.appliedState, "utf-8");
 		const appliedStateStat = statSync(paths.appliedState);
 		expect(appliedStateStat.mode & 0o777).toBe(0o600);
@@ -1116,6 +1142,8 @@ describe("hosted runtime bundle v2", () => {
 		if (!("manifest" in offlineLoad)) throw new Error(JSON.stringify(offlineLoad));
 		expect(offlineLoad.source).toBe("last-good-cache");
 		expect(offlineLoad.offline).toBe(true);
+		expect(offlineLoad.manifest.generation).toBe(2);
+		expect(offlineLoad.manifest.applyGeneration).toBe(1);
 		expect(runtimeAppliedContentIdentity(offlineLoad).sha256).toBe(canonicalContentSha);
 		const offlineConvergence = converge(offlineLoad);
 		expect(offlineConvergence.mode).toBe("degraded-offline");
@@ -1157,6 +1185,19 @@ describe("hosted runtime bundle v2", () => {
 		expect(manifestOnlyCrashLoad.errors.join("\n")).toContain(
 			"cached manifest does not match the durable strict-v2 apply identity",
 		);
+		writeFileSync(
+			paths.manifestLastGood,
+			`${JSON.stringify({ ...committedManifest, applyGeneration: 2 })}\n`,
+		);
+		const applyOnlyCrashLoad = await loadRuntimeManifest(paths);
+		expect("errors" in applyOnlyCrashLoad).toBe(true);
+		if (!("errors" in applyOnlyCrashLoad)) {
+			throw new Error("expected apply-generation mixed snapshot failure");
+		}
+		expect(applyOnlyCrashLoad.errors.join("\n")).toContain(
+			"cached manifest does not match the durable strict-v2 apply identity",
+		);
+		writeFileSync(paths.manifestLastGood, manifestCacheText);
 		writeFileSync(
 			paths.managedSecretCacheFile,
 			`${JSON.stringify({

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5575,6 +5575,8 @@ export interface components {
             instance_id: string;
             /** Generation */
             generation: number;
+            /** Apply Generation */
+            apply_generation?: number | null;
         };
         /** PlatformRuntimeStateUpsert */
         PlatformRuntimeStateUpsert: {
@@ -5585,6 +5587,8 @@ export interface components {
             instance_id: string;
             /** Generation */
             generation: number;
+            /** Apply Generation */
+            apply_generation?: number | null;
             /** Cli Package Spec */
             cli_package_spec: string;
             locale: components["schemas"]["HostedRuntimeLocale"];

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -7,6 +7,7 @@
 			"provider": "telegram"
 		}
 	],
+	"applyGeneration": 1,
 	"manifest": {
 		"clawdiCli": {
 			"packageSpec": "clawdi@0.12.10-beta.57",
@@ -24,7 +25,7 @@
 			"url": "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
 			"version": "12.2.3"
 		},
-		"generation": 7,
+		"generation": 2,
 		"instanceId": "hri_test",
 		"issuedAt": "2026-07-13T00:00:00+00:00",
 		"liveSync": {
@@ -134,5 +135,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "12ae1174be36ad789afcfd639ee54a7061a97e19614822ddb9addac3a53c7fc9"
+	"sourceRevision": "da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1"
 }


### PR DESCRIPTION
## Summary

This consumer PR must deploy before Hosted producer activation.

- preserve `generation` as the existing checkpoint/content generation
- add optional `apply_generation` persistence/API state and root `applyGeneration` bundle identity
- resolve legacy Apply identity through one named helper per language: explicit Apply generation first, otherwise checkpoint generation
- preserve checkpoint and Apply identities independently through online validation, applied-state, last-good/offline recovery, observation, and canonical Agent health
- keep the bundle field omitted, and bundle bytes/source revision unchanged, while persisted Apply generation is null
- keep v1/deprecated environment behavior unchanged

## Consumer-first release gate

Older CLI bundle schemas are strict and reject a new root field, so Hosted must remain default-off until this consumer is deployed. For an existing metadata/Apply `1`, checkpoint `2` deployment, the safe order is:

1. Keep the Hosted producer gate off.
2. Use the existing `POST /v2/deployments/{deployment_id}/restart` mutation. The actual Hosted desired-state path changes only `rollout_nonce`; with the legacy floor still active, this aligns `1/2` to `2/2` without changing runtime-state content.
3. Select the exact compatible CLI pin through the normal controlled rollout, advancing the identities together from `2/2` to `3/3`.
4. Verify the online bundle, `runtime-applied.json`, last-good cache, offline boot, exact observation tuple, and canonical Agent health.
5. Only then enable the Hosted producer gate.

A direct CLI pin at `1/2` is unsafe because it can produce metadata `2`, checkpoint `3`, which a legacy fallback consumer rejects. No direct database, cluster, Pod cache, tenant filesystem, or other production mutation is part of this PR.

The canonical Agent health response intentionally retains desired checkpoint generation and observed Apply generation as separate values, then compares health against explicit Apply identity with the named legacy fallback. The deprecated environment/v1 route retains its checkpoint comparison.

## Cross-repository evidence

Read-only audit against Hosted commit `9efc31182059918d2b9b223e6ed9d55a83569866` found no contradictory producer/consumer contract:

- `public_operations.restart_mutation` sets only `increment_rollout_nonce=True`
- acceptance applies that as `rollout_nonce + 1`
- the producer-off path floors checkpoint generation against metadata generation for old strict CLIs
- the producer-on path sends `apply_generation=metadata_generation`
- the Hosted setting defaults to false
- the Hosted pre-activation alignment test proves metadata `1 -> 2` while checkpoint remains `2`

OSS was already the strict persistence/rendering middle: Admin and Platform upserts forbade unknown fields, runtime state had only checkpoint `generation`, the renderer emitted only inner manifest generation, and the CLI strict root schema rejected additional server fields. This PR expands each boundary additively.

## Safety and compatibility

- Apply and checkpoint generations are independently positive/monotonic identities; there is no ordering relation between their values.
- DB/API update policy rejects explicit null, non-positive values, and Apply regressions; omission preserves legacy null/current state.
- Same-checkpoint Apply advances are allowed without weakening same-checkpoint material conflict checks.
- Platform idempotency omits the new null field when the caller omitted it, preserving pre-upgrade request hashes.
- Explicit Apply-only changes participate in `sourceRevision`, preventing incorrect conditional `304` responses.
- Golden coverage is rendered by the real backend renderer, including metadata/Apply `1`, checkpoint `2`; a separate cross-contract case accepts Apply `3`, checkpoint `2`.

## Complexity audit

Necessary abstractions are limited to one Python and one TypeScript named fallback resolver, plus one Python update-policy helper shared by Admin and Platform. They are needed to make the temporary legacy choice explicit and testable at the identity boundary.

The change removes the old checkpoint/Apply equality conflation and the rejected cross-sequence upper-bound validation; it does not introduce a second renderer, cache, state machine, or permanent dual track. Existing bundle and applied-state schemas are evolved in place. The idempotency shape helper is scoped only to runtime-state upsert.

A smaller observation-only patch is insufficient: environment equality, applied-state persistence, cache/offline recovery, conditional rendering, and backend health would still conflate the two identities and could attest or recover the wrong Apply.

After every active CLI and persisted runtime/applied state carries explicit Apply identity, a follow-up contract release can remove field optionality, the legacy fallback, null-as-omission handling, the Hosted default-off gate and legacy floor, temporary rollout documentation, and fallback-only tests.

## Verification

- `cd backend && pdm test` — `1523 passed, 7 skipped, 0 failed`
- `bun run --cwd packages/cli test` — `1441 passed, 4 skipped, 0 failed` in the clean Docker runner
- focused CLI generation/cache/observation suites — `218 passed, 0 failed`
- `bun run typecheck` — 4/4 packages passed
- `bun run check` — 784 files checked, no fixes
- `cd backend && uv run ruff check app tests alembic` — passed
- `cd backend && uv run ruff format --check app tests alembic` — 276 files already formatted
- `cd backend && uv run python -m compileall -q app scripts tests alembic` — passed
- `cd backend && uv run python scripts/check_generated_api.py` — generated API is current
- Alembic graph — single head `7c2e9a4b6d1f`
- `git diff --check origin/main..HEAD` — passed

## Risks / blockers

The primary risk is release ordering: activating the Hosted producer before compatible CLI deployment makes strict old consumers reject the bundle. The default-off gate, omission behavior, and explicit `1/2 -> 2/2 -> 3/3` sequence are the mitigation. There are no implementation blockers. Do not merge or activate the Hosted producer as part of this PR.
