### PR TITLE
fix(web): refine deploy form layout and Clawdi AI naming

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2000,7 +2000,7 @@ test("deploy keeps AI providers expanded and provider selection exclusive", asyn
 	).toHaveCount(0);
 	const addProvider = page.getByRole("button", { name: /^Add a provider/ });
 	await expect(addProvider).toBeVisible();
-	const managed = page.getByRole("button", { name: /^Managed AI/ });
+	const managed = page.getByRole("button", { name: /^Clawdi AI/ });
 	const unmanaged = page.getByRole("button", { name: /^Configure inside agent/ });
 	await expect(managed).toHaveAttribute("aria-pressed", "true");
 	await expect(unmanaged).toHaveAttribute("aria-pressed", "false");
@@ -2012,6 +2012,202 @@ test("deploy keeps AI providers expanded and provider selection exclusive", asyn
 	await expect(managed).toHaveAttribute("aria-pressed", "true");
 	await expect(unmanaged).toHaveAttribute("aria-pressed", "false");
 	await expect(page.getByRole("button", { name: "Change", exact: true })).toHaveCount(0);
+});
+
+test("deploy sticky action shows free, monthly, and annual offer prices", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await stubHostedApi(page, { plans: [basicPlan, performancePlan], deployments: [] });
+	await page.goto("/deploy");
+	await page.waitForLoadState("networkidle");
+
+	const actionBar = page.getByTestId("deploy-action-bar");
+	const priceLabel = actionBar.getByTestId("deploy-price-label");
+	await expect(priceLabel).toHaveText("Free");
+
+	const performanceChoice = page.getByRole("button", { name: /^Performance/ });
+	await performanceChoice.click();
+	await expect(priceLabel).toHaveText("$20.00/mo");
+	await expect(performanceChoice).toContainText("4 vCPU / 8 GB · $20.00/mo");
+
+	await page.getByRole("button", { name: /Annual.*%/ }).click();
+	await expect(priceLabel).toHaveText("$16.66/mo, billed $200.00/yr");
+	await expect(performanceChoice).toContainText("4 vCPU / 8 GB · $16.66/mo, billed $200.00/yr");
+
+	const priceMetrics = await priceLabel.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(priceMetrics.scrollWidth).toBeLessThanOrEqual(priceMetrics.clientWidth);
+	const pageMetrics = await page.evaluate(() => ({
+		clientWidth: document.documentElement.clientWidth,
+		scrollWidth: document.documentElement.scrollWidth,
+	}));
+	expect(pageMetrics.scrollWidth).toBe(pageMetrics.clientWidth);
+});
+
+test("deploy form stays readable without stretching compact controls", async ({ page }) => {
+	await stubHostedApi(page, { plans: [basicPlan, performancePlan], deployments: [] });
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /^Performance/ }).click();
+	await page.getByRole("button", { name: /Annual.*%/ }).click();
+
+	for (const viewport of [
+		{ columns: 2, name: "desktop", width: 1280, height: 900 },
+		{ columns: 2, name: "tablet without sidebar", width: 700, height: 900 },
+		{ columns: 1, name: "tablet with sidebar", width: 800, height: 900 },
+		{ columns: 1, name: "mobile", width: 390, height: 844 },
+	]) {
+		await page.setViewportSize({ width: viewport.width, height: viewport.height });
+		await page.evaluate(() => {
+			window.scrollTo(0, 0);
+			document.querySelector("#dashboard-scroll-container")?.scrollTo(0, 0);
+		});
+		await page.waitForTimeout(100);
+		const metrics = await page.evaluate(() => {
+			const sectionFor = (title: string) =>
+				Array.from(document.querySelectorAll("section")).find(
+					(section) =>
+						section.querySelector(":scope > div:nth-child(2) > div")?.textContent?.trim() === title,
+				);
+			const rect = (element: Element | null | undefined) => {
+				const box = element?.getBoundingClientRect();
+				return box
+					? { bottom: box.bottom, left: box.left, right: box.right, top: box.top, width: box.width }
+					: null;
+			};
+			const gridMetrics = (element: Element | null | undefined) =>
+				element
+					? {
+							columns: getComputedStyle(element).gridTemplateColumns,
+							rect: rect(element),
+						}
+					: null;
+			const sectionGrid = (title: string) => {
+				const section = sectionFor(title);
+				return gridMetrics(section?.querySelector(":scope > div:nth-child(3) .grid"));
+			};
+			const paymentButton = Array.from(document.querySelectorAll("button")).find((button) =>
+				button.textContent?.includes("Card subscription"),
+			);
+			const coreTitleLabels = [
+				"Hermes",
+				"OpenClaw",
+				"Clawdi AI",
+				"Configure inside agent",
+				"Basic",
+				"Performance",
+				"Card subscription",
+				"Wallet balance",
+			];
+			const titleWidths = Array.from(
+				document.querySelectorAll<HTMLSpanElement>("button span.font-medium"),
+			)
+				.filter((title) => coreTitleLabels.includes(title.textContent?.trim() ?? ""))
+				.map((title) => ({
+					clientWidth: title.clientWidth,
+					label: title.textContent?.trim() ?? "",
+					scrollWidth: title.scrollWidth,
+				}));
+			return {
+				document: {
+					clientWidth: document.documentElement.clientWidth,
+					scrollWidth: document.documentElement.scrollWidth,
+				},
+				main: rect(document.querySelector("main")),
+				agentSoftware: sectionGrid("Agent software"),
+				aiProviders: sectionGrid("AI providers"),
+				compute: sectionGrid("Compute"),
+				payment: gridMetrics(paymentButton?.parentElement),
+				catalogModel: rect(document.querySelector("#deploy-catalog-model")),
+				name: rect(document.querySelector("#agent-name")),
+				language: rect(document.querySelector("#agent-language")),
+				timezone: rect(document.querySelector("#agent-timezone")),
+				billingTerm: rect(document.querySelector('[aria-label="Billing term"]')),
+				action: rect(document.querySelector('button[type="submit"]')),
+				price: (() => {
+					const element = document.querySelector('[data-testid="deploy-price-label"]');
+					return element
+						? {
+								clientWidth: element.clientWidth,
+								scrollWidth: element.scrollWidth,
+								text: element.textContent,
+							}
+						: null;
+				})(),
+				titleWidths,
+			};
+		});
+
+		expect(metrics.document.scrollWidth, `${viewport.name} should not horizontally overflow`).toBe(
+			metrics.document.clientWidth,
+		);
+		expect(metrics.main, `${viewport.name} main bounds`).not.toBeNull();
+		expect(metrics.main?.right, `${viewport.name} main right edge`).toBeLessThanOrEqual(
+			viewport.width,
+		);
+
+		for (const [label, grid] of [
+			["Agent software", metrics.agentSoftware],
+			["AI providers", metrics.aiProviders],
+			["Compute", metrics.compute],
+			["Payment method", metrics.payment],
+		] as const) {
+			expect(grid, `${viewport.name} ${label} grid`).not.toBeNull();
+			if (!grid) continue;
+			const columnWidths = grid.columns.split(/\s+/).map(Number.parseFloat);
+			expect(columnWidths, `${viewport.name} ${label} column count`).toHaveLength(viewport.columns);
+			expect(
+				Math.min(...columnWidths),
+				`${viewport.name} ${label} cards should remain readable`,
+			).toBeGreaterThanOrEqual(300);
+			expect(grid.rect?.right, `${viewport.name} ${label} right edge`).toBeLessThanOrEqual(
+				viewport.width,
+			);
+		}
+
+		expect(metrics.titleWidths, `${viewport.name} core card titles`).toHaveLength(8);
+		for (const title of metrics.titleWidths) {
+			expect(title.scrollWidth, `${viewport.name} ${title.label} title`).toBeLessThanOrEqual(
+				title.clientWidth,
+			);
+		}
+
+		for (const [label, control, maxWidth] of [
+			["Catalog model", metrics.catalogModel, 448],
+			["Name", metrics.name, 448],
+			["Language", metrics.language, 160],
+			["Timezone", metrics.timezone, 384],
+			["Billing term", metrics.billingTerm, 320],
+		] as const) {
+			expect(control, `${viewport.name} ${label} bounds`).not.toBeNull();
+			expect(control?.width, `${viewport.name} ${label} width`).toBeLessThanOrEqual(maxWidth);
+			expect(control?.right, `${viewport.name} ${label} right edge`).toBeLessThanOrEqual(
+				viewport.width,
+			);
+		}
+		expect(metrics.language?.width, `${viewport.name} compact Language select`).toBeLessThan(
+			metrics.name?.width ?? 0,
+		);
+
+		expect(metrics.action, `${viewport.name} sticky action`).not.toBeNull();
+		expect(metrics.action?.top, `${viewport.name} sticky action top`).toBeGreaterThanOrEqual(0);
+		expect(metrics.action?.bottom, `${viewport.name} sticky action bottom`).toBeLessThanOrEqual(
+			viewport.height,
+		);
+		expect(metrics.price?.text, `${viewport.name} sticky annual price`).toBe(
+			"$16.66/mo, billed $200.00/yr",
+		);
+		expect(
+			metrics.price?.scrollWidth,
+			`${viewport.name} sticky price should not truncate`,
+		).toBeLessThanOrEqual(metrics.price?.clientWidth ?? 0);
+		if (viewport.columns === 1) {
+			expect(metrics.action?.width, `${viewport.name} full-width action`).toBeCloseTo(
+				metrics.compute?.rect?.width ?? 0,
+				0,
+			);
+		}
+	}
 });
 
 test("free Basic Deploy submits the declarative create contract", async ({ page }) => {
@@ -2418,7 +2614,7 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 	});
 	await page.goto("/agents/hdep_unmanaged_model/model-provider?source=on-clawdi");
 
-	await page.getByRole("button", { name: /Managed by Clawdi/ }).click();
+	await page.getByRole("button", { name: /Clawdi AI/ }).click();
 	await expect(page.locator("#agent-catalog-model")).toContainText("Luna");
 	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -115,7 +115,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
 	{
 		id: "billing-usage",
 		label: "Usage",
-		description: "Managed-AI spend in USD",
+		description: "Clawdi AI spend in USD",
 		icon: BarChart3,
 		cloudOnly: true,
 	},

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2155,7 +2155,7 @@ function AiProviderTab({
 						) : null}
 					</div>
 					<p className="mt-0.5 text-sm text-muted-foreground">
-						Clawdi-managed models, billed from your wallet.
+						Clawdi AI models, billed from your Wallet.
 					</p>
 				</button>
 				{providers.isLoading ? <EntityCardSkeleton titleBadge trailingBadge /> : null}

--- a/apps/web/src/hosted/billing/components/low-balance-banner.tsx
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.tsx
@@ -12,7 +12,7 @@ import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
  *
  * Shows when the managed-AI balance is low, or an auto-reload attempt needs
  * action (SCA) or was declined. Copy accounts for the shared balance funding
- * both managed AI and wallet compute, and offers top-up / auto-reload links.
+ * both Clawdi AI and wallet compute, and offers top-up / auto-reload links.
  *
  * Returns null when there's nothing to surface, so callers can render it
  * unconditionally at the top of any page.
@@ -38,8 +38,8 @@ export function LowBalanceBanner({
 			: "Your Wallet balance is running low";
 
 	const consequence = hasWalletCompute
-		? "Managed AI and wallet-funded compute can be interrupted if the balance stays low."
-		: "Managed AI can pause if the balance stays low.";
+		? "Clawdi AI and wallet-funded compute can be interrupted if the balance stays low."
+		: "Clawdi AI can pause if the balance stays low.";
 	const body = declined
 		? `We couldn’t charge your saved card. Top up manually or update your payment method. ${consequence}`
 		: needsAction

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -4,6 +4,10 @@ import { validateHostedDeployPersona } from "@clawdi/shared/api";
 import { DEPLOY_ASSISTANT_NAME_MAX_LENGTH } from "@/hosted/billing/deploy/deploy-request";
 
 const wizardSource = readFileSync(new URL("./deploy-wizard.tsx", import.meta.url), "utf8");
+const deployPageSource = readFileSync(
+	new URL("../../../pages/dashboard/deploy/page.tsx", import.meta.url),
+	"utf8",
+);
 const acceptedNavigationSource = readFileSync(
 	new URL("./accepted-deployment-navigation.ts", import.meta.url),
 	"utf8",
@@ -43,6 +47,15 @@ const aiProviderHooksSource = readFileSync(
 );
 
 describe("deploy wizard personalization", () => {
+	test("keeps deploy-specific controls proportionate to their content", () => {
+		expect(wizardSource).toContain('className="w-full max-w-md"');
+		expect(wizardSource).toContain('<div className="flex max-w-2xl flex-col gap-4">');
+		expect(wizardSource).toContain('className="flex w-full max-w-md flex-col gap-1.5"');
+		expect(wizardSource).toContain('<SelectTrigger id="agent-language" type="button">');
+		expect(wizardSource).toContain('className="flex w-full max-w-sm min-w-0 flex-col gap-1.5"');
+		expect(wizardSource).toContain('className="flex max-w-xs flex-col gap-1.5"');
+	});
+
 	test("uses a stable dashboard name within the strictest backend limit", () => {
 		expect(wizardSource).toContain('htmlFor="agent-name"');
 		expect(wizardSource).toContain('<Label htmlFor="agent-name">Name in Clawdi</Label>');
@@ -68,6 +81,36 @@ describe("deploy wizard personalization", () => {
 		expect(wizardSource).toContain("Name limit reached. You can enter up to");
 		expect(wizardSource).toContain('type="submit"');
 		expect(wizardSource).toContain("submitBlockingReason");
+	});
+});
+
+describe("deploy wizard responsive layout", () => {
+	test("keeps the shared page width while sizing card grids from the main pane", () => {
+		expect(wizardSource).toContain("CENTERED_PAGE_WIDTH_CLASS.page");
+		expect(wizardSource).toContain(
+			'const TWO_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2";',
+		);
+		expect(wizardSource).toContain("@5xl/main:grid-cols-3");
+		expect(wizardSource).not.toContain('className="grid gap-2 sm:grid-cols-2"');
+		expect(wizardSource).not.toContain("sm:flex-row sm:items-center sm:justify-between");
+		expect(deployPageSource).toContain('className="grid gap-2 @2xl/main:grid-cols-2"');
+	});
+
+	test("keeps the action bar sticky across the full form and adapts it to the main pane", () => {
+		const formIndex = wizardSource.indexOf("<form");
+		const agentSoftwareIndex = wizardSource.indexOf('title="Agent software"');
+		const actionBarIndex = wizardSource.indexOf('data-testid="deploy-action-bar"');
+		expect(formIndex).toBeGreaterThan(-1);
+		expect(formIndex).toBeLessThan(agentSoftwareIndex);
+		expect(actionBarIndex).toBeGreaterThan(wizardSource.indexOf('title="Personalize"'));
+		expect(wizardSource).toContain("sticky bottom-0 z-10");
+		expect(wizardSource).toContain("@2xl/main:flex-row");
+		expect(wizardSource).toContain("@2xl/main:w-auto");
+		expect(wizardSource).not.toContain("sm:sticky sm:bottom-0");
+	});
+
+	test("hides wide payment badges before they would crowd card titles", () => {
+		expect(wizardSource.match(/hidden @3xl\/main:inline-flex/g)).toHaveLength(2);
 	});
 });
 
@@ -193,15 +236,15 @@ describe("managed model picker", () => {
 			expect(source).not.toContain("Hosted default (Luna)");
 		}
 		expect(modelBindingPickerSource).toContain("modelPickerItems(");
-		expect(modelBindingPickerSource).toContain("Loading managed models…");
-		expect(modelBindingPickerSource).toContain('title="Couldn\'t load managed models"');
+		expect(modelBindingPickerSource).toContain("Loading Clawdi AI models…");
+		expect(modelBindingPickerSource).toContain('title="Couldn\'t load Clawdi AI models"');
 	});
 
-	test("does not blame the user while the Managed AI catalog is loading or unavailable", () => {
-		expect(wizardSource).toContain('return "Loading Managed AI models."');
-		expect(wizardSource).toContain('return "Retry loading Managed AI models above."');
+	test("does not blame the user while the Clawdi AI catalog is loading or unavailable", () => {
+		expect(wizardSource).toContain('return "Loading Clawdi AI models."');
+		expect(wizardSource).toContain('return "Retry loading Clawdi AI models above."');
 		expect(wizardSource).toContain('return "Choose an available primary model."');
-		expect(wizardSource.indexOf('return "Loading Managed AI models."')).toBeLessThan(
+		expect(wizardSource.indexOf('return "Loading Clawdi AI models."')).toBeLessThan(
 			wizardSource.indexOf('return "Choose an available primary model."'),
 		);
 	});
@@ -216,14 +259,20 @@ describe("deploy provider choice", () => {
 		expect(wizardSource).toContain('title={authCardLabel("unmanaged")}');
 		expect(wizardSource).not.toContain("aiProviderEditorOpen");
 		expect(wizardSource).not.toContain("aiProviderSummaryTitle");
-		expect(wizardSource).not.toContain("Using Managed AI");
+		expect(wizardSource).not.toContain("Using Clawdi AI");
 	});
 
-	test("explains that the welcome balance is used before added Wallet funds", () => {
-		expect(wizardSource).toContain(
+	test("puts Clawdi AI before configuring AI inside the agent", () => {
+		expect(wizardSource.indexOf("selected={managedProviderSelected}")).toBeLessThan(
+			wizardSource.indexOf('selected={aiAccessMode === "unmanaged"}'),
+		);
+	});
+
+	test("contrasts Clawdi AI with provider setup without implying free usage", () => {
+		expect(wizardSource).toContain("No setup required. Usage draws from your Wallet.");
+		expect(wizardSource).not.toContain(
 			"Your welcome balance covers usage first; after that, it draws from your Wallet.",
 		);
-		expect(wizardSource).not.toContain("Managed-AI usage paid directly from your Wallet");
 	});
 
 	test("uses an exclusive provider selection and hides the redundant provider picker", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -149,6 +149,7 @@ import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-provide
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
 	MANAGED_AI_CHOICE,
+	MANAGED_PROVIDER_LABEL,
 	modelDisplayName,
 	modelOptionsForProvider,
 	providerCatalogDescription,
@@ -178,11 +179,8 @@ type PaidDeploySelection = {
 	tierLabel: "Basic" | "Performance";
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
-const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
-const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
-const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
-const DEPLOY_MANAGED_AI_LABEL = "Managed AI";
-
+const THREE_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2 @5xl/main:grid-cols-3";
+const TWO_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2";
 const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";
 const WALLET_PAYMENT_TOAST_DURATION_MS = 8_000;
 
@@ -200,7 +198,7 @@ function showWalletPaymentConfirmation(amount: string) {
 
 const aiProviderErrorNormalizer: ApiErrorNormalizer = {
 	isAuthError: isApiAuthError,
-	normalizeError: (error) => `${normalizeApiError(error)} Managed AI still works.`,
+	normalizeError: (error) => `${normalizeApiError(error)} Clawdi AI still works.`,
 };
 
 function AddTile({
@@ -568,8 +566,8 @@ export function DeployWizard() {
 		}
 		if (!computePlanReady) return "Choose an available compute plan.";
 		if (!managedPrimaryModelReady) {
-			if (managedModelsNeedRetry) return "Retry loading Managed AI models above.";
-			if (managedModelsLoading) return "Loading Managed AI models.";
+			if (managedModelsNeedRetry) return "Retry loading Clawdi AI models above.";
+			if (managedModelsLoading) return "Loading Clawdi AI models.";
 			return "Choose an available primary model.";
 		}
 		if (paidSelection && paymentMethod === "wallet") {
@@ -949,7 +947,7 @@ export function DeployWizard() {
 	);
 	const primaryProviderLabel =
 		primaryProviderChoice === MANAGED_AI_CHOICE
-			? DEPLOY_MANAGED_AI_LABEL
+			? MANAGED_PROVIDER_LABEL
 			: providerDisplayLabel(primaryProvider ?? primaryProviderChoice);
 	const aiSummary =
 		aiAccessMode === "unmanaged"
@@ -966,6 +964,12 @@ export function DeployWizard() {
 					.filter(Boolean)
 					.join(" · ");
 	const runtimeSummary = runtimeDisplayName(runtime);
+	const deployPriceLabel =
+		compute === "basic" && basicSelection.mode === "included"
+			? "Free"
+			: paidSelection
+				? recurringOfferLabel(paidSelection.offer)
+				: null;
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Basic"} compute`,
 		aiSummary,
@@ -1010,7 +1014,13 @@ export function DeployWizard() {
 
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
-			<div className="flex flex-col gap-6">
+			<form
+				className="flex flex-col gap-6"
+				onSubmit={(event) => {
+					event.preventDefault();
+					if (canSubmit) void runAction(onDeploy);
+				}}
+			>
 				<PageHeader
 					title="Deploy an Agent"
 					description="Choose how your agent runs and which AI model it will use."
@@ -1019,7 +1029,7 @@ export function DeployWizard() {
 					title="Agent software"
 					description="Choose the software that will power your agent."
 				>
-					<div className={RUNTIME_TILE_GRID_CLASS}>
+					<div className={TWO_TILE_GRID_CLASS}>
 						<EntityChoiceCard
 							selected={runtime === "hermes"}
 							onClick={() => selectRuntime("hermes")}
@@ -1049,6 +1059,18 @@ export function DeployWizard() {
 					<div className="flex flex-col gap-4">
 						<div className={TWO_TILE_GRID_CLASS}>
 							<EntityChoiceCard
+								selected={managedProviderSelected}
+								onClick={() => selectAiProviderChoice(MANAGED_AI_CHOICE)}
+								icon={
+									<IconChip tint="bg-primary/10 text-primary">
+										<Sparkles />
+									</IconChip>
+								}
+								title={MANAGED_PROVIDER_LABEL}
+								description="No setup required. Usage draws from your Wallet."
+								badge={<Badge variant="secondary">Default</Badge>}
+							/>
+							<EntityChoiceCard
 								selected={aiAccessMode === "unmanaged"}
 								onClick={() => setAiAccessMode("unmanaged")}
 								icon={
@@ -1062,22 +1084,10 @@ export function DeployWizard() {
 									aiAccessMode === "unmanaged" ? <Badge variant="secondary">Selected</Badge> : null
 								}
 							/>
-							<EntityChoiceCard
-								selected={managedProviderSelected}
-								onClick={() => selectAiProviderChoice(MANAGED_AI_CHOICE)}
-								icon={
-									<IconChip tint="bg-primary/10 text-primary">
-										<Sparkles />
-									</IconChip>
-								}
-								title={DEPLOY_MANAGED_AI_LABEL}
-								description="Your welcome balance covers usage first; after that, it draws from your Wallet."
-								badge={<Badge variant="secondary">Default</Badge>}
-							/>
 							{aiProviders.isLoading ? (
 								<Skeleton className="h-[74px] w-full rounded-lg" />
 							) : aiProviders.error ? (
-								<div className="sm:col-span-2">
+								<div className="@2xl/main:col-span-2">
 									<ApiErrorPanel
 										title="Couldn't load providers"
 										error={aiProviders.error}
@@ -1118,6 +1128,7 @@ export function DeployWizard() {
 						) : (
 							<ModelBindingPicker
 								idPrefix="deploy"
+								className="w-full max-w-md"
 								providers={providerList}
 								managedModels={managedModels}
 								managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
@@ -1159,7 +1170,7 @@ export function DeployWizard() {
 							<Alert data-hosted="true">
 								<TriangleAlert />
 								<AlertTitle>Free Basic agent availability is unknown</AlertTitle>
-								<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+								<AlertDescription className="flex flex-col gap-3 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
 									<span>
 										We can’t determine whether an existing agent is already using your free Basic
 										allowance. No free agent is assumed.
@@ -1181,7 +1192,7 @@ export function DeployWizard() {
 								</AlertDescription>
 							</Alert>
 						) : null}
-						<div className="grid gap-2 sm:grid-cols-2">
+						<div className={TWO_TILE_GRID_CLASS}>
 							<EntityChoiceCard
 								selected={compute === "basic"}
 								onClick={
@@ -1236,7 +1247,9 @@ export function DeployWizard() {
 								title="Performance"
 								description={
 									perfPlan
-										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB · per-agent subscription`
+										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB${
+												perfOffer ? ` · ${recurringOfferLabel(perfOffer)}` : ""
+											}`
 										: "Performance plan unavailable"
 								}
 								badge={
@@ -1252,7 +1265,7 @@ export function DeployWizard() {
 							/>
 						</div>
 						{paidSelection && (compute === "performance" ? perfOffers : basicOffers).length > 1 ? (
-							<div className="flex flex-col gap-1.5 sm:max-w-xs">
+							<div className="flex max-w-xs flex-col gap-1.5">
 								<span className="text-xs text-muted-foreground">Billing term</span>
 								<TermSwitcher
 									offers={compute === "performance" ? perfOffers : basicOffers}
@@ -1269,7 +1282,7 @@ export function DeployWizard() {
 										Choose how this agent’s compute renews. You can review the charge before paying.
 									</p>
 								</div>
-								<div className="grid gap-2 sm:grid-cols-2">
+								<div className={TWO_TILE_GRID_CLASS}>
 									<EntityChoiceCard
 										selected={paymentMethod === "card"}
 										onClick={() => setPaymentMethod("card")}
@@ -1280,7 +1293,11 @@ export function DeployWizard() {
 										}
 										title="Card subscription"
 										description="Pay securely with Stripe and manage the subscription from billing settings."
-										badge={<Badge variant="secondary">Monthly or Annual</Badge>}
+										badge={
+											<Badge variant="secondary" className="hidden @3xl/main:inline-flex">
+												Monthly or Annual
+											</Badge>
+										}
 									/>
 									<EntityChoiceCard
 										selected={paymentMethod === "wallet"}
@@ -1295,7 +1312,11 @@ export function DeployWizard() {
 											walletDisabledReason ??
 											"Debit the exact quoted USD amount from Wallet, then renew on the selected term."
 										}
-										badge={<Badge variant="outline">Monthly or Annual</Badge>}
+										badge={
+											<Badge variant="outline" className="hidden @3xl/main:inline-flex">
+												Monthly or Annual
+											</Badge>
+										}
 										disabled={walletDisabledReason !== null}
 									/>
 								</div>
@@ -1367,22 +1388,13 @@ export function DeployWizard() {
 						</p>
 					</div>
 				</SettingsSection>
-			</div>
-
-			<form
-				className="flex flex-col gap-6"
-				onSubmit={(event) => {
-					event.preventDefault();
-					if (canSubmit) void runAction(onDeploy);
-				}}
-			>
-				<div className="sm:pb-24">
+				<div className="pb-32 @2xl/main:pb-24">
 					<SettingsSection
 						title="Personalize"
 						description="Choose how this agent appears in Clawdi, plus its language and timezone."
 					>
-						<div className="grid max-w-2xl gap-4 sm:grid-cols-2">
-							<div className="flex flex-col gap-1.5 sm:col-span-2">
+						<div className="flex max-w-2xl flex-col gap-4">
+							<div className="flex w-full max-w-md flex-col gap-1.5">
 								<Label htmlFor="agent-name">Name in Clawdi</Label>
 								<Input
 									id="agent-name"
@@ -1429,63 +1441,81 @@ export function DeployWizard() {
 									</span>
 								) : null}
 							</div>
-							<div className="flex flex-col gap-1.5">
-								<label htmlFor="agent-language" className="text-sm text-muted-foreground">
-									Language
-								</label>
-								<Select
-									items={LANGUAGE_SELECT_ITEMS}
-									value={language || "default"}
-									onValueChange={(v) => {
-										setLanguage(v === null || v === "default" ? "" : v);
-									}}
-								>
-									<SelectTrigger id="agent-language" type="button">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectGroup>
-											<SelectItem value="default">Default</SelectItem>
-											{LANGUAGE_OPTIONS.map((l) => (
-												<SelectItem key={l.code} value={l.code}>
-													{l.label}
-												</SelectItem>
-											))}
-										</SelectGroup>
-									</SelectContent>
-								</Select>
-							</div>
-							{tzOptions.length > 0 ? (
+							<div className="flex flex-wrap items-start gap-4">
 								<div className="flex flex-col gap-1.5">
-									<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
-										Timezone
+									<label htmlFor="agent-language" className="text-sm text-muted-foreground">
+										Language
 									</label>
-									<TimezoneCombobox
-										id="agent-timezone"
-										value={timezone}
-										onValueChange={setTimezone}
-										options={tzOptions}
-									/>
+									<Select
+										items={LANGUAGE_SELECT_ITEMS}
+										value={language || "default"}
+										onValueChange={(v) => {
+											setLanguage(v === null || v === "default" ? "" : v);
+										}}
+									>
+										<SelectTrigger id="agent-language" type="button">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectGroup>
+												<SelectItem value="default">Default</SelectItem>
+												{LANGUAGE_OPTIONS.map((l) => (
+													<SelectItem key={l.code} value={l.code}>
+														{l.label}
+													</SelectItem>
+												))}
+											</SelectGroup>
+										</SelectContent>
+									</Select>
 								</div>
-							) : null}
+								{tzOptions.length > 0 ? (
+									<div className="flex w-full max-w-sm min-w-0 flex-col gap-1.5">
+										<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
+											Timezone
+										</label>
+										<TimezoneCombobox
+											id="agent-timezone"
+											value={timezone}
+											onValueChange={setTimezone}
+											options={tzOptions}
+										/>
+									</div>
+								) : null}
+							</div>
 						</div>
 					</SettingsSection>
 				</div>
 
 				{/* Sticky action bar */}
-				<div className="-mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur sm:sticky sm:bottom-0 lg:-mx-6 lg:px-6">
-					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-						<p className="min-w-0 max-w-full truncate text-xs text-muted-foreground sm:text-sm">
-							{summaryLine}
-						</p>
-						<div className="flex min-w-0 flex-col gap-1 sm:items-end">
-							<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+				<div
+					data-testid="deploy-action-bar"
+					className="sticky bottom-0 z-10 -mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur lg:-mx-6 lg:px-6"
+				>
+					<div className="flex flex-col gap-2 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
+						<div className="flex min-w-0 max-w-full items-center gap-2 text-xs sm:text-sm">
+							{deployPriceLabel ? (
+								<>
+									<span
+										data-testid="deploy-price-label"
+										className="shrink-0 whitespace-nowrap font-medium text-foreground"
+									>
+										{deployPriceLabel}
+									</span>
+									<span aria-hidden="true" className="shrink-0 text-muted-foreground">
+										·
+									</span>
+								</>
+							) : null}
+							<span className="min-w-0 truncate text-muted-foreground">{summaryLine}</span>
+						</div>
+						<div className="flex min-w-0 flex-col gap-1 @2xl/main:items-end">
+							<div className="flex flex-col gap-2 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-end">
 								<Button
 									type="submit"
 									size="lg"
 									disabled={!canSubmit}
 									aria-describedby={submitBlockingReason ? "deploy-blocking-reason" : undefined}
-									className="w-full shrink-0 sm:w-auto"
+									className="w-full shrink-0 @2xl/main:w-auto"
 								>
 									{submitting ? (
 										<Spinner data-icon="inline-start" />
@@ -1496,14 +1526,17 @@ export function DeployWizard() {
 								</Button>
 							</div>
 							{submitTakingLong ? (
-								<p className="max-w-sm text-xs text-muted-foreground sm:text-right" role="status">
+								<p
+									className="max-w-sm text-xs text-muted-foreground @2xl/main:text-right"
+									role="status"
+								>
 									{submitTakingLongCopy}
 								</p>
 							) : submitBlockingReason ? (
 								<p
 									id="deploy-blocking-reason"
 									className={cn(
-										"max-w-sm text-xs sm:text-right",
+										"max-w-sm text-xs @2xl/main:text-right",
 										nameError ? "text-destructive" : "text-muted-foreground",
 									)}
 									role="status"

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -284,7 +284,7 @@ export function isInsufficientBalanceError(error: unknown): boolean {
 export function normalizeBillingError(error: unknown): string {
 	if (error instanceof DeploymentConflictError) return DEPLOYMENT_CONFLICT_MESSAGE;
 	if (isInsufficientBalanceError(error)) {
-		return "Your Wallet balance is too low. Top up or enable auto-reload before managed AI or wallet-funded compute is interrupted.";
+		return "Your Wallet balance is too low. Top up or enable auto-reload before Clawdi AI or wallet-funded compute is interrupted.";
 	}
 	if (error instanceof BillingNetworkError) {
 		return error.kind === "timeout"

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -153,7 +153,7 @@ export function PlanComparison({
 							<FeatureRow>One free active Basic agent per user</FeatureRow>
 							<FeatureRow>Paid additional Basic agents</FeatureRow>
 							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
-							<FeatureRow>BYOK avoids managed-AI usage charges</FeatureRow>
+							<FeatureRow>BYOK avoids Clawdi AI usage charges</FeatureRow>
 							{signupGrantUsd ? (
 								<FeatureRow>{formatUsdExact(signupGrantUsd)} welcome balance on signup</FeatureRow>
 							) : null}
@@ -250,17 +250,17 @@ export function PlanComparison({
 					</CardFooter>
 				</Card>
 
-				{/* Managed AI */}
+				{/* Clawdi AI */}
 				<Card className="flex flex-col bg-muted/30">
 					<CardHeader>
 						<CardTitle className="flex items-center gap-2">
-							<WalletCards className="size-5 text-muted-foreground" aria-hidden /> Managed AI
+							<WalletCards className="size-5 text-muted-foreground" aria-hidden /> Clawdi AI
 						</CardTitle>
 						<div className="mt-2 flex items-baseline gap-1">
 							<span className="text-3xl font-semibold tracking-tight">Pay as you go</span>
 						</div>
 						<CardDescription className="mt-2">
-							Managed AI billed by usage. Top up your wallet and spend only what your agents use.
+							Clawdi AI is billed by usage. Top up your wallet and spend only what your agents use.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="flex-1">
@@ -269,8 +269,8 @@ export function PlanComparison({
 							<FeatureRow>Whole-dollar top-ups from {TOPUP_AMOUNT_RANGE_LABEL}</FeatureRow>
 							<FeatureRow>Optional auto-reload so agents never stall</FeatureRow>
 							<FeatureRow>
-								<span className="font-medium">No managed-AI charge with BYOK</span> — your own key
-								bypasses managed AI
+								<span className="font-medium">No Clawdi AI charge with BYOK</span> — your own key
+								bypasses Clawdi AI
 							</FeatureRow>
 						</ul>
 						<Separator className="my-4" />

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -90,7 +90,7 @@ export function SubscriptionPage() {
 				<CardContent className="space-y-4">
 					<p className="text-sm text-muted-foreground">
 						Upgrade, lifecycle, and delete controls live in that agent’s Settings page. Wallet
-						balance and managed-AI usage stay account-wide.
+						balance and Clawdi AI usage stay account-wide.
 					</p>
 					<div className="flex flex-wrap gap-2">
 						{hostedAccess.canCreateCloudAgents ? (

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
@@ -12,7 +12,7 @@ describe("welcomeWalletDescription", () => {
 				showDeployAction: true,
 			}),
 		).toContain(
-			"welcome balance covers Managed AI first; after that, usage draws from your Wallet.",
+			"welcome balance covers Clawdi AI first; after that, usage draws from your Wallet.",
 		);
 	});
 

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
@@ -18,8 +18,8 @@ export function welcomeWalletDescription({
 				: "Your welcome balance is available in your Wallet.";
 		}
 		return grantAmount
-			? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Managed AI first; after that, usage draws from your Wallet.`
-			: "Your free Basic compute is ready. Managed AI usage draws from your Wallet.";
+			? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Clawdi AI first; after that, usage draws from your Wallet.`
+			: "Your free Basic compute is ready. Clawdi AI usage draws from your Wallet.";
 	}
 	if (grantPending) {
 		if (grantCheckTimedOut) return "It hasn’t appeared yet. Refresh to check again.";

--- a/apps/web/src/hosted/billing/usage/usage-page.test.ts
+++ b/apps/web/src/hosted/billing/usage/usage-page.test.ts
@@ -71,7 +71,7 @@ describe("usage availability rendering", () => {
 		expect(markup).toContain("Retry");
 		expect(markup).not.toContain("No usage yet");
 		expect(markup).not.toContain("$0.00");
-		expect(markup).not.toContain("Managed-AI spend in window");
+		expect(markup).not.toContain("Clawdi AI spend in window");
 	});
 
 	test("names a missing daily section while preserving read totals and model usage", () => {
@@ -115,7 +115,7 @@ describe("usage availability rendering", () => {
 		expect(markup).toContain("Usage totals unavailable");
 		expect(markup).toContain("Model breakdown unavailable");
 		expect(markup).toContain("$9.25");
-		expect(markup).not.toContain("Managed-AI spend in window");
+		expect(markup).not.toContain("Clawdi AI spend in window");
 		expect(markup).not.toContain("Requests in window");
 		expect(markup).not.toContain("No usage yet");
 	});

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -25,7 +25,7 @@ import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Managed-AI usage in USD for the current reporting window across your agents.";
+const DESCRIPTION = "Clawdi AI usage in USD for the current reporting window across your agents.";
 const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 type UnavailableUsageSection = HostedUsageSummary["unavailable_sections"][number];
@@ -160,7 +160,7 @@ export function UsageSummaryView({
 				<EmptyState
 					icon={Activity}
 					title="No usage yet"
-					description="Once your agents start running, managed-AI spend shows up here."
+					description="Once your agents start running, Clawdi AI spend shows up here."
 				/>
 			</div>
 		);
@@ -201,7 +201,7 @@ export function UsageSummaryView({
 							<div className="text-3xl font-semibold tabular-nums">
 								{formatUsdExact(totals.usd)}
 							</div>
-							<div className="text-sm text-muted-foreground">Managed-AI spend in window</div>
+							<div className="text-sm text-muted-foreground">Clawdi AI spend in window</div>
 						</CardContent>
 					</Card>
 					<Card data-hosted="true">

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -136,8 +136,8 @@ export function AutoReloadActionConfirm({
 				<AlertDescription className="flex flex-col items-start gap-3">
 					<span>
 						{declined
-							? "Update your card or top up manually. Auto-reload pauses after repeated declines; managed AI and wallet-funded compute still use the remaining balance."
-							: "Your bank is still confirming the last auto-reload. Managed AI and wallet-funded compute still use the remaining balance until it clears."}
+							? "Update your card or top up manually. Auto-reload pauses after repeated declines; Clawdi AI and wallet-funded compute still use the remaining balance."
+							: "Your bank is still confirming the last auto-reload. Clawdi AI and wallet-funded compute still use the remaining balance until it clears."}
 					</span>
 					{onTopUp ? (
 						<Button type="button" size="sm" onClick={onTopUp}>

--- a/apps/web/src/hosted/billing/wallet/balance-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/balance-card.tsx
@@ -11,7 +11,7 @@ import { isLowBalance } from "@/hosted/billing/wallet/wallet-constants";
 
 /**
  * Balance hero. When the balance trips the low threshold the figure goes
- * warning-toned and an inline chip explains the consequence for managed AI
+ * warning-toned and an inline chip explains the consequence for Clawdi AI
  * and wallet-funded compute.
  */
 export function BalanceCard({
@@ -48,7 +48,7 @@ export function BalanceCard({
 								<Info className="size-3.5" />
 							</TooltipTrigger>
 							<TooltipContent className="max-w-xs">
-								One USD balance shared by managed AI and wallet-funded compute.
+								One USD balance shared by Clawdi AI and wallet-funded compute.
 							</TooltipContent>
 						</Tooltip>
 					</div>
@@ -64,11 +64,11 @@ export function BalanceCard({
 						</span>
 					</div>
 					<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-						<span>Shared across managed AI and wallet-funded compute.</span>
+						<span>Shared across Clawdi AI and wallet-funded compute.</span>
 						{low ? (
 							<span className="inline-flex items-center gap-1 font-medium text-warning-muted-foreground">
 								<TriangleAlert className="size-3.5" aria-hidden /> Low — top up before
-								{hasWalletCompute ? " AI or compute is interrupted" : " managed AI pauses"}
+								{hasWalletCompute ? " AI or compute is interrupted" : " Clawdi AI pauses"}
 							</span>
 						) : null}
 					</div>

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -30,7 +30,7 @@ import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "One balance for managed AI, wallet-funded compute, top-ups, and auto-reload.";
+const DESCRIPTION = "One balance for Clawdi AI, wallet-funded compute, top-ups, and auto-reload.";
 const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 function scrollToAutoReload() {

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -61,7 +61,7 @@ export function X402Card() {
 					</Alert>
 				) : (
 					<p className="text-sm text-muted-foreground">
-						An on-chain deposit address is provisioned with your first managed-AI agent.
+						An on-chain deposit address is provisioned with your first Clawdi AI agent.
 					</p>
 				)}
 			</CardContent>

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -228,7 +228,7 @@ describe("deploymentMutationErrorMessage", () => {
 		const message = deploymentMutationErrorMessage(error);
 
 		expect(message).toContain("selected provider is no longer available");
-		expect(message).toContain("Choose Managed by Clawdi");
+		expect(message).toContain("Choose Clawdi AI");
 		expect(message).not.toContain("billing");
 	});
 

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -14,7 +14,7 @@ const DEFAULT_SERVICE_FAILURE_REASON = "The Clawdi service could not complete th
 
 const CUSTOMER_FAILURE_REASONS_BY_CODE = new Map<string, string>([
 	["provider_not_found", "The selected provider is no longer available in your Clawdi account."],
-	["invalid_managed_provider_id", "Managed by Clawdi cannot be combined with a saved provider."],
+	["invalid_managed_provider_id", "Clawdi AI cannot be combined with a saved provider."],
 	[
 		"insufficient_balance",
 		"Your Wallet balance was too low for the Clawdi service to complete this request.",
@@ -73,10 +73,10 @@ export function deploymentMutationErrorMessage(error: unknown): string {
 			return "Your free Basic compute slot is already in use. Stop that agent or choose paid compute, then try again.";
 		}
 		if (code === "provider_not_found") {
-			return "The selected provider is no longer available in your Clawdi account. Choose Managed by Clawdi or save the provider again, then retry.";
+			return "The selected provider is no longer available in your Clawdi account. Choose Clawdi AI or save the provider again, then retry.";
 		}
 		if (code === "invalid_managed_provider_id") {
-			return "Managed by Clawdi can’t be combined with a saved provider. Choose Managed alone or choose a saved provider, then retry.";
+			return "Clawdi AI can’t be combined with a saved provider. Choose Clawdi AI alone or choose a saved provider, then retry.";
 		}
 		if (error.status === 401) {
 			return "Your session has expired. Sign in again before changing this agent.";

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -139,7 +139,7 @@ export function buildAiBindingFields(
 				error.code === "provider_unusable"
 					? "Provider needs setup"
 					: error.code === "managed_model_unavailable"
-						? "Managed model unavailable"
+						? "Clawdi AI model unavailable"
 						: error.code === "model_required"
 							? "Primary model required"
 							: mode === "create"

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.ts
@@ -35,7 +35,7 @@ export function providerRemovalImpact(usage: ProviderUsage): ProviderRemovalImpa
 		return {
 			acknowledgementRequired: true,
 			warning:
-				"Removing this provider archives it. We couldn't check whether any agents use it. Any affected agent will lose model access until reconfigured; there is no automatic fallback to the managed default.",
+				"Removing this provider archives it. We couldn't check whether any agents use it. Any affected agent will lose model access until reconfigured; there is no automatic fallback to Clawdi AI.",
 		};
 	}
 	if (usage.agentCount > 0) {
@@ -45,7 +45,7 @@ export function providerRemovalImpact(usage: ProviderUsage): ProviderRemovalImpa
 				: `${usage.agentCount} agents currently use`;
 		return {
 			acknowledgementRequired: true,
-			warning: `Removing this provider archives it. ${agents} it and will lose model access until reconfigured; there is no automatic fallback to the managed default.`,
+			warning: `Removing this provider archives it. ${agents} it and will lose model access until reconfigured; there is no automatic fallback to Clawdi AI.`,
 		};
 	}
 	return {

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -90,7 +90,7 @@ export function AiProvidersPage() {
 			/>
 
 			<div className="flex flex-col gap-2">
-				<SectionLabel>Managed default</SectionLabel>
+				<SectionLabel>Clawdi AI</SectionLabel>
 				<ManagedProviderCard />
 			</div>
 

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -70,7 +70,7 @@ export function ModelBindingPicker({
 		: CUSTOM_MODEL_CHOICE;
 	const managedCatalogUnavailableError =
 		isManaged && managedModels.length === 0 && !managedModelsLoading
-			? (managedModelsError ?? new Error("The managed model catalog returned no models."))
+			? (managedModelsError ?? new Error("The Clawdi AI model catalog returned no models."))
 			: null;
 	const primaryProviderItems = primaryProviderPickerItems(
 		selectedProviderChoices,
@@ -111,14 +111,14 @@ export function ModelBindingPicker({
 				) : null}
 				{isManaged && managedModelsLoading ? (
 					<div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
-						<Spinner className="size-3.5" /> Loading managed models…
+						<Spinner className="size-3.5" /> Loading Clawdi AI models…
 					</div>
 				) : managedCatalogUnavailableError ? (
 					<ApiErrorPanel
 						normalizer={managedModelsErrorNormalizer}
 						error={managedCatalogUnavailableError}
 						onRetry={onManagedModelsRetry}
-						title="Couldn't load managed models"
+						title="Couldn't load Clawdi AI models"
 					/>
 				) : hasCatalogModels ? (
 					<div className="flex flex-col gap-1.5">

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -15,6 +15,11 @@ import {
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 describe("model binding", () => {
+	test("uses the canonical Clawdi AI product label", () => {
+		expect(MANAGED_PROVIDER_LABEL).toBe("Clawdi AI");
+		expect(primaryProviderPickerItems([MANAGED_AI_CHOICE], [])[0]?.label).toBe("Clawdi AI");
+	});
+
 	test("does not invent a managed model before the catalog loads", () => {
 		expect(firstModelForProvider(MANAGED_AI_CHOICE, [])).toBe("");
 		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [])).toEqual([]);
@@ -110,7 +115,7 @@ describe("model binding", () => {
 	});
 
 	test("labels empty bindings from their actual auth mode", () => {
-		expect(modelBindingDisplayName(null, "managed", [])).toBe("Managed default");
+		expect(modelBindingDisplayName(null, "managed", [])).toBe("Clawdi AI default");
 		expect(modelBindingDisplayName(null, "unmanaged", [])).toBe("Configured in agent");
 		expect(modelBindingDisplayName(null, "api_key", [])).toBe("Not set");
 	});

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -10,7 +10,7 @@ import { formatModelLabel } from "@/lib/format";
 
 export const MANAGED_AI_CHOICE = "__managed__";
 export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID;
-export const MANAGED_PROVIDER_LABEL = "Managed by Clawdi";
+export const MANAGED_PROVIDER_LABEL = "Clawdi AI";
 export const CUSTOM_MODEL_CHOICE = "__custom__";
 
 type AiProviderModel = NonNullable<AiProvider["models"]>[number];
@@ -164,7 +164,7 @@ export function modelBindingDisplayName(
 ): string {
 	const modelId = primaryModelValue(primaryModel);
 	if (modelId) return modelDisplayName(modelId, catalog);
-	if (authKind === "managed") return "Managed default";
+	if (authKind === "managed") return "Clawdi AI default";
 	if (authKind === "unmanaged") return "Configured in agent";
 	return "Not set";
 }

--- a/apps/web/src/pages/dashboard/deploy/page.tsx
+++ b/apps/web/src/pages/dashboard/deploy/page.tsx
@@ -38,10 +38,8 @@ function DeployRouteSkeleton() {
 						<Skeleton className="h-3.5 w-80 max-w-full" />
 						<Skeleton className="h-3.5 w-56 max-w-full" />
 					</div>
-					<div
-						className={cn("grid gap-2", sectionIndex === 0 ? "sm:grid-cols-3" : "sm:grid-cols-2")}
-					>
-						{Array.from({ length: sectionIndex === 0 ? 3 : 2 }).map((_, tileIndex) => (
+					<div className="grid gap-2 @2xl/main:grid-cols-2">
+						{Array.from({ length: 2 }).map((_, tileIndex) => (
 							<Skeleton key={tileIndex} className="h-[86px] w-full rounded-lg" />
 						))}
 					</div>

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -624,7 +624,7 @@ export async function runDeployFlow(
 					);
 				}
 				prompts.note(
-					"Saved AI providers could not be loaded. Continue with Managed by Clawdi or Configure inside agent.",
+					"Saved AI providers could not be loaded. Continue with Clawdi AI or Configure inside agent.",
 					"Saved providers unavailable",
 				);
 				return [];
@@ -676,7 +676,7 @@ export async function runDeployFlow(
 		const selected = await prompts.select(
 			"AI provider",
 			[
-				{ value: "managed", label: "Managed by Clawdi", hint: "Ready when the agent starts" },
+				{ value: "managed", label: "Clawdi AI", hint: "Ready when the agent starts" },
 				...savedProviders
 					.filter((provider) => provider.usable)
 					.map((provider) => ({
@@ -726,7 +726,7 @@ export async function runDeployFlow(
 	if (aiMode === "managed") {
 		if (managedModels.length === 0) {
 			throw new Error(
-				"The Hosted managed model catalog is empty. Retry later or use unmanaged AI.",
+				"The Clawdi AI model catalog is empty. Retry later or configure AI inside the agent.",
 			);
 		}
 		if (interactive && !parsed.model) {
@@ -1054,7 +1054,7 @@ export async function runDeployFlow(
 		`Runtime: ${hostedDeployRuntimeLabel(runtime)}`,
 		`AI: ${
 			aiMode === "managed"
-				? `Managed by Clawdi · ${model}`
+				? `Clawdi AI · ${model}`
 				: aiMode === "saved"
 					? `${selectedSavedProvider ? savedProviderLabel(selectedSavedProvider) : providerId} · ${model}`
 					: "Configure inside agent"

--- a/packages/cli/tests/commands/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy.test.ts
@@ -480,7 +480,7 @@ describe("deploy orchestration", () => {
 		expect(notes).toContainEqual({
 			title: "Saved providers unavailable",
 			message:
-				"Saved AI providers could not be loaded. Continue with Managed by Clawdi or Configure inside agent.",
+				"Saved AI providers could not be loaded. Continue with Clawdi AI or Configure inside agent.",
 		});
 		expect(JSON.stringify(notes)).not.toContain("secret upstream detail");
 	});


### PR DESCRIPTION
## Summary

- make Deploy card grids respond to the dashboard main pane instead of the browser viewport, preventing cramped two-column cards when the sidebar is open
- keep Catalog model, Name, Language, Timezone, and Billing term proportionate to their content
- make the action bar sticky across the full form and adapt its button/layout to available main-pane width
- place Clawdi AI first and standardize the user-facing product name across Web and CLI
- use the concise deploy copy: “No setup required. Usage draws from your Wallet.”

## Browser verification

Verified with hosted Playwright API stubs at 1280, 800, 700, and 390px:

- no horizontal overflow
- two columns only when the main pane can keep cards at least 300px wide
- one column with an expanded sidebar at 800px and on mobile
- compact Language select remains content-sized
- payment badges hide before they crowd card titles
- sticky action remains inside the viewport

## Automated verification

- Docker-isolated Web typecheck
- Docker-isolated focused Deploy tests: 27 passed
- Docker-isolated OSS production build
- full Docker-isolated Web suite passed in the implementation worktree
- hosted Playwright responsive and interaction regressions passed
- CLI typecheck and 34 focused CLI tests passed
- Biome and `git diff --check` passed

No production or tenant operations were performed.