### PR TITLE
fix(channels): restore Telegram pairing and chat-level unpair UX

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -873,6 +873,8 @@ type HostedApiStubOptions = {
 	channelAccounts?: unknown[];
 	channelAgentLinks?: readonly unknown[];
 	channelBindings?: unknown[];
+	channelBotPool?: unknown;
+	channelHealthItems?: unknown[];
 	createChannelRequests?: string[];
 	createChannelResponse?: unknown;
 	deleteBindingRequests?: string[];
@@ -1590,8 +1592,12 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			options.onCreateChannel?.(response);
 			return fulfillJson(r, response, 201);
 		}
-		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
-		if (p === "/v1/channels/health") return fulfillJson(r, { items: [] });
+		if (p === "/v1/channels/bot-pool") {
+			return fulfillJson(r, options.channelBotPool ?? { providers: {} });
+		}
+		if (p === "/v1/channels/health") {
+			return fulfillJson(r, { items: options.channelHealthItems ?? [] });
+		}
 		if (p === "/v1/channels/agent-links" && r.request().method() === "GET") {
 			return fulfillJson(r, options.channelAgentLinks ?? []);
 		}
@@ -5004,8 +5010,8 @@ test("channel connect updates its auto-linked agent page without reload", async 
 		`/agents/${missingProjectionEnvironmentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 	);
 
-	await expect(page.getByText("No channels linked", { exact: true })).toBeVisible();
-	const connect = page.getByRole("button", { name: "Connect my bot", exact: true });
+	await expect(page.getByText("No connected channels", { exact: true })).toBeVisible();
+	const connect = page.getByRole("button", { name: "Connect a bot", exact: true }).first();
 	await expect(connect).toBeVisible();
 	await connect.click();
 	const dialog = page.getByRole("dialog");
@@ -5018,7 +5024,7 @@ test("channel connect updates its auto-linked agent page without reload", async 
 	await expect(dialog.getByText("message delivery automatically", { exact: false })).toBeVisible();
 	await expect(dialog).not.toContainText("agent token");
 	await dialog.getByRole("button", { name: "Close", exact: true }).first().click();
-	await expect(page.getByText("No channels linked", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("No connected channels", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Browser Telegram", { exact: true }).first()).toBeVisible();
 	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
 		provider: "telegram",
@@ -5026,6 +5032,212 @@ test("channel connect updates its auto-linked agent page without reload", async 
 		provider_token: "123456:browser-test-token",
 	});
 	expect(errors, `channel connect convergence: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Agent Channels uses compact task-ordered rows and the shared Telegram pair dialog", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 1440, height: 1100 });
+	const errors = collectBrowserErrors(page);
+	const agentId = missingProjectionEnvironmentId;
+	const telegramId = "71111111-1111-4111-8111-111111111111";
+	const telegramLinkId = "72222222-2222-4222-8222-222222222222";
+	const discordId = "73333333-3333-4333-8333-333333333333";
+	const discordLinkId = "74444444-4444-4444-8444-444444444444";
+	const ownedId = "75555555-5555-4555-8555-555555555555";
+	const readyId = "76666666-6666-4666-8666-666666666666";
+	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
+	const telegramAccount = {
+		id: telegramId,
+		provider: "telegram",
+		name: "Support Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/support-telegram",
+		created_at: "2026-07-27T12:00:00Z",
+	};
+	const discordAccount = {
+		id: discordId,
+		provider: "discord",
+		name: "Community Discord",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/community-discord",
+		created_at: "2026-07-27T12:05:00Z",
+	};
+	const ownedAccount = {
+		id: ownedId,
+		provider: "telegram",
+		name: "My Telegram bot",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/my-telegram",
+		created_at: "2026-07-27T12:10:00Z",
+	};
+	const pairCodeRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		cloudAgents: [
+			{
+				...sharedLegacyCloudAgent,
+				id: agentId,
+				name: "support-agent",
+				default_name: "Support Agent",
+				machine_name: "support.local",
+				display_name: "Support Agent",
+			},
+		],
+		channelAccounts: [telegramAccount, discordAccount, ownedAccount],
+		channelAgentLinks: [
+			{
+				id: telegramLinkId,
+				account_id: telegramId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-07-27T12:15:00Z",
+				account: telegramAccount,
+			},
+			{
+				id: discordLinkId,
+				account_id: discordId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-07-27T12:20:00Z",
+				account: discordAccount,
+			},
+		],
+		channelBotPool: {
+			providers: {
+				telegram: [
+					{
+						id: readyId,
+						provider: "telegram",
+						name: "Clawdi Ready Bot",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://cloud.example.test/channels/ready-telegram",
+						created_at: "2026-07-27T12:25:00Z",
+						access: "public",
+						capabilities: {
+							link_agent: true,
+							pair_chat: true,
+							send_message: true,
+							manage_account: false,
+							sync_commands: true,
+						},
+						link_count: 0,
+						max_links: null,
+						available: true,
+					},
+				],
+			},
+		},
+		channelHealthItems: [
+			{
+				account_id: telegramId,
+				provider: "telegram",
+				name: "Support Telegram",
+				visibility: "private",
+				channel_status: "active",
+				health_status: "ok",
+				pending_inbox: 0,
+				pending_deliveries: 0,
+				in_progress_deliveries: 0,
+				failed_deliveries: 0,
+				last_message_at: "2026-07-30T10:00:00Z",
+			},
+			{
+				account_id: discordId,
+				provider: "discord",
+				name: "Community Discord",
+				visibility: "private",
+				channel_status: "active",
+				health_status: "ok",
+				pending_inbox: 0,
+				pending_deliveries: 0,
+				in_progress_deliveries: 0,
+				failed_deliveries: 0,
+				last_message_at: "2026-07-30T09:55:00Z",
+			},
+		],
+		pairCodeRequests,
+		pairCodeResponses: [
+			{
+				status: 201,
+				body: {
+					id: "agent-channel-pair-code",
+					agent_link_id: telegramLinkId,
+					agent_id: agentId,
+					agent_token: "agent-channel-token-must-not-render",
+					code: "AGENTPAIR123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair AGENTPAIR123",
+					bot_username: "Clawdi_Ready_Bot",
+					deep_link: "https://t.me/Clawdi_Ready_Bot?start=AGENTPAIR123",
+					qr_payload: "https://t.me/Clawdi_Ready_Bot?start=AGENTPAIR123",
+				},
+			},
+		],
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const connectedSection = page.locator("[data-agent-connected-channels]");
+	const addSection = page.locator("[data-agent-add-channel]");
+	await expect(connectedSection.getByText("Connected channels", { exact: true })).toBeVisible();
+	await expect(addSection.getByText("Add a channel", { exact: true })).toBeVisible();
+	const telegramRow = page.locator(`[data-agent-channel-link-id="${telegramLinkId}"]`);
+	const discordRow = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
+	await expect(telegramRow).toContainText("Support Telegram");
+	await expect(telegramRow).toContainText("Last activity");
+	await expect(discordRow).toContainText("Community Discord");
+	await expect(
+		telegramRow.getByRole("button", { name: "Pair Telegram", exact: true }),
+	).toBeVisible();
+	await expect(discordRow.getByRole("button", { name: "Pair chat", exact: true })).toBeVisible();
+	await expect(telegramRow.getByRole("button", { name: "Unlink", exact: true })).toBeVisible();
+	await expect(addSection.locator(`[data-add-channel-id="${readyId}"]`)).toContainText(
+		"Clawdi Ready Bot",
+	);
+	await expect(addSection.getByText("Use your own bot", { exact: true })).toBeVisible();
+	await expect(page.getByText("Waiting for channel activity", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Finish pairing", { exact: false })).toHaveCount(0);
+	const telegramBox = await telegramRow.boundingBox();
+	const discordBox = await discordRow.boundingBox();
+	expect(Math.abs((telegramBox?.height ?? 0) - (discordBox?.height ?? 0))).toBeLessThanOrEqual(1);
+	await page.screenshot({
+		path:
+			process.env.AGENT_CHANNELS_PAGE_SCREENSHOT_PATH ??
+			testInfo.outputPath("agent-channels-compact-page.png"),
+		fullPage: true,
+	});
+
+	await telegramRow.getByRole("button", { name: "Pair Telegram", exact: true }).click();
+	await expect.poll(() => pairCodeRequests.length).toBe(1);
+	expect(JSON.parse(pairCodeRequests[0] ?? "{}")).toEqual({
+		ttl_seconds: 900,
+		agent_link_id: telegramLinkId,
+	});
+	const pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	await expect(pairDialog.getByRole("button", { name: "Copy link", exact: true })).toBeVisible();
+	await expect(pairDialog.getByRole("button", { name: "Open @Clawdi_Ready_Bot" })).toHaveAttribute(
+		"href",
+		"https://t.me/Clawdi_Ready_Bot?start=AGENTPAIR123",
+	);
+	await expect(page.locator("body")).not.toContainText("agent-channel-token-must-not-render");
+	await page.screenshot({
+		path:
+			process.env.AGENT_CHANNELS_DIALOG_SCREENSHOT_PATH ??
+			testInfo.outputPath("agent-channels-pair-dialog.png"),
+		fullPage: true,
+	});
+	expect(errors, `Agent Channels browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("Telegram pairing uses a compact Agent-row dialog with polled chats and isolated Unpair", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5047,6 +5047,15 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const ownedId = "75555555-5555-4555-8555-555555555555";
 	const readyId = "76666666-6666-4666-8666-666666666666";
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
+	const agentChannelsDeployment = {
+		...runningMissingProjectionDeployment,
+		openclaw_control_ui_url: "https://runtime.example/openclaw",
+		config_info: {
+			...runningMissingProjectionDeployment.config_info,
+			runtime: "openclaw",
+			clawdi_cloud_environments: { openclaw: agentId },
+		},
+	};
 	const telegramAccount = {
 		id: telegramId,
 		provider: "telegram",
@@ -5079,7 +5088,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	};
 	const pairCodeRequests: string[] = [];
 	await stubHostedApi(page, {
-		deployments: [runningMissingProjectionDeployment],
+		deployments: [agentChannelsDeployment],
 		cloudAgents: [
 			{
 				...sharedLegacyCloudAgent,
@@ -5088,6 +5097,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 				default_name: "Support Agent",
 				machine_name: "support.local",
 				display_name: "Support Agent",
+				agent_type: "openclaw",
 			},
 		],
 		channelAccounts: [telegramAccount, discordAccount, ownedAccount],
@@ -5111,10 +5121,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		],
 		channelBotPool: {
 			providers: {
-				telegram: [
+				discord: [
 					{
 						id: readyId,
-						provider: "telegram",
+						provider: "discord",
 						name: "Clawdi Ready Bot",
 						status: "active",
 						visibility: "public",
@@ -5185,7 +5195,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	});
 
 	await page.goto(
-		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${agentChannelsDeployment.id}`,
 	);
 	const connectedSection = page.locator("[data-agent-connected-channels]");
 	const addSection = page.locator("[data-agent-add-channel]");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -872,9 +872,14 @@ type HostedApiStubOptions = {
 	channelAccount?: unknown;
 	channelAccounts?: unknown[];
 	channelAgentLinks?: readonly unknown[];
+	channelBindings?: unknown[];
 	createChannelRequests?: string[];
 	createChannelResponse?: unknown;
+	deleteBindingRequests?: string[];
+	deleteBindingResponses?: StubResponse[];
 	onCreateChannel?: (response: unknown) => void;
+	pairCodeRequests?: string[];
+	pairCodeResponses?: StubResponse[];
 	cloudAgentOverrides?: Record<string, unknown>;
 	cloudAgents?: readonly unknown[];
 	cloudAgentsResponse?: StubResponse;
@@ -910,8 +915,6 @@ type HostedApiStubOptions = {
 	planQuoteRequests?: string[];
 	planQuoteResponses?: unknown[];
 	restartRequests?: string[];
-	rotateAgentTokenRequests?: string[];
-	rotateAgentTokenResponses?: unknown[];
 	runtimeUiRedemptionRequests?: string[];
 	runtimeUiRedemptionResponses?: StubResponse[];
 	runtimeUiResetRequests?: Array<{ idempotencyKey: string | null; ifMatch: string | null }>;
@@ -1598,11 +1601,35 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p.endsWith("/agent-links") && r.request().method() === "GET") {
 			return fulfillJson(r, options.channelAgentLinks ?? []);
 		}
-		if (p.endsWith("/token") && r.request().method() === "POST") {
-			options.rotateAgentTokenRequests?.push(p);
-			return fulfillJson(r, options.rotateAgentTokenResponses?.shift() ?? { agent_token: null });
+		if (p.endsWith("/pair-codes") && r.request().method() === "POST") {
+			options.pairCodeRequests?.push(r.request().postData() ?? "");
+			const response = options.pairCodeResponses?.shift() ?? { body: {}, status: 201 };
+			return fulfillJson(r, response.body, response.status);
 		}
-		if (p.endsWith("/bindings") && r.request().method() === "GET") return fulfillJson(r, []);
+		if (p.match(/\/bindings\/[^/]+$/) && r.request().method() === "DELETE") {
+			options.deleteBindingRequests?.push(p);
+			const response = options.deleteBindingResponses?.shift() ?? {
+				body: {
+					binding_id: p.slice(p.lastIndexOf("/") + 1),
+					unpaired: true,
+					notification_status: "sent",
+					provider_cleanup_status: "succeeded",
+					warning: null,
+				},
+				status: 200,
+			};
+			if (response.status < 400) {
+				const bindingId = p.slice(p.lastIndexOf("/") + 1);
+				const index = options.channelBindings?.findIndex(
+					(binding) => isRecord(binding) && binding.id === bindingId,
+				);
+				if (index !== undefined && index >= 0) options.channelBindings?.splice(index, 1);
+			}
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (p.endsWith("/bindings") && r.request().method() === "GET") {
+			return fulfillJson(r, options.channelBindings ?? []);
+		}
 		if (p.endsWith("/activity") && r.request().method() === "GET") {
 			return fulfillJson(r, { items: [] });
 		}
@@ -4988,7 +5015,8 @@ test("channel connect updates its auto-linked agent page without reload", async 
 
 	await expect.poll(() => createChannelRequests.length).toBe(1);
 	await expect(dialog.getByText("Channel connected", { exact: true })).toBeVisible();
-	await expect(dialog.getByText("An agent was auto-linked", { exact: false })).toBeVisible();
+	await expect(dialog.getByText("message delivery automatically", { exact: false })).toBeVisible();
+	await expect(dialog).not.toContainText("agent token");
 	await dialog.getByRole("button", { name: "Close", exact: true }).first().click();
 	await expect(page.getByText("No channels linked", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Browser Telegram", { exact: true }).first()).toBeVisible();
@@ -5000,14 +5028,18 @@ test("channel connect updates its auto-linked agent page without reload", async 
 	expect(errors, `channel connect convergence: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("rotated channel token blocks silent loss and explains recovery", async ({
+test("Telegram pairing is a visible card flow with safe deep links and isolated Unpair", async ({
 	page,
-	context,
-}) => {
-	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+}, testInfo) => {
+	await page.setViewportSize({ width: 1440, height: 1500 });
+	const errors = collectBrowserErrors(page);
 	const channelId = "11111111-1111-4111-8111-111111111111";
 	const linkId = "22222222-2222-4222-8222-222222222222";
-	const token = "one-time-browser-token";
+	const agentId = "33333333-3333-4333-8333-333333333333";
+	const firstBindingId = "44444444-4444-4444-8444-444444444444";
+	const secondBindingId = "55555555-5555-4555-8555-555555555555";
+	const runtimeToken = "browser-agent-token-must-not-render";
+	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const channelAccount = {
 		id: channelId,
 		provider: "telegram",
@@ -5021,68 +5053,189 @@ test("rotated channel token blocks silent loss and explains recovery", async ({
 	const channelLink = {
 		id: linkId,
 		account_id: channelId,
-		agent_id: "33333333-3333-4333-8333-333333333333",
+		agent_id: agentId,
 		status: "active",
 		created_at: "2026-07-25T12:00:00Z",
 	};
-	const rotateAgentTokenRequests: string[] = [];
+	const channelBindings: unknown[] = [
+		{
+			id: firstBindingId,
+			account_id: channelId,
+			agent_link_id: linkId,
+			external_chat_id: "101",
+			external_chat_type: "private",
+			external_chat_name: "Alice DM",
+			status: "active",
+			created_at: "2026-07-30T10:00:00Z",
+		},
+		{
+			id: secondBindingId,
+			account_id: channelId,
+			agent_link_id: linkId,
+			external_chat_id: "-100202",
+			external_chat_type: "supergroup",
+			external_chat_name: "Ops Group",
+			status: "active",
+			created_at: "2026-07-30T10:05:00Z",
+		},
+	];
+	const pairCodeRequests: string[] = [];
+	const deleteBindingRequests: string[] = [];
 	await stubHostedApi(page, {
 		channelAccount,
 		channelAgentLinks: [channelLink],
-		rotateAgentTokenRequests,
-		rotateAgentTokenResponses: [
-			{ ...channelLink, agent_token: token },
-			{ ...channelLink, agent_token: null },
+		channelBindings,
+		cloudAgents: [
+			{
+				id: agentId,
+				name: "Support Agent",
+				default_name: "Support Agent",
+				machine_name: "support.local",
+				agent_type: "openclaw",
+			},
+		],
+		pairCodeRequests,
+		pairCodeResponses: [
+			{
+				status: 201,
+				body: {
+					id: "pair-valid",
+					agent_link_id: linkId,
+					agent_id: agentId,
+					agent_token: runtimeToken,
+					code: "PAIRVALID123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair PAIRVALID123",
+					bot_username: "Clawdi_Test_Bot",
+					deep_link: "https://t.me/Clawdi_Test_Bot?start=PAIRVALID123",
+					qr_payload: "https://t.me/Clawdi_Test_Bot?start=PAIRVALID123",
+				},
+			},
+			{
+				status: 201,
+				body: {
+					id: "pair-missing-link",
+					agent_link_id: linkId,
+					agent_id: agentId,
+					agent_token: runtimeToken,
+					code: "PAIRMISSING123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair PAIRMISSING123",
+					bot_username: "Clawdi_Test_Bot",
+					deep_link: null,
+					qr_payload: null,
+				},
+			},
+			{
+				status: 201,
+				body: {
+					id: "pair-expired",
+					agent_link_id: linkId,
+					agent_id: agentId,
+					agent_token: runtimeToken,
+					code: "PAIREXPIRED123",
+					expires_at: "2000-01-01T00:00:00Z",
+					pairing_command: "/bot_pair PAIREXPIRED123",
+					bot_username: "Clawdi_Test_Bot",
+					deep_link: "https://t.me/Clawdi_Test_Bot?start=PAIREXPIRED123",
+					qr_payload: "https://t.me/Clawdi_Test_Bot?start=PAIREXPIRED123",
+				},
+			},
+		],
+		deleteBindingRequests,
+		deleteBindingResponses: [
+			{ status: 502, body: { detail: "temporary Telegram cleanup error" } },
+			{
+				status: 200,
+				body: {
+					binding_id: firstBindingId,
+					unpaired: true,
+					notification_status: "failed",
+					provider_cleanup_status: "succeeded",
+					warning: "Chat was unpaired, but the Telegram notification could not be sent.",
+				},
+			},
 		],
 	});
 
 	await page.goto(`/channels/${channelId}`);
-	await page.getByRole("button", { name: "Rotate token", exact: true }).click();
-	await expect.poll(() => rotateAgentTokenRequests.length).toBe(1);
-	await expect(
-		page.getByText(
-			"Shown only once. Copy it or confirm you saved it before leaving this page; it cannot be recovered later.",
-			{ exact: true },
-		),
-	).toBeVisible();
-
-	const serializedBrowserStorage = await page.evaluate(() =>
-		JSON.stringify({ localStorage: { ...localStorage }, sessionStorage: { ...sessionStorage } }),
+	const setupFlow = page.locator("[data-channel-setup-flow]");
+	await expect(setupFlow.getByRole("heading", { name: "Link Agent" })).toBeVisible();
+	await expect(setupFlow.getByRole("heading", { name: "Pair Telegram" })).toBeVisible();
+	await expect(page.locator(`[data-channel-binding-id="${firstBindingId}"]`)).toContainText(
+		"Alice DM",
 	);
-	expect(serializedBrowserStorage).not.toContain(token);
-	await page.getByRole("tab", { name: "Activity", exact: true }).click();
-	await expect(page.getByText("New agent token", { exact: true })).toHaveCount(0);
-	await page.getByRole("tab", { name: "Agents", exact: true }).click();
-	await expect(page.getByText("New agent token", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Settings", exact: true }).click();
-	await expect(page.getByTestId("settings-dialog")).toBeVisible();
-	await page.keyboard.press("Escape");
-	await expect(page.getByTestId("settings-dialog")).toHaveCount(0);
-	await expect(page.getByText("New agent token", { exact: true })).toBeVisible();
-
-	const agentsLink = page.getByTestId("app-sidebar").locator('a[href="/agents"]').first();
-	await agentsLink.click();
-	const leaveDialog = page.getByRole("alertdialog");
-	await expect(leaveDialog).toContainText("Leave without saving the new token?");
-	await expect(leaveDialog).toContainText(
-		"This token was shown once and is not recoverable — rotate again to get a new one.",
+	await expect(page.locator(`[data-channel-binding-id="${secondBindingId}"]`)).toContainText(
+		"Ops Group",
 	);
-	await expect(page).toHaveURL(new RegExp(`/channels/${channelId}$`));
-	await leaveDialog.getByRole("button", { name: "Stay and copy token", exact: true }).click();
+	await expect(page.locator(`[data-channel-binding-id="${firstBindingId}"]`)).toContainText(
+		"Support Agent",
+	);
 
-	await page.getByRole("button", { name: "Copy New agent token", exact: true }).click();
-	await expect(page.getByText("Token copied to clipboard", { exact: true })).toBeVisible();
-	await agentsLink.click();
-	await expect(page).toHaveURL(/\/agents\/?$/);
+	const generate = page.getByRole("button", { name: "Generate Telegram link", exact: true });
+	await generate.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(1);
+	expect(JSON.parse(pairCodeRequests[0] ?? "{}")).toEqual({
+		ttl_seconds: 900,
+		agent_link_id: linkId,
+	});
+	const pairResult = page.locator('[data-telegram-pair-result="true"]');
+	await expect(pairResult.getByRole("img")).toBeVisible();
+	await expect(pairResult.getByRole("button", { name: "Open @Clawdi_Test_Bot" })).toHaveAttribute(
+		"href",
+		"https://t.me/Clawdi_Test_Bot?start=PAIRVALID123",
+	);
+	await expect(pairResult.getByText(/^Expires in /)).toBeVisible();
+	await expect(pairResult.getByText("Manual command", { exact: true })).toBeVisible();
+	await expect(page.locator("body")).not.toContainText(runtimeToken);
+	await expect(page.locator("body")).not.toContainText("Agent token");
 
-	await page.goto(`/channels/${channelId}`);
-	await page.getByRole("button", { name: "Rotate token", exact: true }).click();
-	await expect.poll(() => rotateAgentTokenRequests.length).toBe(2);
+	await page.screenshot({
+		path:
+			process.env.CHANNEL_PAIRING_SCREENSHOT_PATH ??
+			testInfo.outputPath("telegram-channel-pairing.png"),
+		fullPage: true,
+	});
+
+	await generate.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(2);
+	await expect(pairResult.getByText("Telegram link unavailable", { exact: true })).toBeVisible();
+	await expect(pairResult.getByRole("img")).toHaveCount(0);
+	await expect(pairResult.getByRole("button", { name: /^Open/ })).toHaveCount(0);
+	await pairResult.getByText("Manual command", { exact: true }).click();
+	await expect(pairResult.getByText("/bot_pair PAIRMISSING123", { exact: true })).toBeVisible();
+
+	await generate.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(3);
 	await expect(
-		page.getByText(
-			"This token was shown once and is not recoverable — rotate again to get a new one.",
-			{ exact: true },
-		),
+		pairResult.getByText("This Telegram link has expired", { exact: true }),
 	).toBeVisible();
-	await expect(page.getByRole("button", { name: "Copy New agent token" })).toHaveCount(0);
+	await expect(
+		pairResult.getByText("Expired — generate a new link", { exact: true }),
+	).toBeVisible();
+	await expect(pairResult.getByRole("img")).toHaveCount(0);
+	await expect(pairResult.getByText("Manual command", { exact: true })).toHaveCount(0);
+
+	const firstCard = page.locator(`[data-channel-binding-id="${firstBindingId}"]`);
+	await firstCard.getByRole("button", { name: "Unpair", exact: true }).click();
+	let confirmation = page.getByRole("alertdialog");
+	await confirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
+	await expect.poll(() => deleteBindingRequests.length).toBe(1);
+	await expect(page.getByText("Couldn't unpair chat", { exact: true })).toBeVisible();
+	await expect(firstCard).toBeVisible();
+
+	await firstCard.getByRole("button", { name: "Unpair", exact: true }).click();
+	confirmation = page.getByRole("alertdialog");
+	await confirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
+	await expect.poll(() => deleteBindingRequests.length).toBe(2);
+	await expect(firstCard).toHaveCount(0);
+	await expect(
+		page.getByText("Chat was unpaired, but the Telegram notification could not be sent."),
+	).toBeVisible();
+	await expect(page.locator(`[data-channel-binding-id="${secondBindingId}"]`)).toBeVisible();
+
+	const unexpectedErrors = errors.filter(
+		(error) => !error.includes("temporary Telegram cleanup error") && !error.includes("502"),
+	);
+	expect(unexpectedErrors, `Telegram pairing UX: ${unexpectedErrors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1599,7 +1599,14 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, { items: options.channelHealthItems ?? [] });
 		}
 		if (p === "/v1/channels/agent-links" && r.request().method() === "GET") {
-			return fulfillJson(r, options.channelAgentLinks ?? []);
+			const requestedAgentId = new URL(r.request().url()).searchParams.get("agent_id");
+			const links = options.channelAgentLinks ?? [];
+			return fulfillJson(
+				r,
+				requestedAgentId
+					? links.filter((link) => isRecord(link) && link.agent_id === requestedAgentId)
+					: links,
+			);
 		}
 		if (p.match(/^\/v1\/channels\/[^/]+$/) && r.request().method() === "GET") {
 			return fulfillJson(r, options.channelAccount ?? { detail: "Channel not found" }, 200);
@@ -1634,7 +1641,16 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, response.body, response.status);
 		}
 		if (p.endsWith("/bindings") && r.request().method() === "GET") {
-			return fulfillJson(r, options.channelBindings ?? []);
+			const match = p.match(/^\/v1\/channels\/([^/]+)\/bindings$/);
+			const accountId = match?.[1] ? decodeURIComponent(match[1]) : null;
+			return fulfillJson(
+				r,
+				accountId
+					? (options.channelBindings ?? []).filter(
+							(binding) => isRecord(binding) && binding.account_id === accountId,
+						)
+					: [],
+			);
 		}
 		if (p.endsWith("/activity") && r.request().method() === "GET") {
 			return fulfillJson(r, { items: [] });
@@ -5040,12 +5056,17 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await page.setViewportSize({ width: 1440, height: 1100 });
 	const errors = collectBrowserErrors(page);
 	const agentId = missingProjectionEnvironmentId;
+	const otherAgentId = "70000000-0000-4000-8000-000000000000";
 	const telegramId = "71111111-1111-4111-8111-111111111111";
 	const telegramLinkId = "72222222-2222-4222-8222-222222222222";
+	const otherTelegramLinkId = "72222222-2222-4222-8222-333333333333";
 	const discordId = "73333333-3333-4333-8333-333333333333";
 	const discordLinkId = "74444444-4444-4444-8444-444444444444";
 	const ownedId = "75555555-5555-4555-8555-555555555555";
 	const readyId = "76666666-6666-4666-8666-666666666666";
+	const currentBindingId = "77777777-7777-4777-8777-777777777777";
+	const otherAgentBindingId = "78888888-8888-4888-8888-888888888888";
+	const polledBindingId = "79999999-9999-4999-8999-999999999999";
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const agentChannelsDeployment = {
 		...runningMissingProjectionDeployment,
@@ -5087,6 +5108,29 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		created_at: "2026-07-27T12:10:00Z",
 	};
 	const pairCodeRequests: string[] = [];
+	const deleteBindingRequests: string[] = [];
+	const channelBindings: unknown[] = [
+		{
+			id: currentBindingId,
+			account_id: telegramId,
+			agent_link_id: telegramLinkId,
+			external_chat_id: "101",
+			external_chat_type: "private",
+			external_chat_name: "Current Agent DM",
+			status: "active",
+			created_at: "2026-07-30T10:00:00Z",
+		},
+		{
+			id: otherAgentBindingId,
+			account_id: telegramId,
+			agent_link_id: otherTelegramLinkId,
+			external_chat_id: "202",
+			external_chat_type: "private",
+			external_chat_name: "Other Agent DM",
+			status: "active",
+			created_at: "2026-07-30T10:05:00Z",
+		},
+	];
 	await stubHostedApi(page, {
 		deployments: [agentChannelsDeployment],
 		cloudAgents: [
@@ -5101,6 +5145,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			},
 		],
 		channelAccounts: [telegramAccount, discordAccount, ownedAccount],
+		channelBindings,
 		channelAgentLinks: [
 			{
 				id: telegramLinkId,
@@ -5108,6 +5153,14 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 				agent_id: agentId,
 				status: "active",
 				created_at: "2026-07-27T12:15:00Z",
+				account: telegramAccount,
+			},
+			{
+				id: otherTelegramLinkId,
+				account_id: telegramId,
+				agent_id: otherAgentId,
+				status: "active",
+				created_at: "2026-07-27T12:17:00Z",
 				account: telegramAccount,
 			},
 			{
@@ -5174,6 +5227,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 				last_message_at: "2026-07-30T09:55:00Z",
 			},
 		],
+		deleteBindingRequests,
 		pairCodeRequests,
 		pairCodeResponses: [
 			{
@@ -5198,8 +5252,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		`/agents/${agentId}/channel-links?source=on-clawdi&d=${agentChannelsDeployment.id}`,
 	);
 	const connectedSection = page.locator("[data-agent-connected-channels]");
+	const pairedSection = page.locator("[data-agent-paired-chats]");
 	const addSection = page.locator("[data-agent-add-channel]");
 	await expect(connectedSection.getByText("Connected channels", { exact: true })).toBeVisible();
+	await expect(pairedSection.getByText("Paired chats", { exact: true })).toBeVisible();
 	await expect(addSection.getByText("Add a channel", { exact: true })).toBeVisible();
 	const telegramRow = page.locator(`[data-agent-channel-link-id="${telegramLinkId}"]`);
 	const discordRow = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
@@ -5215,6 +5271,12 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		"Clawdi Ready Bot",
 	);
 	await expect(addSection.getByText("Use your own bot", { exact: true })).toBeVisible();
+	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
+	await expect(currentBindingRow).toContainText("Current Agent DM");
+	await expect(currentBindingRow).toContainText("Support Telegram");
+	await expect(page.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`)).toHaveCount(0);
+	await expect(page.getByText("Other Agent DM", { exact: true })).toHaveCount(0);
+	await expect(currentBindingRow).not.toContainText("101");
 	await expect(page.getByText("Waiting for channel activity", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Finish pairing", { exact: false })).toHaveCount(0);
 	const telegramBox = await telegramRow.boundingBox();
@@ -5247,6 +5309,53 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			testInfo.outputPath("agent-channels-pair-dialog.png"),
 		fullPage: true,
 	});
+
+	channelBindings.push({
+		id: polledBindingId,
+		account_id: telegramId,
+		agent_link_id: telegramLinkId,
+		external_chat_id: "303",
+		external_chat_type: "private",
+		external_chat_name: "Newly Paired DM",
+		status: "active",
+		created_at: "2026-07-30T10:10:00Z",
+	});
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(page.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toContainText(
+		"Newly Paired DM",
+		{ timeout: 5_000 },
+	);
+
+	await currentBindingRow.getByRole("button", { name: "Unpair", exact: true }).click();
+	const unpairConfirmation = page.getByRole("alertdialog", { name: "Unpair Current Agent DM?" });
+	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
+	await expect.poll(() => deleteBindingRequests.length).toBe(1);
+	expect(deleteBindingRequests).toEqual([
+		`/v1/channels/${telegramId}/bindings/${currentBindingId}`,
+	]);
+	await expect(currentBindingRow).toHaveCount(0);
+	await expect(page.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toBeVisible();
+	await expect(page.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`)).toHaveCount(0);
+	expect(
+		channelBindings.some((binding) => isRecord(binding) && binding.id === otherAgentBindingId),
+	).toBe(true);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	const mobileChatRow = page.locator(`[data-channel-binding-id="${polledBindingId}"]`);
+	const mobileChatTitle = mobileChatRow.getByText("Newly Paired DM", { exact: true });
+	const mobileUnpair = mobileChatRow.getByRole("button", { name: "Unpair", exact: true });
+	await expect(mobileChatTitle).toBeVisible();
+	await expect(mobileUnpair).toBeVisible();
+	const mobileTitleBox = await mobileChatTitle.boundingBox();
+	const mobileActionBox = await mobileUnpair.boundingBox();
+	expect(mobileTitleBox?.width ?? 0).toBeGreaterThan(100);
+	expect(mobileActionBox?.y ?? 0).toBeGreaterThan(mobileTitleBox?.y ?? 0);
+	const mobileChannelTitle = telegramRow.getByText("Support Telegram", { exact: true });
+	const mobilePairAction = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
+	const mobileChannelTitleBox = await mobileChannelTitle.boundingBox();
+	const mobilePairActionBox = await mobilePairAction.boundingBox();
+	expect(mobileChannelTitleBox?.width ?? 0).toBeGreaterThan(100);
+	expect(mobilePairActionBox?.y ?? 0).toBeGreaterThan(mobileChannelTitleBox?.y ?? 0);
 	expect(errors, `Agent Channels browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
@@ -5505,14 +5614,14 @@ test("Telegram pairing uses a compact Agent-row dialog with polled chats and iso
 
 	const firstCard = page.locator(`[data-channel-binding-id="${firstBindingId}"]`);
 	await firstCard.getByRole("button", { name: "Unpair", exact: true }).click();
-	let confirmation = page.getByRole("alertdialog");
+	const confirmation = page.getByRole("alertdialog");
 	await confirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(1);
 	await expect(page.getByText("Couldn't unpair chat", { exact: true })).toBeVisible();
 	await expect(firstCard).toBeVisible();
+	await expect(firstCard).toContainText("Couldn't unpair · Try again");
+	await expect(confirmation).toBeVisible();
 
-	await firstCard.getByRole("button", { name: "Unpair", exact: true }).click();
-	confirmation = page.getByRole("alertdialog");
 	await confirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(2);
 	await expect(firstCard).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5028,7 +5028,7 @@ test("channel connect updates its auto-linked agent page without reload", async 
 	expect(errors, `channel connect convergence: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("Telegram pairing is a visible card flow with safe deep links and isolated Unpair", async ({
+test("Telegram pairing uses a compact Agent-row dialog with polled chats and isolated Unpair", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 1500 });
@@ -5038,6 +5038,7 @@ test("Telegram pairing is a visible card flow with safe deep links and isolated 
 	const agentId = "33333333-3333-4333-8333-333333333333";
 	const firstBindingId = "44444444-4444-4444-8444-444444444444";
 	const secondBindingId = "55555555-5555-4555-8555-555555555555";
+	const polledBindingId = "66666666-6666-4666-8666-666666666666";
 	const runtimeToken = "browser-agent-token-must-not-render";
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const channelAccount = {
@@ -5111,6 +5112,22 @@ test("Telegram pairing is a visible card flow with safe deep links and isolated 
 					qr_payload: "https://t.me/Clawdi_Test_Bot?start=PAIRVALID123",
 				},
 			},
+			{ status: 503, body: { detail: "temporary Telegram pair error" } },
+			{
+				status: 201,
+				body: {
+					id: "pair-retry",
+					agent_link_id: linkId,
+					agent_id: agentId,
+					agent_token: runtimeToken,
+					code: "PAIRRETRY123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair PAIRRETRY123",
+					bot_username: "Clawdi_Test_Bot",
+					deep_link: "https://t.me/Clawdi_Test_Bot?start=PAIRRETRY123",
+					qr_payload: "https://t.me/Clawdi_Test_Bot?start=PAIRRETRY123",
+				},
+			},
 			{
 				status: 201,
 				body: {
@@ -5160,8 +5177,10 @@ test("Telegram pairing is a visible card flow with safe deep links and isolated 
 
 	await page.goto(`/channels/${channelId}`);
 	const setupFlow = page.locator("[data-channel-setup-flow]");
-	await expect(setupFlow.getByRole("heading", { name: "Link Agent" })).toBeVisible();
-	await expect(setupFlow.getByRole("heading", { name: "Pair Telegram" })).toBeVisible();
+	await expect(setupFlow.getByText("Linked agents", { exact: true })).toBeVisible();
+	await expect(setupFlow.getByText("Paired chats", { exact: true })).toBeVisible();
+	await expect(page.locator("#pair-agent")).toHaveCount(0);
+	await expect(page.locator("#pair-ttl")).toHaveCount(0);
 	await expect(page.locator(`[data-channel-binding-id="${firstBindingId}"]`)).toContainText(
 		"Alice DM",
 	);
@@ -5171,50 +5190,96 @@ test("Telegram pairing is a visible card flow with safe deep links and isolated 
 	await expect(page.locator(`[data-channel-binding-id="${firstBindingId}"]`)).toContainText(
 		"Support Agent",
 	);
+	const agentRow = page.locator(`[data-channel-agent-link-id="${linkId}"]`);
+	await expect(agentRow).toContainText("Support Agent");
+	const pairButton = agentRow.getByRole("button", { name: "Pair Telegram", exact: true });
+	await expect(pairButton).toBeVisible();
+	await expect(page.getByRole("img", { name: "Telegram pairing QR code" })).toHaveCount(0);
+	await page.screenshot({
+		path:
+			process.env.CHANNEL_PAIRING_PAGE_SCREENSHOT_PATH ??
+			testInfo.outputPath("telegram-channel-pairing-compact-page.png"),
+		fullPage: true,
+	});
 
-	const generate = page.getByRole("button", { name: "Generate Telegram link", exact: true });
-	await generate.click();
+	await pairButton.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(1);
 	expect(JSON.parse(pairCodeRequests[0] ?? "{}")).toEqual({
 		ttl_seconds: 900,
 		agent_link_id: linkId,
 	});
-	const pairResult = page.locator('[data-telegram-pair-result="true"]');
-	await expect(pairResult.getByRole("img")).toBeVisible();
-	await expect(pairResult.getByRole("button", { name: "Open @Clawdi_Test_Bot" })).toHaveAttribute(
+	let pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	await expect(pairDialog.getByText(/^Expires in /)).toBeVisible();
+	await expect(pairDialog.getByRole("button", { name: "Copy link", exact: true })).toBeVisible();
+	await expect(pairDialog.getByRole("button", { name: "Open @Clawdi_Test_Bot" })).toHaveAttribute(
 		"href",
 		"https://t.me/Clawdi_Test_Bot?start=PAIRVALID123",
 	);
-	await expect(pairResult.getByText(/^Expires in /)).toBeVisible();
-	await expect(pairResult.getByText("Manual command", { exact: true })).toBeVisible();
+	await expect(pairDialog.getByText("Pair a group manually", { exact: true })).toBeVisible();
 	await expect(page.locator("body")).not.toContainText(runtimeToken);
 	await expect(page.locator("body")).not.toContainText("Agent token");
-
 	await page.screenshot({
 		path:
-			process.env.CHANNEL_PAIRING_SCREENSHOT_PATH ??
-			testInfo.outputPath("telegram-channel-pairing.png"),
+			process.env.CHANNEL_PAIRING_DIALOG_SCREENSHOT_PATH ??
+			testInfo.outputPath("telegram-channel-pairing-dialog.png"),
 		fullPage: true,
 	});
 
-	await generate.click();
-	await expect.poll(() => pairCodeRequests.length).toBe(2);
-	await expect(pairResult.getByText("Telegram link unavailable", { exact: true })).toBeVisible();
-	await expect(pairResult.getByRole("img")).toHaveCount(0);
-	await expect(pairResult.getByRole("button", { name: /^Open/ })).toHaveCount(0);
-	await pairResult.getByText("Manual command", { exact: true }).click();
-	await expect(pairResult.getByText("/bot_pair PAIRMISSING123", { exact: true })).toBeVisible();
+	channelBindings.push({
+		id: polledBindingId,
+		account_id: channelId,
+		agent_link_id: linkId,
+		external_chat_id: "303",
+		external_chat_type: "private",
+		external_chat_name: "Newly Paired DM",
+		status: "active",
+		created_at: "2026-07-30T10:10:00Z",
+	});
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(page.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toContainText(
+		"Newly Paired DM",
+		{ timeout: 5_000 },
+	);
 
-	await generate.click();
+	await pairButton.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(2);
+	pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(
+		pairDialog.getByText("Couldn't create Telegram link", { exact: true }),
+	).toBeVisible();
+	await pairDialog.getByRole("button", { name: "Retry", exact: true }).click();
 	await expect.poll(() => pairCodeRequests.length).toBe(3);
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	await expect(pairDialog.getByRole("button", { name: "Open @Clawdi_Test_Bot" })).toHaveAttribute(
+		"href",
+		"https://t.me/Clawdi_Test_Bot?start=PAIRRETRY123",
+	);
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
+
+	await pairButton.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(4);
+	pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(pairDialog.getByText("Telegram link unavailable", { exact: true })).toBeVisible();
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toHaveCount(0);
+	await expect(pairDialog.getByRole("button", { name: /^Open/ })).toHaveCount(0);
+	await expect(pairDialog.getByRole("button", { name: "Copy link", exact: true })).toHaveCount(0);
+	await pairDialog.getByText("Pair a group manually", { exact: true }).click();
+	await expect(pairDialog.getByText("/bot_pair PAIRMISSING123", { exact: true })).toBeVisible();
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
+
+	await pairButton.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(5);
+	pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
 	await expect(
-		pairResult.getByText("This Telegram link has expired", { exact: true }),
+		pairDialog.getByText("This Telegram link has expired", { exact: true }),
 	).toBeVisible();
 	await expect(
-		pairResult.getByText("Expired — generate a new link", { exact: true }),
+		pairDialog.getByText("Expired — generate a new link", { exact: true }),
 	).toBeVisible();
-	await expect(pairResult.getByRole("img")).toHaveCount(0);
-	await expect(pairResult.getByText("Manual command", { exact: true })).toHaveCount(0);
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toHaveCount(0);
+	await expect(pairDialog.getByText("Pair a group manually", { exact: true })).toHaveCount(0);
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
 
 	const firstCard = page.locator(`[data-channel-binding-id="${firstBindingId}"]`);
 	await firstCard.getByRole("button", { name: "Unpair", exact: true }).click();
@@ -5235,7 +5300,11 @@ test("Telegram pairing is a visible card flow with safe deep links and isolated 
 	await expect(page.locator(`[data-channel-binding-id="${secondBindingId}"]`)).toBeVisible();
 
 	const unexpectedErrors = errors.filter(
-		(error) => !error.includes("temporary Telegram cleanup error") && !error.includes("502"),
+		(error) =>
+			!error.includes("temporary Telegram pair error") &&
+			!error.includes("temporary Telegram cleanup error") &&
+			!error.includes("503") &&
+			!error.includes("502"),
 	);
 	expect(unexpectedErrors, `Telegram pairing UX: ${unexpectedErrors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -30,7 +30,6 @@ import {
 	X,
 	Zap,
 } from "lucide-react";
-import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -218,10 +217,7 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
-import {
-	pairCodeExpiryLabel,
-	telegramPairDeepLink,
-} from "@/hosted/v2/channels/channel-detail-page.logic";
+import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import {
@@ -242,8 +238,8 @@ import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import {
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
-	pairCodeExpired,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentRouteSearch,
 	type AgentSectionId,
@@ -2670,9 +2666,6 @@ type AgentPairCodeResult = {
 	code: string;
 	expires_at: string;
 	pairing_command: string;
-	bot_username: string | null;
-	deep_link: string | null;
-	qr_payload: string | null;
 };
 
 function LinkedChannelRow({
@@ -2694,6 +2687,7 @@ function LinkedChannelRow({
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
+	const [telegramPairOpen, setTelegramPairOpen] = useState(false);
 	const [nowMs, setNowMs] = useState(() => Date.now());
 	const [creatingPairCode, setCreatingPairCode] = useState(false);
 	const pairInFlightRef = useRef(false);
@@ -2704,22 +2698,10 @@ function LinkedChannelRow({
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
 	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
-	const resultExpired = code ? pairCodeExpired(code.expires_at, nowMs) : false;
-	const validTelegramLink =
-		code && provider === "telegram"
-			? telegramPairDeepLink({
-					deepLink: code.deep_link,
-					qrPayload: code.qr_payload,
-					botUsername: code.bot_username,
-					code: code.code,
-				})
-			: null;
 	const chatInstruction =
-		provider === "telegram"
-			? `Open Telegram and start a conversation with the bot you connected as “${name}”.`
-			: provider === "discord"
-				? `Open Discord and choose the server channel or direct message where “${name}” should answer.`
-				: `Open the conversation where you want “${name}” to answer.`;
+		provider === "discord"
+			? `Open Discord and choose the server channel or direct message where “${name}” should answer.`
+			: `Open the conversation where you want “${name}” to answer.`;
 	useEffect(() => {
 		if (!code) return;
 		setNowMs(Date.now());
@@ -2736,9 +2718,6 @@ function LinkedChannelRow({
 				code: data.code,
 				expires_at: data.expires_at,
 				pairing_command: data.pairing_command,
-				bot_username: data.bot_username ?? null,
-				deep_link: data.deep_link ?? null,
-				qr_payload: data.qr_payload ?? null,
 			});
 		} catch {
 			// useCreatePairCode already surfaces the API error.
@@ -2828,71 +2807,22 @@ function LinkedChannelRow({
 					<Button
 						variant="outline"
 						size="sm"
-						disabled={creatingPairCode}
-						onClick={() => void createPairCode()}
+						disabled={provider !== "telegram" && creatingPairCode}
+						onClick={() => {
+							if (provider === "telegram") setTelegramPairOpen(true);
+							else void createPairCode();
+						}}
 					>
 						{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
 						{creatingPairCode
 							? "Generating…"
 							: provider === "telegram"
-								? "Generate Telegram link"
+								? "Pair Telegram"
 								: "Create pairing code"}
 					</Button>
 				</div>
 
-				{code && provider === "telegram" ? (
-					<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-3">
-						{validTelegramLink && !resultExpired ? (
-							<div className="flex flex-col items-center gap-3">
-								<div className="rounded-xl border bg-white p-3 shadow-sm">
-									<QRCodeSVG
-										value={validTelegramLink}
-										size={176}
-										role="img"
-										aria-label="Telegram pairing QR code"
-									/>
-								</div>
-								<Button
-									render={<a href={validTelegramLink} target="_blank" rel="noopener noreferrer" />}
-									nativeButton={false}
-								>
-									{code.bot_username
-										? `Open @${code.bot_username.replace(/^@/, "")}`
-										: "Open Telegram"}
-									<ExternalLink className="size-4" />
-								</Button>
-							</div>
-						) : (
-							<div role="alert" className="rounded-md border border-warning/40 bg-background p-3">
-								<p className="text-sm font-medium">
-									{resultExpired ? "This Telegram link has expired" : "Telegram link unavailable"}
-								</p>
-								<p className="mt-1 text-xs text-muted-foreground">
-									Generate a new link to restore the QR and Telegram action.
-								</p>
-							</div>
-						)}
-						<p
-							role="status"
-							className={cn(
-								"text-center text-xs font-medium",
-								resultExpired ? "text-destructive" : "text-muted-foreground",
-							)}
-						>
-							{pairCodeExpiryLabel(code.expires_at, nowMs)}
-						</p>
-						{!resultExpired ? (
-							<details className="rounded-md border bg-background/70 px-3 py-2">
-								<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
-									Pair a group manually
-								</summary>
-								<div className="mt-2">
-									<CopyInline value={code.pairing_command} label="pairing command" />
-								</div>
-							</details>
-						) : null}
-					</div>
-				) : code ? (
+				{code && provider !== "telegram" ? (
 					<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
 						<p className="text-xs text-muted-foreground">{chatInstruction}</p>
 						<CopyInline value={code.pairing_command} label="pairing command" className="mt-2" />
@@ -2902,6 +2832,16 @@ function LinkedChannelRow({
 					</div>
 				) : null}
 			</div>
+
+			{provider === "telegram" ? (
+				<TelegramPairDialog
+					open={telegramPairOpen}
+					onOpenChange={setTelegramPairOpen}
+					accountId={link.account_id}
+					agentLinkId={link.id}
+					channelName={name}
+				/>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -42,6 +42,7 @@ import { EmptyState } from "@/components/empty-state";
 import { EntityCardSkeleton } from "@/components/entity-card";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SectionLabel } from "@/components/section-label";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { SettingsSection } from "@/components/settings-section";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -255,7 +256,7 @@ import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
-import { cn } from "@/lib/utils";
+import { cn, relativeTime } from "@/lib/utils";
 
 type Runtime = HostedRuntime;
 type HostedAgentTab =
@@ -303,7 +304,7 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Zap,
 	},
 	channels: {
-		description: "Messaging links for this hosted agent.",
+		description: "Channels this Agent can use.",
 		icon: Link2,
 	},
 	settings: {
@@ -2313,12 +2314,10 @@ function ChannelsSyncState({
 
 type LinkableChannel = { id: string; provider: string; name: string };
 
-function channelSelectItems(channels: LinkableChannel[]) {
-	return channels.map((channel) => ({
-		value: channel.id,
-		label: `${providerMeta(channel.provider).label} · ${channel.name}`,
-	}));
-}
+const AGENT_CHANNEL_LIST_CLASS = "divide-y overflow-hidden rounded-lg border bg-card";
+const AGENT_CHANNEL_ROW_CLASS =
+	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3";
+const AGENT_CHANNEL_ACTIONS_CLASS = "flex shrink-0 items-center justify-end gap-2";
 
 function ChannelsTab({ environmentId }: { environmentId: string }) {
 	const api = useApi();
@@ -2328,8 +2327,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 	const health = useChannelHealth();
 	const linked = useAgentChannelLinks(environmentId, isCloudEnvId(environmentId));
 	const unlink = useUnlinkAgentChannel(environmentId);
-	const [readyBotId, setReadyBotId] = useState("");
-	const [ownedChannelId, setOwnedChannelId] = useState("");
 	const [recentLink, setRecentLink] = useState<AgentChannelLink | null>(null);
 	const [connectOpen, setConnectOpen] = useState(false);
 	const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -2379,10 +2376,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
 		[botPool.data, linkedIds],
 	);
-	const selectedReadyBotId = readyBotId || (readyBots.length === 1 ? readyBots[0]?.id : "");
-	const selectedOwnedChannelId =
-		ownedChannelId || (ownedChannels.length === 1 ? ownedChannels[0]?.id : "");
-
 	useEffect(() => {
 		if (!botPool.isLoading && !botPool.error && readyBots.length === 0) setAdvancedOpen(true);
 	}, [botPool.error, botPool.isLoading, readyBots.length]);
@@ -2422,7 +2415,7 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 			qc.invalidateQueries({ queryKey: ["channel-bot-pool"] });
 			qc.invalidateQueries({ queryKey: ["channels"] });
 			toast.success("Channel linked", {
-				description: "Create a pairing code in the linked channel card to connect a conversation.",
+				description: "Pair a chat from the connected channel row.",
 			});
 			return data;
 		} catch (error) {
@@ -2437,8 +2430,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 		setLinkingAccountId(channelId);
 		try {
 			await link.execute(channelId);
-			setReadyBotId("");
-			setOwnedChannelId("");
 		} catch {
 			// The action already surfaces the API error.
 		} finally {
@@ -2469,16 +2460,20 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 	}
 
 	return (
-		<div className="space-y-4">
-			<LiveNote>
-				Hosted agents apply channel credentials automatically — no restart or token copy.
-			</LiveNote>
-
-			{/* Linked channels */}
-			<div className="space-y-2">
-				<div className="text-sm font-medium">Linked channels</div>
+		<div className="flex flex-col gap-6">
+			<section data-agent-connected-channels className="flex flex-col gap-3">
+				<SectionLabel count={visibleLinks.length}>Connected channels</SectionLabel>
 				{linked.isLoading && visibleLinks.length === 0 ? (
-					<Skeleton className="h-16 w-full rounded-lg" />
+					<div className={AGENT_CHANNEL_LIST_CLASS}>
+						<div className={AGENT_CHANNEL_ROW_CLASS}>
+							<Skeleton className="size-8 shrink-0 rounded-md" />
+							<div className="min-w-0 flex-1 space-y-2">
+								<Skeleton className="h-4 w-40" />
+								<Skeleton className="h-3 w-64 max-w-full" />
+							</div>
+							<Skeleton className="h-8 w-28 rounded-md" />
+						</div>
+					</div>
 				) : linked.error && visibleLinks.length === 0 ? (
 					<ApiErrorPanel
 						error={linked.error}
@@ -2488,22 +2483,25 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 				) : visibleLinks.length === 0 ? (
 					<EmptyState
 						variant="inset"
-						title="No channels linked"
-						description="Link a channel below so this agent can send and receive messages."
+						title="No connected channels"
+						description="Add a channel below to get started."
 					/>
 				) : (
-					visibleLinks.map((l) => (
-						<LinkedChannelRow
-							key={l.id}
-							link={l}
-							fallbackAccount={accountSummaries.get(l.account_id)}
-							health={healthByAccount.get(l.account_id)}
-							healthLoading={health.isLoading}
-							healthError={Boolean(health.error)}
-							unlinking={unlinkingLinkIds.has(l.id)}
-							onUnlink={() => startUnlink(l.account_id, l.id)}
-						/>
-					))
+					<div className={AGENT_CHANNEL_LIST_CLASS}>
+						{visibleLinks.map((l) => (
+							<LinkedChannelRow
+								key={l.id}
+								link={l}
+								fallbackAccount={accountSummaries.get(l.account_id)}
+								health={healthByAccount.get(l.account_id)}
+								healthLoading={health.isLoading}
+								healthError={Boolean(health.error)}
+								onHealthRetry={() => void health.refetch()}
+								unlinking={unlinkingLinkIds.has(l.id)}
+								onUnlink={() => startUnlink(l.account_id, l.id)}
+							/>
+						))}
+					</div>
 				)}
 				{linked.error && visibleLinks.length > 0 ? (
 					<ApiErrorPanel
@@ -2512,22 +2510,23 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 						title="Couldn't refresh every linked channel"
 					/>
 				) : null}
-			</div>
+			</section>
 
-			<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
-				<div className="flex items-start gap-3">
-					<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-background text-primary ring-1 ring-primary/20">
-						<Bot className="size-4" />
-					</div>
-					<div>
-						<div className="text-sm font-medium">Fastest: use a ready-to-go bot</div>
-						<p className="mt-1 text-xs text-muted-foreground">
-							No bot account, credentials, or developer setup. Choose one and link it now.
-						</p>
-					</div>
+			<section data-agent-add-channel className="flex flex-col gap-3 border-t pt-6">
+				<div className="space-y-1">
+					<SectionLabel>Add a channel</SectionLabel>
+					<p className="px-0.5 text-sm text-muted-foreground">
+						Link a bot to this Agent, then pair the chats it should answer.
+					</p>
 				</div>
 				{botPool.isLoading ? (
-					<Skeleton className="h-9 w-full rounded-md" />
+					<div className={AGENT_CHANNEL_LIST_CLASS}>
+						<div className={AGENT_CHANNEL_ROW_CLASS}>
+							<Skeleton className="size-8 shrink-0 rounded-md" />
+							<Skeleton className="h-4 min-w-0 flex-1 max-w-48" />
+							<Skeleton className="h-8 w-16 rounded-md" />
+						</div>
+					</div>
 				) : botPool.error ? (
 					<ApiErrorPanel
 						error={botPool.error}
@@ -2535,129 +2534,133 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 						title="Couldn't load ready-to-go bots"
 					/>
 				) : readyBots.length > 0 ? (
-					<div className="flex flex-col gap-2 sm:flex-row">
-						<Select
-							items={channelSelectItems(readyBots)}
-							value={selectedReadyBotId}
-							onValueChange={(value) => {
-								if (value !== null) setReadyBotId(value);
-							}}
-						>
-							<SelectTrigger aria-label="Choose a ready-to-go bot" className="flex-1 bg-background">
-								<SelectValue placeholder="Choose a ready-to-go bot…" />
-							</SelectTrigger>
-							<SelectContent>
-								{readyBots.map((bot) => (
-									<SelectItem key={bot.id} value={bot.id}>
-										{providerMeta(bot.provider).label} · {bot.name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-						<Button
-							disabled={!selectedReadyBotId || linkingAccountId !== null}
-							onClick={() => void submitLink(selectedReadyBotId)}
-						>
-							{linkingAccountId === selectedReadyBotId ? (
-								<Spinner className="size-3.5" />
-							) : (
-								<Link2 className="size-3.5" />
-							)}
-							{linkingAccountId === selectedReadyBotId ? "Linking…" : "Link bot"}
-						</Button>
+					<div className={AGENT_CHANNEL_LIST_CLASS}>
+						{readyBots.map((bot) => (
+							<AddChannelRow
+								key={bot.id}
+								channel={bot}
+								kind="Ready to use"
+								linking={linkingAccountId === bot.id}
+								disabled={linkingAccountId !== null}
+								onLink={() => void submitLink(bot.id)}
+							/>
+						))}
 					</div>
 				) : (
-					<p className="text-sm text-muted-foreground">
-						No ready-to-go bots are available right now. You can use your own bot below.
+					<p className="px-0.5 text-sm text-muted-foreground">
+						No ready-to-go bots are available right now.
 					</p>
 				)}
-			</div>
 
-			<details
-				open={advancedOpen}
-				onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
-				className="group rounded-lg border p-4"
-			>
-				<summary className="cursor-pointer text-sm font-medium">
-					Use your own bot (advanced)
-				</summary>
-				<div className="mt-3 space-y-3">
-					<p className="text-xs text-muted-foreground">
-						Choose a Telegram or Discord bot you already connected, or connect a new one.
-					</p>
-					{channels.isLoading ? (
-						<Skeleton className="h-9 w-full rounded-md" />
-					) : channels.error ? (
-						<ApiErrorPanel
-							error={channels.error}
-							onRetry={() => channels.refetch()}
-							title="Couldn't load your bots"
-						/>
-					) : ownedChannels.length > 0 ? (
-						<div className="flex flex-col gap-2 sm:flex-row">
-							<Select
-								items={channelSelectItems(ownedChannels)}
-								value={selectedOwnedChannelId}
-								onValueChange={(value) => {
-									if (value !== null) setOwnedChannelId(value);
-								}}
-							>
-								<SelectTrigger aria-label="Choose your bot" className="flex-1">
-									<SelectValue placeholder="Choose your bot…" />
-								</SelectTrigger>
-								<SelectContent>
-									{ownedChannels.map((channel) => (
-										<SelectItem key={channel.id} value={channel.id}>
-											{providerMeta(channel.provider).label} · {channel.name}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+				<details
+					open={advancedOpen}
+					onToggle={(event) => setAdvancedOpen(event.currentTarget.open)}
+					className="group border-t pt-4"
+				>
+					<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
+					<div className="mt-3 space-y-3">
+						{channels.isLoading ? (
+							<Skeleton className="h-16 w-full rounded-lg" />
+						) : channels.error ? (
+							<ApiErrorPanel
+								error={channels.error}
+								onRetry={() => channels.refetch()}
+								title="Couldn't load your bots"
+							/>
+						) : ownedChannels.length > 0 ? (
+							<div className={AGENT_CHANNEL_LIST_CLASS}>
+								{ownedChannels.map((channel) => (
+									<AddChannelRow
+										key={channel.id}
+										channel={channel}
+										kind="Your bot"
+										linking={linkingAccountId === channel.id}
+										disabled={linkingAccountId !== null}
+										onLink={() => void submitLink(channel.id)}
+										secondary
+									/>
+								))}
+							</div>
+						) : (
+							<div className={AGENT_CHANNEL_LIST_CLASS}>
+								<div className={AGENT_CHANNEL_ROW_CLASS}>
+									<span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+										<Bot className="size-4" />
+									</span>
+									<div className="min-w-0 flex-1">
+										<p className="text-sm font-medium">No bot connected yet</p>
+									</div>
+									<Button size="sm" onClick={() => setConnectOpen(true)}>
+										<Plus className="size-3.5" />
+										Connect a bot
+									</Button>
+								</div>
+							</div>
+						)}
+						<div className="flex flex-wrap gap-2">
+							{ownedChannels.length > 0 ? (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => setConnectOpen(true)}
+								>
+									<Plus className="size-3.5" />
+									Connect a bot
+								</Button>
+							) : null}
 							<Button
-								disabled={!selectedOwnedChannelId || linkingAccountId !== null}
-								onClick={() => void submitLink(selectedOwnedChannelId)}
+								render={<Link to="/channels" />}
+								nativeButton={false}
+								variant="ghost"
+								size="sm"
 							>
-								{linkingAccountId === selectedOwnedChannelId ? (
-									<Spinner className="size-3.5" />
-								) : (
-									<Link2 className="size-3.5" />
-								)}
-								{linkingAccountId === selectedOwnedChannelId ? "Linking…" : "Link my bot"}
+								View all channels
 							</Button>
 						</div>
-					) : (
-						<EmptyState
-							variant="inset"
-							title="No bot connected yet"
-							description="Connect a Telegram or Discord bot, then it will appear here automatically."
-							action={
-								<Button onClick={() => setConnectOpen(true)}>
-									<Plus className="size-3.5" />
-									Connect my bot
-								</Button>
-							}
-						/>
-					)}
-					<div className="flex flex-wrap gap-2">
-						{ownedChannels.length > 0 ? (
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => setConnectOpen(true)}
-							>
-								<Plus className="size-3.5" />
-								Connect another bot
-							</Button>
-						) : null}
-						<Button render={<Link to="/channels" />} nativeButton={false} variant="ghost" size="sm">
-							View all channel options
-						</Button>
 					</div>
-				</div>
-			</details>
+				</details>
+			</section>
 
 			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
+		</div>
+	);
+}
+
+function AddChannelRow({
+	channel,
+	kind,
+	linking,
+	disabled,
+	onLink,
+	secondary = false,
+}: {
+	channel: LinkableChannel;
+	kind: string;
+	linking: boolean;
+	disabled: boolean;
+	onLink: () => void;
+	secondary?: boolean;
+}) {
+	return (
+		<div data-add-channel-id={channel.id} className={AGENT_CHANNEL_ROW_CLASS}>
+			<ProviderChip provider={channel.provider} size="sm" />
+			<div className="min-w-0">
+				<p className="truncate text-sm font-medium">{channel.name}</p>
+				<p className="truncate text-xs text-muted-foreground">
+					{providerMeta(channel.provider).label} · {kind}
+				</p>
+			</div>
+			<Button
+				type="button"
+				size="sm"
+				variant={secondary ? "outline" : "default"}
+				disabled={disabled}
+				onClick={onLink}
+			>
+				{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+				{linking ? "Linking…" : "Link"}
+			</Button>
 		</div>
 	);
 }
@@ -2676,6 +2679,7 @@ function LinkedChannelRow({
 	health,
 	healthLoading,
 	healthError,
+	onHealthRetry,
 }: {
 	link: AgentChannelLink;
 	onUnlink: () => void;
@@ -2684,6 +2688,7 @@ function LinkedChannelRow({
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	healthLoading: boolean;
 	healthError: boolean;
+	onHealthRetry: () => void;
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
@@ -2698,10 +2703,6 @@ function LinkedChannelRow({
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
 	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
-	const chatInstruction =
-		provider === "discord"
-			? `Open Discord and choose the server channel or direct message where “${name}” should answer.`
-			: `Open the conversation where you want “${name}” to answer.`;
 	useEffect(() => {
 		if (!code) return;
 		setNowMs(Date.now());
@@ -2727,110 +2728,81 @@ function LinkedChannelRow({
 		}
 	}
 	return (
-		<div className="rounded-lg border p-4">
-			<div className="flex items-center gap-3">
-				<ProviderChip provider={provider} />
-				<div className="min-w-0 flex-1">
-					<div className="truncate text-sm font-medium">{name}</div>
-					<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-						{provider ? <span>{providerMeta(provider).label}</span> : null}
-						<ChannelStatusBadge status={link.status} />
-						{health ? <HealthBadge status={health.health_status} /> : null}
-					</div>
+		<div data-agent-channel-link-id={link.id} className={AGENT_CHANNEL_ROW_CLASS}>
+			<ProviderChip provider={provider} size="sm" />
+			<div className="min-w-0">
+				<p className="truncate text-sm font-medium">{name}</p>
+				<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+					{provider ? <span>{providerMeta(provider).label}</span> : null}
+					<ChannelStatusBadge status={link.status} />
+					{health ? <HealthBadge status={health.health_status} /> : null}
+					{healthLoading ? (
+						<span className="inline-flex items-center gap-1">
+							<Spinner className="size-3" /> Checking activity…
+						</span>
+					) : healthError ? (
+						<button
+							type="button"
+							className="font-medium text-destructive underline-offset-2 hover:underline"
+							onClick={onHealthRetry}
+						>
+							Activity unavailable · Retry
+						</button>
+					) : hasActivity ? (
+						<span>Last activity {relativeTime(health?.last_message_at)}</span>
+					) : (
+						<span>No activity yet</span>
+					)}
 				</div>
+				{provider !== "telegram" && pair.error ? (
+					<p className="mt-1 text-xs font-medium text-destructive">Pair failed · Try again</p>
+				) : null}
+				{code && provider !== "telegram" ? (
+					<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+						<CopyInline value={code.pairing_command} label="pairing command" />
+						<span className="text-muted-foreground">
+							{pairCodeExpiryLabel(code.expires_at, nowMs)}
+						</span>
+					</div>
+				) : null}
+			</div>
+			<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+				<Button
+					type="button"
+					variant={provider === "telegram" ? "default" : "outline"}
+					size="sm"
+					disabled={provider !== "telegram" && creatingPairCode}
+					onClick={() => {
+						if (provider === "telegram") setTelegramPairOpen(true);
+						else void createPairCode();
+					}}
+				>
+					{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
+					{creatingPairCode
+						? "Generating…"
+						: provider === "telegram"
+							? "Pair Telegram"
+							: pair.error
+								? "Retry pairing"
+								: "Pair chat"}
+				</Button>
 				<ConfirmAction
 					title="Unlink this channel?"
-					description={<p>The agent stops sending and receiving on this channel.</p>}
+					description={<p>This Agent will stop answering through {name}.</p>}
 					confirmLabel="Unlink"
 					destructive
 					onConfirm={onUnlink}
 				>
 					<Button
 						variant="ghost"
-						size="icon-sm"
+						size="sm"
 						className="text-muted-foreground hover:text-destructive"
 						disabled={unlinking}
-						aria-label="Unlink channel"
 					>
-						{unlinking ? <Spinner className="size-4" /> : <Link2Off className="size-4" />}
+						{unlinking ? <Spinner className="size-3.5" /> : <Link2Off className="size-3.5" />}
+						{unlinking ? "Unlinking…" : "Unlink"}
 					</Button>
 				</ConfirmAction>
-			</div>
-
-			<div
-				role="status"
-				aria-live="polite"
-				className={cn(
-					"mt-3 rounded-lg border p-3",
-					hasActivity ? "border-success/30 bg-success-muted" : "bg-muted/30",
-				)}
-			>
-				<div className="flex items-center gap-2 text-sm font-medium">
-					{healthLoading ? (
-						<Spinner className="size-4" />
-					) : healthError ? (
-						<AlertCircle className="size-4 text-warning-muted-foreground" />
-					) : hasActivity ? (
-						<CircleCheck className="size-4 text-success-muted-foreground" />
-					) : (
-						<span className="size-2 animate-pulse rounded-full bg-info" aria-hidden />
-					)}
-					{healthLoading
-						? "Checking channel activity…"
-						: healthError
-							? "Channel activity is temporarily unavailable"
-							: hasActivity
-								? "Channel activity detected"
-								: "Waiting for channel activity"}
-				</div>
-				<p className="mt-1 text-xs text-muted-foreground">
-					{healthError
-						? "Automatic checks will continue. You can finish the steps below while Clawdi reconnects."
-						: hasActivity
-							? "Clawdi can see activity on this channel. This signal does not yet confirm that the agent received a normal message."
-							: "This page checks automatically every 20 seconds. No refresh needed."}
-				</p>
-			</div>
-
-			<div className="mt-3 space-y-3 border-t pt-3">
-				<div className="flex flex-wrap items-center justify-between gap-2">
-					<div>
-						<p className="text-sm font-medium">
-							{provider === "telegram" ? "Pair Telegram" : "Pair a conversation"}
-						</p>
-						<p className="mt-0.5 text-xs text-muted-foreground">
-							{hasActivity
-								? "Pair another chat, or send a normal message in an existing paired chat."
-								: "Choose the chat where this Agent should answer."}
-						</p>
-					</div>
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={provider !== "telegram" && creatingPairCode}
-						onClick={() => {
-							if (provider === "telegram") setTelegramPairOpen(true);
-							else void createPairCode();
-						}}
-					>
-						{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
-						{creatingPairCode
-							? "Generating…"
-							: provider === "telegram"
-								? "Pair Telegram"
-								: "Create pairing code"}
-					</Button>
-				</div>
-
-				{code && provider !== "telegram" ? (
-					<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
-						<p className="text-xs text-muted-foreground">{chatInstruction}</p>
-						<CopyInline value={code.pairing_command} label="pairing command" className="mt-2" />
-						<p className="mt-2 text-xs text-muted-foreground">
-							{pairCodeExpiryLabel(code.expires_at, nowMs)}
-						</p>
-					</div>
-				) : null}
 			</div>
 
 			{provider === "telegram" ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -18,6 +18,7 @@ import {
 	Link2,
 	Link2Off,
 	type LucideIcon,
+	MessageSquareDashed,
 	MonitorPlay,
 	Plus,
 	QrCode,
@@ -218,6 +219,11 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
+import {
+	activeAgentChannelLinks,
+	type ChannelAccountSummary,
+	selectAgentPairedChats,
+} from "@/hosted/v2/channels/agent-channel-bindings.logic";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
@@ -230,6 +236,7 @@ import {
 import {
 	useAgentChannelLinks,
 	useBotPool,
+	useChannelBindingsForAccounts,
 	useChannelHealth,
 	useChannels,
 	useCreatePairCode,
@@ -241,6 +248,7 @@ import {
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { PairedChatRow } from "@/hosted/v2/channels/paired-chat-row";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentRouteSearch,
@@ -2313,12 +2321,13 @@ function ChannelsSyncState({
 	);
 }
 
-type LinkableChannel = { id: string; provider: string; name: string };
+type LinkableChannel = { id: string } & ChannelAccountSummary;
 
 const AGENT_CHANNEL_LIST_CLASS = "divide-y overflow-hidden rounded-lg border bg-card";
 const AGENT_CHANNEL_ROW_CLASS =
-	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3";
-const AGENT_CHANNEL_ACTIONS_CLASS = "flex shrink-0 items-center justify-end gap-2";
+	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]";
+const AGENT_CHANNEL_ACTIONS_CLASS =
+	"col-span-2 flex min-w-0 items-center justify-end gap-2 sm:col-span-1 sm:col-start-3 sm:row-start-1";
 
 function ChannelsTab({
 	environmentId,
@@ -2356,8 +2365,9 @@ function ChannelsTab({
 			? [recentLink, ...items]
 			: items;
 	}, [linked.data, recentLink]);
+	const visibleActiveLinks = useMemo(() => activeAgentChannelLinks(visibleLinks), [visibleLinks]);
 	const accountSummaries = useMemo(() => {
-		const map = new Map<string, { provider: string; name: string }>();
+		const map = new Map<string, ChannelAccountSummary>();
 		for (const channel of channels.data ?? []) {
 			map.set(channel.id, { provider: channel.provider, name: channel.name });
 		}
@@ -2493,7 +2503,9 @@ function ChannelsTab({
 								<Skeleton className="h-4 w-40" />
 								<Skeleton className="h-3 w-64 max-w-full" />
 							</div>
-							<Skeleton className="h-8 w-28 rounded-md" />
+							<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+								<Skeleton className="h-8 w-28 rounded-md" />
+							</div>
 						</div>
 					</div>
 				) : linked.error && visibleLinks.length === 0 ? (
@@ -2534,6 +2546,12 @@ function ChannelsTab({
 				) : null}
 			</section>
 
+			<AgentPairedChats
+				links={visibleActiveLinks}
+				accountSummaries={accountSummaries}
+				linksLoading={linked.isLoading}
+			/>
+
 			<section data-agent-add-channel className="flex flex-col gap-3 border-t pt-6">
 				<div className="space-y-1">
 					<SectionLabel>Add a channel</SectionLabel>
@@ -2546,7 +2564,9 @@ function ChannelsTab({
 						<div className={AGENT_CHANNEL_ROW_CLASS}>
 							<Skeleton className="size-8 shrink-0 rounded-md" />
 							<Skeleton className="h-4 min-w-0 flex-1 max-w-48" />
-							<Skeleton className="h-8 w-16 rounded-md" />
+							<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+								<Skeleton className="h-8 w-16 rounded-md" />
+							</div>
 						</div>
 					</div>
 				) : botPool.error ? (
@@ -2612,10 +2632,12 @@ function ChannelsTab({
 									<div className="min-w-0 flex-1">
 										<p className="text-sm font-medium">No bot connected yet</p>
 									</div>
-									<Button size="sm" onClick={() => setConnectOpen(true)}>
-										<Plus className="size-3.5" />
-										Connect a bot
-									</Button>
+									<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+										<Button size="sm" onClick={() => setConnectOpen(true)}>
+											<Plus className="size-3.5" />
+											Connect a bot
+										</Button>
+									</div>
 								</div>
 							</div>
 						)}
@@ -2649,6 +2671,92 @@ function ChannelsTab({
 	);
 }
 
+function AgentPairedChats({
+	links,
+	accountSummaries,
+	linksLoading,
+}: {
+	links: AgentChannelLink[];
+	accountSummaries: ReadonlyMap<string, ChannelAccountSummary>;
+	linksLoading: boolean;
+}) {
+	const accountIds = useMemo(
+		() => Array.from(new Set(links.map((link) => link.account_id))),
+		[links],
+	);
+	const bindingQueries = useChannelBindingsForAccounts(accountIds);
+	const items = selectAgentPairedChats({
+		visibleLinks: links,
+		bindingsByAccount: bindingQueries.flatMap((query, index) => {
+			const accountId = accountIds[index];
+			return accountId ? [{ accountId, bindings: query.data ?? [] }] : [];
+		}),
+		accountSummaries,
+	});
+
+	const bindingsLoading = linksLoading || bindingQueries.some((query) => query.isLoading);
+	const failedQueries = bindingQueries.filter((query) => query.error);
+
+	return (
+		<section data-agent-paired-chats className="flex flex-col gap-3 border-t pt-6">
+			<SectionLabel count={items.length}>Paired chats</SectionLabel>
+			{bindingsLoading && items.length === 0 ? (
+				<div className={AGENT_CHANNEL_LIST_CLASS}>
+					<div className={AGENT_CHANNEL_ROW_CLASS}>
+						<Skeleton className="size-8 shrink-0 rounded-md" />
+						<div className="min-w-0 space-y-2">
+							<Skeleton className="h-4 w-40" />
+							<Skeleton className="h-3 w-56 max-w-full" />
+						</div>
+					</div>
+				</div>
+			) : items.length === 0 && failedQueries.length === 0 ? (
+				<div className={AGENT_CHANNEL_LIST_CLASS}>
+					<div className={AGENT_CHANNEL_ROW_CLASS}>
+						<span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+							<MessageSquareDashed className="size-4" />
+						</span>
+						<p className="min-w-0 text-sm text-muted-foreground">No paired chats yet.</p>
+					</div>
+				</div>
+			) : (
+				<div data-agent-paired-chats-list className={AGENT_CHANNEL_LIST_CLASS}>
+					{items.map((item) => (
+						<PairedChatRow
+							key={item.binding.id}
+							accountId={item.accountId}
+							binding={item.binding}
+							provider={item.provider}
+							channelName={item.channelName}
+						/>
+					))}
+					{failedQueries.length > 0 ? (
+						<div role="alert" className={AGENT_CHANNEL_ROW_CLASS}>
+							<span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-destructive/10 text-destructive">
+								<AlertCircle className="size-4" />
+							</span>
+							<p className="min-w-0 text-sm font-medium">Couldn&apos;t load every paired chat</p>
+							<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => {
+										for (const query of failedQueries) void query.refetch();
+									}}
+								>
+									<RefreshCw className="size-3.5" />
+									Retry
+								</Button>
+							</div>
+						</div>
+					) : null}
+				</div>
+			)}
+		</section>
+	);
+}
+
 function AddChannelRow({
 	channel,
 	kind,
@@ -2673,16 +2781,18 @@ function AddChannelRow({
 					{providerMeta(channel.provider).label} · {kind}
 				</p>
 			</div>
-			<Button
-				type="button"
-				size="sm"
-				variant={secondary ? "outline" : "default"}
-				disabled={disabled}
-				onClick={onLink}
-			>
-				{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-				{linking ? "Linking…" : "Link"}
-			</Button>
+			<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+				<Button
+					type="button"
+					size="sm"
+					variant={secondary ? "outline" : "default"}
+					disabled={disabled}
+					onClick={onLink}
+				>
+					{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+					{linking ? "Linking…" : "Link"}
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -237,6 +237,7 @@ import {
 } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import {
+	agentProviderHasSingleLinkLimit,
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -650,7 +651,7 @@ export function HostedAgentDetail({
 						!deploymentProjectionQueryable ? (
 							<StoppedAgentState deployment={deployment} />
 						) : projection.status === "resolved" ? (
-							<ChannelsTab environmentId={environmentId} />
+							<ChannelsTab environmentId={environmentId} agentType={runtime} />
 						) : (
 							<ChannelsSyncState
 								isChecking={isCheckingDeployment || agentQuery.isFetching}
@@ -2319,7 +2320,13 @@ const AGENT_CHANNEL_ROW_CLASS =
 	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3";
 const AGENT_CHANNEL_ACTIONS_CLASS = "flex shrink-0 items-center justify-end gap-2";
 
-function ChannelsTab({ environmentId }: { environmentId: string }) {
+function ChannelsTab({
+	environmentId,
+	agentType,
+}: {
+	environmentId: string;
+	agentType: HostedRuntime;
+}) {
 	const api = useApi();
 	const qc = useQueryClient();
 	const channels = useChannels();
@@ -2349,6 +2356,25 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 			? [recentLink, ...items]
 			: items;
 	}, [linked.data, recentLink]);
+	const accountSummaries = useMemo(() => {
+		const map = new Map<string, { provider: string; name: string }>();
+		for (const channel of channels.data ?? []) {
+			map.set(channel.id, { provider: channel.provider, name: channel.name });
+		}
+		for (const list of Object.values(botPool.data?.providers ?? {})) {
+			for (const bot of list) map.set(bot.id, { provider: bot.provider, name: bot.name });
+		}
+		return map;
+	}, [channels.data, botPool.data]);
+	const linkedProviders = useMemo(
+		() =>
+			new Set(
+				visibleLinks
+					.map((link) => link.account?.provider ?? accountSummaries.get(link.account_id)?.provider)
+					.filter((provider): provider is string => Boolean(provider)),
+			),
+		[accountSummaries, visibleLinks],
+	);
 	const ownedChannels = useMemo(
 		() =>
 			(channels.data ?? [])
@@ -2358,9 +2384,13 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 					name: channel.name,
 				}))
 				.filter(
-					(channel) => channelProviderLinkingReady(channel.provider) && !linkedIds.has(channel.id),
+					(channel) =>
+						channelProviderLinkingReady(channel.provider) &&
+						(!agentProviderHasSingleLinkLimit(agentType, channel.provider) ||
+							!linkedProviders.has(channel.provider)) &&
+						!linkedIds.has(channel.id),
 				),
-		[channels.data, linkedIds],
+		[channels.data, linkedIds, linkedProviders, agentType],
 	);
 	const readyBots = useMemo(
 		() =>
@@ -2371,25 +2401,17 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 						bot.access === "public" &&
 						bot.available &&
 						channelProviderLinkingReady(bot.provider) &&
+						(!agentProviderHasSingleLinkLimit(agentType, bot.provider) ||
+							!linkedProviders.has(bot.provider)) &&
 						!linkedIds.has(bot.id),
 				)
 				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
-		[botPool.data, linkedIds],
+		[botPool.data, linkedIds, linkedProviders, agentType],
 	);
 	useEffect(() => {
 		if (!botPool.isLoading && !botPool.error && readyBots.length === 0) setAdvancedOpen(true);
 	}, [botPool.error, botPool.isLoading, readyBots.length]);
 
-	// Provider/name labels for linked rows whose API payload omits the nested
-	// `account` (the list-by-agent endpoint isn't guaranteed to embed it).
-	// Resolved from the already-loaded channels + shared bot-pool by account id.
-	const accountSummaries = useMemo(() => {
-		const map = new Map<string, { provider: string; name: string }>();
-		for (const c of channels.data ?? []) map.set(c.id, { provider: c.provider, name: c.name });
-		for (const list of Object.values(botPool.data?.providers ?? {}))
-			for (const b of list) map.set(b.id, { provider: b.provider, name: b.name });
-		return map;
-	}, [channels.data, botPool.data]);
 	const healthByAccount = useMemo(
 		() => new Map((health.data?.items ?? []).map((item) => [item.account_id, item])),
 		[health.data],

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -30,6 +30,7 @@ import {
 	X,
 	Zap,
 } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -217,13 +218,17 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
+import {
+	pairCodeExpiryLabel,
+	telegramPairDeepLink,
+} from "@/hosted/v2/channels/channel-detail-page.logic";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import {
 	ChannelStatusBadge,
+	CopyInline,
 	HealthBadge,
 	ProviderChip,
-	TokenReveal,
 } from "@/hosted/v2/channels/channel-ui";
 import {
 	useAgentChannelLinks,
@@ -237,7 +242,7 @@ import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import {
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
-	pairingCommand,
+	pairCodeExpired,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
 import {
 	type AgentRouteSearch,
@@ -2330,7 +2335,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 	const [readyBotId, setReadyBotId] = useState("");
 	const [ownedChannelId, setOwnedChannelId] = useState("");
 	const [recentLink, setRecentLink] = useState<AgentChannelLink | null>(null);
-	const [recentToken, setRecentToken] = useState<{ linkId: string; value: string } | null>(null);
 	const [connectOpen, setConnectOpen] = useState(false);
 	const [advancedOpen, setAdvancedOpen] = useState(false);
 	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
@@ -2410,7 +2414,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 					body: { agent_id: environmentId },
 				}),
 			);
-			setRecentToken(data.agent_token ? { linkId: data.id, value: data.agent_token } : null);
 			setRecentLink({
 				id: data.id,
 				account_id: data.account_id,
@@ -2455,7 +2458,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 		void (async () => {
 			try {
 				await unlink.mutateAsync({ accountId: accountIdToUnlink, linkId });
-				setRecentToken((current) => (current?.linkId === linkId ? null : current));
 				setRecentLink((current) => (current?.id === linkId ? null : current));
 			} catch {
 				// useUnlinkAgentChannel already surfaces the API error.
@@ -2502,7 +2504,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 							health={healthByAccount.get(l.account_id)}
 							healthLoading={health.isLoading}
 							healthError={Boolean(health.error)}
-							token={recentToken?.linkId === l.id ? recentToken.value : undefined}
 							unlinking={unlinkingLinkIds.has(l.id)}
 							onUnlink={() => startUnlink(l.account_id, l.id)}
 						/>
@@ -2665,6 +2666,15 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 	);
 }
 
+type AgentPairCodeResult = {
+	code: string;
+	expires_at: string;
+	pairing_command: string;
+	bot_username: string | null;
+	deep_link: string | null;
+	qr_payload: string | null;
+};
+
 function LinkedChannelRow({
 	link,
 	onUnlink,
@@ -2673,7 +2683,6 @@ function LinkedChannelRow({
 	health,
 	healthLoading,
 	healthError,
-	token,
 }: {
 	link: AgentChannelLink;
 	onUnlink: () => void;
@@ -2682,10 +2691,10 @@ function LinkedChannelRow({
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	healthLoading: boolean;
 	healthError: boolean;
-	token?: string;
 }) {
 	const pair = useCreatePairCode(link.account_id);
-	const [code, setCode] = useState<{ code: string; expires_at: string } | null>(null);
+	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
+	const [nowMs, setNowMs] = useState(() => Date.now());
 	const [creatingPairCode, setCreatingPairCode] = useState(false);
 	const pairInFlightRef = useRef(false);
 	// The list-by-agent payload may omit the nested `account`. Fall back to the
@@ -2694,21 +2703,43 @@ function LinkedChannelRow({
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
 	const name = account?.name ?? "Unnamed channel";
-	const providerLabel = provider ? providerMeta(provider).label : "your chat app";
 	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
+	const resultExpired = code ? pairCodeExpired(code.expires_at, nowMs) : false;
+	const validTelegramLink =
+		code && provider === "telegram"
+			? telegramPairDeepLink({
+					deepLink: code.deep_link,
+					qrPayload: code.qr_payload,
+					botUsername: code.bot_username,
+					code: code.code,
+				})
+			: null;
 	const chatInstruction =
 		provider === "telegram"
 			? `Open Telegram and start a conversation with the bot you connected as “${name}”.`
 			: provider === "discord"
 				? `Open Discord and choose the server channel or direct message where “${name}” should answer.`
 				: `Open the conversation where you want “${name}” to answer.`;
+	useEffect(() => {
+		if (!code) return;
+		setNowMs(Date.now());
+		const interval = window.setInterval(() => setNowMs(Date.now()), 1_000);
+		return () => window.clearInterval(interval);
+	}, [code]);
 	async function createPairCode() {
 		if (pairInFlightRef.current) return;
 		pairInFlightRef.current = true;
 		setCreatingPairCode(true);
 		try {
 			const data = await pair.execute({ agent_link_id: link.id });
-			setCode({ code: data.code, expires_at: data.expires_at });
+			setCode({
+				code: data.code,
+				expires_at: data.expires_at,
+				pairing_command: data.pairing_command,
+				bot_username: data.bot_username ?? null,
+				deep_link: data.deep_link ?? null,
+				qr_payload: data.qr_payload ?? null,
+			});
 		} catch {
 			// useCreatePairCode already surfaces the API error.
 		} finally {
@@ -2782,69 +2813,95 @@ function LinkedChannelRow({
 				</p>
 			</div>
 
-			{hasActivity ? (
-				<div className="mt-3 text-sm">
-					<p className="font-medium">Send a normal message to start chatting</p>
-					<p className="mt-1 text-xs text-muted-foreground">
-						Open {providerLabel} and message the conversation you paired. Channel-level activity is
-						live; agent delivery confirmation is not available yet.
-					</p>
-				</div>
-			) : (
-				<div className="mt-3 space-y-3">
+			<div className="mt-3 space-y-3 border-t pt-3">
+				<div className="flex flex-wrap items-center justify-between gap-2">
 					<div>
-						<p className="text-sm font-medium">Finish connecting your conversation</p>
-						<p className="mt-1 text-xs text-muted-foreground">
-							Linking gives this agent access to the bot. Pairing chooses the exact conversation
-							where it should answer.
+						<p className="text-sm font-medium">
+							{provider === "telegram" ? "Pair Telegram" : "Pair a conversation"}
+						</p>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							{hasActivity
+								? "Pair another chat, or send a normal message in an existing paired chat."
+								: "Choose the chat where this Agent should answer."}
 						</p>
 					</div>
-					<ol className="list-decimal space-y-2 pl-4 text-sm text-muted-foreground">
-						<li>
-							<Button
-								variant="outline"
-								size="sm"
-								className="ml-1"
-								disabled={creatingPairCode}
-								onClick={() => void createPairCode()}
-							>
-								{creatingPairCode ? (
-									<Spinner className="size-3.5" />
-								) : (
-									<QrCode className="size-3.5" />
-								)}
-								{creatingPairCode ? "Creating code…" : "Create pairing code"}
-							</Button>
-						</li>
-						<li>{chatInstruction}</li>
-						<li>Send the command below in that conversation, then send a normal message.</li>
-					</ol>
-					{code ? (
-						<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
-							<p className="text-xs font-medium text-primary">Send this exact command</p>
-							<code className="mt-1 block break-all font-mono font-semibold tracking-wide">
-								{pairingCommand(code.code)}
-							</code>
-							<p className="mt-1 text-xs text-muted-foreground">
-								The code is one-time and expires automatically.
-							</p>
-						</div>
-					) : null}
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={creatingPairCode}
+						onClick={() => void createPairCode()}
+					>
+						{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
+						{creatingPairCode
+							? "Generating…"
+							: provider === "telegram"
+								? "Generate Telegram link"
+								: "Create pairing code"}
+					</Button>
 				</div>
-			)}
 
-			{token ? (
-				<details className="mt-3 rounded-md border p-3">
-					<summary className="cursor-pointer text-xs font-medium">Agent token (advanced)</summary>
-					<div className="mt-2">
-						<TokenReveal
-							label="Agent token"
-							value={token}
-							note="Hosted agents configure this automatically. You do not need to copy it unless support asks you to."
-						/>
+				{code && provider === "telegram" ? (
+					<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-3">
+						{validTelegramLink && !resultExpired ? (
+							<div className="flex flex-col items-center gap-3">
+								<div className="rounded-xl border bg-white p-3 shadow-sm">
+									<QRCodeSVG
+										value={validTelegramLink}
+										size={176}
+										role="img"
+										aria-label="Telegram pairing QR code"
+									/>
+								</div>
+								<Button
+									render={<a href={validTelegramLink} target="_blank" rel="noopener noreferrer" />}
+									nativeButton={false}
+								>
+									{code.bot_username
+										? `Open @${code.bot_username.replace(/^@/, "")}`
+										: "Open Telegram"}
+									<ExternalLink className="size-4" />
+								</Button>
+							</div>
+						) : (
+							<div role="alert" className="rounded-md border border-warning/40 bg-background p-3">
+								<p className="text-sm font-medium">
+									{resultExpired ? "This Telegram link has expired" : "Telegram link unavailable"}
+								</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									Generate a new link to restore the QR and Telegram action.
+								</p>
+							</div>
+						)}
+						<p
+							role="status"
+							className={cn(
+								"text-center text-xs font-medium",
+								resultExpired ? "text-destructive" : "text-muted-foreground",
+							)}
+						>
+							{pairCodeExpiryLabel(code.expires_at, nowMs)}
+						</p>
+						{!resultExpired ? (
+							<details className="rounded-md border bg-background/70 px-3 py-2">
+								<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+									Pair a group manually
+								</summary>
+								<div className="mt-2">
+									<CopyInline value={code.pairing_command} label="pairing command" />
+								</div>
+							</details>
+						) : null}
 					</div>
-				</details>
-			) : null}
+				) : code ? (
+					<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+						<p className="text-xs text-muted-foreground">{chatInstruction}</p>
+						<CopyInline value={code.pairing_command} label="pairing command" className="mt-2" />
+						<p className="mt-2 text-xs text-muted-foreground">
+							{pairCodeExpiryLabel(code.expires_at, nowMs)}
+						</p>
+					</div>
+				) : null}
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -172,7 +172,6 @@ describe("structural secret boundaries without the denylist", () => {
 				[
 					"export function useCreateChannel()",
 					"export function useLinkAgent(accountId: string)",
-					"export function useRotateAgentToken(accountId: string)",
 					"export function useCreatePairCode(accountId: string)",
 					"export function useCreateWhatsappTenantCred(accountId: string)",
 					"return useSensitiveAction",
@@ -215,7 +214,7 @@ describe("structural secret boundaries without the denylist", () => {
 		}
 		expect(
 			source("hosted/v2/channels/channels-hooks.ts").split("return useSensitiveAction"),
-		).toHaveLength(6);
+		).toHaveLength(5);
 		expect(
 			source("hosted/v2/ai-providers/ai-providers-hooks.ts").split("return useSensitiveAction"),
 		).toHaveLength(4);

--- a/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+	activeAgentChannelLinks,
+	selectAgentPairedChats,
+} from "@/hosted/v2/channels/agent-channel-bindings.logic";
+import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
+
+const sharedAccountId = "11111111-1111-4111-8111-111111111111";
+const currentLinkId = "22222222-2222-4222-8222-222222222222";
+const otherAgentLinkId = "33333333-3333-4333-8333-333333333333";
+const archivedLinkId = "44444444-4444-4444-8444-444444444444";
+
+function link(id: string, status = "active"): AgentChannelLink {
+	return {
+		id,
+		account_id: sharedAccountId,
+		agent_id: "55555555-5555-4555-8555-555555555555",
+		status,
+		created_at: "2026-07-31T00:00:00Z",
+	};
+}
+
+function binding(
+	id: string,
+	agentLinkId: string | null,
+	accountId = sharedAccountId,
+): ChannelBinding {
+	return {
+		id,
+		account_id: accountId,
+		agent_link_id: agentLinkId,
+		external_chat_id: id,
+		external_chat_type: "private",
+		external_chat_name: `Chat ${id}`,
+		status: "active",
+		created_at: "2026-07-31T00:05:00Z",
+	};
+}
+
+describe("Agent paired chat selection", () => {
+	test("keeps only bindings owned by visible active links on the queried account", () => {
+		const current = link(currentLinkId);
+		const archived = link(archivedLinkId, "archived");
+		const items = selectAgentPairedChats({
+			visibleLinks: [current, archived],
+			bindingsByAccount: [
+				{
+					accountId: sharedAccountId,
+					bindings: [
+						binding("current", currentLinkId),
+						binding("other-agent", otherAgentLinkId),
+						binding("archived", archivedLinkId),
+						binding("unowned", null),
+						binding("wrong-account", currentLinkId, "66666666-6666-4666-8666-666666666666"),
+					],
+				},
+			],
+			accountSummaries: new Map([
+				[sharedAccountId, { provider: "telegram", name: "Shared Telegram" }],
+			]),
+		});
+
+		expect(items.map((item) => item.binding.id)).toEqual(["current"]);
+		expect(items[0]).toMatchObject({
+			accountId: sharedAccountId,
+			provider: "telegram",
+			channelName: "Shared Telegram",
+		});
+	});
+
+	test("identifies active links without treating archived links as pairing owners", () => {
+		expect(
+			activeAgentChannelLinks([link(currentLinkId), link(archivedLinkId, "archived")]),
+		).toEqual([link(currentLinkId)]);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.ts
@@ -1,0 +1,46 @@
+import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
+
+export type ChannelAccountSummary = { provider: string; name: string };
+
+export type AgentPairedChatItem = {
+	accountId: string;
+	binding: ChannelBinding;
+	provider: string;
+	channelName: string;
+};
+
+export function activeAgentChannelLinks(links: readonly AgentChannelLink[]): AgentChannelLink[] {
+	return links.filter((link) => link.status.toLowerCase() === "active");
+}
+
+export function selectAgentPairedChats({
+	visibleLinks,
+	bindingsByAccount,
+	accountSummaries,
+}: {
+	visibleLinks: readonly AgentChannelLink[];
+	bindingsByAccount: readonly { accountId: string; bindings: readonly ChannelBinding[] }[];
+	accountSummaries: ReadonlyMap<string, ChannelAccountSummary>;
+}): AgentPairedChatItem[] {
+	const activeLinks = activeAgentChannelLinks(visibleLinks);
+	const linksById = new Map(activeLinks.map((link) => [link.id, link]));
+	const items: AgentPairedChatItem[] = [];
+
+	for (const { accountId, bindings } of bindingsByAccount) {
+		for (const binding of bindings) {
+			if (!binding.agent_link_id || binding.account_id !== accountId) continue;
+			const link = linksById.get(binding.agent_link_id);
+			if (!link || link.account_id !== accountId) continue;
+			const account = link.account ?? accountSummaries.get(accountId);
+			items.push({
+				accountId,
+				binding,
+				provider: account?.provider ?? "",
+				channelName: account?.name ?? "Connected channel",
+			});
+		}
+	}
+
+	return items;
+}

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -34,13 +34,14 @@ describe("channel default path", () => {
 	test("moves a successful ready-bot link into the agent finish line", () => {
 		const linkDialog = source("./link-agent-dialog.tsx");
 
-		expect(linkDialog).toContain("The bot is linked to this agent");
-		expect(linkDialog).toContain("Next, create a pairing code");
+		expect(linkDialog).toContain("The bot is linked to this Agent");
+		expect(linkDialog).toContain("Next, create a Telegram pairing link");
 		expect(linkDialog).toContain("agentSectionLink(");
 		expect(linkDialog).toContain('"channels"');
 		expect(linkDialog).toContain("agentDeploymentRouteQuery(routeSearch)");
-		expect(linkDialog).toContain("Finish channel setup");
-		expect(linkDialog).toContain("Agent token (advanced)");
+		expect(linkDialog).toContain("Open Agent Channels");
+		expect(linkDialog).not.toContain("agent_token");
+		expect(linkDialog).not.toContain("Agent token");
 	});
 
 	test("uses customer-facing labels for public bot access", () => {

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-	acknowledgeRotatedToken,
-	hasAtRiskRotatedToken,
 	nativeTransportSummary,
+	pairCodeExpiryLabel,
 	pairCodeRequiresExplicitAgent,
-	rotatedTokenDisplayState,
+	telegramPairDeepLink,
 } from "./channel-detail-page.logic";
 
 describe("pairCodeRequiresExplicitAgent", () => {
@@ -15,23 +14,84 @@ describe("pairCodeRequiresExplicitAgent", () => {
 	});
 });
 
-describe("rotated token display state", () => {
-	test("keeps a returned token at risk until the user acknowledges it", () => {
-		const state = rotatedTokenDisplayState("one-time-secret");
-
-		expect(state).toEqual({
-			status: "available",
-			token: "one-time-secret",
-			acknowledged: false,
-		});
-		expect(hasAtRiskRotatedToken({ link: state }, false)).toBe(true);
-		expect(hasAtRiskRotatedToken({ link: acknowledgeRotatedToken(state) }, false)).toBe(false);
+describe("telegramPairDeepLink", () => {
+	test("accepts only the server-provided bot start link for this code", () => {
+		expect(
+			telegramPairDeepLink({
+				deepLink: "https://t.me/ClawdiBot?start=PAIR123",
+				qrPayload: "https://t.me/ClawdiBot?start=PAIR123",
+				botUsername: "ClawdiBot",
+				code: "PAIR123",
+			}),
+		).toBe("https://t.me/ClawdiBot?start=PAIR123");
+		expect(
+			telegramPairDeepLink({
+				deepLink: "https://t.me/ClawdiBot?start=PAIR123",
+				qrPayload: "https://t.me/ClawdiBot?start=PAIR123",
+				botUsername: null,
+				code: "PAIR123",
+			}),
+		).toBe("https://t.me/ClawdiBot?start=PAIR123");
 	});
 
-	test("treats an absent response token as unrecoverable and guards pending rotations", () => {
-		expect(rotatedTokenDisplayState(null)).toEqual({ status: "unrecoverable" });
-		expect(rotatedTokenDisplayState("   ")).toEqual({ status: "unrecoverable" });
-		expect(hasAtRiskRotatedToken({}, true)).toBe(true);
+	test("fails closed for missing, malformed, mismatched, or expanded links", () => {
+		const input = {
+			botUsername: "ClawdiBot",
+			code: "PAIR123",
+			qrPayload: "https://t.me/ClawdiBot?start=PAIR123",
+		};
+		expect(telegramPairDeepLink({ ...input, deepLink: null })).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "https://t.me/ClawdiBot?start=PAIR123",
+				qrPayload: null,
+			}),
+		).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "https://t.me/ClawdiBot?start=PAIR123",
+				qrPayload: "https://t.me/ClawdiBot?start=DIFFERENT",
+			}),
+		).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "tg://resolve?domain=ClawdiBot",
+				qrPayload: "tg://resolve?domain=ClawdiBot",
+			}),
+		).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "https://t.me/OtherBot?start=PAIR123",
+				qrPayload: "https://t.me/OtherBot?start=PAIR123",
+			}),
+		).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "https://t.me/ClawdiBot?start=OTHER",
+				qrPayload: "https://t.me/ClawdiBot?start=OTHER",
+			}),
+		).toBeNull();
+		expect(
+			telegramPairDeepLink({
+				...input,
+				deepLink: "https://t.me/ClawdiBot?start=PAIR123&admin=true",
+				qrPayload: "https://t.me/ClawdiBot?start=PAIR123&admin=true",
+			}),
+		).toBeNull();
+	});
+});
+
+describe("pairCodeExpiryLabel", () => {
+	test("shows a live countdown and closes the action at expiry", () => {
+		const now = Date.parse("2026-07-30T12:00:00Z");
+		expect(pairCodeExpiryLabel("2026-07-30T12:01:05Z", now)).toBe("Expires in 1m 5s");
+		expect(pairCodeExpiryLabel("2026-07-30T12:00:00Z", now)).toBe("Expired — generate a new link");
+		expect(pairCodeExpiryLabel("invalid", now)).toBe("Expired — generate a new link");
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
@@ -2,17 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
 	nativeTransportSummary,
 	pairCodeExpiryLabel,
-	pairCodeRequiresExplicitAgent,
 	telegramPairDeepLink,
 } from "./channel-detail-page.logic";
-
-describe("pairCodeRequiresExplicitAgent", () => {
-	test("only permits the implicit linked-agent default for exactly one link", () => {
-		expect(pairCodeRequiresExplicitAgent(0)).toBe(true);
-		expect(pairCodeRequiresExplicitAgent(1)).toBe(false);
-		expect(pairCodeRequiresExplicitAgent(2)).toBe(true);
-	});
-});
 
 describe("telegramPairDeepLink", () => {
 	test("accepts only the server-provided bot start link for this code", () => {

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
@@ -2,30 +2,55 @@ export function pairCodeRequiresExplicitAgent(linkedAgentCount: number): boolean
 	return linkedAgentCount !== 1;
 }
 
-export type RotatedTokenDisplayState =
-	| { status: "available"; token: string; acknowledged: boolean }
-	| { status: "unrecoverable" };
-
-export function rotatedTokenDisplayState(
-	token: string | null | undefined,
-): RotatedTokenDisplayState {
-	return token?.trim()
-		? { status: "available", token, acknowledged: false }
-		: { status: "unrecoverable" };
+export function telegramPairDeepLink({
+	deepLink,
+	qrPayload,
+	botUsername,
+	code,
+}: {
+	deepLink: string | null | undefined;
+	qrPayload: string | null | undefined;
+	botUsername: string | null | undefined;
+	code: string;
+}): string | null {
+	const username = botUsername?.trim().replace(/^@/, "");
+	if (!deepLink || qrPayload !== deepLink || (username && !/^[A-Za-z0-9_]{5,32}$/.test(username))) {
+		return null;
+	}
+	try {
+		const url = new URL(deepLink);
+		const query = [...url.searchParams.entries()];
+		const linkedUsername = url.pathname.slice(1);
+		if (
+			url.protocol !== "https:" ||
+			url.hostname !== "t.me" ||
+			url.port ||
+			url.username ||
+			url.password ||
+			url.hash ||
+			url.pathname !== `/${linkedUsername}` ||
+			!/^[A-Za-z0-9_]{5,32}$/.test(linkedUsername) ||
+			(username ? linkedUsername.toLowerCase() !== username.toLowerCase() : false) ||
+			query.length !== 1 ||
+			query[0][0] !== "start" ||
+			query[0][1] !== code
+		) {
+			return null;
+		}
+		return deepLink;
+	} catch {
+		return null;
+	}
 }
 
-export function acknowledgeRotatedToken(state: RotatedTokenDisplayState): RotatedTokenDisplayState {
-	return state.status === "available" ? { ...state, acknowledged: true } : state;
-}
-
-export function hasAtRiskRotatedToken(
-	states: Readonly<Record<string, RotatedTokenDisplayState>>,
-	rotationPending: boolean,
-): boolean {
-	return (
-		rotationPending ||
-		Object.values(states).some((state) => state.status === "available" && !state.acknowledged)
-	);
+export function pairCodeExpiryLabel(expiresAt: string, nowMs: number): string {
+	const expiresAtMs = Date.parse(expiresAt);
+	if (!Number.isFinite(expiresAtMs)) return "Expired — generate a new link";
+	const remainingSeconds = Math.max(0, Math.ceil((expiresAtMs - nowMs) / 1_000));
+	if (remainingSeconds <= 0) return "Expired — generate a new link";
+	const minutes = Math.floor(remainingSeconds / 60);
+	const seconds = remainingSeconds % 60;
+	return `Expires in ${minutes > 0 ? `${minutes}m ` : ""}${seconds}s`;
 }
 
 export type NativeTransportSummary = {

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
@@ -1,7 +1,3 @@
-export function pairCodeRequiresExplicitAgent(linkedAgentCount: number): boolean {
-	return linkedAgentCount !== 1;
-}
-
 export function telegramPairDeepLink({
 	deepLink,
 	qrPayload,

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "@tanstack/react-router";
 import {
 	ArrowDownLeft,
 	ArrowUpRight,
-	ExternalLink,
+	Bot,
 	KeyRound,
 	Link2,
 	Link2Off,
@@ -17,8 +17,7 @@ import {
 	Trash2,
 	TriangleAlert,
 } from "lucide-react";
-import { QRCodeSVG } from "qrcode.react";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
@@ -48,12 +47,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
-import {
-	nativeTransportSummary,
-	pairCodeExpiryLabel,
-	pairCodeRequiresExplicitAgent,
-	telegramPairDeepLink,
-} from "@/hosted/v2/channels/channel-detail-page.logic";
+import { nativeTransportSummary } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type {
 	ChannelActivityItem,
@@ -72,7 +66,6 @@ import {
 	useChannelAgentLinks,
 	useChannelBindings,
 	useChannelHealth,
-	useCreatePairCode,
 	useCreateWhatsappTenantCred,
 	useDeleteChannel,
 	useDeleteChannelBinding,
@@ -84,10 +77,10 @@ import {
 } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import {
-	pairCodeExpired,
 	WHATSAPP_COMING_SOON_MESSAGE,
 	WHATSAPP_LINKING_READY,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentOwnership,
 	agentOwnershipKindFromId,
@@ -98,6 +91,9 @@ import { cn, relativeTime } from "@/lib/utils";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const LIST_TAB_CLASS = "mt-4 min-w-0";
 const FORM_TAB_CLASS = "mt-4 min-w-0 max-w-xl";
+const CHANNEL_RELATION_LIST_CLASS = "divide-y overflow-hidden rounded-lg border bg-card";
+const CHANNEL_RELATION_ROW_CLASS = "flex min-h-16 items-center gap-3 px-4 py-3";
+const CHANNEL_RELATION_ACTIONS_CLASS = "flex shrink-0 items-center justify-end gap-2";
 
 type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
 type Environment = NonNullable<EnvironmentList>[number];
@@ -130,10 +126,29 @@ function envName(
 		: deploymentDisplayName(agentId);
 }
 
-function AgentName({ env, fallback }: { env: Environment | null; fallback: string }) {
+function AgentName({
+	env,
+	fallback,
+	meta,
+}: {
+	env: Environment | null;
+	fallback: string;
+	meta?: ReactNode[];
+}) {
 	const ownership = useAgentOwnership();
 	if (!env) {
-		return <span className="truncate text-sm font-medium">{deploymentDisplayName(fallback)}</span>;
+		return (
+			<EntityHeader
+				className="min-w-0 flex-1"
+				icon={
+					<IconChip size="sm">
+						<Bot />
+					</IconChip>
+				}
+				title={deploymentDisplayName(fallback)}
+				meta={meta}
+			/>
+		);
 	}
 	const ownershipKind = agentOwnershipKindFromId(env.id, ownership);
 	return (
@@ -148,7 +163,8 @@ function AgentName({ env, fallback }: { env: Environment | null; fallback: strin
 			titleAdornment={
 				<AgentSourceBadgeForEnvironment env={env} ownershipKind={ownershipKind} compact />
 			}
-			className="min-w-0"
+			className="min-w-0 flex-1"
+			meta={meta}
 		/>
 	);
 }
@@ -191,33 +207,6 @@ function SectionHeader({
 			<SectionLabel count={count}>{label}</SectionLabel>
 			{action ? <div className="shrink-0">{action}</div> : null}
 		</div>
-	);
-}
-
-function SetupStepCard({
-	step,
-	title,
-	description,
-	children,
-}: {
-	step: number;
-	title: string;
-	description: string;
-	children: ReactNode;
-}) {
-	return (
-		<section data-channel-setup-step={step} className="rounded-xl border bg-card p-4 sm:p-5">
-			<div className="mb-4 flex items-start gap-3">
-				<div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
-					{step}
-				</div>
-				<div className="min-w-0">
-					<h2 className="font-semibold">{title}</h2>
-					<p className="text-sm text-muted-foreground">{description}</p>
-				</div>
-			</div>
-			{children}
-		</section>
 	);
 }
 
@@ -351,45 +340,19 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				</InfoCard>
 			) : null}
 
-			<div data-channel-setup-flow className="flex max-w-3xl flex-col gap-4">
-				<SetupStepCard
-					step={1}
-					title="Link Agent"
-					description="Choose which Agent uses this bot. Credentials sync automatically."
-				>
+			<div data-channel-setup-flow className="flex flex-col gap-6">
+				<section className="flex flex-col gap-3">
 					<AgentsTab
 						accountId={id}
 						accountName={ch.name}
 						provider={ch.provider}
 						readOnly={providerUnavailable}
 					/>
-				</SetupStepCard>
-				{providerUnavailable ? (
-					<section className="rounded-xl border bg-card p-4 sm:p-5">
-						<SectionHeader label="Paired chats" />
-						<div className="mt-3">
-							<BindingsTab accountId={id} />
-						</div>
-					</section>
-				) : (
-					<SetupStepCard
-						step={2}
-						title={ch.provider === "telegram" ? "Pair Telegram" : `Pair ${meta.label}`}
-						description={
-							ch.provider === "telegram"
-								? "Open Telegram from the QR or link, with a short manual command for groups."
-								: "Use the short pairing command in the conversation you want."
-						}
-					>
-						<PairCodeTab accountId={id} provider={ch.provider} />
-						<div className="mt-5 border-t pt-5">
-							<SectionHeader label="Paired chats" />
-							<div className="mt-3">
-								<BindingsTab accountId={id} />
-							</div>
-						</div>
-					</SetupStepCard>
-				)}
+				</section>
+				<section className="flex flex-col gap-3 border-t pt-6">
+					<SectionHeader label="Paired chats" />
+					<BindingsTab accountId={id} />
+				</section>
 			</div>
 
 			<Tabs
@@ -442,7 +405,9 @@ function AgentsTab({
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
 	const unlink = useUnlinkChannelAgent(accountId);
+	const ownership = useAgentOwnership();
 	const [linkOpen, setLinkOpen] = useState(false);
+	const [pairingLink, setPairingLink] = useState<ChannelAgentLink | null>(null);
 	const unlinkingLinksRef = useRef<Set<string>>(new Set());
 	const [unlinkingLinks, setUnlinkingLinks] = useState<ReadonlySet<string>>(() => new Set());
 	function unlinkAgent(linkId: string) {
@@ -510,45 +475,55 @@ function AgentsTab({
 					}
 				/>
 			) : (
-				<div className="flex flex-col gap-2">
+				<div className={CHANNEL_RELATION_LIST_CLASS}>
 					{items.map((link: ChannelAgentLink) => {
 						const isUnlinking = unlinkingLinks.has(link.id);
+						const env = findEnv(envs.data, link.agent_id);
 						return (
-							<div key={link.id} className={ENTITY_CARD_BASE}>
-								<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-									<div className="min-w-0">
-										<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
-										<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-											<ChannelStatusBadge status={link.status} />
-											<span>Linked {relativeTime(link.created_at)}</span>
-										</div>
-									</div>
-									{readOnly ? null : (
-										<div className="flex shrink-0 flex-wrap items-center gap-1.5">
-											<ConfirmAction
-												title="Unlink this agent?"
-												description={<p>It stops sending and receiving on {accountName}.</p>}
-												confirmLabel="Unlink"
-												destructive
-												onConfirm={() => unlinkAgent(link.id)}
+							<div
+								key={link.id}
+								data-channel-agent-link-id={link.id}
+								className={CHANNEL_RELATION_ROW_CLASS}
+							>
+								<AgentName
+									env={env}
+									fallback={link.agent_id}
+									meta={[
+										<ChannelStatusBadge key="status" status={link.status} />,
+										<span key="linked">Linked {relativeTime(link.created_at)}</span>,
+									]}
+								/>
+								{readOnly ? null : (
+									<div className={CHANNEL_RELATION_ACTIONS_CLASS}>
+										{provider === "telegram" ? (
+											<Button size="sm" onClick={() => setPairingLink(link)}>
+												<QrCode className="size-3.5" />
+												Pair Telegram
+											</Button>
+										) : null}
+										<ConfirmAction
+											title="Unlink this agent?"
+											description={<p>It stops sending and receiving on {accountName}.</p>}
+											confirmLabel="Unlink"
+											destructive
+											onConfirm={() => unlinkAgent(link.id)}
+										>
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												className="text-muted-foreground hover:text-destructive"
+												disabled={isUnlinking}
+												aria-label="Unlink agent"
 											>
-												<Button
-													variant="ghost"
-													size="icon-sm"
-													className="text-muted-foreground hover:text-destructive"
-													disabled={isUnlinking}
-													aria-label="Unlink agent"
-												>
-													{isUnlinking ? (
-														<Spinner className="size-4" />
-													) : (
-														<Link2Off className="size-4" />
-													)}
-												</Button>
-											</ConfirmAction>
-										</div>
-									)}
-								</div>
+												{isUnlinking ? (
+													<Spinner className="size-4" />
+												) : (
+													<Link2Off className="size-4" />
+												)}
+											</Button>
+										</ConfirmAction>
+									</div>
+								)}
 							</div>
 						);
 					})}
@@ -556,13 +531,27 @@ function AgentsTab({
 			)}
 
 			{readOnly ? null : (
-				<LinkAgentDialog
-					open={linkOpen}
-					onOpenChange={setLinkOpen}
-					accountId={accountId}
-					accountName={accountName}
-					provider={provider}
-				/>
+				<>
+					<LinkAgentDialog
+						open={linkOpen}
+						onOpenChange={setLinkOpen}
+						accountId={accountId}
+						accountName={accountName}
+						provider={provider}
+					/>
+					{pairingLink ? (
+						<TelegramPairDialog
+							open
+							onOpenChange={(nextOpen) => {
+								if (!nextOpen) setPairingLink(null);
+							}}
+							accountId={accountId}
+							agentLinkId={pairingLink.id}
+							agentName={envName(envs.data, pairingLink.agent_id, ownership, false)}
+							channelName={accountName}
+						/>
+					) : null}
+				</>
 			)}
 		</div>
 	);
@@ -772,283 +761,13 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 	);
 }
 
-// ── Pair code ────────────────────────────────────────────────────────────────
-
-const TTL_OPTIONS = [
-	{ value: "900", label: "15 minutes" },
-	{ value: "3600", label: "1 hour" },
-	{ value: "86400", label: "24 hours" },
-];
-
-type PairCodeResult = {
-	agent_link_id: string;
-	code: string;
-	expires_at: string;
-	pairing_command: string;
-	bot_username: string | null;
-	deep_link: string | null;
-	qr_payload: string | null;
-};
-
-function PairCodeTab({ accountId, provider }: { accountId: string; provider: string }) {
-	const envs = useEnvironments();
-	const links = useChannelAgentLinks(accountId);
-	const create = useCreatePairCode(accountId);
-	const ownership = useAgentOwnership();
-	const [agentLinkId, setAgentLinkId] = useState("");
-	const [ttl, setTtl] = useState("900");
-	const [result, setResult] = useState<PairCodeResult | null>(null);
-	const [nowMs, setNowMs] = useState(() => Date.now());
-	const [generating, setGenerating] = useState(false);
-	const linkedAgents = links.data ?? [];
-	const agentItems = linkedAgents.map((link) => ({
-		value: link.id,
-		label: envName(envs.data, link.agent_id, ownership),
-	}));
-	const generateLocked = useRef(false);
-	const isGenerating = generating || create.isPending;
-	const linkedAgentCount = links.data?.length ?? 0;
-	const requiresExplicitAgent = pairCodeRequiresExplicitAgent(linkedAgentCount);
-	const selectedLink =
-		linkedAgents.find((candidate) => candidate.id === agentLinkId) ??
-		(linkedAgentCount === 1 ? linkedAgents[0] : undefined);
-	const selectionMessage =
-		requiresExplicitAgent && !selectedLink && !links.isLoading && !links.error
-			? linkedAgentCount === 0
-				? "Link an Agent above before creating a pairing link."
-				: "This channel has multiple linked agents. Choose the agent for this pairing code."
-			: null;
-	const canGenerate = !isGenerating && !links.isLoading && !links.error && Boolean(selectedLink);
-	const resultExpired = result ? pairCodeExpired(result.expires_at, nowMs) : false;
-	const validTelegramLink =
-		result && provider === "telegram"
-			? telegramPairDeepLink({
-					deepLink: result.deep_link,
-					qrPayload: result.qr_payload,
-					botUsername: result.bot_username,
-					code: result.code,
-				})
-			: null;
-
-	useEffect(() => {
-		if (!result) return;
-		setNowMs(Date.now());
-		const interval = window.setInterval(() => setNowMs(Date.now()), 1000);
-		return () => window.clearInterval(interval);
-	}, [result]);
-
-	useEffect(() => {
-		if (!result || !links.data) return;
-		if (!links.data.some((link) => link.id === result.agent_link_id)) setResult(null);
-	}, [links.data, result]);
-
-	function generate() {
-		if (!canGenerate || generateLocked.current) return;
-		generateLocked.current = true;
-		setGenerating(true);
-		setResult(null);
-		void (async () => {
-			try {
-				if (!selectedLink) return;
-				const data = await create.execute({
-					agent_link_id: selectedLink.id,
-					ttl_seconds: Number(ttl),
-				});
-				setResult({
-					agent_link_id: data.agent_link_id,
-					code: data.code,
-					expires_at: data.expires_at,
-					pairing_command: data.pairing_command,
-					bot_username: data.bot_username ?? null,
-					deep_link: data.deep_link ?? null,
-					qr_payload: data.qr_payload ?? null,
-				});
-			} catch {
-				// useSensitiveAction already surfaces the API error.
-			} finally {
-				generateLocked.current = false;
-				setGenerating(false);
-			}
-		})();
-	}
-
-	if (provider === "whatsapp" && !WHATSAPP_LINKING_READY) {
-		return (
-			<InfoCard icon={TriangleAlert} title="WhatsApp is coming soon">
-				{WHATSAPP_COMING_SOON_MESSAGE}
-			</InfoCard>
-		);
-	}
-
-	return (
-		<div className="flex flex-col gap-4">
-			<div className="grid gap-3 sm:grid-cols-2">
-				<div className="flex flex-col gap-1.5">
-					<Label htmlFor="pair-agent">Agent</Label>
-					{envs.isLoading || links.isLoading ? (
-						<Skeleton className="h-10 w-full rounded-md" />
-					) : (
-						<Select
-							items={agentItems}
-							value={agentLinkId}
-							onValueChange={(value) => {
-								if (value !== null) {
-									setAgentLinkId(value);
-									setResult(null);
-								}
-							}}
-							disabled={Boolean(links.error) || linkedAgentCount === 0 || isGenerating}
-						>
-							<SelectTrigger
-								id="pair-agent"
-								aria-describedby={selectionMessage ? "pair-agent-requirement" : undefined}
-							>
-								<SelectValue
-									placeholder={requiresExplicitAgent ? "Choose a linked Agent" : "Use linked Agent"}
-								/>
-							</SelectTrigger>
-							<SelectContent>
-								{linkedAgents.map((link) => (
-									<SelectItem
-										key={link.id}
-										value={link.id}
-										label={envName(envs.data, link.agent_id, ownership)}
-									>
-										<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					)}
-					{selectionMessage ? (
-						<p id="pair-agent-requirement" className="text-xs text-warning-muted-foreground">
-							{selectionMessage}
-						</p>
-					) : null}
-				</div>
-				<div className="flex flex-col gap-1.5">
-					<Label htmlFor="pair-ttl">Expires in</Label>
-					<Select
-						items={TTL_OPTIONS}
-						value={ttl}
-						onValueChange={(value) => {
-							if (value !== null) setTtl(value);
-						}}
-						disabled={isGenerating}
-					>
-						<SelectTrigger id="pair-ttl">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{TTL_OPTIONS.map((o) => (
-								<SelectItem key={o.value} value={o.value}>
-									{o.label}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-			</div>
-
-			{envs.error ? (
-				<ApiErrorPanel
-					error={envs.error}
-					onRetry={() => envs.refetch()}
-					title="Couldn't load agents"
-				/>
-			) : null}
-			{links.error ? (
-				<ApiErrorPanel
-					error={links.error}
-					onRetry={() => links.refetch()}
-					title="Couldn't load linked agents"
-				/>
-			) : null}
-
-			<Button onClick={generate} disabled={!canGenerate}>
-				<QrCode className="size-4" />
-				{isGenerating
-					? "Generating…"
-					: provider === "telegram"
-						? "Generate Telegram link"
-						: "Generate pairing code"}
-			</Button>
-
-			{result ? (
-				<div
-					data-telegram-pair-result={provider === "telegram" ? "true" : undefined}
-					className="flex flex-col gap-4 rounded-lg border border-primary/30 bg-primary/5 p-4"
-				>
-					<div className="text-sm font-medium text-primary">
-						{provider === "telegram" ? "Telegram pairing link" : "Pairing code"}
-					</div>
-					{provider === "telegram" ? (
-						validTelegramLink && !resultExpired ? (
-							<div className="flex flex-col items-center gap-3">
-								<div className="rounded-xl border bg-white p-3 shadow-sm">
-									<QRCodeSVG
-										value={validTelegramLink}
-										size={192}
-										role="img"
-										aria-label="Telegram pairing QR code"
-									/>
-								</div>
-								<Button
-									render={<a href={validTelegramLink} target="_blank" rel="noopener noreferrer" />}
-									nativeButton={false}
-								>
-									{result.bot_username
-										? `Open @${result.bot_username.replace(/^@/, "")}`
-										: "Open Telegram"}
-									<ExternalLink className="size-4" />
-								</Button>
-								<CopyInline value={validTelegramLink} label="Telegram pairing link" />
-							</div>
-						) : (
-							<div role="alert" className="rounded-md border border-warning/40 bg-background p-3">
-								<p className="text-sm font-medium">
-									{resultExpired ? "This Telegram link has expired" : "Telegram link unavailable"}
-								</p>
-								<p className="mt-1 text-xs text-muted-foreground">
-									Generate a new pairing link. QR and Open Telegram stay disabled unless the server
-									returns a valid t.me start link.
-								</p>
-							</div>
-						)
-					) : (
-						<div className="font-mono text-3xl font-semibold tracking-[0.2em]">{result.code}</div>
-					)}
-					<p
-						role="status"
-						className={cn(
-							"text-center text-sm font-medium",
-							resultExpired ? "text-destructive" : "text-muted-foreground",
-						)}
-					>
-						{pairCodeExpiryLabel(result.expires_at, nowMs)}
-					</p>
-					{!resultExpired ? (
-						<details className="rounded-md border bg-background/70 px-3 py-2">
-							<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
-								Manual command
-							</summary>
-							<div className="mt-2">
-								<CopyInline value={result.pairing_command} label="pairing command" />
-							</div>
-						</details>
-					) : null}
-				</div>
-			) : null}
-		</div>
-	);
-}
-
 // ── Bindings (paired chats) ──────────────────────────────────────────────────
 
 function BindingsTab({ accountId }: { accountId: string }) {
 	const bindings = useChannelBindings(accountId);
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
+	const ownership = useAgentOwnership();
 	const unpair = useDeleteChannelBinding(accountId);
 	const unpairingRef = useRef<Set<string>>(new Set());
 	const [unpairingIds, setUnpairingIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -1090,13 +809,13 @@ function BindingsTab({ accountId }: { accountId: string }) {
 			<EmptyState
 				icon={MessageSquareDashed}
 				title="No paired chats"
-				description="Generate a pairing code, then send it from a chat to link it here."
+				description="Choose Pair Telegram on a linked Agent to connect a chat."
 			/>
 		);
 	}
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div className={CHANNEL_RELATION_LIST_CLASS}>
 			{items.map((binding: ChannelBinding) => {
 				const link = links.data?.find((candidate) => candidate.id === binding.agent_link_id);
 				const threadLabel = bindingThreadLabel(binding);
@@ -1105,10 +824,7 @@ function BindingsTab({ accountId }: { accountId: string }) {
 					<div
 						key={binding.id}
 						data-channel-binding-id={binding.id}
-						className={cn(
-							ENTITY_CARD_BASE,
-							"flex flex-col items-stretch gap-3 sm:flex-row sm:items-start",
-						)}
+						className={CHANNEL_RELATION_ROW_CLASS}
 					>
 						<EntityHeader
 							className="min-w-0 flex-1"
@@ -1123,19 +839,18 @@ function BindingsTab({ accountId }: { accountId: string }) {
 									{binding.external_chat_type ?? "chat"}
 								</span>,
 								<ChannelStatusBadge key="status" status={binding.status} />,
+								...(link
+									? [
+											<span key="agent">
+												Agent: {envName(envs.data, link.agent_id, ownership, false)}
+											</span>,
+										]
+									: []),
 								<CopyInline key="chat-id" value={binding.external_chat_id} label="chat ID" />,
 								...(threadLabel ? [<span key="thread">Thread: {threadLabel}</span>] : []),
 							]}
 						/>
-						<div className="flex shrink-0 items-center justify-between gap-2 sm:justify-end">
-							{link ? (
-								<div className="min-w-0 max-w-52">
-									<div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-										Agent
-									</div>
-									<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
-								</div>
-							) : null}
+						<div className={CHANNEL_RELATION_ACTIONS_CLASS}>
 							<ConfirmAction
 								title={`Unpair ${binding.external_chat_name ?? "this chat"}?`}
 								description="Only this chat will be disconnected. Other chats and the linked Agent stay active."

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { type ShouldBlockFn, useBlocker, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import {
 	ArrowDownLeft,
 	ArrowUpRight,
-	Check,
-	Copy,
 	ExternalLink,
-	Eye,
-	EyeOff,
 	KeyRound,
 	Link2,
 	Link2Off,
@@ -22,8 +18,7 @@ import {
 	TriangleAlert,
 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
@@ -38,16 +33,6 @@ import { IconChip } from "@/components/icon-chip";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Label } from "@/components/ui/label";
@@ -64,12 +49,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
 import {
-	acknowledgeRotatedToken,
-	hasAtRiskRotatedToken,
 	nativeTransportSummary,
+	pairCodeExpiryLabel,
 	pairCodeRequiresExplicitAgent,
-	type RotatedTokenDisplayState,
-	rotatedTokenDisplayState,
+	telegramPairDeepLink,
 } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type {
@@ -82,7 +65,6 @@ import {
 	CopyInline,
 	DeliveryBadge,
 	HealthBadge,
-	TokenReveal,
 } from "@/hosted/v2/channels/channel-ui";
 import {
 	useChannel,
@@ -93,6 +75,7 @@ import {
 	useCreatePairCode,
 	useCreateWhatsappTenantCred,
 	useDeleteChannel,
+	useDeleteChannelBinding,
 	useEnvironments,
 	useRevokeWhatsappTenantCred,
 	useSyncCommands,
@@ -102,7 +85,6 @@ import {
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import {
 	pairCodeExpired,
-	pairingCommand,
 	WHATSAPP_COMING_SOON_MESSAGE,
 	WHATSAPP_LINKING_READY,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -111,7 +93,6 @@ import {
 	agentOwnershipKindFromId,
 	useAgentOwnership,
 } from "@/lib/agent-ownership";
-import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { cn, relativeTime } from "@/lib/utils";
 
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
@@ -213,10 +194,36 @@ function SectionHeader({
 	);
 }
 
+function SetupStepCard({
+	step,
+	title,
+	description,
+	children,
+}: {
+	step: number;
+	title: string;
+	description: string;
+	children: ReactNode;
+}) {
+	return (
+		<section data-channel-setup-step={step} className="rounded-xl border bg-card p-4 sm:p-5">
+			<div className="mb-4 flex items-start gap-3">
+				<div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+					{step}
+				</div>
+				<div className="min-w-0">
+					<h2 className="font-semibold">{title}</h2>
+					<p className="text-sm text-muted-foreground">{description}</p>
+				</div>
+			</div>
+			{children}
+		</section>
+	);
+}
+
 export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 	const channel = useChannel(id);
 	const health = useChannelHealth();
-	const rotatedTokens = useRotatedTokenLifecycle(id);
 	const router = useRouter();
 	const del = useDeleteChannel();
 	const [removing, setRemoving] = useState(false);
@@ -229,7 +236,6 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 		void (async () => {
 			try {
 				await del.mutateAsync(id);
-				rotatedTokens.discardAtRiskToken();
 				await router.navigate({ href: "/channels" });
 			} catch {
 				// useDeleteChannel already surfaces the API error.
@@ -314,7 +320,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				actions={
 					<ConfirmAction
 						title={`Remove ${ch.name}?`}
-						description={`Agents linked to this channel will stop sending and receiving. This can't be undone.${rotatedTokens.hasTokenAtRisk ? " The one-time token shown here will also be discarded." : ""}`}
+						description="Agents linked to this channel will stop sending and receiving. This can't be undone."
 						confirmLabel="Remove channel"
 						destructive
 						onConfirm={removeChannel}
@@ -345,41 +351,65 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				</InfoCard>
 			) : null}
 
-			<Tabs defaultValue="agents" className="min-w-0">
-				<TabsList className="h-auto flex-wrap justify-start">
-					<TabsTrigger value="agents">Agents</TabsTrigger>
-					{ch.provider === "whatsapp" && !providerUnavailable ? (
-						<TabsTrigger value="devices">Linked devices</TabsTrigger>
-					) : null}
-					{providerUnavailable ? null : <TabsTrigger value="pair">Pair code</TabsTrigger>}
-					<TabsTrigger value="bindings">Chats</TabsTrigger>
-					<TabsTrigger value="activity">Activity</TabsTrigger>
-					<TabsTrigger value="health">Health</TabsTrigger>
-					{providerUnavailable ? null : <TabsTrigger value="commands">Commands</TabsTrigger>}
-				</TabsList>
-
-				<TabsContent value="agents" className={LIST_TAB_CLASS}>
+			<div data-channel-setup-flow className="flex max-w-3xl flex-col gap-4">
+				<SetupStepCard
+					step={1}
+					title="Link Agent"
+					description="Choose which Agent uses this bot. Credentials sync automatically."
+				>
 					<AgentsTab
 						accountId={id}
 						accountName={ch.name}
 						provider={ch.provider}
 						readOnly={providerUnavailable}
-						rotatedTokens={rotatedTokens}
 					/>
-				</TabsContent>
+				</SetupStepCard>
+				{providerUnavailable ? (
+					<section className="rounded-xl border bg-card p-4 sm:p-5">
+						<SectionHeader label="Paired chats" />
+						<div className="mt-3">
+							<BindingsTab accountId={id} />
+						</div>
+					</section>
+				) : (
+					<SetupStepCard
+						step={2}
+						title={ch.provider === "telegram" ? "Pair Telegram" : `Pair ${meta.label}`}
+						description={
+							ch.provider === "telegram"
+								? "Open Telegram from the QR or link, with a short manual command for groups."
+								: "Use the short pairing command in the conversation you want."
+						}
+					>
+						<PairCodeTab accountId={id} provider={ch.provider} />
+						<div className="mt-5 border-t pt-5">
+							<SectionHeader label="Paired chats" />
+							<div className="mt-3">
+								<BindingsTab accountId={id} />
+							</div>
+						</div>
+					</SetupStepCard>
+				)}
+			</div>
+
+			<Tabs
+				defaultValue={ch.provider === "whatsapp" && !providerUnavailable ? "devices" : "activity"}
+				className="min-w-0"
+			>
+				<TabsList className="h-auto flex-wrap justify-start">
+					{ch.provider === "whatsapp" && !providerUnavailable ? (
+						<TabsTrigger value="devices">Linked devices</TabsTrigger>
+					) : null}
+					<TabsTrigger value="activity">Activity</TabsTrigger>
+					<TabsTrigger value="health">Health</TabsTrigger>
+					{providerUnavailable ? null : <TabsTrigger value="commands">Commands</TabsTrigger>}
+				</TabsList>
+
 				{ch.provider === "whatsapp" && !providerUnavailable ? (
 					<TabsContent value="devices" className={FORM_TAB_CLASS}>
 						<WhatsAppDevicesTab accountId={id} />
 					</TabsContent>
 				) : null}
-				{providerUnavailable ? null : (
-					<TabsContent value="pair" className={FORM_TAB_CLASS}>
-						<PairCodeTab accountId={id} provider={ch.provider} />
-					</TabsContent>
-				)}
-				<TabsContent value="bindings" className={LIST_TAB_CLASS}>
-					<BindingsTab accountId={id} />
-				</TabsContent>
 				<TabsContent value="activity" className={LIST_TAB_CLASS}>
 					<ActivityTab accountId={id} />
 				</TabsContent>
@@ -392,267 +422,27 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 					</TabsContent>
 				)}
 			</Tabs>
-			<RotatedTokenNavigationAlert lifecycle={rotatedTokens} />
 		</div>
 	);
 }
 
 // ── Agents ───────────────────────────────────────────────────────────────────
 
-function RotatedTokenCard({
-	state,
-	onAcknowledge,
-}: {
-	state: RotatedTokenDisplayState;
-	onAcknowledge: () => void;
-}) {
-	const [revealed, setRevealed] = useState(false);
-	const [copied, setCopied] = useState(false);
-	const tokenIdentity = state.status === "available" ? state.token : null;
-
-	useEffect(() => {
-		setRevealed(false);
-		setCopied(false);
-	}, [tokenIdentity]);
-
-	if (state.status === "unrecoverable") {
-		return (
-			<div
-				role="alert"
-				className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3"
-			>
-				<TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
-				<div className="space-y-1">
-					<p className="text-xs font-medium text-destructive">New token is not recoverable</p>
-					<p className="text-xs text-muted-foreground">
-						This token was shown once and is not recoverable — rotate again to get a new one.
-					</p>
-				</div>
-			</div>
-		);
-	}
-	const token = state.token;
-
-	async function copyToken() {
-		try {
-			await navigator.clipboard.writeText(token);
-			setCopied(true);
-			onAcknowledge();
-			toast.success("Token copied to clipboard");
-			window.setTimeout(() => setCopied(false), 1_500);
-		} catch {
-			toast.error("Couldn’t copy — select and copy manually.");
-		}
-	}
-
-	return (
-		<div className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3">
-			<div className="text-xs font-medium text-primary">New agent token</div>
-			<div className="flex items-center gap-2">
-				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
-					{revealed ? state.token : "••••••••••••"}
-				</code>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					onClick={() => setRevealed((visible) => !visible)}
-					aria-label={`${revealed ? "Hide" : "Show"} New agent token`}
-					aria-pressed={revealed}
-				>
-					{revealed ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-				</Button>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					onClick={() => void copyToken()}
-					aria-label="Copy New agent token"
-				>
-					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-				</Button>
-			</div>
-			<p className="text-xs text-muted-foreground">
-				{state.acknowledged
-					? "This token is shown only once and cannot be recovered later. If you lose it, rotate again to get a new one."
-					: "Shown only once. Copy it or confirm you saved it before leaving this page; it cannot be recovered later."}
-			</p>
-			{state.acknowledged ? null : (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					className="self-start"
-					onClick={onAcknowledge}
-				>
-					I’ve saved this token
-				</Button>
-			)}
-		</div>
-	);
-}
-
-function useRotatedTokenLifecycle(accountId: string) {
-	const api = useApi();
-	const [rotated, setRotated] = useState<Record<string, RotatedTokenDisplayState>>({});
-	const rotationControllersRef = useRef<Map<string, AbortController>>(new Map());
-	const rotatingLinksRef = useRef<Set<string>>(new Set());
-	const [rotatingLinks, setRotatingLinks] = useState<ReadonlySet<string>>(() => new Set());
-	const hasTokenAtRisk = hasAtRiskRotatedToken(rotated, rotatingLinks.size > 0);
-	const tokenAtRiskRef = useRef(hasTokenAtRisk);
-	tokenAtRiskRef.current = hasTokenAtRisk;
-	const shouldBlockNavigation: ShouldBlockFn = useCallback(
-		({ current, next }) =>
-			tokenAtRiskRef.current && current.pathname.toLowerCase() !== next.pathname.toLowerCase(),
-		[],
-	);
-	const shouldBlockDocumentExit = useCallback(() => tokenAtRiskRef.current, []);
-	const blocker = useBlocker({
-		shouldBlockFn: shouldBlockNavigation,
-		enableBeforeUnload: shouldBlockDocumentExit,
-		withResolver: true,
-	});
-
-	useEffect(() => {
-		setRotated({});
-		setRotatingLinks(new Set());
-		rotatingLinksRef.current.clear();
-		return () => {
-			for (const controller of rotationControllersRef.current.values()) controller.abort();
-			rotationControllersRef.current.clear();
-		};
-	}, [accountId]);
-
-	async function rotateToken(linkId: string) {
-		if (rotatingLinksRef.current.has(linkId)) return;
-		rotatingLinksRef.current.add(linkId);
-		tokenAtRiskRef.current = true;
-		setRotatingLinks((prev) => new Set(prev).add(linkId));
-		setRotated((prev) => {
-			const next = { ...prev };
-			delete next[linkId];
-			return next;
-		});
-		const controller = new AbortController();
-		rotationControllersRef.current.set(linkId, controller);
-		try {
-			const data = unwrap(
-				await api.POST("/v1/channels/{account_id}/agent-links/{link_id}/token", {
-					params: { path: { account_id: accountId, link_id: linkId } },
-					signal: controller.signal,
-				}),
-			);
-			const state = rotatedTokenDisplayState(data.agent_token);
-			setRotated((prev) => ({ ...prev, [linkId]: state }));
-			toast.success("Token rotated", {
-				description:
-					state.status === "available"
-						? "Copy the new token below — the previous one is now invalid."
-						: "The previous token is now invalid. Rotate again to receive a new token.",
-			});
-		} catch (error) {
-			if (controller.signal.aborted) return;
-			setRotated((prev) => ({ ...prev, [linkId]: { status: "unrecoverable" } }));
-			toastApiError("Couldn’t rotate token")(error);
-		} finally {
-			rotationControllersRef.current.delete(linkId);
-			rotatingLinksRef.current.delete(linkId);
-			setRotatingLinks((prev) => {
-				const next = new Set(prev);
-				next.delete(linkId);
-				return next;
-			});
-		}
-	}
-
-	function acknowledgeToken(linkId: string) {
-		setRotated((prev) => {
-			const state = prev[linkId];
-			return state ? { ...prev, [linkId]: acknowledgeRotatedToken(state) } : prev;
-		});
-	}
-
-	function discardAtRiskToken() {
-		tokenAtRiskRef.current = false;
-		for (const controller of rotationControllersRef.current.values()) controller.abort();
-		rotationControllersRef.current.clear();
-		rotatingLinksRef.current.clear();
-		setRotatingLinks(new Set());
-		setRotated((prev) =>
-			Object.fromEntries(Object.keys(prev).map((linkId) => [linkId, { status: "unrecoverable" }])),
-		);
-	}
-
-	function leaveWithoutToken() {
-		discardAtRiskToken();
-		if (blocker.status === "blocked") blocker.proceed();
-	}
-
-	return {
-		acknowledgeToken,
-		blocker,
-		discardAtRiskToken,
-		hasTokenAtRisk,
-		leaveWithoutToken,
-		rotated,
-		rotateToken,
-		rotatingLinks,
-	};
-}
-
-type RotatedTokenLifecycle = ReturnType<typeof useRotatedTokenLifecycle>;
-
-function RotatedTokenNavigationAlert({ lifecycle }: { lifecycle: RotatedTokenLifecycle }) {
-	const { blocker, leaveWithoutToken, rotatingLinks } = lifecycle;
-	return (
-		<AlertDialog
-			open={blocker.status === "blocked"}
-			onOpenChange={(open) => {
-				if (!open && blocker.status === "blocked") blocker.reset();
-			}}
-		>
-			<AlertDialogContent>
-				<AlertDialogHeader>
-					<AlertDialogTitle>
-						{rotatingLinks.size > 0
-							? "Leave while token rotation is in progress?"
-							: "Leave without saving the new token?"}
-					</AlertDialogTitle>
-					<AlertDialogDescription>
-						{rotatingLinks.size > 0
-							? "The one-time token may be returned after this page closes. If you leave, it could be lost and cannot be recovered — rotate again to get a new one."
-							: "This token is shown only once and has not been copied or acknowledged. If you leave, it will be lost. This token was shown once and is not recoverable — rotate again to get a new one."}
-					</AlertDialogDescription>
-				</AlertDialogHeader>
-				<AlertDialogFooter>
-					<AlertDialogCancel>Stay and copy token</AlertDialogCancel>
-					<AlertDialogAction variant="destructive" onClick={leaveWithoutToken}>
-						Leave and lose token
-					</AlertDialogAction>
-				</AlertDialogFooter>
-			</AlertDialogContent>
-		</AlertDialog>
-	);
-}
-
 function AgentsTab({
 	accountId,
 	accountName,
 	provider,
 	readOnly = false,
-	rotatedTokens,
 }: {
 	accountId: string;
 	accountName: string;
 	provider: string;
 	readOnly?: boolean;
-	rotatedTokens: RotatedTokenLifecycle;
 }) {
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
 	const unlink = useUnlinkChannelAgent(accountId);
 	const [linkOpen, setLinkOpen] = useState(false);
-	const { acknowledgeToken, rotateToken, rotated, rotatingLinks } = rotatedTokens;
 	const unlinkingLinksRef = useRef<Set<string>>(new Set());
 	const [unlinkingLinks, setUnlinkingLinks] = useState<ReadonlySet<string>>(() => new Set());
 	function unlinkAgent(linkId: string) {
@@ -722,7 +512,6 @@ function AgentsTab({
 			) : (
 				<div className="flex flex-col gap-2">
 					{items.map((link: ChannelAgentLink) => {
-						const isRotating = rotatingLinks.has(link.id);
 						const isUnlinking = unlinkingLinks.has(link.id);
 						return (
 							<div key={link.id} className={ENTITY_CARD_BASE}>
@@ -736,20 +525,6 @@ function AgentsTab({
 									</div>
 									{readOnly ? null : (
 										<div className="flex shrink-0 flex-wrap items-center gap-1.5">
-											<Button
-												variant="outline"
-												size="sm"
-												// Per-row: only the acting row's button shows pending, not all.
-												disabled={isRotating}
-												onClick={() => rotateToken(link.id)}
-											>
-												{isRotating ? (
-													<Spinner className="size-3.5" />
-												) : (
-													<RefreshCw className="size-3.5" />
-												)}
-												Rotate token
-											</Button>
 											<ConfirmAction
 												title="Unlink this agent?"
 												description={<p>It stops sending and receiving on {accountName}.</p>}
@@ -774,14 +549,6 @@ function AgentsTab({
 										</div>
 									)}
 								</div>
-								{rotated[link.id] ? (
-									<div className="mt-3">
-										<RotatedTokenCard
-											state={rotated[link.id]}
-											onAcknowledge={() => acknowledgeToken(link.id)}
-										/>
-									</div>
-								) : null}
 							</div>
 						);
 					})}
@@ -1014,18 +781,13 @@ const TTL_OPTIONS = [
 ];
 
 type PairCodeResult = {
+	agent_link_id: string;
 	code: string;
 	expires_at: string;
-	agent_link_id: string;
 	pairing_command: string;
 	bot_username: string | null;
 	deep_link: string | null;
 	qr_payload: string | null;
-};
-
-type RevealedAgentToken = {
-	agentLinkId: string;
-	value: string;
 };
 
 function PairCodeTab({ accountId, provider }: { accountId: string; provider: string }) {
@@ -1033,41 +795,40 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const links = useChannelAgentLinks(accountId);
 	const create = useCreatePairCode(accountId);
 	const ownership = useAgentOwnership();
-	// "" = no agent chosen (use the channel's linked agent). Sentinel keeps the
-	// Select controlled; mapped back to undefined in the request below.
-	const [agentId, setAgentId] = useState("");
+	const [agentLinkId, setAgentLinkId] = useState("");
 	const [ttl, setTtl] = useState("900");
 	const [result, setResult] = useState<PairCodeResult | null>(null);
-	const [revealedAgentToken, setRevealedAgentToken] = useState<RevealedAgentToken | null>(null);
 	const [nowMs, setNowMs] = useState(() => Date.now());
 	const [generating, setGenerating] = useState(false);
-	const agentItems = (envs.data ?? []).map((env) => ({
-		value: env.id,
-		label: envName(envs.data, env.id, ownership),
+	const linkedAgents = links.data ?? [];
+	const agentItems = linkedAgents.map((link) => ({
+		value: link.id,
+		label: envName(envs.data, link.agent_id, ownership),
 	}));
 	const generateLocked = useRef(false);
-	const meta = providerMeta(provider);
 	const isGenerating = generating || create.isPending;
 	const linkedAgentCount = links.data?.length ?? 0;
 	const requiresExplicitAgent = pairCodeRequiresExplicitAgent(linkedAgentCount);
+	const selectedLink =
+		linkedAgents.find((candidate) => candidate.id === agentLinkId) ??
+		(linkedAgentCount === 1 ? linkedAgents[0] : undefined);
 	const selectionMessage =
-		requiresExplicitAgent && !agentId && !links.isLoading && !links.error
+		requiresExplicitAgent && !selectedLink && !links.isLoading && !links.error
 			? linkedAgentCount === 0
-				? agentItems.length === 0
-					? "No linked agent is available. Link an agent in the Agents tab first."
-					: "No agent is linked. Choose an agent for this pairing code."
+				? "Link an Agent above before creating a pairing link."
 				: "This channel has multiple linked agents. Choose the agent for this pairing code."
 			: null;
-	const canGenerate =
-		!isGenerating &&
-		!links.isLoading &&
-		!links.error &&
-		(!requiresExplicitAgent || (!envs.isLoading && !envs.error && Boolean(agentId)));
-	const visibleAgentToken =
-		result && revealedAgentToken?.agentLinkId === result.agent_link_id
-			? revealedAgentToken.value
-			: null;
+	const canGenerate = !isGenerating && !links.isLoading && !links.error && Boolean(selectedLink);
 	const resultExpired = result ? pairCodeExpired(result.expires_at, nowMs) : false;
+	const validTelegramLink =
+		result && provider === "telegram"
+			? telegramPairDeepLink({
+					deepLink: result.deep_link,
+					qrPayload: result.qr_payload,
+					botUsername: result.bot_username,
+					code: result.code,
+				})
+			: null;
 
 	useEffect(() => {
 		if (!result) return;
@@ -1076,6 +837,11 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 		return () => window.clearInterval(interval);
 	}, [result]);
 
+	useEffect(() => {
+		if (!result || !links.data) return;
+		if (!links.data.some((link) => link.id === result.agent_link_id)) setResult(null);
+	}, [links.data, result]);
+
 	function generate() {
 		if (!canGenerate || generateLocked.current) return;
 		generateLocked.current = true;
@@ -1083,24 +849,16 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 		setResult(null);
 		void (async () => {
 			try {
-				const selectedLink = links.data?.find((candidate) => candidate.agent_id === agentId);
+				if (!selectedLink) return;
 				const data = await create.execute({
-					...(selectedLink
-						? { agent_link_id: selectedLink.id }
-						: { agent_id: agentId || undefined }),
+					agent_link_id: selectedLink.id,
 					ttl_seconds: Number(ttl),
 				});
-				if (data.agent_token) {
-					setRevealedAgentToken({
-						agentLinkId: data.agent_link_id,
-						value: data.agent_token,
-					});
-				}
 				setResult({
+					agent_link_id: data.agent_link_id,
 					code: data.code,
 					expires_at: data.expires_at,
-					agent_link_id: data.agent_link_id,
-					pairing_command: data.pairing_command || pairingCommand(data.code),
+					pairing_command: data.pairing_command,
 					bot_username: data.bot_username ?? null,
 					deep_link: data.deep_link ?? null,
 					qr_payload: data.qr_payload ?? null,
@@ -1124,11 +882,6 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 
 	return (
 		<div className="flex flex-col gap-4">
-			<InfoCard icon={QrCode} title="Pair a chat">
-				Generate a one-time code, then send it from the {meta.label} chat you want to pair — the
-				agent links that conversation when it sees the code.
-			</InfoCard>
-
 			<div className="grid gap-3 sm:grid-cols-2">
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-agent">Agent</Label>
@@ -1137,28 +890,31 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 					) : (
 						<Select
 							items={agentItems}
-							value={agentId}
+							value={agentLinkId}
 							onValueChange={(value) => {
-								if (value !== null) setAgentId(value);
+								if (value !== null) {
+									setAgentLinkId(value);
+									setResult(null);
+								}
 							}}
-							disabled={Boolean(envs.error || links.error) || isGenerating}
+							disabled={Boolean(links.error) || linkedAgentCount === 0 || isGenerating}
 						>
 							<SelectTrigger
 								id="pair-agent"
 								aria-describedby={selectionMessage ? "pair-agent-requirement" : undefined}
 							>
 								<SelectValue
-									placeholder={requiresExplicitAgent ? "Choose an agent" : "Use linked agent"}
+									placeholder={requiresExplicitAgent ? "Choose a linked Agent" : "Use linked Agent"}
 								/>
 							</SelectTrigger>
 							<SelectContent>
-								{(envs.data ?? []).map((env) => (
+								{linkedAgents.map((link) => (
 									<SelectItem
-										key={env.id}
-										value={env.id}
-										label={envName(envs.data, env.id, ownership)}
+										key={link.id}
+										value={link.id}
+										label={envName(envs.data, link.agent_id, ownership)}
 									>
-										<AgentName env={env} fallback={env.id} />
+										<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
 									</SelectItem>
 								))}
 							</SelectContent>
@@ -1211,64 +967,75 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 
 			<Button onClick={generate} disabled={!canGenerate}>
 				<QrCode className="size-4" />
-				{isGenerating ? "Generating…" : "Generate pairing code"}
+				{isGenerating
+					? "Generating…"
+					: provider === "telegram"
+						? "Generate Telegram link"
+						: "Generate pairing code"}
 			</Button>
 
 			{result ? (
-				<div className="flex flex-col gap-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
-					<div className="text-xs font-medium text-primary">Pairing code</div>
-					{provider === "telegram" && result.qr_payload ? (
-						<div className="flex flex-col items-center gap-3">
-							<div
-								className={cn(
-									"rounded-xl border bg-white p-3 shadow-sm",
-									resultExpired && "pointer-events-none opacity-40 blur-[2px]",
-								)}
-								aria-disabled={resultExpired}
-							>
-								<QRCodeSVG value={result.qr_payload} size={192} />
-							</div>
-							{resultExpired || !result.deep_link ? (
-								<Button disabled>
-									Open Telegram <ExternalLink className="size-4" />
-								</Button>
-							) : (
+				<div
+					data-telegram-pair-result={provider === "telegram" ? "true" : undefined}
+					className="flex flex-col gap-4 rounded-lg border border-primary/30 bg-primary/5 p-4"
+				>
+					<div className="text-sm font-medium text-primary">
+						{provider === "telegram" ? "Telegram pairing link" : "Pairing code"}
+					</div>
+					{provider === "telegram" ? (
+						validTelegramLink && !resultExpired ? (
+							<div className="flex flex-col items-center gap-3">
+								<div className="rounded-xl border bg-white p-3 shadow-sm">
+									<QRCodeSVG
+										value={validTelegramLink}
+										size={192}
+										role="img"
+										aria-label="Telegram pairing QR code"
+									/>
+								</div>
 								<Button
-									render={<a href={result.deep_link} target="_blank" rel="noopener noreferrer" />}
+									render={<a href={validTelegramLink} target="_blank" rel="noopener noreferrer" />}
 									nativeButton={false}
 								>
-									Open Telegram <ExternalLink className="size-4" />
+									{result.bot_username
+										? `Open @${result.bot_username.replace(/^@/, "")}`
+										: "Open Telegram"}
+									<ExternalLink className="size-4" />
 								</Button>
-							)}
-							{result.deep_link && !resultExpired ? (
-								<CopyInline value={result.deep_link} label="Telegram pairing link" />
-							) : null}
-						</div>
+								<CopyInline value={validTelegramLink} label="Telegram pairing link" />
+							</div>
+						) : (
+							<div role="alert" className="rounded-md border border-warning/40 bg-background p-3">
+								<p className="text-sm font-medium">
+									{resultExpired ? "This Telegram link has expired" : "Telegram link unavailable"}
+								</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									Generate a new pairing link. QR and Open Telegram stay disabled unless the server
+									returns a valid t.me start link.
+								</p>
+							</div>
+						)
 					) : (
 						<div className="font-mono text-3xl font-semibold tracking-[0.2em]">{result.code}</div>
 					)}
-					<p className="text-sm text-muted-foreground">
-						{resultExpired ? (
-							"Expired. Generate a new code."
-						) : (
-							<>
-								{provider === "telegram" && !result.deep_link
-									? "This bot has no valid Telegram username, so link and QR pairing are unavailable. "
-									: null}
-								Send <span className="font-mono font-medium">{result.pairing_command}</span> from
-								the chat you want to pair. Expires {relativeTime(result.expires_at)}.
-							</>
+					<p
+						role="status"
+						className={cn(
+							"text-center text-sm font-medium",
+							resultExpired ? "text-destructive" : "text-muted-foreground",
 						)}
+					>
+						{pairCodeExpiryLabel(result.expires_at, nowMs)}
 					</p>
 					{!resultExpired ? (
-						<CopyInline value={result.pairing_command} label="pairing command" />
-					) : null}
-					{visibleAgentToken ? (
-						<TokenReveal
-							label="Agent token"
-							value={visibleAgentToken}
-							note="Copy it now. It won't be shown again. The agent uses it to send and receive on this channel."
-						/>
+						<details className="rounded-md border bg-background/70 px-3 py-2">
+							<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+								Manual command
+							</summary>
+							<div className="mt-2">
+								<CopyInline value={result.pairing_command} label="pairing command" />
+							</div>
+						</details>
 					) : null}
 				</div>
 			) : null}
@@ -1280,6 +1047,32 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 
 function BindingsTab({ accountId }: { accountId: string }) {
 	const bindings = useChannelBindings(accountId);
+	const links = useChannelAgentLinks(accountId);
+	const envs = useEnvironments();
+	const unpair = useDeleteChannelBinding(accountId);
+	const unpairingRef = useRef<Set<string>>(new Set());
+	const [unpairingIds, setUnpairingIds] = useState<ReadonlySet<string>>(() => new Set());
+
+	function unpairChat(bindingId: string) {
+		if (unpairingRef.current.has(bindingId)) return;
+		unpairingRef.current.add(bindingId);
+		setUnpairingIds((current) => new Set(current).add(bindingId));
+		void (async () => {
+			try {
+				await unpair.mutateAsync(bindingId);
+			} catch {
+				// useDeleteChannelBinding surfaces the recoverable error.
+			} finally {
+				unpairingRef.current.delete(bindingId);
+				setUnpairingIds((current) => {
+					const next = new Set(current);
+					next.delete(bindingId);
+					return next;
+				});
+			}
+		})();
+	}
+
 	if (bindings.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
 	if (bindings.error) {
 		return (
@@ -1304,28 +1097,72 @@ function BindingsTab({ accountId }: { accountId: string }) {
 
 	return (
 		<div className="flex flex-col gap-2">
-			{items.map((b: ChannelBinding) => (
-				<div key={b.id} className={cn(ENTITY_CARD_BASE, "flex items-center gap-3")}>
-					<EntityHeader
-						className="min-w-0 flex-1"
-						icon={
-							<IconChip size="sm">
-								<MessageSquareDashed />
-							</IconChip>
-						}
-						title={b.external_chat_name ?? "Chat"}
-						meta={[
-							<span key="type" className="capitalize">
-								{b.external_chat_type ?? "chat"}
-							</span>,
-							<CopyInline key="chat-id" value={b.external_chat_id} label="chat ID" />,
-						]}
-					/>
-					<ChannelStatusBadge status={b.status} />
-				</div>
-			))}
+			{items.map((binding: ChannelBinding) => {
+				const link = links.data?.find((candidate) => candidate.id === binding.agent_link_id);
+				const threadLabel = bindingThreadLabel(binding);
+				const isUnpairing = unpairingIds.has(binding.id);
+				return (
+					<div
+						key={binding.id}
+						data-channel-binding-id={binding.id}
+						className={cn(
+							ENTITY_CARD_BASE,
+							"flex flex-col items-stretch gap-3 sm:flex-row sm:items-start",
+						)}
+					>
+						<EntityHeader
+							className="min-w-0 flex-1"
+							icon={
+								<IconChip size="sm">
+									<MessageSquareDashed />
+								</IconChip>
+							}
+							title={binding.external_chat_name ?? "Telegram chat"}
+							meta={[
+								<span key="type" className="capitalize">
+									{binding.external_chat_type ?? "chat"}
+								</span>,
+								<ChannelStatusBadge key="status" status={binding.status} />,
+								<CopyInline key="chat-id" value={binding.external_chat_id} label="chat ID" />,
+								...(threadLabel ? [<span key="thread">Thread: {threadLabel}</span>] : []),
+							]}
+						/>
+						<div className="flex shrink-0 items-center justify-between gap-2 sm:justify-end">
+							{link ? (
+								<div className="min-w-0 max-w-52">
+									<div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+										Agent
+									</div>
+									<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
+								</div>
+							) : null}
+							<ConfirmAction
+								title={`Unpair ${binding.external_chat_name ?? "this chat"}?`}
+								description="Only this chat will be disconnected. Other chats and the linked Agent stay active."
+								confirmLabel="Unpair chat"
+								destructive
+								onConfirm={() => unpairChat(binding.id)}
+							>
+								<Button variant="outline" size="sm" disabled={isUnpairing}>
+									{isUnpairing ? (
+										<Spinner className="size-3.5" />
+									) : (
+										<Link2Off className="size-3.5" />
+									)}
+									{isUnpairing ? "Unpairing…" : "Unpair"}
+								</Button>
+							</ConfirmAction>
+						</div>
+					</div>
+				);
+			})}
 		</div>
 	);
+}
+
+function bindingThreadLabel(binding: ChannelBinding): string | null {
+	if (!("thread_label" in binding) || typeof binding.thread_label !== "string") return null;
+	return binding.thread_label.trim() || null;
 }
 
 // ── Activity ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -49,11 +49,7 @@ import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
 import { nativeTransportSummary } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
-import type {
-	ChannelActivityItem,
-	ChannelAgentLink,
-	ChannelBinding,
-} from "@/hosted/v2/channels/channel-types";
+import type { ChannelActivityItem, ChannelAgentLink } from "@/hosted/v2/channels/channel-types";
 import {
 	ChannelStatusBadge,
 	CopyInline,
@@ -68,7 +64,6 @@ import {
 	useChannelHealth,
 	useCreateWhatsappTenantCred,
 	useDeleteChannel,
-	useDeleteChannelBinding,
 	useEnvironments,
 	useRevokeWhatsappTenantCred,
 	useSyncCommands,
@@ -80,6 +75,7 @@ import {
 	WHATSAPP_COMING_SOON_MESSAGE,
 	WHATSAPP_LINKING_READY,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { PairedChatRow } from "@/hosted/v2/channels/paired-chat-row";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentOwnership,
@@ -351,7 +347,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				</section>
 				<section className="flex flex-col gap-3 border-t pt-6">
 					<SectionHeader label="Paired chats" />
-					<BindingsTab accountId={id} />
+					<BindingsTab accountId={id} provider={ch.provider} />
 				</section>
 			</div>
 
@@ -763,34 +759,11 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 
 // ── Bindings (paired chats) ──────────────────────────────────────────────────
 
-function BindingsTab({ accountId }: { accountId: string }) {
+function BindingsTab({ accountId, provider }: { accountId: string; provider: string }) {
 	const bindings = useChannelBindings(accountId);
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
 	const ownership = useAgentOwnership();
-	const unpair = useDeleteChannelBinding(accountId);
-	const unpairingRef = useRef<Set<string>>(new Set());
-	const [unpairingIds, setUnpairingIds] = useState<ReadonlySet<string>>(() => new Set());
-
-	function unpairChat(bindingId: string) {
-		if (unpairingRef.current.has(bindingId)) return;
-		unpairingRef.current.add(bindingId);
-		setUnpairingIds((current) => new Set(current).add(bindingId));
-		void (async () => {
-			try {
-				await unpair.mutateAsync(bindingId);
-			} catch {
-				// useDeleteChannelBinding surfaces the recoverable error.
-			} finally {
-				unpairingRef.current.delete(bindingId);
-				setUnpairingIds((current) => {
-					const next = new Set(current);
-					next.delete(bindingId);
-					return next;
-				});
-			}
-		})();
-	}
 
 	if (bindings.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
 	if (bindings.error) {
@@ -816,57 +789,17 @@ function BindingsTab({ accountId }: { accountId: string }) {
 
 	return (
 		<div className={CHANNEL_RELATION_LIST_CLASS}>
-			{items.map((binding: ChannelBinding) => {
+			{items.map((binding) => {
 				const link = links.data?.find((candidate) => candidate.id === binding.agent_link_id);
-				const isUnpairing = unpairingIds.has(binding.id);
 				return (
-					<div
+					<PairedChatRow
 						key={binding.id}
-						data-channel-binding-id={binding.id}
-						className={CHANNEL_RELATION_ROW_CLASS}
-					>
-						<EntityHeader
-							className="min-w-0 flex-1"
-							icon={
-								<IconChip size="sm">
-									<MessageSquareDashed />
-								</IconChip>
-							}
-							title={binding.external_chat_name ?? "Telegram chat"}
-							meta={[
-								<span key="type" className="capitalize">
-									{binding.external_chat_type ?? "chat"}
-								</span>,
-								<ChannelStatusBadge key="status" status={binding.status} />,
-								...(link
-									? [
-											<span key="agent">
-												Agent: {envName(envs.data, link.agent_id, ownership, false)}
-											</span>,
-										]
-									: []),
-								<CopyInline key="chat-id" value={binding.external_chat_id} label="chat ID" />,
-							]}
-						/>
-						<div className={CHANNEL_RELATION_ACTIONS_CLASS}>
-							<ConfirmAction
-								title={`Unpair ${binding.external_chat_name ?? "this chat"}?`}
-								description="Only this chat will be disconnected. Other chats and the linked Agent stay active."
-								confirmLabel="Unpair chat"
-								destructive
-								onConfirm={() => unpairChat(binding.id)}
-							>
-								<Button variant="outline" size="sm" disabled={isUnpairing}>
-									{isUnpairing ? (
-										<Spinner className="size-3.5" />
-									) : (
-										<Link2Off className="size-3.5" />
-									)}
-									{isUnpairing ? "Unpairing…" : "Unpair"}
-								</Button>
-							</ConfirmAction>
-						</div>
-					</div>
+						accountId={accountId}
+						binding={binding}
+						provider={provider}
+						agentName={link ? envName(envs.data, link.agent_id, ownership, false) : undefined}
+						showChatId
+					/>
 				);
 			})}
 		</div>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -818,7 +818,6 @@ function BindingsTab({ accountId }: { accountId: string }) {
 		<div className={CHANNEL_RELATION_LIST_CLASS}>
 			{items.map((binding: ChannelBinding) => {
 				const link = links.data?.find((candidate) => candidate.id === binding.agent_link_id);
-				const threadLabel = bindingThreadLabel(binding);
 				const isUnpairing = unpairingIds.has(binding.id);
 				return (
 					<div
@@ -847,7 +846,6 @@ function BindingsTab({ accountId }: { accountId: string }) {
 										]
 									: []),
 								<CopyInline key="chat-id" value={binding.external_chat_id} label="chat ID" />,
-								...(threadLabel ? [<span key="thread">Thread: {threadLabel}</span>] : []),
 							]}
 						/>
 						<div className={CHANNEL_RELATION_ACTIONS_CLASS}>
@@ -873,11 +871,6 @@ function BindingsTab({ accountId }: { accountId: string }) {
 			})}
 		</div>
 	);
-}
-
-function bindingThreadLabel(binding: ChannelBinding): string | null {
-	if (!("thread_label" in binding) || typeof binding.thread_label !== "string") return null;
-	return binding.thread_label.trim() || null;
 }
 
 // ── Activity ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -25,8 +25,8 @@ describe("hosted-agent channel finish line", () => {
 	test("explains linking, pairing, the target conversation, and the hosted token boundary", () => {
 		expect(agentChannels).toContain("Choose the chat where this Agent should answer.");
 		expect(agentChannels).toContain("Pair Telegram");
-		expect(agentChannels).toContain("Generate Telegram link");
-		expect(agentChannels).toContain("Open @${code.bot_username");
+		expect(agentChannels).toContain("<TelegramPairDialog");
+		expect(agentChannels).toContain("agentLinkId={link.id}");
 		expect(agentChannels).toContain("Open Discord and choose the server channel");
 		expect(agentChannels).toContain("Create pairing code");
 		expect(agentChannels).toContain("Hosted agents apply channel credentials automatically");

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -42,16 +42,20 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).not.toContain("source revision");
 	});
 
-	test("orders the page by connected channels, ready bots, then the own-bot fallback", () => {
-		const connectedIndex = channelsTab.indexOf("Connected channels");
-		const addIndex = channelsTab.indexOf("Add a channel");
+	test("orders the page by connected channels, paired chats, then channel addition", () => {
+		const connectedIndex = channelsTab.indexOf("<section data-agent-connected-channels");
+		const pairedIndex = channelsTab.indexOf("<AgentPairedChats");
+		const addIndex = channelsTab.indexOf("<section data-agent-add-channel");
 		const readyBotIndex = channelsTab.indexOf('kind="Ready to use"');
 		const advancedIndex = channelsTab.indexOf("Use your own bot");
 		expect(connectedIndex).toBeGreaterThanOrEqual(0);
-		expect(addIndex).toBeGreaterThan(connectedIndex);
+		expect(pairedIndex).toBeGreaterThan(connectedIndex);
+		expect(addIndex).toBeGreaterThan(pairedIndex);
 		expect(readyBotIndex).toBeGreaterThan(addIndex);
 		expect(advancedIndex).toBeGreaterThan(readyBotIndex);
 		expect(channelsTab).toContain("data-agent-connected-channels");
+		expect(channelsTab).toContain("data-agent-paired-chats");
+		expect(channelsTab).toContain("Paired chats");
 		expect(channelsTab).toContain("data-agent-add-channel");
 		expect(channelsTab).toContain("data-add-channel-id");
 		expect(channelsTab).toContain("No bot connected yet");

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -8,39 +8,56 @@ const agentChannels = readFileSync(
 const channelDetail = readFileSync(new URL("./channel-detail-page.tsx", import.meta.url), "utf8");
 const channelHooks = readFileSync(new URL("./channels-hooks.ts", import.meta.url), "utf8");
 const linkAgentDialog = readFileSync(new URL("./link-agent-dialog.tsx", import.meta.url), "utf8");
+const channelsTab = agentChannels.slice(
+	agentChannels.indexOf("function ChannelsTab"),
+	agentChannels.indexOf("// ── Settings / Compute"),
+);
 
 describe("hosted-agent channel finish line", () => {
-	test("assembles the existing live health query into an honest automatic activity state", () => {
-		expect(agentChannels).toContain("const health = useChannelHealth()");
-		expect(agentChannels).toContain("channelActivityAfterLink(");
-		expect(agentChannels).toContain("This page checks automatically every 20 seconds");
-		expect(agentChannels).toContain("Channel activity detected");
-		expect(agentChannels).toContain(
-			"This signal does not yet confirm that the agent received a normal message.",
+	test("keeps diagnosis compact inside a shared connected-channel row", () => {
+		expect(channelsTab).toContain("const health = useChannelHealth()");
+		expect(channelsTab).toContain("channelActivityAfterLink(");
+		expect(channelsTab).toContain("AGENT_CHANNEL_LIST_CLASS");
+		expect(channelsTab).toContain("AGENT_CHANNEL_ROW_CLASS");
+		expect(channelsTab).toContain("Last activity");
+		expect(channelsTab).toContain("No activity yet");
+		expect(channelsTab).toContain("Activity unavailable · Retry");
+		expect(channelsTab).toContain("<ChannelStatusBadge status={link.status} />");
+		expect(channelsTab).toContain("<HealthBadge");
+		expect(channelsTab).not.toContain("Waiting for channel activity");
+		expect(channelsTab).not.toContain("This page checks automatically every 20 seconds");
+	});
+
+	test("separates linking a channel from pairing a chat with one short instruction", () => {
+		expect(channelsTab).toContain(
+			"Link a bot to this Agent, then pair the chats it should answer.",
 		);
-		expect(agentChannels).toContain("<ChannelStatusBadge status={link.status} />");
-		expect(agentChannels).toContain("<HealthBadge");
+		expect(channelsTab).toContain("Pair Telegram");
+		expect(channelsTab).toContain("Pair chat");
+		expect(channelsTab).toContain("<TelegramPairDialog");
+		expect(channelsTab).toContain("agentLinkId={link.id}");
+		expect(channelsTab).toContain("pairing_command");
+		expect(channelsTab).not.toContain("Agent token");
+		expect(channelsTab).not.toContain("credential sync");
+		expect(channelsTab).not.toContain("source revision");
 	});
 
-	test("explains linking, pairing, the target conversation, and the hosted token boundary", () => {
-		expect(agentChannels).toContain("Choose the chat where this Agent should answer.");
-		expect(agentChannels).toContain("Pair Telegram");
-		expect(agentChannels).toContain("<TelegramPairDialog");
-		expect(agentChannels).toContain("agentLinkId={link.id}");
-		expect(agentChannels).toContain("Open Discord and choose the server channel");
-		expect(agentChannels).toContain("Create pairing code");
-		expect(agentChannels).toContain("Hosted agents apply channel credentials automatically");
-		expect(agentChannels).not.toContain("Agent token");
-	});
-
-	test("leads with the no-credential path and gives the empty advanced path a primary action", () => {
-		const readyBotIndex = agentChannels.indexOf("Fastest: use a ready-to-go bot");
-		const advancedIndex = agentChannels.indexOf("Use your own bot (advanced)");
-		expect(readyBotIndex).toBeGreaterThanOrEqual(0);
+	test("orders the page by connected channels, ready bots, then the own-bot fallback", () => {
+		const connectedIndex = channelsTab.indexOf("Connected channels");
+		const addIndex = channelsTab.indexOf("Add a channel");
+		const readyBotIndex = channelsTab.indexOf('kind="Ready to use"');
+		const advancedIndex = channelsTab.indexOf("Use your own bot");
+		expect(connectedIndex).toBeGreaterThanOrEqual(0);
+		expect(addIndex).toBeGreaterThan(connectedIndex);
+		expect(readyBotIndex).toBeGreaterThan(addIndex);
 		expect(advancedIndex).toBeGreaterThan(readyBotIndex);
-		expect(agentChannels).toContain("No bot account, credentials, or developer setup");
-		expect(agentChannels).toContain("No bot connected yet");
-		expect(agentChannels).toContain("Connect my bot");
+		expect(channelsTab).toContain("data-agent-connected-channels");
+		expect(channelsTab).toContain("data-agent-add-channel");
+		expect(channelsTab).toContain("data-add-channel-id");
+		expect(channelsTab).toContain("No bot connected yet");
+		expect(channelsTab).toContain("Connect a bot");
+		expect(channelsTab).not.toContain("Fastest: use a ready-to-go bot");
+		expect(channelsTab).not.toContain("Use your own bot (advanced)");
 	});
 
 	test("replaces setup jargon with a bounded automatic wait and exits", () => {

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -23,12 +23,14 @@ describe("hosted-agent channel finish line", () => {
 	});
 
 	test("explains linking, pairing, the target conversation, and the hosted token boundary", () => {
-		expect(agentChannels).toContain("Linking gives this agent access to the bot");
-		expect(agentChannels).toContain("Pairing chooses the exact conversation");
-		expect(agentChannels).toContain("Open Telegram and start a conversation");
+		expect(agentChannels).toContain("Choose the chat where this Agent should answer.");
+		expect(agentChannels).toContain("Pair Telegram");
+		expect(agentChannels).toContain("Generate Telegram link");
+		expect(agentChannels).toContain("Open @${code.bot_username");
 		expect(agentChannels).toContain("Open Discord and choose the server channel");
 		expect(agentChannels).toContain("Create pairing code");
-		expect(agentChannels).toContain("Hosted agents configure this automatically");
+		expect(agentChannels).toContain("Hosted agents apply channel credentials automatically");
+		expect(agentChannels).not.toContain("Agent token");
 	});
 
 	test("leads with the no-credential path and gives the empty advanced path a primary action", () => {

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -27,6 +27,7 @@ describe("channel mutation feedback", () => {
 
 	test("keeps agent-page link, unlink, and pair-code feedback scoped to the acting control", () => {
 		const detail = source("../../agents/hosted-agent-detail.tsx");
+		const pairDialog = source("./telegram-pair-dialog.tsx");
 
 		expectFeedbackBeforeRequest(
 			detail,
@@ -39,9 +40,14 @@ describe("channel mutation feedback", () => {
 			"await unlink.mutateAsync",
 		);
 		expectFeedbackBeforeRequest(detail, "setCreatingPairCode(true)", "await pair.execute");
+		expectFeedbackBeforeRequest(pairDialog, "setGenerating(true)", "await pair.execute");
 		expect(detail).toContain("unlinking={unlinkingLinkIds.has(l.id)}");
 		expect(detail).toContain('linkingAccountId === selectedReadyBotId ? "Linking…" : "Link bot"');
-		expect(detail).toContain('{creatingPairCode ? "Creating code…" : "Create pairing code"}');
+		expect(detail).toContain('creatingPairCode ? <Spinner className="size-3.5" />');
+		expect(detail).toContain('"Generating…"');
+		expect(detail).toContain('"Pair Telegram"');
+		expect(detail).toContain('"Create pairing code"');
+		expect(pairDialog).toContain("Creating a secure Telegram link…");
 	});
 
 	test("uses per-action feedback for detail-page mutations", () => {
@@ -49,16 +55,13 @@ describe("channel mutation feedback", () => {
 
 		for (const [feedback, request] of [
 			["setRemoving(true)", "await del.mutateAsync(id)"],
-			["setRotatingLinks((prev)", "await api.POST"],
 			["setUnlinkingLinks((prev)", "await unlink.mutateAsync(linkId)"],
 			["setCreatingCredential(true)", "await create.execute"],
 			["setRevokingCredentials((prev)", "await revoke.mutateAsync"],
-			["setGenerating(true)", "await create.execute"],
 			["setSyncing(true)", "await sync.mutateAsync"],
 		] as const) {
 			expectFeedbackBeforeRequest(detail, feedback, request);
 		}
-		expect(detail).toContain("const isRotating = rotatingLinks.has(link.id)");
 		expect(detail).toContain("const isUnlinking = unlinkingLinks.has(link.id)");
 		expect(detail).toContain("revokingCredentials.has(d.credential_id)");
 	});

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -42,11 +42,11 @@ describe("channel mutation feedback", () => {
 		expectFeedbackBeforeRequest(detail, "setCreatingPairCode(true)", "await pair.execute");
 		expectFeedbackBeforeRequest(pairDialog, "setGenerating(true)", "await pair.execute");
 		expect(detail).toContain("unlinking={unlinkingLinkIds.has(l.id)}");
-		expect(detail).toContain('linkingAccountId === selectedReadyBotId ? "Linking…" : "Link bot"');
+		expect(detail).toContain('linking ? "Linking…" : "Link"');
 		expect(detail).toContain('creatingPairCode ? <Spinner className="size-3.5" />');
 		expect(detail).toContain('"Generating…"');
 		expect(detail).toContain('"Pair Telegram"');
-		expect(detail).toContain('"Create pairing code"');
+		expect(detail).toContain('"Pair chat"');
 		expect(pairDialog).toContain("Creating a secure Telegram link…");
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -28,6 +28,7 @@ describe("channel mutation feedback", () => {
 	test("keeps agent-page link, unlink, and pair-code feedback scoped to the acting control", () => {
 		const detail = source("../../agents/hosted-agent-detail.tsx");
 		const pairDialog = source("./telegram-pair-dialog.tsx");
+		const pairedChatRow = source("./paired-chat-row.tsx");
 
 		expectFeedbackBeforeRequest(
 			detail,
@@ -48,6 +49,9 @@ describe("channel mutation feedback", () => {
 		expect(detail).toContain('"Pair Telegram"');
 		expect(detail).toContain('"Pair chat"');
 		expect(pairDialog).toContain("Creating a secure Telegram link…");
+		expect(pairedChatRow).toContain("disabled={unpair.isPending}");
+		expect(pairedChatRow).toContain('unpair.isPending ? "Unpairing…"');
+		expect(pairedChatRow).toContain('unpair.error ? "Retry unpair"');
 	});
 
 	test("uses per-action feedback for detail-page mutations", () => {

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+const detail = source("./channel-detail-page.tsx");
+const hooks = source("./channels-hooks.ts");
+const linkDialog = source("./link-agent-dialog.tsx");
+const connectDialog = source("./connect-bot-dialog.tsx");
+const agentDetail = source("../../agents/hosted-agent-detail.tsx");
+
+describe("Telegram channel pairing UX", () => {
+	test("keeps Link Agent, Pair Telegram, and paired chats in one visible card flow", () => {
+		const linkStep = detail.indexOf('title="Link Agent"');
+		const pairStep = detail.indexOf('title={ch.provider === "telegram" ? "Pair Telegram"');
+		const pairedChats = detail.indexOf('label="Paired chats"', pairStep);
+
+		expect(detail).toContain("data-channel-setup-flow");
+		expect(detail).toContain("data-channel-setup-step={step}");
+		expect(linkStep).toBeGreaterThanOrEqual(0);
+		expect(pairStep).toBeGreaterThan(linkStep);
+		expect(pairedChats).toBeGreaterThan(pairStep);
+		expect(detail).not.toContain('<TabsTrigger value="agents">');
+		expect(detail).not.toContain('<TabsTrigger value="pair">');
+		expect(detail).not.toContain('<TabsTrigger value="bindings">');
+	});
+
+	test("makes the validated server deep link and QR primary with compact fallback", () => {
+		expect(detail).toContain("value={validTelegramLink}");
+		expect(detail).toContain("href={validTelegramLink}");
+		expect(detail).toContain("qrPayload: result.qr_payload");
+		expect(detail).toContain('aria-label="Telegram pairing QR code"');
+		expect(detail).toContain("`Open @${result.bot_username");
+		expect(detail).toContain("Telegram link unavailable");
+		expect(detail).toContain("returns a valid t.me start link");
+		expect(detail).toContain("pairCodeExpiryLabel(result.expires_at, nowMs)");
+		expect(detail).toContain("Manual command");
+		expect(detail).not.toContain("QRCodeSVG value={result.qr_payload}");
+		expect(detail).not.toContain("href={result.deep_link}");
+	});
+
+	test("keeps the Agent Channels entry point on the same server-link contract", () => {
+		expect(agentDetail).toContain("telegramPairDeepLink({");
+		expect(agentDetail).toContain("value={validTelegramLink}");
+		expect(agentDetail).toContain("qrPayload: code.qr_payload");
+		expect(agentDetail).toContain("href={validTelegramLink}");
+		expect(agentDetail).toContain("Pair a group manually");
+		expect(agentDetail).toContain("pairCodeExpiryLabel(code.expires_at, nowMs)");
+		expect(agentDetail).toContain("await pair.execute({ agent_link_id: link.id })");
+		expect(agentDetail).not.toContain("href={code.deep_link}");
+		expect(agentDetail).not.toContain("pairingCommand(code.code)");
+	});
+
+	test("requires an existing AgentLink before Pair code creation", () => {
+		expect(detail).toContain("const linkedAgents = links.data ?? []");
+		expect(detail).toContain("agent_link_id: selectedLink.id");
+		expect(detail).toContain("Link an Agent above before creating a pairing link.");
+		expect(detail).not.toContain("agent_id: selectedAgent");
+		expect(hooks).toContain("vars: { agent_link_id: string; ttl_seconds?: number }");
+	});
+
+	test("shows Agent identity and isolates Unpair to the selected chat with recovery", () => {
+		expect(detail).toContain("binding.agent_link_id");
+		expect(detail).toContain("<AgentName");
+		expect(detail).toContain("Only this chat will be disconnected");
+		expect(detail).toContain("await unpair.mutateAsync(bindingId)");
+		expect(detail).toContain("finally");
+		expect(hooks).toContain("export function useDeleteChannelBinding");
+		expect(hooks).toContain("keys.bindings(accountId)");
+		expect(hooks).toContain('toastApiError("Couldn\'t unpair chat")');
+		expect(hooks).toContain("refetchInterval: 3_000");
+	});
+
+	test("never renders returned runtime credentials in Link or Pair surfaces", () => {
+		for (const ui of [detail, linkDialog, connectDialog, agentDetail]) {
+			expect(ui).not.toContain("TokenReveal");
+			expect(ui).not.toContain("agent_token");
+			expect(ui).not.toContain("Agent token");
+			expect(ui).not.toContain("one-time-secret-value");
+		}
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -6,58 +6,65 @@ function source(relativePath: string): string {
 }
 
 const detail = source("./channel-detail-page.tsx");
+const pairDialog = source("./telegram-pair-dialog.tsx");
 const hooks = source("./channels-hooks.ts");
 const linkDialog = source("./link-agent-dialog.tsx");
 const connectDialog = source("./connect-bot-dialog.tsx");
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 
 describe("Telegram channel pairing UX", () => {
-	test("keeps Link Agent, Pair Telegram, and paired chats in one visible card flow", () => {
-		const linkStep = detail.indexOf('title="Link Agent"');
-		const pairStep = detail.indexOf('title={ch.provider === "telegram" ? "Pair Telegram"');
-		const pairedChats = detail.indexOf('label="Paired chats"', pairStep);
-
+	test("keeps a full-width, single-layer linked Agent and paired chat layout", () => {
+		const linkedAgents = detail.indexOf("<AgentsTab");
+		const pairedChats = detail.indexOf('label="Paired chats"');
 		expect(detail).toContain("data-channel-setup-flow");
-		expect(detail).toContain("data-channel-setup-step={step}");
-		expect(linkStep).toBeGreaterThanOrEqual(0);
-		expect(pairStep).toBeGreaterThan(linkStep);
-		expect(pairedChats).toBeGreaterThan(pairStep);
+		expect(linkedAgents).toBeGreaterThanOrEqual(0);
+		expect(pairedChats).toBeGreaterThan(linkedAgents);
+		expect(detail).toContain("CHANNEL_RELATION_LIST_CLASS");
+		expect(detail).toContain("CHANNEL_RELATION_ROW_CLASS");
+		expect(detail).not.toContain("max-w-3xl");
+		expect(detail).not.toContain("SetupStepCard");
+		expect(detail).not.toContain("PairCodeTab");
+		expect(detail).not.toContain('id="pair-agent"');
+		expect(detail).not.toContain('id="pair-ttl"');
+		expect(detail).not.toContain("TTL_OPTIONS");
 		expect(detail).not.toContain('<TabsTrigger value="agents">');
 		expect(detail).not.toContain('<TabsTrigger value="pair">');
 		expect(detail).not.toContain('<TabsTrigger value="bindings">');
 	});
 
-	test("makes the validated server deep link and QR primary with compact fallback", () => {
-		expect(detail).toContain("value={validTelegramLink}");
-		expect(detail).toContain("href={validTelegramLink}");
-		expect(detail).toContain("qrPayload: result.qr_payload");
-		expect(detail).toContain('aria-label="Telegram pairing QR code"');
-		expect(detail).toContain("`Open @${result.bot_username");
-		expect(detail).toContain("Telegram link unavailable");
-		expect(detail).toContain("returns a valid t.me start link");
-		expect(detail).toContain("pairCodeExpiryLabel(result.expires_at, nowMs)");
-		expect(detail).toContain("Manual command");
-		expect(detail).not.toContain("QRCodeSVG value={result.qr_payload}");
-		expect(detail).not.toContain("href={result.deep_link}");
+	test("opens one fixed-TTL dialog from the selected linked Agent row", () => {
+		expect(detail).toContain("setPairingLink(link)");
+		expect(detail).toContain("Pair Telegram");
+		expect(detail).toContain("agentLinkId={pairingLink.id}");
+		expect(pairDialog).toContain("const TELEGRAM_PAIR_TTL_SECONDS = 900");
+		expect(pairDialog).toContain("agent_link_id: agentLinkId");
+		expect(pairDialog).toContain("ttl_seconds: TELEGRAM_PAIR_TTL_SECONDS");
+		expect(pairDialog).toContain("openKeyRef.current === openKey");
+		expect(pairDialog).not.toContain("Select");
 	});
 
-	test("keeps the Agent Channels entry point on the same server-link contract", () => {
-		expect(agentDetail).toContain("telegramPairDeepLink({");
-		expect(agentDetail).toContain("value={validTelegramLink}");
-		expect(agentDetail).toContain("qrPayload: code.qr_payload");
-		expect(agentDetail).toContain("href={validTelegramLink}");
-		expect(agentDetail).toContain("Pair a group manually");
-		expect(agentDetail).toContain("pairCodeExpiryLabel(code.expires_at, nowMs)");
-		expect(agentDetail).toContain("await pair.execute({ agent_link_id: link.id })");
+	test("makes the validated server deep link and QR primary with compact actions", () => {
+		expect(pairDialog).toContain("value={validLink}");
+		expect(pairDialog).toContain("href={validLink}");
+		expect(pairDialog).toContain("qrPayload: result.qr_payload");
+		expect(pairDialog).toContain('aria-label="Telegram pairing QR code"');
+		expect(pairDialog).toContain("`Open @${result.bot_username");
+		expect(pairDialog).toContain('"Copy link"');
+		expect(pairDialog).toContain("Telegram link unavailable");
+		expect(pairDialog).toContain("This Telegram link has expired");
+		expect(pairDialog).toContain("pairCodeExpiryLabel(result.expires_at, nowMs)");
+		expect(pairDialog).toContain("Pair a group manually");
+		expect(pairDialog).not.toContain("QRCodeSVG value={result.qr_payload}");
+		expect(pairDialog).not.toContain("href={result.deep_link}");
+	});
+
+	test("reuses the same dialog from Agent Channels without a second Telegram QR UI", () => {
+		expect(agentDetail).toContain("<TelegramPairDialog");
+		expect(agentDetail).toContain("agentLinkId={link.id}");
+		expect(agentDetail).toContain("setTelegramPairOpen(true)");
+		expect(agentDetail).not.toContain("QRCodeSVG");
+		expect(agentDetail).not.toContain("telegramPairDeepLink");
 		expect(agentDetail).not.toContain("href={code.deep_link}");
-		expect(agentDetail).not.toContain("pairingCommand(code.code)");
-	});
-
-	test("requires an existing AgentLink before Pair code creation", () => {
-		expect(detail).toContain("const linkedAgents = links.data ?? []");
-		expect(detail).toContain("agent_link_id: selectedLink.id");
-		expect(detail).toContain("Link an Agent above before creating a pairing link.");
-		expect(detail).not.toContain("agent_id: selectedAgent");
 		expect(hooks).toContain("vars: { agent_link_id: string; ttl_seconds?: number }");
 	});
 
@@ -74,7 +81,7 @@ describe("Telegram channel pairing UX", () => {
 	});
 
 	test("never renders returned runtime credentials in Link or Pair surfaces", () => {
-		for (const ui of [detail, linkDialog, connectDialog, agentDetail]) {
+		for (const ui of [detail, pairDialog, linkDialog, connectDialog, agentDetail]) {
 			expect(ui).not.toContain("TokenReveal");
 			expect(ui).not.toContain("agent_token");
 			expect(ui).not.toContain("Agent token");

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -11,6 +11,8 @@ const hooks = source("./channels-hooks.ts");
 const linkDialog = source("./link-agent-dialog.tsx");
 const connectDialog = source("./connect-bot-dialog.tsx");
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
+const pairedChatRow = source("./paired-chat-row.tsx");
+const agentBindingLogic = source("./agent-channel-bindings.logic.ts");
 
 describe("Telegram channel pairing UX", () => {
 	test("keeps a full-width, single-layer linked Agent and paired chat layout", () => {
@@ -71,13 +73,24 @@ describe("Telegram channel pairing UX", () => {
 	test("shows Agent identity and isolates Unpair to the selected chat with recovery", () => {
 		expect(detail).toContain("binding.agent_link_id");
 		expect(detail).toContain("<AgentName");
-		expect(detail).toContain("Only this chat will be disconnected");
-		expect(detail).toContain("await unpair.mutateAsync(bindingId)");
-		expect(detail).toContain("finally");
+		expect(detail).toContain("<PairedChatRow");
+		expect(agentDetail).toContain("<PairedChatRow");
+		expect(pairedChatRow).toContain("Only this chat will be disconnected");
+		expect(pairedChatRow).toContain("unpair.mutateAsync(binding.id)");
+		expect(pairedChatRow).toContain("unpair.isPending");
 		expect(hooks).toContain("export function useDeleteChannelBinding");
 		expect(hooks).toContain("keys.bindings(accountId)");
 		expect(hooks).toContain('toastApiError("Couldn\'t unpair chat")');
 		expect(hooks).toContain("refetchInterval: 3_000");
+	});
+
+	test("filters Agent-page chats by visible active agent link and matching account", () => {
+		expect(agentDetail).toContain("useChannelBindingsForAccounts(accountIds)");
+		expect(agentDetail).toContain("selectAgentPairedChats");
+		expect(agentBindingLogic).toContain("activeAgentChannelLinks(visibleLinks)");
+		expect(agentBindingLogic).toContain("binding.account_id !== accountId");
+		expect(agentBindingLogic).toContain("linksById.get(binding.agent_link_id)");
+		expect(agentBindingLogic).toContain("link.account_id !== accountId");
 	});
 
 	test("never renders returned runtime credentials in Link or Pair surfaces", () => {

--- a/apps/web/src/hosted/v2/channels/channel-ui.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-ui.test.ts
@@ -3,10 +3,10 @@ import { readFileSync } from "node:fs";
 
 const uiSource = readFileSync(new URL("./channel-ui.tsx", import.meta.url), "utf8");
 
-describe("TokenReveal", () => {
-	test("masks values by default while retaining reveal and copy controls", () => {
-		expect(uiSource).toContain('{revealed ? value : "••••••••••••"}');
-		expect(uiSource).toMatch(/aria-label=.*revealed.*Hide.*Show.*label/);
+describe("CopyInline", () => {
+	test("copies compact non-secret identifiers without a reveal state", () => {
+		expect(uiSource).toContain("export function CopyInline");
 		expect(uiSource).toContain("onClick={() => copy(value)}");
+		expect(uiSource).not.toContain("TokenReveal");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Check, CircleAlert, CircleCheck, Copy, Eye, EyeOff, TriangleAlert } from "lucide-react";
-import { useState } from "react";
+import { Check, CircleAlert, CircleCheck, Copy, TriangleAlert } from "lucide-react";
 import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
-import { Button } from "@/components/ui/button";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
@@ -95,54 +93,6 @@ export function DeliveryBadge({ status }: { status: string }) {
 
 function useCopy() {
 	return useCopyToClipboard({ error: "Copy failed" });
-}
-
-/** Copyable secret box, masked until the user explicitly reveals it. */
-export function TokenReveal({
-	label,
-	value,
-	note,
-}: {
-	label: string;
-	value: string;
-	note?: string;
-}) {
-	const { copied, copy } = useCopy();
-	const [revealed, setRevealed] = useState(false);
-	return (
-		<div
-			data-hosted="true"
-			data-v2="true"
-			className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
-		>
-			<div className="text-xs font-medium text-primary">{label}</div>
-			<div className="flex items-center gap-2">
-				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
-					{revealed ? value : "••••••••••••"}
-				</code>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					onClick={() => setRevealed((visible) => !visible)}
-					aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
-					aria-pressed={revealed}
-				>
-					{revealed ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-				</Button>
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					onClick={() => copy(value)}
-					aria-label={`Copy ${label}`}
-				>
-					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-				</Button>
-			</div>
-			{note ? <p className="text-xs text-muted-foreground">{note}</p> : null}
-		</div>
-	);
 }
 
 /** Inline copyable monospace value (chat ids, ids, urls). */

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -1,6 +1,12 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	queryOptions,
+	useMutation,
+	useQueries,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useChannelEditApi } from "@/hosted/v2/channels/channel-edit-client";
 import { channelHealthQueryOptions } from "@/hosted/v2/channels/channel-health-query";
@@ -72,9 +78,8 @@ export function useChannelAgentLinks(id: string) {
 	});
 }
 
-export function useChannelBindings(id: string) {
-	const api = useApi();
-	return useQuery({
+function channelBindingsQueryOptions(api: ReturnType<typeof useApi>, id: string) {
+	return queryOptions({
 		queryKey: keys.bindings(id),
 		queryFn: async () =>
 			unwrap(
@@ -84,6 +89,17 @@ export function useChannelBindings(id: string) {
 			),
 		enabled: Boolean(id),
 		refetchInterval: 3_000,
+	});
+}
+
+export function useChannelBindings(id: string) {
+	return useQuery(channelBindingsQueryOptions(useApi(), id));
+}
+
+export function useChannelBindingsForAccounts(accountIds: readonly string[]) {
+	const api = useApi();
+	return useQueries({
+		queries: accountIds.map((accountId) => channelBindingsQueryOptions(api, accountId)),
 	});
 }
 

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -83,6 +83,32 @@ export function useChannelBindings(id: string) {
 				}),
 			),
 		enabled: Boolean(id),
+		refetchInterval: 3_000,
+	});
+}
+
+export function useDeleteChannelBinding(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (bindingId: string) =>
+			unwrap(
+				await api.DELETE("/v1/channels/{account_id}/bindings/{binding_id}", {
+					params: { path: { account_id: accountId, binding_id: bindingId } },
+				}),
+			),
+		onSuccess: async (result) => {
+			await Promise.all([
+				qc.invalidateQueries({ queryKey: keys.bindings(accountId) }),
+				qc.invalidateQueries({ queryKey: keys.activity(accountId) }),
+			]);
+			if (result.warning) {
+				toast.warning("Chat unpaired", { description: result.warning });
+			} else if (result.unpaired) {
+				toast.success("Chat unpaired");
+			}
+		},
+		onError: toastApiError("Couldn't unpair chat"),
 	});
 }
 
@@ -116,7 +142,11 @@ export function useCreateChannel() {
 		try {
 			const result = unwrap(await api.POST("/v1/channels", { body }));
 			await invalidateCreatedChannelQueries(qc, result);
-			return result;
+			return {
+				id: result.id,
+				name: result.name,
+				provider: result.provider,
+			};
 		} catch (error) {
 			toastApiError("Couldn't connect channel")(error);
 			throw error;
@@ -156,36 +186,15 @@ export function useLinkAgent(accountId: string) {
 			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
 			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
 			qc.invalidateQueries({ queryKey: keys.pool });
-			return result;
+			return {
+				id: result.id,
+				account_id: result.account_id,
+				agent_id: result.agent_id,
+				status: result.status,
+				created_at: result.created_at,
+			};
 		} catch (error) {
 			toastApiError("Couldn't link agent")(error);
-			throw error;
-		}
-	});
-}
-
-export function useRotateAgentToken(accountId: string) {
-	const api = useApi();
-	const qc = useQueryClient();
-	return useSensitiveAction(async (linkId: string) => {
-		try {
-			const data = unwrap(
-				await api.POST("/v1/channels/{account_id}/agent-links/{link_id}/token", {
-					params: { path: { account_id: accountId, link_id: linkId } },
-				}),
-			);
-			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
-			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
-			// Always confirm — the new token is also revealed inline when present,
-			// but the rotation must never be a silent no-op even without a token.
-			toast.success("Token rotated", {
-				description: data.agent_token
-					? "Copy the new token below — the previous one is now invalid."
-					: "The previous token is now invalid.",
-			});
-			return data;
-		} catch (error) {
-			toastApiError("Couldn't rotate token")(error);
 			throw error;
 		}
 	});
@@ -194,25 +203,31 @@ export function useRotateAgentToken(accountId: string) {
 export function useCreatePairCode(accountId: string) {
 	const api = useApi();
 	const qc = useQueryClient();
-	return useSensitiveAction(
-		async (vars: { agent_id?: string; agent_link_id?: string; ttl_seconds?: number }) => {
-			try {
-				const result = unwrap(
-					await api.POST("/v1/channels/{account_id}/pair-codes", {
-						params: { path: { account_id: accountId } },
-						body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
-					}),
-				);
-				qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
-				qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
-				qc.invalidateQueries({ queryKey: keys.bindings(accountId) });
-				return result;
-			} catch (error) {
-				toastApiError("Couldn't create pairing code")(error);
-				throw error;
-			}
-		},
-	);
+	return useSensitiveAction(async (vars: { agent_link_id: string; ttl_seconds?: number }) => {
+		try {
+			const result = unwrap(
+				await api.POST("/v1/channels/{account_id}/pair-codes", {
+					params: { path: { account_id: accountId } },
+					body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
+				}),
+			);
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			qc.invalidateQueries({ queryKey: keys.bindings(accountId) });
+			return {
+				code: result.code,
+				expires_at: result.expires_at,
+				agent_link_id: result.agent_link_id,
+				pairing_command: result.pairing_command,
+				bot_username: result.bot_username,
+				deep_link: result.deep_link,
+				qr_payload: result.qr_payload,
+			};
+		} catch (error) {
+			toastApiError("Couldn't create pairing code")(error);
+			throw error;
+		}
+	});
 }
 
 /** An agent's linked channels (+account summary) — fixes the per-channel N+1. */

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -22,8 +22,8 @@ import {
 	type ChannelProviderId,
 	PROVIDER_META,
 } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
-import { ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
+import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
+import { ProviderChip } from "@/hosted/v2/channels/channel-ui";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 import {
 	discordApplicationIdError,
@@ -37,8 +37,7 @@ import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.l
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
  * cloud-api): Telegram = bot token; Discord = bot token + application_id +
  * public_key (+ guild_id); WhatsApp = no token (agent/device linking is
- * gated during the beta). On success the
- * scoped agent token may be revealed once when an agent is auto-linked.
+ * gated during the beta). Runtime credentials reconcile automatically.
  */
 export function ConnectBotDialog({
 	open,
@@ -55,7 +54,11 @@ export function ConnectBotDialog({
 	const [applicationId, setApplicationId] = useState("");
 	const [publicKey, setPublicKey] = useState("");
 	const [guildId, setGuildId] = useState("");
-	const [created, setCreated] = useState<ChannelCreated | null>(null);
+	const [created, setCreated] = useState<{
+		id: string;
+		name: string;
+		provider: string;
+	} | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
 	const openRef = useRef(open);
@@ -131,7 +134,7 @@ export function ConnectBotDialog({
 			const data = await create.execute(body);
 			setToken("");
 			if (openRef.current && dialogSessionRef.current === dialogSession) {
-				setCreated(data);
+				setCreated({ id: data.id, name: data.name, provider: data.provider });
 			} else {
 				toast.success("Channel connected", {
 					description: `${data.name} is ready on the Channels page.`,
@@ -192,13 +195,6 @@ export function ConnectBotDialog({
 									relying on it.
 								</p>
 							</div>
-						) : null}
-						{created.agent_token ? (
-							<TokenReveal
-								label="Agent token"
-								value={created.agent_token}
-								note="An agent was auto-linked. This token lets it send and receive on the channel."
-							/>
 						) : null}
 						<DialogFooter>
 							<Button variant="outline" onClick={() => handleOpenChange(false)}>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -75,7 +75,26 @@ describe("linkAgentBlockReason", () => {
 		);
 	});
 
-	test("allows the current existing link and non-Hermes multi-link behavior", () => {
+	test("blocks a second Telegram link for OpenClaw until group sessions are account-aware", () => {
+		expect(
+			linkAgentBlockReason({
+				provider: "telegram",
+				selectedAgent: { agent_type: "openclaw" },
+				existingAgentLinks: [
+					{
+						account_id: "tg-existing",
+						status: "active",
+						account: { provider: "telegram" },
+					},
+				],
+				accountId: "tg-current",
+			}),
+		).toBe(
+			"OpenClaw agents can use one active Telegram bot at a time. Unlink the current Telegram bot before linking another.",
+		);
+	});
+
+	test("allows the current link and providers without a single-link constraint", () => {
 		expect(
 			linkAgentBlockReason({
 				provider: "telegram",
@@ -92,16 +111,16 @@ describe("linkAgentBlockReason", () => {
 		).toBeNull();
 		expect(
 			linkAgentBlockReason({
-				provider: "telegram",
+				provider: "discord",
 				selectedAgent: { agent_type: "openclaw" },
 				existingAgentLinks: [
 					{
-						account_id: "tg-existing",
+						account_id: "discord-existing",
 						status: "active",
-						account: { provider: "telegram" },
+						account: { provider: "discord" },
 					},
 				],
-				accountId: "tg-current",
+				accountId: "discord-current",
 			}),
 		).toBeNull();
 	});

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -13,10 +13,24 @@ export const WHATSAPP_LINKING_READY = false;
 export const WHATSAPP_COMING_SOON_MESSAGE =
 	"WhatsApp channels are coming soon for hosted agents. Telegram and Discord are available now.";
 
-const HERMES_SINGLE_LINK_PROVIDERS = new Set(["telegram", "discord"]);
+const SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE: Readonly<Record<string, ReadonlySet<string>>> = {
+	hermes: new Set(["telegram", "discord"]),
+	openclaw: new Set(["telegram"]),
+};
+const AGENT_TYPE_LABELS: Readonly<Record<string, string>> = {
+	hermes: "Hermes",
+	openclaw: "OpenClaw",
+};
 
 export function channelProviderLinkingReady(provider: string): boolean {
 	return provider !== "whatsapp" || WHATSAPP_LINKING_READY;
+}
+
+export function agentProviderHasSingleLinkLimit(
+	agentType: string | null | undefined,
+	provider: string,
+): boolean {
+	return Boolean(agentType && SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE[agentType]?.has(provider));
 }
 
 export function pairingCommand(code: string): string {
@@ -55,8 +69,8 @@ export function linkAgentBlockReason({
 	accountId: string;
 }): string | null {
 	if (!channelProviderLinkingReady(provider)) return WHATSAPP_COMING_SOON_MESSAGE;
-	if (selectedAgent?.agent_type !== "hermes") return null;
-	if (!HERMES_SINGLE_LINK_PROVIDERS.has(provider)) return null;
+	const agentType = selectedAgent?.agent_type;
+	if (!agentType || !agentProviderHasSingleLinkLimit(agentType, provider)) return null;
 
 	const hasExistingProviderLink = existingAgentLinks.some(
 		(link) =>
@@ -65,7 +79,7 @@ export function linkAgentBlockReason({
 			link.account.provider === provider,
 	);
 	if (!hasExistingProviderLink) return null;
-	return `Hermes agents can use one active ${providerMetaLabel(provider)} bot at a time. Unlink the current ${providerMetaLabel(provider)} bot before linking another.`;
+	return `${AGENT_TYPE_LABELS[agentType] ?? agentType} agents can use one active ${providerMetaLabel(provider)} bot at a time. Unlink the current ${providerMetaLabel(provider)} bot before linking another.`;
 }
 
 function providerMetaLabel(provider: string): string {

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -33,7 +33,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
-import { TokenReveal } from "@/hosted/v2/channels/channel-ui";
+import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import {
 	useAgentChannelLinks,
 	useCreateWhatsappTenantCred,
@@ -54,9 +54,7 @@ import { agentDeploymentRouteQuery, agentSectionLink } from "@/lib/agent-routes"
 type Environment = components["schemas"]["AgentResponse"];
 
 /**
- * Link an agent to a channel — instant, no token paste. On success
- * the scoped agent token is revealed once (the handle the agent runtime uses
- * to send/receive on this channel).
+ * Link an agent to a channel. Hosted runtime credentials reconcile automatically.
  */
 export function LinkAgentDialog({
 	open,
@@ -80,8 +78,7 @@ export function LinkAgentDialog({
 	// (never flips undefined↔string, which warns), and reads as falsy so submit
 	// stays gated. Radix renders the placeholder for value="".
 	const [agentId, setAgentId] = useState("");
-	const [token, setToken] = useState<string | null>(null);
-	const [linkedNoToken, setLinkedNoToken] = useState(false);
+	const [linked, setLinked] = useState(false);
 	const [whatsappCredentialMinted, setWhatsappCredentialMinted] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
@@ -109,8 +106,7 @@ export function LinkAgentDialog({
 	useEffect(() => {
 		if (!open) return;
 		setAgentId("");
-		setToken(null);
-		setLinkedNoToken(false);
+		setLinked(false);
 		setWhatsappCredentialMinted(false);
 	}, [open]);
 
@@ -134,8 +130,7 @@ export function LinkAgentDialog({
 				return;
 			}
 			if (openRef.current && dialogSessionRef.current === dialogSession) {
-				if (data.agent_token) setToken(data.agent_token);
-				else setLinkedNoToken(true);
+				setLinked(true);
 			} else {
 				toast.success("Agent linked", {
 					description: `${accountName} is linked. Open the agent's Channels tab to pair a chat.`,
@@ -152,7 +147,7 @@ export function LinkAgentDialog({
 	function handleOpenChange(nextOpen: boolean) {
 		if (!nextOpen) {
 			dialogSessionRef.current += 1;
-			setToken(null);
+			setLinked(false);
 		}
 		onOpenChange(nextOpen);
 	}
@@ -168,7 +163,7 @@ export function LinkAgentDialog({
 			}),
 		[agents, ownership],
 	);
-	const linkComplete = Boolean(token || linkedNoToken || whatsappCredentialMinted);
+	const linkComplete = linked || whatsappCredentialMinted;
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
@@ -189,32 +184,19 @@ export function LinkAgentDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				{token || linkedNoToken ? (
+				{linked ? (
 					<div className="space-y-3 rounded-lg border border-success/30 bg-success-muted p-3 text-sm">
 						<div className="flex items-start gap-2 text-success-muted-foreground">
 							<CircleCheck className="mt-0.5 size-4 shrink-0" />
 							<div>
-								<p className="font-medium">The bot is linked to this agent</p>
+								<p className="font-medium">Linked · syncing automatically</p>
 								<p className="mt-1 text-xs">
-									Next, create a pairing code and send it in the exact chat where the agent should
-									answer.
+									{provider === "telegram"
+										? "The bot is linked to this Agent. Next, create a Telegram pairing link for the exact chat where it should answer."
+										: `The bot is linked to this Agent. Next, create a ${providerMeta(provider).label} pairing code for the exact chat where it should answer.`}
 								</p>
 							</div>
 						</div>
-						{token ? (
-							<details className="rounded-md border bg-background p-3">
-								<summary className="cursor-pointer text-xs font-medium">
-									Agent token (advanced)
-								</summary>
-								<div className="mt-2">
-									<TokenReveal
-										label="Agent token"
-										value={token}
-										note="Clawdi agents configure this automatically. Only copy it for a self-managed agent that asks for it."
-									/>
-								</div>
-							</details>
-						) : null}
 					</div>
 				) : whatsappCredentialMinted ? (
 					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
@@ -297,7 +279,7 @@ export function LinkAgentDialog({
 								}
 								nativeButton={false}
 							>
-								Finish channel setup
+								Open Agent Channels
 							</Button>
 						</>
 					) : (

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Link2Off } from "lucide-react";
+import { EntityHeader } from "@/components/entity-card";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Spinner } from "@/components/ui/spinner";
+import { providerMeta } from "@/hosted/v2/channels/channel-providers";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
+import { ChannelStatusBadge, CopyInline, ProviderChip } from "@/hosted/v2/channels/channel-ui";
+import { useDeleteChannelBinding } from "@/hosted/v2/channels/channels-hooks";
+import { cn } from "@/lib/utils";
+
+export const PAIRED_CHAT_ROW_CLASS =
+	"grid min-h-16 grid-cols-[minmax(0,1fr)] items-center gap-2 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3";
+
+export function PairedChatRow({
+	accountId,
+	binding,
+	provider,
+	channelName,
+	agentName,
+	showChatId = false,
+	className,
+}: {
+	accountId: string;
+	binding: ChannelBinding;
+	provider: string;
+	channelName?: string;
+	agentName?: string;
+	showChatId?: boolean;
+	className?: string;
+}) {
+	const unpair = useDeleteChannelBinding(accountId);
+	const fallbackName = `${providerMeta(provider).label} chat`;
+	const chatName = binding.external_chat_name ?? fallbackName;
+
+	return (
+		<div
+			data-channel-binding-id={binding.id}
+			data-channel-binding-account-id={accountId}
+			data-channel-binding-agent-link-id={binding.agent_link_id ?? undefined}
+			className={cn(PAIRED_CHAT_ROW_CLASS, className)}
+		>
+			<EntityHeader
+				className="min-w-0"
+				icon={<ProviderChip provider={provider} size="sm" />}
+				title={chatName}
+				meta={[
+					<span key="provider">{providerMeta(provider).label}</span>,
+					...(channelName ? [<span key="channel">{channelName}</span>] : []),
+					<span key="type" className="capitalize">
+						{binding.external_chat_type ?? "chat"}
+					</span>,
+					<ChannelStatusBadge key="status" status={binding.status} />,
+					...(agentName ? [<span key="agent">Agent: {agentName}</span>] : []),
+					...(showChatId
+						? [<CopyInline key="chat-id" value={binding.external_chat_id} label="chat ID" />]
+						: []),
+					...(unpair.error
+						? [
+								<span key="error" className="font-medium text-destructive">
+									Couldn&apos;t unpair · Try again
+								</span>,
+							]
+						: []),
+				]}
+			/>
+			<div className="flex min-w-0 justify-end sm:shrink-0">
+				<ConfirmAction
+					title={`Unpair ${chatName}?`}
+					description="Only this chat will be disconnected. Other chats and the connected channel stay active."
+					confirmLabel="Unpair chat"
+					destructive
+					onConfirm={() => unpair.mutateAsync(binding.id)}
+				>
+					<Button variant="outline" size="sm" disabled={unpair.isPending}>
+						{unpair.isPending ? (
+							<Spinner className="size-3.5" />
+						) : (
+							<Link2Off className="size-3.5" />
+						)}
+						{unpair.isPending ? "Unpairing…" : unpair.error ? "Retry unpair" : "Unpair"}
+					</Button>
+				</ConfirmAction>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -37,6 +37,8 @@ export function PairedChatRow({
 
 	return (
 		<div
+			data-hosted="true"
+			data-v2="true"
 			data-channel-binding-id={binding.id}
 			data-channel-binding-account-id={accountId}
 			data-channel-binding-agent-link-id={binding.agent_link_id ?? undefined}

--- a/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Check, Copy, ExternalLink, QrCode } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import {
+	pairCodeExpiryLabel,
+	telegramPairDeepLink,
+} from "@/hosted/v2/channels/channel-detail-page.logic";
+import { CopyInline } from "@/hosted/v2/channels/channel-ui";
+import { useCreatePairCode } from "@/hosted/v2/channels/channels-hooks";
+import { pairCodeExpired } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import { cn } from "@/lib/utils";
+
+const TELEGRAM_PAIR_TTL_SECONDS = 900;
+
+type TelegramPairResult = {
+	code: string;
+	expires_at: string;
+	pairing_command: string;
+	bot_username: string | null;
+	deep_link: string | null;
+	qr_payload: string | null;
+};
+
+export function TelegramPairDialog({
+	open,
+	onOpenChange,
+	accountId,
+	agentLinkId,
+	agentName,
+	channelName,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	accountId: string;
+	agentLinkId: string;
+	agentName?: string;
+	channelName?: string;
+}) {
+	const pair = useCreatePairCode(accountId);
+	const { copied, copy } = useCopyToClipboard({
+		success: "Telegram link copied",
+		error: "Couldn't copy Telegram link",
+	});
+	const [result, setResult] = useState<TelegramPairResult | null>(null);
+	const [requestError, setRequestError] = useState<unknown>(null);
+	const [generating, setGenerating] = useState(false);
+	const [nowMs, setNowMs] = useState(() => Date.now());
+	const openKeyRef = useRef<string | null>(null);
+	const sessionRef = useRef(0);
+	const lockedSessionRef = useRef<number | null>(null);
+
+	const generate = useCallback(
+		async (session = sessionRef.current) => {
+			if (lockedSessionRef.current === session) return;
+			lockedSessionRef.current = session;
+			setGenerating(true);
+			setRequestError(null);
+			setResult(null);
+			try {
+				const data = await pair.execute({
+					agent_link_id: agentLinkId,
+					ttl_seconds: TELEGRAM_PAIR_TTL_SECONDS,
+				});
+				if (sessionRef.current !== session) return;
+				setNowMs(Date.now());
+				setResult({
+					code: data.code,
+					expires_at: data.expires_at,
+					pairing_command: data.pairing_command,
+					bot_username: data.bot_username ?? null,
+					deep_link: data.deep_link ?? null,
+					qr_payload: data.qr_payload ?? null,
+				});
+			} catch (error) {
+				if (sessionRef.current === session) setRequestError(error);
+			} finally {
+				if (lockedSessionRef.current === session) lockedSessionRef.current = null;
+				if (sessionRef.current === session) setGenerating(false);
+			}
+		},
+		[agentLinkId, pair.execute],
+	);
+
+	useEffect(() => {
+		const openKey = open ? `${accountId}:${agentLinkId}` : null;
+		if (!openKey) {
+			openKeyRef.current = null;
+			sessionRef.current += 1;
+			lockedSessionRef.current = null;
+			setGenerating(false);
+			setRequestError(null);
+			setResult(null);
+			return;
+		}
+		if (openKeyRef.current === openKey) return;
+		openKeyRef.current = openKey;
+		const session = sessionRef.current + 1;
+		sessionRef.current = session;
+		lockedSessionRef.current = null;
+		void generate(session);
+	}, [accountId, agentLinkId, generate, open]);
+
+	useEffect(() => {
+		if (!open || !result) return;
+		setNowMs(Date.now());
+		const interval = window.setInterval(() => setNowMs(Date.now()), 1_000);
+		return () => window.clearInterval(interval);
+	}, [open, result]);
+
+	const expired = result ? pairCodeExpired(result.expires_at, nowMs) : false;
+	const validLink =
+		result && !expired
+			? telegramPairDeepLink({
+					deepLink: result.deep_link,
+					qrPayload: result.qr_payload,
+					botUsername: result.bot_username,
+					code: result.code,
+				})
+			: null;
+	const context = [agentName, channelName].filter(Boolean).join(" · ");
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Pair Telegram</DialogTitle>
+					<DialogDescription>
+						Scan the QR code or open Telegram{context ? ` for ${context}` : ""}.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div data-telegram-pair-dialog-body className="min-h-64">
+					{generating ? (
+						<div className="flex min-h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
+							<Spinner className="size-5" />
+							<p>Creating a secure Telegram link…</p>
+						</div>
+					) : requestError ? (
+						<ApiErrorPanel
+							error={requestError}
+							onRetry={() => void generate()}
+							title="Couldn't create Telegram link"
+						/>
+					) : result ? (
+						<div className="flex flex-col gap-4">
+							{validLink ? (
+								<div className="flex justify-center">
+									<div className="rounded-xl border bg-white p-3 shadow-sm">
+										<QRCodeSVG
+											value={validLink}
+											size={192}
+											role="img"
+											aria-label="Telegram pairing QR code"
+										/>
+									</div>
+								</div>
+							) : (
+								<div role="alert" className="rounded-lg border border-warning/40 bg-muted/20 p-4">
+									<p className="text-sm font-medium">
+										{expired ? "This Telegram link has expired" : "Telegram link unavailable"}
+									</p>
+									<p className="mt-1 text-xs text-muted-foreground">
+										Create a new link to restore the QR and Telegram actions.
+									</p>
+								</div>
+							)}
+							<p
+								role="status"
+								className={cn(
+									"text-center text-sm font-medium",
+									expired ? "text-destructive" : "text-muted-foreground",
+								)}
+							>
+								{pairCodeExpiryLabel(result.expires_at, nowMs)}
+							</p>
+							{!expired ? (
+								<details className="rounded-md border bg-muted/20 px-3 py-2">
+									<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+										Pair a group manually
+									</summary>
+									<div className="mt-2">
+										<CopyInline value={result.pairing_command} label="pairing command" />
+									</div>
+								</details>
+							) : null}
+						</div>
+					) : null}
+				</div>
+
+				{validLink ? (
+					<DialogFooter>
+						<Button variant="outline" onClick={() => void copy(validLink)}>
+							{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+							{copied ? "Copied" : "Copy link"}
+						</Button>
+						<Button
+							render={<a href={validLink} target="_blank" rel="noopener noreferrer" />}
+							nativeButton={false}
+						>
+							{result?.bot_username
+								? `Open @${result.bot_username.replace(/^@/, "")}`
+								: "Open Telegram"}
+							<ExternalLink className="size-4" />
+						</Button>
+					</DialogFooter>
+				) : result && !generating ? (
+					<DialogFooter>
+						<Button onClick={() => void generate()}>
+							<QrCode className="size-4" />
+							{expired ? "Generate new link" : "Try again"}
+						</Button>
+					</DialogFooter>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -152,6 +152,7 @@ describe("agent routes", () => {
 	it("keeps labels and URL segments in one route table", () => {
 		expect(agentSectionLabel("projects")).toBe("Project Access");
 		expect(agentSectionLabel("console")).toBe("Agent Interface");
+		expect(agentSectionLabel("channels")).toBe("Channels");
 		expect(agentSectionLabelFromSegment("project-access")).toBe("Project Access");
 		expect(agentSectionLabelFromSegment("console")).toBe("Agent Interface");
 		expect(agentSectionLabelFromSegment("model-provider")).toBe("Model Provider");

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -67,7 +67,7 @@ const AGENT_SECTION_LABELS = {
 	console: "Agent Interface",
 	terminal: "Terminal",
 	ai: "Model Provider",
-	channels: "Channel Links",
+	channels: "Channels",
 	settings: "Settings",
 } as const satisfies Record<AgentSectionId, string>;
 

--- a/backend/alembic/versions/c4a7e2d9f1b6_scope_channel_events_to_account.py
+++ b/backend/alembic/versions/c4a7e2d9f1b6_scope_channel_events_to_account.py
@@ -1,0 +1,71 @@
+"""Scope channel provider event identity to the account.
+
+Revision ID: c4a7e2d9f1b6
+Revises: 8d3f1a6c9b2e
+Create Date: 2026-07-30 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4a7e2d9f1b6"
+down_revision: str | Sequence[str] | None = "8d3f1a6c9b2e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index("ux_channel_messages_inbound_provider_message_unbound")
+    op.drop_index("ux_channel_messages_inbound_provider_message_bound")
+    # Earlier schemas allowed one copy per AgentLink. Keep the earliest event as
+    # the durable identity and retain later rows only as non-identity history.
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id,
+                   row_number() OVER (
+                       PARTITION BY account_id, external_chat_id, provider_event_id
+                       ORDER BY created_at, id
+                   ) AS duplicate_rank
+            FROM channel_messages
+            WHERE direction = 'inbound' AND provider_event_id IS NOT NULL
+        )
+        UPDATE channel_messages AS message
+        SET provider_event_id = NULL
+        FROM ranked
+        WHERE message.id = ranked.id AND ranked.duplicate_rank > 1
+        """
+    )
+    op.create_index(
+        "ux_channel_messages_inbound_provider_event_account",
+        "channel_messages",
+        ["account_id", "external_chat_id", "provider_event_id"],
+        unique=True,
+        postgresql_where=sa.text("direction = 'inbound' AND provider_event_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ux_channel_messages_inbound_provider_event_account")
+    op.create_index(
+        "ux_channel_messages_inbound_provider_message_bound",
+        "channel_messages",
+        ["account_id", "external_chat_id", "provider_event_id", "bot_agent_link_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "direction = 'inbound' AND provider_event_id IS NOT NULL "
+            "AND bot_agent_link_id IS NOT NULL"
+        ),
+    )
+    op.create_index(
+        "ux_channel_messages_inbound_provider_message_unbound",
+        "channel_messages",
+        ["account_id", "external_chat_id", "provider_event_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "direction = 'inbound' AND provider_event_id IS NOT NULL AND bot_agent_link_id IS NULL"
+        ),
+    )

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -349,29 +349,12 @@ class ChannelMessage(Base, TimestampMixin):
             "inbox_sequence",
         ),
         Index(
-            "ux_channel_messages_inbound_provider_message_bound",
-            "account_id",
-            "external_chat_id",
-            "provider_event_id",
-            "bot_agent_link_id",
-            unique=True,
-            postgresql_where=sql_text(
-                "direction = 'inbound' "
-                "AND provider_event_id IS NOT NULL "
-                "AND bot_agent_link_id IS NOT NULL"
-            ),
-        ),
-        Index(
-            "ux_channel_messages_inbound_provider_message_unbound",
+            "ux_channel_messages_inbound_provider_event_account",
             "account_id",
             "external_chat_id",
             "provider_event_id",
             unique=True,
-            postgresql_where=sql_text(
-                "direction = 'inbound' "
-                "AND provider_event_id IS NOT NULL "
-                "AND bot_agent_link_id IS NULL"
-            ),
+            postgresql_where=sql_text("direction = 'inbound' AND provider_event_id IS NOT NULL"),
         ),
     )
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -43,9 +43,12 @@ from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
 from app.models.app_setting import AppSetting
 from app.models.channel import (
+    BOT_AGENT_LINK_STATUS_ACTIVE,
+    CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDERS,
     ChannelAccount,
+    ChannelBotAgentLink,
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -1231,7 +1234,25 @@ async def admin_delete_channel(
     db: AsyncSession = Depends(get_session),
 ) -> None:
     account, _owner = await _admin_get_channel_row(db, account_id=account_id)
+    active_links = list(
+        (
+            await db.execute(
+                select(ChannelBotAgentLink).where(
+                    ChannelBotAgentLink.account_id == account.id,
+                    ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                    ChannelBotAgentLink.archived_at.is_(None),
+                )
+            )
+        ).scalars()
+    )
     await archive_channel_account(db, account=account)
+    if account.provider in (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD):
+        for link in active_links:
+            await queue_environment_runtime_manifest_changed(
+                db,
+                link.user_id,
+                link.agent_id,
+            )
     record_control_plane_audit(
         db,
         actor_type="admin",

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -25,6 +25,7 @@ from app.core.auth import (
 from app.core.database import get_session
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
+    BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
@@ -60,6 +61,7 @@ from app.schemas.channel import (
     ChannelAgentLinkCreate,
     ChannelAgentLinkResponse,
     ChannelAgentLinkWithAccountResponse,
+    ChannelBindingDeleteResponse,
     ChannelBindingResponse,
     ChannelBotPoolAccess,
     ChannelBotPoolCapabilities,
@@ -106,6 +108,7 @@ from app.services.channels import (
     sync_channel_commands,
 )
 from app.services.http_cache import if_none_match_contains, strong_json_etag
+from app.services.sync_events import queue_environment_runtime_manifest_changed
 from app.services.vault_crypto import decrypt
 from app.services.whatsapp_baileys import (
     buffer_json,
@@ -135,6 +138,19 @@ SECRETISH_ACTIVITY_DETAIL_KEYS = (
     "credential",
     "cookie",
 )
+
+
+async def _queue_agent_link_runtime_changed(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> None:
+    # The strict v2 runtime source currently projects Telegram and Discord
+    # AgentLinks. Bindings are deliberately absent from that source identity.
+    if account.provider not in (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD):
+        return
+    await queue_environment_runtime_manifest_changed(db, link.user_id, link.agent_id)
 
 
 def _agent_link_response(
@@ -563,6 +579,7 @@ async def create_channel(
                 agent_token=link_agent_token,
             )
             link_agent_token = created_token or link_agent_token
+            await _queue_agent_link_runtime_changed(db, account=account, link=link)
         await store_channel_secrets(db, account=account, secrets_by_name=body.secrets)
         record_control_plane_audit(
             db,
@@ -686,7 +703,20 @@ async def delete_channel(
         account_id=account_id,
         user_id=auth.user_id,
     )
+    active_links = list(
+        (
+            await db.execute(
+                select(ChannelBotAgentLink).where(
+                    ChannelBotAgentLink.account_id == account.id,
+                    ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                    ChannelBotAgentLink.archived_at.is_(None),
+                )
+            )
+        ).scalars()
+    )
     await archive_channel_account(db, account=account)
+    for link in active_links:
+        await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -718,6 +748,8 @@ async def create_channel_pair_code(
         ttl_seconds=body.ttl_seconds,
         agent_token=agent_token,
     )
+    if agent_token is not None:
+        await _queue_agent_link_runtime_changed(db, account=account, link=created.link)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -792,6 +824,8 @@ async def create_channel_agent_link(
         agent_id=agent_id,
         user_id=auth.user_id,
     )
+    if agent_token is not None:
+        await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -826,6 +860,7 @@ async def rotate_channel_agent_link_token(
         db, account=account, link_id=link_id, user_id=auth.user_id
     )
     agent_token = await rotate_bot_agent_link_token(db, account=account, link=link)
+    await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -864,6 +899,7 @@ async def delete_channel_agent_link(
         return
 
     await archive_bot_agent_link(db, link=link)
+    await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -897,6 +933,121 @@ async def list_channel_bindings(
         .order_by(ChannelBinding.created_at.desc())
     )
     return [_binding_response(binding) for binding in result.scalars().all()]
+
+
+@router.delete("/{account_id}/bindings/{binding_id}")
+async def delete_channel_binding(
+    account_id: UUID,
+    binding_id: UUID,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> ChannelBindingDeleteResponse:
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    row = (
+        await db.execute(
+            select(ChannelBinding, ChannelBotAgentLink)
+            .join(
+                ChannelBotAgentLink,
+                and_(
+                    ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
+                    ChannelBotAgentLink.account_id == ChannelBinding.account_id,
+                    ChannelBotAgentLink.user_id == ChannelBinding.user_id,
+                ),
+            )
+            .where(
+                ChannelBinding.id == binding_id,
+                ChannelBinding.account_id == account.id,
+                ChannelBinding.user_id == auth.user_id,
+                ChannelBotAgentLink.user_id == auth.user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            )
+            .with_for_update(of=ChannelBinding)
+        )
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="binding not found")
+    binding, link = row
+    await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=link.agent_id)
+
+    if binding.status != BINDING_STATUS_ACTIVE:
+        return ChannelBindingDeleteResponse(
+            binding_id=binding.id,
+            unpaired=False,
+            notification_status="not_applicable",
+            provider_cleanup_status="not_applicable",
+        )
+
+    binding.status = BINDING_STATUS_ARCHIVED
+    record_control_plane_audit(
+        db,
+        actor_type="user",
+        actor_user_id=auth.user_id,
+        target_user_id=auth.user_id,
+        action="channel.binding.archive",
+        resource_type="channel_binding",
+        resource_id=str(binding.id),
+        environment_id=link.agent_id,
+        channel_account_id=account.id,
+        channel_agent_link_id=link.id,
+        source="api.channels",
+        details={
+            "provider": account.provider,
+            "external_chat_id": binding.external_chat_id,
+        },
+    )
+    # The archive commits before any provider I/O. A failed Telegram cleanup or
+    # notification can never roll back a completed unpair.
+    await db.commit()
+
+    notification_status = "not_applicable"
+    provider_cleanup_status = "not_applicable"
+    warning: str | None = None
+    if account.provider == CHANNEL_PROVIDER_TELEGRAM:
+        from app.routes.channel_routers.telegram import (
+            reconcile_telegram_binding_unpair_from_ui,
+        )
+
+        outcome = await reconcile_telegram_binding_unpair_from_ui(
+            db=db,
+            account=account,
+            link=link,
+            binding=binding,
+        )
+        notification_status = "sent" if outcome.notification_sent else "failed"
+        provider_cleanup_status = (
+            "succeeded" if outcome.commands_cleared and outcome.menu_reset else "failed"
+        )
+        if notification_status == "failed" or provider_cleanup_status == "failed":
+            warning = (
+                "Chat was unpaired, but Telegram notification or per-chat cleanup did not complete."
+            )
+        record_control_plane_audit(
+            db,
+            actor_type="user",
+            actor_user_id=auth.user_id,
+            target_user_id=auth.user_id,
+            action="channel.binding.telegram_cleanup",
+            resource_type="channel_binding",
+            resource_id=str(binding.id),
+            environment_id=link.agent_id,
+            channel_account_id=account.id,
+            channel_agent_link_id=link.id,
+            source="api.channels",
+            details={
+                "notification_status": notification_status,
+                "provider_cleanup_status": provider_cleanup_status,
+            },
+        )
+        await db.commit()
+
+    return ChannelBindingDeleteResponse(
+        binding_id=binding.id,
+        unpaired=True,
+        notification_status=notification_status,
+        provider_cleanup_status=provider_cleanup_status,
+        warning=warning,
+    )
 
 
 @router.post("/{account_id}/commands/sync")

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -416,18 +416,22 @@ def _telegram_error(description: str, error_code: int) -> dict[str, Any]:
     return {"ok": False, "error_code": error_code, "description": description}
 
 
-def _telegram_me(account: ChannelAccount, token: str) -> dict[str, Any]:
-    bot_id = token.split(":", 1)[0]
+def _telegram_me(account: ChannelAccount) -> dict[str, Any]:
+    # Synthetic identities are account-scoped so rotating an AgentLink token
+    # cannot impersonate a different physical bot. Without a provider getMe
+    # snapshot, topic capability must fail closed.
+    bot_id = (account.id.int % 999_999_999) + 1
     config = account.config if isinstance(account.config, dict) else {}
     username = _optional_str(config.get("bot_username")) or account.name.replace(" ", "_")
     return {
-        "id": int(bot_id) if bot_id.isdigit() else abs(hash(bot_id)) % 1_000_000_000,
+        "id": bot_id,
         "is_bot": True,
         "first_name": account.name,
         "username": username,
         "can_join_groups": True,
         "can_read_all_group_messages": False,
         "supports_inline_queries": False,
+        "has_topics_enabled": False,
     }
 
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hmac
 import json
+import logging
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -74,6 +75,7 @@ from app.services.channels import (
     telegram_external_user_id_from_update,
     telegram_file_ids,
     telegram_message_id_from_update,
+    telegram_message_thread_id_from_update,
     telegram_text_from_update,
     verify_hashed_token,
     wait_for_telegram_updates,
@@ -88,6 +90,7 @@ from app.services.telegram_rate_limiter import telegram_rate_limiter
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_http_url
 
 router = APIRouter(prefix="/channels/telegram", tags=["channels"])
+log = logging.getLogger(__name__)
 
 
 # Keep this list explicit. Telegram ignores parameters it doesn't use, so the
@@ -213,6 +216,14 @@ _TELEGRAM_BROAD_COMMAND_SCOPE_TYPES = frozenset(
     }
 )
 _TELEGRAM_CHAT_COMMAND_SCOPE_TYPES = frozenset({"chat", "chat_administrators", "chat_member"})
+TELEGRAM_UI_UNPAIR_REPLY = "Unpaired. This chat is no longer connected to an agent."
+
+
+@dataclass(frozen=True)
+class TelegramBindingUnpairOutcome:
+    notification_sent: bool
+    commands_cleared: bool
+    menu_reset: bool
 
 
 @dataclass(frozen=True)
@@ -408,7 +419,7 @@ async def telegram_bot_api(
     authorization: str | None = Header(default=None),
     db: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
-    agent, agent_token = await _resolve_telegram_agent(
+    agent, _agent_token = await _resolve_telegram_agent(
         db,
         routing_id=routing_id,
         authorization=authorization,
@@ -435,7 +446,7 @@ async def telegram_bot_api(
                 request=request,
                 raw_body=raw_body,
             )
-        return _telegram_ok(_telegram_me(account, agent_token))
+        return _telegram_ok(_telegram_me(account))
     if method_key == "getupdates":
         if _telegram_link_webhook_url(agent.link):
             return _telegram_error_response(
@@ -822,6 +833,7 @@ async def telegram_webhook(
         db,
         account=account,
         external_chat_id=external_chat_id,
+        telegram_message_thread_id=telegram_message_thread_id_from_update(payload),
         command=command,
         binding_result=binding_result,
     )
@@ -1185,14 +1197,15 @@ async def _clear_telegram_commands_for_binding(
     account: ChannelAccount,
     link: ChannelBotAgentLink,
     binding: ChannelBinding,
-) -> None:
+) -> bool:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
-        return
+        return True
     config = link.config if isinstance(link.config, dict) else {}
     shadow = config.get("telegram_agent_commands")
     if not isinstance(shadow, dict):
-        return
+        return True
     cleared: set[str] = set()
+    succeeded = True
     for key in shadow:
         if not isinstance(key, str):
             continue
@@ -1213,10 +1226,17 @@ async def _clear_telegram_commands_for_binding(
                 method="deleteMyCommands",
                 payload=payload,
             )
-        except HTTPException:
-            return
-        if response.status_code >= 400:
-            return
+        except Exception:
+            log.exception(
+                "telegram_binding_command_cleanup_failed account_id=%s binding_id=%s",
+                account.id,
+                binding.id,
+            )
+            succeeded = False
+            continue
+        if not _telegram_provider_call_succeeded(response):
+            succeeded = False
+    return succeeded
 
 
 async def _replay_telegram_commands_on_pair(
@@ -1265,13 +1285,13 @@ async def _reconcile_telegram_menu_button_after_binding_change(
     account: ChannelAccount,
     binding: ChannelBinding,
     paired: bool,
-) -> None:
+) -> bool:
     if (
         not _telegram_binding_supports_menu_button(binding)
         or not account.encrypted_provider_token
         or not account.provider_token_nonce
     ):
-        return
+        return True
     menu_button: dict[str, Any] = {"type": "default"}
     if paired:
         link = await db.get(ChannelBotAgentLink, binding.bot_agent_link_id)
@@ -1281,7 +1301,7 @@ async def _reconcile_telegram_menu_button_after_binding_change(
                 chat_id=binding.external_chat_id,
             )
     try:
-        await _post_telegram_bot_payload(
+        response = await _post_telegram_bot_payload(
             account=account,
             method="setChatMenuButton",
             payload={
@@ -1289,8 +1309,64 @@ async def _reconcile_telegram_menu_button_after_binding_change(
                 "menu_button": menu_button,
             },
         )
-    except HTTPException:
-        return
+    except Exception:
+        log.exception(
+            "telegram_binding_menu_reconcile_failed account_id=%s binding_id=%s",
+            account.id,
+            binding.id,
+        )
+        return False
+    return _telegram_provider_call_succeeded(response)
+
+
+async def reconcile_telegram_binding_unpair_from_ui(
+    *,
+    db: AsyncSession,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+    binding: ChannelBinding,
+) -> TelegramBindingUnpairOutcome:
+    """Best-effort provider cleanup after the binding archive is durable."""
+    commands_cleared = await _clear_telegram_commands_for_binding(
+        account=account,
+        link=link,
+        binding=binding,
+    )
+    menu_reset = await _reconcile_telegram_menu_button_after_binding_change(
+        db=db,
+        account=account,
+        binding=binding,
+        paired=False,
+    )
+    notification_sent = False
+    try:
+        response = await _post_telegram_bot_payload(
+            account=account,
+            method="sendMessage",
+            payload={
+                "chat_id": binding.external_chat_id,
+                "text": TELEGRAM_UI_UNPAIR_REPLY,
+            },
+        )
+        notification_sent = _telegram_provider_call_succeeded(response)
+    except Exception:
+        log.exception(
+            "telegram_binding_unpair_notification_failed account_id=%s binding_id=%s",
+            account.id,
+            binding.id,
+        )
+        notification_sent = False
+    return TelegramBindingUnpairOutcome(
+        notification_sent=notification_sent,
+        commands_cleared=commands_cleared,
+        menu_reset=menu_reset,
+    )
+
+
+def _telegram_provider_call_succeeded(response: httpx.Response) -> bool:
+    if response.status_code >= 400:
+        return False
+    return _telegram_response_json(response).get("ok") is not False
 
 
 def _telegram_command_shadow_parts(key: str) -> tuple[str, str]:

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -193,6 +193,14 @@ class ChannelBindingResponse(BaseModel):
     created_at: datetime
 
 
+class ChannelBindingDeleteResponse(BaseModel):
+    binding_id: UUID
+    unpaired: bool
+    notification_status: Literal["sent", "failed", "not_applicable"]
+    provider_cleanup_status: Literal["succeeded", "failed", "not_applicable"]
+    warning: str | None = None
+
+
 class ChannelSendMessageRequest(BaseModel):
     binding_id: UUID | None = None
     external_chat_id: str | None = Field(default=None, min_length=1, max_length=300)

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -102,7 +102,13 @@ DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
 HERMES_AGENT_TYPE = "hermes"
 OPENCLAW_AGENT_TYPE = "openclaw"
 HOSTED_RUNTIME_AGENT_TYPES = frozenset({HERMES_AGENT_TYPE, OPENCLAW_AGENT_TYPE})
-HERMES_SINGLE_LINK_PROVIDERS = frozenset({CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD})
+SINGLE_LINK_PROVIDERS_BY_HOSTED_AGENT_TYPE = {
+    HERMES_AGENT_TYPE: frozenset({CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}),
+    # OpenClaw's group session key does not yet include the Telegram account.
+    # Keep one account per Agent until upstream makes group sessions account-aware.
+    OPENCLAW_AGENT_TYPE: frozenset({CHANNEL_PROVIDER_TELEGRAM}),
+}
+HOSTED_AGENT_TYPE_LABELS = {HERMES_AGENT_TYPE: "Hermes", OPENCLAW_AGENT_TYPE: "OpenClaw"}
 WHATSAPP_COMING_SOON_DETAIL = (
     "WhatsApp channels are coming soon for hosted agents. Telegram and Discord are available now."
 )
@@ -455,9 +461,12 @@ async def ensure_hosted_agent_provider_link_available(
             status_code=status.HTTP_409_CONFLICT,
             detail=WHATSAPP_COMING_SOON_DETAIL,
         )
-    if agent.agent_type != HERMES_AGENT_TYPE:
-        return
-    if existing_same_account_link or account.provider not in HERMES_SINGLE_LINK_PROVIDERS:
+    single_link_providers = SINGLE_LINK_PROVIDERS_BY_HOSTED_AGENT_TYPE.get(agent.agent_type)
+    if (
+        existing_same_account_link
+        or single_link_providers is None
+        or account.provider not in single_link_providers
+    ):
         return
 
     existing_link = (
@@ -482,7 +491,8 @@ async def ensure_hosted_agent_provider_link_available(
     raise HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail=(
-            f"one-{account.provider}-link-per-Hermes-agent: Hermes agents support one "
+            f"one-{account.provider}-link-per-{agent.agent_type}-agent: "
+            f"{HOSTED_AGENT_TYPE_LABELS[agent.agent_type]} agents support one "
             f"active {account.provider} link. Unlink the existing {account.provider} "
             "channel before linking another."
         ),

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1304,6 +1304,7 @@ async def send_pairing_command_reply(
     account: ChannelAccount,
     external_chat_id: str,
     send_external_chat_id: str | None = None,
+    telegram_message_thread_id: int | None = None,
     command: ChannelPairCommand | None,
     binding_result: InboundBindingResult,
 ) -> ChannelMessage | None:
@@ -1324,6 +1325,7 @@ async def send_pairing_command_reply(
             text=reply,
             bot_agent_link_id=reply_link_id,
             bind_to_existing=bind_reply_to_existing,
+            telegram_message_thread_id=telegram_message_thread_id,
         )
     except HTTPException as exc:
         log.warning(
@@ -1380,6 +1382,27 @@ def telegram_message_id_from_update(payload: dict[str, Any]) -> str | None:
         return None
     message_id = message.get("message_id")
     return str(message_id) if message_id is not None else None
+
+
+def telegram_message_thread_id_from_update(payload: dict[str, Any]) -> int | None:
+    """Return a true Telegram topic for replies, never as binding identity."""
+    message = _telegram_message_from_update(payload)
+    if not isinstance(message, dict):
+        return None
+    message_thread_id = message.get("message_thread_id")
+    if isinstance(message_thread_id, bool) or not isinstance(message_thread_id, int):
+        return None
+    if message_thread_id <= 0 or message.get("is_topic_message") is not True:
+        return None
+    chat = message.get("chat")
+    if not isinstance(chat, dict):
+        return None
+    chat_type = _read_optional_str(chat.get("type"))
+    if chat_type == "private":
+        return message_thread_id
+    if chat_type in {"group", "supergroup"} and chat.get("is_forum") is True:
+        return message_thread_id
+    return None
 
 
 def telegram_event_id_from_update(payload: dict[str, Any]) -> str | None:
@@ -1487,7 +1510,6 @@ async def record_inbound_message(
         existing = await _find_existing_inbound_message(
             db,
             account=account,
-            binding=binding,
             external_chat_id=external_chat_id,
             provider_event_id=event_id,
         )
@@ -1514,7 +1536,6 @@ async def record_inbound_message(
         existing = await _find_existing_inbound_message(
             db,
             account=account,
-            binding=binding,
             external_chat_id=external_chat_id,
             provider_event_id=event_id,
         )
@@ -1529,25 +1550,19 @@ async def _find_existing_inbound_message(
     db: AsyncSession,
     *,
     account: ChannelAccount,
-    binding: ChannelBinding | None,
     external_chat_id: str,
     provider_event_id: str | None,
 ) -> ChannelMessage | None:
     if provider_event_id is None:
         return None
-    filters = [
-        ChannelMessage.account_id == account.id,
-        ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-        ChannelMessage.external_chat_id == external_chat_id,
-        ChannelMessage.provider_event_id == provider_event_id,
-    ]
-    if binding is None:
-        filters.append(ChannelMessage.bot_agent_link_id.is_(None))
-    else:
-        filters.append(ChannelMessage.bot_agent_link_id == binding.bot_agent_link_id)
     result = await db.execute(
         select(ChannelMessage)
-        .where(*filters)
+        .where(
+            ChannelMessage.account_id == account.id,
+            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+            ChannelMessage.external_chat_id == external_chat_id,
+            ChannelMessage.provider_event_id == provider_event_id,
+        )
         .order_by(ChannelMessage.created_at.asc(), ChannelMessage.id.asc())
         .limit(1)
     )
@@ -2470,6 +2485,7 @@ async def send_channel_outbound_message(
     text: str,
     bot_agent_link_id: UUID | None = None,
     bind_to_existing: bool = True,
+    telegram_message_thread_id: int | None = None,
 ) -> ChannelMessage:
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
         return await send_telegram_message(
@@ -2479,6 +2495,7 @@ async def send_channel_outbound_message(
             text=text,
             bot_agent_link_id=bot_agent_link_id,
             bind_to_existing=bind_to_existing,
+            message_thread_id=telegram_message_thread_id,
         )
     if account.provider == CHANNEL_PROVIDER_DISCORD:
         return await send_discord_message(
@@ -2542,12 +2559,14 @@ async def send_telegram_message(
     text: str,
     bot_agent_link_id: UUID | None = None,
     bind_to_existing: bool = True,
+    message_thread_id: int | None = None,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_TELEGRAM)
     provider_message_id, payload = await _send_telegram_provider_payload(
         account=account,
         external_chat_id=external_chat_id,
         text=text,
+        message_thread_id=message_thread_id,
     )
     binding = (
         await find_binding(
@@ -2575,15 +2594,19 @@ async def _send_telegram_provider_payload(
     account: ChannelAccount,
     external_chat_id: str,
     text: str,
+    message_thread_id: int | None = None,
 ) -> tuple[str | None, dict[str, Any]]:
     token = decrypt_provider_token(account)
     base_url = settings.channel_telegram_api_base_url.strip()
     url = f"{base_url.rstrip('/')}/bot{token}/sendMessage"
+    request_payload: dict[str, Any] = {"chat_id": external_chat_id, "text": text}
+    if message_thread_id is not None:
+        request_payload["message_thread_id"] = message_thread_id
     payload = await _post_provider_json(
         channel=CHANNEL_PROVIDER_TELEGRAM,
         method="sendMessage",
         url=url,
-        json_payload={"chat_id": external_chat_id, "text": text},
+        json_payload=request_payload,
         timeout_seconds=20.0,
         unreachable_detail="telegram api unreachable",
         rejected_detail="telegram api rejected message",

--- a/backend/tests/test_channel_event_account_scope_migration.py
+++ b/backend/tests/test_channel_event_account_scope_migration.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+REVISION = "c4a7e2d9f1b6"
+MIGRATION_FILENAME = f"{REVISION}_scope_channel_events_to_account.py"
+
+
+def _load_migration():
+    path = Path(__file__).parents[1] / "alembic" / "versions" / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location("channel_event_account_scope", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def test_channel_event_account_scope_migration_dedupes_cross_link_rows(
+    engine: AsyncEngine,
+) -> None:
+    migration = _load_migration()
+    schema = f"channel_event_account_{uuid.uuid4().hex}"
+    account_id = uuid.uuid4()
+    first_id = uuid.uuid4()
+    second_id = uuid.uuid4()
+    sync_engine = create_engine(engine.url.set(drivername="postgresql+psycopg2"))
+    old_op = migration.op
+    try:
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET search_path TO "{schema}"'))
+            connection.execute(
+                sa.text(
+                    """
+                    CREATE TABLE channel_messages (
+                        id uuid PRIMARY KEY,
+                        account_id uuid NOT NULL,
+                        direction varchar(16) NOT NULL,
+                        external_chat_id varchar(300) NOT NULL,
+                        provider_event_id varchar(300),
+                        bot_agent_link_id uuid,
+                        created_at timestamptz NOT NULL
+                    );
+                    CREATE UNIQUE INDEX ux_channel_messages_inbound_provider_message_bound
+                    ON channel_messages (
+                        account_id, external_chat_id, provider_event_id, bot_agent_link_id
+                    ) WHERE direction = 'inbound' AND provider_event_id IS NOT NULL
+                      AND bot_agent_link_id IS NOT NULL;
+                    CREATE UNIQUE INDEX ux_channel_messages_inbound_provider_message_unbound
+                    ON channel_messages (account_id, external_chat_id, provider_event_id)
+                    WHERE direction = 'inbound' AND provider_event_id IS NOT NULL
+                      AND bot_agent_link_id IS NULL
+                    """
+                )
+            )
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO channel_messages (
+                        id, account_id, direction, external_chat_id, provider_event_id,
+                        bot_agent_link_id, created_at
+                    ) VALUES
+                    (:first_id, :account_id, 'inbound', '42', '7001', :first_link,
+                     '2026-07-30T00:00:00Z'),
+                    (:second_id, :account_id, 'inbound', '42', '7001', :second_link,
+                     '2026-07-30T00:00:01Z')
+                    """
+                ),
+                {
+                    "first_id": first_id,
+                    "second_id": second_id,
+                    "account_id": account_id,
+                    "first_link": uuid.uuid4(),
+                    "second_link": uuid.uuid4(),
+                },
+            )
+            migration.op = Operations(MigrationContext.configure(connection))
+
+            migration.upgrade()
+
+            rows = connection.execute(
+                sa.text(
+                    "SELECT id, provider_event_id FROM channel_messages ORDER BY created_at, id"
+                )
+            ).all()
+            assert rows == [(first_id, "7001"), (second_id, None)]
+            indexes = {
+                index["name"]: index
+                for index in inspect(connection).get_indexes("channel_messages")
+            }
+            scoped = indexes["ux_channel_messages_inbound_provider_event_account"]
+            assert scoped["unique"] is True
+            assert scoped["column_names"] == [
+                "account_id",
+                "external_chat_id",
+                "provider_event_id",
+            ]
+
+            migration.downgrade()
+            downgraded = {
+                index["name"] for index in inspect(connection).get_indexes("channel_messages")
+            }
+            assert "ux_channel_messages_inbound_provider_message_bound" in downgraded
+            assert "ux_channel_messages_inbound_provider_message_unbound" in downgraded
+    finally:
+        migration.op = old_op
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        sync_engine.dispose()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -80,6 +80,7 @@ from app.services.channels import (
     parse_pair_command,
     record_discord_dispatch,
     send_provider_outbound_payload,
+    telegram_message_thread_id_from_update,
     wait_for_telegram_updates,
 )
 from app.services.discord_gateway_worker import (
@@ -804,6 +805,36 @@ async def test_rotate_channel_agent_link_token_replaces_one_time_token(
     assert link.agent_token_hash == hash_token(body["agent_token"])
     assert link.agent_token_hash != hash_token(old_token)
     assert decrypt_agent_link_token(link) == body["agent_token"]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_telegram_identity_is_account_scoped_and_topics_fail_closed(
+    client: httpx.AsyncClient,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": f"synthetic-me-{uuid4().hex}"},
+        )
+    ).json()
+    bot_path = _telegram_bot_path(created, "getMe")
+    before = await client.post(bot_path, headers=_telegram_agent_headers(created), json={})
+    rotated = await client.post(
+        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}/token"
+    )
+    rotated_channel = {**created, "agent_token": rotated.json()["agent_token"]}
+    after = await client.post(
+        bot_path,
+        headers=_telegram_agent_headers(rotated_channel),
+        json={},
+    )
+
+    assert before.status_code == 200
+    assert rotated.status_code == 200
+    assert after.status_code == 200
+    assert before.json()["result"]["id"] == after.json()["result"]["id"]
+    assert before.json()["result"]["has_topics_enabled"] is False
+    assert after.json()["result"]["has_topics_enabled"] is False
 
 
 @pytest.mark.asyncio
@@ -8047,6 +8078,8 @@ async def test_telegram_webhook_pair_code_creates_binding(client: httpx.AsyncCli
             "update_id": 1,
             "message": {
                 "message_id": 42,
+                "message_thread_id": 321,
+                "is_topic_message": True,
                 "text": f"/bot_pair {pair['code']}",
                 "chat": {
                     "id": 987654321,
@@ -8065,6 +8098,46 @@ async def test_telegram_webhook_pair_code_creates_binding(client: httpx.AsyncCli
     assert bindings.json()[0]["external_chat_id"] == "987654321"
     assert bindings.json()[0]["external_chat_type"] == "private"
     assert bindings.json()[0]["external_chat_name"] == "paco"
+
+
+@pytest.mark.asyncio
+async def test_telegram_pairing_threads_share_one_chat_binding(client: httpx.AsyncClient):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": "telegram-chat-level-binding"},
+        )
+    ).json()
+    webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+
+    for update_id, thread_id in ((11, 321), (12, 654)):
+        pair = (
+            await client.post(
+                f"/v1/channels/{created['id']}/pair-codes",
+                json={"agent_link_id": created["agent_link_id"], "ttl_seconds": 900},
+            )
+        ).json()
+        response = await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "update_id": update_id,
+                "message": {
+                    "message_id": update_id,
+                    "message_thread_id": thread_id,
+                    "text": f"/bot_pair {pair['code']}",
+                    "chat": {"id": 987654321, "type": "private"},
+                    "from": {"id": 987654321, "is_bot": False},
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["paired"] is True
+
+    bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
+    assert bindings.status_code == 200
+    assert [binding["external_chat_id"] for binding in bindings.json()] == ["987654321"]
 
 
 @pytest.mark.asyncio
@@ -8213,6 +8286,8 @@ async def test_telegram_webhook_pair_code_sends_user_reply(
             "update_id": 1,
             "message": {
                 "message_id": 42,
+                "message_thread_id": 321,
+                "is_topic_message": True,
                 "text": f"/bot_pair {pair['code']}",
                 "chat": {"id": 987654321, "type": "private", "username": "paco"},
                 "from": {"id": 987654321, "is_bot": False, "username": "paco"},
@@ -8225,6 +8300,7 @@ async def test_telegram_webhook_pair_code_sends_user_reply(
     assert _FakeProviderClient.calls[0]["url"].endswith("/bot123456:telegram-secret/sendMessage")
     assert _FakeProviderClient.calls[0]["json"] == {
         "chat_id": "987654321",
+        "message_thread_id": 321,
         "text": "Paired! This chat is now connected to your agent.",
     }
 
@@ -8254,8 +8330,14 @@ async def test_telegram_webhook_pair_command_sends_failure_replies(
             "update_id": 1,
             "message": {
                 "message_id": 43,
+                "message_thread_id": 322,
+                "is_topic_message": True,
                 "text": "/bot_pair",
-                "chat": {"id": 987654322, "type": "private"},
+                "chat": {
+                    "id": 987654322,
+                    "type": "supergroup",
+                    "is_forum": True,
+                },
                 "from": {"id": 987654322, "is_bot": False},
             },
         },
@@ -8267,6 +8349,8 @@ async def test_telegram_webhook_pair_command_sends_failure_replies(
             "update_id": 2,
             "message": {
                 "message_id": 44,
+                "message_thread_id": 999,
+                "is_topic_message": False,
                 "text": "/bot_pair PAIRDOESNOTEXIST",
                 "chat": {"id": 987654322, "type": "private"},
                 "from": {"id": 987654322, "is_bot": False},
@@ -8276,9 +8360,16 @@ async def test_telegram_webhook_pair_command_sends_failure_replies(
 
     assert missing.status_code == 200
     assert invalid.status_code == 200
-    assert [call["json"]["text"] for call in _FakeProviderClient.calls] == [
-        "Usage: /bot_pair <code>",
-        "Pairing failed: invalid.",
+    assert [call["json"] for call in _FakeProviderClient.calls] == [
+        {
+            "chat_id": "987654322",
+            "message_thread_id": 322,
+            "text": "Usage: /bot_pair <code>",
+        },
+        {
+            "chat_id": "987654322",
+            "text": "Pairing failed: invalid.",
+        },
     ]
 
 
@@ -8313,6 +8404,8 @@ async def test_telegram_webhook_unpair_sends_user_reply(
             "update_id": 1,
             "message": {
                 "message_id": 45,
+                "message_thread_id": 323,
+                "is_topic_message": True,
                 "text": f"/bot_pair {pair['code']}",
                 "chat": {"id": 987654323, "type": "private"},
                 "from": {"id": 987654323, "is_bot": False},
@@ -8326,6 +8419,8 @@ async def test_telegram_webhook_unpair_sends_user_reply(
             "update_id": 2,
             "message": {
                 "message_id": 46,
+                "message_thread_id": 324,
+                "is_topic_message": True,
                 "text": "/bot_unpair",
                 "chat": {"id": 987654323, "type": "private"},
                 "from": {"id": 987654323, "is_bot": False},
@@ -8336,12 +8431,18 @@ async def test_telegram_webhook_unpair_sends_user_reply(
     assert unpaired.status_code == 200
     assert unpaired.json()["unpaired"] is True
     assert [
-        call["json"]["text"]
-        for call in _FakeProviderClient.calls
-        if call["url"].endswith("/sendMessage")
+        call["json"] for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
     ] == [
-        "Paired! This chat is now connected to your agent.",
-        "Unpaired. This chat is no longer connected to an agent.",
+        {
+            "chat_id": "987654323",
+            "message_thread_id": 323,
+            "text": "Paired! This chat is now connected to your agent.",
+        },
+        {
+            "chat_id": "987654323",
+            "message_thread_id": 324,
+            "text": "Unpaired. This chat is no longer connected to an agent.",
+        },
     ]
     assert [
         call["json"]
@@ -8351,6 +8452,315 @@ async def test_telegram_webhook_unpair_sends_user_reply(
         {"chat_id": "987654323", "menu_button": {"type": "default"}},
         {"chat_id": "987654323", "menu_button": {"type": "default"}},
     ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_unpair_redelivery_does_not_duplicate_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 103}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-unpair-redelivery",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    await _pair_telegram_chat(
+        client,
+        created=created,
+        chat_id="987654325",
+        chat_type="private",
+    )
+    payload = {
+        "update_id": 7003,
+        "message": {
+            "message_id": 47,
+            "text": "/bot_unpair",
+            "chat": {"id": 987654325, "type": "private"},
+            "from": {"id": 4242, "is_bot": False},
+        },
+    }
+    webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+
+    first = await client.post(webhook_url, headers=headers, json=payload)
+    redelivery = await client.post(webhook_url, headers=headers, json=payload)
+
+    assert first.status_code == 200
+    assert first.json()["unpaired"] is True
+    assert redelivery.status_code == 200
+    assert redelivery.json()["unpaired"] is False
+    replies = [call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")]
+    assert [call["json"]["text"] for call in replies] == [
+        "Unpaired. This chat is no longer connected to an agent."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_update_dedupe_is_account_scoped_across_repair(
+    client: httpx.AsyncClient,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 104}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-account-dedupe-repair",
+                "provider_token": "123456:telegram-secret",
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    second_link = (
+        await client.post(
+            f"/v1/channels/{created['id']}/agent-links",
+            json={"agent_id": str(second_channel_agent.id)},
+        )
+    ).json()
+    webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+    chat = {"id": 987654326, "type": "private"}
+    actor = {"id": 987654326, "is_bot": False}
+
+    first_pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": created["agent_link_id"], "ttl_seconds": 900},
+        )
+    ).json()
+    first_payload = {
+        "update_id": 7201,
+        "message": {
+            "message_id": 201,
+            "text": f"/bot_pair {first_pair['code']}",
+            "chat": chat,
+            "from": actor,
+        },
+    }
+    assert (await client.post(webhook_url, headers=headers, json=first_payload)).json()[
+        "paired"
+    ] is True
+    assert (
+        await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "update_id": 7202,
+                "message": {
+                    "message_id": 202,
+                    "text": "/bot_unpair",
+                    "chat": chat,
+                    "from": actor,
+                },
+            },
+        )
+    ).json()["unpaired"] is True
+
+    second_pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": second_link["id"], "ttl_seconds": 900},
+        )
+    ).json()
+    assert (
+        await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "update_id": 7203,
+                "message": {
+                    "message_id": 203,
+                    "text": f"/bot_pair {second_pair['code']}",
+                    "chat": chat,
+                    "from": actor,
+                },
+            },
+        )
+    ).json()["paired"] is True
+
+    redelivery = await client.post(webhook_url, headers=headers, json=first_payload)
+    bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
+    replies = [call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")]
+
+    assert redelivery.status_code == 200
+    assert redelivery.json()["paired"] is False
+    assert bindings.json()[0]["agent_link_id"] == second_link["id"]
+    assert [call["json"]["text"] for call in replies] == [
+        "Paired! This chat is now connected to your agent.",
+        "Unpaired. This chat is no longer connected to an agent.",
+        "Paired! This chat is now connected to your agent.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_binding_unpairs_exactly_one_chat_and_cleans_telegram_projection(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    runtime_signals: list[tuple[UUID, UUID]] = []
+
+    async def record_runtime_signal(_db, user_id: UUID, environment_id: UUID) -> bool:
+        runtime_signals.append((user_id, environment_id))
+        return True
+
+    monkeypatch.setattr(
+        "app.routes.channel_routers.public.queue_environment_runtime_manifest_changed",
+        record_runtime_signal,
+    )
+    _reset_fake_provider_client({"ok": True, "result": {"username": "clawdi_test_bot"}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-ui-unpair-isolation",
+                "provider_token": "123456:telegram-secret",
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    runtime_signals.clear()
+    await _pair_telegram_chat(
+        client,
+        created=created,
+        chat_id="111",
+        update_id=101,
+        chat_type="private",
+    )
+    await _pair_telegram_chat(
+        client,
+        created=created,
+        chat_id="222",
+        update_id=102,
+        chat_type="private",
+    )
+    commands = [{"command": "status", "description": "Show status"}]
+    assert (
+        await client.post(
+            _telegram_bot_path(created, "setMyCommands"),
+            headers=_telegram_agent_headers(created),
+            json={"commands": commands},
+        )
+    ).status_code == 200
+    bindings_before = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    target = next(item for item in bindings_before if item["external_chat_id"] == "111")
+    sibling = next(item for item in bindings_before if item["external_chat_id"] == "222")
+    _clear_fake_provider_calls()
+
+    deleted = await client.delete(f"/v1/channels/{created['id']}/bindings/{target['id']}")
+    repeated = await client.delete(f"/v1/channels/{created['id']}/bindings/{target['id']}")
+
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json() == {
+        "binding_id": target["id"],
+        "unpaired": True,
+        "notification_status": "sent",
+        "provider_cleanup_status": "succeeded",
+        "warning": None,
+    }
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json()["unpaired"] is False
+    assert runtime_signals == []
+    binding_rows = {
+        str(binding.id): binding
+        for binding in (
+            await db_session.execute(
+                select(ChannelBinding).where(
+                    ChannelBinding.id.in_([UUID(target["id"]), UUID(sibling["id"])])
+                )
+            )
+        ).scalars()
+    }
+    assert binding_rows[target["id"]].status == BINDING_STATUS_ARCHIVED
+    assert binding_rows[sibling["id"]].status == BINDING_STATUS_ACTIVE
+    link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert link is not None
+    assert link.status != BOT_AGENT_LINK_STATUS_ARCHIVED
+    assert link.archived_at is None
+    remaining = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert [item["id"] for item in remaining] == [sibling["id"]]
+    assert [
+        call["json"]
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/deleteMyCommands")
+    ] == [{"scope": {"type": "chat", "chat_id": "111"}}]
+    assert [
+        call["json"]
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/setChatMenuButton")
+    ] == [{"chat_id": "111", "menu_button": {"type": "default"}}]
+    assert [
+        call["json"] for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
+    ] == [
+        {
+            "chat_id": "111",
+            "text": "Unpaired. This chat is no longer connected to an agent.",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_binding_keeps_unpair_durable_when_telegram_notification_fails(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"username": "clawdi_test_bot"}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-ui-unpair-notify-failure",
+        chat_id="333",
+        chat_type="private",
+    )
+    binding = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()[0]
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FailingProviderClient,
+    )
+
+    deleted = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding['id']}")
+
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json()["unpaired"] is True
+    assert deleted.json()["notification_status"] == "failed"
+    assert deleted.json()["provider_cleanup_status"] == "failed"
+    assert "unpaired" in deleted.json()["warning"].lower()
+    archived = await db_session.get(ChannelBinding, UUID(binding["id"]))
+    assert archived is not None
+    assert archived.status == BINDING_STATUS_ARCHIVED
+    audit = await client.get(
+        "/v1/audit/events",
+        params={"channel_account_id": created["id"], "limit": 20},
+    )
+    cleanup_event = next(
+        item
+        for item in audit.json()["items"]
+        if item["action"] == "channel.binding.telegram_cleanup"
+    )
+    assert cleanup_event["details"] == {
+        "notification_status": "failed",
+        "provider_cleanup_status": "failed",
+    }
 
 
 @pytest.mark.asyncio
@@ -8606,6 +9016,40 @@ def test_parse_pair_command_matches_strict_bot_shapes():
     assert unknown is not None
     assert unknown.kind == "unknown"
     assert unknown.command == "/bot_foo"
+
+
+def test_telegram_reply_thread_requires_a_true_private_or_forum_topic():
+    def update(*, chat_type: str, is_topic: bool, is_forum: bool = False):
+        return {
+            "message": {
+                "message_thread_id": 77,
+                "is_topic_message": is_topic,
+                "chat": {"id": -1001, "type": chat_type, "is_forum": is_forum},
+            }
+        }
+
+    assert telegram_message_thread_id_from_update(update(chat_type="private", is_topic=True)) == 77
+    assert (
+        telegram_message_thread_id_from_update(
+            update(chat_type="supergroup", is_topic=True, is_forum=True)
+        )
+        == 77
+    )
+    assert (
+        telegram_message_thread_id_from_update(update(chat_type="private", is_topic=False)) is None
+    )
+    assert (
+        telegram_message_thread_id_from_update(
+            update(chat_type="supergroup", is_topic=False, is_forum=True)
+        )
+        is None
+    )
+    assert (
+        telegram_message_thread_id_from_update(
+            update(chat_type="group", is_topic=True, is_forum=False)
+        )
+        is None
+    )
 
 
 def test_normalize_telegram_bot_username_requires_bot_suffix():

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1642,31 +1642,39 @@ async def test_public_bot_pool_capacity_rejects_new_agent_links(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD])
-async def test_hermes_agent_rejects_second_active_link_for_single_token_provider(
+@pytest.mark.parametrize(
+    ("agent_type", "provider"),
+    [
+        ("hermes", CHANNEL_PROVIDER_TELEGRAM),
+        ("hermes", CHANNEL_PROVIDER_DISCORD),
+        ("openclaw", CHANNEL_PROVIDER_TELEGRAM),
+    ],
+)
+async def test_hosted_agent_rejects_second_link_when_provider_session_is_not_account_aware(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
+    agent_type: str,
     provider: str,
 ):
     first_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
-        name=f"hermes-{provider}-first-{uuid4().hex}",
+        name=f"{agent_type}-{provider}-first-{uuid4().hex}",
     )
     second_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
-        name=f"hermes-{provider}-second-{uuid4().hex}",
+        name=f"{agent_type}-{provider}-second-{uuid4().hex}",
     )
     assert first_account.status_code == 201, first_account.text
     assert second_account.status_code == 201, second_account.text
     user, agent = await _create_user_with_channel_agent(
         db_session,
-        label=f"hermes-{provider}",
-        agent_type="hermes",
+        label=f"{agent_type}-{provider}",
+        agent_type=agent_type,
     )
 
     async with _client_for_user(db_session, user) as user_client:
@@ -1681,7 +1689,7 @@ async def test_hermes_agent_rejects_second_active_link_for_single_token_provider
 
     assert first_link.status_code == 201, first_link.text
     assert second_link.status_code == 409
-    assert second_link.json()["detail"].startswith(f"one-{provider}-link-per-Hermes-agent")
+    assert second_link.json()["detail"].startswith(f"one-{provider}-link-per-{agent_type}-agent")
 
 
 @pytest.mark.asyncio
@@ -1770,13 +1778,12 @@ async def test_hosted_runtime_agent_rejects_whatsapp_links_and_tenant_credential
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD])
-async def test_openclaw_agent_keeps_multi_link_behavior_for_telegram_and_discord(
+async def test_openclaw_agent_keeps_multi_link_behavior_for_account_aware_provider(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
-    provider: str,
 ):
+    provider = CHANNEL_PROVIDER_DISCORD
     first_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -24,7 +24,12 @@ from app.main import app
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
 from app.models.audit import ControlPlaneAuditEvent
-from app.models.channel import ChannelAccount, ChannelBotAgentLink
+from app.models.channel import (
+    BINDING_STATUS_ACTIVE,
+    ChannelAccount,
+    ChannelBinding,
+    ChannelBotAgentLink,
+)
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.session import AgentEnvironment
 from app.models.user import User
@@ -4010,6 +4015,132 @@ async def test_runtime_bundle_revision_tracks_projected_and_secret_changes_only(
     assert identity(key_rotated) != identity(projected)
     assert identity(channel_added) != identity(key_rotated)
     assert identity(channel_removed) == identity(key_rotated)
+
+
+@pytest.mark.asyncio
+async def test_agent_link_lifecycle_advances_polled_source_but_chat_binding_does_not(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env, _, _, account, link = await _create_bundle_runtime(
+        admin_client,
+        db_session,
+        seed_user,
+    )
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="link-reconcile")
+    unrelated_environment_id = uuid4()
+    target_queue = sync_events.subscribe(
+        seed_user.id,
+        frozenset(),
+        environment_id=env.id,
+    )
+    unrelated_queue = sync_events.subscribe(
+        seed_user.id,
+        frozenset(),
+        environment_id=unrelated_environment_id,
+    )
+
+    async def fetch(client: httpx.AsyncClient) -> httpx.Response:
+        response = await client.get("/v1/runtime/manifest")
+        assert response.status_code == 200, response.text
+        return response
+
+    try:
+        async with await _runtime_client(db_session, seed_user, api_key) as runtime_client:
+            initial = await fetch(runtime_client)
+
+            binding = ChannelBinding(
+                account_id=account.id,
+                bot_agent_link_id=link.id,
+                user_id=seed_user.id,
+                external_chat_id="runtime-source-chat-a",
+                external_chat_type="private",
+                external_chat_name="Runtime source chat A",
+                status=BINDING_STATUS_ACTIVE,
+            )
+            sibling_binding = ChannelBinding(
+                account_id=account.id,
+                bot_agent_link_id=link.id,
+                user_id=seed_user.id,
+                external_chat_id="runtime-source-chat-b",
+                external_chat_type="private",
+                external_chat_name="Runtime source chat B",
+                status=BINDING_STATUS_ACTIVE,
+            )
+            db_session.add_all([binding, sibling_binding])
+            await db_session.commit()
+            paired = await fetch(runtime_client)
+            assert target_queue.empty()
+
+            unpaired = await runtime_client.delete(
+                f"/v1/channels/{account.id}/bindings/{binding.id}"
+            )
+            assert unpaired.status_code == 200, unpaired.text
+            assert unpaired.json()["unpaired"] is True
+            binding_changed = await fetch(runtime_client)
+            sibling_after_unpair = await db_session.get(ChannelBinding, sibling_binding.id)
+            assert sibling_after_unpair is not None
+            assert sibling_after_unpair.status == BINDING_STATUS_ACTIVE
+            assert target_queue.empty()
+
+            rotated = await runtime_client.post(
+                f"/v1/channels/{account.id}/agent-links/{link.id}/token"
+            )
+            assert rotated.status_code == 200, rotated.text
+            credential_changed = await fetch(runtime_client)
+            assert target_queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(env.id),
+            }
+
+            deleted = await runtime_client.delete(
+                f"/v1/channels/{account.id}/agent-links/{link.id}"
+            )
+            assert deleted.status_code == 204, deleted.text
+            link_removed = await fetch(runtime_client)
+            assert target_queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(env.id),
+            }
+
+            restored = await runtime_client.post(
+                f"/v1/channels/{account.id}/agent-links",
+                json={"agent_id": str(env.id)},
+            )
+            assert restored.status_code == 201, restored.text
+            assert restored.json()["id"] != str(link.id)
+            link_restored = await fetch(runtime_client)
+            assert target_queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(env.id),
+            }
+
+            ensured = await runtime_client.post(
+                f"/v1/channels/{account.id}/agent-links",
+                json={"agent_id": str(env.id)},
+            )
+            assert ensured.status_code == 201, ensured.text
+            assert ensured.json()["id"] == restored.json()["id"]
+            link_ensured = await fetch(runtime_client)
+            assert target_queue.empty()
+            assert unrelated_queue.empty()
+    finally:
+        app.dependency_overrides.clear()
+        sync_events.unsubscribe(seed_user.id, target_queue)
+        sync_events.unsubscribe(seed_user.id, unrelated_queue)
+
+    def revision(response: httpx.Response) -> str:
+        return response.json()["sourceRevision"]
+
+    assert revision(paired) == revision(initial)
+    assert revision(binding_changed) == revision(initial)
+    assert revision(credential_changed) != revision(initial)
+    assert revision(link_removed) != revision(credential_changed)
+    assert link_removed.json()["channelBindings"] == []
+    assert revision(link_restored) != revision(link_removed)
+    assert revision(link_ensured) == revision(link_restored)
+    assert len(link_restored.json()["channelBindings"]) == 1
 
 
 @pytest.mark.asyncio

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -346,6 +346,27 @@ The v2 strong ETag is `"sha256:<sourceRevision>"`; the immutable renderer and
 the revision's effective public and secret-source identity make it a strong
 validator without decrypting secrets in the health summary.
 
+### Channel reconcile boundary
+
+Telegram and Discord `ChannelBotAgentLink` rows are runtime desired state. A
+link create or re-link, link delete, account archive, or link credential
+rotation changes the rendered channel projection and therefore
+`sourceRevision`. Those mutation transactions also enqueue the existing
+signal-only `runtime_manifest_changed` event for the linked Agent. The event is
+delivered only after commit; the runtime refetches the manifest and converges at
+the normal ETag/sourceRevision boundary. ETag polling remains the missed-event
+fallback, so no separate restart or channel-specific reconcile state machine is
+required. Creating a pair code emits this signal only when that request also
+creates an AgentLink.
+
+`ChannelBinding` rows are provider routing state, not runtime identity. Pairing
+or unpairing a chat updates only the binding and provider-owned per-chat
+projection, including Telegram command scopes and menu state. It does not enter
+`sourceRevision`, emit a runtime-manifest signal, archive the AgentLink, or
+restart/reconfigure the Agent. Telegram bindings currently identify a chat by
+the stored external chat identity; runtime conversation/session threading is a
+separate concern.
+
 The bundle root optionally carries `applyGeneration`, the deployment Apply
 identity. The inner manifest `generation` remains checkpoint/content identity.
 `applyGeneration` is omitted while persisted runtime state is null, preserving

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -94,22 +94,75 @@ export function renderHermesChannelConfig(
 ): string {
 	const document = parseHermesConfig(content, "Hermes config");
 	for (const [platform, config] of Object.entries(platforms)) {
-		if (platform === "platforms") {
+		if (platform === "platforms" || platform === "display") {
 			const root = document.toJS();
-			if (isPlainRecord(root) && root.platforms !== undefined && !isPlainRecord(root.platforms)) {
-				throw new Error("Hermes config field platforms must be a YAML object.");
+			if (isPlainRecord(root) && root[platform] !== undefined && !isPlainRecord(root[platform])) {
+				throw new Error(`Hermes config field ${platform} must be a YAML object.`);
 			}
-			if (!isPlainRecord(root) || !isPlainRecord(root.platforms)) {
-				document.set("platforms", document.createNode({}));
+			if (!isPlainRecord(root) || !isPlainRecord(root[platform])) {
+				document.set(platform, document.createNode({}));
 			}
-			for (const [nestedPlatform, nestedConfig] of Object.entries(config)) {
-				document.setIn(["platforms", nestedPlatform], document.createNode(nestedConfig));
+			if (platform === "display") {
+				applyHermesChannelNestedPatch(document, [platform], config);
+			} else {
+				for (const [nestedPlatform, nestedConfig] of Object.entries(config)) {
+					if (nestedPlatform === "telegram" && isPlainRecord(nestedConfig)) {
+						applyHermesChannelNestedPatch(document, [platform, nestedPlatform], nestedConfig);
+						const updated = valueAtPath(document.toJS(), [platform, nestedPlatform]);
+						if (isPlainRecord(updated) && Object.keys(updated).length === 0) {
+							document.deleteIn([platform, nestedPlatform]);
+						}
+					} else {
+						document.setIn([platform, nestedPlatform], document.createNode(nestedConfig));
+					}
+				}
+			}
+			const updated = valueAtPath(document.toJS(), [platform]);
+			if (isPlainRecord(updated) && Object.keys(updated).length === 0) {
+				document.delete(platform);
 			}
 			continue;
 		}
 		document.set(platform, document.createNode(config));
 	}
 	return String(document);
+}
+
+function applyHermesChannelNestedPatch(
+	document: ReturnType<typeof parseDocument>,
+	path: string[],
+	patch: Record<string, unknown>,
+): void {
+	for (const [key, value] of Object.entries(patch)) {
+		const nextPath = [...path, key];
+		if (value === null) {
+			document.deleteIn(nextPath);
+			continue;
+		}
+		if (!isPlainRecord(value)) {
+			document.setIn(nextPath, value);
+			continue;
+		}
+		const root = document.toJS();
+		const existing = valueAtPath(root, nextPath);
+		if (!isPlainRecord(existing)) {
+			document.setIn(nextPath, document.createNode({}));
+		}
+		applyHermesChannelNestedPatch(document, nextPath, value);
+		const updated = valueAtPath(document.toJS(), nextPath);
+		if (isPlainRecord(updated) && Object.keys(updated).length === 0) {
+			document.deleteIn(nextPath);
+		}
+	}
+}
+
+function valueAtPath(value: unknown, path: readonly string[]): unknown {
+	let current = value;
+	for (const key of path) {
+		if (!isPlainRecord(current)) return undefined;
+		current = current[key];
+	}
+	return current;
 }
 
 export function mergeHermesRuntimeLocale(configPath: string, timezone: string): void {

--- a/packages/cli/src/runtime/managed-channel-session-contract.test.ts
+++ b/packages/cli/src/runtime/managed-channel-session-contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+// Fixed upstream contracts are used because this repository does not vendor or
+// execute either runtime. Keep these fixtures aligned with the audited sources:
+// OpenClaw f4a7f2b553d3fd788552f3f3ae1004ecac8b2370
+//   src/config/zod-schema.session.ts, src/routing/session-key.ts
+// Hermes 736fc4d86a1acd8c96473aeb55f9c783e2170dca
+//   gateway/session.py, gateway/platforms/telegram.py
+
+function openClawDirectSessionKey(channel: string, accountId: string, peerId: string): string {
+	return `agent:main:${channel}:${accountId}:direct:${peerId}`;
+}
+
+function hermesTelegramThreadId(
+	chatType: "dm" | "group",
+	messageThreadId: string | undefined,
+	isTopicMessage: boolean,
+	isForumGroup: boolean,
+): string | undefined {
+	if (!messageThreadId) return chatType === "group" && isForumGroup ? "1" : undefined;
+	if (chatType === "group" && (isTopicMessage || isForumGroup)) {
+		return messageThreadId;
+	}
+	if (chatType === "dm" && isTopicMessage) return messageThreadId;
+	return undefined;
+}
+
+function hermesTelegramSessionKey(
+	chatType: "dm" | "group",
+	chatId: string,
+	threadId?: string,
+): string {
+	return ["agent:main", "telegram", chatType, chatId, threadId].filter(Boolean).join(":");
+}
+
+describe("managed Telegram upstream session contracts", () => {
+	test("OpenClaw includes account, channel, and peer in every managed DM identity", () => {
+		const first = openClawDirectSessionKey("telegram", "managed-a", "chat-101");
+		const secondChat = openClawDirectSessionKey("telegram", "managed-a", "chat-202");
+		const secondAccount = openClawDirectSessionKey("telegram", "managed-b", "chat-101");
+		const secondChannel = openClawDirectSessionKey("discord", "managed-a", "chat-101");
+
+		expect(first).toBe("agent:main:telegram:managed-a:direct:chat-101");
+		expect(new Set([first, secondChat, secondAccount, secondChannel]).size).toBe(4);
+	});
+
+	test("Hermes isolates DMs by native chat_id and groups by chat", () => {
+		const dmA = hermesTelegramSessionKey("dm", "101");
+		const dmB = hermesTelegramSessionKey("dm", "202");
+		// group_sessions_per_user=false means both participants use this chat key.
+		const groupUserA = hermesTelegramSessionKey("group", "-1001");
+		const groupUserB = hermesTelegramSessionKey("group", "-1001");
+
+		expect(dmA).not.toBe(dmB);
+		expect(groupUserA).toBe(groupUserB);
+		expect(groupUserA).toBe("agent:main:telegram:group:-1001");
+	});
+
+	test("Hermes keeps true forum topics distinct and ignores ordinary reply threads", () => {
+		const forumThread = hermesTelegramThreadId("group", "77", true, true);
+		const anotherForumThread = hermesTelegramThreadId("group", "88", true, true);
+		const ordinaryReplyThread = hermesTelegramThreadId("group", "999", false, false);
+
+		expect(hermesTelegramSessionKey("group", "-1001", forumThread)).not.toBe(
+			hermesTelegramSessionKey("group", "-1001", anotherForumThread),
+		);
+		expect(ordinaryReplyThread).toBeUndefined();
+		expect(hermesTelegramSessionKey("group", "-1001", ordinaryReplyThread)).toBe(
+			"agent:main:telegram:group:-1001",
+		);
+	});
+});

--- a/packages/cli/src/runtime/managed-channel-session-contract.test.ts
+++ b/packages/cli/src/runtime/managed-channel-session-contract.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from "bun:test";
 // Fixed upstream contracts are used because this repository does not vendor or
 // execute either runtime. Keep these fixtures aligned with the audited sources:
 // OpenClaw f4a7f2b553d3fd788552f3f3ae1004ecac8b2370
-//   src/config/zod-schema.session.ts, src/routing/session-key.ts
+//   src/config/zod-schema.session.ts::SessionSchema
+//   src/routing/session-key.ts::buildAgentPeerSessionKey
 // Hermes 736fc4d86a1acd8c96473aeb55f9c783e2170dca
-//   gateway/session.py, gateway/platforms/telegram.py
+//   gateway/session.py::build_session_key
+//   gateway/platforms/telegram.py::TelegramAdapter._build_message_event
 
 function openClawDirectSessionKey(channel: string, accountId: string, peerId: string): string {
 	return `agent:main:${channel}:${accountId}:direct:${peerId}`;
@@ -26,14 +28,41 @@ function hermesTelegramThreadId(
 }
 
 function hermesTelegramSessionKey(
-	chatType: "dm" | "group",
-	chatId: string,
-	threadId?: string,
+	source: {
+		chatType: "dm" | "group";
+		chatId?: string;
+		userId?: string;
+		threadId?: string;
+	},
+	settings: {
+		groupSessionsPerUser: boolean;
+		threadSessionsPerUser: boolean;
+	} = { groupSessionsPerUser: true, threadSessionsPerUser: false },
 ): string {
-	return ["agent:main", "telegram", chatType, chatId, threadId].filter(Boolean).join(":");
+	if (source.chatType === "dm") {
+		if (source.chatId) {
+			return ["agent:main", "telegram", "dm", source.chatId, source.threadId]
+				.filter(Boolean)
+				.join(":");
+		}
+		return ["agent:main", "telegram", "dm", source.threadId].filter(Boolean).join(":");
+	}
+
+	const keyParts = ["agent:main", "telegram", source.chatType];
+	if (source.chatId) keyParts.push(source.chatId);
+	if (source.threadId) keyParts.push(source.threadId);
+	let isolateUser = settings.groupSessionsPerUser;
+	if (source.threadId && !settings.threadSessionsPerUser) isolateUser = false;
+	if (isolateUser && source.userId) keyParts.push(source.userId);
+	return keyParts.join(":");
 }
 
 describe("managed Telegram upstream session contracts", () => {
+	const managedHermesSettings = {
+		groupSessionsPerUser: false,
+		threadSessionsPerUser: false,
+	};
+
 	test("OpenClaw includes account, channel, and peer in every managed DM identity", () => {
 		const first = openClawDirectSessionKey("telegram", "managed-a", "chat-101");
 		const secondChat = openClawDirectSessionKey("telegram", "managed-a", "chat-202");
@@ -45,28 +74,68 @@ describe("managed Telegram upstream session contracts", () => {
 	});
 
 	test("Hermes isolates DMs by native chat_id and groups by chat", () => {
-		const dmA = hermesTelegramSessionKey("dm", "101");
-		const dmB = hermesTelegramSessionKey("dm", "202");
-		// group_sessions_per_user=false means both participants use this chat key.
-		const groupUserA = hermesTelegramSessionKey("group", "-1001");
-		const groupUserB = hermesTelegramSessionKey("group", "-1001");
+		const dmA = hermesTelegramSessionKey({ chatType: "dm", chatId: "101", userId: "user-a" });
+		const dmB = hermesTelegramSessionKey({ chatType: "dm", chatId: "202", userId: "user-b" });
+		const groupUserA = hermesTelegramSessionKey(
+			{ chatType: "group", chatId: "-1001", userId: "user-a" },
+			managedHermesSettings,
+		);
+		const groupUserB = hermesTelegramSessionKey(
+			{ chatType: "group", chatId: "-1001", userId: "user-b" },
+			managedHermesSettings,
+		);
 
 		expect(dmA).not.toBe(dmB);
 		expect(groupUserA).toBe(groupUserB);
 		expect(groupUserA).toBe("agent:main:telegram:group:-1001");
+		expect(
+			hermesTelegramSessionKey({ chatType: "group", chatId: "-1001", userId: "user-a" }),
+		).not.toBe(hermesTelegramSessionKey({ chatType: "group", chatId: "-1001", userId: "user-b" }));
 	});
 
 	test("Hermes keeps true forum topics distinct and ignores ordinary reply threads", () => {
 		const forumThread = hermesTelegramThreadId("group", "77", true, true);
 		const anotherForumThread = hermesTelegramThreadId("group", "88", true, true);
 		const ordinaryReplyThread = hermesTelegramThreadId("group", "999", false, false);
+		const forumUserA = hermesTelegramSessionKey(
+			{ chatType: "group", chatId: "-1001", userId: "user-a", threadId: forumThread },
+			managedHermesSettings,
+		);
+		const forumUserB = hermesTelegramSessionKey(
+			{ chatType: "group", chatId: "-1001", userId: "user-b", threadId: forumThread },
+			managedHermesSettings,
+		);
 
-		expect(hermesTelegramSessionKey("group", "-1001", forumThread)).not.toBe(
-			hermesTelegramSessionKey("group", "-1001", anotherForumThread),
+		expect(forumUserA).toBe(forumUserB);
+		expect(forumUserA).not.toBe(
+			hermesTelegramSessionKey(
+				{
+					chatType: "group",
+					chatId: "-1001",
+					userId: "user-b",
+					threadId: anotherForumThread,
+				},
+				managedHermesSettings,
+			),
 		);
 		expect(ordinaryReplyThread).toBeUndefined();
-		expect(hermesTelegramSessionKey("group", "-1001", ordinaryReplyThread)).toBe(
-			"agent:main:telegram:group:-1001",
-		);
+		expect(
+			hermesTelegramSessionKey(
+				{
+					chatType: "group",
+					chatId: "-1001",
+					userId: "user-a",
+					threadId: ordinaryReplyThread,
+				},
+				managedHermesSettings,
+			),
+		).toBe("agent:main:telegram:group:-1001");
+		expect(
+			hermesTelegramSessionKey({
+				chatType: "dm",
+				chatId: "101",
+				threadId: hermesTelegramThreadId("dm", "77", true, false),
+			}),
+		).toBe("agent:main:telegram:dm:101:77");
 	});
 });

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -129,6 +129,13 @@ function runSettings(command: string, args: string[]): RuntimeRunSettings {
 	return { command, args, env: {}, prependPath: [] };
 }
 
+function systemdProgramRevision(paths: RuntimePaths, programName: string): string {
+	const content = readFileSync(join(paths.systemdEnvRoot, `${programName}.service.env`), "utf-8");
+	const revision = /^CLAWDI_RUNTIME_REV="([^"]+)"$/m.exec(content)?.[1];
+	if (!revision) throw new Error(`Missing CLAWDI_RUNTIME_REV for ${programName}`);
+	return revision;
+}
+
 function manifestLoad(
 	manifest: RuntimeManifest,
 	sourcePath: string,
@@ -2628,6 +2635,65 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(daemonProgramRevision(managedTelegramChannelChange)).toBe(daemonRevision);
 		expect(daemonProgramRevision(egressManifest)).toBe(daemonRevision);
 		expect(daemonProgramRevision(cliOnlyChange)).not.toBe(daemonRevision);
+	});
+
+	test("scopes managed Telegram revisions to the OpenClaw and Hermes runtime programs", () => {
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		const paths = tempRuntimePaths();
+		const command = "/bin/true";
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				run: runSettings(command, ["gateway"]),
+				services: { worker: runSettings(command, ["worker"]) },
+			},
+			hermes: {
+				enabled: true,
+				run: runSettings(command, ["gateway"]),
+				services: {},
+			},
+			observer: {
+				enabled: true,
+				run: runSettings(command, ["observe"]),
+				services: {},
+			},
+		});
+		const managedTelegram: RuntimeManifest = {
+			...manifest,
+			projection: {
+				channels: {
+					telegram: {
+						enabled: true,
+						defaultAccount: "managed-telegram",
+						accounts: { "managed-telegram": { enabled: true } },
+					},
+				},
+			},
+		};
+
+		const baseline = convergeRuntimeManifest(manifestLoad(manifest, "inline-revision-base"), paths);
+		expect(baseline.installErrors).toEqual([]);
+		const workerRevision = systemdProgramRevision(paths, "clawdi-openclaw-worker");
+
+		const projected = convergeRuntimeManifest(
+			manifestLoad(managedTelegram, "inline-revision-managed-telegram"),
+			paths,
+		);
+		expect(projected.installErrors).toEqual([]);
+		expect(runtimeProgramRevision(managedTelegram, "openclaw", {})).not.toBe(
+			runtimeProgramRevision(manifest, "openclaw", {}),
+		);
+		expect(runtimeProgramRevision(managedTelegram, "hermes", {})).not.toBe(
+			runtimeProgramRevision(manifest, "hermes", {}),
+		);
+		expect(runtimeProgramRevision(managedTelegram, "observer", {})).toBe(
+			runtimeProgramRevision(manifest, "observer", {}),
+		);
+		expect(systemdProgramRevision(paths, "clawdi-openclaw-worker")).toBe(workerRevision);
+		expect(runtimeSidecarProgramRevision(managedTelegram)).toBe(
+			runtimeSidecarProgramRevision(manifest),
+		);
+		expect(daemonProgramRevision(managedTelegram)).toBe(daemonProgramRevision(manifest));
 	});
 
 	test.each([

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2493,6 +2493,18 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 			},
 		};
+		const managedTelegramChannelChange: RuntimeManifest = {
+			...manifest,
+			projection: {
+				channels: {
+					telegram: {
+						enabled: true,
+						defaultAccount: "managed-telegram",
+						accounts: { "managed-telegram": { enabled: true } },
+					},
+				},
+			},
+		};
 		const serviceOnlyChange: RuntimeManifest = {
 			...manifest,
 			runtimes: {
@@ -2593,6 +2605,9 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(
 			runtimeProgramRevision(relevantGatewayProjectionChange, "openclaw", secretValues),
 		).not.toBe(runtimeRevision);
+		expect(runtimeProgramRevision(managedTelegramChannelChange, "openclaw", secretValues)).not.toBe(
+			runtimeRevision,
+		);
 		expect(runtimeProgramRevision(skillOnlyChange, "openclaw", secretValues)).not.toBe(
 			runtimeRevision,
 		);
@@ -2605,10 +2620,12 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(runtimeSidecarProgramRevision(cliOnlyChange)).toBe(sidecarRevision);
 		expect(runtimeSidecarProgramRevision(terminalToolingOnlyChange)).toBe(sidecarRevision);
 		expect(runtimeSidecarProgramRevision(skillOnlyChange)).toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(managedTelegramChannelChange)).toBe(sidecarRevision);
 		const daemonRevision = daemonProgramRevision(manifest);
 		expect(daemonProgramRevision(metadataOnlyChange)).toBe(daemonRevision);
 		expect(daemonProgramRevision(terminalToolingOnlyChange)).toBe(daemonRevision);
 		expect(daemonProgramRevision(skillOnlyChange)).toBe(daemonRevision);
+		expect(daemonProgramRevision(managedTelegramChannelChange)).toBe(daemonRevision);
 		expect(daemonProgramRevision(egressManifest)).toBe(daemonRevision);
 		expect(daemonProgramRevision(cliOnlyChange)).not.toBe(daemonRevision);
 	});

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3144,9 +3144,10 @@ function hermesManagedChannelsPatch(
 	channelCredentials: unknown,
 ): Record<string, Record<string, unknown>> {
 	const baseUrl = stripTrailingSlash(cloudApiUrl);
+	const telegramEnabled = channelHasAccounts(channels.telegram);
 	const whatsapp = hermesWhatsAppProjection(channels, channelCredentials, baseUrl);
 	return {
-		telegram: channelHasAccounts(channels.telegram)
+		telegram: telegramEnabled
 			? {
 					enabled: true,
 					dm_policy: "open",
@@ -3184,6 +3185,11 @@ function hermesManagedChannelsPatch(
 				}
 			: { enabled: false },
 		platforms: {
+			telegram: {
+				extra: {
+					group_sessions_per_user: telegramEnabled ? false : null,
+				},
+			},
 			whatsapp: whatsapp
 				? {
 						enabled: true,
@@ -3193,6 +3199,13 @@ function hermesManagedChannelsPatch(
 						},
 					}
 				: { enabled: false },
+		},
+		display: {
+			platforms: {
+				telegram: {
+					streaming: telegramEnabled ? true : null,
+				},
+			},
 		},
 	};
 }
@@ -3251,6 +3264,7 @@ function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record
 	const deleteEntries = openClawManagedChannelDeletes();
 	const runtimeReadyChannels = openClawRuntimeReadyChannels(channels);
 	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(runtimeReadyChannels);
+	const isolatesTelegramDms = channelHasAccounts(runtimeReadyChannels.telegram);
 	return {
 		channels: {
 			...deleteEntries,
@@ -3272,6 +3286,13 @@ function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record
 					},
 				}
 			: undefined,
+		...(isolatesTelegramDms
+			? {
+					session: {
+						dmScope: "per-account-channel-peer",
+					},
+				}
+			: {}),
 	};
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3286,13 +3286,9 @@ function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record
 					},
 				}
 			: undefined,
-		...(isolatesTelegramDms
-			? {
-					session: {
-						dmScope: "per-account-channel-peer",
-					},
-				}
-			: {}),
+		session: {
+			dmScope: isolatesTelegramDms ? "per-account-channel-peer" : null,
+		},
 	};
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -11276,6 +11276,23 @@ exit 64
 			expect(patchText).toContain('"default": {');
 			expect(patchText).toContain('"source": "env"');
 			expect(patchText).toContain('"plugins"');
+			expect(patchText).toContain('"dmScope": "per-account-channel-peer"');
+			expect(patchText).not.toContain('"streaming"');
+			const isolationPatch = patchText
+				.split("\n---\n")
+				.filter((entry) => entry.trim().length > 0)
+				.map((entry): unknown => JSON.parse(entry))
+				.map((entry) => expectRecord(entry, "OpenClaw config patch"))
+				.find((entry) => entry.session !== undefined);
+			if (!isolationPatch) throw new Error("OpenClaw session isolation patch was not rendered");
+			const sessionPatch = expectRecord(isolationPatch.session, "OpenClaw session patch");
+			expect(sessionPatch).toEqual({ dmScope: "per-account-channel-peer" });
+			for (const current of ["main", "per-peer", "per-channel-peer", "per-account-channel-peer"]) {
+				expect({ dmScope: current, resetTriggers: ["/new"], ...sessionPatch }).toEqual({
+					dmScope: "per-account-channel-peer",
+					resetTriggers: ["/new"],
+				});
+			}
 			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
 			const openclawRunConfig = JSON.parse(
 				readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
@@ -11452,9 +11469,33 @@ exit 64
 		const workspace = join(home, "clawdi");
 		const hermesBin = join(home, ".local", "bin", "hermes");
 		mkdirSync(dirname(hermesBin), { recursive: true });
+		mkdirSync(join(home, ".hermes"), { recursive: true });
 		mkdirSync(dirname(ambientHermesConfig), { recursive: true });
 		mkdirSync(workspace, { recursive: true });
 		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
+		writeFileSync(
+			join(home, ".hermes", "config.yaml"),
+			[
+				"custom_root: keep",
+				"streaming:",
+				"  enabled: false",
+				"display:",
+				"  theme: user-theme",
+				"  platforms:",
+				"    discord:",
+				"      streaming: false",
+				"    telegram:",
+				"      compact: true",
+				"platforms:",
+				"  telegram:",
+				"    custom: keep-telegram",
+				"    extra:",
+				"      custom_extra: keep-extra",
+				"  discord:",
+				"    custom: keep-discord",
+				"",
+			].join("\n"),
+		);
 		writeFileSync(ambientHermesConfig, ambientSentinel);
 		chmodSync(hermesBin, 0o700);
 		process.env.HOME = ambientHome;
@@ -11561,6 +11602,27 @@ exit 64
 		expect(hermesConfig).toContain("thread_require_mention: false");
 		expect(hermesConfig).not.toContain("telegram-agent-token");
 		expect(hermesConfig).not.toContain("discord-agent-token");
+		const parsedHermesConfig = readHermesConfigYaml(home);
+		expect(parsedHermesConfig.streaming).toEqual({ enabled: false });
+		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
+		expect(parsedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
+		expect(parsedHermesConfig).toMatchObject({
+			custom_root: "keep",
+			display: {
+				theme: "user-theme",
+				platforms: {
+					discord: { streaming: false },
+					telegram: { compact: true, streaming: true },
+				},
+			},
+			platforms: {
+				telegram: {
+					custom: "keep-telegram",
+					extra: { custom_extra: "keep-extra", group_sessions_per_user: false },
+				},
+				discord: { custom: "keep-discord" },
+			},
+		});
 
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
@@ -11586,6 +11648,46 @@ exit 64
 		const profileBundle = readFileSync(join(state, "config", "egress", "profiles.json"), "utf-8");
 		expect(profileBundle).toContain("/v1/channels/telegram");
 		expect(profileBundle).toContain("/v1/channels/discord");
+
+		const removed = convergeRuntimeManifest(
+			applyRuntimeChannelsToManifestLoad(
+				load,
+				{
+					channels: [],
+					source: "remote-datasource",
+					sourcePath: "https://runtime.test/v1/channels",
+					etag: testBundleEtag("empty-hermes-channels"),
+				},
+				paths,
+			),
+			paths,
+		);
+		expect(removed.installErrors).toEqual([]);
+		const clearedHermesConfig = readHermesConfigYaml(home);
+		expect(clearedHermesConfig.streaming).toEqual({ enabled: false });
+		expect(clearedHermesConfig).not.toHaveProperty("streaming.transport");
+		expect(clearedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
+		expect(clearedHermesConfig).toMatchObject({
+			custom_root: "keep",
+			display: {
+				theme: "user-theme",
+				platforms: {
+					discord: { streaming: false },
+					telegram: { compact: true },
+				},
+			},
+			platforms: {
+				telegram: {
+					custom: "keep-telegram",
+					extra: { custom_extra: "keep-extra" },
+				},
+				discord: { custom: "keep-discord" },
+			},
+		});
+		expect(clearedHermesConfig).not.toHaveProperty(
+			"platforms.telegram.extra.group_sessions_per_user",
+		);
+		expect(clearedHermesConfig).not.toHaveProperty("display.platforms.telegram.streaming");
 	});
 
 	it("keeps Hermes native WhatsApp disabled until upstream websocket support is ready", () => {
@@ -11858,6 +11960,9 @@ exit 64
 		expect(hermesConfig).toContain("enabled: false");
 		expect(hermesConfig).not.toContain("stale: should-be-removed");
 		expect(hermesConfig).not.toContain("/stale/session");
+		const clearedChannelsConfig = readHermesConfigYaml(home);
+		expect(clearedChannelsConfig).not.toHaveProperty("display");
+		expect(clearedChannelsConfig).not.toHaveProperty("platforms.telegram");
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
 		);
@@ -11951,6 +12056,7 @@ exit 0
 		expect(patchText).not.toContain("bluebubbles");
 		expect(patchText).not.toContain('"$patch"');
 		expect(patchText).not.toContain('"botToken"');
+		expect(patchText).not.toContain('"session"');
 	});
 
 	it("does not mutate live config when an OpenClaw channel plugin install fails", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -11605,7 +11605,9 @@ exit 64
 		const parsedHermesConfig = readHermesConfigYaml(home);
 		expect(parsedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
-		expect(parsedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
+		expect(parsedHermesConfig).not.toHaveProperty(
+			"platforms.telegram.extra.thread_sessions_per_user",
+		);
 		expect(parsedHermesConfig).toMatchObject({
 			custom_root: "keep",
 			display: {
@@ -11666,7 +11668,9 @@ exit 64
 		const clearedHermesConfig = readHermesConfigYaml(home);
 		expect(clearedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(clearedHermesConfig).not.toHaveProperty("streaming.transport");
-		expect(clearedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
+		expect(clearedHermesConfig).not.toHaveProperty(
+			"platforms.telegram.extra.thread_sessions_per_user",
+		);
 		expect(clearedHermesConfig).toMatchObject({
 			custom_root: "keep",
 			display: {
@@ -11963,6 +11967,11 @@ exit 64
 		const clearedChannelsConfig = readHermesConfigYaml(home);
 		expect(clearedChannelsConfig).not.toHaveProperty("display");
 		expect(clearedChannelsConfig).not.toHaveProperty("platforms.telegram");
+		expect(clearedChannelsConfig).not.toHaveProperty(
+			"platforms.telegram.extra.thread_sessions_per_user",
+		);
+		expect(clearedChannelsConfig).not.toHaveProperty("streaming.enabled");
+		expect(clearedChannelsConfig).not.toHaveProperty("streaming.transport");
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
 		);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12113,7 +12113,7 @@ exit 0
 		expect(patchText).not.toContain("bluebubbles");
 		expect(patchText).not.toContain('"$patch"');
 		expect(patchText).not.toContain('"botToken"');
-		expect(patchText).not.toContain('"session"');
+		expect(patchText).toContain('"dmScope": null');
 	});
 
 	it("does not mutate live config when an OpenClaw channel plugin install fails", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5698,6 +5698,54 @@ exit 64
 		expect(projected.secretValues).toEqual({ "provider.default.apiKey": "sk-provider" });
 	});
 
+	it("projects multiple Telegram accounts into one hosted runtime", () => {
+		const firstAccount = "clawdi_00000000000000000000000000000001";
+		const secondAccount = "clawdi_00000000000000000000000000000002";
+		const agentRef = (account: string) => `secret://channels/telegram/${account}/agent-token`;
+		const placeholderRef = (account: string) =>
+			`secret://channels/telegram/${account}/placeholder-token`;
+		const bindings: RuntimeBundleChannelBinding[] = [firstAccount, secondAccount].map(
+			(accountKey) => ({
+				provider: "telegram",
+				accountKey,
+				agentTokenSecretRef: agentRef(accountKey),
+				placeholderTokenSecretRef: placeholderRef(accountKey),
+			}),
+		);
+		const loaded: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_multi_telegram",
+				environmentId: "env_multi_telegram",
+				instanceId: "iid_multi_telegram",
+				generation: 1,
+				issuedAt: "2026-07-30T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: { openclaw: { enabled: true } },
+			},
+			source: "remote-datasource",
+			sourcePath: "https://cloud-api.test/v1/runtime/manifest",
+			channelBindings: bindings,
+			secretValues: Object.fromEntries(
+				bindings.flatMap((binding, index) => [
+					[binding.agentTokenSecretRef, `agent-token-${index}`],
+					[binding.placeholderTokenSecretRef, `99999999${index}:${"a".repeat(32)}`],
+				]),
+			),
+		};
+
+		const projected = applyRuntimeBundleChannelsToManifestLoad(loaded);
+
+		expect(projected.manifest.projection?.channels).toMatchObject({
+			telegram: {
+				accounts: {
+					[firstAccount]: { enabled: true },
+					[secondAccount]: { enabled: true },
+				},
+			},
+		});
+	});
+
 	it("reconciles environment-scoped hosted bundle channel create, rotation, and removal", () => {
 		const accountKey = "clawdi_00000000000000000000000000000001";
 		const agentRef = `secret://channels/telegram/${accountKey}/agent-token`;
@@ -12520,11 +12568,16 @@ exit 64
 			offline: false,
 			secretValues: {},
 		});
+		const telegramChannel = {
+			enabled: true,
+			defaultAccount: "default",
+			accounts: { default: { enabled: true, botToken: "telegram-token" } },
+		};
 
 		const initial = convergeRuntimeManifest(
 			manifestWithChannels(
 				{
-					telegram: { enabled: true, botToken: "telegram-token" },
+					telegram: telegramChannel,
 					discord: { enabled: true, token: "discord-token" },
 				},
 				1,
@@ -12532,24 +12585,26 @@ exit 64
 			getRuntimePaths(),
 		);
 		const removed = convergeRuntimeManifest(
-			manifestWithChannels({ telegram: { enabled: true, botToken: "telegram-token" } }, 2),
+			manifestWithChannels({ telegram: telegramChannel }, 2),
 			getRuntimePaths(),
 		);
+		const unlinked = convergeRuntimeManifest(manifestWithChannels({}, 3), getRuntimePaths());
 
 		expect(initial.installErrors).toEqual([]);
 		expect(removed.installErrors).toEqual([]);
+		expect(unlinked.installErrors).toEqual([]);
 		const patches = readFileSync(openclawPatch, "utf-8")
 			.split("\n---\n")
 			.filter((entry) => entry.trim().length > 0)
 			.map((entry) => JSON.parse(entry));
-		expect(patches).toHaveLength(2);
+		expect(patches).toHaveLength(3);
 		expect(patches[0].channels.discord).toEqual({ enabled: true, token: "discord-token" });
+		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
 		expect(patches[1].channels.discord).toBeNull();
 		expect(patches[1].plugins.entries.discord).toBeNull();
-		expect(patches[1].channels.telegram).toEqual({
-			enabled: true,
-			botToken: "telegram-token",
-		});
+		expect(patches[1].channels.telegram).toEqual(telegramChannel);
+		expect(patches[2].session).toEqual({ dmScope: null });
+		expect(patches[2].channels.telegram).toBeNull();
 		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
 	});
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -476,6 +476,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/channels/{account_id}/bindings/{binding_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Channel Binding */
+        delete: operations["delete_channel_binding_v1_channels__account_id__bindings__binding_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/channels/{account_id}/commands/sync": {
         parameters: {
             query?: never;
@@ -3826,6 +3843,28 @@ export interface components {
             /** Agent Token */
             agent_token?: string | null;
             account: components["schemas"]["ChannelAccountResponse"];
+        };
+        /** ChannelBindingDeleteResponse */
+        ChannelBindingDeleteResponse: {
+            /**
+             * Binding Id
+             * Format: uuid
+             */
+            binding_id: string;
+            /** Unpaired */
+            unpaired: boolean;
+            /**
+             * Notification Status
+             * @enum {string}
+             */
+            notification_status: "sent" | "failed" | "not_applicable";
+            /**
+             * Provider Cleanup Status
+             * @enum {string}
+             */
+            provider_cleanup_status: "succeeded" | "failed" | "not_applicable";
+            /** Warning */
+            warning?: string | null;
         };
         /** ChannelBindingResponse */
         ChannelBindingResponse: {
@@ -8325,6 +8364,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChannelBindingResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_channel_binding_v1_channels__account_id__bindings__binding_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                account_id: string;
+                binding_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelBindingDeleteResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Use the canonical full-width detail-page layout with compact, single-layer Linked Agent and Paired Chat rows; remove step circles, nested setup cards, the Agent selector, and the expiry selector.
- Put Pair Telegram on each linked Telegram Agent row. It opens one reusable TelegramPairDialog shared by Channel detail and Agent Channels.
- Generate the server link automatically with a fixed 900-second TTL when the dialog opens. Keep the validated QR, Open Telegram, Copy link, countdown, and collapsed group command in the standard connection-dialog header/body/footer layout.
- Keep paired chats visible as chat-level rows with isolated Unpair; bindings polling adds newly paired chats without a refresh. Close/reopen, API retry, expiry, and missing deep-link behavior fail closed.
- Remove Agent token reveal/copy/rotate surfaces and retain the generated-API-backed chat-level Unpair implementation with exact binding isolation, durable state, best-effort cleanup/notification, and audit visibility.
- Preserve chat-level binding identity while returning command replies to real private/forum topics only; scope Telegram update deduplication to account + chat + update across re-pair.
- Queue runtime manifest changes for AgentLink lifecycle mutations only, with no-op suppression; keep Pair/Unpair outside runtime reconcile.
- Apply the minimal managed-runtime isolation projection: OpenClaw session.dmScope=per-account-channel-peer; Hermes group_sessions_per_user=false and Telegram-only display streaming=true.

- Rework Agent → Channels around Connected channels then Add a channel: shared single-layer provider rows, primary Pair Telegram and secondary Unlink actions, compact activity/retry metadata, ready-bot one-click Link, and a folded own-bot path.\n\n## Verification

- High-confidence credential scan: no matches.
- git diff --check: passed.
- Backend focused Docker tests: 13 passed, 410 deselected.
- Backend Ruff check/format, compileall, generated API check: passed; Alembic has one head, c4a7e2d9f1b6.
- Latest Web focused tests: 28 passed; typecheck passed; targeted and pre-commit Biome passed.\n- Agent Channels Playwright acceptance: 1 passed, covering full-width row alignment, task order, fixed-TTL dialog request, QR, deep link, token absence, and both requested screenshots.
- Playwright Telegram pairing acceptance: 1 passed, covering the compact page, fixed-TTL automatic dialog generation, QR/deep link/copy, close/reopen, retry, expiry, missing-link fail-closed behavior, bindings polling, token absence, and isolated Unpair recovery/warning.
- Earlier full PR verification also passed the OSS production build and workspace Biome check across 789 files.
- CLI manifest/session tests: 164 passed; focused runtime tests: 3 passed; Hermes rendered/stale-cleanup test: 1 passed; typecheck and Biome passed.
- Shared tests: 70 passed; typecheck passed.

No production or tenant operations and no real Telegram API calls were performed.

## Known upstream/runtime limits

- A hosted OpenClaw runtime can currently project multiple Telegram accounts. per-account-channel-peer isolates DMs, but upstream OpenClaw group session keys lack the account dimension, so groups across multiple Telegram accounts remain a P0 isolation risk.
- The minimal follow-up is either an upstream account dimension in group session keys or a temporary product constraint of one active Telegram account per hosted OpenClaw Agent.
- BotFather private threaded capability and complete runtime thread restoration remain separate upstream/runtime P0 work. This PR intentionally does not add thread-scoped bindings, fake chat IDs, or global config overrides.
- Runtime session contract fixtures are pinned to OpenClaw f4a7f2b553d3fd788552f3f3ae1004ecac8b2370 and Hermes 736fc4d86a1acd8c96473aeb55f9c783e2170dca.