### PR TITLE
fix(cli): isolate runtime watch 304 test

### DIFF
--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8041,6 +8041,7 @@ exit 64
 			}),
 		);
 		const paths = getRuntimePaths();
+		seedMitmproxyCache(paths);
 		const initial = mockFetch([
 			{ method: "GET", path: "/v1/runtime/manifest", response: () => manifestResponse() },
 		]);


### PR DESCRIPTION
## Summary
- seed the existing local mitmproxy fixture before the v2 runtime-watch 304 convergence test
- prevent the test from synchronously downloading a real egress artifact and blocking Bun timeout handling
- no runtime, OAuth, Hosted, or v1 behavior changes

## Verification
- target test repeated 20x: 20 passed
- clean Docker focused test: 1 passed
- clean Docker full CLI suite: 1498 passed, 4 skipped
- CLI typecheck, Biome, and diff-check passed