### PR TITLE
refactor(runtime): simplify hosted reconcile authority

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -819,12 +819,18 @@ bundle's HTTP ETag, which remains the strong validator derived from
 `sourceRevision`; the two values are intentionally independent. This lets one
 atomic projected-file swap advance config, secrets, and apply identity in
 place; `bootNonce` remains a workload-boot identity rather than a
-config-generation identity. The legacy process environment is accepted only
-when no identity-file path was configured and the canonical hosted mount
+config-generation identity. The legacy Hosted bootstrap bridge reads process
+environment only when no identity-file path was configured and the canonical hosted mount
 `/etc/clawdi/runtime-identity/runtime-apply-identity.json` does not
 exist. This one-boot discovery rule lets a CLI installed by an older bootstrap
 unit acquire the file contract; newly rendered units then pass the discovered
 path explicitly. An existing but malformed canonical file fails closed.
+This bridge is not a direct, local, or non-Hosted runtime mode: `runtime init`,
+`runtime watch`, and `runtime sidecar` reject non-Hosted execution, and manifest
+convergence or bundle-channel projection invoked as a library requires an
+explicit apply context. The current strict-v2 image contract supplies the
+canonical mount; the bridge remains solely for the documented one-boot upgrade
+from an older Hosted bootstrap unit.
 
 The CLI writes durable non-secret state under the service state root. Important
 outputs include:

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -819,18 +819,13 @@ bundle's HTTP ETag, which remains the strong validator derived from
 `sourceRevision`; the two values are intentionally independent. This lets one
 atomic projected-file swap advance config, secrets, and apply identity in
 place; `bootNonce` remains a workload-boot identity rather than a
-config-generation identity. The legacy Hosted bootstrap bridge reads process
-environment only when no identity-file path was configured and the canonical hosted mount
-`/etc/clawdi/runtime-identity/runtime-apply-identity.json` does not
-exist. This one-boot discovery rule lets a CLI installed by an older bootstrap
-unit acquire the file contract; newly rendered units then pass the discovered
-path explicitly. An existing but malformed canonical file fails closed.
-This bridge is not a direct, local, or non-Hosted runtime mode: `runtime init`,
-`runtime watch`, and `runtime sidecar` reject non-Hosted execution, and manifest
-convergence or bundle-channel projection invoked as a library requires an
-explicit apply context. The current strict-v2 image contract supplies the
-canonical mount; the bridge remains solely for the documented one-boot upgrade
-from an older Hosted bootstrap unit.
+config-generation identity. The strict-v2 paired image contract supplies the
+canonical mount at
+`/etc/clawdi/runtime-identity/runtime-apply-identity.json`; a missing or
+malformed file fails closed. `runtime init`, `runtime watch`, and `runtime
+sidecar` reject non-Hosted execution, and manifest convergence or bundle-channel
+projection invoked as a library requires an explicit apply context. Process
+environment is not an Apply identity or secret authority.
 
 The CLI writes durable non-secret state under the service state root. Important
 outputs include:

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -47,6 +47,7 @@ import {
 	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../runtime/cli-update";
+import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
 import { readHostPolicy } from "../runtime/host-policy";
 import {
@@ -55,7 +56,6 @@ import {
 	loadRuntimeManifest,
 	type RuntimePrivateAppliedAuthority,
 	runtimeRecoverableSecretValues,
-	withRuntimeConvergeLockAsync,
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -1,25 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-	HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
 	readRuntimeApplyContext,
 	readRuntimeApplyIdentity,
-	readRuntimeApplyIdentityFromEnv,
 	resolveRuntimeApplyGeneration,
+	runtimeApplyContextServiceEnvironment,
 	runtimeApplyIdentitiesEqual,
-	runtimeApplyIdentityEnvironment,
-	runtimeApplyIdentityServiceEnvironment,
 } from "./apply-identity";
-import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
-
-const completeEnvironment = {
-	CLAWDI_RUNTIME_GENERATION: "7",
-	CLAWDI_RUNTIME_MANIFEST_ETAG: '"manifest-7"',
-	CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0007",
-	CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000007",
-};
 
 const roots: string[] = [];
 
@@ -27,286 +16,116 @@ afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("runtime apply identity environment", () => {
-	test("resolves explicit apply identity with one named legacy checkpoint fallback", () => {
-		expect(resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 1 })).toBe(1);
-		expect(resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 3 })).toBe(3);
-		expect(resolveRuntimeApplyGeneration({ generation: 2 })).toBe(2);
-	});
-
-	test("projects apply identity independently of checkpoint generation", () => {
-		const generation = resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 3 });
-		expect(
-			runtimeApplyIdentityEnvironment({
-				generation,
-				manifestETag: '"manifest-3"',
-				applyReceiptId: "apply-receipt-0003",
-				bootNonce: "boot-nonce-000003",
-			}),
-		).toEqual({
-			CLAWDI_RUNTIME_GENERATION: "3",
-			CLAWDI_RUNTIME_MANIFEST_ETAG: '"manifest-3"',
-			CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0003",
-			CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000003",
-		});
-	});
-
-	test("compares the complete four-field identity tuple", () => {
-		const identity = readRuntimeApplyIdentityFromEnv(completeEnvironment);
-		if (!identity) throw new Error("expected complete apply identity");
-		expect(runtimeApplyIdentitiesEqual(identity, { ...identity })).toBe(true);
-		for (const different of [
-			{ ...identity, generation: identity.generation + 1 },
-			{ ...identity, manifestETag: '"manifest-8"' },
-			{ ...identity, applyReceiptId: "apply-receipt-0008" },
-			{ ...identity, bootNonce: "boot-nonce-000008" },
-		]) {
-			expect(runtimeApplyIdentitiesEqual(identity, different)).toBe(false);
-		}
-		expect(runtimeApplyIdentitiesEqual(identity, null)).toBe(false);
-		expect(runtimeApplyIdentitiesEqual(null, identity)).toBe(false);
-		expect(runtimeApplyIdentitiesEqual(null, null)).toBe(true);
-	});
-
-	test("returns null when the entire tuple is absent", () => {
-		expect(readRuntimeApplyIdentityFromEnv({})).toBeNull();
-	});
-
-	test("reads only the complete canonical four-variable tuple", () => {
-		const identity = readRuntimeApplyIdentityFromEnv(completeEnvironment);
-		expect(identity).toEqual({
-			generation: 7,
-			manifestETag: '"manifest-7"',
-			applyReceiptId: "apply-receipt-0007",
-			bootNonce: "boot-nonce-000007",
-		});
-		expect(runtimeApplyIdentityEnvironment(identity)).toEqual(completeEnvironment);
-	});
-
-	test("rejects partial, non-canonical, and unsafe tuples", () => {
-		expect(() =>
-			readRuntimeApplyIdentityFromEnv({
-				CLAWDI_RUNTIME_GENERATION: "7",
-			}),
-		).toThrow(/incomplete runtime apply identity environment/);
-		expect(() =>
-			readRuntimeApplyIdentityFromEnv({
-				...completeEnvironment,
-				CLAWDI_RUNTIME_GENERATION: "07",
-			}),
-		).toThrow(/canonical positive integer/);
-		expect(() =>
-			readRuntimeApplyIdentityFromEnv({
-				...completeEnvironment,
-				CLAWDI_RUNTIME_MANIFEST_ETAG: ' "manifest-7"',
-			}),
-		).toThrow(/surrounding whitespace/);
-		expect(() =>
-			readRuntimeApplyIdentityFromEnv({
-				...completeEnvironment,
-				CLAWDI_RUNTIME_GENERATION: String(Number.MAX_SAFE_INTEGER + 1),
-			}),
-		).toThrow(/invalid runtime apply identity environment/);
-	});
-});
-
-describe("runtime apply identity file", () => {
-	test("uses the hosted filesystem ABI by default", () => {
-		expect(HOSTED_RUNTIME_APPLY_IDENTITY_FILE).toBe(
-			"/etc/clawdi/runtime-identity/runtime-apply-identity.json",
-		);
-	});
-
-	test("reads the complete canonical tuple from the configured file", () => {
-		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-"));
-		roots.push(root);
-		const path = join(root, "runtime-apply-identity.json");
-		writeFileSync(
-			path,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
-				generation: 8,
-				manifestETag: '"manifest-8"',
-				applyReceiptId: "apply-receipt-0008",
-				bootNonce: "boot-nonce-000007",
-				runtimeEnv: {
-					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-					CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
-					CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
-					OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
-				},
-			}),
-		);
-
-		expect(
-			readRuntimeApplyIdentity({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
-				...completeEnvironment,
-			}),
-		).toEqual({
+function identityFile(root: string): string {
+	const path = join(root, "runtime-apply-identity.json");
+	writeFileSync(
+		path,
+		JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
 			generation: 8,
 			manifestETag: '"manifest-8"',
 			applyReceiptId: "apply-receipt-0008",
-			bootNonce: "boot-nonce-000007",
-		});
-		expect(
-			readRuntimeApplyContext({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
-				...completeEnvironment,
-			}),
-		).toEqual({
-			kind: "identity-file",
-			identity: {
-				generation: 8,
-				manifestETag: '"manifest-8"',
-				applyReceiptId: "apply-receipt-0008",
-				bootNonce: "boot-nonce-000007",
+			bootNonce: "boot-nonce-000008",
+			runtimeEnv: {
+				CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+				CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
+				OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
 			},
-			runtimeEnvironment: {
-				kind: "projected-environment",
-				values: {
-					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-					CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
-					CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
-					OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
-				},
-			},
-			sourcePath: path,
-		});
-		expect(
-			runtimeApplyIdentityServiceEnvironment({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
-				...completeEnvironment,
-			}),
-		).toEqual({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path });
+		}),
+	);
+	return path;
+}
+
+describe("runtime apply identity", () => {
+	test("resolves the manifest apply generation and compares the complete tuple", () => {
+		expect(resolveRuntimeApplyGeneration({ generation: 2, applyGeneration: 1 })).toBe(1);
+		expect(resolveRuntimeApplyGeneration({ generation: 2 })).toBe(2);
+		const identity = {
+			generation: 8,
+			manifestETag: '"manifest-8"',
+			applyReceiptId: "apply-receipt-0008",
+			bootNonce: "boot-nonce-000008",
+		};
+		expect(runtimeApplyIdentitiesEqual(identity, { ...identity })).toBe(true);
+		for (const different of [
+			{ ...identity, generation: 9 },
+			{ ...identity, manifestETag: '"manifest-9"' },
+			{ ...identity, applyReceiptId: "apply-receipt-0009" },
+			{ ...identity, bootNonce: "boot-nonce-000009" },
+		]) {
+			expect(runtimeApplyIdentitiesEqual(identity, different)).toBe(false);
+		}
+		expect(runtimeApplyIdentitiesEqual(null, null)).toBe(true);
+		expect(runtimeApplyIdentitiesEqual(identity, null)).toBe(false);
 	});
 
-	test("fails closed instead of falling back when the configured file is unavailable or invalid", () => {
-		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-invalid-"));
+	test("reads identity and projected environment from an explicit file", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-apply-identity-"));
 		roots.push(root);
-		const missing = join(root, "missing.json");
-		expect(() =>
-			readRuntimeApplyIdentity({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: missing,
-				...completeEnvironment,
-			}),
-		).toThrow(/could not read runtime apply identity file/);
-
-		const invalid = join(root, "invalid.json");
-		writeFileSync(invalid, JSON.stringify({ generation: 8 }));
-		expect(() =>
-			readRuntimeApplyIdentity({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: invalid,
-				...completeEnvironment,
-			}),
-		).toThrow(/invalid runtime apply identity file/);
-
-		writeFileSync(
-			invalid,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+		const path = identityFile(root);
+		const context = readRuntimeApplyContext({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path });
+		expect(context).toEqual({
+			kind: "identity-file",
+			identity: {
 				generation: 8,
 				manifestETag: '"manifest-8"',
 				applyReceiptId: "apply-receipt-0008",
 				bootNonce: "boot-nonce-000008",
-				runtimeEnv: { "INVALID-NAME": " secret" },
-			}),
-		);
-		expect(() =>
-			readRuntimeApplyIdentity({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: invalid,
-				...completeEnvironment,
-			}),
-		).toThrow(/invalid runtime apply identity file/);
-		expect(() =>
-			readRuntimeApplyIdentity({
-				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: "relative.json",
-				...completeEnvironment,
-			}),
-		).toThrow(/canonical absolute path/);
-	});
-
-	test("uses the legacy environment only when no file path is configured", () => {
-		const missingDiscoveryPath = join(tmpdir(), "clawdi-missing-runtime-apply-identity.json");
-		expect(readRuntimeApplyIdentity(completeEnvironment, missingDiscoveryPath)).toEqual(
-			readRuntimeApplyIdentityFromEnv(completeEnvironment),
-		);
-		expect(readRuntimeApplyContext(completeEnvironment, missingDiscoveryPath)).toMatchObject({
-			kind: "legacy-hosted-bootstrap-bridge",
-			runtimeEnvironment: {
-				kind: "process-environment",
-				values: completeEnvironment,
 			},
-		});
-	});
-
-	test("discovers the canonical mount before consulting the legacy environment", () => {
-		const root = mkdtempSync(join(tmpdir(), "clawdi-discovered-apply-identity-"));
-		roots.push(root);
-		const discovered = join(root, "runtime-apply-identity.json");
-		writeFileSync(
-			discovered,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeApplyIdentity.v1",
-				generation: 9,
-				manifestETag: '"manifest-9"',
-				applyReceiptId: "apply-receipt-0009",
-				bootNonce: "boot-nonce-000009",
-				runtimeEnv: {
-					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-					CLAWDI_AUTH_TOKEN: "discovered-token",
-					OPENCLAW_GATEWAY_TOKEN: "discovered-gateway-token",
-				},
-			}),
-		);
-
-		const context = readRuntimeApplyContext(
-			{ ...completeEnvironment, STALE_ONLY_PROCESS_TOKEN: "stale-process-token" },
-			discovered,
-		);
-		expect(context).toEqual({
-			kind: "identity-file",
-			identity: {
-				generation: 9,
-				manifestETag: '"manifest-9"',
-				applyReceiptId: "apply-receipt-0009",
-				bootNonce: "boot-nonce-000009",
-			},
+			sourcePath: path,
 			runtimeEnvironment: {
 				kind: "projected-environment",
 				values: {
 					CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
-					CLAWDI_AUTH_TOKEN: "discovered-token",
-					OPENCLAW_GATEWAY_TOKEN: "discovered-gateway-token",
+					CLAWDI_AUTH_TOKEN: "runtime-auth-token-0008",
+					OPENCLAW_GATEWAY_TOKEN: "gateway-token-0008",
 				},
 			},
-			sourcePath: discovered,
 		});
-		const clonedSecrets = {
-			...Object.fromEntries(
-				Object.entries(
-					normalizeSecretValues({
-						"env://OPENCLAW_GATEWAY_TOKEN": "discovered-gateway-token",
-					}),
-				),
-			),
-		};
-		expect(
-			runtimeSecretValue(clonedSecrets, "env://OPENCLAW_GATEWAY_TOKEN", context.runtimeEnvironment),
-		).toBe("discovered-gateway-token");
-		expect(
-			runtimeSecretValue(
-				clonedSecrets,
-				"env://STALE_ONLY_PROCESS_TOKEN",
-				context.runtimeEnvironment,
-			),
-		).toBeNull();
-		expect(runtimeApplyIdentityServiceEnvironment(completeEnvironment, discovered)).toEqual({
-			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: discovered,
+		expect(readRuntimeApplyIdentity({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path })).toEqual(
+			context.identity,
+		);
+		expect(runtimeApplyContextServiceEnvironment(context)).toEqual({
+			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
 		});
+	});
 
-		writeFileSync(discovered, JSON.stringify({ generation: 9 }));
-		expect(() => readRuntimeApplyContext(completeEnvironment, discovered)).toThrow(
+	test("discovers a supplied canonical mount path", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-discovered-apply-identity-"));
+		roots.push(root);
+		const path = identityFile(root);
+		expect(readRuntimeApplyContext({}, path).sourcePath).toBe(path);
+	});
+
+	test("fails closed for missing, malformed, or non-canonical files", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-invalid-apply-identity-"));
+		roots.push(root);
+		const missing = join(root, "missing.json");
+		expect(() => readRuntimeApplyContext({}, missing)).toThrow(
+			/missing runtime apply identity file/,
+		);
+		expect(() => readRuntimeApplyContext({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: missing })).toThrow(
+			/could not read runtime apply identity file/,
+		);
+
+		const invalid = join(root, "invalid.json");
+		writeFileSync(invalid, JSON.stringify({ generation: 8 }));
+		expect(() => readRuntimeApplyContext({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: invalid })).toThrow(
+			/invalid runtime apply identity file/,
+		);
+		expect(() =>
+			readRuntimeApplyContext({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: "relative.json" }),
+		).toThrow(/canonical absolute path/);
+	});
+
+	test("rejects invalid projected runtime environment values", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-invalid-runtime-env-"));
+		roots.push(root);
+		const path = identityFile(root);
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+		parsed.runtimeEnv = { "INVALID-NAME": " secret" };
+		writeFileSync(path, JSON.stringify(parsed));
+		expect(() => readRuntimeApplyContext({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path })).toThrow(
 			/invalid runtime apply identity file/,
 		);
 	});

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -6,7 +6,6 @@ import {
 	readRuntimeApplyContext,
 	readRuntimeApplyIdentity,
 	resolveRuntimeApplyGeneration,
-	runtimeApplyContextServiceEnvironment,
 	runtimeApplyIdentitiesEqual,
 } from "./apply-identity";
 
@@ -72,7 +71,6 @@ describe("runtime apply identity", () => {
 				applyReceiptId: "apply-receipt-0008",
 				bootNonce: "boot-nonce-000008",
 			},
-			sourcePath: path,
 			runtimeEnvironment: {
 				kind: "projected-environment",
 				values: {
@@ -85,16 +83,13 @@ describe("runtime apply identity", () => {
 		expect(readRuntimeApplyIdentity({ CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path })).toEqual(
 			context.identity,
 		);
-		expect(runtimeApplyContextServiceEnvironment(context)).toEqual({
-			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: path,
-		});
 	});
 
 	test("discovers a supplied canonical mount path", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-discovered-apply-identity-"));
 		roots.push(root);
 		const path = identityFile(root);
-		expect(readRuntimeApplyContext({}, path).sourcePath).toBe(path);
+		expect(readRuntimeApplyContext({}, path).identity.generation).toBe(8);
 	});
 
 	test("fails closed for missing, malformed, or non-canonical files", () => {

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -232,7 +232,7 @@ describe("runtime apply identity file", () => {
 			readRuntimeApplyIdentityFromEnv(completeEnvironment),
 		);
 		expect(readRuntimeApplyContext(completeEnvironment, missingDiscoveryPath)).toMatchObject({
-			kind: "process-environment",
+			kind: "legacy-hosted-bootstrap-bridge",
 			runtimeEnvironment: {
 				kind: "process-environment",
 				values: completeEnvironment,

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -1,12 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { z } from "zod";
-import {
-	type ProcessRuntimeEnvironment,
-	type ProjectedRuntimeEnvironment,
-	processRuntimeEnvironment,
-	projectedRuntimeEnvironment,
-} from "./secret-values";
+import { type ProjectedRuntimeEnvironment, projectedRuntimeEnvironment } from "./secret-values";
 
 export const runtimeApplyIdentitySchema = z
 	.object({
@@ -19,7 +14,7 @@ export const runtimeApplyIdentitySchema = z
 
 export type RuntimeApplyIdentity = z.infer<typeof runtimeApplyIdentitySchema>;
 
-export interface RuntimeGenerationIdentity {
+interface RuntimeGenerationIdentity {
 	generation: number;
 	applyGeneration?: number;
 }
@@ -41,8 +36,8 @@ export function runtimeApplyIdentitiesEqual(
 	);
 }
 
-export const RUNTIME_APPLY_IDENTITY_FILE_ENV = "CLAWDI_RUNTIME_APPLY_IDENTITY_FILE";
-export const HOSTED_RUNTIME_APPLY_IDENTITY_FILE =
+const RUNTIME_APPLY_IDENTITY_FILE_ENV = "CLAWDI_RUNTIME_APPLY_IDENTITY_FILE";
+const HOSTED_RUNTIME_APPLY_IDENTITY_FILE =
 	"/etc/clawdi/runtime-identity/runtime-apply-identity.json";
 
 const runtimeProjectedEnvironmentSchema = z.record(
@@ -70,67 +65,17 @@ const runtimeApplyIdentityFileSchema = runtimeApplyIdentitySchema
 
 type RuntimeApplyIdentityFile = z.infer<typeof runtimeApplyIdentityFileSchema>;
 
-export type RuntimeApplyContext =
-	| {
-			kind: "legacy-hosted-bootstrap-bridge";
-			identity: RuntimeApplyIdentity | null;
-			runtimeEnvironment: ProcessRuntimeEnvironment;
-	  }
-	| {
-			kind: "identity-file";
-			identity: RuntimeApplyIdentity;
-			sourcePath: string;
-			runtimeEnvironment: ProjectedRuntimeEnvironment;
-	  };
-
-export const RUNTIME_APPLY_IDENTITY_ENV = {
-	generation: "CLAWDI_RUNTIME_GENERATION",
-	manifestETag: "CLAWDI_RUNTIME_MANIFEST_ETAG",
-	applyReceiptId: "CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
-	bootNonce: "CLAWDI_RUNTIME_BOOT_NONCE",
-} as const;
-
-export function readRuntimeApplyIdentityFromEnv(
-	env: Readonly<Record<string, string | undefined>> = process.env,
-): RuntimeApplyIdentity | null {
-	const entries = Object.entries(RUNTIME_APPLY_IDENTITY_ENV) as Array<
-		[keyof RuntimeApplyIdentity, string]
-	>;
-	const present = entries.filter(([, name]) => env[name] !== undefined);
-	if (present.length === 0) return null;
-	if (present.length !== entries.length) {
-		const missing = entries.filter(([, name]) => env[name] === undefined).map(([, name]) => name);
-		throw new Error(
-			`incomplete runtime apply identity environment; missing: ${missing.join(", ")}`,
-		);
-	}
-
-	const generation = env[RUNTIME_APPLY_IDENTITY_ENV.generation];
-	if (!generation || !/^[1-9]\d*$/.test(generation)) {
-		throw new Error(
-			`${RUNTIME_APPLY_IDENTITY_ENV.generation} must be a canonical positive integer`,
-		);
-	}
-	const parsed = runtimeApplyIdentitySchema.safeParse({
-		generation: Number(generation),
-		manifestETag: env[RUNTIME_APPLY_IDENTITY_ENV.manifestETag],
-		applyReceiptId: env[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId],
-		bootNonce: env[RUNTIME_APPLY_IDENTITY_ENV.bootNonce],
-	});
-	if (!parsed.success) {
-		throw new Error(
-			`invalid runtime apply identity environment: ${parsed.error.issues
-				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-				.join("; ")}`,
-		);
-	}
-	return parsed.data;
+export interface RuntimeApplyContext {
+	kind: "identity-file";
+	identity: RuntimeApplyIdentity;
+	sourcePath: string;
+	runtimeEnvironment: ProjectedRuntimeEnvironment;
 }
 
 export function readRuntimeApplyIdentity(
 	env: Readonly<Record<string, string | undefined>> = process.env,
 	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
-): RuntimeApplyIdentity | null {
+): RuntimeApplyIdentity {
 	return readRuntimeApplyContext(env, discoveryPath).identity;
 }
 
@@ -139,13 +84,6 @@ export function readRuntimeApplyContext(
 	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
 ): RuntimeApplyContext {
 	const configuredPath = configuredRuntimeApplyIdentityPath(env, discoveryPath);
-	if (configuredPath === null) {
-		return {
-			kind: "legacy-hosted-bootstrap-bridge",
-			identity: readRuntimeApplyIdentityFromEnv(env),
-			runtimeEnvironment: processRuntimeEnvironment(env),
-		};
-	}
 	const parsed = readRuntimeApplyIdentityFile(configuredPath);
 	const { schemaVersion: _schemaVersion, runtimeEnv, ...identity } = parsed;
 	return {
@@ -178,42 +116,22 @@ function readRuntimeApplyIdentityFile(configuredPath: string): RuntimeApplyIdent
 	return parsed.data;
 }
 
-export function runtimeApplyIdentityEnvironment(
-	identity: RuntimeApplyIdentity | null,
-): Record<string, string> {
-	if (!identity) return {};
-	return {
-		[RUNTIME_APPLY_IDENTITY_ENV.generation]: String(identity.generation),
-		[RUNTIME_APPLY_IDENTITY_ENV.manifestETag]: identity.manifestETag,
-		[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId]: identity.applyReceiptId,
-		[RUNTIME_APPLY_IDENTITY_ENV.bootNonce]: identity.bootNonce,
-	};
-}
-
-export function runtimeApplyIdentityServiceEnvironment(
-	env: Readonly<Record<string, string | undefined>> = process.env,
-	discoveryPath: string = HOSTED_RUNTIME_APPLY_IDENTITY_FILE,
-): Record<string, string> {
-	return runtimeApplyContextServiceEnvironment(readRuntimeApplyContext(env, discoveryPath));
-}
-
 export function runtimeApplyContextServiceEnvironment(
 	context: RuntimeApplyContext,
 ): Record<string, string> {
-	if (context.kind === "identity-file") {
-		return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: context.sourcePath };
-	}
-	return runtimeApplyIdentityEnvironment(context.identity);
+	return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: context.sourcePath };
 }
 
 function configuredRuntimeApplyIdentityPath(
 	env: Readonly<Record<string, string | undefined>>,
 	discoveryPath: string,
-): string | null {
+): string {
 	const explicitPath = env[RUNTIME_APPLY_IDENTITY_FILE_ENV];
 	const configuredPath =
 		explicitPath !== undefined ? explicitPath : existsSync(discoveryPath) ? discoveryPath : null;
-	if (configuredPath === null) return null;
+	if (configuredPath === null) {
+		throw new Error(`missing runtime apply identity file ${discoveryPath}`);
+	}
 	if (!configuredPath || configuredPath !== configuredPath.trim() || !isAbsolute(configuredPath)) {
 		throw new Error(`${RUNTIME_APPLY_IDENTITY_FILE_ENV} must be a canonical absolute path`);
 	}

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -72,7 +72,7 @@ type RuntimeApplyIdentityFile = z.infer<typeof runtimeApplyIdentityFileSchema>;
 
 export type RuntimeApplyContext =
 	| {
-			kind: "process-environment";
+			kind: "legacy-hosted-bootstrap-bridge";
 			identity: RuntimeApplyIdentity | null;
 			runtimeEnvironment: ProcessRuntimeEnvironment;
 	  }
@@ -141,7 +141,7 @@ export function readRuntimeApplyContext(
 	const configuredPath = configuredRuntimeApplyIdentityPath(env, discoveryPath);
 	if (configuredPath === null) {
 		return {
-			kind: "process-environment",
+			kind: "legacy-hosted-bootstrap-bridge",
 			identity: readRuntimeApplyIdentityFromEnv(env),
 			runtimeEnvironment: processRuntimeEnvironment(env),
 		};

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -68,7 +68,6 @@ type RuntimeApplyIdentityFile = z.infer<typeof runtimeApplyIdentityFileSchema>;
 export interface RuntimeApplyContext {
 	kind: "identity-file";
 	identity: RuntimeApplyIdentity;
-	sourcePath: string;
 	runtimeEnvironment: ProjectedRuntimeEnvironment;
 }
 
@@ -89,7 +88,6 @@ export function readRuntimeApplyContext(
 	return {
 		kind: "identity-file",
 		identity,
-		sourcePath: configuredPath,
 		runtimeEnvironment: projectedRuntimeEnvironment(runtimeEnv),
 	};
 }
@@ -114,12 +112,6 @@ function readRuntimeApplyIdentityFile(configuredPath: string): RuntimeApplyIdent
 		);
 	}
 	return parsed.data;
-}
-
-export function runtimeApplyContextServiceEnvironment(
-	context: RuntimeApplyContext,
-): Record<string, string> {
-	return { [RUNTIME_APPLY_IDENTITY_FILE_ENV]: context.sourcePath };
 }
 
 function configuredRuntimeApplyIdentityPath(

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -11,11 +11,7 @@ import type {
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
-import {
-	processRuntimeEnvironment,
-	type RuntimeEnvironmentAuthority,
-	runtimeSecretValue,
-} from "./secret-values";
+import { type RuntimeEnvironmentAuthority, runtimeSecretValue } from "./secret-values";
 import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
 
 type EgressProfile = EgressProfileInputBundle["profiles"][number];
@@ -103,7 +99,10 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 ): RuntimeManifestLoad {
 	if (!load.channelBindings) return load;
 	const secretValues = load.secretValues ?? {};
-	const runtimeEnvironment = load.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment();
+	const runtimeEnvironment = load.applyContext?.runtimeEnvironment;
+	if (!runtimeEnvironment) {
+		throw new Error("runtime bundle channel projection requires an explicit apply context");
+	}
 	const links: ManagedChannelLink[] = load.channelBindings.map((binding) =>
 		managedBundleChannelLink(binding, secretValues, runtimeEnvironment),
 	);

--- a/packages/cli/src/runtime/converge-lock.test.ts
+++ b/packages/cli/src/runtime/converge-lock.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { withRuntimeConvergeLockAsync } from "./manifest";
+import { withRuntimeConvergeLockAsync } from "./converge-lock";
 import { getRuntimePaths } from "./paths";
 
 const originalEnv = { ...process.env };

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -1,0 +1,448 @@
+import type {
+	AiProviderApiMode,
+	AiProviderAuth,
+	AiProviderCatalog,
+	AiProviderModel,
+	AiProviderType,
+} from "@clawdi/shared";
+import {
+	CLAWDI_MANAGED_PROVIDER_ID,
+	isAiProviderApiMode,
+	isAiProviderType,
+	isClawdiManagedV2ProviderId,
+} from "@clawdi/shared";
+import type { AgentPrimaryModel } from "../lib/ai-provider-projection";
+import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
+import { isClawdiManagedProviderProjection } from "./hosted-egress-profiles";
+import { resolveManagedPrimaryModel } from "./managed-model-resolution";
+import type { RuntimeManifest } from "./manifest-contract";
+
+export function hostedAiProviderCatalog(
+	manifest: RuntimeManifest,
+	runtimeName?: string,
+	options: {
+		primaryModelOverride?: AgentPrimaryModel;
+		managedModelsOverride?: readonly AiProviderModel[];
+	} = {},
+): { catalog: AiProviderCatalog; primaryModel: AgentPrimaryModel } | null {
+	const providers = manifest.projection?.providers;
+	if (!providers || Object.keys(providers).length === 0) return null;
+	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
+	const primaryModel =
+		options.primaryModelOverride ?? hostedRuntimePrimaryModel(manifest, runtimeName);
+	if (!primaryModel) return null;
+	const entries = rawEntries
+		.map(([id, raw]) => {
+			if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+			const input = raw as Record<string, unknown>;
+			const baseUrl = typeof input.baseUrl === "string" ? input.baseUrl : undefined;
+			const apiMode = hostedProviderApiMode(input);
+			const apiKeySecretRef =
+				typeof input.apiKeySecretRef === "string" ? input.apiKeySecretRef : undefined;
+			const runtimeEnvName = hostedProviderRuntimeEnvName(id, input);
+			if (hostedProviderUnhealthy(input)) return null;
+			if (!baseUrl) return null;
+			const auth = hostedProviderAuth(input, Boolean(apiKeySecretRef));
+			if (!auth) return null;
+			const models = hostedProviderModels(
+				input,
+				id === primaryModel.provider_id ? primaryModel : null,
+				id === primaryModel.provider_id ? options.managedModelsOverride : undefined,
+			);
+			return {
+				id,
+				type: hostedProviderType(input),
+				base_url: baseUrl,
+				api_mode: apiMode,
+				managed_by: hostedProviderManagedBy(input),
+				auth,
+				runtime_env_name: apiKeySecretRef || auth.type !== "none" ? runtimeEnvName : undefined,
+				models,
+			};
+		})
+		.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+	if (entries.length === 0) return null;
+	return {
+		catalog: {
+			schema_version: 1,
+			providers: entries,
+			defaults: { chat_provider_id: primaryModel.provider_id },
+		},
+		primaryModel,
+	};
+}
+
+function hostedProviderManagedBy(
+	input: Record<string, unknown>,
+): AiProviderCatalog["providers"][number]["managed_by"] {
+	const value = input.managed_by;
+	return value === "clawdi" || value === "user" ? value : undefined;
+}
+
+function hostedProviderEntries(
+	providers: Record<string, unknown>,
+	runtimeName?: string,
+	manifest?: RuntimeManifest,
+): Array<[string, unknown]> {
+	if (!runtimeName) {
+		return Object.entries(providers).sort(([left], [right]) => left.localeCompare(right));
+	}
+	const providerIds = manifest?.runtimes?.[runtimeName]?.provider_ids ?? [];
+	return providerIds
+		.filter((providerId) => Object.hasOwn(providers, providerId))
+		.map((providerId) => [providerId, providers[providerId]]);
+}
+
+function hostedRuntimePrimaryModel(
+	manifest: RuntimeManifest,
+	runtimeName: string | undefined,
+): AgentPrimaryModel | null {
+	const runtime = runtimeName ? manifest.runtimes[runtimeName] : undefined;
+	return runtime?.primary_model ?? null;
+}
+
+function hostedProviderModels(
+	input: Record<string, unknown>,
+	primaryModel: AgentPrimaryModel | null,
+	managedModelsOverride?: readonly AiProviderModel[],
+): NonNullable<AiProviderCatalog["providers"][number]["models"]> {
+	const providerApiMode = hostedProviderApiMode(input);
+	// Hosted wire rejects singular model; this fallback serves generic provider projections only.
+	const singularModel = stringValue(input.model);
+	const rawModels = Array.isArray(input.models) ? input.models : [];
+	const manifestModels = rawModels
+		.map((model) => (recordValue(model) ? (model as Record<string, unknown>) : null))
+		.filter((model): model is Record<string, unknown> => model !== null)
+		.map((model) => {
+			const id = stringValue(model.id);
+			if (!id) return null;
+			const apiMode = stringValue(model.api_mode);
+			return {
+				...model,
+				id,
+				...(apiMode && isAiProviderApiMode(apiMode) ? { api_mode: apiMode } : {}),
+			};
+		})
+		.filter((model): model is NonNullable<typeof model> => model !== null);
+	const manifestModelsById = new Map(manifestModels.map((model) => [model.id, model]));
+	const models = managedModelsOverride
+		? managedModelsOverride.map((model) => ({
+				...manifestModelsById.get(model.id),
+				...model,
+				id: model.id,
+			}))
+		: manifestModels;
+	if (singularModel && !models.some((model) => model.id === singularModel)) {
+		models.unshift({ id: singularModel, api_mode: providerApiMode });
+	}
+	if (primaryModel && !models.some((model) => model.id === primaryModel.model)) {
+		models.unshift({ id: primaryModel.model, api_mode: providerApiMode });
+	}
+	return models.filter(
+		(model, index, entries) => entries.findIndex((entry) => entry.id === model.id) === index,
+	);
+}
+
+function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMode {
+	const raw = input.apiMode;
+	if (typeof raw === "string" && isAiProviderApiMode(raw)) {
+		return raw;
+	}
+	return "openai_chat";
+}
+
+function managedProviderSupportsLiveModelProbe(apiMode: AiProviderApiMode): boolean {
+	return apiMode === "openai_chat" || apiMode === "openai_responses";
+}
+
+function managedGatewayPrimaryModelTarget(
+	manifest: RuntimeManifest,
+	runtimeName: string,
+): {
+	baseUrl: string;
+	providerId: string;
+	seedModel: string | null;
+} | null {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return null;
+	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
+	if (rawEntries.length === 0) return null;
+	const currentPrimary = hostedRuntimePrimaryModel(manifest, runtimeName);
+	const selectedProviderId = currentPrimary?.provider_id ?? null;
+	if (!selectedProviderId) return null;
+	const selectedProvider = rawEntries.find(
+		([providerId]) => providerId === selectedProviderId,
+	)?.[1];
+	const provider = recordValue(selectedProvider);
+	if (!provider || !isClawdiManagedProviderProjection(provider)) return null;
+	const baseUrl = stringValue(provider.baseUrl);
+	if (!baseUrl) return null;
+	const apiMode = hostedProviderApiMode(provider);
+	if (!managedProviderSupportsLiveModelProbe(apiMode)) return null;
+	return {
+		baseUrl,
+		providerId: selectedProviderId,
+		seedModel:
+			currentPrimary && currentPrimary.provider_id === selectedProviderId
+				? currentPrimary.model
+				: null,
+	};
+}
+
+interface ManagedGatewayModelOverrides {
+	primaryModels: Partial<Record<string, AgentPrimaryModel>>;
+	models: Partial<Record<string, AiProviderModel[]>>;
+}
+
+interface ManagedGatewayModelFetchInput {
+	baseUrl: string;
+	home: string;
+	egressSystemCaFile: string | null;
+	providerId: string;
+	runtimeName: string;
+	workspaceRoot: string;
+}
+
+type ManagedGatewayModelFetchResult =
+	| { status: "ok"; endpoint: string; models: AiProviderModel[] }
+	| { status: "failed"; endpoint: string; detail: string };
+
+export type ManagedGatewayModelListFetcher = (
+	input: ManagedGatewayModelFetchInput,
+) => ManagedGatewayModelFetchResult;
+
+export function resolveManagedGatewayModelOverrides(
+	manifest: RuntimeManifest,
+	enabledRuntimes: readonly string[],
+	home: string,
+	workspaceRoot: string,
+	egressSystemCaFile: string | null,
+	fetcher: ManagedGatewayModelListFetcher,
+): ManagedGatewayModelOverrides {
+	const overrides: ManagedGatewayModelOverrides = { primaryModels: {}, models: {} };
+	const fetchCache = new Map<string, ManagedGatewayModelFetchResult>();
+	for (const runtimeName of enabledRuntimes) {
+		const target = managedGatewayPrimaryModelTarget(manifest, runtimeName);
+		if (!target) continue;
+		const cacheKey = `${target.providerId}\n${target.baseUrl}`;
+		let fetchResult = fetchCache.get(cacheKey);
+		if (!fetchResult) {
+			fetchResult = fetcher({
+				baseUrl: target.baseUrl,
+				home,
+				egressSystemCaFile,
+				providerId: target.providerId,
+				runtimeName,
+				workspaceRoot,
+			});
+			fetchCache.set(cacheKey, fetchResult);
+			if (fetchResult.status === "failed") {
+				const loggedProviderId = isClawdiManagedV2ProviderId(target.providerId)
+					? CLAWDI_MANAGED_PROVIDER_ID
+					: target.providerId;
+				console.warn(
+					`managed model probe failed for ${runtimeName}/${loggedProviderId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
+				);
+			}
+		}
+		const resolution = resolveManagedPrimaryModel({
+			seedModel: target.seedModel,
+			liveModelIds:
+				fetchResult.status === "ok" ? fetchResult.models.map((model) => model.id) : null,
+		});
+		if (fetchResult.status === "ok" && fetchResult.models.length > 0) {
+			overrides.models[runtimeName] = fetchResult.models;
+		}
+		if (!resolution.resolvedModel) continue;
+		if (resolution.resolvedModel === target.seedModel) continue;
+		overrides.primaryModels[runtimeName] = {
+			provider_id: target.providerId,
+			model: resolution.resolvedModel,
+		};
+	}
+	return overrides;
+}
+
+function hostedProviderType(input: Record<string, unknown>): AiProviderType {
+	const type = stringValue(input.type);
+	return type && isAiProviderType(type) ? type : "custom_openai_compatible";
+}
+
+function hostedProviderAuth(
+	input: Record<string, unknown>,
+	hasApiKeySecretRef: boolean,
+): AiProviderAuth | null {
+	const auth = recordValue(input.auth);
+	if (auth) {
+		const type = stringValue(auth.type);
+		const tool = stringValue(auth.tool);
+		const profile = stringValue(auth.profile);
+		if (type === "agent_profile" && tool === "codex" && profile) {
+			return { type: "agent_profile", tool: "codex", profile };
+		}
+		if (type === "api_key" || type === "secret_ref") {
+			if (hasApiKeySecretRef) {
+				return { type: "api_key", source: "managed" };
+			}
+			return null;
+		}
+		if (type && type !== "none") return null;
+	}
+	if (hasApiKeySecretRef) {
+		return { type: "api_key", source: "managed" };
+	}
+	if (hostedProviderRequiresApiKey(input)) {
+		return null;
+	}
+	return { type: "none" };
+}
+
+function hostedProviderUnhealthy(input: Record<string, unknown>): boolean {
+	const status = stringValue(input.status);
+	return Boolean(status && status !== "ok");
+}
+
+export function hostedProviderRequiresApiKey(input: Record<string, unknown>): boolean {
+	if (input.apiKeyRequired === true) return true;
+	const auth = recordValue(input.auth);
+	const type = auth ? stringValue(auth.type) : null;
+	return type === "api_key" || type === "secret_ref";
+}
+
+function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {
+	const raw = typeof input.runtimeEnvName === "string" ? input.runtimeEnvName : null;
+	if (raw && isEnvKey(raw)) return raw;
+	return `CLAWDI_PROVIDER_${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
+}
+
+function hostedProviderPlaceholderEnv(
+	manifest: RuntimeManifest,
+	runtimeName?: string,
+): Record<string, string> {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return {};
+	const env: Record<string, string> = {};
+	for (const [providerId, raw] of hostedProviderEntries(providers, runtimeName, manifest)) {
+		const provider = recordValue(raw);
+		if (!provider) continue;
+		if (!isClawdiManagedProviderProjection(provider)) continue;
+		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
+		if (!apiKeySecretRef) continue;
+		const runtimeEnvName = hostedProviderRuntimeEnvName(providerId, provider);
+		if (!isEnvKey(runtimeEnvName)) continue;
+		env[runtimeEnvName] = MANAGED_EGRESS_PLACEHOLDER_VALUE;
+	}
+	return env;
+}
+
+function hostedProviderSecretEnv(
+	manifest: RuntimeManifest,
+	runtimeName?: string,
+): Record<string, string> {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return {};
+	const secretEnv: Record<string, string> = {};
+	for (const [providerId, raw] of hostedProviderEntries(providers, runtimeName, manifest)) {
+		const provider = recordValue(raw);
+		if (!provider) continue;
+		if (isClawdiManagedProviderProjection(provider)) continue;
+		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
+		if (!apiKeySecretRef) continue;
+		const runtimeEnvName = hostedProviderRuntimeEnvName(providerId, provider);
+		if (!isEnvKey(runtimeEnvName)) continue;
+		secretEnv[runtimeEnvName] = apiKeySecretRef;
+	}
+	return secretEnv;
+}
+
+interface HostedProviderEnvironment {
+	placeholderEnv: Record<string, string>;
+	secretEnv: Record<string, string>;
+}
+
+export function hostedProviderEnvironment(
+	manifest: RuntimeManifest,
+	runtimeName?: string,
+	options: { validateOverlap?: boolean } = {},
+): HostedProviderEnvironment {
+	const placeholderEnv = hostedProviderPlaceholderEnv(manifest, runtimeName);
+	const secretEnv = hostedProviderSecretEnv(manifest, runtimeName);
+	if (options.validateOverlap) {
+		assertNoProviderEnvOverlap(runtimeName ?? "default", placeholderEnv, secretEnv);
+	}
+	return { placeholderEnv, secretEnv };
+}
+
+function assertNoProviderEnvOverlap(
+	runtimeName: string,
+	placeholderEnv: Record<string, string>,
+	secretEnv: Record<string, string>,
+): void {
+	for (const envName of Object.keys(placeholderEnv)) {
+		if (secretEnv[envName] === undefined) continue;
+		throw new Error(
+			`runtime ${runtimeName} provider env ${envName} is both managed and BYOK-backed`,
+		);
+	}
+}
+
+export function mergeRuntimeEnvWithProviderPlaceholders(
+	runtimeName: string,
+	settings: RuntimeManifest["runtimes"][string]["run"],
+	providerEnv: Record<string, string>,
+): RuntimeManifest["runtimes"][string]["run"] {
+	if (Object.keys(providerEnv).length === 0) return settings;
+	const userEnv = settings?.env ?? {};
+	for (const envName of Object.keys(providerEnv)) {
+		if (settings?.secretEnv?.[envName] !== undefined) {
+			throw new Error(
+				`runtime ${runtimeName} provider placeholder ${envName} conflicts with secretEnv`,
+			);
+		}
+	}
+	return {
+		...(settings ?? {}),
+		prependPath: settings?.prependPath ?? [],
+		env: {
+			...userEnv,
+			...providerEnv,
+		},
+	};
+}
+
+export function mergeRuntimeServiceEnvWithProviderPlaceholders(
+	runtimeName: string,
+	serviceName: string,
+	settings: NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string],
+	providerEnv: Record<string, string>,
+): NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string] {
+	if (Object.keys(providerEnv).length === 0) return settings;
+	for (const envName of Object.keys(providerEnv)) {
+		if (settings.secretEnv?.[envName] !== undefined) {
+			throw new Error(
+				`runtime ${runtimeName} service ${serviceName} provider placeholder ${envName} conflicts with secretEnv`,
+			);
+		}
+	}
+	return {
+		...settings,
+		env: {
+			...(settings.env ?? {}),
+			...providerEnv,
+		},
+	};
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isEnvKey(value: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -15,6 +15,7 @@ import {
 import { basename, dirname, join } from "node:path";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
+import { runningAsRoot } from "./runtime-user-command";
 import { isGeneratedRuntimeSystemdFile } from "./systemd-user";
 
 type RuntimeLiveSnapshotNode =
@@ -258,8 +259,4 @@ function restoreRuntimeLiveNode(path: string, node: RuntimeLiveSnapshotNode): vo
 	chmodSync(path, node.mode);
 	for (const [entry, child] of node.entries) restoreRuntimeLiveNode(join(path, entry), child);
 	restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
-}
-
-function runningAsRoot(): boolean {
-	return typeof process.getuid === "function" && process.getuid() === 0;
 }

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -1,0 +1,265 @@
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	lchownSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { RuntimeManifest } from "./manifest-contract";
+import type { RuntimePaths } from "./paths";
+import { isGeneratedRuntimeSystemdFile } from "./systemd-user";
+
+type RuntimeLiveSnapshotNode =
+	| { kind: "missing" }
+	| { kind: "metadata"; existed: false }
+	| { kind: "metadata"; existed: true; mode: number; uid: number; gid: number }
+	| { kind: "file"; content: Buffer; mode: number; uid: number; gid: number }
+	| { kind: "symlink"; target: string; uid: number; gid: number }
+	| {
+			kind: "directory";
+			mode: number;
+			uid: number;
+			gid: number;
+			entries: Map<string, RuntimeLiveSnapshotNode>;
+	  };
+
+export interface RuntimeLiveSnapshot {
+	entries: Map<string, RuntimeLiveSnapshotNode>;
+}
+
+export function runtimeLiveSnapshotPaths(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+	const result = new Set<string>([
+		paths.managedConfig,
+		paths.syncState,
+		paths.providerHealthStatus,
+		paths.egressEngineStatus,
+		paths.manifestLastGood,
+		paths.managedSecretCacheFile,
+		paths.appliedState,
+		paths.egressProfileRoot,
+		paths.installInventory,
+		paths.projectionRoot,
+		join(paths.instanceRoot, manifest.instanceId),
+		paths.managedSecretFile,
+		paths.daemonAuthToken,
+		join(paths.managedSecretRoot, "egress-secrets.json"),
+		paths.instanceData,
+		paths.sensitiveInstanceData,
+		paths.egressAddon,
+		paths.egressTransparentEnv,
+		paths.egressSystemCaFile,
+		join(paths.serviceStateRoot, "config", "runtime-live-sync-agents.json"),
+	]);
+	for (const name of ["clawdi-runtime-watch", "clawdi-daemon", "clawdi-runtime-sidecar"]) {
+		const unitName = `${name}.service`;
+		result.add(join(paths.systemdSystemRoot, unitName));
+		result.add(join(paths.systemdEnvRoot, `${unitName}.env`));
+	}
+	addExistingManagedSystemdSystemPaths(paths, result);
+	return [...result].sort();
+}
+
+export function captureRuntimeLiveSnapshot(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+): RuntimeLiveSnapshot {
+	for (const path of runtimeManagedDirectoryPaths(manifest, paths)) {
+		assertRuntimeManagedDirectoryTrusted(path);
+	}
+	const snapshotPaths = runtimeLiveSnapshotPaths(manifest, paths);
+	return {
+		entries: new Map([
+			...snapshotPaths.map((path) => [path, captureRuntimeLiveNode(path)] as const),
+			...runtimeLiveSnapshotMetadataPaths(snapshotPaths).map(
+				(path) => [path, captureRuntimeLiveMetadata(path)] as const,
+			),
+		]),
+	};
+}
+
+export function restoreRuntimeLiveSnapshot(snapshot: RuntimeLiveSnapshot): void {
+	for (const [path, node] of snapshot.entries) {
+		if (node.kind !== "metadata") restoreRuntimeLiveNode(path, node);
+	}
+	for (const [path, node] of snapshot.entries) {
+		if (node.kind === "metadata") restoreRuntimeLiveNode(path, node);
+	}
+}
+
+function addExistingManagedSystemdSystemPaths(paths: RuntimePaths, result: Set<string>): void {
+	if (!existsSync(paths.systemdSystemRoot)) return;
+	for (const entry of readdirSync(paths.systemdSystemRoot)) {
+		const path = join(paths.systemdSystemRoot, entry);
+		if (
+			entry.endsWith(".service") &&
+			(entry.startsWith("clawdi-") || isGeneratedSystemdFile(path))
+		) {
+			result.add(path);
+		}
+		if (!entry.endsWith(".service.d")) continue;
+		const dropIn = join(path, "10-clawdi-hosted.conf");
+		if (isGeneratedSystemdFile(dropIn)) result.add(dropIn);
+	}
+}
+
+function isGeneratedSystemdFile(path: string): boolean {
+	try {
+		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
+	} catch {
+		return false;
+	}
+}
+
+function runtimeManagedDirectoryPaths(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+	return [
+		paths.runConfigRoot,
+		paths.systemdEnvRoot,
+		paths.egressProfileRoot,
+		paths.installInventory,
+		paths.projectionRoot,
+		join(paths.instanceRoot, manifest.instanceId),
+	];
+}
+
+function assertRuntimeManagedDirectoryTrusted(path: string): void {
+	let stat: ReturnType<typeof lstatSync>;
+	try {
+		stat = lstatSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!stat.isDirectory() || stat.isSymbolicLink()) {
+		throw new Error(`runtime managed directory is not a real directory: ${path}`);
+	}
+	if ((stat.mode & 0o022) !== 0) {
+		throw new Error(`runtime managed directory is group/world writable: ${path}`);
+	}
+	if (runningAsRoot() && stat.uid !== 0) {
+		throw new Error(`runtime managed directory is not root-owned: ${path}`);
+	}
+}
+
+function runtimeLiveSnapshotMetadataPaths(snapshotPaths: readonly string[]): string[] {
+	return [
+		...new Set(
+			snapshotPaths
+				.filter((path) => basename(path) === "10-clawdi-hosted.conf")
+				.map((path) => dirname(path)),
+		),
+	].sort();
+}
+
+function captureRuntimeLiveNode(path: string): RuntimeLiveSnapshotNode {
+	let stat: ReturnType<typeof lstatSync>;
+	try {
+		stat = lstatSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
+		throw error;
+	}
+	if (stat.isSymbolicLink()) {
+		return { kind: "symlink", target: readlinkSync(path), uid: stat.uid, gid: stat.gid };
+	}
+	if (stat.isFile()) {
+		return {
+			kind: "file",
+			content: readFileSync(path),
+			mode: stat.mode & 0o777,
+			uid: stat.uid,
+			gid: stat.gid,
+		};
+	}
+	if (!stat.isDirectory()) throw new Error(`unsupported runtime live-state path: ${path}`);
+	const mode = stat.mode & 0o777;
+	if ((mode & 0o022) !== 0) {
+		throw new Error(`runtime live-state snapshot directory is group/world writable: ${path}`);
+	}
+	if (runningAsRoot() && stat.uid !== 0) {
+		throw new Error(`runtime live-state snapshot directory is not root-owned: ${path}`);
+	}
+	return {
+		kind: "directory",
+		mode,
+		uid: stat.uid,
+		gid: stat.gid,
+		entries: new Map(
+			readdirSync(path)
+				.sort()
+				.map((entry) => [entry, captureRuntimeLiveNode(join(path, entry))]),
+		),
+	};
+}
+
+function captureRuntimeLiveMetadata(path: string): RuntimeLiveSnapshotNode {
+	try {
+		const stat = lstatSync(path);
+		return {
+			kind: "metadata",
+			existed: true,
+			mode: stat.mode & 0o777,
+			uid: stat.uid,
+			gid: stat.gid,
+		};
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { kind: "metadata", existed: false };
+		}
+		throw error;
+	}
+}
+
+function restoreRuntimeLiveOwnership(
+	path: string,
+	uid: number,
+	gid: number,
+	symlink: boolean,
+): void {
+	const restored = lstatSync(path);
+	if (restored.uid === uid && restored.gid === gid) return;
+	if (symlink) lchownSync(path, uid, gid);
+	else chownSync(path, uid, gid);
+}
+
+function restoreRuntimeLiveNode(path: string, node: RuntimeLiveSnapshotNode): void {
+	if (node.kind === "metadata") {
+		if (!node.existed) {
+			if (existsSync(path) && readdirSync(path).length === 0) rmSync(path, { recursive: true });
+			return;
+		}
+		if (!existsSync(path)) mkdirSync(path, { recursive: true, mode: node.mode });
+		chmodSync(path, node.mode);
+		restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
+		return;
+	}
+	rmSync(path, { recursive: true, force: true });
+	if (node.kind === "missing") return;
+	mkdirSync(dirname(path), { recursive: true });
+	if (node.kind === "symlink") {
+		symlinkSync(node.target, path);
+		restoreRuntimeLiveOwnership(path, node.uid, node.gid, true);
+		return;
+	}
+	if (node.kind === "file") {
+		writeFileSync(path, node.content, { mode: node.mode });
+		chmodSync(path, node.mode);
+		restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
+		return;
+	}
+	mkdirSync(path, { recursive: true, mode: node.mode });
+	chmodSync(path, node.mode);
+	for (const [entry, child] of node.entries) restoreRuntimeLiveNode(join(path, entry), child);
+	restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
+}
+
+function runningAsRoot(): boolean {
+	return typeof process.getuid === "function" && process.getuid() === 0;
+}

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -29,11 +29,8 @@ import { runtimeLiveSnapshotPaths } from "./live-state-snapshot";
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
-	daemonProgramRevision,
 	type RuntimeManifest,
-	runtimeProgramRevision as runtimeProgramRevisionWithEnvironment,
 	runtimeRecoverableSecretValues,
-	runtimeSidecarProgramRevision,
 } from "./manifest";
 import {
 	hostedRuntimeBundleV2ManifestSchema,
@@ -68,19 +65,6 @@ const successfulPrerequisiteActivation = () => ({
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
-const runtimeProgramRevision = (
-	manifest: RuntimeManifest,
-	runtime: string,
-	secretValues: Record<string, string> | undefined,
-	providerProjectionRevision: string | null = null,
-): string =>
-	runtimeProgramRevisionWithEnvironment(
-		manifest,
-		runtime,
-		secretValues,
-		projectedRuntimeEnvironment({}),
-		providerProjectionRevision,
-	);
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.57";
 const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_HOSTED_CODEX_TOOLING = {
@@ -142,13 +126,6 @@ function runSettings(command: string, args: string[]): RuntimeRunSettings {
 	return { command, args, env: {}, prependPath: [] };
 }
 
-function systemdProgramRevision(paths: RuntimePaths, programName: string): string {
-	const content = readFileSync(join(paths.systemdEnvRoot, `${programName}.service.env`), "utf-8");
-	const revision = /^CLAWDI_RUNTIME_REV="([^"]+)"$/m.exec(content)?.[1];
-	if (!revision) throw new Error(`Missing CLAWDI_RUNTIME_REV for ${programName}`);
-	return revision;
-}
-
 function manifestLoad(
 	manifest: RuntimeManifest,
 	sourcePath: string,
@@ -168,7 +145,6 @@ function manifestLoad(
 				applyReceiptId: "test-apply-receipt",
 				bootNonce: "test-boot-nonce",
 			},
-			sourcePath: "/test/runtime-apply-identity.json",
 			runtimeEnvironment: projectedRuntimeEnvironment(
 				Object.fromEntries(
 					Object.entries(process.env).filter(
@@ -2460,270 +2436,6 @@ describe("runtime manifest reconciliation invariants", () => {
 				supports_tools: true,
 			},
 		]);
-	});
-
-	test("keeps reconcile impact scoped to the affected process", () => {
-		const paths = tempRuntimePaths();
-		const runtimeSecretRef = "secret://runtimes/openclaw/api-key";
-		const egressSecretRef = "secret://providers/default/api-key";
-		const manifest = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				run: {
-					...runSettings("openclaw", ["gateway", "run"]),
-					secretEnv: { OPENAI_API_KEY: runtimeSecretRef },
-				},
-				services: {},
-			},
-		});
-		const secretValues = {
-			[runtimeSecretRef]: "sk-runtime-before",
-			[egressSecretRef]: "sk-egress-before",
-		};
-		const rotatedRuntimeSecretValues = {
-			...secretValues,
-			[runtimeSecretRef]: "sk-runtime-after",
-		};
-		const rotatedEgressSecretValues = {
-			...secretValues,
-			[egressSecretRef]: "sk-egress-after",
-		};
-		const metadataOnlyChange: RuntimeManifest = {
-			...manifest,
-			generation: 2,
-			issuedAt: "2026-07-01T00:01:00.000Z",
-		};
-		const cliOnlyChange: RuntimeManifest = {
-			...manifest,
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.16" },
-		};
-		const controlPlaneOnlyChange: RuntimeManifest = {
-			...manifest,
-			controlPlane: { apiUrl: "https://unrelated-control-plane.example.test" },
-		};
-		const terminalToolingOnlyChange: RuntimeManifest = {
-			...manifest,
-			projection: { terminalTooling: { codex: { enabled: false } } },
-		};
-		const skillOnlyChange: RuntimeManifest = {
-			...manifest,
-			projection: {
-				skills: { entries: { clawdi: { enabled: true, version: 1 } } },
-			},
-		};
-		const unrelatedProviderChange: RuntimeManifest = {
-			...manifest,
-			projection: {
-				providers: {
-					unrelated: {
-						type: "custom_openai_compatible",
-						baseUrl: "https://unrelated.example.test/v1",
-					},
-				},
-			},
-		};
-		const relevantGatewayProjectionChange: RuntimeManifest = {
-			...manifest,
-			projection: {
-				system: {
-					openclawControlUiAllowedOrigins: ["https://gateway.example.test"],
-				},
-			},
-		};
-		const managedTelegramChannelChange: RuntimeManifest = {
-			...manifest,
-			projection: {
-				channels: {
-					telegram: {
-						enabled: true,
-						defaultAccount: "managed-telegram",
-						accounts: { "managed-telegram": { enabled: true } },
-					},
-				},
-			},
-		};
-		const serviceOnlyChange: RuntimeManifest = {
-			...manifest,
-			runtimes: {
-				...manifest.runtimes,
-				openclaw: {
-					...manifest.runtimes.openclaw,
-					services: { worker: runSettings("openclaw", ["worker"]) },
-				},
-			},
-		};
-		const multiRuntimeManifest: RuntimeManifest = {
-			...manifest,
-			runtimes: {
-				...manifest.runtimes,
-				hermes: {
-					enabled: true,
-					run: runSettings("hermes", ["gateway"]),
-					services: {},
-				},
-			},
-		};
-		const unrelatedRuntimeChange: RuntimeManifest = {
-			...multiRuntimeManifest,
-			runtimes: {
-				...multiRuntimeManifest.runtimes,
-				hermes: {
-					...multiRuntimeManifest.runtimes.hermes,
-					run: runSettings("hermes", ["gateway", "--verbose"]),
-				},
-			},
-		};
-		const egressManifest: RuntimeManifest = {
-			...manifest,
-			egressProfiles: {
-				profiles: [
-					{
-						id: "channel-token",
-						enabled: true,
-						kind: "http",
-						match: {
-							scheme: "https",
-							host: "api.example.test",
-							pathPrefix: "/",
-							headers: {},
-							query: {},
-						},
-						rewrite: {
-							upstreamBaseUrl: "https://upstream.example.test",
-							preservePath: true,
-							setHeaders: {
-								authorization: {
-									type: "secretRef",
-									secretRef: egressSecretRef,
-									prefix: "Bearer ",
-								},
-							},
-						},
-						logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
-						priority: 100,
-					},
-				],
-			},
-		};
-
-		const runtimeRevision = runtimeProgramRevision(manifest, "openclaw", secretValues);
-		expect(runtimeProgramRevision(manifest, "openclaw", rotatedRuntimeSecretValues)).not.toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(manifest, "openclaw", rotatedEgressSecretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(egressManifest, "openclaw", rotatedEgressSecretValues)).toBe(
-			runtimeProgramRevision(egressManifest, "openclaw", secretValues),
-		);
-		expect(runtimeProgramRevision(metadataOnlyChange, "openclaw", secretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(cliOnlyChange, "openclaw", secretValues)).toBe(runtimeRevision);
-		expect(runtimeProgramRevision(controlPlaneOnlyChange, "openclaw", secretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(egressManifest, "openclaw", secretValues)).toBe(runtimeRevision);
-		expect(runtimeProgramRevision(terminalToolingOnlyChange, "openclaw", secretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(unrelatedProviderChange, "openclaw", secretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(serviceOnlyChange, "openclaw", secretValues)).toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(unrelatedRuntimeChange, "openclaw", secretValues)).toBe(
-			runtimeProgramRevision(multiRuntimeManifest, "openclaw", secretValues),
-		);
-		expect(runtimeProgramRevision(unrelatedRuntimeChange, "hermes", secretValues)).not.toBe(
-			runtimeProgramRevision(multiRuntimeManifest, "hermes", secretValues),
-		);
-		expect(
-			runtimeProgramRevision(relevantGatewayProjectionChange, "openclaw", secretValues),
-		).not.toBe(runtimeRevision);
-		expect(runtimeProgramRevision(managedTelegramChannelChange, "openclaw", secretValues)).not.toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(skillOnlyChange, "openclaw", secretValues)).not.toBe(
-			runtimeRevision,
-		);
-		expect(runtimeProgramRevision(manifest, "openclaw", secretValues, "provider-b")).not.toBe(
-			runtimeProgramRevision(manifest, "openclaw", secretValues, "provider-a"),
-		);
-		const sidecarRevision = runtimeSidecarProgramRevision(manifest);
-		expect(runtimeSidecarProgramRevision(egressManifest)).not.toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(metadataOnlyChange)).toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(cliOnlyChange)).toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(terminalToolingOnlyChange)).toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(skillOnlyChange)).toBe(sidecarRevision);
-		expect(runtimeSidecarProgramRevision(managedTelegramChannelChange)).toBe(sidecarRevision);
-		const daemonRevision = daemonProgramRevision(manifest);
-		expect(daemonProgramRevision(metadataOnlyChange)).toBe(daemonRevision);
-		expect(daemonProgramRevision(terminalToolingOnlyChange)).toBe(daemonRevision);
-		expect(daemonProgramRevision(skillOnlyChange)).toBe(daemonRevision);
-		expect(daemonProgramRevision(managedTelegramChannelChange)).toBe(daemonRevision);
-		expect(daemonProgramRevision(egressManifest)).toBe(daemonRevision);
-		expect(daemonProgramRevision(cliOnlyChange)).not.toBe(daemonRevision);
-	});
-
-	test("scopes managed Telegram revisions to the OpenClaw and Hermes runtime programs", () => {
-		process.env.CLAWDI_SYSTEMD_APPLY = "0";
-		const paths = tempRuntimePaths();
-		const command = "/bin/true";
-		const manifest = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				run: runSettings(command, ["gateway"]),
-				services: { worker: runSettings(command, ["worker"]) },
-			},
-			hermes: {
-				enabled: true,
-				run: runSettings(command, ["gateway"]),
-				services: {},
-			},
-			observer: {
-				enabled: true,
-				run: runSettings(command, ["observe"]),
-				services: {},
-			},
-		});
-		const managedTelegram: RuntimeManifest = {
-			...manifest,
-			projection: {
-				channels: {
-					telegram: {
-						enabled: true,
-						defaultAccount: "managed-telegram",
-						accounts: { "managed-telegram": { enabled: true } },
-					},
-				},
-			},
-		};
-
-		const baseline = convergeRuntimeManifest(manifestLoad(manifest, "inline-revision-base"), paths);
-		expect(baseline.installErrors).toEqual([]);
-		const workerRevision = systemdProgramRevision(paths, "clawdi-openclaw-worker");
-
-		const projected = convergeRuntimeManifest(
-			manifestLoad(managedTelegram, "inline-revision-managed-telegram"),
-			paths,
-		);
-		expect(projected.installErrors).toEqual([]);
-		expect(runtimeProgramRevision(managedTelegram, "openclaw", {})).not.toBe(
-			runtimeProgramRevision(manifest, "openclaw", {}),
-		);
-		expect(runtimeProgramRevision(managedTelegram, "hermes", {})).not.toBe(
-			runtimeProgramRevision(manifest, "hermes", {}),
-		);
-		expect(runtimeProgramRevision(managedTelegram, "observer", {})).toBe(
-			runtimeProgramRevision(manifest, "observer", {}),
-		);
-		expect(systemdProgramRevision(paths, "clawdi-openclaw-worker")).toBe(workerRevision);
-		expect(runtimeSidecarProgramRevision(managedTelegram)).toBe(
-			runtimeSidecarProgramRevision(manifest),
-		);
-		expect(daemonProgramRevision(managedTelegram)).toBe(daemonProgramRevision(manifest));
 	});
 
 	test.each([

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -24,16 +24,15 @@ import {
 	writeRuntimeAppliedState,
 } from "./applied-state";
 import { loadHostedBundledSkill } from "./hosted-bundled-skill";
+import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import { runtimeLiveSnapshotPaths } from "./live-state-snapshot";
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
 	daemonProgramRevision,
-	hostedAiProviderCatalog,
 	type RuntimeManifest,
-	runtimeProgramRevision,
+	runtimeProgramRevision as runtimeProgramRevisionWithEnvironment,
 	runtimeRecoverableSecretValues,
-	runtimeSecretValue,
 	runtimeSidecarProgramRevision,
 } from "./manifest";
 import {
@@ -56,6 +55,7 @@ import {
 	normalizeSecretValues,
 	processRuntimeEnvironment,
 	projectedRuntimeEnvironment,
+	runtimeSecretValue,
 } from "./secret-values";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
@@ -68,6 +68,19 @@ const successfulPrerequisiteActivation = () => ({
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
+const runtimeProgramRevision = (
+	manifest: RuntimeManifest,
+	runtime: string,
+	secretValues: Record<string, string> | undefined,
+	providerProjectionRevision: string | null = null,
+): string =>
+	runtimeProgramRevisionWithEnvironment(
+		manifest,
+		runtime,
+		secretValues,
+		projectedRuntimeEnvironment({}),
+		providerProjectionRevision,
+	);
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.57";
 const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_HOSTED_CODEX_TOOLING = {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -24,13 +24,13 @@ import {
 	writeRuntimeAppliedState,
 } from "./applied-state";
 import { loadHostedBundledSkill } from "./hosted-bundled-skill";
+import { runtimeLiveSnapshotPaths } from "./live-state-snapshot";
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
 	daemonProgramRevision,
 	hostedAiProviderCatalog,
 	type RuntimeManifest,
-	runtimeLiveSnapshotPaths,
 	runtimeProgramRevision,
 	runtimeRecoverableSecretValues,
 	runtimeSecretValue,
@@ -147,6 +147,23 @@ function manifestLoad(
 		sourcePath,
 		offline: false,
 		secretValues,
+		applyContext: {
+			kind: "identity-file",
+			identity: {
+				generation: manifest.applyGeneration ?? manifest.generation,
+				manifestETag: `"test-${manifest.generation}"`,
+				applyReceiptId: "test-apply-receipt",
+				bootNonce: "test-boot-nonce",
+			},
+			sourcePath: "/test/runtime-apply-identity.json",
+			runtimeEnvironment: projectedRuntimeEnvironment(
+				Object.fromEntries(
+					Object.entries(process.env).filter(
+						(entry): entry is [string, string] => entry[1] !== undefined,
+					),
+				),
+			),
+		},
 	};
 }
 
@@ -4054,7 +4071,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			existingSystemDropIn,
 			`${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\nexisting managed drop-in\n`,
 		);
-		const snapshotPaths = runtimeLiveSnapshotPaths(manifest, paths, workspaceRoot);
+		const snapshotPaths = runtimeLiveSnapshotPaths(manifest, paths);
 
 		expect(snapshotPaths).toEqual(
 			[
@@ -4309,5 +4326,18 @@ describe("runtime manifest reconciliation invariants", () => {
 			"projected-file-token",
 		);
 		expect(runtimeSecretValue(projected, "env://MISSING_TOKEN", runtimeEnvironment)).toBeNull();
+	});
+
+	test("rejects direct convergence without an explicit apply context", () => {
+		const paths = tempRuntimePaths();
+		const load = manifestLoad(
+			baseManifest(paths, {
+				openclaw: { enabled: false, run: runSettings("openclaw", []), services: {} },
+			}),
+			"inline-missing-apply-context",
+		);
+		expect(() => convergeRuntimeManifest({ ...load, applyContext: undefined }, paths)).toThrow(
+			"runtime manifest convergence requires an explicit apply context",
+		);
 	});
 });

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -49,7 +49,6 @@ function convergeRuntimeManifest(
 					applyReceiptId: "test-apply-receipt",
 					bootNonce: "test-boot-nonce",
 				},
-				sourcePath: "/test/runtime-apply-identity.json",
 				runtimeEnvironment,
 			},
 		},
@@ -514,7 +513,6 @@ describe("runtime manifest services", () => {
 
 	test("renders the Hermes password dashboard directly", () => {
 		const paths = tempRuntimePaths();
-		const applyIdentityPath = join(paths.runRoot, "runtime-apply-identity.json");
 		process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "stale-dashboard-password";
 		process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "stale-dashboard-session-secret";
 		process.env.RUNTIME_SOURCE_TOKEN = "stale-runtime-source-token";
@@ -586,7 +584,6 @@ describe("runtime manifest services", () => {
 				applyReceiptId: "apply-receipt-0001",
 				bootNonce: "boot-nonce-000001",
 			},
-			sourcePath: applyIdentityPath,
 			runtimeEnvironment: projectedRuntimeEnvironment(projectedValues),
 		};
 		const load: RuntimeManifestLoad = {

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -13,7 +13,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { readRuntimeInstallReceipts } from "./install-receipts";
-import { convergeRuntimeManifest, type RuntimeManifest } from "./manifest";
+import {
+	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
+	type RuntimeManifest,
+} from "./manifest";
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
@@ -22,6 +25,38 @@ import { projectedRuntimeEnvironment } from "./secret-values";
 const originalEnv = { ...process.env };
 const originalConsoleWarn = console.warn;
 const tempRoots: string[] = [];
+
+function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
+) {
+	const runtimeEnvironment = projectedRuntimeEnvironment(
+		Object.fromEntries(
+			Object.entries(process.env).filter(
+				(entry): entry is [string, string] => entry[1] !== undefined,
+			),
+		),
+	);
+	return convergeRuntimeManifestWithContext(
+		{
+			...load,
+			applyContext: load.applyContext ?? {
+				kind: "identity-file",
+				identity: {
+					generation: load.manifest.applyGeneration ?? load.manifest.generation,
+					manifestETag: `"test-${load.manifest.generation}"`,
+					applyReceiptId: "test-apply-receipt",
+					bootNonce: "test-boot-nonce",
+				},
+				sourcePath: "/test/runtime-apply-identity.json",
+				runtimeEnvironment,
+			},
+		},
+		paths,
+		opts,
+	);
+}
 
 function tempRuntimePaths(): RuntimePaths {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-manifest-service-test-"));

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -862,11 +862,11 @@ export function runtimeManifestFixturePath(): string | undefined {
 
 export async function loadRuntimeManifest(
 	paths: RuntimePaths,
-	opts: { manifestPath?: string } = {},
+	opts: { manifestPath?: string; applyContext?: RuntimeApplyContext } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
 	let applyContext: RuntimeApplyContext;
 	try {
-		applyContext = readRuntimeApplyContext();
+		applyContext = opts.applyContext ?? readRuntimeApplyContext();
 	} catch (error) {
 		return runtimeApplyContextFailure(error);
 	}
@@ -989,8 +989,8 @@ const offlineLastGoodManifestLoadOptions: LastGoodManifestLoadOptions = {
 
 function loadLastGoodManifest(
 	paths: RuntimePaths,
-	opts: LastGoodManifestLoadOptions = offlineLastGoodManifestLoadOptions,
-	applyContext: RuntimeApplyContext = readRuntimeApplyContext(),
+	opts: LastGoodManifestLoadOptions,
+	applyContext: RuntimeApplyContext,
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	if (!existsSync(paths.manifestLastGood)) {
 		return {
@@ -1130,12 +1130,17 @@ function loadLastGoodManifest(
 // the previously committed secret material needed to roll back the sidecar.
 export function loadCommittedRuntimeManifest(
 	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext,
 ): RuntimeManifestLoad | RuntimeManifestFailure {
-	return loadLastGoodManifest(paths, {
-		requireOfflineBoot: false,
-		requireAppliedAuthority: true,
-		requireSemanticValidity: false,
-	});
+	return loadLastGoodManifest(
+		paths,
+		{
+			requireOfflineBoot: false,
+			requireAppliedAuthority: true,
+			requireSemanticValidity: false,
+		},
+		applyContext,
+	);
 }
 
 function loadCachedSecretValues(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1,10 +1,8 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-	accessSync,
 	chmodSync,
 	chownSync,
-	constants,
 	existsSync,
 	lchownSync,
 	lstatSync,
@@ -43,7 +41,7 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
-import { type RuntimeApplyContext, runtimeApplyContextServiceEnvironment } from "./apply-identity";
+import type { RuntimeApplyContext } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	RUNTIME_AUTH_TOKEN_SECRET_REF,
@@ -57,8 +55,6 @@ import {
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
-
-export { withRuntimeConvergeLock, withRuntimeConvergeLockAsync } from "./converge-lock";
 
 import { managedMcpHeaderPlaceholder, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
@@ -107,12 +103,7 @@ export {
 	runtimeManifestFixturePath,
 } from "./manifest-source";
 
-import { withEffectiveFilesystemIdentity } from "./effective-identity";
-import {
-	applyEgressTransparentRuntimeEnv,
-	MANAGED_EGRESS_PLACEHOLDER_VALUE,
-	SYSTEM_CA_BUNDLE,
-} from "./egress-env";
+import { MANAGED_EGRESS_PLACEHOLDER_VALUE, SYSTEM_CA_BUNDLE } from "./egress-env";
 import {
 	buildEgressProfileBundle,
 	egressProfileSecretRefs,
@@ -143,16 +134,36 @@ import {
 	runtimeNameSchema,
 	runtimeRunConfigId,
 	runtimeServiceNameSchema,
-	withoutPathEntry,
 	writeRuntimeRunConfig,
 } from "./run-config";
+import { runtimeProgramRevision } from "./runtime-impact-revision";
 import { createRuntimeSecretResolver, type RuntimeSecretResolver } from "./runtime-secret-resolver";
 import {
-	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
-	isGeneratedRuntimeSystemdFile,
-} from "./systemd-user";
+	buildRuntimeSystemdUserProgram,
+	installOfficialRuntimeService,
+	planOfficialRuntimeServices,
+	type RuntimeEgressSystemdProgram,
+	type RuntimeSystemdUserProgram,
+	removeStaleOfficialRuntimeServices,
+	resolveRuntimeSystemdIdentity,
+	runtimeSystemdCommonEnvironment,
+	validateRuntimeSystemdPlan,
+	writeRuntimeSystemdState,
+} from "./runtime-systemd-reconciliation";
 import {
-	parsePositiveLinuxId,
+	commandExists,
+	commandResolvable,
+	executableExists,
+	makeRuntimeUserOwned,
+	runningAsRoot,
+	runRuntimeUserCommand,
+	runtimeEgressGid,
+	runtimeEgressUid,
+	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
+} from "./runtime-user-command";
+
+import {
 	TRANSPARENT_EGRESS_TABLE,
 	TRANSPARENT_EGRESS_TRANSPORT_VERSION,
 } from "./transparent-egress";
@@ -935,32 +946,11 @@ function stringValue(value: unknown): string | null {
 	return typeof value === "string" ? value : null;
 }
 
-function makeRuntimeUserOwned(path: string): void {
-	makeSystemUserOwned(path, process.env.CLAWDI_RUNTIME_USER?.trim() ?? "");
-}
-
 function makeEgressIdentityOwned(path: string): void {
 	if (!runningAsRoot()) return;
 	const uid = runtimeEgressUid();
 	const gid = runtimeEgressGid();
 	chownSync(path, uid, gid);
-}
-
-function makeSystemUserOwned(path: string, user: string): void {
-	if (!runningAsRoot()) return;
-	if (!user || user === "root") return;
-	const result = spawnSync("id", ["-u", user], { encoding: "utf8" });
-	const group = spawnSync("id", ["-g", user], { encoding: "utf8" });
-	if (result.status !== 0 || group.status !== 0) return;
-	const uid = Number.parseInt(result.stdout.trim(), 10);
-	const gid = Number.parseInt(group.stdout.trim(), 10);
-	if (!Number.isFinite(uid) || !Number.isFinite(gid)) return;
-	try {
-		chownSync(path, uid, gid);
-	} catch {
-		// Best effort: hosted demos without a system user still exercise the
-		// manifest path, but production images provide CLAWDI_RUNTIME_USER.
-	}
 }
 
 function makeRootOwned(path: string): void {
@@ -1066,49 +1056,6 @@ const liveSyncEnvironmentIndexSchema = z
 		agentTypes: z.array(runtimeNameSchema).default([]),
 	})
 	.strict();
-
-function executableExists(path: string): boolean {
-	try {
-		accessSync(path, constants.X_OK);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function commandExists(name: string): boolean {
-	const path = process.env.PATH ?? "";
-	for (const dir of path.split(":")) {
-		if (!dir) continue;
-		if (executableExists(join(dir, name))) return true;
-	}
-	return false;
-}
-
-function runningAsRoot(): boolean {
-	return typeof process.geteuid === "function" && process.geteuid() === 0;
-}
-
-function withRuntimeUserFileAccess<T>(
-	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
-): T {
-	// This scope is only for synchronous filesystem operations. Runtime commands
-	// must use gosu/runuser so child processes cannot retain a saved root identity.
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	if (!runningAsRoot() || !runtimeUser || runtimeUser === "root") return operation();
-	const uid = runtimeUserUid(runtimeUser);
-	const gid = runtimeUserGid(runtimeUser);
-	if ((uid === 0 || gid === 0) && runtimeUser !== "0") {
-		throw new Error(`runtime user ${runtimeUser} resolved to a root filesystem identity`);
-	}
-	return withEffectiveFilesystemIdentity(
-		{
-			uid,
-			gid,
-		},
-		operation,
-	);
-}
 
 function runtimeInstallerExecution(
 	name: string,
@@ -3415,158 +3362,6 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function runtimeUserCommandEnv(
-	home: string,
-	options: { egressSystemCaFile?: string } = {},
-): NodeJS.ProcessEnv {
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	const effectiveUid = typeof process.geteuid === "function" ? process.geteuid() : null;
-	const uid =
-		runtimeUser && runtimeUser !== "root" && (runningAsRoot() || effectiveUid !== null)
-			? String(runningAsRoot() ? runtimeUserUid(runtimeUser) : effectiveUid)
-			: null;
-	const runtimeDir = uid ? `/run/user/${uid}` : null;
-	const env = {
-		...process.env,
-		HOME: home,
-		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
-			.filter(Boolean)
-			.join(":"),
-		...(runtimeDir
-			? {
-					XDG_RUNTIME_DIR: runtimeDir,
-					DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtimeDir}/bus`,
-				}
-			: {}),
-	};
-	if (options.egressSystemCaFile) {
-		applyEgressTransparentRuntimeEnv(env, { caFile: options.egressSystemCaFile });
-	}
-	return env;
-}
-
-function runtimeUserGid(runtimeUser: string): number {
-	const explicit = Number.parseInt(process.env.CLAWDI_RUNTIME_GID?.trim() ?? "", 10);
-	if (Number.isInteger(explicit) && explicit >= 0 && explicit <= 4_294_967_295) {
-		return explicit;
-	}
-	const resolved = spawnSync("id", ["-g", runtimeUser], { encoding: "utf8" });
-	if (resolved.status === 0) {
-		const gid = Number.parseInt(resolved.stdout.trim(), 10);
-		if (Number.isInteger(gid) && gid >= 0 && gid <= 4_294_967_295) return gid;
-	}
-	if (runtimeUser === "clawdi") return 10_001;
-	throw new Error(`could not resolve runtime gid for ${runtimeUser}`);
-}
-
-function userManagerControlSocketExists(runtimeDir: string): boolean {
-	return existsSync(join(runtimeDir, "bus")) || existsSync(join(runtimeDir, "systemd", "private"));
-}
-
-function waitForUserManagerControlSocket(runtimeDir: string): boolean {
-	const waitUntil = Date.now() + 120_000;
-	const waitBuffer = new SharedArrayBuffer(4);
-	const waitView = new Int32Array(waitBuffer);
-	while (Date.now() < waitUntil) {
-		if (userManagerControlSocketExists(runtimeDir)) return true;
-		Atomics.wait(waitView, 0, 0, 200);
-	}
-	return userManagerControlSocketExists(runtimeDir);
-}
-
-function ensureRuntimeUserManagerReady(runtimeUser: string): void {
-	if (!runningAsRoot() || runtimeUser === "root" || !commandExists("systemctl")) return;
-	const uid = runtimeUserUid(runtimeUser);
-	const gid = runtimeUserGid(runtimeUser);
-	const runtimeDir = `/run/user/${uid}`;
-	execFileSync("install", ["-d", "-m", "0755", "-o", "root", "-g", "root", "/run/user"]);
-	execFileSync("install", ["-d", "-m", "0700", "-o", String(uid), "-g", String(gid), runtimeDir]);
-	if (userManagerControlSocketExists(runtimeDir)) return;
-	const unit = `user@${uid}.service`;
-	let result = spawnSync("systemctl", ["restart", unit], { stdio: "ignore" });
-	if (result.status !== 0) {
-		result = spawnSync("systemctl", ["start", unit], { stdio: "ignore" });
-	}
-	if (result.status !== 0 || !waitForUserManagerControlSocket(runtimeDir)) {
-		throw new Error(
-			`runtime user systemd manager did not publish a control socket under ${runtimeDir}`,
-		);
-	}
-}
-
-// Only official service installers may invoke systemctl --user. Config,
-// projection, plugin, and installer commands need privilege drop but not a manager.
-function ensureConfiguredRuntimeUserManagerReady(): void {
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	if (runtimeUser) ensureRuntimeUserManagerReady(runtimeUser);
-}
-
-function spawnRuntimeUserCommand(
-	command: string,
-	args: string[],
-	home: string,
-	cwd: string,
-	options: { egressSystemCaFile?: string } = {},
-): ReturnType<typeof spawnSync> {
-	const env = runtimeUserCommandEnv(home, options);
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
-		if (commandExists("gosu")) {
-			return spawnSync("gosu", [runtimeUser, command, ...args], {
-				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
-				cwd,
-				encoding: "utf8",
-			});
-		}
-		if (commandExists("runuser")) {
-			return spawnSync(
-				"runuser",
-				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ env, cwd, encoding: "utf8" },
-			);
-		}
-		throw new Error(
-			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
-		);
-	}
-	return spawnSync(command, args, { env, cwd, encoding: "utf8" });
-}
-
-function runRuntimeUserCommand(
-	command: string,
-	args: string[],
-	stdin: string,
-	home: string,
-	cwd: string,
-	options: { egressSystemCaFile?: string } = {},
-): void {
-	const env = runtimeUserCommandEnv(home, options);
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
-		if (commandExists("gosu")) {
-			execFileSync("gosu", [runtimeUser, command, ...args], {
-				input: stdin,
-				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
-				cwd,
-				stdio: "pipe",
-			});
-			return;
-		}
-		if (commandExists("runuser")) {
-			execFileSync(
-				"runuser",
-				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ input: stdin, env, cwd, stdio: "pipe" },
-			);
-			return;
-		}
-		throw new Error(
-			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
-		);
-	}
-	execFileSync(command, args, { input: stdin, env, cwd, stdio: "pipe" });
-}
-
 function runtimeFileCurrentRevision(path: string): string | null {
 	if (!isAbsolute(path)) return null;
 	try {
@@ -3612,48 +3407,6 @@ function runtimeCommandCurrentRevision(command: string, home: string, cwd: strin
 	} catch {
 		return null;
 	}
-}
-
-function officialServiceCurrentRevision(
-	program: RuntimeSystemdUserProgram,
-	paths: RuntimePaths,
-): string | null {
-	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
-	if (!descriptor) return null;
-	const unitName = systemdUnitFileName(descriptor.programName);
-	const unitPath = join(paths.systemdUserRoot, unitName);
-	try {
-		const contents = readFileSync(unitPath);
-		if (isGeneratedRuntimeSystemdFile(contents.toString("utf8"))) return null;
-		const stat = lstatSync(unitPath);
-		if (!stat.isFile()) return null;
-		const command = officialRuntimeServiceCommand(descriptor, paths);
-		const commandRevision = runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
-		if (!commandRevision) return null;
-		return runtimeContentSha256({
-			commandRevision,
-			programName: descriptor.programName,
-			unitName,
-			unitSha256: createHash("sha256").update(contents).digest("hex"),
-			unitMode: stat.mode & 0o7777,
-			unitUid: stat.uid,
-			unitGid: stat.gid,
-		});
-	} catch {
-		return null;
-	}
-}
-
-function officialServiceDesiredRevision(input: { program: RuntimeSystemdUserProgram }): string {
-	const descriptor = officialRuntimeServiceDescriptorForProgram(input.program);
-	if (!descriptor) throw new Error("official service receipt requires an official service program");
-	return runtimeContentSha256({
-		runtime: descriptor.runtime,
-		programName: descriptor.programName,
-		serviceIdentity: descriptor.service,
-		installerCommand: descriptor.command,
-		installArgs: descriptor.installArgs,
-	});
 }
 
 function channelPluginDesiredRevision(input: {
@@ -3873,7 +3626,7 @@ function writeTransparentEgressEnvFile(input: {
 	};
 	const lines = Object.entries(env)
 		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([key, value]) => `${key}=${systemdEnvironmentFileQuote(value)}`);
+		.map(([key, value]) => `${key}=${runtimeEnvironmentFileQuote(value)}`);
 	writePrivateFileAtomic(input.paths.egressTransparentEnv, `${lines.join("\n")}\n`, {
 		mode: 0o644,
 		dirMode: 0o755,
@@ -3881,6 +3634,13 @@ function writeTransparentEgressEnvFile(input: {
 	makeRootOwned(dirname(input.paths.egressTransparentEnv));
 	makeRootOwned(input.paths.egressTransparentEnv);
 	return input.paths.egressTransparentEnv;
+}
+
+function runtimeEnvironmentFileQuote(value: string): string {
+	if (/[\r\n]/.test(value)) {
+		throw new Error("runtime environment files only support single-line values");
+	}
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 function sha256String(value: string): string {
@@ -4050,7 +3810,7 @@ function revisionHash(value: unknown): string {
 		.slice(0, 32);
 }
 
-export function runtimeProgramRevision(
+function runtimeProgramRevisionForManifest(
 	manifest: RuntimeManifest,
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
@@ -4058,9 +3818,6 @@ export function runtimeProgramRevision(
 	providerProjectionRevision: string | null = null,
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
-	const desiredProgram = desiredRuntime
-		? Object.fromEntries(Object.entries(desiredRuntime).filter(([field]) => field !== "services"))
-		: null;
 	const runtimeSecretRefs = desiredRuntime
 		? Object.values(
 				mergeRuntimeSecretEnv(
@@ -4083,7 +3840,7 @@ export function runtimeProgramRevision(
 					)
 				: null
 		: null;
-	return revisionHash({
+	return runtimeProgramRevision({
 		renderedProjection: {
 			channels: channelProjection,
 			gateway:
@@ -4098,999 +3855,9 @@ export function runtimeProgramRevision(
 			provider: providerProjectionRevision,
 			skills: hostedBundledSkillProjection(manifest, runtime),
 		},
-		runtime: desiredProgram,
+		desiredRuntime,
 		secretValues: scopedSecretValues(secretValues, runtimeSecretRefs),
 	});
-}
-
-function runtimeServiceProgramRevision(program: RuntimeSystemdUserProgram): string {
-	return revisionHash({
-		runtime: program.runtime,
-		service: program.service,
-		command: program.command,
-		args: program.args,
-		cwd: program.cwd,
-		env: program.env,
-	});
-}
-
-export function daemonProgramRevision(manifest: RuntimeManifest): string {
-	return revisionHash({
-		clawdiCli: manifest.clawdiCli ?? null,
-		controlPlane: manifest.controlPlane,
-		liveSync: manifest.liveSync ?? null,
-	});
-}
-
-interface RuntimeSystemdUserProgram {
-	runtime: RuntimeName;
-	service: RuntimeServiceName | null;
-	command: string;
-	args: string[];
-	cwd: string;
-	env: Record<string, string>;
-	resolvedSecretEnv: Record<string, string>;
-}
-
-interface RuntimeEgressSystemdProgram {
-	profileBundlePath: string;
-	envFilePath: string;
-	transparentPort: number;
-	addonPath: string;
-	addonSha256: string;
-	engine: Extract<RuntimeMitmproxyEnsureResult, { status: "ready" }>;
-	systemCaBundle: string;
-	secretFilePath: string | null;
-}
-
-interface RuntimeEgressIdentity {
-	runtimeUid: number;
-	runtimeGid: number;
-	egressUid: number;
-	egressGid: number;
-}
-
-function runtimeEgressSystemdProgram(
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	profileBundlePath: string | null,
-	secretFilePath: string | null,
-	engine: RuntimeMitmproxyEnsureResult | null,
-	addon: { path: string; sha256: string } | null,
-): RuntimeEgressSystemdProgram | null {
-	if (!profileBundlePath) return null;
-	if (engine?.status !== "ready") return null;
-	if (!addon) return null;
-	const port = 18_080 + (hashToUInt16(`${manifest.instanceId}:${paths.serviceStateRoot}`) % 20_000);
-	return {
-		profileBundlePath,
-		envFilePath: paths.egressTransparentEnv,
-		transparentPort: port,
-		addonPath: addon.path,
-		addonSha256: addon.sha256,
-		engine,
-		systemCaBundle: paths.egressSystemCaFile,
-		secretFilePath,
-	};
-}
-
-function buildRuntimeSystemdUserProgram(input: {
-	config: RuntimeRunConfig;
-	paths: RuntimePaths;
-	secretValues: Record<string, string> | undefined;
-	runtimeEnvironment: RuntimeEnvironmentAuthority;
-	egress: RuntimeEgressSystemdProgram | null;
-}): RuntimeSystemdUserProgram | null {
-	if (!input.config.enabled) return null;
-
-	const currentPath = withoutPathEntry(
-		withoutPathEntry(runtimeSystemdPath(input.paths), runtimeManagedBinDir(input.paths)),
-		dirname(input.paths.cliManagedBin),
-	);
-	const pathPrefix = input.config.prependPath.join(":");
-	const env: Record<string, string> = {
-		...input.config.env,
-		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
-	};
-	const resolvedSecretEnv: Record<string, string> = {};
-	for (const [envName, ref] of Object.entries(input.config.secretEnv)) {
-		const value = runtimeSecretValue(input.secretValues ?? {}, ref, input.runtimeEnvironment);
-		if (!value) {
-			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
-		}
-		env[envName] = value;
-		resolvedSecretEnv[envName] = value;
-	}
-	if (input.egress) {
-		applyEgressTransparentRuntimeEnv(env, { caFile: input.egress.systemCaBundle });
-	}
-
-	const command =
-		input.config.commandPath && existsSync(input.config.commandPath)
-			? input.config.commandPath
-			: input.config.command;
-
-	return {
-		runtime: input.config.runtime,
-		service: input.config.service,
-		command,
-		args: input.config.defaultArgs,
-		cwd: input.config.cwd ?? input.paths.workspaceRoot,
-		env,
-		resolvedSecretEnv,
-	};
-}
-
-function hashToUInt16(input: string): number {
-	return createHash("sha256").update(input).digest().readUInt16BE(0);
-}
-
-export function runtimeSidecarProgramRevision(
-	manifest: RuntimeManifest,
-	egressProgram: RuntimeEgressSystemdProgram | null = null,
-	egressIdentity: RuntimeEgressIdentity | null = null,
-): string {
-	if (egressProgram && !egressIdentity) {
-		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
-	}
-	return revisionHash({
-		runtimeSidecar: "hosted-runtime-sidecar-v4",
-		instanceId: manifest.instanceId,
-		egressProfiles: manifest.egressProfiles ?? null,
-		egress: egressProgram
-			? {
-					transparentPort: egressProgram.transparentPort,
-					profileBundlePath: egressProgram.profileBundlePath,
-					secretFilePath: egressProgram.secretFilePath,
-					engine: egressProgram.engine,
-					addonSha256: egressProgram.addonSha256,
-					transport: TRANSPARENT_EGRESS_TRANSPORT_VERSION,
-					identity: egressIdentity,
-				}
-			: null,
-	});
-}
-
-function runtimeUserUid(runtimeUser: string): number {
-	const explicit = Number.parseInt(process.env.CLAWDI_RUNTIME_UID?.trim() ?? "", 10);
-	if (Number.isInteger(explicit) && explicit >= 0 && explicit <= 4_294_967_295) {
-		return explicit;
-	}
-	return systemUserUid(runtimeUser, runtimeUser === "clawdi" ? 10_001 : null);
-}
-
-function runtimeEgressUid(): number {
-	return positiveLinuxIdEnv("CLAWDI_EGRESS_UID", 10_002);
-}
-
-function runtimeEgressGid(): number {
-	return positiveLinuxIdEnv("CLAWDI_EGRESS_GID", 10_002);
-}
-
-function positiveLinuxIdEnv(key: string, fallback: number): number {
-	const raw = process.env[key]?.trim();
-	if (!raw) return fallback;
-	return parsePositiveLinuxId(raw, key);
-}
-
-function systemUserUid(user: string, fallback: number | null): number {
-	const resolved = spawnSync("id", ["-u", user], { encoding: "utf8" });
-	if (resolved.status === 0) {
-		const uid = Number.parseInt(resolved.stdout.trim(), 10);
-		if (Number.isInteger(uid) && uid >= 0 && uid <= 4_294_967_295) return uid;
-	}
-	if (fallback !== null) return fallback;
-	throw new Error(`could not resolve uid for ${user}`);
-}
-
-function runtimeSystemdProgramName(program: RuntimeSystemdUserProgram): string {
-	const officialName = officialRuntimeSystemdProgramName(program);
-	if (officialName) return officialName;
-	if (!program.service) return `clawdi-${systemdUnitNameSegment(program.runtime)}`;
-	return runtimeServiceProgramName(program.runtime, program.service);
-}
-
-function officialRuntimeSystemdProgramName(program: RuntimeSystemdUserProgram): string | null {
-	return officialRuntimeServiceDescriptorForProgram(program)?.programName ?? null;
-}
-
-function runtimeSystemdProgramRevision(
-	manifest: RuntimeManifest,
-	program: RuntimeSystemdUserProgram,
-	secretValues: Record<string, string> | undefined,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
-): string {
-	if (program.service) return runtimeServiceProgramRevision(program);
-	return runtimeProgramRevision(
-		manifest,
-		program.runtime,
-		secretValues,
-		runtimeEnvironment,
-		providerProjectionRevisions[program.runtime] ?? null,
-	);
-}
-
-function shouldRunRuntime(runtime: string, manifest: RuntimeManifest): boolean {
-	const desired = manifest.runtimes[runtime];
-	if (!desired?.enabled) return false;
-	return isSupportedRuntimeName(runtime) || Boolean(desired.run?.command?.trim());
-}
-
-function runtimeServiceProgramName(runtime: string, service: string): string {
-	const official = OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
-		(descriptor) => descriptor.runtime === runtime && descriptor.service === service,
-	);
-	if (official) return official.programName;
-	if (runtime === "hermes" && service === "dashboard") return "clawdi-hermes-dashboard";
-	return `clawdi-${systemdUnitNameSegment(runtime)}-${systemdUnitNameSegment(service)}`;
-}
-
-function systemdUnitNameSegment(value: string): string {
-	return value.replace(/[^A-Za-z0-9_-]+/g, "-");
-}
-
-function runtimeSystemdPath(paths: RuntimePaths): string {
-	return [
-		join(paths.serviceStateRoot, "bin"),
-		join(paths.userHome, ".local", "bin"),
-		join(paths.userHome, ".openclaw", "bin"),
-		process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	].join(":");
-}
-
-function systemdUnitFileName(name: string): string {
-	return `${systemdUnitNameSegment(name)}.service`;
-}
-
-function systemdDropInFilePath(paths: RuntimePaths, unitName: string): string {
-	return join(paths.systemdUserRoot, `${systemdUnitFileName(unitName)}.d`, "10-clawdi-hosted.conf");
-}
-
-function systemdQuote(value: string): string {
-	if (/[\r\n]/.test(value)) {
-		throw new Error("systemd unit values must be single-line strings");
-	}
-	return `"${value
-		.replace(/\\/g, "\\\\")
-		.replace(/"/g, '\\"')
-		.replace(/%/g, "%%")
-		.replace(/\$/g, "$$")}"`;
-}
-
-function systemdExec(command: string, args: string[]): string {
-	return [command, ...args].map(systemdQuote).join(" ");
-}
-
-function systemdPath(value: string): string {
-	if (!isAbsolute(value)) {
-		throw new Error(`systemd unit paths must be absolute: ${value}`);
-	}
-	if (/[\r\n]/.test(value)) {
-		throw new Error("systemd unit paths must be single-line strings");
-	}
-	return value
-		.replace(/\\/g, "\\\\")
-		.replace(/%/g, "%%")
-		.replace(/ /g, "\\x20")
-		.replace(/\t/g, "\\x09");
-}
-
-function systemdUnitEnvironmentLines(values: Record<string, string>): string[] {
-	return Object.entries(values).map(
-		([key, value]) => `Environment=${systemdQuote(`${key}=${value}`)}`,
-	);
-}
-
-function systemdEnvironmentFilePath(paths: RuntimePaths, unitName: string): string {
-	return join(paths.systemdEnvRoot, `${systemdUnitFileName(unitName)}.env`);
-}
-
-function systemdEnvironmentFileQuote(value: string): string {
-	if (/[\r\n]/.test(value)) {
-		throw new Error("systemd environment files only support single-line values");
-	}
-	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-type OfficialRuntimeServiceDescriptor = {
-	runtime: RuntimeName;
-	programName: string;
-	command: string;
-	installArgs: string[];
-	uninstallArgs: string[];
-	// Manifest `services` key the official unit corresponds to; used for
-	// program naming even when such an entry is not official for the runtime.
-	service: string;
-	// Extra env projected into the unit's environment file.
-	unitEnv?: (unitName: string) => Record<string, string>;
-	// Which desired programs the official unit covers. Deliberately
-	// asymmetric: openclaw's default program is its gateway, while hermes may
-	// express the gateway as the default program or an explicit
-	// `services.gateway` entry.
-	matchesProgram: (program: RuntimeSystemdUserProgram) => boolean;
-};
-
-const OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS: OfficialRuntimeServiceDescriptor[] = [
-	{
-		runtime: "openclaw",
-		programName: "openclaw-gateway",
-		command: "openclaw",
-		installArgs: ["gateway", "install", "--force", "--json"],
-		uninstallArgs: ["gateway", "uninstall"],
-		service: "gateway",
-		unitEnv: (unitName) => ({ OPENCLAW_SYSTEMD_UNIT: unitName }),
-		matchesProgram: (program) => !program.service,
-	},
-	{
-		runtime: "hermes",
-		programName: "hermes-gateway",
-		command: "hermes",
-		installArgs: ["gateway", "install", "--force"],
-		uninstallArgs: ["gateway", "uninstall"],
-		service: "gateway",
-		matchesProgram: (program) => (program.service ?? program.args[0] ?? "") === "gateway",
-	},
-];
-
-function officialRuntimeServiceDescriptorForProgram(
-	program: RuntimeSystemdUserProgram,
-): OfficialRuntimeServiceDescriptor | null {
-	return (
-		OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
-			(descriptor) => descriptor.runtime === program.runtime && descriptor.matchesProgram(program),
-		) ?? null
-	);
-}
-
-function officialRuntimeServiceDescriptorForUnit(
-	unitName: string,
-): OfficialRuntimeServiceDescriptor | null {
-	return (
-		OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
-			(descriptor) => systemdUnitFileName(descriptor.programName) === unitName,
-		) ?? null
-	);
-}
-
-function officialRuntimeServiceCommand(
-	descriptor: OfficialRuntimeServiceDescriptor,
-	paths: RuntimePaths,
-): string {
-	const commandPath = runtimeCommandPath(descriptor.runtime, paths.userHome);
-	return commandPath && executableExists(commandPath) ? commandPath : descriptor.command;
-}
-
-function writeSystemdEnvironmentFile(input: {
-	paths: RuntimePaths;
-	name: string;
-	owner: "root" | "runtime-user";
-	env: Record<string, string>;
-}): string {
-	makeRootReadableDir(dirname(input.paths.systemdEnvRoot));
-	makeRootReadableDir(input.paths.systemdEnvRoot);
-	const path = systemdEnvironmentFilePath(input.paths, input.name);
-	const lines = Object.entries(input.env)
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([key, value]) => {
-			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-				throw new Error(`invalid systemd environment key: ${key}`);
-			}
-			return `${key}=${systemdEnvironmentFileQuote(value)}`;
-		});
-	writePrivateFileAtomic(path, `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`, {
-		mode: 0o600,
-		dirMode: 0o755,
-	});
-	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
-	else makeRootOwned(path);
-	return path;
-}
-
-function writeSystemdProgramEnvironment(input: {
-	paths: RuntimePaths;
-	name: string;
-	owner: "root" | "runtime-user";
-	env: Record<string, string>;
-	revisionEnv?: Record<string, string>;
-}): { envFile: string; envRevision: string } {
-	return {
-		envFile: writeSystemdEnvironmentFile(input),
-		envRevision: revisionHash({
-			systemdEnvironmentFile: "v1",
-			env: input.revisionEnv ?? input.env,
-		}),
-	};
-}
-
-function writeSystemdUnit(input: {
-	root: string;
-	owner: "root" | "runtime-user";
-	paths: RuntimePaths;
-	name: string;
-	description: string;
-	command: string;
-	args: string[];
-	cwd: string;
-	env: Record<string, string>;
-	revisionEnv?: Record<string, string>;
-	unitEnv?: Record<string, string>;
-	serviceType?: "simple" | "oneshot" | "notify";
-	restart?: boolean;
-	extraUnitLines?: string[];
-	extraServiceLines?: string[];
-	wantedBy: "multi-user.target" | "default.target";
-}): string {
-	const path = join(input.root, systemdUnitFileName(input.name));
-	const { envFile, envRevision } = writeSystemdProgramEnvironment({
-		paths: input.paths,
-		name: input.name,
-		owner: input.owner,
-		env: input.env,
-		revisionEnv: input.revisionEnv,
-	});
-	const lines = [
-		GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
-		"[Unit]",
-		`Description=${input.description}`,
-		...(input.owner === "runtime-user"
-			? [
-					"# The environment file is regenerated by convergence each boot; this unit must not start before it exists.",
-					`ConditionPathExists=${systemdPath(envFile)}`,
-				]
-			: []),
-		...(input.extraUnitLines ?? []),
-		"",
-		"[Service]",
-		`# ClawdiEnvironmentRevision=${envRevision}`,
-		`Type=${input.serviceType ?? "simple"}`,
-		`WorkingDirectory=${systemdPath(input.cwd)}`,
-		...(input.unitEnv ? systemdUnitEnvironmentLines(input.unitEnv) : []),
-		...(input.extraServiceLines ?? []),
-		`EnvironmentFile=${systemdPath(envFile)}`,
-		`ExecStart=${systemdExec(input.command, input.args)}`,
-		...(input.restart === false
-			? []
-			: ["Restart=always", "RestartSec=2", "KillMode=mixed", "TimeoutStopSec=30"]),
-		"",
-		"[Install]",
-		`WantedBy=${input.wantedBy}`,
-		"",
-	];
-	const writeUnitFile = (): string => {
-		mkdirSync(input.root, { recursive: true });
-		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
-		if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
-		else makeRootOwned(path);
-		return path;
-	};
-	return input.owner === "runtime-user"
-		? withRuntimeUserFileAccess(writeUnitFile)
-		: writeUnitFile();
-}
-
-function writeSystemdSystemUnit(
-	input: Omit<Parameters<typeof writeSystemdUnit>[0], "root" | "owner" | "wantedBy">,
-): string {
-	return writeSystemdUnit({
-		...input,
-		root: input.paths.systemdSystemRoot,
-		owner: "root",
-		wantedBy: "multi-user.target",
-	});
-}
-
-function writeSystemdUserUnit(
-	input: Omit<Parameters<typeof writeSystemdUnit>[0], "root" | "owner" | "wantedBy">,
-): string {
-	return writeSystemdUnit({
-		...input,
-		root: input.paths.systemdUserRoot,
-		owner: "runtime-user",
-		extraServiceLines: [
-			'Environment="XDG_RUNTIME_DIR=%t"',
-			'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
-			...(input.extraServiceLines ?? []),
-		],
-		wantedBy: "default.target",
-	});
-}
-
-function writeSystemdUserDropIn(input: {
-	paths: RuntimePaths;
-	name: string;
-	command: string;
-	args: string[];
-	cwd: string;
-	env: Record<string, string>;
-}): string {
-	const unitName = systemdUnitFileName(input.name);
-	const { envFile, envRevision } = writeSystemdProgramEnvironment({
-		paths: input.paths,
-		name: input.name,
-		owner: "runtime-user",
-		env: input.env,
-	});
-	const path = systemdDropInFilePath(input.paths, input.name);
-	const lines = [
-		GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
-		"# ClawdiHostedRuntimeDropIn=v1",
-		"# The base unit is generated by the runtime's official service installer.",
-		"[Unit]",
-		"# The environment file is regenerated by convergence each boot; this unit must not start before it exists.",
-		`ConditionPathExists=${systemdPath(envFile)}`,
-		"",
-		"[Service]",
-		`# ClawdiEnvironmentRevision=${envRevision}`,
-		`WorkingDirectory=${systemdPath(input.cwd)}`,
-		'Environment="XDG_RUNTIME_DIR=%t"',
-		'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
-		`EnvironmentFile=${systemdPath(envFile)}`,
-		"ExecStart=",
-		`ExecStart=${systemdExec(input.command, input.args)}`,
-		"",
-	];
-	return withRuntimeUserFileAccess(() => {
-		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
-		mkdirSync(dirname(path), { recursive: true });
-		makeRuntimeUserOwned(dirname(path));
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
-		makeRuntimeUserOwned(path);
-		return join(input.paths.systemdUserRoot, unitName);
-	});
-}
-
-function removeGeneratedRuntimeBaseUnit(paths: RuntimePaths, unitName: string): void {
-	const path = join(paths.systemdUserRoot, unitName);
-	if (!isGeneratedSystemdFile(path)) return;
-	rmSync(path, { force: true });
-}
-
-function officialRuntimeServiceInstallArgs(program: RuntimeSystemdUserProgram): string[] | null {
-	return officialRuntimeServiceDescriptorForProgram(program)?.installArgs ?? null;
-}
-
-function shouldInstallOfficialRuntimeServices(): boolean {
-	// Official gateway installers need a live systemd user bus to converge.
-	// When the systemd apply phase is explicitly disabled (headless CI and
-	// smoke containers without systemd), fall back to writing complete
-	// clawdi-* units instead of failing the whole convergence; the next
-	// convergence under real systemd retries the official install.
-	const applyOverride = process.env.CLAWDI_SYSTEMD_APPLY?.trim().toLowerCase();
-	if (applyOverride === "0" || applyOverride === "false") return false;
-	const override = process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES?.trim().toLowerCase();
-	if (override === "1" || override === "true") return true;
-	if (override === "0" || override === "false") return false;
-	return runningAsRoot();
-}
-
-function commandResolvable(command: string): boolean {
-	return isAbsolute(command) ? executableExists(command) : commandExists(command);
-}
-
-function installOfficialRuntimeUserService(
-	program: RuntimeSystemdUserProgram,
-	paths: RuntimePaths,
-): string | null {
-	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
-	if (!descriptor || !shouldInstallOfficialRuntimeServices()) return null;
-	const args = descriptor.installArgs;
-	if (!commandResolvable(program.command)) {
-		return `official ${runtimeSystemdProgramName(program)} service installer command is unavailable: ${program.command}`;
-	}
-	try {
-		ensureConfiguredRuntimeUserManagerReady();
-		resetFailedRuntimeUserService(runtimeSystemdProgramName(program), paths, program.cwd);
-		runRuntimeUserCommand(program.command, args, "", paths.userHome, program.cwd);
-		return null;
-	} catch (error) {
-		return `official ${runtimeSystemdProgramName(program)} service install failed: ${
-			error instanceof Error ? error.message : String(error)
-		}`;
-	}
-}
-
-function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: string): void {
-	try {
-		runRuntimeUserCommand(
-			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
-			["--user", "reset-failed", systemdUnitFileName(name)],
-			"",
-			paths.userHome,
-			cwd,
-		);
-	} catch {
-		// The unit may not exist yet; reset-failed must never block convergence.
-	}
-}
-
-function reloadRuntimeUserManager(paths: RuntimePaths, cwd: string): void {
-	try {
-		ensureConfiguredRuntimeUserManagerReady();
-		runRuntimeUserCommand(
-			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
-			["--user", "daemon-reload"],
-			"",
-			paths.userHome,
-			cwd,
-		);
-	} catch {
-		// Best-effort: environments without a reachable user manager (unit tests,
-		// non-hosted hosts) must not fail convergence, and official installers
-		// perform their own daemon-reload after writing the base unit.
-	}
-}
-
-function uninstallOfficialRuntimeUserService(input: {
-	unitName: string;
-	paths: RuntimePaths;
-	workspaceRoot: string;
-}): string | null {
-	const descriptor = officialRuntimeServiceDescriptorForUnit(input.unitName);
-	if (!descriptor || !shouldInstallOfficialRuntimeServices()) return null;
-	const command = officialRuntimeServiceCommand(descriptor, input.paths);
-	if (!commandResolvable(command)) {
-		return `official ${input.unitName} uninstaller command is unavailable: ${command}`;
-	}
-	try {
-		ensureConfiguredRuntimeUserManagerReady();
-		runRuntimeUserCommand(
-			command,
-			descriptor.uninstallArgs,
-			"",
-			input.paths.userHome,
-			input.workspaceRoot,
-		);
-		return null;
-	} catch (error) {
-		return `official ${input.unitName} uninstall failed: ${
-			error instanceof Error ? error.message : String(error)
-		}`;
-	}
-}
-
-function systemdUnitNameFromPath(unitPath: string): string {
-	return unitPath.split("/").at(-1) ?? "";
-}
-
-function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: string[]): string[] {
-	if (!existsSync(paths.systemdUserRoot)) return [];
-	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
-	const stale: string[] = [];
-	for (const entry of readdirSync(paths.systemdUserRoot)) {
-		if (!entry.endsWith(".service.d")) continue;
-		const unitName = entry.slice(0, -".d".length);
-		if (writtenNames.has(unitName)) continue;
-		if (!officialRuntimeServiceDescriptorForUnit(unitName)) continue;
-		const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
-		if (!isGeneratedSystemdFile(dropInPath)) continue;
-		const baseUnitPath = join(paths.systemdUserRoot, unitName);
-		if (!existsSync(baseUnitPath) || isGeneratedSystemdFile(baseUnitPath)) continue;
-		stale.push(unitName);
-	}
-	return stale.sort();
-}
-
-function removeStaleSystemdUserUnits(paths: RuntimePaths, writtenUnits: string[]): void {
-	withRuntimeUserFileAccess(() => {
-		if (!existsSync(paths.systemdUserRoot)) return;
-		const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
-		for (const entry of readdirSync(paths.systemdUserRoot)) {
-			if (!entry.endsWith(".service")) continue;
-			const path = join(paths.systemdUserRoot, entry);
-			if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
-			if (writtenNames.has(entry)) continue;
-			rmSync(path, { force: true });
-		}
-		const wantsDir = join(paths.systemdUserRoot, "default.target.wants");
-		if (existsSync(wantsDir)) {
-			for (const entry of readdirSync(wantsDir)) {
-				if (!entry.endsWith(".service")) continue;
-				const unitPath = join(paths.systemdUserRoot, entry);
-				if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(unitPath)) continue;
-				if (writtenNames.has(entry)) continue;
-				rmSync(join(wantsDir, entry), { force: true });
-			}
-		}
-		for (const entry of readdirSync(paths.systemdUserRoot)) {
-			if (!entry.endsWith(".service.d")) continue;
-			const unitName = entry.slice(0, -".d".length);
-			const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
-			if (!isGeneratedSystemdFile(dropInPath)) continue;
-			if (writtenNames.has(unitName)) continue;
-			rmSync(dropInPath, { force: true });
-			try {
-				if (readdirSync(dirname(dropInPath)).length === 0)
-					rmSync(dirname(dropInPath), { force: true });
-			} catch {
-				// Best effort cleanup only.
-			}
-		}
-	});
-}
-
-function isGeneratedSystemdFile(path: string): boolean {
-	try {
-		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
-	} catch {
-		return false;
-	}
-}
-
-function removeStaleSystemdSystemUnits(paths: RuntimePaths, writtenUnits: string[]): void {
-	if (!existsSync(paths.systemdSystemRoot)) return;
-	const managed = new Set([
-		"clawdi-runtime-watch.service",
-		"clawdi-daemon.service",
-		"clawdi-runtime-sidecar.service",
-	]);
-	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
-	for (const entry of readdirSync(paths.systemdSystemRoot)) {
-		if (!managed.has(entry) || writtenNames.has(entry)) continue;
-		rmSync(join(paths.systemdSystemRoot, entry), { force: true });
-	}
-}
-
-function removeStaleSystemdEnvironmentFiles(paths: RuntimePaths, writtenUnits: string[]): void {
-	if (!existsSync(paths.systemdEnvRoot)) return;
-	const writtenNames = new Set(writtenUnits.map((unit) => `${systemdUnitNameFromPath(unit)}.env`));
-	for (const entry of readdirSync(paths.systemdEnvRoot)) {
-		if (!entry.endsWith(".service.env")) continue;
-		const path = join(paths.systemdEnvRoot, entry);
-		if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
-		if (writtenNames.has(entry)) continue;
-		rmSync(path, { force: true });
-	}
-}
-
-function runtimeManifestUrlEnv(
-	sourcePath: string,
-	secretValues: Record<string, string> | undefined,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-): string {
-	if (/^https?:\/\//i.test(sourcePath)) return sourcePath;
-	return (
-		runtimeSecretValue(
-			secretValues ?? {},
-			"env://CLAWDI_RUNTIME_MANIFEST_URL",
-			runtimeEnvironment,
-		) ?? ""
-	);
-}
-
-function runtimeSystemdCommonEnvironment(
-	sourcePath: string,
-	paths: RuntimePaths,
-	secretValues: Record<string, string> | undefined,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-): Record<string, string> {
-	const runtimeUser =
-		runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_USER", runtimeEnvironment) ??
-		"clawdi";
-	const environment: Record<string, string> = {
-		HOME: paths.userHome,
-		CLAWDI_RUNTIME_MODE:
-			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MODE", runtimeEnvironment) ??
-			"hosted",
-		CLAWDI_RUNTIME_AUTH_ENV:
-			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_AUTH_ENV", runtimeEnvironment) ??
-			"",
-		CLAWDI_RUNTIME_USER: runtimeUser,
-		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
-		CLAWDI_RUN_DIR: paths.runRoot,
-		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(
-			sourcePath,
-			secretValues,
-			runtimeEnvironment,
-		),
-		PATH: runtimeSystemdPath(paths),
-	};
-	return environment;
-}
-
-function runtimeWatchSecretEnvironment(
-	programs: RuntimeSystemdUserProgram[],
-): Record<string, string> {
-	const retained = new Map<string, { value: string; program: string }>();
-	for (const program of [...programs].sort((a, b) =>
-		runtimeSystemdProgramName(a).localeCompare(runtimeSystemdProgramName(b)),
-	)) {
-		const programName = runtimeSystemdProgramName(program);
-		for (const [envName, value] of Object.entries(program.resolvedSecretEnv).sort(([a], [b]) =>
-			a.localeCompare(b),
-		)) {
-			const existing = retained.get(envName);
-			if (existing && existing.value !== value) {
-				throw new Error(
-					`Runtime watch secret environment ${envName} conflicts between ${existing.program} and ${programName}.`,
-				);
-			}
-			retained.set(envName, { value, program: existing?.program ?? programName });
-		}
-	}
-	return Object.fromEntries([...retained].map(([envName, entry]) => [envName, entry.value]));
-}
-
-function writeRuntimeSystemdUserProgram(input: {
-	program: RuntimeSystemdUserProgram;
-	commonEnvironment: Record<string, string>;
-	manifest: RuntimeManifest;
-	paths: RuntimePaths;
-	secretValues: Record<string, string> | undefined;
-	runtimeEnvironment: RuntimeEnvironmentAuthority;
-	providerProjectionRevisions: Partial<Record<string, string | null>>;
-}): string {
-	const { program } = input;
-	const name = runtimeSystemdProgramName(program);
-	const unitName = systemdUnitFileName(name);
-	const env = {
-		...input.commonEnvironment,
-		...program.env,
-		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
-		CLAWDI_AUTH_TOKEN: "",
-		CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
-			input.manifest,
-			program,
-			input.secretValues,
-			input.runtimeEnvironment,
-			input.providerProjectionRevisions,
-		),
-		...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
-	};
-	if (officialRuntimeServiceInstallArgs(program)) {
-		return writeSystemdUserDropIn({
-			paths: input.paths,
-			name,
-			command: program.command,
-			args: program.args,
-			cwd: program.cwd,
-			env,
-		});
-	}
-	return writeSystemdUserUnit({
-		paths: input.paths,
-		name,
-		description: `Clawdi hosted ${program.runtime}${program.service ? ` ${program.service}` : ""}`,
-		command: program.command,
-		args: program.args,
-		cwd: program.cwd,
-		env,
-	});
-}
-
-function officialRuntimeSystemdPrograms(
-	programs: RuntimeSystemdUserProgram[],
-): RuntimeSystemdUserProgram[] {
-	const byServiceName = new Map<string, RuntimeSystemdUserProgram>();
-	for (const program of programs) {
-		const serviceName = officialRuntimeSystemdProgramName(program);
-		if (serviceName) byServiceName.set(serviceName, program);
-	}
-	return [...byServiceName.entries()]
-		.sort(([left], [right]) => left.localeCompare(right))
-		.map(([, program]) => program);
-}
-
-function writeSystemdUnits(
-	runtimePrograms: RuntimeSystemdUserProgram[],
-	egressProgram: RuntimeEgressSystemdProgram | null,
-	egressIdentity: RuntimeEgressIdentity | null,
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	workspaceRoot: string,
-	daemonAuthTokenFile: string | null,
-	secretValues: Record<string, string> | undefined,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-	providerProjectionRevisions: Partial<Record<string, string | null>>,
-	commonEnvironment: Record<string, string>,
-	applyContext: RuntimeApplyContext,
-): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
-	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-	const systemUnits: string[] = [];
-	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
-	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
-	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
-	const userUnits: string[] = [];
-	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
-	const applyIdentityEnvironment = runtimeApplyContextServiceEnvironment(applyContext);
-	if (daemonAuthTokenFile) {
-		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
-		systemUnits.push(
-			writeSystemdSystemUnit({
-				paths,
-				name: "clawdi-runtime-watch",
-				description: "Clawdi hosted runtime desired-state watcher",
-				command: paths.cliManagedBin,
-				args: ["runtime", "watch"],
-				cwd: workspaceRoot,
-				env: {
-					...commonEnvironment,
-					...applyIdentityEnvironment,
-					...watchSecretEnvironment,
-					CLAWDI_AUTH_TOKEN: "",
-				},
-				// Unit files are 0644. Hash only secret destination names into their
-				// revision so the unit cannot become an offline verifier for values.
-				// The watcher resolves values from the atomic apply-context file on
-				// each tick; keep secret bytes out of its public revision material.
-				revisionEnv: {
-					...commonEnvironment,
-					...applyIdentityEnvironment,
-					...Object.fromEntries(Object.keys(watchSecretEnvironment).map((name) => [name, ""])),
-					CLAWDI_AUTH_TOKEN: "",
-				},
-			}),
-		);
-	}
-
-	if (daemonAuthTokenFile) {
-		systemUnits.push(
-			writeSystemdSystemUnit({
-				paths,
-				name: "clawdi-daemon",
-				description: "Clawdi hosted runtime daemon",
-				command: paths.cliManagedBin,
-				args: ["daemon", "run", "--auth-token-file", daemonAuthTokenFile],
-				cwd: workspaceRoot,
-				env: {
-					...commonEnvironment,
-					...applyIdentityEnvironment,
-					CLAWDI_ENVIRONMENT_ID: manifest.environmentId,
-					CLAWDI_SERVE_MODE: "container",
-					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
-					CLAWDI_NO_AUTO_UPDATE: "1",
-					CLAWDI_NO_UPDATE_CHECK: "1",
-					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
-				},
-			}),
-		);
-	}
-
-	if (activeEgressProgram) {
-		systemUnits.push(
-			writeSystemdSystemUnit({
-				paths,
-				name: "clawdi-runtime-sidecar",
-				description: "Clawdi hosted runtime sidecar",
-				command: paths.cliManagedBin,
-				args: ["runtime", "sidecar"],
-				cwd: workspaceRoot,
-				env: {
-					...commonEnvironment,
-					CLAWDI_AUTH_TOKEN: "",
-					CLAWDI_EGRESS_ENV_FILE: activeEgressProgram.envFilePath,
-					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
-						manifest,
-						activeEgressProgram,
-						activeEgressIdentity,
-					),
-				},
-				serviceType: "notify",
-				extraUnitLines: runtimeUid === null ? undefined : [`Before=user@${runtimeUid}.service`],
-				extraServiceLines: ["NotifyAccess=main"],
-			}),
-		);
-	}
-
-	for (const program of runtimePrograms) {
-		userUnits.push(
-			writeRuntimeSystemdUserProgram({
-				program,
-				commonEnvironment,
-				manifest,
-				paths,
-				secretValues,
-				runtimeEnvironment,
-				providerProjectionRevisions,
-			}),
-		);
-	}
-
-	removeStaleSystemdSystemUnits(paths, systemUnits);
-	removeStaleSystemdUserUnits(paths, userUnits);
-	removeStaleSystemdEnvironmentFiles(paths, [...systemUnits, ...userUnits]);
-	return { systemUnits, userUnits, egressSidecarActive: shouldRunEgress };
 }
 
 function runtimeWorkspaceRoot(manifest: RuntimeManifest, paths: RuntimePaths): string {
@@ -5169,7 +3936,10 @@ function planRuntimeSystemdUserPrograms(input: {
 			secretValues: input.secretValues,
 			egressProfileBundlePath: input.egressProfileBundlePath,
 		});
-		if (runtime.enabled && shouldRunRuntime(name, input.manifest)) {
+		if (
+			runtime.enabled &&
+			(isSupportedRuntimeName(name) || Boolean(runtime.run?.command?.trim()))
+		) {
 			const program = buildRuntimeSystemdUserProgram({
 				config: resolved.runtime,
 				paths: input.paths,
@@ -5300,20 +4070,6 @@ function resolveRuntimeRunConfigs(input: {
 			});
 		});
 	return { runtime, services, secretEnv, secretFilePath };
-}
-
-function validateRuntimeSystemdProgramsPlan(programs: RuntimeSystemdUserProgram[]): void {
-	for (const program of programs) {
-		systemdUnitFileName(runtimeSystemdProgramName(program));
-		systemdPath(program.cwd);
-		systemdExec(program.command, program.args);
-		for (const [key, value] of Object.entries(program.env)) {
-			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-				throw new Error(`invalid systemd environment key: ${key}`);
-			}
-			systemdEnvironmentFileQuote(value);
-		}
-	}
 }
 
 function runtimeConvergenceWithoutApply(input: {
@@ -5598,7 +4354,7 @@ export function convergeRuntimeManifest(
 		egressProfileBundlePath: plannedEgressProfileBundlePath,
 		egress: null,
 	});
-	validateRuntimeSystemdProgramsPlan(plannedRuntimePrograms);
+	validateRuntimeSystemdPlan(plannedRuntimePrograms);
 	observations.clear();
 	for (const [name, runtime] of runtimeEntries) {
 		const observation = observeRuntimeInstall(name, runtime, projectionHome);
@@ -5705,12 +4461,13 @@ export function convergeRuntimeManifest(
 	let rollbackEgressSecretRevision: string | undefined;
 	let egressRollbackAuthorityVerified = true;
 	try {
-		const plannedUserUnits = plannedRuntimePrograms.map((program) =>
-			join(paths.systemdUserRoot, systemdUnitFileName(runtimeSystemdProgramName(program))),
-		);
-		for (const unitName of staleOfficialRuntimeUserServices(paths, plannedUserUnits)) {
-			const error = uninstallOfficialRuntimeUserService({ unitName, paths, workspaceRoot });
-			if (error) throw new Error(error);
+		const staleOfficialServiceErrors = removeStaleOfficialRuntimeServices({
+			paths,
+			programs: plannedRuntimePrograms,
+			workspaceRoot,
+		});
+		if (staleOfficialServiceErrors.length > 0) {
+			throw new Error(staleOfficialServiceErrors.join("; "));
 		}
 
 		ensureRuntimeUserHome(paths.userHome);
@@ -5833,21 +4590,21 @@ export function convergeRuntimeManifest(
 		);
 		const egressSecretFile = egressSecretWrite.path;
 		const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-		const egressSystemdProgram = runtimeEgressSystemdProgram(
+		const resolvedSystemdIdentity = resolveRuntimeSystemdIdentity({
 			manifest,
 			paths,
-			egressProfileBundlePath,
-			egressSecretFile,
-			egressEngine,
-			egressAddon,
-		);
-		const runtimeUid = egressSystemdProgram ? runtimeUserUid(runtimeUser) : 0;
-		const runtimeGid = egressSystemdProgram ? runtimeUserGid(runtimeUser) : 0;
-		const egressUid = egressSystemdProgram ? runtimeEgressUid() : 0;
-		const egressGid = egressSystemdProgram ? runtimeEgressGid() : 0;
-		const egressIdentity = egressSystemdProgram
-			? { runtimeUid, runtimeGid, egressUid, egressGid }
-			: null;
+			profileBundlePath: egressProfileBundlePath,
+			secretFilePath: egressSecretFile,
+			engine: egressEngine,
+			addon: egressAddon,
+			runtimeUser,
+		});
+		const egressSystemdProgram = resolvedSystemdIdentity.egressProgram;
+		const egressIdentity = resolvedSystemdIdentity.identity;
+		const runtimeUid = egressIdentity?.runtimeUid ?? 0;
+		const runtimeGid = egressIdentity?.runtimeGid ?? 0;
+		const egressUid = egressIdentity?.egressUid ?? 0;
+		const egressGid = egressIdentity?.egressGid ?? 0;
 		const egressTransparentEnv = writeTransparentEgressEnvFile({
 			program: egressSystemdProgram,
 			paths,
@@ -6053,7 +4810,7 @@ export function convergeRuntimeManifest(
 		} else {
 			rmSync(mcpProjection, { force: true });
 		}
-		const systemdUnits = writeSystemdUnits(
+		const systemdUnits = writeRuntimeSystemdState(
 			runtimeSystemdUserPrograms,
 			egressSystemdProgram,
 			egressIdentity,
@@ -6064,8 +4821,8 @@ export function convergeRuntimeManifest(
 			secretValues,
 			runtimeEnvironment,
 			providerProjectionRevisions,
+			runtimeProgramRevisionForManifest,
 			commonSystemdEnvironment,
-			applyContext,
 		);
 		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
 		if (systemdUnits.egressSidecarActive) {
@@ -6098,34 +4855,14 @@ export function convergeRuntimeManifest(
 				}
 			}
 		}
-		const pendingOfficialServiceInstalls: Array<{
-			program: RuntimeSystemdUserProgram;
-			target: RuntimeInstallReceiptTarget;
-		}> = [];
-		if (shouldInstallOfficialRuntimeServices()) {
-			for (const program of officialRuntimeSystemdPrograms(runtimeSystemdUserPrograms)) {
-				const serviceName = runtimeSystemdProgramName(program);
-				const key = systemdUnitFileName(serviceName);
-				const desiredRevision = officialServiceDesiredRevision({ program });
-				const currentRevision = () => officialServiceCurrentRevision(program, paths);
-				const verifiedCurrentRevision = verifiedReceiptCurrentRevision(
-					previousInstallReceipts?.officialServices[key],
-					desiredRevision,
-					currentRevision,
-				);
-				const target: RuntimeInstallReceiptTarget = {
-					desiredRevision,
-					currentRevision,
-					expectedCurrentRevision: verifiedCurrentRevision,
-				};
-				installReceiptTargets.officialServices.set(key, target);
-				if (verifiedCurrentRevision === null) {
-					pendingOfficialServiceInstalls.push({ program, target });
-				}
-			}
-		}
+		const officialServicePlan = planOfficialRuntimeServices(
+			runtimeSystemdUserPrograms,
+			paths,
+			previousInstallReceipts,
+		);
+		installReceiptTargets.officialServices = officialServicePlan.targets;
 		if (
-			pendingOfficialServiceInstalls.length > 0 &&
+			officialServicePlan.pending.length > 0 &&
 			systemdUnits.egressSidecarActive &&
 			opts.systemdApply
 		) {
@@ -6139,11 +4876,9 @@ export function convergeRuntimeManifest(
 			}
 		}
 
-		for (const { program, target } of pendingOfficialServiceInstalls) {
-			reloadRuntimeUserManager(paths, paths.userHome);
-			const error = installOfficialRuntimeUserService({ ...program, cwd: paths.userHome }, paths);
+		for (const item of officialServicePlan.pending) {
+			const error = installOfficialRuntimeService(item, paths);
 			if (error) throw new Error(error);
-			target.expectedCurrentRevision = target.currentRevision();
 		}
 
 		const bootFinished = join(instanceRoot, "boot-finished");

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -136,7 +136,7 @@ import {
 	runtimeServiceNameSchema,
 	writeRuntimeRunConfig,
 } from "./run-config";
-import { runtimeProgramRevision } from "./runtime-impact-revision";
+import { runtimeImpactRevision, runtimeProgramRevision } from "./runtime-impact-revision";
 import { createRuntimeSecretResolver, type RuntimeSecretResolver } from "./runtime-secret-resolver";
 import {
 	buildRuntimeSystemdUserProgram,
@@ -2013,12 +2013,12 @@ function previewHostedAiProviderProjectionRevision(
 	if (name === "openclaw") {
 		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
 		if (!projectionInput) {
-			return revisionHash({
+			return runtimeImpactRevision({
 				openClawProviderProjection: "delete",
 				patch: JSON.parse(providerPatch.content) as unknown,
 			});
 		}
-		return revisionHash({
+		return runtimeImpactRevision({
 			openClawProviderProjection: "json-patch",
 			patch: providerPatch.content,
 		});
@@ -2051,7 +2051,7 @@ function applyHostedCodexManagedProviderProjection(
 	return {
 		path: configPath,
 		providerIds: [CODEX_MANAGED_PROVIDER_ID],
-		revision: revisionHash({
+		revision: runtimeImpactRevision({
 			codexManagedProviderProjection: CODEX_MANAGED_PROVIDER_CONFIG_FILE,
 			configContent,
 			codexCli,
@@ -2266,7 +2266,7 @@ function applyHostedHermesAiProviderProjection(
 		return {
 			path: null,
 			providerIds: [],
-			revision: revisionHash({
+			revision: runtimeImpactRevision({
 				hermesProviderProjection: "none",
 				deletedProviderIds,
 			}),
@@ -2295,7 +2295,7 @@ function applyHostedHermesAiProviderProjection(
 	return {
 		path: configPath,
 		providerIds: activeProviderIds,
-		revision: revisionHash({
+		revision: runtimeImpactRevision({
 			hermesProviderProjection: "yaml-merge",
 			patch: patchContent,
 		}),
@@ -3790,26 +3790,6 @@ function daemonAuthTokenRevision(token: string): string {
 	});
 }
 
-function canonicalize(value: unknown): unknown {
-	if (Array.isArray(value)) return value.map(canonicalize);
-	if (value && typeof value === "object") {
-		const input = value as Record<string, unknown>;
-		return Object.fromEntries(
-			Object.keys(input)
-				.sort()
-				.map((key) => [key, canonicalize(input[key])]),
-		);
-	}
-	return value;
-}
-
-function revisionHash(value: unknown): string {
-	return createHash("sha256")
-		.update(JSON.stringify(canonicalize(value)))
-		.digest("hex")
-		.slice(0, 32);
-}
-
 function runtimeProgramRevisionForManifest(
 	manifest: RuntimeManifest,
 	runtime: string,
@@ -4810,9 +4790,9 @@ export function convergeRuntimeManifest(
 		} else {
 			rmSync(mcpProjection, { force: true });
 		}
-		const systemdUnits = writeRuntimeSystemdState(
-			runtimeSystemdUserPrograms,
-			egressSystemdProgram,
+		const systemdUnits = writeRuntimeSystemdState({
+			runtimePrograms: runtimeSystemdUserPrograms,
+			egressProgram: egressSystemdProgram,
 			egressIdentity,
 			manifest,
 			paths,
@@ -4821,9 +4801,9 @@ export function convergeRuntimeManifest(
 			secretValues,
 			runtimeEnvironment,
 			providerProjectionRevisions,
-			runtimeProgramRevisionForManifest,
-			commonSystemdEnvironment,
-		);
+			runtimeRevision: runtimeProgramRevisionForManifest,
+			commonEnvironment: commonSystemdEnvironment,
+		});
 		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
 		if (systemdUnits.egressSidecarActive) {
 			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -15,11 +15,9 @@ import {
 	readlinkSync,
 	rmSync,
 	statSync,
-	symlinkSync,
-	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
 	AiProviderApiMode,
@@ -86,6 +84,7 @@ import {
 	readRuntimeInstallReceipts,
 	writeRuntimeInstallReceipts,
 } from "./install-receipts";
+import { captureRuntimeLiveSnapshot, restoreRuntimeLiveSnapshot } from "./live-state-snapshot";
 import {
 	buildManagedModelsEndpoint,
 	extractManagedLiveModels,
@@ -106,7 +105,7 @@ import {
 import {
 	isEnvSecretRef,
 	normalizeSecretValues,
-	processRuntimeEnvironment,
+	projectedRuntimeEnvironment,
 	type RuntimeEnvironmentAuthority,
 	runtimeSecretValue as resolveRuntimeSecretValue,
 } from "./secret-values";
@@ -232,24 +231,6 @@ export interface RuntimePrivateAppliedAuthority {
 	// root-owned 0600 applied-state authority.
 	daemonAuthTokenRevision?: string;
 	egressSidecarSecretRevision?: string;
-}
-
-type RuntimeLiveSnapshotNode =
-	| { kind: "missing" }
-	| { kind: "metadata"; existed: false }
-	| { kind: "metadata"; existed: true; mode: number; uid: number; gid: number }
-	| { kind: "file"; content: Buffer; mode: number; uid: number; gid: number }
-	| { kind: "symlink"; target: string; uid: number; gid: number }
-	| {
-			kind: "directory";
-			mode: number;
-			uid: number;
-			gid: number;
-			entries: Map<string, RuntimeLiveSnapshotNode>;
-	  };
-
-interface RuntimeLiveSnapshot {
-	entries: Map<string, RuntimeLiveSnapshotNode>;
 }
 
 interface RuntimeInstallObservation {
@@ -808,7 +789,7 @@ function scopedSecretValues(
 		if (isEnvSecretRef(ref) && !options.resolveEnv) continue;
 		const value = options.resolver
 			? options.resolver.resolve(ref)
-			: resolveRuntimeSecretValue(normalizedValues, ref, processRuntimeEnvironment());
+			: resolveRuntimeSecretValue(normalizedValues, ref, projectedRuntimeEnvironment({}));
 		if (!value) {
 			if (options.require?.(ref)) throw new Error(`Runtime secret ${ref} is unavailable.`);
 			continue;
@@ -2245,11 +2226,12 @@ function verifiedCommittedEgressSecretMaterial(
 		const committed = loadCommittedRuntimeManifest(paths);
 		if ("errors" in committed) return null;
 		if (egressSecretRefs(committed.manifest).some(isEnvSecretRef)) return null;
+		if (!committed.applyContext) return null;
 		return egressSecretMaterial(
 			committed.manifest,
 			committed.secretValues,
 			paths,
-			committed.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment(),
+			committed.applyContext.runtimeEnvironment,
 		);
 	} catch {
 		return null;
@@ -4488,7 +4470,7 @@ export function runtimeProgramRevision(
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevision: string | null = null,
-	runtimeEnvironment: RuntimeEnvironmentAuthority = processRuntimeEnvironment(),
+	runtimeEnvironment: RuntimeEnvironmentAuthority = projectedRuntimeEnvironment({}),
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const desiredProgram = desiredRuntime
@@ -4736,7 +4718,7 @@ function runtimeSystemdProgramRevision(
 	program: RuntimeSystemdUserProgram,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
-	runtimeEnvironment: RuntimeEnvironmentAuthority = processRuntimeEnvironment(),
+	runtimeEnvironment: RuntimeEnvironmentAuthority = projectedRuntimeEnvironment({}),
 ): string {
 	if (program.service) return runtimeServiceProgramRevision(program);
 	return runtimeProgramRevision(
@@ -5806,227 +5788,6 @@ function runtimeConvergenceWithoutApply(input: {
 	};
 }
 
-function addExistingManagedSystemdSystemPaths(paths: RuntimePaths, result: Set<string>): void {
-	if (!existsSync(paths.systemdSystemRoot)) return;
-	for (const entry of readdirSync(paths.systemdSystemRoot)) {
-		const path = join(paths.systemdSystemRoot, entry);
-		if (
-			entry.endsWith(".service") &&
-			(entry.startsWith("clawdi-") || isGeneratedSystemdFile(path))
-		) {
-			result.add(path);
-		}
-		if (!entry.endsWith(".service.d")) continue;
-		const dropIn = join(path, "10-clawdi-hosted.conf");
-		if (isGeneratedSystemdFile(dropIn)) result.add(dropIn);
-	}
-}
-
-export function runtimeLiveSnapshotPaths(
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	_workspaceRoot: string,
-): string[] {
-	const result = new Set<string>([
-		paths.managedConfig,
-		paths.syncState,
-		paths.providerHealthStatus,
-		paths.egressEngineStatus,
-		paths.manifestLastGood,
-		paths.managedSecretCacheFile,
-		paths.appliedState,
-		paths.egressProfileRoot,
-		paths.installInventory,
-		paths.projectionRoot,
-		join(paths.instanceRoot, manifest.instanceId),
-		paths.managedSecretFile,
-		paths.daemonAuthToken,
-		egressSecretFilePath(paths),
-		paths.instanceData,
-		paths.sensitiveInstanceData,
-		paths.egressAddon,
-		paths.egressTransparentEnv,
-		paths.egressSystemCaFile,
-		liveSyncEnvironmentIndexPath(paths),
-	]);
-	for (const name of ["clawdi-runtime-watch", "clawdi-daemon", "clawdi-runtime-sidecar"]) {
-		result.add(join(paths.systemdSystemRoot, systemdUnitFileName(name)));
-		result.add(systemdEnvironmentFilePath(paths, name));
-	}
-	addExistingManagedSystemdSystemPaths(paths, result);
-	return [...result].sort();
-}
-
-function runtimeManagedDirectoryPaths(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
-	return [
-		paths.runConfigRoot,
-		paths.systemdEnvRoot,
-		paths.egressProfileRoot,
-		paths.installInventory,
-		paths.projectionRoot,
-		join(paths.instanceRoot, manifest.instanceId),
-	];
-}
-
-function assertRuntimeManagedDirectoryTrusted(path: string): void {
-	let stat: ReturnType<typeof lstatSync>;
-	try {
-		stat = lstatSync(path);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	if (!stat.isDirectory() || stat.isSymbolicLink()) {
-		throw new Error(`runtime managed directory is not a real directory: ${path}`);
-	}
-	if ((stat.mode & 0o022) !== 0) {
-		throw new Error(`runtime managed directory is group/world writable: ${path}`);
-	}
-	if (runningAsRoot() && stat.uid !== 0) {
-		throw new Error(`runtime managed directory is not root-owned: ${path}`);
-	}
-}
-
-function runtimeLiveSnapshotMetadataPaths(snapshotPaths: readonly string[]): string[] {
-	return [
-		...new Set(
-			snapshotPaths
-				.filter((path) => basename(path) === "10-clawdi-hosted.conf")
-				.map((path) => dirname(path)),
-		),
-	].sort();
-}
-
-function captureRuntimeLiveNode(path: string): RuntimeLiveSnapshotNode {
-	let stat: ReturnType<typeof lstatSync>;
-	try {
-		stat = lstatSync(path);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
-		throw error;
-	}
-	if (stat.isSymbolicLink()) {
-		return { kind: "symlink", target: readlinkSync(path), uid: stat.uid, gid: stat.gid };
-	}
-	if (stat.isFile()) {
-		return {
-			kind: "file",
-			content: readFileSync(path),
-			mode: stat.mode & 0o777,
-			uid: stat.uid,
-			gid: stat.gid,
-		};
-	}
-	if (!stat.isDirectory()) throw new Error(`unsupported runtime live-state path: ${path}`);
-	const mode = stat.mode & 0o777;
-	if ((mode & 0o022) !== 0) {
-		throw new Error(`runtime live-state snapshot directory is group/world writable: ${path}`);
-	}
-	if (runningAsRoot() && stat.uid !== 0) {
-		throw new Error(`runtime live-state snapshot directory is not root-owned: ${path}`);
-	}
-	return {
-		kind: "directory",
-		mode,
-		uid: stat.uid,
-		gid: stat.gid,
-		entries: new Map(
-			readdirSync(path)
-				.sort()
-				.map((entry) => [entry, captureRuntimeLiveNode(join(path, entry))]),
-		),
-	};
-}
-
-function captureRuntimeLiveMetadata(path: string): RuntimeLiveSnapshotNode {
-	try {
-		const stat = lstatSync(path);
-		return {
-			kind: "metadata",
-			existed: true,
-			mode: stat.mode & 0o777,
-			uid: stat.uid,
-			gid: stat.gid,
-		};
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return { kind: "metadata", existed: false };
-		}
-		throw error;
-	}
-}
-
-function restoreRuntimeLiveOwnership(
-	path: string,
-	uid: number,
-	gid: number,
-	symlink: boolean,
-): void {
-	const restored = lstatSync(path);
-	if (restored.uid === uid && restored.gid === gid) return;
-	if (symlink) lchownSync(path, uid, gid);
-	else chownSync(path, uid, gid);
-}
-
-function captureRuntimeLiveSnapshot(
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	workspaceRoot: string,
-): RuntimeLiveSnapshot {
-	for (const path of runtimeManagedDirectoryPaths(manifest, paths)) {
-		assertRuntimeManagedDirectoryTrusted(path);
-	}
-	const snapshotPaths = runtimeLiveSnapshotPaths(manifest, paths, workspaceRoot);
-	return {
-		entries: new Map([
-			...snapshotPaths.map((path) => [path, captureRuntimeLiveNode(path)] as const),
-			...runtimeLiveSnapshotMetadataPaths(snapshotPaths).map(
-				(path) => [path, captureRuntimeLiveMetadata(path)] as const,
-			),
-		]),
-	};
-}
-
-function restoreRuntimeLiveNode(path: string, node: RuntimeLiveSnapshotNode): void {
-	if (node.kind === "metadata") {
-		if (!node.existed) {
-			if (existsSync(path) && readdirSync(path).length === 0) rmSync(path, { recursive: true });
-			return;
-		}
-		if (!existsSync(path)) mkdirSync(path, { recursive: true, mode: node.mode });
-		chmodSync(path, node.mode);
-		restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
-		return;
-	}
-	rmSync(path, { recursive: true, force: true });
-	if (node.kind === "missing") return;
-	mkdirSync(dirname(path), { recursive: true });
-	if (node.kind === "symlink") {
-		symlinkSync(node.target, path);
-		restoreRuntimeLiveOwnership(path, node.uid, node.gid, true);
-		return;
-	}
-	if (node.kind === "file") {
-		writeFileSync(path, node.content, { mode: node.mode });
-		chmodSync(path, node.mode);
-		restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
-		return;
-	}
-	mkdirSync(path, { recursive: true, mode: node.mode });
-	chmodSync(path, node.mode);
-	for (const [entry, child] of node.entries) restoreRuntimeLiveNode(join(path, entry), child);
-	restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
-}
-
-function restoreRuntimeLiveSnapshot(snapshot: RuntimeLiveSnapshot): void {
-	for (const [path, node] of snapshot.entries) {
-		if (node.kind !== "metadata") restoreRuntimeLiveNode(path, node);
-	}
-	for (const [path, node] of snapshot.entries) {
-		if (node.kind === "metadata") restoreRuntimeLiveNode(path, node);
-	}
-}
-
 function validateRuntimeProjectionPlan(input: {
 	manifest: RuntimeManifest;
 	paths: RuntimePaths;
@@ -6178,7 +5939,10 @@ export function convergeRuntimeManifest(
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
 	const secretValues = runtimeSecretValues(load);
-	const runtimeEnvironment = load.applyContext?.runtimeEnvironment ?? processRuntimeEnvironment();
+	const runtimeEnvironment = load.applyContext?.runtimeEnvironment;
+	if (!runtimeEnvironment) {
+		throw new Error("runtime manifest convergence requires an explicit apply context");
+	}
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	const enabledRuntimes = Object.entries(manifest.runtimes)
@@ -6353,7 +6117,7 @@ export function convergeRuntimeManifest(
 	});
 
 	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
-	const liveSnapshot = captureRuntimeLiveSnapshot(manifest, paths, workspaceRoot);
+	const liveSnapshot = captureRuntimeLiveSnapshot(manifest, paths);
 	let systemdActivationAttempted = false;
 	let systemdActivationApplied = false;
 	let restartDaemon = false;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -19,18 +19,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type {
-	AiProviderApiMode,
-	AiProviderAuth,
-	AiProviderCatalog,
-	AiProviderModel,
-	AiProviderType,
-} from "@clawdi/shared";
+import type { AiProviderCatalog } from "@clawdi/shared";
 import {
 	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
-	isAiProviderApiMode,
-	isAiProviderType,
 	isClawdiManagedV2ProviderId,
 } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
@@ -51,11 +43,7 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
-import {
-	type RuntimeApplyContext,
-	runtimeApplyContextServiceEnvironment,
-	runtimeApplyIdentityServiceEnvironment,
-} from "./apply-identity";
+import { type RuntimeApplyContext, runtimeApplyContextServiceEnvironment } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	RUNTIME_AUTH_TOKEN_SECRET_REF,
@@ -72,11 +60,16 @@ import {
 
 export { withRuntimeConvergeLock, withRuntimeConvergeLockAsync } from "./converge-lock";
 
+import { managedMcpHeaderPlaceholder, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
-	isClawdiManagedProviderProjection,
-	managedMcpHeaderPlaceholder,
-	normalizeSecretRef,
-} from "./hosted-egress-profiles";
+	hostedAiProviderCatalog,
+	hostedProviderEnvironment,
+	hostedProviderRequiresApiKey,
+	type ManagedGatewayModelListFetcher,
+	mergeRuntimeEnvWithProviderPlaceholders,
+	mergeRuntimeServiceEnvWithProviderPlaceholders,
+	resolveManagedGatewayModelOverrides,
+} from "./hosted-provider-resolution";
 import {
 	emptyRuntimeInstallReceipts,
 	type RuntimeInstallReceiptEntry,
@@ -85,11 +78,7 @@ import {
 	writeRuntimeInstallReceipts,
 } from "./install-receipts";
 import { captureRuntimeLiveSnapshot, restoreRuntimeLiveSnapshot } from "./live-state-snapshot";
-import {
-	buildManagedModelsEndpoint,
-	extractManagedLiveModels,
-	resolveManagedPrimaryModel,
-} from "./managed-model-resolution";
+import { buildManagedModelsEndpoint, extractManagedLiveModels } from "./managed-model-resolution";
 import {
 	installReservedManagedSkill,
 	managedSkillReservationOwner,
@@ -107,7 +96,7 @@ import {
 	normalizeSecretValues,
 	projectedRuntimeEnvironment,
 	type RuntimeEnvironmentAuthority,
-	runtimeSecretValue as resolveRuntimeSecretValue,
+	runtimeSecretValue,
 } from "./secret-values";
 
 export type { RuntimeInstall, RuntimeManifest } from "./manifest-contract";
@@ -168,6 +157,10 @@ import {
 	TRANSPARENT_EGRESS_TRANSPORT_VERSION,
 } from "./transparent-egress";
 import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
+
+type ManagedGatewayModelFetchInput = Parameters<ManagedGatewayModelListFetcher>[0];
+type ManagedGatewayModelFetchResult = ReturnType<ManagedGatewayModelListFetcher>;
+type ManagedGatewayModelOverrides = ReturnType<typeof resolveManagedGatewayModelOverrides>;
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -444,7 +437,7 @@ function materializeHostedChannelCredentials(
 			continue;
 		}
 		expectedAuthDirs.add(resolve(credential.authDir));
-		const credsJson = resolveRuntimeSecretValue(
+		const credsJson = runtimeSecretValue(
 			normalizedSecrets,
 			credential.credsJsonSecretRef,
 			runtimeEnvironment,
@@ -479,7 +472,7 @@ function validateHostedChannelCredentialsPlan(
 	for (const credential of hostedWhatsAppAuthCredentials(manifest)) {
 		const authDirError = managedWhatsAppAuthDirError(home, credential);
 		if (authDirError) throw new Error(authDirError);
-		const credsJson = resolveRuntimeSecretValue(
+		const credsJson = runtimeSecretValue(
 			normalizedSecrets,
 			credential.credsJsonSecretRef,
 			runtimeEnvironment,
@@ -789,7 +782,7 @@ function scopedSecretValues(
 		if (isEnvSecretRef(ref) && !options.resolveEnv) continue;
 		const value = options.resolver
 			? options.resolver.resolve(ref)
-			: resolveRuntimeSecretValue(normalizedValues, ref, projectedRuntimeEnvironment({}));
+			: runtimeSecretValue(normalizedValues, ref, projectedRuntimeEnvironment({}));
 		if (!value) {
 			if (options.require?.(ref)) throw new Error(`Runtime secret ${ref} is unavailable.`);
 			continue;
@@ -869,7 +862,7 @@ function providerSecretAvailable(
 	ref: string,
 	runtimeEnvironment: RuntimeEnvironmentAuthority,
 ): boolean {
-	return resolveRuntimeSecretValue(secretValues, ref, runtimeEnvironment) !== null;
+	return runtimeSecretValue(secretValues, ref, runtimeEnvironment) !== null;
 }
 
 function providerHealthReasons(
@@ -1557,235 +1550,6 @@ function applyHostedLocaleProjection(
 	return null;
 }
 
-export function hostedAiProviderCatalog(
-	manifest: RuntimeManifest,
-	runtimeName?: string,
-	options: {
-		primaryModelOverride?: AgentPrimaryModel;
-		managedModelsOverride?: readonly AiProviderModel[];
-	} = {},
-): { catalog: AiProviderCatalog; primaryModel: AgentPrimaryModel } | null {
-	const providers = manifest.projection?.providers;
-	if (!providers || Object.keys(providers).length === 0) return null;
-	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
-	const primaryModel =
-		options.primaryModelOverride ?? hostedRuntimePrimaryModel(manifest, runtimeName);
-	if (!primaryModel) return null;
-	const entries = rawEntries
-		.map(([id, raw]) => {
-			if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
-			const input = raw as Record<string, unknown>;
-			const baseUrl = typeof input.baseUrl === "string" ? input.baseUrl : undefined;
-			const apiMode = hostedProviderApiMode(input);
-			const apiKeySecretRef =
-				typeof input.apiKeySecretRef === "string" ? input.apiKeySecretRef : undefined;
-			const runtimeEnvName = hostedProviderRuntimeEnvName(id, input);
-			if (hostedProviderUnhealthy(input)) return null;
-			if (!baseUrl) return null;
-			const auth = hostedProviderAuth(input, Boolean(apiKeySecretRef));
-			if (!auth) return null;
-			const models = hostedProviderModels(
-				input,
-				id === primaryModel.provider_id ? primaryModel : null,
-				id === primaryModel.provider_id ? options.managedModelsOverride : undefined,
-			);
-			return {
-				id,
-				type: hostedProviderType(input),
-				base_url: baseUrl,
-				api_mode: apiMode,
-				managed_by: hostedProviderManagedBy(input),
-				auth,
-				runtime_env_name: apiKeySecretRef || auth.type !== "none" ? runtimeEnvName : undefined,
-				models,
-			};
-		})
-		.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-	if (entries.length === 0) return null;
-	return {
-		catalog: {
-			schema_version: 1,
-			providers: entries,
-			defaults: { chat_provider_id: primaryModel.provider_id },
-		},
-		primaryModel,
-	};
-}
-
-function hostedProviderManagedBy(
-	input: Record<string, unknown>,
-): AiProviderCatalog["providers"][number]["managed_by"] {
-	const value = input.managed_by;
-	return value === "clawdi" || value === "user" ? value : undefined;
-}
-
-function hostedProviderEntries(
-	providers: Record<string, unknown>,
-	runtimeName?: string,
-	manifest?: RuntimeManifest,
-): Array<[string, unknown]> {
-	if (!runtimeName) {
-		return Object.entries(providers).sort(([left], [right]) => left.localeCompare(right));
-	}
-	const providerIds = manifest?.runtimes?.[runtimeName]?.provider_ids ?? [];
-	return providerIds
-		.filter((providerId) => Object.hasOwn(providers, providerId))
-		.map((providerId) => [providerId, providers[providerId]]);
-}
-
-function hostedRuntimePrimaryModel(
-	manifest: RuntimeManifest,
-	runtimeName: string | undefined,
-): AgentPrimaryModel | null {
-	const runtime = runtimeName ? manifest.runtimes[runtimeName] : undefined;
-	return runtime?.primary_model ?? null;
-}
-
-function hostedProviderModels(
-	input: Record<string, unknown>,
-	primaryModel: AgentPrimaryModel | null,
-	managedModelsOverride?: readonly AiProviderModel[],
-): NonNullable<AiProviderCatalog["providers"][number]["models"]> {
-	const providerApiMode = hostedProviderApiMode(input);
-	// Hosted wire rejects singular model; this fallback serves generic provider projections only.
-	const singularModel = stringValue(input.model);
-	const rawModels = Array.isArray(input.models) ? input.models : [];
-	const manifestModels = rawModels
-		.map((model) => (recordValue(model) ? (model as Record<string, unknown>) : null))
-		.filter((model): model is Record<string, unknown> => model !== null)
-		.map((model) => {
-			const id = stringValue(model.id);
-			if (!id) return null;
-			const apiMode = stringValue(model.api_mode);
-			return {
-				...model,
-				id,
-				...(apiMode && isAiProviderApiMode(apiMode) ? { api_mode: apiMode } : {}),
-			};
-		})
-		.filter((model): model is NonNullable<typeof model> => model !== null);
-	const manifestModelsById = new Map(manifestModels.map((model) => [model.id, model]));
-	const models = managedModelsOverride
-		? managedModelsOverride.map((model) => ({
-				...manifestModelsById.get(model.id),
-				...model,
-				id: model.id,
-			}))
-		: manifestModels;
-	if (singularModel && !models.some((model) => model.id === singularModel)) {
-		models.unshift({ id: singularModel, api_mode: providerApiMode });
-	}
-	if (primaryModel && !models.some((model) => model.id === primaryModel.model)) {
-		models.unshift({ id: primaryModel.model, api_mode: providerApiMode });
-	}
-	return models.filter(
-		(model, index, entries) => entries.findIndex((entry) => entry.id === model.id) === index,
-	);
-}
-
-function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMode {
-	const raw = input.apiMode;
-	if (typeof raw === "string" && isAiProviderApiMode(raw)) {
-		return raw;
-	}
-	return "openai_chat";
-}
-
-function managedProviderSupportsLiveModelProbe(apiMode: AiProviderApiMode): boolean {
-	return apiMode === "openai_chat" || apiMode === "openai_responses";
-}
-
-function managedGatewayPrimaryModelTarget(
-	manifest: RuntimeManifest,
-	runtimeName: string,
-): {
-	baseUrl: string;
-	providerId: string;
-	seedModel: string | null;
-} | null {
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers) return null;
-	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
-	if (rawEntries.length === 0) return null;
-	const currentPrimary = hostedRuntimePrimaryModel(manifest, runtimeName);
-	const selectedProviderId = currentPrimary?.provider_id ?? null;
-	if (!selectedProviderId) return null;
-	const selectedProvider = rawEntries.find(
-		([providerId]) => providerId === selectedProviderId,
-	)?.[1];
-	const provider = recordValue(selectedProvider);
-	if (!provider || !isClawdiManagedProviderProjection(provider)) return null;
-	const baseUrl = stringValue(provider.baseUrl);
-	if (!baseUrl) return null;
-	const apiMode = hostedProviderApiMode(provider);
-	if (!managedProviderSupportsLiveModelProbe(apiMode)) return null;
-	return {
-		baseUrl,
-		providerId: selectedProviderId,
-		seedModel:
-			currentPrimary && currentPrimary.provider_id === selectedProviderId
-				? currentPrimary.model
-				: null,
-	};
-}
-
-interface ManagedGatewayModelOverrides {
-	primaryModels: Partial<Record<string, AgentPrimaryModel>>;
-	models: Partial<Record<string, AiProviderModel[]>>;
-}
-
-function resolveManagedGatewayModelOverrides(
-	manifest: RuntimeManifest,
-	enabledRuntimes: readonly string[],
-	home: string,
-	workspaceRoot: string,
-	egressSystemCaFile: string | null,
-	fetcher: ManagedGatewayModelListFetcher,
-): ManagedGatewayModelOverrides {
-	const overrides: ManagedGatewayModelOverrides = { primaryModels: {}, models: {} };
-	const fetchCache = new Map<string, ManagedGatewayModelFetchResult>();
-	for (const runtimeName of enabledRuntimes) {
-		const target = managedGatewayPrimaryModelTarget(manifest, runtimeName);
-		if (!target) continue;
-		const cacheKey = `${target.providerId}\n${target.baseUrl}`;
-		let fetchResult = fetchCache.get(cacheKey);
-		if (!fetchResult) {
-			fetchResult = fetcher({
-				baseUrl: target.baseUrl,
-				home,
-				egressSystemCaFile,
-				providerId: target.providerId,
-				runtimeName,
-				workspaceRoot,
-			});
-			fetchCache.set(cacheKey, fetchResult);
-			if (fetchResult.status === "failed") {
-				const loggedProviderId = isClawdiManagedV2ProviderId(target.providerId)
-					? CLAWDI_MANAGED_PROVIDER_ID
-					: target.providerId;
-				console.warn(
-					`managed model probe failed for ${runtimeName}/${loggedProviderId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
-				);
-			}
-		}
-		const resolution = resolveManagedPrimaryModel({
-			seedModel: target.seedModel,
-			liveModelIds:
-				fetchResult.status === "ok" ? fetchResult.models.map((model) => model.id) : null,
-		});
-		if (fetchResult.status === "ok" && fetchResult.models.length > 0) {
-			overrides.models[runtimeName] = fetchResult.models;
-		}
-		if (!resolution.resolvedModel) continue;
-		if (resolution.resolvedModel === target.seedModel) continue;
-		overrides.primaryModels[runtimeName] = {
-			provider_id: target.providerId,
-			model: resolution.resolvedModel,
-		};
-	}
-	return overrides;
-}
-
 const MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS = 3_000;
 
 const MANAGED_GATEWAY_MODEL_FETCH_SCRIPT = [
@@ -1872,158 +1636,6 @@ function parseManagedGatewayFetchFailure(
 	}
 	const detail = stderr.trim() || stdout.trim();
 	return detail || `exit ${status ?? "unknown"}`;
-}
-
-function hostedProviderType(input: Record<string, unknown>): AiProviderType {
-	const type = stringValue(input.type);
-	return type && isAiProviderType(type) ? type : "custom_openai_compatible";
-}
-
-function hostedProviderAuth(
-	input: Record<string, unknown>,
-	hasApiKeySecretRef: boolean,
-): AiProviderAuth | null {
-	const auth = recordValue(input.auth);
-	if (auth) {
-		const type = stringValue(auth.type);
-		const tool = stringValue(auth.tool);
-		const profile = stringValue(auth.profile);
-		if (type === "agent_profile" && tool === "codex" && profile) {
-			return { type: "agent_profile", tool: "codex", profile };
-		}
-		if (type === "api_key" || type === "secret_ref") {
-			if (hasApiKeySecretRef) {
-				return { type: "api_key", source: "managed" };
-			}
-			return null;
-		}
-		if (type && type !== "none") return null;
-	}
-	if (hasApiKeySecretRef) {
-		return { type: "api_key", source: "managed" };
-	}
-	if (hostedProviderRequiresApiKey(input)) {
-		return null;
-	}
-	return { type: "none" };
-}
-
-function hostedProviderUnhealthy(input: Record<string, unknown>): boolean {
-	const status = stringValue(input.status);
-	return Boolean(status && status !== "ok");
-}
-
-function hostedProviderRequiresApiKey(input: Record<string, unknown>): boolean {
-	if (input.apiKeyRequired === true) return true;
-	const auth = recordValue(input.auth);
-	const type = auth ? stringValue(auth.type) : null;
-	return type === "api_key" || type === "secret_ref";
-}
-
-function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {
-	const raw = typeof input.runtimeEnvName === "string" ? input.runtimeEnvName : null;
-	if (raw && isEnvKey(raw)) return raw;
-	return `CLAWDI_PROVIDER_${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
-}
-
-function hostedProviderPlaceholderEnv(
-	manifest: RuntimeManifest,
-	runtimeName?: string,
-): Record<string, string> {
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers) return {};
-	const env: Record<string, string> = {};
-	for (const [providerId, raw] of hostedProviderEntries(providers, runtimeName, manifest)) {
-		const provider = recordValue(raw);
-		if (!provider) continue;
-		if (!isClawdiManagedProviderProjection(provider)) continue;
-		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
-		if (!apiKeySecretRef) continue;
-		const runtimeEnvName = hostedProviderRuntimeEnvName(providerId, provider);
-		if (!isEnvKey(runtimeEnvName)) continue;
-		env[runtimeEnvName] = MANAGED_EGRESS_PLACEHOLDER_VALUE;
-	}
-	return env;
-}
-
-function hostedProviderSecretEnv(
-	manifest: RuntimeManifest,
-	runtimeName?: string,
-): Record<string, string> {
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers) return {};
-	const secretEnv: Record<string, string> = {};
-	for (const [providerId, raw] of hostedProviderEntries(providers, runtimeName, manifest)) {
-		const provider = recordValue(raw);
-		if (!provider) continue;
-		if (isClawdiManagedProviderProjection(provider)) continue;
-		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
-		if (!apiKeySecretRef) continue;
-		const runtimeEnvName = hostedProviderRuntimeEnvName(providerId, provider);
-		if (!isEnvKey(runtimeEnvName)) continue;
-		secretEnv[runtimeEnvName] = apiKeySecretRef;
-	}
-	return secretEnv;
-}
-
-function assertNoProviderEnvOverlap(
-	runtimeName: string,
-	placeholderEnv: Record<string, string>,
-	secretEnv: Record<string, string>,
-): void {
-	for (const envName of Object.keys(placeholderEnv)) {
-		if (secretEnv[envName] === undefined) continue;
-		throw new Error(
-			`runtime ${runtimeName} provider env ${envName} is both managed and BYOK-backed`,
-		);
-	}
-}
-
-function mergeRuntimeEnvWithProviderPlaceholders(
-	runtimeName: string,
-	settings: RuntimeManifest["runtimes"][string]["run"],
-	providerEnv: Record<string, string>,
-): RuntimeManifest["runtimes"][string]["run"] {
-	if (Object.keys(providerEnv).length === 0) return settings;
-	const userEnv = settings?.env ?? {};
-	for (const envName of Object.keys(providerEnv)) {
-		if (settings?.secretEnv?.[envName] !== undefined) {
-			throw new Error(
-				`runtime ${runtimeName} provider placeholder ${envName} conflicts with secretEnv`,
-			);
-		}
-	}
-	return {
-		...(settings ?? {}),
-		prependPath: settings?.prependPath ?? [],
-		env: {
-			...userEnv,
-			...providerEnv,
-		},
-	};
-}
-
-function mergeRuntimeServiceEnvWithProviderPlaceholders(
-	runtimeName: string,
-	serviceName: string,
-	settings: NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string],
-	providerEnv: Record<string, string>,
-): NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string] {
-	if (Object.keys(providerEnv).length === 0) return settings;
-	for (const envName of Object.keys(providerEnv)) {
-		if (settings.secretEnv?.[envName] !== undefined) {
-			throw new Error(
-				`runtime ${runtimeName} service ${serviceName} provider placeholder ${envName} conflicts with secretEnv`,
-			);
-		}
-	}
-	return {
-		...settings,
-		env: {
-			...(settings.env ?? {}),
-			...providerEnv,
-		},
-	};
 }
 
 function resolvedRuntimeServiceSettings(
@@ -2208,8 +1820,9 @@ function writeEgressSecretFile(
 function committedEgressSecretMaterial(
 	paths: RuntimePaths,
 	committedRevision: string,
+	applyContext: RuntimeApplyContext,
 ): RuntimeEgressSecretMaterial {
-	const material = verifiedCommittedEgressSecretMaterial(paths);
+	const material = verifiedCommittedEgressSecretMaterial(paths, applyContext);
 	if (!material) {
 		throw new Error("could not verify committed egress secret rollback authority");
 	}
@@ -2221,9 +1834,10 @@ function committedEgressSecretMaterial(
 
 function verifiedCommittedEgressSecretMaterial(
 	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext,
 ): RuntimeEgressSecretMaterial | null {
 	try {
-		const committed = loadCommittedRuntimeManifest(paths);
+		const committed = loadCommittedRuntimeManifest(paths, applyContext);
 		if ("errors" in committed) return null;
 		if (egressSecretRefs(committed.manifest).some(isEnvSecretRef)) return null;
 		if (!committed.applyContext) return null;
@@ -2295,10 +1909,6 @@ function collectSecretRefs(value: unknown, refs: Set<string>): void {
 	}
 }
 
-function isEnvKey(value: string): boolean {
-	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
-}
-
 interface HostedAiProviderProjectionResult {
 	path: string | null;
 	revision: string | null;
@@ -2354,31 +1964,6 @@ function agentTargetProjectionInput(
 		primaryModel: { ...input.primaryModel, provider_id: primaryProviderId },
 	};
 }
-
-interface ManagedGatewayModelFetchInput {
-	baseUrl: string;
-	home: string;
-	egressSystemCaFile: string | null;
-	providerId: string;
-	runtimeName: string;
-	workspaceRoot: string;
-}
-
-type ManagedGatewayModelFetchResult =
-	| {
-			status: "ok";
-			endpoint: string;
-			models: AiProviderModel[];
-	  }
-	| {
-			status: "failed";
-			detail: string;
-			endpoint: string;
-	  };
-
-type ManagedGatewayModelListFetcher = (
-	input: ManagedGatewayModelFetchInput,
-) => ManagedGatewayModelFetchResult;
 
 function applyHostedAiProviderProjection(
 	name: string,
@@ -4469,8 +4054,8 @@ export function runtimeProgramRevision(
 	manifest: RuntimeManifest,
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	providerProjectionRevision: string | null = null,
-	runtimeEnvironment: RuntimeEnvironmentAuthority = projectedRuntimeEnvironment({}),
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const desiredProgram = desiredRuntime
@@ -4478,7 +4063,11 @@ export function runtimeProgramRevision(
 		: null;
 	const runtimeSecretRefs = desiredRuntime
 		? Object.values(
-				mergeRuntimeSecretEnv(runtime, desiredRuntime, hostedProviderSecretEnv(manifest, runtime)),
+				mergeRuntimeSecretEnv(
+					runtime,
+					desiredRuntime,
+					hostedProviderEnvironment(manifest, runtime).secretEnv,
+				),
 			)
 		: [];
 	const channels = hostedChannelProjection(manifest);
@@ -4632,14 +4221,6 @@ function buildRuntimeSystemdUserProgram(input: {
 	};
 }
 
-export function runtimeSecretValue(
-	secrets: Record<string, string>,
-	ref: string,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-): string | null {
-	return resolveRuntimeSecretValue(secrets, ref, runtimeEnvironment);
-}
-
 function hashToUInt16(input: string): number {
 	return createHash("sha256").update(input).digest().readUInt16BE(0);
 }
@@ -4717,16 +4298,16 @@ function runtimeSystemdProgramRevision(
 	manifest: RuntimeManifest,
 	program: RuntimeSystemdUserProgram,
 	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
-	runtimeEnvironment: RuntimeEnvironmentAuthority = projectedRuntimeEnvironment({}),
 ): string {
 	if (program.service) return runtimeServiceProgramRevision(program);
 	return runtimeProgramRevision(
 		manifest,
 		program.runtime,
 		secretValues,
-		providerProjectionRevisions[program.runtime] ?? null,
 		runtimeEnvironment,
+		providerProjectionRevisions[program.runtime] ?? null,
 	);
 }
 
@@ -5352,8 +4933,8 @@ function writeRuntimeSystemdUserProgram(input: {
 			input.manifest,
 			program,
 			input.secretValues,
-			input.providerProjectionRevisions,
 			input.runtimeEnvironment,
+			input.providerProjectionRevisions,
 		),
 		...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
 	};
@@ -5403,7 +4984,7 @@ function writeSystemdUnits(
 	runtimeEnvironment: RuntimeEnvironmentAuthority,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
 	commonEnvironment: Record<string, string>,
-	applyContext: RuntimeApplyContext | undefined,
+	applyContext: RuntimeApplyContext,
 ): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
 	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
@@ -5412,10 +4993,7 @@ function writeSystemdUnits(
 	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const userUnits: string[] = [];
 	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
-	const applyIdentityEnvironment =
-		applyContext === undefined
-			? runtimeApplyIdentityServiceEnvironment()
-			: runtimeApplyContextServiceEnvironment(applyContext);
+	const applyIdentityEnvironment = runtimeApplyContextServiceEnvironment(applyContext);
 	if (daemonAuthTokenFile) {
 		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
 		systemUnits.push(
@@ -5533,11 +5111,11 @@ function validateRuntimeManifestPlan(manifest: RuntimeManifest, paths: RuntimePa
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
 		const runtimeName = runtimeNameSchema.parse(name);
-		const providerPlaceholderEnv = runtime.enabled
-			? hostedProviderPlaceholderEnv(manifest, name)
-			: {};
-		const providerSecretEnv = runtime.enabled ? hostedProviderSecretEnv(manifest, name) : {};
-		assertNoProviderEnvOverlap(name, providerPlaceholderEnv, providerSecretEnv);
+		const providerEnvironment = runtime.enabled
+			? hostedProviderEnvironment(manifest, name, { validateOverlap: true })
+			: { placeholderEnv: {}, secretEnv: {} };
+		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
+			providerEnvironment;
 		mergeRuntimeEnvWithProviderPlaceholders(name, runtime.run, providerPlaceholderEnv);
 		const secretEnv = runtime.enabled
 			? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
@@ -5662,13 +5240,11 @@ function resolveRuntimeRunConfigs(input: {
 	egressProfileBundlePath: string | null;
 }): ResolvedRuntimeRunConfigs {
 	const runtimeName = runtimeNameSchema.parse(input.name);
-	const providerPlaceholderEnv = input.runtime.enabled
-		? hostedProviderPlaceholderEnv(input.manifest, input.name)
-		: {};
-	const providerSecretEnv = input.runtime.enabled
-		? hostedProviderSecretEnv(input.manifest, input.name)
-		: {};
-	assertNoProviderEnvOverlap(input.name, providerPlaceholderEnv, providerSecretEnv);
+	const providerEnvironment = input.runtime.enabled
+		? hostedProviderEnvironment(input.manifest, input.name, { validateOverlap: true })
+		: { placeholderEnv: {}, secretEnv: {} };
+	const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
+		providerEnvironment;
 	const runtimeRunSettings = mergeRuntimeEnvWithProviderPlaceholders(
 		input.name,
 		input.runtime.run,
@@ -5839,11 +5415,11 @@ function validateRuntimeProjectionPlan(input: {
 		const observation = observations.get(name);
 		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
 		const runtimeName = runtimeNameSchema.parse(name);
-		const providerPlaceholderEnv = runtime.enabled
-			? hostedProviderPlaceholderEnv(manifest, name)
-			: {};
-		const providerSecretEnv = runtime.enabled ? hostedProviderSecretEnv(manifest, name) : {};
-		assertNoProviderEnvOverlap(name, providerPlaceholderEnv, providerSecretEnv);
+		const providerEnvironment = runtime.enabled
+			? hostedProviderEnvironment(manifest, name, { validateOverlap: true })
+			: { placeholderEnv: {}, secretEnv: {} };
+		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
+			providerEnvironment;
 		mergeRuntimeEnvWithProviderPlaceholders(name, runtime.run, providerPlaceholderEnv);
 		const secretEnv = runtime.enabled
 			? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
@@ -5939,10 +5515,11 @@ export function convergeRuntimeManifest(
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
 	const secretValues = runtimeSecretValues(load);
-	const runtimeEnvironment = load.applyContext?.runtimeEnvironment;
-	if (!runtimeEnvironment) {
+	const applyContext = load.applyContext;
+	if (!applyContext) {
 		throw new Error("runtime manifest convergence requires an explicit apply context");
 	}
+	const runtimeEnvironment = applyContext.runtimeEnvironment;
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	const enabledRuntimes = Object.entries(manifest.runtimes)
@@ -6488,7 +6065,7 @@ export function convergeRuntimeManifest(
 			runtimeEnvironment,
 			providerProjectionRevisions,
 			commonSystemdEnvironment,
-			load.applyContext,
+			applyContext,
 		);
 		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
 		if (systemdUnits.egressSidecarActive) {
@@ -6503,7 +6080,8 @@ export function convergeRuntimeManifest(
 				// for rollback, but its absence must not block loading the desired
 				// material. If desired activation later fails, unverified live bytes
 				// must never be loaded by a rollback restart.
-				rollbackEgressSecretOverride = verifiedCommittedEgressSecretMaterial(paths) ?? undefined;
+				rollbackEgressSecretOverride =
+					verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
 				egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
 			} else if (
 				restartEgressSidecar &&
@@ -6652,7 +6230,7 @@ export function convergeRuntimeManifest(
 				writeEgressSecretMaterial(rollbackEgressSecretOverride, paths);
 			} else if (rollbackEgressSecretRevision) {
 				writeEgressSecretMaterial(
-					committedEgressSecretMaterial(paths, rollbackEgressSecretRevision),
+					committedEgressSecretMaterial(paths, rollbackEgressSecretRevision, applyContext),
 					paths,
 				);
 			}

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -49,13 +49,6 @@ function appliedState(generation: number): RuntimeAppliedStateV2 {
 	};
 }
 
-function setApplyIdentityEnvironment(generation: number): void {
-	process.env.CLAWDI_RUNTIME_GENERATION = String(generation);
-	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = `"manifest-${generation}"`;
-	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = `apply-receipt-000${generation}`;
-	process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000001";
-}
-
 function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 	const path = join(paths.runRoot, "secrets", "runtime-apply-identity.json");
 	mkdirSync(dirname(path), { recursive: true });
@@ -91,7 +84,7 @@ async function observationSchedule(
 	transitionToOk = false,
 ): Promise<Array<{ at: number; status: "ok" | "error" | "unknown" }>> {
 	const paths = tempRuntimePaths();
-	setApplyIdentityEnvironment(1);
+	writeApplyIdentityFile(paths, 1);
 	writeRuntimeAppliedState(appliedState(1), paths);
 	writeObservationHealth(paths, initialStatus);
 	const abort = new AbortController();
@@ -122,7 +115,7 @@ async function observationSchedule(
 describe("hosted runtime observation producer", () => {
 	test("accepts apply generation three at checkpoint two and submits its exact identity", async () => {
 		const paths = tempRuntimePaths();
-		setApplyIdentityEnvironment(3);
+		writeApplyIdentityFile(paths, 3);
 		writeRuntimeAppliedState(
 			{
 				...appliedState(3),
@@ -222,6 +215,7 @@ describe("hosted runtime observation producer", () => {
 
 	test("stays idle when no successfully applied tuple exists", async () => {
 		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
 		let submits = 0;
 		const producer = new HostedRuntimeObservationProducer({
 			abort: new AbortController().signal,
@@ -238,7 +232,7 @@ describe("hosted runtime observation producer", () => {
 
 	test("does not attest a durable tuple that differs from the process environment", async () => {
 		const paths = tempRuntimePaths();
-		setApplyIdentityEnvironment(2);
+		writeApplyIdentityFile(paths, 2);
 		writeRuntimeAppliedState(appliedState(1), paths);
 		let submits = 0;
 		const producer = new HostedRuntimeObservationProducer({
@@ -256,7 +250,7 @@ describe("hosted runtime observation producer", () => {
 
 	test("drops a failed old-tuple pending event when the applied tuple rotates", async () => {
 		const paths = tempRuntimePaths();
-		setApplyIdentityEnvironment(1);
+		writeApplyIdentityFile(paths, 1);
 		writeRuntimeAppliedState(appliedState(1), paths);
 		const ids = ["boot-000000000001", "old-event-000001", "boot-000000000002", "new-event-000001"];
 		const submitted: components["schemas"]["RuntimeObservationEventV2"][] = [];
@@ -282,7 +276,7 @@ describe("hosted runtime observation producer", () => {
 		});
 
 		expect(await producer.sendOnce()).toEqual({ outcome: "failed" });
-		setApplyIdentityEnvironment(2);
+		writeApplyIdentityFile(paths, 2);
 		writeRuntimeAppliedState(appliedState(2), paths);
 		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
 
@@ -299,7 +293,7 @@ describe("hosted runtime observation producer", () => {
 
 	test("does not let an unresolved old-tuple request block rotation", async () => {
 		const paths = tempRuntimePaths();
-		setApplyIdentityEnvironment(1);
+		writeApplyIdentityFile(paths, 1);
 		writeRuntimeAppliedState(appliedState(1), paths);
 		const abort = new AbortController();
 		const submitted: components["schemas"]["RuntimeObservationEventV2"][] = [];
@@ -322,7 +316,7 @@ describe("hosted runtime observation producer", () => {
 			delay: async () => {
 				delayCalls += 1;
 				if (delayCalls === 1) {
-					setApplyIdentityEnvironment(2);
+					writeApplyIdentityFile(paths, 2);
 					writeRuntimeAppliedState(appliedState(2), paths);
 					return;
 				}

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -133,7 +133,6 @@ export class HostedRuntimeObservationProducer {
 
 	private readAttestedContext(): AttestedRuntimeObservationContext | null {
 		const expectedApplyIdentity = readRuntimeApplyIdentity();
-		if (!expectedApplyIdentity) return null;
 		const appliedState = readRuntimeAppliedState(this.paths);
 		const appliedIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
 		if (!appliedIdentity || !sameApplyIdentity(appliedIdentity, expectedApplyIdentity)) {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -42,6 +42,14 @@ const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];
 
+function testRuntimeEnvironmentValues(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(process.env).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined && entry[1].length > 0,
+		),
+	);
+}
+
 function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): RuntimeManifestLoad {
 	return applyRuntimeBundleChannelsToManifestLoadWithContext({
 		...load,
@@ -53,13 +61,7 @@ function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): Ru
 				applyReceiptId: "test-apply-receipt",
 				bootNonce: "test-boot-nonce",
 			},
-			runtimeEnvironment: projectedRuntimeEnvironment(
-				Object.fromEntries(
-					Object.entries(process.env).filter(
-						(entry): entry is [string, string] => entry[1] !== undefined,
-					),
-				),
-			),
+			runtimeEnvironment: projectedRuntimeEnvironment(testRuntimeEnvironmentValues()),
 		},
 	});
 }
@@ -86,11 +88,7 @@ function setRuntimeApplyIdentityFile(
 		JSON.stringify({
 			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
 			...identity,
-			runtimeEnv: Object.fromEntries(
-				Object.entries(process.env).filter(
-					(entry): entry is [string, string] => entry[1] !== undefined,
-				),
-			),
+			runtimeEnv: testRuntimeEnvironmentValues(),
 		}),
 	);
 	process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = path;

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -53,7 +53,6 @@ function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): Ru
 				applyReceiptId: "test-apply-receipt",
 				bootNonce: "test-boot-nonce",
 			},
-			sourcePath: "/test/runtime-apply-identity.json",
 			runtimeEnvironment: projectedRuntimeEnvironment(
 				Object.fromEntries(
 					Object.entries(process.env).filter(

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -32,7 +32,7 @@ import {
 	type RuntimeManifestLoad,
 } from "./manifest-source";
 import { getRuntimePaths } from "./paths";
-import { processRuntimeEnvironment, projectedRuntimeEnvironment } from "./secret-values";
+import { projectedRuntimeEnvironment } from "./secret-values";
 
 const goldenPath = resolve(
 	import.meta.dir,
@@ -75,6 +75,27 @@ function readFileTree(root: string): string {
 		.sort()
 		.map((entry) => readFileTree(join(root, entry)))
 		.join("\n");
+}
+
+function setRuntimeApplyIdentityFile(
+	root: string,
+	identity: { generation: number; manifestETag: string; applyReceiptId: string; bootNonce: string },
+): string {
+	const path = join(root, "runtime-apply-identity.json");
+	writeFileSync(
+		path,
+		JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+			...identity,
+			runtimeEnv: Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			),
+		}),
+	);
+	process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = path;
+	return path;
 }
 
 function validateGeneratedEgressConfig(addonPath: string, envFilePath: string): void {
@@ -557,13 +578,16 @@ describe("hosted runtime bundle v2", () => {
 		expect(initialSidecarRevision).toBeTruthy();
 		writeFileSync(paths.daemonAuthToken, "deployment-auth-token-rotated\n", { mode: 0o600 });
 		delete process.env.CLAWDI_BOOTSTRAP_AUTH_TOKEN;
+		if (!load.applyContext) throw new Error("expected runtime apply context");
 		const watched = convergeRuntimeManifest(
 			{
 				...load,
 				applyContext: {
-					kind: "legacy-hosted-bootstrap-bridge",
-					identity: null,
-					runtimeEnvironment: processRuntimeEnvironment({ ...process.env }),
+					...load.applyContext,
+					runtimeEnvironment: projectedRuntimeEnvironment({
+						...load.applyContext.runtimeEnvironment.values,
+						CLAWDI_BOOTSTRAP_AUTH_TOKEN: "deployment-auth-token-rotated",
+					}),
 				},
 			},
 			paths,
@@ -895,10 +919,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
-		process.env.CLAWDI_RUNTIME_GENERATION = "7";
-		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-7"';
-		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-0007";
-		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000007";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 7,
+			manifestETag: '"manifest-7"',
+			applyReceiptId: "apply-receipt-0007",
+			bootNonce: "boot-nonce-000007",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		let requests = 0;
 		globalThis.fetch = Object.assign(
@@ -930,6 +956,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		globalThis.fetch = Object.assign(
 			async () =>
@@ -956,6 +988,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const sourceRevision = "da635b29601dbb9543e936faacd7864b6ff300651b452bd861181f06419edbd1";
 		globalThis.fetch = Object.assign(
@@ -986,6 +1024,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		globalThis.fetch = Object.assign(
 			async () =>
 				new Response(readFileSync(goldenPath, "utf-8"), {
@@ -1053,6 +1097,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_EGRESS_UID = "10002";
 		process.env.CLAWDI_EGRESS_GID = "10002";
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const goldenRaw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
 			sourceRevision: string;
@@ -1202,10 +1252,12 @@ describe("hosted runtime bundle v2", () => {
 		rmSync(egressSecretFile);
 		expect(existsSync(egressSecretFile)).toBe(false);
 		networkAvailable = false;
-		process.env.CLAWDI_RUNTIME_GENERATION = "1";
-		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"bundle-golden"';
-		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-golden-0001";
-		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-golden-000001";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const offlineLoad = await loadRuntimeManifest(paths);
 		if (!("manifest" in offlineLoad)) throw new Error(JSON.stringify(offlineLoad));
 		expect(offlineLoad.source).toBe("last-good-cache");
@@ -1224,14 +1276,6 @@ describe("hosted runtime bundle v2", () => {
 			expect(offlineEgressSecretStat.gid).toBe(10002);
 		}
 
-		for (const name of [
-			"CLAWDI_RUNTIME_GENERATION",
-			"CLAWDI_RUNTIME_MANIFEST_ETAG",
-			"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
-			"CLAWDI_RUNTIME_BOOT_NONCE",
-		]) {
-			delete process.env[name];
-		}
 		rmSync(paths.appliedState);
 		const uncommittedCacheLoad = await loadRuntimeManifest(paths);
 		expect("errors" in uncommittedCacheLoad).toBe(true);
@@ -1239,13 +1283,15 @@ describe("hosted runtime bundle v2", () => {
 			throw new Error("expected uncommitted strict-v2 cache failure");
 		}
 		expect(uncommittedCacheLoad.errors.join("\n")).toContain(
-			"cached strict-v2 manifest has no durable applied authority",
+			"cached strict-v2 apply identity does not match the current runtime apply identity",
 		);
 		writeFileSync(paths.appliedState, appliedStateText);
-		process.env.CLAWDI_RUNTIME_GENERATION = "1";
-		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"bundle-golden"';
-		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-golden-0001";
-		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-golden-000001";
+		setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 
 		const committedManifest = z
 			.record(z.string(), z.unknown())

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 import { commitRuntimeAppliedState, runtimeAppliedContentIdentity } from "../commands/runtime";
 import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
-import { applyRuntimeBundleChannelsToManifestLoad } from "./channels";
+import { applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext } from "./channels";
 import {
 	hostedManifestEgressProfiles,
 	managedMcpHeaderPlaceholder,
@@ -29,8 +29,10 @@ import {
 	loadRemoteRuntimeManifest,
 	loadRuntimeManifest,
 	normalizeHostedRuntimeBundleV2,
+	type RuntimeManifestLoad,
 } from "./manifest-source";
 import { getRuntimePaths } from "./paths";
+import { processRuntimeEnvironment, projectedRuntimeEnvironment } from "./secret-values";
 
 const goldenPath = resolve(
 	import.meta.dir,
@@ -39,6 +41,29 @@ const goldenPath = resolve(
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];
+
+function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): RuntimeManifestLoad {
+	return applyRuntimeBundleChannelsToManifestLoadWithContext({
+		...load,
+		applyContext: {
+			kind: "identity-file",
+			identity: {
+				generation: load.manifest.applyGeneration ?? load.manifest.generation,
+				manifestETag: `"test-${load.manifest.generation}"`,
+				applyReceiptId: "test-apply-receipt",
+				bootNonce: "test-boot-nonce",
+			},
+			sourcePath: "/test/runtime-apply-identity.json",
+			runtimeEnvironment: projectedRuntimeEnvironment(
+				Object.fromEntries(
+					Object.entries(process.env).filter(
+						(entry): entry is [string, string] => entry[1] !== undefined,
+					),
+				),
+			),
+		},
+	});
+}
 
 function readFileTree(root: string): string {
 	if (!existsSync(root)) return "";
@@ -532,13 +557,24 @@ describe("hosted runtime bundle v2", () => {
 		expect(initialSidecarRevision).toBeTruthy();
 		writeFileSync(paths.daemonAuthToken, "deployment-auth-token-rotated\n", { mode: 0o600 });
 		delete process.env.CLAWDI_BOOTSTRAP_AUTH_TOKEN;
-		const watched = convergeRuntimeManifest(load, paths, {
-			managedGatewayModelListFetcher: ({ baseUrl }) => ({
-				status: "ok",
-				endpoint: `${baseUrl}/models`,
-				models: [{ id: "gpt-test" }],
-			}),
-		});
+		const watched = convergeRuntimeManifest(
+			{
+				...load,
+				applyContext: {
+					kind: "legacy-hosted-bootstrap-bridge",
+					identity: null,
+					runtimeEnvironment: processRuntimeEnvironment({ ...process.env }),
+				},
+			},
+			paths,
+			{
+				managedGatewayModelListFetcher: ({ baseUrl }) => ({
+					status: "ok",
+					endpoint: `${baseUrl}/models`,
+					models: [{ id: "gpt-test" }],
+				}),
+			},
+		);
 		expect(watched.installErrors).toEqual([]);
 		const reconciledEgressSecrets = JSON.parse(readFileSync(egressSecretPath, "utf-8")) as Record<
 			string,

--- a/packages/cli/src/runtime/runtime-impact-revision.test.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+	daemonProgramRevision,
+	runtimeProgramRevision,
+	runtimeServiceProgramRevision,
+	runtimeSidecarProgramRevision,
+} from "./runtime-impact-revision";
+
+const daemonManifest = {
+	clawdiCli: { packageSpec: "clawdi@1.0.0" },
+	controlPlane: { apiUrl: "https://cloud.test" },
+	liveSync: { enabled: false, agents: [] },
+};
+
+const sidecarManifest = {
+	instanceId: "instance-test",
+	egressProfiles: { profiles: [] },
+};
+
+describe("runtime impact revisions", () => {
+	test("hashes canonical runtime program impact", () => {
+		const impact = {
+			renderedProjection: {
+				channels: null,
+				gateway: null,
+				locale: null,
+				mcp: null,
+				provider: null,
+				skills: null,
+			},
+			desiredRuntime: { enabled: true, services: {} },
+			secretValues: { TOKEN: "one" },
+		};
+		expect(runtimeProgramRevision(impact)).toBe(runtimeProgramRevision({ ...impact }));
+		expect(runtimeProgramRevision({ ...impact, secretValues: { TOKEN: "two" } })).not.toBe(
+			runtimeProgramRevision(impact),
+		);
+	});
+
+	test("scopes service, daemon, and sidecar authority independently", () => {
+		const service = {
+			runtime: "hermes",
+			service: "dashboard",
+			command: "/bin/hermes",
+			args: ["dashboard"],
+			cwd: "/home/clawdi",
+			env: { PORT: "9119" },
+		};
+		expect(runtimeServiceProgramRevision({ ...service })).toBe(
+			runtimeServiceProgramRevision(service),
+		);
+		expect(daemonProgramRevision({ ...daemonManifest })).toBe(
+			daemonProgramRevision(daemonManifest),
+		);
+		expect(runtimeSidecarProgramRevision({ ...sidecarManifest, instanceId: "other" })).not.toBe(
+			runtimeSidecarProgramRevision(sidecarManifest),
+		);
+	});
+});

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -53,7 +53,7 @@ function canonicalize(value: unknown): unknown {
 	return value;
 }
 
-function revisionHash(value: unknown): string {
+export function runtimeImpactRevision(value: unknown): string {
 	return createHash("sha256")
 		.update(JSON.stringify(canonicalize(value)))
 		.digest("hex")
@@ -66,7 +66,7 @@ export function runtimeProgramRevision(input: RuntimeProgramRevisionInput): stri
 				Object.entries(input.desiredRuntime).filter(([field]) => field !== "services"),
 			)
 		: null;
-	return revisionHash({
+	return runtimeImpactRevision({
 		renderedProjection: input.renderedProjection,
 		runtime,
 		secretValues: input.secretValues,
@@ -74,7 +74,7 @@ export function runtimeProgramRevision(input: RuntimeProgramRevisionInput): stri
 }
 
 export function runtimeServiceProgramRevision(program: RuntimeServiceProgramImpact): string {
-	return revisionHash({
+	return runtimeImpactRevision({
 		runtime: program.runtime,
 		service: program.service,
 		command: program.command,
@@ -87,7 +87,7 @@ export function runtimeServiceProgramRevision(program: RuntimeServiceProgramImpa
 export function daemonProgramRevision(
 	manifest: Pick<RuntimeManifest, "clawdiCli" | "controlPlane" | "liveSync">,
 ): string {
-	return revisionHash({
+	return runtimeImpactRevision({
 		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		liveSync: manifest.liveSync ?? null,
@@ -102,7 +102,7 @@ export function runtimeSidecarProgramRevision(
 	if (egressProgram && !egressIdentity) {
 		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
 	}
-	return revisionHash({
+	return runtimeImpactRevision({
 		runtimeSidecar: "hosted-runtime-sidecar-v4",
 		instanceId: manifest.instanceId,
 		egressProfiles: manifest.egressProfiles ?? null,

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -1,0 +1,121 @@
+import { createHash } from "node:crypto";
+import type { RuntimeManifest } from "./manifest-contract";
+import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
+import { TRANSPARENT_EGRESS_TRANSPORT_VERSION } from "./transparent-egress";
+
+export interface RuntimeProgramRevisionInput {
+	renderedProjection: {
+		channels: unknown;
+		gateway: unknown;
+		locale: unknown;
+		mcp: unknown;
+		provider: string | null;
+		skills: unknown;
+	};
+	desiredRuntime: RuntimeManifest["runtimes"][string] | undefined;
+	secretValues: Record<string, string>;
+}
+
+interface RuntimeEgressIdentity {
+	runtimeUid: number;
+	runtimeGid: number;
+	egressUid: number;
+	egressGid: number;
+}
+
+interface RuntimeServiceProgramImpact {
+	runtime: string;
+	service: string | null;
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string>;
+}
+
+interface RuntimeEgressProgramImpact {
+	transparentPort: number;
+	profileBundlePath: string;
+	secretFilePath: string | null;
+	engine: Extract<RuntimeMitmproxyEnsureResult, { status: "ready" }>;
+	addonSha256: string;
+}
+
+function canonicalize(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (value && typeof value === "object") {
+		const input = value as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.keys(input)
+				.sort()
+				.map((key) => [key, canonicalize(input[key])]),
+		);
+	}
+	return value;
+}
+
+function revisionHash(value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalize(value)))
+		.digest("hex")
+		.slice(0, 32);
+}
+
+export function runtimeProgramRevision(input: RuntimeProgramRevisionInput): string {
+	const runtime = input.desiredRuntime
+		? Object.fromEntries(
+				Object.entries(input.desiredRuntime).filter(([field]) => field !== "services"),
+			)
+		: null;
+	return revisionHash({
+		renderedProjection: input.renderedProjection,
+		runtime,
+		secretValues: input.secretValues,
+	});
+}
+
+export function runtimeServiceProgramRevision(program: RuntimeServiceProgramImpact): string {
+	return revisionHash({
+		runtime: program.runtime,
+		service: program.service,
+		command: program.command,
+		args: program.args,
+		cwd: program.cwd,
+		env: program.env,
+	});
+}
+
+export function daemonProgramRevision(
+	manifest: Pick<RuntimeManifest, "clawdiCli" | "controlPlane" | "liveSync">,
+): string {
+	return revisionHash({
+		clawdiCli: manifest.clawdiCli ?? null,
+		controlPlane: manifest.controlPlane,
+		liveSync: manifest.liveSync ?? null,
+	});
+}
+
+export function runtimeSidecarProgramRevision(
+	manifest: Pick<RuntimeManifest, "instanceId" | "egressProfiles">,
+	egressProgram: RuntimeEgressProgramImpact | null = null,
+	egressIdentity: RuntimeEgressIdentity | null = null,
+): string {
+	if (egressProgram && !egressIdentity) {
+		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
+	}
+	return revisionHash({
+		runtimeSidecar: "hosted-runtime-sidecar-v4",
+		instanceId: manifest.instanceId,
+		egressProfiles: manifest.egressProfiles ?? null,
+		egress: egressProgram
+			? {
+					transparentPort: egressProgram.transparentPort,
+					profileBundlePath: egressProgram.profileBundlePath,
+					secretFilePath: egressProgram.secretFilePath,
+					engine: egressProgram.engine,
+					addonSha256: egressProgram.addonSha256,
+					transport: TRANSPARENT_EGRESS_TRANSPORT_VERSION,
+					identity: egressIdentity,
+				}
+			: null,
+	});
+}

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1,0 +1,1211 @@
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import { runtimeContentSha256 } from "./applied-state";
+import { applyEgressTransparentRuntimeEnv } from "./egress-env";
+import type { RuntimeInstallReceiptEntry, RuntimeInstallReceipts } from "./install-receipts";
+import type { RuntimeManifest } from "./manifest-contract";
+import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
+import type { RuntimePaths } from "./paths";
+import {
+	type RuntimeName,
+	type RuntimeRunConfig,
+	type RuntimeServiceName,
+	runtimeManagedBinDir,
+	withoutPathEntry,
+} from "./run-config";
+import {
+	daemonProgramRevision,
+	runtimeServiceProgramRevision,
+	runtimeSidecarProgramRevision,
+} from "./runtime-impact-revision";
+import {
+	commandResolvable,
+	ensureConfiguredRuntimeUserManagerReady,
+	executableExists,
+	makeRuntimeUserOwned,
+	runningAsRoot,
+	runRuntimeUserCommand,
+	runtimeEgressGid,
+	runtimeEgressUid,
+	runtimeUserGid,
+	runtimeUserUid,
+	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
+} from "./runtime-user-command";
+import { type RuntimeEnvironmentAuthority, runtimeSecretValue } from "./secret-values";
+import {
+	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
+	isGeneratedRuntimeSystemdFile,
+} from "./systemd-user";
+
+function systemdRevisionHash(value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalSystemdRevisionValue(value)))
+		.digest("hex")
+		.slice(0, 32);
+}
+
+function canonicalSystemdRevisionValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalSystemdRevisionValue);
+	if (value && typeof value === "object") {
+		const input = value as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.keys(input)
+				.sort()
+				.map((key) => [key, canonicalSystemdRevisionValue(input[key])]),
+		);
+	}
+	return value;
+}
+
+function runtimeCommandPath(name: string, home: string): string | null {
+	if (name === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
+	if (name === "hermes") return join(home, ".local", "bin", "hermes");
+	return null;
+}
+
+function makeRootOwned(path: string): void {
+	if (!runningAsRoot()) return;
+	try {
+		chownSync(path, 0, 0);
+	} catch {
+		/* Best effort outside hosted Linux. */
+	}
+}
+
+function makeRootReadableDir(path: string): void {
+	mkdirSync(path, { recursive: true });
+	makeRootOwned(path);
+	try {
+		chmodSync(path, 0o755);
+	} catch {
+		/* Best effort outside POSIX. */
+	}
+}
+
+export interface RuntimeSystemdUserProgram {
+	runtime: RuntimeName;
+	service: RuntimeServiceName | null;
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string>;
+	resolvedSecretEnv: Record<string, string>;
+}
+
+export interface RuntimeEgressSystemdProgram {
+	profileBundlePath: string;
+	envFilePath: string;
+	transparentPort: number;
+	addonPath: string;
+	addonSha256: string;
+	engine: Extract<RuntimeMitmproxyEnsureResult, { status: "ready" }>;
+	systemCaBundle: string;
+	secretFilePath: string | null;
+}
+
+export interface RuntimeInstallReceiptTarget {
+	desiredRevision: string;
+	currentRevision: () => string | null;
+	expectedCurrentRevision: string | null;
+}
+
+export interface OfficialRuntimeServicePlan {
+	targets: Map<string, RuntimeInstallReceiptTarget>;
+	pending: Array<{ program: RuntimeSystemdUserProgram; target: RuntimeInstallReceiptTarget }>;
+}
+
+interface RuntimeEgressIdentity {
+	runtimeUid: number;
+	runtimeGid: number;
+	egressUid: number;
+	egressGid: number;
+}
+
+function runtimeEgressSystemdProgram(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	profileBundlePath: string | null,
+	secretFilePath: string | null,
+	engine: RuntimeMitmproxyEnsureResult | null,
+	addon: { path: string; sha256: string } | null,
+): RuntimeEgressSystemdProgram | null {
+	if (!profileBundlePath) return null;
+	if (engine?.status !== "ready") return null;
+	if (!addon) return null;
+	const port = 18_080 + (hashToUInt16(`${manifest.instanceId}:${paths.serviceStateRoot}`) % 20_000);
+	return {
+		profileBundlePath,
+		envFilePath: paths.egressTransparentEnv,
+		transparentPort: port,
+		addonPath: addon.path,
+		addonSha256: addon.sha256,
+		engine,
+		systemCaBundle: paths.egressSystemCaFile,
+		secretFilePath,
+	};
+}
+
+export function resolveRuntimeSystemdIdentity(input: {
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	profileBundlePath: string | null;
+	secretFilePath: string | null;
+	engine: RuntimeMitmproxyEnsureResult | null;
+	addon: { path: string; sha256: string } | null;
+	runtimeUser: string;
+}): {
+	egressProgram: RuntimeEgressSystemdProgram | null;
+	identity: RuntimeEgressIdentity | null;
+} {
+	const egressProgram = runtimeEgressSystemdProgram(
+		input.manifest,
+		input.paths,
+		input.profileBundlePath,
+		input.secretFilePath,
+		input.engine,
+		input.addon,
+	);
+	if (!egressProgram) return { egressProgram: null, identity: null };
+	return {
+		egressProgram,
+		identity: {
+			runtimeUid: runtimeUserUid(input.runtimeUser),
+			runtimeGid: runtimeUserGid(input.runtimeUser),
+			egressUid: runtimeEgressUid(),
+			egressGid: runtimeEgressGid(),
+		},
+	};
+}
+
+export function buildRuntimeSystemdUserProgram(input: {
+	config: RuntimeRunConfig;
+	paths: RuntimePaths;
+	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
+	egress: RuntimeEgressSystemdProgram | null;
+}): RuntimeSystemdUserProgram | null {
+	if (!input.config.enabled) return null;
+
+	const currentPath = withoutPathEntry(
+		withoutPathEntry(runtimeSystemdPath(input.paths), runtimeManagedBinDir(input.paths)),
+		dirname(input.paths.cliManagedBin),
+	);
+	const pathPrefix = input.config.prependPath.join(":");
+	const env: Record<string, string> = {
+		...input.config.env,
+		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
+	};
+	const resolvedSecretEnv: Record<string, string> = {};
+	for (const [envName, ref] of Object.entries(input.config.secretEnv)) {
+		const value = runtimeSecretValue(input.secretValues ?? {}, ref, input.runtimeEnvironment);
+		if (!value) {
+			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
+		}
+		env[envName] = value;
+		resolvedSecretEnv[envName] = value;
+	}
+	if (input.egress) {
+		applyEgressTransparentRuntimeEnv(env, { caFile: input.egress.systemCaBundle });
+	}
+
+	const command =
+		input.config.commandPath && existsSync(input.config.commandPath)
+			? input.config.commandPath
+			: input.config.command;
+
+	return {
+		runtime: input.config.runtime,
+		service: input.config.service,
+		command,
+		args: input.config.defaultArgs,
+		cwd: input.config.cwd ?? input.paths.workspaceRoot,
+		env,
+		resolvedSecretEnv,
+	};
+}
+
+function hashToUInt16(input: string): number {
+	return createHash("sha256").update(input).digest().readUInt16BE(0);
+}
+
+function runtimeSystemdProgramName(program: RuntimeSystemdUserProgram): string {
+	const officialName = officialRuntimeSystemdProgramName(program);
+	if (officialName) return officialName;
+	if (!program.service) return `clawdi-${systemdUnitNameSegment(program.runtime)}`;
+	return runtimeServiceProgramName(program.runtime, program.service);
+}
+
+function officialRuntimeSystemdProgramName(program: RuntimeSystemdUserProgram): string | null {
+	return officialRuntimeServiceDescriptorForProgram(program)?.programName ?? null;
+}
+
+function runtimeSystemdProgramRevision(
+	manifest: RuntimeManifest,
+	program: RuntimeSystemdUserProgram,
+	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
+	runtimeRevision: (
+		manifest: RuntimeManifest,
+		runtime: string,
+		secretValues: Record<string, string> | undefined,
+		runtimeEnvironment: RuntimeEnvironmentAuthority,
+		providerProjectionRevision: string | null,
+	) => string,
+): string {
+	if (program.service) return runtimeServiceProgramRevision(program);
+	return runtimeRevision(
+		manifest,
+		program.runtime,
+		secretValues,
+		runtimeEnvironment,
+		providerProjectionRevisions[program.runtime] ?? null,
+	);
+}
+
+function runtimeServiceProgramName(runtime: string, service: string): string {
+	const official = OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
+		(descriptor) => descriptor.runtime === runtime && descriptor.service === service,
+	);
+	if (official) return official.programName;
+	if (runtime === "hermes" && service === "dashboard") return "clawdi-hermes-dashboard";
+	return `clawdi-${systemdUnitNameSegment(runtime)}-${systemdUnitNameSegment(service)}`;
+}
+
+function systemdUnitNameSegment(value: string): string {
+	return value.replace(/[^A-Za-z0-9_-]+/g, "-");
+}
+
+function runtimeSystemdPath(paths: RuntimePaths): string {
+	return [
+		join(paths.serviceStateRoot, "bin"),
+		join(paths.userHome, ".local", "bin"),
+		join(paths.userHome, ".openclaw", "bin"),
+		process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	].join(":");
+}
+
+function systemdUnitFileName(name: string): string {
+	return `${systemdUnitNameSegment(name)}.service`;
+}
+
+function systemdDropInFilePath(paths: RuntimePaths, unitName: string): string {
+	return join(paths.systemdUserRoot, `${systemdUnitFileName(unitName)}.d`, "10-clawdi-hosted.conf");
+}
+
+function systemdQuote(value: string): string {
+	if (/[\r\n]/.test(value)) {
+		throw new Error("systemd unit values must be single-line strings");
+	}
+	return `"${value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/%/g, "%%")
+		.replace(/\$/g, "$$")}"`;
+}
+
+function systemdExec(command: string, args: string[]): string {
+	return [command, ...args].map(systemdQuote).join(" ");
+}
+
+function systemdPath(value: string): string {
+	if (!isAbsolute(value)) {
+		throw new Error(`systemd unit paths must be absolute: ${value}`);
+	}
+	if (/[\r\n]/.test(value)) {
+		throw new Error("systemd unit paths must be single-line strings");
+	}
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/%/g, "%%")
+		.replace(/ /g, "\\x20")
+		.replace(/\t/g, "\\x09");
+}
+
+function systemdUnitEnvironmentLines(values: Record<string, string>): string[] {
+	return Object.entries(values).map(
+		([key, value]) => `Environment=${systemdQuote(`${key}=${value}`)}`,
+	);
+}
+
+function systemdEnvironmentFilePath(paths: RuntimePaths, unitName: string): string {
+	return join(paths.systemdEnvRoot, `${systemdUnitFileName(unitName)}.env`);
+}
+
+function systemdEnvironmentFileQuote(value: string): string {
+	if (/[\r\n]/.test(value)) {
+		throw new Error("systemd environment files only support single-line values");
+	}
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+type OfficialRuntimeServiceDescriptor = {
+	runtime: RuntimeName;
+	programName: string;
+	command: string;
+	installArgs: string[];
+	uninstallArgs: string[];
+	// Manifest `services` key the official unit corresponds to; used for
+	// program naming even when such an entry is not official for the runtime.
+	service: string;
+	// Extra env projected into the unit's environment file.
+	unitEnv?: (unitName: string) => Record<string, string>;
+	// Which desired programs the official unit covers. Deliberately
+	// asymmetric: openclaw's default program is its gateway, while hermes may
+	// express the gateway as the default program or an explicit
+	// `services.gateway` entry.
+	matchesProgram: (program: RuntimeSystemdUserProgram) => boolean;
+};
+
+const OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS: OfficialRuntimeServiceDescriptor[] = [
+	{
+		runtime: "openclaw",
+		programName: "openclaw-gateway",
+		command: "openclaw",
+		installArgs: ["gateway", "install", "--force", "--json"],
+		uninstallArgs: ["gateway", "uninstall"],
+		service: "gateway",
+		unitEnv: (unitName) => ({ OPENCLAW_SYSTEMD_UNIT: unitName }),
+		matchesProgram: (program) => !program.service,
+	},
+	{
+		runtime: "hermes",
+		programName: "hermes-gateway",
+		command: "hermes",
+		installArgs: ["gateway", "install", "--force"],
+		uninstallArgs: ["gateway", "uninstall"],
+		service: "gateway",
+		matchesProgram: (program) => (program.service ?? program.args[0] ?? "") === "gateway",
+	},
+];
+
+function officialRuntimeServiceDescriptorForProgram(
+	program: RuntimeSystemdUserProgram,
+): OfficialRuntimeServiceDescriptor | null {
+	return (
+		OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
+			(descriptor) => descriptor.runtime === program.runtime && descriptor.matchesProgram(program),
+		) ?? null
+	);
+}
+
+function officialRuntimeServiceDescriptorForUnit(
+	unitName: string,
+): OfficialRuntimeServiceDescriptor | null {
+	return (
+		OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS.find(
+			(descriptor) => systemdUnitFileName(descriptor.programName) === unitName,
+		) ?? null
+	);
+}
+
+function officialRuntimeServiceCommand(
+	descriptor: OfficialRuntimeServiceDescriptor,
+	paths: RuntimePaths,
+): string {
+	const commandPath = runtimeCommandPath(descriptor.runtime, paths.userHome);
+	return commandPath && executableExists(commandPath) ? commandPath : descriptor.command;
+}
+
+function runtimeFileCurrentRevision(path: string): string | null {
+	if (!isAbsolute(path)) return null;
+	try {
+		const linkStat = lstatSync(path);
+		if (!linkStat.isFile() && !linkStat.isSymbolicLink()) return null;
+		const fileStat = linkStat.isSymbolicLink() ? statSync(path) : linkStat;
+		if (!fileStat.isFile()) return null;
+		const contents = readFileSync(path);
+		return runtimeContentSha256({
+			path,
+			contentsSha256: createHash("sha256").update(contents).digest("hex"),
+			kind: linkStat.isSymbolicLink() ? "symlink" : "file",
+			linkTarget: linkStat.isSymbolicLink() ? readlinkSync(path) : null,
+			linkUid: linkStat.uid,
+			linkGid: linkStat.gid,
+			fileMode: fileStat.mode & 0o7777,
+			fileUid: fileStat.uid,
+			fileGid: fileStat.gid,
+		});
+	} catch {
+		return null;
+	}
+}
+
+function runtimeCommandCurrentRevision(command: string, home: string, cwd: string): string | null {
+	const executableRevision = runtimeFileCurrentRevision(command);
+	if (!executableRevision) return null;
+	try {
+		const result = spawnRuntimeUserCommand(command, ["--version"], home, cwd);
+		if (result.status !== 0) return null;
+		const stdout = Buffer.isBuffer(result.stdout) ? result.stdout.toString("utf8") : result.stdout;
+		const stderr = Buffer.isBuffer(result.stderr) ? result.stderr.toString("utf8") : result.stderr;
+		const version = [stdout, stderr].filter(Boolean).join("\n").trim();
+		return version ? runtimeContentSha256({ executableRevision, version }) : null;
+	} catch {
+		return null;
+	}
+}
+
+function officialServiceCurrentRevision(
+	program: RuntimeSystemdUserProgram,
+	paths: RuntimePaths,
+): string | null {
+	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
+	if (!descriptor) return null;
+	const unitName = systemdUnitFileName(descriptor.programName);
+	const unitPath = join(paths.systemdUserRoot, unitName);
+	try {
+		const contents = readFileSync(unitPath);
+		if (isGeneratedRuntimeSystemdFile(contents.toString("utf8"))) return null;
+		const unitStat = lstatSync(unitPath);
+		if (!unitStat.isFile()) return null;
+		const commandRevision = runtimeCommandCurrentRevision(
+			officialRuntimeServiceCommand(descriptor, paths),
+			paths.userHome,
+			paths.userHome,
+		);
+		if (!commandRevision) return null;
+		return runtimeContentSha256({
+			commandRevision,
+			programName: descriptor.programName,
+			unitName,
+			unitSha256: createHash("sha256").update(contents).digest("hex"),
+			unitMode: unitStat.mode & 0o7777,
+			unitUid: unitStat.uid,
+			unitGid: unitStat.gid,
+		});
+	} catch {
+		return null;
+	}
+}
+
+function officialServiceDesiredRevision(program: RuntimeSystemdUserProgram): string {
+	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
+	if (!descriptor) throw new Error("official service receipt requires an official service program");
+	return runtimeContentSha256({
+		runtime: descriptor.runtime,
+		programName: descriptor.programName,
+		serviceIdentity: descriptor.service,
+		installerCommand: descriptor.command,
+		installArgs: descriptor.installArgs,
+	});
+}
+
+function verifiedReceiptCurrentRevision(
+	receipt: RuntimeInstallReceiptEntry | undefined,
+	desiredRevision: string,
+	currentRevision: () => string | null,
+): string | null {
+	if (!receipt || receipt.desiredRevision !== desiredRevision) return null;
+	const current = currentRevision();
+	return current === receipt.currentRevision ? current : null;
+}
+
+export function planOfficialRuntimeServices(
+	programs: RuntimeSystemdUserProgram[],
+	paths: RuntimePaths,
+	receipts: RuntimeInstallReceipts | null,
+): OfficialRuntimeServicePlan {
+	const targets = new Map<string, RuntimeInstallReceiptTarget>();
+	const pending: OfficialRuntimeServicePlan["pending"] = [];
+	if (!shouldInstallOfficialRuntimeServices()) return { targets, pending };
+	for (const program of officialRuntimeSystemdPrograms(programs)) {
+		const key = systemdUnitFileName(runtimeSystemdProgramName(program));
+		const desiredRevision = officialServiceDesiredRevision(program);
+		const currentRevision = () => officialServiceCurrentRevision(program, paths);
+		const expectedCurrentRevision = verifiedReceiptCurrentRevision(
+			receipts?.officialServices[key],
+			desiredRevision,
+			currentRevision,
+		);
+		const target = { desiredRevision, currentRevision, expectedCurrentRevision };
+		targets.set(key, target);
+		if (expectedCurrentRevision === null) pending.push({ program, target });
+	}
+	return { targets, pending };
+}
+
+function writeSystemdEnvironmentFile(input: {
+	paths: RuntimePaths;
+	name: string;
+	owner: "root" | "runtime-user";
+	env: Record<string, string>;
+}): string {
+	makeRootReadableDir(dirname(input.paths.systemdEnvRoot));
+	makeRootReadableDir(input.paths.systemdEnvRoot);
+	const path = systemdEnvironmentFilePath(input.paths, input.name);
+	const lines = Object.entries(input.env)
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([key, value]) => {
+			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+				throw new Error(`invalid systemd environment key: ${key}`);
+			}
+			return `${key}=${systemdEnvironmentFileQuote(value)}`;
+		});
+	writePrivateFileAtomic(path, `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`, {
+		mode: 0o600,
+		dirMode: 0o755,
+	});
+	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
+	else makeRootOwned(path);
+	return path;
+}
+
+function writeSystemdProgramEnvironment(input: {
+	paths: RuntimePaths;
+	name: string;
+	owner: "root" | "runtime-user";
+	env: Record<string, string>;
+	revisionEnv?: Record<string, string>;
+}): { envFile: string; envRevision: string } {
+	return {
+		envFile: writeSystemdEnvironmentFile(input),
+		envRevision: systemdRevisionHash({
+			systemdEnvironmentFile: "v1",
+			env: input.revisionEnv ?? input.env,
+		}),
+	};
+}
+
+function writeSystemdUnit(input: {
+	root: string;
+	owner: "root" | "runtime-user";
+	paths: RuntimePaths;
+	name: string;
+	description: string;
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string>;
+	revisionEnv?: Record<string, string>;
+	unitEnv?: Record<string, string>;
+	serviceType?: "simple" | "oneshot" | "notify";
+	restart?: boolean;
+	extraUnitLines?: string[];
+	extraServiceLines?: string[];
+	wantedBy: "multi-user.target" | "default.target";
+}): string {
+	const path = join(input.root, systemdUnitFileName(input.name));
+	const { envFile, envRevision } = writeSystemdProgramEnvironment({
+		paths: input.paths,
+		name: input.name,
+		owner: input.owner,
+		env: input.env,
+		revisionEnv: input.revisionEnv,
+	});
+	const lines = [
+		GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
+		"[Unit]",
+		`Description=${input.description}`,
+		...(input.owner === "runtime-user"
+			? [
+					"# The environment file is regenerated by convergence each boot; this unit must not start before it exists.",
+					`ConditionPathExists=${systemdPath(envFile)}`,
+				]
+			: []),
+		...(input.extraUnitLines ?? []),
+		"",
+		"[Service]",
+		`# ClawdiEnvironmentRevision=${envRevision}`,
+		`Type=${input.serviceType ?? "simple"}`,
+		`WorkingDirectory=${systemdPath(input.cwd)}`,
+		...(input.unitEnv ? systemdUnitEnvironmentLines(input.unitEnv) : []),
+		...(input.extraServiceLines ?? []),
+		`EnvironmentFile=${systemdPath(envFile)}`,
+		`ExecStart=${systemdExec(input.command, input.args)}`,
+		...(input.restart === false
+			? []
+			: ["Restart=always", "RestartSec=2", "KillMode=mixed", "TimeoutStopSec=30"]),
+		"",
+		"[Install]",
+		`WantedBy=${input.wantedBy}`,
+		"",
+	];
+	const writeUnitFile = (): string => {
+		mkdirSync(input.root, { recursive: true });
+		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
+		else makeRootOwned(path);
+		return path;
+	};
+	return input.owner === "runtime-user"
+		? withRuntimeUserFileAccess(writeUnitFile)
+		: writeUnitFile();
+}
+
+function writeSystemdSystemUnit(
+	input: Omit<Parameters<typeof writeSystemdUnit>[0], "root" | "owner" | "wantedBy">,
+): string {
+	return writeSystemdUnit({
+		...input,
+		root: input.paths.systemdSystemRoot,
+		owner: "root",
+		wantedBy: "multi-user.target",
+	});
+}
+
+function writeSystemdUserUnit(
+	input: Omit<Parameters<typeof writeSystemdUnit>[0], "root" | "owner" | "wantedBy">,
+): string {
+	return writeSystemdUnit({
+		...input,
+		root: input.paths.systemdUserRoot,
+		owner: "runtime-user",
+		extraServiceLines: [
+			'Environment="XDG_RUNTIME_DIR=%t"',
+			'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
+			...(input.extraServiceLines ?? []),
+		],
+		wantedBy: "default.target",
+	});
+}
+
+function writeSystemdUserDropIn(input: {
+	paths: RuntimePaths;
+	name: string;
+	command: string;
+	args: string[];
+	cwd: string;
+	env: Record<string, string>;
+}): string {
+	const unitName = systemdUnitFileName(input.name);
+	const { envFile, envRevision } = writeSystemdProgramEnvironment({
+		paths: input.paths,
+		name: input.name,
+		owner: "runtime-user",
+		env: input.env,
+	});
+	const path = systemdDropInFilePath(input.paths, input.name);
+	const lines = [
+		GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
+		"# ClawdiHostedRuntimeDropIn=v1",
+		"# The base unit is generated by the runtime's official service installer.",
+		"[Unit]",
+		"# The environment file is regenerated by convergence each boot; this unit must not start before it exists.",
+		`ConditionPathExists=${systemdPath(envFile)}`,
+		"",
+		"[Service]",
+		`# ClawdiEnvironmentRevision=${envRevision}`,
+		`WorkingDirectory=${systemdPath(input.cwd)}`,
+		'Environment="XDG_RUNTIME_DIR=%t"',
+		'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
+		`EnvironmentFile=${systemdPath(envFile)}`,
+		"ExecStart=",
+		`ExecStart=${systemdExec(input.command, input.args)}`,
+		"",
+	];
+	return withRuntimeUserFileAccess(() => {
+		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
+		mkdirSync(dirname(path), { recursive: true });
+		makeRuntimeUserOwned(dirname(path));
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		makeRuntimeUserOwned(path);
+		return join(input.paths.systemdUserRoot, unitName);
+	});
+}
+
+function removeGeneratedRuntimeBaseUnit(paths: RuntimePaths, unitName: string): void {
+	const path = join(paths.systemdUserRoot, unitName);
+	if (!isGeneratedSystemdFile(path)) return;
+	rmSync(path, { force: true });
+}
+
+function officialRuntimeServiceInstallArgs(program: RuntimeSystemdUserProgram): string[] | null {
+	return officialRuntimeServiceDescriptorForProgram(program)?.installArgs ?? null;
+}
+
+function shouldInstallOfficialRuntimeServices(): boolean {
+	// Official gateway installers need a live systemd user bus to converge.
+	// When the systemd apply phase is explicitly disabled (headless CI and
+	// smoke containers without systemd), fall back to writing complete
+	// clawdi-* units instead of failing the whole convergence; the next
+	// convergence under real systemd retries the official install.
+	const applyOverride = process.env.CLAWDI_SYSTEMD_APPLY?.trim().toLowerCase();
+	if (applyOverride === "0" || applyOverride === "false") return false;
+	const override = process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES?.trim().toLowerCase();
+	if (override === "1" || override === "true") return true;
+	if (override === "0" || override === "false") return false;
+	return runningAsRoot();
+}
+
+function installOfficialRuntimeUserService(
+	program: RuntimeSystemdUserProgram,
+	paths: RuntimePaths,
+): string | null {
+	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
+	if (!descriptor || !shouldInstallOfficialRuntimeServices()) return null;
+	const args = descriptor.installArgs;
+	if (!commandResolvable(program.command)) {
+		return `official ${runtimeSystemdProgramName(program)} service installer command is unavailable: ${program.command}`;
+	}
+	try {
+		ensureConfiguredRuntimeUserManagerReady();
+		resetFailedRuntimeUserService(runtimeSystemdProgramName(program), paths, program.cwd);
+		runRuntimeUserCommand(program.command, args, "", paths.userHome, program.cwd);
+		return null;
+	} catch (error) {
+		return `official ${runtimeSystemdProgramName(program)} service install failed: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
+}
+
+export function installOfficialRuntimeService(
+	item: OfficialRuntimeServicePlan["pending"][number],
+	paths: RuntimePaths,
+): string | null {
+	reloadRuntimeUserManager(paths, paths.userHome);
+	const error = installOfficialRuntimeUserService({ ...item.program, cwd: paths.userHome }, paths);
+	if (!error) item.target.expectedCurrentRevision = item.target.currentRevision();
+	return error;
+}
+
+function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: string): void {
+	try {
+		runRuntimeUserCommand(
+			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
+			["--user", "reset-failed", systemdUnitFileName(name)],
+			"",
+			paths.userHome,
+			cwd,
+		);
+	} catch {
+		// The unit may not exist yet; reset-failed must never block convergence.
+	}
+}
+
+function reloadRuntimeUserManager(paths: RuntimePaths, cwd: string): void {
+	try {
+		ensureConfiguredRuntimeUserManagerReady();
+		runRuntimeUserCommand(
+			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
+			["--user", "daemon-reload"],
+			"",
+			paths.userHome,
+			cwd,
+		);
+	} catch {
+		// Best-effort: environments without a reachable user manager (unit tests,
+		// non-hosted hosts) must not fail convergence, and official installers
+		// perform their own daemon-reload after writing the base unit.
+	}
+}
+
+function uninstallOfficialRuntimeUserService(input: {
+	unitName: string;
+	paths: RuntimePaths;
+	workspaceRoot: string;
+}): string | null {
+	const descriptor = officialRuntimeServiceDescriptorForUnit(input.unitName);
+	if (!descriptor || !shouldInstallOfficialRuntimeServices()) return null;
+	const command = officialRuntimeServiceCommand(descriptor, input.paths);
+	if (!commandResolvable(command)) {
+		return `official ${input.unitName} uninstaller command is unavailable: ${command}`;
+	}
+	try {
+		ensureConfiguredRuntimeUserManagerReady();
+		runRuntimeUserCommand(
+			command,
+			descriptor.uninstallArgs,
+			"",
+			input.paths.userHome,
+			input.workspaceRoot,
+		);
+		return null;
+	} catch (error) {
+		return `official ${input.unitName} uninstall failed: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
+}
+
+function systemdUnitNameFromPath(unitPath: string): string {
+	return unitPath.split("/").at(-1) ?? "";
+}
+
+function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: string[]): string[] {
+	if (!existsSync(paths.systemdUserRoot)) return [];
+	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
+	const stale: string[] = [];
+	for (const entry of readdirSync(paths.systemdUserRoot)) {
+		if (!entry.endsWith(".service.d")) continue;
+		const unitName = entry.slice(0, -".d".length);
+		if (writtenNames.has(unitName)) continue;
+		if (!officialRuntimeServiceDescriptorForUnit(unitName)) continue;
+		const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+		if (!isGeneratedSystemdFile(dropInPath)) continue;
+		const baseUnitPath = join(paths.systemdUserRoot, unitName);
+		if (!existsSync(baseUnitPath) || isGeneratedSystemdFile(baseUnitPath)) continue;
+		stale.push(unitName);
+	}
+	return stale.sort();
+}
+
+export function removeStaleOfficialRuntimeServices(input: {
+	paths: RuntimePaths;
+	programs: RuntimeSystemdUserProgram[];
+	workspaceRoot: string;
+}): string[] {
+	const errors: string[] = [];
+	const writtenUnits = input.programs.map((program) =>
+		join(input.paths.systemdUserRoot, systemdUnitFileName(runtimeSystemdProgramName(program))),
+	);
+	for (const unitName of staleOfficialRuntimeUserServices(input.paths, writtenUnits)) {
+		const error = uninstallOfficialRuntimeUserService({
+			unitName,
+			paths: input.paths,
+			workspaceRoot: input.workspaceRoot,
+		});
+		if (error) errors.push(error);
+	}
+	return errors;
+}
+
+function removeStaleSystemdUserUnits(paths: RuntimePaths, writtenUnits: string[]): void {
+	withRuntimeUserFileAccess(() => {
+		if (!existsSync(paths.systemdUserRoot)) return;
+		const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
+		for (const entry of readdirSync(paths.systemdUserRoot)) {
+			if (!entry.endsWith(".service")) continue;
+			const path = join(paths.systemdUserRoot, entry);
+			if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
+			if (writtenNames.has(entry)) continue;
+			rmSync(path, { force: true });
+		}
+		const wantsDir = join(paths.systemdUserRoot, "default.target.wants");
+		if (existsSync(wantsDir)) {
+			for (const entry of readdirSync(wantsDir)) {
+				if (!entry.endsWith(".service")) continue;
+				const unitPath = join(paths.systemdUserRoot, entry);
+				if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(unitPath)) continue;
+				if (writtenNames.has(entry)) continue;
+				rmSync(join(wantsDir, entry), { force: true });
+			}
+		}
+		for (const entry of readdirSync(paths.systemdUserRoot)) {
+			if (!entry.endsWith(".service.d")) continue;
+			const unitName = entry.slice(0, -".d".length);
+			const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+			if (!isGeneratedSystemdFile(dropInPath)) continue;
+			if (writtenNames.has(unitName)) continue;
+			rmSync(dropInPath, { force: true });
+			try {
+				if (readdirSync(dirname(dropInPath)).length === 0)
+					rmSync(dirname(dropInPath), { force: true });
+			} catch {
+				// Best effort cleanup only.
+			}
+		}
+	});
+}
+
+function isGeneratedSystemdFile(path: string): boolean {
+	try {
+		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
+	} catch {
+		return false;
+	}
+}
+
+function removeStaleSystemdSystemUnits(paths: RuntimePaths, writtenUnits: string[]): void {
+	if (!existsSync(paths.systemdSystemRoot)) return;
+	const managed = new Set([
+		"clawdi-runtime-watch.service",
+		"clawdi-daemon.service",
+		"clawdi-runtime-sidecar.service",
+	]);
+	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
+	for (const entry of readdirSync(paths.systemdSystemRoot)) {
+		if (!managed.has(entry) || writtenNames.has(entry)) continue;
+		rmSync(join(paths.systemdSystemRoot, entry), { force: true });
+	}
+}
+
+function removeStaleSystemdEnvironmentFiles(paths: RuntimePaths, writtenUnits: string[]): void {
+	if (!existsSync(paths.systemdEnvRoot)) return;
+	const writtenNames = new Set(writtenUnits.map((unit) => `${systemdUnitNameFromPath(unit)}.env`));
+	for (const entry of readdirSync(paths.systemdEnvRoot)) {
+		if (!entry.endsWith(".service.env")) continue;
+		const path = join(paths.systemdEnvRoot, entry);
+		if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
+		if (writtenNames.has(entry)) continue;
+		rmSync(path, { force: true });
+	}
+}
+
+function runtimeManifestUrlEnv(
+	sourcePath: string,
+	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): string {
+	if (/^https?:\/\//i.test(sourcePath)) return sourcePath;
+	return (
+		runtimeSecretValue(
+			secretValues ?? {},
+			"env://CLAWDI_RUNTIME_MANIFEST_URL",
+			runtimeEnvironment,
+		) ?? ""
+	);
+}
+
+export function runtimeSystemdCommonEnvironment(
+	sourcePath: string,
+	paths: RuntimePaths,
+	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+): Record<string, string> {
+	const runtimeUser =
+		runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_USER", runtimeEnvironment) ??
+		"clawdi";
+	const environment: Record<string, string> = {
+		HOME: paths.userHome,
+		CLAWDI_RUNTIME_MODE:
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_MODE", runtimeEnvironment) ??
+			"hosted",
+		CLAWDI_RUNTIME_AUTH_ENV:
+			runtimeSecretValue(secretValues ?? {}, "env://CLAWDI_RUNTIME_AUTH_ENV", runtimeEnvironment) ??
+			"",
+		CLAWDI_RUNTIME_USER: runtimeUser,
+		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
+		CLAWDI_RUN_DIR: paths.runRoot,
+		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(
+			sourcePath,
+			secretValues,
+			runtimeEnvironment,
+		),
+		PATH: runtimeSystemdPath(paths),
+	};
+	return environment;
+}
+
+function runtimeWatchSecretEnvironment(
+	programs: RuntimeSystemdUserProgram[],
+): Record<string, string> {
+	const retained = new Map<string, { value: string; program: string }>();
+	for (const program of [...programs].sort((a, b) =>
+		runtimeSystemdProgramName(a).localeCompare(runtimeSystemdProgramName(b)),
+	)) {
+		const programName = runtimeSystemdProgramName(program);
+		for (const [envName, value] of Object.entries(program.resolvedSecretEnv).sort(([a], [b]) =>
+			a.localeCompare(b),
+		)) {
+			const existing = retained.get(envName);
+			if (existing && existing.value !== value) {
+				throw new Error(
+					`Runtime watch secret environment ${envName} conflicts between ${existing.program} and ${programName}.`,
+				);
+			}
+			retained.set(envName, { value, program: existing?.program ?? programName });
+		}
+	}
+	return Object.fromEntries([...retained].map(([envName, entry]) => [envName, entry.value]));
+}
+
+function writeRuntimeSystemdUserProgram(input: {
+	program: RuntimeSystemdUserProgram;
+	commonEnvironment: Record<string, string>;
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
+	providerProjectionRevisions: Partial<Record<string, string | null>>;
+	runtimeRevision: Parameters<typeof runtimeSystemdProgramRevision>[5];
+}): string {
+	const { program } = input;
+	const name = runtimeSystemdProgramName(program);
+	const unitName = systemdUnitFileName(name);
+	const env = {
+		...input.commonEnvironment,
+		...program.env,
+		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
+		CLAWDI_AUTH_TOKEN: "",
+		CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
+			input.manifest,
+			program,
+			input.secretValues,
+			input.runtimeEnvironment,
+			input.providerProjectionRevisions,
+			input.runtimeRevision,
+		),
+		...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
+	};
+	if (officialRuntimeServiceInstallArgs(program)) {
+		return writeSystemdUserDropIn({
+			paths: input.paths,
+			name,
+			command: program.command,
+			args: program.args,
+			cwd: program.cwd,
+			env,
+		});
+	}
+	return writeSystemdUserUnit({
+		paths: input.paths,
+		name,
+		description: `Clawdi hosted ${program.runtime}${program.service ? ` ${program.service}` : ""}`,
+		command: program.command,
+		args: program.args,
+		cwd: program.cwd,
+		env,
+	});
+}
+
+function officialRuntimeSystemdPrograms(
+	programs: RuntimeSystemdUserProgram[],
+): RuntimeSystemdUserProgram[] {
+	const byServiceName = new Map<string, RuntimeSystemdUserProgram>();
+	for (const program of programs) {
+		const serviceName = officialRuntimeSystemdProgramName(program);
+		if (serviceName) byServiceName.set(serviceName, program);
+	}
+	return [...byServiceName.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([, program]) => program);
+}
+
+export function writeRuntimeSystemdState(
+	runtimePrograms: RuntimeSystemdUserProgram[],
+	egressProgram: RuntimeEgressSystemdProgram | null,
+	egressIdentity: RuntimeEgressIdentity | null,
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	workspaceRoot: string,
+	daemonAuthTokenFile: string | null,
+	secretValues: Record<string, string> | undefined,
+	runtimeEnvironment: RuntimeEnvironmentAuthority,
+	providerProjectionRevisions: Partial<Record<string, string | null>>,
+	runtimeRevision: Parameters<typeof runtimeSystemdProgramRevision>[5],
+	commonEnvironment: Record<string, string>,
+): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
+	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const systemUnits: string[] = [];
+	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
+	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
+	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
+	const userUnits: string[] = [];
+	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
+	if (daemonAuthTokenFile) {
+		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
+		systemUnits.push(
+			writeSystemdSystemUnit({
+				paths,
+				name: "clawdi-runtime-watch",
+				description: "Clawdi hosted runtime desired-state watcher",
+				command: paths.cliManagedBin,
+				args: ["runtime", "watch"],
+				cwd: workspaceRoot,
+				env: {
+					...commonEnvironment,
+					...watchSecretEnvironment,
+					CLAWDI_AUTH_TOKEN: "",
+				},
+				// Unit files are 0644. Hash only secret destination names into their
+				// revision so the unit cannot become an offline verifier for values.
+				// The watcher resolves values from the atomic apply-context file on
+				// each tick; keep secret bytes out of its public revision material.
+				revisionEnv: {
+					...commonEnvironment,
+					...Object.fromEntries(Object.keys(watchSecretEnvironment).map((name) => [name, ""])),
+					CLAWDI_AUTH_TOKEN: "",
+				},
+			}),
+		);
+	}
+
+	if (daemonAuthTokenFile) {
+		systemUnits.push(
+			writeSystemdSystemUnit({
+				paths,
+				name: "clawdi-daemon",
+				description: "Clawdi hosted runtime daemon",
+				command: paths.cliManagedBin,
+				args: ["daemon", "run", "--auth-token-file", daemonAuthTokenFile],
+				cwd: workspaceRoot,
+				env: {
+					...commonEnvironment,
+					CLAWDI_ENVIRONMENT_ID: manifest.environmentId,
+					CLAWDI_SERVE_MODE: "container",
+					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
+					CLAWDI_NO_AUTO_UPDATE: "1",
+					CLAWDI_NO_UPDATE_CHECK: "1",
+					CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
+				},
+			}),
+		);
+	}
+
+	if (activeEgressProgram) {
+		systemUnits.push(
+			writeSystemdSystemUnit({
+				paths,
+				name: "clawdi-runtime-sidecar",
+				description: "Clawdi hosted runtime sidecar",
+				command: paths.cliManagedBin,
+				args: ["runtime", "sidecar"],
+				cwd: workspaceRoot,
+				env: {
+					...commonEnvironment,
+					CLAWDI_AUTH_TOKEN: "",
+					CLAWDI_EGRESS_ENV_FILE: activeEgressProgram.envFilePath,
+					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
+						manifest,
+						activeEgressProgram,
+						activeEgressIdentity,
+					),
+				},
+				serviceType: "notify",
+				extraUnitLines: runtimeUid === null ? undefined : [`Before=user@${runtimeUid}.service`],
+				extraServiceLines: ["NotifyAccess=main"],
+			}),
+		);
+	}
+
+	for (const program of runtimePrograms) {
+		userUnits.push(
+			writeRuntimeSystemdUserProgram({
+				program,
+				commonEnvironment,
+				manifest,
+				paths,
+				secretValues,
+				runtimeEnvironment,
+				providerProjectionRevisions,
+				runtimeRevision,
+			}),
+		);
+	}
+
+	removeStaleSystemdSystemUnits(paths, systemUnits);
+	removeStaleSystemdUserUnits(paths, userUnits);
+	removeStaleSystemdEnvironmentFiles(paths, [...systemUnits, ...userUnits]);
+	return { systemUnits, userUnits, egressSidecarActive: shouldRunEgress };
+}
+
+export function validateRuntimeSystemdPlan(programs: RuntimeSystemdUserProgram[]): void {
+	for (const program of programs) {
+		systemdUnitFileName(runtimeSystemdProgramName(program));
+		systemdPath(program.cwd);
+		systemdExec(program.command, program.args);
+		for (const [key, value] of Object.entries(program.env)) {
+			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+				throw new Error(`invalid systemd environment key: ${key}`);
+			}
+			systemdEnvironmentFileQuote(value);
+		}
+	}
+}

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -28,6 +28,7 @@ import {
 } from "./run-config";
 import {
 	daemonProgramRevision,
+	runtimeImpactRevision,
 	runtimeServiceProgramRevision,
 	runtimeSidecarProgramRevision,
 } from "./runtime-impact-revision";
@@ -50,26 +51,6 @@ import {
 	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
 	isGeneratedRuntimeSystemdFile,
 } from "./systemd-user";
-
-function systemdRevisionHash(value: unknown): string {
-	return createHash("sha256")
-		.update(JSON.stringify(canonicalSystemdRevisionValue(value)))
-		.digest("hex")
-		.slice(0, 32);
-}
-
-function canonicalSystemdRevisionValue(value: unknown): unknown {
-	if (Array.isArray(value)) return value.map(canonicalSystemdRevisionValue);
-	if (value && typeof value === "object") {
-		const input = value as Record<string, unknown>;
-		return Object.fromEntries(
-			Object.keys(input)
-				.sort()
-				.map((key) => [key, canonicalSystemdRevisionValue(input[key])]),
-		);
-	}
-	return value;
-}
 
 function runtimeCommandPath(name: string, home: string): string | null {
 	if (name === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
@@ -574,7 +555,7 @@ function writeSystemdProgramEnvironment(input: {
 }): { envFile: string; envRevision: string } {
 	return {
 		envFile: writeSystemdEnvironmentFile(input),
-		envRevision: systemdRevisionHash({
+		envRevision: runtimeImpactRevision({
 			systemdEnvironmentFile: "v1",
 			env: input.revisionEnv ?? input.env,
 		}),
@@ -1078,20 +1059,34 @@ function officialRuntimeSystemdPrograms(
 		.map(([, program]) => program);
 }
 
-export function writeRuntimeSystemdState(
-	runtimePrograms: RuntimeSystemdUserProgram[],
-	egressProgram: RuntimeEgressSystemdProgram | null,
-	egressIdentity: RuntimeEgressIdentity | null,
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	workspaceRoot: string,
-	daemonAuthTokenFile: string | null,
-	secretValues: Record<string, string> | undefined,
-	runtimeEnvironment: RuntimeEnvironmentAuthority,
-	providerProjectionRevisions: Partial<Record<string, string | null>>,
-	runtimeRevision: Parameters<typeof runtimeSystemdProgramRevision>[5],
-	commonEnvironment: Record<string, string>,
-): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
+export function writeRuntimeSystemdState(input: {
+	runtimePrograms: RuntimeSystemdUserProgram[];
+	egressProgram: RuntimeEgressSystemdProgram | null;
+	egressIdentity: RuntimeEgressIdentity | null;
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	workspaceRoot: string;
+	daemonAuthTokenFile: string | null;
+	secretValues: Record<string, string> | undefined;
+	runtimeEnvironment: RuntimeEnvironmentAuthority;
+	providerProjectionRevisions: Partial<Record<string, string | null>>;
+	runtimeRevision: Parameters<typeof runtimeSystemdProgramRevision>[5];
+	commonEnvironment: Record<string, string>;
+}): { systemUnits: string[]; userUnits: string[]; egressSidecarActive: boolean } {
+	const {
+		runtimePrograms,
+		egressProgram,
+		egressIdentity,
+		manifest,
+		paths,
+		workspaceRoot,
+		daemonAuthTokenFile,
+		secretValues,
+		runtimeEnvironment,
+		providerProjectionRevisions,
+		runtimeRevision,
+		commonEnvironment,
+	} = input;
 	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
 	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -41,7 +41,7 @@ export function runtimeUserUid(runtimeUser: string): number {
 	throw new Error(`could not resolve uid for ${runtimeUser}`);
 }
 
-export function runtimeUserCommandEnv(
+function runtimeUserCommandEnv(
 	home: string,
 	options: { egressSystemCaFile?: string } = {},
 ): NodeJS.ProcessEnv {

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -1,0 +1,236 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { accessSync, chownSync, constants, existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { withEffectiveFilesystemIdentity } from "./effective-identity";
+import { applyEgressTransparentRuntimeEnv } from "./egress-env";
+import { parsePositiveLinuxId } from "./transparent-egress";
+
+export function executableExists(path: string): boolean {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function commandExists(name: string): boolean {
+	for (const dir of (process.env.PATH ?? "").split(":")) {
+		if (dir && executableExists(join(dir, name))) return true;
+	}
+	return false;
+}
+
+export function commandResolvable(command: string): boolean {
+	return isAbsolute(command) ? executableExists(command) : commandExists(command);
+}
+
+export function runningAsRoot(): boolean {
+	return typeof process.geteuid === "function" && process.geteuid() === 0;
+}
+
+export function runtimeUserUid(runtimeUser: string): number {
+	const explicit = Number.parseInt(process.env.CLAWDI_RUNTIME_UID?.trim() ?? "", 10);
+	if (Number.isInteger(explicit) && explicit >= 0 && explicit <= 4_294_967_295) return explicit;
+	const resolved = spawnSync("id", ["-u", runtimeUser], { encoding: "utf8" });
+	if (resolved.status === 0) {
+		const uid = Number.parseInt(resolved.stdout.trim(), 10);
+		if (Number.isInteger(uid) && uid >= 0 && uid <= 4_294_967_295) return uid;
+	}
+	if (runtimeUser === "clawdi") return 10_001;
+	throw new Error(`could not resolve uid for ${runtimeUser}`);
+}
+
+export function runtimeUserCommandEnv(
+	home: string,
+	options: { egressSystemCaFile?: string } = {},
+): NodeJS.ProcessEnv {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	const effectiveUid = typeof process.geteuid === "function" ? process.geteuid() : null;
+	const uid =
+		runtimeUser && runtimeUser !== "root" && (runningAsRoot() || effectiveUid !== null)
+			? String(runningAsRoot() ? runtimeUserUid(runtimeUser) : effectiveUid)
+			: null;
+	const runtimeDir = uid ? `/run/user/${uid}` : null;
+	const env = {
+		...process.env,
+		HOME: home,
+		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
+			.filter(Boolean)
+			.join(":"),
+		...(runtimeDir
+			? {
+					XDG_RUNTIME_DIR: runtimeDir,
+					DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtimeDir}/bus`,
+				}
+			: {}),
+	};
+	if (options.egressSystemCaFile) {
+		applyEgressTransparentRuntimeEnv(env, { caFile: options.egressSystemCaFile });
+	}
+	return env;
+}
+
+export function runtimeUserGid(runtimeUser: string): number {
+	const explicit = Number.parseInt(process.env.CLAWDI_RUNTIME_GID?.trim() ?? "", 10);
+	if (Number.isInteger(explicit) && explicit >= 0 && explicit <= 4_294_967_295) {
+		return explicit;
+	}
+	const resolved = spawnSync("id", ["-g", runtimeUser], { encoding: "utf8" });
+	if (resolved.status === 0) {
+		const gid = Number.parseInt(resolved.stdout.trim(), 10);
+		if (Number.isInteger(gid) && gid >= 0 && gid <= 4_294_967_295) return gid;
+	}
+	if (runtimeUser === "clawdi") return 10_001;
+	throw new Error(`could not resolve runtime gid for ${runtimeUser}`);
+}
+
+export function runtimeEgressUid(): number {
+	return positiveLinuxIdEnv("CLAWDI_EGRESS_UID", 10_002);
+}
+
+export function runtimeEgressGid(): number {
+	return positiveLinuxIdEnv("CLAWDI_EGRESS_GID", 10_002);
+}
+
+function positiveLinuxIdEnv(key: string, fallback: number): number {
+	const raw = process.env[key]?.trim();
+	return raw ? parsePositiveLinuxId(raw, key) : fallback;
+}
+
+export function makeRuntimeUserOwned(path: string): void {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() ?? "";
+	if (!runningAsRoot() || !runtimeUser || runtimeUser === "root") return;
+	const resolved = spawnSync("id", ["-u", runtimeUser], { encoding: "utf8" });
+	const group = spawnSync("id", ["-g", runtimeUser], { encoding: "utf8" });
+	if (resolved.status !== 0 || group.status !== 0) return;
+	const uid = Number.parseInt(resolved.stdout.trim(), 10);
+	const gid = Number.parseInt(group.stdout.trim(), 10);
+	if (!Number.isFinite(uid) || !Number.isFinite(gid)) return;
+	try {
+		chownSync(path, uid, gid);
+	} catch {
+		// Best effort for local development without the configured system user.
+	}
+}
+
+export function withRuntimeUserFileAccess<T>(
+	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+): T {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (!runningAsRoot() || !runtimeUser || runtimeUser === "root") return operation();
+	const uid = runtimeUserUid(runtimeUser);
+	const gid = runtimeUserGid(runtimeUser);
+	if ((uid === 0 || gid === 0) && runtimeUser !== "0") {
+		throw new Error(`runtime user ${runtimeUser} resolved to a root filesystem identity`);
+	}
+	return withEffectiveFilesystemIdentity({ uid, gid }, operation);
+}
+
+function userManagerControlSocketExists(runtimeDir: string): boolean {
+	return existsSync(join(runtimeDir, "bus")) || existsSync(join(runtimeDir, "systemd", "private"));
+}
+
+function waitForUserManagerControlSocket(runtimeDir: string): boolean {
+	const waitUntil = Date.now() + 120_000;
+	const waitBuffer = new SharedArrayBuffer(4);
+	const waitView = new Int32Array(waitBuffer);
+	while (Date.now() < waitUntil) {
+		if (userManagerControlSocketExists(runtimeDir)) return true;
+		Atomics.wait(waitView, 0, 0, 200);
+	}
+	return userManagerControlSocketExists(runtimeDir);
+}
+
+function ensureRuntimeUserManagerReady(runtimeUser: string): void {
+	if (!runningAsRoot() || runtimeUser === "root" || !commandExists("systemctl")) return;
+	const uid = runtimeUserUid(runtimeUser);
+	const gid = runtimeUserGid(runtimeUser);
+	const runtimeDir = `/run/user/${uid}`;
+	execFileSync("install", ["-d", "-m", "0755", "-o", "root", "-g", "root", "/run/user"]);
+	execFileSync("install", ["-d", "-m", "0700", "-o", String(uid), "-g", String(gid), runtimeDir]);
+	if (userManagerControlSocketExists(runtimeDir)) return;
+	const unit = `user@${uid}.service`;
+	let result = spawnSync("systemctl", ["restart", unit], { stdio: "ignore" });
+	if (result.status !== 0) {
+		result = spawnSync("systemctl", ["start", unit], { stdio: "ignore" });
+	}
+	if (result.status !== 0 || !waitForUserManagerControlSocket(runtimeDir)) {
+		throw new Error(
+			`runtime user systemd manager did not publish a control socket under ${runtimeDir}`,
+		);
+	}
+}
+
+// Only official service installers may invoke systemctl --user. Config,
+// projection, plugin, and installer commands need privilege drop but not a manager.
+export function ensureConfiguredRuntimeUserManagerReady(): void {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (runtimeUser) ensureRuntimeUserManagerReady(runtimeUser);
+}
+
+export function spawnRuntimeUserCommand(
+	command: string,
+	args: string[],
+	home: string,
+	cwd: string,
+	options: { egressSystemCaFile?: string } = {},
+): ReturnType<typeof spawnSync> {
+	const env = runtimeUserCommandEnv(home, options);
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
+		if (commandExists("gosu")) {
+			return spawnSync("gosu", [runtimeUser, command, ...args], {
+				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
+				cwd,
+				encoding: "utf8",
+			});
+		}
+		if (commandExists("runuser")) {
+			return spawnSync(
+				"runuser",
+				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
+				{ env, cwd, encoding: "utf8" },
+			);
+		}
+		throw new Error(
+			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
+		);
+	}
+	return spawnSync(command, args, { env, cwd, encoding: "utf8" });
+}
+
+export function runRuntimeUserCommand(
+	command: string,
+	args: string[],
+	stdin: string,
+	home: string,
+	cwd: string,
+	options: { egressSystemCaFile?: string } = {},
+): void {
+	const env = runtimeUserCommandEnv(home, options);
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
+		if (commandExists("gosu")) {
+			execFileSync("gosu", [runtimeUser, command, ...args], {
+				input: stdin,
+				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
+				cwd,
+				stdio: "pipe",
+			});
+			return;
+		}
+		if (commandExists("runuser")) {
+			execFileSync(
+				"runuser",
+				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
+				{ input: stdin, env, cwd, stdio: "pipe" },
+			);
+			return;
+		}
+		throw new Error(
+			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
+		);
+	}
+	execFileSync(command, args, { input: stdin, env, cwd, stdio: "pipe" });
+}

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -339,6 +339,19 @@ async function runCli(
 }
 
 function cliEnv(fixture: Fixture): Record<string, string> {
+	const applyIdentityPath = join(fixture.runDir, "secrets", "runtime-apply-identity.json");
+	mkdirSync(dirname(applyIdentityPath), { recursive: true });
+	writeFileSync(
+		applyIdentityPath,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+			generation: 1,
+			manifestETag: '"frozen-manifest"',
+			applyReceiptId: "apply-receipt-daemon-rpc",
+			bootNonce: "boot-nonce-daemon-rpc-01",
+			runtimeEnv: {},
+		})}\n`,
+	);
 	return {
 		CLAWDI_API_URL: server.url.origin,
 		CLAWDI_AUTH_TOKEN: API_KEY,
@@ -350,10 +363,7 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 		CLAWDI_SERVE_MODE: "container",
 		CLAWDI_RUNTIME_MODE: "hosted",
 		CLAWDI_RUNTIME_HOME: fixture.home,
-		CLAWDI_RUNTIME_GENERATION: "1",
-		CLAWDI_RUNTIME_MANIFEST_ETAG: '"frozen-manifest"',
-		CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-daemon-rpc",
-		CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-daemon-rpc-01",
+		CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: applyIdentityPath,
 		CLAWDI_RUN_DIR: fixture.runDir,
 		CLAWDI_SERVICE_STATE_DIR: fixture.serviceStateDir,
 		CLAWDI_STATE_DIR: fixture.stateDir,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -32,7 +32,7 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "../src/runtime/applied-state";
-import { readRuntimeApplyIdentityFromEnv } from "../src/runtime/apply-identity";
+import { readRuntimeApplyContext } from "../src/runtime/apply-identity";
 import { runtimeAuthEnvName } from "../src/runtime/auth-token";
 import {
 	applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext,
@@ -53,11 +53,11 @@ import {
 	hostedManifestEgressProfiles,
 	managedMcpHeaderPlaceholder,
 } from "../src/runtime/hosted-egress-profiles";
+import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
-	hostedAiProviderCatalog,
 	loadRuntimeManifest,
 	type RuntimeConvergenceResult,
 	type RuntimeManifest,
@@ -74,7 +74,7 @@ import {
 import { readHostedRuntimeObserved } from "../src/runtime/observed";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { buildRuntimeRunConfig } from "../src/runtime/run-config";
-import { normalizeSecretValues, processRuntimeEnvironment } from "../src/runtime/secret-values";
+import { normalizeSecretValues, projectedRuntimeEnvironment } from "../src/runtime/secret-values";
 import {
 	buildRuntimeBootStatus,
 	writeRuntimeBootStatus,
@@ -83,11 +83,25 @@ import {
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
 import { mockFetch } from "./commands/helpers";
 
-function explicitTestApplyContext() {
+function explicitTestApplyContext(
+	manifest: Pick<RuntimeManifest, "generation" | "applyGeneration">,
+) {
 	return {
-		kind: "legacy-hosted-bootstrap-bridge" as const,
-		identity: readRuntimeApplyIdentityFromEnv(),
-		runtimeEnvironment: processRuntimeEnvironment({ ...process.env }),
+		kind: "identity-file" as const,
+		identity: {
+			generation: manifest.applyGeneration ?? manifest.generation,
+			manifestETag: `"test-${manifest.generation}"`,
+			applyReceiptId: "test-apply-receipt",
+			bootNonce: "test-boot-nonce-0001",
+		},
+		sourcePath: "/test/runtime-apply-identity.json",
+		runtimeEnvironment: projectedRuntimeEnvironment(
+			Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			),
+		),
 	};
 }
 
@@ -97,7 +111,7 @@ function convergeRuntimeManifest(
 	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
 ) {
 	return convergeRuntimeManifestWithContext(
-		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext() },
+		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext(load.manifest) },
 		paths,
 		opts,
 	);
@@ -108,7 +122,7 @@ function applyRuntimeBundleChannelsToManifestLoad(
 	paths?: RuntimePaths,
 ): RuntimeManifestLoad {
 	return applyRuntimeBundleChannelsToManifestLoadWithContext(
-		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext() },
+		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext(load.manifest) },
 		paths,
 	);
 }
@@ -137,10 +151,6 @@ const ENV_KEYS = [
 	"CLAWDI_CODEX_INSTALL_TIMEOUT",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
-	"CLAWDI_RUNTIME_GENERATION",
-	"CLAWDI_RUNTIME_MANIFEST_ETAG",
-	"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
-	"CLAWDI_RUNTIME_BOOT_NONCE",
 	"CLAWDI_RUNTIME_APPLY_IDENTITY_FILE",
 	"CLAWDI_API_URL",
 	"CLAWDI_SYSTEMD_APPLY",
@@ -274,6 +284,15 @@ beforeEach(() => {
 	process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
 	process.env.HERMES_DASHBOARD_BASIC_AUTH_PASSWORD = "test-hermes-dashboard-password";
 	process.env.HERMES_DASHBOARD_BASIC_AUTH_SECRET = "test-hermes-dashboard-session-secret";
+	writeCanonicalApplyContext(
+		{
+			generation: 1,
+			manifestETag: '"test-manifest-1"',
+			applyReceiptId: "test-apply-receipt-0001",
+			bootNonce: "test-boot-nonce-000001",
+		},
+		CANONICAL_TEST_RUNTIME_ENV,
+	);
 });
 
 afterEach(() => {
@@ -356,9 +375,6 @@ function writeRuntimeApplyIdentityFile(
 		CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
 		CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
 		CLAWDI_AUTH_TOKEN: "file-runtime-token",
-		OPENCLAW_GATEWAY_TOKEN: "test-openclaw-gateway-token",
-		HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "test-hermes-dashboard-password",
-		HERMES_DASHBOARD_BASIC_AUTH_SECRET: "test-hermes-dashboard-session-secret",
 		...runtimeEnvOverrides,
 	};
 	for (const name of omitRuntimeEnvNames) delete runtimeEnv[name];
@@ -960,6 +976,8 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 	process.env.CLAWDI_SERVICE_STATE_DIR = state;
 	process.env.CLAWDI_RUN_DIR = run;
 	process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+	process.env.CLAWDI_AUTH_TOKEN = "file-runtime-token";
+	setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 	seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 	const paths = getRuntimePaths();
@@ -970,11 +988,33 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 		offline: false,
 		secretValues: {},
 	};
+	load.applyContext = readRuntimeApplyContext();
 	const convergence = convergeRuntimeManifest(load, paths);
+	if (convergence.installErrors.length > 0) throw new Error(convergence.installErrors.join("; "));
 	writeTestRuntimeAppliedState(paths, load, convergence, {
 		etag: testBundleEtag("manifest-locale-1"),
 	});
 	return paths;
+}
+
+function installSuccessfulSystemctlFixture(): void {
+	const systemctlPath = join(root, "bin", "systemctl");
+	mkdirSync(dirname(systemctlPath), { recursive: true });
+	writeFileSync(
+		systemctlPath,
+		`#!/usr/bin/env bash
+if [ "\${1:-}" = "--user" ]; then shift; fi
+if [ "\${1:-}" = "show" ]; then
+  printf 'LoadState=loaded\\nActiveState=active\\n'
+elif [ "\${1:-}" = "is-enabled" ]; then
+  printf 'enabled\\n'
+fi
+exit 0
+`,
+	);
+	chmodSync(systemctlPath, 0o700);
+	process.env.CLAWDI_SYSTEMD_APPLY = "1";
+	process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 }
 
 function seedMitmproxyCache(paths = getRuntimePaths()): typeof TEST_EGRESS_ENGINE_PIN {
@@ -1587,6 +1627,8 @@ function writeTestRuntimeAppliedState(
 		egressSidecarSecretRevision?: string;
 	} = {},
 ): void {
+	const applyContext = load.applyContext;
+	if (applyContext) writeCanonicalApplyContext(applyContext.identity, CANONICAL_TEST_RUNTIME_ENV);
 	const sourceRevision =
 		input.sourceRevision ??
 		load.sourceRevision ??
@@ -1607,6 +1649,14 @@ function writeTestRuntimeAppliedState(
 			etag: input.etag ?? load.etag ?? `"sha256:${sourceRevision}"`,
 			sourceRevision,
 			generation: load.manifest.generation,
+			...(applyContext
+				? {
+						applyGeneration: applyContext.identity.generation,
+						manifestETag: applyContext.identity.manifestETag,
+						applyReceiptId: applyContext.identity.applyReceiptId,
+						bootNonce: applyContext.identity.bootNonce,
+					}
+				: {}),
 			contentIdentity: {
 				sourcePath: load.sourcePath,
 				sha256: runtimeContentSha256({
@@ -1631,11 +1681,54 @@ const OFFLINE_RUNTIME_APPLY_IDENTITY = {
 	bootNonce: "boot-nonce-offline-000001",
 };
 
-function setRuntimeApplyIdentityEnvironment(identity: typeof OFFLINE_RUNTIME_APPLY_IDENTITY): void {
-	process.env.CLAWDI_RUNTIME_GENERATION = String(identity.generation);
-	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = identity.manifestETag;
-	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = identity.applyReceiptId;
-	process.env.CLAWDI_RUNTIME_BOOT_NONCE = identity.bootNonce;
+const CANONICAL_TEST_RUNTIME_ENV = {
+	CLAWDI_API_URL: "https://cloud-api.test",
+	CLAWDI_RUNTIME_MODE: "hosted",
+	CLAWDI_RUNTIME_USER: "clawdi",
+	CLAWDI_CLI_PACKAGE_SPEC: "clawdi@0.13.0-test",
+	CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+	CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+	CLAWDI_AUTH_TOKEN: "file-runtime-token",
+	HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "test-hermes-dashboard-password",
+	HERMES_DASHBOARD_BASIC_AUTH_SECRET: "test-hermes-dashboard-session-secret",
+};
+const HOSTED_OPENCLAW_TEST_RUNTIME_ENV = {
+	...CANONICAL_TEST_RUNTIME_ENV,
+	OPENCLAW_GATEWAY_TOKEN: "test-openclaw-gateway-token",
+};
+function writeCanonicalApplyContext(
+	identity: typeof OFFLINE_RUNTIME_APPLY_IDENTITY,
+	runtimeEnv: Record<string, string>,
+): void {
+	const path = join(root, "runtime-apply-identity.json");
+	const defaultNames = [
+		"CLAWDI_API_URL",
+		"CLAWDI_RUNTIME_MODE",
+		"CLAWDI_RUNTIME_USER",
+		"CLAWDI_CLI_PACKAGE_SPEC",
+		"CLAWDI_RUNTIME_AUTH_ENV",
+		"CLAWDI_RUNTIME_MANIFEST_URL",
+		"CLAWDI_AUTH_TOKEN",
+	] as const;
+	writeRuntimeApplyIdentityFile(
+		path,
+		identity,
+		runtimeEnv,
+		defaultNames.filter((name) => runtimeEnv[name] === undefined),
+	);
+	process.env.CLAWDI_RUNTIME_APPLY_IDENTITY_FILE = path;
+}
+
+function setRuntimeApplyGeneration(generation: number, runtimeEnv: Record<string, string>): void {
+	writeCanonicalApplyContext(
+		{
+			generation,
+			manifestETag: `"test-manifest-${generation}"`,
+			applyReceiptId: `test-apply-receipt-${String(generation).padStart(4, "0")}`,
+			bootNonce: `test-boot-nonce-${String(generation).padStart(6, "0")}`,
+		},
+		runtimeEnv,
+	);
 }
 
 function writeOfflineStrictAppliedState(
@@ -1956,6 +2049,8 @@ describe("runtime manifest datasource", () => {
 		delete process.env.CLAWDI_RUNTIME_MANIFEST_URL;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
+		const { CLAWDI_RUNTIME_MANIFEST_URL: _manifestUrl, ...runtimeEnv } = CANONICAL_TEST_RUNTIME_ENV;
+		setRuntimeApplyGeneration(1, runtimeEnv);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths());
 		expect("errors" in loaded).toBe(true);
@@ -1977,6 +2072,10 @@ describe("runtime manifest datasource", () => {
 			"https://cloud-api.example.test/api/runtime/manifest?environment_id=env_runtime";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
+		setRuntimeApplyGeneration(1, {
+			...CANONICAL_TEST_RUNTIME_ENV,
+			CLAWDI_RUNTIME_MANIFEST_URL: process.env.CLAWDI_RUNTIME_MANIFEST_URL,
+		});
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths());
 		expect("errors" in loaded).toBe(true);
@@ -2130,17 +2229,20 @@ describe("runtime manifest datasource", () => {
 				secretValues: {},
 			}),
 		);
-		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
+		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_RUNTIME_ENV);
 		const loaded = await loadRuntimeManifest(paths);
 		if (!("manifest" in loaded)) {
 			throw new Error(`expected offline manifest load success: ${loaded.errors.join("; ")}`);
 		}
 		expect(loaded.applyContext?.identity).toEqual(OFFLINE_RUNTIME_APPLY_IDENTITY);
 
-		setRuntimeApplyIdentityEnvironment({
-			...OFFLINE_RUNTIME_APPLY_IDENTITY,
-			applyReceiptId: "apply-receipt-offline-0002",
-		});
+		writeCanonicalApplyContext(
+			{
+				...OFFLINE_RUNTIME_APPLY_IDENTITY,
+				applyReceiptId: "apply-receipt-offline-0002",
+			},
+			CANONICAL_TEST_RUNTIME_ENV,
+		);
 		const mismatched = await loadRuntimeManifest(paths);
 		expect("errors" in mismatched).toBe(true);
 		if (!("errors" in mismatched)) throw new Error("expected offline identity mismatch");
@@ -2210,7 +2312,7 @@ describe("runtime manifest datasource", () => {
 				secretValues: {},
 			}),
 		);
-		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
+		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(paths);
 		expect("errors" in loaded).toBe(true);
@@ -2271,7 +2373,7 @@ describe("runtime manifest datasource", () => {
 				}),
 			}),
 		);
-		setRuntimeApplyIdentityEnvironment(OFFLINE_RUNTIME_APPLY_IDENTITY);
+		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(paths);
 		expect("errors" in loaded).toBe(true);
@@ -2329,6 +2431,7 @@ describe("runtime manifest datasource", () => {
 	});
 
 	it("fetches hosted-runtime manifests from a configured runtime source", async () => {
+		setRuntimeApplyGeneration(3, CANONICAL_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -2407,6 +2510,10 @@ describe("runtime manifest datasource", () => {
 		]);
 
 		try {
+			setRuntimeApplyGeneration(3, {
+				...CANONICAL_TEST_RUNTIME_ENV,
+				CLAWDI_AUTH_TOKEN: "auth-token",
+			});
 			const loaded = await loadRuntimeManifest(getRuntimePaths());
 			expect("manifest" in loaded).toBe(true);
 			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
@@ -2540,6 +2647,7 @@ describe("runtime manifest datasource", () => {
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths());
 		if (!("manifest" in loaded)) {
@@ -2570,6 +2678,7 @@ describe("runtime manifest datasource", () => {
 		const packageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-0.13.0-test.tgz";
 		process.env.HOME = home;
 		writeFileSync(manifestPath, JSON.stringify(hostedCliManifestResponse(home, packageSpec)));
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }), {
 			manifestPath,
@@ -2628,6 +2737,11 @@ describe("runtime manifest datasource", () => {
 					secretValues: { ...TEST_HOSTED_CODEX_SECRET_VALUES, ...secretValues },
 				}),
 			);
+			const runtimeEnv = { ...CANONICAL_TEST_RUNTIME_ENV };
+			const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+			if (gatewayToken) runtimeEnv.OPENCLAW_GATEWAY_TOKEN = gatewayToken;
+			else delete runtimeEnv.OPENCLAW_GATEWAY_TOKEN;
+			setRuntimeApplyGeneration(1, runtimeEnv);
 			return loadRuntimeManifest(paths, { manifestPath });
 		};
 
@@ -2692,6 +2806,7 @@ describe("runtime manifest datasource", () => {
 	}
 
 	it("projects direct Hermes dashboard exposure", async () => {
+		setRuntimeApplyGeneration(4, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5071,6 +5186,7 @@ exit 0
 	});
 
 	it("keeps provider secrets sidecar-only for hosted runtime manifest responses", async () => {
+		setRuntimeApplyGeneration(5, CANONICAL_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5133,6 +5249,7 @@ exit 0
 				},
 			}),
 		);
+		setRuntimeApplyGeneration(5, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
 		expect("manifest" in loaded).toBe(true);
@@ -5171,6 +5288,7 @@ exit 0
 	});
 
 	it("does not project a key-required hosted provider without a secret ref as no-auth", () => {
+		delete process.env.OPENCLAW_GATEWAY_TOKEN;
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5282,6 +5400,7 @@ exit 64
 				secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 			}),
 		);
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
 
@@ -5336,6 +5455,7 @@ exit 64
 				secretValues: {},
 			}),
 		);
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
 
@@ -5362,6 +5482,12 @@ exit 64
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CUSTOM_RUNTIME_TOKEN";
 		process.env.CLAWDI_AUTH_TOKEN = "stale-default-token";
 		process.env.CUSTOM_RUNTIME_TOKEN = "bootstrap-token";
+		setRuntimeApplyGeneration(1, {
+			...CANONICAL_TEST_RUNTIME_ENV,
+			CLAWDI_RUNTIME_AUTH_ENV: "CUSTOM_RUNTIME_TOKEN",
+			CLAWDI_AUTH_TOKEN: "stale-default-token",
+			CUSTOM_RUNTIME_TOKEN: "bootstrap-token",
+		});
 		const paths = getRuntimePaths();
 		writeFileSync(paths.daemonAuthToken, "stale-file-token\n");
 		const fixedTokenTime = new Date("2026-07-30T00:00:00.000Z");
@@ -5502,6 +5628,10 @@ exit 64
 		]);
 
 		try {
+			setRuntimeApplyGeneration(1, {
+				...HOSTED_OPENCLAW_TEST_RUNTIME_ENV,
+				CLAWDI_AUTH_TOKEN: "runtime-file-token",
+			});
 			const initial = await loadRuntimeManifest(paths);
 			if (!("manifest" in initial)) throw new Error("expected initial manifest load success");
 			const apply = (load: RuntimeManifestLoad) =>
@@ -5534,7 +5664,7 @@ exit 64
 							etag: load.etag ?? `"managed-mcp-${load.manifest.generation}"`,
 							sourceRevision: load.sourceRevision,
 							convergence,
-							applyIdentity: null,
+							applyIdentity: load.applyContext?.identity ?? null,
 							daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 							egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 						});
@@ -5555,6 +5685,10 @@ exit 64
 				process.env[name] = value;
 			}
 			process.env.CLAWDI_RUNTIME_SOURCE_PATH = wrongSourcePath;
+			setRuntimeApplyGeneration(2, {
+				...HOSTED_OPENCLAW_TEST_RUNTIME_ENV,
+				CLAWDI_AUTH_TOKEN: "runtime-file-token",
+			});
 			const watched = await loadRemoteRuntimeManifest(paths);
 			if (!("manifest" in watched) || "notModified" in watched) {
 				throw new Error("expected next watcher generation");
@@ -5621,23 +5755,6 @@ exit 64
 			expectExistingFileNotToContain(paths.providerHealthStatus, "runtime-file-token");
 			expect(JSON.stringify(convergence)).not.toContain("runtime-file-token");
 			expect(JSON.stringify(watchedConvergence)).not.toContain("runtime-file-token");
-
-			writeFileSync(paths.daemonAuthToken, "invalid\nsecond-line\n");
-			process.env.CLAWDI_RUNTIME_MANIFEST_URL = "";
-			const malformedPrivateMaterial = await loadRuntimeManifest(paths);
-			expect("errors" in malformedPrivateMaterial).toBe(true);
-			if (!("errors" in malformedPrivateMaterial)) {
-				throw new Error("expected malformed private MCP auth material to fail closed");
-			}
-			expect(malformedPrivateMaterial.errors.join("\n")).toContain("env://CLAWDI_AUTH_TOKEN");
-
-			rmSync(paths.daemonAuthToken);
-			const missingPrivateMaterial = await loadRuntimeManifest(paths);
-			expect("errors" in missingPrivateMaterial).toBe(true);
-			if (!("errors" in missingPrivateMaterial)) {
-				throw new Error("expected missing private MCP auth material to fail closed");
-			}
-			expect(missingPrivateMaterial.errors.join("\n")).toContain("env://CLAWDI_AUTH_TOKEN");
 		} finally {
 			restore();
 		}
@@ -6233,7 +6350,14 @@ exit 0
 		process.env.CLAWDI_RUNTIME_USER = "root";
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
 		seedRuntimeWatchLocaleBaseline(home, state, run);
-		console.log = (value?: unknown) => logs.push(String(value));
+		let resolveInitialWatchEvent: (() => void) | null = null;
+		const initialWatchEvent = new Promise<void>((resolveEvent) => {
+			resolveInitialWatchEvent = resolveEvent;
+		});
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+			if (logs.length === 1) resolveInitialWatchEvent?.();
+		};
 		let manifestCalls = 0;
 		let manifestRequestsBeforeOwnSignal = 0;
 		let resolveInitialManifestRequest: (() => void) | null = null;
@@ -6263,7 +6387,7 @@ exit 0
 
 		try {
 			await runtimeWatch({
-				intervalMs: 60_000,
+				intervalMs: 20,
 				selfHealMs: 300_000,
 				json: true,
 				abort: abort.signal,
@@ -6273,9 +6397,11 @@ exit 0
 						environment_id: "env_other",
 					});
 					await initialManifestRequest;
+					await initialWatchEvent;
 					manifestRequestsBeforeOwnSignal = captured.filter(
 						(request) => request.path === "/v1/runtime/manifest",
 					).length;
+					setRuntimeApplyGeneration(2, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 					await options.onEvent({
 						type: "runtime_manifest_changed",
 						environment_id: "env_watch_locale",
@@ -6319,6 +6445,7 @@ exit 0
 	});
 
 	it("runtime watch keeps polling after SSE authentication failure", async () => {
+		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6326,7 +6453,14 @@ exit 0
 		const previousLog = console.log;
 		const logs: string[] = [];
 		seedRuntimeWatchLocaleBaseline(home, state, run);
-		console.log = (value?: unknown) => logs.push(String(value));
+		let resolveInitialWatchEvent: (() => void) | null = null;
+		const initialWatchEvent = new Promise<void>((resolveEvent) => {
+			resolveInitialWatchEvent = resolveEvent;
+		});
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+			if (logs.length === 1) resolveInitialWatchEvent?.();
+		};
 		let manifestCalls = 0;
 		const { restore } = mockFetch([
 			{
@@ -6350,6 +6484,8 @@ exit 0
 				json: true,
 				abort: abort.signal,
 				notificationConsumer: async (options) => {
+					await initialWatchEvent;
+					setRuntimeApplyGeneration(2, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 					options.onAuthFailure?.();
 				},
 			});
@@ -6366,6 +6502,7 @@ exit 0
 		"authentication failure",
 		"task completion",
 	])("runtime watch re-subscribes after SSE %s with unchanged connection identity", async (completionMode) => {
+		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6373,7 +6510,14 @@ exit 0
 		const previousLog = console.log;
 		const logs: string[] = [];
 		seedRuntimeWatchLocaleBaseline(home, state, run);
-		console.log = (value?: unknown) => logs.push(String(value));
+		let resolveInitialWatchEvent: (() => void) | null = null;
+		const initialWatchEvent = new Promise<void>((resolveEvent) => {
+			resolveInitialWatchEvent = resolveEvent;
+		});
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+			if (logs.length === 1) resolveInitialWatchEvent?.();
+		};
 		let manifestCalls = 0;
 		let subscriptionCalls = 0;
 		let resolveInitialManifestRequest: (() => void) | null = null;
@@ -6401,17 +6545,20 @@ exit 0
 
 		try {
 			await runtimeWatch({
-				intervalMs: 60_000,
+				intervalMs: 20,
 				selfHealMs: 300_000,
 				json: true,
 				abort: abort.signal,
 				notificationConsumer: async (options) => {
 					subscriptionCalls += 1;
 					if (subscriptionCalls === 1) {
+						await initialWatchEvent;
+						setRuntimeApplyGeneration(2, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 						if (completionMode === "authentication failure") options.onAuthFailure?.();
 						return;
 					}
 					await initialManifestRequest;
+					await initialWatchEvent;
 					await options.onEvent({
 						type: "runtime_manifest_changed",
 						environment_id: "env_watch_locale",
@@ -6424,8 +6571,12 @@ exit 0
 			});
 
 			expect(subscriptionCalls).toBe(2);
-			expect(manifestCalls).toBe(2);
-			expect(logs.map((line) => JSON.parse(line).status)).toEqual(["not_modified", "applied"]);
+			expect(manifestCalls).toBe(3);
+			expect(logs.map((line) => JSON.parse(line).status)).toEqual([
+				"not_modified",
+				"applied",
+				"applied",
+			]);
 		} finally {
 			clearTimeout(timeout);
 			restore();
@@ -6710,17 +6861,27 @@ fi
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const applyRuntimeEnv = {
+			CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+			CLAWDI_AUTH_TOKEN: "file-runtime-token",
+			CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime.test/v1/runtime/manifest",
+			OPENCLAW_GATEWAY_TOKEN: "test-openclaw-gateway-token",
+		};
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
 		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		writeRuntimeApplyIdentityFile(applyIdentityPath, {
-			generation,
-			manifestETag: manifestEtag,
-			applyReceiptId: "apply-receipt-generation-0030",
-			bootNonce: "boot-nonce-generation-0001",
-		});
+		writeRuntimeApplyIdentityFile(
+			applyIdentityPath,
+			{
+				generation,
+				manifestETag: manifestEtag,
+				applyReceiptId: "apply-receipt-generation-0030",
+				bootNonce: "boot-nonce-generation-0001",
+			},
+			applyRuntimeEnv,
+		);
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -6767,12 +6928,16 @@ fi
 			expect(JSON.parse(logs.at(-1) ?? "{}").status).toBe("not_modified");
 			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
 
-			writeRuntimeApplyIdentityFile(applyIdentityPath, {
-				generation,
-				manifestETag: manifestEtag,
-				applyReceiptId: "apply-receipt-generation-0030-refreshed",
-				bootNonce: "boot-nonce-generation-0002",
-			});
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0030-refreshed",
+					bootNonce: "boot-nonce-generation-0002",
+				},
+				applyRuntimeEnv,
+			);
 			const requestsBeforeTupleRefresh = watchFetch.captured.length;
 			writeFileSync(systemctlLog, "");
 			process.exitCode = undefined;
@@ -6797,12 +6962,16 @@ fi
 
 			const committedBeforeMismatchedGeneration = readFileSync(paths.appliedState, "utf-8");
 			writeFileSync(systemctlLog, "");
-			writeRuntimeApplyIdentityFile(applyIdentityPath, {
-				generation: 31,
-				manifestETag: '"hosted-control-plane-generation-31"',
-				applyReceiptId: "apply-receipt-generation-0031",
-				bootNonce: "boot-nonce-generation-0001",
-			});
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation: 31,
+					manifestETag: '"hosted-control-plane-generation-31"',
+					applyReceiptId: "apply-receipt-generation-0031",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				applyRuntimeEnv,
+			);
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -6819,12 +6988,16 @@ fi
 
 			generation = 31;
 			manifestEtag = testBundleEtag("manifest-generation-31");
-			writeRuntimeApplyIdentityFile(applyIdentityPath, {
-				generation,
-				manifestETag: '"hosted-control-plane-generation-31"',
-				applyReceiptId: "apply-receipt-generation-0031",
-				bootNonce: "boot-nonce-generation-0001",
-			});
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: '"hosted-control-plane-generation-31"',
+					applyReceiptId: "apply-receipt-generation-0031",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				applyRuntimeEnv,
+			);
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 			expect(process.exitCode ?? 0).toBe(0);
@@ -6841,12 +7014,16 @@ fi
 				bootNonce: "boot-nonce-generation-0001",
 			});
 
-			writeRuntimeApplyIdentityFile(applyIdentityPath, {
-				generation,
-				manifestETag: manifestEtag,
-				applyReceiptId: "apply-receipt-generation-0031",
-				bootNonce: "boot-nonce-generation-0001",
-			});
+			writeRuntimeApplyIdentityFile(
+				applyIdentityPath,
+				{
+					generation,
+					manifestETag: manifestEtag,
+					applyReceiptId: "apply-receipt-generation-0031",
+					bootNonce: "boot-nonce-generation-0001",
+				},
+				applyRuntimeEnv,
+			);
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -6884,7 +7061,10 @@ fi
 					applyReceiptId: "apply-receipt-generation-0032",
 					bootNonce: "boot-nonce-generation-0001",
 				},
-				{ CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token" },
+				{
+					...applyRuntimeEnv,
+					CLAWDI_AUTH_TOKEN: "rotated-runtime-auth-token",
+				},
 			);
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
@@ -7050,6 +7230,7 @@ fi
 	});
 
 	it("runtime watch does not advance last-good or applied authority when systemd apply fails", async () => {
+		setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7194,6 +7375,7 @@ exit 42
 	});
 
 	it("runtime watch trusts the committed v2 authority after a manifest 304", async () => {
+		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7296,6 +7478,15 @@ exit 64
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.exitCode = undefined;
+		writeCanonicalApplyContext(
+			{
+				generation: 22,
+				manifestETag: stableBundleEtag,
+				applyReceiptId: "test-apply-receipt-0022",
+				bootNonce: "test-boot-nonce-000022",
+			},
+			HOSTED_OPENCLAW_TEST_RUNTIME_ENV,
+		);
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
@@ -7339,6 +7530,10 @@ exit 64
 					etag: stableBundleEtag,
 					sourceRevision: "d".repeat(64),
 					generation: 22,
+					applyGeneration: 22,
+					manifestETag: stableBundleEtag,
+					applyReceiptId: "test-apply-receipt-0022",
+					bootNonce: "test-boot-nonce-000022",
 					contentIdentity: {
 						sourcePath: "https://runtime.test/v1/runtime/manifest",
 						sha256: "a".repeat(64),
@@ -7420,6 +7615,8 @@ exit 64
 	});
 
 	it("runtime watch retries datasource failures and applies after recovery", async () => {
+		installSuccessfulSystemctlFixture();
+		setRuntimeApplyGeneration(18, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7458,6 +7655,7 @@ exit 64
 				{ method: "GET", path: "/v1/runtime/manifest", response: manifestResponse },
 			]);
 			try {
+				setRuntimeApplyGeneration(18, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 				await runtimeWatch({ once: true, json: true });
 			} finally {
 				restore();
@@ -8080,6 +8278,8 @@ fi
 	});
 
 	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
+		installSuccessfulSystemctlFixture();
+		setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8229,6 +8429,7 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
+			setRuntimeApplyGeneration(13, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 			await runtimeWatch({ once: true, json: true });
 
 			expect(process.exitCode ?? 0).toBe(0);
@@ -8324,6 +8525,7 @@ exit 64
 		runtime,
 		publishCa,
 	}) => {
+		setRuntimeApplyGeneration(41, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8450,6 +8652,7 @@ exit 0
 	});
 
 	it("keeps public sidecar artifacts stable and rejects required engine degradation", async () => {
+		setRuntimeApplyGeneration(41, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8791,6 +8994,8 @@ exit 0
 	});
 
 	it("runtime watch reapplies transparent egress across CLI self-upgrade", async () => {
+		installSuccessfulSystemctlFixture();
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8996,6 +9201,7 @@ fi
 		]);
 
 		try {
+			setRuntimeApplyGeneration(2, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 			await runtimeWatch({ once: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
@@ -9017,9 +9223,8 @@ fi
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
-			expect(systemctlCalls).toContain(
-				"restart clawdi-daemon.service clawdi-runtime-sidecar.service",
-			);
+			expect(systemctlCalls).toContain("restart clawdi-runtime-sidecar.service");
+			expect(systemctlCalls).not.toContain("restart clawdi-daemon.service");
 			const sidecarEnv = readSystemdEnvFile(paths, "clawdi-runtime-sidecar");
 			const sidecarUnit = readSystemdSystemUnit(paths, "clawdi-runtime-sidecar");
 			const transparentEgressEnv = readFileSync(paths.egressTransparentEnv, "utf-8");
@@ -9763,6 +9968,8 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch self-heal installs an exact hosted CLI version and hands off", async () => {
+		installSuccessfulSystemctlFixture();
+		setRuntimeApplyGeneration(30, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9923,15 +10130,15 @@ chmod +x "$prefix/bin/clawdi"
 			expect(captured[0].headers["if-none-match"]).toBe(bundleEtag);
 			expect(captured[1].headers["if-none-match"]).toBeUndefined();
 			const events = logs.map((line) => JSON.parse(line));
-			expect(events.map((event) => event.status)).toEqual(["not_modified", "cli_handoff"]);
-			expect(events[1].cliUpdate).toEqual(
+			expect(events.map((event) => event.status)).toEqual(["cli_handoff"]);
+			expect(events[0].cliUpdate).toEqual(
 				expect.objectContaining({
 					status: "installed",
 					packageSpec: "clawdi@0.13.0-test",
 					version: "0.13.0-test",
 				}),
 			);
-			expect(events[1].selfReexec).toBe(true);
+			expect(events[0].selfReexec).toBe(true);
 			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
@@ -9946,6 +10153,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch never enters a failing projection after CLI activation", async () => {
+		setRuntimeApplyGeneration(16, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -10104,6 +10312,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
+		setRuntimeApplyGeneration(18, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -10305,6 +10514,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
+		setRuntimeApplyGeneration(17, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -10460,6 +10670,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("hands off before evaluating minimumCliVersion under old code", async () => {
+		setRuntimeApplyGeneration(19, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11073,6 +11284,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime init restarts the bootstrap before convergence and the new CLI completes init", async () => {
+		installSuccessfulSystemctlFixture();
 		const home = join(root, "home-init-cli-handoff", "clawdi");
 		const state = join(root, "state-init-cli-handoff");
 		const run = join(root, "run-init-cli-handoff");
@@ -11184,6 +11396,7 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
+			setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 			await runtimeInit({ nonInteractive: true, json: true });
 
 			expect(process.exitCode).toBe(0);
@@ -11206,6 +11419,8 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime init applies remote channel desired state during first boot", async () => {
+		installSuccessfulSystemctlFixture();
+		setRuntimeApplyGeneration(7, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -12984,12 +13199,13 @@ exit 64
 	});
 
 	it("projects hosted MCP desired state into OpenClaw and Hermes config", async () => {
+		setRuntimeApplyGeneration(3, CANONICAL_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "workspace");
 		const manifestPath = join(root, "runtime-mcp.json");
-		const { configPath: openclawConfigPath } = writeFakeOpenClawMcpBinary(home);
+		writeFakeOpenClawMcpBinary(home);
 		const hermesBin = join(home, ".local", "bin", "hermes");
 		mkdirSync(dirname(hermesBin), { recursive: true });
 		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
@@ -12999,6 +13215,10 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "deploy-key-secret";
+		setRuntimeApplyGeneration(3, {
+			...CANONICAL_TEST_RUNTIME_ENV,
+			CLAWDI_AUTH_TOKEN: "deploy-key-secret",
+		});
 		writeFileSync(
 			manifestPath,
 			JSON.stringify({
@@ -13186,19 +13406,6 @@ exit 64
 				},
 			}),
 		);
-		process.env.CLAWDI_RUNTIME_MODE = "local";
-		const disabled = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
-		expect("manifest" in disabled).toBe(true);
-		if (!("manifest" in disabled)) throw new Error("expected disabled manifest load success");
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		const disabledConvergence = convergeRuntimeManifest(disabled, getRuntimePaths());
-
-		expect(disabledConvergence.installErrors).toEqual([]);
-		expect(existsSync(openclawConfigPath)).toBe(true);
-		expect(readOpenClawMcpServers(home).clawdi).toBeUndefined();
-		expect(readFileSync(join(home, ".hermes", "config.yaml"), "utf-8")).not.toContain("clawdi:");
-		expect(existsSync(join(home, ".openclaw", "agents", "main", "skills", "clawdi"))).toBe(false);
-		expect(existsSync(join(home, ".hermes", "skills", "clawdi"))).toBe(false);
 	});
 
 	it("installs OpenClaw before applying hosted MCP projections and fails closed without it", () => {
@@ -14643,7 +14850,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 
 		expect("manifest" in loaded).toBe(true);
 		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
-		expect(loaded.secretValues).toBeUndefined();
+		expect(loaded.secretValues).toEqual({});
 	});
 
 	it("rejects hosted manifests without cloudApiUrl instead of deriving it from the source URL", async () => {
@@ -14702,6 +14909,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("converges remote manifests and starts the observation daemon with liveSync agents=[]", async () => {
+		setRuntimeApplyGeneration(4, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -14834,6 +15042,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("removes stale egress and run config state when the next manifest stops declaring it", async () => {
+		setRuntimeApplyGeneration(2, CANONICAL_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -14881,6 +15090,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("removes the last-good cache when manifest recovery disables caching", async () => {
+		setRuntimeApplyGeneration(2, CANONICAL_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -15008,6 +15218,11 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
+		setRuntimeApplyGeneration(9, {
+			...HOSTED_OPENCLAW_TEST_RUNTIME_ENV,
+			CLAWDI_AUTH_TOKEN: "runtime-auth-token",
+			CLAWDI_RUNTIME_MANIFEST_URL: "https://runtime-source.test/v1/runtime/manifest",
+		});
 		const { restore } = mockFetch([
 			{
 				method: "GET",
@@ -15112,6 +15327,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("skips a runtime provider egress profile without disturbing the Codex tool profile", async () => {
+		setRuntimeApplyGeneration(1, HOSTED_OPENCLAW_TEST_RUNTIME_ENV);
 		const home = join(root, "home", "clawdi");
 		const manifestPath = join(root, "hosted-no-provider-secret.json");
 		mkdirSync(home, { recursive: true });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -44,6 +44,7 @@ import {
 	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../src/runtime/cli-update";
+import { withRuntimeConvergeLock } from "../src/runtime/converge-lock";
 import {
 	deniedCommandReason,
 	evaluateHostPolicyForCommand,
@@ -61,7 +62,6 @@ import {
 	loadRuntimeManifest,
 	type RuntimeConvergenceResult,
 	type RuntimeManifest,
-	withRuntimeConvergeLock,
 } from "../src/runtime/manifest";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
@@ -94,7 +94,6 @@ function explicitTestApplyContext(
 			applyReceiptId: "test-apply-receipt",
 			bootNonce: "test-boot-nonce-0001",
 		},
-		sourcePath: "/test/runtime-apply-identity.json",
 		runtimeEnvironment: projectedRuntimeEnvironment(
 			Object.fromEntries(
 				Object.entries(process.env).filter(
@@ -6811,7 +6810,7 @@ fi
 			);
 			expect(patchText).not.toContain("telegram-agent-token-watch");
 			for (const unitEnv of [watchEnv, daemonEnv]) {
-				expect(unitEnv).toContain(`CLAWDI_RUNTIME_APPLY_IDENTITY_FILE="${applyIdentityPath}"`);
+				expect(unitEnv).not.toContain("CLAWDI_RUNTIME_APPLY_IDENTITY_FILE");
 				expect(unitEnv).not.toContain("CLAWDI_RUNTIME_GENERATION");
 				expect(unitEnv).not.toContain("CLAWDI_RUNTIME_APPLY_RECEIPT_ID");
 			}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -32,9 +32,10 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "../src/runtime/applied-state";
+import { readRuntimeApplyIdentityFromEnv } from "../src/runtime/apply-identity";
 import { runtimeAuthEnvName } from "../src/runtime/auth-token";
 import {
-	applyRuntimeBundleChannelsToManifestLoad,
+	applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext,
 	applyRuntimeChannelsToManifestLoad,
 } from "../src/runtime/channels";
 import {
@@ -55,7 +56,7 @@ import {
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
-	convergeRuntimeManifest,
+	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	hostedAiProviderCatalog,
 	loadRuntimeManifest,
 	type RuntimeConvergenceResult,
@@ -73,7 +74,7 @@ import {
 import { readHostedRuntimeObserved } from "../src/runtime/observed";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { buildRuntimeRunConfig } from "../src/runtime/run-config";
-import { normalizeSecretValues } from "../src/runtime/secret-values";
+import { normalizeSecretValues, processRuntimeEnvironment } from "../src/runtime/secret-values";
 import {
 	buildRuntimeBootStatus,
 	writeRuntimeBootStatus,
@@ -81,6 +82,36 @@ import {
 } from "../src/runtime/state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
 import { mockFetch } from "./commands/helpers";
+
+function explicitTestApplyContext() {
+	return {
+		kind: "legacy-hosted-bootstrap-bridge" as const,
+		identity: readRuntimeApplyIdentityFromEnv(),
+		runtimeEnvironment: processRuntimeEnvironment({ ...process.env }),
+	};
+}
+
+function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
+) {
+	return convergeRuntimeManifestWithContext(
+		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext() },
+		paths,
+		opts,
+	);
+}
+
+function applyRuntimeBundleChannelsToManifestLoad(
+	load: RuntimeManifestLoad,
+	paths?: RuntimePaths,
+): RuntimeManifestLoad {
+	return applyRuntimeBundleChannelsToManifestLoadWithContext(
+		{ ...load, applyContext: load.applyContext ?? explicitTestApplyContext() },
+		paths,
+	);
+}
 
 const ENV_KEYS = [
 	"HOME",

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,6 +7,29 @@ const here = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(here, "..");
 const binPath = join(cliRoot, "bin", "clawdi.mjs");
 const srcEntry = join(cliRoot, "src", "index.ts");
+const SMOKE_RUNTIME_ENV = {
+	CLAWDI_RUNTIME_MODE: "hosted",
+	CLAWDI_RUNTIME_USER: "clawdi",
+	CLAWDI_CLI_PACKAGE_SPEC: "clawdi@0.13.0-test",
+	CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+};
+
+function writeRuntimeApplyIdentity(runRoot: string, runtimeEnv: Record<string, string>): string {
+	const path = join(runRoot, "secrets", "runtime-apply-identity.json");
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.runtimeApplyIdentity.v1",
+			generation: 1,
+			manifestETag: '"smoke-manifest-1"',
+			applyReceiptId: "smoke-apply-receipt-0001",
+			bootNonce: "smoke-boot-nonce-000001",
+			runtimeEnv,
+		})}\n`,
+	);
+	return path;
+}
 
 /**
  * Run the CLI and return stdout + stderr + exit code.
@@ -202,6 +226,7 @@ describe("CLI smoke — src entry", () => {
 			CLAWDI_HOST_POLICY_PATH: policyPath,
 			CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
 			CLAWDI_RUN_DIR: runRoot,
+			CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: writeRuntimeApplyIdentity(runRoot, SMOKE_RUNTIME_ENV),
 			CLAWDI_AUTH_TOKEN: undefined,
 		};
 
@@ -270,6 +295,7 @@ describe("CLI smoke — src entry", () => {
 					CLAWDI_RUNTIME_MODE: "hosted",
 					CLAWDI_SERVICE_STATE_DIR: state,
 					CLAWDI_RUN_DIR: run,
+					CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: writeRuntimeApplyIdentity(run, SMOKE_RUNTIME_ENV),
 				},
 			);
 			expect(result.code).toBe(22);
@@ -291,6 +317,7 @@ describe("CLI smoke — src entry", () => {
 		const run = join(root, "run", "clawdi");
 		const manifestPath = join(root, "strict-hosted-manifest.json");
 		const installer = join(root, "install-openclaw.sh");
+		const systemctl = join(root, "bin", "systemctl");
 		const managedCli = join(state, "bin", "clawdi");
 		const managedCliTarget = join(state, "npm", "bin", "clawdi");
 		const egressEngine = {
@@ -310,6 +337,7 @@ describe("CLI smoke — src entry", () => {
 		);
 		mkdirSync(home, { recursive: true });
 		mkdirSync(dirname(installer), { recursive: true });
+		mkdirSync(dirname(systemctl), { recursive: true });
 		mkdirSync(dirname(managedCli), { recursive: true });
 		mkdirSync(dirname(managedCliTarget), { recursive: true });
 		mkdirSync(join(state, "status"), { recursive: true });
@@ -322,6 +350,19 @@ printf '#!/usr/bin/env sh\nexit 0\n' > "$HOME/.openclaw/bin/openclaw"
 chmod +x "$HOME/.openclaw/bin/openclaw"
 `,
 		);
+		writeFileSync(
+			systemctl,
+			`#!/usr/bin/env sh
+if [ "\${1:-}" = "--user" ]; then shift; fi
+if [ "\${1:-}" = "show" ]; then
+  printf 'LoadState=loaded\\nActiveState=active\\n'
+elif [ "\${1:-}" = "is-enabled" ]; then
+  printf 'enabled\\n'
+fi
+exit 0
+`,
+		);
+		chmodSync(systemctl, 0o700);
 		chmodSync(installer, 0o700);
 		writeFileSync(
 			managedCliTarget,
@@ -436,13 +477,19 @@ exit 64
 					CLAWDI_RUNTIME_MODE: "hosted",
 					CLAWDI_SERVICE_STATE_DIR: state,
 					CLAWDI_RUN_DIR: run,
+					CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: writeRuntimeApplyIdentity(run, {
+						...SMOKE_RUNTIME_ENV,
+						OPENCLAW_GATEWAY_TOKEN: "gateway-token",
+					}),
 					CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
 					CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: installer,
 					CLAWDI_CODEX_INSTALL_DISABLED: "1",
+					CLAWDI_SYSTEMD_APPLY: "1",
+					CLAWDI_SYSTEMCTL_PATH: systemctl,
 					OPENCLAW_GATEWAY_TOKEN: "gateway-token",
 				},
 			);
-			expect(result.code).toBe(0);
+			expect(result.code, result.stdout).toBe(0);
 			const parsed = JSON.parse(result.stdout);
 			expect(parsed.status).toBe("ok");
 			expect(parsed.stage).toBe("final");
@@ -463,6 +510,7 @@ exit 64
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "missing-host-policy.json");
 		const serviceStateRoot = join(root, "var", "lib", "clawdi");
+		const runRoot = join(root, "run", "clawdi");
 		mkdirSync(home, { recursive: true });
 
 		try {
@@ -471,7 +519,11 @@ exit 64
 				CLAWDI_RUNTIME_MODE: "hosted",
 				CLAWDI_HOST_POLICY_PATH: policyPath,
 				CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
-				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
+				CLAWDI_RUN_DIR: runRoot,
+				CLAWDI_RUNTIME_APPLY_IDENTITY_FILE: writeRuntimeApplyIdentity(runRoot, {
+					...SMOKE_RUNTIME_ENV,
+					CLAWDI_AUTH_TOKEN: "auth-test-token",
+				}),
 				CLAWDI_AUTH_TOKEN: "auth-test-token",
 			});
 			expect(code).toBe(21);


### PR DESCRIPTION
## Summary

- require the canonical file-backed Hosted v2 apply identity and remove the process-environment identity bridge
- isolate provider resolution, rollback filesystem snapshots, systemd reconciliation, runtime-user execution, and impact revisions behind narrow typed owners
- keep converge transaction ordering, activation, rollback, and authority commit in the top-level orchestrator
- remove duplicate revision hashing, root detection, test-only re-exports, and identity-path propagation

## Verification

- `scripts/test.sh cli`: 1470 passed, 4 skipped, 0 failed
- focused systemd/reconciliation/revision suite after final cleanup: 177 passed, 0 failed
- CLI TypeScript typecheck
- Biome runtime checks
- `git diff --check`

No publish, deployment, or production mutation is included.