### PR TITLE
Fix v2 provider model overlay authority

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -439,6 +439,19 @@ non-empty `error.message`. A
 `provider_not_found` entry contains `kind` plus that error pair; other error and
 healthy entries retain the normal `kind`, `type`, and `baseUrl` projection.
 
+For a strict-v2 Clawdi-managed provider, the CLI validates the runtime-facing
+`/models` response and materializes its canonical model catalog and resolved
+primary model into the effective manifest before native config and systemd are
+rendered. That effective manifest is the value stored in last-good and hashed
+by the applied content identity, so offline recovery replays it without a
+network probe. A manifest `304` still revalidates this independently changing
+model representation: changed model bytes converge even when the bundle ETag
+is unchanged, while identical model bytes do not restart the runtime. The
+`/models` ETag is only an in-process conditional-request validator; it is not
+stored in applied state or included in a runtime revision, and it advances only
+after the represented bytes are committed or proven identical to committed
+authority.
+
 This strict typing claim applies only to the Hosted fields modeled in this
 release. `egressEngine` and `egressProfiles` use closed schemas matching the
 Hosted CLI wire and are validated at admin write and manifest read boundaries.
@@ -872,6 +885,9 @@ Each reconciliation plan declares the exact managed root and runtime-user file
 targets it may mutate. Before any command that can change live state, Apply
 captures complete in-memory pre-images for those targets, including absence,
 regular-file bytes or symlink target, mode, uid, gid, and directory metadata.
+A strict-v2 plan includes the selected runtime's native provider config and the
+managed legacy Hermes model-provider plugin subtree, so model authority cannot
+diverge from the restored sidecar and applied state.
 A synchronous failure restores that same bounded set and then reconciles
 systemd to the restored files. It never snapshots `$HOME` or a runtime-user
 tree. A process crash has no durable rollback journal: the next cycle converges

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -10,6 +10,7 @@ import {
 	readFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isClawdiManagedV2ProviderId } from "@clawdi/shared";
 import type { components } from "@clawdi/shared/api";
 import chalk from "chalk";
 import { parse as parseYaml } from "yaml";
@@ -47,14 +48,20 @@ import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
 import { readHostPolicy } from "../runtime/host-policy";
 import {
+	acceptManagedGatewayModelTransportValidators,
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
 	loadRuntimeManifest,
+	type ManagedGatewayModelAuthorityResolution,
+	type ManagedGatewayModelListFetcher,
+	type ManagedGatewayModelTransportValidators,
 	type RuntimePrivateAppliedAuthority,
+	resolveManagedGatewayModelAuthorityForLoad,
 	runtimeRecoverableSecretValues,
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {
+	loadCommittedRuntimeManifest,
 	loadRemoteRuntimeManifest,
 	type RuntimeManifestFailure,
 	type RuntimeManifestLoad,
@@ -1187,6 +1194,7 @@ interface RuntimeWatchOptions {
 	notifications?: boolean;
 	notificationConsumer?: typeof consumeSse;
 	applyContext?: RuntimeApplyContext;
+	managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
 }
 
 interface RuntimeVerifyOptions {
@@ -1253,6 +1261,9 @@ interface RuntimeApplyOptions {
 	manifestIdentity?: RuntimeManifestIdentity;
 	recoverFailedSystemdUnits?: boolean;
 	requireSystemdApplied?: boolean;
+	managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+	managedGatewayModelTransportValidators?: ManagedGatewayModelTransportValidators;
+	managedGatewayModelAuthorityResolution?: ManagedGatewayModelAuthorityResolution;
 }
 
 interface RuntimeManifestIdentity {
@@ -1321,8 +1332,12 @@ export function commitRuntimeAppliedState(input: {
 	}
 	// The apply identity names the Hosted control-plane snapshot; `etag` names
 	// the independently rendered runtime bundle. Persist both authorities.
-	const providerIds = runtimeSourceProviderIds(input.load.manifest);
-	input.convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(input.load, input.paths);
+	const committedLoad = { ...input.load, manifest: input.convergence.manifest };
+	const providerIds = runtimeSourceProviderIds(committedLoad.manifest);
+	input.convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(
+		committedLoad,
+		input.paths,
+	);
 	input.convergence.outputs.appliedState = writeRuntimeAppliedState(
 		{
 			schemaVersion: "clawdi.runtimeAppliedState.v2",
@@ -1341,7 +1356,7 @@ export function commitRuntimeAppliedState(input: {
 						bootNonce: input.applyIdentity.bootNonce,
 					}
 				: {}),
-			contentIdentity: runtimeAppliedContentIdentity(input.load),
+			contentIdentity: runtimeAppliedContentIdentity(committedLoad),
 			...(input.daemonAuthTokenRevision
 				? { daemonAuthTokenRevision: input.daemonAuthTokenRevision }
 				: {}),
@@ -2474,6 +2489,8 @@ async function runtimeWatchTick(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+		managedGatewayModelTransportValidators?: ManagedGatewayModelTransportValidators;
 	},
 ): Promise<Record<string, unknown>> {
 	return withRuntimeConvergeLockAsync(paths, () => runtimeWatchTickLocked(paths, opts));
@@ -2487,6 +2504,8 @@ async function runtimeWatchTickLocked(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+		managedGatewayModelTransportValidators?: ManagedGatewayModelTransportValidators;
 	},
 ): Promise<Record<string, unknown>> {
 	let reconciliation: RuntimeCliReconciliationResult;
@@ -2528,6 +2547,8 @@ async function runtimeWatchTickAfterCliReconciliation(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+		managedGatewayModelTransportValidators?: ManagedGatewayModelTransportValidators;
 	},
 ): Promise<Record<string, unknown>> {
 	const activeAppliedState = readRuntimeAppliedState(paths);
@@ -2549,6 +2570,8 @@ async function runtimeWatchTickAfterCliReconciliation(
 		};
 	}
 	const responseManifestEtag = manifestLoad.etag ?? manifestEtag ?? null;
+	let preparedModelAuthority: ManagedGatewayModelAuthorityResolution | undefined;
+	let unchangedModelAuthority: ManagedGatewayModelAuthorityResolution | undefined;
 	if (
 		"notModified" in manifestLoad &&
 		activeAppliedState !== null &&
@@ -2558,24 +2581,109 @@ async function runtimeWatchTickAfterCliReconciliation(
 			runtimeAppliedApplyIdentity(activeAppliedState),
 		)
 	) {
-		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
-		return {
-			schemaVersion: "clawdi.runtimeWatchEvent.v1",
-			status: "not_modified",
-			sourcePath: manifestLoad.sourcePath,
-			etag: responseManifestEtag,
-			sourceRevision: activeAppliedState.sourceRevision,
-			generation: activeAppliedState.generation,
-			instanceId: activeAppliedState.instanceId,
-			selfReexec: completion.selfReexec,
-		};
+		const appliedProviderIds = [
+			...activeAppliedState.providerIds,
+			...Object.values(activeAppliedState.projectedProviderIds).flat(),
+		];
+		if (appliedProviderIds.some(isClawdiManagedV2ProviderId)) {
+			const applyContext = manifestLoad.applyContext;
+			if (!applyContext) {
+				return {
+					schemaVersion: "clawdi.runtimeWatchEvent.v1",
+					status: "error",
+					stage: "final",
+					errors: ["runtime bundle is missing applied authority context"],
+					error: "runtime bundle is missing applied authority context",
+					activeGeneration: activeAppliedState.generation,
+					rejectedGeneration: activeAppliedState.generation,
+					instanceId: activeAppliedState.instanceId,
+				};
+			}
+			const committed = loadCommittedRuntimeManifest(paths, applyContext);
+			if ("manifest" in committed) {
+				if (
+					committed.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2"
+				) {
+					try {
+						const committedRemoteLoad: RuntimeManifestLoad = {
+							...committed,
+							offline: false,
+							sourcePath: manifestLoad.sourcePath,
+							etag: responseManifestEtag ?? undefined,
+							sourceRevision: activeAppliedState.sourceRevision,
+						};
+						preparedModelAuthority = resolveManagedGatewayModelAuthorityForLoad(
+							committedRemoteLoad,
+							paths,
+							opts.managedGatewayModelListFetcher,
+							opts.managedGatewayModelTransportValidators,
+						);
+						if (
+							runtimeAppliedContentIdentity(preparedModelAuthority.load).sha256 !==
+							activeAppliedState.contentIdentity.sha256
+						) {
+							// The transport bundle is unchanged, but its dynamic provider
+							// representation has new effective bytes and must converge.
+						} else {
+							unchangedModelAuthority = preparedModelAuthority;
+							preparedModelAuthority = undefined;
+						}
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error);
+						return {
+							schemaVersion: "clawdi.runtimeWatchEvent.v1",
+							status: "error",
+							stage: "final",
+							errors: [message],
+							error: message,
+							activeGeneration: activeAppliedState.generation,
+							rejectedGeneration: activeAppliedState.generation,
+							instanceId: activeAppliedState.instanceId,
+						};
+					}
+				}
+			} else {
+				return {
+					schemaVersion: "clawdi.runtimeWatchEvent.v1",
+					status: "error",
+					stage: "final",
+					errors: committed.errors,
+					error: committed.errors[0],
+					activeGeneration: activeAppliedState.generation,
+					rejectedGeneration: activeAppliedState.generation,
+					instanceId: activeAppliedState.instanceId,
+				};
+			}
+		}
+		if (preparedModelAuthority) {
+			// Continue below with the already resolved effective manifest.
+		} else {
+			if (unchangedModelAuthority) {
+				acceptManagedGatewayModelTransportValidators(
+					opts.managedGatewayModelTransportValidators,
+					unchangedModelAuthority.transportValidators,
+				);
+			}
+			const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "not_modified",
+				sourcePath: manifestLoad.sourcePath,
+				etag: responseManifestEtag,
+				sourceRevision: activeAppliedState.sourceRevision,
+				generation: activeAppliedState.generation,
+				instanceId: activeAppliedState.instanceId,
+				selfReexec: completion.selfReexec,
+			};
+		}
 	}
 
 	try {
 		const fresh =
-			"notModified" in manifestLoad
+			preparedModelAuthority?.load ??
+			("notModified" in manifestLoad
 				? await loadFullRuntimeManifestForWatch(paths, opts.applyContext)
-				: manifestLoad;
+				: manifestLoad);
 		if ("errors" in fresh) {
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
@@ -2618,6 +2726,9 @@ async function runtimeWatchTickAfterCliReconciliation(
 			manifestIdentity,
 			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
 			requireSystemdApplied: applyIdentity !== null,
+			managedGatewayModelListFetcher: opts.managedGatewayModelListFetcher,
+			managedGatewayModelTransportValidators: opts.managedGatewayModelTransportValidators,
+			managedGatewayModelAuthorityResolution: preparedModelAuthority,
 		});
 		if (applyResult.kind === "cli_handoff") {
 			const activeAppliedState = readRuntimeAppliedState(paths);
@@ -2775,6 +2886,9 @@ function applyRuntimeDesiredState(
 	let egressPrerequisiteActivated = false;
 	const convergence = convergeRuntimeManifest(load, paths, {
 		cacheLastGood: false,
+		managedGatewayModelListFetcher: opts.managedGatewayModelListFetcher,
+		managedGatewayModelTransportValidators: opts.managedGatewayModelTransportValidators,
+		managedGatewayModelAuthorityResolution: opts.managedGatewayModelAuthorityResolution,
 		commitAuthority: (committedConvergence, authority) => {
 			if (opts.requireSystemdApplied && !systemdApply.applied) {
 				throw new Error("systemd apply did not activate the rendered runtime manifest");
@@ -2959,6 +3073,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 	let cliInstallBackoffMs = 0;
 	let nextCliInstallRetryAt = 0;
 	const wakeSignal = createRuntimeWatchWakeSignal();
+	const managedGatewayModelTransportValidators: ManagedGatewayModelTransportValidators = new Map();
 	let notificationSubscription: RuntimeWatchNotificationSubscription | null = null;
 
 	if (mode !== "hosted") {
@@ -3017,6 +3132,8 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 				// Conditional retries run every 15 seconds. Recover failed units
 				// only on the five-minute full refresh, or once in one-shot mode.
 				recoverFailedSystemdUnits: forceRefresh || opts.once === true,
+				managedGatewayModelListFetcher: opts.managedGatewayModelListFetcher,
+				managedGatewayModelTransportValidators,
 				deferCliInstallReason: deferCliInstall
 					? `CLI install retry is in backoff until ${new Date(nextCliInstallRetryAt).toISOString()}`
 					: undefined,

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -12,10 +12,16 @@ import {
 	isClawdiManagedV2ProviderId,
 } from "@clawdi/shared";
 import type { AgentPrimaryModel } from "../lib/ai-provider-projection";
+import { runtimeContentSha256 } from "./applied-state";
 import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import { isClawdiManagedProviderProjection } from "./hosted-egress-profiles";
-import { resolveManagedPrimaryModel } from "./managed-model-resolution";
+import {
+	buildManagedModelsEndpoint,
+	normalizeManagedLiveModels,
+	resolveManagedPrimaryModel,
+} from "./managed-model-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifestLoad } from "./manifest-source";
 
 export function hostedAiProviderCatalog(
 	manifest: RuntimeManifest,
@@ -189,54 +195,104 @@ function managedGatewayPrimaryModelTarget(
 	};
 }
 
-interface ManagedGatewayModelOverrides {
+export interface ManagedGatewayModelOverrides {
 	primaryModels: Partial<Record<string, AgentPrimaryModel>>;
 	models: Partial<Record<string, AiProviderModel[]>>;
 }
 
-interface ManagedGatewayModelFetchInput {
+export interface ManagedGatewayModelFetchInput {
 	baseUrl: string;
 	home: string;
 	egressSystemCaFile: string | null;
+	ifNoneMatch?: string;
 	providerId: string;
 	runtimeName: string;
+	validationMode: "legacy" | "strict-v2";
 	workspaceRoot: string;
 }
 
-type ManagedGatewayModelFetchResult =
-	| { status: "ok"; endpoint: string; models: AiProviderModel[] }
+export type ManagedGatewayModelFetchResult =
+	| { status: "ok"; endpoint: string; etag?: string; models: AiProviderModel[] }
+	| { status: "not_modified"; endpoint: string; etag?: string }
 	| { status: "failed"; endpoint: string; detail: string };
 
 export type ManagedGatewayModelListFetcher = (
 	input: ManagedGatewayModelFetchInput,
 ) => ManagedGatewayModelFetchResult;
 
-export function resolveManagedGatewayModelOverrides(
-	manifest: RuntimeManifest,
+export interface ManagedGatewayModelAuthorityResolution {
+	baseManifestRevision: string;
+	load: RuntimeManifestLoad;
+	overrides: ManagedGatewayModelOverrides;
+	transportValidators: ManagedGatewayModelTransportValidators;
+}
+
+export type ManagedGatewayModelTransportValidators = Map<string, string>;
+
+export function resolveManagedGatewayModelAuthority(
+	load: RuntimeManifestLoad,
 	enabledRuntimes: readonly string[],
 	home: string,
 	workspaceRoot: string,
 	egressSystemCaFile: string | null,
 	fetcher: ManagedGatewayModelListFetcher,
-): ManagedGatewayModelOverrides {
+	transportValidators?: ManagedGatewayModelTransportValidators,
+): ManagedGatewayModelAuthorityResolution {
+	const { manifest } = load;
+	const baseManifestRevision = runtimeContentSha256(manifest);
+	const strictV2 = manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+	const resolvedTransportValidators = new Map(transportValidators);
 	const overrides: ManagedGatewayModelOverrides = { primaryModels: {}, models: {} };
 	const fetchCache = new Map<string, ManagedGatewayModelFetchResult>();
+	const modelCache = new Map<string, AiProviderModel[]>();
+	let effectiveManifest = manifest;
 	for (const runtimeName of enabledRuntimes) {
 		const target = managedGatewayPrimaryModelTarget(manifest, runtimeName);
 		if (!target) continue;
+		const strictTarget = strictV2 && isClawdiManagedV2ProviderId(target.providerId);
 		const cacheKey = `${target.providerId}\n${target.baseUrl}`;
 		let fetchResult = fetchCache.get(cacheKey);
+		if (!fetchResult && strictTarget && load.offline) {
+			fetchResult = {
+				status: "ok",
+				endpoint: buildManagedModelsEndpoint(target.baseUrl),
+				models: strictManagedProviderModels(manifest, target.providerId),
+			};
+			fetchCache.set(cacheKey, fetchResult);
+		}
 		if (!fetchResult) {
+			const ifNoneMatch =
+				strictTarget && load.source === "last-good-cache"
+					? resolvedTransportValidators.get(cacheKey)
+					: undefined;
 			fetchResult = fetcher({
 				baseUrl: target.baseUrl,
 				home,
 				egressSystemCaFile,
+				ifNoneMatch,
 				providerId: target.providerId,
 				runtimeName,
+				validationMode: strictTarget ? "strict-v2" : "legacy",
 				workspaceRoot,
 			});
 			fetchCache.set(cacheKey, fetchResult);
-			if (fetchResult.status === "failed") {
+			if (
+				strictTarget &&
+				fetchResult.status === "not_modified" &&
+				(!ifNoneMatch || fetchResult.etag !== ifNoneMatch)
+			) {
+				throw new Error(
+					`managed model probe returned 304 with a mismatched final validator for ${runtimeName}/${target.providerId}`,
+				);
+			}
+			if (strictTarget && fetchResult.status !== "failed") {
+				if (isStrongEntityTag(fetchResult.etag)) {
+					resolvedTransportValidators.set(cacheKey, fetchResult.etag);
+				} else {
+					resolvedTransportValidators.delete(cacheKey);
+				}
+			}
+			if (fetchResult.status === "failed" && !strictTarget) {
 				const loggedProviderId = isClawdiManagedV2ProviderId(target.providerId)
 					? CLAWDI_MANAGED_PROVIDER_ID
 					: target.providerId;
@@ -245,22 +301,124 @@ export function resolveManagedGatewayModelOverrides(
 				);
 			}
 		}
+		if (strictTarget && fetchResult.status === "failed") {
+			throw new Error(
+				`managed model probe failed for ${runtimeName}/${target.providerId} at ${fetchResult.endpoint}: ${fetchResult.detail}`,
+			);
+		}
+		let liveModels = modelCache.get(cacheKey);
+		if (!liveModels) {
+			if (fetchResult.status === "ok") {
+				liveModels = strictTarget
+					? normalizeManagedLiveModels(fetchResult.models)
+					: fetchResult.models;
+			} else if (fetchResult.status === "not_modified" && strictTarget) {
+				liveModels = strictManagedProviderModels(manifest, target.providerId);
+			} else {
+				liveModels = [];
+			}
+			modelCache.set(cacheKey, liveModels);
+		}
 		const resolution = resolveManagedPrimaryModel({
 			seedModel: target.seedModel,
-			liveModelIds:
-				fetchResult.status === "ok" ? fetchResult.models.map((model) => model.id) : null,
+			liveModelIds: fetchResult.status === "failed" ? null : liveModels.map((model) => model.id),
 		});
-		if (fetchResult.status === "ok" && fetchResult.models.length > 0) {
-			overrides.models[runtimeName] = fetchResult.models;
+		if (liveModels.length > 0) {
+			overrides.models[runtimeName] = liveModels;
 		}
 		if (!resolution.resolvedModel) continue;
+		if (strictTarget) {
+			effectiveManifest = withManagedProviderAuthority(
+				effectiveManifest,
+				runtimeName,
+				target.providerId,
+				liveModels,
+				resolution.resolvedModel,
+			);
+		}
 		if (resolution.resolvedModel === target.seedModel) continue;
 		overrides.primaryModels[runtimeName] = {
 			provider_id: target.providerId,
 			model: resolution.resolvedModel,
 		};
 	}
-	return overrides;
+	return {
+		baseManifestRevision,
+		load: effectiveManifest === manifest ? load : { ...load, manifest: effectiveManifest },
+		overrides,
+		transportValidators: resolvedTransportValidators,
+	};
+}
+
+export function acceptManagedGatewayModelTransportValidators(
+	target: ManagedGatewayModelTransportValidators | undefined,
+	resolved: ManagedGatewayModelTransportValidators,
+): void {
+	if (!target) return;
+	target.clear();
+	for (const [key, etag] of resolved) target.set(key, etag);
+}
+
+export function requiresStrictManagedGatewayModelProbe(
+	load: RuntimeManifestLoad,
+	enabledRuntimes: readonly string[],
+): boolean {
+	return (
+		!load.offline &&
+		load.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		enabledRuntimes.some((runtimeName) => {
+			const target = managedGatewayPrimaryModelTarget(load.manifest, runtimeName);
+			return target !== null && isClawdiManagedV2ProviderId(target.providerId);
+		})
+	);
+}
+
+function strictManagedProviderModels(
+	manifest: RuntimeManifest,
+	providerId: string,
+): AiProviderModel[] {
+	const providers = recordValue(manifest.projection?.providers);
+	const provider = providers ? recordValue(providers[providerId]) : null;
+	if (!provider || !Array.isArray(provider.models)) {
+		throw new Error(`committed managed provider ${providerId} has no model authority`);
+	}
+	return normalizeManagedLiveModels(provider.models);
+}
+
+function withManagedProviderAuthority(
+	manifest: RuntimeManifest,
+	runtimeName: string,
+	providerId: string,
+	models: readonly AiProviderModel[],
+	resolvedModel: string,
+): RuntimeManifest {
+	const projection = structuredClone(manifest.projection);
+	const providers = recordValue(projection?.providers);
+	const provider = providers ? recordValue(providers[providerId]) : null;
+	const runtime = manifest.runtimes[runtimeName];
+	if (!projection || !providers || !provider || !runtime) {
+		throw new Error(`managed provider ${providerId} is absent from runtime ${runtimeName}`);
+	}
+	projection.providers = {
+		...providers,
+		[providerId]: { ...provider, models: [...models] },
+	};
+	return {
+		...manifest,
+		projection,
+		runtimes: {
+			...manifest.runtimes,
+			[runtimeName]: {
+				...runtime,
+				primary_model: { provider_id: providerId, model: resolvedModel },
+			},
+		},
+	};
+}
+
+function isStrongEntityTag(value: string | null | undefined): value is string {
+	if (!value || value.startsWith("W/")) return false;
+	return /^"[\x21\x23-\x7e\x80-\xff]*"$/.test(value);
 }
 
 function hostedProviderType(input: Record<string, unknown>): AiProviderType {

--- a/packages/cli/src/runtime/managed-model-resolution.test.ts
+++ b/packages/cli/src/runtime/managed-model-resolution.test.ts
@@ -3,6 +3,7 @@ import {
 	buildManagedModelsEndpoint,
 	extractManagedLiveModelIds,
 	extractManagedLiveModels,
+	parseManagedLiveModels,
 	resolveManagedPrimaryModel,
 } from "./managed-model-resolution";
 
@@ -152,5 +153,32 @@ describe("managed model resolution", () => {
 				max_tokens: 16_384,
 			},
 		]);
+	});
+
+	test("strictly validates and canonicalizes an authority-bearing catalog", () => {
+		expect(
+			parseManagedLiveModels({
+				data: [
+					{ id: "model-b", supports_tools: true },
+					{ id: "model-a", context_window: 128_000 },
+				],
+			}),
+		).toEqual([
+			{ id: "model-a", context_window: 128_000 },
+			{ id: "model-b", supports_tools: true },
+		]);
+
+		for (const payload of [
+			null,
+			{},
+			{ data: [] },
+			{ data: [{ id: "model-a" }, { id: "model-a" }] },
+			{ data: [{ id: " model-a" }] },
+			{ data: [{ id: "model-a", supports_tools: "yes" }] },
+			{ data: [{ id: "model-a", cost: { input: 1 } }] },
+			{ data: Array.from({ length: 513 }, (_, index) => ({ id: `model-${index}` })) },
+		]) {
+			expect(() => parseManagedLiveModels(payload)).toThrow();
+		}
 	});
 });

--- a/packages/cli/src/runtime/managed-model-resolution.ts
+++ b/packages/cli/src/runtime/managed-model-resolution.ts
@@ -5,6 +5,9 @@ import {
 	isAiProviderApiMode,
 } from "@clawdi/shared";
 
+const MAX_MANAGED_LIVE_MODELS = 512;
+const MAX_MANAGED_MODEL_TEXT_LENGTH = 256;
+
 export interface ManagedPrimaryModelResolutionInput {
 	seedModel: string | null;
 	liveModelIds: readonly string[] | null;
@@ -39,6 +42,115 @@ export function extractManagedLiveModels(payload: unknown): AiProviderModel[] {
 		models.push(model);
 	}
 	return models;
+}
+
+export function parseManagedLiveModels(payload: unknown): AiProviderModel[] {
+	if (!isPlainRecord(payload) || !Array.isArray(payload.data)) {
+		throw new Error("catalog must be an object with a data array");
+	}
+	return normalizeManagedLiveModels(payload.data);
+}
+
+export function normalizeManagedLiveModels(models: readonly unknown[]): AiProviderModel[] {
+	if (models.length === 0) throw new Error("catalog data must not be empty");
+	if (models.length > MAX_MANAGED_LIVE_MODELS) {
+		throw new Error(`catalog exceeds ${MAX_MANAGED_LIVE_MODELS} models`);
+	}
+	const sorted = models
+		.map((model, index) => {
+			if (!isPlainRecord(model)) throw new Error(`catalog data[${index}] must be an object`);
+			validateManagedLiveModelEntry(model, index);
+			const canonical = extractManagedLiveModel(model);
+			if (!canonical) throw new Error(`catalog data[${index}] has an invalid id`);
+			return canonical;
+		})
+		.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+	if (new Set(sorted.map((model) => model.id)).size !== sorted.length) {
+		throw new Error("catalog model ids must be unique");
+	}
+	return sorted;
+}
+
+function validateManagedLiveModelEntry(entry: Record<string, unknown>, index: number): void {
+	for (const field of ["id", "label", "alias"] as const) {
+		if (entry[field] === undefined && field !== "id") continue;
+		const value = entry[field];
+		if (
+			typeof value !== "string" ||
+			value.length === 0 ||
+			value.length > MAX_MANAGED_MODEL_TEXT_LENGTH ||
+			value.trim() !== value
+		) {
+			throw new Error(`catalog data[${index}].${field} must be a canonical bounded string`);
+		}
+	}
+	if (
+		entry.api_mode !== undefined &&
+		(typeof entry.api_mode !== "string" || !isAiProviderApiMode(entry.api_mode))
+	) {
+		throw new Error(`catalog data[${index}].api_mode is invalid`);
+	}
+	if (entry.input_modalities !== undefined) {
+		if (
+			!Array.isArray(entry.input_modalities) ||
+			entry.input_modalities.length === 0 ||
+			entry.input_modalities.length > 4 ||
+			!entry.input_modalities.every(isManagedInputModality) ||
+			new Set(entry.input_modalities).size !== entry.input_modalities.length
+		) {
+			throw new Error(`catalog data[${index}].input_modalities is invalid`);
+		}
+	}
+	for (const field of ["supports_vision", "supports_tools", "supports_reasoning"] as const) {
+		if (entry[field] !== undefined && typeof entry[field] !== "boolean") {
+			throw new Error(`catalog data[${index}].${field} must be boolean`);
+		}
+	}
+	for (const field of [
+		"context_window",
+		"context_length",
+		"max_input_tokens",
+		"max_tokens",
+		"max_output_tokens",
+	] as const) {
+		if (entry[field] !== undefined && positiveInteger(entry[field]) === undefined) {
+			throw new Error(`catalog data[${index}].${field} must be a positive integer`);
+		}
+	}
+	if (entry.cost !== undefined) validateManagedLiveCost(entry.cost, index);
+	if (entry.capabilities !== undefined) validateManagedLiveCapabilities(entry.capabilities, index);
+}
+
+function validateManagedLiveCost(value: unknown, index: number): void {
+	if (!isPlainRecord(value)) throw new Error(`catalog data[${index}].cost must be an object`);
+	for (const field of ["input", "output"] as const) {
+		if (nonNegativeNumber(value[field]) === undefined) {
+			throw new Error(`catalog data[${index}].cost.${field} must be non-negative`);
+		}
+	}
+	for (const field of ["cache_read", "cache_write"] as const) {
+		if (value[field] !== undefined && nonNegativeNumber(value[field]) === undefined) {
+			throw new Error(`catalog data[${index}].cost.${field} must be non-negative`);
+		}
+	}
+}
+
+function validateManagedLiveCapabilities(value: unknown, index: number): void {
+	if (!isPlainRecord(value)) {
+		throw new Error(`catalog data[${index}].capabilities must be an object`);
+	}
+	for (const field of [
+		"chat",
+		"responses",
+		"tools",
+		"vision",
+		"embeddings",
+		"image_generation",
+	] as const) {
+		if (value[field] !== undefined && typeof value[field] !== "boolean") {
+			throw new Error(`catalog data[${index}].capabilities.${field} must be boolean`);
+		}
+	}
 }
 
 function extractManagedLiveModel(value: unknown): AiProviderModel | null {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 import {
 	chmodSync,
 	chownSync,
@@ -25,7 +26,10 @@ import {
 	writeRuntimeAppliedState,
 } from "./applied-state";
 import { loadHostedBundledSkill } from "./hosted-bundled-skill";
-import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
+import {
+	hostedAiProviderCatalog,
+	resolveManagedGatewayModelAuthority,
+} from "./hosted-provider-resolution";
 import {
 	captureRuntimeLiveSnapshot,
 	restoreRuntimeLiveSnapshot,
@@ -35,6 +39,7 @@ import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
 	type RuntimeManifest,
+	resolveManagedGatewayModelAuthorityForLoad,
 	runtimeInstallerMutationTargets,
 	runtimeRecoverableSecretValues,
 	runtimeUserMutationTargets,
@@ -177,6 +182,51 @@ function baseManifest(
 		runtimes,
 		recovery: {},
 		...overrides,
+	};
+}
+
+async function startMalformedUtf8ModelServer(): Promise<{
+	baseUrl: string;
+	close: () => Promise<void>;
+}> {
+	const script = [
+		'const { createServer } = require("node:http");',
+		'const body = Buffer.concat([Buffer.from(\'{"data":[{"id":"model-\'), Buffer.from([0xff]), Buffer.from(\'"}]}\')]);',
+		"const server = createServer((_request, response) => {",
+		'  response.writeHead(200, { "content-type": "application/json", "content-length": body.length });',
+		"  response.end(body);",
+		"});",
+		'server.listen(0, "127.0.0.1", () => {',
+		"  const address = server.address();",
+		'  if (!address || typeof address === "string") process.exit(1);',
+		"  process.stdout.write(String(address.port));",
+		"});",
+		'server.on("error", (error) => { process.stderr.write(error.message); process.exit(1); });',
+		'server.on("close", () => process.exit(0));',
+		'process.on("SIGTERM", () => server.close());',
+	].join("\n");
+	const child = spawn(process.execPath, ["-e", script], {
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stderr = "";
+	child.stderr.setEncoding("utf8");
+	child.stderr.on("data", (chunk: string) => {
+		stderr += chunk;
+	});
+	const port = await Promise.race([
+		once(child.stdout, "data").then(([chunk]) => Number.parseInt(String(chunk), 10)),
+		once(child, "exit").then(([code]) => {
+			throw new Error(`malformed UTF-8 test server exited ${String(code)}: ${stderr}`);
+		}),
+	]);
+	if (!Number.isInteger(port) || port <= 0) throw new Error(`invalid test server port: ${port}`);
+	return {
+		baseUrl: `http://127.0.0.1:${port}/v1`,
+		close: async () => {
+			if (child.exitCode !== null) return;
+			child.kill("SIGTERM");
+			await once(child, "exit");
+		},
 	};
 }
 
@@ -2259,6 +2309,214 @@ describe("runtime manifest reconciliation invariants", () => {
 		]);
 	});
 
+	test("materializes strict-v2 model authority and replays it offline without probing", () => {
+		const paths = tempRuntimePaths();
+		const providerId = "clawdi-managed-v2";
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "model-a" },
+					services: {},
+				},
+			},
+			{
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					providers: {
+						[providerId]: {
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl: "https://api.example.test/v1",
+							models: [{ id: "seed-only" }],
+							apiMode: "openai_chat",
+							runtimeEnvName: "OPENAI_API_KEY",
+							apiKeySecretRef: "secret://providers/default/api-key",
+						},
+					},
+				},
+			},
+		);
+		const load = manifestLoad(manifest, "https://runtime.example.test/v1/runtime/manifest");
+		const cacheKey = `${providerId}\nhttps://api.example.test/v1`;
+		const committedValidators = new Map([[cacheKey, '"models-a"']]);
+		const online = resolveManagedGatewayModelAuthority(
+			load,
+			["openclaw"],
+			paths.userHome,
+			join(paths.userHome, "clawdi"),
+			paths.egressSystemCaFile,
+			(input) => {
+				expect(input.validationMode).toBe("strict-v2");
+				expect(input.ifNoneMatch).toBeUndefined();
+				return {
+					status: "ok",
+					endpoint: "https://api.example.test/v1/models",
+					etag: '"models-b"',
+					models: [{ id: "model-b" }, { id: "model-a", supports_tools: true }],
+				};
+			},
+			committedValidators,
+		);
+
+		expect(committedValidators.get(cacheKey)).toBe('"models-a"');
+		expect(online.transportValidators.get(cacheKey)).toBe('"models-b"');
+		expect(
+			(online.load.manifest.projection?.providers?.[providerId] as { models: unknown[] }).models,
+		).toEqual([{ id: "model-a", supports_tools: true }, { id: "model-b" }]);
+		expect(online.load.manifest.runtimes.openclaw?.primary_model).toEqual({
+			provider_id: providerId,
+			model: "model-a",
+		});
+
+		let offlineProbeCalls = 0;
+		const offline = resolveManagedGatewayModelAuthority(
+			{ ...online.load, source: "last-good-cache", offline: true },
+			["openclaw"],
+			paths.userHome,
+			join(paths.userHome, "clawdi"),
+			paths.egressSystemCaFile,
+			() => {
+				offlineProbeCalls += 1;
+				throw new Error("offline model authority must not probe");
+			},
+			online.transportValidators,
+		);
+		expect(offlineProbeCalls).toBe(0);
+		expect(offline.load.manifest).toEqual(online.load.manifest);
+	});
+
+	test("rejects malformed UTF-8 only at the strict model authority boundary", async () => {
+		const paths = tempRuntimePaths();
+		mkdirSync(dirname(paths.egressSystemCaFile), { recursive: true });
+		mkdirSync(join(paths.userHome, "clawdi"), { recursive: true });
+		writeFileSync(paths.egressSystemCaFile, "");
+		const providerId = "clawdi-managed-v2";
+		const server = await startMalformedUtf8ModelServer();
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "model-a" },
+					services: {},
+				},
+			},
+			{
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					providers: {
+						[providerId]: {
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl: server.baseUrl,
+							models: [{ id: "model-a" }],
+							apiMode: "openai_chat",
+							runtimeEnvName: "OPENAI_API_KEY",
+							apiKeySecretRef: "secret://providers/default/api-key",
+						},
+					},
+				},
+			},
+		);
+
+		try {
+			expect(() =>
+				resolveManagedGatewayModelAuthorityForLoad(
+					manifestLoad(manifest, "inline-strict-malformed-utf8"),
+					paths,
+				),
+			).toThrow(
+				/managed model probe failed.*(?:Invalid byte sequence|encoded data was not valid)/s,
+			);
+
+			const legacy = resolveManagedGatewayModelAuthorityForLoad(
+				manifestLoad(
+					{ ...manifest, projection: { ...manifest.projection, sourceBundleVersion: undefined } },
+					"inline-legacy-malformed-utf8",
+				),
+				paths,
+			);
+			expect(legacy.overrides.models.openclaw).toEqual([{ id: "model-�" }]);
+			expect(legacy.overrides.primaryModels.openclaw).toEqual({
+				provider_id: providerId,
+				model: "model-�",
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("advances model transport validators only after authority commit succeeds", () => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const providerId = "clawdi-managed-v2";
+		const manifest = egressRuntimeManifest(paths, { generation: 1, profile: "absent" });
+		manifest.runtimes.openclaw = {
+			...manifest.runtimes.openclaw,
+			provider_ids: [providerId],
+			primary_model: { provider_id: providerId, model: "model-a" },
+		};
+		manifest.projection = {
+			...manifest.projection,
+			providers: {
+				[providerId]: {
+					type: "custom_openai_compatible",
+					managed_by: "clawdi",
+					baseUrl: "https://api.example.test/v1",
+					models: [{ id: "model-a" }],
+					apiMode: "openai_chat",
+					runtimeEnvName: "OPENAI_API_KEY",
+					apiKeySecretRef: "secret://providers/default/api-key",
+				},
+			},
+		};
+		const load = manifestLoad(manifest, "inline-model-validator", {
+			...TEST_HOSTED_SECRET_VALUES,
+			"secret://providers/default/api-key": "provider-secret",
+		});
+		const cacheKey = `${providerId}\nhttps://api.example.test/v1`;
+		const validators = new Map([[cacheKey, '"models-a"']]);
+		const modelFetcher = () => ({
+			status: "ok" as const,
+			endpoint: "https://api.example.test/v1/models",
+			etag: '"models-b"',
+			models: [{ id: "model-a" }, { id: "model-b" }],
+		});
+		const systemdApply = {
+			activateEgressPrerequisite: successfulPrerequisiteActivation,
+			activate: successfulPrerequisiteActivation,
+			rollback: () => {},
+		};
+
+		const failed = convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			managedGatewayModelListFetcher: modelFetcher,
+			managedGatewayModelTransportValidators: validators,
+			commitAuthority: () => {
+				throw new Error("injected authority failure");
+			},
+			systemdApply,
+		});
+		expect(failed.installErrors.join("\n")).toContain("injected authority failure");
+		expect(validators.get(cacheKey)).toBe('"models-a"');
+
+		const committed = convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			managedGatewayModelListFetcher: modelFetcher,
+			managedGatewayModelTransportValidators: validators,
+			commitAuthority: () => {},
+			systemdApply,
+		});
+		expect(committed.installErrors).toEqual([]);
+		expect(validators.get(cacheKey)).toBe('"models-b"');
+	});
+
 	test.each([
 		"openclaw",
 		"default",
@@ -2606,7 +2864,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		}
 		expect(upgradeErrors).not.toContain("test-token");
 		expect(upgradeCommits).toBe(0);
-		expect(rollbackCalls).toBe(1);
+		expect(rollbackCalls).toBe(failure === "activation" ? 1 : 0);
 		expectSnapshot(previous);
 		expect(
 			JSON.parse(readFileSync(runtimeRunConfigPath("openclaw", upgradePaths), "utf-8")),
@@ -2648,6 +2906,89 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(readRuntimeAppliedState(paths)?.generation).toBe(1);
 		expect(existsSync(paths.manifestLastGood)).toBe(true);
 		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(true);
+	});
+
+	test("removes a fresh sidecar prerequisite when strict model probing fails", () => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const engine = installCachedTestEgressEngine(paths, "12.2.3-model-probe");
+		const providerId = "clawdi-managed-v2";
+		const manifest = egressRuntimeManifest(paths, {
+			generation: 1,
+			engine,
+			profile: "enabled",
+		});
+		manifest.runtimes.openclaw = {
+			...manifest.runtimes.openclaw,
+			provider_ids: [providerId],
+			primary_model: { provider_id: providerId, model: "model-a" },
+		};
+		manifest.projection = {
+			...manifest.projection,
+			providers: {
+				[providerId]: {
+					type: "custom_openai_compatible",
+					managed_by: "clawdi",
+					baseUrl: "https://api.example.test/v1",
+					models: [{ id: "model-a" }],
+					apiMode: "openai_chat",
+					runtimeEnvName: "OPENAI_API_KEY",
+					apiKeySecretRef: "secret://providers/default/api-key",
+				},
+			},
+		};
+		const sidecarUnit = join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service");
+		const staleSidecarPaths = [
+			sidecarUnit,
+			join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
+			join(paths.managedSecretRoot, "egress-secrets.json"),
+		];
+		for (const path of staleSidecarPaths) {
+			mkdirSync(dirname(path), { recursive: true });
+			chmodSync(dirname(path), 0o755);
+			writeFileSync(
+				path,
+				path.endsWith("egress-secrets.json") ? "{}\n" : "uncommitted stale sidecar state\n",
+			);
+		}
+		let prerequisiteCalls = 0;
+		let activationCalls = 0;
+		let rollbackCalls = 0;
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "inline-model-probe-failure", {
+				...TEST_HOSTED_SECRET_VALUES,
+				"secret://providers/default/api-key": "provider-secret",
+			}),
+			paths,
+			{
+				cacheLastGood: false,
+				systemdApply: {
+					activateEgressPrerequisite: () => {
+						prerequisiteCalls += 1;
+						expect(existsSync(sidecarUnit)).toBe(true);
+						return successfulPrerequisiteActivation();
+					},
+					activate: () => {
+						activationCalls += 1;
+						return successfulPrerequisiteActivation();
+					},
+					rollback: () => {
+						rollbackCalls += 1;
+						expect(existsSync(sidecarUnit)).toBe(false);
+					},
+				},
+			},
+		);
+
+		expect(result.installErrors.join("\n")).toContain("managed model probe failed");
+		expect(prerequisiteCalls).toBe(1);
+		expect(activationCalls).toBe(0);
+		expect(rollbackCalls).toBe(1);
+		expect(readFileSync(sidecarUnit, "utf-8")).toBe("uncommitted stale sidecar state\n");
+		expect(
+			readFileSync(join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"), "utf-8"),
+		).toBe("uncommitted stale sidecar state\n");
+		expect(existsSync(join(paths.managedSecretRoot, "egress-secrets.json"))).toBe(false);
 	});
 
 	test.each([
@@ -3769,7 +4110,9 @@ describe("runtime manifest reconciliation invariants", () => {
 		chmodSync(paths.managedConfig, 0o640);
 		const previousManagedStat = statSync(paths.managedConfig);
 		const previous = new Map(rootManagedPaths.map((path) => [path, readFileSync(path)]));
+		const previousNativeConfig = readFileSync(targetConfig);
 		const previousSystemEnvironment = readFileSync(systemEnvironment);
+		process.env.OPENCLAW_GATEWAY_TOKEN = "rollback-gateway-token";
 		const manifest = baseManifest(
 			paths,
 			{
@@ -3779,7 +4122,14 @@ describe("runtime manifest reconciliation invariants", () => {
 					services: {},
 				},
 			},
-			{ locale: { language: "en", timezone: "UTC" } },
+			{
+				locale: { language: "en", timezone: "UTC" },
+				openclawGatewayAuth: hostedOpenClawNativeAuth(),
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					system: hostedSystemFixture(),
+				},
+			},
 		);
 
 		let activateCalls = 0;
@@ -3789,6 +4139,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => {
 					activateCalls += 1;
+					expect(readFileSync(targetConfig)).not.toEqual(previousNativeConfig);
 					throw new Error("injected systemd activation failure");
 				},
 				rollback: () => {
@@ -3902,13 +4253,127 @@ describe("runtime manifest reconciliation invariants", () => {
 		for (const path of staleFiles) expect(existsSync(path)).toBe(false);
 	});
 
+	test.each([
+		"activation",
+		"authorityCommit",
+	] as const)("rolls back strict-v2 Hermes native provider state after %s failure", (failure) => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const commandPath = join(paths.userHome, ".hermes", "bin", "hermes");
+		const targetConfig = join(paths.userHome, ".hermes", "config.yaml");
+		const legacyPluginDir = join(paths.userHome, ".hermes", "plugins", "model-providers", "clawdi");
+		const legacyPluginFile = join(legacyPluginDir, "__init__.py");
+		mkdirSync(dirname(commandPath), { recursive: true });
+		mkdirSync(legacyPluginDir, { recursive: true });
+		chmodSync(legacyPluginDir, 0o700);
+		writeFileSync(commandPath, "#!/usr/bin/env sh\nexit 0\n");
+		chmodSync(commandPath, 0o700);
+		writeFileSync(targetConfig, "model:\n  default: old-model\n");
+		writeFileSync(legacyPluginFile, 'LEGACY_MODEL = "committed-model"\n');
+		const previousNativeConfig = readFileSync(targetConfig);
+		const previousLegacyPlugin = readFileSync(legacyPluginFile);
+		const failureMessage =
+			failure === "activation"
+				? "injected activation failure"
+				: "injected authority commit failure";
+		const providerId = "clawdi-managed-v2";
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(commandPath, ["gateway", "run"]),
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "model-a" },
+					services: {},
+				},
+			},
+			{
+				locale: { language: "en", timezone: "Asia/Tokyo" },
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					providers: {
+						[providerId]: {
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl: "https://api.example.test/v1",
+							models: [{ id: "model-a" }],
+							apiMode: "openai_chat",
+							runtimeEnvName: "OPENAI_API_KEY",
+							apiKeySecretRef: "secret://providers/default/api-key",
+						},
+					},
+				},
+			},
+		);
+		const sourceLoad = manifestLoad(manifest, "inline-hermes-rollback", {
+			"secret://providers/default/api-key": "provider-secret",
+		});
+		let modelFetchCalls = 0;
+		const preparedModelAuthority = resolveManagedGatewayModelAuthority(
+			sourceLoad,
+			["hermes"],
+			paths.userHome,
+			join(paths.userHome, "clawdi"),
+			paths.egressSystemCaFile,
+			() => {
+				modelFetchCalls += 1;
+				return {
+					status: "ok",
+					endpoint: "https://api.example.test/v1/models",
+					etag: '"models-b"',
+					models: [{ id: "model-b" }],
+				};
+			},
+		);
+		expect(preparedModelAuthority.load.manifest.runtimes.hermes?.primary_model?.model).toBe(
+			"model-b",
+		);
+		let rollbackCalls = 0;
+		let authorityCommitCalls = 0;
+		const result = convergeRuntimeManifest(preparedModelAuthority.load, paths, {
+			cacheLastGood: false,
+			managedGatewayModelAuthorityResolution: preparedModelAuthority,
+			commitAuthority: () => {
+				authorityCommitCalls += 1;
+				expect(existsSync(legacyPluginDir)).toBe(false);
+				if (failure === "authorityCommit") throw new Error(failureMessage);
+			},
+			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
+				activate: () => {
+					expect(readFileSync(targetConfig)).not.toEqual(previousNativeConfig);
+					expect(existsSync(legacyPluginDir)).toBe(false);
+					if (failure === "activation") throw new Error(failureMessage);
+					return successfulPrerequisiteActivation();
+				},
+				rollback: () => {
+					rollbackCalls += 1;
+				},
+			},
+		});
+
+		expect(result.installErrors.join("\n")).toContain(failureMessage);
+		expect(readFileSync(targetConfig)).toEqual(previousNativeConfig);
+		expect(readFileSync(legacyPluginFile)).toEqual(previousLegacyPlugin);
+		expect(modelFetchCalls).toBe(1);
+		expect(authorityCommitCalls).toBe(failure === "authorityCommit" ? 1 : 0);
+		expect(rollbackCalls).toBe(1);
+	});
+
 	test("uses an explicit managed snapshot allowlist without broad runtime roots", () => {
 		const paths = tempRuntimePaths();
 		const workspaceRoot = join(paths.userHome, "clawdi");
-		const manifest = baseManifest(paths, {
-			openclaw: { enabled: true, run: runSettings("openclaw", []), services: {} },
-			hermes: { enabled: true, run: runSettings("hermes", []), services: {} },
-		});
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: { enabled: true, run: runSettings("openclaw", []), services: {} },
+				hermes: { enabled: true, run: runSettings("hermes", []), services: {} },
+			},
+			{
+				projection: { sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2" },
+			},
+		);
 		const existingSystemUnit = join(paths.systemdSystemRoot, "clawdi-existing.service");
 		const existingSystemDropIn = join(
 			paths.systemdSystemRoot,
@@ -3967,6 +4432,9 @@ describe("runtime manifest reconciliation invariants", () => {
 		);
 		expect(runtimeUserMutationTargets(manifest, paths, workspaceRoot, new Map())).toEqual(
 			expect.arrayContaining([
+				join(paths.userHome, ".openclaw", "openclaw.json"),
+				join(paths.userHome, ".hermes", "config.yaml"),
+				join(paths.userHome, ".hermes", "plugins", "model-providers", "clawdi"),
 				join(paths.userHome, ".hermes", "auth.json"),
 				join(paths.userHome, ".hermes", "auth.lock"),
 				openClawDatabase,
@@ -3980,10 +4448,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			paths.userHome,
 			workspaceRoot,
 			join(workspaceRoot, "SOUL.md"),
-			join(paths.userHome, ".openclaw", "openclaw.json"),
-			join(paths.userHome, ".hermes", "config.yaml"),
 			join(paths.userHome, ".hermes", "SOUL.md"),
-			join(paths.userHome, ".hermes", "plugins", "model-providers", "clawdi"),
 			join(paths.userHome, ".codex", "config.toml"),
 			join(paths.userHome, ".openclaw", "agents", "main", "skills", "clawdi"),
 			join(paths.userHome, ".hermes", "skills", "clawdi"),

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -73,13 +73,20 @@ import {
 
 import { managedMcpHeaderPlaceholder, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
+	acceptManagedGatewayModelTransportValidators,
 	hostedAiProviderCatalog,
 	hostedProviderEnvironment,
 	hostedProviderRequiresApiKey,
+	type ManagedGatewayModelAuthorityResolution,
+	type ManagedGatewayModelFetchInput,
+	type ManagedGatewayModelFetchResult,
 	type ManagedGatewayModelListFetcher,
+	type ManagedGatewayModelOverrides,
+	type ManagedGatewayModelTransportValidators,
 	mergeRuntimeEnvWithProviderPlaceholders,
 	mergeRuntimeServiceEnvWithProviderPlaceholders,
-	resolveManagedGatewayModelOverrides,
+	requiresStrictManagedGatewayModelProbe,
+	resolveManagedGatewayModelAuthority,
 } from "./hosted-provider-resolution";
 import {
 	emptyRuntimeInstallReceipts,
@@ -95,7 +102,11 @@ import {
 	runtimeRootLiveMutationDirectories,
 	runtimeRootLiveMutationTargets,
 } from "./live-state-snapshot";
-import { buildManagedModelsEndpoint, extractManagedLiveModels } from "./managed-model-resolution";
+import {
+	buildManagedModelsEndpoint,
+	extractManagedLiveModels,
+	parseManagedLiveModels,
+} from "./managed-model-resolution";
 import {
 	installReservedManagedSkill,
 	managedSkillReservationOwner,
@@ -109,6 +120,13 @@ import {
 } from "./manifest-resources";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
 
+export {
+	acceptManagedGatewayModelTransportValidators,
+	type ManagedGatewayModelAuthorityResolution,
+	type ManagedGatewayModelListFetcher,
+	type ManagedGatewayModelTransportValidators,
+	resolveManagedGatewayModelAuthority,
+} from "./hosted-provider-resolution";
 export type { RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 export {
 	loadRuntimeManifest,
@@ -165,6 +183,7 @@ import {
 	runtimeSystemdCommonEnvironment,
 	uninstallStaleOfficialRuntimeServices,
 	validateRuntimeSystemdPlan,
+	writeRuntimeSidecarSystemdUnit,
 	writeRuntimeSystemdState,
 } from "./runtime-systemd-reconciliation";
 import {
@@ -185,10 +204,6 @@ import {
 	TRANSPARENT_EGRESS_TRANSPORT_VERSION,
 } from "./transparent-egress";
 import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
-
-type ManagedGatewayModelFetchInput = Parameters<ManagedGatewayModelListFetcher>[0];
-type ManagedGatewayModelFetchResult = ReturnType<ManagedGatewayModelListFetcher>;
-type ManagedGatewayModelOverrides = ReturnType<typeof resolveManagedGatewayModelOverrides>;
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -1451,21 +1466,45 @@ function applyHostedLocaleProjection(
 }
 
 const MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS = 3_000;
+const MAX_MANAGED_GATEWAY_MODEL_RESPONSE_BYTES = 1024 * 1024;
 
 const MANAGED_GATEWAY_MODEL_FETCH_SCRIPT = [
-	"const [url, timeoutRaw] = process.argv.slice(1);",
+	"const [url, timeoutRaw, maxBytesRaw, utf8Mode, ifNoneMatch] = process.argv.slice(1);",
 	"const timeoutMs = Number.parseInt(timeoutRaw ?? '', 10) || 3000;",
+	"const maxBytes = Number.parseInt(maxBytesRaw ?? '', 10);",
 	"const controller = new AbortController();",
 	"const timer = setTimeout(() => controller.abort(), timeoutMs);",
 	"(async () => {",
 	"  try {",
+	"    const headers = { accept: 'application/json' };",
+	"    if (ifNoneMatch) headers['if-none-match'] = ifNoneMatch;",
 	"    const response = await fetch(url, {",
 	"      method: 'GET',",
-	"      headers: { accept: 'application/json' },",
+	"      headers,",
 	"      signal: controller.signal,",
 	"    });",
-	"    const body = await response.text();",
-	"    process.stdout.write(JSON.stringify({ ok: response.ok, status: response.status, body }));",
+	"    const etag = response.headers.get('etag');",
+	"    if (response.status === 304) {",
+	"      process.stdout.write(JSON.stringify({ status: response.status, etag }));",
+	"      process.exit(0);",
+	"    }",
+	"    const contentLength = Number.parseInt(response.headers.get('content-length') ?? '', 10);",
+	"    if (maxBytes > 0 && Number.isFinite(contentLength) && contentLength > maxBytes) throw new Error('response exceeds byte limit');",
+	"    const chunks = [];",
+	"    let total = 0;",
+	"    if (response.body) {",
+	"      const reader = response.body.getReader();",
+	"      while (true) {",
+	"        const { done, value } = await reader.read();",
+	"        if (done) break;",
+	"        total += value.byteLength;",
+	"        if (maxBytes > 0 && total > maxBytes) { await reader.cancel(); throw new Error('response exceeds byte limit'); }",
+	"        chunks.push(value);",
+	"      }",
+	"    }",
+	"    const bodyBytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total);",
+	"    const body = utf8Mode === 'fatal' ? new TextDecoder('utf-8', { fatal: true }).decode(bodyBytes) : bodyBytes.toString('utf8');",
+	"    process.stdout.write(JSON.stringify({ status: response.status, etag, body }));",
 	"    process.exit(response.ok ? 0 : 1);",
 	"  } catch (error) {",
 	"    const detail = error && typeof error === 'object' && 'name' in error && error.name === 'AbortError'",
@@ -1497,11 +1536,17 @@ function fetchManagedGatewayModelList(
 			MANAGED_GATEWAY_MODEL_FETCH_SCRIPT,
 			endpoint,
 			String(MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS),
+			String(input.validationMode === "strict-v2" ? MAX_MANAGED_GATEWAY_MODEL_RESPONSE_BYTES : 0),
+			input.validationMode === "strict-v2" ? "fatal" : "replace",
+			...(input.ifNoneMatch ? [input.ifNoneMatch] : []),
 		],
 		input.home,
 		input.workspaceRoot,
 		{
 			egressSystemCaFile: input.egressSystemCaFile,
+			...(input.validationMode === "strict-v2"
+				? { maxBuffer: MAX_MANAGED_GATEWAY_MODEL_RESPONSE_BYTES * 2 + 64 * 1024 }
+				: {}),
 		},
 	);
 	const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString("utf8");
@@ -1511,9 +1556,27 @@ function fetchManagedGatewayModelList(
 		return { status: "failed", detail, endpoint };
 	}
 	try {
-		const payload = JSON.parse(stdout) as { body?: string };
+		const payload = JSON.parse(stdout) as { body?: string; etag?: unknown; status?: unknown };
+		const etag = typeof payload.etag === "string" ? payload.etag : undefined;
+		if (payload.status === 304) {
+			return input.validationMode === "strict-v2"
+				? { status: "not_modified", endpoint, etag }
+				: { status: "failed", detail: "HTTP 304", endpoint };
+		}
+		const status = typeof payload.status === "number" ? payload.status : null;
+		const acceptedStatus =
+			input.validationMode === "strict-v2"
+				? status === 200
+				: status !== null && status >= 200 && status < 300;
+		if (!acceptedStatus) {
+			return { status: "failed", detail: `HTTP ${String(payload.status)}`, endpoint };
+		}
 		const body = payload.body ? JSON.parse(payload.body) : null;
-		return { status: "ok", endpoint, models: extractManagedLiveModels(body) };
+		const models =
+			input.validationMode === "strict-v2"
+				? parseManagedLiveModels(body)
+				: extractManagedLiveModels(body);
+		return { status: "ok", endpoint, etag, models };
 	} catch (error) {
 		return {
 			status: "failed",
@@ -1536,6 +1599,27 @@ function parseManagedGatewayFetchFailure(
 	}
 	const detail = stderr.trim() || stdout.trim();
 	return detail || `exit ${status ?? "unknown"}`;
+}
+
+export function resolveManagedGatewayModelAuthorityForLoad(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	fetcher: ManagedGatewayModelListFetcher = fetchManagedGatewayModelList,
+	transportValidators?: ManagedGatewayModelTransportValidators,
+): ManagedGatewayModelAuthorityResolution {
+	const enabledRuntimes = Object.entries(load.manifest.runtimes)
+		.filter(([, runtime]) => runtime.enabled)
+		.map(([name]) => name)
+		.sort();
+	return resolveManagedGatewayModelAuthority(
+		load,
+		enabledRuntimes,
+		hostedRuntimeProjectionHome(load.manifest, paths),
+		runtimeWorkspaceRoot(load.manifest, paths),
+		paths.egressSystemCaFile,
+		fetcher,
+		transportValidators,
+	);
 }
 
 function resolvedRuntimeServiceSettings(
@@ -4910,12 +4994,15 @@ export function convergeRuntimeManifest(
 			authority: RuntimePrivateAppliedAuthority,
 		) => void;
 		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+		managedGatewayModelTransportValidators?: ManagedGatewayModelTransportValidators;
+		managedGatewayModelAuthorityResolution?: ManagedGatewayModelAuthorityResolution;
 		egressEngineEnsureOptions?: EnsureRuntimeMitmproxyOptions;
 		systemdApply?: RuntimeSystemdApplyHooks;
 		executeOfficialServiceInstallers?: boolean;
 	} = {},
 ): RuntimeConvergenceResult {
-	const { manifest } = load;
+	let manifest = load.manifest;
+	let convergenceLoad = load;
 	const secretValues = runtimeSecretValues(load);
 	const applyContext = load.applyContext;
 	if (!applyContext) {
@@ -4997,6 +5084,49 @@ export function convergeRuntimeManifest(
 		egress: null,
 	});
 	validateRuntimeSystemdPlan(plannedRuntimePrograms);
+	let managedModelResolution = opts.managedGatewayModelAuthorityResolution;
+	const adoptManagedModelResolution = (
+		resolution: ManagedGatewayModelAuthorityResolution,
+		prepared: boolean,
+	): void => {
+		const expectedRevision = prepared
+			? runtimeContentSha256(resolution.load.manifest)
+			: resolution.baseManifestRevision;
+		if (expectedRevision !== runtimeContentSha256(load.manifest)) {
+			throw new Error("managed model authority was resolved for a different runtime manifest");
+		}
+		convergenceLoad = resolution.load;
+		manifest = convergenceLoad.manifest;
+		validateRuntimeProjectionPlan({
+			manifest,
+			paths,
+			workspaceRoot,
+			secretValues,
+			observations,
+			previousProjectedProviderIds,
+			managedModelOverrides: resolution.overrides,
+		});
+	};
+	if (managedModelResolution) adoptManagedModelResolution(managedModelResolution, true);
+	const strictManagedProbeRequired = requiresStrictManagedGatewayModelProbe(
+		convergenceLoad,
+		enabledRuntimes,
+	);
+	if (
+		!managedModelResolution &&
+		(!strictManagedProbeRequired || opts.managedGatewayModelListFetcher !== undefined)
+	) {
+		managedModelResolution = resolveManagedGatewayModelAuthority(
+			convergenceLoad,
+			enabledRuntimes,
+			projectionHome,
+			workspaceRoot,
+			plannedEgressProfileBundlePath ? paths.egressSystemCaFile : null,
+			opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
+			opts.managedGatewayModelTransportValidators,
+		);
+		adoptManagedModelResolution(managedModelResolution, false);
+	}
 	const mutationPlan = runtimeManagedMutationPlan({
 		manifest,
 		paths,
@@ -5006,6 +5136,10 @@ export function convergeRuntimeManifest(
 	});
 	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
 	const liveSnapshot = captureRuntimeLiveSnapshot(mutationPlan.snapshot);
+	const runtimeInstallerWillRun = [...observations.values()].some(
+		(observation) => observation.install !== null && observation.status === "configured",
+	);
+	let systemdActivationAttempted = false;
 	let systemdActivationApplied = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
@@ -5019,7 +5153,9 @@ export function convergeRuntimeManifest(
 		systemUnits: [],
 		userUnits: [],
 	};
+	let egressPrerequisiteActivated = false;
 	try {
+		if (runtimeInstallerWillRun && opts.systemdApply) systemdActivationAttempted = true;
 		observations.clear();
 		for (const [name, runtime] of runtimeEntries) {
 			const observation = observeRuntimeInstall(name, runtime, projectionHome);
@@ -5090,24 +5226,6 @@ export function convergeRuntimeManifest(
 			}
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
-
-		const managedModelOverrides = resolveManagedGatewayModelOverrides(
-			manifest,
-			enabledRuntimes,
-			projectionHome,
-			workspaceRoot,
-			plannedEgressProfileBundlePath ? paths.egressSystemCaFile : null,
-			opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
-		);
-		validateRuntimeProjectionPlan({
-			manifest,
-			paths,
-			workspaceRoot,
-			secretValues,
-			observations,
-			previousProjectedProviderIds,
-			managedModelOverrides,
-		});
 
 		ensureRuntimeUserHome(paths.userHome);
 		withRuntimeUserFileAccess(() => {
@@ -5253,6 +5371,79 @@ export function convergeRuntimeManifest(
 				egress: egressSystemdProgram,
 			}),
 		);
+		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(paths);
+		const egressSidecarActive =
+			egressSystemdProgram !== null &&
+			egressIdentity !== null &&
+			runtimeSystemdUserPrograms.length > 0;
+		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
+		if (egressSidecarActive) {
+			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
+			restartEgressSidecar =
+				egressSecretWrite.changed ||
+				committedEgressSidecarSecretRevision === undefined ||
+				committedEgressSidecarSecretRevision !== desiredEgressSidecarSecretRevision;
+			if (committedEgressSidecarSecretRevision === undefined) {
+				if (appliedState !== null || !strictManagedProbeRequired) {
+					rollbackEgressSecretOverride =
+						verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
+					egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
+				} else {
+					egressRollbackAuthorityVerified = false;
+				}
+			} else if (
+				committedEgressSidecarSecretRevision !== undefined &&
+				restartEgressSidecar &&
+				egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
+			) {
+				if (desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
+					rollbackEgressSecretOverride = egressSecretWrite.material;
+				} else {
+					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
+				}
+			}
+		}
+		if (strictManagedProbeRequired && managedModelResolution === undefined) {
+			if (!egressSidecarActive || !egressSystemdProgram || !egressIdentity || !opts.systemdApply) {
+				throw new Error(
+					"managed model probe requires the transparent-egress prerequisite on fresh boot",
+				);
+			}
+			writeRuntimeSidecarSystemdUnit({
+				program: egressSystemdProgram,
+				identity: egressIdentity,
+				manifest,
+				paths,
+				workspaceRoot,
+				commonEnvironment: commonSystemdEnvironment,
+			});
+			systemdActivationAttempted = true;
+			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
+				restartDaemon: false,
+				restartEgressSidecar,
+				stopEgressSidecar: false,
+				reconcileUserUnits: [],
+				staleSystemUnits: [],
+				staleUserUnits: [],
+			});
+			if (!prerequisite.applied) {
+				throw new Error("transparent-egress system prerequisites did not reach readiness");
+			}
+			egressPrerequisiteActivated = true;
+		}
+		if (!managedModelResolution) {
+			managedModelResolution = resolveManagedGatewayModelAuthority(
+				convergenceLoad,
+				enabledRuntimes,
+				projectionHome,
+				workspaceRoot,
+				plannedEgressProfileBundlePath ? paths.egressSystemCaFile : null,
+				opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
+				opts.managedGatewayModelTransportValidators,
+			);
+			adoptManagedModelResolution(managedModelResolution, false);
+		}
+		const managedModelOverrides = managedModelResolution.overrides;
 		const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
 		for (const [name] of runtimeEntries) {
 			const observation = observations.get(name);
@@ -5266,7 +5457,6 @@ export function convergeRuntimeManifest(
 				managedModelOverrides,
 			);
 		}
-		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(paths);
 		try {
 			const codexProjection = withRuntimeUserFileAccess(() =>
 				applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
@@ -5473,37 +5663,6 @@ export function convergeRuntimeManifest(
 			commonEnvironment: commonSystemdEnvironment,
 		});
 		staleSystemdFiles = systemdUnits.staleFiles;
-		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
-		if (systemdUnits.egressSidecarActive) {
-			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
-			restartEgressSidecar =
-				egressSecretWrite.changed ||
-				committedEgressSidecarSecretRevision === undefined ||
-				committedEgressSidecarSecretRevision !== desiredEgressSidecarSecretRevision;
-			if (committedEgressSidecarSecretRevision === undefined) {
-				// Legacy applied state has no private egress revision. An exact
-				// applied content identity can still prove complete last-good material
-				// for rollback, but its absence must not block loading the desired
-				// material. If desired activation later fails, unverified live bytes
-				// must never be loaded by a rollback restart.
-				rollbackEgressSecretOverride =
-					verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
-				egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
-			} else if (
-				restartEgressSidecar &&
-				egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
-			) {
-				if (desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
-					rollbackEgressSecretOverride = egressSecretWrite.material;
-				} else {
-					// A crash may have already advanced both the live file and last-good
-					// cache while the applied authority still describes the loaded secret.
-					// Do not require rollback material until activation actually fails:
-					// successfully restarting the desired material can safely commit it.
-					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
-				}
-			}
-		}
 		const officialServicePlan = planOfficialRuntimeServices(
 			runtimeSystemdUserPrograms,
 			paths,
@@ -5528,8 +5687,10 @@ export function convergeRuntimeManifest(
 				(hermesDashboardArtifactPlan.program !== null &&
 					hermesDashboardArtifactPlan.target?.expectedCurrentRevision === null)) &&
 			systemdUnits.egressSidecarActive &&
-			opts.systemdApply
+			opts.systemdApply &&
+			!egressPrerequisiteActivated
 		) {
+			systemdActivationAttempted = true;
 			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
 				restartDaemon,
 				restartEgressSidecar,
@@ -5541,6 +5702,14 @@ export function convergeRuntimeManifest(
 			if (!prerequisite.applied) {
 				throw new Error("transparent-egress system prerequisites did not reach readiness");
 			}
+			egressPrerequisiteActivated = true;
+		}
+		if (
+			officialServicePlan.pending.length > 0 ||
+			(hermesDashboardArtifactPlan.program !== null &&
+				hermesDashboardArtifactPlan.target?.expectedCurrentRevision === null)
+		) {
+			systemdActivationAttempted = true;
 		}
 
 		for (const item of officialServicePlan.pending) {
@@ -5557,6 +5726,7 @@ export function convergeRuntimeManifest(
 		const bootFinished = join(instanceRoot, "boot-finished");
 		writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);
 		if (opts.systemdApply) {
+			systemdActivationAttempted = true;
 			const activation = opts.systemdApply.activate({
 				restartDaemon,
 				restartEgressSidecar,
@@ -5633,6 +5803,10 @@ export function convergeRuntimeManifest(
 					? { egressSidecarSecretRevision: desiredEgressSidecarSecretRevision }
 					: {}),
 			});
+			acceptManagedGatewayModelTransportValidators(
+				opts.managedGatewayModelTransportValidators,
+				managedModelResolution.transportValidators,
+			);
 			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			try {
 				for (const cleanupError of removeStaleRuntimeSystemdFiles(paths, systemdUnits.staleFiles)) {
@@ -5700,7 +5874,7 @@ export function convergeRuntimeManifest(
 				);
 			}
 		}
-		if (opts.systemdApply && filesystemRollbackSucceeded) {
+		if (systemdActivationAttempted && opts.systemdApply && filesystemRollbackSucceeded) {
 			try {
 				opts.systemdApply.rollback({
 					restartDaemon,
@@ -5717,7 +5891,7 @@ export function convergeRuntimeManifest(
 					}`,
 				);
 			}
-		} else if (opts.systemdApply) {
+		} else if (systemdActivationAttempted && opts.systemdApply) {
 			installErrors.push(
 				"runtime systemd rollback skipped because filesystem authority restoration failed",
 			);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -131,7 +131,7 @@ export interface RuntimeSystemdStaleFilePlan {
 	userUnits: string[];
 }
 
-interface RuntimeEgressIdentity {
+export interface RuntimeEgressIdentity {
 	runtimeUid: number;
 	runtimeGid: number;
 	egressUid: number;
@@ -1305,6 +1305,37 @@ function officialRuntimeSystemdPrograms(
 		.map(([, program]) => program);
 }
 
+export function writeRuntimeSidecarSystemdUnit(input: {
+	program: RuntimeEgressSystemdProgram;
+	identity: RuntimeEgressIdentity;
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	workspaceRoot: string;
+	commonEnvironment: Record<string, string>;
+}): string {
+	return writeSystemdSystemUnit({
+		paths: input.paths,
+		name: "clawdi-runtime-sidecar",
+		description: "Clawdi hosted runtime sidecar",
+		command: input.paths.cliManagedBin,
+		args: ["runtime", "sidecar"],
+		cwd: input.workspaceRoot,
+		env: {
+			...input.commonEnvironment,
+			CLAWDI_AUTH_TOKEN: "",
+			CLAWDI_EGRESS_ENV_FILE: input.program.envFilePath,
+			CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
+				input.manifest,
+				input.program,
+				input.identity,
+			),
+		},
+		serviceType: "notify",
+		extraUnitLines: [`Before=user@${input.identity.runtimeUid}.service`],
+		extraServiceLines: ["NotifyAccess=main"],
+	});
+}
+
 export function writeRuntimeSystemdState(input: {
 	runtimePrograms: RuntimeSystemdUserProgram[];
 	egressProgram: RuntimeEgressSystemdProgram | null;
@@ -1336,13 +1367,11 @@ export function writeRuntimeSystemdState(input: {
 		runtimeRevision,
 		commonEnvironment,
 	} = input;
-	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
 	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
 	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
 	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const userUnits: string[] = [];
-	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
 	const desiredSystemUnitNames = [
 		...(daemonAuthTokenFile ? ["clawdi-runtime-watch.service", "clawdi-daemon.service"] : []),
 		...(activeEgressProgram ? ["clawdi-runtime-sidecar.service"] : []),
@@ -1406,27 +1435,17 @@ export function writeRuntimeSystemdState(input: {
 	}
 
 	if (activeEgressProgram) {
+		if (!activeEgressIdentity) {
+			throw new Error("runtime sidecar egress revision requires the configured numeric identity");
+		}
 		systemUnits.push(
-			writeSystemdSystemUnit({
+			writeRuntimeSidecarSystemdUnit({
+				program: activeEgressProgram,
+				identity: activeEgressIdentity,
+				manifest,
 				paths,
-				name: "clawdi-runtime-sidecar",
-				description: "Clawdi hosted runtime sidecar",
-				command: paths.cliManagedBin,
-				args: ["runtime", "sidecar"],
-				cwd: workspaceRoot,
-				env: {
-					...commonEnvironment,
-					CLAWDI_AUTH_TOKEN: "",
-					CLAWDI_EGRESS_ENV_FILE: activeEgressProgram.envFilePath,
-					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
-						manifest,
-						activeEgressProgram,
-						activeEgressIdentity,
-					),
-				},
-				serviceType: "notify",
-				extraUnitLines: runtimeUid === null ? undefined : [`Before=user@${runtimeUid}.service`],
-				extraServiceLines: ["NotifyAccess=main"],
+				workspaceRoot,
+				commonEnvironment,
 			}),
 		);
 	}

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -140,7 +140,12 @@ export function spawnRuntimeUserCommand(
 	args: string[],
 	home: string,
 	cwd: string,
-	options: { egressSystemCaFile?: string; input?: string; timeoutMs?: number } = {},
+	options: {
+		egressSystemCaFile?: string;
+		input?: string;
+		maxBuffer?: number;
+		timeoutMs?: number;
+	} = {},
 ): ReturnType<typeof spawnSync> {
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
@@ -150,6 +155,7 @@ export function spawnRuntimeUserCommand(
 				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
 				cwd,
 				encoding: "utf8",
+				...(options.maxBuffer ? { maxBuffer: options.maxBuffer } : {}),
 				input: options.input,
 				timeout: options.timeoutMs,
 			});
@@ -158,7 +164,14 @@ export function spawnRuntimeUserCommand(
 			return spawnSync(
 				"runuser",
 				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ env, cwd, encoding: "utf8", input: options.input, timeout: options.timeoutMs },
+				{
+					env,
+					cwd,
+					encoding: "utf8",
+					...(options.maxBuffer ? { maxBuffer: options.maxBuffer } : {}),
+					input: options.input,
+					timeout: options.timeoutMs,
+				},
 			);
 		}
 		throw new Error(
@@ -169,6 +182,7 @@ export function spawnRuntimeUserCommand(
 		env,
 		cwd,
 		encoding: "utf8",
+		...(options.maxBuffer ? { maxBuffer: options.maxBuffer } : {}),
 		input: options.input,
 		timeout: options.timeoutMs,
 	});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5687,7 +5687,13 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect("manifest" in loaded).toBe(true);
 		if (!("manifest" in loaded)) throw new Error("expected hosted manifest load success");
 
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+			managedGatewayModelListFetcher: () => ({
+				status: "ok",
+				endpoint: "https://ai-gateway.example.test/v1/models",
+				models: [{ id: "gpt-5.5" }],
+			}),
+		});
 
 		expect(convergence.installErrors).toEqual([]);
 		const runConfig = JSON.parse(
@@ -7744,8 +7750,10 @@ exit 42
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		const openclawUnit = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
+		const previousPath = process.env.PATH;
 		const logs: string[] = [];
 		const providerSecretRef = "secret://provider.default.apiKey";
 		const channelSecretRef = "secret://channels/telegram/clawdi_accttelegram/agent-token";
@@ -7806,6 +7814,7 @@ exit 42
 				...TEST_RUNTIME_SERVICE_SECRET_VALUES,
 				...TEST_HOSTED_CODEX_SECRET_VALUES,
 				[providerSecretRef]: "sk-provider-watch",
+				[TEST_HOSTED_CODEX_SECRET_REF]: "sk-codex-watch",
 				[channelSecretRef]: "agent-token-watch",
 				[channelPlaceholderSecretRef]: "999999999:54db03c2296520629c70cfb6e3b15f8e",
 			},
@@ -7822,6 +7831,14 @@ exit 42
 
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: join(root, "systemctl-model-catalog.log"),
+			stateRoot: join(root, "systemctl-model-catalog-state"),
+			sidecarReadyPath: join(run, "egress", "systemd", "ca.pem"),
+		});
+		writeFileSync(join(bin, "gosu"), '#!/bin/sh\nshift\nexec "$@"\n');
+		chmodSync(join(bin, "gosu"), 0o700);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -7831,15 +7848,24 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   cat >/dev/null
   exit 0
 fi
+if [ "$*" = "gateway install --force --json" ]; then
+  mkdir -p '${dirname(openclawUnit)}'
+  printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${openclawUnit}'
+  printf '{"ok":true}\\n'
+  exit 0
+fi
 printf 'unexpected openclaw command: %s\\n' "$*" >&2
 exit 64
 `,
 		);
 		chmodSync(openclawBin, 0o700);
+		mkdirSync(dirname(openclawUnit), { recursive: true });
+		writeFileSync(openclawUnit, `[Unit]\n[Service]\nExecStart=${openclawBin} gateway run\n`);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
+		process.env.PATH = [bin, previousPath].filter(Boolean).join(":");
 		process.exitCode = undefined;
 		writeCanonicalApplyContext(
 			{
@@ -7865,38 +7891,32 @@ exit 64
 			if (!("manifest" in manifestLoad) || "notModified" in manifestLoad) {
 				throw new Error("expected initial manifest load success");
 			}
-			const initialConvergence = convergeRuntimeManifest(
-				applyRuntimeBundleChannelsToManifestLoad(manifestLoad as RuntimeManifestLoad),
-				paths,
+			const initialLoad = applyRuntimeBundleChannelsToManifestLoad(
+				manifestLoad as RuntimeManifestLoad,
 			);
+			const initialConvergence = convergeRuntimeManifest(initialLoad, paths, {
+				cacheLastGood: false,
+				managedGatewayModelListFetcher: () => ({
+					status: "ok",
+					endpoint: "https://sub2api.test/v1/models",
+					etag: '"models-a"',
+					models: [{ id: "gpt-5.5" }],
+				}),
+			});
 			expect(initialConvergence.installErrors).toEqual([]);
 			expectEgressProfileBundleUsesSecretRef(
 				initialConvergence.outputs.egressProfileBundle,
 				"secret://provider.default.apiKey",
 				"sk-provider-watch",
 			);
-			mkdirSync(dirname(paths.appliedState), { recursive: true });
-			writeFileSync(
-				paths.appliedState,
-				JSON.stringify({
-					schemaVersion: "clawdi.runtimeAppliedState.v2",
-					appliedAt: "2026-07-13T00:00:00.000Z",
-					instanceId: "iid_watch_secret",
-					etag: stableBundleEtag,
-					sourceRevision: "d".repeat(64),
-					generation: 22,
-					applyGeneration: 22,
-					manifestETag: stableBundleEtag,
-					applyReceiptId: "test-apply-receipt-0022",
-					bootNonce: "test-boot-nonce-000022",
-					contentIdentity: {
-						sourcePath: "https://runtime.test/v1/runtime/manifest",
-						sha256: "a".repeat(64),
-					},
-					providerIds: ["clawdi-managed-v2"],
-					projectedProviderIds: { openclaw: ["clawdi-managed-v2"] },
-				}),
-			);
+			commitRuntimeAppliedState({
+				load: initialLoad,
+				paths,
+				etag: stableBundleEtag,
+				sourceRevision: hostedPayload.sourceRevision,
+				convergence: initialConvergence,
+				applyIdentity: initialLoad.applyContext?.identity ?? null,
+			});
 		} finally {
 			initial.restore();
 		}
@@ -7906,6 +7926,12 @@ exit 64
 		);
 		expect(baselineMitmSecrets["secret://provider.default.apiKey"]).toBe("sk-provider-watch");
 		expect(baselineMitmSecrets[channelSecretRef]).toBe("agent-token-watch");
+		const baselineAppliedSha = readRuntimeAppliedState(paths)?.contentIdentity.sha256;
+		if (!baselineAppliedSha) throw new Error("expected committed model authority");
+		const baselineAppliedState = readRuntimeAppliedState(paths);
+		if (!baselineAppliedState) throw new Error("expected committed applied state");
+		writeRuntimeAppliedState({ ...baselineAppliedState, providerIds: [] }, paths);
+		const modelProbeValidators: Array<string | undefined> = [];
 
 		const watchFetch = mockFetch([
 			{
@@ -7922,7 +7948,19 @@ exit 64
 		]);
 
 		try {
-			await runtimeWatch({ once: true, json: true });
+			await runtimeWatch({
+				once: true,
+				json: true,
+				managedGatewayModelListFetcher: (input) => {
+					modelProbeValidators.push(input.ifNoneMatch);
+					return {
+						status: "ok",
+						endpoint: "https://sub2api.test/v1/models",
+						etag: '"models-b"',
+						models: [{ id: "gpt-5.5" }],
+					};
+				},
+			});
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
@@ -7938,10 +7976,12 @@ exit 64
 				etag: stableBundleEtag,
 				sourceRevision: "d".repeat(64),
 				generation: 22,
-				providerIds: ["clawdi-managed-v2"],
+				providerIds: [],
 			});
 			expect(event.systemdUnitsChanged).toBeUndefined();
 			expect(event.systemdApply).toBeUndefined();
+			expect(modelProbeValidators).toEqual([undefined]);
+			expect(readRuntimeAppliedState(paths)?.contentIdentity.sha256).toBe(baselineAppliedSha);
 			const egressSecrets = JSON.parse(
 				readFileSync(join(run, "secrets", "egress-secrets.json"), "utf-8"),
 			);
@@ -7950,9 +7990,43 @@ exit 64
 			expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
 				baselineRevision,
 			);
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({
+				once: true,
+				json: true,
+				managedGatewayModelListFetcher: () => ({
+					status: "ok",
+					endpoint: "https://sub2api.test/v1/models",
+					etag: '"models-c"',
+					models: [{ id: "gpt-5.5" }, { id: "gpt-5.6" }],
+				}),
+			});
+			if (process.exitCode !== undefined && process.exitCode !== 0) {
+				throw new Error(logs.join("\n"));
+			}
+			const changedEvent = JSON.parse(logs[0]);
+			expect(changedEvent.status).toBe("applied");
+			expect(changedEvent.etag).toBe(stableBundleEtag);
+			expect(changedEvent.sourceRevision).toBe(hostedPayload.sourceRevision);
+			expect(watchFetch.captured).toHaveLength(2);
+			expect(readRuntimeAppliedState(paths)?.contentIdentity.sha256).not.toBe(baselineAppliedSha);
+			expect(
+				(
+					JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as {
+						projection: { providers: Record<string, { models: unknown[] }> };
+					}
+				).projection.providers["clawdi-managed-v2"].models,
+			).toEqual([{ id: "gpt-5.5" }, { id: "gpt-5.6" }]);
+			expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).not.toBe(
+				baselineRevision,
+			);
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
 			process.exitCode = previousExitCode;
 		}
 	});
@@ -9342,7 +9416,7 @@ fi
 			expect(readFileSync(paths.manifestLastGood, "utf-8")).toBe(committedLastGood);
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const invalidEngineRollbackCalls = readFileSync(systemctlLog, "utf-8");
-			expect(invalidEngineRollbackCalls).toContain("--user restart openclaw-gateway.service");
+			expect(invalidEngineRollbackCalls).not.toContain("--user restart openclaw-gateway.service");
 		} finally {
 			console.log = previousLog;
 			process.exitCode = previousExitCode;
@@ -15106,7 +15180,13 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			const loaded = await loadRuntimeManifest(getRuntimePaths());
 			if (!("manifest" in loaded))
 				throw new Error(`expected manifest load success: ${JSON.stringify(loaded)}`);
-			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+				managedGatewayModelListFetcher: () => ({
+					status: "ok",
+					endpoint: "https://sub2api.test/v1/models",
+					models: [{ id: "gpt-test" }],
+				}),
+			});
 
 			expect(convergence.mode).toBe("normal");
 			expect(convergence.installErrors).toEqual([]);


### PR DESCRIPTION
## Summary

- validate and canonicalize strict-v2 managed `/models` output, including fatal UTF-8 decoding before JSON parsing, then materialize the catalog and resolved primary model into the existing effective runtime manifest
- preserve legacy discovery's permissive UTF-8 replacement behavior while preventing malformed strict-v2 bytes from entering applied authority
- bind effective model bytes to the existing last-good manifest and private applied content identity so offline recovery reproduces the same native projection without a network probe
- revalidate dynamic model authority when the runtime bundle returns `304`; converge when model bytes change, and avoid a runtime restart when only the transport validator changes
- keep the `/models` ETag in the runtime-watch process only, advancing it after authority commit or after proving the represented bytes identical to committed authority
- roll back strict-v2 OpenClaw or Hermes native config and the managed legacy Hermes model-provider plugin subtree together with existing root-managed authority
- remove an uncommitted fresh-boot sidecar prerequisite on probe failure while preserving generic and legacy-v1 behavior

Companion Hosted contract test: https://github.com/Clawdi-AI/clawdi-hosted/pull/1157

## Authority and recovery invariant

1. The runtime native projection, last-good manifest, and applied content identity describe the same canonical model catalog and resolved primary model.
2. Offline recovery replays the committed effective manifest without calling `/models`.
3. A changed final `/models` representation converges even when the runtime bundle ETag is unchanged.
4. The final strong `/models` ETag remains transport metadata, is never persisted as restart authority, and does not enter systemd revisions.
5. Malformed UTF-8 cannot be normalized into strict-v2 authority.
6. Failed probes, activation, or authority commit restore the prior native provider state, sidecar inputs, and committed authority without advancing the in-process validator.

The implementation deliberately adds no provider-model snapshot directory, no applied-state field, no revision pointer, and no second state machine. It reuses the effective manifest, last-good cache, applied content hash, existing live-state snapshot, and existing authority commit.

Fresh strict-v2 boot renders and activates only the sidecar prerequisite before the model probe. The existing `writeSystemdUnits` path still performs exactly one full systemd render after model authority has resolved.

## Upstream main audit

- #622 already separated bundle/apply authority and added sidecar private revision plus rollback; this PR reuses that mechanism.
- #639 already unified remote manifest loading; this PR reuses the committed last-good loader on bundle `304`.
- Those changes invalidate the old parallel snapshot/pointer implementation, which is not present in this branch.
- The final rebase base `c708df43019050475108f1ed8d4e6219ff42d671` adds only unrelated Web compute-card changes and does not replace this fix.

## Scope and minimality

- 7 existing files, `+1325/-163`
- production: `+699/-116` across `packages/cli/src/commands/runtime.ts`, `packages/cli/src/runtime/manifest.ts`, and `packages/cli/src/runtime/managed-model-resolution.ts`
- focused tests cover canonical authority, fatal strict-v2 UTF-8 with unchanged legacy replacement semantics, offline replay, manifest-`304` model changes, validator commit ordering, strict native-provider rollback after activation and authority-commit failures, fresh sidecar cleanup, and generic/v1 compatibility
- documentation updates the existing managed-runtime authority and rollback contract
- duplicate transport-validator map replacement code was consolidated, and duplicate strict catalog validation/normalization passes were removed

## Verification

- `bun run --cwd packages/cli typecheck`
- focused Biome check for the changed TypeScript files
- hermetic Docker runner after the final rebase: `167 pass, 0 fail, 1217 assertions` for `manifest-reconciliation.test.ts`
- `git diff --check origin/main..HEAD`

No production, tenant, cluster, Pod, deployment, image publication, or live database operation was performed. Keep this PR unmerged pending coordinated review with the Hosted companion.
