### PR TITLE
Bind Hosted v2 CLI updates to root bootstrap integrity

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1300,6 +1300,36 @@ function cacheRuntimeSourceManifest(load: RuntimeManifestLoad, paths: RuntimePat
 	return cacheRuntimeLastGoodManifest(load.manifest, paths, load.secretValues);
 }
 
+function readCommittedRuntimeCliManifestAuthority(
+	paths: RuntimePaths,
+	appliedState: NonNullable<ReturnType<typeof readRuntimeAppliedState>>,
+): RuntimeManifestLoad["manifest"] {
+	if (!existsSync(paths.manifestLastGood)) {
+		throw new Error("committed runtime manifest authority is missing");
+	}
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as unknown;
+	} catch (error) {
+		throw new Error(
+			`committed runtime manifest authority is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const parsed = runtimeDesiredStateSchema.safeParse(raw);
+	if (!parsed.success) {
+		throw new Error("committed runtime manifest authority is invalid");
+	}
+	const manifest = parsed.data;
+	if (
+		manifest.instanceId !== appliedState.instanceId ||
+		manifest.generation !== appliedState.generation ||
+		resolveRuntimeApplyGeneration(manifest) !== resolveRuntimeApplyGeneration(appliedState)
+	) {
+		throw new Error("committed runtime manifest authority does not match applied state");
+	}
+	return manifest;
+}
+
 export function runtimeAppliedContentIdentity(
 	load: RuntimeManifestLoad,
 ): RuntimeAppliedContentIdentity {
@@ -2152,38 +2182,6 @@ async function runtimeInitLocked(
 		process.exitCode = 20;
 		return;
 	}
-	try {
-		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
-		if (reconciliation.selfReexec) {
-			finishRuntimeInitCliHandoff({
-				opts,
-				paths,
-				mode,
-				bootId,
-				hostPolicy,
-				detail: { reconciliation },
-			});
-			return;
-		}
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		const status = repairStatus(
-			{
-				bootId,
-				runtimeMode: mode,
-				stage: "local",
-				exitCode: 23,
-				errors: [message],
-			},
-			paths,
-		);
-		writeRuntimeBootStatus(status, paths);
-		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
-		else console.log(chalk.red(message));
-		process.exitCode = 23;
-		return;
-	}
-
 	const credentialAvailable = hasRuntimeCredential({ manifestPath: opts.manifestFile, paths });
 	const nonInteractiveOk = opts.nonInteractive === true;
 	const errors: string[] = [];
@@ -2237,6 +2235,41 @@ async function runtimeInitLocked(
 				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
 			}
 			process.exitCode = exitCode;
+			return;
+		}
+		try {
+			const reconciliation = reconcilePendingRuntimeCliUpgrade(
+				paths,
+				getCliVersion(),
+				loaded.manifest,
+			);
+			if (reconciliation.selfReexec) {
+				finishRuntimeInitCliHandoff({
+					opts,
+					paths,
+					mode,
+					bootId,
+					hostPolicy,
+					detail: { reconciliation },
+				});
+				return;
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const status = repairStatus(
+				{
+					bootId,
+					runtimeMode: mode,
+					stage: "local",
+					exitCode: 23,
+					errors: [message],
+				},
+				paths,
+			);
+			writeRuntimeBootStatus(status, paths);
+			if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
+			else console.log(chalk.red(message));
+			process.exitCode = 23;
 			return;
 		}
 
@@ -2387,7 +2420,9 @@ async function runtimeInitLocked(
 		const { convergence } = applyResult;
 		const runtimeErrors = [...convergence.installErrors];
 		const installOk = runtimeErrors.length === 0;
-		if (installOk) completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		if (installOk) {
+			completePendingRuntimeCliUpgrade(paths, getCliVersion(), convergenceLoad.manifest);
+		}
 		const activeAppliedState = readRuntimeAppliedState(paths);
 		const status = buildRuntimeBootStatus(
 			{
@@ -2479,38 +2514,10 @@ async function runtimeWatchTickLocked(
 		recoverFailedSystemdUnits?: boolean;
 	},
 ): Promise<Record<string, unknown>> {
-	let reconciliation: RuntimeCliReconciliationResult;
-	try {
-		reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		return {
-			schemaVersion: "clawdi.runtimeWatchEvent.v1",
-			status: "error",
-			stage: "cli-update",
-			errors: [message],
-			error: message,
-			selfReexec: false,
-		};
-	}
-	if (reconciliation.selfReexec) {
-		return {
-			schemaVersion: "clawdi.runtimeWatchEvent.v1",
-			status: "cli_handoff",
-			stage: "cli-update",
-			handoff: "cli_reexec",
-			reconciliation,
-			selfReexec: true,
-		};
-	}
-	const event = await runtimeWatchTickAfterCliReconciliation(paths, opts);
-	return {
-		...event,
-		selfReexec: reconciliation.selfReexec || event.selfReexec === true,
-	};
+	return runtimeWatchTickWithManifestAuthority(paths, opts);
 }
 
-async function runtimeWatchTickAfterCliReconciliation(
+async function runtimeWatchTickWithManifestAuthority(
 	paths: ReturnType<typeof getRuntimePaths>,
 	opts: {
 		forceRefresh: boolean;
@@ -2544,7 +2551,23 @@ async function runtimeWatchTickAfterCliReconciliation(
 			runtimeAppliedApplyIdentity(activeAppliedState),
 		)
 	) {
-		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		let committedManifest: RuntimeManifestLoad["manifest"];
+		try {
+			committedManifest = readCommittedRuntimeCliManifestAuthority(paths, activeAppliedState);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "error",
+				mode: "repair",
+				stage: "local",
+				errors: [message],
+				error: message,
+				activeGeneration: activeAppliedState.generation,
+				rejectedGeneration: null,
+			};
+		}
+		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion(), committedManifest);
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "not_modified",
@@ -2573,6 +2596,30 @@ async function runtimeWatchTickAfterCliReconciliation(
 			};
 		}
 		const loaded = applyRuntimeBundleChannelsToManifestLoad(fresh, paths);
+		let reconciliation: RuntimeCliReconciliationResult;
+		try {
+			reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion(), loaded.manifest);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "error",
+				stage: "cli-update",
+				errors: [message],
+				error: message,
+				selfReexec: false,
+			};
+		}
+		if (reconciliation.selfReexec) {
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "cli_handoff",
+				stage: "cli-update",
+				handoff: "cli_reexec",
+				reconciliation,
+				selfReexec: true,
+			};
+		}
 		const bundleEtag = loaded.etag;
 		const sourceRevision = loaded.sourceRevision;
 		if (!bundleEtag || !sourceRevision) {
@@ -2674,7 +2721,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
 			systemdApplyResult.userUnitsChanged.length > 0;
 		if (errors.length > 0) {
-			const cliRollback = maybeRollbackFailedCliUpgrade(paths, errors);
+			const cliRollback = maybeRollbackFailedCliUpgrade(paths, errors, loaded.manifest);
 			if (cliRollback.status === "rolled_back") selfReexec = true;
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			return {
@@ -2694,7 +2741,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 				convergence: convergence.outputs,
 			};
 		}
-		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion(), loaded.manifest);
 		selfReexec = selfReexec || completion.selfReexec;
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
@@ -2890,10 +2937,12 @@ function runtimeManifestIdentityForWatch(
 function maybeRollbackFailedCliUpgrade(
 	paths: RuntimePaths,
 	errors: string[],
+	authorityManifest: RuntimeManifestLoad["manifest"],
 ): RuntimeCliRollbackResult {
 	const rollback = rollbackPendingRuntimeCliUpgrade(
 		paths,
 		`first converge after CLI upgrade failed: ${errors[0] ?? "unknown error"}`,
+		authorityManifest,
 	);
 	if (rollback.status === "rolled_back") {
 		errors.push(

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -59,6 +59,7 @@ import {
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {
+	loadCommittedRuntimeManifest,
 	loadRemoteRuntimeManifest,
 	type RuntimeManifestFailure,
 	type RuntimeManifestLoad,
@@ -1300,36 +1301,6 @@ function cacheRuntimeSourceManifest(load: RuntimeManifestLoad, paths: RuntimePat
 	return cacheRuntimeLastGoodManifest(load.manifest, paths, load.secretValues);
 }
 
-function readCommittedRuntimeCliManifestAuthority(
-	paths: RuntimePaths,
-	appliedState: NonNullable<ReturnType<typeof readRuntimeAppliedState>>,
-): RuntimeManifestLoad["manifest"] {
-	if (!existsSync(paths.manifestLastGood)) {
-		throw new Error("committed runtime manifest authority is missing");
-	}
-	let raw: unknown;
-	try {
-		raw = JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as unknown;
-	} catch (error) {
-		throw new Error(
-			`committed runtime manifest authority is unreadable: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-	const parsed = runtimeDesiredStateSchema.safeParse(raw);
-	if (!parsed.success) {
-		throw new Error("committed runtime manifest authority is invalid");
-	}
-	const manifest = parsed.data;
-	if (
-		manifest.instanceId !== appliedState.instanceId ||
-		manifest.generation !== appliedState.generation ||
-		resolveRuntimeApplyGeneration(manifest) !== resolveRuntimeApplyGeneration(appliedState)
-	) {
-		throw new Error("committed runtime manifest authority does not match applied state");
-	}
-	return manifest;
-}
-
 export function runtimeAppliedContentIdentity(
 	load: RuntimeManifestLoad,
 ): RuntimeAppliedContentIdentity {
@@ -2544,6 +2515,7 @@ async function runtimeWatchTickWithManifestAuthority(
 	const responseManifestEtag = manifestLoad.etag ?? manifestEtag ?? null;
 	if (
 		"notModified" in manifestLoad &&
+		manifestLoad.applyContext !== undefined &&
 		activeAppliedState !== null &&
 		activeAppliedState.etag === responseManifestEtag &&
 		runtimeApplyIdentitiesEqual(
@@ -2551,11 +2523,27 @@ async function runtimeWatchTickWithManifestAuthority(
 			runtimeAppliedApplyIdentity(activeAppliedState),
 		)
 	) {
-		let committedManifest: RuntimeManifestLoad["manifest"];
-		try {
-			committedManifest = readCommittedRuntimeCliManifestAuthority(paths, activeAppliedState);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
+		const committed = loadCommittedRuntimeManifest(paths, manifestLoad.applyContext);
+		if ("errors" in committed) {
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "error",
+				mode: committed.mode,
+				stage: committed.stage,
+				errors: committed.errors,
+				error: committed.errors[0],
+				activeGeneration: activeAppliedState.generation,
+				rejectedGeneration: null,
+			};
+		}
+		const committedManifest = committed.manifest;
+		if (
+			committedManifest.instanceId !== activeAppliedState.instanceId ||
+			committedManifest.generation !== activeAppliedState.generation ||
+			resolveRuntimeApplyGeneration(committedManifest) !==
+				resolveRuntimeApplyGeneration(activeAppliedState)
+		) {
+			const message = "committed runtime manifest authority does not match applied state";
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
 				status: "error",

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -51,6 +51,7 @@ interface RuntimeCliBootstrapStatus {
 	activeTarget?: string;
 	version?: string;
 	verification?: RuntimeCliVerification;
+	cliIntegrity?: unknown;
 }
 
 type RuntimeCliInstallIdentity = Required<
@@ -205,6 +206,24 @@ const cliUpgradeStateV1Schema = z
 	})
 	.strict();
 
+const cliBootstrapIntegritySchema = z
+	.string()
+	.regex(/^sha512-[A-Za-z0-9+/]{86}==$/, "must be a sha512 Subresource Integrity value")
+	.refine((value) => {
+		const digest = value.slice("sha512-".length);
+		return Buffer.from(digest, "base64").toString("base64") === digest;
+	}, "must use canonical base64 encoding");
+
+const cliVerificationStateSchema = z
+	.object({
+		verifiedAt: z.string().min(1),
+		device: z.number().finite(),
+		inode: z.number().finite(),
+		size: z.number().finite().nonnegative(),
+		modifiedAtMs: z.number().finite(),
+	})
+	.strict();
+
 export function applyRuntimeCliDesiredState(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
@@ -249,6 +268,31 @@ export function applyRuntimeCliDesiredState(
 		packageSpec,
 		registry,
 	);
+	if (requiresHostedV2RootBootstrap(manifest, paths)) {
+		const binding = requireHostedV2CliBootstrapBinding(paths, current);
+		if (binding.identity.packageSpec !== packageSpec || binding.identity.registry !== registry) {
+			return baseResult("deferred", paths, {
+				packageSpec,
+				registry,
+				npmPrefix: binding.identity.npmPrefix,
+				activeTarget: binding.identity.activeTarget,
+				version: binding.identity.version,
+				error:
+					"Hosted v2 CLI replacement is deferred until the root bootstrap installs the promoted artifact",
+			});
+		}
+		if (!isCurrentCliInstall(current, paths, packageSpec, registry)) {
+			throw new Error("Hosted v2 CLI bootstrap status did not verify; root bootstrap is required");
+		}
+		requireHostedV2CliBootstrapBinding(paths, readBootstrapStatus(paths.cliBootstrapStatus));
+		return baseResult("current", paths, {
+			packageSpec,
+			registry,
+			npmPrefix: binding.identity.npmPrefix,
+			activeTarget: binding.identity.activeTarget,
+			version: binding.identity.version,
+		});
+	}
 	if (isCurrentCliInstall(current, paths, packageSpec, registry)) {
 		return baseResult("current", paths, {
 			packageSpec,
@@ -331,6 +375,7 @@ export function applyRuntimeCliDesiredState(
 			version: installed.version,
 		},
 		installed.verification,
+		{ preserveExistingIntegrity: false },
 	);
 	activateCliUpgradeTransaction(paths);
 	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousIdentity?.npmPrefix ?? null]);
@@ -345,6 +390,13 @@ export function applyRuntimeCliDesiredState(
 			version: installed.version,
 		},
 		true,
+	);
+}
+
+function requiresHostedV2RootBootstrap(manifest: RuntimeManifest, paths: RuntimePaths): boolean {
+	return (
+		paths.mode === "hosted" &&
+		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2"
 	);
 }
 
@@ -406,6 +458,72 @@ function readBootstrapStatus(path: string): RuntimeCliBootstrapStatus | null {
 	} catch {
 		return null;
 	}
+}
+
+function bootstrapStatusInstallIdentity(
+	status: RuntimeCliBootstrapStatus | null,
+	paths: RuntimePaths,
+): RuntimeCliInstallIdentity | null {
+	if (
+		status?.status !== "installed" ||
+		status.source !== "npm" ||
+		status.activePath !== paths.cliManagedBin
+	) {
+		return null;
+	}
+	const parsed = cliInstallIdentityStateSchema.safeParse({
+		packageSpec: status.packageSpec,
+		registry: status.registry ?? null,
+		npmPrefix: status.npmPrefix,
+		activeTarget: status.activeTarget,
+		version: status.version,
+	});
+	if (!parsed.success) return null;
+	return parsed.data;
+}
+
+function requireHostedV2CliBootstrapBinding(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): { identity: RuntimeCliInstallIdentity; cliIntegrity: string } {
+	const identity = bootstrapStatusInstallIdentity(status, paths);
+	if (
+		!identity ||
+		!hostedCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
+		identity.registry !== "https://registry.npmjs.org" ||
+		!isManagedCliTarget(paths, identity.activeTarget) ||
+		!isManagedCliPrefix(paths, identity.npmPrefix) ||
+		resolve(prefixForActiveTarget(identity.activeTarget)) !== resolve(identity.npmPrefix) ||
+		exactNpmPackageVersion(identity.packageSpec) !== identity.version ||
+		activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget ||
+		!isExecutable(identity.activeTarget) ||
+		!isExecutable(paths.cliManagedBin)
+	) {
+		throw new Error("Hosted v2 CLI bootstrap status has no valid promoted install identity");
+	}
+	const integrity = cliBootstrapIntegritySchema.safeParse(status?.cliIntegrity);
+	if (!integrity.success) {
+		throw new Error(
+			"Hosted v2 CLI bootstrap status has no supported promoted cliIntegrity; root bootstrap is required",
+		);
+	}
+	if (status?.verification !== undefined) {
+		const verification = cliVerificationStateSchema.safeParse(status.verification);
+		const fileIdentity = cliVerificationIdentity(identity.activeTarget);
+		if (
+			!verification.success ||
+			!fileIdentity ||
+			!verificationIdentityMatches(verification.data, fileIdentity)
+		) {
+			writeCliBootstrapStatus(paths, identity, undefined, {
+				preserveExistingIntegrity: false,
+			});
+			throw new Error(
+				"Hosted v2 CLI target changed after promoted bootstrap verification; root bootstrap is required",
+			);
+		}
+	}
+	return { identity, cliIntegrity: integrity.data };
 }
 
 function migrateAndHardenCurrentCliInstall(
@@ -984,14 +1102,9 @@ function swapActiveCli(activePath: string, activeTarget: string): void {
 
 function writeCliBootstrapStatus(
 	paths: RuntimePaths,
-	input: {
-		packageSpec: string;
-		registry: string | null;
-		npmPrefix: string;
-		activeTarget: string;
-		version: string;
-	},
+	input: RuntimeCliInstallIdentity,
 	verification?: RuntimeCliVerification,
+	opts: { preserveExistingIntegrity?: boolean } = {},
 ): void {
 	const currentIdentity = cliVerificationIdentity(input.activeTarget);
 	if (
@@ -1000,6 +1113,10 @@ function writeCliBootstrapStatus(
 	) {
 		throw new Error(`clawdi CLI target changed after verification: ${input.activeTarget}`);
 	}
+	const cliIntegrity =
+		opts.preserveExistingIntegrity === false
+			? undefined
+			: preservedCliIntegrity(paths, input, currentIdentity);
 	writePrivateFileAtomic(
 		paths.cliBootstrapStatus,
 		`${JSON.stringify(
@@ -1016,12 +1133,55 @@ function writeCliBootstrapStatus(
 				activeTarget: input.activeTarget,
 				version: input.version,
 				verification,
+				...(cliIntegrity === undefined ? {} : { cliIntegrity }),
 				error: null,
 			},
 			null,
 			2,
 		)}\n`,
 		{ mode: 0o600, dirMode: 0o755 },
+	);
+}
+
+function preservedCliIntegrity(
+	paths: RuntimePaths,
+	input: RuntimeCliInstallIdentity,
+	currentFileIdentity: Omit<RuntimeCliVerification, "verifiedAt"> | null,
+): string | undefined {
+	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	if (
+		!status ||
+		!statusHasInstallIdentity(status, input) ||
+		activeLinkTarget(paths.cliManagedBin) !== input.activeTarget ||
+		!currentFileIdentity
+	) {
+		return undefined;
+	}
+	const integrity = cliBootstrapIntegritySchema.safeParse(status.cliIntegrity);
+	if (!integrity.success) return undefined;
+	if (status.verification === undefined) return integrity.data;
+	const previousVerification = cliVerificationStateSchema.safeParse(status.verification);
+	if (
+		!previousVerification.success ||
+		!verificationIdentityMatches(previousVerification.data, currentFileIdentity)
+	) {
+		return undefined;
+	}
+	return integrity.data;
+}
+
+function statusHasInstallIdentity(
+	status: RuntimeCliBootstrapStatus,
+	identity: RuntimeCliInstallIdentity,
+): boolean {
+	return (
+		status.status === "installed" &&
+		status.source === "npm" &&
+		status.packageSpec === identity.packageSpec &&
+		(status.registry ?? null) === identity.registry &&
+		status.npmPrefix === identity.npmPrefix &&
+		status.activeTarget === identity.activeTarget &&
+		status.version === identity.version
 	);
 }
 
@@ -1208,10 +1368,12 @@ function reconcileCliUpgradeTransaction(
 	}
 
 	if (activeTarget === transaction.newIdentity.activeTarget) {
-		if (!verifyStoredCliIdentity(paths, transaction.newIdentity)) {
+		const verification = verifyStoredCliIdentity(paths, transaction.newIdentity);
+		if (!verification) {
 			rollBackInvalidTransaction(paths, transaction);
 			return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
 		}
+		writeCliBootstrapStatus(paths, transaction.newIdentity, verification);
 		return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
 	}
 	if (transaction.previousIdentity && activeTarget === previousTarget) {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -236,9 +236,13 @@ export function applyRuntimeCliDesiredState(
 	} = {},
 ): RuntimeCliUpdateResult {
 	const rootBootstrapRequired = requiresHostedV2RootBootstrap(manifest, paths);
-	if (rootBootstrapRequired) supersedeCliUpgradeStateWithRootBootstrap(paths);
+	const rootBinding = rootBootstrapRequired
+		? supersedeCliUpgradeStateWithRootBootstrap(paths)
+		: null;
 	const reconciliation = rootBootstrapRequired
-		? cliReconciliationResult(paths, "unchanged", opts.runningVersion)
+		? rootBinding
+			? cliReconciliationResult(paths, "unchanged", opts.runningVersion)
+			: { status: "unchanged" as const, selfReexec: false }
 		: reconcileCliUpgradeTransaction(paths, opts);
 	if (reconciliation.selfReexec) {
 		const status = readBootstrapStatus(paths.cliBootstrapStatus);
@@ -272,14 +276,19 @@ export function applyRuntimeCliDesiredState(
 		? hardenRootBootstrappedCliInstall(paths, bootstrapStatus)
 		: migrateAndHardenCurrentCliInstall(paths, bootstrapStatus, packageSpec, registry);
 	if (rootBootstrapRequired) {
-		const binding = requireHostedV2CliBootstrapBinding(paths, current);
-		if (binding.identity.packageSpec !== packageSpec || binding.identity.registry !== registry) {
+		const promotedBinding =
+			current?.cliIntegrity === undefined
+				? null
+				: requireHostedV2CliBootstrapBinding(paths, current);
+		const identity =
+			promotedBinding?.identity ?? requireHostedV2CliBootstrapIdentity(paths, current);
+		if (identity.packageSpec !== packageSpec || identity.registry !== registry) {
 			return baseResult("deferred", paths, {
 				packageSpec,
 				registry,
-				npmPrefix: binding.identity.npmPrefix,
-				activeTarget: binding.identity.activeTarget,
-				version: binding.identity.version,
+				npmPrefix: identity.npmPrefix,
+				activeTarget: identity.activeTarget,
+				version: identity.version,
 				error:
 					"Hosted v2 CLI replacement is deferred until the root bootstrap installs the promoted artifact",
 			});
@@ -287,13 +296,16 @@ export function applyRuntimeCliDesiredState(
 		if (!isCurrentCliInstall(current, paths, packageSpec, registry)) {
 			throw new Error("Hosted v2 CLI bootstrap status did not verify; root bootstrap is required");
 		}
-		requireHostedV2CliBootstrapBinding(paths, readBootstrapStatus(paths.cliBootstrapStatus));
+		const verifiedStatus = readBootstrapStatus(paths.cliBootstrapStatus);
+		if (promotedBinding && verifiedStatus?.cliIntegrity !== undefined) {
+			requireHostedV2CliBootstrapBinding(paths, verifiedStatus);
+		}
 		return baseResult("current", paths, {
 			packageSpec,
 			registry,
-			npmPrefix: binding.identity.npmPrefix,
-			activeTarget: binding.identity.activeTarget,
-			version: binding.identity.version,
+			npmPrefix: identity.npmPrefix,
+			activeTarget: identity.activeTarget,
+			version: identity.version,
 		});
 	}
 	if (isCurrentCliInstall(current, paths, packageSpec, registry)) {
@@ -499,21 +511,7 @@ function requireHostedV2CliBootstrapBinding(
 	paths: RuntimePaths,
 	status: RuntimeCliBootstrapStatus | null,
 ): { identity: RuntimeCliInstallIdentity; cliIntegrity: string } {
-	const identity = bootstrapStatusInstallIdentity(status, paths);
-	if (
-		!identity ||
-		!hostedCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
-		identity.registry !== "https://registry.npmjs.org" ||
-		!isManagedCliTarget(paths, identity.activeTarget) ||
-		!isManagedCliPrefix(paths, identity.npmPrefix) ||
-		resolve(prefixForActiveTarget(identity.activeTarget)) !== resolve(identity.npmPrefix) ||
-		exactNpmPackageVersion(identity.packageSpec) !== identity.version ||
-		activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget ||
-		!isExecutable(identity.activeTarget) ||
-		!isExecutable(paths.cliManagedBin)
-	) {
-		throw new Error("Hosted v2 CLI bootstrap status has no valid promoted install identity");
-	}
+	const identity = requireHostedV2CliBootstrapIdentity(paths, status);
 	const integrity = cliBootstrapIntegritySchema.safeParse(status?.cliIntegrity);
 	if (!integrity.success) {
 		throw new Error(
@@ -532,6 +530,28 @@ function requireHostedV2CliBootstrapBinding(
 		);
 	}
 	return { identity, cliIntegrity: integrity.data };
+}
+
+function requireHostedV2CliBootstrapIdentity(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliInstallIdentity {
+	const identity = bootstrapStatusInstallIdentity(status, paths);
+	if (
+		!identity ||
+		!hostedCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
+		identity.registry !== "https://registry.npmjs.org" ||
+		!isManagedCliTarget(paths, identity.activeTarget) ||
+		!isManagedCliPrefix(paths, identity.npmPrefix) ||
+		resolve(prefixForActiveTarget(identity.activeTarget)) !== resolve(identity.npmPrefix) ||
+		exactNpmPackageVersion(identity.packageSpec) !== identity.version ||
+		activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget ||
+		!isExecutable(identity.activeTarget) ||
+		!isExecutable(paths.cliManagedBin)
+	) {
+		throw new Error("Hosted v2 CLI bootstrap status has no valid promoted install identity");
+	}
+	return identity;
 }
 
 function migrateAndHardenCurrentCliInstall(
@@ -1212,6 +1232,15 @@ export function rollbackPendingRuntimeCliUpgrade(
 			previousActiveTarget: null,
 		};
 	}
+	if (hasHostedRootBootstrapStatus(paths)) {
+		return {
+			status: "not_pending",
+			version: null,
+			previousVersion: null,
+			activeTarget: activeLinkTarget(paths.cliManagedBin),
+			previousActiveTarget: null,
+		};
+	}
 	let transaction: RuntimeCliUpgradeTransaction | null = null;
 	try {
 		transaction = readCliUpgradeState(paths).transaction ?? null;
@@ -1286,6 +1315,9 @@ export function completePendingRuntimeCliUpgrade(
 	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
 		return cliReconciliationResult(paths, "unchanged", currentVersion);
 	}
+	if (hasHostedRootBootstrapStatus(paths)) {
+		return { status: "unchanged", selfReexec: false };
+	}
 	const reconciliation = reconcileCliUpgradeTransaction(paths, {
 		runningVersion: currentVersion,
 	});
@@ -1312,7 +1344,24 @@ export function reconcilePendingRuntimeCliUpgrade(
 	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
 		return cliReconciliationResult(paths, "unchanged", runningVersion);
 	}
+	if (hasHostedRootBootstrapStatus(paths)) {
+		return { status: "unchanged", selfReexec: false };
+	}
 	return reconcileCliUpgradeTransaction(paths, { runningVersion });
+}
+
+function hasHostedRootBootstrapStatus(paths: RuntimePaths): boolean {
+	if (paths.mode !== "hosted") return false;
+	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	return (
+		status?.schemaVersion === "clawdi.cliNpmBootstrapStatus.v1" &&
+		status.status === "installed" &&
+		status.source === "npm" &&
+		status.registry === "https://registry.npmjs.org" &&
+		status.activePath === paths.cliManagedBin &&
+		typeof status.packageSpec === "string" &&
+		hostedCliPackageSpecSchema.safeParse(status.packageSpec).success
+	);
 }
 
 function promotedRootBootstrapBinding(

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -1216,7 +1216,10 @@ function statusHasInstallIdentity(
 export function rollbackPendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	reason: string,
+	authorityManifest?: RuntimeManifest,
 ): RuntimeCliRollbackResult {
+	const rootBootstrapRequired =
+		authorityManifest !== undefined && requiresHostedV2RootBootstrap(authorityManifest, paths);
 	let rootBinding: ReturnType<typeof promotedRootBootstrapBinding>;
 	try {
 		rootBinding = supersedeCliUpgradeStateWithRootBootstrap(paths);
@@ -1232,7 +1235,7 @@ export function rollbackPendingRuntimeCliUpgrade(
 			previousActiveTarget: null,
 		};
 	}
-	if (hasHostedRootBootstrapStatus(paths)) {
+	if (rootBootstrapRequired || hasHostedRootBootstrapStatus(paths)) {
 		return {
 			status: "not_pending",
 			version: null,
@@ -1311,11 +1314,15 @@ export function rollbackPendingRuntimeCliUpgrade(
 export function completePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	currentVersion: string,
+	authorityManifest?: RuntimeManifest,
 ): RuntimeCliReconciliationResult {
 	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
 		return cliReconciliationResult(paths, "unchanged", currentVersion);
 	}
-	if (hasHostedRootBootstrapStatus(paths)) {
+	if (
+		(authorityManifest !== undefined && requiresHostedV2RootBootstrap(authorityManifest, paths)) ||
+		hasHostedRootBootstrapStatus(paths)
+	) {
 		return { status: "unchanged", selfReexec: false };
 	}
 	const reconciliation = reconcileCliUpgradeTransaction(paths, {
@@ -1340,11 +1347,15 @@ export function completePendingRuntimeCliUpgrade(
 export function reconcilePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	runningVersion: string,
+	authorityManifest?: RuntimeManifest,
 ): RuntimeCliReconciliationResult {
 	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
 		return cliReconciliationResult(paths, "unchanged", runningVersion);
 	}
-	if (hasHostedRootBootstrapStatus(paths)) {
+	if (
+		(authorityManifest !== undefined && requiresHostedV2RootBootstrap(authorityManifest, paths)) ||
+		hasHostedRootBootstrapStatus(paths)
+	) {
 		return { status: "unchanged", selfReexec: false };
 	}
 	return reconcileCliUpgradeTransaction(paths, { runningVersion });

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -42,6 +42,7 @@ export interface RuntimeCliUpdateResult {
 }
 
 interface RuntimeCliBootstrapStatus {
+	schemaVersion?: string;
 	status?: string;
 	source?: string;
 	packageSpec?: string;
@@ -234,7 +235,11 @@ export function applyRuntimeCliDesiredState(
 		runningVersion?: string;
 	} = {},
 ): RuntimeCliUpdateResult {
-	const reconciliation = reconcileCliUpgradeTransaction(paths, opts);
+	const rootBootstrapRequired = requiresHostedV2RootBootstrap(manifest, paths);
+	if (rootBootstrapRequired) supersedeCliUpgradeStateWithRootBootstrap(paths);
+	const reconciliation = rootBootstrapRequired
+		? cliReconciliationResult(paths, "unchanged", opts.runningVersion)
+		: reconcileCliUpgradeTransaction(paths, opts);
 	if (reconciliation.selfReexec) {
 		const status = readBootstrapStatus(paths.cliBootstrapStatus);
 		return baseResult(
@@ -262,13 +267,11 @@ export function applyRuntimeCliDesiredState(
 	}
 	validatePackageSpec(packageSpec);
 	const registry = cliRegistry(manifest);
-	const current = migrateAndHardenCurrentCliInstall(
-		paths,
-		readBootstrapStatus(paths.cliBootstrapStatus),
-		packageSpec,
-		registry,
-	);
-	if (requiresHostedV2RootBootstrap(manifest, paths)) {
+	const bootstrapStatus = readBootstrapStatus(paths.cliBootstrapStatus);
+	const current = rootBootstrapRequired
+		? hardenRootBootstrappedCliInstall(paths, bootstrapStatus)
+		: migrateAndHardenCurrentCliInstall(paths, bootstrapStatus, packageSpec, registry);
+	if (rootBootstrapRequired) {
 		const binding = requireHostedV2CliBootstrapBinding(paths, current);
 		if (binding.identity.packageSpec !== packageSpec || binding.identity.registry !== registry) {
 			return baseResult("deferred", paths, {
@@ -400,6 +403,15 @@ function requiresHostedV2RootBootstrap(manifest: RuntimeManifest, paths: Runtime
 	);
 }
 
+function hardenRootBootstrappedCliInstall(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliBootstrapStatus | null {
+	hardenHostedImageShimBestEffort(paths);
+	hardenExistingManagedCliBoundary(paths, status);
+	return status;
+}
+
 type RuntimeCliResultValues = Pick<
 	RuntimeCliUpdateResult,
 	"packageSpec" | "registry" | "activeTarget" | "version"
@@ -465,6 +477,7 @@ function bootstrapStatusInstallIdentity(
 	paths: RuntimePaths,
 ): RuntimeCliInstallIdentity | null {
 	if (
+		status?.schemaVersion !== "clawdi.cliNpmBootstrapStatus.v1" ||
 		status?.status !== "installed" ||
 		status.source !== "npm" ||
 		status.activePath !== paths.cliManagedBin
@@ -507,21 +520,16 @@ function requireHostedV2CliBootstrapBinding(
 			"Hosted v2 CLI bootstrap status has no supported promoted cliIntegrity; root bootstrap is required",
 		);
 	}
-	if (status?.verification !== undefined) {
-		const verification = cliVerificationStateSchema.safeParse(status.verification);
-		const fileIdentity = cliVerificationIdentity(identity.activeTarget);
-		if (
-			!verification.success ||
-			!fileIdentity ||
-			!verificationIdentityMatches(verification.data, fileIdentity)
-		) {
-			writeCliBootstrapStatus(paths, identity, undefined, {
-				preserveExistingIntegrity: false,
-			});
-			throw new Error(
-				"Hosted v2 CLI target changed after promoted bootstrap verification; root bootstrap is required",
-			);
-		}
+	const verification = cliVerificationStateSchema.safeParse(status?.verification);
+	const fileIdentity = cliVerificationIdentity(identity.activeTarget);
+	if (
+		!verification.success ||
+		!fileIdentity ||
+		!verificationIdentityMatches(verification.data, fileIdentity)
+	) {
+		throw new Error(
+			"Hosted v2 CLI target changed after promoted bootstrap verification; root bootstrap is required",
+		);
 	}
 	return { identity, cliIntegrity: integrity.data };
 }
@@ -1150,7 +1158,8 @@ function preservedCliIntegrity(
 ): string | undefined {
 	const status = readBootstrapStatus(paths.cliBootstrapStatus);
 	if (
-		!status ||
+		status?.schemaVersion !== "clawdi.cliNpmBootstrapStatus.v1" ||
+		status.activePath !== paths.cliManagedBin ||
 		!statusHasInstallIdentity(status, input) ||
 		activeLinkTarget(paths.cliManagedBin) !== input.activeTarget ||
 		!currentFileIdentity
@@ -1159,7 +1168,6 @@ function preservedCliIntegrity(
 	}
 	const integrity = cliBootstrapIntegritySchema.safeParse(status.cliIntegrity);
 	if (!integrity.success) return undefined;
-	if (status.verification === undefined) return integrity.data;
 	const previousVerification = cliVerificationStateSchema.safeParse(status.verification);
 	if (
 		!previousVerification.success ||
@@ -1189,6 +1197,21 @@ export function rollbackPendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	reason: string,
 ): RuntimeCliRollbackResult {
+	let rootBinding: ReturnType<typeof promotedRootBootstrapBinding>;
+	try {
+		rootBinding = supersedeCliUpgradeStateWithRootBootstrap(paths);
+	} catch (error) {
+		return rollbackErrorResult(null, error);
+	}
+	if (rootBinding) {
+		return {
+			status: "not_pending",
+			version: rootBinding.identity.version,
+			previousVersion: null,
+			activeTarget: rootBinding.identity.activeTarget,
+			previousActiveTarget: null,
+		};
+	}
 	let transaction: RuntimeCliUpgradeTransaction | null = null;
 	try {
 		transaction = readCliUpgradeState(paths).transaction ?? null;
@@ -1260,6 +1283,9 @@ export function completePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	currentVersion: string,
 ): RuntimeCliReconciliationResult {
+	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
+		return cliReconciliationResult(paths, "unchanged", currentVersion);
+	}
 	const reconciliation = reconcileCliUpgradeTransaction(paths, {
 		runningVersion: currentVersion,
 	});
@@ -1283,7 +1309,48 @@ export function reconcilePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	runningVersion: string,
 ): RuntimeCliReconciliationResult {
+	if (supersedeCliUpgradeStateWithRootBootstrap(paths)) {
+		return cliReconciliationResult(paths, "unchanged", runningVersion);
+	}
 	return reconcileCliUpgradeTransaction(paths, { runningVersion });
+}
+
+function promotedRootBootstrapBinding(
+	paths: RuntimePaths,
+): { identity: RuntimeCliInstallIdentity; cliIntegrity: string } | null {
+	if (paths.mode !== "hosted") return null;
+	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	if (status?.cliIntegrity === undefined) return null;
+	return requireHostedV2CliBootstrapBinding(paths, status);
+}
+
+function supersedeCliUpgradeStateWithRootBootstrap(
+	paths: RuntimePaths,
+): { identity: RuntimeCliInstallIdentity; cliIntegrity: string } | null {
+	const binding = promotedRootBootstrapBinding(paths);
+	if (!binding || !existsSync(paths.cliUpgradeState)) return binding;
+
+	let badVersions: RuntimeCliBadVersion[] = [];
+	try {
+		const parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
+		const v2 = cliUpgradeStateV2Schema.safeParse(parsed);
+		if (v2.success) {
+			if (v2.data.transaction === null) return binding;
+			badVersions = v2.data.badVersions;
+		} else {
+			const v1 = cliUpgradeStateV1Schema.safeParse(parsed);
+			if (v1.success) badVersions = v1.data.badVersions ?? [];
+		}
+	} catch {
+		// A canonical root binding is the sole authority. Malformed legacy state
+		// is intentionally replaced without attempting its executable recovery.
+	}
+	writeCliUpgradeState(paths, {
+		schemaVersion: "clawdi.cliUpgradeState.v2",
+		transaction: null,
+		badVersions,
+	});
+	return binding;
 }
 
 function prepareCliUpgradeTransaction(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8308,7 +8308,7 @@ fi
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
 	});
 
-	it("runtime watch fails closed without a root-promoted Hosted v2 CLI binding", async () => {
+	it("runtime watch loads strict-v2 authority before a missing-status legacy journal", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
@@ -8415,6 +8415,41 @@ chmod +x "$prefix/bin/clawdi"
 					),
 			},
 		]);
+		seedCurrentCliInstall(
+			state,
+			`clawdi@${currentVersion}`,
+			currentVersion,
+			"https://registry.npmjs.org",
+		);
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const activeIdentity = {
+			packageSpec: `clawdi@${currentVersion}`,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: paths.cliNpmPrefix,
+			activeTarget,
+			version: currentVersion,
+		};
+		const executionMarker = join(root, "watch-legacy-journal-executed");
+		const previousIdentity = createVersionedCliFixture(paths, "0.13.21");
+		writeFileSync(
+			previousIdentity.activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${previousIdentity.version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			{ mode: 0o700 },
+		);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity: activeIdentity,
+			rollbackReason: "legacy rollback must stay inert before manifest authority",
+		});
+		const staleJournal = readFileSync(paths.cliUpgradeState, "utf-8");
+		rmSync(paths.cliBootstrapStatus);
 
 		try {
 			await runtimeWatch({ once: true, json: true });
@@ -8433,12 +8468,13 @@ chmod +x "$prefix/bin/clawdi"
 				systemUnitsChanged: [],
 				userUnitsChanged: [],
 			});
-			const paths = getRuntimePaths();
 			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(staleJournal);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+			expect(existsSync(executionMarker)).toBe(false);
 			expect(existsSync(npmLog)).toBe(false);
 			expect(existsSync(join(state, "status", "cli-bootstrap.json"))).toBe(false);
 		} finally {
@@ -9553,6 +9589,85 @@ exit 64
 		});
 	});
 
+	it("keeps strict-v2 legacy journals inert with partial or noncanonical bootstrap status", () => {
+		const version = "0.13.22";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-authority-journal", "clawdi");
+		const state = join(root, "state-cli-authority-journal");
+		const run = join(root, "run-cli-authority-journal");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const activeIdentity = {
+			packageSpec,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: paths.cliNpmPrefix,
+			activeTarget,
+			version,
+		};
+		const executionMarker = join(root, "authority-legacy-journal-executed");
+		const previousIdentity = createVersionedCliFixture(paths, "0.13.21");
+		writeFileSync(
+			previousIdentity.activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${previousIdentity.version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			{ mode: 0o700 },
+		);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity: activeIdentity,
+			rollbackReason: "strict-v2 authority owns CLI recovery",
+		});
+		const staleJournal = readFileSync(paths.cliUpgradeState, "utf-8");
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+		const untrustedStatuses = [
+			JSON.stringify({
+				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+				status: "installed",
+				source: "npm",
+			}),
+			JSON.stringify({
+				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+				status: "installed",
+				source: "npm",
+				packageSpec: "clawdi@latest",
+				registry: "https://registry.npmjs.org",
+				activePath: paths.cliManagedBin,
+			}),
+		];
+
+		for (const status of untrustedStatuses) {
+			writeFileSync(paths.cliBootstrapStatus, status);
+			expect(reconcilePendingRuntimeCliUpgrade(paths, version, desired.manifest)).toEqual({
+				status: "unchanged",
+				selfReexec: false,
+			});
+			expect(completePendingRuntimeCliUpgrade(paths, version, desired.manifest)).toEqual({
+				status: "unchanged",
+				selfReexec: false,
+			});
+			expect(
+				rollbackPendingRuntimeCliUpgrade(
+					paths,
+					"strict-v2 must not restore legacy bytes",
+					desired.manifest,
+				),
+			).toMatchObject({ status: "not_pending", version: null, previousVersion: null });
+			expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(staleJournal);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+			expect(existsSync(executionMarker)).toBe(false);
+		}
+	});
+
 	it("does not carry promoted integrity to CLI-installed bytes with a different identity", () => {
 		const home = join(root, "home-cli-integrity-install", "clawdi");
 		const state = join(root, "state-cli-integrity-install");
@@ -10320,6 +10435,11 @@ chmod +x "$prefix/bin/clawdi"
 			},
 			secretValues: {},
 		};
+		mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
+		writeFileSync(
+			paths.manifestLastGood,
+			JSON.stringify(normalizeManifestPayload(manifestPayload).manifest),
+		);
 		const bundleEtag = `"sha256:${"a".repeat(64)}"`;
 		writeRuntimeAppliedState(
 			{
@@ -10725,7 +10845,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("keeps an old no-integrity bootstrap current or deferred without invoking npm", async () => {
+	it("keeps an old no-integrity same-package current and changed-package deferred", async () => {
 		setRuntimeApplyGeneration(17, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -11489,7 +11609,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime init fails closed until root bootstrap selects the Hosted v2 CLI", async () => {
+	it("runtime init loads strict-v2 authority before a corrupt-status legacy journal", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home-init-cli-handoff", "clawdi");
 		const state = join(root, "state-init-cli-handoff");
@@ -11580,11 +11700,45 @@ chmod +x "$prefix/bin/clawdi"
 					}),
 			},
 		]);
+		seedCurrentCliInstall(
+			state,
+			`clawdi@${currentVersion}`,
+			currentVersion,
+			"https://registry.npmjs.org",
+		);
+		const paths = getRuntimePaths();
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const activeIdentity = {
+			packageSpec: `clawdi@${currentVersion}`,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: paths.cliNpmPrefix,
+			activeTarget,
+			version: currentVersion,
+		};
+		const executionMarker = join(root, "init-legacy-journal-executed");
+		const previousIdentity = createVersionedCliFixture(paths, "0.13.19");
+		writeFileSync(
+			previousIdentity.activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${previousIdentity.version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			{ mode: 0o700 },
+		);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity: activeIdentity,
+			rollbackReason: "legacy rollback must stay inert before init manifest authority",
+		});
+		const staleJournal = readFileSync(paths.cliUpgradeState, "utf-8");
+		writeFileSync(paths.cliBootstrapStatus, "{corrupt bootstrap status");
 
 		try {
 			await runtimeInit({ nonInteractive: true, json: true });
 
-			const paths = getRuntimePaths();
 			expect(process.exitCode).toBe(23);
 			expect(captured).toHaveLength(1);
 			const event = JSON.parse(logs[0]);
@@ -11597,8 +11751,10 @@ chmod +x "$prefix/bin/clawdi"
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(existsSync(paths.cliUpgradeState)).toBe(false);
-			expect(existsSync(paths.cliBootstrapStatus)).toBe(false);
+			expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(staleJournal);
+			expect(readFileSync(paths.cliBootstrapStatus, "utf-8")).toBe("{corrupt bootstrap status");
+			expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+			expect(existsSync(executionMarker)).toBe(false);
 			expect(existsSync(npmLog)).toBe(false);
 		} finally {
 			restore();

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -58,6 +58,7 @@ import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resoluti
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
+	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	loadRuntimeManifest,
 	type RuntimeConvergenceResult,
@@ -7472,6 +7473,7 @@ exit 42
 				},
 			],
 			secretValues: {
+				...TEST_HOSTED_CODEX_SECRET_VALUES,
 				[providerSecretRef]: "sk-provider-watch",
 				[channelSecretRef]: "agent-token-watch",
 				[channelPlaceholderSecretRef]: "999999999:54db03c2296520629c70cfb6e3b15f8e",
@@ -7541,38 +7543,30 @@ exit 64
 			if (!("manifest" in manifestLoad) || "notModified" in manifestLoad) {
 				throw new Error("expected initial manifest load success");
 			}
-			const initialConvergence = convergeRuntimeManifest(
-				applyRuntimeBundleChannelsToManifestLoad(manifestLoad as RuntimeManifestLoad),
-				paths,
+			const committedLoad = applyRuntimeBundleChannelsToManifestLoad(
+				manifestLoad as RuntimeManifestLoad,
 			);
+			const committedAuthorityLoad: RuntimeManifestLoad = {
+				...committedLoad,
+				manifest: structuredClone(committedLoad.manifest),
+				secretValues: { ...committedLoad.secretValues },
+			};
+			const initialConvergence = convergeRuntimeManifest(committedLoad, paths);
 			expect(initialConvergence.installErrors).toEqual([]);
 			expectEgressProfileBundleUsesSecretRef(
 				initialConvergence.outputs.egressProfileBundle,
 				"secret://provider.default.apiKey",
 				"sk-provider-watch",
 			);
-			mkdirSync(dirname(paths.appliedState), { recursive: true });
-			writeFileSync(
-				paths.appliedState,
-				JSON.stringify({
-					schemaVersion: "clawdi.runtimeAppliedState.v2",
-					appliedAt: "2026-07-13T00:00:00.000Z",
-					instanceId: "iid_watch_secret",
-					etag: stableBundleEtag,
-					sourceRevision: "d".repeat(64),
-					generation: 22,
-					applyGeneration: 22,
-					manifestETag: stableBundleEtag,
-					applyReceiptId: "test-apply-receipt-0022",
-					bootNonce: "test-boot-nonce-000022",
-					contentIdentity: {
-						sourcePath: "https://runtime.test/v1/runtime/manifest",
-						sha256: "a".repeat(64),
-					},
-					providerIds: ["clawdi-managed-v2"],
-					projectedProviderIds: { openclaw: ["clawdi-managed-v2"] },
-				}),
-			);
+			if (!committedLoad.sourceRevision) throw new Error("expected runtime source revision");
+			commitRuntimeAppliedState({
+				load: committedAuthorityLoad,
+				paths,
+				etag: stableBundleEtag,
+				sourceRevision: committedLoad.sourceRevision,
+				convergence: initialConvergence,
+				applyIdentity: committedLoad.applyContext?.identity ?? null,
+			});
 		} finally {
 			initial.restore();
 		}
@@ -7638,6 +7632,128 @@ exit 64
 			expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
 				baselineRevision,
 			);
+		} finally {
+			watchFetch.restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
+		}
+	});
+
+	it("runtime watch leaves a legacy CLI journal inert when committed cache content drifts", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const logs: string[] = [];
+		const currentVersion = getCliVersion();
+		const packageSpec = `clawdi@${currentVersion}`;
+		const bundleEtag = testBundleEtag("committed-cli-authority-content-drift");
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		seedOpenClawBinary(home);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		seedCurrentCliInstall(state, packageSpec, currentVersion, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const initial = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () =>
+					hostedRuntimeBundleResponse(hostedCliManifestResponse(home, packageSpec), {
+						etag: bundleEtag,
+					}),
+			},
+		]);
+		try {
+			const fresh = await loadRemoteRuntimeManifest(paths);
+			if (!("manifest" in fresh) || "notModified" in fresh) {
+				throw new Error("expected initial manifest load success");
+			}
+			const committedLoad = applyRuntimeBundleChannelsToManifestLoad(fresh);
+			const convergence = convergeRuntimeManifest(committedLoad, paths);
+			expect(convergence.installErrors).toEqual([]);
+			if (!committedLoad.etag || !committedLoad.sourceRevision) {
+				throw new Error("expected committed runtime bundle identity");
+			}
+			commitRuntimeAppliedState({
+				load: committedLoad,
+				paths,
+				etag: committedLoad.etag,
+				sourceRevision: committedLoad.sourceRevision,
+				convergence,
+				applyIdentity: committedLoad.applyContext?.identity ?? null,
+			});
+		} finally {
+			initial.restore();
+		}
+
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const activeIdentity = {
+			packageSpec,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: paths.cliNpmPrefix,
+			activeTarget,
+			version: currentVersion,
+		};
+		const executionMarker = join(root, "tampered-authority-legacy-journal-executed");
+		const previousIdentity = createVersionedCliFixture(paths, "0.13.21");
+		writeFileSync(
+			previousIdentity.activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${previousIdentity.version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			{ mode: 0o700 },
+		);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity: activeIdentity,
+			rollbackReason: "tampered committed authority must not execute legacy recovery",
+		});
+		const staleJournal = readFileSync(paths.cliUpgradeState, "utf-8");
+		rmSync(paths.cliBootstrapStatus);
+		const tamperedManifest = JSON.parse(
+			readFileSync(paths.manifestLastGood, "utf-8"),
+		) as RuntimeManifest;
+		expect(tamperedManifest.projection?.sourceBundleVersion).toBe(
+			"clawdi.hosted-runtime.bundle.v2",
+		);
+		if (!tamperedManifest.projection) throw new Error("expected strict-v2 projection marker");
+		delete tamperedManifest.projection.sourceBundleVersion;
+		writeFileSync(paths.manifestLastGood, JSON.stringify(tamperedManifest));
+
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		const watchFetch = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => new Response(null, { status: 304, headers: { etag: bundleEtag } }),
+			},
+		]);
+		try {
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			expect(watchFetch.captured).toHaveLength(1);
+			expect(watchFetch.captured[0].headers["if-none-match"]).toBe(bundleEtag);
+			const event = JSON.parse(logs[0]);
+			expect(event).toMatchObject({ status: "error", mode: "repair", stage: "local" });
+			expect(event.error).toContain(
+				"cached manifest does not match the durable strict-v2 apply identity",
+			);
+			expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(staleJournal);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+			expect(existsSync(executionMarker)).toBe(false);
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;
@@ -10435,12 +10551,24 @@ chmod +x "$prefix/bin/clawdi"
 			},
 			secretValues: {},
 		};
-		mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
-		writeFileSync(
-			paths.manifestLastGood,
-			JSON.stringify(normalizeManifestPayload(manifestPayload).manifest),
-		);
 		const bundleEtag = `"sha256:${"a".repeat(64)}"`;
+		const normalizedManifest = normalizeManifestPayload(manifestPayload).manifest;
+		const committedLoad: RuntimeManifestLoad = {
+			manifest: {
+				...normalizedManifest,
+				projection: {
+					...normalizedManifest.projection,
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+				},
+			},
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/runtime/manifest",
+			offline: false,
+			secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
+			etag: bundleEtag,
+			sourceRevision: "a".repeat(64),
+		};
+		cacheRuntimeLastGoodManifest(committedLoad.manifest, paths, committedLoad.secretValues);
 		writeRuntimeAppliedState(
 			{
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
@@ -10449,10 +10577,7 @@ chmod +x "$prefix/bin/clawdi"
 				etag: bundleEtag,
 				sourceRevision: "a".repeat(64),
 				generation: 30,
-				contentIdentity: {
-					sourcePath: "https://runtime.test/v1/runtime/manifest",
-					sha256: "b".repeat(64),
-				},
+				contentIdentity: runtimeAppliedContentIdentity(committedLoad),
 				providerIds: ["default"],
 				projectedProviderIds: {},
 			},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -338,6 +338,7 @@ echo "seeded clawdi"
 	chmodSync(target, 0o700);
 	rmSync(active, { force: true });
 	symlinkSync(target, active);
+	const targetStat = statSync(target);
 	writeFileSync(
 		join(state, "status", "cli-bootstrap.json"),
 		JSON.stringify({
@@ -353,6 +354,13 @@ echo "seeded clawdi"
 			activeTarget: target,
 			version,
 			cliIntegrity: TEST_CLI_INTEGRITY,
+			verification: {
+				verifiedAt: new Date().toISOString(),
+				device: targetStat.dev,
+				inode: targetStat.ino,
+				size: targetStat.size,
+				modifiedAtMs: targetStat.mtimeMs,
+			},
 			error: null,
 		}),
 	);
@@ -466,7 +474,6 @@ function writeCliBootstrapFixture(paths: RuntimePaths, identity: RuntimeCliFixtu
 			activePath: paths.cliManagedBin,
 			activeTarget: identity.activeTarget,
 			version: identity.version,
-			cliIntegrity: TEST_CLI_INTEGRITY,
 			error: null,
 		})}\n`,
 		{ mode: 0o600 },
@@ -8422,7 +8429,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("migrates a writable legacy hosted CLI entrypoint into the root-only boundary", () => {
+	it("migrates a generic legacy hosted CLI entrypoint without promoting spoofed integrity", () => {
 		const version = "0.13.1-beta.0";
 		const packageSpec = `clawdi@${version}`;
 		const home = join(root, "home-cli-boundary", "clawdi");
@@ -8473,8 +8480,15 @@ exit 64
 		paths.imageShim = join(root, "usr", "local", "lib", "clawdi", "bootstrap", "clawdi");
 		paths.legacyImageShim = legacyImageShim;
 
-		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
-		const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+		const hostedDesired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+		expect(() => applyRuntimeCliDesiredState(hostedDesired.manifest, paths)).toThrow(
+			/no valid promoted install identity/,
+		);
+		expect(existsSync(paths.cliManagedBin)).toBe(false);
+		expect(readlinkSync(legacyActive)).toBe(activeTarget);
+
+		const desired = genericCliDesiredState(packageSpec);
+		const result = applyRuntimeCliDesiredState(desired, paths);
 
 		expect(result.status).toBe("current");
 		expect(paths.cliManagedBin).toBe(join(state, "managed-cli", "bin", "clawdi"));
@@ -8485,9 +8499,9 @@ exit 64
 		expect(statSync(paths.cliNpmPrefix).mode & 0o777).toBe(0o700);
 		expect(statSync(activeTarget).mode & 0o777).toBe(0o700);
 		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
-		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity).toBe(
-			TEST_CLI_INTEGRITY,
-		);
+		expect(
+			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity,
+		).toBeUndefined();
 		expect(statSync(legacyImageShim).mode & 0o777).toBe(0o700);
 	});
 
@@ -9323,7 +9337,59 @@ chmod +x "$prefix/bin/clawdi"
 		expect(status.verification).toBeDefined();
 	});
 
-	it("invalidates promoted CLI integrity without executing bytes changed after verification", () => {
+	it("does not promote unverified integrity during a generic verification rewrite", () => {
+		const version = "0.13.12-beta.0";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-integrity-unverified-rewrite", "clawdi");
+		const state = join(root, "state-cli-integrity-unverified-rewrite");
+		const run = join(root, "run-cli-integrity-unverified-rewrite");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		delete status.verification;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(status));
+
+		const result = applyRuntimeCliDesiredState(genericCliDesiredState(packageSpec), paths);
+		const rewritten = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		expect(result.status).toBe("current");
+		expect(rewritten.verification).toBeDefined();
+		expect(rewritten.cliIntegrity).toBeUndefined();
+		expect(() =>
+			applyRuntimeCliDesiredState(
+				normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec)).manifest,
+				paths,
+			),
+		).toThrow(/no supported promoted cliIntegrity/);
+	});
+
+	it("rejects promoted root status without executable verification identity", () => {
+		const version = "0.13.12-beta.0";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-integrity-no-verification", "clawdi");
+		const state = join(root, "state-cli-integrity-no-verification");
+		const run = join(root, "run-cli-integrity-no-verification");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		delete status.verification;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(status));
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+
+		expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
+			/target changed after promoted bootstrap verification/,
+		);
+	});
+
+	it("rejects promoted CLI drift without discarding the root-bootstrap marker", () => {
 		const version = "0.13.12-beta.1";
 		const packageSpec = `clawdi@${version}`;
 		const home = join(root, "home-cli-integrity-bytes", "clawdi");
@@ -9356,9 +9422,9 @@ exit 64
 			/target changed after promoted bootstrap verification/,
 		);
 		expect(existsSync(executionMarker)).toBe(false);
-		expect(
-			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity,
-		).toBeUndefined();
+		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity).toBe(
+			TEST_CLI_INTEGRITY,
+		);
 	});
 
 	it.each([
@@ -9386,6 +9452,78 @@ exit 64
 		expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
 			/no supported promoted cliIntegrity/,
 		);
+		expect(rollbackPendingRuntimeCliUpgrade(paths, "invalid root binding")).toMatchObject({
+			status: "error",
+			error: expect.stringMatching(/no supported promoted cliIntegrity/),
+		});
+	});
+
+	it("lets a promoted root bootstrap supersede a stale CLI upgrade journal", () => {
+		const version = "0.13.12-beta.5";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-root-journal", "clawdi");
+		const state = join(root, "state-cli-root-journal");
+		const run = join(root, "run-cli-root-journal");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const executionMarker = join(root, "stale-root-journal-executed");
+		const previousIdentity = createVersionedCliFixture(paths, "0.13.11");
+		writeFileSync(
+			previousIdentity.activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${previousIdentity.version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+			{ mode: 0o700 },
+		);
+		const promotedIdentity = {
+			packageSpec,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: paths.cliNpmPrefix,
+			activeTarget: readlinkSync(paths.cliManagedBin),
+			version,
+		};
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity: promotedIdentity,
+			rollbackReason: "stale unbound rollback",
+		});
+
+		expect(reconcilePendingRuntimeCliUpgrade(paths, version)).toEqual({
+			status: "unchanged",
+			selfReexec: false,
+		});
+		expect(completePendingRuntimeCliUpgrade(paths, version)).toEqual({
+			status: "unchanged",
+			selfReexec: false,
+		});
+		expect(rollbackPendingRuntimeCliUpgrade(paths, "must not restore unbound bytes")).toMatchObject(
+			{
+				status: "not_pending",
+				version,
+				previousVersion: null,
+			},
+		);
+
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+		expect(applyRuntimeCliDesiredState(desired.manifest, paths).status).toBe("current");
+		expect(existsSync(executionMarker)).toBe(false);
+		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toEqual({
+			schemaVersion: "clawdi.cliUpgradeState.v2",
+			transaction: null,
+			badVersions: [],
+		});
+		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+			packageSpec,
+			cliIntegrity: TEST_CLI_INTEGRITY,
+		});
 	});
 
 	it("does not carry promoted integrity to CLI-installed bytes with a different identity", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -171,6 +171,8 @@ let originalEnv: Partial<Record<EnvKey, string>>;
 let originalUmask: number;
 let root: string;
 
+const TEST_CLI_INTEGRITY = `sha512-${"A".repeat(86)}==`;
+
 function fakeSystemdStatePath(
 	stateRoot: string,
 	scope: "system" | "user",
@@ -350,6 +352,7 @@ echo "seeded clawdi"
 			activePath: active,
 			activeTarget: target,
 			version,
+			cliIntegrity: TEST_CLI_INTEGRITY,
 			error: null,
 		}),
 	);
@@ -463,6 +466,7 @@ function writeCliBootstrapFixture(paths: RuntimePaths, identity: RuntimeCliFixtu
 			activePath: paths.cliManagedBin,
 			activeTarget: identity.activeTarget,
 			version: identity.version,
+			cliIntegrity: TEST_CLI_INTEGRITY,
 			error: null,
 		})}\n`,
 		{ mode: 0o600 },
@@ -8276,7 +8280,7 @@ fi
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
 	});
 
-	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
+	it("runtime watch fails closed without a root-promoted Hosted v2 CLI binding", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
@@ -8387,30 +8391,15 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			if (process.exitCode !== undefined && process.exitCode !== 0) {
-				throw new Error(logs.join("\n"));
-			}
-			expect(process.exitCode ?? 0).toBe(0);
+			expect(process.exitCode).toBe(1);
 			expect(captured).toHaveLength(1);
-			const active = join(state, "managed-cli", "bin", "clawdi");
-			const sharedPrefixTarget = join(state, "npm", "bin", "clawdi");
-			const activeTarget = readlinkSync(active);
-			expect(readlinkSync(active)).toBe(activeTarget);
-			const status = JSON.parse(readFileSync(join(state, "status", "cli-bootstrap.json"), "utf-8"));
-			expect(status.packageSpec).toBe(`clawdi@${currentVersion}`);
-			expect(status.activePath).toBe(active);
-			expect(status.activeTarget).toBe(activeTarget);
-			expect(status.npmPrefix.startsWith(join(state, "npm", "packages"))).toBe(true);
-			expect(activeTarget).toBe(join(status.npmPrefix, "bin", "clawdi"));
-			expect(activeTarget).not.toBe(sharedPrefixTarget);
-			expect(status.version).toBe(currentVersion);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("cli_handoff");
-			expect(event.handoff).toBe("cli_reexec");
-			expect(event.selfReexec).toBe(true);
-			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.status).toBe("error");
+			expect(event.stage).toBe("cli-update");
+			expect(event.selfReexec).toBe(false);
+			expect(event.cliUpdate.status).toBe("error");
 			expect(event.cliUpdate.packageSpec).toBe(`clawdi@${currentVersion}`);
-			expect(event.systemdUnitsChanged).toBe(false);
+			expect(event.cliUpdate.error).toContain("no valid promoted install identity");
 			expect(event.systemdApply).toEqual({
 				applied: false,
 				systemUnitsChanged: [],
@@ -8421,27 +8410,9 @@ chmod +x "$prefix/bin/clawdi"
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated" },
-				badVersions: [],
-			});
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode ?? 0).toBe(0);
-			expect(captured).toHaveLength(2);
-			const completedEvent = JSON.parse(logs[0]);
-			expect(completedEvent.status).toBe("applied");
-			expect(completedEvent.selfReexec).toBe(false);
-			expect(completedEvent.cliUpdate.status).toBe("current");
-			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: null,
-				badVersions: [],
-			});
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(existsSync(npmLog)).toBe(false);
+			expect(existsSync(join(state, "status", "cli-bootstrap.json"))).toBe(false);
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -8489,6 +8460,7 @@ exit 64
 				activePath: legacyActive,
 				activeTarget,
 				version,
+				cliIntegrity: TEST_CLI_INTEGRITY,
 			}),
 			{ mode: 0o644 },
 		);
@@ -8513,6 +8485,9 @@ exit 64
 		expect(statSync(paths.cliNpmPrefix).mode & 0o777).toBe(0o700);
 		expect(statSync(activeTarget).mode & 0o777).toBe(0o700);
 		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
+		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity).toBe(
+			TEST_CLI_INTEGRITY,
+		);
 		expect(statSync(legacyImageShim).mode & 0o777).toBe(0o700);
 	});
 
@@ -8992,7 +8967,7 @@ exit 0
 		}
 	});
 
-	it("runtime watch reapplies transparent egress across CLI self-upgrade", async () => {
+	it("runtime watch reapplies transparent egress with a root-bootstrapped CLI", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
@@ -9079,7 +9054,12 @@ fi
 			}),
 		);
 		const paths = getRuntimePaths();
-		seedCurrentCliInstall(state, "clawdi@0.13.1-beta.0", "0.13.1-beta.0");
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.13.2-beta.0",
+			"0.13.2-beta.0",
+			"https://registry.npmjs.org",
+		);
 		const mitmproxy = seedMitmproxyCache(paths);
 		convergeRuntimeManifest(
 			{
@@ -9172,7 +9152,7 @@ fi
 								egressEngine: mitmproxy,
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: `clawdi@${currentVersion}`,
+									packageSpec: "clawdi@0.13.2-beta.0",
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -9206,19 +9186,10 @@ fi
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
-			const handoff = JSON.parse(logs[0]);
-			expect(handoff.status).toBe("cli_handoff");
-			expect(handoff.selfReexec).toBe(true);
-			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(0);
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("applied");
-			expect(event.selfReexec).toBe(false);
+			expect(event.cliUpdate.status).toBe("current");
+			expect(event.selfReexec).toBe(true);
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
@@ -9246,7 +9217,7 @@ fi
 	it.each([
 		["upgrades", "0.12.10-beta.48", "0.12.10-beta.49"],
 		["downgrades", "0.12.10-beta.50", "0.12.10-beta.49"],
-	])("hosted exact CLI desired state %s without npm view", (_name, currentVersion, desiredVersion) => {
+	])("defers Hosted v2 exact CLI %s to root bootstrap without executing npm", (_name, currentVersion, desiredVersion) => {
 		const home = join(root, `home-${currentVersion}`, "clawdi");
 		const state = join(root, `state-${currentVersion}`);
 		const run = join(root, `run-${currentVersion}`);
@@ -9302,26 +9273,151 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
 			const paths = getRuntimePaths();
+			const activeTarget = readlinkSync(paths.cliManagedBin);
 			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
 
-			expect(result.status).toBe("installed");
-			expect(result.selfReexec).toBe(true);
+			expect(result.status).toBe("deferred");
 			expect(result.packageSpec).toBe(desiredSpec);
-			expect(result.version).toBe(desiredVersion);
+			expect(result.version).toBe(currentVersion);
 			expect(result.activePath).toBe(join(state, "managed-cli", "bin", "clawdi"));
-			expect(readlinkSync(result.activePath)).toBe(result.activeTarget);
+			expect(result.activeTarget).toBe(activeTarget);
+			expect(readlinkSync(result.activePath)).toBe(activeTarget);
 			expect(existsSync(join(state, "bin", "clawdi"))).toBe(false);
 			expect(statSync(join(state, "managed-cli")).mode & 0o777).toBe(0o700);
 			expect(statSync(dirname(result.activePath)).mode & 0o777).toBe(0o700);
 			expect(statSync(paths.cliNpmPrefix).mode & 0o777).toBe(0o700);
-			expect(statSync(result.npmPrefix).mode & 0o777).toBe(0o700);
-			if (!result.activeTarget) throw new Error("CLI update did not return an active target");
-			expect(statSync(result.activeTarget).mode & 0o777).toBe(0o700);
+			expect(statSync(activeTarget).mode & 0o777).toBe(0o700);
 			expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
-			expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(existsSync(npmLog)).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+				packageSpec: currentSpec,
+				activeTarget,
+				cliIntegrity: TEST_CLI_INTEGRITY,
+			});
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("preserves promoted CLI integrity across a same-identity verification rewrite", () => {
+		const version = "0.13.12-beta.0";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-integrity-rewrite", "clawdi");
+		const state = join(root, "state-cli-integrity-rewrite");
+		const run = join(root, "run-cli-integrity-rewrite");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+
+		const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		expect(result.status).toBe("current");
+		expect(status.cliIntegrity).toBe(TEST_CLI_INTEGRITY);
+		expect(status.verification).toBeDefined();
+	});
+
+	it("invalidates promoted CLI integrity without executing bytes changed after verification", () => {
+		const version = "0.13.12-beta.1";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, "home-cli-integrity-bytes", "clawdi");
+		const state = join(root, "state-cli-integrity-bytes");
+		const run = join(root, "run-cli-integrity-bytes");
+		const executionMarker = join(root, "changed-cli-executed");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+		applyRuntimeCliDesiredState(desired.manifest, paths);
+		const activeTarget = readlinkSync(paths.cliManagedBin);
+		writeFileSync(
+			activeTarget,
+			`#!/usr/bin/env bash
+touch '${executionMarker}'
+if [ "\${1:-}" = "--version" ]; then echo '${version}'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+exit 64
+`,
+		);
+		chmodSync(activeTarget, 0o700);
+		const changedAt = new Date("2030-01-01T00:00:00.000Z");
+		utimesSync(activeTarget, changedAt, changedAt);
+
+		expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
+			/target changed after promoted bootstrap verification/,
+		);
+		expect(existsSync(executionMarker)).toBe(false);
+		expect(
+			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity,
+		).toBeUndefined();
+	});
+
+	it.each([
+		"sha256-deadbeef",
+		"sha512-not-base64",
+		`sha512-${"A".repeat(85)}B==`,
+		42,
+	])("fails closed on unsupported or malformed promoted CLI integrity %p", (cliIntegrity) => {
+		const version = "0.13.12-beta.2";
+		const packageSpec = `clawdi@${version}`;
+		const home = join(root, `home-cli-integrity-invalid-${String(cliIntegrity)}`, "clawdi");
+		const state = join(root, `state-cli-integrity-invalid-${String(cliIntegrity)}`);
+		const run = join(root, `run-cli-integrity-invalid-${String(cliIntegrity)}`);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		status.cliIntegrity = cliIntegrity;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(status));
+		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
+
+		expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
+			/no supported promoted cliIntegrity/,
+		);
+	});
+
+	it("does not carry promoted integrity to CLI-installed bytes with a different identity", () => {
+		const home = join(root, "home-cli-integrity-install", "clawdi");
+		const state = join(root, "state-cli-integrity-install");
+		const run = join(root, "run-cli-integrity-install");
+		const bin = join(root, "bin-cli-integrity-install");
+		const previousPath = process.env.PATH;
+		installVersionedCliNpmStub(bin);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.13.12-beta.3",
+			"0.13.12-beta.3",
+			"https://registry.npmjs.org",
+		);
+		const paths = getRuntimePaths();
+
+		try {
+			const result = applyRuntimeCliDesiredState(
+				genericCliDesiredState("clawdi@0.13.12-beta.4"),
+				paths,
+			);
+			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+			expect(result.status).toBe("installed");
+			expect(status.packageSpec).toBe("clawdi@0.13.12-beta.4");
+			expect(status.cliIntegrity).toBeUndefined();
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
@@ -9709,7 +9805,7 @@ exit 64
 		}
 	});
 
-	it("recovers an exact CLI install when matching bootstrap status has no version", () => {
+	it("generic runtime recovers an exact CLI install when matching status has no version", () => {
 		const desiredVersion = "0.12.10-beta.49";
 		const desiredSpec = `clawdi@${desiredVersion}`;
 		const home = join(root, "home-exact-recovery", "clawdi");
@@ -9761,8 +9857,7 @@ exit 64
 		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
 
 		try {
-			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
-			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+			const result = applyRuntimeCliDesiredState(genericCliDesiredState(desiredSpec), paths);
 
 			expect(result.status).toBe("current");
 			expect(result.packageSpec).toBe(desiredSpec);
@@ -9775,13 +9870,14 @@ exit 64
 			expect(repairedStatus.version).toBe(desiredVersion);
 			expect(repairedStatus.npmPrefix).toBe(exactPrefix);
 			expect(repairedStatus.activeTarget).toBe(exactTarget);
+			expect(repairedStatus.cliIntegrity).toBeUndefined();
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}
 	});
 
-	it("reinstalls an exact CLI spec when the active link uses a legacy hash prefix", () => {
+	it("generic runtime reinstalls an exact CLI spec from a legacy hash prefix", () => {
 		const desiredVersion = "0.12.10-beta.49";
 		const desiredSpec = `clawdi@${desiredVersion}`;
 		const registry = "https://registry.npmjs.org";
@@ -9862,8 +9958,7 @@ exit 64
 		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
 
 		try {
-			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
-			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+			const result = applyRuntimeCliDesiredState(genericCliDesiredState(desiredSpec), paths);
 			const canonicalPrefix = join(paths.cliNpmPrefix, "packages", desiredVersion);
 			const canonicalTarget = join(canonicalPrefix, "bin", "clawdi");
 
@@ -9879,13 +9974,14 @@ exit 64
 			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
 			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 			expect(repairedStatus.version).toBe(desiredVersion);
+			expect(repairedStatus.cliIntegrity).toBeUndefined();
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}
 	});
 
-	it("rejects an exact CLI install that reports a different version without swapping active", () => {
+	it("generic runtime rejects an exact CLI install that reports a different version", () => {
 		const desiredVersion = "0.12.10-beta.49";
 		const actualVersion = "0.12.10-beta.48";
 		const desiredSpec = `clawdi@${desiredVersion}`;
@@ -9948,8 +10044,7 @@ chmod +x "$prefix/bin/clawdi"
 		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 
 		try {
-			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
-			expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
+			expect(() => applyRuntimeCliDesiredState(genericCliDesiredState(desiredSpec), paths)).toThrow(
 				`npm install ${desiredSpec} reported version ${actualVersion}, expected ${desiredVersion}`,
 			);
 
@@ -9966,7 +10061,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch self-heal installs an exact hosted CLI version and hands off", async () => {
+	it("runtime watch self-heal defers a changed Hosted v2 CLI to root bootstrap", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(30, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
@@ -10129,18 +10224,16 @@ chmod +x "$prefix/bin/clawdi"
 			expect(captured[0].headers["if-none-match"]).toBe(bundleEtag);
 			expect(captured[1].headers["if-none-match"]).toBeUndefined();
 			const events = logs.map((line) => JSON.parse(line));
-			expect(events.map((event) => event.status)).toEqual(["cli_handoff"]);
-			expect(events[0].cliUpdate).toEqual(
+			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
+			expect(events[1].cliUpdate).toEqual(
 				expect.objectContaining({
-					status: "installed",
+					status: "deferred",
 					packageSpec: "clawdi@0.13.0-test",
-					version: "0.13.0-test",
+					version: "0.12.10-beta.49",
 				}),
 			);
-			expect(events[0].selfReexec).toBe(true);
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
+			expect(events[1].selfReexec).toBe(true);
+			expect(existsSync(npmLog)).toBe(false);
 		} finally {
 			if (timeoutId !== undefined) clearTimeout(timeoutId);
 			restore();
@@ -10151,7 +10244,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch never enters a failing projection after CLI activation", async () => {
+	it("runtime watch reports convergence failure with a root-bootstrapped CLI", async () => {
 		setRuntimeApplyGeneration(16, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -10239,6 +10332,12 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.13.3-beta.0",
+			"0.13.3-beta.0",
+			"https://registry.npmjs.org",
+		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -10292,13 +10391,13 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(0);
+			expect(process.exitCode).toBe(1);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("cli_handoff");
-			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.status).toBe("error");
+			expect(event.cliUpdate.status).toBe("current");
 			expect(event.selfReexec).toBe(true);
-			expect(event.errors).toBeUndefined();
-			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(false);
+			expect(event.errors[0]).toContain("runtime openclaw provider projection failed");
+			expect(event.errors[0]).toContain("projection boom");
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
 			expect(existsSync(getRuntimePaths().appliedState)).toBe(false);
 		} finally {
@@ -10310,7 +10409,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		}
 	});
 
-	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
+	it("does not start a Hosted v2 CLI transaction when deferred convergence fails", async () => {
 		setRuntimeApplyGeneration(18, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -10386,7 +10485,12 @@ chmod +x "$prefix/bin/clawdi"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.13.4-beta.0",
+			"0.13.4-beta.0",
+			"https://registry.npmjs.org",
+		);
 		const paths = getRuntimePaths();
 		const oldTarget = readlinkSync(paths.cliManagedBin);
 		const manifest = {
@@ -10446,63 +10550,15 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(0);
-			const handoffEvent = JSON.parse(logs[0]);
-			expect(handoffEvent.status).toBe("cli_handoff");
-			expect(handoffEvent.cliUpdate.status).toBe("installed");
-			expect(handoffEvent.cliRollback).toBeUndefined();
-			expect(readlinkSync(paths.cliManagedBin)).not.toBe(oldTarget);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
 			expect(process.exitCode).toBe(1);
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("error");
-			expect(event.cliUpdate.status).toBe("current");
-			expect(event.cliRollback.status).toBe("rolled_back");
-			expect(event.cliRollback.version).toBe(currentVersion);
+			expect(event.cliUpdate.status).toBe("deferred");
+			expect(event.cliRollback.status).toBe("not_pending");
 			expect(event.selfReexec).toBe(true);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(upgradeState.transaction).toBeNull();
-			expect(upgradeState.badVersions).toContainEqual(
-				expect.objectContaining({
-					packageSpec: `clawdi@${currentVersion}`,
-					version: currentVersion,
-				}),
-			);
-			const beforeRetryLog = readFileSync(npmLog, "utf-8");
-			expect(() =>
-				applyRuntimeCliDesiredState(
-					{
-						schemaVersion: "clawdi.runtimeDesiredState.v1",
-						deploymentId: "dep_cli_rollback",
-						environmentId: "env_cli_rollback",
-						instanceId: "iid_cli_rollback",
-						generation: 18,
-						issuedAt: "2026-06-06T00:00:00Z",
-						controlPlane: { apiUrl: "https://cloud-api.test" },
-						clawdiCli: {
-							source: "npm:clawdi",
-							packageSpec: `clawdi@${currentVersion}`,
-							registry: "https://registry.npmjs.org",
-						},
-						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-						recovery: {},
-					},
-					paths,
-				),
-			).toThrow(/marked bad/);
-			const afterRetryLog = readFileSync(npmLog, "utf-8");
-			expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
-				beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
-			);
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(existsSync(npmLog)).toBe(false);
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -10731,6 +10787,12 @@ chmod +x "$prefix/bin/clawdi"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.13.9-beta.0",
+			"0.13.9-beta.0",
+			"https://registry.npmjs.org",
+		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -10768,13 +10830,14 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(0);
+			expect(process.exitCode).toBe(1);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("cli_handoff");
-			expect(event.stage).toBe("cli-update");
-			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.status).toBe("error");
+			expect(event.stage).toBe("config");
+			expect(event.mode).toBe("minimum_cli_version_gated");
+			expect(event.cliUpdate.status).toBe("deferred");
 			expect(event.selfReexec).toBe(true);
-			expect(event.gate).toBeUndefined();
+			expect(event.gate.minimumCliVersion).toBe("999.0.0");
 			const paths = getRuntimePaths();
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 		} finally {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1020,12 +1020,15 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 		offline: false,
 		secretValues: {},
 	};
-	load.applyContext = readRuntimeApplyContext();
+	const applyContext = readRuntimeApplyContext();
+	load.applyContext = applyContext;
 	const convergence = convergeRuntimeManifest(load, paths);
 	if (convergence.installErrors.length > 0) throw new Error(convergence.installErrors.join("; "));
+	cacheRuntimeLastGoodManifest(load.manifest, paths, load.secretValues);
 	writeTestRuntimeAppliedState(paths, load, convergence, {
 		etag: testBundleEtag("manifest-locale-1"),
 	});
+	writeCanonicalApplyContext(applyContext.identity, applyContext.runtimeEnvironment.values);
 	return paths;
 }
 
@@ -7656,6 +7659,7 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		seedCurrentCliInstall(state, packageSpec, currentVersion, "https://registry.npmjs.org");
 		const paths = getRuntimePaths();
@@ -10553,6 +10557,7 @@ chmod +x "$prefix/bin/clawdi"
 		};
 		const bundleEtag = `"sha256:${"a".repeat(64)}"`;
 		const normalizedManifest = normalizeManifestPayload(manifestPayload).manifest;
+		const committedApplyContext = readRuntimeApplyContext();
 		const committedLoad: RuntimeManifestLoad = {
 			manifest: {
 				...normalizedManifest,
@@ -10567,6 +10572,7 @@ chmod +x "$prefix/bin/clawdi"
 			secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 			etag: bundleEtag,
 			sourceRevision: "a".repeat(64),
+			applyContext: committedApplyContext,
 		};
 		cacheRuntimeLastGoodManifest(committedLoad.manifest, paths, committedLoad.secretValues);
 		writeRuntimeAppliedState(
@@ -10577,6 +10583,10 @@ chmod +x "$prefix/bin/clawdi"
 				etag: bundleEtag,
 				sourceRevision: "a".repeat(64),
 				generation: 30,
+				applyGeneration: committedApplyContext.identity.generation,
+				manifestETag: committedApplyContext.identity.manifestETag,
+				applyReceiptId: committedApplyContext.identity.applyReceiptId,
+				bootNonce: committedApplyContext.identity.bootNonce,
 				contentIdentity: runtimeAppliedContentIdentity(committedLoad),
 				providerIds: ["default"],
 				projectedProviderIds: {},
@@ -10971,6 +10981,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("keeps an old no-integrity same-package current and changed-package deferred", async () => {
+		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(17, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -338,7 +338,6 @@ echo "seeded clawdi"
 	chmodSync(target, 0o700);
 	rmSync(active, { force: true });
 	symlinkSync(target, active);
-	const targetStat = statSync(target);
 	writeFileSync(
 		join(state, "status", "cli-bootstrap.json"),
 		JSON.stringify({
@@ -353,6 +352,29 @@ echo "seeded clawdi"
 			activePath: active,
 			activeTarget: target,
 			version,
+			error: null,
+		}),
+	);
+}
+
+function seedRootBootstrappedCliInstall(
+	state: string,
+	packageSpec: string,
+	version: string,
+	registry = "https://registry.npmjs.org",
+): void {
+	seedCurrentCliInstall(state, packageSpec, version, registry);
+	promoteCliBootstrapStatus(state);
+}
+
+function promoteCliBootstrapStatus(state: string): void {
+	const statusPath = join(state, "status", "cli-bootstrap.json");
+	const status = JSON.parse(readFileSync(statusPath, "utf-8"));
+	const targetStat = statSync(status.activeTarget);
+	writeFileSync(
+		statusPath,
+		JSON.stringify({
+			...status,
 			cliIntegrity: TEST_CLI_INTEGRITY,
 			verification: {
 				verifiedAt: new Date().toISOString(),
@@ -361,7 +383,6 @@ echo "seeded clawdi"
 				size: targetStat.size,
 				modifiedAtMs: targetStat.mtimeMs,
 			},
-			error: null,
 		}),
 	);
 }
@@ -9068,12 +9089,7 @@ fi
 			}),
 		);
 		const paths = getRuntimePaths();
-		seedCurrentCliInstall(
-			state,
-			"clawdi@0.13.2-beta.0",
-			"0.13.2-beta.0",
-			"https://registry.npmjs.org",
-		);
+		seedRootBootstrappedCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
 		const mitmproxy = seedMitmproxyCache(paths);
 		convergeRuntimeManifest(
 			{
@@ -9166,7 +9182,7 @@ fi
 								egressEngine: mitmproxy,
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@0.13.2-beta.0",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -9203,7 +9219,7 @@ fi
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("applied");
 			expect(event.cliUpdate.status).toBe("current");
-			expect(event.selfReexec).toBe(true);
+			expect(event.selfReexec).toBe(false);
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
@@ -9282,7 +9298,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUN_DIR = run;
 		const currentSpec = `clawdi@${currentVersion}`;
 		const desiredSpec = `clawdi@${desiredVersion}`;
-		seedCurrentCliInstall(state, currentSpec, currentVersion, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, currentSpec, currentVersion);
 
 		try {
 			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
@@ -9325,7 +9341,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, packageSpec, version);
 		const paths = getRuntimePaths();
 		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
 
@@ -9337,7 +9353,7 @@ chmod +x "$prefix/bin/clawdi"
 		expect(status.verification).toBeDefined();
 	});
 
-	it("does not promote unverified integrity during a generic verification rewrite", () => {
+	it("does not promote unverified integrity while keeping old current status compatible", () => {
 		const version = "0.13.12-beta.0";
 		const packageSpec = `clawdi@${version}`;
 		const home = join(root, "home-cli-integrity-unverified-rewrite", "clawdi");
@@ -9347,7 +9363,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, packageSpec, version);
 		const paths = getRuntimePaths();
 		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 		delete status.verification;
@@ -9359,12 +9375,12 @@ chmod +x "$prefix/bin/clawdi"
 		expect(result.status).toBe("current");
 		expect(rewritten.verification).toBeDefined();
 		expect(rewritten.cliIntegrity).toBeUndefined();
-		expect(() =>
+		expect(
 			applyRuntimeCliDesiredState(
 				normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec)).manifest,
 				paths,
-			),
-		).toThrow(/no supported promoted cliIntegrity/);
+			).status,
+		).toBe("current");
 	});
 
 	it("rejects promoted root status without executable verification identity", () => {
@@ -9377,7 +9393,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, packageSpec, version);
 		const paths = getRuntimePaths();
 		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 		delete status.verification;
@@ -9400,7 +9416,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, packageSpec, version);
 		const paths = getRuntimePaths();
 		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
 		applyRuntimeCliDesiredState(desired.manifest, paths);
@@ -9442,7 +9458,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, packageSpec, version, "https://registry.npmjs.org");
+		seedRootBootstrappedCliInstall(state, packageSpec, version);
 		const paths = getRuntimePaths();
 		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 		status.cliIntegrity = cliIntegrity;
@@ -9458,7 +9474,7 @@ exit 64
 		});
 	});
 
-	it("lets a promoted root bootstrap supersede a stale CLI upgrade journal", () => {
+	it("keeps Hosted legacy journals inert until a promoted root binding supersedes them", () => {
 		const version = "0.13.12-beta.5";
 		const packageSpec = `clawdi@${version}`;
 		const home = join(root, "home-cli-root-journal", "clawdi");
@@ -9495,6 +9511,7 @@ exit 64
 			newIdentity: promotedIdentity,
 			rollbackReason: "stale unbound rollback",
 		});
+		const staleJournal = readFileSync(paths.cliUpgradeState, "utf-8");
 
 		expect(reconcilePendingRuntimeCliUpgrade(paths, version)).toEqual({
 			status: "unchanged",
@@ -9507,7 +9524,7 @@ exit 64
 		expect(rollbackPendingRuntimeCliUpgrade(paths, "must not restore unbound bytes")).toMatchObject(
 			{
 				status: "not_pending",
-				version,
+				version: null,
 				previousVersion: null,
 			},
 		);
@@ -9515,6 +9532,16 @@ exit 64
 		const desired = normalizeManifestPayload(hostedCliManifestResponse(home, packageSpec));
 		expect(applyRuntimeCliDesiredState(desired.manifest, paths).status).toBe("current");
 		expect(existsSync(executionMarker)).toBe(false);
+		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(staleJournal);
+		expect(
+			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity,
+		).toBeUndefined();
+
+		promoteCliBootstrapStatus(state);
+		expect(reconcilePendingRuntimeCliUpgrade(paths, version)).toEqual({
+			status: "unchanged",
+			selfReexec: false,
+		});
 		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toEqual({
 			schemaVersion: "clawdi.cliUpgradeState.v2",
 			transaction: null,
@@ -9538,12 +9565,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(
-			state,
-			"clawdi@0.13.12-beta.3",
-			"0.13.12-beta.3",
-			"https://registry.npmjs.org",
-		);
+		seedRootBootstrappedCliInstall(state, "clawdi@0.13.12-beta.3", "0.13.12-beta.3");
 		const paths = getRuntimePaths();
 
 		try {
@@ -10211,6 +10233,8 @@ chmod +x "$prefix/bin/clawdi"
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
+		const abort = new AbortController();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -10272,12 +10296,7 @@ chmod +x "$prefix/bin/clawdi"
 			}),
 		);
 		const paths = getRuntimePaths();
-		seedCurrentCliInstall(
-			state,
-			"clawdi@0.12.10-beta.49",
-			"0.12.10-beta.49",
-			"https://registry.npmjs.org",
-		);
+		seedRootBootstrappedCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
 		const manifestPayload = {
 			manifest: {
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
@@ -10319,19 +10338,22 @@ chmod +x "$prefix/bin/clawdi"
 			},
 			paths,
 		);
+		let manifestCalls = 0;
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
 				path: "/v1/runtime/manifest",
-				response: (request) =>
-					request.headers["if-none-match"]
-						? new Response(null, {
-								status: 304,
-								headers: { etag: bundleEtag },
-							})
-						: hostedRuntimeBundleResponse(manifestPayload, {
-								etag: bundleEtag,
-							}),
+				response: (request) => {
+					manifestCalls += 1;
+					if (request.headers["if-none-match"]) {
+						return new Response(null, {
+							status: 304,
+							headers: { etag: bundleEtag },
+						});
+					}
+					if (manifestCalls === 2) setTimeout(() => abort.abort(), 0);
+					return hostedRuntimeBundleResponse(manifestPayload, { etag: bundleEtag });
+				},
 			},
 		]);
 		let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -10343,6 +10365,7 @@ chmod +x "$prefix/bin/clawdi"
 					selfHealMs: 10,
 					json: true,
 					notifications: false,
+					abort: abort.signal,
 				}),
 				new Promise<never>(
 					(_, reject) =>
@@ -10367,10 +10390,10 @@ chmod +x "$prefix/bin/clawdi"
 				expect.objectContaining({
 					status: "deferred",
 					packageSpec: "clawdi@0.13.0-test",
-					version: "0.12.10-beta.49",
+					version: currentVersion,
 				}),
 			);
-			expect(events[1].selfReexec).toBe(true);
+			expect(events[1].selfReexec).toBe(false);
 			expect(existsSync(npmLog)).toBe(false);
 		} finally {
 			if (timeoutId !== undefined) clearTimeout(timeoutId);
@@ -10393,6 +10416,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -10470,12 +10494,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(
-			state,
-			"clawdi@0.13.3-beta.0",
-			"0.13.3-beta.0",
-			"https://registry.npmjs.org",
-		);
+		seedRootBootstrappedCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -10498,7 +10517,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@0.13.3-beta.0",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -10533,7 +10552,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("error");
 			expect(event.cliUpdate.status).toBe("current");
-			expect(event.selfReexec).toBe(true);
+			expect(event.selfReexec).toBe(false);
 			expect(event.errors[0]).toContain("runtime openclaw provider projection failed");
 			expect(event.errors[0]).toContain("projection boom");
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
@@ -10693,7 +10712,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.status).toBe("error");
 			expect(event.cliUpdate.status).toBe("deferred");
 			expect(event.cliRollback.status).toBe("not_pending");
-			expect(event.selfReexec).toBe(true);
+			expect(event.selfReexec).toBe(false);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
 			expect(existsSync(paths.cliUpgradeState)).toBe(false);
 			expect(existsSync(npmLog)).toBe(false);
@@ -10706,7 +10725,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
+	it("keeps an old no-integrity bootstrap current or deferred without invoking npm", async () => {
 		setRuntimeApplyGeneration(17, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -10717,6 +10736,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		const oldVersion = "0.13.20";
 		const firstAttempt = join(root, "npm-etarget-first-attempt");
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
@@ -10779,6 +10799,13 @@ chmod +x "$prefix/bin/clawdi"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
+		seedCurrentCliInstall(state, `clawdi@${oldVersion}`, oldVersion, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const current = normalizeManifestPayload(
+			hostedCliManifestResponse(home, `clawdi@${oldVersion}`),
+		);
+		expect(applyRuntimeCliDesiredState(current.manifest, paths).status).toBe("current");
+		expect(existsSync(firstAttempt)).toBe(false);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -10818,41 +10845,20 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(1);
+			expect(process.exitCode ?? 0).toBe(0);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("error");
-			expect(event.stage).toBe("cli-update");
-			expect(event.cliUpdate.status).toBe("error");
-			expect(event.error).toContain("ETARGET");
-			expect(event.activeGeneration).toBeNull();
-			expect(event.rejectedGeneration).toBe(17);
-			const paths = getRuntimePaths();
-			expect(event.convergence).toBeUndefined();
-			expect(event.systemdUnitsChanged).toBe(false);
-			expect(event.systemdApply).toEqual({
-				applied: false,
-				systemUnitsChanged: [],
-				userUnitsChanged: [],
+			expect(event.status).toBe("applied");
+			expect(event.cliUpdate).toMatchObject({
+				status: "deferred",
+				packageSpec: `clawdi@${currentVersion}`,
+				version: oldVersion,
+				selfReexec: false,
 			});
-			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
-			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
-			expect(existsSync(paths.manifestLastGood)).toBe(false);
-			expect(existsSync(paths.appliedState)).toBe(false);
 			expect(existsSync(paths.cliUpgradeState)).toBe(false);
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			const handoff = JSON.parse(logs[0]);
-			expect(handoff.status).toBe("cli_handoff");
-			expect(handoff.cliUpdate.status).toBe("installed");
-			expect(handoff.cliRollback).toBeUndefined();
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
+			expect(existsSync(firstAttempt)).toBe(false);
+			expect(
+				JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).cliIntegrity,
+			).toBeUndefined();
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -10862,7 +10868,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("hands off before evaluating minimumCliVersion under old code", async () => {
+	it("gates minimumCliVersion while an old bootstrap defers CLI replacement", async () => {
 		setRuntimeApplyGeneration(19, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -10974,7 +10980,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.stage).toBe("config");
 			expect(event.mode).toBe("minimum_cli_version_gated");
 			expect(event.cliUpdate.status).toBe("deferred");
-			expect(event.selfReexec).toBe(true);
+			expect(event.selfReexec).toBe(false);
 			expect(event.gate.minimumCliVersion).toBe("999.0.0");
 			const paths = getRuntimePaths();
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
@@ -11483,7 +11489,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime init restarts the bootstrap before convergence and the new CLI completes init", async () => {
+	it("runtime init fails closed until root bootstrap selects the Hosted v2 CLI", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home-init-cli-handoff", "clawdi");
 		const state = join(root, "state-init-cli-handoff");
@@ -11491,6 +11497,7 @@ chmod +x "$prefix/bin/clawdi"
 		const sourcePath = join(root, "runtime-source-init-cli-handoff.json");
 		const policyPath = join(root, "etc-init-cli-handoff", "host-policy.json");
 		const bin = join(root, "bin-init-cli-handoff");
+		const npmLog = join(root, "npm-init-cli-handoff.log");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
@@ -11504,6 +11511,7 @@ chmod +x "$prefix/bin/clawdi"
 			join(bin, "npm"),
 			`#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> '${npmLog}'
 prefix=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--prefix" ]; then
@@ -11577,38 +11585,21 @@ chmod +x "$prefix/bin/clawdi"
 			await runtimeInit({ nonInteractive: true, json: true });
 
 			const paths = getRuntimePaths();
-			expect(process.exitCode).toBe(75);
+			expect(process.exitCode).toBe(23);
 			expect(captured).toHaveLength(1);
-			const handoff = JSON.parse(logs[0]);
-			expect(handoff.status).toBe("ok");
-			expect(handoff.handoff).toBe("cli_reexec");
-			expect(handoff.cliUpdate.status).toBe("installed");
-			expect(handoff.selfReexec).toBe(true);
-			expect(handoff.exitCode).toBe(75);
+			const event = JSON.parse(logs[0]);
+			expect(event.status).toBe("error");
+			expect(event.mode).toBe("repair");
+			expect(event.stage).toBe("final");
+			expect(event.error).toContain("no valid promoted install identity");
+			expect(event.exitCode).toBe(23);
 			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
-			await runtimeInit({ nonInteractive: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			expect(captured).toHaveLength(2);
-			const completed = JSON.parse(logs[0]);
-			expect(completed.status).toBe("ok");
-			expect(completed.handoff).toBeUndefined();
-			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 1 });
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: null,
-				badVersions: [],
-			});
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(existsSync(paths.cliBootstrapStatus)).toBe(false);
+			expect(existsSync(npmLog)).toBe(false);
 		} finally {
 			restore();
 			console.log = previousLog;

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -307,9 +307,8 @@ describe("CLI smoke — src entry", () => {
 
 	it("runtime init converges a strict hosted manifest-file fixture", async () => {
 		const { tmpdir } = await import("node:os");
-		const { chmodSync, existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } = await import(
-			"node:fs"
-		);
+		const { chmodSync, existsSync, mkdirSync, rmSync, statSync, symlinkSync, writeFileSync } =
+			await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-strict-${Date.now()}`);
 		const previousUmask = process.umask(0o022);
 		const home = join(root, "home", "clawdi");
@@ -318,7 +317,7 @@ describe("CLI smoke — src entry", () => {
 		const manifestPath = join(root, "strict-hosted-manifest.json");
 		const installer = join(root, "install-openclaw.sh");
 		const systemctl = join(root, "bin", "systemctl");
-		const managedCli = join(state, "bin", "clawdi");
+		const managedCli = join(state, "managed-cli", "bin", "clawdi");
 		const managedCliTarget = join(state, "npm", "bin", "clawdi");
 		const egressEngine = {
 			type: "mitmproxy",
@@ -377,6 +376,7 @@ exit 64
 		mkdirSync(dirname(mitmdump), { recursive: true });
 		writeFileSync(mitmdump, "#!/usr/bin/env sh\nexit 0\n");
 		chmodSync(mitmdump, 0o755);
+		const managedCliStat = statSync(managedCliTarget);
 		writeFileSync(
 			join(state, "status", "cli-bootstrap.json"),
 			JSON.stringify({
@@ -384,10 +384,20 @@ exit 64
 				status: "installed",
 				source: "npm",
 				packageSpec: "clawdi@0.12.10-beta.57",
+				cliIntegrity: `sha512-${"A".repeat(86)}==`,
 				registry: "https://registry.npmjs.org",
+				npmPrefix: join(state, "npm"),
+				npmCache: join(state, "npm-cache"),
 				activePath: managedCli,
 				activeTarget: managedCliTarget,
 				version: "0.12.10-beta.57",
+				verification: {
+					verifiedAt: new Date().toISOString(),
+					device: managedCliStat.dev,
+					inode: managedCliStat.ino,
+					size: managedCliStat.size,
+					modifiedAtMs: managedCliStat.mtimeMs,
+				},
 			}),
 		);
 		writeFileSync(

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getCliVersion } from "../src/lib/version";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(here, "..");
@@ -314,6 +315,7 @@ describe("CLI smoke — src entry", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
+		const cliVersion = getCliVersion();
 		const manifestPath = join(root, "strict-hosted-manifest.json");
 		const installer = join(root, "install-openclaw.sh");
 		const systemctl = join(root, "bin", "systemctl");
@@ -366,7 +368,7 @@ exit 0
 		writeFileSync(
 			managedCliTarget,
 			`#!/usr/bin/env sh
-if [ "\${1:-}" = "--version" ]; then echo '0.12.10-beta.57'; exit 0; fi
+if [ "\${1:-}" = "--version" ]; then echo '${cliVersion}'; exit 0; fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
 exit 64
 `,
@@ -383,14 +385,14 @@ exit 64
 				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
 				status: "installed",
 				source: "npm",
-				packageSpec: "clawdi@0.12.10-beta.57",
+				packageSpec: `clawdi@${cliVersion}`,
 				cliIntegrity: `sha512-${"A".repeat(86)}==`,
 				registry: "https://registry.npmjs.org",
 				npmPrefix: join(state, "npm"),
 				npmCache: join(state, "npm-cache"),
 				activePath: managedCli,
 				activeTarget: managedCliTarget,
-				version: "0.12.10-beta.57",
+				version: cliVersion,
 				verification: {
 					verifiedAt: new Date().toISOString(),
 					device: managedCliStat.dev,
@@ -405,7 +407,7 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					minimumCliVersion: "0.12.10-beta.57",
+					minimumCliVersion: cliVersion,
 					runtime: "openclaw",
 					deploymentId: "dep_strict_smoke",
 					environmentId: "env_strict_smoke",
@@ -429,7 +431,7 @@ exit 64
 					egressEngine,
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@0.12.10-beta.57",
+						packageSpec: `clawdi@${cliVersion}`,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {


### PR DESCRIPTION
## Summary

- Require Hosted v2 bundles to use the root bootstrap canonical install identity, SHA-512 SRI, and executable verification evidence.
- Defer Hosted v2 CLI version changes to the root shim without invoking npm from the running CLI.
- Atomically neutralize stale CLI upgrade journals when a valid promoted root binding exists, while preserving generic/self-managed behavior.

## Rollout order

This is C0, the consumer-first contract. Merge and deploy this PR before enabling the Hosted producer PR. It is safe on its own because the strict path is selected only for Hosted v2 bundles with root-bootstrap evidence.

## Complexity audit

- Replaced path: the Hosted v2 in-process npm install/swap branch is replaced by validation of the existing root bootstrap state and a `deferred` result when the requested version differs.
- Persistent/wire fields: no new OSS persistence authority is added. The CLI consumes additive bootstrap-status fields `schemaVersion`, `cliIntegrity`, and `verification`; generic status rewrites preserve integrity only when exact identity and file verification still match.
- Compatibility window: generic and self-managed installations keep the existing npm transaction state machine. Hosted v2 requires a canonical root binding and fails closed on missing, malformed, or drifted evidence.
- No permanent dual track: Hosted v2 has exactly one installer, the root shim. The CLI does not add a second artifact tuple or installation workflow.

## Verification

- `scripts/test.sh cli tests/runtime.test.ts tests/smoke.test.ts` — 196 passed, 0 failed.
- `bun run --cwd packages/cli test` — 1469 passed, 4 skipped, 0 failed.
- `bun run --cwd packages/cli typecheck` — passed.
- `bunx biome check packages/cli/src/runtime/cli-update.ts packages/cli/tests/runtime.test.ts packages/cli/tests/smoke.test.ts` — passed.
- `git diff --check origin/main..HEAD` — passed.

No production, cluster, tenant, image publication, or deployment operation was performed.