### PR TITLE
Wait for npm provenance visibility

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -68,7 +68,17 @@ jobs:
           console.log(attestations.url);
           NODE
             )
-            attestation_bundle=$(curl --fail --silent --show-error --location "$attestation_url")
+            attestation_bundle=""
+            for attempt in $(seq 1 12); do
+              if attestation_bundle=$(curl --fail --silent --location "$attestation_url"); then
+                break
+              fi
+              if [ "$attempt" -lt 12 ]; then sleep 5; fi
+            done
+            if [ -z "$attestation_bundle" ]; then
+              echo "clawdi@$version provenance was not visible after 60 seconds" >&2
+              exit 69
+            fi
           fi
           release_json=null
           if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish,assets 2>/dev/null); then
@@ -335,7 +345,17 @@ jobs:
           console.log(attestations.url);
           NODE
           )
-          attestation_bundle=$(curl --fail --silent --show-error --location "$attestation_url")
+          attestation_bundle=""
+          for attempt in $(seq 1 12); do
+            if attestation_bundle=$(curl --fail --silent --location "$attestation_url"); then
+              break
+            fi
+            if [ "$attempt" -lt 12 ]; then sleep 5; fi
+          done
+          if [ -z "$attestation_bundle" ]; then
+            echo "clawdi@$VERSION provenance was not visible after 60 seconds" >&2
+            exit 69
+          fi
           tag="clawdi-cli-v$VERSION"
           release_json=null
           if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish,assets 2>/dev/null); then

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -143,7 +143,7 @@ describe("CLI publish workflow contract", () => {
 			'if [ "$NPM_ACTION" = "publish" ] && npm_release_visible; then',
 		);
 		const publishDecision = workflow.indexOf('case "$NPM_ACTION" in');
-		const visibilityWait = workflow.indexOf("for attempt in $(seq 1 12); do");
+		const visibilityWait = workflow.indexOf("for attempt in $(seq 1 12); do", publishDecision);
 		const integrityRead = workflow.indexOf(
 			'published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)',
 		);
@@ -155,6 +155,15 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain('if [ "$attempt" -lt 12 ]; then sleep 5; fi');
 		expect(workflow).toContain(
 			'echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2',
+		);
+		expect(workflow.match(/attestation_bundle=\$\(curl --fail --silent --location/g)).toHaveLength(
+			2,
+		);
+		expect(workflow).toContain(
+			'echo "clawdi@$VERSION provenance was not visible after 60 seconds" >&2',
+		);
+		expect(workflow).toContain(
+			'echo "clawdi@$version provenance was not visible after 60 seconds" >&2',
 		);
 	});
 


### PR DESCRIPTION
## Summary

- wait for the exact npm attestation bundle at both release recovery boundaries
- keep integrity, provenance and source-commit validation fail-closed
- cover the two bounded provenance reads in the workflow contract

## Incident

`clawdi@0.13.18` published successfully with provenance, then its newly advertised attestation URL returned a transient 404. The failed-job recovery succeeded once the bundle propagated.

## Verification

- `bun test packages/cli/tests/cli-publish-workflow.test.ts` (6 passed)
- `bun run typecheck`
- Biome
- `git diff --check`