### PR TITLE
Fix hosted Skill projection privilege boundary

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	chownSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -3707,6 +3708,76 @@ describe("runtime manifest reconciliation invariants", () => {
 			expect(readFileSync(path)).toEqual(expected);
 		}
 		expect(existsSync(installerLog)).toBe(false);
+	});
+
+	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
+		if (process.geteuid?.() !== 0) return;
+		const paths = tempRuntimePaths();
+		const fixtureRoot = dirname(paths.serviceStateRoot);
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const skillDir = join(paths.userHome, ".hermes", "skills", "clawdi");
+		const ledger = join(paths.projectionRoot, "managed-skills.json");
+		const runtimeUid = Number.parseInt(
+			execFileSync("id", ["-u", "nobody"], { encoding: "utf8" }).trim(),
+			10,
+		);
+		const runtimeGid = Number.parseInt(
+			execFileSync("id", ["-g", "nobody"], { encoding: "utf8" }).trim(),
+			10,
+		);
+		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+
+		chmodSync(fixtureRoot, 0o755);
+		mkdirSync(paths.projectionRoot, { recursive: true });
+		chmodSync(paths.projectionRoot, 0o755);
+		mkdirSync(paths.clawdiHome, { recursive: true });
+		chownSync(paths.clawdiHome, runtimeUid, runtimeGid);
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n");
+		chmodSync(hermesCommand, 0o755);
+
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(hermesCommand, ["gateway"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
+		);
+
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-hermes-skill"), paths);
+
+		expect(result.installErrors).toEqual([]);
+		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toContain("# Clawdi");
+		expect(statSync(skillDir).uid).toBe(runtimeUid);
+		expect(statSync(join(skillDir, "SKILL.md")).uid).toBe(runtimeUid);
+		expect(statSync(paths.projectionRoot).uid).toBe(0);
+		expect(statSync(paths.projectionRoot).mode & 0o777).toBe(0o755);
+		expect(statSync(ledger).uid).toBe(0);
+		expect(statSync(ledger).mode & 0o022).toBe(0);
+
+		expect(() =>
+			execFileSync("runuser", ["-u", "nobody", "--", "test", "-w", paths.projectionRoot]),
+		).toThrow();
+
+		const removal = convergeRuntimeManifest(
+			manifestLoad(
+				{ ...manifest, projection: { skills: { entries: {} } } },
+				"inline-hermes-skill-removal",
+			),
+			paths,
+		);
+
+		expect(removal.installErrors).toEqual([]);
+		expect(existsSync(skillDir)).toBe(false);
+		expect(readFileSync(ledger, "utf8")).not.toContain(skillDir);
+		expect(statSync(ledger).uid).toBe(0);
+		expect(statSync(ledger).mode & 0o022).toBe(0);
 	});
 
 	test("rolls back root managed state and leaves user projections for forward convergence", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3519,6 +3519,8 @@ function applyHostedBundledSkills(
 	manifest: RuntimeManifest,
 	home: string,
 ): string[] {
+	// Reservation state is root-authoritative. Drop privilege only inside the
+	// callbacks that mutate runtime-user-owned Skill trees.
 	const installEnabled = hostedBundledSkillsEnabled();
 	const targets: string[] = [];
 	for (const skillName of hostedBundledSkillIds()) {
@@ -3545,7 +3547,8 @@ function applyHostedBundledSkills(
 				targetDir,
 				id: skillName,
 				manager: "hosted-manifest",
-				removeTarget: () => rmSync(targetDir, { recursive: true, force: true }),
+				removeTarget: () =>
+					withRuntimeUserFileAccess(() => rmSync(targetDir, { recursive: true, force: true })),
 			});
 			continue;
 		}
@@ -3569,13 +3572,15 @@ function applyHostedBundledSkills(
 				digest: bundled.digest,
 			},
 			() =>
-				reconcileHostedBundledSkill({
-					skillId: skillName,
-					version: desired.version,
-					sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
-					targetDir,
-					reserved: true,
-				}),
+				withRuntimeUserFileAccess(() =>
+					reconcileHostedBundledSkill({
+						skillId: skillName,
+						version: desired.version,
+						sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
+						targetDir,
+						reserved: true,
+					}),
+				),
 		);
 		if (result === "unchanged") continue;
 		makeRuntimeUserOwnedAncestors(targetDir, home);
@@ -6544,9 +6549,7 @@ export function convergeRuntimeManifest(
 		}
 		for (const name of HOSTED_RUNTIME_TARGETS) {
 			try {
-				withRuntimeUserFileAccess(() =>
-					applyHostedBundledSkills(name, observations.get(name), manifest, projectionHome),
-				);
+				applyHostedBundledSkills(name, observations.get(name), manifest, projectionHome);
 			} catch (error) {
 				installErrors.push(
 					`runtime ${name} skill projection failed: ${


### PR DESCRIPTION
## Summary

- keep hosted managed-Skill reservation ledger reads, writes, rollback, and release under root authority
- drop to the runtime user only for Skill target install and removal callbacks
- add a root-semantics regression that creates and updates the hosted ledger while the projection root stays root-owned and non-user-writable

## Verification

- root Docker CLI typecheck plus focused ownership regression: 1 pass, 159 filtered, 0 fail
- root Docker CLI typecheck plus full manifest reconciliation file: 160 pass, 0 fail
- standard isolated Docker CLI suite: 1465 pass, 4 skip, 0 fail across 102 files
- Biome check on both changed files: clean

No production, cluster, database, tenant, release, merge, or shared-checkout operations were performed.
