### PR TITLE
fix(web): clarify deploy pricing and form copy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1290,6 +1290,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					balanceBeforeUsd,
 					balanceAfterUsd,
 				});
+			if (isStubResponse(response) && response.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
 				: fulfillJson(r, response);
@@ -2132,35 +2135,106 @@ test("deploy keeps AI providers expanded and provider selection exclusive", asyn
 	await expect(page.getByRole("button", { name: "Change", exact: true })).toHaveCount(0);
 });
 
-test("deploy sticky action shows free, monthly, and annual offer prices", async ({ page }) => {
+test("deploy cards and CTA-adjacent amount distinguish free, monthly, and annual prices", async ({
+	page,
+}) => {
 	await page.setViewportSize({ width: 390, height: 844 });
 	await stubHostedApi(page, { plans: [basicPlan, performancePlan], deployments: [] });
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
 	const actionBar = page.getByTestId("deploy-action-bar");
-	const priceLabel = actionBar.getByTestId("deploy-price-label");
-	await expect(priceLabel).toHaveText("Free");
+	const amount = actionBar.getByTestId("deploy-amount");
+	await expect(amount).toHaveText("Free");
+	await expect(actionBar.getByRole("button", { name: "Deploy" })).toBeVisible();
 
 	const performanceChoice = page.getByRole("button", { name: /^Performance/ });
 	await performanceChoice.click();
-	await expect(priceLabel).toHaveText("$20.00/mo");
-	await expect(performanceChoice).toContainText("4 vCPU / 8 GB · $20.00/mo");
+	const computePrice = page.getByTestId("performance-compute-price");
+	await expect(computePrice).toContainText("$20.00/mo");
+	await expect(computePrice).toContainText("Billed monthly");
+	await expect(performanceChoice).toContainText("4 vCPU / 8 GB");
+	await expect(amount).toContainText("$20.00/mo");
+	await expect(amount).toContainText("Billed monthly");
+	await expect(actionBar.getByRole("button", { name: "Continue to checkout" })).toBeVisible();
 
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
-	await expect(priceLabel).toHaveText("$16.66/mo, billed $200.00/yr");
-	await expect(performanceChoice).toContainText("4 vCPU / 8 GB · $16.66/mo, billed $200.00/yr");
+	await expect(computePrice).toContainText("$16.66/mo");
+	await expect(computePrice.locator(".line-through")).toHaveText("$20.00/mo");
+	await expect(computePrice).toContainText("Billed $200.00 yearly · save $40.00");
+	await expect(amount).toContainText("$200.00/yr");
+	await expect(amount).toContainText("$16.66/mo, billed annually");
 
-	const priceMetrics = await priceLabel.evaluate((element) => ({
+	const amountMetrics = await amount.evaluate((element) => ({
 		clientWidth: element.clientWidth,
 		scrollWidth: element.scrollWidth,
 	}));
-	expect(priceMetrics.scrollWidth).toBeLessThanOrEqual(priceMetrics.clientWidth);
+	expect(amountMetrics.scrollWidth).toBeLessThanOrEqual(amountMetrics.clientWidth);
 	const pageMetrics = await page.evaluate(() => ({
 		clientWidth: document.documentElement.clientWidth,
 		scrollWidth: document.documentElement.scrollWidth,
 	}));
 	expect(pageMetrics.scrollWidth).toBe(pageMetrics.clientWidth);
+});
+
+test("deploy CTA-adjacent Wallet amount handles loading, retry, and insufficient balance", async ({
+	page,
+}) => {
+	const delayedQuote = walletSubscriptionQuote({
+		planSlug: "compute_basic",
+		billingTermMonths: 1,
+		termPriceCents: 1_000,
+		debitAmountUsd: "10.00",
+		balanceBeforeUsd: "25.00",
+		balanceAfterUsd: "15.00",
+	});
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan],
+		subscriptionQuoteResponses: [{ status: 200, body: delayedQuote, delayMs: 700 }],
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+
+	const amount = page.getByTestId("deploy-amount");
+	await expect(amount).toContainText("Debit today: —");
+	await expect(amount).toContainText("Getting quote…");
+	await expect(page.getByRole("button", { name: "Pay & deploy" })).toBeDisabled();
+	await expect(amount).toContainText("Debit today: $10.00");
+	await expect(amount).toContainText("From Wallet · renews monthly");
+	await expect(page.getByRole("button", { name: "Pay & deploy" })).toBeEnabled();
+
+	await page.unrouteAll({ behavior: "wait" });
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan],
+		subscriptionQuoteResponses: [
+			{ status: 400, body: { detail: "quote unavailable" } },
+			delayedQuote,
+		],
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+	await expect(amount).toContainText("Quote unavailable");
+	await expect(page.getByRole("button", { name: "Pay & deploy" })).toBeDisabled();
+	await amount.getByRole("button", { name: "Retry" }).click();
+	await expect(amount).toContainText("Debit today: $10.00");
+
+	await page.unrouteAll({ behavior: "wait" });
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan],
+		walletState: { ...walletState, balance_usd: "5.00" },
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+	await expect(amount).toContainText("Debit today: $10.00");
+	await expect(amount).toContainText("Available $5.00 · short $5.00");
+	const topUp = page.getByRole("button", { name: "Top up Wallet", exact: true });
+	await expect(topUp).toHaveCount(1);
+	await expect(topUp).toBeEnabled();
+	await topUp.click();
+	await expect(page.getByRole("dialog").filter({ hasText: "Top up Wallet" })).toBeVisible();
 });
 
 test("deploy form stays readable without stretching compact controls", async ({ page }) => {
@@ -2242,12 +2316,15 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 				timezone: rect(document.querySelector("#agent-timezone")),
 				billingTerm: rect(document.querySelector('[aria-label="Billing term"]')),
 				action: rect(document.querySelector('button[type="submit"]')),
-				price: (() => {
-					const element = document.querySelector('[data-testid="deploy-price-label"]');
+				amount: (() => {
+					const element = document.querySelector('[data-testid="deploy-amount"]');
+					const primary = element?.querySelector("span.font-semibold");
 					return element
 						? {
-								clientWidth: element.clientWidth,
-								scrollWidth: element.scrollWidth,
+								rect: rect(element),
+								primaryClientWidth: primary?.clientWidth ?? 0,
+								primaryScrollWidth: primary?.scrollWidth ?? 0,
+								primaryText: primary?.textContent,
 								text: element.textContent,
 							}
 						: null;
@@ -2312,18 +2389,36 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 		expect(metrics.action?.bottom, `${viewport.name} sticky action bottom`).toBeLessThanOrEqual(
 			viewport.height,
 		);
-		expect(metrics.price?.text, `${viewport.name} sticky annual price`).toBe(
-			"$16.66/mo, billed $200.00/yr",
+		expect(metrics.amount?.primaryText, `${viewport.name} sticky annual amount`).toBe("$200.00/yr");
+		expect(metrics.amount?.text, `${viewport.name} sticky annual caption`).toContain(
+			"$16.66/mo, billed annually",
 		);
 		expect(
-			metrics.price?.scrollWidth,
-			`${viewport.name} sticky price should not truncate`,
-		).toBeLessThanOrEqual(metrics.price?.clientWidth ?? 0);
+			metrics.amount?.primaryScrollWidth,
+			`${viewport.name} sticky amount should not truncate`,
+		).toBeLessThanOrEqual(metrics.amount?.primaryClientWidth ?? 0);
+		expect(metrics.amount?.rect?.right, `${viewport.name} amount right edge`).toBeLessThanOrEqual(
+			viewport.width,
+		);
 		if (viewport.columns === 1) {
 			expect(metrics.action?.width, `${viewport.name} full-width action`).toBeCloseTo(
 				metrics.compute?.rect?.width ?? 0,
 				0,
 			);
+			expect(metrics.amount?.rect?.bottom, `${viewport.name} amount above CTA`).toBeLessThanOrEqual(
+				metrics.action?.top ?? 0,
+			);
+		} else {
+			expect(metrics.amount?.rect?.right, `${viewport.name} amount beside CTA`).toBeLessThanOrEqual(
+				metrics.action?.left ?? 0,
+			);
+		}
+		if (viewport.width === 1_280 || viewport.width === 390) {
+			await page.getByRole("button", { name: /^Performance/ }).scrollIntoViewIfNeeded();
+			await page.waitForTimeout(100);
+			await page.screenshot({
+				path: `/tmp/deploy-pricing-${viewport.width}.png`,
+			});
 		}
 	}
 });
@@ -2368,7 +2463,7 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 	});
 	await page.goto("/deploy");
 
-	await page.getByRole("button", { name: "Deploy agent" }).click();
+	await page.getByRole("button", { name: "Deploy", exact: true }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
 	await expect.poll(() => deploymentListRequests.length).toBeGreaterThanOrEqual(2);
 	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
@@ -2634,7 +2729,7 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 	// therefore precedes teardown rather than waiting for a completed list read.
 	expect(completedDeleteIds.has("hdep_included")).toBe(false);
 	await page.goto("/deploy");
-	await expect(page.getByRole("button", { name: "Deploy agent", exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Deploy", exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Continue to checkout" })).toHaveCount(0);
 	expect(completedDeleteIds.has("hdep_included")).toBe(false);
 
@@ -2695,7 +2790,7 @@ test("managed model picker lists the curated catalog without Custom or image mod
 	await expect(page.getByRole("option", { name: /gpt-image/i })).toHaveCount(0);
 
 	await page.getByRole("option", { name: "Sol", exact: true }).click();
-	await page.getByRole("button", { name: "Deploy agent" }).click();
+	await page.getByRole("button", { name: "Deploy", exact: true }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
 
 	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
@@ -2715,10 +2810,11 @@ test("Basic paid checkout stays hidden until deployment inventory succeeds", asy
 	await expect(page.getByText("Checking your free Basic slot…", { exact: true })).toBeVisible();
 	await expect(page.getByText("$10.00/mo", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Continue to checkout" })).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Deploy agent" })).toBeDisabled();
+	await expect(page.getByRole("button", { name: "Deploy", exact: true })).toBeDisabled();
 
-	await expect(page.getByText("First Basic agent — Free", { exact: false })).toBeVisible();
-	await expect(page.getByRole("button", { name: "Deploy agent" })).toBeEnabled();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("Free");
+	await expect(page.getByTestId("basic-compute-price")).toContainText("First Basic agent");
+	await expect(page.getByRole("button", { name: "Deploy", exact: true })).toBeEnabled();
 });
 
 test("empty plans and wallet failures expose working retries", async ({ page }) => {
@@ -2745,12 +2841,11 @@ test("empty plans and wallet failures expose working retries", async ({ page }) 
 	await page.goto("/deploy");
 	await page.getByRole("button", { name: /Wallet balance/ }).click();
 
-	const walletError = page
-		.getByRole("alert")
-		.filter({ hasText: "Couldn't load your Wallet balance" });
-	await expect(walletError).toBeVisible();
-	await walletError.getByRole("button", { name: "Retry" }).click();
-	await expect(page.getByTestId("wallet-debit-equation")).toBeVisible();
+	const amount = page.getByTestId("deploy-amount");
+	await expect(amount).toContainText("Quote unavailable");
+	await amount.getByRole("button", { name: "Retry" }).click();
+	await expect(amount).toContainText("Debit today: $10.00");
+	await expect(page.getByRole("button", { name: "Pay & deploy" })).toBeEnabled();
 	await expect.poll(() => walletRequests.length).toBe(2);
 });
 
@@ -3438,8 +3533,8 @@ test("Basic create always follows the wizard-selected funding path", async ({ pa
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
-	await expect(page.getByText(/2 vCPU \/ 4 GB · \$10\.00\/mo/)).toBeVisible();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("$10.00/mo");
+	await expect(page.getByRole("button", { name: /^Basic/ })).toContainText("2 vCPU / 4 GB");
 	await expectNoQuarterlyCopy(page);
 	await capturePricingScreenshot(page, "/tmp/basic-paid-funded-slot-available-final.png");
 
@@ -3508,7 +3603,7 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("$10.00/mo");
 	await expect(page.getByText("Monthly", { exact: true })).toBeVisible();
 	const annualTerm = page.getByRole("button", { name: /Annual.*%/ });
 	await expect(annualTerm).toBeVisible();
@@ -3516,10 +3611,11 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await annualTerm.click();
 	await expect(page.getByText("Wallet balance", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /Wallet balance/ })).toBeVisible();
-	await expect(page.getByText(/2 vCPU \/ 4 GB · \$8\.33\/mo, billed \$100\.00\/yr/)).toBeVisible();
-	await expect(
-		page.getByText(/this Basic agent at \$8\.33\/mo, billed \$100\.00\/yr/),
-	).toBeVisible();
+	const basicPrice = page.getByTestId("basic-compute-price");
+	await expect(basicPrice).toContainText("$8.33/mo");
+	await expect(basicPrice.locator(".line-through")).toHaveText("$10.00/mo");
+	await expect(basicPrice).toContainText("Billed $100.00 yearly · save $20.00");
+	await expect(page.getByTestId("deploy-amount")).toContainText("$100.00/yr");
 	await capturePricingScreenshot(page, "/tmp/basic-free-funded-slot-occupied-final.png");
 
 	await page.getByRole("button", { name: "Continue to checkout" }).click();
@@ -3576,20 +3672,16 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
-	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("$10.00/mo");
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
-	await expect(page.getByText(/2 vCPU \/ 4 GB · \$8\.33\/mo, billed \$100\.00\/yr/)).toBeVisible();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("$8.33/mo");
 	await page.getByRole("button", { name: /Wallet balance/ }).click();
 	await expect.poll(() => subscriptionQuoteRequests.length).toBe(1);
-	const equation = page.getByTestId("wallet-debit-equation");
-	await expect(equation).toContainText("Balance before");
-	await expect(equation).toContainText("$100.00");
-	await expect(equation).toContainText("Exact debit");
-	await expect(equation).toContainText("$100.00");
-	await expect(equation).toContainText("Balance after");
-	await expect(equation).toContainText("$0.00");
+	const walletAmount = page.getByTestId("deploy-amount");
+	await expect(walletAmount).toContainText("Debit today: $100.00");
+	await expect(walletAmount).toContainText("From Wallet · renews yearly");
 
-	await page.getByRole("button", { name: "Pay $100.00 from Wallet & deploy" }).click();
+	await page.getByRole("button", { name: "Pay & deploy" }).click();
 	const accepting = page.getByRole("button", { name: "Confirming payment & creating agent…" });
 	await expect(accepting).toBeDisabled();
 	await page.evaluate(() => window.dispatchEvent(new Event("focus")));
@@ -4332,7 +4424,7 @@ test("paid Basic checkout abandonment preserves the checkout-ready wizard", asyn
 
 	await expect(page.getByText("Checkout canceled", { exact: true })).toBeVisible();
 	await expect(page.getByText("You were not charged. Your agent was not deployed.")).toBeVisible();
-	await expect(page.getByText("$10.00/mo", { exact: true })).toBeVisible();
+	await expect(page.getByTestId("basic-compute-price")).toContainText("$10.00/mo");
 	await expect(page.getByRole("button", { name: "Continue to checkout" })).toBeVisible();
 	await expect(page.getByText("First slot free", { exact: true })).toHaveCount(0);
 	expect(checkoutRequests).toEqual([]);

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -370,6 +370,7 @@ export function EntityChoiceCard({
 	icon,
 	title,
 	description,
+	details,
 	badge,
 	selected,
 	onClick,
@@ -379,6 +380,8 @@ export function EntityChoiceCard({
 	icon: ReactNode;
 	title: ReactNode;
 	description?: ReactNode;
+	/** Optional detail block below the description (for example, pricing). */
+	details?: ReactNode;
 	/** Trailing badge in the title row (e.g. "Default", an auth chip). */
 	badge?: ReactNode;
 	selected?: boolean;
@@ -397,6 +400,7 @@ export function EntityChoiceCard({
 				{description ? (
 					<p className="mt-0.5 break-words text-sm text-muted-foreground">{description}</p>
 				) : null}
+				{details ? <div className="mt-2">{details}</div> : null}
 			</div>
 			{selected ? <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden /> : null}
 		</>

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -239,7 +239,7 @@ describe("hosted agent customer language", () => {
 		}
 		expect(detailSource).toContain("Starting your agent…");
 		expect(detailSource).toContain("Your agent is running");
-		expect(wizardSource).toContain("After your agent is running");
+		expect(wizardSource).not.toContain("After your agent is running");
 	});
 
 	test("keeps delayed and unavailable states honest without implementation vocabulary", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -110,8 +110,10 @@ import type {
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
 import {
+	fallbackTimezones,
 	LANGUAGE_OPTIONS,
 	LANGUAGE_SELECT_ITEMS,
+	mergeTimezoneOptions,
 	normalizeHostedLanguage,
 	supportedTimezones,
 	TimezoneCombobox,
@@ -2990,15 +2992,21 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 	const [syncedLocaleIdentity, setSyncedLocaleIdentity] = useState(localeIdentity);
 	const [language, setLanguage] = useState(configLanguage);
 	const [timezone, setTimezone] = useState(configTimezone);
+	const [runtimeTimezoneOptions, setRuntimeTimezoneOptions] = useState(() =>
+		fallbackTimezones(configTimezone ? [configTimezone] : []),
+	);
 	if (syncedLocaleIdentity !== localeIdentity) {
 		setSyncedLocaleIdentity(localeIdentity);
 		setLanguage(configLanguage);
 		setTimezone(configTimezone);
 	}
-	const timezoneOptions = useMemo(() => {
-		const options = supportedTimezones();
-		return timezone && !options.includes(timezone) ? [timezone, ...options] : options;
-	}, [timezone]);
+	useEffect(() => {
+		setRuntimeTimezoneOptions(supportedTimezones(configTimezone ? [configTimezone] : []));
+	}, [configTimezone]);
+	const timezoneOptions = useMemo(
+		() => mergeTimezoneOptions(runtimeTimezoneOptions, [configTimezone, timezone].filter(Boolean)),
+		[configTimezone, runtimeTimezoneOptions, timezone],
+	);
 	const dirty = language !== configLanguage || timezone !== configTimezone;
 
 	return (

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { BillingOffer } from "@/hosted/billing/contracts";
+import {
+	cardDeployAmountPresentation,
+	computePricePresentation,
+	walletDeployAmountPresentation,
+} from "@/hosted/billing/deploy/deploy-price-presentation";
+
+const monthly: BillingOffer = {
+	billing_term_months: 1,
+	price_cents: 2_000,
+	effective_monthly_price_cents: 2_000,
+	discount_percent: 0,
+};
+const annual: BillingOffer = {
+	billing_term_months: 12,
+	price_cents: 20_000,
+	effective_monthly_price_cents: 1_666,
+	discount_percent: 17,
+};
+
+describe("computePricePresentation", () => {
+	test("makes monthly and annual pricing visibly distinct", () => {
+		expect(computePricePresentation(monthly, [monthly, annual])).toEqual({
+			primary: "$20.00/mo",
+			comparison: null,
+			secondary: "Billed monthly",
+		});
+		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
+			primary: "$16.66/mo",
+			comparison: "$20.00/mo",
+			secondary: "Billed $200.00 yearly · save $40.00",
+		});
+	});
+
+	test("omits comparison and savings when a monthly offer is missing", () => {
+		expect(computePricePresentation(annual, [annual])).toEqual({
+			primary: "$16.66/mo",
+			comparison: null,
+			secondary: "Billed $200.00 yearly",
+		});
+	});
+});
+
+describe("CTA-adjacent amount presentation", () => {
+	test("uses term price for card checkout and authoritative debit for Wallet", () => {
+		expect(cardDeployAmountPresentation(monthly)).toEqual({
+			amount: "$20.00/mo",
+			caption: "Billed monthly",
+			detail: null,
+		});
+		expect(cardDeployAmountPresentation(annual)).toEqual({
+			amount: "$200.00/yr",
+			caption: "$16.66/mo, billed annually",
+			detail: null,
+		});
+		expect(
+			walletDeployAmountPresentation({
+				billingTermMonths: 12,
+				state: "ready",
+				walletDebit: {
+					balanceBeforeUsd: "100.00",
+					debitAmountUsd: "100.00",
+					balanceAfterUsd: "0.00",
+				},
+			}),
+		).toEqual({
+			amount: "Debit today: $100.00",
+			caption: "From Wallet · renews yearly",
+			detail: null,
+		});
+	});
+
+	test("covers loading, error, and insufficient Wallet states without inventing a debit", () => {
+		expect(
+			walletDeployAmountPresentation({
+				billingTermMonths: 1,
+				state: "loading",
+				walletDebit: null,
+			}),
+		).toEqual({ amount: "Debit today: —", caption: "Getting quote…", detail: null });
+		expect(
+			walletDeployAmountPresentation({
+				billingTermMonths: 1,
+				state: "error",
+				walletDebit: null,
+			}),
+		).toEqual({ amount: "Quote unavailable", caption: null, detail: null });
+		expect(
+			walletDeployAmountPresentation({
+				billingTermMonths: 1,
+				state: "ready",
+				walletDebit: {
+					balanceBeforeUsd: "12.50",
+					debitAmountUsd: "20.00",
+					balanceAfterUsd: "-7.50",
+				},
+			}),
+		).toEqual({
+			amount: "Debit today: $20.00",
+			caption: "From Wallet · renews monthly",
+			detail: "Available $12.50 · short $7.50",
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -1,0 +1,110 @@
+import type { BillingOffer } from "@/hosted/billing/contracts";
+import {
+	billingTermLabel,
+	billingTermSuffix,
+	formatCents,
+	formatUsd,
+	formatUsdExact,
+} from "@/hosted/billing/format";
+import type { WalletDebitSummary } from "@/hosted/billing/wallet/wallet-debit-summary";
+import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-summary";
+
+export type ComputePricePresentation = {
+	primary: string;
+	comparison: string | null;
+	secondary: string;
+};
+
+export type DeployAmountPresentation = {
+	amount: string;
+	caption: string | null;
+	detail: string | null;
+};
+
+function monthlyPrice(offer: BillingOffer): string {
+	return `${formatCents(offer.effective_monthly_price_cents)}/mo`;
+}
+
+export function computePricePresentation(
+	offer: BillingOffer,
+	offers: readonly BillingOffer[],
+): ComputePricePresentation {
+	if (offer.billing_term_months === 1) {
+		return {
+			primary: monthlyPrice(offer),
+			comparison: null,
+			secondary: "Billed monthly",
+		};
+	}
+
+	const monthlyOffer = offers.find((candidate) => candidate.billing_term_months === 1);
+	const comparisonIsCheaper =
+		monthlyOffer !== undefined &&
+		offer.effective_monthly_price_cents < monthlyOffer.effective_monthly_price_cents;
+	const undiscountedTermPrice = monthlyOffer
+		? monthlyOffer.price_cents * offer.billing_term_months
+		: null;
+	const savingsCents =
+		comparisonIsCheaper && undiscountedTermPrice !== null
+			? undiscountedTermPrice - offer.price_cents
+			: 0;
+	const billed =
+		offer.billing_term_months === 12
+			? `Billed ${formatCents(offer.price_cents)} yearly`
+			: `Billed ${formatCents(offer.price_cents)} every ${offer.billing_term_months} months`;
+
+	return {
+		primary: monthlyPrice(offer),
+		comparison: comparisonIsCheaper ? monthlyPrice(monthlyOffer) : null,
+		secondary: savingsCents > 0 ? `${billed} · save ${formatCents(savingsCents)}` : billed,
+	};
+}
+
+export function cardDeployAmountPresentation(offer: BillingOffer): DeployAmountPresentation {
+	if (offer.billing_term_months === 1) {
+		return {
+			amount: `${formatCents(offer.price_cents)}/mo`,
+			caption: "Billed monthly",
+			detail: null,
+		};
+	}
+	if (offer.billing_term_months === 12) {
+		return {
+			amount: `${formatCents(offer.price_cents)}/yr`,
+			caption: `${monthlyPrice(offer)}, billed annually`,
+			detail: null,
+		};
+	}
+	return {
+		amount: `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`,
+		caption: `${monthlyPrice(offer)}, billed ${billingTermLabel(offer.billing_term_months).toLowerCase()}`,
+		detail: null,
+	};
+}
+
+export function walletDeployAmountPresentation({
+	billingTermMonths,
+	state,
+	walletDebit,
+}: {
+	billingTermMonths: number;
+	state: "loading" | "error" | "ready";
+	walletDebit: WalletDebitSummary | null;
+}): DeployAmountPresentation {
+	if (state === "error") {
+		return { amount: "Quote unavailable", caption: null, detail: null };
+	}
+	if (state === "loading" || !walletDebit) {
+		return { amount: "Debit today: —", caption: "Getting quote…", detail: null };
+	}
+
+	const shortfallUsd = walletDebitShortfallUsd(walletDebit);
+	return {
+		amount: `Debit today: ${formatUsdExact(walletDebit.debitAmountUsd)}`,
+		caption: `From Wallet · renews ${billingTermMonths === 12 ? "yearly" : "monthly"}`,
+		detail:
+			shortfallUsd === null
+				? null
+				: `Available ${formatUsdExact(walletDebit.balanceBeforeUsd)} · short ${formatUsd(shortfallUsd)}`,
+	};
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -65,21 +65,22 @@ describe("deploy wizard personalization", () => {
 		expect(
 			validateHostedDeployPersona({ assistantName: "", language: "en", timezone: "Etc/UTC" }),
 		).toContainEqual({ field: "assistantName", message: "Enter a name for this agent." });
-		expect(wizardSource).toContain("Used to identify this agent in Clawdi.");
+		expect(wizardSource).not.toContain("Used to identify this agent in Clawdi.");
 		expect(wizardSource).toContain("runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME)");
 		expect(wizardSource).toContain("assistantNameEditedRef");
 		expect(wizardSource).toContain("deployAssistantNameAfterRuntimeChange");
 		expect(wizardSource).toContain("required");
 		expect(wizardSource).toContain("aria-invalid={nameError ? true : undefined}");
 		expect(wizardSource).toContain('"agent-name-error agent-name-count"');
-		expect(wizardSource).toContain('"agent-name-help agent-name-count"');
+		expect(wizardSource).not.toContain("agent-name-help");
 		expect(wizardSource).toContain('id="agent-name-count"');
+		expect(wizardSource).toContain("showNameCount");
 		expect(wizardSource).toContain("nameLimitReached");
 		expect(wizardSource).toContain('className="sr-only" role="status" aria-live="polite"');
 		expect(wizardSource).toContain('aria-live="polite"');
 		expect(wizardSource).toContain('" — limit reached."');
 		expect(wizardSource).toContain("Name limit reached. You can enter up to");
-		expect(wizardSource).toContain('type="submit"');
+		expect(wizardSource).toContain('type={walletTopUpAction ? "button" : "submit"}');
 		expect(wizardSource).toContain("submitBlockingReason");
 	});
 });
@@ -109,8 +110,10 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource).not.toContain("sm:sticky sm:bottom-0");
 	});
 
-	test("hides wide payment badges before they would crowd card titles", () => {
-		expect(wizardSource.match(/hidden @3xl\/main:inline-flex/g)).toHaveLength(2);
+	test("removes redundant payment badges and keeps concise funding copy", () => {
+		expect(wizardSource).not.toContain("hidden @3xl/main:inline-flex");
+		expect(wizardSource).toContain("Recurring subscription via Stripe. Manage or cancel anytime.");
+		expect(wizardSource).toContain("Paid upfront from your Wallet balance. Renews from Wallet.");
 	});
 });
 
@@ -118,8 +121,13 @@ describe("deploy wizard product copy and flow", () => {
 	test("uses customer language and keeps channels out of the decision flow", () => {
 		expect(wizardSource).toContain('title="Agent software"');
 		expect(wizardSource).toContain("<DeploySectionSkeleton columns={2} />");
-		expect(wizardSource).toContain('description="Choose a compute plan and how paid plans renew."');
-		expect(wizardSource).toContain("After your agent is running, connect channels from its page.");
+		expect(wizardSource).not.toContain(
+			'description="Choose a compute plan and how paid plans renew."',
+		);
+		expect(wizardSource).not.toContain(
+			"After your agent is running, connect channels from its page.",
+		);
+		expect(wizardSource).not.toContain("No AI provider will be selected for you.");
 		expect(wizardSource).not.toContain('title="Runtimes"');
 		expect(wizardSource).not.toContain("execution engine");
 		expect(wizardSource).not.toContain("per-deployment funding");
@@ -188,9 +196,9 @@ describe("plan-change copy", () => {
 
 describe("first Basic agent copy", () => {
 	test("describes the first Basic agent as free instead of included", () => {
-		expect(wizardSource).toContain("First Basic agent — Free");
-		expect(wizardSource).toContain('message: "Your first Basic agent is free.');
-		expect(wizardSource).toContain('? "Free"');
+		expect(wizardSource).toContain('primary: "Free"');
+		expect(wizardSource).toContain('secondary: "First Basic agent"');
+		expect(wizardSource).not.toContain("Your first Basic agent is free.");
 		expect(wizardSource).not.toContain("included Basic slot");
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
@@ -252,7 +260,8 @@ describe("managed model picker", () => {
 
 describe("deploy provider choice", () => {
 	test("shows every provider choice in the expanded form", () => {
-		expect(wizardSource).toContain(
+		expect(wizardSource).toContain('<SettingsSection title="AI providers">');
+		expect(wizardSource).not.toContain(
 			'description="Choose how your agent accesses AI models and select its primary model."',
 		);
 		expect(wizardSource).toContain('title="Add a provider"');
@@ -303,8 +312,9 @@ describe("billing-read gates", () => {
 		expect(wizardSource).toContain('title="Couldn\'t check existing agents"');
 		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
-		expect(wizardSource).toContain('title="Couldn\'t load your Wallet balance"');
-		expect(wizardSource).toContain("onRetry={() => void wallet.refetch()}");
+		expect(wizardSource).toContain("async function retryWalletQuote()");
+		expect(wizardSource).toContain('toast.error("Couldn’t refresh Wallet quote"');
+		expect(wizardSource).toContain("onClick={() => void retryWalletQuote()}");
 	});
 });
 
@@ -318,7 +328,11 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain(
 			"submitting || lastSuccessfulSubscriptionQuote ? null : subscriptionCreateQuote.error;",
 		);
-		expect(wizardSource).not.toContain("await subscriptionCreateQuote.refetch()");
+		const onDeploySource = wizardSource.slice(
+			wizardSource.indexOf("async function onDeploy()"),
+			wizardSource.indexOf("const deployLabel"),
+		);
+		expect(onDeploySource).not.toContain("await subscriptionCreateQuote.refetch()");
 		expect(wizardSource).not.toContain("subscription-checkout-hosted-fallback");
 		expect(wizardSource).not.toContain("checkoutSessionId");
 		expect(wizardSource).not.toContain("subscriptionHostedFallbackRequest");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -54,7 +54,6 @@ import {
 	type StripeCheckoutSummary,
 } from "@/hosted/billing/components/stripe-checkout-dialog";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
-import { WalletDebitEquation } from "@/hosted/billing/components/wallet-debit-equation";
 import type {
 	BillingOffer,
 	ComputePlanSlug,
@@ -75,6 +74,12 @@ import {
 	usesActiveIncludedBasicSlot,
 } from "@/hosted/billing/deploy/deploy-model";
 import {
+	type ComputePricePresentation,
+	cardDeployAmountPresentation,
+	computePricePresentation,
+	walletDeployAmountPresentation,
+} from "@/hosted/billing/deploy/deploy-price-presentation";
+import {
 	buildHostedDeployRequest,
 	DEPLOY_ASSISTANT_NAME_MAX_LENGTH,
 	type DeployAiFields,
@@ -82,8 +87,10 @@ import {
 import {
 	browserLanguage,
 	browserTimezone,
+	fallbackTimezones,
 	LANGUAGE_OPTIONS,
 	LANGUAGE_SELECT_ITEMS,
+	mergeTimezoneOptions,
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
@@ -94,12 +101,7 @@ import {
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
-import {
-	billingTermLabel,
-	billingTermSuffix,
-	formatCents,
-	formatUsdExact,
-} from "@/hosted/billing/format";
+import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
 import {
 	useCheckoutReturnRefresh,
 	useHostedDeployments,
@@ -252,35 +254,29 @@ function computeCheckoutSummary({
 	};
 }
 
-function recurringOfferLabel(offer: BillingOffer): string {
-	const monthly = `${formatCents(offer.effective_monthly_price_cents)}/mo`;
-	return offer.billing_term_months === 1
-		? monthly
-		: `${monthly}, billed ${formatCents(offer.price_cents)}${billingTermSuffix(
-				offer.billing_term_months,
-			)}`;
-}
-
-interface ComputeStatusInput {
-	compute: Compute;
-	basicSelection: ReturnType<typeof resolveBasicDeploySelection>;
-	basicOffer: BillingOffer | null;
-	perfOffer: BillingOffer | null;
-	paymentMethod: DeployPaymentMethod;
-}
-
-function ComputeStatusLine(input: ComputeStatusInput) {
-	const status = computeStatusLine(input);
-	if (!status) return null;
+function ComputePriceBlock({
+	presentation,
+	testId,
+}: {
+	presentation: ComputePricePresentation;
+	testId: string;
+}) {
 	return (
-		<p
-			className={cn(
-				"text-xs",
-				status.tone === "destructive" ? "text-destructive" : "text-muted-foreground",
-			)}
-		>
-			{status.message}
-		</p>
+		<div data-testid={testId} className="flex min-w-0 flex-col items-end text-right tabular-nums">
+			<div className="flex flex-wrap items-baseline justify-end gap-x-1.5">
+				<span className="whitespace-nowrap text-base font-semibold text-foreground">
+					{presentation.primary}
+				</span>
+				{presentation.comparison ? (
+					<span className="whitespace-nowrap text-xs text-muted-foreground line-through">
+						{presentation.comparison}
+					</span>
+				) : null}
+			</div>
+			<span className="whitespace-nowrap text-xs font-normal text-muted-foreground">
+				{presentation.secondary}
+			</span>
+		</div>
 	);
 }
 
@@ -300,64 +296,6 @@ function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
 			</div>
 		</section>
 	);
-}
-
-function computeStatusLine({
-	compute,
-	basicSelection,
-	basicOffer,
-	perfOffer,
-	paymentMethod,
-}: ComputeStatusInput): { message: string; tone: "destructive" | "muted" } | null {
-	if (compute === "basic") {
-		if (basicSelection.mode === "unavailable") {
-			if (basicSelection.reason === "inventory_unavailable") return null;
-			return {
-				tone: "destructive",
-				message:
-					basicSelection.reason === "offers_missing"
-						? "Paid Basic checkout isn’t available from the billing service. Retry plans or choose Performance."
-						: "The Basic plan isn’t available from the billing service. Retry plans before deploying.",
-			};
-		}
-		if (basicSelection.mode === "included") {
-			return {
-				tone: "muted",
-				message: "Your first Basic agent is free. No compute subscription is required.",
-			};
-		}
-		if (basicOffer) {
-			return {
-				tone: "muted",
-				message:
-					paymentMethod === "wallet"
-						? `Wallet funds this Basic agent at ${recurringOfferLabel(basicOffer)}.`
-						: `Checkout opens here for this Basic agent at ${recurringOfferLabel(basicOffer)}.`,
-			};
-		}
-		return null;
-	}
-	if (paymentMethod === "wallet") {
-		return {
-			tone: "muted",
-			message: "Wallet charges the exact amount shown now and renews on the selected billing term.",
-		};
-	}
-
-	if (perfOffer && perfOffer.billing_term_months !== 1) {
-		return {
-			tone: "muted",
-			message: `Checkout opens here. Billed ${formatCents(
-				perfOffer.price_cents,
-			)}${billingTermSuffix(
-				perfOffer.billing_term_months,
-			)}; each Performance agent uses its own subscription.`,
-		};
-	}
-	return {
-		tone: "muted",
-		message: "Checkout opens here. Each Performance agent uses its own subscription.",
-	};
 }
 
 export function DeployWizard() {
@@ -404,6 +342,7 @@ export function DeployWizard() {
 	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
+	const [timezoneOptions, setTimezoneOptions] = useState(fallbackTimezones);
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
@@ -417,10 +356,12 @@ export function DeployWizard() {
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
 	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
 
-	// Default language + timezone to the browser's after mount (avoids an SSR
-	// mismatch). Both stay explicitly unsettable back to the runtime default.
+	// Keep the first client render on the same deterministic fallback as SSR,
+	// then adopt runtime IANA data and best-effort browser defaults after mount.
 	useEffect(() => {
-		setTimezone((tz) => tz || browserTimezone());
+		const browserTimezoneValue = browserTimezone();
+		setTimezone((current) => current || browserTimezoneValue);
+		setTimezoneOptions(supportedTimezones(browserTimezoneValue ? [browserTimezoneValue] : []));
 		setLanguage((lang) => lang || browserLanguage());
 	}, []);
 	useEffect(() => {
@@ -429,10 +370,8 @@ export function DeployWizard() {
 		return () => window.clearTimeout(timeout);
 	}, [submitting]);
 	const tzOptions = useMemo(() => {
-		const all = supportedTimezones();
-		if (timezone && !all.includes(timezone)) return [timezone, ...all];
-		return all;
-	}, [timezone]);
+		return mergeTimezoneOptions(timezoneOptions, timezone ? [timezone] : []);
+	}, [timezone, timezoneOptions]);
 
 	const basicPlan = resolveBasicPlan(plans.data);
 	const perfPlan = resolvePerformancePlan(plans.data);
@@ -463,6 +402,10 @@ export function DeployWizard() {
 	const perfBillingTermMonths = perfOfferSelection?.billingTermMonths ?? term;
 	const basicOffers = basicPlan ? explicitPlanOffers(basicPlan) : [];
 	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
+	const basicPricePresentation = basicOffer
+		? computePricePresentation(basicOffer, basicOffers)
+		: null;
+	const perfPricePresentation = perfOffer ? computePricePresentation(perfOffer, perfOffers) : null;
 	const paidSelection: PaidDeploySelection | null = !deployments.isSuccess
 		? null
 		: compute === "performance" && perfPlan && perfOfferSelection
@@ -507,6 +450,12 @@ export function DeployWizard() {
 	const walletDebit = lastSuccessfulSubscriptionQuote?.walletDebit ?? null;
 	const walletShortfallUsd = walletDebitShortfallUsd(walletDebit);
 	const walletInsufficient = walletShortfallUsd !== null;
+	const walletQuoteState =
+		(!wallet.data && wallet.error) || visibleSubscriptionQuoteError
+			? "error"
+			: walletDebit
+				? "ready"
+				: "loading";
 	const basicUnavailable = basicSelection.mode === "unavailable";
 
 	const providerList = usableProviders(aiProviders.data ?? []);
@@ -549,6 +498,7 @@ export function DeployWizard() {
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
 	const trimmedAssistantName = assistantName.trim();
 	const nameLimitReached = assistantName.length >= DEPLOY_ASSISTANT_NAME_MAX_LENGTH;
+	const showNameCount = assistantName.length >= DEPLOY_ASSISTANT_NAME_MAX_LENGTH - 10;
 	const personaIssues = validateHostedDeployPersona({
 		assistantName: trimmedAssistantName,
 		language,
@@ -556,6 +506,13 @@ export function DeployWizard() {
 	});
 	const nameError = personaIssues.find((issue) => issue.field === "assistantName")?.message ?? null;
 	const personaError = personaIssues[0]?.message ?? null;
+	const nameDescriptionIds = nameError
+		? showNameCount
+			? "agent-name-error agent-name-count"
+			: "agent-name-error"
+		: showNameCount
+			? "agent-name-count"
+			: undefined;
 	const submitBlockingReason = (() => {
 		if (submitting) return null;
 		if (personaError) return personaError;
@@ -578,7 +535,7 @@ export function DeployWizard() {
 					: "Loading your Wallet balance.";
 			}
 			if (visibleSubscriptionQuoteError) return "Retry the Wallet quote above.";
-			if (visibleSubscriptionQuoteFetching) return "Refreshing your Wallet quote.";
+			if (visibleSubscriptionQuoteFetching && !walletDebit) return "Refreshing your Wallet quote.";
 			if (!walletDebit) return "Waiting for your Wallet quote.";
 			if (walletInsufficient) return "Top up your Wallet to continue.";
 		}
@@ -620,6 +577,21 @@ export function DeployWizard() {
 
 	function setComputeTier(next: Compute) {
 		setCompute(next);
+	}
+
+	async function retryWalletQuote() {
+		try {
+			if (!wallet.data) {
+				const walletResult = await wallet.refetch();
+				if (walletResult.error) throw walletResult.error;
+			}
+			const quoteResult = await subscriptionCreateQuote.refetch();
+			if (quoteResult.error) throw quoteResult.error;
+		} catch (error) {
+			toast.error("Couldn’t refresh Wallet quote", {
+				description: normalizeBillingError(error),
+			});
+		}
 	}
 
 	function aiDeployFields(): DeployAiFields | null {
@@ -934,15 +906,11 @@ export function DeployWizard() {
 
 	const deployLabel = paidSelection
 		? paymentMethod === "wallet"
-			? visibleSubscriptionQuoteFetching
-				? "Getting wallet quote…"
-				: walletInsufficient
-					? "Top up to deploy"
-					: walletDebit
-						? `Pay ${formatUsdExact(walletDebit.debitAmountUsd)} from Wallet & deploy`
-						: "Review wallet quote"
+			? walletInsufficient
+				? "Top up Wallet"
+				: "Pay & deploy"
 			: "Continue to checkout"
-		: "Deploy agent";
+		: "Deploy";
 	const primaryProvider = providerList.find(
 		(provider) => provider.provider_id === primaryProviderChoice,
 	);
@@ -965,12 +933,28 @@ export function DeployWizard() {
 					.filter(Boolean)
 					.join(" · ");
 	const runtimeSummary = runtimeDisplayName(runtime);
-	const deployPriceLabel =
+	const deployAmount =
 		compute === "basic" && basicSelection.mode === "included"
-			? "Free"
+			? { amount: "Free", caption: null, detail: null }
 			: paidSelection
-				? recurringOfferLabel(paidSelection.offer)
+				? paymentMethod === "wallet"
+					? walletDeployAmountPresentation({
+							billingTermMonths: paidSelection.billingTermMonths,
+							state: walletQuoteState,
+							walletDebit,
+						})
+					: cardDeployAmountPresentation(paidSelection.offer)
 				: null;
+	const walletTopUpAction =
+		paidSelection !== null && paymentMethod === "wallet" && walletInsufficient;
+	const primaryActionDisabled = walletTopUpAction
+		? submitting || postPaymentBlocked || !wallet.data
+		: !canSubmit;
+	const amountExplainsBlocking =
+		paidSelection !== null &&
+		paymentMethod === "wallet" &&
+		(walletQuoteState !== "ready" || walletInsufficient);
+	const visibleSubmitBlockingReason = amountExplainsBlocking ? null : submitBlockingReason;
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Basic"} compute`,
 		aiSummary,
@@ -1022,14 +1006,8 @@ export function DeployWizard() {
 					if (canSubmit) void runAction(onDeploy);
 				}}
 			>
-				<PageHeader
-					title="Deploy an Agent"
-					description="Choose how your agent runs and which AI model it will use."
-				/>
-				<SettingsSection
-					title="Agent software"
-					description="Choose the software that will power your agent."
-				>
+				<PageHeader title="Deploy an Agent" />
+				<SettingsSection title="Agent software">
 					<div className={TWO_TILE_GRID_CLASS}>
 						<EntityChoiceCard
 							selected={runtime === "hermes"}
@@ -1053,10 +1031,7 @@ export function DeployWizard() {
 					</div>
 				</SettingsSection>
 
-				<SettingsSection
-					title="AI providers"
-					description="Choose how your agent accesses AI models and select its primary model."
-				>
+				<SettingsSection title="AI providers">
 					<div className="flex flex-col gap-4">
 						<div className={TWO_TILE_GRID_CLASS}>
 							<EntityChoiceCard
@@ -1122,11 +1097,7 @@ export function DeployWizard() {
 								onClick={() => setAddProviderOpen(true)}
 							/>
 						</div>
-						{aiAccessMode === "unmanaged" ? (
-							<p className="text-sm text-muted-foreground">
-								No AI provider will be selected for you. Add one inside the agent after it is ready.
-							</p>
-						) : (
+						{aiAccessMode !== "unmanaged" ? (
 							<ModelBindingPicker
 								idPrefix="deploy"
 								className="w-full max-w-md"
@@ -1144,14 +1115,11 @@ export function DeployWizard() {
 								onPrimaryProviderChange={selectAiProviderChoice}
 								onPrimaryModelChange={setPrimaryModel}
 							/>
-						)}
+						) : null}
 					</div>
 				</SettingsSection>
 
-				<SettingsSection
-					title="Compute"
-					description="Choose a compute plan and how paid plans renew."
-				>
+				<SettingsSection title="Compute">
 					<div className="flex flex-col gap-3">
 						{!deployments.isSuccess ? (
 							deployments.error ? (
@@ -1193,6 +1161,16 @@ export function DeployWizard() {
 								</AlertDescription>
 							</Alert>
 						) : null}
+						{paidSelection && (compute === "performance" ? perfOffers : basicOffers).length > 1 ? (
+							<div className="flex max-w-xs flex-col gap-1.5">
+								<span className="text-xs text-muted-foreground">Billing term</span>
+								<TermSwitcher
+									offers={compute === "performance" ? perfOffers : basicOffers}
+									value={compute === "performance" ? perfBillingTermMonths : basicBillingTermMonths}
+									onChange={setTerm}
+								/>
+							</div>
+						) : null}
 						<div className={TWO_TILE_GRID_CLASS}>
 							<EntityChoiceCard
 								selected={compute === "basic"}
@@ -1212,31 +1190,40 @@ export function DeployWizard() {
 										? deployments.error
 											? "Basic availability couldn't be checked"
 											: "Checking free Basic slot availability"
-										: basicSelection.mode === "included"
-											? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · First Basic agent — Free`
-											: basicOffer
-												? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · ${recurringOfferLabel(basicOffer)}`
-												: "Basic funding unavailable"
+										: `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB`
+								}
+								details={
+									deployments.isSuccess && basicSelection.mode === "included" ? (
+										<ComputePriceBlock
+											testId="basic-compute-price"
+											presentation={{
+												primary: "Free",
+												comparison: null,
+												secondary: "First Basic agent",
+											}}
+										/>
+									) : deployments.isSuccess && basicPricePresentation ? (
+										<ComputePriceBlock
+											testId="basic-compute-price"
+											presentation={basicPricePresentation}
+										/>
+									) : null
 								}
 								badge={
-									<Badge variant="secondary">
-										{!deployments.isSuccess
-											? deployments.error
-												? "Unavailable"
-												: "Checking…"
-											: basicSelection.mode === "included"
-												? "Free"
-												: basicOffer
-													? `${formatCents(basicOffer.effective_monthly_price_cents)}/mo`
-													: "Unavailable"}
-									</Badge>
+									!deployments.isSuccess ? (
+										<Badge variant="secondary">
+											{deployments.error ? "Unavailable" : "Checking…"}
+										</Badge>
+									) : basicSelection.mode === "unavailable" ? (
+										<Badge variant="secondary">Unavailable</Badge>
+									) : null
 								}
 								disabled={!deployments.isSuccess || basicUnavailable}
 							/>
 							<EntityChoiceCard
 								selected={compute === "performance"}
 								onClick={
-									deployments.isSuccess && perfPlan
+									deployments.isSuccess && perfPlan && perfOfferSelection
 										? () => setComputeTier("performance")
 										: undefined
 								}
@@ -1248,41 +1235,24 @@ export function DeployWizard() {
 								title="Performance"
 								description={
 									perfPlan
-										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB${
-												perfOffer ? ` · ${recurringOfferLabel(perfOffer)}` : ""
-											}`
+										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB`
 										: "Performance plan unavailable"
 								}
-								badge={
-									<Badge>
-										{perfOffer
-											? `${formatCents(perfOffer.effective_monthly_price_cents)}/mo`
-											: perfPlan
-												? `${formatCents(perfPlan.price_cents)}/mo`
-												: "Unavailable"}
-									</Badge>
+								details={
+									perfPricePresentation ? (
+										<ComputePriceBlock
+											testId="performance-compute-price"
+											presentation={perfPricePresentation}
+										/>
+									) : null
 								}
-								disabled={!deployments.isSuccess || !perfPlan}
+								badge={perfPricePresentation ? null : <Badge>Unavailable</Badge>}
+								disabled={!deployments.isSuccess || !perfPlan || !perfOfferSelection}
 							/>
 						</div>
-						{paidSelection && (compute === "performance" ? perfOffers : basicOffers).length > 1 ? (
-							<div className="flex max-w-xs flex-col gap-1.5">
-								<span className="text-xs text-muted-foreground">Billing term</span>
-								<TermSwitcher
-									offers={compute === "performance" ? perfOffers : basicOffers}
-									value={compute === "performance" ? perfBillingTermMonths : basicBillingTermMonths}
-									onChange={setTerm}
-								/>
-							</div>
-						) : null}
 						{paidSelection ? (
 							<div className="flex flex-col gap-3">
-								<div>
-									<div className="text-sm font-medium">Payment method</div>
-									<p className="text-xs text-muted-foreground">
-										Choose how this agent’s compute renews. You can review the charge before paying.
-									</p>
-								</div>
+								<div className="text-sm font-medium">Payment method</div>
 								<div className={TWO_TILE_GRID_CLASS}>
 									<EntityChoiceCard
 										selected={paymentMethod === "card"}
@@ -1293,12 +1263,7 @@ export function DeployWizard() {
 											</IconChip>
 										}
 										title="Card subscription"
-										description="Pay securely with Stripe and manage the subscription from billing settings."
-										badge={
-											<Badge variant="secondary" className="hidden @3xl/main:inline-flex">
-												Monthly or Annual
-											</Badge>
-										}
+										description="Recurring subscription via Stripe. Manage or cancel anytime."
 									/>
 									<EntityChoiceCard
 										selected={paymentMethod === "wallet"}
@@ -1311,89 +1276,31 @@ export function DeployWizard() {
 										title="Wallet balance"
 										description={
 											walletDisabledReason ??
-											"Debit the exact quoted USD amount from Wallet, then renew on the selected term."
-										}
-										badge={
-											<Badge variant="outline" className="hidden @3xl/main:inline-flex">
-												Monthly or Annual
-											</Badge>
+											"Paid upfront from your Wallet balance. Renews from Wallet."
 										}
 										disabled={walletDisabledReason !== null}
 									/>
 								</div>
-
-								{paymentMethod === "wallet" ? (
-									<div className="flex flex-col gap-3">
-										{!wallet.data && wallet.isFetching ? (
-											<p className="text-sm text-muted-foreground" role="status">
-												Loading your Wallet balance…
-											</p>
-										) : !wallet.data && wallet.error ? (
-											<ApiErrorPanel
-												normalizer={billingErrorNormalizer}
-												error={wallet.error}
-												onRetry={() => void wallet.refetch()}
-												title="Couldn't load your Wallet balance"
-											/>
-										) : visibleSubscriptionQuoteFetching && !lastSuccessfulSubscriptionQuote ? (
-											<p className="text-sm text-muted-foreground" role="status">
-												Getting the exact wallet debit…
-											</p>
-										) : visibleSubscriptionQuoteError ? (
-											<ApiErrorPanel
-												normalizer={billingErrorNormalizer}
-												error={visibleSubscriptionQuoteError}
-												onRetry={() => void subscriptionCreateQuote.refetch()}
-												title="Couldn’t get subscription quote"
-											/>
-										) : walletDebit ? (
-											<>
-												<WalletDebitEquation
-													balanceBeforeUsd={walletDebit.balanceBeforeUsd}
-													debitAmountUsd={walletDebit.debitAmountUsd}
-													balanceAfterUsd={walletDebit.balanceAfterUsd}
-												/>
-												{walletInsufficient ? (
-													<Alert variant="destructive">
-														<TriangleAlert aria-hidden />
-														<AlertTitle>Not enough Wallet balance</AlertTitle>
-														<AlertDescription className="flex flex-col items-start gap-3">
-															<span>Top up the shortfall, then review a fresh wallet quote.</span>
-															<Button
-																type="button"
-																size="sm"
-																variant="outline"
-																disabled={!wallet.data}
-																onClick={() => walletTopUp.show(walletShortfallUsd)}
-															>
-																<WalletCards data-icon="inline-start" /> Top up Wallet
-															</Button>
-														</AlertDescription>
-													</Alert>
-												) : null}
-											</>
-										) : null}
-									</div>
-								) : null}
 							</div>
 						) : null}
-						<ComputeStatusLine
-							compute={compute}
-							basicSelection={basicSelection}
-							basicOffer={basicOffer}
-							perfOffer={perfOffer}
-							paymentMethod={paymentMethod}
-						/>
-						<p className="text-xs text-muted-foreground">
-							After your agent is running, connect channels from its page.
-						</p>
+						{compute === "basic" &&
+						basicSelection.mode === "unavailable" &&
+						basicSelection.reason !== "inventory_unavailable" ? (
+							<p className="text-xs text-destructive" role="alert">
+								{basicSelection.reason === "offers_missing"
+									? "Paid Basic checkout isn’t available. Retry plans or choose Performance."
+									: "The Basic plan isn’t available. Retry plans before deploying."}
+							</p>
+						) : null}
+						{compute === "performance" && perfPlan && !perfOfferSelection ? (
+							<p className="text-xs text-destructive" role="alert">
+								Performance pricing isn’t available. Retry plans before deploying.
+							</p>
+						) : null}
 					</div>
 				</SettingsSection>
 				<div className="pb-32 @2xl/main:pb-24">
-					<SettingsSection
-						title="Personalize"
-						description="Choose how this agent appears in Clawdi, plus its language and timezone."
-					>
+					<SettingsSection title="Personalize">
 						<div className="flex max-w-2xl flex-col gap-4">
 							<div className="flex w-full max-w-md flex-col gap-1.5">
 								<Label htmlFor="agent-name">Name in Clawdi</Label>
@@ -1403,11 +1310,7 @@ export function DeployWizard() {
 									maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
 									required
 									aria-invalid={nameError ? true : undefined}
-									aria-describedby={
-										nameError
-											? "agent-name-error agent-name-count"
-											: "agent-name-help agent-name-count"
-									}
+									aria-describedby={nameDescriptionIds}
 									onChange={(event) => {
 										assistantNameEditedRef.current = true;
 										setAssistantName(event.target.value);
@@ -1418,24 +1321,22 @@ export function DeployWizard() {
 									<p id="agent-name-error" className="text-xs text-destructive" role="alert">
 										{nameError}
 									</p>
-								) : (
-									<p id="agent-name-help" className="text-xs text-muted-foreground">
-										Used to identify this agent in Clawdi.
+								) : null}
+								{showNameCount ? (
+									<p
+										id="agent-name-count"
+										className={cn(
+											"text-xs",
+											nameLimitReached
+												? "font-medium text-warning-muted-foreground"
+												: "text-muted-foreground",
+										)}
+									>
+										{`${assistantName.length} / ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters${
+											nameLimitReached ? " — limit reached." : ""
+										}`}
 									</p>
-								)}
-								<p
-									id="agent-name-count"
-									className={cn(
-										"text-xs",
-										nameLimitReached
-											? "font-medium text-warning-muted-foreground"
-											: "text-muted-foreground",
-									)}
-								>
-									{`${assistantName.length} / ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters${
-										nameLimitReached ? " — limit reached." : ""
-									}`}
-								</p>
+								) : null}
 								{nameLimitReached ? (
 									<span className="sr-only" role="status" aria-live="polite">
 										{`Name limit reached. You can enter up to ${DEPLOY_ASSISTANT_NAME_MAX_LENGTH} characters.`}
@@ -1493,29 +1394,59 @@ export function DeployWizard() {
 					className="sticky bottom-0 z-10 -mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur lg:-mx-6 lg:px-6"
 				>
 					<div className="flex flex-col gap-2 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
-						<div className="flex min-w-0 max-w-full items-center gap-2 text-xs sm:text-sm">
-							{deployPriceLabel ? (
-								<>
-									<span
-										data-testid="deploy-price-label"
-										className="shrink-0 whitespace-nowrap font-medium text-foreground"
-									>
-										{deployPriceLabel}
-									</span>
-									<span aria-hidden="true" className="shrink-0 text-muted-foreground">
-										·
-									</span>
-								</>
-							) : null}
-							<span className="min-w-0 truncate text-muted-foreground">{summaryLine}</span>
+						<div
+							data-testid="deploy-configuration-summary"
+							className="min-w-0 truncate text-xs text-muted-foreground sm:text-sm"
+						>
+							{summaryLine}
 						</div>
-						<div className="flex min-w-0 flex-col gap-1 @2xl/main:items-end">
-							<div className="flex flex-col gap-2 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-end">
+						<div className="flex w-full shrink-0 flex-col gap-2 @2xl/main:w-auto @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-end">
+							{deployAmount ? (
+								<div
+									data-testid="deploy-amount"
+									className="flex min-w-0 flex-col @2xl/main:items-end @2xl/main:text-right"
+									aria-live="polite"
+								>
+									<div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 @2xl/main:justify-end">
+										<span className="whitespace-nowrap font-semibold tabular-nums text-foreground">
+											{deployAmount.amount}
+										</span>
+										{paymentMethod === "wallet" && walletQuoteState === "error" ? (
+											<Button
+												type="button"
+												variant="link"
+												size="sm"
+												className="h-auto p-0"
+												disabled={wallet.isFetching || subscriptionCreateQuote.isFetching}
+												onClick={() => void retryWalletQuote()}
+											>
+												Retry
+											</Button>
+										) : null}
+									</div>
+									{deployAmount.caption ? (
+										<span className="whitespace-nowrap text-xs text-muted-foreground">
+											{deployAmount.caption}
+										</span>
+									) : null}
+									{deployAmount.detail ? (
+										<span className="whitespace-nowrap text-xs font-medium text-destructive">
+											{deployAmount.detail}
+										</span>
+									) : null}
+								</div>
+							) : null}
+							<div className="flex min-w-0 flex-col gap-1 @2xl/main:items-end">
 								<Button
-									type="submit"
+									type={walletTopUpAction ? "button" : "submit"}
 									size="lg"
-									disabled={!canSubmit}
-									aria-describedby={submitBlockingReason ? "deploy-blocking-reason" : undefined}
+									disabled={primaryActionDisabled}
+									aria-describedby={
+										visibleSubmitBlockingReason ? "deploy-blocking-reason" : undefined
+									}
+									onClick={
+										walletTopUpAction ? () => walletTopUp.show(walletShortfallUsd) : undefined
+									}
 									className="w-full shrink-0 @2xl/main:w-auto"
 								>
 									{submitting ? (
@@ -1525,26 +1456,26 @@ export function DeployWizard() {
 									)}
 									{submitting ? submitBusyLabel : deployLabel}
 								</Button>
+								{submitTakingLong ? (
+									<p
+										className="max-w-sm text-xs text-muted-foreground @2xl/main:text-right"
+										role="status"
+									>
+										{submitTakingLongCopy}
+									</p>
+								) : visibleSubmitBlockingReason ? (
+									<p
+										id="deploy-blocking-reason"
+										className={cn(
+											"max-w-sm text-xs @2xl/main:text-right",
+											nameError ? "text-destructive" : "text-muted-foreground",
+										)}
+										role="status"
+									>
+										{visibleSubmitBlockingReason}
+									</p>
+								) : null}
 							</div>
-							{submitTakingLong ? (
-								<p
-									className="max-w-sm text-xs text-muted-foreground @2xl/main:text-right"
-									role="status"
-								>
-									{submitTakingLongCopy}
-								</p>
-							) : submitBlockingReason ? (
-								<p
-									id="deploy-blocking-reason"
-									className={cn(
-										"max-w-sm text-xs @2xl/main:text-right",
-										nameError ? "text-destructive" : "text-muted-foreground",
-									)}
-									role="status"
-								>
-									{submitBlockingReason}
-								</p>
-							) : null}
 						</div>
 					</div>
 				</div>
@@ -1560,7 +1491,7 @@ export function DeployWizard() {
 				<TopUpDialog
 					{...walletTopUp.dialogProps}
 					onComplete={() => {
-						if (!submitting) void subscriptionCreateQuote.refetch();
+						if (!submitting) void retryWalletQuote();
 					}}
 				/>
 			) : null}

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -15,7 +15,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-/** Common UI languages offered during onboarding and hosted runtime settings. */
+/** Curated languages supported by the hosted deployment contract. */
 export const LANGUAGE_OPTIONS = HOSTED_DEPLOY_LANGUAGE_OPTIONS;
 
 export type HostedLanguage = (typeof LANGUAGE_OPTIONS)[number]["code"];
@@ -30,9 +30,8 @@ export function normalizeHostedLanguage(value: string | null | undefined): Hoste
 }
 
 /**
- * Best-effort map of the browser's preferred languages onto a supported hosted
- * language. Returns "" when none match, so the caller falls back to the
- * unset/"Default" choice. Client-only (reads navigator); call after mount.
+ * Best-effort map of browser preferences onto the curated hosted contract.
+ * Client-only (reads navigator); call after mount.
  */
 export function browserLanguage(): HostedLanguage | "" {
 	try {
@@ -55,467 +54,86 @@ export function browserLanguage(): HostedLanguage | "" {
 	return "";
 }
 
-// Static IANA timezone list keeps SSR and client markup deterministic.
-const TIMEZONE_OPTIONS = `
-Africa/Abidjan
-Africa/Accra
-Africa/Addis_Ababa
-Africa/Algiers
-Africa/Asmara
-Africa/Bamako
-Africa/Bangui
-Africa/Banjul
-Africa/Bissau
-Africa/Blantyre
-Africa/Brazzaville
-Africa/Bujumbashi
-Africa/Cairo
-Africa/Casablanca
-Africa/Ceuta
-Africa/Conakry
-Africa/Dakar
-Africa/Dar_es_Salaam
-Africa/Djibouti
-Africa/Douala
-Africa/El_Aaiun
-Africa/Freetown
-Africa/Gaborone
-Africa/Harare
-Africa/Johannesburg
-Africa/Juba
-Africa/Kampala
-Africa/Khartoum
-Africa/Kigali
-Africa/Kinshasa
-Africa/Lagos
-Africa/Libreville
-Africa/Lome
-Africa/Luanda
-Africa/Lubumbashi
-Africa/Lusaka
-Africa/Malabo
-Africa/Maputo
-Africa/Maseru
-Africa/Mbabane
-Africa/Mogadishu
-Africa/Monrovia
-Africa/Nairobi
-Africa/Ndjamena
-Africa/Niamey
-Africa/Nouakchott
-Africa/Ouagadougou
-Africa/Porto-Novo
-Africa/Sao_Tome
-Africa/Tripoli
-Africa/Tunis
-Africa/Windhoek
-America/Adak
-America/Anchorage
-America/Anguilla
-America/Antigua
-America/Araguaina
-America/Argentina/Buenos_Aires
-America/Argentina/Catamarca
-America/Argentina/Cordoba
-America/Argentina/Jujuy
-America/Argentina/La_Rioja
-America/Argentina/Mendoza
-America/Argentina/Rio_Gallegos
-America/Argentina/Salta
-America/Argentina/San_Juan
-America/Argentina/San_Luis
-America/Argentina/Tucuman
-America/Argentina/Ushuaia
-America/Aruba
-America/Asuncion
-America/Atikokan
-America/Bahia
-America/Bahia_Banderas
-America/Barbados
-America/Belem
-America/Belize
-America/Blanc-Sablon
-America/Boa_Vista
-America/Bogota
-America/Boise
-America/Cambridge_Bay
-America/Campo_Grande
-America/Cancun
-America/Caracas
-America/Cayenne
-America/Cayman
-America/Chicago
-America/Chihuahua
-America/Ciudad_Juarez
-America/Costa_Rica
-America/Creston
-America/Cuiaba
-America/Curacao
-America/Danmarkshavn
-America/Dawson
-America/Dawson_Creek
-America/Denver
-America/Detroit
-America/Dominica
-America/Edmonton
-America/Eirunepe
-America/El_Salvador
-America/Fort_Nelson
-America/Fortaleza
-America/Glace_Bay
-America/Goose_Bay
-America/Grand_Turk
-America/Grenada
-America/Guadeloupe
-America/Guatemala
-America/Guayaquil
-America/Guyana
-America/Halifax
-America/Havana
-America/Hermosillo
-America/Indiana/Indianapolis
-America/Indiana/Knox
-America/Indiana/Marengo
-America/Indiana/Petersburg
-America/Indiana/Tell_City
-America/Indiana/Vevay
-America/Indiana/Vincennes
-America/Indiana/Winamac
-America/Inuvik
-America/Iqaluit
-America/Jamaica
-America/Juneau
-America/Kentucky/Louisville
-America/Kentucky/Monticello
-America/Kralendijk
-America/La_Paz
-America/Lima
-America/Los_Angeles
-America/Lower_Princes
-America/Maceio
-America/Managua
-America/Manaus
-America/Marigot
-America/Martinique
-America/Matamoros
-America/Mazatlan
-America/Menominee
-America/Merida
-America/Metlakatla
-America/Mexico_City
-America/Miquelon
-America/Moncton
-America/Monterrey
-America/Montevideo
-America/Montserrat
-America/Nassau
-America/New_York
-America/Nome
-America/Noronha
-America/North_Dakota/Beulah
-America/North_Dakota/Center
-America/North_Dakota/New_Salem
-America/Nuuk
-America/Ojinaga
-America/Panama
-America/Paramaribo
-America/Phoenix
-America/Port-au-Prince
-America/Port_of_Spain
-America/Porto_Velho
-America/Puerto_Rico
-America/Punta_Arenas
-America/Rankin_Inlet
-America/Recife
-America/Regina
-America/Resolute
-America/Rio_Branco
-America/Santarem
-America/Santiago
-America/Santo_Domingo
-America/Sao_Paulo
-America/Scoresbysund
-America/Sitka
-America/St_Barthelemy
-America/St_Johns
-America/St_Kitts
-America/St_Lucia
-America/St_Thomas
-America/St_Vincent
-America/Swift_Current
-America/Tegucigalpa
-America/Thule
-America/Tijuana
-America/Toronto
-America/Tortola
-America/Vancouver
-America/Whitehorse
-America/Winnipeg
-America/Yakutat
-Antarctica/Casey
-Antarctica/Davis
-Antarctica/DumontDUrville
-Antarctica/Macquarie
-Antarctica/Mawson
-Antarctica/McMurdo
-Antarctica/Palmer
-Antarctica/Rothera
-Antarctica/Syowa
-Antarctica/Troll
-Antarctica/Vostok
-Arctic/Longyearbyen
-Asia/Aden
-Asia/Almaty
-Asia/Amman
-Asia/Anadyr
-Asia/Aqtau
-Asia/Aqtobe
-Asia/Ashgabat
-Asia/Atyrau
-Asia/Baghdad
-Asia/Bahrain
-Asia/Baku
-Asia/Bangkok
-Asia/Barnaul
-Asia/Beirut
-Asia/Bishkek
-Asia/Brunei
-Asia/Chita
-Asia/Choibalsan
-Asia/Colombo
-Asia/Damascus
-Asia/Dhaka
-Asia/Dili
-Asia/Dubai
-Asia/Dushanbe
-Asia/Famagusta
-Asia/Gaza
-Asia/Hebron
-Asia/Ho_Chi_Minh
-Asia/Hong_Kong
-Asia/Hovd
-Asia/Irkutsk
-Asia/Jakarta
-Asia/Jayapura
-Asia/Jerusalem
-Asia/Kabul
-Asia/Kamchatka
-Asia/Karachi
-Asia/Kathmandu
-Asia/Khandyga
-Asia/Kolkata
-Asia/Krasnoyarsk
-Asia/Kuala_Lumpur
-Asia/Kuching
-Asia/Kuwait
-Asia/Macau
-Asia/Magadan
-Asia/Makassar
-Asia/Manila
-Asia/Muscat
-Asia/Nicosia
-Asia/Novokuznetsk
-Asia/Novosibirsk
-Asia/Omsk
-Asia/Oral
-Asia/Phnom_Penh
-Asia/Pontianak
-Asia/Pyongyang
-Asia/Qatar
-Asia/Qostanay
-Asia/Qyzylorda
-Asia/Riyadh
-Asia/Sakhalin
-Asia/Samarkand
-Asia/Seoul
-Asia/Shanghai
-Asia/Singapore
-Asia/Srednekolymsk
-Asia/Taipei
-Asia/Tashkent
-Asia/Tbilisi
-Asia/Tehran
-Asia/Thimphu
-Asia/Tokyo
-Asia/Tomsk
-Asia/Ulaanbaatar
-Asia/Urumqi
-Asia/Ust-Nera
-Asia/Vientiane
-Asia/Vladivostok
-Asia/Yakutsk
-Asia/Yangon
-Asia/Yekaterinburg
-Asia/Yerevan
-Atlantic/Azores
-Atlantic/Bermuda
-Atlantic/Canary
-Atlantic/Cape_Verde
-Atlantic/Faroe
-Atlantic/Madeira
-Atlantic/Reykjavik
-Atlantic/South_Georgia
-Atlantic/St_Helena
-Atlantic/Stanley
-Australia/Adelaide
-Australia/Brisbane
-Australia/Broken_Hill
-Australia/Darwin
-Australia/Eucla
-Australia/Hobart
-Australia/Lindeman
-Australia/Lord_Howe
-Australia/Melbourne
-Australia/Perth
-Australia/Sydney
-Etc/GMT+1
-Etc/GMT+10
-Etc/GMT+11
-Etc/GMT+12
-Etc/GMT+2
-Etc/GMT+3
-Etc/GMT+4
-Etc/GMT+5
-Etc/GMT+6
-Etc/GMT+7
-Etc/GMT+8
-Etc/GMT+9
-Etc/GMT-1
-Etc/GMT-10
-Etc/GMT-11
-Etc/GMT-12
-Etc/GMT-13
-Etc/GMT-14
-Etc/GMT-2
-Etc/GMT-3
-Etc/GMT-4
-Etc/GMT-5
-Etc/GMT-6
-Etc/GMT-7
-Etc/GMT-8
-Etc/GMT-9
-Europe/Amsterdam
-Europe/Andorra
-Europe/Astrakhan
-Europe/Athens
-Europe/Belgrade
-Europe/Berlin
-Europe/Bratislava
-Europe/Brussels
-Europe/Bucharest
-Europe/Budapest
-Europe/Busingen
-Europe/Chisinau
-Europe/Copenhagen
-Europe/Dublin
-Europe/Gibraltar
-Europe/Guernsey
-Europe/Helsinki
-Europe/Isle_of_Man
-Europe/Istanbul
-Europe/Jersey
-Europe/Kaliningrad
-Europe/Kirov
-Europe/Kyiv
-Europe/Lisbon
-Europe/Ljubljana
-Europe/London
-Europe/Luxembourg
-Europe/Madrid
-Europe/Malta
-Europe/Mariehamn
-Europe/Minsk
-Europe/Monaco
-Europe/Moscow
-Europe/Oslo
-Europe/Paris
-Europe/Podgorica
-Europe/Prague
-Europe/Riga
-Europe/Rome
-Europe/Samara
-Europe/San_Marino
-Europe/Sarajevo
-Europe/Saratov
-Europe/Simferopol
-Europe/Skopje
-Europe/Sofia
-Europe/Stockholm
-Europe/Tallinn
-Europe/Tirane
-Europe/Ulyanovsk
-Europe/Vaduz
-Europe/Vatican
-Europe/Vienna
-Europe/Vilnius
-Europe/Volgograd
-Europe/Warsaw
-Europe/Zagreb
-Europe/Zurich
-Indian/Antananarivo
-Indian/Chagos
-Indian/Christmas
-Indian/Cocos
-Indian/Comoro
-Indian/Kerguelen
-Indian/Mahe
-Indian/Maldives
-Indian/Mauritius
-Indian/Mayotte
-Indian/Reunion
-Pacific/Apia
-Pacific/Auckland
-Pacific/Bougainville
-Pacific/Chatham
-Pacific/Chuuk
-Pacific/Easter
-Pacific/Efate
-Pacific/Fakaofo
-Pacific/Fiji
-Pacific/Funafuti
-Pacific/Galapagos
-Pacific/Gambier
-Pacific/Guadalcanal
-Pacific/Guam
-Pacific/Honolulu
-Pacific/Kanton
-Pacific/Kiritimati
-Pacific/Kosrae
-Pacific/Kwajalein
-Pacific/Majuro
-Pacific/Marquesas
-Pacific/Midway
-Pacific/Nauru
-Pacific/Niue
-Pacific/Norfolk
-Pacific/Noumea
-Pacific/Pago_Pago
-Pacific/Palau
-Pacific/Pitcairn
-Pacific/Pohnpei
-Pacific/Port_Moresby
-Pacific/Rarotonga
-Pacific/Saipan
-Pacific/Tahiti
-Pacific/Tarawa
-Pacific/Tongatapu
-Pacific/Wake
-Pacific/Wallis
-UTC
-`
-	.trim()
-	.split("\n");
+const FALLBACK_TIMEZONES = [
+	"UTC",
+	"Africa/Johannesburg",
+	"America/Chicago",
+	"America/Los_Angeles",
+	"America/New_York",
+	"America/Sao_Paulo",
+	"Asia/Dubai",
+	"Asia/Hong_Kong",
+	"Asia/Kolkata",
+	"Asia/Shanghai",
+	"Asia/Singapore",
+	"Asia/Tokyo",
+	"Australia/Sydney",
+	"Europe/Berlin",
+	"Europe/London",
+	"Pacific/Auckland",
+] as const;
+
+function timezoneSort(left: string, right: string): number {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function isValidTimezone(value: string | null | undefined): value is string {
+	if (!value) return false;
+	try {
+		new Intl.DateTimeFormat("en-US", { timeZone: value }).format(0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function runtimeTimezones(): readonly string[] | null {
+	const intl = Intl as typeof Intl & {
+		supportedValuesOf?: (key: "timeZone") => string[];
+	};
+	if (typeof intl.supportedValuesOf !== "function") return null;
+	try {
+		return intl.supportedValuesOf("timeZone");
+	} catch {
+		return null;
+	}
+}
+
+function validatedTimezones(values: readonly string[]): string[] {
+	return [...new Set(values.filter(isValidTimezone))].sort(timezoneSort);
+}
+
+/**
+ * Runtime IANA data with a standards-valid fallback. Passing `null` explicitly
+ * exercises the fallback path; additional valid values preserve browser or
+ * persisted choices omitted by a runtime's enumeration.
+ */
+export function supportedTimezones(
+	additional: readonly string[] = [],
+	runtimeValues: readonly string[] | null = runtimeTimezones(),
+): string[] {
+	return validatedTimezones([...(runtimeValues ?? FALLBACK_TIMEZONES), "UTC", ...additional]);
+}
+
+/** Stable initial options for SSR and the first client render. */
+export function fallbackTimezones(additional: readonly string[] = []): string[] {
+	return supportedTimezones(additional, null);
+}
 
 export function browserTimezone(): string {
 	try {
-		return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+		const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+		return isValidTimezone(timezone) ? timezone : "";
 	} catch {
 		return "";
 	}
 }
 
-export function supportedTimezones(): string[] {
-	return [...TIMEZONE_OPTIONS];
+export function mergeTimezoneOptions(
+	options: readonly string[],
+	additional: readonly string[],
+): string[] {
+	return validatedTimezones([...options, ...additional]);
 }
 
 function timezoneLabel(timezone: string): string {
@@ -560,23 +178,25 @@ export function TimezoneCombobox({
 						<CommandList className="max-h-72">
 							<CommandEmpty>No timezone found.</CommandEmpty>
 							<CommandGroup>
-								{options.map((tz) => {
-									const selected = value === tz;
-									const label = timezoneLabel(tz);
+								{options.map((timezone) => {
+									const selected = value === timezone;
+									const label = timezoneLabel(timezone);
 									return (
 										<CommandItem
-											key={tz}
-											value={tz}
-											keywords={[label, tz.replaceAll("/", " ")]}
+											key={timezone}
+											value={timezone}
+											keywords={[label, timezone.replaceAll("/", " ")]}
 											onSelect={() => {
-												onValueChange(tz);
+												onValueChange(timezone);
 												setOpen(false);
 											}}
 										>
 											<Check className={cn("size-4", selected ? "opacity-100" : "opacity-0")} />
 											<span className="truncate">{label}</span>
-											{label !== tz ? (
-												<span className="ml-auto truncate text-xs text-muted-foreground">{tz}</span>
+											{label !== timezone ? (
+												<span className="ml-auto truncate text-xs text-muted-foreground">
+													{timezone}
+												</span>
 											) : null}
 										</CommandItem>
 									);

--- a/apps/web/src/hosted/billing/deploy/timezones.test.ts
+++ b/apps/web/src/hosted/billing/deploy/timezones.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import {
+	fallbackTimezones,
+	isValidTimezone,
+	mergeTimezoneOptions,
+	supportedTimezones,
+} from "@/hosted/billing/deploy/language-timezone-controls";
+
+describe("timezone options", () => {
+	test("uses validated, sorted, deduplicated runtime IANA data and always includes UTC", () => {
+		expect(
+			supportedTimezones(
+				[],
+				["Europe/London", "Invalid/Timezone", "America/New_York", "Europe/London"],
+			),
+		).toEqual(["America/New_York", "Europe/London", "UTC"]);
+	});
+
+	test("uses a small standards-valid fallback without supportedValuesOf", () => {
+		const fallback = fallbackTimezones();
+		expect(fallback).toContain("UTC");
+		expect(fallback).toContain("America/New_York");
+		expect(fallback).toContain("Asia/Tokyo");
+		expect(fallback.length).toBeLessThan(25);
+		expect(fallback).toEqual([...fallback].sort());
+		expect(fallback.every(isValidTimezone)).toBe(true);
+	});
+
+	test("preserves valid current values omitted from runtime enumeration", () => {
+		expect(mergeTimezoneOptions(["UTC"], ["Etc/UTC", "Not/AZone"])).toEqual(["Etc/UTC", "UTC"]);
+	});
+});


### PR DESCRIPTION
## Summary
- make monthly and annual compute pricing directly comparable on plan cards
- place the authoritative card or Wallet amount beside the deploy action, including loading, retry, and insufficient-balance states
- replace the handwritten timezone catalog with validated Intl data and an SSR-safe fallback
- remove redundant deploy form copy while keeping Clawdi AI first and setup-free

## Verification
- `bun run test web src/hosted/billing/deploy/` (Docker clean runner: typecheck, 55 tests, OSS build)
- `bun run check` (796 files)
- focused hosted Playwright across pricing, Wallet states, paid Basic, annual Wallet, and 1280/800/700/390 widths

## Baseline note
The full hosted Playwright run exposed two pre-existing failures in unrelated agent recovery/list selectors. Both reproduce unchanged on a clean `origin/main` worktree. Deploy-related tests pass.