### PR TITLE
fix(cli): hand off before runtime convergence

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1195,6 +1195,11 @@ interface RuntimeVerifyOptions {
 	json?: boolean;
 }
 
+// The image bootstrap is a RemainAfterExit oneshot with Restart=on-failure.
+// A dedicated temporary-failure exit makes it start the newly activated CLI;
+// runtime watch instead exits cleanly because its unit uses Restart=always.
+const RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE = 75;
+
 interface RuntimeDoctorCheck {
 	name: string;
 	ok: boolean;
@@ -1212,6 +1217,7 @@ interface MinimumCliVersionGate {
 
 type RuntimeApplyResult =
 	| RuntimeApplyConvergedResult
+	| RuntimeApplyCliHandoffResult
 	| RuntimeApplyGatedResult
 	| RuntimeApplyCliUpdateFailedResult;
 
@@ -1226,6 +1232,11 @@ interface RuntimeApplyGatedResult {
 	kind: "minimum_cli_version_gated";
 	cliUpdate: RuntimeCliUpdateResult;
 	gate: MinimumCliVersionGate;
+}
+
+interface RuntimeApplyCliHandoffResult {
+	kind: "cli_handoff";
+	cliUpdate: RuntimeCliUpdateResult;
 }
 
 interface RuntimeApplyCliUpdateFailedResult {
@@ -1945,6 +1956,10 @@ function emitRuntimeWatchEvent(value: unknown, json: boolean | undefined): void 
 		console.log(`runtime watch applied generation ${event.generation ?? "unknown"}`);
 		return;
 	}
+	if (event.status === "cli_handoff") {
+		console.log("runtime watch handed off to the managed CLI");
+		return;
+	}
 	if (event.status === "error") {
 		console.error(`runtime watch error: ${event.error ?? event.errors?.[0] ?? "unknown error"}`);
 	}
@@ -1978,6 +1993,67 @@ function repairStatus(
 		},
 		paths,
 	);
+}
+
+function finishRuntimeInitCliHandoff(input: {
+	opts: RuntimeInitOptions;
+	paths: ReturnType<typeof getRuntimePaths>;
+	mode: "hosted";
+	bootId: string;
+	hostPolicy: ReturnType<typeof readHostPolicy>;
+	manifestLoad?: RuntimeManifestLoad;
+	detail:
+		| { cliUpdate: RuntimeCliUpdateResult }
+		| { reconciliation: RuntimeCliReconciliationResult };
+}): void {
+	const activeAppliedState = readRuntimeAppliedState(input.paths);
+	const status = buildRuntimeBootStatus(
+		{
+			mode: input.manifestLoad?.offline ? "degraded-offline" : "normal",
+			status: "ok",
+			stage: "config",
+			bootId: input.bootId,
+			runtimeMode: input.mode,
+			activeGeneration: activeAppliedState?.generation ?? null,
+			rejectedGeneration: null,
+			instanceId: activeAppliedState?.instanceId ?? null,
+			enabledRuntimes: [],
+			errors: [],
+			exitCode: RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE,
+			datasource: "RuntimeSource",
+			hostPolicy: hostPolicySummary(input.hostPolicy),
+			...(input.manifestLoad
+				? {
+						manifestSource: {
+							type: input.manifestLoad.source,
+							path: input.manifestLoad.sourcePath,
+							offline: input.manifestLoad.offline,
+						},
+					}
+				: {}),
+		},
+		input.paths,
+	);
+	writeRuntimeBootStatus(status, input.paths);
+	if (input.opts.json || !process.stdout.isTTY) {
+		console.log(
+			JSON.stringify(
+				{
+					...status,
+					handoff: "cli_reexec",
+					...input.detail,
+					selfReexec: true,
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		console.log(chalk.bold("clawdi runtime init"));
+		console.log(chalk.green("  CLI activated; restarting under the managed binary"));
+		console.log(chalk.gray(`  status: ${input.paths.bootStatus}`));
+	}
+	process.exitCode = RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE;
 }
 
 export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
@@ -2074,6 +2150,37 @@ async function runtimeInitLocked(
 		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
 		else console.log(chalk.red(status.error));
 		process.exitCode = 20;
+		return;
+	}
+	try {
+		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
+		if (reconciliation.selfReexec) {
+			finishRuntimeInitCliHandoff({
+				opts,
+				paths,
+				mode,
+				bootId,
+				hostPolicy,
+				detail: { reconciliation },
+			});
+			return;
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const status = repairStatus(
+			{
+				bootId,
+				runtimeMode: mode,
+				stage: "local",
+				exitCode: 23,
+				errors: [message],
+			},
+			paths,
+		);
+		writeRuntimeBootStatus(status, paths);
+		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
+		else console.log(chalk.red(message));
+		process.exitCode = 23;
 		return;
 	}
 
@@ -2222,6 +2329,18 @@ async function runtimeInitLocked(
 			process.exitCode = 23;
 			return;
 		}
+		if (applyResult.kind === "cli_handoff") {
+			finishRuntimeInitCliHandoff({
+				opts,
+				paths,
+				mode,
+				bootId,
+				hostPolicy,
+				manifestLoad: convergenceLoad,
+				detail: { cliUpdate: applyResult.cliUpdate },
+			});
+			return;
+		}
 		if (applyResult.kind === "minimum_cli_version_gated") {
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			const status = buildRuntimeBootStatus(
@@ -2268,6 +2387,7 @@ async function runtimeInitLocked(
 		const { convergence } = applyResult;
 		const runtimeErrors = [...convergence.installErrors];
 		const installOk = runtimeErrors.length === 0;
+		if (installOk) completePendingRuntimeCliUpgrade(paths, getCliVersion());
 		const activeAppliedState = readRuntimeAppliedState(paths);
 		const status = buildRuntimeBootStatus(
 			{
@@ -2373,6 +2493,16 @@ async function runtimeWatchTickLocked(
 			selfReexec: false,
 		};
 	}
+	if (reconciliation.selfReexec) {
+		return {
+			schemaVersion: "clawdi.runtimeWatchEvent.v1",
+			status: "cli_handoff",
+			stage: "cli-update",
+			handoff: "cli_reexec",
+			reconciliation,
+			selfReexec: true,
+		};
+	}
 	const event = await runtimeWatchTickAfterCliReconciliation(paths, opts);
 	return {
 		...event,
@@ -2473,6 +2603,26 @@ async function runtimeWatchTickAfterCliReconciliation(
 			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
 			requireSystemdApplied: applyIdentity !== null,
 		});
+		if (applyResult.kind === "cli_handoff") {
+			const activeAppliedState = readRuntimeAppliedState(paths);
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "cli_handoff",
+				stage: "cli-update",
+				handoff: "cli_reexec",
+				activeGeneration: activeAppliedState?.generation ?? null,
+				desiredGeneration: loaded.manifest.generation,
+				instanceId: activeAppliedState?.instanceId ?? null,
+				cliUpdate: applyResult.cliUpdate,
+				selfReexec: true,
+				systemdUnitsChanged: false,
+				systemdApply: {
+					applied: false,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				},
+			};
+		}
 		if (applyResult.kind === "cli_update_failed") {
 			const error = applyResult.cliUpdate.error ?? "CLI update failed";
 			const activeAppliedState = readRuntimeAppliedState(paths);
@@ -2486,7 +2636,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 				rejectedGeneration: loaded.manifest.generation,
 				instanceId: activeAppliedState?.instanceId ?? null,
 				cliUpdate: applyResult.cliUpdate,
-				selfReexec: shouldSelfReexecForCliUpdate(applyResult.cliUpdate),
+				selfReexec: applyResult.cliUpdate.selfReexec,
 				systemdUnitsChanged: false,
 				systemdApply: {
 					applied: false,
@@ -2511,7 +2661,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 				activeGeneration: applyResult.gate.activeGeneration,
 				rejectedGeneration: applyResult.gate.rejectedGeneration,
 				cliUpdate: applyResult.cliUpdate,
-				selfReexec: shouldSelfReexecForCliUpdate(applyResult.cliUpdate),
+				selfReexec: applyResult.cliUpdate.selfReexec,
 				gate: applyResult.gate,
 			};
 		}
@@ -2519,7 +2669,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 		const cliUpdateError =
 			cliUpdate.status === "error" ? (cliUpdate.error ?? "CLI update failed") : null;
 		const errors = [...(cliUpdateError ? [cliUpdateError] : []), ...convergence.installErrors];
-		let selfReexec = shouldSelfReexecForCliUpdate(cliUpdate);
+		let selfReexec = cliUpdate.selfReexec;
 		const systemdUnitsChanged =
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
 			systemdApplyResult.userUnitsChanged.length > 0;
@@ -2593,7 +2743,7 @@ function applyRuntimeDesiredState(
 		};
 	}
 	if (cliUpdate.selfReexec) {
-		return { kind: "cli_update_failed", cliUpdate };
+		return { kind: "cli_handoff", cliUpdate };
 	}
 	const gate = minimumCliVersionGate(load.manifest, paths);
 	if (gate) {
@@ -2722,13 +2872,6 @@ function runtimeCliUpdateError(
 		selfReexec: false,
 		error: error instanceof Error ? error.message : String(error),
 	};
-}
-
-function shouldSelfReexecForCliUpdate(cliUpdate: RuntimeCliUpdateResult): boolean {
-	if (cliUpdate.selfReexec) return true;
-	if (cliUpdate.status === "installed") return true;
-	if (!cliUpdate.version || !cliUpdate.activeTarget) return false;
-	return cliUpdate.version !== getCliVersion();
 }
 
 function runtimeManifestIdentityForWatch(

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -35,6 +35,8 @@ export interface RuntimeCliUpdateResult {
 	activePath: string;
 	activeTarget: string | null;
 	version: string | null;
+	// The active managed target no longer matches the code in this process.
+	// Callers must stop before manifest convergence or any authority side effect.
 	selfReexec: boolean;
 	error?: string | null;
 }
@@ -332,13 +334,18 @@ export function applyRuntimeCliDesiredState(
 	);
 	activateCliUpgradeTransaction(paths);
 	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousIdentity?.npmPrefix ?? null]);
-	return baseResult("installed", paths, {
-		packageSpec,
-		registry,
-		npmPrefix: installed.npmPrefix,
-		activeTarget: installed.activeTarget,
-		version: installed.version,
-	});
+	return baseResult(
+		"installed",
+		paths,
+		{
+			packageSpec,
+			registry,
+			npmPrefix: installed.npmPrefix,
+			activeTarget: installed.activeTarget,
+			version: installed.version,
+		},
+		true,
+	);
 }
 
 type RuntimeCliResultValues = Pick<
@@ -1161,7 +1168,7 @@ function reconcileCliUpgradeTransaction(
 	const state = readCliUpgradeState(paths);
 	if (state.migratedFromV1) writeCliUpgradeState(paths, state);
 	const transaction = state.transaction ?? null;
-	if (!transaction) return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
+	if (!transaction) return { status: "unchanged", selfReexec: false };
 	if (transaction.rollback) {
 		finishCliRollback(paths, transaction);
 		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
@@ -1228,7 +1235,6 @@ function cliReconciliationResult(
 	return {
 		status,
 		selfReexec:
-			status !== "unchanged" &&
 			runningVersion !== undefined &&
 			activeVersion !== undefined &&
 			activeVersion !== runningVersion,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -26,6 +26,7 @@ import {
 	runtimePublicContentRevision,
 	runtimeWatch,
 } from "../src/commands/runtime";
+import { getCliVersion } from "../src/lib/version";
 import {
 	readRuntimeAppliedState,
 	runtimeContentSha256,
@@ -7934,7 +7935,7 @@ fi
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
 	});
 
-	it("runtime watch installs changed CLI package specs and marks itself for re-exec", async () => {
+	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7944,6 +7945,7 @@ fi
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -7970,7 +7972,7 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "0.13.1-beta.0"
+  echo "${currentVersion}"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -8025,7 +8027,7 @@ chmod +x "$prefix/bin/clawdi"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@0.13.1-beta.0",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -8052,27 +8054,49 @@ chmod +x "$prefix/bin/clawdi"
 			const activeTarget = readlinkSync(active);
 			expect(readlinkSync(active)).toBe(activeTarget);
 			const status = JSON.parse(readFileSync(join(state, "status", "cli-bootstrap.json"), "utf-8"));
-			expect(status.packageSpec).toBe("clawdi@0.13.1-beta.0");
+			expect(status.packageSpec).toBe(`clawdi@${currentVersion}`);
 			expect(status.activePath).toBe(active);
 			expect(status.activeTarget).toBe(activeTarget);
 			expect(status.npmPrefix.startsWith(join(state, "npm", "packages"))).toBe(true);
 			expect(activeTarget).toBe(join(status.npmPrefix, "bin", "clawdi"));
 			expect(activeTarget).not.toBe(sharedPrefixTarget);
-			expect(status.version).toBe("0.13.1-beta.0");
+			expect(status.version).toBe(currentVersion);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("applied");
+			expect(event.status).toBe("cli_handoff");
+			expect(event.handoff).toBe("cli_reexec");
 			expect(event.selfReexec).toBe(true);
 			expect(event.cliUpdate.status).toBe("installed");
-			expect(event.cliUpdate.packageSpec).toBe("clawdi@0.13.1-beta.0");
-			expect(event.systemdUnitsChanged).toBe(true);
+			expect(event.cliUpdate.packageSpec).toBe(`clawdi@${currentVersion}`);
+			expect(event.systemdUnitsChanged).toBe(false);
 			expect(event.systemdApply).toEqual({
 				applied: false,
-				systemUnitsChanged: [
-					"clawdi-daemon.service",
-					"clawdi-runtime-sidecar.service",
-					"clawdi-runtime-watch.service",
-				],
-				userUnitsChanged: ["openclaw-gateway.service"],
+				systemUnitsChanged: [],
+				userUnitsChanged: [],
+			});
+			const paths = getRuntimePaths();
+			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
+			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
+			expect(existsSync(paths.manifestLastGood)).toBe(false);
+			expect(existsSync(paths.appliedState)).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: { phase: "activated" },
+				badVersions: [],
+			});
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(captured).toHaveLength(2);
+			const completedEvent = JSON.parse(logs[0]);
+			expect(completedEvent.status).toBe("applied");
+			expect(completedEvent.selfReexec).toBe(false);
+			expect(completedEvent.cliUpdate.status).toBe("current");
+			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: null,
+				badVersions: [],
 			});
 		} finally {
 			restore();
@@ -8632,6 +8656,7 @@ exit 0
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -8657,7 +8682,7 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "0.13.2-beta.0"
+  echo "${currentVersion}"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -8799,7 +8824,7 @@ fi
 								egressEngine: mitmproxy,
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@0.13.2-beta.0",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -8832,9 +8857,19 @@ fi
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
+			const handoff = JSON.parse(logs[0]);
+			expect(handoff.status).toBe("cli_handoff");
+			expect(handoff.selfReexec).toBe(true);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(0);
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("applied");
-			expect(event.selfReexec).toBe(true);
+			expect(event.selfReexec).toBe(false);
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
@@ -8922,6 +8957,7 @@ chmod +x "$prefix/bin/clawdi"
 			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
 
 			expect(result.status).toBe("installed");
+			expect(result.selfReexec).toBe(true);
 			expect(result.packageSpec).toBe(desiredSpec);
 			expect(result.version).toBe(desiredVersion);
 			expect(result.activePath).toBe(join(state, "managed-cli", "bin", "clawdi"));
@@ -8992,6 +9028,28 @@ chmod +x "$prefix/bin/clawdi"
 			version: newIdentity.version,
 		});
 		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
+	});
+
+	it("keeps an old process behind the handoff fence for an activated transaction", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-activated-old-process"),
+			join(root, "run-cli-activated-old-process"),
+		);
+		pointManagedCliAt(paths, newIdentity);
+		writeCliBootstrapFixture(paths, newIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity,
+		});
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
+
+		expect(recovered).toEqual({ status: "unchanged", selfReexec: true });
+		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+			transaction: { phase: "activated", newIdentity },
+			badVersions: [],
+		});
 	});
 
 	it("rolls back an activated CLI transaction whose new target is invalid", () => {
@@ -9560,7 +9618,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch self-heal applies an exact hosted CLI version without npm view", async () => {
+	it("runtime watch self-heal installs an exact hosted CLI version and hands off", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9721,7 +9779,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(captured[0].headers["if-none-match"]).toBe(bundleEtag);
 			expect(captured[1].headers["if-none-match"]).toBeUndefined();
 			const events = logs.map((line) => JSON.parse(line));
-			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
+			expect(events.map((event) => event.status)).toEqual(["not_modified", "cli_handoff"]);
 			expect(events[1].cliUpdate).toEqual(
 				expect.objectContaining({
 					status: "installed",
@@ -9743,7 +9801,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch keeps self re-exec when convergence fails after CLI install", async () => {
+	it("runtime watch never enters a failing projection after CLI activation", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9883,14 +9941,15 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(1);
+			expect(process.exitCode).toBe(0);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("error");
+			expect(event.status).toBe("cli_handoff");
 			expect(event.cliUpdate.status).toBe("installed");
 			expect(event.selfReexec).toBe(true);
-			expect(event.errors[0]).toContain("runtime openclaw provider projection failed");
-			expect(event.errors[0]).toContain("projection boom");
+			expect(event.errors).toBeUndefined();
+			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(false);
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
+			expect(existsSync(getRuntimePaths().appliedState)).toBe(false);
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -9911,6 +9970,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -9921,7 +9981,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 set -euo pipefail
 printf '%s\\n' "$*" >> '${npmLog}'
 if [ "\${1:-}" = "view" ]; then
-  echo '"0.13.5-beta.0"'
+  echo '"${currentVersion}"'
   exit 0
 fi
 prefix=""
@@ -9937,7 +9997,7 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "0.13.5-beta.0"
+  echo "${currentVersion}"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -9974,7 +10034,7 @@ chmod +x "$prefix/bin/clawdi"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(state, "clawdi@0.13.4-beta.0", "0.13.4-beta.0");
+		seedCurrentCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
 		const paths = getRuntimePaths();
 		const oldTarget = readlinkSync(paths.cliManagedBin);
 		const manifest = {
@@ -9992,7 +10052,7 @@ chmod +x "$prefix/bin/clawdi"
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@0.13.5-beta.0",
+				packageSpec: `clawdi@${currentVersion}`,
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: {
@@ -10034,20 +10094,35 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
+			expect(process.exitCode).toBe(0);
+			const handoffEvent = JSON.parse(logs[0]);
+			expect(handoffEvent.status).toBe("cli_handoff");
+			expect(handoffEvent.cliUpdate.status).toBe("installed");
+			expect(handoffEvent.cliRollback).toBeUndefined();
+			expect(readlinkSync(paths.cliManagedBin)).not.toBe(oldTarget);
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
+				badVersions: [],
+			});
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
 			expect(process.exitCode).toBe(1);
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("error");
-			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.cliUpdate.status).toBe("current");
 			expect(event.cliRollback.status).toBe("rolled_back");
-			expect(event.cliRollback.version).toBe("0.13.5-beta.0");
+			expect(event.cliRollback.version).toBe(currentVersion);
 			expect(event.selfReexec).toBe(true);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
 			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
 			expect(upgradeState.transaction).toBeNull();
 			expect(upgradeState.badVersions).toContainEqual(
 				expect.objectContaining({
-					packageSpec: "clawdi@0.13.5-beta.0",
-					version: "0.13.5-beta.0",
+					packageSpec: `clawdi@${currentVersion}`,
+					version: currentVersion,
 				}),
 			);
 			const beforeRetryLog = readFileSync(npmLog, "utf-8");
@@ -10063,7 +10138,7 @@ chmod +x "$prefix/bin/clawdi"
 						controlPlane: { apiUrl: "https://cloud-api.test" },
 						clawdiCli: {
 							source: "npm:clawdi",
-							packageSpec: "clawdi@0.13.5-beta.0",
+							packageSpec: `clawdi@${currentVersion}`,
 							registry: "https://registry.npmjs.org",
 						},
 						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
@@ -10085,7 +10160,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch does not converge or apply systemd when CLI install fails", async () => {
+	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -10094,11 +10169,48 @@ chmod +x "$prefix/bin/clawdi"
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
+		const firstAttempt = join(root, "npm-etarget-first-attempt");
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		seedOpenClawBinary(home);
-		writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\necho npm down >&2\nexit 42\n");
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ ! -e '${firstAttempt}' ]; then
+  touch '${firstAttempt}'
+  echo 'npm ERR! code ETARGET' >&2
+  echo 'npm ERR! notarget No matching version found' >&2
+  exit 1
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${currentVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
 		chmodSync(join(bin, "npm"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.HOME = home;
@@ -10142,7 +10254,7 @@ chmod +x "$prefix/bin/clawdi"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@0.13.4-beta.0",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -10164,6 +10276,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.status).toBe("error");
 			expect(event.stage).toBe("cli-update");
 			expect(event.cliUpdate.status).toBe("error");
+			expect(event.error).toContain("ETARGET");
 			expect(event.activeGeneration).toBeNull();
 			expect(event.rejectedGeneration).toBe(17);
 			const paths = getRuntimePaths();
@@ -10178,6 +10291,21 @@ chmod +x "$prefix/bin/clawdi"
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 			expect(existsSync(paths.appliedState)).toBe(false);
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(0);
+			const handoff = JSON.parse(logs[0]);
+			expect(handoff.status).toBe("cli_handoff");
+			expect(handoff.cliUpdate.status).toBe("installed");
+			expect(handoff.cliRollback).toBeUndefined();
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
+				badVersions: [],
+			});
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -10187,7 +10315,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runs CLI update before blocking desired state below minimumCliVersion", async () => {
+	it("hands off before evaluating minimumCliVersion under old code", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -10286,14 +10414,13 @@ chmod +x "$prefix/bin/clawdi"
 		try {
 			await runtimeWatch({ once: true, json: true });
 
-			expect(process.exitCode).toBe(1);
+			expect(process.exitCode).toBe(0);
 			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("error");
-			expect(event.stage).toBe("config");
-			expect(event.mode).toBe("minimum_cli_version_gated");
+			expect(event.status).toBe("cli_handoff");
+			expect(event.stage).toBe("cli-update");
 			expect(event.cliUpdate.status).toBe("installed");
 			expect(event.selfReexec).toBe(true);
-			expect(event.gate.minimumCliVersion).toBe("999.0.0");
+			expect(event.gate).toBeUndefined();
 			const paths = getRuntimePaths();
 			expect(existsSync(paths.manifestLastGood)).toBe(false);
 		} finally {
@@ -10796,6 +10923,139 @@ chmod +x "$prefix/bin/clawdi"
 				status.npmPrefix,
 			);
 		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("runtime init restarts the bootstrap before convergence and the new CLI completes init", async () => {
+		const home = join(root, "home-init-cli-handoff", "clawdi");
+		const state = join(root, "state-init-cli-handoff");
+		const run = join(root, "run-init-cli-handoff");
+		const sourcePath = join(root, "runtime-source-init-cli-handoff.json");
+		const policyPath = join(root, "etc-init-cli-handoff", "host-policy.json");
+		const bin = join(root, "bin-init-cli-handoff");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(dirname(policyPath), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		seedOpenClawBinary(home);
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${currentVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		writeFileSync(
+			policyPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				cliUpdateMode: "system-managed-npm",
+				deniedCommands: ["setup", "teardown", "update"],
+			}),
+		);
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_HOST_POLICY_PATH = policyPath;
+		process.exitCode = undefined;
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () =>
+					hostedRuntimeBundleResponse(hostedCliManifestResponse(home, `clawdi@${currentVersion}`), {
+						etag: testBundleEtag("etag-init-cli-handoff"),
+					}),
+			},
+		]);
+
+		try {
+			await runtimeInit({ nonInteractive: true, json: true });
+
+			const paths = getRuntimePaths();
+			expect(process.exitCode).toBe(75);
+			expect(captured).toHaveLength(1);
+			const handoff = JSON.parse(logs[0]);
+			expect(handoff.status).toBe("ok");
+			expect(handoff.handoff).toBe("cli_reexec");
+			expect(handoff.cliUpdate.status).toBe("installed");
+			expect(handoff.selfReexec).toBe(true);
+			expect(handoff.exitCode).toBe(75);
+			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
+			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
+			expect(existsSync(paths.manifestLastGood)).toBe(false);
+			expect(existsSync(paths.appliedState)).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
+				badVersions: [],
+			});
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeInit({ nonInteractive: true, json: true });
+
+			expect(process.exitCode).toBe(0);
+			expect(captured).toHaveLength(2);
+			const completed = JSON.parse(logs[0]);
+			expect(completed.status).toBe("ok");
+			expect(completed.handoff).toBeUndefined();
+			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 1 });
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: null,
+				badVersions: [],
+			});
+		} finally {
+			restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}


### PR DESCRIPTION
## Summary
- stop old CLI processes before manifest, systemd, or authority convergence after activating a managed CLI target
- model the transition as an explicit successful `cli_handoff` for runtime watch and init
- keep init and watch restart semantics aligned with their existing systemd units
- preserve retryable install failures and post-handoff rollback behavior

## Production evidence
A Kingsley canary installed `clawdi@0.13.19`, then the still-running `0.13.18` process continued convergence, hit its old bundled-Skill EACCES path, and incorrectly rolled back/marked `0.13.19` bad. This change places the handoff fence before all convergence side effects.

## Verification
- focused handoff/recovery/ETARGET/init tests: 4 passed
- full runtime suite: 171 passed
- isolated Docker CLI suite: 1468 passed, 4 skipped, 0 failed
- CLI typecheck
- Biome
- `git diff --check`