### PR TITLE
fix(web): label the main model selection

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2510,7 +2510,7 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 		);
 
 		for (const [label, control, maxWidth] of [
-			["Model", metrics.catalogModel, 448],
+			["Main model", metrics.catalogModel, 448],
 			["Name", metrics.name, 448],
 			["Language", metrics.language, 160],
 			["Timezone", metrics.timezone, 384],
@@ -2554,14 +2554,14 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			const firstModelChoiceCenter = metrics.firstModelChoice
 				? (metrics.firstModelChoice.top + metrics.firstModelChoice.bottom) / 2
 				: Number.POSITIVE_INFINITY;
-			expect(firstModelChoiceCenter, `${viewport.name} inline Model choices`).toBeCloseTo(
+			expect(firstModelChoiceCenter, `${viewport.name} inline Main model choices`).toBeCloseTo(
 				modelLabelCenter,
 				0,
 			);
 		} else {
 			expect(
 				metrics.firstModelChoice?.top,
-				`${viewport.name} wrapped Model choices`,
+				`${viewport.name} wrapped Main model choices`,
 			).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
 		}
 
@@ -2958,7 +2958,7 @@ test("deploy managed model picker renders backend order and submits the selected
 	await page.goto("/deploy");
 
 	const managedModels = page.getByTestId("managed-model-choices");
-	await expect(managedModels).toHaveAccessibleName("Model");
+	await expect(managedModels).toHaveAccessibleName("Main model");
 	await expect(managedModels.getByRole("button")).toHaveText([
 		"Sol",
 		"Kimi K3",
@@ -3108,7 +3108,7 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 	await page.getByRole("button", { name: /Clawdi AI/ }).click();
 	const agentModelSelect = page.locator("#agent-catalog-model");
 	await expect(agentModelSelect).toHaveRole("combobox");
-	await expect(agentModelSelect).toHaveAccessibleName("Model");
+	await expect(agentModelSelect).toHaveAccessibleName("Main model");
 	await expect(agentModelSelect).toContainText("Luna");
 	await expect(page.getByTestId("managed-model-choices")).toHaveCount(0);
 	const agentModelFrame = await agentModelSelect.evaluate((element) => {
@@ -3122,6 +3122,22 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 			: null;
 	});
 	expect(agentModelFrame).toEqual({ borderTopWidth: 1, paddingTop: 12 });
+	for (const viewport of [
+		{ height: 900, width: 1280 },
+		{ height: 900, width: 800 },
+		{ height: 900, width: 700 },
+		{ height: 844, width: 390 },
+	]) {
+		await page.setViewportSize(viewport);
+		await expect(agentModelSelect).toHaveAccessibleName("Main model");
+		const documentWidth = await page.evaluate(() => ({
+			clientWidth: document.documentElement.clientWidth,
+			scrollWidth: document.documentElement.scrollWidth,
+		}));
+		expect(documentWidth.scrollWidth, `agent settings at ${viewport.width}px`).toBe(
+			documentWidth.clientWidth,
+		);
+	}
 	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -41,19 +41,19 @@ function deferred() {
 
 const managedModelCatalog = {
 	models: [
-		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
-		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
-		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
+		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: true },
+		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false, is_featured: false },
+		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false, is_featured: false },
 	],
 };
 
 const dynamicManagedModelCatalog = {
 	models: [
-		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
-		{ id: "k3", display_name: "Kimi K3", is_default: false },
-		{ id: "future-model", display_name: "Future model", is_default: false },
-		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
-		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
+		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false, is_featured: true },
+		{ id: "k3", display_name: "Kimi K3", is_default: false, is_featured: true },
+		{ id: "future-model", display_name: "Future model", is_default: false, is_featured: false },
+		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: false },
+		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false, is_featured: false },
 	],
 };
 
@@ -2385,8 +2385,10 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			const modelPickerFrame = catalogModel?.closest('div[data-hosted="true"][data-v2="true"]');
 			const modelPickerFrameStyle = modelPickerFrame ? getComputedStyle(modelPickerFrame) : null;
 			const managedModelChoices = document.querySelector('[data-testid="managed-model-choices"]');
+			const managedModelControls = document.querySelector('[data-testid="managed-model-controls"]');
+			const managedModelOverflow = document.querySelector('[data-testid="managed-model-overflow"]');
 			const modelLabel = document.querySelector("#deploy-catalog-model-label");
-			const firstModelChoice = managedModelChoices?.querySelector("button");
+			const firstModelChoice = managedModelChoices?.querySelector("label");
 			return {
 				document: {
 					clientWidth: document.documentElement.clientWidth,
@@ -2402,14 +2404,23 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 				managedModelChoices: managedModelChoices
 					? {
 							clientWidth: managedModelChoices.clientWidth,
-							labels: Array.from(managedModelChoices.querySelectorAll("button")).map(
-								(button) => button.textContent?.trim() ?? "",
+							labels: Array.from(managedModelChoices.querySelectorAll("label")).map(
+								(label) => label.textContent?.trim() ?? "",
 							),
 							rect: rect(managedModelChoices),
 							scrollWidth: managedModelChoices.scrollWidth,
 						}
 					: null,
+				managedModelControls: managedModelControls
+					? {
+							clientWidth: managedModelControls.clientWidth,
+							rect: rect(managedModelControls),
+							scrollWidth: managedModelControls.scrollWidth,
+						}
+					: null,
+				managedModelOverflow: rect(managedModelOverflow),
 				modelLabel: rect(modelLabel),
+				modelPickerFrameRect: rect(modelPickerFrame),
 				modelPickerFrame: modelPickerFrameStyle
 					? {
 							borderTopWidth: Number.parseFloat(modelPickerFrameStyle.borderTopWidth),
@@ -2532,38 +2543,27 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			paddingTop: 0,
 		});
 		expect(metrics.managedModelChoices, `${viewport.name} managed model choices`).not.toBeNull();
-		expect(metrics.managedModelChoices?.labels, `${viewport.name} backend model order`).toEqual([
+		expect(metrics.managedModelChoices?.labels, `${viewport.name} featured model order`).toEqual([
 			"Sol",
 			"Kimi K3",
-			"Future model",
-			"Luna",
-			"Terra",
 		]);
 		expect(
-			metrics.managedModelChoices?.scrollWidth,
-			`${viewport.name} managed model choices should not overflow`,
-		).toBeLessThanOrEqual(metrics.managedModelChoices?.clientWidth ?? 0);
+			metrics.managedModelControls?.scrollWidth,
+			`${viewport.name} managed model controls should not overflow`,
+		).toBeLessThanOrEqual(metrics.managedModelControls?.clientWidth ?? 0);
 		expect(
-			metrics.managedModelChoices?.rect?.right,
-			`${viewport.name} managed model choices right edge`,
+			metrics.managedModelControls?.rect?.right,
+			`${viewport.name} managed model controls right edge`,
 		).toBeLessThanOrEqual(viewport.width);
-		if (viewport.width >= 700) {
-			const modelLabelCenter = metrics.modelLabel
-				? (metrics.modelLabel.top + metrics.modelLabel.bottom) / 2
-				: 0;
-			const firstModelChoiceCenter = metrics.firstModelChoice
-				? (metrics.firstModelChoice.top + metrics.firstModelChoice.bottom) / 2
-				: Number.POSITIVE_INFINITY;
-			expect(firstModelChoiceCenter, `${viewport.name} inline Main model choices`).toBeCloseTo(
-				modelLabelCenter,
-				0,
-			);
-		} else {
-			expect(
-				metrics.firstModelChoice?.top,
-				`${viewport.name} wrapped Main model choices`,
-			).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
-		}
+		expect(metrics.managedModelOverflow, `${viewport.name} overflow model select`).not.toBeNull();
+		expect(
+			metrics.managedModelOverflow?.width,
+			`${viewport.name} overflow model select stays content-sized`,
+		).toBeLessThan(metrics.modelPickerFrameRect?.width ?? Number.POSITIVE_INFINITY);
+		expect(
+			metrics.firstModelChoice?.top,
+			`${viewport.name} Main model choices follow the section title`,
+		).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
 
 		expect(metrics.action, `${viewport.name} sticky action`).not.toBeNull();
 		expect(metrics.action?.top, `${viewport.name} sticky action top`).toBeGreaterThanOrEqual(0);
@@ -2945,7 +2945,7 @@ test("rejected detail delete stays on the current agent without accepted cleanup
 	await expect(page.getByText("internal delete coordinator", { exact: false })).toHaveCount(0);
 });
 
-test("deploy managed model picker renders backend order and submits the selected model", async ({
+test("deploy managed model picker preserves featured and overflow order and submits overflow", async ({
 	page,
 }) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
@@ -2959,31 +2959,49 @@ test("deploy managed model picker renders backend order and submits the selected
 
 	const managedModels = page.getByTestId("managed-model-choices");
 	await expect(managedModels).toHaveAccessibleName("Main model");
-	await expect(managedModels.getByRole("button")).toHaveText([
-		"Sol",
-		"Kimi K3",
-		"Future model",
-		"Luna",
-		"Terra",
-	]);
-	await expect(managedModels.getByRole("button", { name: "Luna" })).toHaveAttribute(
-		"aria-pressed",
-		"true",
-	);
-	await expect(managedModels.getByRole("button", { name: "Kimi K3" })).toBeVisible();
+	const featuredModels = managedModels.getByRole("radio");
+	await expect(featuredModels).toHaveCount(2);
+	await expect(featuredModels.nth(0)).toHaveAccessibleName("Sol");
+	await expect(featuredModels.nth(1)).toHaveAccessibleName("Kimi K3");
+	const overflowModels = page.getByTestId("managed-model-overflow");
+	await expect(overflowModels).toHaveAccessibleName("More managed models");
+	await expect(overflowModels).toContainText("Luna");
+	await expect(featuredModels.nth(0)).not.toBeChecked();
+	await expect(featuredModels.nth(1)).not.toBeChecked();
 	await expect(page.locator("#deploy-primary-model")).toHaveCount(0);
 
-	await managedModels.getByRole("button", { name: "Sol" }).click();
-	await expect(managedModels.getByRole("button", { name: "Sol" })).toHaveAttribute(
-		"aria-pressed",
-		"true",
-	);
+	for (const viewport of [
+		{ width: 1280, height: 900 },
+		{ width: 800, height: 900 },
+		{ width: 700, height: 900 },
+		{ width: 390, height: 844 },
+	]) {
+		await page.setViewportSize(viewport);
+		const documentWidth = await page.evaluate(() => ({
+			clientWidth: document.documentElement.clientWidth,
+			scrollWidth: document.documentElement.scrollWidth,
+		}));
+		expect(documentWidth.scrollWidth, `model picker at ${viewport.width}px`).toBe(
+			documentWidth.clientWidth,
+		);
+		await expect(managedModels).toBeVisible();
+		await expect(overflowModels).toBeVisible();
+	}
+
+	await featuredModels.nth(0).click();
+	await expect(featuredModels.nth(0)).toBeChecked();
+	await expect(overflowModels).toContainText("More models");
+	await overflowModels.click();
+	await expect(page.getByRole("option")).toHaveText(["Future model", "Luna", "Terra"]);
+	await page.getByRole("option", { name: "Terra" }).click();
+	await expect(overflowModels).toContainText("Terra");
+	await expect(featuredModels.nth(0)).not.toBeChecked();
 	await page.getByRole("button", { name: "Deploy", exact: true }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
 
 	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		primary_model: {
-			model: "gpt-5.6-sol",
+			model: "gpt-5.6-terra",
 		},
 	});
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2547,10 +2547,23 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			metrics.managedModelChoices?.rect?.right,
 			`${viewport.name} managed model choices right edge`,
 		).toBeLessThanOrEqual(viewport.width);
-		expect(
-			metrics.firstModelChoice?.top,
-			`${viewport.name} wrapped Main model choices`,
-		).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
+		if (viewport.width >= 700) {
+			const modelLabelCenter = metrics.modelLabel
+				? (metrics.modelLabel.top + metrics.modelLabel.bottom) / 2
+				: 0;
+			const firstModelChoiceCenter = metrics.firstModelChoice
+				? (metrics.firstModelChoice.top + metrics.firstModelChoice.bottom) / 2
+				: Number.POSITIVE_INFINITY;
+			expect(firstModelChoiceCenter, `${viewport.name} inline Main model choices`).toBeCloseTo(
+				modelLabelCenter,
+				0,
+			);
+		} else {
+			expect(
+				metrics.firstModelChoice?.top,
+				`${viewport.name} wrapped Main model choices`,
+			).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
+		}
 
 		expect(metrics.action, `${viewport.name} sticky action`).not.toBeNull();
 		expect(metrics.action?.top, `${viewport.name} sticky action top`).toBeGreaterThanOrEqual(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2547,23 +2547,10 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 			metrics.managedModelChoices?.rect?.right,
 			`${viewport.name} managed model choices right edge`,
 		).toBeLessThanOrEqual(viewport.width);
-		if (viewport.width >= 700) {
-			const modelLabelCenter = metrics.modelLabel
-				? (metrics.modelLabel.top + metrics.modelLabel.bottom) / 2
-				: 0;
-			const firstModelChoiceCenter = metrics.firstModelChoice
-				? (metrics.firstModelChoice.top + metrics.firstModelChoice.bottom) / 2
-				: Number.POSITIVE_INFINITY;
-			expect(firstModelChoiceCenter, `${viewport.name} inline Main model choices`).toBeCloseTo(
-				modelLabelCenter,
-				0,
-			);
-		} else {
-			expect(
-				metrics.firstModelChoice?.top,
-				`${viewport.name} wrapped Main model choices`,
-			).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
-		}
+		expect(
+			metrics.firstModelChoice?.top,
+			`${viewport.name} wrapped Main model choices`,
+		).toBeGreaterThanOrEqual(metrics.modelLabel?.bottom ?? Number.POSITIVE_INFINITY);
 
 		expect(metrics.action, `${viewport.name} sticky action`).not.toBeNull();
 		expect(metrics.action?.top, `${viewport.name} sticky action top`).toBeGreaterThanOrEqual(0);

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
+import { cn } from "@/lib/utils";
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
+	return (
+		<RadioGroupPrimitive
+			data-slot="radio-group"
+			className={cn("grid gap-3", className)}
+			{...props}
+		/>
+	);
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
+	return (
+		<RadioPrimitive.Root
+			data-slot="radio-group-item"
+			className={cn(
+				"peer relative flex size-4 shrink-0 items-center justify-center rounded-full border border-input shadow-xs transition-shadow outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-disabled:cursor-not-allowed data-disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		>
+			<RadioPrimitive.Indicator
+				data-slot="radio-group-indicator"
+				className="size-2 rounded-full bg-primary data-unchecked:hidden"
+			/>
+		</RadioPrimitive.Root>
+	);
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -138,12 +138,12 @@ describe("managed model catalog", () => {
 		const client = testClient(async (request) => {
 			requests.push(request.clone());
 			return jsonResponse({
-				models: [{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true }],
+				models: [{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: true }],
 			});
 		});
 
 		await expect(client.getManagedModelCatalog()).resolves.toEqual({
-			models: [{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true }],
+			models: [{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: true }],
 		});
 		expect(new URL(requests[0]?.url ?? "https://invalid").pathname).toBe(
 			"/v2/ai-providers/managed/models",

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -391,7 +391,7 @@ export function createBillingClient(
 			unwrapDeploy(
 				await api.POST("/v2/wallet/topup", {
 					body,
-					headers: { "Idempotency-Key": idempotencyKey },
+					params: { header: { "Idempotency-Key": idempotencyKey } },
 				}),
 			),
 		setAutoReload: async (body: WalletAutoReloadRequest) =>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -267,8 +267,14 @@ describe("managed model picker", () => {
 		expect(modelBindingPickerSource).toContain("catalogModelItems.map((item) =>");
 		expect(modelBindingPickerSource).toContain("aria-labelledby=");
 		expect(modelBindingPickerSource).toContain("<Label id=");
-		expect(modelBindingPickerSource).toContain(">Model</Label>");
-		expect(modelBindingPickerSource).toContain("<Label htmlFor={catalogInputId}>Model</Label>");
+		expect(modelBindingPickerSource).toContain(">Main model</Label>");
+		expect(modelBindingPickerSource).toContain(
+			"<Label htmlFor={catalogInputId}>Main model</Label>",
+		);
+		expect(modelBindingPickerSource).toContain(
+			'{hasCatalogModels ? "Custom model" : "Main model"}',
+		);
+		expect(modelBindingPickerSource).not.toContain("Primary model");
 		expect(modelBindingPickerSource).not.toContain("Catalog model");
 		expect(modelBindingPickerSource).not.toContain("More models");
 		expect(modelBindingPickerSource).toContain(
@@ -281,9 +287,9 @@ describe("managed model picker", () => {
 	test("does not blame the user while the Clawdi AI catalog is loading or unavailable", () => {
 		expect(wizardSource).toContain('return "Loading Clawdi AI models."');
 		expect(wizardSource).toContain('return "Retry loading Clawdi AI models above."');
-		expect(wizardSource).toContain('return "Choose an available primary model."');
+		expect(wizardSource).toContain('return "Choose an available main model."');
 		expect(wizardSource.indexOf('return "Loading Clawdi AI models."')).toBeLessThan(
-			wizardSource.indexOf('return "Choose an available primary model."'),
+			wizardSource.indexOf('return "Choose an available main model."'),
 		);
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -264,7 +264,11 @@ describe("managed model picker", () => {
 		);
 		expect(wizardSource).toContain("compactManagedModelChoices");
 		expect(agentDetailSource).not.toContain("compactManagedModelChoices");
-		expect(modelBindingPickerSource).toContain("catalogModelItems.map((item) =>");
+		expect(modelBindingPickerSource).toContain("compactManagedItems.featured.map((item) =>");
+		expect(modelBindingPickerSource).toContain("compactManagedItems.overflow.map((item) =>");
+		expect(modelBindingPickerSource).toContain("<RadioGroup");
+		expect(modelBindingPickerSource).toContain('data-testid="managed-model-overflow"');
+		expect(modelBindingPickerSource).toContain('placeholder="More models"');
 		expect(modelBindingPickerSource).toContain("aria-labelledby=");
 		expect(modelBindingPickerSource).toContain("<Label id=");
 		expect(modelBindingPickerSource).toContain(">Main model</Label>");
@@ -276,7 +280,6 @@ describe("managed model picker", () => {
 		);
 		expect(modelBindingPickerSource).not.toContain("Primary model");
 		expect(modelBindingPickerSource).not.toContain("Catalog model");
-		expect(modelBindingPickerSource).not.toContain("More models");
 		expect(modelBindingPickerSource).toContain(
 			'"flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3"',
 		);

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -548,7 +548,7 @@ export function DeployWizard() {
 		if (!managedPrimaryModelReady) {
 			if (managedModelsNeedRetry) return "Retry loading Clawdi AI models above.";
 			if (managedModelsLoading) return "Loading Clawdi AI models.";
-			return "Choose an available primary model.";
+			return "Choose an available main model.";
 		}
 		if (paidSelection && paymentMethod === "wallet") {
 			if (!wallet.isSuccess || !wallet.data) {

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -77,6 +77,27 @@ describe("AI provider binding fields", () => {
 		});
 	});
 
+	test("names a missing configured selection as the main model", () => {
+		let thrown: unknown;
+		try {
+			buildAiBindingFields(
+				{
+					bindingMode: "configured",
+					providerChoices: [MANAGED_AI_CHOICE],
+					primaryProviderChoice: MANAGED_AI_CHOICE,
+					primaryModel: "",
+				},
+				{ managedModels, mode: "create", providers: [] },
+			);
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(AiBindingBuildError);
+		if (!(thrown instanceof AiBindingBuildError)) throw thrown;
+		expect(thrown.title).toBe("Main model required");
+	});
+
 	test("create omits an empty bootstrap while update clears it", () => {
 		const draft = {
 			bindingMode: "configured" as const,

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -14,7 +14,9 @@ import {
 	toggleAiBindingProvider,
 } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 
-const managedModels = [{ id: "gpt-managed", display_name: "Managed", is_default: true }];
+const managedModels = [
+	{ id: "gpt-managed", display_name: "Managed", is_default: true, is_featured: true },
+];
 
 const apiKeyProvider: AiProvider = {
 	id: "row-api-key",

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -141,7 +141,7 @@ export function buildAiBindingFields(
 					: error.code === "managed_model_unavailable"
 						? "Clawdi AI model unavailable"
 						: error.code === "model_required"
-							? "Primary model required"
+							? "Main model required"
 							: mode === "create"
 								? "Provider unavailable"
 								: "Provider configuration is invalid";

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -124,7 +124,7 @@ export function ModelBindingPicker({
 						title="Couldn't load Clawdi AI models"
 					/>
 				) : isManaged && compactManagedModelChoices && hasCatalogModels ? (
-					<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
+					<div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
 						<Label id={`${catalogInputId}-label`}>Main model</Label>
 						<ToggleGroup
 							id={catalogInputId}
@@ -137,17 +137,12 @@ export function ModelBindingPicker({
 							}}
 							variant="outline"
 							size="sm"
-							spacing={1}
 							className="flex min-w-0 max-w-full flex-wrap justify-start"
 							aria-labelledby={`${catalogInputId}-label`}
 							data-testid="managed-model-choices"
 						>
 							{catalogModelItems.map((item) => (
-								<ToggleGroupItem
-									key={item.value}
-									value={item.value}
-									className="min-w-0 max-w-full px-2"
-								>
+								<ToggleGroupItem key={item.value} value={item.value} className="min-w-0 max-w-full">
 									<span className="truncate">{item.label}</span>
 								</ToggleGroupItem>
 							))}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -4,6 +4,7 @@ import type { ApiErrorNormalizer } from "@/components/api-error-panel";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
 	Select,
 	SelectContent,
@@ -13,12 +14,12 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import {
 	CUSTOM_MODEL_CHOICE,
 	MANAGED_AI_CHOICE,
 	type ModelBindingPickerItem,
+	managedModelPickerItems,
 	modelPickerItems,
 	primaryProviderPickerItems,
 } from "@/hosted/v2/ai-providers/model-binding";
@@ -67,6 +68,7 @@ export function ModelBindingPicker({
 	const customInputId = `${idPrefix}-primary-model`;
 	const isManaged = primaryProviderChoice === MANAGED_AI_CHOICE;
 	const catalogModelItems = modelPickerItems(primaryProviderChoice, providers, managedModels);
+	const compactManagedItems = managedModelPickerItems(managedModels);
 	const hasCatalogModels = catalogModelItems.some((item) => item.value !== CUSTOM_MODEL_CHOICE);
 	const modelChoice = catalogModelItems.some((item) => item.value === primaryModel)
 		? primaryModel
@@ -124,34 +126,67 @@ export function ModelBindingPicker({
 						title="Couldn't load Clawdi AI models"
 					/>
 				) : isManaged && compactManagedModelChoices && hasCatalogModels ? (
-					<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
+					<div className="flex min-w-0 flex-col gap-1.5">
 						<Label id={`${catalogInputId}-label`}>Main model</Label>
-						<ToggleGroup
-							id={catalogInputId}
-							value={
-								catalogModelItems.some((item) => item.value === modelChoice) ? [modelChoice] : []
-							}
-							onValueChange={(values) => {
-								const value = values[0];
-								if (value) onPrimaryModelChange(value);
-							}}
-							variant="outline"
-							size="sm"
-							spacing={1}
-							className="flex min-w-0 max-w-full flex-wrap justify-start"
-							aria-labelledby={`${catalogInputId}-label`}
-							data-testid="managed-model-choices"
+						<div
+							className="flex min-w-0 max-w-full flex-wrap items-center gap-1.5"
+							data-testid="managed-model-controls"
 						>
-							{catalogModelItems.map((item) => (
-								<ToggleGroupItem
-									key={item.value}
-									value={item.value}
-									className="min-w-0 max-w-full px-2"
+							{compactManagedItems.featured.length > 0 ? (
+								<RadioGroup
+									id={catalogInputId}
+									value={modelChoice}
+									onValueChange={(value) => {
+										if (typeof value === "string") onPrimaryModelChange(value);
+									}}
+									className="flex min-w-0 max-w-full flex-wrap gap-1.5"
+									aria-labelledby={`${catalogInputId}-label`}
+									data-testid="managed-model-choices"
 								>
-									<span className="truncate">{item.label}</span>
-								</ToggleGroupItem>
-							))}
-						</ToggleGroup>
+									{compactManagedItems.featured.map((item) => (
+										<Label
+											key={item.value}
+											className="h-8 min-w-0 max-w-full cursor-pointer gap-1.5 rounded-md border border-input bg-transparent px-2 shadow-xs transition-[color,box-shadow] hover:bg-muted has-data-checked:bg-muted"
+										>
+											<RadioGroupItem value={item.value} />
+											<span className="truncate">{item.label}</span>
+										</Label>
+									))}
+								</RadioGroup>
+							) : null}
+							{compactManagedItems.overflow.length > 0 ? (
+								<Select
+									items={compactManagedItems.overflow}
+									value={
+										compactManagedItems.overflow.some((item) => item.value === modelChoice)
+											? modelChoice
+											: null
+									}
+									onValueChange={(value) => {
+										if (value) onPrimaryModelChange(value);
+									}}
+								>
+									<SelectTrigger
+										id={compactManagedItems.featured.length === 0 ? catalogInputId : undefined}
+										size="sm"
+										className="max-w-full"
+										aria-label="More managed models"
+										data-testid="managed-model-overflow"
+									>
+										<SelectValue className="min-w-0" placeholder="More models" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectGroup>
+											{compactManagedItems.overflow.map((item) => (
+												<SelectItem key={item.value} value={item.value}>
+													{item.label}
+												</SelectItem>
+											))}
+										</SelectGroup>
+									</SelectContent>
+								</Select>
+							) : null}
+						</div>
 					</div>
 				) : hasCatalogModels ? (
 					<div className="flex flex-col gap-1.5">

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -124,7 +124,7 @@ export function ModelBindingPicker({
 						title="Couldn't load Clawdi AI models"
 					/>
 				) : isManaged && compactManagedModelChoices && hasCatalogModels ? (
-					<div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
+					<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
 						<Label id={`${catalogInputId}-label`}>Main model</Label>
 						<ToggleGroup
 							id={catalogInputId}
@@ -137,12 +137,17 @@ export function ModelBindingPicker({
 							}}
 							variant="outline"
 							size="sm"
+							spacing={1}
 							className="flex min-w-0 max-w-full flex-wrap justify-start"
 							aria-labelledby={`${catalogInputId}-label`}
 							data-testid="managed-model-choices"
 						>
 							{catalogModelItems.map((item) => (
-								<ToggleGroupItem key={item.value} value={item.value} className="min-w-0 max-w-full">
+								<ToggleGroupItem
+									key={item.value}
+									value={item.value}
+									className="min-w-0 max-w-full px-2"
+								>
 									<span className="truncate">{item.label}</span>
 								</ToggleGroupItem>
 							))}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -124,8 +124,8 @@ export function ModelBindingPicker({
 						title="Couldn't load Clawdi AI models"
 					/>
 				) : isManaged && compactManagedModelChoices && hasCatalogModels ? (
-					<div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
-						<Label id={`${catalogInputId}-label`}>Model</Label>
+					<div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
+						<Label id={`${catalogInputId}-label`}>Main model</Label>
 						<ToggleGroup
 							id={catalogInputId}
 							value={
@@ -137,12 +137,17 @@ export function ModelBindingPicker({
 							}}
 							variant="outline"
 							size="sm"
+							spacing={1}
 							className="flex min-w-0 max-w-full flex-wrap justify-start"
 							aria-labelledby={`${catalogInputId}-label`}
 							data-testid="managed-model-choices"
 						>
 							{catalogModelItems.map((item) => (
-								<ToggleGroupItem key={item.value} value={item.value} className="min-w-0 max-w-full">
+								<ToggleGroupItem
+									key={item.value}
+									value={item.value}
+									className="min-w-0 max-w-full px-2"
+								>
 									<span className="truncate">{item.label}</span>
 								</ToggleGroupItem>
 							))}
@@ -150,7 +155,7 @@ export function ModelBindingPicker({
 					</div>
 				) : hasCatalogModels ? (
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor={catalogInputId}>Model</Label>
+						<Label htmlFor={catalogInputId}>Main model</Label>
 						<Select
 							items={catalogModelItems}
 							value={modelChoice}
@@ -177,9 +182,7 @@ export function ModelBindingPicker({
 			</div>
 			{!isManaged && modelChoice === CUSTOM_MODEL_CHOICE ? (
 				<div className="flex flex-col gap-1.5">
-					<Label htmlFor={customInputId}>
-						{hasCatalogModels ? "Custom model" : "Primary model"}
-					</Label>
+					<Label htmlFor={customInputId}>{hasCatalogModels ? "Custom model" : "Main model"}</Label>
 					<Input
 						id={customInputId}
 						value={primaryModel}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -4,6 +4,7 @@ import {
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_LABEL,
+	managedModelPickerItems,
 	modelBindingDisplayName,
 	modelDisplayName,
 	modelOptionsForProvider,
@@ -28,9 +29,9 @@ describe("model binding", () => {
 
 	test("preserves backend catalog order while selecting its declared default", () => {
 		const managedModels = [
-			{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
-			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
-			{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
+			{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false, is_featured: true },
+			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: true },
+			{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false, is_featured: false },
 		];
 
 		expect(
@@ -46,9 +47,33 @@ describe("model binding", () => {
 		expect(modelDisplayName("gpt-5.6-sol", managedModels)).toBe("Sol");
 	});
 
+	test("splits featured and overflow models without changing backend order", () => {
+		const managedModels = [
+			{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false, is_featured: true },
+			{ id: "k3", display_name: "Kimi K3", is_default: false, is_featured: true },
+			{ id: "future-model", display_name: "Future model", is_default: false, is_featured: false },
+			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true, is_featured: false },
+			{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false, is_featured: false },
+		];
+
+		expect(managedModelPickerItems(managedModels)).toEqual({
+			featured: [
+				{ value: "gpt-5.6-sol", label: "Sol" },
+				{ value: "k3", label: "Kimi K3" },
+			],
+			overflow: [
+				{ value: "future-model", label: "Future model" },
+				{ value: "gpt-5.6-luna", label: "Luna" },
+				{ value: "gpt-5.6-terra", label: "Terra" },
+			],
+		});
+	});
+
 	test("uses catalog metadata before the shared formatter and raw id fallback", () => {
 		expect(
-			modelDisplayName("model", [{ id: "model", display_name: "Display", is_default: false }]),
+			modelDisplayName("model", [
+				{ id: "model", display_name: "Display", is_default: false, is_featured: false },
+			]),
 		).toBe("Display");
 		expect(modelDisplayName("model", [{ id: "model", label: "Label", alias: "Alias" }])).toBe(
 			"Label",

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -21,6 +21,11 @@ export type ModelBindingPickerItem = {
 	label: string;
 };
 
+export type ManagedModelPickerItems = {
+	featured: ModelBindingPickerItem[];
+	overflow: ModelBindingPickerItem[];
+};
+
 export type PrimaryModelRef = {
 	provider_id: string;
 	model: string;
@@ -200,6 +205,24 @@ export function modelPickerItems(
 			? []
 			: [{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" }]),
 	];
+}
+
+export function managedModelPickerItems(
+	managedModels: readonly ManagedModelCatalogItem[],
+): ManagedModelPickerItems {
+	const sections: ManagedModelPickerItems = { featured: [], overflow: [] };
+	const seen = new Set<string>();
+	for (const model of managedModels) {
+		const modelId = model.id.trim();
+		if (!modelId || seen.has(modelId)) continue;
+		seen.add(modelId);
+		const item = {
+			value: modelId,
+			label: modelDisplayName(modelId, [model]),
+		};
+		sections[model.is_featured ? "featured" : "overflow"].push(item);
+	}
+	return sections;
 }
 
 export function firstModelForProvider(

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -141,7 +141,7 @@ describe("hosted deploy request contract", () => {
 				timezone: "Etc/UTC",
 				ai: { mode: "managed", model: "gpt-test" },
 			},
-			[{ id: "gpt-test", display_name: "GPT Test", is_default: true }],
+			[{ id: "gpt-test", display_name: "GPT Test", is_default: true, is_featured: true }],
 		);
 
 		expect(result).toEqual({
@@ -176,7 +176,7 @@ describe("hosted deploy request contract", () => {
 				timezone: "Etc/UTC",
 				ai: { mode: "managed", model: "missing" },
 			},
-			[{ id: "available", display_name: "Available", is_default: true }],
+			[{ id: "available", display_name: "Available", is_default: true, is_featured: true }],
 		);
 
 		expect(result.ok).toBe(false);

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -3228,8 +3228,8 @@ export interface operations {
     create_wallet_topup_v2_wallet_topup_post: {
         parameters: {
             query?: never;
-            header?: {
-                "Idempotency-Key"?: string | null;
+            header: {
+                "Idempotency-Key": string;
             };
             path?: never;
             cookie?: never;

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1797,6 +1797,8 @@ export interface components {
             display_name: string;
             /** Is Default */
             is_default: boolean;
+            /** Is Featured */
+            is_featured: boolean;
         };
         /** V2ManagedModelCatalogResponse */
         V2ManagedModelCatalogResponse: {

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -14,7 +14,9 @@ import {
 	toHostedRuntimeAiProvider,
 } from "./hosted-ai-binding";
 
-const managedModels = [{ id: "gpt-managed", display_name: "Managed", is_default: true }];
+const managedModels = [
+	{ id: "gpt-managed", display_name: "Managed", is_default: true, is_featured: true },
+];
 
 const apiKeyProvider = {
 	id: "row-api",


### PR DESCRIPTION
## Summary

- label the shared Deploy and Agent Settings selection as “Main model” across managed, catalog, and custom-input states
- align related validation copy and accessibility names while keeping `primary_model` protocol fields unchanged
- preserve the compact managed picker at desktop/tablet widths and natural wrapping on mobile

## Verification

- `bun run --cwd apps/web test:internal src/hosted/billing/deploy/deploy-wizard.test.ts src/hosted/v2/ai-providers/ai-provider-binding.test.ts`
- focused hosted Playwright suite: 6 passed, covering provider behavior, model submission, Agent Settings, pricing, Wallet, and 1280/800/700/390 responsive overflow checks
- `bun run --cwd apps/web test` (Docker clean Web typecheck, full tests, OSS build)
- `bunx biome check` on all changed files
- `git diff --check origin/main..HEAD`