### PR TITLE
refactor(client): enforce managed model catalog contract

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -133,6 +133,12 @@ describe("unwrapDeploy", () => {
 });
 
 describe("managed model catalog", () => {
+	it("preserves an empty hosted catalog instead of inventing a client fallback", async () => {
+		const client = testClient(async () => jsonResponse({ models: [] }));
+
+		await expect(client.getManagedModelCatalog()).resolves.toEqual({ models: [] });
+	});
+
 	it("fetches the authenticated v2 managed-model endpoint", async () => {
 		const requests: Request[] = [];
 		const client = testClient(async (request) => {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -4,6 +4,7 @@ import {
 	type DeployPaths,
 	extractApiDetail,
 	projectHostedDeployRequest,
+	projectManagedModelCatalog,
 	unwrapDeploymentEventStreamSnapshotHandoff,
 	unwrapDeploymentList,
 } from "@clawdi/shared/api";
@@ -379,7 +380,7 @@ export function createBillingClient(
 
 	return {
 		getManagedModelCatalog: async () =>
-			unwrapDeploy(await api.GET("/v2/ai-providers/managed/models")),
+			projectManagedModelCatalog(unwrapDeploy(await api.GET("/v2/ai-providers/managed/models"))),
 		getWallet: async () => unwrapDeploy(await api.GET("/v2/wallet")),
 		getLedger: async (limit = 50) =>
 			unwrapDeploy(

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -43,7 +43,6 @@ export type HostedEventStreamSnapshotHandoff = Schemas["EventStreamSnapshotHando
 export type HostedFundingFact = Schemas["V2HostedCommercialFundingFactInfo"];
 export type HostedUsageSummary = Schemas["V2HostedUsageSummaryResponse"];
 export type HostedRuntimeConfiguration = Schemas["RuntimeConfiguration"];
-export type ManagedModelCatalogItem = Schemas["V2ManagedModelCatalogItem"];
 export type HostedUser = Schemas["V1UserResponse"];
 export type HostedConfigRequest = Schemas["V2HostedConfigRequest"];
 export type Plan = Schemas["V2PlanResponse"];

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ManagedModelCatalogItem } from "@clawdi/shared/api";
 import { Activity, AlertCircle, RefreshCw } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
@@ -10,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
-import type { HostedUsageSummary, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import type { HostedUsageSummary } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useManagedModelCatalog, useUsage } from "@/hosted/billing/hooks";

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -2,8 +2,9 @@ import {
 	buildHostedAiBindingFields,
 	HostedAiBindingError,
 	type HostedAiProviderBootstrap,
+	type ManagedModelCatalogItem,
 } from "@clawdi/shared";
-import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import type { AiProviderAuthKind } from "@/hosted/billing/contracts";
 import {
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_LABEL,

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ManagedModelCatalogItem } from "@clawdi/shared/api";
 import type { ApiErrorNormalizer } from "@/components/api-error-panel";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Input } from "@/components/ui/input";
@@ -14,7 +15,6 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import {
 	CUSTOM_MODEL_CHOICE,
 	MANAGED_AI_CHOICE,

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -3,7 +3,8 @@ import {
 	isClawdiManagedProviderId,
 	isFirstPartyManagedAiProvider,
 } from "@clawdi/shared";
-import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import type { ManagedModelCatalogItem } from "@clawdi/shared/api";
+import type { AiProviderAuthKind } from "@/hosted/billing/contracts";
 import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatModelLabel } from "@/lib/format";

--- a/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
@@ -1,5 +1,5 @@
+import type { ManagedModelCatalogItem } from "@clawdi/shared/api";
 import { useEffect, useRef, useState } from "react";
-import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import type {
 	AiBindingMode,
 	AiBindingOperationMode,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -14,7 +14,6 @@ import {
 	type HostedDeployCheckoutResult,
 	type HostedDeployComputePlanSlug,
 	type HostedDeployDeployment,
-	type HostedDeployManagedModel,
 	type HostedDeployOperation,
 	type HostedDeployPlan,
 	type HostedDeployRequest,
@@ -28,6 +27,7 @@ import {
 	isHostedDeployComputePlan,
 	isHostedDeployRuntime,
 	isValidHostedDeployTimezone,
+	type ManagedModelCatalogItem,
 	projectHostedDeployRequest,
 	resolveHostedDeployIncludedBasicSelection,
 	selectHostedDeployOfferForTerm,
@@ -213,7 +213,7 @@ export interface HostedDeployGateway {
 	supportsPaidCheckout(): boolean;
 	getPlans(): Promise<HostedDeployPlan[]>;
 	listDeployments(): Promise<HostedDeployDeployment[]>;
-	getManagedModels(): Promise<HostedDeployManagedModel[]>;
+	getManagedModels(): Promise<ManagedModelCatalogItem[]>;
 	getSavedAiProviders(): Promise<HostedSavedAiProvider[]>;
 	quoteSubscription(
 		body: HostedDeploySubscriptionQuoteRequest,
@@ -358,7 +358,7 @@ function defaultTimezone(): string {
 	}
 }
 
-function defaultManagedModel(models: readonly HostedDeployManagedModel[]): string {
+function defaultManagedModel(models: readonly ManagedModelCatalogItem[]): string {
 	return models.find((model) => model.is_default)?.id ?? models[0]?.id ?? "";
 }
 

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -6,7 +6,6 @@ import {
 	type HostedDeployCheckoutRequest,
 	type HostedDeployCheckoutResult,
 	type HostedDeployDeployment,
-	type HostedDeployManagedModel,
 	type HostedDeployOperation,
 	type HostedDeployPlan,
 	type HostedDeployRequest,
@@ -15,7 +14,9 @@ import {
 	type HostedDeploySubscriptionQuoteRequest,
 	type HostedDeployWallet,
 	type HostedSavedAiProvider,
+	type ManagedModelCatalogItem,
 	type paths,
+	projectManagedModelCatalog,
 	unwrapDeploymentList,
 } from "@clawdi/shared/api";
 import createClient, { type Client, type Middleware } from "openapi-fetch";
@@ -157,8 +158,10 @@ export class HostedDeployClient {
 		return unwrapDeploymentList(unwrapHosted(await this.client.GET("/v2/deployments")));
 	}
 
-	async getManagedModels(): Promise<HostedDeployManagedModel[]> {
-		return unwrapHosted(await this.client.GET("/v2/ai-providers/managed/models")).models;
+	async getManagedModels(): Promise<ManagedModelCatalogItem[]> {
+		return projectManagedModelCatalog(
+			unwrapHosted(await this.client.GET("/v2/ai-providers/managed/models")),
+		).models;
 	}
 
 	async getSavedAiProviders(): Promise<HostedSavedAiProvider[]> {

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -1,4 +1,5 @@
 import { CLAWDI_MANAGED_PROVIDER_ID } from "../ai-provider";
+import type { ManagedModelCatalogItem } from "./deploy";
 import type { components as DeployComponents } from "./deploy.generated";
 
 type Schemas = DeployComponents["schemas"];
@@ -17,7 +18,6 @@ export type HostedDeployLanguage = NonNullable<HostedDeployRequest["language"]>;
 export type HostedDeployPlan = Schemas["V2PlanResponse"];
 export type HostedDeployBillingOffer = Schemas["V2BillingOfferResponse"];
 export type HostedDeployDeployment = Schemas["V2HostedDeploymentReadResponse"];
-export type HostedDeployManagedModel = Schemas["V2ManagedModelCatalogItem"];
 export type HostedDeploySubscriptionQuote = Schemas["V2ComputeSubscriptionQuoteResponse-Output"];
 export type HostedDeploySubscriptionQuoteRequest = Schemas["V2ComputeSubscriptionQuoteRequest"];
 export type HostedDeployCheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
@@ -200,7 +200,7 @@ export function validateHostedDeployPersona(
 /** Validate the CLI/Web wizard boundary and build the generated request type. */
 export function validateAndBuildHostedDeployRequest(
 	draft: HostedDeployWizardDraft,
-	managedModels: readonly HostedDeployManagedModel[] = [],
+	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): HostedDeployValidationResult {
 	const assistantName = draft.assistantName.trim();
 	const issues = validateHostedDeployPersona({

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -8,6 +8,7 @@ import {
 	isDeploymentEventStreamSnapshotHandoff,
 	isRuntimeUiCredentials,
 	isRuntimeUiEndpointInfo,
+	projectManagedModelCatalog,
 	unwrapDeploymentEventStreamSnapshotHandoff,
 	unwrapDeploymentList,
 } from "./deploy";
@@ -69,6 +70,53 @@ describe("deployment list response split", () => {
 				read_only: false,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("managed model catalog contract", () => {
+	test("projects only the public fields without inventing catalog entries", () => {
+		expect(projectManagedModelCatalog({ models: [], internal_version: "private" })).toEqual({
+			models: [],
+		});
+		expect(
+			projectManagedModelCatalog({
+				models: [
+					{
+						id: "model-from-hosted",
+						display_name: "Hosted model",
+						is_default: true,
+						is_featured: false,
+						internal_route: "private-provider/model-from-hosted",
+					},
+				],
+			}),
+		).toEqual({
+			models: [
+				{
+					id: "model-from-hosted",
+					display_name: "Hosted model",
+					is_default: true,
+					is_featured: false,
+				},
+			],
+		});
+	});
+
+	test("rejects responses that do not satisfy the generated public contract", () => {
+		expect(() => projectManagedModelCatalog({ models: null })).toThrow(
+			"The managed model catalog response is invalid.",
+		);
+		expect(() =>
+			projectManagedModelCatalog({
+				models: [
+					{
+						id: "model-from-hosted",
+						display_name: "Hosted model",
+						is_default: true,
+					},
+				],
+			}),
+		).toThrow("The managed model catalog response is invalid.");
 	});
 });
 

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -27,6 +27,8 @@ export type DeploymentRead = S["V2HostedDeploymentReadResponse"];
 export type Deployment = DeploymentRead;
 export type DeployRequestRead = S["V2HostedDeployRequestReadResponse"];
 export type DeploymentEventStreamSnapshotHandoff = S["EventStreamSnapshotHandoff"];
+export type ManagedModelCatalog = S["V2ManagedModelCatalogResponse"];
+export type ManagedModelCatalogItem = S["V2ManagedModelCatalogItem"];
 export type RuntimeUiCredentials =
 	| S["V2HermesRuntimeUiCredentials"]
 	| S["V2OpenClawRuntimeUiCredentials"];
@@ -37,6 +39,32 @@ export type RuntimeUiAuthMode = RuntimeUiEndpointInfo["auth_mode"];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function projectManagedModelCatalog(value: unknown): ManagedModelCatalog {
+	if (!isRecord(value) || !Array.isArray(value.models)) {
+		throw new Error("The managed model catalog response is invalid.");
+	}
+
+	return {
+		models: value.models.map((model) => {
+			if (
+				!isRecord(model) ||
+				typeof model.id !== "string" ||
+				typeof model.display_name !== "string" ||
+				typeof model.is_default !== "boolean" ||
+				typeof model.is_featured !== "boolean"
+			) {
+				throw new Error("The managed model catalog response is invalid.");
+			}
+			return {
+				id: model.id,
+				display_name: model.display_name,
+				is_default: model.is_default,
+				is_featured: model.is_featured,
+			};
+		}),
+	};
 }
 
 export function isRuntimeUiEndpointInfo(value: unknown): value is RuntimeUiEndpointInfo {

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -9,7 +9,8 @@ import {
 	validateAiProviderCatalog,
 } from "../ai-provider";
 import type { components } from "./api.generated";
-import type { HostedDeployAiFields, HostedDeployManagedModel } from "./deploy-wizard";
+import type { ManagedModelCatalogItem } from "./deploy";
+import type { HostedDeployAiFields } from "./deploy-wizard";
 
 type Schemas = components["schemas"];
 
@@ -131,7 +132,7 @@ export function buildHostedAiBindingFields({
 	providers,
 	selection,
 }: {
-	managedModels: readonly HostedDeployManagedModel[];
+	managedModels: readonly ManagedModelCatalogItem[];
 	mode: HostedAiBindingOperationMode;
 	providers: readonly HostedSavedAiProvider[];
 	selection: HostedAiBindingSelection;

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -6,6 +6,8 @@ export type {
 	DeploymentRead,
 	DeployPaths,
 	DeployRequestRead,
+	ManagedModelCatalog,
+	ManagedModelCatalogItem,
 	RuntimeUiAuthMode,
 	RuntimeUiCredentials,
 	RuntimeUiEndpointInfo,
@@ -14,6 +16,7 @@ export {
 	isDeploymentEventStreamSnapshotHandoff,
 	isRuntimeUiCredentials,
 	isRuntimeUiEndpointInfo,
+	projectManagedModelCatalog,
 	unwrapDeploymentEventStreamSnapshotHandoff,
 	unwrapDeploymentList,
 } from "./deploy";


### PR DESCRIPTION
## Summary

- expose the managed-model catalog response and item directly from the generated deploy API contract, then remove the duplicate Web billing alias and the deploy-wizard-specific compatibility name
- validate and project Hosted catalog responses to the public `id`, `display_name`, `is_default`, and `is_featured` fields before Web or CLI consumers use them
- preserve fail-closed behavior: an empty Hosted catalog stays empty and invalid responses fail instead of falling back to hardcoded client model business configuration
- keep the existing model UI unchanged: Main model remains on its own line, featured choices remain outside the compact non-featured select, and Wallet/Checkout paths are untouched

## Verification

- `bun run --cwd apps/web test` (Docker-isolated clean Web runner)
- `bun run --cwd packages/shared test` (Docker-isolated; 73 passed)
- `bun run --cwd packages/cli test` (Docker-isolated)
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src packages/shared/src/api packages/cli/src/commands/deploy.ts packages/cli/src/lib/hosted-deploy-client.ts`
- `bun run --cwd apps/web test:internal src/hosted/oss-clean.test.ts` (15 passed)
- `bun run --cwd apps/web build:oss`
- focused contract/UI/CLI suites: shared deploy contract 7 passed, Web managed-model/deploy suites 55 passed, CLI deploy 34 passed
- `git diff --check origin/main..HEAD`

Schema generation was not needed: this PR does not change the wire schema, and the checked-in generated contract already contains exactly the four public fields above. Browser verification was not repeated because there are no JSX, style, or rendered-behavior changes.

## Rollout

Hosted remains the sole owner of model catalog business configuration; this PR adds no catalog or fallback to the OSS backend or clients. There is no wire-contract change in this PR. If a coordinated Hosted rollout changes or introduces the four-field response, deploy Hosted first because clients now fail closed when any required field is absent; otherwise this client refactor is independently deployable.