### PR TITLE
Reconcile compatible hosted runtime generations in place

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -782,6 +782,26 @@ from the generation, and the generation cannot be inferred from the ETag. These
 CONFIG convergence fields are separate from hosted provider COMPUTE convergence
 fields such as desired or observed replica generation.
 
+Strict-v2 workloads may provide their current apply authority through the
+single JSON file named by `CLAWDI_RUNTIME_APPLY_IDENTITY_FILE`. The file is a
+strict `clawdi.runtimeApplyIdentity.v1` object containing `generation`,
+`manifestETag`, `applyReceiptId`, `bootNonce`, and a required `runtimeEnv` map.
+`runtimeEnv` contains the exact canonical process-environment values projected
+for that authority tuple. When the path is configured, a missing or malformed
+file fails closed, `env://NAME` resolves only from `runtimeEnv`, and a missing
+name never falls back to stale process-start environment. These projected
+values remain in memory and service environment files; they are not copied to
+the last-good secret cache. The applied generation must match the manifest and
+`manifestETag` must match the fetched bundle ETag before durable authority can
+advance. This lets one atomic projected-file swap advance config, secrets, and
+apply identity in place; `bootNonce` remains a workload-boot identity rather
+than a config-generation identity. The legacy process environment is accepted
+only when no identity-file path was configured and the canonical hosted mount
+`/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json` does not
+exist. This one-boot discovery rule lets a CLI installed by an older bootstrap
+unit acquire the file contract; newly rendered units then pass the discovered
+path explicitly. An existing but malformed canonical file fails closed.
+
 The CLI writes durable non-secret state under the service state root. Important
 outputs include:
 

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -22,17 +22,19 @@ import { getCliVersion } from "../lib/version";
 import {
 	type RuntimeAppliedContentIdentity,
 	readRuntimeAppliedState,
+	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "../runtime/applied-state";
 import {
 	type RuntimeApplyIdentity,
-	readRuntimeApplyIdentityFromEnv,
+	readRuntimeApplyContext,
 	resolveRuntimeApplyGeneration,
+	runtimeApplyIdentitiesEqual,
 } from "../runtime/apply-identity";
 import {
-	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
+	readRuntimeCredential,
 	runtimeAuthTokenFileLabel,
 } from "../runtime/auth-token";
 import { applyRuntimeBundleChannelsToManifestLoad } from "../runtime/channels";
@@ -1253,7 +1255,8 @@ function hasRuntimeCredential(input: {
 	if (input.manifestPath) return true;
 	const paths = input.paths ?? getRuntimePaths();
 	if (existsSync(paths.manifestLastGood)) return true;
-	return ensureRuntimeAuthTokenFile(paths) !== null;
+	const applyContext = readRuntimeApplyContext();
+	return readRuntimeCredential(paths, applyContext.runtimeEnvironment) !== null;
 }
 
 function runtimeCredentialName(paths: ReturnType<typeof getRuntimePaths>): string {
@@ -2404,7 +2407,11 @@ async function runtimeWatchTickAfterCliReconciliation(
 	if (
 		"notModified" in manifestLoad &&
 		activeAppliedState !== null &&
-		activeAppliedState.etag === responseManifestEtag
+		activeAppliedState.etag === responseManifestEtag &&
+		runtimeApplyIdentitiesEqual(
+			manifestLoad.applyContext?.identity ?? null,
+			runtimeAppliedApplyIdentity(activeAppliedState),
+		)
 	) {
 		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
 		return {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1317,6 +1317,11 @@ export function commitRuntimeAppliedState(input: {
 			`runtime apply identity generation ${input.applyIdentity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(input.convergence.manifest)}`,
 		);
 	}
+	if (input.applyIdentity && input.applyIdentity.manifestETag !== input.etag) {
+		throw new Error(
+			`runtime apply identity manifest ETag ${input.applyIdentity.manifestETag} does not match fetched bundle ETag ${input.etag}`,
+		);
+	}
 	const providerIds = runtimeSourceProviderIds(input.load.manifest);
 	input.convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(input.load, input.paths);
 	input.convergence.outputs.appliedState = writeRuntimeAppliedState(
@@ -1504,7 +1509,7 @@ function readFileIfExists(path: string): string | null {
 	return readFileSync(path, "utf-8");
 }
 
-interface SystemdUnitSnapshot {
+export interface SystemdUnitSnapshot {
 	system: Map<string, string>;
 	user: Map<string, string>;
 }
@@ -1525,7 +1530,9 @@ interface CommandResult {
 const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
 const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
 
-function readSystemdUnitSnapshot(paths: ReturnType<typeof getRuntimePaths>): SystemdUnitSnapshot {
+export function readSystemdUnitSnapshot(
+	paths: ReturnType<typeof getRuntimePaths>,
+): SystemdUnitSnapshot {
 	return {
 		system: readManagedSystemdUnits(paths.systemdSystemRoot),
 		user: readManagedSystemdUnits(paths.systemdUserRoot),
@@ -1583,7 +1590,7 @@ function changedSystemdUnits(
 	};
 }
 
-function applySystemdRuntimeUpdate(
+export function applySystemdRuntimeUpdate(
 	paths: ReturnType<typeof getRuntimePaths>,
 	before: SystemdUnitSnapshot,
 	after: SystemdUnitSnapshot,
@@ -2122,7 +2129,7 @@ async function runtimeInitLocked(
 		try {
 			convergenceLoad = applyRuntimeBundleChannelsToManifestLoad(loaded, paths);
 			const contentRevision = runtimePublicContentRevision(convergenceLoad);
-			const applyIdentity = readRuntimeApplyIdentityFromEnv();
+			const applyIdentity = convergenceLoad.applyIdentity ?? null;
 			applyResult = applyRuntimeDesiredState(convergenceLoad, paths, {
 				authorityCommit: (convergence, authority) =>
 					commitRuntimeAppliedState({
@@ -2420,7 +2427,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			bundleEtag,
 			paths,
 		);
-		const applyIdentity = readRuntimeApplyIdentityFromEnv();
+		const applyIdentity = loaded.applyIdentity ?? null;
 		const applyResult = applyRuntimeDesiredState(loaded, paths, {
 			authorityCommit: (convergence, authority) =>
 				commitRuntimeAppliedState({

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1307,6 +1307,7 @@ export function commitRuntimeAppliedState(input: {
 	sourceRevision: string;
 	convergence: ReturnType<typeof convergeRuntimeManifest>;
 	applyIdentity: RuntimeApplyIdentity | null;
+	daemonAuthTokenRevision?: string;
 	egressSidecarSecretRevision?: string;
 }): void {
 	if (
@@ -1343,6 +1344,9 @@ export function commitRuntimeAppliedState(input: {
 					}
 				: {}),
 			contentIdentity: runtimeAppliedContentIdentity(input.load),
+			...(input.daemonAuthTokenRevision
+				? { daemonAuthTokenRevision: input.daemonAuthTokenRevision }
+				: {}),
 			...(input.egressSidecarSecretRevision
 				? { egressSidecarSecretRevision: input.egressSidecarSecretRevision }
 				: {}),
@@ -1528,6 +1532,7 @@ interface CommandResult {
 }
 
 const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
+const RUNTIME_DAEMON_SYSTEM_UNIT = "clawdi-daemon.service";
 const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
 
 export function readSystemdUnitSnapshot(
@@ -2129,7 +2134,7 @@ async function runtimeInitLocked(
 		try {
 			convergenceLoad = applyRuntimeBundleChannelsToManifestLoad(loaded, paths);
 			const contentRevision = runtimePublicContentRevision(convergenceLoad);
-			const applyIdentity = convergenceLoad.applyIdentity ?? null;
+			const applyIdentity = convergenceLoad.applyContext?.identity ?? null;
 			applyResult = applyRuntimeDesiredState(convergenceLoad, paths, {
 				authorityCommit: (convergence, authority) =>
 					commitRuntimeAppliedState({
@@ -2139,6 +2144,7 @@ async function runtimeInitLocked(
 						sourceRevision: loaded.sourceRevision ?? contentRevision,
 						convergence,
 						applyIdentity,
+						daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 						egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 					}),
 				manifestIdentity: {
@@ -2427,7 +2433,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			bundleEtag,
 			paths,
 		);
-		const applyIdentity = loaded.applyIdentity ?? null;
+		const applyIdentity = loaded.applyContext?.identity ?? null;
 		const applyResult = applyRuntimeDesiredState(loaded, paths, {
 			authorityCommit: (convergence, authority) =>
 				commitRuntimeAppliedState({
@@ -2437,6 +2443,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 					sourceRevision,
 					convergence,
 					applyIdentity,
+					daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 					egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 				}),
 			continueOnCliUpdateError: true,
@@ -2618,7 +2625,7 @@ function applyRuntimeDesiredState(
 					);
 				}
 			},
-			activate: ({ restartEgressSidecar }) => {
+			activate: ({ restartDaemon, restartEgressSidecar }) => {
 				// Official installers run after the prerequisite phase and add their
 				// base units, so final reconciliation must observe a fresh rendered state.
 				failedSystemdUnits = readSystemdUnitSnapshot(paths);
@@ -2628,7 +2635,10 @@ function applyRuntimeDesiredState(
 						previousSystemdUnits,
 						failedSystemdUnits,
 						{
-							forceRestartSystemUnits: restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
+							forceRestartSystemUnits: [
+								...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
+								...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
+							],
 							recoverFailedUnits: opts.recoverFailedSystemdUnits,
 							skipActivatedSystemUnits: egressPrerequisiteActivated
 								? [RUNTIME_SIDECAR_SYSTEM_UNIT]
@@ -2642,10 +2652,13 @@ function applyRuntimeDesiredState(
 					);
 				}
 			},
-			rollback: ({ restartEgressSidecar }) => {
+			rollback: ({ restartDaemon, restartEgressSidecar }) => {
 				if (!failedSystemdUnits) return;
 				applySystemdRuntimeUpdate(paths, failedSystemdUnits, readSystemdUnitSnapshot(paths), {
-					forceRestartSystemUnits: restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
+					forceRestartSystemUnits: [
+						...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
+						...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
+					],
 					recoverFailedUnits: false,
 				});
 			},

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe("runtime applied state", () => {
-	test("uses a strict v2 schema with one applied authority", () => {
+	test("uses a strict v2 schema for private applied authority", () => {
 		const state = appliedStateFixture();
 		expect(runtimeAppliedStateSchema.safeParse(state).success).toBe(true);
 		expect(runtimeAppliedStateSchema.safeParse({ ...state, unexpected: true }).success).toBe(false);
@@ -70,6 +70,18 @@ describe("runtime applied state", () => {
 			runtimeAppliedStateSchema.safeParse({
 				...state,
 				egressSidecarSecretRevision: "not-a-private-revision",
+			}).success,
+		).toBe(false);
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				daemonAuthTokenRevision: "d".repeat(64),
+			}).success,
+		).toBe(true);
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				daemonAuthTokenRevision: "not-a-private-revision",
 			}).success,
 		).toBe(false);
 	});

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -46,6 +46,10 @@ export const runtimeAppliedStateSchema = z
 			.string()
 			.regex(/^[a-f0-9]{64}$/)
 			.optional(),
+		daemonAuthTokenRevision: z
+			.string()
+			.regex(/^[a-f0-9]{64}$/)
+			.optional(),
 		providerIds: providerIdsSchema,
 		projectedProviderIds: projectedProviderIdsSchema,
 	})

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -7,6 +7,7 @@ import {
 	readRuntimeApplyIdentity,
 	readRuntimeApplyIdentityFromEnv,
 	resolveRuntimeApplyGeneration,
+	runtimeApplyIdentitiesEqual,
 	runtimeApplyIdentityEnvironment,
 	runtimeApplyIdentityServiceEnvironment,
 } from "./apply-identity";
@@ -47,6 +48,23 @@ describe("runtime apply identity environment", () => {
 			CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0003",
 			CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000003",
 		});
+	});
+
+	test("compares the complete four-field identity tuple", () => {
+		const identity = readRuntimeApplyIdentityFromEnv(completeEnvironment);
+		if (!identity) throw new Error("expected complete apply identity");
+		expect(runtimeApplyIdentitiesEqual(identity, { ...identity })).toBe(true);
+		for (const different of [
+			{ ...identity, generation: identity.generation + 1 },
+			{ ...identity, manifestETag: '"manifest-8"' },
+			{ ...identity, applyReceiptId: "apply-receipt-0008" },
+			{ ...identity, bootNonce: "boot-nonce-000008" },
+		]) {
+			expect(runtimeApplyIdentitiesEqual(identity, different)).toBe(false);
+		}
+		expect(runtimeApplyIdentitiesEqual(identity, null)).toBe(false);
+		expect(runtimeApplyIdentitiesEqual(null, identity)).toBe(false);
+		expect(runtimeApplyIdentitiesEqual(null, null)).toBe(true);
 	});
 
 	test("returns null when the entire tuple is absent", () => {

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+	readRuntimeApplyContext,
+	readRuntimeApplyIdentity,
 	readRuntimeApplyIdentityFromEnv,
 	resolveRuntimeApplyGeneration,
 	runtimeApplyIdentityEnvironment,
+	runtimeApplyIdentityServiceEnvironment,
 } from "./apply-identity";
 
 const completeEnvironment = {
@@ -11,6 +17,12 @@ const completeEnvironment = {
 	CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0007",
 	CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000007",
 };
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 
 describe("runtime apply identity environment", () => {
 	test("resolves explicit apply identity with one named legacy checkpoint fallback", () => {
@@ -75,5 +87,165 @@ describe("runtime apply identity environment", () => {
 				CLAWDI_RUNTIME_GENERATION: String(Number.MAX_SAFE_INTEGER + 1),
 			}),
 		).toThrow(/invalid runtime apply identity environment/);
+	});
+});
+
+describe("runtime apply identity file", () => {
+	test("reads the complete canonical tuple from the configured file", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-"));
+		roots.push(root);
+		const path = join(root, "runtime-apply-identity.json");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+				generation: 8,
+				manifestETag: '"manifest-8"',
+				applyReceiptId: "apply-receipt-0008",
+				bootNonce: "boot-nonce-000007",
+				runtimeEnv: {
+					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+					CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+					CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
+					OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
+				},
+			}),
+		);
+
+		expect(
+			readRuntimeApplyIdentity({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
+				...completeEnvironment,
+			}),
+		).toEqual({
+			generation: 8,
+			manifestETag: '"manifest-8"',
+			applyReceiptId: "apply-receipt-0008",
+			bootNonce: "boot-nonce-000007",
+		});
+		expect(
+			readRuntimeApplyContext({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
+				...completeEnvironment,
+			}),
+		).toEqual({
+			identity: {
+				generation: 8,
+				manifestETag: '"manifest-8"',
+				applyReceiptId: "apply-receipt-0008",
+				bootNonce: "boot-nonce-000007",
+			},
+			runtimeEnv: {
+				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+				CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+				CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
+				OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
+			},
+			sourcePath: path,
+		});
+		expect(
+			runtimeApplyIdentityServiceEnvironment({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
+				...completeEnvironment,
+			}),
+		).toEqual({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path });
+	});
+
+	test("fails closed instead of falling back when the configured file is unavailable or invalid", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-invalid-"));
+		roots.push(root);
+		const missing = join(root, "missing.json");
+		expect(() =>
+			readRuntimeApplyIdentity({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: missing,
+				...completeEnvironment,
+			}),
+		).toThrow(/could not read runtime apply identity file/);
+
+		const invalid = join(root, "invalid.json");
+		writeFileSync(invalid, JSON.stringify({ generation: 8 }));
+		expect(() =>
+			readRuntimeApplyIdentity({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: invalid,
+				...completeEnvironment,
+			}),
+		).toThrow(/invalid runtime apply identity file/);
+
+		writeFileSync(
+			invalid,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+				generation: 8,
+				manifestETag: '"manifest-8"',
+				applyReceiptId: "apply-receipt-0008",
+				bootNonce: "boot-nonce-000008",
+				runtimeEnv: { "INVALID-NAME": " secret" },
+			}),
+		);
+		expect(() =>
+			readRuntimeApplyIdentity({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: invalid,
+				...completeEnvironment,
+			}),
+		).toThrow(/invalid runtime apply identity file/);
+		expect(() =>
+			readRuntimeApplyIdentity({
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: "relative.json",
+				...completeEnvironment,
+			}),
+		).toThrow(/canonical absolute path/);
+	});
+
+	test("uses the legacy environment only when no file path is configured", () => {
+		const missingDiscoveryPath = join(tmpdir(), "clawdi-missing-runtime-apply-identity.json");
+		expect(readRuntimeApplyIdentity(completeEnvironment, missingDiscoveryPath)).toEqual(
+			readRuntimeApplyIdentityFromEnv(completeEnvironment),
+		);
+		expect(readRuntimeApplyContext(completeEnvironment, missingDiscoveryPath)).toMatchObject({
+			runtimeEnv: null,
+			sourcePath: null,
+		});
+	});
+
+	test("discovers the canonical mount before consulting the legacy environment", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-discovered-apply-identity-"));
+		roots.push(root);
+		const discovered = join(root, "runtime-apply-identity.json");
+		writeFileSync(
+			discovered,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+				generation: 9,
+				manifestETag: '"manifest-9"',
+				applyReceiptId: "apply-receipt-0009",
+				bootNonce: "boot-nonce-000009",
+				runtimeEnv: {
+					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+					CLAWDI_AUTH_TOKEN: "discovered-token",
+				},
+			}),
+		);
+
+		expect(readRuntimeApplyContext(completeEnvironment, discovered)).toEqual({
+			identity: {
+				generation: 9,
+				manifestETag: '"manifest-9"',
+				applyReceiptId: "apply-receipt-0009",
+				bootNonce: "boot-nonce-000009",
+			},
+			runtimeEnv: {
+				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+				CLAWDI_AUTH_TOKEN: "discovered-token",
+			},
+			sourcePath: discovered,
+		});
+		expect(runtimeApplyIdentityServiceEnvironment(completeEnvironment, discovered)).toEqual({
+			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: discovered,
+		});
+
+		writeFileSync(discovered, JSON.stringify({ generation: 9 }));
+		expect(() => readRuntimeApplyContext(completeEnvironment, discovered)).toThrow(
+			/invalid runtime apply identity file/,
+		);
 	});
 });

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -10,6 +10,7 @@ import {
 	runtimeApplyIdentityEnvironment,
 	runtimeApplyIdentityServiceEnvironment,
 } from "./apply-identity";
+import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
 
 const completeEnvironment = {
 	CLAWDI_RUNTIME_GENERATION: "7",
@@ -129,17 +130,21 @@ describe("runtime apply identity file", () => {
 				...completeEnvironment,
 			}),
 		).toEqual({
+			kind: "identity-file",
 			identity: {
 				generation: 8,
 				manifestETag: '"manifest-8"',
 				applyReceiptId: "apply-receipt-0008",
 				bootNonce: "boot-nonce-000007",
 			},
-			runtimeEnv: {
-				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-				CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
-				CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
-				OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
+			runtimeEnvironment: {
+				kind: "projected-environment",
+				values: {
+					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+					CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+					CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
+					OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
+				},
 			},
 			sourcePath: path,
 		});
@@ -202,8 +207,11 @@ describe("runtime apply identity file", () => {
 			readRuntimeApplyIdentityFromEnv(completeEnvironment),
 		);
 		expect(readRuntimeApplyContext(completeEnvironment, missingDiscoveryPath)).toMatchObject({
-			runtimeEnv: null,
-			sourcePath: null,
+			kind: "process-environment",
+			runtimeEnvironment: {
+				kind: "process-environment",
+				values: completeEnvironment,
+			},
 		});
 	});
 
@@ -222,23 +230,52 @@ describe("runtime apply identity file", () => {
 				runtimeEnv: {
 					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
 					CLAWDI_AUTH_TOKEN: "discovered-token",
+					OPENCLAW_GATEWAY_TOKEN: "discovered-gateway-token",
 				},
 			}),
 		);
 
-		expect(readRuntimeApplyContext(completeEnvironment, discovered)).toEqual({
+		const context = readRuntimeApplyContext(
+			{ ...completeEnvironment, STALE_ONLY_PROCESS_TOKEN: "stale-process-token" },
+			discovered,
+		);
+		expect(context).toEqual({
+			kind: "identity-file",
 			identity: {
 				generation: 9,
 				manifestETag: '"manifest-9"',
 				applyReceiptId: "apply-receipt-0009",
 				bootNonce: "boot-nonce-000009",
 			},
-			runtimeEnv: {
-				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-				CLAWDI_AUTH_TOKEN: "discovered-token",
+			runtimeEnvironment: {
+				kind: "projected-environment",
+				values: {
+					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+					CLAWDI_AUTH_TOKEN: "discovered-token",
+					OPENCLAW_GATEWAY_TOKEN: "discovered-gateway-token",
+				},
 			},
 			sourcePath: discovered,
 		});
+		const clonedSecrets = {
+			...Object.fromEntries(
+				Object.entries(
+					normalizeSecretValues({
+						"env://OPENCLAW_GATEWAY_TOKEN": "discovered-gateway-token",
+					}),
+				),
+			),
+		};
+		expect(
+			runtimeSecretValue(clonedSecrets, "env://OPENCLAW_GATEWAY_TOKEN", context.runtimeEnvironment),
+		).toBe("discovered-gateway-token");
+		expect(
+			runtimeSecretValue(
+				clonedSecrets,
+				"env://STALE_ONLY_PROCESS_TOKEN",
+				context.runtimeEnvironment,
+			),
+		).toBeNull();
 		expect(runtimeApplyIdentityServiceEnvironment(completeEnvironment, discovered)).toEqual({
 			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: discovered,
 		});

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -1,6 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { z } from "zod";
+import {
+	type ProcessRuntimeEnvironment,
+	type ProjectedRuntimeEnvironment,
+	processRuntimeEnvironment,
+	projectedRuntimeEnvironment,
+} from "./secret-values";
 
 export const runtimeApplyIdentitySchema = z
 	.object({
@@ -51,12 +57,18 @@ const runtimeApplyIdentityFileSchema = runtimeApplyIdentitySchema
 
 type RuntimeApplyIdentityFile = z.infer<typeof runtimeApplyIdentityFileSchema>;
 
-export interface RuntimeApplyContext {
-	identity: RuntimeApplyIdentity;
-	// null preserves the legacy process-environment contract when no file is configured.
-	runtimeEnv: Record<string, string> | null;
-	sourcePath: string | null;
-}
+export type RuntimeApplyContext =
+	| {
+			kind: "process-environment";
+			identity: RuntimeApplyIdentity | null;
+			runtimeEnvironment: ProcessRuntimeEnvironment;
+	  }
+	| {
+			kind: "identity-file";
+			identity: RuntimeApplyIdentity;
+			sourcePath: string;
+			runtimeEnvironment: ProjectedRuntimeEnvironment;
+	  };
 
 export const RUNTIME_APPLY_IDENTITY_ENV = {
 	generation: "CLAWDI_RUNTIME_GENERATION",
@@ -106,34 +118,32 @@ export function readRuntimeApplyIdentity(
 	env: Readonly<Record<string, string | undefined>> = process.env,
 	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
 ): RuntimeApplyIdentity | null {
-	return readRuntimeApplyContext(env, discoveryPath)?.identity ?? null;
+	return readRuntimeApplyContext(env, discoveryPath).identity;
 }
 
 export function readRuntimeApplyContext(
 	env: Readonly<Record<string, string | undefined>> = process.env,
 	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
-): RuntimeApplyContext | null {
-	const explicitPath = env[RUNTIME_APPLY_IDENTITY_FILE_ENV];
-	const configuredPath =
-		explicitPath !== undefined
-			? explicitPath
-			: existsSync(discoveryPath)
-				? discoveryPath
-				: undefined;
-	if (configuredPath === undefined) {
-		const identity = readRuntimeApplyIdentityFromEnv(env);
-		return identity ? { identity, runtimeEnv: null, sourcePath: null } : null;
+): RuntimeApplyContext {
+	const configuredPath = configuredRuntimeApplyIdentityPath(env, discoveryPath);
+	if (configuredPath === null) {
+		return {
+			kind: "process-environment",
+			identity: readRuntimeApplyIdentityFromEnv(env),
+			runtimeEnvironment: processRuntimeEnvironment(env),
+		};
 	}
 	const parsed = readRuntimeApplyIdentityFile(configuredPath);
 	const { schemaVersion: _schemaVersion, runtimeEnv, ...identity } = parsed;
-	return { identity, runtimeEnv, sourcePath: configuredPath };
+	return {
+		kind: "identity-file",
+		identity,
+		sourcePath: configuredPath,
+		runtimeEnvironment: projectedRuntimeEnvironment(runtimeEnv),
+	};
 }
 
 function readRuntimeApplyIdentityFile(configuredPath: string): RuntimeApplyIdentityFile {
-	if (!configuredPath || configuredPath !== configuredPath.trim() || !isAbsolute(configuredPath)) {
-		throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
-	}
-
 	let raw: unknown;
 	try {
 		raw = JSON.parse(readFileSync(configuredPath, "utf-8")) as unknown;
@@ -171,24 +181,30 @@ export function runtimeApplyIdentityServiceEnvironment(
 	env: Readonly<Record<string, string | undefined>> = process.env,
 	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
 ): Record<string, string> {
+	return runtimeApplyContextServiceEnvironment(readRuntimeApplyContext(env, discoveryPath));
+}
+
+export function runtimeApplyContextServiceEnvironment(
+	context: RuntimeApplyContext,
+): Record<string, string> {
+	if (context.kind === "identity-file") {
+		return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: context.sourcePath };
+	}
+	return runtimeApplyIdentityEnvironment(context.identity);
+}
+
+function configuredRuntimeApplyIdentityPath(
+	env: Readonly<Record<string, string | undefined>>,
+	discoveryPath: string,
+): string | null {
 	const explicitPath = env[RUNTIME_APPLY_IDENTITY_FILE_ENV];
 	const configuredPath =
-		explicitPath !== undefined
-			? explicitPath
-			: existsSync(discoveryPath)
-				? discoveryPath
-				: undefined;
-	if (configuredPath !== undefined) {
-		if (
-			!configuredPath ||
-			configuredPath !== configuredPath.trim() ||
-			!isAbsolute(configuredPath)
-		) {
-			throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
-		}
-		return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: configuredPath };
+		explicitPath !== undefined ? explicitPath : existsSync(discoveryPath) ? discoveryPath : null;
+	if (configuredPath === null) return null;
+	if (!configuredPath || configuredPath !== configuredPath.trim() || !isAbsolute(configuredPath)) {
+		throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
 	}
-	return runtimeApplyIdentityEnvironment(readRuntimeApplyIdentityFromEnv(env));
+	return configuredPath;
 }
 
 function canonicalIdentityValue(min: number, max: number): z.ZodString {

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -28,6 +28,19 @@ export function resolveRuntimeApplyGeneration(identity: RuntimeGenerationIdentit
 	return identity.applyGeneration ?? identity.generation;
 }
 
+export function runtimeApplyIdentitiesEqual(
+	left: RuntimeApplyIdentity | null,
+	right: RuntimeApplyIdentity | null,
+): boolean {
+	if (left === null || right === null) return left === right;
+	return (
+		left.generation === right.generation &&
+		left.manifestETag === right.manifestETag &&
+		left.applyReceiptId === right.applyReceiptId &&
+		left.bootNonce === right.bootNonce
+	);
+}
+
 export const RUNTIME_APPLY_IDENTITY_FILE_ENV = "CLAWDI_RUNTIME_APPLY_IDENTITY_FILE";
 export const HOSTED_RUNTIME_APPLY_IDENTITY_FILE =
 	"/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json";

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { z } from "zod";
 
 export const runtimeApplyIdentitySchema = z
@@ -18,6 +20,42 @@ export interface RuntimeGenerationIdentity {
 
 export function resolveRuntimeApplyGeneration(identity: RuntimeGenerationIdentity): number {
 	return identity.applyGeneration ?? identity.generation;
+}
+
+export const RUNTIME_APPLY_IDENTITY_FILE_ENV = "CLAWDI_RUNTIME_APPLY_IDENTITY_FILE";
+export const HOSTED_RUNTIME_APPLY_IDENTITY_FILE =
+	"/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json";
+
+const runtimeProjectedEnvironmentSchema = z.record(
+	z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
+	z
+		.string()
+		.min(1)
+		.refine((value) => value === value.trim(), "must not have surrounding whitespace")
+		.refine(
+			(value) =>
+				[...value].every((character) => {
+					const code = character.charCodeAt(0);
+					return code > 0x1f && code !== 0x7f;
+				}),
+			"must not contain control characters",
+		),
+);
+
+const runtimeApplyIdentityFileSchema = runtimeApplyIdentitySchema
+	.safeExtend({
+		schemaVersion: z.literal("clawdi.runtimeApplyIdentity.v1"),
+		runtimeEnv: runtimeProjectedEnvironmentSchema,
+	})
+	.strict();
+
+type RuntimeApplyIdentityFile = z.infer<typeof runtimeApplyIdentityFileSchema>;
+
+export interface RuntimeApplyContext {
+	identity: RuntimeApplyIdentity;
+	// null preserves the legacy process-environment contract when no file is configured.
+	runtimeEnv: Record<string, string> | null;
+	sourcePath: string | null;
 }
 
 export const RUNTIME_APPLY_IDENTITY_ENV = {
@@ -64,6 +102,59 @@ export function readRuntimeApplyIdentityFromEnv(
 	return parsed.data;
 }
 
+export function readRuntimeApplyIdentity(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
+): RuntimeApplyIdentity | null {
+	return readRuntimeApplyContext(env, discoveryPath)?.identity ?? null;
+}
+
+export function readRuntimeApplyContext(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
+): RuntimeApplyContext | null {
+	const explicitPath = env[RUNTIME_APPLY_IDENTITY_FILE_ENV];
+	const configuredPath =
+		explicitPath !== undefined
+			? explicitPath
+			: existsSync(discoveryPath)
+				? discoveryPath
+				: undefined;
+	if (configuredPath === undefined) {
+		const identity = readRuntimeApplyIdentityFromEnv(env);
+		return identity ? { identity, runtimeEnv: null, sourcePath: null } : null;
+	}
+	const parsed = readRuntimeApplyIdentityFile(configuredPath);
+	const { schemaVersion: _schemaVersion, runtimeEnv, ...identity } = parsed;
+	return { identity, runtimeEnv, sourcePath: configuredPath };
+}
+
+function readRuntimeApplyIdentityFile(configuredPath: string): RuntimeApplyIdentityFile {
+	if (!configuredPath || configuredPath !== configuredPath.trim() || !isAbsolute(configuredPath)) {
+		throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
+	}
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(configuredPath, "utf-8")) as unknown;
+	} catch (error) {
+		throw new Error(
+			`could not read runtime apply identity file ${configuredPath}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	const parsed = runtimeApplyIdentityFileSchema.safeParse(raw);
+	if (!parsed.success) {
+		throw new Error(
+			`invalid runtime apply identity file ${configuredPath}: ${parsed.error.issues
+				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+				.join("; ")}`,
+		);
+	}
+	return parsed.data;
+}
+
 export function runtimeApplyIdentityEnvironment(
 	identity: RuntimeApplyIdentity | null,
 ): Record<string, string> {
@@ -74,6 +165,30 @@ export function runtimeApplyIdentityEnvironment(
 		[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId]: identity.applyReceiptId,
 		[RUNTIME_APPLY_IDENTITY_ENV.bootNonce]: identity.bootNonce,
 	};
+}
+
+export function runtimeApplyIdentityServiceEnvironment(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
+): Record<string, string> {
+	const explicitPath = env[RUNTIME_APPLY_IDENTITY_FILE_ENV];
+	const configuredPath =
+		explicitPath !== undefined
+			? explicitPath
+			: existsSync(discoveryPath)
+				? discoveryPath
+				: undefined;
+	if (configuredPath !== undefined) {
+		if (
+			!configuredPath ||
+			configuredPath !== configuredPath.trim() ||
+			!isAbsolute(configuredPath)
+		) {
+			throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
+		}
+		return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: configuredPath };
+	}
+	return runtimeApplyIdentityEnvironment(readRuntimeApplyIdentityFromEnv(env));
 }
 
 function canonicalIdentityValue(min: number, max: number): z.ZodString {

--- a/packages/cli/src/runtime/auth-token.test.ts
+++ b/packages/cli/src/runtime/auth-token.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { readRuntimeCredential } from "./auth-token";
+import { getRuntimePaths } from "./paths";
+import { processRuntimeEnvironment, projectedRuntimeEnvironment } from "./secret-values";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function runtimePaths() {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-credential-"));
+	roots.push(root);
+	const previousRunDir = process.env.CLAWDI_RUN_DIR;
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	try {
+		return getRuntimePaths({ mode: "hosted" });
+	} finally {
+		if (previousRunDir === undefined) delete process.env.CLAWDI_RUN_DIR;
+		else process.env.CLAWDI_RUN_DIR = previousRunDir;
+	}
+}
+
+function seedLegacyToken(path: string): { bytes: string; mtimeMs: number } {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, "legacy-file-token\n");
+	const fixedTime = new Date("2026-07-30T00:00:00.000Z");
+	utimesSync(path, fixedTime, fixedTime);
+	return { bytes: readFileSync(path, "utf-8"), mtimeMs: statSync(path).mtimeMs };
+}
+
+describe("runtime credential reads", () => {
+	test("uses only the projected credential and never falls back to the legacy file", () => {
+		const paths = runtimePaths();
+		const before = seedLegacyToken(paths.daemonAuthToken);
+		expect(
+			readRuntimeCredential(
+				paths,
+				projectedRuntimeEnvironment({
+					CLAWDI_RUNTIME_AUTH_ENV: "PROJECTED_RUNTIME_TOKEN",
+					PROJECTED_RUNTIME_TOKEN: "projected-runtime-token",
+				}),
+			),
+		).toBe("projected-runtime-token");
+		expect(
+			readRuntimeCredential(
+				paths,
+				projectedRuntimeEnvironment({
+					CLAWDI_RUNTIME_AUTH_ENV: "PROJECTED_RUNTIME_TOKEN",
+				}),
+			),
+		).toBeNull();
+		expect(readFileSync(paths.daemonAuthToken, "utf-8")).toBe(before.bytes);
+		expect(statSync(paths.daemonAuthToken).mtimeMs).toBe(before.mtimeMs);
+	});
+
+	test("keeps legacy process-environment precedence and file fallback", () => {
+		const paths = runtimePaths();
+		const before = seedLegacyToken(paths.daemonAuthToken);
+		expect(
+			readRuntimeCredential(
+				paths,
+				processRuntimeEnvironment({
+					CLAWDI_RUNTIME_AUTH_ENV: "PROCESS_RUNTIME_TOKEN",
+					PROCESS_RUNTIME_TOKEN: "process-runtime-token",
+				}),
+			),
+		).toBe("process-runtime-token");
+		expect(
+			readRuntimeCredential(
+				paths,
+				processRuntimeEnvironment({
+					CLAWDI_RUNTIME_AUTH_ENV: "PROCESS_RUNTIME_TOKEN",
+				}),
+			),
+		).toBe("legacy-file-token");
+		expect(readFileSync(paths.daemonAuthToken, "utf-8")).toBe(before.bytes);
+		expect(statSync(paths.daemonAuthToken).mtimeMs).toBe(before.mtimeMs);
+	});
+});

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -2,6 +2,7 @@ import { readFileSync, rmSync } from "node:fs";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeApplyContext } from "./apply-identity";
 import type { RuntimePaths } from "./paths";
+import type { RuntimeEnvironmentAuthority } from "./secret-values";
 
 export const RUNTIME_AUTH_TOKEN_ENV = "CLAWDI_AUTH_TOKEN";
 export const RUNTIME_AUTH_TOKEN_SECRET_REF = `env://${RUNTIME_AUTH_TOKEN_ENV}`;
@@ -44,22 +45,15 @@ export function writeRuntimeAuthToken(paths: RuntimePaths, token: string): strin
 
 export function ensureRuntimeAuthTokenFile(
 	paths: RuntimePaths,
-	projectedRuntimeEnv: Record<string, string> | null | undefined = undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority = readRuntimeApplyContext().runtimeEnvironment,
 ): string | null {
-	const resolvedRuntimeEnv =
-		projectedRuntimeEnv === undefined
-			? (readRuntimeApplyContext()?.runtimeEnv ?? null)
-			: projectedRuntimeEnv;
 	const envName =
 		paths.mode === "hosted"
-			? runtimeAuthEnvName(resolvedRuntimeEnv ?? process.env)
+			? runtimeAuthEnvName(runtimeEnvironment.values)
 			: RUNTIME_AUTH_TOKEN_ENV;
-	const token =
-		resolvedRuntimeEnv === null
-			? process.env[envName]?.trim()
-			: resolvedRuntimeEnv?.[envName]?.trim();
+	const token = runtimeEnvironment.values[envName]?.trim();
 	if (token) return writeRuntimeAuthToken(paths, token);
-	if (resolvedRuntimeEnv !== null) {
+	if (runtimeEnvironment.kind === "projected-environment") {
 		rmSync(paths.daemonAuthToken, { force: true });
 		return null;
 	}

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -1,6 +1,5 @@
 import { readFileSync, rmSync } from "node:fs";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
-import { readRuntimeApplyContext } from "./apply-identity";
 import type { RuntimePaths } from "./paths";
 import type { RuntimeEnvironmentAuthority } from "./secret-values";
 
@@ -43,23 +42,22 @@ export function writeRuntimeAuthToken(paths: RuntimePaths, token: string): strin
 	return paths.daemonAuthToken;
 }
 
+export function readRuntimeCredential(
+	paths: RuntimePaths,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): string | null {
+	return readRuntimeCredentialSource(paths, runtimeEnvironment)?.token ?? null;
+}
+
 export function ensureRuntimeAuthTokenFile(
 	paths: RuntimePaths,
-	runtimeEnvironment: RuntimeEnvironmentAuthority = readRuntimeApplyContext().runtimeEnvironment,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): string | null {
-	const envName =
-		paths.mode === "hosted"
-			? runtimeAuthEnvName(runtimeEnvironment.values)
-			: RUNTIME_AUTH_TOKEN_ENV;
-	const token = runtimeEnvironment.values[envName]?.trim();
-	if (token) return writeRuntimeAuthToken(paths, token);
-	if (runtimeEnvironment.kind === "projected-environment") {
-		rmSync(paths.daemonAuthToken, { force: true });
-		return null;
+	const credential = readRuntimeCredentialSource(paths, runtimeEnvironment);
+	if (credential?.source === "environment") {
+		return writeRuntimeAuthToken(paths, credential.token);
 	}
-	if (readRuntimeAuthToken(paths)) {
-		return paths.daemonAuthToken;
-	}
+	if (credential?.source === "file") return paths.daemonAuthToken;
 	rmSync(paths.daemonAuthToken, { force: true });
 	return null;
 }
@@ -76,4 +74,25 @@ function normalizeRuntimeAuthToken(token: string): string | null {
 		if (code <= 0x1f || code === 0x7f) return null;
 	}
 	return normalized;
+}
+
+function readRuntimeCredentialSource(
+	paths: RuntimePaths,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): { source: "environment" | "file"; token: string } | null {
+	const envName =
+		paths.mode === "hosted"
+			? runtimeAuthEnvName(runtimeEnvironment.values)
+			: RUNTIME_AUTH_TOKEN_ENV;
+	const rawToken = runtimeEnvironment.values[envName];
+	if (rawToken?.trim()) {
+		const token = normalizeRuntimeAuthToken(rawToken);
+		if (!token) {
+			throw new Error("runtime auth token must be non-empty and contain no control characters");
+		}
+		return { source: "environment", token };
+	}
+	if (runtimeEnvironment.kind === "projected-environment") return null;
+	const token = readRuntimeAuthToken(paths);
+	return token ? { source: "file", token } : null;
 }

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -1,13 +1,16 @@
 import { readFileSync, rmSync } from "node:fs";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { readRuntimeApplyContext } from "./apply-identity";
 import type { RuntimePaths } from "./paths";
 
 export const RUNTIME_AUTH_TOKEN_ENV = "CLAWDI_AUTH_TOKEN";
 export const RUNTIME_AUTH_TOKEN_SECRET_REF = `env://${RUNTIME_AUTH_TOKEN_ENV}`;
 export const RUNTIME_AUTH_ENV_SELECTOR = "CLAWDI_RUNTIME_AUTH_ENV";
 
-export function runtimeAuthEnvName(): string {
-	const selected = process.env[RUNTIME_AUTH_ENV_SELECTOR]?.trim();
+export function runtimeAuthEnvName(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+	const selected = env[RUNTIME_AUTH_ENV_SELECTOR]?.trim();
 	if (!selected) {
 		throw new Error(`missing ${RUNTIME_AUTH_ENV_SELECTOR}`);
 	}
@@ -39,10 +42,27 @@ export function writeRuntimeAuthToken(paths: RuntimePaths, token: string): strin
 	return paths.daemonAuthToken;
 }
 
-export function ensureRuntimeAuthTokenFile(paths: RuntimePaths): string | null {
-	const envName = paths.mode === "hosted" ? runtimeAuthEnvName() : RUNTIME_AUTH_TOKEN_ENV;
-	const token = process.env[envName]?.trim();
+export function ensureRuntimeAuthTokenFile(
+	paths: RuntimePaths,
+	projectedRuntimeEnv: Record<string, string> | null | undefined = undefined,
+): string | null {
+	const resolvedRuntimeEnv =
+		projectedRuntimeEnv === undefined
+			? (readRuntimeApplyContext()?.runtimeEnv ?? null)
+			: projectedRuntimeEnv;
+	const envName =
+		paths.mode === "hosted"
+			? runtimeAuthEnvName(resolvedRuntimeEnv ?? process.env)
+			: RUNTIME_AUTH_TOKEN_ENV;
+	const token =
+		resolvedRuntimeEnv === null
+			? process.env[envName]?.trim()
+			: resolvedRuntimeEnv?.[envName]?.trim();
 	if (token) return writeRuntimeAuthToken(paths, token);
+	if (resolvedRuntimeEnv !== null) {
+		rmSync(paths.daemonAuthToken, { force: true });
+		return null;
+	}
 	if (readRuntimeAuthToken(paths)) {
 		return paths.daemonAuthToken;
 	}

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -11,7 +11,11 @@ import type {
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
-import { runtimeSecretValue } from "./secret-values";
+import {
+	processRuntimeEnvironment,
+	type RuntimeEnvironmentAuthority,
+	runtimeSecretValue,
+} from "./secret-values";
 import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
 
 type EgressProfile = EgressProfileInputBundle["profiles"][number];
@@ -99,8 +103,9 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 ): RuntimeManifestLoad {
 	if (!load.channelBindings) return load;
 	const secretValues = load.secretValues ?? {};
+	const runtimeEnvironment = load.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment();
 	const links: ManagedChannelLink[] = load.channelBindings.map((binding) =>
-		managedBundleChannelLink(binding, secretValues),
+		managedBundleChannelLink(binding, secretValues, runtimeEnvironment),
 	);
 	return {
 		...load,
@@ -112,9 +117,18 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 function managedBundleChannelLink(
 	binding: RuntimeBundleChannelBinding,
 	secretValues: Record<string, string>,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): ManagedChannelLink {
-	const agentToken = runtimeSecretValue(secretValues, binding.agentTokenSecretRef);
-	const placeholderToken = runtimeSecretValue(secretValues, binding.placeholderTokenSecretRef);
+	const agentToken = runtimeSecretValue(
+		secretValues,
+		binding.agentTokenSecretRef,
+		runtimeEnvironment,
+	);
+	const placeholderToken = runtimeSecretValue(
+		secretValues,
+		binding.placeholderTokenSecretRef,
+		runtimeEnvironment,
+	);
 	if (!agentToken) throw new Error(`runtime bundle is missing ${binding.agentTokenSecretRef}`);
 	if (!placeholderToken) {
 		throw new Error(`runtime bundle is missing ${binding.placeholderTokenSecretRef}`);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -48,7 +48,11 @@ import {
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
-import { markProjectedRuntimeEnvironment, normalizeSecretValues } from "./secret-values";
+import {
+	normalizeSecretValues,
+	processRuntimeEnvironment,
+	projectedRuntimeEnvironment,
+} from "./secret-values";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const successfulPrerequisiteActivation = () => ({
@@ -1902,7 +1906,9 @@ describe("runtime manifest reconciliation invariants", () => {
 			OPENCLAW_GATEWAY_TOKEN: "env://OPENCLAW_GATEWAY_TOKEN",
 		});
 		expect(runConfig.secretFilePath).toBeNull();
-		expect(runtimeSecretValue({}, "env://OPENCLAW_GATEWAY_TOKEN")).toBe("gateway-token");
+		expect(
+			runtimeSecretValue({}, "env://OPENCLAW_GATEWAY_TOKEN", processRuntimeEnvironment()),
+		).toBe("gateway-token");
 		const unit = readFileSync(
 			join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
 			"utf8",
@@ -4023,35 +4029,41 @@ describe("runtime manifest reconciliation invariants", () => {
 			runtimeSecretValue(
 				{ "secret://providers/default/api-key": "sk-exact" },
 				"secret://providers/default/api-key",
+				processRuntimeEnvironment(),
 			),
 		).toBe("sk-exact");
 		expect(
 			runtimeSecretValue(
 				{ "secret://providers/default/api-key": "sk-normalized" },
 				"providers/default/api-key",
+				processRuntimeEnvironment(),
 			),
 		).toBe("sk-normalized");
 		expect(
 			runtimeSecretValue(
 				{ "providers/default/api-key": "sk-stripped" },
 				"secret://providers/default/api-key",
+				processRuntimeEnvironment(),
 			),
 		).toBe("sk-stripped");
-		expect(runtimeSecretValue({}, "secret://providers/default/api-key")).toBeNull();
+		expect(
+			runtimeSecretValue({}, "secret://providers/default/api-key", processRuntimeEnvironment()),
+		).toBeNull();
 	});
 
 	test("uses a discovered apply-context snapshot instead of stale process env", () => {
 		delete process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE;
 		process.env.OPENCLAW_GATEWAY_TOKEN = "stale-process-token";
-		const projected = normalizeSecretValues(
-			markProjectedRuntimeEnvironment({
-				"env://OPENCLAW_GATEWAY_TOKEN": "projected-file-token",
-			}),
-		);
+		const projected = normalizeSecretValues({
+			"env://OPENCLAW_GATEWAY_TOKEN": "projected-file-token",
+		});
+		const runtimeEnvironment = projectedRuntimeEnvironment({
+			OPENCLAW_GATEWAY_TOKEN: "projected-file-token",
+		});
 
-		expect(runtimeSecretValue(projected, "env://OPENCLAW_GATEWAY_TOKEN")).toBe(
+		expect(runtimeSecretValue(projected, "env://OPENCLAW_GATEWAY_TOKEN", runtimeEnvironment)).toBe(
 			"projected-file-token",
 		);
-		expect(runtimeSecretValue(projected, "env://MISSING_TOKEN")).toBeNull();
+		expect(runtimeSecretValue(projected, "env://MISSING_TOKEN", runtimeEnvironment)).toBeNull();
 	});
 });

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -23,6 +23,7 @@ import {
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
+	daemonProgramRevision,
 	hostedAiProviderCatalog,
 	type RuntimeManifest,
 	runtimeLiveSnapshotPaths,
@@ -47,7 +48,7 @@ import {
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
-import { normalizeSecretValues } from "./secret-values";
+import { markProjectedRuntimeEnvironment, normalizeSecretValues } from "./secret-values";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const successfulPrerequisiteActivation = () => ({
@@ -2414,7 +2415,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		]);
 	});
 
-	test("keeps runtime secret revisions scoped to runtime programs", () => {
+	test("keeps reconcile impact scoped to the affected process", () => {
 		const paths = tempRuntimePaths();
 		const runtimeSecretRef = "secret://runtimes/openclaw/api-key";
 		const egressSecretRef = "secret://providers/default/api-key";
@@ -2445,14 +2446,76 @@ describe("runtime manifest reconciliation invariants", () => {
 			generation: 2,
 			issuedAt: "2026-07-01T00:01:00.000Z",
 		};
-		const egressManifest: RuntimeManifest = {
+		const cliOnlyChange: RuntimeManifest = {
 			...manifest,
-			runtimes: {
-				openclaw: {
-					...manifest.runtimes.openclaw,
-					run: runSettings("openclaw", ["gateway", "run"]),
+			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.16" },
+		};
+		const controlPlaneOnlyChange: RuntimeManifest = {
+			...manifest,
+			controlPlane: { apiUrl: "https://unrelated-control-plane.example.test" },
+		};
+		const terminalToolingOnlyChange: RuntimeManifest = {
+			...manifest,
+			projection: { terminalTooling: { codex: { enabled: false } } },
+		};
+		const skillOnlyChange: RuntimeManifest = {
+			...manifest,
+			projection: {
+				skills: { entries: { clawdi: { enabled: true, version: 1 } } },
+			},
+		};
+		const unrelatedProviderChange: RuntimeManifest = {
+			...manifest,
+			projection: {
+				providers: {
+					unrelated: {
+						type: "custom_openai_compatible",
+						baseUrl: "https://unrelated.example.test/v1",
+					},
 				},
 			},
+		};
+		const relevantGatewayProjectionChange: RuntimeManifest = {
+			...manifest,
+			projection: {
+				system: {
+					openclawControlUiAllowedOrigins: ["https://gateway.example.test"],
+				},
+			},
+		};
+		const serviceOnlyChange: RuntimeManifest = {
+			...manifest,
+			runtimes: {
+				...manifest.runtimes,
+				openclaw: {
+					...manifest.runtimes.openclaw,
+					services: { worker: runSettings("openclaw", ["worker"]) },
+				},
+			},
+		};
+		const multiRuntimeManifest: RuntimeManifest = {
+			...manifest,
+			runtimes: {
+				...manifest.runtimes,
+				hermes: {
+					enabled: true,
+					run: runSettings("hermes", ["gateway"]),
+					services: {},
+				},
+			},
+		};
+		const unrelatedRuntimeChange: RuntimeManifest = {
+			...multiRuntimeManifest,
+			runtimes: {
+				...multiRuntimeManifest.runtimes,
+				hermes: {
+					...multiRuntimeManifest.runtimes.hermes,
+					run: runSettings("hermes", ["gateway", "--verbose"]),
+				},
+			},
+		};
+		const egressManifest: RuntimeManifest = {
+			...manifest,
 			egressProfiles: {
 				profiles: [
 					{
@@ -2497,9 +2560,47 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(runtimeProgramRevision(metadataOnlyChange, "openclaw", secretValues)).toBe(
 			runtimeRevision,
 		);
+		expect(runtimeProgramRevision(cliOnlyChange, "openclaw", secretValues)).toBe(runtimeRevision);
+		expect(runtimeProgramRevision(controlPlaneOnlyChange, "openclaw", secretValues)).toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(egressManifest, "openclaw", secretValues)).toBe(runtimeRevision);
+		expect(runtimeProgramRevision(terminalToolingOnlyChange, "openclaw", secretValues)).toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(unrelatedProviderChange, "openclaw", secretValues)).toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(serviceOnlyChange, "openclaw", secretValues)).toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(unrelatedRuntimeChange, "openclaw", secretValues)).toBe(
+			runtimeProgramRevision(multiRuntimeManifest, "openclaw", secretValues),
+		);
+		expect(runtimeProgramRevision(unrelatedRuntimeChange, "hermes", secretValues)).not.toBe(
+			runtimeProgramRevision(multiRuntimeManifest, "hermes", secretValues),
+		);
+		expect(
+			runtimeProgramRevision(relevantGatewayProjectionChange, "openclaw", secretValues),
+		).not.toBe(runtimeRevision);
+		expect(runtimeProgramRevision(skillOnlyChange, "openclaw", secretValues)).not.toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(manifest, "openclaw", secretValues, "provider-b")).not.toBe(
+			runtimeProgramRevision(manifest, "openclaw", secretValues, "provider-a"),
+		);
 		const sidecarRevision = runtimeSidecarProgramRevision(manifest);
 		expect(runtimeSidecarProgramRevision(egressManifest)).not.toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(metadataOnlyChange)).not.toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(metadataOnlyChange)).toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(cliOnlyChange)).toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(terminalToolingOnlyChange)).toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(skillOnlyChange)).toBe(sidecarRevision);
+		const daemonRevision = daemonProgramRevision(manifest);
+		expect(daemonProgramRevision(metadataOnlyChange)).toBe(daemonRevision);
+		expect(daemonProgramRevision(terminalToolingOnlyChange)).toBe(daemonRevision);
+		expect(daemonProgramRevision(skillOnlyChange)).toBe(daemonRevision);
+		expect(daemonProgramRevision(egressManifest)).toBe(daemonRevision);
+		expect(daemonProgramRevision(cliOnlyChange)).not.toBe(daemonRevision);
 	});
 
 	test.each([
@@ -2836,20 +2937,56 @@ describe("runtime manifest reconciliation invariants", () => {
 		const secretFile = join(paths.managedSecretRoot, "egress-secrets.json");
 		const sidecarUnit = join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service");
 
-		expect(converge(activeManifest, "000000").installErrors).toEqual([]);
+		const initial = converge(activeManifest, "000000");
+		expect(initial.installErrors).toEqual([]);
+		const renderedGatewayUnit = initial.outputs.systemdUserUnits[0];
+		if (!renderedGatewayUnit) throw new Error("active runtime did not render a gateway unit");
+		const gatewayUnitName = renderedGatewayUnit.split("/").at(-1);
+		if (!gatewayUnitName) throw new Error("rendered gateway unit has no file name");
+		const gatewayUnit = join(
+			paths.systemdUserRoot,
+			`${gatewayUnitName}.d`,
+			"10-clawdi-hosted.conf",
+		);
+		const gatewayEnv = join(paths.systemdEnvRoot, `${gatewayUnitName}.env`);
 		expect(signals.at(-1)).toBe(true);
 		expect(statSync(secretFile).mode & 0o777).toBe(0o600);
 		expect(readFileSync(secretFile, "utf-8")).toContain("000000");
+		const activeGatewayUnit = readFileSync(gatewayUnit, "utf-8");
+		expect(readFileSync(gatewayEnv, "utf-8")).toContain("NODE_EXTRA_CA_CERTS");
 
 		expect(converge(activeManifest, "000000").installErrors).toEqual([]);
 		expect(signals.at(-1)).toBe(false);
+		expect(readFileSync(gatewayUnit, "utf-8")).toBe(activeGatewayUnit);
 
 		expect(converge(activeManifest, "000001").installErrors).toEqual([]);
 		expect(signals.at(-1)).toBe(true);
 		expect(readFileSync(secretFile, "utf-8")).toContain("000001");
+		expect(readFileSync(gatewayUnit, "utf-8")).toBe(activeGatewayUnit);
+
+		const changedProfileManifest: RuntimeManifest = {
+			...activeManifest,
+			egressProfiles: {
+				profiles:
+					activeManifest.egressProfiles?.profiles.map((profile) => ({
+						...profile,
+						priority: profile.priority + 1,
+					})) ?? [],
+			},
+		};
+		expect(converge(changedProfileManifest, "000001").installErrors).toEqual([]);
+		expect(readFileSync(gatewayUnit, "utf-8")).toBe(activeGatewayUnit);
+
+		const noEgressManifest: RuntimeManifest = {
+			...activeManifest,
+			egressProfiles: { profiles: [] },
+		};
+		expect(converge(noEgressManifest, undefined).installErrors).toEqual([]);
+		expect(readFileSync(gatewayUnit, "utf-8")).not.toBe(activeGatewayUnit);
+		expect(readFileSync(gatewayEnv, "utf-8")).not.toContain("NODE_EXTRA_CA_CERTS");
 
 		const noSidecarManifest: RuntimeManifest = {
-			...activeManifest,
+			...changedProfileManifest,
 			runtimes: { openclaw: { ...activeManifest.runtimes.openclaw, enabled: false } },
 		};
 		expect(converge(noSidecarManifest, "000002").installErrors).toEqual([]);
@@ -2868,7 +3005,7 @@ describe("runtime manifest reconciliation invariants", () => {
 
 		expect(converge(deletedManifest, undefined).installErrors).toEqual([]);
 		expect(signals.at(-1)).toBe(false);
-		expect(signals).toEqual([true, false, true, false, false, false]);
+		expect(signals).toEqual([true, false, true, false, false, false, false, false]);
 	});
 
 	test("recovers committed egress secrets before retrying a crash-interrupted sidecar load", () => {
@@ -3901,5 +4038,20 @@ describe("runtime manifest reconciliation invariants", () => {
 			),
 		).toBe("sk-stripped");
 		expect(runtimeSecretValue({}, "secret://providers/default/api-key")).toBeNull();
+	});
+
+	test("uses a discovered apply-context snapshot instead of stale process env", () => {
+		delete process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE;
+		process.env.OPENCLAW_GATEWAY_TOKEN = "stale-process-token";
+		const projected = normalizeSecretValues(
+			markProjectedRuntimeEnvironment({
+				"env://OPENCLAW_GATEWAY_TOKEN": "projected-file-token",
+			}),
+		);
+
+		expect(runtimeSecretValue(projected, "env://OPENCLAW_GATEWAY_TOKEN")).toBe(
+			"projected-file-token",
+		);
+		expect(runtimeSecretValue(projected, "env://MISSING_TOKEN")).toBeNull();
 	});
 });

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -17,6 +17,7 @@ import { convergeRuntimeManifest, type RuntimeManifest } from "./manifest";
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
+import { projectedRuntimeEnvironment } from "./secret-values";
 
 const originalEnv = { ...process.env };
 const originalConsoleWarn = console.warn;
@@ -478,10 +479,7 @@ describe("runtime manifest services", () => {
 
 	test("renders the Hermes password dashboard directly", () => {
 		const paths = tempRuntimePaths();
-		process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = join(
-			paths.runRoot,
-			"runtime-apply-identity.json",
-		);
+		const applyIdentityPath = join(paths.runRoot, "runtime-apply-identity.json");
 		process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "stale-dashboard-password";
 		process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "stale-dashboard-session-secret";
 		process.env.RUNTIME_SOURCE_TOKEN = "stale-runtime-source-token";
@@ -538,16 +536,31 @@ describe("runtime manifest services", () => {
 			},
 			recovery: {},
 		};
+		const projectedValues = {
+			CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+			CLAWDI_AUTH_TOKEN: "test-token",
+			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "dashboard-password",
+			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "dashboard-session-secret",
+			RUNTIME_SOURCE_TOKEN: "runtime-source-token",
+		};
+		const applyContext = {
+			kind: "identity-file" as const,
+			identity: {
+				generation: 1,
+				manifestETag: '"manifest-1"',
+				applyReceiptId: "apply-receipt-0001",
+				bootNonce: "boot-nonce-000001",
+			},
+			sourcePath: applyIdentityPath,
+			runtimeEnvironment: projectedRuntimeEnvironment(projectedValues),
+		};
 		const load: RuntimeManifestLoad = {
 			manifest,
 			source: "fixture-file",
 			sourcePath: "inline-hermes-single",
 			offline: false,
+			applyContext,
 			secretValues: {
-				"env://CLAWDI_AUTH_TOKEN": "test-token",
-				"env://HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "dashboard-password",
-				"env://HERMES_DASHBOARD_BASIC_AUTH_SECRET": "dashboard-session-secret",
-				"env://RUNTIME_SOURCE_TOKEN": "runtime-source-token",
 				"secret://runtime/token": "bundle-runtime-token",
 				"secret://unrelated": "unrelated-inline-secret",
 			},
@@ -657,10 +670,13 @@ describe("runtime manifest services", () => {
 		const rotated = convergeRuntimeManifest(
 			{
 				...load,
-				secretValues: {
-					...load.secretValues,
-					"env://HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "rotated-dashboard-password",
-					"env://HERMES_DASHBOARD_BASIC_AUTH_SECRET": "rotated-dashboard-session-secret",
+				applyContext: {
+					...applyContext,
+					runtimeEnvironment: projectedRuntimeEnvironment({
+						...projectedValues,
+						HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "rotated-dashboard-password",
+						HERMES_DASHBOARD_BASIC_AUTH_SECRET: "rotated-dashboard-session-secret",
+					}),
 				},
 			},
 			paths,
@@ -710,9 +726,12 @@ describe("runtime manifest services", () => {
 			{
 				...load,
 				manifest: sourceChangedManifest,
-				secretValues: {
-					...load.secretValues,
-					"env://NEXT_RUNTIME_SOURCE_TOKEN": "next-runtime-source-value",
+				applyContext: {
+					...applyContext,
+					runtimeEnvironment: projectedRuntimeEnvironment({
+						...projectedValues,
+						NEXT_RUNTIME_SOURCE_TOKEN: "next-runtime-source-value",
+					}),
 				},
 			},
 			paths,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -478,9 +478,13 @@ describe("runtime manifest services", () => {
 
 	test("renders the Hermes password dashboard directly", () => {
 		const paths = tempRuntimePaths();
-		process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "dashboard-password";
-		process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "dashboard-session-secret";
-		process.env.RUNTIME_SOURCE_TOKEN = "runtime-source-token";
+		process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = join(
+			paths.runRoot,
+			"runtime-apply-identity.json",
+		);
+		process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "stale-dashboard-password";
+		process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "stale-dashboard-session-secret";
+		process.env.RUNTIME_SOURCE_TOKEN = "stale-runtime-source-token";
 		process.env.UNRELATED_RUNTIME_SECRET = "must-not-be-exposed";
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
 		const warnings: string[] = [];
@@ -540,6 +544,10 @@ describe("runtime manifest services", () => {
 			sourcePath: "inline-hermes-single",
 			offline: false,
 			secretValues: {
+				"env://CLAWDI_AUTH_TOKEN": "test-token",
+				"env://HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "dashboard-password",
+				"env://HERMES_DASHBOARD_BASIC_AUTH_SECRET": "dashboard-session-secret",
+				"env://RUNTIME_SOURCE_TOKEN": "runtime-source-token",
 				"secret://runtime/token": "bundle-runtime-token",
 				"secret://unrelated": "unrelated-inline-secret",
 			},
@@ -585,6 +593,7 @@ describe("runtime manifest services", () => {
 		);
 		const watchUnitPath = join(paths.systemdSystemRoot, "clawdi-runtime-watch.service");
 		const watchUnit = readFileSync(watchUnitPath, "utf8");
+		const gatewayUnit = readUserServiceConfig(paths, "hermes-gateway");
 		const watchEnvPath = join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env");
 		const watchEnvStat = statSync(watchEnvPath);
 		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME="admin"');
@@ -645,14 +654,23 @@ describe("runtime manifest services", () => {
 		expect(hermesConfig).not.toContain("dashboard-session-secret");
 		expect(existsSync(runtimeRunConfigPath("openclaw", paths))).toBe(false);
 
-		// Changing process.env here models platform reinjection before a watcher
-		// restart. A running watcher cannot acquire a newly injected or rotated
-		// source variable by rewriting its EnvironmentFile.
-		process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "rotated-dashboard-password";
-		process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "rotated-dashboard-session-secret";
-		process.env.RUNTIME_SOURCE_TOKEN = "rotated-runtime-source-token";
-		const rotated = convergeRuntimeManifest(load, paths);
+		const rotated = convergeRuntimeManifest(
+			{
+				...load,
+				secretValues: {
+					...load.secretValues,
+					"env://HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "rotated-dashboard-password",
+					"env://HERMES_DASHBOARD_BASIC_AUTH_SECRET": "rotated-dashboard-session-secret",
+				},
+			},
+			paths,
+		);
 		expect(rotated.installErrors).toEqual([]);
+		const rotatedDashboardUnit = readFileSync(
+			join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
+			"utf8",
+		);
+		const rotatedGatewayUnit = readUserServiceConfig(paths, "hermes-gateway");
 		const rotatedWatchEnv = readFileSync(watchEnvPath, "utf8");
 		const rotatedWatchUnit = readFileSync(watchUnitPath, "utf8");
 		expect(rotatedWatchEnv).toContain(
@@ -661,7 +679,7 @@ describe("runtime manifest services", () => {
 		expect(rotatedWatchEnv).toContain(
 			'HERMES_DASHBOARD_BASIC_AUTH_SECRET="rotated-dashboard-session-secret"',
 		);
-		expect(rotatedWatchEnv).toContain('RUNTIME_TARGET_TOKEN="rotated-runtime-source-token"');
+		expect(rotatedWatchEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
 		expect(rotatedWatchEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
 		expect(rotatedWatchEnv).not.toContain(
 			'HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="dashboard-password"',
@@ -669,8 +687,10 @@ describe("runtime manifest services", () => {
 		expect(rotatedWatchEnv).not.toContain(
 			'HERMES_DASHBOARD_BASIC_AUTH_SECRET="dashboard-session-secret"',
 		);
-		expect(rotatedWatchEnv).not.toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
-		// Value-only rotation must not alter the public unit or its revision.
+		expect(rotatedDashboardUnit).not.toBe(dashboardUnit);
+		expect(rotatedGatewayUnit).toBe(gatewayUnit);
+		// The root watcher consumes projected files on each tick, so its public
+		// unit need not restart solely to acquire rotated secret bytes.
 		expect(rotatedWatchUnit).toBe(watchUnit);
 		expect(rotatedWatchUnit).not.toContain("runtime-source-token");
 		expect(rotatedWatchUnit).not.toContain("rotated-runtime-source-token");
@@ -687,7 +707,14 @@ describe("runtime manifest services", () => {
 		process.env.NEXT_RUNTIME_SOURCE_TOKEN = "next-runtime-source-value";
 		sourceChangedRun.secretEnv.RUNTIME_TARGET_TOKEN = "env://NEXT_RUNTIME_SOURCE_TOKEN";
 		const sourceChanged = convergeRuntimeManifest(
-			{ ...load, manifest: sourceChangedManifest },
+			{
+				...load,
+				manifest: sourceChangedManifest,
+				secretValues: {
+					...load.secretValues,
+					"env://NEXT_RUNTIME_SOURCE_TOKEN": "next-runtime-source-value",
+				},
+			},
 			paths,
 		);
 		expect(sourceChanged.installErrors).toEqual([]);

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -8,6 +8,11 @@ import {
 } from "./applied-state";
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import {
+	type RuntimeApplyContext,
+	type RuntimeApplyIdentity,
+	readRuntimeApplyContext,
+} from "./apply-identity";
+import {
 	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
 	runtimeAuthTokenFileLabel,
@@ -33,15 +38,26 @@ import {
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
 import { createRuntimeSecretResolver } from "./runtime-secret-resolver";
-import { canonicalSecretRefName, normalizeSecretValues } from "./secret-values";
+import {
+	canonicalSecretRefName,
+	envSecretRefName,
+	markProjectedRuntimeEnvironment,
+	normalizeSecretValues,
+} from "./secret-values";
 
 export interface RuntimeManifestLoad {
 	manifest: RuntimeManifest;
 	source: "fixture-file" | "remote-datasource" | "last-good-cache";
 	sourcePath: string;
 	offline: boolean;
-	// Values supplied by the manifest datasource. Keep this deploy-surface map provider-only.
+	// Datasource values plus the in-memory exact projected env-secret snapshot.
 	secretValues?: Record<string, string>;
+	// Exact projected authority captured before fetching this manifest.
+	applyIdentity?: RuntimeApplyIdentity;
+	// null means this load deliberately used the legacy process environment.
+	applyIdentityFilePath?: string | null;
+	// In-memory only; undefined is reserved for direct internal/test loads.
+	applyIdentityRuntimeEnv?: Record<string, string> | null;
 	channelBindings?: RuntimeBundleChannelBinding[];
 	sourceRevision?: string;
 	// Original datasource manifest before local runtime projections are applied.
@@ -124,6 +140,9 @@ export interface RuntimeManifestNotModified {
 	sourcePath: string;
 	notModified: true;
 	etag?: string;
+	applyIdentity?: RuntimeApplyIdentity;
+	applyIdentityFilePath?: string | null;
+	applyIdentityRuntimeEnv?: Record<string, string> | null;
 }
 
 export interface RuntimeManifestFailure {
@@ -317,13 +336,22 @@ function rawGeneration(value: unknown): number | null {
 	return typeof generation === "number" && Number.isInteger(generation) ? generation : null;
 }
 
-function runtimeCredential(paths: RuntimePaths): string | null {
-	ensureRuntimeAuthTokenFile(paths);
+function runtimeCredential(
+	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext | null,
+): string | null {
+	ensureRuntimeAuthTokenFile(paths, applyContext?.runtimeEnv ?? null);
 	return readRuntimeAuthToken(paths);
 }
 
-function resolveRuntimeSource(paths: RuntimePaths): RuntimeSource {
-	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
+function resolveRuntimeSource(
+	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext | null,
+): RuntimeSource {
+	const explicit =
+		applyContext?.runtimeEnv === null || !applyContext
+			? process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim()
+			: applyContext.runtimeEnv.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
 	if (explicit) {
 		let url: URL;
 		try {
@@ -371,6 +399,7 @@ function readRuntimeSource(paths: RuntimePaths): RuntimeSource {
 
 async function fetchRuntimeManifestPayload(
 	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext | null,
 	opts: { ifNoneMatch?: string } = {},
 ): Promise<
 	| {
@@ -384,8 +413,8 @@ async function fetchRuntimeManifestPayload(
 			etag?: string;
 	  }
 > {
-	const source = resolveRuntimeSource(paths);
-	const token = runtimeCredential(paths);
+	const source = resolveRuntimeSource(paths, applyContext);
+	const token = runtimeCredential(paths, applyContext);
 	if (!token) {
 		throw new Error(`missing ${runtimeAuthTokenFileLabel(paths)}`);
 	}
@@ -440,9 +469,15 @@ export async function loadRemoteRuntimeManifest(
 	paths: RuntimePaths,
 	opts: { ifNoneMatch?: string } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure | RuntimeManifestNotModified> {
+	let applyContext: RuntimeApplyContext | null;
+	try {
+		applyContext = readRuntimeApplyContext();
+	} catch (error) {
+		return runtimeApplyContextFailure(error);
+	}
 	let fetched: Awaited<ReturnType<typeof fetchRuntimeManifestPayload>>;
 	try {
-		fetched = await fetchRuntimeManifestPayload(paths, opts);
+		fetched = await fetchRuntimeManifestPayload(paths, applyContext, opts);
 	} catch (error) {
 		return {
 			mode: "repair",
@@ -460,6 +495,7 @@ export async function loadRemoteRuntimeManifest(
 			sourcePath: fetched.url,
 			notModified: true,
 			etag: fetched.etag ?? opts.ifNoneMatch,
+			...runtimeApplyContextLoadFields(applyContext),
 		};
 	}
 
@@ -470,7 +506,10 @@ export async function loadRemoteRuntimeManifest(
 		sourceRevision?: string;
 	};
 	try {
-		normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+		normalized = bindRuntimeApplyContext(
+			normalizeRemoteManifestPayload(fetched.raw, paths),
+			applyContext,
+		);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -482,9 +521,50 @@ export async function loadRemoteRuntimeManifest(
 	}
 	const loaded = validateLoadedManifest(normalized, paths, "remote-datasource", fetched.url);
 	if ("manifest" in loaded) {
-		return { ...loaded, etag: fetched.etag };
+		return {
+			...loaded,
+			etag: fetched.etag,
+			...runtimeApplyContextLoadFields(applyContext),
+		};
 	}
 	return loaded;
+}
+
+function runtimeApplyContextFailure(error: unknown): RuntimeManifestFailure {
+	return {
+		mode: "repair",
+		stage: "local",
+		errors: [error instanceof Error ? error.message : String(error)],
+	};
+}
+
+function runtimeApplyContextLoadFields(applyContext: RuntimeApplyContext | null): {
+	applyIdentity?: RuntimeApplyIdentity;
+	applyIdentityFilePath: string | null;
+	applyIdentityRuntimeEnv: Record<string, string> | null;
+} {
+	return {
+		...(applyContext ? { applyIdentity: applyContext.identity } : {}),
+		applyIdentityFilePath: applyContext?.sourcePath ?? null,
+		applyIdentityRuntimeEnv: applyContext?.runtimeEnv ?? null,
+	};
+}
+
+function bindRuntimeApplyContext<
+	T extends {
+		secretValues?: Record<string, string>;
+	},
+>(input: T, applyContext: RuntimeApplyContext | null): T {
+	if (applyContext?.runtimeEnv === null || !applyContext) return input;
+	const secretValues = markProjectedRuntimeEnvironment(
+		Object.fromEntries(
+			Object.entries(input.secretValues ?? {}).filter(([ref]) => envSecretRefName(ref) === null),
+		),
+	);
+	for (const [envName, value] of Object.entries(applyContext.runtimeEnv)) {
+		secretValues[`env://${envName}`] = value;
+	}
+	return { ...input, secretValues };
 }
 
 function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
@@ -774,6 +854,12 @@ export async function loadRuntimeManifest(
 	paths: RuntimePaths,
 	opts: { manifestPath?: string } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
+	let applyContext: RuntimeApplyContext | null;
+	try {
+		applyContext = readRuntimeApplyContext();
+	} catch (error) {
+		return runtimeApplyContextFailure(error);
+	}
 	const manifestPath = opts.manifestPath ?? runtimeManifestFixturePath();
 	if (
 		manifestPath &&
@@ -789,13 +875,13 @@ export async function loadRuntimeManifest(
 	if (!manifestPath) {
 		let fetched: { url: string; raw: unknown; etag?: string };
 		try {
-			const result = await fetchRuntimeManifestPayload(paths);
+			const result = await fetchRuntimeManifestPayload(paths, applyContext);
 			if ("notModified" in result) {
 				throw new Error("runtime manifest datasource returned 304 without If-None-Match");
 			}
 			fetched = result;
 		} catch (error) {
-			const cached = loadLastGoodManifest(paths);
+			const cached = loadLastGoodManifest(paths, offlineLastGoodManifestLoadOptions, applyContext);
 			if ("manifest" in cached) return cached;
 			return {
 				mode: "repair",
@@ -811,7 +897,10 @@ export async function loadRuntimeManifest(
 
 		let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 		try {
-			normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+			normalized = bindRuntimeApplyContext(
+				normalizeRemoteManifestPayload(fetched.raw, paths),
+				applyContext,
+			);
 		} catch (error) {
 			return {
 				mode: "manifest-rejected",
@@ -822,7 +911,13 @@ export async function loadRuntimeManifest(
 			};
 		}
 		const loaded = validateLoadedManifest(normalized, paths, "remote-datasource", fetched.url);
-		if ("manifest" in loaded) return { ...loaded, etag: fetched.etag };
+		if ("manifest" in loaded) {
+			return {
+				...loaded,
+				etag: fetched.etag,
+				...runtimeApplyContextLoadFields(applyContext),
+			};
+		}
 		return loaded;
 	}
 
@@ -858,7 +953,7 @@ export async function loadRuntimeManifest(
 	}
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = normalizeManifestFixturePayload(raw, paths);
+		normalized = bindRuntimeApplyContext(normalizeManifestFixturePayload(raw, paths), applyContext);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -885,7 +980,11 @@ export async function loadRuntimeManifest(
 		};
 	}
 
-	return validateLoadedManifest(normalized, paths, "fixture-file", manifestPath);
+	const loaded = validateLoadedManifest(normalized, paths, "fixture-file", manifestPath);
+	if ("manifest" in loaded) {
+		return { ...loaded, ...runtimeApplyContextLoadFields(applyContext) };
+	}
+	return loaded;
 }
 
 interface LastGoodManifestLoadOptions {
@@ -903,6 +1002,7 @@ const offlineLastGoodManifestLoadOptions: LastGoodManifestLoadOptions = {
 function loadLastGoodManifest(
 	paths: RuntimePaths,
 	opts: LastGoodManifestLoadOptions = offlineLastGoodManifestLoadOptions,
+	applyContext: RuntimeApplyContext | null = readRuntimeApplyContext(),
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	if (!existsSync(paths.manifestLastGood)) {
 		return {
@@ -937,11 +1037,12 @@ function loadLastGoodManifest(
 			manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
 		const cached = loadCachedSecretValues(paths);
 		if ("errors" in cached) return cached;
+		const boundCached = bindRuntimeApplyContext(cached, applyContext);
 		const secretRefs = manifestSecretRefs(manifest);
 		if (secretRefs.length > 0) {
 			const missingSecretRefs = manifestSecretRefsMissingValues(
 				manifest,
-				cached.secretValues,
+				boundCached.secretValues,
 				paths,
 			);
 			if (missingSecretRefs.length > 0) {
@@ -972,7 +1073,14 @@ function loadLastGoodManifest(
 				resolveRuntimeApplyGeneration(appliedState) !== resolveRuntimeApplyGeneration(manifest) ||
 				appliedState.instanceId !== manifest.instanceId ||
 				appliedState.contentIdentity.sha256 !==
-					runtimeContentSha256({ manifest, secretValues: cached.secretValues }))
+					runtimeContentSha256({
+						manifest,
+						secretValues: Object.fromEntries(
+							Object.entries(boundCached.secretValues).filter(
+								([ref]) => envSecretRefName(ref) === null,
+							),
+						),
+					}))
 		) {
 			return {
 				mode: "repair",
@@ -989,7 +1097,8 @@ function loadLastGoodManifest(
 				source: "last-good-cache",
 				sourcePath: paths.manifestLastGood,
 				offline: true,
-				secretValues: cached.secretValues,
+				secretValues: boundCached.secretValues,
+				...runtimeApplyContextLoadFields(applyContext),
 			};
 		}
 		return {
@@ -997,6 +1106,7 @@ function loadLastGoodManifest(
 			source: "last-good-cache",
 			sourcePath: paths.manifestLastGood,
 			offline: true,
+			...runtimeApplyContextLoadFields(applyContext),
 		};
 	} catch (error) {
 		return {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -8,15 +8,11 @@ import {
 } from "./applied-state";
 import {
 	type RuntimeApplyContext,
-	type RuntimeApplyIdentity,
 	readRuntimeApplyContext,
 	resolveRuntimeApplyGeneration,
+	runtimeApplyIdentitiesEqual,
 } from "./apply-identity";
-import {
-	ensureRuntimeAuthTokenFile,
-	readRuntimeAuthToken,
-	runtimeAuthTokenFileLabel,
-} from "./auth-token";
+import { readRuntimeCredential, runtimeAuthTokenFileLabel } from "./auth-token";
 import { egressProfileSecretRefs } from "./egress-profiles";
 import {
 	hostedManifestEgressProfiles,
@@ -332,8 +328,7 @@ function rawGeneration(value: unknown): number | null {
 }
 
 function runtimeCredential(paths: RuntimePaths, applyContext: RuntimeApplyContext): string | null {
-	ensureRuntimeAuthTokenFile(paths, applyContext.runtimeEnvironment);
-	return readRuntimeAuthToken(paths);
+	return readRuntimeCredential(paths, applyContext.runtimeEnvironment);
 }
 
 function resolveRuntimeSource(
@@ -1014,6 +1009,20 @@ function loadLastGoodManifest(
 		const cachedApplyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
 		const strictV2Cache =
 			manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+		if (
+			opts.requireOfflineBoot &&
+			(strictV2Cache || cachedApplyIdentity !== null) &&
+			!runtimeApplyIdentitiesEqual(applyContext.identity, cachedApplyIdentity)
+		) {
+			return {
+				mode: "repair",
+				stage: "local",
+				errors: [
+					"cached strict-v2 apply identity does not match the current runtime apply identity; refusing offline boot",
+				],
+				activeGeneration: appliedState?.generation ?? null,
+			};
+		}
 		const cached = loadCachedSecretValues(paths);
 		if ("errors" in cached) return cached;
 		const boundCached = bindRuntimeApplyContext(cached, applyContext);

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -6,11 +6,11 @@ import {
 	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
 } from "./applied-state";
-import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import {
 	type RuntimeApplyContext,
 	type RuntimeApplyIdentity,
 	readRuntimeApplyContext,
+	resolveRuntimeApplyGeneration,
 } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
@@ -41,8 +41,8 @@ import { createRuntimeSecretResolver } from "./runtime-secret-resolver";
 import {
 	canonicalSecretRefName,
 	envSecretRefName,
-	markProjectedRuntimeEnvironment,
 	normalizeSecretValues,
+	type RuntimeEnvironmentAuthority,
 } from "./secret-values";
 
 export interface RuntimeManifestLoad {
@@ -50,14 +50,11 @@ export interface RuntimeManifestLoad {
 	source: "fixture-file" | "remote-datasource" | "last-good-cache";
 	sourcePath: string;
 	offline: boolean;
-	// Datasource values plus the in-memory exact projected env-secret snapshot.
+	// Datasource secret values; env:// refs resolve only through applyContext.
 	secretValues?: Record<string, string>;
-	// Exact projected authority captured before fetching this manifest.
-	applyIdentity?: RuntimeApplyIdentity;
-	// null means this load deliberately used the legacy process environment.
-	applyIdentityFilePath?: string | null;
-	// In-memory only; undefined is reserved for direct internal/test loads.
-	applyIdentityRuntimeEnv?: Record<string, string> | null;
+	// In-memory apply identity and the single env:// authority selected before fetch.
+	// Undefined is reserved for direct internal/test loads, which use process.env.
+	applyContext?: RuntimeApplyContext;
 	channelBindings?: RuntimeBundleChannelBinding[];
 	sourceRevision?: string;
 	// Original datasource manifest before local runtime projections are applied.
@@ -140,9 +137,7 @@ export interface RuntimeManifestNotModified {
 	sourcePath: string;
 	notModified: true;
 	etag?: string;
-	applyIdentity?: RuntimeApplyIdentity;
-	applyIdentityFilePath?: string | null;
-	applyIdentityRuntimeEnv?: Record<string, string> | null;
+	applyContext?: RuntimeApplyContext;
 }
 
 export interface RuntimeManifestFailure {
@@ -336,22 +331,16 @@ function rawGeneration(value: unknown): number | null {
 	return typeof generation === "number" && Number.isInteger(generation) ? generation : null;
 }
 
-function runtimeCredential(
-	paths: RuntimePaths,
-	applyContext: RuntimeApplyContext | null,
-): string | null {
-	ensureRuntimeAuthTokenFile(paths, applyContext?.runtimeEnv ?? null);
+function runtimeCredential(paths: RuntimePaths, applyContext: RuntimeApplyContext): string | null {
+	ensureRuntimeAuthTokenFile(paths, applyContext.runtimeEnvironment);
 	return readRuntimeAuthToken(paths);
 }
 
 function resolveRuntimeSource(
 	paths: RuntimePaths,
-	applyContext: RuntimeApplyContext | null,
+	applyContext: RuntimeApplyContext,
 ): RuntimeSource {
-	const explicit =
-		applyContext?.runtimeEnv === null || !applyContext
-			? process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim()
-			: applyContext.runtimeEnv.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
+	const explicit = applyContext.runtimeEnvironment.values.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
 	if (explicit) {
 		let url: URL;
 		try {
@@ -399,7 +388,7 @@ function readRuntimeSource(paths: RuntimePaths): RuntimeSource {
 
 async function fetchRuntimeManifestPayload(
 	paths: RuntimePaths,
-	applyContext: RuntimeApplyContext | null,
+	applyContext: RuntimeApplyContext,
 	opts: { ifNoneMatch?: string } = {},
 ): Promise<
 	| {
@@ -469,7 +458,7 @@ export async function loadRemoteRuntimeManifest(
 	paths: RuntimePaths,
 	opts: { ifNoneMatch?: string } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure | RuntimeManifestNotModified> {
-	let applyContext: RuntimeApplyContext | null;
+	let applyContext: RuntimeApplyContext;
 	try {
 		applyContext = readRuntimeApplyContext();
 	} catch (error) {
@@ -538,32 +527,21 @@ function runtimeApplyContextFailure(error: unknown): RuntimeManifestFailure {
 	};
 }
 
-function runtimeApplyContextLoadFields(applyContext: RuntimeApplyContext | null): {
-	applyIdentity?: RuntimeApplyIdentity;
-	applyIdentityFilePath: string | null;
-	applyIdentityRuntimeEnv: Record<string, string> | null;
+function runtimeApplyContextLoadFields(applyContext: RuntimeApplyContext): {
+	applyContext: RuntimeApplyContext;
 } {
-	return {
-		...(applyContext ? { applyIdentity: applyContext.identity } : {}),
-		applyIdentityFilePath: applyContext?.sourcePath ?? null,
-		applyIdentityRuntimeEnv: applyContext?.runtimeEnv ?? null,
-	};
+	return { applyContext };
 }
 
 function bindRuntimeApplyContext<
 	T extends {
 		secretValues?: Record<string, string>;
 	},
->(input: T, applyContext: RuntimeApplyContext | null): T {
-	if (applyContext?.runtimeEnv === null || !applyContext) return input;
-	const secretValues = markProjectedRuntimeEnvironment(
-		Object.fromEntries(
-			Object.entries(input.secretValues ?? {}).filter(([ref]) => envSecretRefName(ref) === null),
-		),
+>(input: T, applyContext: RuntimeApplyContext): T {
+	if (applyContext.kind !== "identity-file") return input;
+	const secretValues = Object.fromEntries(
+		Object.entries(input.secretValues ?? {}).filter(([ref]) => envSecretRefName(ref) === null),
 	);
-	for (const [envName, value] of Object.entries(applyContext.runtimeEnv)) {
-		secretValues[`env://${envName}`] = value;
-	}
 	return { ...input, secretValues };
 }
 
@@ -854,7 +832,7 @@ export async function loadRuntimeManifest(
 	paths: RuntimePaths,
 	opts: { manifestPath?: string } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
-	let applyContext: RuntimeApplyContext | null;
+	let applyContext: RuntimeApplyContext;
 	try {
 		applyContext = readRuntimeApplyContext();
 	} catch (error) {
@@ -967,6 +945,7 @@ export async function loadRuntimeManifest(
 		normalized.manifest,
 		normalized.secretValues,
 		paths,
+		applyContext.runtimeEnvironment,
 	);
 	if (missingSecretRefs.length > 0) {
 		return {
@@ -1002,7 +981,7 @@ const offlineLastGoodManifestLoadOptions: LastGoodManifestLoadOptions = {
 function loadLastGoodManifest(
 	paths: RuntimePaths,
 	opts: LastGoodManifestLoadOptions = offlineLastGoodManifestLoadOptions,
-	applyContext: RuntimeApplyContext | null = readRuntimeApplyContext(),
+	applyContext: RuntimeApplyContext = readRuntimeApplyContext(),
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	if (!existsSync(paths.manifestLastGood)) {
 		return {
@@ -1044,6 +1023,7 @@ function loadLastGoodManifest(
 				manifest,
 				boundCached.secretValues,
 				paths,
+				applyContext.runtimeEnvironment,
 			);
 			if (missingSecretRefs.length > 0) {
 				return {
@@ -1201,9 +1181,15 @@ function manifestSecretRefsMissingValues(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	paths: RuntimePaths,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): string[] {
 	const normalizedValues = normalizeSecretValues(secretValues ?? {});
-	const resolver = createRuntimeSecretResolver(manifest, paths, normalizedValues);
+	const resolver = createRuntimeSecretResolver(
+		manifest,
+		paths,
+		normalizedValues,
+		runtimeEnvironment,
+	);
 	return manifestSecretRefs(manifest).filter((ref) => resolver.resolve(ref) === null);
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -53,8 +53,17 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
-import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
-import { ensureRuntimeAuthTokenFile } from "./auth-token";
+import {
+	RUNTIME_APPLY_IDENTITY_FILE_ENV,
+	runtimeApplyIdentityEnvironment,
+	runtimeApplyIdentityServiceEnvironment,
+} from "./apply-identity";
+import {
+	ensureRuntimeAuthTokenFile,
+	RUNTIME_AUTH_TOKEN_SECRET_REF,
+	readRuntimeAuthToken,
+	writeRuntimeAuthToken,
+} from "./auth-token";
 import {
 	adoptableLegacyHostedBundledSkill,
 	assertHostedBundledSkillCatalogDigest,
@@ -2322,6 +2331,7 @@ function applyHostedAiProviderProjection(
 	name: string,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
+	secretValues: Record<string, string> | undefined,
 	home: string,
 	workspaceRoot: string,
 	previousProviderIds: readonly string[],
@@ -2339,7 +2349,13 @@ function applyHostedAiProviderProjection(
 	assertHostedProviderProjectionMode(name, manifest, projectionInput);
 	if (manifest.runtimes[name]?.providerMode === "configured" && !projectionInput) {
 		if (name === "openclaw") {
-			applyOpenClawGatewayHostedProjection(observation.commandPath, manifest, home, workspaceRoot);
+			applyOpenClawGatewayHostedProjection(
+				observation.commandPath,
+				manifest,
+				secretValues,
+				home,
+				workspaceRoot,
+			);
 		}
 		return { path: null, revision: null, providerIds: [...previousProviderIds] };
 	}
@@ -2352,7 +2368,13 @@ function applyHostedAiProviderProjection(
 		);
 	}
 	if (name === "openclaw") {
-		applyOpenClawGatewayHostedProjection(observation.commandPath, manifest, home, workspaceRoot);
+		applyOpenClawGatewayHostedProjection(
+			observation.commandPath,
+			manifest,
+			secretValues,
+			home,
+			workspaceRoot,
+		);
 		const activeProviderIds = projectionInput
 			? [...openClawProjectedProviderIds(projectionInput)].sort()
 			: [];
@@ -2390,7 +2412,7 @@ function previewHostedAiProviderProjectionRevision(
 	managedModelOverrides: ManagedGatewayModelOverrides,
 ): string | null {
 	if (
-		name !== "hermes" ||
+		(name !== "openclaw" && name !== "hermes") ||
 		!observation.enabled ||
 		observation.status === "install_failed" ||
 		!observation.commandPath
@@ -2406,6 +2428,32 @@ function previewHostedAiProviderProjectionRevision(
 	assertHostedProviderProjectionMode(name, manifest, projectionInput);
 	if (manifest.runtimes[name]?.providerMode === "configured" && !projectionInput) {
 		return null;
+	}
+	if (name === "openclaw") {
+		const activeProviderIds = projectionInput
+			? [...openClawProjectedProviderIds(projectionInput)].sort()
+			: [];
+		const deletedProviderIds = staleProviderIds(
+			new Set(previousProviderIds),
+			new Set(activeProviderIds),
+		);
+		if (!projectionInput) {
+			return revisionHash({
+				openClawProviderProjection: "delete",
+				patch: openClawProviderDeletePatch(deletedProviderIds),
+			});
+		}
+		const projection = buildAgentTargetProjection(
+			"openclaw",
+			projectionInput.catalog,
+			projectionInput.primaryModel,
+		);
+		const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
+		if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
+		return revisionHash({
+			openClawProviderProjection: "json-patch",
+			patch: mergeOpenClawProviderDeletes(file.content, deletedProviderIds),
+		});
 	}
 	return applyHostedHermesAiProviderProjection(
 		observation,
@@ -2869,9 +2917,15 @@ function staleProviderIds(
 		.sort((left, right) => left.localeCompare(right));
 }
 
-function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, unknown> | null {
+function openClawGatewayHostedPatch(
+	manifest: RuntimeManifest,
+	secretValues: Record<string, string> | undefined,
+): Record<string, unknown> | null {
 	const allowedOrigins = openClawControlUiAllowedOrigins(manifest);
-	const gatewayToken = process.env[OPENCLAW_GATEWAY_TOKEN_ENV]?.trim();
+	const gatewayToken = runtimeSecretValue(
+		secretValues ?? {},
+		manifest.openclawGatewayAuth?.tokenRef ?? `env://${OPENCLAW_GATEWAY_TOKEN_ENV}`,
+	);
 	const isHostedV2 = manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
 	const nativeAuth = isHostedV2 ? manifest.openclawGatewayAuth : undefined;
 	if (isHostedV2 && nativeAuth?.activation.enabled !== true) {
@@ -2936,10 +2990,11 @@ function openClawControlUiBasePath(manifest: RuntimeManifest): string {
 function applyOpenClawGatewayHostedProjection(
 	command: string,
 	manifest: RuntimeManifest,
+	secretValues: Record<string, string> | undefined,
 	home: string,
 	workspaceRoot: string,
 ): void {
-	const patch = openClawGatewayHostedPatch(manifest);
+	const patch = openClawGatewayHostedPatch(manifest, secretValues);
 	if (!patch) return;
 	runRuntimeUserCommand(
 		command,
@@ -3484,6 +3539,22 @@ function applyHostedBundledSkills(
 		for (const entry of readdirSync(targetDir)) makeRuntimeUserOwned(join(targetDir, entry));
 	}
 	return targets;
+}
+
+function hostedBundledSkillProjection(
+	manifest: RuntimeManifest,
+	runtime: string,
+): Array<{ id: string; version: number; digest: string }> | null {
+	if (runtime !== "openclaw" && runtime !== "hermes") return null;
+	if (manifest.runtimes[runtime]?.enabled !== true) return [];
+	return hostedBundledSkillIds()
+		.sort((left, right) => left.localeCompare(right))
+		.flatMap((skillId) => {
+			const desired = manifest.projection?.skills?.entries[skillId];
+			if (desired?.enabled !== true) return [];
+			const bundled = resolveHostedBundledSkill(skillId, desired.version);
+			return [{ id: bundled.id, version: bundled.version, digest: bundled.digest }];
+		});
 }
 
 function applyHostedMcpProjections(
@@ -4298,8 +4369,22 @@ function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: Runt
 	);
 }
 
-function writeDaemonAuthToken(paths: RuntimePaths): string | null {
-	const path = ensureRuntimeAuthTokenFile(paths);
+function writeDaemonAuthToken(
+	paths: RuntimePaths,
+	secretValues: Record<string, string> | undefined,
+	applyIdentityRuntimeEnv: Record<string, string> | null | undefined,
+): string | null {
+	if (applyIdentityRuntimeEnv !== undefined) {
+		const path = ensureRuntimeAuthTokenFile(paths, applyIdentityRuntimeEnv);
+		if (!path) return null;
+		makeManagedSecretRoot(dirname(path));
+		makeRootOwned(path);
+		return path;
+	}
+	const projectedToken = runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF);
+	const path = projectedToken
+		? writeRuntimeAuthToken(paths, projectedToken)
+		: ensureRuntimeAuthTokenFile(paths);
 	if (!path) return null;
 	makeManagedSecretRoot(dirname(path));
 	makeRootOwned(path);
@@ -4333,19 +4418,40 @@ export function runtimeProgramRevision(
 	providerProjectionRevision: string | null = null,
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
+	const desiredProgram = desiredRuntime
+		? Object.fromEntries(Object.entries(desiredRuntime).filter(([field]) => field !== "services"))
+		: null;
 	const runtimeSecretRefs = desiredRuntime
 		? Object.values(
 				mergeRuntimeSecretEnv(runtime, desiredRuntime, hostedProviderSecretEnv(manifest, runtime)),
 			)
 		: [];
+	const channels = hostedChannelProjection(manifest);
+	const hostedTarget = runtime === "openclaw" || runtime === "hermes";
+	const channelProjection = channels
+		? runtime === "openclaw"
+			? openClawManagedChannelsPatch(channels)
+			: runtime === "hermes"
+				? hermesManagedChannelsPatch(
+						channels,
+						manifest.controlPlane.apiUrl,
+						manifest.projection?.channelCredentials,
+					)
+				: null
+		: null;
 	return revisionHash({
-		clawdiCli: manifest.clawdiCli ?? null,
-		controlPlane: manifest.controlPlane,
-		egressProfiles: manifest.egressProfiles ?? null,
-		locale: manifest.locale ?? null,
-		projection: manifest.projection ?? null,
-		providerProjectionRevision,
-		runtime: desiredRuntime ?? null,
+		renderedProjection: {
+			channels: channelProjection,
+			gateway: runtime === "openclaw" ? openClawGatewayHostedPatch(manifest, secretValues) : null,
+			locale:
+				manifest.locale && hostedTarget
+					? managedLocaleBlock(manifest.locale)
+					: (manifest.locale?.timezone ?? null),
+			mcp: hostedTarget ? hostedMcpIntent(manifest) : null,
+			provider: providerProjectionRevision,
+			skills: hostedBundledSkillProjection(manifest, runtime),
+		},
+		runtime: desiredProgram,
 		secretValues: scopedSecretValues(secretValues, runtimeSecretRefs),
 	});
 }
@@ -4356,8 +4462,6 @@ function runtimeServiceProgramRevision(
 	service: string,
 ): string {
 	return revisionHash({
-		clawdiCli: manifest.clawdiCli ?? null,
-		controlPlane: manifest.controlPlane,
 		runtime: runtime,
 		service,
 		settings: manifest.runtimes[runtime]?.services?.[service] ?? null,
@@ -4365,11 +4469,15 @@ function runtimeServiceProgramRevision(
 	});
 }
 
-function daemonProgramRevision(manifest: RuntimeManifest): string {
+export function daemonProgramRevision(
+	manifest: RuntimeManifest,
+	runtimeAuthToken: string | null = null,
+): string {
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		liveSync: manifest.liveSync ?? null,
+		runtimeAuthToken,
 	});
 }
 
@@ -4488,10 +4596,8 @@ export function runtimeSidecarProgramRevision(
 		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
 	}
 	return revisionHash({
-		clawdiCli: manifest.clawdiCli ?? null,
 		runtimeSidecar: "hosted-runtime-sidecar-v4",
 		instanceId: manifest.instanceId,
-		generation: manifest.generation,
 		egressProfiles: manifest.egressProfiles ?? null,
 		egress: egressProgram
 			? {
@@ -5090,24 +5196,31 @@ function removeStaleSystemdEnvironmentFiles(paths: RuntimePaths, writtenUnits: s
 	}
 }
 
-function runtimeManifestUrlEnv(sourcePath: string): string {
+function runtimeManifestUrlEnv(
+	sourcePath: string,
+	secretValues: Record<string, string> | undefined,
+): string {
 	if (/^https?:\/\//i.test(sourcePath)) return sourcePath;
-	return process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim() || "";
+	return runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MANIFEST_URL") ?? "";
 }
 
 function runtimeSystemdCommonEnvironment(
 	sourcePath: string,
 	paths: RuntimePaths,
+	secretValues: Record<string, string> | undefined,
 ): Record<string, string> {
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const runtimeUser =
+		runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_USER") ?? "clawdi";
 	const environment: Record<string, string> = {
 		HOME: paths.userHome,
-		CLAWDI_RUNTIME_MODE: "hosted",
-		CLAWDI_RUNTIME_AUTH_ENV: process.env.CLAWDI_RUNTIME_AUTH_ENV?.trim() ?? "",
+		CLAWDI_RUNTIME_MODE:
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MODE") ?? "hosted",
+		CLAWDI_RUNTIME_AUTH_ENV:
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_AUTH_ENV") ?? "",
 		CLAWDI_RUNTIME_USER: runtimeUser,
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
-		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(sourcePath),
+		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(sourcePath, secretValues),
 		PATH: runtimeSystemdPath(paths),
 	};
 	return environment;
@@ -5205,17 +5318,23 @@ function writeSystemdUnits(
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
 	commonEnvironment: Record<string, string>,
+	applyIdentityFilePath: string | null | undefined,
+	applyIdentity: RuntimeManifestLoad["applyIdentity"],
+	runtimeAuthToken: string | null,
 ): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
 	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
 	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
 	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const userUnits: string[] = [];
 	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
-	const applyIdentityEnvironment = runtimeApplyIdentityEnvironment(
-		readRuntimeApplyIdentityFromEnv(),
-	);
+	const applyIdentityEnvironment =
+		applyIdentityFilePath === undefined
+			? runtimeApplyIdentityServiceEnvironment()
+			: applyIdentityFilePath === null
+				? runtimeApplyIdentityEnvironment(applyIdentity ?? null)
+				: { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: applyIdentityFilePath };
 	if (daemonAuthTokenFile) {
 		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
 		systemUnits.push(
@@ -5234,8 +5353,8 @@ function writeSystemdUnits(
 				},
 				// Unit files are 0644. Hash only secret destination names into their
 				// revision so the unit cannot become an offline verifier for values.
-				// A running watcher acquires rotated values only after the platform
-				// reinjects its environment and restarts it.
+				// The watcher resolves values from the atomic apply-context file on
+				// each tick; keep secret bytes out of its public revision material.
 				revisionEnv: {
 					...commonEnvironment,
 					...applyIdentityEnvironment,
@@ -5263,7 +5382,7 @@ function writeSystemdUnits(
 					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
 					CLAWDI_NO_AUTO_UPDATE: "1",
 					CLAWDI_NO_UPDATE_CHECK: "1",
-					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
+					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest, runtimeAuthToken),
 				},
 			}),
 		);
@@ -5839,7 +5958,7 @@ function validateRuntimeProjectionPlan(input: {
 			} else if (!configuredProjectionUnavailable) {
 				JSON.stringify(openClawProviderDeletePatch(previousProjectedProviderIds.openclaw ?? []));
 			}
-			JSON.stringify(openClawGatewayHostedPatch(manifest));
+			JSON.stringify(openClawGatewayHostedPatch(manifest, secretValues));
 		}
 		if (name === "hermes") {
 			if (projectionInput && !projectionRequiresInstalledModelProbe) {
@@ -6150,7 +6269,9 @@ export function convergeRuntimeManifest(
 		writeJsonFile(paths.sensitiveInstanceData, {
 			schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
 			generatedAt,
-			tokenSource: process.env.CLAWDI_AUTH_TOKEN ? "CLAWDI_AUTH_TOKEN" : load.source,
+			tokenSource: runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
+				? "CLAWDI_AUTH_TOKEN"
+				: load.source,
 			token: "<redacted>",
 		});
 
@@ -6165,7 +6286,12 @@ export function convergeRuntimeManifest(
 		);
 		requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
 		const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
-		const daemonAuthTokenFile = writeDaemonAuthToken(paths);
+		const daemonAuthTokenFile = writeDaemonAuthToken(
+			paths,
+			secretValues,
+			load.applyIdentityRuntimeEnv,
+		);
+		const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
 		writeSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(manifest));
 		try {
 			materializeHostedChannelCredentials(manifest, secretValues, projectionHome);
@@ -6231,7 +6357,11 @@ export function convergeRuntimeManifest(
 				managedModelOverrides,
 			);
 		}
-		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(load.sourcePath, paths);
+		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(
+			load.sourcePath,
+			paths,
+			secretValues,
+		);
 		try {
 			const codexProjection = applyHostedCodexManagedProviderProjection(
 				manifest,
@@ -6325,6 +6455,7 @@ export function convergeRuntimeManifest(
 					name,
 					observation,
 					manifest,
+					secretValues,
 					projectionHome,
 					workspaceRoot,
 					previousProjectedProviderIds[name] ?? [],
@@ -6443,6 +6574,9 @@ export function convergeRuntimeManifest(
 			secretValues,
 			providerProjectionRevisions,
 			commonSystemdEnvironment,
+			load.applyIdentityFilePath,
+			load.applyIdentity,
+			runtimeAuthToken,
 		);
 		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
 		if (systemdUnits.egressSidecarActive) {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -54,15 +54,14 @@ import {
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
 import {
-	RUNTIME_APPLY_IDENTITY_FILE_ENV,
-	runtimeApplyIdentityEnvironment,
+	type RuntimeApplyContext,
+	runtimeApplyContextServiceEnvironment,
 	runtimeApplyIdentityServiceEnvironment,
 } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	RUNTIME_AUTH_TOKEN_SECRET_REF,
 	readRuntimeAuthToken,
-	writeRuntimeAuthToken,
 } from "./auth-token";
 import {
 	adoptableLegacyHostedBundledSkill,
@@ -106,6 +105,8 @@ import {
 import {
 	isEnvSecretRef,
 	normalizeSecretValues,
+	processRuntimeEnvironment,
+	type RuntimeEnvironmentAuthority,
 	runtimeSecretValue as resolveRuntimeSecretValue,
 } from "./secret-values";
 
@@ -214,6 +215,7 @@ type RuntimeSystemdApplyResult = {
 interface RuntimeSystemdApplySignal {
 	// Private, in-memory apply metadata. It must not enter convergence outputs,
 	// status, diagnostics, logs, or any generated public artifact.
+	restartDaemon: boolean;
 	restartEgressSidecar: boolean;
 }
 
@@ -224,8 +226,9 @@ interface RuntimeSystemdApplyHooks {
 }
 
 export interface RuntimePrivateAppliedAuthority {
-	// This is a secret-dependent verifier and may only be persisted in the
+	// These are secret-dependent verifiers and may only be persisted in the
 	// root-owned 0600 applied-state authority.
+	daemonAuthTokenRevision?: string;
 	egressSidecarSecretRevision?: string;
 }
 
@@ -439,6 +442,7 @@ const MANAGED_HERMES_WHATSAPP_AUTH_ROOT = [".hermes", "platforms", "whatsapp"] a
 function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	home: string,
 ): void {
 	if (!hostedChannelCredentialsDeclared(manifest)) return;
@@ -457,7 +461,11 @@ function materializeHostedChannelCredentials(
 			continue;
 		}
 		expectedAuthDirs.add(resolve(credential.authDir));
-		const credsJson = resolveRuntimeSecretValue(normalizedSecrets, credential.credsJsonSecretRef);
+		const credsJson = resolveRuntimeSecretValue(
+			normalizedSecrets,
+			credential.credsJsonSecretRef,
+			runtimeEnvironment,
+		);
 		if (!credsJson) {
 			removeManagedWhatsAppAuthDir(credential.authDir);
 			errors.push(
@@ -480,6 +488,7 @@ function materializeHostedChannelCredentials(
 function validateHostedChannelCredentialsPlan(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	home: string,
 ): void {
 	if (!hostedChannelCredentialsDeclared(manifest) || !WHATSAPP_UPSTREAM_READY) return;
@@ -487,7 +496,11 @@ function validateHostedChannelCredentialsPlan(
 	for (const credential of hostedWhatsAppAuthCredentials(manifest)) {
 		const authDirError = managedWhatsAppAuthDirError(home, credential);
 		if (authDirError) throw new Error(authDirError);
-		const credsJson = resolveRuntimeSecretValue(normalizedSecrets, credential.credsJsonSecretRef);
+		const credsJson = resolveRuntimeSecretValue(
+			normalizedSecrets,
+			credential.credsJsonSecretRef,
+			runtimeEnvironment,
+		);
 		if (!credsJson) {
 			throw new Error(
 				`missing WhatsApp auth state secret for ${credential.accountKey}/${credential.credentialId}`,
@@ -793,7 +806,7 @@ function scopedSecretValues(
 		if (isEnvSecretRef(ref) && !options.resolveEnv) continue;
 		const value = options.resolver
 			? options.resolver.resolve(ref)
-			: resolveRuntimeSecretValue(normalizedValues, ref);
+			: resolveRuntimeSecretValue(normalizedValues, ref, processRuntimeEnvironment());
 		if (!value) {
 			if (options.require?.(ref)) throw new Error(`Runtime secret ${ref} is unavailable.`);
 			continue;
@@ -816,6 +829,7 @@ export function runtimeRecoverableSecretValues(
 function writeProviderHealthStatus(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	paths: RuntimePaths,
 ): string | null {
 	const providers = recordValue(manifest.projection?.providers);
@@ -832,7 +846,7 @@ function writeProviderHealthStatus(
 		const secretAvailable =
 			apiKeySecretRef === null
 				? null
-				: providerSecretAvailable(secretValues ?? {}, apiKeySecretRef);
+				: providerSecretAvailable(secretValues ?? {}, apiKeySecretRef, runtimeEnvironment);
 		const reasons = providerHealthReasons(provider, secretAvailable);
 		observed[providerId] = {
 			status: reasons.length > 0 ? "error" : "ok",
@@ -867,8 +881,12 @@ function writeProviderHealthStatus(
 	return paths.providerHealthStatus;
 }
 
-function providerSecretAvailable(secretValues: Record<string, string>, ref: string): boolean {
-	return resolveRuntimeSecretValue(secretValues, ref) !== null;
+function providerSecretAvailable(
+	secretValues: Record<string, string>,
+	ref: string,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): boolean {
+	return resolveRuntimeSecretValue(secretValues, ref, runtimeEnvironment) !== null;
 }
 
 function providerHealthReasons(
@@ -2086,8 +2104,9 @@ function egressSecretMaterial(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	paths: RuntimePaths,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): RuntimeEgressSecretMaterial {
-	const resolver = createRuntimeSecretResolver(manifest, paths, secretValues);
+	const resolver = createRuntimeSecretResolver(manifest, paths, secretValues, runtimeEnvironment);
 	const scoped = scopedSecretValues(secretValues, egressSecretRefs(manifest), {
 		resolveEnv: true,
 		resolver,
@@ -2140,6 +2159,7 @@ function writeEgressSecretFile(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	paths: RuntimePaths,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): {
 	path: string | null;
 	changed: boolean;
@@ -2148,7 +2168,7 @@ function writeEgressSecretFile(
 } {
 	const secretFilePath = egressSecretFilePath(paths);
 	const previousContent = existsSync(secretFilePath) ? readFileSync(secretFilePath, "utf-8") : null;
-	const material = egressSecretMaterial(manifest, secretValues, paths);
+	const material = egressSecretMaterial(manifest, secretValues, paths, runtimeEnvironment);
 	const path = writeEgressSecretMaterial(material, paths);
 	return {
 		path,
@@ -2179,7 +2199,12 @@ function verifiedCommittedEgressSecretMaterial(
 		const committed = loadCommittedRuntimeManifest(paths);
 		if ("errors" in committed) return null;
 		if (egressSecretRefs(committed.manifest).some(isEnvSecretRef)) return null;
-		return egressSecretMaterial(committed.manifest, committed.secretValues, paths);
+		return egressSecretMaterial(
+			committed.manifest,
+			committed.secretValues,
+			paths,
+			committed.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment(),
+		);
 	} catch {
 		return null;
 	}
@@ -2266,7 +2291,7 @@ interface HostedCodexManagedProvider {
 	apiKeySecretRef: string | null;
 }
 
-type HostedAiProviderProjectionInput = {
+export type HostedAiProviderProjectionInput = {
 	catalog: AiProviderCatalog;
 	primaryModel: AgentPrimaryModel;
 };
@@ -2332,6 +2357,7 @@ function applyHostedAiProviderProjection(
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	home: string,
 	workspaceRoot: string,
 	previousProviderIds: readonly string[],
@@ -2353,6 +2379,7 @@ function applyHostedAiProviderProjection(
 				observation.commandPath,
 				manifest,
 				secretValues,
+				runtimeEnvironment,
 				home,
 				workspaceRoot,
 			);
@@ -2372,33 +2399,25 @@ function applyHostedAiProviderProjection(
 			observation.commandPath,
 			manifest,
 			secretValues,
+			runtimeEnvironment,
 			home,
 			workspaceRoot,
 		);
-		const activeProviderIds = projectionInput
-			? [...openClawProjectedProviderIds(projectionInput)].sort()
-			: [];
-		const deletedProviderIds = staleProviderIds(
-			new Set(previousProviderIds),
-			new Set(activeProviderIds),
-		);
-		if (projectionInput) {
-			applyOpenClawHostedProviderProjection(
+		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
+		if (providerPatch.apply) {
+			runRuntimeUserCommand(
 				observation.commandPath,
-				projectionInput,
-				deletedProviderIds,
-				home,
-				workspaceRoot,
-			);
-		} else if (deletedProviderIds.length > 0) {
-			applyOpenClawHostedProviderDeleteProjection(
-				observation.commandPath,
-				deletedProviderIds,
+				["config", "patch", "--stdin", ...providerPatch.args],
+				providerPatch.content,
 				home,
 				workspaceRoot,
 			);
 		}
-		return { path: observation.commandPath, revision: null, providerIds: activeProviderIds };
+		return {
+			path: observation.commandPath,
+			revision: null,
+			providerIds: providerPatch.providerIds,
+		};
 	}
 	return { path: null, revision: null, providerIds: [] };
 }
@@ -2430,29 +2449,16 @@ function previewHostedAiProviderProjectionRevision(
 		return null;
 	}
 	if (name === "openclaw") {
-		const activeProviderIds = projectionInput
-			? [...openClawProjectedProviderIds(projectionInput)].sort()
-			: [];
-		const deletedProviderIds = staleProviderIds(
-			new Set(previousProviderIds),
-			new Set(activeProviderIds),
-		);
+		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
 		if (!projectionInput) {
 			return revisionHash({
 				openClawProviderProjection: "delete",
-				patch: openClawProviderDeletePatch(deletedProviderIds),
+				patch: JSON.parse(providerPatch.content) as unknown,
 			});
 		}
-		const projection = buildAgentTargetProjection(
-			"openclaw",
-			projectionInput.catalog,
-			projectionInput.primaryModel,
-		);
-		const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
-		if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
 		return revisionHash({
 			openClawProviderProjection: "json-patch",
-			patch: mergeOpenClawProviderDeletes(file.content, deletedProviderIds),
+			patch: providerPatch.content,
 		});
 	}
 	return applyHostedHermesAiProviderProjection(
@@ -2746,13 +2752,26 @@ function removeLegacyHermesModelProviderPlugin(home: string): void {
 	rmSync(legacyHermesModelProviderPluginDir(home), { recursive: true, force: true });
 }
 
-function applyOpenClawHostedProviderProjection(
-	command: string,
-	projectionInput: HostedAiProviderProjectionInput,
-	deletedProviderIds: readonly string[],
-	home: string,
-	workspaceRoot: string,
-): void {
+export interface OpenClawHostedProviderPatch {
+	apply: boolean;
+	args: string[];
+	content: string;
+	providerIds: string[];
+}
+
+export function buildOpenClawHostedProviderPatch(
+	projectionInput: HostedAiProviderProjectionInput | null,
+	previousProviderIds: readonly string[],
+): OpenClawHostedProviderPatch {
+	if (!projectionInput) {
+		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
+		return {
+			apply: deletedProviderIds.length > 0,
+			args: [],
+			content: `${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`,
+			providerIds: [],
+		};
+	}
 	const projection = buildAgentTargetProjection(
 		"openclaw",
 		projectionInput.catalog,
@@ -2760,41 +2779,14 @@ function applyOpenClawHostedProviderProjection(
 	);
 	const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
 	if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
-	runRuntimeUserCommand(
-		command,
-		["config", "patch", "--stdin", ...openClawProviderModelReplacementArgs(file.content)],
-		mergeOpenClawProviderDeletes(file.content, deletedProviderIds),
-		home,
-		workspaceRoot,
-	);
-}
-
-function applyOpenClawHostedProviderDeleteProjection(
-	command: string,
-	deletedProviderIds: readonly string[],
-	home: string,
-	workspaceRoot: string,
-): void {
-	runRuntimeUserCommand(
-		command,
-		["config", "patch", "--stdin"],
-		`${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`,
-		home,
-		workspaceRoot,
-	);
-}
-
-function openClawProjectedProviderIds(
-	projectionInput: HostedAiProviderProjectionInput,
-): Set<string> {
-	const projection = buildAgentTargetProjection(
-		"openclaw",
-		projectionInput.catalog,
-		projectionInput.primaryModel,
-	);
-	const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
-	if (!file) return new Set();
-	return openClawProviderIdsFromPatch(file.content);
+	const providerIds = [...openClawProviderIdsFromPatch(file.content)].sort();
+	const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set(providerIds));
+	return {
+		apply: true,
+		args: openClawProviderModelReplacementArgs(file.content),
+		content: mergeOpenClawProviderDeletes(file.content, deletedProviderIds),
+		providerIds,
+	};
 }
 
 function openClawProviderIdsFromPatch(content: string): Set<string> {
@@ -2920,11 +2912,13 @@ function staleProviderIds(
 function openClawGatewayHostedPatch(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): Record<string, unknown> | null {
 	const allowedOrigins = openClawControlUiAllowedOrigins(manifest);
 	const gatewayToken = runtimeSecretValue(
 		secretValues ?? {},
 		manifest.openclawGatewayAuth?.tokenRef ?? `env://${OPENCLAW_GATEWAY_TOKEN_ENV}`,
+		runtimeEnvironment,
 	);
 	const isHostedV2 = manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
 	const nativeAuth = isHostedV2 ? manifest.openclawGatewayAuth : undefined;
@@ -2991,10 +2985,11 @@ function applyOpenClawGatewayHostedProjection(
 	command: string,
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	home: string,
 	workspaceRoot: string,
 ): void {
-	const patch = openClawGatewayHostedPatch(manifest, secretValues);
+	const patch = openClawGatewayHostedPatch(manifest, secretValues, runtimeEnvironment);
 	if (!patch) return;
 	runRuntimeUserCommand(
 		command,
@@ -4371,24 +4366,20 @@ function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: Runt
 
 function writeDaemonAuthToken(
 	paths: RuntimePaths,
-	secretValues: Record<string, string> | undefined,
-	applyIdentityRuntimeEnv: Record<string, string> | null | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): string | null {
-	if (applyIdentityRuntimeEnv !== undefined) {
-		const path = ensureRuntimeAuthTokenFile(paths, applyIdentityRuntimeEnv);
-		if (!path) return null;
-		makeManagedSecretRoot(dirname(path));
-		makeRootOwned(path);
-		return path;
-	}
-	const projectedToken = runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF);
-	const path = projectedToken
-		? writeRuntimeAuthToken(paths, projectedToken)
-		: ensureRuntimeAuthTokenFile(paths);
+	const path = ensureRuntimeAuthTokenFile(paths, runtimeEnvironment);
 	if (!path) return null;
 	makeManagedSecretRoot(dirname(path));
 	makeRootOwned(path);
 	return path;
+}
+
+function daemonAuthTokenRevision(token: string): string {
+	return runtimeContentSha256({
+		schemaVersion: "clawdi.daemonAuthTokenRevision.v1",
+		token,
+	});
 }
 
 function canonicalize(value: unknown): unknown {
@@ -4416,6 +4407,7 @@ export function runtimeProgramRevision(
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevision: string | null = null,
+	runtimeEnvironment: RuntimeEnvironmentAuthority = processRuntimeEnvironment(),
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const desiredProgram = desiredRuntime
@@ -4442,7 +4434,10 @@ export function runtimeProgramRevision(
 	return revisionHash({
 		renderedProjection: {
 			channels: channelProjection,
-			gateway: runtime === "openclaw" ? openClawGatewayHostedPatch(manifest, secretValues) : null,
+			gateway:
+				runtime === "openclaw"
+					? openClawGatewayHostedPatch(manifest, secretValues, runtimeEnvironment)
+					: null,
 			locale:
 				manifest.locale && hostedTarget
 					? managedLocaleBlock(manifest.locale)
@@ -4469,15 +4464,11 @@ function runtimeServiceProgramRevision(
 	});
 }
 
-export function daemonProgramRevision(
-	manifest: RuntimeManifest,
-	runtimeAuthToken: string | null = null,
-): string {
+export function daemonProgramRevision(manifest: RuntimeManifest): string {
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		liveSync: manifest.liveSync ?? null,
-		runtimeAuthToken,
 	});
 }
 
@@ -4537,6 +4528,7 @@ function buildRuntimeSystemdUserProgram(input: {
 	config: RuntimeRunConfig;
 	paths: RuntimePaths;
 	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
 	egress: RuntimeEgressSystemdProgram | null;
 }): RuntimeSystemdUserProgram | null {
 	if (!input.config.enabled) return null;
@@ -4552,7 +4544,7 @@ function buildRuntimeSystemdUserProgram(input: {
 	};
 	const resolvedSecretEnv: Record<string, string> = {};
 	for (const [envName, ref] of Object.entries(input.config.secretEnv)) {
-		const value = runtimeSecretValue(input.secretValues ?? {}, ref);
+		const value = runtimeSecretValue(input.secretValues ?? {}, ref, input.runtimeEnvironment);
 		if (!value) {
 			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
 		}
@@ -4579,8 +4571,12 @@ function buildRuntimeSystemdUserProgram(input: {
 	};
 }
 
-export function runtimeSecretValue(secrets: Record<string, string>, ref: string): string | null {
-	return resolveRuntimeSecretValue(secrets, ref);
+export function runtimeSecretValue(
+	secrets: Record<string, string>,
+	ref: string,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): string | null {
+	return resolveRuntimeSecretValue(secrets, ref, runtimeEnvironment);
 }
 
 function hashToUInt16(input: string): number {
@@ -4661,6 +4657,7 @@ function runtimeSystemdProgramRevision(
 	program: RuntimeSystemdUserProgram,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
+	runtimeEnvironment: RuntimeEnvironmentAuthority = processRuntimeEnvironment(),
 ): string {
 	if (program.service)
 		return runtimeServiceProgramRevision(manifest, program.runtime, program.service);
@@ -4669,6 +4666,7 @@ function runtimeSystemdProgramRevision(
 		program.runtime,
 		secretValues,
 		providerProjectionRevisions[program.runtime] ?? null,
+		runtimeEnvironment,
 	);
 }
 
@@ -5199,28 +5197,43 @@ function removeStaleSystemdEnvironmentFiles(paths: RuntimePaths, writtenUnits: s
 function runtimeManifestUrlEnv(
 	sourcePath: string,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): string {
 	if (/^https?:\/\//i.test(sourcePath)) return sourcePath;
-	return runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MANIFEST_URL") ?? "";
+	return (
+		runtimeSecretValue(
+			secretValues ?? {},
+			"env://CLAWDI_RUNTIME_MANIFEST_URL",
+			runtimeEnvironment,
+		) ?? ""
+	);
 }
 
 function runtimeSystemdCommonEnvironment(
 	sourcePath: string,
 	paths: RuntimePaths,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): Record<string, string> {
 	const runtimeUser =
-		runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_USER") ?? "clawdi";
+		runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_USER", runtimeEnvironment) ??
+		"clawdi";
 	const environment: Record<string, string> = {
 		HOME: paths.userHome,
 		CLAWDI_RUNTIME_MODE:
-			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MODE") ?? "hosted",
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MODE", runtimeEnvironment) ??
+			"hosted",
 		CLAWDI_RUNTIME_AUTH_ENV:
-			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_AUTH_ENV") ?? "",
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_AUTH_ENV", runtimeEnvironment) ??
+			"",
 		CLAWDI_RUNTIME_USER: runtimeUser,
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
-		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(sourcePath, secretValues),
+		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(
+			sourcePath,
+			secretValues,
+			runtimeEnvironment,
+		),
 		PATH: runtimeSystemdPath(paths),
 	};
 	return environment;
@@ -5255,6 +5268,7 @@ function writeRuntimeSystemdUserProgram(input: {
 	manifest: RuntimeManifest;
 	paths: RuntimePaths;
 	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
 	providerProjectionRevisions: Partial<Record<string, string | null>>;
 }): string {
 	const { program } = input;
@@ -5270,6 +5284,7 @@ function writeRuntimeSystemdUserProgram(input: {
 			program,
 			input.secretValues,
 			input.providerProjectionRevisions,
+			input.runtimeEnvironment,
 		),
 		...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
 	};
@@ -5316,11 +5331,10 @@ function writeSystemdUnits(
 	workspaceRoot: string,
 	daemonAuthTokenFile: string | null,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
 	commonEnvironment: Record<string, string>,
-	applyIdentityFilePath: string | null | undefined,
-	applyIdentity: RuntimeManifestLoad["applyIdentity"],
-	runtimeAuthToken: string | null,
+	applyContext: RuntimeApplyContext | undefined,
 ): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
 	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
@@ -5330,11 +5344,9 @@ function writeSystemdUnits(
 	const userUnits: string[] = [];
 	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
 	const applyIdentityEnvironment =
-		applyIdentityFilePath === undefined
+		applyContext === undefined
 			? runtimeApplyIdentityServiceEnvironment()
-			: applyIdentityFilePath === null
-				? runtimeApplyIdentityEnvironment(applyIdentity ?? null)
-				: { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: applyIdentityFilePath };
+			: runtimeApplyContextServiceEnvironment(applyContext);
 	if (daemonAuthTokenFile) {
 		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
 		systemUnits.push(
@@ -5382,7 +5394,7 @@ function writeSystemdUnits(
 					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
 					CLAWDI_NO_AUTO_UPDATE: "1",
 					CLAWDI_NO_UPDATE_CHECK: "1",
-					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest, runtimeAuthToken),
+					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
 				},
 			}),
 		);
@@ -5422,6 +5434,7 @@ function writeSystemdUnits(
 				manifest,
 				paths,
 				secretValues,
+				runtimeEnvironment,
 				providerProjectionRevisions,
 			}),
 		);
@@ -5486,6 +5499,7 @@ function planRuntimeSystemdUserPrograms(input: {
 	workspaceRoot: string;
 	generatedAt: string;
 	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
 	observations: Map<string, RuntimeInstallObservation>;
 	egressProfileBundlePath: string | null;
 	egress: RuntimeEgressSystemdProgram | null;
@@ -5532,6 +5546,7 @@ function planRuntimeSystemdUserPrograms(input: {
 				config: runConfig,
 				paths: input.paths,
 				secretValues: input.secretValues,
+				runtimeEnvironment: input.runtimeEnvironment,
 				egress: input.egress,
 			});
 			if (program) programs.push(program);
@@ -5571,6 +5586,7 @@ function planRuntimeSystemdUserPrograms(input: {
 				config: serviceRunConfig,
 				paths: input.paths,
 				secretValues: input.secretValues,
+				runtimeEnvironment: input.runtimeEnvironment,
 				egress: input.egress,
 			});
 			if (program) programs.push(program);
@@ -5863,6 +5879,7 @@ function validateRuntimeProjectionPlan(input: {
 	paths: RuntimePaths;
 	workspaceRoot: string;
 	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
 	observations: Map<string, RuntimeInstallObservation>;
 	previousProjectedProviderIds: Record<string, string[]>;
 	managedModelOverrides?: ManagedGatewayModelOverrides;
@@ -5872,6 +5889,7 @@ function validateRuntimeProjectionPlan(input: {
 		paths,
 		workspaceRoot,
 		secretValues,
+		runtimeEnvironment,
 		observations,
 		previousProjectedProviderIds,
 		managedModelOverrides,
@@ -5941,24 +5959,14 @@ function validateRuntimeProjectionPlan(input: {
 			managedModelOverrides === undefined;
 		if (name === "openclaw") {
 			if (projectionInput && !projectionRequiresInstalledModelProbe) {
-				const projection = buildAgentTargetProjection(
-					"openclaw",
-					projectionInput.catalog,
-					projectionInput.primaryModel,
-				);
-				const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
-				if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
-				mergeOpenClawProviderDeletes(
-					file.content,
-					staleProviderIds(
-						new Set(previousProjectedProviderIds.openclaw ?? []),
-						openClawProviderIdsFromPatch(file.content),
-					),
+				buildOpenClawHostedProviderPatch(
+					projectionInput,
+					previousProjectedProviderIds.openclaw ?? [],
 				);
 			} else if (!configuredProjectionUnavailable) {
-				JSON.stringify(openClawProviderDeletePatch(previousProjectedProviderIds.openclaw ?? []));
+				buildOpenClawHostedProviderPatch(null, previousProjectedProviderIds.openclaw ?? []);
 			}
-			JSON.stringify(openClawGatewayHostedPatch(manifest, secretValues));
+			JSON.stringify(openClawGatewayHostedPatch(manifest, secretValues, runtimeEnvironment));
 		}
 		if (name === "hermes") {
 			if (projectionInput && !projectionRequiresInstalledModelProbe) {
@@ -5996,7 +6004,7 @@ function validateRuntimeProjectionPlan(input: {
 		}
 	}
 	validateHostedMcpProjectionPlan(manifest, paths, observations);
-	validateHostedChannelCredentialsPlan(manifest, secretValues, home);
+	validateHostedChannelCredentialsPlan(manifest, secretValues, runtimeEnvironment, home);
 }
 
 export function convergeRuntimeManifest(
@@ -6015,6 +6023,7 @@ export function convergeRuntimeManifest(
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
 	const secretValues = runtimeSecretValues(load);
+	const runtimeEnvironment = load.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment();
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	const enabledRuntimes = Object.entries(manifest.runtimes)
@@ -6063,6 +6072,7 @@ export function convergeRuntimeManifest(
 		paths,
 		workspaceRoot,
 		secretValues,
+		runtimeEnvironment,
 		observations,
 		previousProjectedProviderIds,
 	});
@@ -6087,6 +6097,7 @@ export function convergeRuntimeManifest(
 		workspaceRoot,
 		generatedAt,
 		secretValues,
+		runtimeEnvironment,
 		observations,
 		egressProfileBundlePath: plannedEgressProfileBundlePath,
 		egress: null,
@@ -6180,6 +6191,7 @@ export function convergeRuntimeManifest(
 		paths,
 		workspaceRoot,
 		secretValues,
+		runtimeEnvironment,
 		observations,
 		previousProjectedProviderIds,
 		managedModelOverrides,
@@ -6189,6 +6201,8 @@ export function convergeRuntimeManifest(
 	const liveSnapshot = captureRuntimeLiveSnapshot(manifest, paths, workspaceRoot);
 	let systemdActivationAttempted = false;
 	let systemdActivationApplied = false;
+	let restartDaemon = false;
+	let desiredDaemonAuthTokenRevision: string | undefined;
 	let restartEgressSidecar = false;
 	let desiredEgressSidecarSecretRevision: string | undefined;
 	let rollbackEgressSecretOverride: RuntimeEgressSecretMaterial | undefined;
@@ -6269,7 +6283,11 @@ export function convergeRuntimeManifest(
 		writeJsonFile(paths.sensitiveInstanceData, {
 			schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
 			generatedAt,
-			tokenSource: runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
+			tokenSource: runtimeSecretValue(
+				secretValues ?? {},
+				RUNTIME_AUTH_TOKEN_SECRET_REF,
+				runtimeEnvironment,
+			)
 				? "CLAWDI_AUTH_TOKEN"
 				: load.source,
 			token: "<redacted>",
@@ -6286,15 +6304,20 @@ export function convergeRuntimeManifest(
 		);
 		requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
 		const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
-		const daemonAuthTokenFile = writeDaemonAuthToken(
-			paths,
-			secretValues,
-			load.applyIdentityRuntimeEnv,
-		);
+		const daemonAuthTokenFile = writeDaemonAuthToken(paths, runtimeEnvironment);
 		const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
+		if (runtimeAuthToken) {
+			desiredDaemonAuthTokenRevision = daemonAuthTokenRevision(runtimeAuthToken);
+			restartDaemon = desiredDaemonAuthTokenRevision !== appliedState?.daemonAuthTokenRevision;
+		}
 		writeSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(manifest));
 		try {
-			materializeHostedChannelCredentials(manifest, secretValues, projectionHome);
+			materializeHostedChannelCredentials(
+				manifest,
+				secretValues,
+				runtimeEnvironment,
+				projectionHome,
+			);
 		} catch (error) {
 			installErrors.push(
 				`runtime channel credential materialization failed: ${
@@ -6302,7 +6325,12 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		const egressSecretWrite = writeEgressSecretFile(manifest, secretValues, paths);
+		const egressSecretWrite = writeEgressSecretFile(
+			manifest,
+			secretValues,
+			paths,
+			runtimeEnvironment,
+		);
 		const egressSecretFile = egressSecretWrite.path;
 		const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 		const egressSystemdProgram = runtimeEgressSystemdProgram(
@@ -6329,7 +6357,7 @@ export function convergeRuntimeManifest(
 			egressUid,
 			egressGid,
 		});
-		writeProviderHealthStatus(manifest, load.secretValues, paths);
+		writeProviderHealthStatus(manifest, load.secretValues, runtimeEnvironment, paths);
 		const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 		const writtenRunConfigIds = new Set<string>();
 		runtimeSystemdUserPrograms.push(
@@ -6339,6 +6367,7 @@ export function convergeRuntimeManifest(
 				workspaceRoot,
 				generatedAt,
 				secretValues,
+				runtimeEnvironment,
 				observations,
 				egressProfileBundlePath,
 				egress: egressSystemdProgram,
@@ -6361,6 +6390,7 @@ export function convergeRuntimeManifest(
 			load.sourcePath,
 			paths,
 			secretValues,
+			runtimeEnvironment,
 		);
 		try {
 			const codexProjection = applyHostedCodexManagedProviderProjection(
@@ -6456,6 +6486,7 @@ export function convergeRuntimeManifest(
 					observation,
 					manifest,
 					secretValues,
+					runtimeEnvironment,
 					projectionHome,
 					workspaceRoot,
 					previousProjectedProviderIds[name] ?? [],
@@ -6572,11 +6603,10 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			daemonAuthTokenFile,
 			secretValues,
+			runtimeEnvironment,
 			providerProjectionRevisions,
 			commonSystemdEnvironment,
-			load.applyIdentityFilePath,
-			load.applyIdentity,
-			runtimeAuthToken,
+			load.applyContext,
 		);
 		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
 		if (systemdUnits.egressSidecarActive) {
@@ -6641,6 +6671,7 @@ export function convergeRuntimeManifest(
 		) {
 			systemdActivationAttempted = true;
 			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
+				restartDaemon,
 				restartEgressSidecar,
 			});
 			if (!prerequisite.applied) {
@@ -6661,7 +6692,7 @@ export function convergeRuntimeManifest(
 		removeStaleRuntimeSecretFiles(writtenRuntimeSecretIds, paths);
 		if (opts.systemdApply) {
 			systemdActivationAttempted = true;
-			const activation = opts.systemdApply.activate({ restartEgressSidecar });
+			const activation = opts.systemdApply.activate({ restartDaemon, restartEgressSidecar });
 			systemdActivationApplied = activation.applied;
 		}
 		if (installErrors.length === 0 && opts.cacheLastGood !== false) {
@@ -6711,10 +6742,17 @@ export function convergeRuntimeManifest(
 			},
 		};
 		if (installErrors.length === 0) {
+			const daemonRevisionPreviouslyCommitted =
+				desiredDaemonAuthTokenRevision !== undefined &&
+				desiredDaemonAuthTokenRevision === appliedState?.daemonAuthTokenRevision;
 			const egressRevisionPreviouslyCommitted =
 				desiredEgressSidecarSecretRevision !== undefined &&
 				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
 			opts.commitAuthority?.(convergence, {
+				...(desiredDaemonAuthTokenRevision !== undefined &&
+				(systemdActivationApplied || daemonRevisionPreviouslyCommitted)
+					? { daemonAuthTokenRevision: desiredDaemonAuthTokenRevision }
+					: {}),
 				...(desiredEgressSidecarSecretRevision !== undefined &&
 				(systemdActivationApplied || egressRevisionPreviouslyCommitted)
 					? { egressSidecarSecretRevision: desiredEgressSidecarSecretRevision }
@@ -6762,7 +6800,7 @@ export function convergeRuntimeManifest(
 			egressRollbackAuthorityVerified
 		) {
 			try {
-				opts.systemdApply.rollback({ restartEgressSidecar });
+				opts.systemdApply.rollback({ restartDaemon, restartEgressSidecar });
 			} catch (rollbackError) {
 				installErrors.push(
 					`runtime systemd rollback failed: ${

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -39,7 +39,7 @@ function appliedState(generation: number): RuntimeAppliedStateV2 {
 		generation,
 		manifestETag: `"manifest-${generation}"`,
 		applyReceiptId: `apply-receipt-000${generation}`,
-		bootNonce: `boot-nonce-00000${generation}`,
+		bootNonce: "boot-nonce-000001",
 		contentIdentity: {
 			sourcePath: "https://runtime.test/v1/runtime/manifest",
 			sha256: (generation === 1 ? "c" : "d").repeat(64),
@@ -53,7 +53,28 @@ function setApplyIdentityEnvironment(generation: number): void {
 	process.env.CLAWDI_RUNTIME_GENERATION = String(generation);
 	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = `"manifest-${generation}"`;
 	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = `apply-receipt-000${generation}`;
-	process.env.CLAWDI_RUNTIME_BOOT_NONCE = `boot-nonce-00000${generation}`;
+	process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000001";
+}
+
+function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
+	const path = join(paths.runRoot, "secrets", "runtime-apply-identity.json");
+	mkdirSync(dirname(path), { recursive: true });
+	process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = path;
+	writeFileSync(
+		path,
+		JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+			generation,
+			manifestETag: `"manifest-${generation}"`,
+			applyReceiptId: `apply-receipt-000${generation}`,
+			bootNonce: "boot-nonce-000001",
+			runtimeEnv: {
+				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+				CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+				CLAWDI_AUTH_TOKEN: "runtime-auth-token",
+			},
+		}),
+	);
 }
 
 function writeObservationHealth(paths: RuntimePaths, status: "ok" | "error"): void {
@@ -138,9 +159,9 @@ describe("hosted runtime observation producer", () => {
 		});
 	});
 
-	test("re-reads the applied tuple after rotation and emits a new boot identity", async () => {
+	test("re-reads the projected tuple after rotation and preserves the workload boot nonce", async () => {
 		const paths = tempRuntimePaths();
-		setApplyIdentityEnvironment(1);
+		writeApplyIdentityFile(paths, 1);
 		writeRuntimeAppliedState(appliedState(1), paths);
 		const ids = [
 			"boot-000000000001",
@@ -176,7 +197,7 @@ describe("hosted runtime observation producer", () => {
 		});
 
 		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
-		setApplyIdentityEnvironment(2);
+		writeApplyIdentityFile(paths, 2);
 		writeRuntimeAppliedState(appliedState(2), paths);
 		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
 
@@ -194,7 +215,7 @@ describe("hosted runtime observation producer", () => {
 			sequence: 1,
 			eventId: "event-00000000002",
 			applyReceiptId: "apply-receipt-0002",
-			bootNonce: "boot-nonce-000002",
+			bootNonce: "boot-nonce-000001",
 			applied: { generation: 2, etag: '"manifest-2"' },
 		});
 	});

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -154,7 +154,7 @@ describe("hosted runtime observation producer", () => {
 			sequence: 1,
 			eventId: "event-or-boot-identity",
 			applyReceiptId: "apply-receipt-0003",
-			bootNonce: "boot-nonce-000003",
+			bootNonce: "boot-nonce-000001",
 			applied: { generation: 3, etag: '"manifest-3"' },
 		});
 	});

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { log, toErrorMessage } from "../serve/log";
 import { readRuntimeAppliedState, runtimeAppliedApplyIdentity } from "./applied-state";
-import { type RuntimeApplyIdentity, readRuntimeApplyIdentityFromEnv } from "./apply-identity";
+import { type RuntimeApplyIdentity, readRuntimeApplyIdentity } from "./apply-identity";
 import {
 	HostedRuntimeHeartbeatSession,
 	type HostedRuntimeObservedEvent,
@@ -132,7 +132,7 @@ export class HostedRuntimeObservationProducer {
 	}
 
 	private readAttestedContext(): AttestedRuntimeObservationContext | null {
-		const expectedApplyIdentity = readRuntimeApplyIdentityFromEnv();
+		const expectedApplyIdentity = readRuntimeApplyIdentity();
 		if (!expectedApplyIdentity) return null;
 		const appliedState = readRuntimeAppliedState(this.paths);
 		const appliedIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -4,9 +4,13 @@ import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { getCliVersion } from "../lib/version";
 import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-state";
-import { resolveRuntimeApplyGeneration } from "./apply-identity";
+import { readRuntimeApplyContext, resolveRuntimeApplyGeneration } from "./apply-identity";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
-import { runtimeSecretValue } from "./secret-values";
+import {
+	projectedRuntimeEnvironment,
+	type RuntimeEnvironmentAuthority,
+	runtimeSecretValue,
+} from "./secret-values";
 import { type RuntimeBootStatus, readRuntimeBootStatus } from "./state";
 import {
 	isGeneratedRuntimeSystemdFile,
@@ -159,13 +163,16 @@ function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProvide
 		...(readJsonRecord(paths.managedSecretFile) ?? {}),
 		...(readJsonRecord(join(paths.managedSecretRoot, "egress-secrets.json")) ?? {}),
 	};
+	const runtimeEnvironment = observedFallbackRuntimeEnvironment();
 	const observed: HostedRuntimeObservedProviders = {};
 	for (const providerId of Object.keys(providers).sort()) {
 		const provider = recordValue(providers[providerId]);
 		if (!provider) continue;
 		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
 		const secretAvailable =
-			apiKeySecretRef === null ? null : providerSecretAvailable(secrets, apiKeySecretRef);
+			apiKeySecretRef === null
+				? null
+				: providerSecretAvailable(secrets, apiKeySecretRef, runtimeEnvironment);
 		const reasons = providerReasons(provider, secretAvailable);
 		observed[providerId] = {
 			status: reasons.length > 0 ? "error" : "ok",
@@ -181,8 +188,21 @@ function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProvide
 	return Object.keys(observed).length > 0 ? observed : null;
 }
 
-function providerSecretAvailable(secrets: JsonRecord, ref: string): boolean {
-	return runtimeSecretValue(secrets, ref) !== null;
+function observedFallbackRuntimeEnvironment(): RuntimeEnvironmentAuthority {
+	try {
+		return readRuntimeApplyContext().runtimeEnvironment;
+	} catch {
+		// A configured but unreadable identity file must not fall back to ambient env.
+		return projectedRuntimeEnvironment({});
+	}
+}
+
+function providerSecretAvailable(
+	secrets: JsonRecord,
+	ref: string,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): boolean {
+	return runtimeSecretValue(secrets, ref, runtimeEnvironment) !== null;
 }
 
 function providerReasons(provider: JsonRecord, secretAvailable: boolean | null): string[] {

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -5,7 +5,7 @@ import { writePrivateFileAtomic } from "../lib/private-file";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
-import { runtimeSecretValue } from "./secret-values";
+import { processRuntimeEnvironment, runtimeSecretValue } from "./secret-values";
 
 export const runtimeNameSchema = z
 	.string()
@@ -227,7 +227,11 @@ export function buildRuntimeRunInvocation(
 	const env = {
 		...baseEnv,
 		...read.config.env,
-		...runtimeSecretEnv(read.config.secretFilePath, read.config.secretEnv),
+		...runtimeSecretEnv(
+			read.config.secretFilePath,
+			read.config.secretEnv,
+			processRuntimeEnvironment(baseEnv),
+		),
 		...(read.config.secretFilePath && read.config.egressProfileBundlePath
 			? { CLAWDI_EGRESS_SECRET_FILE: read.config.secretFilePath }
 			: {}),
@@ -270,6 +274,7 @@ function defaultRuntimeArgs(runtime: RuntimeName): string[] {
 function runtimeSecretEnv(
 	secretFilePath: string | null,
 	secretEnv: Record<string, string>,
+	runtimeEnvironment: ReturnType<typeof processRuntimeEnvironment>,
 ): Record<string, string> {
 	const entries = Object.entries(secretEnv);
 	if (entries.length === 0) return {};
@@ -294,7 +299,7 @@ function runtimeSecretEnv(
 	}
 	const env: Record<string, string> = {};
 	for (const [envName, ref] of entries) {
-		const value = runtimeSecretValue(secrets, ref);
+		const value = runtimeSecretValue(secrets, ref, runtimeEnvironment);
 		if (!value) {
 			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
 		}

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1048,7 +1048,7 @@ describe("hosted runtime bundle v2", () => {
 			convergence: onlineConvergence,
 			applyIdentity: {
 				generation: 1,
-				manifestETag: '"manifest-golden-1"',
+				manifestETag: '"bundle-golden"',
 				applyReceiptId: "apply-receipt-golden-0001",
 				bootNonce: "boot-nonce-golden-000001",
 			},
@@ -1138,6 +1138,10 @@ describe("hosted runtime bundle v2", () => {
 		rmSync(egressSecretFile);
 		expect(existsSync(egressSecretFile)).toBe(false);
 		networkAvailable = false;
+		process.env.CLAWDI_RUNTIME_GENERATION = "1";
+		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"bundle-golden"';
+		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-golden-0001";
+		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-golden-000001";
 		const offlineLoad = await loadRuntimeManifest(paths);
 		if (!("manifest" in offlineLoad)) throw new Error(JSON.stringify(offlineLoad));
 		expect(offlineLoad.source).toBe("last-good-cache");
@@ -1156,6 +1160,14 @@ describe("hosted runtime bundle v2", () => {
 			expect(offlineEgressSecretStat.gid).toBe(10002);
 		}
 
+		for (const name of [
+			"CLAWDI_RUNTIME_GENERATION",
+			"CLAWDI_RUNTIME_MANIFEST_ETAG",
+			"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
+			"CLAWDI_RUNTIME_BOOT_NONCE",
+		]) {
+			delete process.env[name];
+		}
 		rmSync(paths.appliedState);
 		const uncommittedCacheLoad = await loadRuntimeManifest(paths);
 		expect("errors" in uncommittedCacheLoad).toBe(true);
@@ -1166,6 +1178,10 @@ describe("hosted runtime bundle v2", () => {
 			"cached strict-v2 manifest has no durable applied authority",
 		);
 		writeFileSync(paths.appliedState, appliedStateText);
+		process.env.CLAWDI_RUNTIME_GENERATION = "1";
+		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"bundle-golden"';
+		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-golden-0001";
+		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-golden-000001";
 
 		const committedManifest = z
 			.record(z.string(), z.unknown())

--- a/packages/cli/src/runtime/runtime-secret-resolver.ts
+++ b/packages/cli/src/runtime/runtime-secret-resolver.ts
@@ -2,7 +2,7 @@ import { RUNTIME_AUTH_TOKEN_ENV, readRuntimeAuthToken } from "./auth-token";
 import type { RuntimeManifest } from "./manifest-contract";
 import { hostedMcpDesiredStateSchema } from "./manifest-resources";
 import type { RuntimePaths } from "./paths";
-import { runtimeSecretValue } from "./secret-values";
+import { type RuntimeEnvironmentAuthority, runtimeSecretValue } from "./secret-values";
 
 const HOSTED_MCP_AUTH_SECRET_REF = `env://${RUNTIME_AUTH_TOKEN_ENV}`;
 
@@ -15,6 +15,7 @@ export function createRuntimeSecretResolver(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): RuntimeSecretResolver {
 	const privateFileBackedRefs = new Set<string>();
 	if (paths.mode === "hosted" && hostedMcpAuthSecretRefDeclared(manifest)) {
@@ -24,7 +25,7 @@ export function createRuntimeSecretResolver(
 	return {
 		resolve(ref) {
 			if (privateFileBackedRefs.has(ref)) return readRuntimeAuthToken(paths);
-			return runtimeSecretValue(secretValues ?? {}, ref);
+			return runtimeSecretValue(secretValues ?? {}, ref, runtimeEnvironment);
 		},
 		isPrivateFileBacked(ref) {
 			return privateFileBackedRefs.has(ref);

--- a/packages/cli/src/runtime/runtime-secret-resolver.ts
+++ b/packages/cli/src/runtime/runtime-secret-resolver.ts
@@ -1,4 +1,4 @@
-import { RUNTIME_AUTH_TOKEN_ENV, readRuntimeAuthToken } from "./auth-token";
+import { RUNTIME_AUTH_TOKEN_ENV, readRuntimeCredential } from "./auth-token";
 import type { RuntimeManifest } from "./manifest-contract";
 import { hostedMcpDesiredStateSchema } from "./manifest-resources";
 import type { RuntimePaths } from "./paths";
@@ -24,7 +24,9 @@ export function createRuntimeSecretResolver(
 
 	return {
 		resolve(ref) {
-			if (privateFileBackedRefs.has(ref)) return readRuntimeAuthToken(paths);
+			if (privateFileBackedRefs.has(ref)) {
+				return readRuntimeCredential(paths, runtimeEnvironment);
+			}
 			return runtimeSecretValue(secretValues ?? {}, ref, runtimeEnvironment);
 		},
 		isPrivateFileBacked(ref) {

--- a/packages/cli/src/runtime/secret-values.ts
+++ b/packages/cli/src/runtime/secret-values.ts
@@ -1,7 +1,25 @@
+import { RUNTIME_APPLY_IDENTITY_FILE_ENV } from "./apply-identity";
 import { normalizeSecretRef } from "./hosted-egress-profiles";
 
 const ENV_SECRET_REF_PREFIX = "env://";
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const PROJECTED_RUNTIME_ENV = Symbol("clawdi.projectedRuntimeEnv");
+
+type RuntimeSecretValues = Record<string, unknown> & {
+	[PROJECTED_RUNTIME_ENV]?: true;
+};
+
+export function markProjectedRuntimeEnvironment<T extends Record<string, string>>(values: T): T {
+	Object.defineProperty(values, PROJECTED_RUNTIME_ENV, {
+		value: true,
+		enumerable: true,
+	});
+	return values;
+}
+
+function hasProjectedRuntimeEnvironment(values: Record<string, unknown>): boolean {
+	return (values as RuntimeSecretValues)[PROJECTED_RUNTIME_ENV] === true;
+}
 
 export function envSecretRefName(ref: string): string | null {
 	if (!ref.startsWith(ENV_SECRET_REF_PREFIX)) return null;
@@ -16,6 +34,8 @@ export function isEnvSecretRef(ref: string): boolean {
 export function normalizeSecretValues(
 	secretValues: Record<string, string> | undefined,
 ): Record<string, string> {
+	const projectedRuntimeEnvironment =
+		secretValues !== undefined && hasProjectedRuntimeEnvironment(secretValues);
 	const canonicalValues = new Map<string, string>();
 	for (const [ref, value] of Object.entries(secretValues ?? {})) {
 		if (isEnvSecretRef(ref)) continue;
@@ -35,7 +55,7 @@ export function normalizeSecretValues(
 	for (const [secretRef, value] of canonicalValues) {
 		normalized[secretRef] = value;
 	}
-	return normalized;
+	return projectedRuntimeEnvironment ? markProjectedRuntimeEnvironment(normalized) : normalized;
 }
 
 export function canonicalSecretRefName(ref: string | null | undefined): string | null {
@@ -46,6 +66,13 @@ export function canonicalSecretRefName(ref: string | null | undefined): string |
 export function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
 	const envName = envSecretRefName(ref);
 	if (envName) {
+		if (
+			process.env[RUNTIME_APPLY_IDENTITY_FILE_ENV] !== undefined ||
+			hasProjectedRuntimeEnvironment(secrets)
+		) {
+			const projected = secrets[`${ENV_SECRET_REF_PREFIX}${envName}`];
+			return typeof projected === "string" && projected.length > 0 ? projected : null;
+		}
 		const value = process.env[envName]?.trim();
 		return value ? value : null;
 	}

--- a/packages/cli/src/runtime/secret-values.ts
+++ b/packages/cli/src/runtime/secret-values.ts
@@ -1,24 +1,30 @@
-import { RUNTIME_APPLY_IDENTITY_FILE_ENV } from "./apply-identity";
 import { normalizeSecretRef } from "./hosted-egress-profiles";
 
 const ENV_SECRET_REF_PREFIX = "env://";
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const PROJECTED_RUNTIME_ENV = Symbol("clawdi.projectedRuntimeEnv");
 
-type RuntimeSecretValues = Record<string, unknown> & {
-	[PROJECTED_RUNTIME_ENV]?: true;
-};
-
-export function markProjectedRuntimeEnvironment<T extends Record<string, string>>(values: T): T {
-	Object.defineProperty(values, PROJECTED_RUNTIME_ENV, {
-		value: true,
-		enumerable: true,
-	});
-	return values;
+export interface ProcessRuntimeEnvironment {
+	kind: "process-environment";
+	values: Readonly<Record<string, string | undefined>>;
 }
 
-function hasProjectedRuntimeEnvironment(values: Record<string, unknown>): boolean {
-	return (values as RuntimeSecretValues)[PROJECTED_RUNTIME_ENV] === true;
+export interface ProjectedRuntimeEnvironment {
+	kind: "projected-environment";
+	values: Readonly<Record<string, string>>;
+}
+
+export type RuntimeEnvironmentAuthority = ProcessRuntimeEnvironment | ProjectedRuntimeEnvironment;
+
+export function processRuntimeEnvironment(
+	values: Readonly<Record<string, string | undefined>> = process.env,
+): ProcessRuntimeEnvironment {
+	return { kind: "process-environment", values };
+}
+
+export function projectedRuntimeEnvironment(
+	values: Readonly<Record<string, string>>,
+): ProjectedRuntimeEnvironment {
+	return { kind: "projected-environment", values: { ...values } };
 }
 
 export function envSecretRefName(ref: string): string | null {
@@ -34,8 +40,6 @@ export function isEnvSecretRef(ref: string): boolean {
 export function normalizeSecretValues(
 	secretValues: Record<string, string> | undefined,
 ): Record<string, string> {
-	const projectedRuntimeEnvironment =
-		secretValues !== undefined && hasProjectedRuntimeEnvironment(secretValues);
 	const canonicalValues = new Map<string, string>();
 	for (const [ref, value] of Object.entries(secretValues ?? {})) {
 		if (isEnvSecretRef(ref)) continue;
@@ -55,7 +59,7 @@ export function normalizeSecretValues(
 	for (const [secretRef, value] of canonicalValues) {
 		normalized[secretRef] = value;
 	}
-	return projectedRuntimeEnvironment ? markProjectedRuntimeEnvironment(normalized) : normalized;
+	return normalized;
 }
 
 export function canonicalSecretRefName(ref: string | null | undefined): string | null {
@@ -63,17 +67,14 @@ export function canonicalSecretRefName(ref: string | null | undefined): string |
 	return normalized?.startsWith("secret://") ? normalized.slice("secret://".length) : null;
 }
 
-export function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
+export function runtimeSecretValue(
+	secrets: Record<string, unknown>,
+	ref: string,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): string | null {
 	const envName = envSecretRefName(ref);
 	if (envName) {
-		if (
-			process.env[RUNTIME_APPLY_IDENTITY_FILE_ENV] !== undefined ||
-			hasProjectedRuntimeEnvironment(secrets)
-		) {
-			const projected = secrets[`${ENV_SECRET_REF_PREFIX}${envName}`];
-			return typeof projected === "string" && projected.length > 0 ? projected : null;
-		}
-		const value = process.env[envName]?.trim();
+		const value = runtimeEnvironment.values[envName]?.trim();
 		return value ? value : null;
 	}
 	const normalized = normalizeSecretRef(ref);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -18,7 +18,9 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
+	applySystemdRuntimeUpdate,
 	commitRuntimeAppliedState,
+	readSystemdUnitSnapshot,
 	runtimeAppliedContentIdentity,
 	runtimeInit,
 	runtimePublicContentRevision,
@@ -105,6 +107,7 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_MANIFEST_ETAG",
 	"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
 	"CLAWDI_RUNTIME_BOOT_NONCE",
+	"CLAWDI_RUNTIME_APPLY_IDENTITY_FILE",
 	"CLAWDI_API_URL",
 	"CLAWDI_SYSTEMD_APPLY",
 	"CLAWDI_SYSTEMD_SYSTEM_ROOT",
@@ -297,6 +300,42 @@ echo "seeded clawdi"
 			version,
 			error: null,
 		}),
+	);
+}
+
+function writeRuntimeApplyIdentityFile(
+	path: string,
+	identity: {
+		generation: number;
+		manifestETag: string;
+		applyReceiptId: string;
+		bootNonce: string;
+	},
+	runtimeEnvOverrides: Record<string, string> = {},
+	omitRuntimeEnvNames: readonly string[] = [],
+): void {
+	const runtimeEnv = {
+		CLAWDI_API_URL: "https://cloud-api.test",
+		CLAWDI_RUNTIME_MODE: "hosted",
+		CLAWDI_RUNTIME_USER: process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi",
+		CLAWDI_CLI_PACKAGE_SPEC: "clawdi@0.13.0-test",
+		CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+		CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+		CLAWDI_AUTH_TOKEN: "file-runtime-token",
+		OPENCLAW_GATEWAY_TOKEN: "test-openclaw-gateway-token",
+		HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "test-hermes-dashboard-password",
+		HERMES_DASHBOARD_BASIC_AUTH_SECRET: "test-hermes-dashboard-session-secret",
+		...runtimeEnvOverrides,
+	};
+	for (const name of omitRuntimeEnvNames) delete runtimeEnv[name];
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+			...identity,
+			runtimeEnv,
+		})}\n`,
 	);
 }
 
@@ -6188,6 +6227,7 @@ exit 0
 		const bin = join(root, "bin");
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-watch-channel-patch.jsonl");
+		const applyIdentityPath = join(run, "secrets", "runtime-apply-identity.json");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
@@ -6228,10 +6268,20 @@ fi
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
 		process.env.CLAWDI_RUNTIME_USER = "root";
-		process.env.CLAWDI_RUNTIME_GENERATION = "12";
-		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-watch-12"';
-		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-0012";
-		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000012";
+		process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = applyIdentityPath;
+		writeRuntimeApplyIdentityFile(
+			applyIdentityPath,
+			{
+				generation: 12,
+				manifestETag: '"etag-watch-12"',
+				applyReceiptId: "apply-receipt-0012",
+				bootNonce: "boot-nonce-000012",
+			},
+			{
+				CLAWDI_AUTH_TOKEN: "file-runtime-token",
+				OPENCLAW_GATEWAY_TOKEN: "gateway-token-watch",
+			},
+		);
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token-watch";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
@@ -6346,7 +6396,7 @@ fi
 				etag: '"etag-watch-12"',
 				sourceRevision: "a".repeat(64),
 				generation: 12,
-				manifestETag: '"manifest-watch-12"',
+				manifestETag: '"etag-watch-12"',
 				applyReceiptId: "apply-receipt-0012",
 				bootNonce: "boot-nonce-000012",
 				providerIds: ["default"],
@@ -6396,10 +6446,9 @@ fi
 			);
 			expect(patchText).not.toContain("telegram-agent-token-watch");
 			for (const unitEnv of [watchEnv, daemonEnv]) {
-				expect(unitEnv).toContain('CLAWDI_RUNTIME_GENERATION="12"');
-				expect(unitEnv).toContain('CLAWDI_RUNTIME_MANIFEST_ETAG="\\"manifest-watch-12\\""');
-				expect(unitEnv).toContain('CLAWDI_RUNTIME_APPLY_RECEIPT_ID="apply-receipt-0012"');
-				expect(unitEnv).toContain('CLAWDI_RUNTIME_BOOT_NONCE="boot-nonce-000012"');
+				expect(unitEnv).toContain(`CLAWDI_RUNTIME_APPLY_IDENTITY_FILE="${applyIdentityPath}"`);
+				expect(unitEnv).not.toContain("CLAWDI_RUNTIME_GENERATION");
+				expect(unitEnv).not.toContain("CLAWDI_RUNTIME_APPLY_RECEIPT_ID");
 			}
 		} finally {
 			restore();
@@ -6413,23 +6462,50 @@ fi
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const sourcePath = join(root, "runtime-source.json");
+		const applyIdentityPath = join(run, "secrets", "runtime-apply-identity.json");
+		const systemctlPath = join(root, "bin", "systemctl");
+		const systemctlLog = join(root, "systemctl.log");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
 		let generation = 30;
 		let manifestEtag = '"manifest-generation-30"';
 		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(dirname(systemctlPath), { recursive: true });
+		writeFileSync(
+			systemctlPath,
+			`#!/usr/bin/env bash
+printf '%s\\n' "$*" >> '${systemctlLog}'
+if [ "\${1:-}" = "--user" ]; then shift; fi
+if [ "\${1:-}" = "show" ]; then
+  printf 'LoadState=loaded\\nActiveState=active\\n'
+elif [ "\${1:-}" = "is-enabled" ]; then
+  printf 'enabled\\n'
+fi
+`,
+		);
+		chmodSync(systemctlPath, 0o700);
 		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = applyIdentityPath;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
 		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeRuntimeApplyIdentityFile(applyIdentityPath, {
+			generation,
+			manifestETag: manifestEtag,
+			applyReceiptId: "apply-receipt-generation-0030",
+			bootNonce: "boot-nonce-generation-0001",
+		});
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -6459,6 +6535,28 @@ fi
 
 			generation = 31;
 			manifestEtag = '"manifest-generation-31"';
+			writeRuntimeApplyIdentityFile(applyIdentityPath, {
+				generation,
+				manifestETag: '"manifest-generation-30"',
+				applyReceiptId: "apply-receipt-generation-0031",
+				bootNonce: "boot-nonce-generation-0001",
+			});
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+			expect(process.exitCode).toBe(1);
+			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+				status: "error",
+				stage: "final",
+			});
+			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain("does not match fetched bundle ETag");
+			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(30);
+
+			writeRuntimeApplyIdentityFile(applyIdentityPath, {
+				generation,
+				manifestETag: manifestEtag,
+				applyReceiptId: "apply-receipt-generation-0031",
+				bootNonce: "boot-nonce-generation-0001",
+			});
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -6470,8 +6568,143 @@ fi
 			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
 				etag: '"manifest-generation-31"',
 				generation: 31,
+				manifestETag: '"manifest-generation-31"',
+				applyReceiptId: "apply-receipt-generation-0031",
+				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(watchFetch.captured).toHaveLength(2);
+			expect(watchFetch.captured).toHaveLength(3);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"--user restart openclaw-gateway.service",
+			);
+
+			writeFileSync(systemctlLog, "");
+			process.env.CLAWDI_AUTH_TOKEN = "stale-process-auth-token";
+			process.env.CLAWDI_RUNTIME_AUTH_ENV = "STALE_RUNTIME_AUTH_TOKEN";
+			process.env.STALE_RUNTIME_AUTH_TOKEN = "stale-selected-auth-token";
+			process.env.OPENCLAW_GATEWAY_TOKEN = "stale-process-gateway-token";
+			generation = 32;
+			manifestEtag = '"manifest-generation-32"';
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0032",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				{ CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token" },
+			);
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+				generation: 32,
+				manifestETag: '"manifest-generation-32"',
+				bootNonce: "boot-nonce-generation-0001",
+			});
+			expect(watchFetch.captured.at(-1)?.headers.authorization).toBe(
+				"Bearer rotated-runtime-auth-token",
+			);
+			expect(readFileSync(join(run, "secrets", "auth-token"), "utf-8")).toBe(
+				"rotated-runtime-auth-token\n",
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).toContain("restart clawdi-daemon.service");
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"--user restart openclaw-gateway.service",
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"restart clawdi-runtime-sidecar.service",
+			);
+
+			writeFileSync(systemctlLog, "");
+			generation = 33;
+			manifestEtag = '"manifest-generation-33"';
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0033",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				{
+					CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token",
+					OPENCLAW_GATEWAY_TOKEN: "rotated-projected-gateway-token",
+				},
+			);
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+				generation: 33,
+				manifestETag: '"manifest-generation-33"',
+				bootNonce: "boot-nonce-generation-0001",
+			});
+			expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).toContain(
+				'OPENCLAW_GATEWAY_TOKEN="rotated-projected-gateway-token"',
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).toContain(
+				"--user restart openclaw-gateway.service",
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain("restart clawdi-daemon.service");
+
+			writeFileSync(systemctlLog, "");
+			generation = 34;
+			manifestEtag = '"manifest-generation-34"';
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0034",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				{ CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token" },
+				["OPENCLAW_GATEWAY_TOKEN"],
+			);
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+				status: "error",
+				stage: "final",
+			});
+			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain(
+				"OpenClaw native gateway token is unavailable",
+			);
+			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(33);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"--user restart openclaw-gateway.service",
+			);
+
+			const fetchCountBeforeMissingAuth = watchFetch.captured.length;
+			generation = 35;
+			manifestEtag = '"manifest-generation-35"';
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0035",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				{},
+				["CLAWDI_AUTH_TOKEN"],
+			);
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+				status: "error",
+				stage: "network",
+			});
+			expect(watchFetch.captured).toHaveLength(fetchCountBeforeMissingAuth);
+			expect(existsSync(join(run, "secrets", "auth-token"))).toBe(false);
+			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(33);
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;
@@ -7430,6 +7663,78 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				reasons: ["model_missing", "secret_missing"],
 			},
 		});
+	});
+
+	it("restarts only the Clawdi daemon when the rendered CLI package changes", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const systemctlPath = join(root, "bin", "systemctl");
+		const systemctlLog = join(root, "systemctl.log");
+		mkdirSync(dirname(systemctlPath), { recursive: true });
+		writeFileSync(
+			systemctlPath,
+			`#!/usr/bin/env bash
+printf '%s\\n' "$*" >> '${systemctlLog}'
+if [ "\${1:-}" = "--user" ]; then shift; fi
+if [ "\${1:-}" = "show" ]; then
+  printf 'LoadState=loaded\\nActiveState=active\\n'
+elif [ "\${1:-}" = "is-enabled" ]; then
+  printf 'enabled\\n'
+fi
+`,
+		);
+		chmodSync(systemctlPath, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
+		seedOpenClawBinary(home);
+		const paths = getRuntimePaths();
+		const current = runtimeWatchLocaleManifest(home, 10);
+		expect(
+			convergeRuntimeManifest(
+				{
+					manifest: current,
+					source: "fixture-file",
+					sourcePath: "test://cli-current",
+					offline: false,
+				},
+				paths,
+			).installErrors,
+		).toEqual([]);
+		const before = readSystemdUnitSnapshot(paths);
+		const next: RuntimeManifest = {
+			...current,
+			generation: 11,
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@0.13.1-test",
+				registry: "https://registry.npmjs.org",
+			},
+		};
+		expect(
+			convergeRuntimeManifest(
+				{ manifest: next, source: "fixture-file", sourcePath: "test://cli-next", offline: false },
+				paths,
+			).installErrors,
+		).toEqual([]);
+
+		const applied = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths));
+
+		expect(applied).toEqual({
+			applied: true,
+			systemUnitsChanged: ["clawdi-daemon.service"],
+			userUnitsChanged: [],
+		});
+		const calls = readFileSync(systemctlLog, "utf-8");
+		expect(calls).toContain("restart clawdi-daemon.service");
+		expect(calls).not.toContain("restart openclaw-gateway.service");
+		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
 	});
 
 	it("runtime watch installs changed CLI package specs and marks itself for re-exec", async () => {
@@ -13408,7 +13713,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(readSystemdEnvFile(paths, "clawdi-hermes")).toContain('TZ="Asia/Taipei"');
 	});
 
-	it("runtime program revision changes for control-plane changes but not sibling runtimes", () => {
+	it("runtime program revisions ignore unrelated control-plane and sibling runtime changes", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -13427,12 +13732,22 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.0-test" },
 			runtimes: {
-				openclaw: { enabled: true },
+				openclaw: {
+					enabled: true,
+					services: {
+						worker: {
+							command: "/bin/true",
+							args: [],
+							env: {},
+							prependPath: [],
+						},
+					},
+				},
 				hermes: { enabled: false },
 			},
 			recovery: {},
 		};
-		const revisionFor = (manifest: RuntimeManifest, runtime: string) => {
+		const revisionFor = (manifest: RuntimeManifest, unitName: string) => {
 			const paths = getRuntimePaths();
 			convergeRuntimeManifest(
 				{
@@ -13444,18 +13759,33 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 				},
 				paths,
 			);
-			const unitName = runtime === "openclaw" ? "openclaw-gateway" : `clawdi-${runtime}`;
 			return systemdEnvRevision(readSystemdEnvFile(paths, unitName));
 		};
 
-		const baseRev = revisionFor(baseManifest, "openclaw");
+		const baseRev = revisionFor(baseManifest, "openclaw-gateway");
+		const baseWorkerRev = revisionFor(baseManifest, "clawdi-openclaw-worker");
 		const controlPlaneRev = revisionFor(
 			{
 				...baseManifest,
 				controlPlane: { apiUrl: "https://cloud-api-next.test" },
 			},
-			"openclaw",
+			"openclaw-gateway",
 		);
+		const controlPlaneWorkerRev = revisionFor(
+			{
+				...baseManifest,
+				controlPlane: { apiUrl: "https://cloud-api-next.test" },
+			},
+			"clawdi-openclaw-worker",
+		);
+		const skillOnlyManifest: RuntimeManifest = {
+			...baseManifest,
+			projection: {
+				skills: { entries: { clawdi: { enabled: true, version: 1 } } },
+			},
+		};
+		const skillGatewayRev = revisionFor(skillOnlyManifest, "openclaw-gateway");
+		const skillWorkerRev = revisionFor(skillOnlyManifest, "clawdi-openclaw-worker");
 		const siblingRuntimeRev = revisionFor(
 			{
 				...baseManifest,
@@ -13464,10 +13794,13 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 					hermes: { enabled: true },
 				},
 			},
-			"openclaw",
+			"openclaw-gateway",
 		);
 
-		expect(controlPlaneRev).not.toBe(baseRev);
+		expect(controlPlaneRev).toBe(baseRev);
+		expect(controlPlaneWorkerRev).toBe(baseWorkerRev);
+		expect(skillGatewayRev).not.toBe(baseRev);
+		expect(skillWorkerRev).toBe(baseWorkerRev);
 		expect(siblingRuntimeRev).toBe(baseRev);
 	});
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1586,6 +1586,20 @@ function writeTestRuntimeAppliedState(
 	);
 }
 
+const OFFLINE_RUNTIME_APPLY_IDENTITY = {
+	generation: 3,
+	manifestETag: '"manifest-etag-offline"',
+	applyReceiptId: "apply-receipt-offline-0001",
+	bootNonce: "boot-nonce-offline-000001",
+};
+
+function setRuntimeApplyIdentityEnvironment(identity: typeof OFFLINE_RUNTIME_APPLY_IDENTITY): void {
+	process.env.CLAWDI_RUNTIME_GENERATION = String(identity.generation);
+	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = identity.manifestETag;
+	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = identity.applyReceiptId;
+	process.env.CLAWDI_RUNTIME_BOOT_NONCE = identity.bootNonce;
+}
+
 function writeOfflineStrictAppliedState(
 	paths: RuntimePaths,
 	manifest: RuntimeManifest,
@@ -1599,9 +1613,9 @@ function writeOfflineStrictAppliedState(
 			etag: '"transport-etag-offline"',
 			sourceRevision: "a".repeat(64),
 			generation: manifest.generation,
-			manifestETag: '"manifest-etag-offline"',
-			applyReceiptId: "apply-receipt-offline-0001",
-			bootNonce: "boot-nonce-offline-000001",
+			manifestETag: OFFLINE_RUNTIME_APPLY_IDENTITY.manifestETag,
+			applyReceiptId: OFFLINE_RUNTIME_APPLY_IDENTITY.applyReceiptId,
+			bootNonce: OFFLINE_RUNTIME_APPLY_IDENTITY.bootNonce,
 			contentIdentity: {
 				sourcePath: "https://runtime.test/v1/runtime/manifest",
 				sha256: contentSha256,
@@ -2042,7 +2056,7 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("does not reuse a cached strict-v2 tuple as new applied authority", async () => {
+	it("gates strict-v2 offline cache on the current, durable, and migration identity states", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -2065,6 +2079,7 @@ describe("runtime manifest datasource", () => {
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: { openclaw: { enabled: false } },
+			projection: { sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2" },
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
 		writeFileSync(join(state, "cache", "manifest.last-good.json"), JSON.stringify(manifest));
@@ -2077,24 +2092,46 @@ describe("runtime manifest datasource", () => {
 				secretValues: {},
 			}),
 		);
+		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
 		const loaded = await loadRuntimeManifest(paths);
 		if (!("manifest" in loaded)) {
 			throw new Error(`expected offline manifest load success: ${loaded.errors.join("; ")}`);
 		}
-		const convergence = convergeRuntimeManifest(loaded, paths, { cacheLastGood: false });
-		commitRuntimeAppliedState({
-			load: loaded,
-			paths,
-			etag: '"transport-etag-offline-reapplied"',
-			sourceRevision: "c".repeat(64),
-			convergence,
-			applyIdentity: null,
+		expect(loaded.applyContext?.identity).toEqual(OFFLINE_RUNTIME_APPLY_IDENTITY);
+
+		setRuntimeApplyIdentityEnvironment({
+			...OFFLINE_RUNTIME_APPLY_IDENTITY,
+			applyReceiptId: "apply-receipt-offline-0002",
 		});
-		const reapplied = readRuntimeAppliedState(paths);
-		expect(reapplied?.generation).toBe(3);
-		expect(reapplied?.manifestETag).toBeUndefined();
-		expect(reapplied?.applyReceiptId).toBeUndefined();
-		expect(reapplied?.bootNonce).toBeUndefined();
+		const mismatched = await loadRuntimeManifest(paths);
+		expect("errors" in mismatched).toBe(true);
+		if (!("errors" in mismatched)) throw new Error("expected offline identity mismatch");
+		expect(mismatched.errors).toContain(
+			"cached strict-v2 apply identity does not match the current runtime apply identity; refusing offline boot",
+		);
+
+		const applied = readRuntimeAppliedState(paths);
+		if (!applied) throw new Error("expected durable offline applied state");
+		const {
+			manifestETag: _manifestETag,
+			applyReceiptId: _applyReceiptId,
+			bootNonce: _bootNonce,
+			...legacyApplied
+		} = applied;
+		writeRuntimeAppliedState(legacyApplied, paths);
+		const applyIdentityPath = join(run, "secrets", "runtime-apply-identity.json");
+		writeRuntimeApplyIdentityFile(applyIdentityPath, OFFLINE_RUNTIME_APPLY_IDENTITY, {}, [
+			"CLAWDI_AUTH_TOKEN",
+		]);
+		process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = applyIdentityPath;
+		const firstIdentityFileMigration = await loadRuntimeManifest(paths);
+		expect("errors" in firstIdentityFileMigration).toBe(true);
+		if (!("errors" in firstIdentityFileMigration)) {
+			throw new Error("expected first identity-file migration to fail closed");
+		}
+		expect(firstIdentityFileMigration.errors).toContain(
+			"cached strict-v2 apply identity does not match the current runtime apply identity; refusing offline boot",
+		);
 	});
 
 	it("refuses strict-v2 offline identity restoration when cached manifest content changed", async () => {
@@ -2135,6 +2172,7 @@ describe("runtime manifest datasource", () => {
 				secretValues: {},
 			}),
 		);
+		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
 
 		const loaded = await loadRuntimeManifest(paths);
 		expect("errors" in loaded).toBe(true);
@@ -2195,6 +2233,7 @@ describe("runtime manifest datasource", () => {
 				}),
 			}),
 		);
+		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
 
 		const loaded = await loadRuntimeManifest(paths);
 		expect("errors" in loaded).toBe(true);
@@ -5270,7 +5309,7 @@ exit 64
 		);
 	});
 
-	it("uses the deployment-selected auth env and ignores runtime source file auth", async () => {
+	it("reads the deployment-selected auth env without mutating the legacy token file", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5285,7 +5324,11 @@ exit 64
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CUSTOM_RUNTIME_TOKEN";
 		process.env.CLAWDI_AUTH_TOKEN = "stale-default-token";
 		process.env.CUSTOM_RUNTIME_TOKEN = "bootstrap-token";
-		writeFileSync(join(run, "secrets", "auth-token"), "stale-file-token\n");
+		const paths = getRuntimePaths();
+		writeFileSync(paths.daemonAuthToken, "stale-file-token\n");
+		const fixedTokenTime = new Date("2026-07-30T00:00:00.000Z");
+		utimesSync(paths.daemonAuthToken, fixedTokenTime, fixedTokenTime);
+		const tokenMtimeBeforeFetch = statSync(paths.daemonAuthToken).mtimeMs;
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -5327,10 +5370,11 @@ exit 64
 		]);
 
 		try {
-			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			const loaded = await loadRuntimeManifest(paths);
 			if (!("manifest" in loaded)) throw new Error(loaded.errors.join("\n"));
 			expect(captured[0].headers.authorization).toBe("Bearer bootstrap-token");
-			expect(readFileSync(join(run, "secrets", "auth-token"), "utf-8")).toBe("bootstrap-token\n");
+			expect(readFileSync(paths.daemonAuthToken, "utf-8")).toBe("stale-file-token\n");
+			expect(statSync(paths.daemonAuthToken).mtimeMs).toBe(tokenMtimeBeforeFetch);
 		} finally {
 			restore();
 		}
@@ -6538,10 +6582,12 @@ fi
 			{
 				method: "GET",
 				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, generation), {
-						etag: manifestEtag,
-					}),
+				response: (request) =>
+					request.headers["if-none-match"]
+						? new Response(null, { status: 304, headers: { etag: manifestEtag } })
+						: hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, generation), {
+								etag: manifestEtag,
+							}),
 			},
 		]);
 
@@ -6558,7 +6604,44 @@ fi
 			expect(initialDaemonAuthTokenRevision).toMatch(/^[a-f0-9]{64}$/);
 			const initialDaemonUnit = readSystemdSystemUnit(paths, "clawdi-daemon");
 			const initialDaemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
+			const requestsBeforeMatchingTuple = watchFetch.captured.length;
 			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(watchFetch.captured.slice(requestsBeforeMatchingTuple)).toHaveLength(1);
+			expect(watchFetch.captured.at(-1)?.headers["if-none-match"]).toBe('"manifest-generation-30"');
+			expect(JSON.parse(logs.at(-1) ?? "{}").status).toBe("not_modified");
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+
+			writeRuntimeApplyIdentityFile(applyIdentityPath, {
+				generation,
+				manifestETag: manifestEtag,
+				applyReceiptId: "apply-receipt-generation-0030-refreshed",
+				bootNonce: "boot-nonce-generation-0002",
+			});
+			const requestsBeforeTupleRefresh = watchFetch.captured.length;
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(watchFetch.captured.slice(requestsBeforeTupleRefresh)).toHaveLength(2);
+			expect(
+				watchFetch.captured
+					.slice(requestsBeforeTupleRefresh)
+					.map((request) => request.headers["if-none-match"] ?? null),
+			).toEqual(['"manifest-generation-30"', null]);
+			expect(readRuntimeAppliedState(paths)).toMatchObject({
+				generation: 30,
+				manifestETag: '"manifest-generation-30"',
+				applyReceiptId: "apply-receipt-generation-0030-refreshed",
+				bootNonce: "boot-nonce-generation-0002",
+			});
+			expect(readFileSync(systemctlLog, "utf-8")).not.toMatch(
+				/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
+			);
 
 			generation = 31;
 			manifestEtag = '"manifest-generation-31"';
@@ -6599,7 +6682,7 @@ fi
 				applyReceiptId: "apply-receipt-generation-0031",
 				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(watchFetch.captured).toHaveLength(3);
+			expect(watchFetch.captured).toHaveLength(8);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
@@ -6723,6 +6806,12 @@ fi
 				{ CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token" },
 				["OPENCLAW_GATEWAY_TOKEN"],
 			);
+			const tokenPath = join(run, "secrets", "auth-token");
+			const fixedTokenTime = new Date("2026-07-30T00:00:00.000Z");
+			utimesSync(tokenPath, fixedTokenTime, fixedTokenTime);
+			const tokenBeforeRejection = readFileSync(tokenPath, "utf-8");
+			const tokenMtimeBeforeRejection = statSync(tokenPath).mtimeMs;
+			const appliedStateBeforeRejection = readFileSync(paths.appliedState, "utf-8");
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -6735,11 +6824,13 @@ fi
 				"OpenClaw native gateway token is unavailable",
 			);
 			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(33);
-			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
-				"--user restart openclaw-gateway.service",
-			);
+			expect(readFileSync(tokenPath, "utf-8")).toBe(tokenBeforeRejection);
+			expect(statSync(tokenPath).mtimeMs).toBe(tokenMtimeBeforeRejection);
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(appliedStateBeforeRejection);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
 
 			const fetchCountBeforeMissingAuth = watchFetch.captured.length;
+			writeFileSync(systemctlLog, "");
 			generation = 35;
 			manifestEtag = '"manifest-generation-35"';
 			writeRuntimeApplyIdentityFile(
@@ -6753,6 +6844,9 @@ fi
 				{},
 				["CLAWDI_AUTH_TOKEN"],
 			);
+			const tokenBeforeFetchFailure = readFileSync(tokenPath, "utf-8");
+			const tokenMtimeBeforeFetchFailure = statSync(tokenPath).mtimeMs;
+			const appliedStateBeforeFetchFailure = readFileSync(paths.appliedState, "utf-8");
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -6762,7 +6856,10 @@ fi
 				stage: "network",
 			});
 			expect(watchFetch.captured).toHaveLength(fetchCountBeforeMissingAuth);
-			expect(existsSync(join(run, "secrets", "auth-token"))).toBe(false);
+			expect(readFileSync(tokenPath, "utf-8")).toBe(tokenBeforeFetchFailure);
+			expect(statSync(tokenPath).mtimeMs).toBe(tokenMtimeBeforeFetchFailure);
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(appliedStateBeforeFetchFailure);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
 			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(33);
 		} finally {
 			watchFetch.restore();

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -53,7 +53,9 @@ import {
 } from "../src/runtime/hosted-egress-profiles";
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
+	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest,
+	hostedAiProviderCatalog,
 	loadRuntimeManifest,
 	type RuntimeConvergenceResult,
 	type RuntimeManifest,
@@ -3866,11 +3868,26 @@ exit 0
 				etag: `"${providerCase.id}-1"`,
 			});
 
-			const second = convergeRuntimeManifest(
-				hostedProviderSwitchLoad(home, providerCase.second, 2),
-				paths,
-			);
+			const secondLoad = hostedProviderSwitchLoad(home, providerCase.second, 2);
+			const second = convergeRuntimeManifest(secondLoad, paths);
 			expect(second.installErrors).toEqual([]);
+			if (providerCase.id === "byok-to-byok") {
+				const projectionInput = hostedAiProviderCatalog(secondLoad.manifest, "openclaw");
+				expect(projectionInput).not.toBeNull();
+				if (!projectionInput) throw new Error("expected OpenClaw provider projection input");
+				const sharedPatch = buildOpenClawHostedProviderPatch(projectionInput, [firstAgentProvider]);
+				const appliedProviderPatches = readFileSync(openclawPatchLog, "utf-8")
+					.split("\n---\n")
+					.map((content) => content.trim())
+					.filter(Boolean)
+					.map((content) => JSON.parse(content) as unknown)
+					.filter((patch): patch is Record<string, unknown> => {
+						if (!isRecord(patch)) return false;
+						const models = patch.models;
+						return isRecord(models) && isRecord(models.providers);
+					});
+				expect(appliedProviderPatches.at(-1)).toEqual(JSON.parse(sharedPatch.content));
+			}
 
 			const openclawProviders = applyOpenClawProviderPatchLog(openclawPatchLog, {
 				"user-local": {
@@ -5436,6 +5453,7 @@ exit 64
 							sourceRevision: load.sourceRevision,
 							convergence,
 							applyIdentity: null,
+							daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 							egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 						});
 					},
@@ -6467,6 +6485,7 @@ fi
 		const systemctlLog = join(root, "systemctl.log");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
+		const previousUmask = process.umask(0o022);
 		const logs: string[] = [];
 		let generation = 30;
 		let manifestEtag = '"manifest-generation-30"';
@@ -6528,10 +6547,18 @@ fi
 
 		try {
 			await runtimeWatch({ once: true, json: true });
-			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+			const paths = getRuntimePaths();
+			const initialAppliedState = readRuntimeAppliedState(paths);
+			if (!initialAppliedState) throw new Error(logs.join("\n"));
+			expect(initialAppliedState).toMatchObject({
 				etag: '"manifest-generation-30"',
 				generation: 30,
 			});
+			const initialDaemonAuthTokenRevision = initialAppliedState?.daemonAuthTokenRevision;
+			expect(initialDaemonAuthTokenRevision).toMatch(/^[a-f0-9]{64}$/);
+			const initialDaemonUnit = readSystemdSystemUnit(paths, "clawdi-daemon");
+			const initialDaemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
+			writeFileSync(systemctlLog, "");
 
 			generation = 31;
 			manifestEtag = '"manifest-generation-31"';
@@ -6576,6 +6603,8 @@ fi
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain("restart clawdi-daemon.service");
+			const committedBeforeTokenRotation = readFileSync(paths.appliedState, "utf-8");
 
 			writeFileSync(systemctlLog, "");
 			process.env.CLAWDI_AUTH_TOKEN = "stale-process-auth-token";
@@ -6598,11 +6627,14 @@ fi
 			await runtimeWatch({ once: true, json: true });
 
 			expect(process.exitCode ?? 0).toBe(0);
-			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+			const rotatedAppliedState = readRuntimeAppliedState(paths);
+			expect(rotatedAppliedState).toMatchObject({
 				generation: 32,
 				manifestETag: '"manifest-generation-32"',
 				bootNonce: "boot-nonce-generation-0001",
 			});
+			expect(rotatedAppliedState?.daemonAuthTokenRevision).toMatch(/^[a-f0-9]{64}$/);
+			expect(rotatedAppliedState?.daemonAuthTokenRevision).not.toBe(initialDaemonAuthTokenRevision);
 			expect(watchFetch.captured.at(-1)?.headers.authorization).toBe(
 				"Bearer rotated-runtime-auth-token",
 			);
@@ -6615,6 +6647,33 @@ fi
 			);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"restart clawdi-runtime-sidecar.service",
+			);
+			expect(readSystemdSystemUnit(paths, "clawdi-daemon")).toBe(initialDaemonUnit);
+			expect(readSystemdEnvFile(paths, "clawdi-daemon")).toBe(initialDaemonEnv);
+			expect(initialDaemonUnit).not.toContain(
+				rotatedAppliedState?.daemonAuthTokenRevision ?? "missing-daemon-token-revision",
+			);
+			expect(initialDaemonEnv).not.toContain(
+				rotatedAppliedState?.daemonAuthTokenRevision ?? "missing-daemon-token-revision",
+			);
+
+			// Simulate a crash after the desired token file/unit were written but before
+			// the private applied authority advanced. The unchanged public unit cannot
+			// prove activation, so the next pass must retry the daemon restart.
+			writeFileSync(paths.appliedState, committedBeforeTokenRotation);
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(
+				readFileSync(systemctlLog, "utf-8")
+					.trim()
+					.split("\n")
+					.filter((call) => call === "restart clawdi-daemon.service"),
+			).toHaveLength(1);
+			expect(readSystemdSystemUnit(paths, "clawdi-daemon")).toBe(initialDaemonUnit);
+			expect(readRuntimeAppliedState(paths)?.daemonAuthTokenRevision).toBe(
+				rotatedAppliedState?.daemonAuthTokenRevision,
 			);
 
 			writeFileSync(systemctlLog, "");
@@ -6708,6 +6767,7 @@ fi
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;
+			process.umask(previousUmask);
 			process.exitCode = previousExitCode;
 		}
 	});


### PR DESCRIPTION
## Summary
- project canonical apply identity and runtime environment for in-place generations
- restart only affected runtime services and keep immutable changes on Pod replacement
- gate credentials, offline cache, and 304 handling before side effects
- preserve exact authority and crash recovery semantics

## Verification
- isolated CLI suite: 1459 passed, 4 skipped, 0 failed
- workspace typecheck and Biome check
- git diff --check

Paired with Clawdi-AI/clawdi-hosted#1158. No production changes are performed by this PR.
