### PR TITLE
Fix v2 runtime reconcile authority boundaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.16",
+      "version": "0.13.17",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -792,11 +792,14 @@ file fails closed, `env://NAME` resolves only from `runtimeEnv`, and a missing
 name never falls back to stale process-start environment. These projected
 values remain in memory and service environment files; they are not copied to
 the last-good secret cache. The applied generation must match the manifest and
-`manifestETag` must match the fetched bundle ETag before durable authority can
-advance. This lets one atomic projected-file swap advance config, secrets, and
-apply identity in place; `bootNonce` remains a workload-boot identity rather
-than a config-generation identity. The legacy process environment is accepted
-only when no identity-file path was configured and the canonical hosted mount
+is validated before convergence can mutate live state. `manifestETag` names the
+Hosted control-plane snapshot and is persisted separately from the fetched
+bundle's HTTP ETag, which remains the strong validator derived from
+`sourceRevision`; the two values are intentionally independent. This lets one
+atomic projected-file swap advance config, secrets, and apply identity in
+place; `bootNonce` remains a workload-boot identity rather than a
+config-generation identity. The legacy process environment is accepted only
+when no identity-file path was configured and the canonical hosted mount
 `/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json` does not
 exist. This one-boot discovery rule lets a CLI installed by an older bootstrap
 unit acquire the file contract; newly rendered units then pass the discovered
@@ -824,6 +827,15 @@ outputs include:
 | `$CLAWDI_RUN_DIR/systemd/system/*.service` or `/run/systemd/system/*.service` | Generated system units for root-owned Clawdi support programs |
 | `$HOME/.config/systemd/user/*.service` | Official runtime gateway base units and direct runtime-user programs |
 | `$HOME/.config/systemd/user/*.service.d/10-clawdi-hosted.conf` | Transparent hosted drop-ins for official runtime units |
+
+Reconciliation has two recovery groups. Root system authority (system units,
+their env files, sidecar inputs, caches, and applied state) is snapshotted and
+rolled back as one group. Runtime-user launch state (user units and drop-ins,
+their env files, run configs, runtime secret projections, and native agent
+config) stays on the desired generation and converges forward on retry. Directory
+trust checks are independent of this recovery choice: every root-managed
+directory must still be a real, root-owned directory without group/world write
+permission before Apply begins.
 
 Generic MCP reconciliation compares desired servers, the previous managed
 last-applied map, and the current native map. OpenClaw current state is the

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.16",
+	"version": "0.13.17",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -58,7 +58,11 @@ import {
 	withRuntimeConvergeLockAsync,
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
-import { loadRemoteRuntimeManifest, type RuntimeManifestLoad } from "../runtime/manifest-source";
+import {
+	loadRemoteRuntimeManifest,
+	type RuntimeManifestFailure,
+	type RuntimeManifestLoad,
+} from "../runtime/manifest-source";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
 import {
 	buildRuntimeBootStatus,
@@ -1321,11 +1325,8 @@ export function commitRuntimeAppliedState(input: {
 			`runtime apply identity generation ${input.applyIdentity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(input.convergence.manifest)}`,
 		);
 	}
-	if (input.applyIdentity && input.applyIdentity.manifestETag !== input.etag) {
-		throw new Error(
-			`runtime apply identity manifest ETag ${input.applyIdentity.manifestETag} does not match fetched bundle ETag ${input.etag}`,
-		);
-	}
+	// The apply identity names the Hosted control-plane snapshot; `etag` names
+	// the independently rendered runtime bundle. Persist both authorities.
 	const providerIds = runtimeSourceProviderIds(input.load.manifest);
 	input.convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(input.load, input.paths);
 	input.convergence.outputs.appliedState = writeRuntimeAppliedState(
@@ -2429,6 +2430,18 @@ async function runtimeWatchTickAfterCliReconciliation(
 	try {
 		const fresh =
 			"notModified" in manifestLoad ? await loadFullRuntimeManifestForWatch(paths) : manifestLoad;
+		if ("errors" in fresh) {
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "error",
+				mode: fresh.mode,
+				stage: fresh.stage,
+				errors: fresh.errors,
+				error: fresh.errors[0],
+				activeGeneration: fresh.activeGeneration ?? null,
+				rejectedGeneration: fresh.rejectedGeneration ?? null,
+			};
+		}
 		const loaded = applyRuntimeBundleChannelsToManifestLoad(fresh, paths);
 		const bundleEtag = loaded.etag;
 		const sourceRevision = loaded.sourceRevision;
@@ -2751,13 +2764,10 @@ function maybeRollbackFailedCliUpgrade(
 
 async function loadFullRuntimeManifestForWatch(
 	paths: ReturnType<typeof getRuntimePaths>,
-): Promise<RuntimeManifestLoad> {
+): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
 	const loaded = await loadRemoteRuntimeManifest(paths);
 	if ("notModified" in loaded) {
 		throw new Error("runtime manifest datasource returned 304 without If-None-Match");
-	}
-	if ("errors" in loaded) {
-		throw new Error(loaded.errors.join("; "));
 	}
 	return loaded;
 }

--- a/packages/cli/src/runtime/effective-identity.test.ts
+++ b/packages/cli/src/runtime/effective-identity.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type EffectiveIdentityProcess,
+	withEffectiveFilesystemIdentity,
+} from "./effective-identity";
+
+function fakeCredentials() {
+	let uid = 0;
+	let gid = 0;
+	let groups = [0, 27];
+	const transitions: string[] = [];
+	const credentials: EffectiveIdentityProcess = {
+		geteuid: () => uid,
+		getegid: () => gid,
+		getgroups: () => [...groups],
+		seteuid: (value) => {
+			uid = value;
+			transitions.push(`uid:${value}`);
+		},
+		setegid: (value) => {
+			gid = value;
+			transitions.push(`gid:${value}`);
+		},
+		setgroups: (value) => {
+			groups = [...value];
+			transitions.push(`groups:${value.join(",")}`);
+		},
+	};
+	return { credentials, transitions, current: () => ({ uid, gid, groups }) };
+}
+
+describe("effective filesystem identity", () => {
+	test("drops supplementary groups and restores root after success", () => {
+		const fake = fakeCredentials();
+		const result = withEffectiveFilesystemIdentity(
+			{ uid: 10_001, gid: 10_001 },
+			() => fake.current(),
+			fake.credentials,
+		);
+		expect(result).toEqual({ uid: 10_001, gid: 10_001, groups: [10_001] });
+		expect(fake.current()).toEqual({ uid: 0, gid: 0, groups: [0, 27] });
+		expect(fake.transitions).toEqual([
+			"groups:10001",
+			"gid:10001",
+			"uid:10001",
+			"uid:0",
+			"groups:0,27",
+			"gid:0",
+		]);
+	});
+
+	test("restores root before propagating an operation failure", () => {
+		const fake = fakeCredentials();
+		expect(() =>
+			withEffectiveFilesystemIdentity(
+				{ uid: 10_001, gid: 10_001 },
+				() => {
+					throw new Error("projection failed");
+				},
+				fake.credentials,
+			),
+		).toThrow("projection failed");
+		expect(fake.current()).toEqual({ uid: 0, gid: 0, groups: [0, 27] });
+	});
+
+	test("rejects a partial drop that retains a root uid or gid", () => {
+		for (const identity of [
+			{ uid: 0, gid: 10_001 },
+			{ uid: 10_001, gid: 0 },
+		]) {
+			const fake = fakeCredentials();
+			expect(() =>
+				withEffectiveFilesystemIdentity(identity, () => undefined, fake.credentials),
+			).toThrow("effective filesystem identity must be non-root");
+			expect(fake.transitions).toEqual([]);
+		}
+	});
+});

--- a/packages/cli/src/runtime/effective-identity.ts
+++ b/packages/cli/src/runtime/effective-identity.ts
@@ -1,0 +1,72 @@
+export interface EffectiveIdentity {
+	uid: number;
+	gid: number;
+}
+
+export interface EffectiveIdentityProcess {
+	geteuid(): number;
+	getegid(): number;
+	getgroups(): number[];
+	seteuid(id: number): void;
+	setegid(id: number): void;
+	setgroups(groups: readonly number[]): void;
+}
+
+const processIdentity: EffectiveIdentityProcess = {
+	geteuid: () => requiredCredentialFunction("geteuid", process.geteuid)(),
+	getegid: () => requiredCredentialFunction("getegid", process.getegid)(),
+	getgroups: () => requiredCredentialFunction("getgroups", process.getgroups)(),
+	seteuid: (id) => requiredCredentialFunction("seteuid", process.seteuid)(id),
+	setegid: (id) => requiredCredentialFunction("setegid", process.setegid)(id),
+	setgroups: (groups) => requiredCredentialFunction("setgroups", process.setgroups)([...groups]),
+};
+
+function requiredCredentialFunction<T extends (...args: never[]) => unknown>(
+	name: string,
+	value: T | undefined,
+): T {
+	if (typeof value !== "function") {
+		throw new Error(`effective identity requires process.${name}`);
+	}
+	return value;
+}
+
+export function withEffectiveFilesystemIdentity<T>(
+	identity: EffectiveIdentity,
+	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+	credentials: EffectiveIdentityProcess = processIdentity,
+): T {
+	const originalUid = credentials.geteuid();
+	const originalGid = credentials.getegid();
+	const originalGroups = credentials.getgroups();
+	if (originalUid !== 0 || (identity.uid === originalUid && identity.gid === originalGid)) {
+		return operation();
+	}
+	if (identity.uid === 0 || identity.gid === 0) {
+		throw new Error("effective filesystem identity must be non-root");
+	}
+
+	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+	try {
+		credentials.setgroups([identity.gid]);
+		credentials.setegid(identity.gid);
+		credentials.seteuid(identity.uid);
+		outcome = { ok: true, value: operation() };
+	} catch (error) {
+		outcome = { ok: false, error };
+	}
+
+	let restoreError: unknown;
+	try {
+		credentials.seteuid(originalUid);
+		credentials.setgroups(originalGroups);
+		credentials.setegid(originalGid);
+	} catch (error) {
+		restoreError = error;
+	}
+	if (restoreError !== undefined) {
+		throw new Error("failed to restore root filesystem identity", { cause: restoreError });
+	}
+	if (!outcome.ok) throw outcome.error;
+	return outcome.value;
+}

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -243,6 +243,7 @@ export class HostedRuntimeHeartbeatSession {
 		const snapshot = readHostedRuntimeObserved(this.paths, {
 			reportedAt: capturedAt,
 			appliedState: this.capturedAppliedState,
+			etagAuthority: "control-plane",
 		});
 		if (!snapshot) return null;
 		const event = hostedRuntimeObservedEventSchema.parse({

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -9,6 +9,7 @@ import {
 	readFileSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -2664,7 +2665,6 @@ describe("runtime manifest reconciliation invariants", () => {
 			paths.egressSystemCaFile,
 			join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"),
 			join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
-			runtimeRunConfigPath("openclaw", paths),
 		];
 		const capture = (paths: readonly string[]) =>
 			new Map(paths.map((path) => [path, existsSync(path) ? readFileSync(path, "utf-8") : null]));
@@ -2704,6 +2704,13 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(firstErrors).not.toContain("test-token");
 		expect(firstCommits).toBe(0);
 		expectSnapshot(firstSnapshot);
+		if (failure === "activation") {
+			expect(
+				JSON.parse(readFileSync(runtimeRunConfigPath("openclaw", firstPaths), "utf-8")),
+			).toMatchObject({
+				generation: 1,
+			});
+		}
 		expect(existsSync(firstPaths.manifestLastGood)).toBe(false);
 		expect(existsSync(firstPaths.appliedState)).toBe(false);
 
@@ -2764,6 +2771,9 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(upgradeCommits).toBe(0);
 		expect(rollbackCalls).toBe(failure === "activation" ? 1 : 0);
 		expectSnapshot(previous);
+		expect(
+			JSON.parse(readFileSync(runtimeRunConfigPath("openclaw", upgradePaths), "utf-8")),
+		).toMatchObject({ generation: failure === "activation" ? 2 : 1 });
 		expect(readRuntimeAppliedState(upgradePaths)?.generation).toBe(1);
 		expect(JSON.parse(readFileSync(upgradePaths.manifestLastGood, "utf-8"))).toMatchObject({
 			generation: 1,
@@ -3719,8 +3729,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		mkdirSync(dirname(paths.managedConfig), { recursive: true });
 		mkdirSync(paths.runConfigRoot, { recursive: true });
 		mkdirSync(paths.runtimeSecretFileRoot, { recursive: true });
+		mkdirSync(paths.systemdEnvRoot, { recursive: true });
 		mkdirSync(paths.systemdUserRoot, { recursive: true });
 		chmodSync(paths.runConfigRoot, 0o755);
+		chmodSync(paths.systemdEnvRoot, 0o755);
 		chmodSync(paths.managedSecretRoot, 0o711);
 		chmodSync(paths.runtimeSecretFileRoot, 0o700);
 		writeFileSync(
@@ -3752,14 +3764,20 @@ describe("runtime manifest reconciliation invariants", () => {
 				readFileSync(path),
 			]),
 		);
-		const rootManagedPaths = [paths.managedConfig, join(paths.runConfigRoot, "stale.json")];
+		const rootManagedPaths = [paths.managedConfig];
+		const forwardRunConfig = join(paths.runConfigRoot, "openclaw.json");
 		const forwardRuntimeSecret = join(paths.runtimeSecretFileRoot, "stale.json");
 		const staleUserUnit = join(paths.systemdUserRoot, "clawdi-old.service");
+		const userEnvironment = join(paths.systemdEnvRoot, "openclaw-gateway.service.env");
+		const systemEnvironment = join(paths.systemdEnvRoot, "clawdi-daemon.service.env");
 		for (const [index, path] of [
 			...rootManagedPaths,
+			forwardRunConfig,
 			forwardRuntimeSecret,
 			staleUserUnit,
 			targetConfig,
+			userEnvironment,
+			systemEnvironment,
 		].entries()) {
 			mkdirSync(dirname(path), { recursive: true });
 			writeFileSync(path, path === targetConfig ? '{"mcp":{"servers":{}}}\n' : `old-${index}\n`);
@@ -3767,6 +3785,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		chmodSync(paths.managedConfig, 0o640);
 		const previousManagedStat = statSync(paths.managedConfig);
 		const previous = new Map(rootManagedPaths.map((path) => [path, readFileSync(path)]));
+		const previousSystemEnvironment = readFileSync(systemEnvironment);
 		const manifest = baseManifest(
 			paths,
 			{
@@ -3800,7 +3819,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			expect(readFileSync(path)).toEqual(expected);
 		}
 		expect(existsSync(forwardRuntimeSecret)).toBe(false);
+		expect(readFileSync(forwardRunConfig, "utf-8")).not.toContain("old-");
 		expect(readFileSync(targetConfig, "utf-8")).toBe(forwardConfig);
+		expect(readFileSync(userEnvironment, "utf-8")).not.toContain("old-");
+		expect(readFileSync(systemEnvironment)).toEqual(previousSystemEnvironment);
 		expect(existsSync(staleUserUnit)).toBe(false);
 		expect(existsSync(managedUserDropIn)).toBe(false);
 		expect(readFileSync(siblingUserDropIn)).toEqual(previousSiblingUserDropIn);
@@ -3846,7 +3868,6 @@ describe("runtime manifest reconciliation invariants", () => {
 				paths.manifestLastGood,
 				paths.managedSecretCacheFile,
 				paths.appliedState,
-				paths.runConfigRoot,
 				paths.egressProfileRoot,
 				paths.installInventory,
 				paths.projectionRoot,
@@ -3854,7 +3875,9 @@ describe("runtime manifest reconciliation invariants", () => {
 				paths.managedSecretFile,
 				paths.daemonAuthToken,
 				join(paths.managedSecretRoot, "egress-secrets.json"),
-				paths.systemdEnvRoot,
+				join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
+				join(paths.systemdEnvRoot, "clawdi-daemon.service.env"),
+				join(paths.systemdEnvRoot, "clawdi-runtime-sidecar.service.env"),
 				paths.instanceData,
 				paths.sensitiveInstanceData,
 				paths.egressAddon,
@@ -3890,6 +3913,8 @@ describe("runtime manifest reconciliation invariants", () => {
 			paths.egressScratchRoot,
 			paths.egressCaDir,
 			paths.runtimeSecretFileRoot,
+			paths.systemdEnvRoot,
+			paths.runConfigRoot,
 		]) {
 			expect(snapshotPaths).not.toContain(userWritablePath);
 		}
@@ -3899,13 +3924,35 @@ describe("runtime manifest reconciliation invariants", () => {
 			}
 		}
 
-		mkdirSync(paths.runConfigRoot, { recursive: true });
-		chmodSync(paths.runConfigRoot, 0o777);
+		mkdirSync(paths.projectionRoot, { recursive: true });
+		chmodSync(paths.projectionRoot, 0o777);
 		expect(() =>
 			convergeRuntimeManifest(manifestLoad(baseManifest(paths, {}), "inline-writable-root"), paths),
-		).toThrow(
-			`runtime live-state snapshot directory is group/world writable: ${paths.runConfigRoot}`,
-		);
+		).toThrow(`runtime managed directory is group/world writable: ${paths.projectionRoot}`);
+
+		for (const key of ["runConfigRoot", "systemdEnvRoot"] as const) {
+			const unsafePaths = tempRuntimePaths();
+			mkdirSync(unsafePaths[key], { recursive: true });
+			chmodSync(unsafePaths[key], 0o777);
+			expect(() =>
+				convergeRuntimeManifest(
+					manifestLoad(baseManifest(unsafePaths, {}), `inline-writable-${key}`),
+					unsafePaths,
+				),
+			).toThrow(`runtime managed directory is group/world writable: ${unsafePaths[key]}`);
+		}
+
+		const symlinkPaths = tempRuntimePaths();
+		const redirectedRoot = join(dirname(symlinkPaths.serviceStateRoot), "redirected-run-config");
+		mkdirSync(redirectedRoot, { recursive: true });
+		mkdirSync(dirname(symlinkPaths.runConfigRoot), { recursive: true });
+		symlinkSync(redirectedRoot, symlinkPaths.runConfigRoot);
+		expect(() =>
+			convergeRuntimeManifest(
+				manifestLoad(baseManifest(symlinkPaths, {}), "inline-symlink-run-config"),
+				symlinkPaths,
+			),
+		).toThrow(`runtime managed directory is not a real directory: ${symlinkPaths.runConfigRoot}`);
 	});
 
 	test("rejects a malformed Hermes MCP patch before Apply", () => {

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -615,6 +615,18 @@ describe("runtime manifest services", () => {
 		expect(dashboardEnv).toContain(
 			'HERMES_DASHBOARD_PUBLIC_URL="https://agent.example.test/hermes"',
 		);
+		const dashboardRunConfig = JSON.parse(
+			readFileSync(runtimeRunConfigPath("hermes", paths, "dashboard"), "utf8"),
+		) as { env?: Record<string, string>; secretEnv?: Record<string, string> };
+		expect(dashboardRunConfig.env).toMatchObject({
+			HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "admin",
+			HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS: "43200",
+			HERMES_DASHBOARD_PUBLIC_URL: "https://agent.example.test/hermes",
+		});
+		expect(dashboardRunConfig.secretEnv).toMatchObject({
+			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "env://HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "env://HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+		});
 		expect(gatewayEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
 		expect(gatewayEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
 		expect(watchEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="dashboard-password"');

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -490,10 +490,10 @@ export async function loadRemoteRuntimeManifest(
 		sourceRevision?: string;
 	};
 	try {
-		normalized = bindRuntimeApplyContext(
-			normalizeRemoteManifestPayload(fetched.raw, paths),
-			applyContext,
-		);
+		normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+		assertRemoteBundleAuthority(normalized.sourceRevision, fetched.etag);
+		assertRuntimeApplyContextMatchesManifest(normalized.manifest, applyContext);
+		normalized = bindRuntimeApplyContext(normalized, applyContext);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -538,6 +538,33 @@ function bindRuntimeApplyContext<
 		Object.entries(input.secretValues ?? {}).filter(([ref]) => envSecretRefName(ref) === null),
 	);
 	return { ...input, secretValues };
+}
+
+function assertRuntimeApplyContextMatchesManifest(
+	manifest: RuntimeManifest,
+	applyContext: RuntimeApplyContext,
+): void {
+	if (
+		applyContext.identity &&
+		applyContext.identity.generation !== resolveRuntimeApplyGeneration(manifest)
+	) {
+		throw new Error(
+			`runtime apply identity generation ${applyContext.identity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(manifest)}`,
+		);
+	}
+}
+
+function assertRemoteBundleAuthority(
+	sourceRevision: string | undefined,
+	etag: string | undefined,
+): void {
+	if (!sourceRevision) return;
+	const expected = `"sha256:${sourceRevision}"`;
+	if (etag !== expected) {
+		throw new Error(
+			`runtime bundle ETag ${etag ?? "missing"} does not match its sourceRevision validator ${expected}`,
+		);
+	}
 }
 
 function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
@@ -868,12 +895,16 @@ export async function loadRuntimeManifest(
 			};
 		}
 
-		let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
+		let normalized: {
+			manifest: RuntimeManifest;
+			secretValues?: Record<string, string>;
+			sourceRevision?: string;
+		};
 		try {
-			normalized = bindRuntimeApplyContext(
-				normalizeRemoteManifestPayload(fetched.raw, paths),
-				applyContext,
-			);
+			normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+			assertRemoteBundleAuthority(normalized.sourceRevision, fetched.etag);
+			assertRuntimeApplyContextMatchesManifest(normalized.manifest, applyContext);
+			normalized = bindRuntimeApplyContext(normalized, applyContext);
 		} catch (error) {
 			return {
 				mode: "manifest-rejected",
@@ -926,7 +957,9 @@ export async function loadRuntimeManifest(
 	}
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = bindRuntimeApplyContext(normalizeManifestFixturePayload(raw, paths), applyContext);
+		normalized = normalizeManifestFixturePayload(raw, paths);
+		assertRuntimeApplyContextMatchesManifest(normalized.manifest, applyContext);
+		normalized = bindRuntimeApplyContext(normalized, applyContext);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -118,6 +118,7 @@ export {
 	runtimeManifestFixturePath,
 } from "./manifest-source";
 
+import { withEffectiveFilesystemIdentity } from "./effective-identity";
 import {
 	applyEgressTransparentRuntimeEnv,
 	MANAGED_EGRESS_PLACEHOLDER_VALUE,
@@ -1032,6 +1033,15 @@ function makeRuntimeUserPrivateDir(path: string, home: string): void {
 	}
 }
 
+function ensureRuntimeUserHome(path: string): void {
+	mkdirSync(path, { recursive: true });
+	const node = lstatSync(path);
+	if (node.isSymbolicLink() || !node.isDirectory()) {
+		throw new Error(`runtime user home must be a real directory: ${path}`);
+	}
+	makeRuntimeUserOwned(path);
+}
+
 function makeEgressIdentityPrivateDir(path: string): void {
 	mkdirSync(path, { recursive: true });
 	makeEgressIdentityOwned(path);
@@ -1101,7 +1111,28 @@ function commandExists(name: string): boolean {
 }
 
 function runningAsRoot(): boolean {
-	return typeof process.getuid === "function" && process.getuid() === 0;
+	return typeof process.geteuid === "function" && process.geteuid() === 0;
+}
+
+function withRuntimeUserFileAccess<T>(
+	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+): T {
+	// This scope is only for synchronous filesystem operations. Runtime commands
+	// must use gosu/runuser so child processes cannot retain a saved root identity.
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (!runningAsRoot() || !runtimeUser || runtimeUser === "root") return operation();
+	const uid = runtimeUserUid(runtimeUser);
+	const gid = runtimeUserGid(runtimeUser);
+	if ((uid === 0 || gid === 0) && runtimeUser !== "0") {
+		throw new Error(`runtime user ${runtimeUser} resolved to a root filesystem identity`);
+	}
+	return withEffectiveFilesystemIdentity(
+		{
+			uid,
+			gid,
+		},
+		operation,
+	);
 }
 
 function runtimeInstallerExecution(
@@ -1293,8 +1324,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 		});
 	}
 
-	mkdirSync(install.home, { recursive: true });
-	makeRuntimeUserOwned(install.home);
+	ensureRuntimeUserHome(install.home);
 	const url = executionInstallerUrl(name, install.url);
 	const materialized = materializeInstaller(name, url);
 	try {
@@ -2402,11 +2432,13 @@ function applyHostedAiProviderProjection(
 		return { path: null, revision: null, providerIds: [...previousProviderIds] };
 	}
 	if (name === "hermes") {
-		return applyHostedHermesAiProviderProjection(
-			observation,
-			projectionInput,
-			previousProviderIds,
-			home,
+		return withRuntimeUserFileAccess(() =>
+			applyHostedHermesAiProviderProjection(
+				observation,
+				projectionInput,
+				previousProviderIds,
+				home,
+			),
 		);
 	}
 	if (name === "openclaw") {
@@ -3057,15 +3089,17 @@ function applyHostedChannelProjection(
 
 	if (name === "hermes") {
 		const configPath = join(home, ".hermes", "config.yaml");
-		mergeHermesChannelConfig(
-			configPath,
-			hermesManagedChannelsPatch(
-				channels,
-				manifest.controlPlane.apiUrl,
-				manifest.projection?.channelCredentials,
-			),
-		);
-		makeRuntimeUserOwned(configPath);
+		withRuntimeUserFileAccess(() => {
+			mergeHermesChannelConfig(
+				configPath,
+				hermesManagedChannelsPatch(
+					channels,
+					manifest.controlPlane.apiUrl,
+					manifest.projection?.channelCredentials,
+				),
+			);
+			makeRuntimeUserOwned(configPath);
+		});
 		return configPath;
 	}
 	runRuntimeUserCommand(
@@ -3577,7 +3611,7 @@ function applyHostedMcpProjections(
 	const ledgerPath = hostedMcpLedgerPath(paths);
 	const outputs = new Set<string>();
 	// Hermes is one staged atomic file write. Apply it before OpenClaw so the
-	// unified runtime snapshot proves cross-runtime rollback on a later command failure.
+	// forward-convergence group completes before the root-owned ledger advances.
 	for (const runtime of [...plan.runtimes].sort((left, right) =>
 		left.name === right.name ? 0 : left.name === "hermes" ? -1 : 1,
 	)) {
@@ -3586,8 +3620,11 @@ function applyHostedMcpProjections(
 			if (runtime.nextHermesContent === null) {
 				throw new Error("Hermes MCP reconciliation did not produce staged config");
 			}
-			writePrivateFileAtomic(runtime.native.path, runtime.nextHermesContent);
-			makeRuntimeUserOwned(runtime.native.path);
+			const nextHermesContent = runtime.nextHermesContent;
+			withRuntimeUserFileAccess(() => {
+				writePrivateFileAtomic(runtime.native.path, nextHermesContent);
+				makeRuntimeUserOwned(runtime.native.path);
+			});
 			outputs.add(runtime.native.path);
 			continue;
 		}
@@ -3791,9 +3828,10 @@ function runtimeUserCommandEnv(
 	options: { egressSystemCaFile?: string } = {},
 ): NodeJS.ProcessEnv {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	const effectiveUid = typeof process.geteuid === "function" ? process.geteuid() : null;
 	const uid =
-		runtimeUser && runtimeUser !== "root" && runningAsRoot()
-			? String(runtimeUserUid(runtimeUser))
+		runtimeUser && runtimeUser !== "root" && (runningAsRoot() || effectiveUid !== null)
+			? String(runningAsRoot() ? runtimeUserUid(runtimeUser) : effectiveUid)
 			: null;
 	const runtimeDir = uid ? `/run/user/${uid}` : null;
 	const env = {
@@ -4310,41 +4348,44 @@ function desiredLiveSyncAgents(manifest: RuntimeManifest): LiveSyncAgent[] {
 }
 
 function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
-	const envDir = paths.localEnvironments;
-	mkdirSync(envDir, { recursive: true });
-	makeRuntimeUserOwned(envDir);
 	const agents = desiredLiveSyncAgents(manifest);
 	const desiredTypes = new Set(agents.map((agent) => agent.agentType));
 	const staleCandidates = new Set<RuntimeName>([
 		...readLiveSyncEnvironmentIndex(paths),
 		...MANAGED_LIVE_SYNC_AGENTS,
 	] as RuntimeName[]);
-	for (const agentType of staleCandidates) {
-		if (!desiredTypes.has(agentType)) {
-			rmSync(join(envDir, `${agentType}.json`), { force: true });
+	const written = withRuntimeUserFileAccess(() => {
+		const envDir = paths.localEnvironments;
+		mkdirSync(envDir, { recursive: true });
+		makeRuntimeUserOwned(envDir);
+		for (const agentType of staleCandidates) {
+			if (!desiredTypes.has(agentType)) {
+				rmSync(join(envDir, `${agentType}.json`), { force: true });
+			}
 		}
-	}
-	const written: string[] = [];
-	for (const agent of agents) {
-		const path = join(envDir, `${agent.agentType}.json`);
-		writePrivateFileAtomic(
-			path,
-			`${JSON.stringify(
-				{
-					id: agent.environmentId,
-					agentType: agent.agentType,
-					managedBy: "clawdi runtime init",
-					deploymentId: manifest.deploymentId,
-					instanceId: manifest.instanceId,
-				},
-				null,
-				2,
-			)}\n`,
-			{ mode: 0o600, dirMode: 0o700 },
-		);
-		makeRuntimeUserOwned(path);
-		written.push(path);
-	}
+		const outputs: string[] = [];
+		for (const agent of agents) {
+			const path = join(envDir, `${agent.agentType}.json`);
+			writePrivateFileAtomic(
+				path,
+				`${JSON.stringify(
+					{
+						id: agent.environmentId,
+						agentType: agent.agentType,
+						managedBy: "clawdi runtime init",
+						deploymentId: manifest.deploymentId,
+						instanceId: manifest.instanceId,
+					},
+					null,
+					2,
+				)}\n`,
+				{ mode: 0o600, dirMode: 0o700 },
+			);
+			makeRuntimeUserOwned(path);
+			outputs.push(path);
+		}
+		return outputs;
+	});
 	writeLiveSyncEnvironmentIndex(desiredTypes, paths);
 	return written;
 }
@@ -4892,8 +4933,6 @@ function writeSystemdUnit(input: {
 	extraServiceLines?: string[];
 	wantedBy: "multi-user.target" | "default.target";
 }): string {
-	mkdirSync(input.root, { recursive: true });
-	if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
 	const path = join(input.root, systemdUnitFileName(input.name));
 	const { envFile, envRevision } = writeSystemdProgramEnvironment({
 		paths: input.paths,
@@ -4930,10 +4969,17 @@ function writeSystemdUnit(input: {
 		`WantedBy=${input.wantedBy}`,
 		"",
 	];
-	writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
-	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
-	else makeRootOwned(path);
-	return path;
+	const writeUnitFile = (): string => {
+		mkdirSync(input.root, { recursive: true });
+		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
+		else makeRootOwned(path);
+		return path;
+	};
+	return input.owner === "runtime-user"
+		? withRuntimeUserFileAccess(writeUnitFile)
+		: writeUnitFile();
 }
 
 function writeSystemdSystemUnit(
@@ -4972,7 +5018,6 @@ function writeSystemdUserDropIn(input: {
 	env: Record<string, string>;
 }): string {
 	const unitName = systemdUnitFileName(input.name);
-	removeGeneratedRuntimeBaseUnit(input.paths, unitName);
 	const { envFile, envRevision } = writeSystemdProgramEnvironment({
 		paths: input.paths,
 		name: input.name,
@@ -4980,8 +5025,6 @@ function writeSystemdUserDropIn(input: {
 		env: input.env,
 	});
 	const path = systemdDropInFilePath(input.paths, input.name);
-	mkdirSync(dirname(path), { recursive: true });
-	makeRuntimeUserOwned(dirname(path));
 	const lines = [
 		GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
 		"# ClawdiHostedRuntimeDropIn=v1",
@@ -5000,9 +5043,14 @@ function writeSystemdUserDropIn(input: {
 		`ExecStart=${systemdExec(input.command, input.args)}`,
 		"",
 	];
-	writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
-	makeRuntimeUserOwned(path);
-	return join(input.paths.systemdUserRoot, unitName);
+	return withRuntimeUserFileAccess(() => {
+		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
+		mkdirSync(dirname(path), { recursive: true });
+		makeRuntimeUserOwned(dirname(path));
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		makeRuntimeUserOwned(path);
+		return join(input.paths.systemdUserRoot, unitName);
+	});
 }
 
 function removeGeneratedRuntimeBaseUnit(paths: RuntimePaths, unitName: string): void {
@@ -5137,39 +5185,41 @@ function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: str
 }
 
 function removeStaleSystemdUserUnits(paths: RuntimePaths, writtenUnits: string[]): void {
-	if (!existsSync(paths.systemdUserRoot)) return;
-	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
-	for (const entry of readdirSync(paths.systemdUserRoot)) {
-		if (!entry.endsWith(".service")) continue;
-		const path = join(paths.systemdUserRoot, entry);
-		if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
-		if (writtenNames.has(entry)) continue;
-		rmSync(path, { force: true });
-	}
-	const wantsDir = join(paths.systemdUserRoot, "default.target.wants");
-	if (existsSync(wantsDir)) {
-		for (const entry of readdirSync(wantsDir)) {
+	withRuntimeUserFileAccess(() => {
+		if (!existsSync(paths.systemdUserRoot)) return;
+		const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
+		for (const entry of readdirSync(paths.systemdUserRoot)) {
 			if (!entry.endsWith(".service")) continue;
-			const unitPath = join(paths.systemdUserRoot, entry);
-			if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(unitPath)) continue;
+			const path = join(paths.systemdUserRoot, entry);
+			if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
 			if (writtenNames.has(entry)) continue;
-			rmSync(join(wantsDir, entry), { force: true });
+			rmSync(path, { force: true });
 		}
-	}
-	for (const entry of readdirSync(paths.systemdUserRoot)) {
-		if (!entry.endsWith(".service.d")) continue;
-		const unitName = entry.slice(0, -".d".length);
-		const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
-		if (!isGeneratedSystemdFile(dropInPath)) continue;
-		if (writtenNames.has(unitName)) continue;
-		rmSync(dropInPath, { force: true });
-		try {
-			if (readdirSync(dirname(dropInPath)).length === 0)
-				rmSync(dirname(dropInPath), { force: true });
-		} catch {
-			// Best effort cleanup only.
+		const wantsDir = join(paths.systemdUserRoot, "default.target.wants");
+		if (existsSync(wantsDir)) {
+			for (const entry of readdirSync(wantsDir)) {
+				if (!entry.endsWith(".service")) continue;
+				const unitPath = join(paths.systemdUserRoot, entry);
+				if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(unitPath)) continue;
+				if (writtenNames.has(entry)) continue;
+				rmSync(join(wantsDir, entry), { force: true });
+			}
 		}
-	}
+		for (const entry of readdirSync(paths.systemdUserRoot)) {
+			if (!entry.endsWith(".service.d")) continue;
+			const unitName = entry.slice(0, -".d".length);
+			const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+			if (!isGeneratedSystemdFile(dropInPath)) continue;
+			if (writtenNames.has(unitName)) continue;
+			rmSync(dropInPath, { force: true });
+			try {
+				if (readdirSync(dirname(dropInPath)).length === 0)
+					rmSync(dirname(dropInPath), { force: true });
+			} catch {
+				// Best effort cleanup only.
+			}
+		}
+	});
 }
 
 function isGeneratedSystemdFile(path: string): boolean {
@@ -6297,10 +6347,12 @@ export function convergeRuntimeManifest(
 			if (error) throw new Error(error);
 		}
 
-		mkdirSync(workspaceRoot, { recursive: true });
-		makeRuntimeUserOwned(paths.userHome);
-		makeRuntimeUserPrivateDir(paths.clawdiHome, paths.userHome);
-		makeRuntimeUserOwned(workspaceRoot);
+		ensureRuntimeUserHome(paths.userHome);
+		withRuntimeUserFileAccess(() => {
+			mkdirSync(workspaceRoot, { recursive: true });
+			makeRuntimeUserPrivateDir(paths.clawdiHome, paths.userHome);
+			makeRuntimeUserOwned(workspaceRoot);
+		});
 		makeRootReadableDir(paths.installInventory);
 		makeRootReadableDir(paths.projectionRoot);
 		makeRootReadableDir(instanceRoot);
@@ -6392,11 +6444,13 @@ export function convergeRuntimeManifest(
 		}
 		writeSecretValues(secretValues, paths, egressSidecarOnlySecretRefs(manifest));
 		try {
-			materializeHostedChannelCredentials(
-				manifest,
-				secretValues,
-				runtimeEnvironment,
-				projectionHome,
+			withRuntimeUserFileAccess(() =>
+				materializeHostedChannelCredentials(
+					manifest,
+					secretValues,
+					runtimeEnvironment,
+					projectionHome,
+				),
 			);
 		} catch (error) {
 			installErrors.push(
@@ -6473,10 +6527,8 @@ export function convergeRuntimeManifest(
 			runtimeEnvironment,
 		);
 		try {
-			const codexProjection = applyHostedCodexManagedProviderProjection(
-				manifest,
-				projectionHome,
-				codexCli,
+			const codexProjection = withRuntimeUserFileAccess(() =>
+				applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
 			);
 			providerProjectionRevisions.codex = codexProjection.revision;
 			projectedProviderIds.codex = codexProjection.providerIds;
@@ -6492,7 +6544,9 @@ export function convergeRuntimeManifest(
 		}
 		for (const name of HOSTED_RUNTIME_TARGETS) {
 			try {
-				applyHostedBundledSkills(name, observations.get(name), manifest, projectionHome);
+				withRuntimeUserFileAccess(() =>
+					applyHostedBundledSkills(name, observations.get(name), manifest, projectionHome),
+				);
 			} catch (error) {
 				installErrors.push(
 					`runtime ${name} skill projection failed: ${
@@ -6546,11 +6600,8 @@ export function convergeRuntimeManifest(
 			writeJsonFile(projectionPath, projectionPayload(name, manifest));
 			projections.push(projectionPath);
 			try {
-				const localeFile = applyHostedLocaleProjection(
-					name,
-					manifest,
-					projectionHome,
-					workspaceRoot,
+				const localeFile = withRuntimeUserFileAccess(() =>
+					applyHostedLocaleProjection(name, manifest, projectionHome, workspaceRoot),
 				);
 				if (localeFile) managedLocaleFiles.push(localeFile);
 			} catch (error) {
@@ -6826,9 +6877,17 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		if (!workspaceExistedBeforeApply && existsSync(workspaceRoot)) {
+		if (
+			!workspaceExistedBeforeApply &&
+			resolve(workspaceRoot) !== resolve(paths.userHome) &&
+			existsSync(workspaceRoot)
+		) {
 			try {
-				if (readdirSync(workspaceRoot).length === 0) rmSync(workspaceRoot, { recursive: true });
+				withRuntimeUserFileAccess(() => {
+					if (readdirSync(workspaceRoot).length === 0) {
+						rmSync(workspaceRoot, { recursive: true });
+					}
+				});
 			} catch (rollbackError) {
 				installErrors.push(
 					`runtime workspace rollback failed: ${

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2014,6 +2014,21 @@ function mergeRuntimeServiceEnvWithProviderPlaceholders(
 	};
 }
 
+function resolvedRuntimeServiceSettings(
+	manifest: RuntimeManifest,
+	runtime: RuntimeName,
+	service: RuntimeServiceName,
+	settings: RuntimeRunSettings,
+	providerEnv: Record<string, string>,
+): RuntimeRunSettings {
+	return mergeRuntimeServiceEnvWithProviderPlaceholders(
+		runtime,
+		service,
+		hermesDashboardServiceSettings(manifest, runtime, service, settings),
+		providerEnv,
+	);
+}
+
 function runtimeSecretFilePath(paths: RuntimePaths, runtimeName: string): string {
 	return join(paths.runtimeSecretFileRoot, `${runtimeName}.json`);
 }
@@ -4451,16 +4466,14 @@ export function runtimeProgramRevision(
 	});
 }
 
-function runtimeServiceProgramRevision(
-	manifest: RuntimeManifest,
-	runtime: string,
-	service: string,
-): string {
+function runtimeServiceProgramRevision(program: RuntimeSystemdUserProgram): string {
 	return revisionHash({
-		runtime: runtime,
-		service,
-		settings: manifest.runtimes[runtime]?.services?.[service] ?? null,
-		timezone: manifest.locale?.timezone ?? null,
+		runtime: program.runtime,
+		service: program.service,
+		command: program.command,
+		args: program.args,
+		cwd: program.cwd,
+		env: program.env,
 	});
 }
 
@@ -4659,8 +4672,7 @@ function runtimeSystemdProgramRevision(
 	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
 	runtimeEnvironment: RuntimeEnvironmentAuthority = processRuntimeEnvironment(),
 ): string {
-	if (program.service)
-		return runtimeServiceProgramRevision(manifest, program.runtime, program.service);
+	if (program.service) return runtimeServiceProgramRevision(program);
 	return runtimeProgramRevision(
 		manifest,
 		program.runtime,
@@ -5475,8 +5487,9 @@ function validateRuntimeManifestPlan(manifest: RuntimeManifest, paths: RuntimePa
 			: {};
 		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
 			const service = runtimeServiceNameSchema.parse(serviceName);
-			const settings = mergeRuntimeServiceEnvWithProviderPlaceholders(
-				name,
+			const settings = resolvedRuntimeServiceSettings(
+				manifest,
+				runtimeName,
 				service,
 				serviceSettings,
 				providerPlaceholderEnv,
@@ -5508,42 +5521,22 @@ function planRuntimeSystemdUserPrograms(input: {
 	for (const [name, runtime] of Object.entries(input.manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
 	)) {
-		const runtimeName = runtimeNameSchema.parse(name);
 		const observation = input.observations.get(name);
 		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-		const providerPlaceholderEnv = runtime.enabled
-			? hostedProviderPlaceholderEnv(input.manifest, name)
-			: {};
-		const providerSecretEnv = runtime.enabled ? hostedProviderSecretEnv(input.manifest, name) : {};
-		const settings = mergeRuntimeEnvWithProviderPlaceholders(
+		const resolved = resolveRuntimeRunConfigs({
+			manifest: input.manifest,
+			paths: input.paths,
 			name,
-			runtime.run,
-			providerPlaceholderEnv,
-		);
-		const secretEnv = runtime.enabled
-			? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
-			: {};
-		const secretFilePath =
-			Object.keys(scopedSecretValues(input.secretValues, Object.values(secretEnv))).length > 0
-				? runtimeSecretFilePath(input.paths, name)
-				: null;
-		const runConfig = buildRuntimeRunConfig({
-			runtime: runtimeName,
-			enabled: runtime.enabled,
-			generatedAt: input.generatedAt,
-			generation: input.manifest.generation,
-			instanceId: input.manifest.instanceId,
-			commandPath: observation.commandPath,
-			appRoot: observation.appRoot,
+			runtime,
+			observation,
 			workspaceRoot: input.workspaceRoot,
+			generatedAt: input.generatedAt,
+			secretValues: input.secretValues,
 			egressProfileBundlePath: input.egressProfileBundlePath,
-			settings,
-			secretFilePath,
-			secretEnv,
 		});
 		if (runtime.enabled && shouldRunRuntime(name, input.manifest)) {
 			const program = buildRuntimeSystemdUserProgram({
-				config: runConfig,
+				config: resolved.runtime,
 				paths: input.paths,
 				secretValues: input.secretValues,
 				runtimeEnvironment: input.runtimeEnvironment,
@@ -5551,37 +5544,7 @@ function planRuntimeSystemdUserPrograms(input: {
 			});
 			if (program) programs.push(program);
 		}
-		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
-			const service = runtimeServiceNameSchema.parse(serviceName);
-			const dashboardSettings = hermesDashboardServiceSettings(
-				input.manifest,
-				runtimeName,
-				service,
-				serviceSettings,
-			);
-			const serviceRunSettings = mergeRuntimeServiceEnvWithProviderPlaceholders(
-				name,
-				service,
-				dashboardSettings,
-				providerPlaceholderEnv,
-			);
-			const serviceSecretEnv = runtime.enabled
-				? mergeRuntimeServiceSecretEnv(name, service, serviceRunSettings, secretEnv)
-				: {};
-			const serviceRunConfig = buildRuntimeRunConfig({
-				runtime: runtimeName,
-				service,
-				enabled: runtime.enabled,
-				generatedAt: input.generatedAt,
-				generation: input.manifest.generation,
-				instanceId: input.manifest.instanceId,
-				commandPath: observation.commandPath,
-				appRoot: observation.appRoot,
-				workspaceRoot: input.workspaceRoot,
-				settings: serviceRunSettings,
-				secretFilePath: null,
-				secretEnv: serviceSecretEnv,
-			});
+		for (const serviceRunConfig of resolved.services) {
 			const program = buildRuntimeSystemdUserProgram({
 				config: serviceRunConfig,
 				paths: input.paths,
@@ -5621,6 +5584,89 @@ function hermesDashboardServiceSettings(
 			HERMES_DASHBOARD_BASIC_AUTH_SECRET: auth.sessionSecretRef,
 		},
 	};
+}
+
+interface ResolvedRuntimeRunConfigs {
+	runtime: RuntimeRunConfig;
+	services: RuntimeRunConfig[];
+	secretEnv: Record<string, string>;
+	secretFilePath: string | null;
+}
+
+function resolveRuntimeRunConfigs(input: {
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	name: string;
+	runtime: RuntimeManifest["runtimes"][string];
+	observation: RuntimeInstallObservation;
+	workspaceRoot: string;
+	generatedAt: string;
+	secretValues: Record<string, string> | undefined;
+	egressProfileBundlePath: string | null;
+}): ResolvedRuntimeRunConfigs {
+	const runtimeName = runtimeNameSchema.parse(input.name);
+	const providerPlaceholderEnv = input.runtime.enabled
+		? hostedProviderPlaceholderEnv(input.manifest, input.name)
+		: {};
+	const providerSecretEnv = input.runtime.enabled
+		? hostedProviderSecretEnv(input.manifest, input.name)
+		: {};
+	assertNoProviderEnvOverlap(input.name, providerPlaceholderEnv, providerSecretEnv);
+	const runtimeRunSettings = mergeRuntimeEnvWithProviderPlaceholders(
+		input.name,
+		input.runtime.run,
+		providerPlaceholderEnv,
+	);
+	const secretEnv = input.runtime.enabled
+		? mergeRuntimeSecretEnv(input.name, input.runtime, providerSecretEnv)
+		: {};
+	const secretFilePath =
+		Object.keys(scopedSecretValues(input.secretValues, Object.values(secretEnv))).length > 0
+			? runtimeSecretFilePath(input.paths, input.name)
+			: null;
+	const runtime = buildRuntimeRunConfig({
+		runtime: runtimeName,
+		enabled: input.runtime.enabled,
+		generatedAt: input.generatedAt,
+		generation: input.manifest.generation,
+		instanceId: input.manifest.instanceId,
+		commandPath: input.observation.commandPath,
+		appRoot: input.observation.appRoot,
+		workspaceRoot: input.workspaceRoot,
+		egressProfileBundlePath: input.egressProfileBundlePath,
+		settings: runtimeRunSettings,
+		secretFilePath,
+		secretEnv,
+	});
+	const services = Object.entries(input.runtime.services ?? {})
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([serviceName, serviceSettings]) => {
+			const service = runtimeServiceNameSchema.parse(serviceName);
+			const settings = resolvedRuntimeServiceSettings(
+				input.manifest,
+				runtimeName,
+				service,
+				serviceSettings,
+				providerPlaceholderEnv,
+			);
+			return buildRuntimeRunConfig({
+				runtime: runtimeName,
+				service,
+				enabled: input.runtime.enabled,
+				generatedAt: input.generatedAt,
+				generation: input.manifest.generation,
+				instanceId: input.manifest.instanceId,
+				commandPath: input.observation.commandPath,
+				appRoot: input.observation.appRoot,
+				workspaceRoot: input.workspaceRoot,
+				settings,
+				secretFilePath: null,
+				secretEnv: input.runtime.enabled
+					? mergeRuntimeServiceSecretEnv(input.name, service, settings, secretEnv)
+					: {},
+			});
+		});
+	return { runtime, services, secretEnv, secretFilePath };
 }
 
 function validateRuntimeSystemdProgramsPlan(programs: RuntimeSystemdUserProgram[]): void {
@@ -5714,7 +5760,6 @@ export function runtimeLiveSnapshotPaths(
 		paths.manifestLastGood,
 		paths.managedSecretCacheFile,
 		paths.appliedState,
-		paths.runConfigRoot,
 		paths.egressProfileRoot,
 		paths.installInventory,
 		paths.projectionRoot,
@@ -5722,7 +5767,6 @@ export function runtimeLiveSnapshotPaths(
 		paths.managedSecretFile,
 		paths.daemonAuthToken,
 		egressSecretFilePath(paths),
-		paths.systemdEnvRoot,
 		paths.instanceData,
 		paths.sensitiveInstanceData,
 		paths.egressAddon,
@@ -5732,9 +5776,40 @@ export function runtimeLiveSnapshotPaths(
 	]);
 	for (const name of ["clawdi-runtime-watch", "clawdi-daemon", "clawdi-runtime-sidecar"]) {
 		result.add(join(paths.systemdSystemRoot, systemdUnitFileName(name)));
+		result.add(systemdEnvironmentFilePath(paths, name));
 	}
 	addExistingManagedSystemdSystemPaths(paths, result);
 	return [...result].sort();
+}
+
+function runtimeManagedDirectoryPaths(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+	return [
+		paths.runConfigRoot,
+		paths.systemdEnvRoot,
+		paths.egressProfileRoot,
+		paths.installInventory,
+		paths.projectionRoot,
+		join(paths.instanceRoot, manifest.instanceId),
+	];
+}
+
+function assertRuntimeManagedDirectoryTrusted(path: string): void {
+	let stat: ReturnType<typeof lstatSync>;
+	try {
+		stat = lstatSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!stat.isDirectory() || stat.isSymbolicLink()) {
+		throw new Error(`runtime managed directory is not a real directory: ${path}`);
+	}
+	if ((stat.mode & 0o022) !== 0) {
+		throw new Error(`runtime managed directory is group/world writable: ${path}`);
+	}
+	if (runningAsRoot() && stat.uid !== 0) {
+		throw new Error(`runtime managed directory is not root-owned: ${path}`);
+	}
 }
 
 function runtimeLiveSnapshotMetadataPaths(snapshotPaths: readonly string[]): string[] {
@@ -5823,6 +5898,9 @@ function captureRuntimeLiveSnapshot(
 	paths: RuntimePaths,
 	workspaceRoot: string,
 ): RuntimeLiveSnapshot {
+	for (const path of runtimeManagedDirectoryPaths(manifest, paths)) {
+		assertRuntimeManagedDirectoryTrusted(path);
+	}
 	const snapshotPaths = runtimeLiveSnapshotPaths(manifest, paths, workspaceRoot);
 	return {
 		entries: new Map([
@@ -5924,6 +6002,7 @@ function validateRuntimeProjectionPlan(input: {
 	)) {
 		const observation = observations.get(name);
 		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+		const runtimeName = runtimeNameSchema.parse(name);
 		const providerPlaceholderEnv = runtime.enabled
 			? hostedProviderPlaceholderEnv(manifest, name)
 			: {};
@@ -5936,8 +6015,9 @@ function validateRuntimeProjectionPlan(input: {
 		scopedSecretValues(secretValues, Object.values(secretEnv));
 		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
 			const service = runtimeServiceNameSchema.parse(serviceName);
-			const settings = mergeRuntimeServiceEnvWithProviderPlaceholders(
-				name,
+			const settings = resolvedRuntimeServiceSettings(
+				manifest,
+				runtimeName,
 				service,
 				serviceSettings,
 				providerPlaceholderEnv,
@@ -6512,72 +6592,36 @@ export function convergeRuntimeManifest(
 			if (installErrors.length > 0) {
 				throw new Error(installErrors.join("; "));
 			}
-			const runtimeName = runtimeNameSchema.parse(name);
-			const providerPlaceholderEnv = runtime.enabled
-				? hostedProviderPlaceholderEnv(manifest, name)
-				: {};
-			const providerSecretEnv = runtime.enabled ? hostedProviderSecretEnv(manifest, name) : {};
-			assertNoProviderEnvOverlap(name, providerPlaceholderEnv, providerSecretEnv);
-			const runtimeRunSettings = mergeRuntimeEnvWithProviderPlaceholders(
+			const resolved = resolveRuntimeRunConfigs({
+				manifest,
+				paths,
 				name,
-				runtime.run,
-				providerPlaceholderEnv,
-			);
-			const secretEnv = runtime.enabled
-				? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
-				: {};
+				runtime,
+				observation,
+				workspaceRoot,
+				generatedAt,
+				secretValues,
+				egressProfileBundlePath,
+			});
 			const runtimeProviderSecretFile = writeRuntimeProviderSecretFile(
 				name,
 				secretValues,
-				secretEnv,
+				resolved.secretEnv,
 				paths,
 			);
+			if (runtimeProviderSecretFile !== resolved.secretFilePath) {
+				throw new Error(`runtime ${name} secret projection did not match its resolved plan`);
+			}
 			if (runtimeProviderSecretFile) writtenRuntimeSecretIds.add(name);
-			const runConfig = buildRuntimeRunConfig({
-				runtime: runtimeName,
-				enabled: runtime.enabled,
-				generatedAt,
-				generation: manifest.generation,
-				instanceId: manifest.instanceId,
-				commandPath: observation.commandPath,
-				appRoot: observation.appRoot,
-				workspaceRoot,
-				egressProfileBundlePath,
-				settings: runtimeRunSettings,
-				secretFilePath: runtimeProviderSecretFile,
-				secretEnv,
-			});
-			const runConfigPath = writeRuntimeRunConfig(runConfig, paths);
+			const runConfigPath = writeRuntimeRunConfig(resolved.runtime, paths);
 			runConfigs.push(runConfigPath);
-			writtenRunConfigIds.add(runtimeRunConfigId(runtimeName));
-			for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
-				const service = runtimeServiceNameSchema.parse(serviceName);
-				const serviceRunSettings = mergeRuntimeServiceEnvWithProviderPlaceholders(
-					name,
-					service,
-					serviceSettings,
-					providerPlaceholderEnv,
-				);
-				const serviceSecretEnv = runtime.enabled
-					? mergeRuntimeServiceSecretEnv(name, service, serviceRunSettings, secretEnv)
-					: {};
-				const serviceRunConfig = buildRuntimeRunConfig({
-					runtime: runtimeName,
-					service,
-					enabled: runtime.enabled,
-					generatedAt,
-					generation: manifest.generation,
-					instanceId: manifest.instanceId,
-					commandPath: observation.commandPath,
-					appRoot: observation.appRoot,
-					workspaceRoot,
-					settings: serviceRunSettings,
-					secretFilePath: null,
-					secretEnv: serviceSecretEnv,
-				});
+			writtenRunConfigIds.add(runtimeRunConfigId(resolved.runtime.runtime));
+			for (const serviceRunConfig of resolved.services) {
 				const serviceRunConfigPath = writeRuntimeRunConfig(serviceRunConfig, paths);
 				runConfigs.push(serviceRunConfigPath);
-				writtenRunConfigIds.add(runtimeRunConfigId(runtimeName, service));
+				writtenRunConfigIds.add(
+					runtimeRunConfigId(serviceRunConfig.runtime, serviceRunConfig.service),
+				);
 			}
 
 			const semaphorePath = join(semRoot, `${name}.enabled`);

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -60,6 +60,7 @@ describe("hosted runtime observed v2", () => {
 		const companion = readHostedRuntimeObserved(paths, {
 			reportedAt: "2026-07-13T06:01:00.000Z",
 			appliedState: readRuntimeAppliedState(paths),
+			etagAuthority: "control-plane",
 		});
 		expect(companion?.applied).toEqual({
 			etag: '"frozen-companion-manifest"',

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -36,6 +36,7 @@ export function readHostedRuntimeObserved(
 	options: {
 		reportedAt?: string;
 		appliedState?: RuntimeAppliedState | null;
+		etagAuthority?: "bundle" | "control-plane";
 	} = {},
 ): HostedRuntimeObserved | null {
 	if (paths.mode !== "hosted") return null;
@@ -49,9 +50,9 @@ export function readHostedRuntimeObserved(
 	const appliedAuthority = appliedState
 		? {
 				etag:
-					options.appliedState === undefined
-						? appliedState.etag
-						: (appliedState.manifestETag ?? appliedState.etag),
+					options.etagAuthority === "control-plane"
+						? (appliedState.manifestETag ?? appliedState.etag)
+						: appliedState.etag,
 				sourceRevision: appliedState.sourceRevision,
 				generation: resolveRuntimeApplyGeneration(appliedState),
 				instanceId: appliedState.instanceId,

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -921,13 +921,14 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
 		const paths = getRuntimePaths({ mode: "hosted" });
+		const sourceRevision = "da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1";
 		globalThis.fetch = Object.assign(
 			async () =>
 				new Response(readFileSync(goldenPath, "utf-8"), {
 					status: 200,
 					headers: {
 						"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-						etag: '"bundle-golden"',
+						etag: `"sha256:${sourceRevision}"`,
 					},
 				}),
 			{ preconnect: () => undefined },
@@ -935,11 +936,37 @@ describe("hosted runtime bundle v2", () => {
 
 		const loaded = await loadRemoteRuntimeManifest(paths);
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
-		expect(loaded.etag).toBe('"bundle-golden"');
-		expect(loaded.sourceRevision).toBe(
-			"da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1",
-		);
+		expect(loaded.etag).toBe(`"sha256:${sourceRevision}"`);
+		expect(loaded.sourceRevision).toBe(sourceRevision);
 		expect(loaded.channelBindings).toHaveLength(1);
+	});
+
+	test("rejects a bundle whose HTTP validator does not name its source revision", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-authority-"));
+		roots.push(root);
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		process.env.CLAWDI_RUN_DIR = join(root, "run");
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
+		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		globalThis.fetch = Object.assign(
+			async () =>
+				new Response(readFileSync(goldenPath, "utf-8"), {
+					status: 200,
+					headers: {
+						"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+						etag: '"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
+					},
+				}),
+			{ preconnect: () => undefined },
+		);
+
+		const loaded = await loadRemoteRuntimeManifest(getRuntimePaths({ mode: "hosted" }));
+		expect(loaded).toMatchObject({ mode: "manifest-rejected", stage: "network" });
+		expect("errors" in loaded ? loaded.errors.join("\n") : "").toContain(
+			"does not match its sourceRevision validator",
+		);
 	});
 
 	test("caches the effective projected manifest and complete active secret union", () => {
@@ -992,6 +1019,7 @@ describe("hosted runtime bundle v2", () => {
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const goldenRaw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
+			sourceRevision: string;
 			manifest: { egressEngine: { version: string; sha256: string } };
 		};
 		const goldenEngine = goldenRaw.manifest.egressEngine;
@@ -1017,7 +1045,7 @@ describe("hosted runtime bundle v2", () => {
 					status: 200,
 					headers: {
 						"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-						etag: '"bundle-golden"',
+						etag: `"sha256:${goldenRaw.sourceRevision}"`,
 					},
 				});
 			},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13514,6 +13514,9 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(existsSync(join(run, "secrets", "runtimes", "openclaw.json"))).toBe(false);
 		expect(statSync(egressSecretPath).mode & 0o777).toBe(0o600);
 		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			const openclawUnitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+			expect(statSync(openclawUnitPath).uid).toBe(10_001);
+			expect(statSync(openclawUnitPath).gid).toBe(10_001);
 			expect(statSync(egressSecretPath).uid).toBe(10002);
 			expect(statSync(egressSecretPath).gid).toBe(10002);
 		}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -660,6 +660,10 @@ interface HostedRuntimeResponseFixture {
 	channelBindings?: RuntimeBundleChannelBinding[];
 }
 
+function testBundleEtag(label: string): string {
+	return `"sha256:${runtimeContentSha256({ testBundleEtag: label })}"`;
+}
+
 function hostedRuntimeBundleResponse(
 	payload: HostedRuntimeResponseFixture,
 	options: { etag?: string; sourceRevision?: string } = {},
@@ -677,8 +681,10 @@ function hostedRuntimeBundleResponse(
 		...TEST_HOSTED_CODEX_SECRET_VALUES,
 		...(payload.secretValues ?? {}),
 	};
+	const etagSourceRevision = options.etag?.match(/^"sha256:([a-f0-9]{64})"$/)?.[1];
 	const sourceRevision =
 		options.sourceRevision ??
+		etagSourceRevision ??
 		runtimeContentSha256({
 			manifest: payload.manifest,
 			channelBindings,
@@ -688,8 +694,8 @@ function hostedRuntimeBundleResponse(
 		throw new Error("hosted runtime bundle fixture sourceRevision must be 64 hex characters");
 	}
 	const etag = options.etag ?? `"sha256:${sourceRevision}"`;
-	if (!/^"[^"]+"$/.test(etag)) {
-		throw new Error("hosted runtime bundle fixture ETag must be a strong quoted validator");
+	if (etag !== `"sha256:${sourceRevision}"`) {
+		throw new Error("hosted runtime bundle fixture ETag must name its sourceRevision");
 	}
 	return new Response(
 		JSON.stringify({
@@ -934,7 +940,7 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 	};
 	const convergence = convergeRuntimeManifest(load, paths);
 	writeTestRuntimeAppliedState(paths, load, convergence, {
-		etag: '"manifest-locale-1"',
+		etag: testBundleEtag("manifest-locale-1"),
 	});
 	return paths;
 }
@@ -1610,7 +1616,7 @@ function writeOfflineStrictAppliedState(
 			schemaVersion: "clawdi.runtimeAppliedState.v2",
 			appliedAt: "2026-07-16T00:01:00.000Z",
 			instanceId: manifest.instanceId,
-			etag: '"transport-etag-offline"',
+			etag: testBundleEtag("transport-etag-offline"),
 			sourceRevision: "a".repeat(64),
 			generation: manifest.generation,
 			manifestETag: OFFLINE_RUNTIME_APPLY_IDENTITY.manifestETag,
@@ -5618,6 +5624,7 @@ exit 64
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "";
+		const currentEtag = testBundleEtag("etag-current");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -5635,22 +5642,22 @@ exit 64
 				response: () =>
 					new Response(null, {
 						status: 304,
-						headers: { etag: '"etag-current"' },
+						headers: { etag: currentEtag },
 					}),
 			},
 		]);
 
 		try {
 			const loaded = await loadRemoteRuntimeManifest(getRuntimePaths(), {
-				ifNoneMatch: '"etag-current"',
+				ifNoneMatch: currentEtag,
 			});
 
 			expect("notModified" in loaded).toBe(true);
 			if (!("notModified" in loaded)) throw new Error("expected 304 manifest load");
-			expect(loaded.etag).toBe('"etag-current"');
+			expect(loaded.etag).toBe(currentEtag);
 			expect(captured).toHaveLength(1);
 			expect(captured[0].headers.authorization).toBe("Bearer file-runtime-token");
-			expect(captured[0].headers["if-none-match"]).toBe('"etag-current"');
+			expect(captured[0].headers["if-none-match"]).toBe(currentEtag);
 		} finally {
 			restore();
 		}
@@ -5680,7 +5687,7 @@ exit 64
 			channels: [],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"empty-channels"',
+			etag: testBundleEtag("empty-channels"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
@@ -5767,7 +5774,7 @@ exit 64
 			],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"channel-secret-boundary"',
+			etag: testBundleEtag("channel-secret-boundary"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
@@ -5870,7 +5877,7 @@ exit 64
 			],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"whatsapp-creds"',
+			etag: testBundleEtag("whatsapp-creds"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
@@ -5973,7 +5980,7 @@ exit 64
 			channels: [],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"empty-channels"',
+			etag: testBundleEtag("empty-channels"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
@@ -6041,7 +6048,7 @@ exit 64
 			],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"channels"',
+			etag: testBundleEtag("channels"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
@@ -6098,12 +6105,12 @@ exit 0
 						resolveInitialManifestRequest?.();
 						return new Response(null, {
 							status: 304,
-							headers: { etag: '"manifest-locale-1"' },
+							headers: { etag: testBundleEtag("manifest-locale-1") },
 						});
 					}
 					setTimeout(() => abort.abort(), 25);
 					return hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 2), {
-						etag: '"manifest-locale-2"',
+						etag: testBundleEtag("manifest-locale-2"),
 					});
 				},
 			},
@@ -6141,12 +6148,12 @@ exit 0
 			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
 			expect(events[0].generation).toBe(1);
 			expect(events[0].instanceId).toBe("iid_watch_locale");
-			expect(events[1].etag).toBe('"manifest-locale-2"');
+			expect(events[1].etag).toBe(testBundleEtag("manifest-locale-2"));
 			expect(
 				captured.filter((request) => request.path === "/v1/runtime/manifest")[1].headers[
 					"if-none-match"
 				],
-			).toBe('"manifest-locale-1"');
+			).toBe(testBundleEtag("manifest-locale-1"));
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
 			expect(systemctlCalls).toContain("--user restart openclaw-gateway.service");
 			expect(systemctlCalls.some((call) => call.includes("reset-failed"))).toBe(false);
@@ -6185,7 +6192,7 @@ exit 0
 					if (manifestCalls === 1) return new Response(null, { status: 304 });
 					setTimeout(() => abort.abort(), 0);
 					return hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 2), {
-						etag: '"manifest-locale-2"',
+						etag: testBundleEtag("manifest-locale-2"),
 					});
 				},
 			},
@@ -6240,7 +6247,7 @@ exit 0
 					}
 					setTimeout(() => abort.abort(), 0);
 					return hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 2), {
-						etag: '"manifest-locale-2"',
+						etag: testBundleEtag("manifest-locale-2"),
 					});
 				},
 			},
@@ -6424,7 +6431,7 @@ fi
 							status: 200,
 							headers: {
 								"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-								etag: '"etag-watch-12"',
+								etag: `"sha256:${"a".repeat(64)}"`,
 							},
 						},
 					),
@@ -6455,7 +6462,7 @@ fi
 			expect(appliedState).toMatchObject({
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				instanceId: "iid_watch",
-				etag: '"etag-watch-12"',
+				etag: `"sha256:${"a".repeat(64)}"`,
 				sourceRevision: "a".repeat(64),
 				generation: 12,
 				manifestETag: '"etag-watch-12"',
@@ -6466,7 +6473,7 @@ fi
 			const event = JSON.parse(logs.at(-1) ?? "{}");
 			expect(event.status).toBe("applied");
 			expect(event.generation).toBe(12);
-			expect(event.etag).toBe('"etag-watch-12"');
+			expect(event.etag).toBe(`"sha256:${"a".repeat(64)}"`);
 			expect(event.convergence.appliedState).toBe(getRuntimePaths().appliedState);
 			expect(event.systemdUnitsChanged).toBe(true);
 			expect(event.systemdApply).toEqual({
@@ -6485,7 +6492,7 @@ fi
 			const observed = readHostedRuntimeObserved(getRuntimePaths());
 			expect(observed?.status).toBe("ok");
 			expect(observed?.applied).toMatchObject({
-				etag: '"etag-watch-12"',
+				etag: `"sha256:${"a".repeat(64)}"`,
 				sourceRevision: "a".repeat(64),
 				generation: 12,
 				appliedProviderIds: ["default"],
@@ -6532,7 +6539,7 @@ fi
 		const previousUmask = process.umask(0o022);
 		const logs: string[] = [];
 		let generation = 30;
-		let manifestEtag = '"manifest-generation-30"';
+		let manifestEtag = testBundleEtag("manifest-generation-30");
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(dirname(systemctlPath), { recursive: true });
 		writeFileSync(
@@ -6597,7 +6604,7 @@ fi
 			const initialAppliedState = readRuntimeAppliedState(paths);
 			if (!initialAppliedState) throw new Error(logs.join("\n"));
 			expect(initialAppliedState).toMatchObject({
-				etag: '"manifest-generation-30"',
+				etag: testBundleEtag("manifest-generation-30"),
 				generation: 30,
 			});
 			const initialDaemonAuthTokenRevision = initialAppliedState?.daemonAuthTokenRevision;
@@ -6611,7 +6618,7 @@ fi
 
 			expect(process.exitCode ?? 0).toBe(0);
 			expect(watchFetch.captured.slice(requestsBeforeMatchingTuple)).toHaveLength(1);
-			expect(watchFetch.captured.at(-1)?.headers["if-none-match"]).toBe('"manifest-generation-30"');
+			expect(watchFetch.captured.at(-1)?.headers["if-none-match"]).toBe(manifestEtag);
 			expect(JSON.parse(logs.at(-1) ?? "{}").status).toBe("not_modified");
 			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
 
@@ -6632,10 +6639,10 @@ fi
 				watchFetch.captured
 					.slice(requestsBeforeTupleRefresh)
 					.map((request) => request.headers["if-none-match"] ?? null),
-			).toEqual(['"manifest-generation-30"', null]);
+			).toEqual([manifestEtag, null]);
 			expect(readRuntimeAppliedState(paths)).toMatchObject({
 				generation: 30,
-				manifestETag: '"manifest-generation-30"',
+				manifestETag: manifestEtag,
 				applyReceiptId: "apply-receipt-generation-0030-refreshed",
 				bootNonce: "boot-nonce-generation-0002",
 			});
@@ -6643,23 +6650,51 @@ fi
 				/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
 			);
 
-			generation = 31;
-			manifestEtag = '"manifest-generation-31"';
+			const committedBeforeMismatchedGeneration = readFileSync(paths.appliedState, "utf-8");
+			writeFileSync(systemctlLog, "");
 			writeRuntimeApplyIdentityFile(applyIdentityPath, {
-				generation,
-				manifestETag: '"manifest-generation-30"',
+				generation: 31,
+				manifestETag: '"hosted-control-plane-generation-31"',
 				applyReceiptId: "apply-receipt-generation-0031",
 				bootNonce: "boot-nonce-generation-0001",
 			});
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
+
 			expect(process.exitCode).toBe(1);
 			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
 				status: "error",
-				stage: "final",
+				mode: "manifest-rejected",
 			});
-			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain("does not match fetched bundle ETag");
-			expect(readRuntimeAppliedState(getRuntimePaths())?.generation).toBe(30);
+			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain(
+				"runtime apply identity generation 31 does not match resolved manifest apply generation 30",
+			);
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedBeforeMismatchedGeneration);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+
+			generation = 31;
+			manifestEtag = testBundleEtag("manifest-generation-31");
+			writeRuntimeApplyIdentityFile(applyIdentityPath, {
+				generation,
+				manifestETag: '"hosted-control-plane-generation-31"',
+				applyReceiptId: "apply-receipt-generation-0031",
+				bootNonce: "boot-nonce-generation-0001",
+			});
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+				status: "applied",
+				generation: 31,
+				etag: testBundleEtag("manifest-generation-31"),
+			});
+			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+				etag: testBundleEtag("manifest-generation-31"),
+				generation: 31,
+				manifestETag: '"hosted-control-plane-generation-31"',
+				applyReceiptId: "apply-receipt-generation-0031",
+				bootNonce: "boot-nonce-generation-0001",
+			});
 
 			writeRuntimeApplyIdentityFile(applyIdentityPath, {
 				generation,
@@ -6674,15 +6709,15 @@ fi
 			const event = JSON.parse(logs.at(-1) ?? "{}");
 			expect(event.status).toBe("applied");
 			expect(event.generation).toBe(31);
-			expect(event.etag).toBe('"manifest-generation-31"');
+			expect(event.etag).toBe(manifestEtag);
 			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
-				etag: '"manifest-generation-31"',
+				etag: testBundleEtag("manifest-generation-31"),
 				generation: 31,
-				manifestETag: '"manifest-generation-31"',
+				manifestETag: manifestEtag,
 				applyReceiptId: "apply-receipt-generation-0031",
 				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(watchFetch.captured).toHaveLength(8);
+			expect(watchFetch.captured).toHaveLength(10);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
@@ -6695,7 +6730,7 @@ fi
 			process.env.STALE_RUNTIME_AUTH_TOKEN = "stale-selected-auth-token";
 			process.env.OPENCLAW_GATEWAY_TOKEN = "stale-process-gateway-token";
 			generation = 32;
-			manifestEtag = '"manifest-generation-32"';
+			manifestEtag = testBundleEtag("manifest-generation-32");
 			writeRuntimeApplyIdentityFile(
 				applyIdentityPath,
 				{
@@ -6713,7 +6748,7 @@ fi
 			const rotatedAppliedState = readRuntimeAppliedState(paths);
 			expect(rotatedAppliedState).toMatchObject({
 				generation: 32,
-				manifestETag: '"manifest-generation-32"',
+				manifestETag: manifestEtag,
 				bootNonce: "boot-nonce-generation-0001",
 			});
 			expect(rotatedAppliedState?.daemonAuthTokenRevision).toMatch(/^[a-f0-9]{64}$/);
@@ -6761,7 +6796,7 @@ fi
 
 			writeFileSync(systemctlLog, "");
 			generation = 33;
-			manifestEtag = '"manifest-generation-33"';
+			manifestEtag = testBundleEtag("manifest-generation-33");
 			writeRuntimeApplyIdentityFile(
 				applyIdentityPath,
 				{
@@ -6781,7 +6816,7 @@ fi
 			expect(process.exitCode ?? 0).toBe(0);
 			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
 				generation: 33,
-				manifestETag: '"manifest-generation-33"',
+				manifestETag: manifestEtag,
 				bootNonce: "boot-nonce-generation-0001",
 			});
 			expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).toContain(
@@ -6794,7 +6829,7 @@ fi
 
 			writeFileSync(systemctlLog, "");
 			generation = 34;
-			manifestEtag = '"manifest-generation-34"';
+			manifestEtag = testBundleEtag("manifest-generation-34");
 			writeRuntimeApplyIdentityFile(
 				applyIdentityPath,
 				{
@@ -6832,7 +6867,7 @@ fi
 			const fetchCountBeforeMissingAuth = watchFetch.captured.length;
 			writeFileSync(systemctlLog, "");
 			generation = 35;
-			manifestEtag = '"manifest-generation-35"';
+			manifestEtag = testBundleEtag("manifest-generation-35");
 			writeRuntimeApplyIdentityFile(
 				applyIdentityPath,
 				{
@@ -6902,9 +6937,10 @@ exit 42
 		mkdirSync(paths.runConfigRoot, { recursive: true });
 		mkdirSync(paths.systemdUserRoot, { recursive: true });
 		const targetConfig = join(home, ".openclaw", "openclaw.json");
-		const rollbackFixtures = [paths.managedConfig, join(paths.runConfigRoot, "openclaw.json")];
+		const forwardRunConfig = join(paths.runConfigRoot, "openclaw.json");
+		const rollbackFixtures = [paths.managedConfig];
 		const previousUserUnit = join(paths.systemdUserRoot, "clawdi-previous.service");
-		const forwardOnlyFixtures = [previousUserUnit, targetConfig];
+		const forwardOnlyFixtures = [previousUserUnit, targetConfig, forwardRunConfig];
 		const seededFixtures = [...rollbackFixtures, ...forwardOnlyFixtures];
 		for (const [index, path] of seededFixtures.entries()) {
 			mkdirSync(dirname(path), { recursive: true });
@@ -6920,7 +6956,7 @@ exit 42
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T05:00:00.000Z",
 				instanceId: "iid_watch_systemd_failure",
-				etag: '"etag-watch-previous"',
+				etag: testBundleEtag("etag-watch-previous"),
 				sourceRevision: "a".repeat(64),
 				generation: 12,
 				contentIdentity: {
@@ -6979,7 +7015,7 @@ exit 42
 							},
 							secretValues: {},
 						},
-						{ etag: '"etag-watch-systemd-failure"' },
+						{ etag: testBundleEtag("etag-watch-systemd-failure") },
 					),
 			},
 		]);
@@ -7003,6 +7039,7 @@ exit 42
 				if (!expected) throw new Error(`missing rollback fixture for ${path}`);
 				expect(readFileSync(path)).toEqual(expected);
 			}
+			expect(readFileSync(forwardRunConfig, "utf-8")).not.toContain("previous-");
 			expect(existsSync(previousUserUnit)).toBe(false);
 		} finally {
 			restore();
@@ -7082,12 +7119,13 @@ exit 42
 				[channelPlaceholderSecretRef]: "999999999:54db03c2296520629c70cfb6e3b15f8e",
 			},
 		};
-		const manifestResponse = (etag = '"manifest-etag-stable"') =>
+		const stableBundleEtag = `"sha256:${hostedPayload.sourceRevision}"`;
+		const manifestResponse = () =>
 			new Response(JSON.stringify(hostedPayload), {
 				status: 200,
 				headers: {
 					"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-					etag,
+					etag: stableBundleEtag,
 				},
 			});
 
@@ -7153,7 +7191,7 @@ exit 64
 					schemaVersion: "clawdi.runtimeAppliedState.v2",
 					appliedAt: "2026-07-13T00:00:00.000Z",
 					instanceId: "iid_watch_secret",
-					etag: '"manifest-etag-stable"',
+					etag: stableBundleEtag,
 					sourceRevision: "d".repeat(64),
 					generation: 22,
 					contentIdentity: {
@@ -7188,9 +7226,9 @@ exit 64
 					request.headers["if-none-match"]
 						? new Response(null, {
 								status: 304,
-								headers: { etag: '"manifest-etag-stable"' },
+								headers: { etag: stableBundleEtag },
 							})
-						: manifestResponse('"manifest-etag-effective"'),
+						: manifestResponse(),
 			},
 		]);
 
@@ -7201,14 +7239,14 @@ exit 64
 				throw new Error(logs.join("\n"));
 			}
 			expect(watchFetch.captured.map((request) => request.path)).toEqual(["/v1/runtime/manifest"]);
-			expect(watchFetch.captured[0].headers["if-none-match"]).toBe('"manifest-etag-stable"');
+			expect(watchFetch.captured[0].headers["if-none-match"]).toBe(stableBundleEtag);
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("not_modified");
 			expect(event.generation).toBe(22);
-			expect(event.etag).toBe('"manifest-etag-stable"');
+			expect(event.etag).toBe(stableBundleEtag);
 			expect(readRuntimeAppliedState(paths)).toMatchObject({
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
-				etag: '"manifest-etag-stable"',
+				etag: stableBundleEtag,
 				sourceRevision: "d".repeat(64),
 				generation: 22,
 				providerIds: ["clawdi-managed-v2"],
@@ -7295,7 +7333,7 @@ exit 64
 						status: 200,
 						headers: {
 							"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-							etag: '"malformed-bundle"',
+							etag: testBundleEtag("malformed-bundle"),
 						},
 					}),
 				"error",
@@ -7326,13 +7364,15 @@ exit 64
 							},
 							secretValues: {},
 						},
-						{ etag: '"etag-recovered"' },
+						{ etag: testBundleEtag("etag-recovered") },
 					),
 				"applied",
 			);
 
 			expect(recovered.generation).toBe(18);
-			expect(readRuntimeAppliedState(getRuntimePaths())?.etag).toBe('"etag-recovered"');
+			expect(readRuntimeAppliedState(getRuntimePaths())?.etag).toBe(
+				testBundleEtag("etag-recovered"),
+			);
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
 		} finally {
 			console.log = previousLog;
@@ -7714,7 +7754,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T06:00:00.000Z",
 				instanceId: "iid-provider-observed",
-				etag: '"provider-observed"',
+				etag: testBundleEtag("provider-observed"),
 				sourceRevision: "a".repeat(64),
 				generation: 9,
 				contentIdentity: {
@@ -7994,7 +8034,7 @@ chmod +x "$prefix/bin/clawdi"
 							},
 							secretValues: {},
 						},
-						{ etag: '"etag-cli-update-13"' },
+						{ etag: testBundleEtag("etag-cli-update-13") },
 					),
 			},
 		]);
@@ -8185,7 +8225,7 @@ exit 0
 				response: () =>
 					hostedRuntimeBundleResponse(
 						hostedEgressSecretRotationPayload(home, mitmproxy, "cold-home-secret", runtime),
-						{ etag: '"cold-home-egress"' },
+						{ etag: testBundleEtag("cold-home-egress") },
 					),
 			},
 		]);
@@ -8237,7 +8277,7 @@ exit 0
 		}
 		expect(readRuntimeAppliedState(paths)).toMatchObject({
 			generation: 41,
-			etag: '"cold-home-egress"',
+			etag: testBundleEtag("cold-home-egress"),
 		});
 	});
 
@@ -8304,7 +8344,7 @@ exit 0
 					response: () =>
 						hostedRuntimeBundleResponse(
 							hostedEgressSecretRotationPayload(home, mitmproxy, initialSecret),
-							{ etag: '"egress-secret-revision-a"' },
+							{ etag: testBundleEtag("egress-secret-revision-a") },
 						),
 				},
 			]);
@@ -8368,7 +8408,7 @@ exit 0
 					response: () =>
 						hostedRuntimeBundleResponse(
 							hostedEgressSecretRotationPayload(home, mitmproxy, initialSecret),
-							{ etag: '"egress-secret-revision-a-retry"' },
+							{ etag: testBundleEtag("egress-secret-revision-a-retry") },
 						),
 				},
 			]);
@@ -8414,7 +8454,7 @@ exit 0
 					response: () =>
 						hostedRuntimeBundleResponse(
 							hostedEgressSecretRotationPayload(home, mitmproxy, rotatedSecret),
-							{ etag: '"egress-secret-revision-b"' },
+							{ etag: testBundleEtag("egress-secret-revision-b") },
 						),
 				},
 			]);
@@ -8496,7 +8536,7 @@ exit 0
 					response: () =>
 						hostedRuntimeBundleResponse(
 							hostedEgressSecretRotationPayload(home, mitmproxy, rejectedSecret),
-							{ etag: '"egress-secret-revision-c"' },
+							{ etag: testBundleEtag("egress-secret-revision-c") },
 						),
 				},
 			]);
@@ -8550,7 +8590,7 @@ exit 0
 								},
 								invalidEngineSecret,
 							),
-							{ etag: '"egress-secret-revision-d"' },
+							{ etag: testBundleEtag("egress-secret-revision-d") },
 						),
 				},
 			]);
@@ -8781,7 +8821,7 @@ fi
 								"provider.default.apiKey": "sk-after-upgrade",
 							},
 						},
-						{ etag: '"etag-cli-egress-2"' },
+						{ etag: testBundleEtag("etag-cli-egress-2") },
 					),
 			},
 		]);
@@ -9620,12 +9660,13 @@ chmod +x "$prefix/bin/clawdi"
 			},
 			secretValues: {},
 		};
+		const bundleEtag = `"sha256:${"a".repeat(64)}"`;
 		writeRuntimeAppliedState(
 			{
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T05:00:00.000Z",
 				instanceId: "iid_cli_self_heal",
-				etag: '"manifest-self-heal"',
+				etag: bundleEtag,
 				sourceRevision: "a".repeat(64),
 				generation: 30,
 				contentIdentity: {
@@ -9645,10 +9686,10 @@ chmod +x "$prefix/bin/clawdi"
 					request.headers["if-none-match"]
 						? new Response(null, {
 								status: 304,
-								headers: { etag: '"manifest-self-heal"' },
+								headers: { etag: bundleEtag },
 							})
 						: hostedRuntimeBundleResponse(manifestPayload, {
-								etag: '"manifest-self-heal"',
+								etag: bundleEtag,
 							}),
 			},
 		]);
@@ -9677,7 +9718,7 @@ chmod +x "$prefix/bin/clawdi"
 				"/v1/runtime/manifest",
 				"/v1/runtime/manifest",
 			]);
-			expect(captured[0].headers["if-none-match"]).toBe('"manifest-self-heal"');
+			expect(captured[0].headers["if-none-match"]).toBe(bundleEtag);
 			expect(captured[1].headers["if-none-match"]).toBeUndefined();
 			const events = logs.map((line) => JSON.parse(line));
 			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
@@ -9834,7 +9875,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 									"999999999:00000000000000000000000000000000",
 							},
 						},
-						{ etag: '"etag-projection-failed"' },
+						{ etag: testBundleEtag("etag-projection-failed") },
 					),
 			},
 		]);
@@ -9963,7 +10004,7 @@ chmod +x "$prefix/bin/clawdi"
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T05:00:00.000Z",
 				instanceId: "iid_cli_rollback",
-				etag: '"etag-cli-rollback"',
+				etag: testBundleEtag("etag-cli-rollback"),
 				sourceRevision: "a".repeat(64),
 				generation: 18,
 				contentIdentity: {
@@ -9985,7 +10026,7 @@ chmod +x "$prefix/bin/clawdi"
 							manifest,
 							secretValues: {},
 						},
-						{ etag: '"etag-cli-rollback"' },
+						{ etag: testBundleEtag("etag-cli-rollback") },
 					),
 			},
 		]);
@@ -10110,7 +10151,7 @@ chmod +x "$prefix/bin/clawdi"
 							},
 							secretValues: {},
 						},
-						{ etag: '"etag-cli-failed"' },
+						{ etag: testBundleEtag("etag-cli-failed") },
 					),
 			},
 		]);
@@ -10237,7 +10278,7 @@ chmod +x "$prefix/bin/clawdi"
 							},
 							secretValues: {},
 						},
-						{ etag: '"etag-min-cli"' },
+						{ etag: testBundleEtag("etag-min-cli") },
 					),
 			},
 		]);
@@ -10606,7 +10647,7 @@ chmod +x "$prefix/bin/clawdi"
 		const paths = getRuntimePaths();
 		const manifestIdentity = {
 			generation: 1,
-			etag: '"etag-cli-rollback-lifecycle"',
+			etag: testBundleEtag("etag-cli-rollback-lifecycle"),
 			previouslyApplied: true,
 		};
 		const manifestFor = (version: string): RuntimeManifest => ({
@@ -10878,7 +10919,7 @@ exit 64
 									"clawdi_00000000000000000000000000000000",
 							},
 						},
-						{ etag: '"manifest-etag-init-7"' },
+						{ etag: testBundleEtag("manifest-etag-init-7") },
 					),
 			},
 		]);
@@ -10890,7 +10931,7 @@ exit 64
 			expect(captured).toHaveLength(1);
 			expect(captured[0].path).toBe("/v1/runtime/manifest");
 			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
-				etag: '"manifest-etag-init-7"',
+				etag: testBundleEtag("manifest-etag-init-7"),
 				generation: 7,
 			});
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
@@ -11002,6 +11043,7 @@ exit 64
 				"utf-8",
 			),
 		) as {
+			sourceRevision: string;
 			manifest: {
 				runtime: string;
 				system: Record<string, unknown>;
@@ -11013,6 +11055,11 @@ exit 64
 		const missingSecretRef = bundle.channelBindings[0]?.agentTokenSecretRef;
 		if (!missingSecretRef) throw new Error("golden bundle has no channel binding");
 		delete bundle.secretValues[missingSecretRef];
+		bundle.sourceRevision = runtimeContentSha256({
+			manifest: bundle.manifest,
+			channelBindings: bundle.channelBindings,
+			secretValues: bundle.secretValues,
+		});
 
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(dirname(policyPath), { recursive: true });
@@ -11046,7 +11093,7 @@ exit 64
 						status: 200,
 						headers: {
 							"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-							etag: '"bundle-malformed-channel-ref"',
+							etag: `"sha256:${bundle.sourceRevision}"`,
 						},
 					}),
 			},
@@ -11171,7 +11218,7 @@ exit 64
 			],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"hermes-channels"',
+			etag: testBundleEtag("hermes-channels"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(load, channels, paths);
@@ -11317,7 +11364,7 @@ exit 64
 			],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"hermes-whatsapp"',
+			etag: testBundleEtag("hermes-whatsapp"),
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(load, channels);
@@ -11361,7 +11408,7 @@ exit 64
 				channels: [],
 				source: "remote-datasource",
 				sourcePath: "https://runtime.test/v1/channels",
-				etag: '"empty-hermes-whatsapp"',
+				etag: testBundleEtag("empty-hermes-whatsapp"),
 			}),
 			getRuntimePaths(),
 		);
@@ -11473,7 +11520,7 @@ exit 64
 			channels: [],
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/v1/channels",
-			etag: '"empty-hermes-channels"',
+			etag: testBundleEtag("empty-hermes-channels"),
 		});
 
 		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
@@ -13700,7 +13747,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T05:00:00.000Z",
 				instanceId: previousManifest.instanceId,
-				etag: '"manifest-generation-1"',
+				etag: testBundleEtag("manifest-generation-1"),
 				sourceRevision: "a".repeat(64),
 				generation: 1,
 				contentIdentity: {
@@ -13996,7 +14043,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 				schemaVersion: "clawdi.runtimeAppliedState.v2",
 				appliedAt: "2026-07-13T05:00:00.000Z",
 				instanceId: desiredManifest.instanceId,
-				etag: '"generation-reset-previous"',
+				etag: testBundleEtag("generation-reset-previous"),
 				sourceRevision: "a".repeat(64),
 				generation: 42,
 				contentIdentity: {


### PR DESCRIPTION
## Summary

- separate control-plane manifest authority from fetched bundle HTTP caching and gate generation/ETag identity before side effects
- make plan/apply share one run-config authority and keep rollback scoped to root/system-owned state
- write runtime-user projections under the runtime user's effective filesystem identity while keeping external commands permanently privilege-dropped
- release the verified changes as `clawdi@0.13.17`

## Runtime impact

- compatible v2 reconciles remain in-place and restart only affected services
- no runtime image customization or rebuild is required; Hosted should validate the exact package against the existing digest-pinned image
- malformed or mixed-generation authority fails closed before projection or systemd activation

## Verification

- `bun run check`
- `bun run typecheck`
- focused v2/reconcile tests: 346 passed
- final manifest/effective-identity tests: 162 passed
- root effective UID/GID drop and restoration exercised
- Docker CLI suite: 1461 passed, 4 skipped; one unrelated 5-second timing timeout passed in isolated rerun
- `git diff --check`

## Release

Publishes `clawdi@0.13.17` through the protected CLI workflow after merge.
