### PR TITLE
fix(web): align provider setup UI patterns

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Search } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useMemo, useState } from "react";
 import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { SearchInput } from "@/components/ui/search-input";
 import {
 	PROVIDER_PRESET_CATEGORIES,
 	PROVIDER_PRESET_CATEGORY_LABEL,
@@ -115,20 +114,13 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 
 	return (
 		<div data-hosted="true" data-v2="true" className="flex flex-col gap-4">
-			<div className="flex flex-col gap-1.5">
-				<Label htmlFor="provider-search">Search providers</Label>
-				<div className="relative">
-					<Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-					<Input
-						id="provider-search"
-						value={query}
-						onChange={(event) => setQuery(event.target.value)}
-						placeholder="OpenAI, DeepSeek, Moonshot…"
-						className="pl-9"
-						autoComplete="off"
-					/>
-				</div>
-			</div>
+			<SearchInput
+				name="provider-search"
+				ariaLabel="Search providers"
+				value={query}
+				onChange={setQuery}
+				placeholder="OpenAI, DeepSeek, Moonshot…"
+			/>
 
 			{normalizedQuery ? (
 				<div className="flex flex-col gap-2">
@@ -138,13 +130,19 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 					{searchResults.length > 0 ? (
 						<ChoiceGrid entries={searchResults} onSelect={onSelect} />
 					) : (
-						<button
-							type="button"
+						<EntityChoiceCard
 							onClick={() => onSelect({ kind: "type", type: "custom_openai_compatible" })}
-							className="rounded-lg border border-dashed p-4 text-left text-sm transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-						>
-							Use a custom endpoint for “{query.trim()}”
-						</button>
+							icon={
+								<EntityIcon
+									kind="provider"
+									id="custom_openai_compatible"
+									label="Custom endpoint"
+									size="sm"
+								/>
+							}
+							title="Use a custom endpoint"
+							description={`No matches for “${query.trim()}”. Configure it manually.`}
+						/>
 					)}
 				</div>
 			) : (
@@ -154,11 +152,12 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 						<ChoiceGrid entries={popular} onSelect={onSelect} />
 					</div>
 					<details className="group rounded-lg border bg-muted/20">
-						<summary className="cursor-pointer list-none px-3 py-2.5 text-sm font-medium marker:hidden">
+						<summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium marker:hidden">
 							Browse all providers
-							<span className="float-right text-muted-foreground transition-transform group-open:rotate-180">
-								⌄
-							</span>
+							<ChevronDown
+								className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+								aria-hidden
+							/>
 						</summary>
 						<div className="flex flex-col gap-4 border-t px-3 py-3">
 							{PROVIDER_PRESET_CATEGORIES.map((category) => {

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { CircleAlert, ExternalLink, KeyRound, RefreshCw, UserRound } from "lucide-react";
+import {
+	ChevronDown,
+	CircleAlert,
+	ExternalLink,
+	KeyRound,
+	RefreshCw,
+	UserRound,
+} from "lucide-react";
+import { useCallback } from "react";
 import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
@@ -75,6 +83,15 @@ export function ProviderFieldsForm({
 	const showPrimaryName = meta.custom === true;
 	const showAdvancedName = !showPrimaryName && isEdit;
 	const showRuntimeEnv = !isOAuthEdit && form.authMethod === "api_key";
+	const defaultAdvancedOpen = meta.custom || isEdit;
+	// React has no defaultOpen prop for native details. Initialize once through a
+	// stable ref so later renders leave the user's disclosure state untouched.
+	const initializeAdvancedDetails = useCallback(
+		(details: HTMLDetailsElement | null) => {
+			if (details) details.open = defaultAdvancedOpen;
+		},
+		[defaultAdvancedOpen],
+	);
 
 	return (
 		<div data-hosted="true" data-v2="true" className="flex flex-col gap-4">
@@ -214,12 +231,13 @@ export function ProviderFieldsForm({
 			)}
 
 			{form.authMethod === "api_key" ? (
-				<details className="group rounded-lg border bg-muted/20" open={meta.custom || isEdit}>
-					<summary className="cursor-pointer list-none px-3 py-2.5 text-sm font-medium marker:hidden">
+				<details ref={initializeAdvancedDetails} className="group rounded-lg border bg-muted/20">
+					<summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium marker:hidden">
 						Advanced
-						<span className="float-right text-muted-foreground transition-transform group-open:rotate-180">
-							⌄
-						</span>
+						<ChevronDown
+							className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+							aria-hidden
+						/>
 					</summary>
 					<div className="flex flex-col gap-3 border-t p-3">
 						{showAdvancedName ? (

--- a/apps/web/src/hosted/v2/ai-providers/provider-oauth-flow.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-oauth-flow.tsx
@@ -81,10 +81,12 @@ export function ProviderOAuthFlow({
 				)}
 			</div>
 
-			<Button variant="outline" onClick={onRestart} disabled={starting}>
-				{starting ? <Spinner /> : null}
-				Get a new code
-			</Button>
+			{issue ? (
+				<Button variant="outline" onClick={onRestart} disabled={starting}>
+					{starting ? <Spinner /> : null}
+					Get a new code
+				</Button>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const chooserSource = readFileSync(new URL("./provider-chooser.tsx", import.meta.url), "utf8");
+const fieldsSource = readFileSync(new URL("./provider-fields-form.tsx", import.meta.url), "utf8");
+
+describe("AI provider design-system consistency", () => {
+	test("uses the canonical search and entity choice components", () => {
+		expect(chooserSource).toContain('import { SearchInput } from "@/components/ui/search-input";');
+		expect(chooserSource).not.toContain('from "@/components/ui/input"');
+		expect(chooserSource).not.toContain('from "@/components/ui/label"');
+		expect(chooserSource).toContain('id="custom_openai_compatible"');
+		expect(chooserSource).toContain("<EntityChoiceCard");
+		expect(chooserSource).not.toContain("border-dashed");
+	});
+
+	test("keeps disclosure controls canonical and Advanced user-collapsible", () => {
+		expect(chooserSource).toContain("<ChevronDown");
+		expect(fieldsSource).toContain("<ChevronDown");
+		expect(chooserSource).not.toContain("⌄");
+		expect(fieldsSource).not.toContain("⌄");
+		expect(fieldsSource).toContain("const defaultAdvancedOpen = meta.custom || isEdit");
+		expect(fieldsSource).toContain("details.open = defaultAdvancedOpen");
+		expect(fieldsSource).toContain("ref={initializeAdvancedDetails}");
+		expect(fieldsSource).not.toContain("open={meta.custom || isEdit}");
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/use-provider-oauth-device-flow.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-provider-oauth-device-flow.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ProviderOAuthFlow } from "./provider-oauth-flow";
 import {
 	cancelOAuthSessionLifecycle,
 	isCurrentOAuthGeneration,
@@ -107,9 +109,27 @@ describe("provider OAuth device flow lifecycle", () => {
 		expect(started.map((session) => session.state)).toEqual(["replacement"]);
 	});
 
-	test("allows an explicit new code while the current session is polling", () => {
-		const source = readFileSync(new URL("./provider-oauth-flow.tsx", import.meta.url), "utf8");
-		expect(source).toContain("onClick={onRestart} disabled={starting}");
-		expect(source).not.toContain("disabled={starting || polling}");
+	test("only offers a new code after the current code expires or fails", () => {
+		const props = {
+			verificationUrl: "https://auth.openai.com/codex/device",
+			userCode: "ABCD-EFGH",
+			starting: false,
+			polling: true,
+			onRestart: () => {},
+		};
+		const waiting = renderToStaticMarkup(
+			createElement(ProviderOAuthFlow, { ...props, issue: null }),
+		);
+		const expired = renderToStaticMarkup(
+			createElement(ProviderOAuthFlow, { ...props, issue: "expired" }),
+		);
+		const failed = renderToStaticMarkup(
+			createElement(ProviderOAuthFlow, { ...props, issue: "failed" }),
+		);
+
+		expect(waiting).toContain("Waiting for ChatGPT authorization");
+		expect(waiting).not.toContain("Get a new code");
+		expect(expired).toContain("Get a new code");
+		expect(failed).toContain("Get a new code");
 	});
 });


### PR DESCRIPTION
## Summary
- reuse the canonical SearchInput and EntityChoiceCard in the provider chooser
- use the existing Lucide disclosure icon and preserve user-controlled Advanced disclosure state
- show device-code regeneration only as an expired/failed recovery action
- no backend, CLI, Hosted repository, v1, or old onboarding changes

## Verification
- AI provider focused suite: 76 passed
- Web typecheck passed
- full Web Biome passed (490 files)
- focused behavior tests and diff-check passed after reviewer refinement