### PR TITLE
refactor(web): remove v2 prelaunch compatibility paths

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1586,8 +1586,7 @@ export function AppSidebar({
 		},
 		[],
 	);
-	const showCloudFeatures =
-		hydrated && IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error");
+	const showCloudFeatures = hydrated && IS_HOSTED && hostedAccess.canCreateCloudAgents;
 	const agentRoute = parseAgentPathname(pathname);
 	const activeAgentId = agentRoute?.agentId ?? null;
 	const activeDeploymentSelector = agentRoute ? agentDeploymentSelector(routeSearch) : null;

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -169,11 +169,11 @@ function CommandPalette({
 			searchText: "settings general profile api keys model providers billing preferences account",
 		};
 		const shortcuts = [...BASE_NAV_SHORTCUTS, settingsShortcut];
-		if (IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error")) {
+		if (IS_HOSTED && hostedAccess.canCreateCloudAgents) {
 			shortcuts.push(...CLOUD_NAV_SHORTCUTS);
 		}
 		return shortcuts;
-	}, [hostedAccess.canCreateCloudAgents, hostedAccess.status]);
+	}, [hostedAccess.canCreateCloudAgents]);
 
 	// Reset the input when the palette closes so reopening is a fresh state
 	// — otherwise stale results from the previous query briefly flash before

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -165,15 +165,6 @@ export type {
 } from "@/hosted/hosted-agent-resolution";
 export { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 
-export function useCreateTerminalSession() {
-	const client = useBillingClient();
-	return useMutation({
-		mutationFn: (vars: { id: string }) => client.createTerminalSession(vars.id),
-		onError: (error) =>
-			toast.error("Couldn't open terminal", { description: deploymentMutationErrorMessage(error) }),
-	});
-}
-
 export function useDeploymentLifecycle() {
 	const client = useBillingClient();
 	const qc = useQueryClient();

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -649,27 +649,4 @@ describe("compute plan changes", () => {
 		await expect(result).rejects.toBeInstanceOf(PlanChangeTerminalError);
 		await expect(result).rejects.toThrow("The payment method was rejected");
 	});
-
-	it("keeps the deployed synchronous response compatible without a competing read", async () => {
-		const requests: Request[] = [];
-		const client = testClient(async (request) => {
-			requests.push(request.clone());
-			return jsonResponse({
-				operation_id: "plan-change-1",
-				subscription_id: 42,
-				funding_source: "stripe",
-				current_plan_slug: "compute_basic",
-				target_plan_slug: "compute_performance",
-				target_billing_term_months: 1,
-				status: "awaiting_payment",
-				effective_at: NOW,
-			});
-		});
-
-		await expect(client.changePlan({ operation_id: "plan-change-1" })).resolves.toEqual({
-			kind: "pending",
-			waitingFor: "payment",
-		});
-		expect(requests.map((request) => request.method)).toEqual(["POST"]);
-	});
 });

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -248,23 +248,6 @@ function completedPlanChange(operation: ParsedPlanChangeOperation): ComputePlanC
 	throw invalidPlanChangeResponse();
 }
 
-function legacyPlanChangeResult(value: unknown): ComputePlanChangeResult | null {
-	if (!isRecord(value) || !("operation_id" in value)) return null;
-	if (typeof value.status !== "string" || typeof value.effective_at !== "string") {
-		throw invalidPlanChangeResponse();
-	}
-	if (value.status === "complete" || value.status === "scheduled") {
-		return { kind: value.status, effectiveAt: value.effective_at };
-	}
-	if (value.status === "awaiting_payment") {
-		return { kind: "pending", waitingFor: "payment" };
-	}
-	if (value.status === "awaiting_projection") {
-		return { kind: "pending", waitingFor: "update" };
-	}
-	throw invalidPlanChangeResponse();
-}
-
 /**
  * Generated deploy-api client facade. Request/response bodies come from
  * `packages/shared/src/api/deploy.generated.ts`; this hook only centralizes
@@ -436,14 +419,13 @@ export function createBillingClient(
 			body: ComputePlanChangeRequest,
 			onAccepted?: (operationName: string) => void,
 		): Promise<ComputePlanChangeResult> => {
-			const response: unknown = unwrapDeploy(
+			const response = unwrapDeploy(
 				await api.POST("/v2/subscription/plan/change", {
 					headers: { "Idempotency-Key": body.operation_id },
 					body,
 				}),
 			);
-			const legacy = legacyPlanChangeResult(response);
-			return legacy ?? waitForPlanChange(response, body.operation_id, onAccepted);
+			return waitForPlanChange(response, body.operation_id, onAccepted);
 		},
 		checkPlanChange: async (operationName: string) =>
 			getOperation(operationIdFromName(operationName)).then((value) => {

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -13,7 +13,6 @@ import {
 import { useCallback, useEffect, useRef } from "react";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
-	ComputeFixPaymentRequest,
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeRequest,
 	ComputePlanChangeResult,
@@ -22,19 +21,14 @@ import type {
 	ComputeSubscriptionResumeRequest,
 	HostedComputeSubscription,
 	HostedDeployment,
-	PortalRequest,
 } from "@/hosted/billing/contracts";
 import { billingQueryRetry } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import {
-	type SubscriptionCreateOutcomeView,
 	type SubscriptionCreateQuoteView,
-	type SubscriptionCreateRequestView,
 	type SubscriptionCreateSelection,
-	subscriptionCreateOutcome,
 	subscriptionCreateQuoteRequest,
 	subscriptionCreateQuoteView,
-	subscriptionCreateRequest,
 } from "@/hosted/billing/subscription/subscription-create-adapter";
 import {
 	deploymentPollingState,
@@ -163,25 +157,6 @@ export function usePlans() {
 	});
 }
 
-export function useCreateSubscription() {
-	const client = useBillingClient();
-	const qc = useQueryClient();
-	return useMutation<SubscriptionCreateOutcomeView, Error, SubscriptionCreateRequestView>({
-		mutationFn: async (request) => {
-			const apiRequest = subscriptionCreateRequest(request);
-			return subscriptionCreateOutcome(
-				await client.checkout(apiRequest.body, apiRequest.idempotencyKey),
-			);
-		},
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
-			qc.invalidateQueries({ queryKey: ["agents"] });
-		},
-	});
-}
-
 export function useSubscriptionCreateQuote(
 	selection: SubscriptionCreateSelection | null,
 	{ enabled = true }: { enabled?: boolean } = {},
@@ -248,20 +223,6 @@ export function useCancelSubscription() {
 		onSuccess: (next, body) => {
 			applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
 		},
-	});
-}
-
-export function usePortal() {
-	const client = useBillingClient();
-	return useMutation({
-		mutationFn: (body: PortalRequest) => client.portal(body),
-	});
-}
-
-export function useFixPayment() {
-	const client = useBillingClient();
-	return useMutation({
-		mutationFn: (body: ComputeFixPaymentRequest) => client.fixPayment(body),
 	});
 }
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { WalletLedgerEntry, WalletTopupResult } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
+import { WALLET_TOPUP_ACCEPTED_TOAST } from "@/hosted/billing/wallet/top-up-return.logic";
 import {
 	TOPUP_INCREMENT_CENTS,
 	TOPUP_MAX_CENTS,
@@ -62,8 +63,8 @@ export function completeTopup(
 	controls.resetAttempt();
 	controls.onComplete?.(status);
 	if (status === "succeeded") {
-		controls.toastInfo("Payment accepted", {
-			description: "We're confirming your Wallet credit now.",
+		controls.toastInfo(WALLET_TOPUP_ACCEPTED_TOAST.title, {
+			description: WALLET_TOPUP_ACCEPTED_TOAST.description,
 		});
 	} else {
 		controls.toastInfo("Payment processing", {

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -17,6 +17,11 @@ export interface WalletTopupReturnToast {
 	description: string;
 }
 
+export const WALLET_TOPUP_ACCEPTED_TOAST = {
+	title: "Payment accepted",
+	description: "We're confirming your Wallet credit now.",
+} as const;
+
 export function buildWalletTopupReturnUrl(currentHref: string): string {
 	const url = new URL(currentHref);
 	url.searchParams.set(SETTINGS_QUERY_KEY, "billing-wallet");
@@ -45,8 +50,7 @@ export function walletTopupReturnToast(status: string | null | undefined): Walle
 	if (status === "succeeded") {
 		return {
 			kind: "info",
-			title: "Payment accepted",
-			description: "We're confirming your Wallet credit now.",
+			...WALLET_TOPUP_ACCEPTED_TOAST,
 		};
 	}
 	if (status === "processing") {

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -111,9 +111,7 @@ export function WalletPage() {
 				const status = paymentIntent?.status;
 				showWalletTopupReturnToast(walletTopupReturnToast(status));
 				invalidateWalletActivity(queryClient);
-				if (status === "succeeded") {
-					void confirmWalletTopup(queryClient, paymentIntent?.id ?? null);
-				} else if (status === "processing" || status === "requires_capture") {
+				if (status === "succeeded" || status === "processing" || status === "requires_capture") {
 					void confirmWalletTopup(queryClient, paymentIntent?.id ?? null);
 				}
 			} catch {

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -255,7 +255,6 @@ describe("structural secret boundaries without the denylist", () => {
 		];
 		const legacyCallers: string[] = [];
 		for (const path of productionSourceFiles(sourceRoot)) {
-			if (path.endsWith("/hosted/billing/hooks.ts")) continue;
 			const contents = readFileSync(path, "utf8");
 			for (const hook of legacySensitiveHooks) {
 				if (new RegExp(`\\b${hook}\\s*\\(`).test(contents)) {

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -5,7 +5,7 @@ import {
 	defaultAiProviderModels,
 	defaultAiProviderRuntimeEnvName,
 } from "@clawdi/shared";
-import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import type { AiProvider, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 /**
  * The six AI provider types (backend `ProviderType`) with the defaults the
@@ -22,11 +22,7 @@ export const PROVIDER_TYPES = [
 ] as const;
 export type ProviderTypeId = (typeof PROVIDER_TYPES)[number];
 
-export type ApiMode =
-	| "openai_chat"
-	| "openai_responses"
-	| "anthropic_messages"
-	| "google_generate_content";
+export type ApiMode = NonNullable<AiProviderUpsert["api_mode"]>;
 
 export type ProviderCatalogModel = NonNullable<AiProvider["models"]>[number];
 


### PR DESCRIPTION
## Summary

- remove the unused legacy billing and terminal hooks, and make the sensitive-mutation boundary scan exhaustive
- drop the obsolete synchronous plan-change response shim after confirming the generated deploy client exposes only the `202 LongRunningOperation` response
- derive AI provider API modes from the generated upsert schema and fail Cloud navigation closed when hosted access cannot be loaded
- collapse duplicate Wallet settlement handling and share the accepted-payment toast copy

The deploy generated-client drift check already exists on `main` in `client-ci.yml`: contract-affecting PRs run it in network-tolerant warning mode, while the scheduled job runs it strictly. This PR leaves that existing minimal CI wiring unchanged.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bunx biome check apps/web/src`
- `bun test src/hosted/sensitive-boundaries.test.ts src/hosted/oss-clean.test.ts src/hosted/billing` (234 passed)
- `bun test src/lib/hosted-product-access.test.ts` (8 passed)
- `git diff --check`
