### PR TITLE
Refine Stripe client-secret types from generated checkout union

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -197,8 +197,20 @@ describe("declarative deployment mutations", () => {
 				return jsonResponse({
 					flow_type: "checkout_session",
 					funding_source: "stripe",
+					action_url: "https://checkout.example.com/session",
 					checkout_url: "https://checkout.example.com/session",
-					deploy_request_id: intentKey,
+					client_secret: null,
+					subscription_id: null,
+					invoice_id: null,
+					deployment_id: null,
+					deployment_name: null,
+					metadata_generation: null,
+					deploy_request_id: null,
+					debited_usd: null,
+					balance_after_usd: null,
+					current_period_start: null,
+					current_period_end: null,
+					entitled_until: null,
 				});
 			}
 			if (path === `/v2/deployments/by-request/${intentKey}`) {
@@ -247,7 +259,8 @@ describe("declarative deployment mutations", () => {
 			},
 			intentKey,
 		);
-		expect(checkout.deploy_request_id).toBe(intentKey);
+		expect(checkout.flow_type).toBe("checkout_session");
+		expect(checkout.checkout_url).toBe("https://checkout.example.com/session");
 		expect(await client.waitForDeploymentRequest(intentKey)).toMatchObject({
 			deploymentId: "hdep_test",
 			operation: { done: false, name: "operations/create-happy" },

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -530,6 +530,9 @@ export function createBillingClient(
 	};
 }
 
+export type BillingClient = ReturnType<typeof createBillingClient>;
+export type CheckoutOperationResult = Awaited<ReturnType<BillingClient["checkout"]>>;
+
 export function useBillingClient() {
 	const { getToken } = useAuthToken();
 	return useMemo(() => createBillingClient(getToken), [getToken]);

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import { env } from "@/lib/env";
 
 export type StripeCheckoutSummary = {
@@ -30,7 +31,7 @@ export type StripeCheckoutSummary = {
 };
 
 type StripeCheckoutDialogProps = {
-	clientSecret: string | null;
+	clientSecret: CheckoutSessionClientSecret | null;
 	description: string;
 	onComplete: () => void;
 	onOpenChange: (open: boolean) => void;

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -1,37 +1,43 @@
 import { describe, expect, test } from "bun:test";
+import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
 import {
 	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
+	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
 	findNewDeploymentId,
-	hasCheckoutClientSecret,
 } from "@/hosted/billing/components/stripe-checkout.logic";
-import type { CheckoutResult } from "@/hosted/billing/contracts";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("stripe checkout logic", () => {
-	test("prefers the action_url for hosted Checkout redirects", () => {
-		const result: CheckoutResult = {
+	function checkoutResult(
+		overrides: Partial<Extract<CheckoutOperationResult, { flow_type: "checkout_session" }>>,
+	): CheckoutOperationResult {
+		return {
 			flow_type: "checkout_session",
 			funding_source: "stripe",
+			action_url: null,
+			checkout_url: "",
+			client_secret: null,
+			...overrides,
+		};
+	}
+
+	test("prefers the action_url for hosted Checkout redirects", () => {
+		const result = checkoutResult({
 			action_url: "https://checkout.stripe.com/primary",
 			checkout_url: "https://checkout.stripe.com/secondary",
-			client_secret: null,
-		};
+		});
 
 		expect(checkoutRedirectUrl(result)).toBe("https://checkout.stripe.com/primary");
 	});
 
 	test("detects elements checkout responses from a client secret", () => {
-		const result: CheckoutResult = {
-			flow_type: "checkout_session",
-			funding_source: "stripe",
-			action_url: null,
-			checkout_url: "",
+		const result = checkoutResult({
 			client_secret: "cs_test_elements",
-		};
+		});
 
-		expect(hasCheckoutClientSecret(result)).toBe(true);
+		expect(checkoutSessionClientSecret(result) === "cs_test_elements").toBe(true);
 	});
 
 	test("documents the checkout elements ui mode for the installed Stripe SDK", () => {

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
@@ -1,4 +1,7 @@
-import type { CheckoutResult, HostedDeployment } from "@/hosted/billing/contracts";
+import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+
+export { checkoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 
 export const CHECKOUT_ELEMENTS_UI_MODE = "custom";
 export const HOSTED_CHECKOUT_UI_MODE = "hosted";
@@ -9,14 +12,10 @@ export function checkoutUiModeForPublishableKey(
 	return publishableKey ? CHECKOUT_ELEMENTS_UI_MODE : HOSTED_CHECKOUT_UI_MODE;
 }
 
-export function checkoutRedirectUrl(result: CheckoutResult): string | null {
-	return result.action_url || result.checkout_url || null;
-}
-
-export function hasCheckoutClientSecret(
-	result: CheckoutResult,
-): result is CheckoutResult & { client_secret: string } {
-	return typeof result.client_secret === "string" && result.client_secret.length > 0;
+export function checkoutRedirectUrl(result: CheckoutOperationResult): string | null {
+	return result.flow_type === "checkout_session"
+		? result.action_url || result.checkout_url || null
+		: result.checkout_url || null;
 }
 
 export function findNewDeploymentId(

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -10,7 +10,6 @@ export type AiProviderAuthKind = NonNullable<
 >;
 export type BillingOffer = Schemas["V2BillingOfferResponse"];
 export type CheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
-export type CheckoutResult = Schemas["V2CheckoutResponse"];
 export type ComputePlanSlug = Schemas["V2HostedDeployRequest"]["compute_plan_slug"];
 export type ComputeSubscriptionActionResult = Schemas["V2ComputeSubscriptionActionResponse"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -45,9 +45,9 @@ import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
 import {
 	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
+	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
 	findNewDeploymentId,
-	hasCheckoutClientSecret,
 } from "@/hosted/billing/components/stripe-checkout.logic";
 import {
 	StripeCheckoutDialog,
@@ -118,6 +118,7 @@ import {
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
 import { useSensitiveCreateSubscription } from "@/hosted/billing/sensitive-actions";
+import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import {
 	type SubscriptionCreateRequestView,
 	type SubscriptionCreateSelection,
@@ -168,7 +169,7 @@ import { cn } from "@/lib/utils";
 type Compute = "basic" | "performance";
 type DeployPaymentMethod = "card" | "wallet";
 type NativeDeployCheckout = {
-	clientSecret: string;
+	clientSecret: CheckoutSessionClientSecret;
 	previousDeploymentIds: string[];
 	request: SubscriptionCreateRequestView;
 	summary: StripeCheckoutSummary;
@@ -865,9 +866,10 @@ export function DeployWizard() {
 					return;
 				}
 				const result = outcome.checkout;
-				if (cardCheckoutUiMode === CHECKOUT_ELEMENTS_UI_MODE && hasCheckoutClientSecret(result)) {
+				const clientSecret = checkoutSessionClientSecret(result);
+				if (cardCheckoutUiMode === CHECKOUT_ELEMENTS_UI_MODE && clientSecret) {
 					setCheckoutSession({
-						clientSecret: result.client_secret,
+						clientSecret,
 						previousDeploymentIds: (deployments.data ?? []).map(
 							(deployment) => deployment.resource.id,
 						),

--- a/apps/web/src/hosted/billing/stripe-client-secret.test.ts
+++ b/apps/web/src/hosted/billing/stripe-client-secret.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
+import type { WalletTopupResult } from "@/hosted/billing/contracts";
+import {
+	checkoutSessionClientSecret,
+	stripeReturnPaymentIntentClientSecret,
+	walletTopupPaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
+
+function checkoutResult(clientSecret: string | null): CheckoutOperationResult {
+	return {
+		flow_type: "checkout_session",
+		funding_source: "stripe",
+		action_url: null,
+		checkout_url: "",
+		client_secret: clientSecret,
+	};
+}
+
+function walletTopupResult(
+	flowType: string | null,
+	clientSecret: string | null,
+): WalletTopupResult {
+	return {
+		status: "requires_payment_method",
+		flow_type: flowType,
+		payment_intent_id: null,
+		client_secret: clientSecret,
+		amount_usd: null,
+	};
+}
+
+describe("Stripe client secret semantic refinement", () => {
+	test("accepts opaque checkout values only from the checkout arm", () => {
+		expect(
+			checkoutSessionClientSecret(checkoutResult("opaque checkout value")) ===
+				"opaque checkout value",
+		).toBe(true);
+		expect(
+			checkoutSessionClientSecret({
+				flow_type: "subscription_activation",
+				funding_source: "stripe",
+				checkout_url: "",
+				subscription_id: "csub_contract",
+				invoice_id: null,
+				deployment_id: null,
+				deployment_name: null,
+				metadata_generation: null,
+				deploy_request_id: null,
+				debited_usd: null,
+				balance_after_usd: null,
+				current_period_start: null,
+				current_period_end: null,
+				entitled_until: null,
+			}),
+		).toBeNull();
+	});
+
+	test("accepts opaque payment values only from PaymentIntent provenance", () => {
+		expect(
+			walletTopupPaymentIntentClientSecret(
+				walletTopupResult("payment_intent", "opaque payment value"),
+			) === "opaque payment value",
+		).toBe(true);
+		expect(
+			walletTopupPaymentIntentClientSecret(
+				walletTopupResult("checkout_session", "opaque but wrong flow"),
+			),
+		).toBeNull();
+		expect(stripeReturnPaymentIntentClientSecret("   ")).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/billing/stripe-client-secret.ts
+++ b/apps/web/src/hosted/billing/stripe-client-secret.ts
@@ -1,0 +1,64 @@
+import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
+import type { WalletAutoReloadAction, WalletTopupResult } from "@/hosted/billing/contracts";
+
+declare const checkoutSessionClientSecretBrand: unique symbol;
+declare const paymentIntentClientSecretBrand: unique symbol;
+
+type CheckoutSessionResult = Extract<CheckoutOperationResult, { flow_type: "checkout_session" }>;
+
+export type CheckoutSessionClientSecret = NonNullable<CheckoutSessionResult["client_secret"]> & {
+	readonly [checkoutSessionClientSecretBrand]: "CheckoutSessionClientSecret";
+};
+
+export type PaymentIntentClientSecret = (
+	| NonNullable<WalletTopupResult["client_secret"]>
+	| WalletAutoReloadAction["client_secret"]
+) & {
+	readonly [paymentIntentClientSecretBrand]: "PaymentIntentClientSecret";
+};
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isCheckoutSessionClientSecret(value: unknown): value is CheckoutSessionClientSecret {
+	return isNonEmptyString(value);
+}
+
+function isPaymentIntentClientSecret(value: unknown): value is PaymentIntentClientSecret {
+	return isNonEmptyString(value);
+}
+
+export function checkoutSessionClientSecret(
+	result: CheckoutOperationResult,
+): CheckoutSessionClientSecret | null {
+	if (
+		result.flow_type !== "checkout_session" ||
+		!isCheckoutSessionClientSecret(result.client_secret)
+	) {
+		return null;
+	}
+	return result.client_secret;
+}
+
+export function walletTopupPaymentIntentClientSecret(
+	result: WalletTopupResult,
+): PaymentIntentClientSecret | null {
+	if (result.flow_type !== "payment_intent" || !isPaymentIntentClientSecret(result.client_secret)) {
+		return null;
+	}
+	return result.client_secret;
+}
+
+export function walletAutoReloadPaymentIntentClientSecret(
+	action: WalletAutoReloadAction | null | undefined,
+): PaymentIntentClientSecret | null {
+	if (!action || !isPaymentIntentClientSecret(action.client_secret)) return null;
+	return action.client_secret;
+}
+
+export function stripeReturnPaymentIntentClientSecret(
+	value: unknown,
+): PaymentIntentClientSecret | null {
+	return isPaymentIntentClientSecret(value) ? value : null;
+}

--- a/apps/web/src/hosted/billing/stripe-client-secret.type-test.ts
+++ b/apps/web/src/hosted/billing/stripe-client-secret.type-test.ts
@@ -1,0 +1,30 @@
+import type { ComponentProps } from "react";
+import type { StripeCheckoutDialog } from "@/hosted/billing/components/stripe-checkout-dialog";
+import type {
+	CheckoutSessionClientSecret,
+	PaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
+import type { StripePaymentForm } from "@/hosted/billing/wallet/stripe-payment-form";
+
+declare const checkoutSecret: CheckoutSessionClientSecret;
+declare const paymentIntentSecret: PaymentIntentClientSecret;
+
+declare function acceptCheckoutSecret(
+	value: ComponentProps<typeof StripeCheckoutDialog>["clientSecret"],
+): void;
+declare function acceptPaymentIntentSecret(
+	value: ComponentProps<typeof StripePaymentForm>["clientSecret"],
+): void;
+
+acceptCheckoutSecret(checkoutSecret);
+acceptPaymentIntentSecret(paymentIntentSecret);
+
+// @ts-expect-error PaymentIntent secrets cannot initialize CheckoutElementsProvider.
+acceptCheckoutSecret(paymentIntentSecret);
+// @ts-expect-error Checkout Session secrets cannot initialize Elements.
+acceptPaymentIntentSecret(checkoutSecret);
+
+const stripeAcceptsCheckoutAsString: string = checkoutSecret;
+const stripeAcceptsPaymentIntentAsString: string = paymentIntentSecret;
+void stripeAcceptsCheckoutAsString;
+void stripeAcceptsPaymentIntentAsString;

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type {
-	CheckoutResult,
-	ComputeSubscriptionQuoteResponse,
-	DeployRequest,
-} from "@/hosted/billing/contracts";
+import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
+import type { ComputeSubscriptionQuoteResponse, DeployRequest } from "@/hosted/billing/contracts";
 import {
 	type SubscriptionCreateRequestView,
 	subscriptionCreateOutcome,
@@ -113,12 +110,19 @@ describe("subscription creation adapter", () => {
 	});
 
 	test("projects activation identity and entitlement fields consumed by the UI", () => {
-		const activation: CheckoutResult = {
+		const activation: Extract<CheckoutOperationResult, { flow_type: "subscription_activation" }> = {
 			flow_type: "subscription_activation",
 			funding_source: "wallet",
 			checkout_url: "",
+			subscription_id: "csub_contract",
+			invoice_id: null,
 			deploy_request_id: "subscription-create-test",
 			deployment_id: "hdep_created",
+			deployment_name: null,
+			metadata_generation: null,
+			debited_usd: null,
+			balance_after_usd: null,
+			current_period_start: null,
 			current_period_end: "2027-07-15T00:00:00Z",
 			entitled_until: "2027-07-16T00:00:00Z",
 		};

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -3,10 +3,12 @@ import {
 	buildHostedDeploySubscriptionQuoteRequest,
 	type HostedDeployCheckoutUiMode,
 } from "@clawdi/shared/api";
-import { acceptDeclarativeOperation } from "@/hosted/billing/billing-client";
+import {
+	acceptDeclarativeOperation,
+	type CheckoutOperationResult,
+} from "@/hosted/billing/billing-client";
 import type {
 	CheckoutRequest,
-	CheckoutResult,
 	ComputePlanSlug,
 	ComputeSubscriptionQuoteRequest,
 	ComputeSubscriptionQuoteResponse,
@@ -56,7 +58,7 @@ export type SubscriptionCreateRequestView = {
 export type SubscriptionCreateOutcomeView =
 	| {
 			flowType: "checkout";
-			checkout: CheckoutResult;
+			checkout: CheckoutOperationResult;
 	  }
 	| {
 			flowType: "subscription_activation";
@@ -121,7 +123,9 @@ export function subscriptionCreateRequest(request: SubscriptionCreateRequestView
 	return { body, idempotencyKey: request.idempotencyKey };
 }
 
-export function subscriptionCreateOutcome(result: CheckoutResult): SubscriptionCreateOutcomeView {
+export function subscriptionCreateOutcome(
+	result: CheckoutOperationResult,
+): SubscriptionCreateOutcomeView {
 	if (result.flow_type !== "subscription_activation") {
 		return { flowType: "checkout", checkout: result };
 	}

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -11,6 +11,10 @@ import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { useSensitiveWalletSnapshot } from "@/hosted/billing/sensitive-actions";
 import {
+	type PaymentIntentClientSecret,
+	walletAutoReloadPaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
+import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
@@ -35,14 +39,14 @@ export function AutoReloadActionConfirm({
 }: {
 	wallet: WalletCacheSnapshot;
 	onTopUp?: () => void;
-	initialClientSecret?: string | null;
+	initialClientSecret?: PaymentIntentClientSecret | null;
 	onDiscardClientSecret?: () => void;
 }) {
 	const qc = useQueryClient();
 	const walletSnapshot = useSensitiveWalletSnapshot();
 	const [confirming, setConfirming] = useState(false);
 	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
-	const [clientSecret, setClientSecret] = useState<string | null>(
+	const [clientSecret, setClientSecret] = useState<PaymentIntentClientSecret | null>(
 		() => initialClientSecret ?? null,
 	);
 	const [secretUnavailable, setSecretUnavailable] = useState(false);
@@ -109,7 +113,9 @@ export function AutoReloadActionConfirm({
 			const latest = await walletSnapshot.execute();
 			const latestAction = latest.auto_reload_action;
 			const secret =
-				latestAction?.attempt_id === actionAttemptId ? latestAction.client_secret : null;
+				latestAction?.attempt_id === actionAttemptId
+					? walletAutoReloadPaymentIntentClientSecret(latestAction)
+					: null;
 			if (!secret) {
 				setSecretUnavailable(true);
 				toast.error("Payment confirmation unavailable", {

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -22,6 +22,10 @@ import { Switch } from "@/components/ui/switch";
 import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { useSensitiveSetAutoReload } from "@/hosted/billing/sensitive-actions";
+import {
+	type PaymentIntentClientSecret,
+	walletAutoReloadPaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { AutoReloadActionConfirm } from "@/hosted/billing/wallet/auto-reload-action";
 import {
@@ -62,7 +66,9 @@ export function AutoReloadCard({
 	const [draft, setDraft] = useState<AutoReloadDraft>(initialDraft);
 	const [blurred, setBlurred] = useState<BlurredFields>(PRISTINE_FIELDS);
 	const [requestError, setRequestError] = useState<AutoReloadSaveError | null>(null);
-	const [actionClientSecret, setActionClientSecret] = useState<string | null>(null);
+	const [actionClientSecret, setActionClientSecret] = useState<PaymentIntentClientSecret | null>(
+		null,
+	);
 	const draftRef = useRef(draft);
 	const baselineRef = useRef(baseline);
 	const pendingRef = useRef(save.isPending);
@@ -120,7 +126,9 @@ export function AutoReloadCard({
 		setRequestError(null);
 		try {
 			const nextWallet = await save.execute(request);
-			setActionClientSecret(nextWallet.auto_reload_action?.client_secret ?? null);
+			setActionClientSecret(
+				walletAutoReloadPaymentIntentClientSecret(nextWallet.auto_reload_action),
+			);
 			queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 			const next = autoReloadDraftFromWallet(nextWallet);
 			setBaseline(next);

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import type { PaymentIntentClientSecret } from "@/hosted/billing/stripe-client-secret";
 import {
 	type PaymentOutcome,
 	paymentOutcomeForStatus,
@@ -120,7 +121,7 @@ export function StripePaymentForm({
 	summary,
 	onSubmittingChange,
 }: {
-	clientSecret: string;
+	clientSecret: PaymentIntentClientSecret;
 	onComplete: (status: PaymentOutcome) => void;
 	onCancel: () => void;
 	returnUrl?: PaymentReturnUrl;

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -1,6 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { WalletLedgerEntry, WalletTopupResult } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
+import {
+	type PaymentIntentClientSecret,
+	walletTopupPaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
 import { WALLET_TOPUP_ACCEPTED_TOAST } from "@/hosted/billing/wallet/top-up-return.logic";
 import {
 	TOPUP_INCREMENT_CENTS,
@@ -23,7 +27,7 @@ export interface TopupCompletionControls {
 }
 
 export interface TopupStartResultControls extends TopupCompletionControls {
-	startPayment: (clientSecret: string) => void;
+	startPayment: (clientSecret: PaymentIntentClientSecret) => void;
 	toastError: TopupToast;
 }
 
@@ -132,14 +136,15 @@ export function handleTopupStartResult(
 		completeTopup("succeeded", controls);
 		return;
 	}
-	if (result.flow_type === "payment_intent" && result.client_secret) {
+	const clientSecret = walletTopupPaymentIntentClientSecret(result);
+	if (clientSecret) {
 		// A pending ledger row matters only on a mounted activity surface. Keep
 		// balance and the rest of wallet activity untouched until payment settles.
 		void controls.queryClient.refetchQueries({
 			queryKey: billingKeys.ledgerRoot,
 			type: "active",
 		});
-		controls.startPayment(result.client_secret);
+		controls.startPayment(clientSecret);
 		return;
 	}
 	if (isProcessingTopupStatus(result.status)) {

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -28,6 +28,7 @@ import { isIdempotencyKeyReusedError, normalizeBillingError } from "@/hosted/bil
 import { formatCents } from "@/hosted/billing/format";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
 import { useSensitiveTopUp } from "@/hosted/billing/sensitive-actions";
+import type { PaymentIntentClientSecret } from "@/hosted/billing/stripe-client-secret";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	type PaymentOutcome,
@@ -96,7 +97,7 @@ export function TopUpDialog({
 	const runAction = useActionLock();
 	const [step, setStep] = useState<Step>("amount");
 	const [dollars, setDollars] = useState(String(TOPUP_DEFAULT_CENTS / 100));
-	const [clientSecret, setClientSecret] = useState<string | null>(null);
+	const [clientSecret, setClientSecret] = useState<PaymentIntentClientSecret | null>(null);
 	const [amountTouched, setAmountTouched] = useState(false);
 	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
 	useSettingsEditState({ dirty: false, busy: open && (topUp.isPending || paymentSubmitting) });

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
@@ -14,11 +14,10 @@ describe("wallet top-up return URL helpers", () => {
 	});
 
 	test("reads only marked Stripe PaymentIntent returns", () => {
-		expect(
-			readWalletTopupReturn(
-				"?settings=billing-wallet&topup_return=1&payment_intent_client_secret=pi_secret",
-			),
-		).toEqual({ clientSecret: "pi_secret" });
+		const result = readWalletTopupReturn(
+			"?settings=billing-wallet&topup_return=1&payment_intent_client_secret=pi_secret",
+		);
+		expect(result?.clientSecret === "pi_secret").toBe(true);
 		expect(
 			readWalletTopupReturn("?settings=billing-wallet&payment_intent_client_secret=pi_secret"),
 		).toBe(null);

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -1,3 +1,7 @@
+import {
+	type PaymentIntentClientSecret,
+	stripeReturnPaymentIntentClientSecret,
+} from "@/hosted/billing/stripe-client-secret";
 import { SETTINGS_QUERY_KEY } from "@/lib/settings-routes";
 
 export const WALLET_TOPUP_RETURN_PARAM = "topup_return";
@@ -8,7 +12,7 @@ export const STRIPE_REDIRECT_STATUS_PARAM = "redirect_status";
 export type WalletTopupReturnToastKind = "info" | "error";
 
 export interface WalletTopupReturnState {
-	clientSecret: string;
+	clientSecret: PaymentIntentClientSecret;
 }
 
 export interface WalletTopupReturnToast {
@@ -32,7 +36,9 @@ export function buildWalletTopupReturnUrl(currentHref: string): string {
 export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {
 	const params = new URLSearchParams(search);
 	if (params.get(WALLET_TOPUP_RETURN_PARAM) !== "1") return null;
-	const clientSecret = params.get(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
+	const clientSecret = stripeReturnPaymentIntentClientSecret(
+		params.get(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM),
+	);
 	if (!clientSecret) return null;
 	return { clientSecret };
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -11,7 +11,6 @@ import {
 	DEFAULT_HOSTED_DEPLOY_RUNTIME,
 	HOSTED_DEPLOY_LANGUAGE_OPTIONS,
 	type HostedDeployCheckoutRequest,
-	type HostedDeployCheckoutResult,
 	type HostedDeployComputePlanSlug,
 	type HostedDeployDeployment,
 	type HostedDeployManagedModel,
@@ -38,7 +37,11 @@ import chalk from "chalk";
 import { openInBrowser } from "../lib/browser";
 import { ClerkOAuthError } from "../lib/clerk-oauth";
 import { HostedDeployAuthorizationError } from "../lib/hosted-deploy-auth";
-import { HostedDeployApiError, HostedDeployClient } from "../lib/hosted-deploy-client";
+import {
+	HostedDeployApiError,
+	type HostedDeployCheckoutOperationResult,
+	HostedDeployClient,
+} from "../lib/hosted-deploy-client";
 import { isInteractive } from "../lib/tty";
 
 export type DeployCommandOptions = {
@@ -225,7 +228,7 @@ export interface HostedDeployGateway {
 	checkout(
 		body: HostedDeployCheckoutRequest,
 		idempotencyKey: string,
-	): Promise<HostedDeployCheckoutResult>;
+	): Promise<HostedDeployCheckoutOperationResult>;
 	getOperation(operationName: string): Promise<HostedDeployOperation>;
 	getDeploymentRequest(requestId: string): Promise<HostedDeployRequestStatus>;
 }
@@ -433,7 +436,12 @@ function terminalRequestFailure(
 	return new PublicDeployFailure("deployment_failed", "Hosted could not complete this deployment.");
 }
 
-export function hostedCheckoutUrl(result: HostedDeployCheckoutResult): string {
+type HostedDeployCheckoutSessionResult = Extract<
+	HostedDeployCheckoutOperationResult,
+	{ flow_type: "checkout_session" }
+>;
+
+export function hostedCheckoutUrl(result: HostedDeployCheckoutSessionResult): string {
 	const raw = result.action_url?.trim() || result.checkout_url.trim();
 	let url: URL;
 	try {
@@ -1139,41 +1147,21 @@ export async function runDeployFlow(
 			}),
 			requestId,
 		);
-		if (checkout.client_secret?.trim()) {
-			throw new PublicDeployFailure(
-				"invalid_checkout_response",
-				"Hosted returned a browser-only checkout secret that the CLI will not handle.",
-			);
-		}
 		if (checkout.funding_source !== fundingSource) {
 			throw new PublicDeployFailure(
 				"checkout_mismatch",
 				"Hosted checkout did not match the selected payment method.",
 			);
 		}
-		const returnedRequestId = checkout.deploy_request_id?.trim() || null;
-		if (returnedRequestId && returnedRequestId !== requestId) {
-			throw new PublicDeployFailure(
-				"checkout_mismatch",
-				"Hosted checkout did not match the requested deployment intent.",
-			);
-		}
 		deployRequestId = requestId;
-		deploymentId = checkout.deployment_id?.trim() || null;
-		if (payment === "wallet" && checkout.flow_type !== "subscription_activation") {
-			throw new PublicDeployFailure(
-				"wallet_activation_incomplete",
-				"Wallet checkout did not confirm subscription activation. No additional payment was sent.",
-			);
-		}
-		if (checkout.flow_type === "subscription_activation" && !deploymentId) {
-			throw new PublicDeployFailure(
-				"invalid_deployment_result",
-				"Hosted accepted payment without returning the agent identifier. Do not start another payment; check Agents in the dashboard.",
-			);
-		}
 
 		if (checkout.flow_type === "checkout_session") {
+			if (checkout.client_secret?.trim()) {
+				throw new PublicDeployFailure(
+					"invalid_checkout_response",
+					"Hosted returned a browser-only checkout secret that the CLI will not handle.",
+				);
+			}
 			if (payment !== "card") {
 				throw new PublicDeployFailure(
 					"wallet_activation_incomplete",
@@ -1191,6 +1179,20 @@ export async function runDeployFlow(
 				if (parsed.open) openUrl(checkoutUrl);
 			}
 		} else {
+			const returnedRequestId = checkout.deploy_request_id?.trim() || null;
+			if (returnedRequestId && returnedRequestId !== requestId) {
+				throw new PublicDeployFailure(
+					"checkout_mismatch",
+					"Hosted checkout did not match the requested deployment intent.",
+				);
+			}
+			deploymentId = checkout.deployment_id?.trim() || null;
+			if (!deploymentId) {
+				throw new PublicDeployFailure(
+					"invalid_deployment_result",
+					"Hosted accepted payment without returning the agent identifier. Do not start another payment; check Agents in the dashboard.",
+				);
+			}
 			onEvent({
 				stage: "accepted",
 				message:

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -4,7 +4,6 @@ import {
 	type DeployPaths,
 	extractApiDetail,
 	type HostedDeployCheckoutRequest,
-	type HostedDeployCheckoutResult,
 	type HostedDeployDeployment,
 	type HostedDeployManagedModel,
 	type HostedDeployOperation,
@@ -190,10 +189,7 @@ export class HostedDeployClient {
 		);
 	}
 
-	async checkout(
-		body: HostedDeployCheckoutRequest,
-		idempotencyKey: string,
-	): Promise<HostedDeployCheckoutResult> {
+	async checkout(body: HostedDeployCheckoutRequest, idempotencyKey: string) {
 		return unwrapHosted(
 			await this.client.POST("/v2/subscription/checkout", {
 				body,
@@ -221,3 +217,7 @@ export class HostedDeployClient {
 		);
 	}
 }
+
+export type HostedDeployCheckoutOperationResult = Awaited<
+	ReturnType<HostedDeployClient["checkout"]>
+>;

--- a/packages/cli/tests/commands/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy.test.ts
@@ -9,7 +9,6 @@ import {
 } from "@clawdi/shared";
 import type {
 	HostedDeployCheckoutRequest,
-	HostedDeployCheckoutResult,
 	HostedDeployDeployment,
 	HostedDeployOperation,
 	HostedDeployPlan,
@@ -30,7 +29,10 @@ import {
 	runDeployFlow,
 	safeDeployError,
 } from "../../src/commands/deploy";
-import { HostedDeployApiError } from "../../src/lib/hosted-deploy-client";
+import {
+	HostedDeployApiError,
+	type HostedDeployCheckoutOperationResult,
+} from "../../src/lib/hosted-deploy-client";
 
 function plan(slug: "compute_basic" | "compute_performance", priceCents: number): HostedDeployPlan {
 	return {
@@ -120,23 +122,30 @@ class FakeDeployGateway implements HostedDeployGateway {
 	checkoutFactory: (
 		body: HostedDeployCheckoutRequest,
 		idempotencyKey: string,
-	) => HostedDeployCheckoutResult = (body, idempotencyKey) =>
+	) => HostedDeployCheckoutOperationResult = (body, idempotencyKey) =>
 		body.funding_source === "stripe"
 			? {
 					flow_type: "checkout_session",
 					funding_source: "stripe",
 					action_url: "https://checkout.stripe.test/session/stable",
 					checkout_url: "https://checkout.stripe.test/session/stable",
-					deploy_request_id: idempotencyKey,
+					client_secret: null,
 				}
 			: {
 					flow_type: "subscription_activation",
 					funding_source: "wallet",
 					checkout_url: "",
+					subscription_id: "csub_paid",
+					invoice_id: null,
 					deployment_id: "hdep_paid",
+					deployment_name: null,
+					metadata_generation: null,
 					deploy_request_id: idempotencyKey,
 					debited_usd: "290.000000",
 					balance_after_usd: "10.000000",
+					current_period_start: null,
+					current_period_end: null,
+					entitled_until: null,
 				};
 	operationPolls = 0;
 	requestPolls = 0;
@@ -903,12 +912,12 @@ describe("deploy orchestration", () => {
 			yes: true,
 		});
 		const secretClient = new FakeDeployGateway();
-		secretClient.checkoutFactory = (_body, idempotencyKey) => ({
+		secretClient.checkoutFactory = (_body, _idempotencyKey) => ({
 			flow_type: "checkout_session",
 			funding_source: "stripe",
+			action_url: null,
 			checkout_url: "https://checkout.stripe.test/session/secret",
 			client_secret: "must-not-leak",
-			deploy_request_id: idempotencyKey,
 		});
 		let secretError: unknown;
 		try {
@@ -924,10 +933,20 @@ describe("deploy orchestration", () => {
 
 		const mismatchClient = new FakeDeployGateway();
 		mismatchClient.checkoutFactory = () => ({
-			flow_type: "checkout_session",
+			flow_type: "subscription_activation",
 			funding_source: "stripe",
-			checkout_url: "https://checkout.stripe.test/session/mismatch",
+			checkout_url: "",
+			subscription_id: "csub_paid",
+			invoice_id: null,
+			deployment_id: "hdep_paid",
+			deployment_name: null,
+			metadata_generation: null,
 			deploy_request_id: "different-request-id",
+			debited_usd: null,
+			balance_after_usd: null,
+			current_period_start: null,
+			current_period_end: null,
+			entitled_until: null,
 		});
 		await expect(
 			runDeployFlow(options, { client: mismatchClient, interactive: false }),
@@ -1335,8 +1354,10 @@ describe("deploy orchestration", () => {
 		const base = {
 			flow_type: "checkout_session",
 			funding_source: "stripe",
+			action_url: null,
 			checkout_url: "https://checkout.stripe.test/session/stable",
-		} satisfies HostedDeployCheckoutResult;
+			client_secret: null,
+		} satisfies HostedDeployCheckoutOperationResult;
 		expect(() => hostedCheckoutUrl({ ...base, checkout_url: "http://stripe.test/x" })).toThrow(
 			"valid secure",
 		);

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -21,7 +21,6 @@ export type HostedDeployManagedModel = Schemas["V2ManagedModelCatalogItem"];
 export type HostedDeploySubscriptionQuote = Schemas["V2ComputeSubscriptionQuoteResponse-Output"];
 export type HostedDeploySubscriptionQuoteRequest = Schemas["V2ComputeSubscriptionQuoteRequest"];
 export type HostedDeployCheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
-export type HostedDeployCheckoutResult = Schemas["V2CheckoutResponse"];
 export type HostedDeployOperation = Schemas["LongRunningOperation"];
 export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"];
 export type HostedDeployWallet = Schemas["V2WalletResponse"];

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1062,51 +1062,47 @@ export interface components {
             /** Discount Percent */
             discount_percent: number;
         };
-        /** V2CheckoutResponse */
-        V2CheckoutResponse: {
+        V2CheckoutResponse: components["schemas"]["V2CheckoutSessionResponse"] | components["schemas"]["V2SubscriptionActivationResponse"];
+        /** V2CheckoutSessionResponse */
+        V2CheckoutSessionResponse: {
             /**
-             * Flow Type
-             * @default checkout_session
+             * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            flow_type: "checkout_session" | "subscription_activation";
+            flow_type: "checkout_session";
             /**
              * Funding Source
-             * @default stripe
-             * @enum {string}
+             * @constant
              */
-            funding_source: "stripe" | "wallet";
+            funding_source: "stripe";
             /** Action Url */
-            action_url?: string | null;
-            /**
-             * Checkout Url
-             * @default
-             */
+            action_url: string | null;
+            /** Checkout Url */
             checkout_url: string;
             /** Client Secret */
-            client_secret?: string | null;
+            client_secret: string | null;
             /** Subscription Id */
-            subscription_id?: string | null;
+            subscription_id: null;
             /** Invoice Id */
-            invoice_id?: string | null;
+            invoice_id: null;
             /** Deployment Id */
-            deployment_id?: string | null;
+            deployment_id: null;
             /** Deployment Name */
-            deployment_name?: string | null;
+            deployment_name: null;
             /** Metadata Generation */
-            metadata_generation?: number | null;
+            metadata_generation: null;
             /** Deploy Request Id */
-            deploy_request_id?: string | null;
+            deploy_request_id: null;
             /** Debited Usd */
-            debited_usd?: string | null;
+            debited_usd: null;
             /** Balance After Usd */
-            balance_after_usd?: string | null;
+            balance_after_usd: null;
             /** Current Period Start */
-            current_period_start?: string | null;
+            current_period_start: null;
             /** Current Period End */
-            current_period_end?: string | null;
+            current_period_end: null;
             /** Entitled Until */
-            entitled_until?: string | null;
+            entitled_until: null;
         };
         /** V2ComputeBillingHistoryItem */
         V2ComputeBillingHistoryItem: {
@@ -1897,6 +1893,54 @@ export interface components {
             effective_at?: string | null;
             /** Amount Due Usd */
             amount_due_usd?: number | null;
+        };
+        /** V2SubscriptionActivationResponse */
+        V2SubscriptionActivationResponse: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            flow_type: "subscription_activation";
+            /**
+             * Funding Source
+             * @enum {string}
+             */
+            funding_source: "stripe" | "wallet";
+            /** Action Url */
+            action_url: null;
+            /**
+             * Checkout Url
+             * @constant
+             */
+            checkout_url: "";
+            /** Client Secret */
+            client_secret: null;
+            /**
+             * Subscription Id
+             * Format: sqid
+             * @example csub_K8fJ3pQm
+             */
+            subscription_id: string;
+            /** Invoice Id */
+            invoice_id: string | null;
+            /** Deployment Id */
+            deployment_id: string | null;
+            /** Deployment Name */
+            deployment_name: string | null;
+            /** Metadata Generation */
+            metadata_generation: number | null;
+            /** Deploy Request Id */
+            deploy_request_id: string | null;
+            /** Debited Usd */
+            debited_usd: string | null;
+            /** Balance After Usd */
+            balance_after_usd: string | null;
+            /** Current Period Start */
+            current_period_start: string | null;
+            /** Current Period End */
+            current_period_end: string | null;
+            /** Entitled Until */
+            entitled_until: string | null;
         };
         /** V2UpdateDeploymentRequest */
         V2UpdateDeploymentRequest: {


### PR DESCRIPTION
## Depends on

- Hosted schema/backend PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/1188

That PR must merge first. This PR's generated deploy client is produced from its OpenAPI schema (on top of hosted `main`, including the durable wallet dispatch consolidation), so any CI check comparing against the live hosted-main schema may wait until Hosted #1188 lands.

## Summary

- regenerate the deploy OpenAPI client from the hosted `flow_type` discriminated checkout union
- derive `CheckoutOperationResult` and `HostedDeployCheckoutOperationResult` from the generated client operation instead of maintaining handwritten aliases
- remove the unused synonymous `CheckoutResult` and `HostedDeployCheckoutResult` aliases
- refine generated checkout/wallet response values into opaque `CheckoutSessionClientSecret` and `PaymentIntentClientSecret` types only at provenance boundaries
- narrow Checkout Elements and PaymentIntent Elements props/state so cross-wiring secrets fails TypeScript
- preserve the existing provider architecture and same-Checkout-Session retry behavior; no fallback Session path is added

The refiners require the generated response discriminant/status and a non-empty string. They deliberately do not inspect `cs_`/`pi_` prefixes. The Stripe return adapter uses the explicit wallet return marker and canonical PaymentIntent client-secret query field, without format sniffing.

Negative `@ts-expect-error` contracts prove that PaymentIntent secrets cannot initialize `CheckoutElementsProvider` and Checkout Session secrets cannot initialize PaymentIntent Elements. Branded strings remain directly assignable to Stripe JS string inputs. There are no `as any`, `as unknown as`, non-null assertions, `@ts-ignore`, or compatibility adapters in the new boundary.

## Generated source

`packages/shared/src/api/deploy.generated.ts` was regenerated through the repository script from Hosted #1188's `backend/openapi.json`; it was not hand-edited. The generated diff also incorporates the already-current hosted wallet top-up `Idempotency-Key` requirement.

## Verification

- `bun run test` on current OSS `origin/main` (1470 package/client tests passed, 4 skipped; 1555 backend tests passed, 7 skipped)
- `bun run typecheck`
- `bun run check`
- `DEPLOY_OPENAPI_SOURCE=<Hosted #1188 OpenAPI path> scripts/check-deploy-generated-api.sh`
- focused Playwright: `Elements load failure retries the same Checkout Session` (1 passed; confirms a retry reuses the same client secret and creates no fallback Session)
- pre-commit Biome hook (23 changed files checked)
- `git diff --check`

All verification used local stubs/hermetic containers. No production/tenant operation, real Stripe request, charge, deployment, or merge was performed.

## Merge/deploy order

1. Merge Hosted #1188.
2. Let hosted-main schema/drift checks converge.
3. Merge this OSS PR.
4. Treat deployment as a separate deliberate operation; neither PR should deploy automatically as part of this task.
