### PR TITLE
Release CLI 0.13.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.15",
+      "version": "0.13.16",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.15",
+	"version": "0.13.16",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary
- bump the immutable Clawdi CLI release from 0.13.15 to 0.13.16
- publish the in-place runtime reconcile implementation merged in #617

## Verification
- CLI typecheck
- release recovery contracts: 12 passed
- git diff --check

This is a two-file version-only release change. Production selection remains controlled by the Hosted exact-version rollout.
