### PR TITLE
fix(web): compact deploy compute plan cards

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2153,15 +2153,14 @@ test("deploy cards and CTA-adjacent amount distinguish free, monthly, and annual
 	const computePrice = page.getByTestId("performance-compute-price");
 	await expect(computePrice).toContainText("$20.00/mo");
 	await expect(computePrice).toContainText("Billed monthly");
-	await expect(performanceChoice).toContainText("4 vCPU / 8 GB");
+	await expect(performanceChoice).toContainText("4 vCPU · 8 GB RAM");
 	await expect(amount).toContainText("$20.00/mo");
 	await expect(amount).toContainText("Billed monthly");
 	await expect(actionBar.getByRole("button", { name: "Continue to checkout" })).toBeVisible();
 
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
 	await expect(computePrice).toContainText("$16.66/mo");
-	await expect(computePrice.locator(".line-through")).toHaveText("$20.00/mo");
-	await expect(computePrice).toContainText("Billed $200.00 yearly · save $40.00");
+	await expect(computePrice).toContainText("Billed $200.00/yr · save $40.00");
 	await expect(amount).toContainText("$200.00/yr");
 	await expect(amount).toContainText("$16.66/mo, billed annually");
 
@@ -2180,6 +2179,7 @@ test("deploy cards and CTA-adjacent amount distinguish free, monthly, and annual
 test("deploy CTA-adjacent Wallet amount handles loading, retry, and insufficient balance", async ({
 	page,
 }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
 	const delayedQuote = walletSubscriptionQuote({
 		planSlug: "compute_basic",
 		billingTermMonths: 1,
@@ -2233,8 +2233,12 @@ test("deploy CTA-adjacent Wallet amount handles loading, retry, and insufficient
 	const topUp = page.getByRole("button", { name: "Top up Wallet", exact: true });
 	await expect(topUp).toHaveCount(1);
 	await expect(topUp).toBeEnabled();
+	await page.screenshot({ path: "/tmp/deploy-wallet-insufficient-390.png" });
 	await topUp.click();
-	await expect(page.getByRole("dialog").filter({ hasText: "Top up Wallet" })).toBeVisible();
+	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up Wallet" });
+	await expect(topUpDialog).toBeVisible();
+	await expect(topUpDialog.getByRole("spinbutton", { name: "Amount (USD)" })).toHaveValue("10");
+	await expect(topUpDialog.getByRole("button", { name: "Continue with $10.00" })).toBeVisible();
 });
 
 test("deploy form stays readable without stretching compact controls", async ({ page }) => {
@@ -2300,6 +2304,25 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 					label: title.textContent?.trim() ?? "",
 					scrollWidth: title.scrollWidth,
 				}));
+			const computePlans = ["Basic", "Performance"].map((label) => {
+				const title = Array.from(
+					document.querySelectorAll<HTMLSpanElement>("button span.font-medium"),
+				).find((candidate) => candidate.textContent?.trim() === label);
+				const card = title?.closest("button");
+				const resources = card?.querySelector("p");
+				const price = card?.querySelector(
+					`[data-testid="${label === "Basic" ? "basic" : "performance"}-compute-price"]`,
+				);
+				const primaryPrice = price?.querySelector("span.font-semibold");
+				return {
+					card: rect(card),
+					label,
+					price: rect(price),
+					primaryPrice: rect(primaryPrice),
+					resources: rect(resources),
+					title: rect(title),
+				};
+			});
 			return {
 				document: {
 					clientWidth: document.documentElement.clientWidth,
@@ -2329,6 +2352,7 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 							}
 						: null;
 				})(),
+				computePlans,
 				titleWidths,
 			};
 		});
@@ -2365,6 +2389,19 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			expect(title.scrollWidth, `${viewport.name} ${title.label} title`).toBeLessThanOrEqual(
 				title.clientWidth,
 			);
+		}
+		for (const plan of metrics.computePlans) {
+			expect(plan.card, `${viewport.name} ${plan.label} card`).not.toBeNull();
+			const cardHeight = plan.card ? plan.card.bottom - plan.card.top : Number.POSITIVE_INFINITY;
+			expect(cardHeight, `${viewport.name} ${plan.label} height`).toBeLessThanOrEqual(96);
+			expect(plan.primaryPrice?.top, `${viewport.name} ${plan.label} price top`).toBeCloseTo(
+				plan.title?.top ?? 0,
+				0,
+			);
+			expect(
+				plan.price?.top,
+				`${viewport.name} ${plan.label} price should stay with title and resources`,
+			).toBeLessThanOrEqual(plan.resources?.bottom ?? 0);
 		}
 
 		for (const [label, control, maxWidth] of [
@@ -2413,13 +2450,7 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 				metrics.action?.left ?? 0,
 			);
 		}
-		if (viewport.width === 1_280 || viewport.width === 390) {
-			await page.getByRole("button", { name: /^Performance/ }).scrollIntoViewIfNeeded();
-			await page.waitForTimeout(100);
-			await page.screenshot({
-				path: `/tmp/deploy-pricing-${viewport.width}.png`,
-			});
-		}
+		await capturePricingScreenshot(page, `/tmp/deploy-compute-card-${viewport.width}.png`);
 	}
 });
 
@@ -3534,7 +3565,7 @@ test("Basic create always follows the wizard-selected funding path", async ({ pa
 	await page.waitForLoadState("networkidle");
 
 	await expect(page.getByTestId("basic-compute-price")).toContainText("$10.00/mo");
-	await expect(page.getByRole("button", { name: /^Basic/ })).toContainText("2 vCPU / 4 GB");
+	await expect(page.getByRole("button", { name: /^Basic/ })).toContainText("2 vCPU · 4 GB RAM");
 	await expectNoQuarterlyCopy(page);
 	await capturePricingScreenshot(page, "/tmp/basic-paid-funded-slot-available-final.png");
 
@@ -3613,8 +3644,7 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await expect(page.getByRole("button", { name: /Wallet balance/ })).toBeVisible();
 	const basicPrice = page.getByTestId("basic-compute-price");
 	await expect(basicPrice).toContainText("$8.33/mo");
-	await expect(basicPrice.locator(".line-through")).toHaveText("$10.00/mo");
-	await expect(basicPrice).toContainText("Billed $100.00 yearly · save $20.00");
+	await expect(basicPrice).toContainText("Billed $100.00/yr · save $20.00");
 	await expect(page.getByTestId("deploy-amount")).toContainText("$100.00/yr");
 	await capturePricingScreenshot(page, "/tmp/basic-free-funded-slot-occupied-final.png");
 

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -371,6 +371,7 @@ export function EntityChoiceCard({
 	title,
 	description,
 	details,
+	detailsPlacement = "stacked",
 	badge,
 	selected,
 	onClick,
@@ -382,6 +383,8 @@ export function EntityChoiceCard({
 	description?: ReactNode;
 	/** Optional detail block below the description (for example, pricing). */
 	details?: ReactNode;
+	/** Keep dense, comparable details beside the main copy when space allows. */
+	detailsPlacement?: "stacked" | "trailing";
 	/** Trailing badge in the title row (e.g. "Default", an auth chip). */
 	badge?: ReactNode;
 	selected?: boolean;
@@ -392,17 +395,37 @@ export function EntityChoiceCard({
 	const content = (
 		<>
 			{icon}
-			<div className="min-w-0 flex-1">
-				<div className="flex min-w-0 items-center gap-2">
-					<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
-					{badge ? <span className="shrink-0">{badge}</span> : null}
+			<div
+				className={cn(
+					"min-w-0 flex-1",
+					details && detailsPlacement === "trailing" && "flex items-start gap-3",
+				)}
+			>
+				<div className="min-w-0 flex-1">
+					<div className="flex min-w-0 items-center gap-2">
+						<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+						{badge ? <span className="shrink-0">{badge}</span> : null}
+					</div>
+					{description ? (
+						<p className="mt-0.5 break-words text-sm text-muted-foreground">{description}</p>
+					) : null}
 				</div>
-				{description ? (
-					<p className="mt-0.5 break-words text-sm text-muted-foreground">{description}</p>
+				{details ? (
+					<div
+						className={cn(
+							"min-w-0",
+							detailsPlacement === "trailing" ? "max-w-[50%] shrink-0" : "mt-2",
+						)}
+					>
+						{details}
+					</div>
 				) : null}
-				{details ? <div className="mt-2">{details}</div> : null}
 			</div>
-			{selected ? <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden /> : null}
+			{selected ? (
+				<Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+			) : detailsPlacement === "trailing" ? (
+				<span className="size-4 shrink-0" aria-hidden />
+			) : null}
 		</>
 	);
 	const cardClass = cn(

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -23,21 +23,18 @@ describe("computePricePresentation", () => {
 	test("makes monthly and annual pricing visibly distinct", () => {
 		expect(computePricePresentation(monthly, [monthly, annual])).toEqual({
 			primary: "$20.00/mo",
-			comparison: null,
 			secondary: "Billed monthly",
 		});
 		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
 			primary: "$16.66/mo",
-			comparison: "$20.00/mo",
-			secondary: "Billed $200.00 yearly · save $40.00",
+			secondary: "Billed $200.00/yr · save $40.00",
 		});
 	});
 
-	test("omits comparison and savings when a monthly offer is missing", () => {
+	test("omits savings when a monthly offer is missing", () => {
 		expect(computePricePresentation(annual, [annual])).toEqual({
 			primary: "$16.66/mo",
-			comparison: null,
-			secondary: "Billed $200.00 yearly",
+			secondary: "Billed $200.00/yr",
 		});
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -11,7 +11,6 @@ import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-su
 
 export type ComputePricePresentation = {
 	primary: string;
-	comparison: string | null;
 	secondary: string;
 };
 
@@ -32,7 +31,6 @@ export function computePricePresentation(
 	if (offer.billing_term_months === 1) {
 		return {
 			primary: monthlyPrice(offer),
-			comparison: null,
 			secondary: "Billed monthly",
 		};
 	}
@@ -50,12 +48,11 @@ export function computePricePresentation(
 			: 0;
 	const billed =
 		offer.billing_term_months === 12
-			? `Billed ${formatCents(offer.price_cents)} yearly`
+			? `Billed ${formatCents(offer.price_cents)}/yr`
 			: `Billed ${formatCents(offer.price_cents)} every ${offer.billing_term_months} months`;
 
 	return {
 		primary: monthlyPrice(offer),
-		comparison: comparisonIsCheaper ? monthlyPrice(monthlyOffer) : null,
 		secondary: savingsCents > 0 ? `${billed} · save ${formatCents(savingsCents)}` : billed,
 	};
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -97,6 +97,12 @@ describe("deploy wizard responsive layout", () => {
 		expect(deployPageSource).toContain('className="grid gap-2 @2xl/main:grid-cols-2"');
 	});
 
+	test("keeps compute identity, resources, and recurring price in one compact hierarchy", () => {
+		expect(wizardSource.match(/detailsPlacement="trailing"/g)).toHaveLength(2);
+		expect(wizardSource.match(/className="items-center p-3"/g)).toHaveLength(2);
+		expect(wizardSource.match(/vCPU · .* GB RAM/g)).toHaveLength(2);
+	});
+
 	test("keeps the action bar sticky across the full form and adapts it to the main pane", () => {
 		const formIndex = wizardSource.indexOf("<form");
 		const agentSoftwareIndex = wizardSource.indexOf('title="Agent software"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -263,17 +263,12 @@ function ComputePriceBlock({
 }) {
 	return (
 		<div data-testid={testId} className="flex min-w-0 flex-col items-end text-right tabular-nums">
-			<div className="flex flex-wrap items-baseline justify-end gap-x-1.5">
-				<span className="whitespace-nowrap text-base font-semibold text-foreground">
+			<div className="flex items-baseline justify-end leading-5">
+				<span className="whitespace-nowrap text-sm font-semibold text-foreground">
 					{presentation.primary}
 				</span>
-				{presentation.comparison ? (
-					<span className="whitespace-nowrap text-xs text-muted-foreground line-through">
-						{presentation.comparison}
-					</span>
-				) : null}
 			</div>
-			<span className="whitespace-nowrap text-xs font-normal text-muted-foreground">
+			<span className="text-xs leading-4 font-normal text-muted-foreground">
 				{presentation.secondary}
 			</span>
 		</div>
@@ -1180,25 +1175,27 @@ export function DeployWizard() {
 										: undefined
 								}
 								icon={
-									<IconChip tint="bg-identity-3-bg text-identity-3-fg">
+									<IconChip size="sm" tint="bg-identity-3-bg text-identity-3-fg">
 										<Cpu />
 									</IconChip>
 								}
 								title="Basic"
 								description={
-									!deployments.isSuccess
-										? deployments.error
-											? "Basic availability couldn't be checked"
-											: "Checking free Basic slot availability"
-										: `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB`
+									<span className="text-xs">
+										{!deployments.isSuccess
+											? deployments.error
+												? "Basic availability couldn't be checked"
+												: "Checking free Basic slot availability"
+											: `${basicPlan?.vcpu ?? 2} vCPU · ${basicPlan?.ram_gb ?? 4} GB RAM`}
+									</span>
 								}
+								detailsPlacement="trailing"
 								details={
 									deployments.isSuccess && basicSelection.mode === "included" ? (
 										<ComputePriceBlock
 											testId="basic-compute-price"
 											presentation={{
 												primary: "Free",
-												comparison: null,
 												secondary: "First Basic agent",
 											}}
 										/>
@@ -1219,6 +1216,7 @@ export function DeployWizard() {
 									) : null
 								}
 								disabled={!deployments.isSuccess || basicUnavailable}
+								className="items-center p-3"
 							/>
 							<EntityChoiceCard
 								selected={compute === "performance"}
@@ -1228,16 +1226,19 @@ export function DeployWizard() {
 										: undefined
 								}
 								icon={
-									<IconChip tint="bg-identity-8-bg text-identity-8-fg">
+									<IconChip size="sm" tint="bg-identity-8-bg text-identity-8-fg">
 										<Zap />
 									</IconChip>
 								}
 								title="Performance"
 								description={
-									perfPlan
-										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB`
-										: "Performance plan unavailable"
+									<span className="text-xs">
+										{perfPlan
+											? `${perfPlan.vcpu} vCPU · ${perfPlan.ram_gb} GB RAM`
+											: "Performance plan unavailable"}
+									</span>
 								}
+								detailsPlacement="trailing"
 								details={
 									perfPricePresentation ? (
 										<ComputePriceBlock
@@ -1248,6 +1249,7 @@ export function DeployWizard() {
 								}
 								badge={perfPricePresentation ? null : <Badge>Unavailable</Badge>}
 								disabled={!deployments.isSuccess || !perfPlan || !perfOfferSelection}
+								className="items-center p-3"
 							/>
 						</div>
 						{paidSelection ? (


### PR DESCRIPTION
## Summary
- place each compute plan title, resources, and recurring price in one compact card hierarchy
- keep monthly and annual pricing distinct while shortening annual billing copy and preserving the Wallet-authoritative debit in the sticky action area
- strengthen responsive and Wallet-state browser coverage, including 1280/800/700/390 widths, quote loading/error, insufficient balance, and shortfall-aware Top up

## Verification
- `bun run --cwd apps/web test src/hosted/billing/deploy/deploy-price-presentation.test.ts src/hosted/billing/deploy/deploy-wizard.test.ts` (Docker-isolated typecheck, 32 tests, OSS build)
- `bun run --cwd apps/web e2e:hosted --grep "deploy form stays readable without stretching compact controls|deploy CTA-adjacent Wallet amount handles loading, retry, and insufficient balance|deploy cards and CTA-adjacent amount distinguish free, monthly, and annual prices|empty plans and wallet failures expose working retries" --retries=1` (4 passed)
- `bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts`

No production, live-cluster, or tenant-data operations were performed.