### PR TITLE
Quote the SENTRY_RELEASE ERB so operator kamal runs parse

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -157,7 +157,7 @@ env:
     ENVIRONMENT: production
     DEBUG: "false"
     # CI exports GITHUB_SHA; operator deploys without it simply go untagged.
-    SENTRY_RELEASE: <%= ENV.fetch("GITHUB_SHA", "") %>
+    SENTRY_RELEASE: "<%= ENV.fetch('GITHUB_SHA', '') %>"
     PUBLIC_API_URL: https://cloud-api.clawdi.ai
     WEB_ORIGIN: https://cloud.clawdi.ai
     CORS_ORIGINS: '["https://www.clawdi.ai","https://clawdi.ai","https://api.clawdi.ai","https://cloud.clawdi.ai"]'


### PR DESCRIPTION
One-character fix for an operator-side regression from the release-tag change: without `GITHUB_SHA`, the unquoted ERB rendered a null YAML value and every local kamal invocation failed config validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)