### PR TITLE
Release Clawdi CLI 0.13.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.17",
+      "version": "0.13.18",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.17",
+	"version": "0.13.18",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the immutable Clawdi CLI package version to 0.13.18
- publish the root-owned hosted Skill ledger authority fix from #624

## Verification

- #624 Client CI passed
- root manifest suite: 160 passed
- full CLI suite: 1465 passed, 4 skipped, 0 failed
- package/lockfile version exact match