### PR TITLE
feat(web): align hosted plan comparison copy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5965,12 +5965,14 @@ test("card past due uses Fix payment instead of wallet recovery", async ({ page 
 	expect(errors, `card payment recovery: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("compute plans keep signup credits without advertising subscription credit grants", async ({
+test("compute comparison uses API prices without stale signup or subscription credit claims", async ({
 	page,
 }) => {
 	const errors = collectBrowserErrors(page);
+	const planRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [paidBasicDeployment],
+		planRequests,
 		plans: [
 			{ ...basicPlan, subscription_grant_credits: 500 },
 			{ ...performancePlan, subscription_grant_credits: 1_000 },
@@ -5980,9 +5982,13 @@ test("compute plans keep signup credits without advertising subscription credit 
 
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog).toBeVisible();
-	await expect(
-		settingsDialog.getByText("$5.00 welcome balance on signup", { exact: true }),
-	).toBeVisible();
+	await expect(settingsDialog.getByText("then $10.00/mo", { exact: true })).toBeVisible();
+	await expect(settingsDialog.getByText("$20.00", { exact: true })).toBeVisible();
+	await expect(settingsDialog).toContainText(
+		"Wallet top-ups from $10.00–$2,000.00 in whole-dollar amounts",
+	);
+	expect(planRequests).toEqual([`${DEPLOY_API}/v2/subscription/plans`]);
+	await expect(settingsDialog).not.toContainText("welcome balance on signup");
 	await expect(settingsDialog).not.toContainText("AI Credits per subscription");
 	await expect(settingsDialog).not.toContainText("AI Credits added to Wallet");
 	await expect(settingsDialog).not.toContainText("credits do not expire");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5965,11 +5965,10 @@ test("card past due uses Fix payment instead of wallet recovery", async ({ page 
 	expect(errors, `card payment recovery: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("compute comparison uses API prices without stale signup or subscription credit claims", async ({
+test("compute comparison synchronizes API prices across the shared billing term", async ({
 	page,
 }) => {
 	const errors = collectBrowserErrors(page);
-	const planRequests: string[] = [];
 	const comparisonBasicPlan = {
 		...basicPlan,
 		price_cents: 1_234,
@@ -6006,102 +6005,35 @@ test("compute comparison uses API prices without stale signup or subscription cr
 			},
 		],
 	};
-	await page.setViewportSize({ width: 1_440, height: 1_100 });
-	await page.emulateMedia({ reducedMotion: "reduce" });
 	await stubHostedApi(page, {
 		deployments: [paidBasicDeployment],
-		planRequests,
-		plans: [
-			{ ...comparisonBasicPlan, subscription_grant_credits: 500 },
-			{ ...comparisonPerformancePlan, subscription_grant_credits: 1_000 },
-		],
+		plans: [comparisonBasicPlan, comparisonPerformancePlan],
 	});
 	await page.goto("/channels?settings=billing-plan");
 
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog).toBeVisible();
 	const comparison = settingsDialog.getByRole("region", { name: "Compare compute options" });
-	const termSwitcher = comparison.getByRole("group", {
-		name: "Billing term for Basic and Performance",
-	});
-	await expect(termSwitcher).toBeVisible();
-	await expect(termSwitcher).not.toContainText("%");
+	const termSwitcher = comparison.getByRole("group", { name: /Billing term/ });
+	await expect(termSwitcher).toHaveCount(1);
+	const cards = comparison.locator('[data-slot="card"]');
+	const basicCard = cards.nth(0);
+	const performanceCard = cards.nth(1);
+	const aiCard = cards.nth(2);
 	await expect(termSwitcher.getByRole("button", { name: "Monthly", exact: true })).toHaveAttribute(
 		"aria-pressed",
 		"true",
 	);
-	await expect(comparison.getByText("$12.34/mo", { exact: true })).toBeVisible();
-	await expect(comparison.getByText("$56.78/mo", { exact: true })).toBeVisible();
+	await expect(basicCard).toContainText("$12.34/mo");
+	await expect(performanceCard).toContainText("$56.78/mo");
+	await expect(aiCard).toContainText("Pay as you go");
 
 	await termSwitcher.getByRole("button", { name: "Annual", exact: true }).click();
-	await expect(comparison.getByText("$10.29/mo", { exact: true })).toBeVisible();
-	await expect(comparison.getByText("Billed $123.48/yr", { exact: true })).toBeVisible();
-	await expect(comparison.getByText("$45.27/mo", { exact: true })).toBeVisible();
-	await expect(comparison.getByText("Billed $543.24/yr", { exact: true })).toBeVisible();
-	await expect(
-		comparison.getByText("Not affected by compute billing term", { exact: true }),
-	).toBeVisible();
-	await expect(comparison.locator('[data-slot="card"]')).toHaveCount(3);
-
-	const desktopMetrics = await comparison.evaluate((section) => {
-		const cards = Array.from(section.querySelectorAll<HTMLElement>('[data-slot="card"]'));
-		const selector = section.querySelector<HTMLElement>(
-			'[aria-label="Billing term for Basic and Performance"]',
-		);
-		return {
-			overflow: section.scrollWidth - section.clientWidth,
-			cardTops: cards.map((card) => Math.round(card.getBoundingClientRect().top)),
-			cardBottoms: cards.map((card) => Math.round(card.getBoundingClientRect().bottom)),
-			selectorBottom: selector ? Math.round(selector.getBoundingClientRect().bottom) : null,
-			firstCardTop: cards[0] ? Math.round(cards[0].getBoundingClientRect().top) : null,
-		};
-	});
-	expect(desktopMetrics.overflow).toBeLessThanOrEqual(0);
-	expect(new Set(desktopMetrics.cardTops).size).toBe(1);
-	expect(new Set(desktopMetrics.cardBottoms).size).toBe(1);
-	expect(desktopMetrics.selectorBottom).toBeLessThanOrEqual(desktopMetrics.firstCardTop ?? 0);
-	await comparison.screenshot({ path: "/tmp/clawdi-pricing-comparison-desktop.png" });
-
-	await page.setViewportSize({ width: 390, height: 844 });
-	await comparison.scrollIntoViewIfNeeded();
-	const mobileMetrics = await comparison.evaluate((section) => {
-		const cards = Array.from(section.querySelectorAll<HTMLElement>('[data-slot="card"]'));
-		const sectionRect = section.getBoundingClientRect();
-		return {
-			documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
-			sectionOverflow: section.scrollWidth - section.clientWidth,
-			cardsInside: cards.every((card) => {
-				const rect = card.getBoundingClientRect();
-				return rect.left >= sectionRect.left && rect.right <= sectionRect.right;
-			}),
-			cardsSeparated: cards.slice(1).every((card, index) => {
-				const previous = cards[index];
-				return previous
-					? previous.getBoundingClientRect().bottom <= card.getBoundingClientRect().top
-					: false;
-			}),
-		};
-	});
-	expect(mobileMetrics.documentOverflow).toBeLessThanOrEqual(0);
-	expect(mobileMetrics.sectionOverflow).toBeLessThanOrEqual(0);
-	expect(mobileMetrics.cardsInside).toBe(true);
-	expect(mobileMetrics.cardsSeparated).toBe(true);
-	const comparisonCards = comparison.locator('[data-slot="card"]');
-	await comparisonCards.first().scrollIntoViewIfNeeded();
-	await expect(comparisonCards.first()).toBeInViewport();
-	await page.screenshot({ path: "/tmp/clawdi-pricing-comparison-mobile-top.png" });
-	await comparisonCards.last().scrollIntoViewIfNeeded();
-	await expect(comparisonCards.last()).toBeInViewport();
-	const openWalletButton = comparisonCards.last().getByRole("button", { name: "Open Wallet" });
-	await openWalletButton.scrollIntoViewIfNeeded();
-	await expect(openWalletButton).toBeVisible();
-	await page.screenshot({ path: "/tmp/clawdi-pricing-comparison-mobile-bottom.png" });
-
-	expect(planRequests).toEqual([`${DEPLOY_API}/v2/subscription/plans`]);
-	await expect(settingsDialog).not.toContainText("welcome balance on signup");
-	await expect(settingsDialog).not.toContainText("AI Credits per subscription");
-	await expect(settingsDialog).not.toContainText("AI Credits added to Wallet");
-	await expect(settingsDialog).not.toContainText("credits do not expire");
+	await expect(basicCard).toContainText("$10.29/mo");
+	await expect(basicCard).toContainText("Billed $123.48/yr");
+	await expect(performanceCard).toContainText("$45.27/mo");
+	await expect(performanceCard).toContainText("Billed $543.24/yr");
+	await expect(aiCard).toContainText("Pay as you go");
 	expect(errors, `compute plan comparison: ${errors.join(" | ")}`).toEqual([]);
 });
 

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5984,9 +5984,7 @@ test("compute comparison uses API prices without stale signup or subscription cr
 	await expect(settingsDialog).toBeVisible();
 	await expect(settingsDialog.getByText("then $10.00/mo", { exact: true })).toBeVisible();
 	await expect(settingsDialog.getByText("$20.00", { exact: true })).toBeVisible();
-	await expect(settingsDialog).toContainText(
-		"Wallet top-ups from $10.00–$2,000.00 in whole-dollar amounts",
-	);
+	await expect(settingsDialog).toContainText("Whole-dollar wallet top-ups");
 	expect(planRequests).toEqual([`${DEPLOY_API}/v2/subscription/plans`]);
 	await expect(settingsDialog).not.toContainText("welcome balance on signup");
 	await expect(settingsDialog).not.toContainText("AI Credits per subscription");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5970,21 +5970,133 @@ test("compute comparison uses API prices without stale signup or subscription cr
 }) => {
 	const errors = collectBrowserErrors(page);
 	const planRequests: string[] = [];
+	const comparisonBasicPlan = {
+		...basicPlan,
+		price_cents: 1_234,
+		offers: [
+			{
+				billing_term_months: 1,
+				price_cents: 1_234,
+				effective_monthly_price_cents: 1_234,
+				discount_percent: 0,
+			},
+			{
+				billing_term_months: 12,
+				price_cents: 12_348,
+				effective_monthly_price_cents: 1_029,
+				discount_percent: 17,
+			},
+		],
+	};
+	const comparisonPerformancePlan = {
+		...performancePlan,
+		price_cents: 5_678,
+		offers: [
+			{
+				billing_term_months: 1,
+				price_cents: 5_678,
+				effective_monthly_price_cents: 5_678,
+				discount_percent: 0,
+			},
+			{
+				billing_term_months: 12,
+				price_cents: 54_324,
+				effective_monthly_price_cents: 4_527,
+				discount_percent: 20,
+			},
+		],
+	};
+	await page.setViewportSize({ width: 1_440, height: 1_100 });
+	await page.emulateMedia({ reducedMotion: "reduce" });
 	await stubHostedApi(page, {
 		deployments: [paidBasicDeployment],
 		planRequests,
 		plans: [
-			{ ...basicPlan, subscription_grant_credits: 500 },
-			{ ...performancePlan, subscription_grant_credits: 1_000 },
+			{ ...comparisonBasicPlan, subscription_grant_credits: 500 },
+			{ ...comparisonPerformancePlan, subscription_grant_credits: 1_000 },
 		],
 	});
 	await page.goto("/channels?settings=billing-plan");
 
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog).toBeVisible();
-	await expect(settingsDialog.getByText("then $10.00/mo", { exact: true })).toBeVisible();
-	await expect(settingsDialog.getByText("$20.00", { exact: true })).toBeVisible();
-	await expect(settingsDialog).toContainText("Whole-dollar wallet top-ups");
+	const comparison = settingsDialog.getByRole("region", { name: "Compare compute options" });
+	const termSwitcher = comparison.getByRole("group", {
+		name: "Billing term for Basic and Performance",
+	});
+	await expect(termSwitcher).toBeVisible();
+	await expect(termSwitcher).not.toContainText("%");
+	await expect(termSwitcher.getByRole("button", { name: "Monthly", exact: true })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await expect(comparison.getByText("$12.34/mo", { exact: true })).toBeVisible();
+	await expect(comparison.getByText("$56.78/mo", { exact: true })).toBeVisible();
+
+	await termSwitcher.getByRole("button", { name: "Annual", exact: true }).click();
+	await expect(comparison.getByText("$10.29/mo", { exact: true })).toBeVisible();
+	await expect(comparison.getByText("Billed $123.48/yr", { exact: true })).toBeVisible();
+	await expect(comparison.getByText("$45.27/mo", { exact: true })).toBeVisible();
+	await expect(comparison.getByText("Billed $543.24/yr", { exact: true })).toBeVisible();
+	await expect(
+		comparison.getByText("Not affected by compute billing term", { exact: true }),
+	).toBeVisible();
+	await expect(comparison.locator('[data-slot="card"]')).toHaveCount(3);
+
+	const desktopMetrics = await comparison.evaluate((section) => {
+		const cards = Array.from(section.querySelectorAll<HTMLElement>('[data-slot="card"]'));
+		const selector = section.querySelector<HTMLElement>(
+			'[aria-label="Billing term for Basic and Performance"]',
+		);
+		return {
+			overflow: section.scrollWidth - section.clientWidth,
+			cardTops: cards.map((card) => Math.round(card.getBoundingClientRect().top)),
+			cardBottoms: cards.map((card) => Math.round(card.getBoundingClientRect().bottom)),
+			selectorBottom: selector ? Math.round(selector.getBoundingClientRect().bottom) : null,
+			firstCardTop: cards[0] ? Math.round(cards[0].getBoundingClientRect().top) : null,
+		};
+	});
+	expect(desktopMetrics.overflow).toBeLessThanOrEqual(0);
+	expect(new Set(desktopMetrics.cardTops).size).toBe(1);
+	expect(new Set(desktopMetrics.cardBottoms).size).toBe(1);
+	expect(desktopMetrics.selectorBottom).toBeLessThanOrEqual(desktopMetrics.firstCardTop ?? 0);
+	await comparison.screenshot({ path: "/tmp/clawdi-pricing-comparison-desktop.png" });
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await comparison.scrollIntoViewIfNeeded();
+	const mobileMetrics = await comparison.evaluate((section) => {
+		const cards = Array.from(section.querySelectorAll<HTMLElement>('[data-slot="card"]'));
+		const sectionRect = section.getBoundingClientRect();
+		return {
+			documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+			sectionOverflow: section.scrollWidth - section.clientWidth,
+			cardsInside: cards.every((card) => {
+				const rect = card.getBoundingClientRect();
+				return rect.left >= sectionRect.left && rect.right <= sectionRect.right;
+			}),
+			cardsSeparated: cards.slice(1).every((card, index) => {
+				const previous = cards[index];
+				return previous
+					? previous.getBoundingClientRect().bottom <= card.getBoundingClientRect().top
+					: false;
+			}),
+		};
+	});
+	expect(mobileMetrics.documentOverflow).toBeLessThanOrEqual(0);
+	expect(mobileMetrics.sectionOverflow).toBeLessThanOrEqual(0);
+	expect(mobileMetrics.cardsInside).toBe(true);
+	expect(mobileMetrics.cardsSeparated).toBe(true);
+	const comparisonCards = comparison.locator('[data-slot="card"]');
+	await comparisonCards.first().scrollIntoViewIfNeeded();
+	await expect(comparisonCards.first()).toBeInViewport();
+	await page.screenshot({ path: "/tmp/clawdi-pricing-comparison-mobile-top.png" });
+	await comparisonCards.last().scrollIntoViewIfNeeded();
+	await expect(comparisonCards.last()).toBeInViewport();
+	const openWalletButton = comparisonCards.last().getByRole("button", { name: "Open Wallet" });
+	await openWalletButton.scrollIntoViewIfNeeded();
+	await expect(openWalletButton).toBeVisible();
+	await page.screenshot({ path: "/tmp/clawdi-pricing-comparison-mobile-bottom.png" });
+
 	expect(planRequests).toEqual([`${DEPLOY_API}/v2/subscription/plans`]);
 	await expect(settingsDialog).not.toContainText("welcome balance on signup");
 	await expect(settingsDialog).not.toContainText("AI Credits per subscription");

--- a/apps/web/src/hosted/billing/components/term-switcher.tsx
+++ b/apps/web/src/hosted/billing/components/term-switcher.tsx
@@ -13,10 +13,14 @@ export function TermSwitcher({
 	offers,
 	value,
 	onChange,
+	showDiscount = true,
+	ariaLabel = "Billing term",
 }: {
 	offers: BillingOffer[];
 	value: number;
 	onChange: (months: number) => void;
+	showDiscount?: boolean;
+	ariaLabel?: string;
 }) {
 	if (offers.length <= 1) return null;
 	const sorted = [...offers].sort((a, b) => a.billing_term_months - b.billing_term_months);
@@ -31,7 +35,7 @@ export function TermSwitcher({
 			variant="outline"
 			size="sm"
 			className="w-full"
-			aria-label="Billing term"
+			aria-label={ariaLabel}
 		>
 			{sorted.map((offer) => (
 				<ToggleGroupItem
@@ -40,7 +44,7 @@ export function TermSwitcher({
 					className="flex-1 gap-1.5"
 				>
 					{billingTermLabel(offer.billing_term_months)}
-					{offer.discount_percent > 0 ? (
+					{showDiscount && offer.discount_percent > 0 ? (
 						<span className="text-xs text-success-muted-foreground">
 							−{offer.discount_percent}%
 						</span>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -12,10 +12,6 @@ const acceptedNavigationSource = readFileSync(
 	new URL("./accepted-deployment-navigation.ts", import.meta.url),
 	"utf8",
 );
-const planComparisonSource = readFileSync(
-	new URL("../subscription/plan-comparison.tsx", import.meta.url),
-	"utf8",
-);
 const planChangeDialogSource = readFileSync(
 	new URL("../subscription/plan-change-dialog.tsx", import.meta.url),
 	"utf8",
@@ -220,9 +216,6 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("included Basic slot");
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
-		expect(planComparisonSource).toContain("The first active Basic agent is free.");
-		expect(planComparisonSource).toContain("Your first active Basic agent is free.");
-		expect(planComparisonSource).not.toContain("agent is included");
 		expect(wizardSource).toContain("acceptDeployment(created.deploymentId)");
 		expect(wizardSource).toContain("acceptDeployment(outcome.deploymentId)");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
@@ -242,10 +235,6 @@ describe("first Basic agent copy", () => {
 	});
 
 	test("keeps infrastructure vocabulary out of customer copy", () => {
-		expect(planComparisonSource).toContain("Managed confidential-compute infrastructure");
-		expect(planComparisonSource).toContain("Public ports for agent services");
-		expect(planComparisonSource).not.toContain("hosted runtime");
-		expect(planComparisonSource).not.toContain("runtime-owned services");
 		expect(providerFieldsFormSource).toContain("Agent environment variable");
 		expect(providerFieldsFormSource).not.toContain("Runtime mapping");
 		expect(providerFieldsFormSource).not.toContain("Runtime env var");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -242,7 +242,7 @@ describe("first Basic agent copy", () => {
 	});
 
 	test("keeps infrastructure vocabulary out of customer copy", () => {
-		expect(planComparisonSource).toContain("Always-on agent with TEE protection");
+		expect(planComparisonSource).toContain("Managed confidential-compute infrastructure");
 		expect(planComparisonSource).toContain("Public ports for agent services");
 		expect(planComparisonSource).not.toContain("hosted runtime");
 		expect(planComparisonSource).not.toContain("runtime-owned services");

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -26,7 +26,6 @@ import {
 	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
-import { TOPUP_AMOUNT_RANGE_LABEL } from "@/hosted/billing/wallet/wallet-constants";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
 function partitionPlans(plans: Plan[]): { basic?: Plan; performance?: Plan } {
@@ -270,9 +269,7 @@ export function PlanComparison({
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>Usage billed directly in USD</FeatureRow>
-							<FeatureRow>
-								Wallet top-ups from {TOPUP_AMOUNT_RANGE_LABEL} in whole-dollar amounts
-							</FeatureRow>
+							<FeatureRow>Whole-dollar wallet top-ups</FeatureRow>
 							<FeatureRow>Optional auto-reload</FeatureRow>
 							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -110,7 +110,7 @@ export function PlanComparison({
 					<CardHeader>
 						<div className="flex items-center justify-between">
 							<CardTitle className="flex items-center gap-2">
-								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Basic
+								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
 							</CardTitle>
 						</div>
 						<div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
@@ -143,7 +143,7 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Always-on agent with TEE protection</FeatureRow>
+							<FeatureRow>Managed confidential-compute infrastructure</FeatureRow>
 							<FeatureRow>
 								Burstable compute
 								{basicResources
@@ -167,11 +167,11 @@ export function PlanComparison({
 								className="w-full"
 								variant="outline"
 							>
-								<Rocket /> Deploy Basic agent
+								<Rocket /> Deploy Compute Basic
 							</Button>
 						) : (
 							<Button className="w-full" variant="outline" disabled>
-								<Rocket /> Deploy Basic agent
+								<Rocket /> Deploy Compute Basic
 							</Button>
 						)}
 					</CardFooter>
@@ -183,7 +183,7 @@ export function PlanComparison({
 					<CardHeader>
 						<div className="flex items-center justify-between">
 							<CardTitle className="flex items-center gap-2">
-								<Zap className="size-5 text-primary" aria-hidden /> Performance
+								<Zap className="size-5 text-primary" aria-hidden /> Compute Performance
 							</CardTitle>
 						</div>
 						<div className="mt-2 flex items-baseline gap-1">
@@ -220,7 +220,7 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Everything in Basic, plus:</FeatureRow>
+							<FeatureRow>Everything in Compute Basic, plus:</FeatureRow>
 							<FeatureRow>
 								Higher burst
 								{performance ? ` (${performance.vcpu} vCPU / ${performance.ram_gb} GB)` : ""}
@@ -240,11 +240,11 @@ export function PlanComparison({
 								className="w-full"
 								disabled={!performance}
 							>
-								Deploy Performance agent
+								Deploy Compute Performance
 							</Button>
 						) : (
 							<Button className="w-full" disabled>
-								Deploy Performance agent
+								Deploy Compute Performance
 							</Button>
 						)}
 					</CardFooter>
@@ -260,18 +260,21 @@ export function PlanComparison({
 							<span className="text-3xl font-semibold tracking-tight">Pay as you go</span>
 						</div>
 						<CardDescription className="mt-2">
-							Clawdi AI is billed by usage. Top up your wallet and spend only what your agents use.
+							Top up your Wallet and pay only for the AI usage your agents consume.
 						</CardDescription>
+						<div className="mt-3 rounded-lg border bg-background/70 px-3 py-2">
+							<p className="text-sm font-medium">
+								30% cheaper than direct API pricing on supported models
+							</p>
+							<p className="mt-0.5 text-xs text-muted-foreground">Actual savings vary by model.</p>
+						</div>
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>Usage billed directly in USD</FeatureRow>
 							<FeatureRow>Whole-dollar top-ups from {TOPUP_AMOUNT_RANGE_LABEL}</FeatureRow>
-							<FeatureRow>Optional auto-reload so agents never stall</FeatureRow>
-							<FeatureRow>
-								<span className="font-medium">No Clawdi AI charge with BYOK</span> — your own key
-								bypasses Clawdi AI
-							</FeatureRow>
+							<FeatureRow>Optional auto-reload</FeatureRow>
+							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>
 						<Separator className="my-4" />
 						<p className="text-xs text-muted-foreground">

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -143,14 +143,15 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Managed confidential compute</FeatureRow>
 							{basic ? (
 								<FeatureRow>
-									{basic.vcpu} vCPU · {basic.ram_gb} GB RAM · {basic.disk_size} GB disk
+									Up to {basic.vcpu} vCPU · {basic.ram_gb} GB RAM · {basic.disk_size} GB storage
 								</FeatureRow>
 							) : null}
-							<FeatureRow>One runtime: OpenClaw or Hermes</FeatureRow>
-							<FeatureRow>Bring your own AI keys (BYOK)</FeatureRow>
+							<FeatureRow>
+								Managed confidential compute · one runtime (OpenClaw or Hermes)
+							</FeatureRow>
+							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>
@@ -197,14 +198,14 @@ export function PlanComparison({
 						<ul className="space-y-2">
 							{performance ? (
 								<FeatureRow>
-									{performance.vcpu} vCPU · {performance.ram_gb} GB RAM · {performance.disk_size} GB
-									disk
+									Up to {performance.vcpu} vCPU · {performance.ram_gb} GB RAM ·{" "}
+									{performance.disk_size} GB storage
 								</FeatureRow>
 							) : null}
-							<FeatureRow>Managed confidential compute</FeatureRow>
-							<FeatureRow>One runtime: OpenClaw or Hermes</FeatureRow>
-							<FeatureRow>Public ports for agent services</FeatureRow>
-							<FeatureRow>Bring your own AI keys (BYOK)</FeatureRow>
+							<FeatureRow>
+								Managed confidential compute · one runtime (OpenClaw or Hermes)
+							</FeatureRow>
+							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>
@@ -242,7 +243,7 @@ export function PlanComparison({
 								model.
 							</FeatureRow>
 							<FeatureRow>Pay from your Wallet</FeatureRow>
-							<FeatureRow>Use your own AI keys (BYOK)</FeatureRow>
+							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -16,11 +16,10 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { Plan } from "@/hosted/billing/contracts";
-import { billingTermSuffix, formatCents, formatUsdExact } from "@/hosted/billing/format";
+import { billingTermSuffix, formatCents } from "@/hosted/billing/format";
 import { usePlans } from "@/hosted/billing/hooks";
 import {
 	explicitPlanOffers,
-	largestSignupGrantUsd,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
@@ -89,7 +88,6 @@ export function PlanComparison({
 
 	if (!plansQuery.data) return null;
 
-	const signupGrantUsd = largestSignupGrantUsd(plansQuery.data);
 	const basicOffers = basic ? explicitPlanOffers(basic) : [];
 	const basicResources = basic;
 	const performanceOffers = performance ? planOffers(performance) : [];
@@ -147,16 +145,16 @@ export function PlanComparison({
 							<FeatureRow>
 								Burstable compute
 								{basicResources
-									? ` (${basicResources.vcpu} vCPU / ${basicResources.ram_gb} GB burst)`
+									? ` (${basicResources.vcpu} vCPU / ${basicResources.ram_gb} GB)`
 									: ""}
+							</FeatureRow>
+							<FeatureRow>
+								Disk{basicResources ? ` (${basicResources.disk_size} GB)` : ""}
 							</FeatureRow>
 							<FeatureRow>One free active Basic agent per user</FeatureRow>
 							<FeatureRow>Paid additional Basic agents</FeatureRow>
 							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
 							<FeatureRow>BYOK avoids Clawdi AI usage charges</FeatureRow>
-							{signupGrantUsd ? (
-								<FeatureRow>{formatUsdExact(signupGrantUsd)} welcome balance on signup</FeatureRow>
-							) : null}
 						</ul>
 					</CardContent>
 					<CardFooter>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -270,7 +270,9 @@ export function PlanComparison({
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>Usage billed directly in USD</FeatureRow>
-							<FeatureRow>Whole-dollar top-ups from {TOPUP_AMOUNT_RANGE_LABEL}</FeatureRow>
+							<FeatureRow>
+								Wallet top-ups from {TOPUP_AMOUNT_RANGE_LABEL} in whole-dollar amounts
+							</FeatureRow>
 							<FeatureRow>Optional auto-reload</FeatureRow>
 							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
 						</ul>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -2,8 +2,7 @@
 
 import { Link, useLocation } from "@tanstack/react-router";
 import { Check, Cpu, Rocket, Sparkles, WalletCards, Zap } from "lucide-react";
-import { useMemo, useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -13,18 +12,15 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { Plan } from "@/hosted/billing/contracts";
-import { billingTermSuffix, formatCents } from "@/hosted/billing/format";
+import { computePricePresentation } from "@/hosted/billing/deploy/deploy-price-presentation";
 import { usePlans } from "@/hosted/billing/hooks";
 import {
+	commonExplicitBillingOffers,
 	explicitPlanOffers,
-	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
-	selectExplicitOfferForTerm,
-	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
@@ -47,113 +43,114 @@ function FeatureRow({ children }: { children: React.ReactNode }) {
 /**
  * The Basic / Performance / managed-AI comparison, folded into the Plan tab's
  * deploy flow (its own Pricing tab was redundant in Settings — Linear/Vercel
- * keep Plan + Usage). Self-contained; safe to drop below the current-plan card.
+ * keep Plan + Usage). Billing-term state is controlled by the page so the
+ * single selector updates both compute cards together.
  */
 export function PlanComparison({
-	term: termProp,
+	term,
 	onTermChange,
 	canCreateCloudAgents = false,
 }: {
-	/** When provided, the billing term is controlled by the parent so the
-	 * page's other TermSwitchers stay in sync (no two desynced toggles). */
-	term?: number;
-	onTermChange?: (term: number) => void;
+	term: number;
+	onTermChange: (term: number) => void;
 	canCreateCloudAgents?: boolean;
-} = {}) {
+}) {
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const searchParams = new URLSearchParams(searchStr);
 	const plansQuery = usePlans();
-	const [internalTerm, setInternalTerm] = useState(1);
-	const term = termProp ?? internalTerm;
-	const setTerm = onTermChange ?? setInternalTerm;
 
 	const { basic, performance } = useMemo(
 		() => partitionPlans(plansQuery.data ?? []),
 		[plansQuery.data],
 	);
 
-	const performanceOfferSelection = useMemo(
-		() => (performance ? selectOfferForTerm(performance, term) : null),
-		[performance, term],
-	);
-	const performanceOffer = performanceOfferSelection?.offer ?? null;
-	const performanceBillingTermMonths = performanceOfferSelection?.billingTermMonths ?? term;
-	const basicOfferSelection = useMemo(
-		() => (basic ? selectExplicitOfferForTerm(basic, term) : null),
-		[basic, term],
-	);
-	const basicOffer = basicOfferSelection?.offer ?? null;
-	const basicBillingTermMonths = basicOfferSelection?.billingTermMonths ?? term;
-
 	if (!plansQuery.data) return null;
 
 	const basicOffers = basic ? explicitPlanOffers(basic) : [];
-	const basicResources = basic;
-	const performanceOffers = performance ? planOffers(performance) : [];
-	const annualOffer = performanceOffers.find((o) => o.billing_term_months === 12);
+	const performanceOffers = performance ? explicitPlanOffers(performance) : [];
+	const commonOffers =
+		basic && performance ? commonExplicitBillingOffers([basic, performance]) : [];
+	const selectedTerm =
+		commonOffers.find((offer) => offer.billing_term_months === term)?.billing_term_months ??
+		commonOffers[0]?.billing_term_months ??
+		null;
+	const basicOffer =
+		selectedTerm === null
+			? null
+			: (basicOffers.find((offer) => offer.billing_term_months === selectedTerm) ?? null);
+	const performanceOffer =
+		selectedTerm === null
+			? null
+			: (performanceOffers.find((offer) => offer.billing_term_months === selectedTerm) ?? null);
+	const basicPrice = basicOffer ? computePricePresentation(basicOffer, basicOffers) : null;
+	const performancePrice = performanceOffer
+		? computePricePresentation(performanceOffer, performanceOffers)
+		: null;
+	const sharedPricingUnavailable =
+		basic !== undefined && performance !== undefined && !selectedTerm;
 
 	return (
-		<div data-hosted="true" className="space-y-3">
-			<div>
-				<h3 className="text-base font-semibold">Compare compute options</h3>
-				<p className="text-sm text-muted-foreground">
-					The first active Basic agent is free. Additional Basic and Performance agents are billed
-					separately.
-				</p>
+		<section data-hosted="true" className="space-y-4" aria-labelledby="plan-comparison-heading">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+				<div>
+					<h3 id="plan-comparison-heading" className="text-base font-semibold">
+						Compare compute options
+					</h3>
+					{sharedPricingUnavailable ? (
+						<p className="mt-1 text-sm text-muted-foreground">
+							A shared Basic and Performance billing term is not currently available.
+						</p>
+					) : null}
+				</div>
+				{commonOffers.length > 1 && selectedTerm !== null ? (
+					<div className="w-full shrink-0 space-y-1.5 sm:w-64">
+						<p className="text-xs font-medium text-muted-foreground">
+							Billing term for Basic + Performance
+						</p>
+						<TermSwitcher
+							offers={commonOffers}
+							value={selectedTerm}
+							onChange={onTermChange}
+							showDiscount={false}
+							ariaLabel="Billing term for Basic and Performance"
+						/>
+					</div>
+				) : null}
 			</div>
-			<div className="grid items-start gap-4 lg:grid-cols-3">
+			<div className="grid gap-3 lg:grid-cols-3">
 				{/* Basic */}
-				<Card className="flex flex-col">
-					<CardHeader>
-						<div className="flex items-center justify-between">
-							<CardTitle className="flex items-center gap-2">
-								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
-							</CardTitle>
+				<Card size="sm">
+					<CardHeader className="gap-2">
+						<CardTitle className="flex items-center gap-2">
+							<Cpu className="size-5 text-muted-foreground" aria-hidden /> Basic
+						</CardTitle>
+						<CardDescription>First active Basic agent included at no charge.</CardDescription>
+						<div className="pt-1">
+							<p className="text-xs text-muted-foreground">Each additional Basic agent</p>
+							{basicPrice ? (
+								<>
+									<p className="text-3xl font-semibold tracking-tight tabular-nums">
+										{basicPrice.primary}
+									</p>
+									{basicOffer?.billing_term_months !== 1 ? (
+										<p className="text-xs text-muted-foreground">{basicPrice.secondary}</p>
+									) : null}
+								</>
+							) : (
+								<p className="text-sm font-medium">Pricing unavailable</p>
+							)}
 						</div>
-						<div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-							<span className="text-2xl font-semibold tracking-tight">First agent free</span>
-							<span className="text-sm text-muted-foreground">
-								{basicOffer
-									? `then ${formatCents(basicOffer.effective_monthly_price_cents)}/mo`
-									: "additional pricing unavailable"}
-							</span>
-						</div>
-						<CardDescription className="mt-2">
-							Your first active Basic agent is free. Each additional Basic agent uses its own
-							subscription.
-						</CardDescription>
-						{basicOffer && basicOffer.billing_term_months !== 1 ? (
-							<p className="text-xs text-muted-foreground">
-								Additional agents billed {formatCents(basicOffer.price_cents)}
-								{billingTermSuffix(basicOffer.billing_term_months)}
-							</p>
-						) : null}
-						{basicOffers.length > 1 ? (
-							<div className="mt-3">
-								<TermSwitcher
-									offers={basicOffers}
-									value={basicBillingTermMonths}
-									onChange={setTerm}
-								/>
-							</div>
-						) : null}
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Managed confidential-compute infrastructure</FeatureRow>
-							<FeatureRow>
-								Burstable compute
-								{basicResources
-									? ` (${basicResources.vcpu} vCPU / ${basicResources.ram_gb} GB)`
-									: ""}
-							</FeatureRow>
-							<FeatureRow>
-								Disk{basicResources ? ` (${basicResources.disk_size} GB)` : ""}
-							</FeatureRow>
-							<FeatureRow>One free active Basic agent per user</FeatureRow>
-							<FeatureRow>Paid additional Basic agents</FeatureRow>
-							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
-							<FeatureRow>BYOK avoids Clawdi AI usage charges</FeatureRow>
+							<FeatureRow>Managed confidential compute</FeatureRow>
+							{basic ? (
+								<FeatureRow>
+									{basic.vcpu} vCPU · {basic.ram_gb} GB RAM · {basic.disk_size} GB disk
+								</FeatureRow>
+							) : null}
+							<FeatureRow>One runtime: OpenClaw or Hermes</FeatureRow>
+							<FeatureRow>Bring your own AI keys (BYOK)</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>
@@ -164,69 +161,49 @@ export function PlanComparison({
 								className="w-full"
 								variant="outline"
 							>
-								<Rocket /> Deploy Compute Basic
+								<Rocket /> Deploy Basic
 							</Button>
 						) : (
 							<Button className="w-full" variant="outline" disabled>
-								<Rocket /> Deploy Compute Basic
+								<Rocket /> Deploy Basic
 							</Button>
 						)}
 					</CardFooter>
 				</Card>
 
 				{/* Performance */}
-				<Card className="relative flex flex-col border-primary/50 shadow-sm ring-1 ring-primary/20">
-					<Badge className="-top-2.5 absolute left-1/2 -translate-x-1/2 shadow-sm">Per agent</Badge>
-					<CardHeader>
-						<div className="flex items-center justify-between">
-							<CardTitle className="flex items-center gap-2">
-								<Zap className="size-5 text-primary" aria-hidden /> Compute Performance
-							</CardTitle>
+				<Card size="sm" className="border-primary/30">
+					<CardHeader className="gap-2">
+						<CardTitle className="flex items-center gap-2">
+							<Zap className="size-5 text-primary" aria-hidden /> Performance
+						</CardTitle>
+						<CardDescription>Higher compute resources with public ports.</CardDescription>
+						<div className="pt-1">
+							<p className="text-xs text-muted-foreground">Each Performance agent</p>
+							{performancePrice ? (
+								<>
+									<p className="text-3xl font-semibold tracking-tight tabular-nums">
+										{performancePrice.primary}
+									</p>
+									{performanceOffer?.billing_term_months !== 1 ? (
+										<p className="text-xs text-muted-foreground">{performancePrice.secondary}</p>
+									) : null}
+								</>
+							) : (
+								<p className="text-sm font-medium">Pricing unavailable</p>
+							)}
 						</div>
-						<div className="mt-2 flex items-baseline gap-1">
-							<span className="text-3xl font-semibold tracking-tight tabular-nums">
-								{performanceOffer
-									? formatCents(performanceOffer.effective_monthly_price_cents)
-									: performance
-										? formatCents(performance.price_cents)
-										: "—"}
-							</span>
-							<span className="text-sm text-muted-foreground">/mo</span>
-							{performanceOffer && performanceOffer.billing_term_months !== 1 ? (
-								<span className="ml-1 text-xs text-muted-foreground">
-									billed {formatCents(performanceOffer.price_cents)}
-									{billingTermSuffix(performanceOffer.billing_term_months)}
-								</span>
-							) : null}
-						</div>
-						<CardDescription className="mt-2">
-							More compute, larger disk, and public-port entitlement for demanding agents.
-							{annualOffer && annualOffer.discount_percent > 0
-								? ` Save ${annualOffer.discount_percent}% on annual.`
-								: ""}
-						</CardDescription>
-						{performanceOffers.length > 1 ? (
-							<div className="mt-3">
-								<TermSwitcher
-									offers={performanceOffers}
-									value={performanceBillingTermMonths}
-									onChange={setTerm}
-								/>
-							</div>
-						) : null}
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Everything in Compute Basic, plus:</FeatureRow>
-							<FeatureRow>
-								Higher burst
-								{performance ? ` (${performance.vcpu} vCPU / ${performance.ram_gb} GB)` : ""}
-							</FeatureRow>
-							<FeatureRow>One subscription per Performance agent</FeatureRow>
+							<FeatureRow>Everything in Basic, with higher resources</FeatureRow>
+							{performance ? (
+								<FeatureRow>
+									{performance.vcpu} vCPU · {performance.ram_gb} GB RAM · {performance.disk_size} GB
+									disk
+								</FeatureRow>
+							) : null}
 							<FeatureRow>Public ports for agent services</FeatureRow>
-							<FeatureRow>
-								Larger disk{performance ? ` (${performance.disk_size} GB)` : ""}
-							</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>
@@ -237,47 +214,41 @@ export function PlanComparison({
 								className="w-full"
 								disabled={!performance}
 							>
-								Deploy Compute Performance
+								Deploy Performance
 							</Button>
 						) : (
 							<Button className="w-full" disabled>
-								Deploy Compute Performance
+								Deploy Performance
 							</Button>
 						)}
 					</CardFooter>
 				</Card>
 
 				{/* Clawdi AI */}
-				<Card className="flex flex-col bg-muted/30">
-					<CardHeader>
+				<Card size="sm" className="bg-muted/20">
+					<CardHeader className="gap-2">
 						<CardTitle className="flex items-center gap-2">
 							<WalletCards className="size-5 text-muted-foreground" aria-hidden /> Clawdi AI
 						</CardTitle>
-						<div className="mt-2 flex items-baseline gap-1">
-							<span className="text-3xl font-semibold tracking-tight">Pay as you go</span>
-						</div>
-						<CardDescription className="mt-2">
-							Top up your Wallet and pay only for the AI usage your agents consume.
-						</CardDescription>
-						<div className="mt-3 rounded-lg border bg-background/70 px-3 py-2">
-							<p className="text-sm font-medium">
-								30% cheaper than direct API pricing on supported models
-							</p>
-							<p className="mt-0.5 text-xs text-muted-foreground">Actual savings vary by model.</p>
+						<CardDescription>Use Wallet funds or bring your own AI keys.</CardDescription>
+						<div className="pt-1">
+							<p className="text-3xl font-semibold tracking-tight">Pay as you go</p>
+							<p className="text-xs text-muted-foreground">Not affected by compute billing term</p>
 						</div>
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Usage billed directly in USD</FeatureRow>
-							<FeatureRow>Whole-dollar wallet top-ups</FeatureRow>
-							<FeatureRow>Optional auto-reload</FeatureRow>
-							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
+							<FeatureRow>
+								<span>
+									30% below direct API pricing on supported models
+									<span className="mt-0.5 block text-xs text-muted-foreground">
+										Eligible models only; actual savings vary by model.
+									</span>
+								</span>
+							</FeatureRow>
+							<FeatureRow>Pay from your Wallet</FeatureRow>
+							<FeatureRow>Use your own AI keys (BYOK)</FeatureRow>
 						</ul>
-						<Separator className="my-4" />
-						<p className="text-xs text-muted-foreground">
-							Works with both Basic and Performance compute. Manage balance and auto-reload from the
-							Wallet.
-						</p>
 					</CardContent>
 					<CardFooter>
 						<Button
@@ -291,6 +262,6 @@ export function PlanComparison({
 					</CardFooter>
 				</Card>
 			</div>
-		</div>
+		</section>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -122,7 +122,7 @@ export function PlanComparison({
 				<Card size="sm">
 					<CardHeader className="gap-2">
 						<CardTitle className="flex items-center gap-2">
-							<Cpu className="size-5 text-muted-foreground" aria-hidden /> Basic
+							<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
 						</CardTitle>
 						<CardDescription>First active Basic agent included at no charge.</CardDescription>
 						<div className="pt-1">
@@ -161,11 +161,11 @@ export function PlanComparison({
 								className="w-full"
 								variant="outline"
 							>
-								<Rocket /> Deploy Basic
+								<Rocket /> Deploy Compute Basic
 							</Button>
 						) : (
 							<Button className="w-full" variant="outline" disabled>
-								<Rocket /> Deploy Basic
+								<Rocket /> Deploy Compute Basic
 							</Button>
 						)}
 					</CardFooter>
@@ -175,9 +175,8 @@ export function PlanComparison({
 				<Card size="sm" className="border-primary/30">
 					<CardHeader className="gap-2">
 						<CardTitle className="flex items-center gap-2">
-							<Zap className="size-5 text-primary" aria-hidden /> Performance
+							<Zap className="size-5 text-primary" aria-hidden /> Compute Performance
 						</CardTitle>
-						<CardDescription>Higher compute resources with public ports.</CardDescription>
 						<div className="pt-1">
 							<p className="text-xs text-muted-foreground">Each Performance agent</p>
 							{performancePrice ? (
@@ -196,14 +195,16 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Everything in Basic, with higher resources</FeatureRow>
 							{performance ? (
 								<FeatureRow>
 									{performance.vcpu} vCPU · {performance.ram_gb} GB RAM · {performance.disk_size} GB
 									disk
 								</FeatureRow>
 							) : null}
+							<FeatureRow>Managed confidential compute</FeatureRow>
+							<FeatureRow>One runtime: OpenClaw or Hermes</FeatureRow>
 							<FeatureRow>Public ports for agent services</FeatureRow>
+							<FeatureRow>Bring your own AI keys (BYOK)</FeatureRow>
 						</ul>
 					</CardContent>
 					<CardFooter>
@@ -214,11 +215,11 @@ export function PlanComparison({
 								className="w-full"
 								disabled={!performance}
 							>
-								Deploy Performance
+								Deploy Compute Performance
 							</Button>
 						) : (
 							<Button className="w-full" disabled>
-								Deploy Performance
+								Deploy Compute Performance
 							</Button>
 						)}
 					</CardFooter>
@@ -230,21 +231,15 @@ export function PlanComparison({
 						<CardTitle className="flex items-center gap-2">
 							<WalletCards className="size-5 text-muted-foreground" aria-hidden /> Clawdi AI
 						</CardTitle>
-						<CardDescription>Use Wallet funds or bring your own AI keys.</CardDescription>
 						<div className="pt-1">
 							<p className="text-3xl font-semibold tracking-tight">Pay as you go</p>
-							<p className="text-xs text-muted-foreground">Not affected by compute billing term</p>
 						</div>
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>
-								<span>
-									30% below direct API pricing on supported models
-									<span className="mt-0.5 block text-xs text-muted-foreground">
-										Eligible models only; actual savings vary by model.
-									</span>
-								</span>
+								30% cheaper than direct API pricing on supported models. Actual savings vary by
+								model.
 							</FeatureRow>
 							<FeatureRow>Pay from your Wallet</FeatureRow>
 							<FeatureRow>Use your own AI keys (BYOK)</FeatureRow>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -82,10 +82,7 @@ export function SubscriptionPage() {
 			<Card data-hosted="true">
 				<CardHeader>
 					<CardTitle>Compute is managed per agent</CardTitle>
-					<CardDescription>
-						Basic includes one free active hosted-agent slot. Additional Basic and Performance
-						agents each use a separate subscription.
-					</CardDescription>
+					<CardDescription>Deploy new hosted agents from here.</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-4">
 					<p className="text-sm text-muted-foreground">

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -306,14 +306,18 @@ describe("commonExplicitBillingOffers", () => {
 		expect(shared).toEqual([monthly]);
 	});
 
-	test("does not synthesize a shared term when either plan has no explicit offers", () => {
+	test("returns no shared term for disjoint non-empty explicit offer sets", () => {
 		expect(
 			commonExplicitBillingOffers([
-				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 1_234, offers: [] }),
+				plan({
+					slug: COMPUTE_BASIC_SLUG,
+					price_cents: 1_234,
+					offers: [offer(1, 1_234)],
+				}),
 				plan({
 					slug: COMPUTE_PERFORMANCE_SLUG,
 					price_cents: 5_678,
-					offers: [offer(1, 5_678)],
+					offers: [offer(12, 54_324)],
 				}),
 			]),
 		).toEqual([]);

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -3,6 +3,7 @@ import type { BillingOffer, HostedComputeSubscription, Plan } from "@/hosted/bil
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
+	commonExplicitBillingOffers,
 	computeFundingMode,
 	computeFundingSource,
 	computeSubscriptionId,
@@ -282,6 +283,40 @@ describe("selectExplicitOfferForTerm", () => {
 				1,
 			),
 		).toBeNull();
+	});
+});
+
+describe("commonExplicitBillingOffers", () => {
+	test("keeps only terms explicitly offered by both compute plans", () => {
+		const monthly = offer(1, 1_234);
+		const annual = offer(12, 12_345);
+		const shared = commonExplicitBillingOffers([
+			plan({
+				slug: COMPUTE_BASIC_SLUG,
+				price_cents: 1_234,
+				offers: [annual, monthly],
+			}),
+			plan({
+				slug: COMPUTE_PERFORMANCE_SLUG,
+				price_cents: 5_678,
+				offers: [offer(1, 5_678)],
+			}),
+		]);
+
+		expect(shared).toEqual([monthly]);
+	});
+
+	test("does not synthesize a shared term when either plan has no explicit offers", () => {
+		expect(
+			commonExplicitBillingOffers([
+				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 1_234, offers: [] }),
+				plan({
+					slug: COMPUTE_PERFORMANCE_SLUG,
+					price_cents: 5_678,
+					offers: [offer(1, 5_678)],
+				}),
+			]),
+		).toEqual([]);
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -251,6 +251,32 @@ export function explicitPlanOffers(plan: Plan): BillingOffer[] {
 	return plan.offers ?? [];
 }
 
+/**
+ * Explicit offers from the first plan whose terms are also explicitly offered
+ * by every other plan. Prices remain plan-specific; callers use this list only
+ * to drive a synchronized billing-term control.
+ */
+export function commonExplicitBillingOffers(plans: readonly Plan[]): BillingOffer[] {
+	const [firstPlan, ...otherPlans] = plans;
+	if (!firstPlan || otherPlans.length === 0) return [];
+
+	const firstOffers = explicitPlanOffers(firstPlan);
+	const otherTermSets = otherPlans.map(
+		(plan) => new Set(explicitPlanOffers(plan).map((offer) => offer.billing_term_months)),
+	);
+	if (firstOffers.length === 0 || otherTermSets.some((terms) => terms.size === 0)) return [];
+
+	const seenTerms = new Set<number>();
+	return firstOffers
+		.filter((offer) => {
+			const term = offer.billing_term_months;
+			if (seenTerms.has(term) || !otherTermSets.every((terms) => terms.has(term))) return false;
+			seenTerms.add(term);
+			return true;
+		})
+		.sort((a, b) => a.billing_term_months - b.billing_term_months);
+}
+
 export function selectExplicitOfferForTerm(plan: Plan, term: number): ResolvedBillingOffer | null {
 	const offers = explicitPlanOffers(plan);
 	const offer = offers.find((candidate) => candidate.billing_term_months === term) ?? offers[0];


### PR DESCRIPTION
## Summary

- align the in-app comparison with the public v2 offer: Compute Basic, Compute Performance, and Clawdi AI
- keep Basic and Performance amounts, resources, discounts, and billing terms driven by clawdi-hosted GET /v2/subscription/plans
- show the Basic disk value and remove the unrelated signup-grant marketing row
- keep the qualified Clawdi AI savings claim and model-dependent disclaimer
- preserve internal /deploy and Wallet actions
- remove brittle source-text pricing assertions from an unrelated deploy-wizard test

## Product facts

- first active Basic agent is free
- additional Basic and Performance agents use API-returned prices and billing terms
- Clawdi AI is pay as you go through Wallet
- 30% cheaper than direct API pricing on supported models; actual savings vary by model
- BYOK bypasses Clawdi AI charges
- confidential-compute wording remains provider-neutral

## Verification

- hermetic web suite passed: typecheck, tests, and OSS production build
- focused Biome check and git diff --check passed

No shared cross-repo component, duplicated pricing contract, production operation, or merge was added.