### PR TITLE
Use the canonical hosted runtime identity path

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -800,7 +800,7 @@ atomic projected-file swap advance config, secrets, and apply identity in
 place; `bootNonce` remains a workload-boot identity rather than a
 config-generation identity. The legacy process environment is accepted only
 when no identity-file path was configured and the canonical hosted mount
-`/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json` does not
+`/etc/clawdi/runtime-identity/runtime-apply-identity.json` does not
 exist. This one-boot discovery rule lets a CLI installed by an older bootstrap
 unit acquire the file contract; newly rendered units then pass the discovered
 path explicitly. An existing but malformed canonical file fails closed.

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
 	readRuntimeApplyContext,
 	readRuntimeApplyIdentity,
 	readRuntimeApplyIdentityFromEnv,
@@ -110,6 +111,12 @@ describe("runtime apply identity environment", () => {
 });
 
 describe("runtime apply identity file", () => {
+	test("uses the hosted filesystem ABI by default", () => {
+		expect(HOSTED_RUNTIME_APPLY_IDENTITY_FILE).toBe(
+			"/etc/clawdi/runtime-identity/runtime-apply-identity.json",
+		);
+	});
+
 	test("reads the complete canonical tuple from the configured file", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-"));
 		roots.push(root);

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -43,7 +43,7 @@ export function runtimeApplyIdentitiesEqual(
 
 export const RUNTIME_APPLY_IDENTITY_FILE_ENV = "CLAWDI_RUNTIME_APPLY_IDENTITY_FILE";
 export const HOSTED_RUNTIME_APPLY_IDENTITY_FILE =
-	"/var/run/secrets/clawdi-runtime-identity/runtime-apply-identity.json";
+	"/etc/clawdi/runtime-identity/runtime-apply-identity.json";
 
 const runtimeProjectedEnvironmentSchema = z.record(
 	z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),


### PR DESCRIPTION
## Summary
- discover the hosted apply identity from its stable `/etc/clawdi/runtime-identity` filesystem ABI
- keep explicit path overrides for direct CLI and test use only
- document and test the canonical fail-closed discovery path

## Verification
- `bun test packages/cli/src/runtime/apply-identity.test.ts`
- `bun run typecheck`
- full isolated CLI suite: 1468 passed, 4 skipped

## Release ordering
Publish this CLI before promoting the paired Hosted change that removes bootstrap path environment projection.