### PR TITLE
fix(cli): preload hosted skill source before privilege drop

### DIFF
--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
 	adoptableLegacyHostedBundledSkill,
+	loadHostedBundledSkill,
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
@@ -51,9 +52,7 @@ describe("hosted bundled skill reconciliation", () => {
 		activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
 	) {
 		return reconcileHostedBundledSkill({
-			skillId: "clawdi",
-			version: 1,
-			sourceDir,
+			bundle: loadHostedBundledSkill("clawdi", 1, sourceDir),
 			targetDir,
 			activation,
 		});
@@ -229,23 +228,30 @@ describe("hosted bundled skill reconciliation", () => {
 		expect(existsSync(targetDir)).toBe(false);
 	});
 
+	it("materializes only from the verified in-memory bundle", () => {
+		const copiedSource = join(root, "captured-source");
+		cpSync(bundledSourceDir, copiedSource, { recursive: true });
+		const bundle = loadHostedBundledSkill("clawdi", 1, copiedSource);
+		rmSync(copiedSource, { recursive: true });
+
+		expect(
+			reconcileHostedBundledSkill({
+				bundle,
+				targetDir,
+			}),
+		).toBe("replaced");
+		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
+			readFileSync(join(bundledSourceDir, "SKILL.md")),
+		);
+	});
+
 	it("fails closed for unknown ids, unknown versions, and unmanaged targets", () => {
-		expect(() =>
-			reconcileHostedBundledSkill({
-				skillId: "unknown",
-				version: 1,
-				sourceDir: bundledSourceDir,
-				targetDir,
-			}),
-		).toThrow("no bundled hosted skill is registered for unknown");
-		expect(() =>
-			reconcileHostedBundledSkill({
-				skillId: "clawdi",
-				version: 2,
-				sourceDir: bundledSourceDir,
-				targetDir,
-			}),
-		).toThrow("no bundled hosted skill clawdi version 2 is registered");
+		expect(() => loadHostedBundledSkill("unknown", 1, bundledSourceDir)).toThrow(
+			"no bundled hosted skill is registered for unknown",
+		);
+		expect(() => loadHostedBundledSkill("clawdi", 2, bundledSourceDir)).toThrow(
+			"no bundled hosted skill clawdi version 2 is registered",
+		);
 
 		mkdirSync(targetDir, { recursive: true });
 		writeFileSync(join(targetDir, "SKILL.md"), "user owned\n");

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
 	chmodSync,
-	cpSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
@@ -63,14 +62,24 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 ]);
 
 export interface ReconcileHostedBundledSkillInput {
-	skillId: string;
-	version: number;
-	sourceDir: string;
+	bundle: HostedBundledSkillBundle;
 	targetDir: string;
 	/** A root-owned reservation for this exact target authorizes replacement. */
 	reserved?: boolean;
 	/** Deterministic failure hooks for the shared activation contract. */
 	activation?: ManagedSkillDirectoryActivationOptions;
+}
+
+interface HostedBundledSkillFile {
+	readonly relativePath: string;
+	readonly mode: 0o644 | 0o755;
+	/** Base64 keeps the captured bytes immutable across the privilege boundary. */
+	readonly contentBase64: string;
+}
+
+export interface HostedBundledSkillBundle {
+	readonly catalogEntry: HostedBundledSkillCatalogEntry;
+	readonly files: readonly HostedBundledSkillFile[];
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -271,11 +280,46 @@ export function assertHostedBundledSkillCatalogDigest(
 	}
 }
 
+export function loadHostedBundledSkill(
+	skillId: string,
+	version: number,
+	sourceDir: string,
+): HostedBundledSkillBundle {
+	const catalogEntry = resolveHostedBundledSkill(skillId, version);
+	const sourceFiles: ManagedBundleHashEntry[] = [];
+	const stat = lstatSync(sourceDir);
+	if (!stat.isDirectory()) {
+		throw new Error(`bundled hosted skill path is not a directory: ${sourceDir}`);
+	}
+	collectHostedBundledSkillFiles(sourceDir, "", false, false, sourceFiles);
+	if (computeManagedBundleHash(sourceFiles) !== catalogEntry.digest) {
+		throw new Error(
+			`bundled hosted skill catalog digest mismatch for ${catalogEntry.id} version ${catalogEntry.version}`,
+		);
+	}
+	const files = sourceFiles.map((file) =>
+		Object.freeze({
+			relativePath: file.relativePath,
+			mode: canonicalManagedBundleFileMode(file.mode),
+			contentBase64: Buffer.from(file.content).toString("base64"),
+		}),
+	);
+	return Object.freeze({ catalogEntry, files: Object.freeze(files) });
+}
+
+function materializeHostedBundledSkill(bundle: HostedBundledSkillBundle, targetDir: string): void {
+	mkdirSync(targetDir, { recursive: true, mode: HOSTED_BUNDLED_SKILL_DIRECTORY_MODE });
+	for (const file of bundle.files) {
+		const path = join(targetDir, file.relativePath);
+		mkdirSync(dirname(path), { recursive: true, mode: HOSTED_BUNDLED_SKILL_DIRECTORY_MODE });
+		writeFileSync(path, Buffer.from(file.contentBase64, "base64"), { mode: file.mode });
+	}
+}
+
 export function reconcileHostedBundledSkill(
 	input: ReconcileHostedBundledSkillInput,
 ): "unchanged" | "replaced" {
-	const catalogEntry = resolveHostedBundledSkill(input.skillId, input.version);
-	assertHostedBundledSkillCatalogDigest(catalogEntry, input.sourceDir);
+	const catalogEntry = input.bundle.catalogEntry;
 	const marker: HostedBundledSkillMarker = {
 		schema: HOSTED_BUNDLED_SKILL_MARKER_SCHEMA,
 		owner: HOSTED_BUNDLED_SKILL_OWNER,
@@ -306,7 +350,7 @@ export function reconcileHostedBundledSkill(
 	const stagedTarget = join(stagingRoot, basename(input.targetDir));
 	const trash = join(parent, `.${basename(input.targetDir)}-trash-${process.pid}-${randomUUID()}`);
 	try {
-		cpSync(input.sourceDir, stagedTarget, { recursive: true });
+		materializeHostedBundledSkill(input.bundle, stagedTarget);
 		normalizeHostedBundledSkillModes(stagedTarget);
 		if (hostedBundledSkillDigest(stagedTarget, false, true) !== catalogEntry.digest) {
 			throw new Error(

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	chownSync,
+	cpSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -14,7 +15,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { commitRuntimeAppliedState } from "../commands/runtime";
 import {
@@ -22,6 +23,7 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "./applied-state";
+import { loadHostedBundledSkill } from "./hosted-bundled-skill";
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
@@ -3717,6 +3719,18 @@ describe("runtime manifest reconciliation invariants", () => {
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
 		const skillDir = join(paths.userHome, ".hermes", "skills", "clawdi");
 		const ledger = join(paths.projectionRoot, "managed-skills.json");
+		const cliRoot = resolve(import.meta.dir, "../..");
+		const skillSource = join(cliRoot, "skills", "hosted-versions", "1", "clawdi");
+		const protectedSourceAncestors = [
+			skillSource,
+			dirname(skillSource),
+			dirname(dirname(skillSource)),
+			dirname(dirname(dirname(skillSource))),
+			cliRoot,
+		];
+		const originalSourceModes = new Map(
+			protectedSourceAncestors.map((path) => [path, statSync(path).mode & 0o777]),
+		);
 		const runtimeUid = Number.parseInt(
 			execFileSync("id", ["-u", "nobody"], { encoding: "utf8" }).trim(),
 			10,
@@ -3749,35 +3763,64 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
 		);
-
-		const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-hermes-skill"), paths);
-
-		expect(result.installErrors).toEqual([]);
-		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toContain("# Clawdi");
-		expect(statSync(skillDir).uid).toBe(runtimeUid);
-		expect(statSync(join(skillDir, "SKILL.md")).uid).toBe(runtimeUid);
-		expect(statSync(paths.projectionRoot).uid).toBe(0);
-		expect(statSync(paths.projectionRoot).mode & 0o777).toBe(0o755);
-		expect(statSync(ledger).uid).toBe(0);
-		expect(statSync(ledger).mode & 0o022).toBe(0);
-
-		expect(() =>
-			execFileSync("runuser", ["-u", "nobody", "--", "test", "-w", paths.projectionRoot]),
-		).toThrow();
-
-		const removal = convergeRuntimeManifest(
-			manifestLoad(
-				{ ...manifest, projection: { skills: { entries: {} } } },
-				"inline-hermes-skill-removal",
-			),
-			paths,
+		const driftedSource = join(fixtureRoot, "drifted-skill-source");
+		cpSync(skillSource, driftedSource, { recursive: true });
+		writeFileSync(join(driftedSource, "SKILL.md"), "catalog drift\n");
+		expect(() => loadHostedBundledSkill("clawdi", 1, driftedSource)).toThrow(
+			"catalog digest mismatch",
 		);
 
-		expect(removal.installErrors).toEqual([]);
-		expect(existsSync(skillDir)).toBe(false);
-		expect(readFileSync(ledger, "utf8")).not.toContain(skillDir);
-		expect(statSync(ledger).uid).toBe(0);
-		expect(statSync(ledger).mode & 0o022).toBe(0);
+		for (const path of protectedSourceAncestors) chmodSync(path, 0o700);
+		try {
+			for (const path of protectedSourceAncestors) {
+				expect(() => execFileSync("runuser", ["-u", "nobody", "--", "test", "-x", path])).toThrow();
+			}
+			expect(() =>
+				execFileSync("runuser", [
+					"-u",
+					"nobody",
+					"--",
+					"test",
+					"-r",
+					join(skillSource, "SKILL.md"),
+				]),
+			).toThrow();
+			const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-hermes-skill"), paths);
+			expect(result.installErrors).toEqual([]);
+			expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toContain("# Clawdi");
+			expect(statSync(skillDir).uid).toBe(runtimeUid);
+			expect(statSync(join(skillDir, "SKILL.md")).uid).toBe(runtimeUid);
+			expect(statSync(paths.projectionRoot).uid).toBe(0);
+			expect(statSync(paths.projectionRoot).mode & 0o777).toBe(0o755);
+			expect(statSync(ledger).uid).toBe(0);
+			expect(statSync(ledger).mode & 0o022).toBe(0);
+			for (const path of protectedSourceAncestors) {
+				expect(statSync(path).mode & 0o777).toBe(0o700);
+			}
+
+			expect(() =>
+				execFileSync("runuser", ["-u", "nobody", "--", "test", "-w", paths.projectionRoot]),
+			).toThrow();
+
+			const removal = convergeRuntimeManifest(
+				manifestLoad(
+					{ ...manifest, projection: { skills: { entries: {} } } },
+					"inline-hermes-skill-removal",
+				),
+				paths,
+			);
+
+			expect(removal.installErrors).toEqual([]);
+			expect(existsSync(skillDir)).toBe(false);
+			expect(readFileSync(ledger, "utf8")).not.toContain(skillDir);
+			expect(statSync(ledger).uid).toBe(0);
+			expect(statSync(ledger).mode & 0o022).toBe(0);
+			for (const path of protectedSourceAncestors) {
+				expect(statSync(path).mode & 0o777).toBe(0o700);
+			}
+		} finally {
+			for (const [path, mode] of [...originalSourceModes].reverse()) chmodSync(path, mode);
+		}
 	});
 
 	test("rolls back root managed state and leaves user projections for forward convergence", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -67,6 +67,7 @@ import {
 	adoptableLegacyHostedBundledSkill,
 	assertHostedBundledSkillCatalogDigest,
 	hostedBundledSkillIds,
+	loadHostedBundledSkill,
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
@@ -3563,6 +3564,13 @@ function applyHostedBundledSkills(
 			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
 		}
 		const bundled = catalogEntry;
+		// Root captures and verifies the source before the callback drops to the
+		// runtime identity. The callback can only mutate the target from bytes.
+		const bundle = loadHostedBundledSkill(
+			skillName,
+			desired.version,
+			hostedBundledSkillSourceDir(bundled.assetDirectory),
+		);
 		const result = installReservedManagedSkill(
 			{
 				targetDir,
@@ -3574,18 +3582,13 @@ function applyHostedBundledSkills(
 			() =>
 				withRuntimeUserFileAccess(() =>
 					reconcileHostedBundledSkill({
-						skillId: skillName,
-						version: desired.version,
-						sourceDir: hostedBundledSkillSourceDir(bundled.assetDirectory),
+						bundle,
 						targetDir,
 						reserved: true,
 					}),
 				),
 		);
 		if (result === "unchanged") continue;
-		makeRuntimeUserOwnedAncestors(targetDir, home);
-		makeRuntimeUserOwned(targetDir);
-		for (const entry of readdirSync(targetDir)) makeRuntimeUserOwned(join(targetDir, entry));
 	}
 	return targets;
 }


### PR DESCRIPTION
## Summary

- capture bundled hosted Skill files as an immutable, base64-backed in-memory bundle under root authority
- verify the captured bundle against the pinned catalog digest before entering the runtime UID filesystem scope
- materialize and atomically activate only from captured bytes as the runtime UID, without expanding managed CLI access or root-writing the runtime tree
- preserve the root-owned managed-skills reservation ledger and existing activation rollback contract

## Regression coverage

- root Docker regression makes every bundled Skill source ancestor from the Skill directory through the CLI package root mode 0700 and verifies the runtime UID cannot traverse or read it
- verifies catalog digest drift rejection, install and removal, root ledger ownership/mode, runtime-user target ownership, and unchanged source permissions
- unit regression removes the source after capture and proves reconciliation uses only the verified in-memory bundle

## Verification

- root Docker focused regression: 1 pass, 31 assertions
- full root manifest suite: 160 pass, 0 fail, 1106 assertions
- full CLI clean-runner suite: 1466 pass, 4 skipped, 0 fail, 6774 assertions
- packages/cli typecheck: pass
- Biome focused check: pass
- git diff --check: pass

This PR is intentionally unmerged. No production, tenant, database, Kubernetes, release, or deployment operations were performed.