### PR TITLE
Fix npm publication visibility recovery

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -292,6 +292,15 @@ jobs:
         run: |
           local_integrity=$(node -e 'const { createHash }=require("node:crypto"); const { readFileSync }=require("node:fs"); console.log(`sha512-${createHash("sha512").update(readFileSync(process.argv[1])).digest("base64")}`)' "./release/$CLI_TARBALL_FILENAME")
           local_sha512=$(node -e 'const { createHash }=require("node:crypto"); const { readFileSync }=require("node:fs"); console.log(createHash("sha512").update(readFileSync(process.argv[1])).digest("hex"))' "./release/$CLI_TARBALL_FILENAME")
+          npm_release_visible() {
+            test "$(npm view "clawdi@$VERSION" version 2>/dev/null)" = "$VERSION"
+          }
+          # Re-evaluate the immutable registry boundary in this job. A failed-job
+          # rerun can inherit an earlier publish decision after npm accepted the
+          # package, and another release job may win the same race.
+          if [ "$NPM_ACTION" = "publish" ] && npm_release_visible; then
+            NPM_ACTION=verify
+          fi
           case "$NPM_ACTION" in
             publish)
               npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
@@ -302,6 +311,21 @@ jobs:
               exit 64
               ;;
           esac
+          # npm publication is immutable but registry reads are eventually
+          # consistent. Wait only for the exact version just published or found;
+          # all integrity and provenance checks below remain unchanged.
+          registry_visible=false
+          for attempt in $(seq 1 12); do
+            if npm_release_visible; then
+              registry_visible=true
+              break
+            fi
+            if [ "$attempt" -lt 12 ]; then sleep 5; fi
+          done
+          if [ "$registry_visible" != "true" ]; then
+            echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2
+            exit 69
+          fi
           published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)
           attestations=$(npm view "clawdi@$VERSION" dist.attestations --json)
           attestation_url=$(ATTESTATIONS="$attestations" node - <<'NODE'

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -138,6 +138,26 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).not.toContain("NPM_TOKEN");
 	});
 
+	test("recovers registry publication races without republishing", () => {
+		const boundaryCheck = workflow.indexOf(
+			'if [ "$NPM_ACTION" = "publish" ] && npm_release_visible; then',
+		);
+		const publishDecision = workflow.indexOf('case "$NPM_ACTION" in');
+		const visibilityWait = workflow.indexOf("for attempt in $(seq 1 12); do");
+		const integrityRead = workflow.indexOf(
+			'published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)',
+		);
+
+		expect(boundaryCheck).toBeGreaterThan(-1);
+		expect(boundaryCheck).toBeLessThan(publishDecision);
+		expect(visibilityWait).toBeGreaterThan(publishDecision);
+		expect(visibilityWait).toBeLessThan(integrityRead);
+		expect(workflow).toContain('if [ "$attempt" -lt 12 ]; then sleep 5; fi');
+		expect(workflow).toContain(
+			'echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2',
+		);
+	});
+
 	test("creates the CLI release only after publishing", () => {
 		expect(workflow.indexOf("npm publish ")).toBeLessThan(
 			workflow.indexOf('release create "$tag"'),


### PR DESCRIPTION
## Summary

- re-check the immutable npm version at the protected publish boundary so a failed-job rerun or concurrent winner switches from publish to verify
- wait up to 60 seconds for exact-version registry visibility after npm accepts the package
- preserve the existing integrity, provenance, source commit, and GitHub Release recovery gates
- add a workflow contract test for ordering and the bounded wait

## Incident

The `clawdi@0.13.17` publish succeeded, then the immediate `npm view` returned a transient 404. Rerunning only the failed job inherited the original `publish` decision and npm correctly rejected an overwrite. A full workflow rerun recovered successfully. This change makes the original job and failed-job reruns idempotent.

## Verification

- `bun test packages/cli/tests/cli-publish-workflow.test.ts` — 6 passed
- `bun run check`
- `bun run typecheck`
- `git diff --check`
