### PR TITLE
fix(web): polish deploy form presentation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -47,6 +47,16 @@ const managedModelCatalog = {
 	],
 };
 
+const dynamicManagedModelCatalog = {
+	models: [
+		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
+		{ id: "k3", display_name: "Kimi K3", is_default: false },
+		{ id: "future-model", display_name: "Future model", is_default: false },
+		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
+		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
+	],
+};
+
 type DeploymentComputeSubscription = NonNullable<
 	NonNullable<DeploymentRead["commercial_display"]>["compute_subscription"]
 >;
@@ -1687,6 +1697,15 @@ async function capturePricingScreenshot(page: Page, path: string) {
 	await basicCard.locator("xpath=ancestor::section[1]").screenshot({ path });
 }
 
+async function captureModelScreenshot(page: Page, path: string) {
+	const modelPicker = page.locator("#deploy-catalog-model");
+	await modelPicker.evaluate((element) => {
+		element.scrollIntoView({ block: "center", inline: "nearest" });
+	});
+	await page.waitForTimeout(100);
+	await modelPicker.locator("xpath=ancestor::section[1]").screenshot({ path });
+}
+
 function collectBrowserErrors(page: Page): string[] {
 	const errors: string[] = [];
 	page.on("console", (m) => {
@@ -2129,9 +2148,11 @@ test("deploy keeps AI providers expanded and provider selection exclusive", asyn
 	await unmanaged.click();
 	await expect(unmanaged).toHaveAttribute("aria-pressed", "true");
 	await expect(managed).toHaveAttribute("aria-pressed", "false");
+	await expect(page.getByTestId("managed-model-choices")).toHaveCount(0);
 	await managed.click();
 	await expect(managed).toHaveAttribute("aria-pressed", "true");
 	await expect(unmanaged).toHaveAttribute("aria-pressed", "false");
+	await expect(page.getByTestId("managed-model-choices")).toBeVisible();
 	await expect(page.getByRole("button", { name: "Change", exact: true })).toHaveCount(0);
 });
 
@@ -2242,7 +2263,11 @@ test("deploy CTA-adjacent Wallet amount handles loading, retry, and insufficient
 });
 
 test("deploy form stays readable without stretching compact controls", async ({ page }) => {
-	await stubHostedApi(page, { plans: [basicPlan, performancePlan], deployments: [] });
+	await stubHostedApi(page, {
+		plans: [basicPlan, performancePlan],
+		deployments: [],
+		managedModels: dynamicManagedModelCatalog,
+	});
 	await page.goto("/deploy");
 	await page.getByRole("button", { name: /^Performance/ }).click();
 	await page.getByRole("button", { name: /Annual.*%/ }).click();
@@ -2278,6 +2303,31 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 							rect: rect(element),
 						}
 					: null;
+			const inlineTextMetrics = (element: Element | null | undefined) =>
+				element
+					? (() => {
+							const textRange = document.createRange();
+							textRange.selectNodeContents(element);
+							const lineTops = new Set(
+								Array.from(textRange.getClientRects()).map((box) => Math.round(box.top * 10)),
+							);
+							return {
+								lineCount: lineTops.size,
+								text: element.textContent?.trim() ?? "",
+								whiteSpace: getComputedStyle(element).whiteSpace,
+							};
+						})()
+					: null;
+			const labelMetrics = (controlId: string) => {
+				const label = document.querySelector(`[data-slot="label"][for="${controlId}"]`);
+				if (!label) return null;
+				const style = getComputedStyle(label);
+				return {
+					fontSize: style.fontSize,
+					fontWeight: style.fontWeight,
+					lineHeight: style.lineHeight,
+				};
+			};
 			const sectionGrid = (title: string) => {
 				const section = sectionFor(title);
 				return gridMetrics(section?.querySelector(":scope > div:nth-child(3) .grid"));
@@ -2305,24 +2355,38 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 					scrollWidth: title.scrollWidth,
 				}));
 			const computePlans = ["Basic", "Performance"].map((label) => {
+				const testIdPrefix = label === "Basic" ? "basic" : "performance";
 				const title = Array.from(
 					document.querySelectorAll<HTMLSpanElement>("button span.font-medium"),
 				).find((candidate) => candidate.textContent?.trim() === label);
 				const card = title?.closest("button");
 				const resources = card?.querySelector("p");
-				const price = card?.querySelector(
-					`[data-testid="${label === "Basic" ? "basic" : "performance"}-compute-price"]`,
-				);
+				const price = card?.querySelector(`[data-testid="${testIdPrefix}-compute-price"]`);
 				const primaryPrice = price?.querySelector("span.font-semibold");
 				return {
 					card: rect(card),
 					label,
 					price: rect(price),
 					primaryPrice: rect(primaryPrice),
+					ramUnit: inlineTextMetrics(
+						card?.querySelector(`[data-testid="${testIdPrefix}-ram-resource"]`),
+					),
 					resources: rect(resources),
+					savings: inlineTextMetrics(
+						price?.querySelector(`[data-testid="${testIdPrefix}-compute-price-savings"]`),
+					),
+					secondaryWhiteSpace: price
+						? getComputedStyle(price.querySelector(":scope > div:last-child") ?? price).whiteSpace
+						: null,
 					title: rect(title),
 				};
 			});
+			const catalogModel = document.querySelector("#deploy-catalog-model");
+			const modelPickerFrame = catalogModel?.closest('div[data-hosted="true"][data-v2="true"]');
+			const modelPickerFrameStyle = modelPickerFrame ? getComputedStyle(modelPickerFrame) : null;
+			const managedModelChoices = document.querySelector('[data-testid="managed-model-choices"]');
+			const modelLabel = document.querySelector("#deploy-catalog-model-label");
+			const firstModelChoice = managedModelChoices?.querySelector("button");
 			return {
 				document: {
 					clientWidth: document.documentElement.clientWidth,
@@ -2333,10 +2397,31 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 				aiProviders: sectionGrid("AI providers"),
 				compute: sectionGrid("Compute"),
 				payment: gridMetrics(paymentButton?.parentElement),
-				catalogModel: rect(document.querySelector("#deploy-catalog-model")),
+				catalogModel: rect(catalogModel),
+				firstModelChoice: rect(firstModelChoice),
+				managedModelChoices: managedModelChoices
+					? {
+							clientWidth: managedModelChoices.clientWidth,
+							labels: Array.from(managedModelChoices.querySelectorAll("button")).map(
+								(button) => button.textContent?.trim() ?? "",
+							),
+							rect: rect(managedModelChoices),
+							scrollWidth: managedModelChoices.scrollWidth,
+						}
+					: null,
+				modelLabel: rect(modelLabel),
+				modelPickerFrame: modelPickerFrameStyle
+					? {
+							borderTopWidth: Number.parseFloat(modelPickerFrameStyle.borderTopWidth),
+							paddingTop: Number.parseFloat(modelPickerFrameStyle.paddingTop),
+						}
+					: null,
 				name: rect(document.querySelector("#agent-name")),
+				nameLabel: labelMetrics("agent-name"),
 				language: rect(document.querySelector("#agent-language")),
+				languageLabel: labelMetrics("agent-language"),
 				timezone: rect(document.querySelector("#agent-timezone")),
+				timezoneLabel: labelMetrics("agent-timezone"),
 				billingTerm: rect(document.querySelector('[aria-label="Billing term"]')),
 				action: rect(document.querySelector('button[type="submit"]')),
 				amount: (() => {
@@ -2402,10 +2487,30 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 				plan.price?.top,
 				`${viewport.name} ${plan.label} price should stay with title and resources`,
 			).toBeLessThanOrEqual(plan.resources?.bottom ?? 0);
+			expect(plan.ramUnit?.text, `${viewport.name} ${plan.label} RAM unit`).toMatch(/^\d+ GB RAM$/);
+			expect(plan.ramUnit?.whiteSpace, `${viewport.name} ${plan.label} RAM unit`).toBe("nowrap");
+			expect(plan.ramUnit?.lineCount, `${viewport.name} ${plan.label} RAM unit`).toBe(1);
+			expect(
+				plan.secondaryWhiteSpace,
+				`${viewport.name} ${plan.label} billing copy may wrap naturally`,
+			).toBe("normal");
 		}
+		const performancePlanMetrics = metrics.computePlans.find(
+			(plan) => plan.label === "Performance",
+		);
+		expect(performancePlanMetrics?.savings?.text, `${viewport.name} annual savings copy`).toBe(
+			"· save $40.00",
+		);
+		expect(
+			performancePlanMetrics?.savings?.whiteSpace,
+			`${viewport.name} annual savings copy`,
+		).toBe("nowrap");
+		expect(performancePlanMetrics?.savings?.lineCount, `${viewport.name} annual savings copy`).toBe(
+			1,
+		);
 
 		for (const [label, control, maxWidth] of [
-			["Catalog model", metrics.catalogModel, 448],
+			["Model", metrics.catalogModel, 448],
 			["Name", metrics.name, 448],
 			["Language", metrics.language, 160],
 			["Timezone", metrics.timezone, 384],
@@ -2420,6 +2525,45 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 		expect(metrics.language?.width, `${viewport.name} compact Language select`).toBeLessThan(
 			metrics.name?.width ?? 0,
 		);
+		expect(metrics.languageLabel, `${viewport.name} Language label`).toEqual(metrics.nameLabel);
+		expect(metrics.timezoneLabel, `${viewport.name} Timezone label`).toEqual(metrics.nameLabel);
+		expect(metrics.modelPickerFrame, `${viewport.name} unframed deploy model picker`).toEqual({
+			borderTopWidth: 0,
+			paddingTop: 0,
+		});
+		expect(metrics.managedModelChoices, `${viewport.name} managed model choices`).not.toBeNull();
+		expect(metrics.managedModelChoices?.labels, `${viewport.name} backend model order`).toEqual([
+			"Sol",
+			"Kimi K3",
+			"Future model",
+			"Luna",
+			"Terra",
+		]);
+		expect(
+			metrics.managedModelChoices?.scrollWidth,
+			`${viewport.name} managed model choices should not overflow`,
+		).toBeLessThanOrEqual(metrics.managedModelChoices?.clientWidth ?? 0);
+		expect(
+			metrics.managedModelChoices?.rect?.right,
+			`${viewport.name} managed model choices right edge`,
+		).toBeLessThanOrEqual(viewport.width);
+		if (viewport.width >= 700) {
+			const modelLabelCenter = metrics.modelLabel
+				? (metrics.modelLabel.top + metrics.modelLabel.bottom) / 2
+				: 0;
+			const firstModelChoiceCenter = metrics.firstModelChoice
+				? (metrics.firstModelChoice.top + metrics.firstModelChoice.bottom) / 2
+				: Number.POSITIVE_INFINITY;
+			expect(firstModelChoiceCenter, `${viewport.name} inline Model choices`).toBeCloseTo(
+				modelLabelCenter,
+				0,
+			);
+		} else {
+			expect(
+				metrics.firstModelChoice?.top,
+				`${viewport.name} wrapped Model choices`,
+			).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
+		}
 
 		expect(metrics.action, `${viewport.name} sticky action`).not.toBeNull();
 		expect(metrics.action?.top, `${viewport.name} sticky action top`).toBeGreaterThanOrEqual(0);
@@ -2451,6 +2595,7 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			);
 		}
 		await capturePricingScreenshot(page, `/tmp/deploy-compute-card-${viewport.width}.png`);
+		await captureModelScreenshot(page, `/tmp/deploy-ai-provider-${viewport.width}.png`);
 	}
 });
 
@@ -2800,7 +2945,7 @@ test("rejected detail delete stays on the current agent without accepted cleanup
 	await expect(page.getByText("internal delete coordinator", { exact: false })).toHaveCount(0);
 });
 
-test("managed model picker lists the curated catalog without Custom or image models", async ({
+test("deploy managed model picker renders backend order and submits the selected model", async ({
 	page,
 }) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
@@ -2808,19 +2953,31 @@ test("managed model picker lists the curated catalog without Custom or image mod
 		plans: [basicPlan],
 		deployments: [],
 		createDeploymentRequests,
+		managedModels: dynamicManagedModelCatalog,
 	});
 	await page.goto("/deploy");
 
-	await expect(page.locator("#deploy-catalog-model")).toContainText("Luna");
-	await page.locator("#deploy-catalog-model").click();
-	await expect(page.getByRole("option", { name: "Luna", exact: true })).toBeVisible();
-	await expect(page.getByRole("option", { name: "Sol", exact: true })).toBeVisible();
-	await expect(page.getByRole("option", { name: "Terra", exact: true })).toBeVisible();
-	await expect(page.getByRole("option", { name: "Hosted default (Luna)" })).toHaveCount(0);
-	await expect(page.getByRole("option", { name: "Custom model" })).toHaveCount(0);
-	await expect(page.getByRole("option", { name: /gpt-image/i })).toHaveCount(0);
+	const managedModels = page.getByTestId("managed-model-choices");
+	await expect(managedModels).toHaveAccessibleName("Model");
+	await expect(managedModels.getByRole("button")).toHaveText([
+		"Sol",
+		"Kimi K3",
+		"Future model",
+		"Luna",
+		"Terra",
+	]);
+	await expect(managedModels.getByRole("button", { name: "Luna" })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await expect(managedModels.getByRole("button", { name: "Kimi K3" })).toBeVisible();
+	await expect(page.locator("#deploy-primary-model")).toHaveCount(0);
 
-	await page.getByRole("option", { name: "Sol", exact: true }).click();
+	await managedModels.getByRole("button", { name: "Sol" }).click();
+	await expect(managedModels.getByRole("button", { name: "Sol" })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
 	await page.getByRole("button", { name: "Deploy", exact: true }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
 
@@ -2949,7 +3106,22 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 	await page.goto("/agents/hdep_unmanaged_model/model-provider?source=on-clawdi");
 
 	await page.getByRole("button", { name: /Clawdi AI/ }).click();
-	await expect(page.locator("#agent-catalog-model")).toContainText("Luna");
+	const agentModelSelect = page.locator("#agent-catalog-model");
+	await expect(agentModelSelect).toHaveRole("combobox");
+	await expect(agentModelSelect).toHaveAccessibleName("Model");
+	await expect(agentModelSelect).toContainText("Luna");
+	await expect(page.getByTestId("managed-model-choices")).toHaveCount(0);
+	const agentModelFrame = await agentModelSelect.evaluate((element) => {
+		const frame = element.closest('div[data-hosted="true"][data-v2="true"]');
+		const style = frame ? getComputedStyle(frame) : null;
+		return style
+			? {
+					borderTopWidth: Number.parseFloat(style.borderTopWidth),
+					paddingTop: Number.parseFloat(style.paddingTop),
+				}
+			: null;
+	});
+	expect(agentModelFrame).toEqual({ borderTopWidth: 1, paddingTop: 12 });
 	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -24,10 +24,12 @@ describe("computePricePresentation", () => {
 		expect(computePricePresentation(monthly, [monthly, annual])).toEqual({
 			primary: "$20.00/mo",
 			secondary: "Billed monthly",
+			savings: null,
 		});
 		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
 			primary: "$16.66/mo",
-			secondary: "Billed $200.00/yr · save $40.00",
+			secondary: "Billed $200.00/yr",
+			savings: "save $40.00",
 		});
 	});
 
@@ -35,6 +37,7 @@ describe("computePricePresentation", () => {
 		expect(computePricePresentation(annual, [annual])).toEqual({
 			primary: "$16.66/mo",
 			secondary: "Billed $200.00/yr",
+			savings: null,
 		});
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -12,6 +12,7 @@ import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-su
 export type ComputePricePresentation = {
 	primary: string;
 	secondary: string;
+	savings: string | null;
 };
 
 export type DeployAmountPresentation = {
@@ -32,6 +33,7 @@ export function computePricePresentation(
 		return {
 			primary: monthlyPrice(offer),
 			secondary: "Billed monthly",
+			savings: null,
 		};
 	}
 
@@ -53,7 +55,8 @@ export function computePricePresentation(
 
 	return {
 		primary: monthlyPrice(offer),
-		secondary: savingsCents > 0 ? `${billed} · save ${formatCents(savingsCents)}` : billed,
+		secondary: billed,
+		savings: savingsCents > 0 ? `save ${formatCents(savingsCents)}` : null,
 	};
 }
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -48,9 +48,13 @@ const aiProviderHooksSource = readFileSync(
 
 describe("deploy wizard personalization", () => {
 	test("keeps deploy-specific controls proportionate to their content", () => {
-		expect(wizardSource).toContain('className="w-full max-w-md"');
+		expect(wizardSource).toContain(
+			'className="w-full max-w-md rounded-none border-0 bg-transparent p-0"',
+		);
 		expect(wizardSource).toContain('<div className="flex max-w-2xl flex-col gap-4">');
 		expect(wizardSource).toContain('className="flex w-full max-w-md flex-col gap-1.5"');
+		expect(wizardSource).toContain('<Label htmlFor="agent-language">Language</Label>');
+		expect(wizardSource).toContain('<Label htmlFor="agent-timezone">Timezone</Label>');
 		expect(wizardSource).toContain('<SelectTrigger id="agent-language" type="button">');
 		expect(wizardSource).toContain('className="flex w-full max-w-sm min-w-0 flex-col gap-1.5"');
 		expect(wizardSource).toContain('className="flex max-w-xs flex-col gap-1.5"');
@@ -91,7 +95,8 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource).toContain(
 			'const TWO_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2";',
 		);
-		expect(wizardSource).toContain("@5xl/main:grid-cols-3");
+		expect(wizardSource).not.toContain("THREE_TILE_GRID_CLASS");
+		expect(wizardSource).not.toContain("@5xl/main:grid-cols-3");
 		expect(wizardSource).not.toContain('className="grid gap-2 sm:grid-cols-2"');
 		expect(wizardSource).not.toContain("sm:flex-row sm:items-center sm:justify-between");
 		expect(deployPageSource).toContain('className="grid gap-2 @2xl/main:grid-cols-2"');
@@ -100,7 +105,10 @@ describe("deploy wizard responsive layout", () => {
 	test("keeps compute identity, resources, and recurring price in one compact hierarchy", () => {
 		expect(wizardSource.match(/detailsPlacement="trailing"/g)).toHaveLength(2);
 		expect(wizardSource.match(/className="items-center p-3"/g)).toHaveLength(2);
-		expect(wizardSource.match(/vCPU · .* GB RAM/g)).toHaveLength(2);
+		expect(wizardSource).toContain('testId="basic-ram-resource"');
+		expect(wizardSource).toContain('testId="performance-ram-resource"');
+		expect(wizardSource).toContain('className="whitespace-nowrap" data-testid={testId}');
+		expect(wizardSource).toMatch(/data-testid=\{`\$\{testId\}-savings`\}/);
 	});
 
 	test("keeps the action bar sticky across the full form and adapts it to the main pane", () => {
@@ -126,7 +134,7 @@ describe("deploy wizard responsive layout", () => {
 describe("deploy wizard product copy and flow", () => {
 	test("uses customer language and keeps channels out of the decision flow", () => {
 		expect(wizardSource).toContain('title="Agent software"');
-		expect(wizardSource).toContain("<DeploySectionSkeleton columns={2} />");
+		expect(wizardSource.match(/<DeploySectionSkeleton \/>/g)).toHaveLength(4);
 		expect(wizardSource).not.toContain(
 			'description="Choose a compute plan and how paid plans renew."',
 		);
@@ -250,6 +258,22 @@ describe("managed model picker", () => {
 			expect(source).not.toContain("Hosted default (Luna)");
 		}
 		expect(modelBindingPickerSource).toContain("modelPickerItems(");
+		expect(modelBindingPickerSource).toContain("compactManagedModelChoices = false");
+		expect(modelBindingPickerSource).toContain(
+			"isManaged && compactManagedModelChoices && hasCatalogModels",
+		);
+		expect(wizardSource).toContain("compactManagedModelChoices");
+		expect(agentDetailSource).not.toContain("compactManagedModelChoices");
+		expect(modelBindingPickerSource).toContain("catalogModelItems.map((item) =>");
+		expect(modelBindingPickerSource).toContain("aria-labelledby=");
+		expect(modelBindingPickerSource).toContain("<Label id=");
+		expect(modelBindingPickerSource).toContain(">Model</Label>");
+		expect(modelBindingPickerSource).toContain("<Label htmlFor={catalogInputId}>Model</Label>");
+		expect(modelBindingPickerSource).not.toContain("Catalog model");
+		expect(modelBindingPickerSource).not.toContain("More models");
+		expect(modelBindingPickerSource).toContain(
+			'"flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3"',
+		);
 		expect(modelBindingPickerSource).toContain("Loading Clawdi AI models…");
 		expect(modelBindingPickerSource).toContain('title="Couldn\'t load Clawdi AI models"');
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -182,7 +182,6 @@ type PaidDeploySelection = {
 	tierLabel: "Basic" | "Performance";
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
-const THREE_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2 @5xl/main:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 @2xl/main:grid-cols-2";
 const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";
 const WALLET_PAYMENT_TOAST_DURATION_MS = 8_000;
@@ -268,14 +267,42 @@ function ComputePriceBlock({
 					{presentation.primary}
 				</span>
 			</div>
-			<span className="text-xs leading-4 font-normal text-muted-foreground">
+			<div className="text-xs leading-4 font-normal text-muted-foreground">
 				{presentation.secondary}
-			</span>
+				{presentation.savings ? (
+					<>
+						{" "}
+						<span className="whitespace-nowrap" data-testid={`${testId}-savings`}>
+							· {presentation.savings}
+						</span>
+					</>
+				) : null}
+			</div>
 		</div>
 	);
 }
 
-function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
+function ComputeResources({
+	testId,
+	vcpu,
+	ramGb,
+}: {
+	testId: string;
+	vcpu: number;
+	ramGb: number;
+}) {
+	return (
+		<span className="text-xs">
+			<span className="whitespace-nowrap">{vcpu} vCPU</span>
+			{" · "}
+			<span className="whitespace-nowrap" data-testid={testId}>
+				{ramGb} GB RAM
+			</span>
+		</span>
+	);
+}
+
+function DeploySectionSkeleton() {
 	return (
 		<section className="flex flex-col gap-4">
 			<Separator />
@@ -284,8 +311,8 @@ function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
 				<Skeleton className="h-3.5 w-80 max-w-full" />
 				<Skeleton className="h-3.5 w-56 max-w-full" />
 			</div>
-			<div className={columns === 3 ? THREE_TILE_GRID_CLASS : TWO_TILE_GRID_CLASS}>
-				{Array.from({ length: columns }).map((_, index) => (
+			<div className={TWO_TILE_GRID_CLASS}>
+				{Array.from({ length: 2 }).map((_, index) => (
 					<Skeleton key={index} className="h-[86px] w-full rounded-lg" />
 				))}
 			</div>
@@ -984,7 +1011,7 @@ export function DeployWizard() {
 		return (
 			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 				<PageHeader title="Deploy an Agent" description="Preparing your compute options…" />
-				<DeploySectionSkeleton columns={2} />
+				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
@@ -1095,7 +1122,7 @@ export function DeployWizard() {
 						{aiAccessMode !== "unmanaged" ? (
 							<ModelBindingPicker
 								idPrefix="deploy"
-								className="w-full max-w-md"
+								className="w-full max-w-md rounded-none border-0 bg-transparent p-0"
 								providers={providerList}
 								managedModels={managedModels}
 								managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
@@ -1104,6 +1131,7 @@ export function DeployWizard() {
 								onManagedModelsRetry={() => void managedModelCatalog.refetch()}
 								customProviders={providerList}
 								showProviderSelect={false}
+								compactManagedModelChoices
 								selectedProviderChoices={selectedProviderChoices}
 								primaryProviderChoice={primaryProviderChoice}
 								primaryModel={primaryModel}
@@ -1181,13 +1209,19 @@ export function DeployWizard() {
 								}
 								title="Basic"
 								description={
-									<span className="text-xs">
-										{!deployments.isSuccess
-											? deployments.error
+									!deployments.isSuccess ? (
+										<span className="text-xs">
+											{deployments.error
 												? "Basic availability couldn't be checked"
-												: "Checking free Basic slot availability"
-											: `${basicPlan?.vcpu ?? 2} vCPU · ${basicPlan?.ram_gb ?? 4} GB RAM`}
-									</span>
+												: "Checking free Basic slot availability"}
+										</span>
+									) : (
+										<ComputeResources
+											testId="basic-ram-resource"
+											vcpu={basicPlan?.vcpu ?? 2}
+											ramGb={basicPlan?.ram_gb ?? 4}
+										/>
+									)
 								}
 								detailsPlacement="trailing"
 								details={
@@ -1197,6 +1231,7 @@ export function DeployWizard() {
 											presentation={{
 												primary: "Free",
 												secondary: "First Basic agent",
+												savings: null,
 											}}
 										/>
 									) : deployments.isSuccess && basicPricePresentation ? (
@@ -1232,11 +1267,15 @@ export function DeployWizard() {
 								}
 								title="Performance"
 								description={
-									<span className="text-xs">
-										{perfPlan
-											? `${perfPlan.vcpu} vCPU · ${perfPlan.ram_gb} GB RAM`
-											: "Performance plan unavailable"}
-									</span>
+									perfPlan ? (
+										<ComputeResources
+											testId="performance-ram-resource"
+											vcpu={perfPlan.vcpu}
+											ramGb={perfPlan.ram_gb}
+										/>
+									) : (
+										<span className="text-xs">Performance plan unavailable</span>
+									)
 								}
 								detailsPlacement="trailing"
 								details={
@@ -1347,9 +1386,7 @@ export function DeployWizard() {
 							</div>
 							<div className="flex flex-wrap items-start gap-4">
 								<div className="flex flex-col gap-1.5">
-									<label htmlFor="agent-language" className="text-sm text-muted-foreground">
-										Language
-									</label>
+									<Label htmlFor="agent-language">Language</Label>
 									<Select
 										items={LANGUAGE_SELECT_ITEMS}
 										value={language || "default"}
@@ -1374,9 +1411,7 @@ export function DeployWizard() {
 								</div>
 								{tzOptions.length > 0 ? (
 									<div className="flex w-full max-w-sm min-w-0 flex-col gap-1.5">
-										<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
-											Timezone
-										</label>
+										<Label htmlFor="agent-timezone">Timezone</Label>
 										<TimezoneCombobox
 											id="agent-timezone"
 											value={timezone}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -13,6 +13,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import {
 	CUSTOM_MODEL_CHOICE,
@@ -36,6 +37,7 @@ export function ModelBindingPicker({
 	customProviders,
 	additionalProviderItems = [],
 	showProviderSelect = true,
+	compactManagedModelChoices = false,
 	selectedProviderChoices,
 	primaryProviderChoice,
 	primaryModel,
@@ -53,6 +55,7 @@ export function ModelBindingPicker({
 	customProviders: readonly AiProvider[];
 	additionalProviderItems?: readonly ModelBindingPickerItem[];
 	showProviderSelect?: boolean;
+	compactManagedModelChoices?: boolean;
 	selectedProviderChoices: readonly string[];
 	primaryProviderChoice: string;
 	primaryModel: string;
@@ -120,9 +123,34 @@ export function ModelBindingPicker({
 						onRetry={onManagedModelsRetry}
 						title="Couldn't load Clawdi AI models"
 					/>
+				) : isManaged && compactManagedModelChoices && hasCatalogModels ? (
+					<div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
+						<Label id={`${catalogInputId}-label`}>Model</Label>
+						<ToggleGroup
+							id={catalogInputId}
+							value={
+								catalogModelItems.some((item) => item.value === modelChoice) ? [modelChoice] : []
+							}
+							onValueChange={(values) => {
+								const value = values[0];
+								if (value) onPrimaryModelChange(value);
+							}}
+							variant="outline"
+							size="sm"
+							className="flex min-w-0 max-w-full flex-wrap justify-start"
+							aria-labelledby={`${catalogInputId}-label`}
+							data-testid="managed-model-choices"
+						>
+							{catalogModelItems.map((item) => (
+								<ToggleGroupItem key={item.value} value={item.value} className="min-w-0 max-w-full">
+									<span className="truncate">{item.label}</span>
+								</ToggleGroupItem>
+							))}
+						</ToggleGroup>
+					</div>
 				) : hasCatalogModels ? (
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor={catalogInputId}>Catalog model</Label>
+						<Label htmlFor={catalogInputId}>Model</Label>
 						<Select
 							items={catalogModelItems}
 							value={modelChoice}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -7,6 +7,7 @@ import {
 	modelBindingDisplayName,
 	modelDisplayName,
 	modelOptionsForProvider,
+	modelPickerItems,
 	primaryProviderPickerItems,
 	providerChoiceFromRef,
 	providerDisplayLabel,
@@ -25,7 +26,7 @@ describe("model binding", () => {
 		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [])).toEqual([]);
 	});
 
-	test("puts the catalog default first and exposes real managed model names", () => {
+	test("preserves backend catalog order while selecting its declared default", () => {
 		const managedModels = [
 			{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
 			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
@@ -34,12 +35,13 @@ describe("model binding", () => {
 
 		expect(
 			modelOptionsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((model) => model.id),
-		).toEqual(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+		).toEqual(["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra"]);
 		expect(firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels)).toBe("gpt-5.6-luna");
-		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [], managedModels)).toEqual([
-			managedModels[1],
-			managedModels[0],
-			managedModels[2],
+		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [], managedModels)).toEqual(managedModels);
+		expect(modelPickerItems(MANAGED_AI_CHOICE, [], managedModels)).toEqual([
+			{ value: "gpt-5.6-sol", label: "Sol" },
+			{ value: "gpt-5.6-luna", label: "Luna" },
+			{ value: "gpt-5.6-terra", label: "Terra" },
 		]);
 		expect(modelDisplayName("gpt-5.6-sol", managedModels)).toBe("Sol");
 	});

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -116,10 +116,7 @@ export function modelOptionsForProvider(
 ): ModelCatalogItem[] {
 	let models: readonly ModelCatalogItem[];
 	if (choice === MANAGED_AI_CHOICE || isManagedProviderId(choice)) {
-		const defaultModel = managedModels.find((model) => model.is_default);
-		models = defaultModel
-			? [defaultModel, ...managedModels.filter((model) => model !== defaultModel)]
-			: managedModels;
+		models = managedModels;
 	} else {
 		models =
 			providers.find((item) => item.id === choice || item.provider_id === choice)?.models ?? [];
@@ -210,7 +207,13 @@ export function firstModelForProvider(
 	providers: readonly AiProvider[],
 	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): string {
-	return modelOptionsForProvider(choice, providers, managedModels)[0]?.id ?? "";
+	const models = modelOptionsForProvider(choice, providers, managedModels);
+	if (choice === MANAGED_AI_CHOICE || isManagedProviderId(choice)) {
+		return (
+			models.find((model) => "is_default" in model && model.is_default)?.id ?? models[0]?.id ?? ""
+		);
+	}
+	return models[0]?.id ?? "";
 }
 
 export function normalizeSelectedProviderIds(


### PR DESCRIPTION
## Summary

- keep Model under AI providers while removing only the deploy form's redundant picker frame
- add a deploy-only compact managed Model toggle group that renders every API-returned item in backend order; the shared picker remains a Select by default for agent settings and BYOK/custom providers
- keep annual savings and resource units together without preventing surrounding billing copy from wrapping
- align Personalize labels with the shared Label component and remove the unreachable three-tile skeleton branch
- expand responsive browser coverage for 1280, 800, 700, and 390 widths, including no horizontal overflow, backend model order/default, Kimi K3 when returned, wrapping, and shared-picker regression assertions

## Verification

- `bun run --cwd apps/web test` (clean Docker runner: typecheck, full web tests, OSS production build)
- `E2E_HOSTED_PORT=3197 bun run --cwd apps/web e2e:hosted -- --grep "deploy form stays readable|deploy managed model picker|deploy keeps AI providers expanded|hosted AI provider Apply accepts the managed Luna default"` (4 passed)
- `bunx biome check apps/web/src apps/web/e2e` (483 files)
- `git diff --check origin/main..HEAD`

## Follow-up boundary

The frontend intentionally contains no managed-model IDs, priority list, or visibility threshold. Any future product-specific model ordering/visibility must come from the hosted catalog contract; the existing hosted App Setting covers the default model, not catalog ordering or visibility.
