### PR TITLE
fix(channels): enforce Discord guild and DM trust boundaries

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5494,7 +5494,7 @@ test("app 404 offers a working exit to the dashboard", async ({ page }) => {
 	expect(errors, `app 404: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("Channels inventories only owned bots without ready-pool operations", async ({
+test("Channels separates owned and shared bots with compact connect forms", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 1100 });
@@ -5660,21 +5660,32 @@ test("Channels inventories only owned bots without ready-pool operations", async
 
 	await page.goto("/channels");
 	const ownedSection = page.locator("[data-owned-bots-section]");
-	await expect(ownedSection).toContainText(/Bots\s*2/);
+	const sharedSection = page.locator("[data-shared-bots-section]");
+	await expect(ownedSection).toContainText(/Your bots\s*2/);
+	await expect(sharedSection).toContainText(/Shared bots\s*2/);
 	expect(
 		await ownedSection
 			.locator("[data-channel-account-id]")
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-channel-account-id"))),
 	).toEqual([personalTelegramId, personalDiscordId]);
-	await expect(page.getByRole("button", { name: /All\s+2/ })).toBeVisible();
-	await expect(page.getByRole("button", { name: /Telegram\s+1/ })).toBeVisible();
-	await expect(page.getByRole("button", { name: /Discord\s+1/ })).toBeVisible();
+	expect(
+		await sharedSection
+			.locator("[data-shared-channel-account-id]")
+			.evaluateAll((cards) =>
+				cards.map((card) => card.getAttribute("data-shared-channel-account-id")),
+			),
+	).toEqual([accountId, discordBotId]);
+	await expect(page.getByRole("button", { name: /All\s+4/ })).toBeVisible();
+	await expect(page.getByRole("button", { name: /Telegram\s+2/ })).toBeVisible();
+	await expect(page.getByRole("button", { name: /Discord\s+2/ })).toBeVisible();
 	await expect(page.getByRole("button", { name: /WhatsApp/ })).toHaveCount(0);
 	await expect(page.locator("[data-ready-bots-section]")).toHaveCount(0);
 	await expect(page.locator("[data-pool-account-id]")).toHaveCount(0);
 	await expect(page.getByText("Ready-to-go bots", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Clawdi Support Bot", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Clawdi Community Bot", { exact: true })).toHaveCount(0);
+	await expect(sharedSection.getByText("Clawdi Support Bot", { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText("Clawdi Community Bot", { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText("Shared", { exact: true })).toHaveCount(0);
+	await expect(sharedSection.getByText("Discord", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Link an agent", exact: true })).toHaveCount(0);
 	await expect(page.getByRole("dialog", { name: "Link an agent" })).toHaveCount(0);
 	await page.screenshot({
@@ -5684,8 +5695,27 @@ test("Channels inventories only owned bots without ready-pool operations", async
 		fullPage: true,
 	});
 
+	await page.getByRole("button", { name: "Connect bot", exact: true }).click();
+	let connectDialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await expect(connectDialog.getByRole("button", { name: /^Telegram Telegram$/ })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await expect(connectDialog.getByLabel("Application ID")).toHaveCount(0);
+	await expect(
+		connectDialog.getByText("Create a bot with @BotFather", { exact: true }),
+	).toBeVisible();
+	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-desktop.png") });
+	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await expect(connectDialog.getByLabel("Application ID")).toBeVisible();
+	await expect(connectDialog.getByLabel("Public key")).toBeVisible();
+	await expect(connectDialog.getByText(/Server ID/i)).toHaveCount(0);
+	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-desktop.png") });
+	await connectDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
 	await page.setViewportSize({ width: 320, height: 844 });
 	await expect(ownedSection.getByText("Personal Telegram", { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText("Clawdi Community Bot", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /WhatsApp/ })).toHaveCount(0);
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
 	await page.screenshot({
@@ -5695,19 +5725,72 @@ test("Channels inventories only owned bots without ready-pool operations", async
 		fullPage: true,
 	});
 	await page.getByRole("button", { name: "Connect bot", exact: true }).click();
-	const connectDialog = page.getByRole("dialog", { name: "Connect a channel" });
-	await connectDialog.getByLabel("Name").fill("Inventory Telegram");
-	await connectDialog.getByLabel("Bot token").fill("123456:inventory-browser-token");
-	await connectDialog.getByRole("button", { name: "Connect", exact: true }).click();
-	await expect.poll(() => createChannelRequests.length).toBe(1);
-	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
-		provider: "telegram",
-		name: "Inventory Telegram",
-		provider_token: "123456:inventory-browser-token",
-		agent_id: null,
-	});
-	await expect(page.getByRole("dialog", { name: "Channel connected" })).toBeVisible();
+	connectDialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-320.png") });
+	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await expect(connectDialog.getByLabel("Public key")).toBeVisible();
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-320.png") });
 	expect(errors, `Channels inventory browser errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Channels shared-only inventory stays primary without duplicate empty actions", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	const errors = collectBrowserErrors(page);
+	const sharedDiscordId = "10eeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+	await stubHostedApi(page, {
+		channelAccounts: [],
+		channelBotPool: {
+			providers: {
+				discord: [
+					{
+						id: sharedDiscordId,
+						provider: "discord",
+						name: "Shared Discord",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://cloud.example.test/channels/shared-discord",
+						created_at: "2026-07-31T00:00:00Z",
+						access: "public",
+						capabilities: {
+							link_agent: true,
+							pair_chat: true,
+							send_message: true,
+							manage_account: false,
+							sync_commands: false,
+						},
+						link_count: 0,
+						max_links: null,
+						available: true,
+					},
+				],
+			},
+		},
+	});
+
+	await page.goto("/channels");
+	await expect(page.locator("[data-owned-bots-section]")).toHaveCount(0);
+	const sharedSection = page.locator("[data-shared-bots-section]");
+	await expect(sharedSection.getByText("Shared Discord", { exact: true })).toBeVisible();
+	await expect(sharedSection.getByRole("img", { name: "Discord" })).toBeVisible();
+	await expect(page.getByText("No bots yet", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Connect bot", exact: true })).toHaveCount(1);
+	await expect(page.getByRole("button", { name: /Discord\s+1/ })).toBeVisible();
+	await page.screenshot({
+		path: testInfo.outputPath("channels-shared-only-desktop.png"),
+		fullPage: true,
+	});
+
+	await page.setViewportSize({ width: 320, height: 844 });
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await page.screenshot({
+		path: testInfo.outputPath("channels-shared-only-320.png"),
+		fullPage: true,
+	});
+	expect(errors, `Channels shared-only browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("channel connect updates its auto-linked agent page without reload", async ({ page }) => {
@@ -5818,6 +5901,66 @@ test("channel connect updates its auto-linked agent page without reload", async 
 	expect(errors, `channel connect convergence: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	const errors = collectBrowserErrors(page);
+	const agentId = missingProjectionEnvironmentId;
+	const telegramId = "6aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+	const telegramLinkId = "6bbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+	const telegramAccount = {
+		id: telegramId,
+		provider: "telegram",
+		name: "Linked Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/linked-telegram",
+		created_at: "2026-07-31T00:00:00Z",
+	};
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: [telegramAccount],
+		channelAgentLinks: [
+			{
+				id: telegramLinkId,
+				account_id: telegramId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-07-31T00:01:00Z",
+				account: telegramAccount,
+			},
+		],
+		channelBotPool: { providers: {} },
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await page.getByText("Use your own bot", { exact: true }).click();
+	await page.getByRole("button", { name: "Connect a bot", exact: true }).click();
+	let dialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await expect(dialog.getByRole("button", { name: /Telegram.*Already linked/ })).toBeDisabled();
+	await expect(dialog.getByRole("button", { name: /^Discord Discord$/ })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await expect(
+		dialog.getByText("Unlink Telegram from this Agent first.", { exact: true }),
+	).toBeVisible();
+	await expect(dialog.getByLabel("Application ID")).toBeVisible();
+	await dialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-default-desktop.png") });
+
+	await page.setViewportSize({ width: 320, height: 844 });
+	dialog = page.getByRole("dialog", { name: "Connect a bot" });
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expect(dialog.getByLabel("Public key")).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
+	await dialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-default-320.png") });
+	expect(errors, `Agent connect default browser errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("Agent Channels uses compact task-ordered rows and the shared Telegram pair dialog", async ({
 	page,
 }, testInfo) => {
@@ -5835,6 +5978,8 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const currentBindingId = "77777777-7777-4777-8777-777777777777";
 	const otherAgentBindingId = "78888888-8888-4888-8888-888888888888";
 	const polledBindingId = "79999999-9999-4999-8999-999999999999";
+	const discordServerBindingId = "7aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+	const discordDmBindingId = "7bbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const successfulPairResponse = (id: string, code: string): StubResponse => ({
 		status: 201,
@@ -5913,6 +6058,26 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			external_chat_name: "Other Agent DM",
 			status: "active",
 			created_at: "2026-07-30T10:05:00Z",
+		},
+		{
+			id: discordServerBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-guild-1",
+			external_chat_type: "guild",
+			external_chat_name: "Clawdi Community",
+			status: "active",
+			created_at: "2026-07-30T10:06:00Z",
+		},
+		{
+			id: discordDmBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-dm-1",
+			external_chat_type: "private",
+			external_chat_name: "Discord DM",
+			status: "active",
+			created_at: "2026-07-30T10:07:00Z",
 		},
 	];
 	await stubHostedApi(page, {
@@ -6061,6 +6226,20 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 					qr_payload: "https://t.me/Clawdi_Ready_Bot?start=AGENTEXPIRED123",
 				},
 			},
+			{ status: 503, body: { detail: "temporary Discord preparation error" } },
+			{
+				status: 201,
+				body: {
+					id: "agent-channel-discord-pair-retry",
+					agent_link_id: discordLinkId,
+					agent_id: agentId,
+					code: "DISCORDPAIR123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair DISCORDPAIR123",
+					discord_install_url:
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+				},
+			},
 		],
 	});
 
@@ -6082,21 +6261,27 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect(discordRow).toContainText("Community Discord");
 	const pairButton = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
 	await expect(pairButton).toBeVisible();
-	await expect(discordRow.getByRole("button", { name: "Pair chat", exact: true })).toBeVisible();
+	const discordPairButton = discordRow.getByRole("button", { name: "Pair Discord", exact: true });
+	await expect(discordPairButton).toBeVisible();
 	await expect(telegramRow.getByRole("button", { name: "Unlink", exact: true })).toBeVisible();
-	await expect(addSection.locator(`[data-add-channel-id="${readyId}"]`)).toContainText(
-		"Clawdi Ready Bot",
-	);
-	await expect(addSection.getByText("Use your own bot", { exact: true })).toBeVisible();
-	await expect(addSection.locator("details")).not.toHaveAttribute("open", "");
+	await expect(addSection.locator(`[data-add-channel-id="${readyId}"]`)).toHaveCount(0);
+	await expect(addSection.getByText("Use your own bot", { exact: true })).toHaveCount(0);
+	await expect(addSection.locator("details")).toHaveCount(0);
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);
 	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
 	await expect(currentBindingRow).toContainText("Current Agent DM");
 	await expect(
 		telegramGroup.locator(`[data-channel-binding-id="${currentBindingId}"]`),
 	).toBeVisible();
-	await expect(discordGroup.locator("[data-channel-binding-id]")).toHaveCount(0);
-	await expect(discordGroup.locator("[data-agent-channel-chats-for]")).toHaveCount(0);
+	const discordServerRow = discordGroup.locator(
+		`[data-channel-binding-id="${discordServerBindingId}"]`,
+	);
+	const discordDmRow = discordGroup.locator(`[data-channel-binding-id="${discordDmBindingId}"]`);
+	await expect(discordServerRow).toContainText("Server · Clawdi Community");
+	await expect(discordDmRow).toContainText("Direct message · Discord DM");
+	await expect(discordServerRow).toContainText("Run /bot_unpair in this server.");
+	await expect(discordDmRow).toContainText("Run /bot_unpair in this direct message.");
+	await expect(discordGroup.getByRole("button", { name: /Unpair/ })).toHaveCount(0);
 	await expect(currentBindingRow).not.toContainText("Support Telegram");
 	await expect(page.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`)).toHaveCount(0);
 	await expect(page.getByText("Other Agent DM", { exact: true })).toHaveCount(0);
@@ -6199,6 +6384,36 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	);
 	await recoveryDialog.getByRole("button", { name: "Close", exact: true }).click();
 
+	await discordPairButton.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(6);
+	let discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expect(
+		discordPairDialog.getByText("Couldn't prepare Discord pairing", { exact: true }),
+	).toBeVisible();
+	await discordPairDialog.screenshot({
+		path: testInfo.outputPath("agent-discord-pair-error-desktop.png"),
+	});
+	await discordPairDialog.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect.poll(() => pairCodeRequests.length).toBe(7);
+	discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expect(discordPairDialog.getByText("Server", { exact: true })).toBeVisible();
+	await expect(discordPairDialog.getByText("Direct message", { exact: true })).toBeVisible();
+	await expect(discordPairDialog.getByText("DISCORDPAIR123", { exact: true })).toBeVisible();
+	await expect(discordPairDialog.getByRole("button", { name: "Add to server" })).toHaveAttribute(
+		"href",
+		/permissions=274878024768/,
+	);
+	await discordPairDialog.screenshot({
+		path: testInfo.outputPath("agent-discord-pair-code-desktop.png"),
+	});
+	await page.setViewportSize({ width: 320, height: 844 });
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await discordPairDialog.screenshot({
+		path: testInfo.outputPath("agent-discord-pair-code-320.png"),
+	});
+	await page.keyboard.press("Escape");
+	await page.setViewportSize({ width: 1440, height: 1100 });
+
 	await currentBindingRow.getByRole("button", { name: "Unpair", exact: true }).click();
 	const unpairConfirmation = page.getByRole("alertdialog", { name: "Unpair Current Agent DM?" });
 	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
@@ -6253,6 +6468,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		(error) =>
 			!error.includes("temporary Telegram pair error") &&
 			!error.includes("temporary Telegram cleanup error") &&
+			!error.includes("temporary Discord preparation error") &&
 			!error.includes("503") &&
 			!error.includes("502"),
 	);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -231,9 +231,9 @@ import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.lo
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import {
 	agentProviderHasSingleLinkLimit,
+	availableBotProvidersForAgent,
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
-	discordPairingShouldSyncCommands,
 	pairingActionLabel,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import {
@@ -2334,6 +2334,10 @@ function ChannelsTab({
 		agentLinkId: string;
 		channelName: string;
 	} | null>(null);
+	const [discordPair, setDiscordPair] = useState<{
+		accountId: string;
+		agentLinkId: string;
+	} | null>(null);
 	const [connectOpen, setConnectOpen] = useState(false);
 	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
 	const linkInFlightRef = useRef(false);
@@ -2608,7 +2612,7 @@ function ChannelsTab({
 							<AddChannelRow
 								key={bot.id}
 								channel={bot}
-								kind="Ready to use"
+								kind="Shared bot"
 								linking={linkingAccountId === bot.id}
 								disabled={linkingAccountId !== null}
 								onLink={() => void submitLink(bot.id)}
@@ -2617,52 +2621,54 @@ function ChannelsTab({
 					</div>
 				) : null}
 
-				<details className="group border-t pt-4">
-					<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
-					<div className="mt-3 space-y-3">
-						{channels.isLoading ? (
-							<Skeleton className="h-16 w-full rounded-lg" />
-						) : channels.error ? (
-							<ApiErrorPanel
-								error={channels.error}
-								onRetry={() => channels.refetch()}
-								title="Couldn't load your bots"
-							/>
-						) : ownedChannels.length > 0 ? (
-							<div className={AGENT_CHANNEL_LIST_CLASS}>
-								{ownedChannels.map((channel) => (
-									<AddChannelRow
-										key={channel.id}
-										channel={channel}
-										kind="Your bot"
-										linking={linkingAccountId === channel.id}
-										disabled={linkingAccountId !== null}
-										onLink={() => void submitLink(channel.id)}
-										secondary
-									/>
-								))}
-							</div>
-						) : (
-							<Button size="sm" onClick={() => setConnectOpen(true)}>
-								<Plus className="size-3.5" />
-								Connect a bot
-							</Button>
-						)}
-						{ownedChannels.length > 0 ? (
-							<div className="flex flex-wrap gap-2">
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onClick={() => setConnectOpen(true)}
-								>
+				{availableBotProvidersForAgent(environmentId, agentType, linkedProviders).length > 0 ? (
+					<details className="group border-t pt-4">
+						<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
+						<div className="mt-3 space-y-3">
+							{channels.isLoading ? (
+								<Skeleton className="h-16 w-full rounded-lg" />
+							) : channels.error ? (
+								<ApiErrorPanel
+									error={channels.error}
+									onRetry={() => channels.refetch()}
+									title="Couldn't load your bots"
+								/>
+							) : ownedChannels.length > 0 ? (
+								<div className={AGENT_CHANNEL_LIST_CLASS}>
+									{ownedChannels.map((channel) => (
+										<AddChannelRow
+											key={channel.id}
+											channel={channel}
+											kind={undefined}
+											linking={linkingAccountId === channel.id}
+											disabled={linkingAccountId !== null}
+											onLink={() => void submitLink(channel.id)}
+											secondary
+										/>
+									))}
+								</div>
+							) : (
+								<Button size="sm" onClick={() => setConnectOpen(true)}>
 									<Plus className="size-3.5" />
 									Connect a bot
 								</Button>
-							</div>
-						) : null}
-					</div>
-				</details>
+							)}
+							{ownedChannels.length > 0 ? (
+								<div className="flex flex-wrap gap-2">
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={() => setConnectOpen(true)}
+									>
+										<Plus className="size-3.5" />
+										Connect a bot
+									</Button>
+								</div>
+							) : null}
+						</div>
+					</details>
+				) : null}
 			</section>
 
 			<ConnectBotDialog
@@ -2680,12 +2686,9 @@ function ChannelsTab({
 						});
 						return;
 					}
-					toast.success("Channel connected", {
-						description:
-							bot.provider === "discord"
-								? "Use Pair Discord from the connected Discord Bot row."
-								: "Pair a chat from the connected channel row.",
-					});
+					if (bot.provider === "discord") {
+						setDiscordPair({ accountId: bot.id, agentLinkId: bot.agentLinkId });
+					}
 				}}
 			/>
 			{telegramPair ? (
@@ -2698,6 +2701,16 @@ function ChannelsTab({
 					agentLinkId={telegramPair.agentLinkId}
 					agentName={agentName}
 					channelName={telegramPair.channelName}
+				/>
+			) : null}
+			{discordPair ? (
+				<DiscordPairDialog
+					open
+					onOpenChange={(open) => {
+						if (!open) setDiscordPair(null);
+					}}
+					accountId={discordPair.accountId}
+					agentLinkId={discordPair.agentLinkId}
 				/>
 			) : null}
 		</div>
@@ -2794,7 +2807,7 @@ function AddChannelRow({
 	secondary = false,
 }: {
 	channel: LinkableChannel;
-	kind: string;
+	kind?: string;
 	linking: boolean;
 	disabled: boolean;
 	onLink: () => void;
@@ -2805,7 +2818,7 @@ function AddChannelRow({
 			<ProviderChip provider={channel.provider} size="sm" />
 			<div className="min-w-0">
 				<p className="truncate text-sm font-medium">{channel.name}</p>
-				<p className="truncate text-xs text-muted-foreground">{kind}</p>
+				{kind ? <p className="truncate text-xs text-muted-foreground">{kind}</p> : null}
 			</div>
 			<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
 				<Button
@@ -2861,7 +2874,6 @@ function LinkedChannelRow({
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
 	const isDiscord = provider === "discord";
-	const syncDiscordCommands = discordPairingShouldSyncCommands(account?.visibility);
 	const name = account?.name ?? "Unnamed channel";
 	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
 	useEffect(() => {
@@ -2983,7 +2995,6 @@ function LinkedChannelRow({
 					onOpenChange={setDiscordPairOpen}
 					accountId={link.account_id}
 					agentLinkId={link.id}
-					syncCommandsBeforePairing={syncDiscordCommands}
 				/>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -233,6 +233,8 @@ import {
 	agentProviderHasSingleLinkLimit,
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
+	discordPairingShouldSyncCommands,
+	pairingActionLabel,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import {
 	ChannelStatusBadge,
@@ -252,6 +254,7 @@ import {
 	useUnlinkAgentChannel,
 } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
+import { DiscordPairDialog } from "@/hosted/v2/channels/discord-pair-dialog";
 import { PairedChatRow } from "@/hosted/v2/channels/paired-chat-row";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
@@ -2355,10 +2358,20 @@ function ChannelsTab({
 	const accountSummaries = useMemo(() => {
 		const map = new Map<string, ChannelAccountSummary>();
 		for (const channel of channels.data ?? []) {
-			map.set(channel.id, { provider: channel.provider, name: channel.name });
+			map.set(channel.id, {
+				provider: channel.provider,
+				name: channel.name,
+				visibility: channel.visibility,
+			});
 		}
 		for (const list of Object.values(botPool.data?.providers ?? {})) {
-			for (const bot of list) map.set(bot.id, { provider: bot.provider, name: bot.name });
+			for (const bot of list) {
+				map.set(bot.id, {
+					provider: bot.provider,
+					name: bot.name,
+					visibility: bot.visibility,
+				});
+			}
 		}
 		return map;
 	}, [channels.data, botPool.data]);
@@ -2456,7 +2469,10 @@ function ChannelsTab({
 				});
 			} else {
 				toast.success("Channel linked", {
-					description: "Pair a chat from the connected channel row.",
+					description:
+						account?.provider === "discord"
+							? "Use Pair Discord from the connected Discord Bot row."
+							: "Pair a chat from the connected channel row.",
 				});
 			}
 			return data;
@@ -2567,7 +2583,7 @@ function ChannelsTab({
 				<div className="space-y-1">
 					<SectionLabel>Add a channel</SectionLabel>
 					<p className="px-0.5 text-sm text-muted-foreground">
-						Link a bot to this Agent, then pair the chats it should answer.
+						Link a bot to this Agent, then choose where it should answer.
 					</p>
 				</div>
 				{botPool.isLoading ? (
@@ -2665,7 +2681,10 @@ function ChannelsTab({
 						return;
 					}
 					toast.success("Channel connected", {
-						description: "Pair a chat from the connected channel row.",
+						description:
+							bot.provider === "discord"
+								? "Use Pair Discord from the connected Discord Bot row."
+								: "Pair a chat from the connected channel row.",
 					});
 				}}
 			/>
@@ -2706,13 +2725,14 @@ function ConnectedChannelGroup({
 	onBindingsRetry: () => void;
 	onUnlink: () => void;
 	unlinking: boolean;
-	fallbackAccount?: { provider: string; name: string };
+	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	healthLoading: boolean;
 	healthError: boolean;
 	onHealthRetry: () => void;
 }) {
 	const showChats = pairedChats.length > 0 || bindingsLoading || bindingsError;
+	const provider = link.account?.provider ?? fallbackAccount?.provider ?? "";
 
 	return (
 		<div data-agent-channel-group-id={link.id} className="min-w-0">
@@ -2748,7 +2768,11 @@ function ConnectedChannelGroup({
 							className="ml-4 flex min-h-12 flex-wrap items-center gap-2 border-l-2 border-muted py-2 pl-3"
 						>
 							<AlertCircle className="size-4 shrink-0 text-destructive" />
-							<p className="min-w-0 flex-1 text-sm font-medium">Couldn&apos;t load paired chats</p>
+							<p className="min-w-0 flex-1 text-sm font-medium">
+								{provider === "discord"
+									? "Couldn’t load paired servers or direct messages"
+									: "Couldn’t load paired chats"}
+							</p>
 							<Button type="button" variant="outline" size="sm" onClick={onBindingsRetry}>
 								<RefreshCw className="size-3.5" />
 								Retry
@@ -2818,7 +2842,7 @@ function LinkedChannelRow({
 	link: AgentChannelLink;
 	onUnlink: () => void;
 	unlinking: boolean;
-	fallbackAccount?: { provider: string; name: string };
+	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	healthLoading: boolean;
 	healthError: boolean;
@@ -2827,6 +2851,7 @@ function LinkedChannelRow({
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
 	const [telegramPairOpen, setTelegramPairOpen] = useState(false);
+	const [discordPairOpen, setDiscordPairOpen] = useState(false);
 	const [nowMs, setNowMs] = useState(() => Date.now());
 	const [creatingPairCode, setCreatingPairCode] = useState(false);
 	const pairInFlightRef = useRef(false);
@@ -2835,6 +2860,8 @@ function LinkedChannelRow({
 	// account NEVER white-screens (apps/web/src has no ErrorBoundary).
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
+	const isDiscord = provider === "discord";
+	const syncDiscordCommands = discordPairingShouldSyncCommands(account?.visibility);
 	const name = account?.name ?? "Unnamed channel";
 	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
 	useEffect(() => {
@@ -2889,10 +2916,10 @@ function LinkedChannelRow({
 						<span>No activity yet</span>
 					)}
 				</div>
-				{provider !== "telegram" && pair.error ? (
+				{provider !== "telegram" && !isDiscord && pair.error ? (
 					<p className="mt-1 text-xs font-medium text-destructive">Pair failed · Try again</p>
 				) : null}
-				{code && provider !== "telegram" ? (
+				{code && provider !== "telegram" && !isDiscord ? (
 					<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
 						<CopyInline value={code.pairing_command} label="pairing command" />
 						<span className="text-muted-foreground">
@@ -2909,6 +2936,7 @@ function LinkedChannelRow({
 					disabled={provider !== "telegram" && creatingPairCode}
 					onClick={() => {
 						if (provider === "telegram") setTelegramPairOpen(true);
+						else if (isDiscord) setDiscordPairOpen(true);
 						else void createPairCode();
 					}}
 				>
@@ -2919,7 +2947,7 @@ function LinkedChannelRow({
 							? "Pair Telegram"
 							: pair.error
 								? "Retry pairing"
-								: "Pair chat"}
+								: pairingActionLabel(provider)}
 				</Button>
 				<ConfirmAction
 					title="Unlink this channel?"
@@ -2947,6 +2975,15 @@ function LinkedChannelRow({
 					accountId={link.account_id}
 					agentLinkId={link.id}
 					channelName={name}
+				/>
+			) : null}
+			{isDiscord ? (
+				<DiscordPairDialog
+					open={discordPairOpen}
+					onOpenChange={setDiscordPairOpen}
+					accountId={link.account_id}
+					agentLinkId={link.id}
+					syncCommandsBeforePairing={syncDiscordCommands}
 				/>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.ts
@@ -1,7 +1,11 @@
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 
-export type ChannelAccountSummary = { provider: string; name: string };
+export type ChannelAccountSummary = {
+	provider: string;
+	name: string;
+	visibility?: "private" | "public";
+};
 
 export type AgentPairedChatItem = {
 	accountId: string;

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -6,15 +6,16 @@ function source(relativePath: string): string {
 }
 
 describe("global Channels inventory", () => {
-	test("shows only owned bot assets and never exposes the ready-bot linking flow", () => {
+	test("separates owned and shared bot inventory without relationship actions", () => {
 		const channelsPage = source("./channels-page.tsx");
 
 		expect(channelsPage).toContain("<OwnedBotsSection");
 		expect(channelsPage).toContain("data-owned-bots-section");
-		expect(channelsPage).toContain("Manage the bots you own");
+		expect(channelsPage).toContain("<SharedBotsSection");
+		expect(channelsPage).toContain("data-shared-bots-section");
 		expect(channelsPage).toContain("Connect bot");
 		expect(channelsPage).toContain("orderedChannelsForFilter");
-		expect(channelsPage).not.toContain("useBotPool");
+		expect(channelsPage).toContain("useBotPool");
 		expect(channelsPage).not.toContain("ReadyBotsSection");
 		expect(channelsPage).not.toContain("Ready-to-go bots");
 		expect(channelsPage).not.toContain("data-ready-bots-section");
@@ -22,7 +23,8 @@ describe("global Channels inventory", () => {
 		expect(channelsPage).not.toContain("LinkAgentDialog");
 		expect(channelsPage).not.toContain("Link an agent");
 		expect(channelsPage).not.toContain("At capacity");
-		expect(channelsPage).toContain("providersWithOwnedBots(counts)");
+		expect(channelsPage).toContain("providersWithBots(counts)");
+		expect(channelsPage).not.toContain("· Shared");
 	});
 
 	test("uses the shared channel-linking module without dead global relationship hooks", () => {
@@ -46,20 +48,22 @@ describe("global Channels inventory", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
 		const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 
-		expect(connectDialog).toContain("const linkTarget = { agent_id: agentId ?? null }");
+		expect(connectDialog).toContain("agent_id: agentId ?? null");
 		expect(agentDetail).toContain("agentId={environmentId}");
 		expect(agentDetail).toContain("onAgentConnected={(bot)");
 		expect(agentDetail).toContain("setTelegramPair({");
 	});
 
-	test("renders actionable provider steps and real external links in the connect dialog", () => {
+	test("renders a compact credential form with official external links", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
 
-		expect(connectDialog).toContain("meta.setupSteps.map");
 		expect(connectDialog).toContain("href={meta.setupUrl}");
 		expect(connectDialog).toContain('target="_blank"');
-		expect(connectDialog).toContain("This is the name shown in Clawdi");
-		expect(connectDialog).toContain("Server ID");
+		expect(connectDialog).toContain("Application ID");
+		expect(connectDialog).toContain("Public key");
+		expect(connectDialog).not.toContain("setupSteps");
+		expect(connectDialog).not.toContain("WhatsApp");
+		expect(connectDialog).not.toContain("Server ID");
 		expect(connectDialog).not.toContain("Guild ID");
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -28,12 +28,11 @@ describe("hosted-agent channel finish line", () => {
 	});
 
 	test("separates linking a channel from pairing a chat with one short instruction", () => {
-		expect(channelsTab).toContain(
-			"Link a bot to this Agent, then pair the chats it should answer.",
-		);
+		expect(channelsTab).toContain("Link a bot to this Agent, then choose where it should answer.");
 		expect(channelsTab).toContain("Pair Telegram");
-		expect(channelsTab).toContain("Pair chat");
+		expect(channelsTab).toContain("pairingActionLabel(provider)");
 		expect(channelsTab).toContain("<TelegramPairDialog");
+		expect(channelsTab).toContain("<DiscordPairDialog");
 		expect(channelsTab).toContain("agentLinkId={link.id}");
 		expect(channelsTab).toContain("pairing_command");
 		expect(channelsTab).not.toContain("Agent token");

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -43,7 +43,7 @@ describe("hosted-agent channel finish line", () => {
 	test("nests paired chats under their channel before channel addition", () => {
 		const connectedIndex = channelsTab.indexOf("<section data-agent-connected-channels");
 		const addIndex = channelsTab.indexOf("<section data-agent-add-channel");
-		const readyBotIndex = channelsTab.indexOf('kind="Ready to use"');
+		const readyBotIndex = channelsTab.indexOf('kind="Shared bot"');
 		const advancedIndex = channelsTab.indexOf("Use your own bot");
 		expect(connectedIndex).toBeGreaterThanOrEqual(0);
 		expect(addIndex).toBeGreaterThan(connectedIndex);

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
 	agentProviderHasSingleLinkLimit,
-	agentProviderLinkLimitDescription,
+	availableBotProvidersForAgent,
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
-	discordPairingShouldSyncCommands,
 	pairCodeExpired,
 	pairingActionLabel,
 	pairingCommand,
-	prepareProviderPairing,
 } from "./channel-linking.logic";
 
 describe("hosted channel instructions and gates", () => {
@@ -21,66 +19,20 @@ describe("hosted channel instructions and gates", () => {
 		expect(pairingActionLabel("imessage")).toBe("Pair chat");
 	});
 
-	test("syncs commands only for user-owned private Discord bots", () => {
-		expect(discordPairingShouldSyncCommands("private")).toBe(true);
-		expect(discordPairingShouldSyncCommands("public")).toBe(false);
-		expect(discordPairingShouldSyncCommands(undefined)).toBe(false);
-	});
-
-	test("syncs Discord commands before creating a pair code and stops on sync failure", async () => {
-		const events: string[] = [];
-		const result = await prepareProviderPairing({
-			provider: "discord",
-			syncCommands: async () => {
-				events.push("sync commands");
-			},
-			createPairCode: async () => {
-				events.push("create pair code");
-				return "PAIRABC123";
-			},
-		});
-		expect(result).toBe("PAIRABC123");
-		expect(events).toEqual(["sync commands", "create pair code"]);
-
-		let pairCodeCreated = false;
-		await expect(
-			prepareProviderPairing({
-				provider: "discord",
-				syncCommands: async () => {
-					throw new Error("sync failed");
-				},
-				createPairCode: async () => {
-					pairCodeCreated = true;
-				},
-			}),
-		).rejects.toThrow("sync failed");
-		expect(pairCodeCreated).toBe(false);
-	});
-
-	test("lets public Discord bots use centrally managed commands without owner-only sync", async () => {
-		const events: string[] = [];
-		const result = await prepareProviderPairing({
-			provider: "discord",
-			createPairCode: async () => {
-				events.push("create pair code");
-				return "PUBLICPAIR123";
-			},
-		});
-
-		expect(result).toBe("PUBLICPAIR123");
-		expect(events).toEqual(["create pair code"]);
-	});
-
-	test("does not alter non-Discord pairing with command sync", async () => {
-		let syncCalled = false;
-		await prepareProviderPairing({
-			provider: "telegram",
-			syncCommands: async () => {
-				syncCalled = true;
-			},
-			createPairCode: async () => "telegram-code",
-		});
-		expect(syncCalled).toBe(false);
+	test("selects the first unlinked provider and exposes no form when both are linked", () => {
+		expect(availableBotProvidersForAgent("agent-1", "openclaw", new Set())).toEqual([
+			"telegram",
+			"discord",
+		]);
+		expect(availableBotProvidersForAgent("agent-1", "openclaw", new Set(["telegram"]))).toEqual([
+			"discord",
+		]);
+		expect(
+			availableBotProvidersForAgent("agent-1", "openclaw", new Set(["telegram", "discord"])),
+		).toEqual([]);
+		expect(
+			availableBotProvidersForAgent(undefined, undefined, new Set(["telegram", "discord"])),
+		).toEqual(["telegram", "discord"]);
 	});
 
 	test("expires pairing actions exactly at the server deadline", () => {
@@ -104,12 +56,6 @@ describe("hosted channel instructions and gates", () => {
 		}
 		expect(agentProviderHasSingleLinkLimit("openclaw", "whatsapp")).toBe(false);
 		expect(agentProviderHasSingleLinkLimit("codex", "telegram")).toBe(false);
-		expect(agentProviderLinkLimitDescription("telegram")).toBe(
-			"This Agent already has a Telegram bot. Unlink it before connecting another.",
-		);
-		expect(agentProviderLinkLimitDescription("discord")).toBe(
-			"This Agent already has a Discord bot. Unlink it before connecting another.",
-		);
 	});
 
 	test("only treats real account activity after linking as new channel activity", () => {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -4,13 +4,83 @@ import {
 	agentProviderLinkLimitDescription,
 	channelActivityAfterLink,
 	channelProviderLinkingReady,
+	discordPairingShouldSyncCommands,
 	pairCodeExpired,
+	pairingActionLabel,
 	pairingCommand,
+	prepareProviderPairing,
 } from "./channel-linking.logic";
 
 describe("hosted channel instructions and gates", () => {
 	test("renders the exact command accepted by the channel backend", () => {
 		expect(pairingCommand("PAIRABC123")).toBe("/bot_pair PAIRABC123");
+	});
+
+	test("uses one discoverable Discord pairing action for servers and direct messages", () => {
+		expect(pairingActionLabel("discord")).toBe("Pair Discord");
+		expect(pairingActionLabel("imessage")).toBe("Pair chat");
+	});
+
+	test("syncs commands only for user-owned private Discord bots", () => {
+		expect(discordPairingShouldSyncCommands("private")).toBe(true);
+		expect(discordPairingShouldSyncCommands("public")).toBe(false);
+		expect(discordPairingShouldSyncCommands(undefined)).toBe(false);
+	});
+
+	test("syncs Discord commands before creating a pair code and stops on sync failure", async () => {
+		const events: string[] = [];
+		const result = await prepareProviderPairing({
+			provider: "discord",
+			syncCommands: async () => {
+				events.push("sync commands");
+			},
+			createPairCode: async () => {
+				events.push("create pair code");
+				return "PAIRABC123";
+			},
+		});
+		expect(result).toBe("PAIRABC123");
+		expect(events).toEqual(["sync commands", "create pair code"]);
+
+		let pairCodeCreated = false;
+		await expect(
+			prepareProviderPairing({
+				provider: "discord",
+				syncCommands: async () => {
+					throw new Error("sync failed");
+				},
+				createPairCode: async () => {
+					pairCodeCreated = true;
+				},
+			}),
+		).rejects.toThrow("sync failed");
+		expect(pairCodeCreated).toBe(false);
+	});
+
+	test("lets public Discord bots use centrally managed commands without owner-only sync", async () => {
+		const events: string[] = [];
+		const result = await prepareProviderPairing({
+			provider: "discord",
+			createPairCode: async () => {
+				events.push("create pair code");
+				return "PUBLICPAIR123";
+			},
+		});
+
+		expect(result).toBe("PUBLICPAIR123");
+		expect(events).toEqual(["create pair code"]);
+	});
+
+	test("does not alter non-Discord pairing with command sync", async () => {
+		let syncCalled = false;
+		await prepareProviderPairing({
+			provider: "telegram",
+			syncCommands: async () => {
+				syncCalled = true;
+			},
+			createPairCode: async () => "telegram-code",
+		});
+		expect(syncCalled).toBe(false);
 	});
 
 	test("expires pairing actions exactly at the server deadline", () => {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -1,5 +1,8 @@
 export const WHATSAPP_LINKING_READY = false;
 
+export const CONNECTABLE_BOT_PROVIDERS = ["telegram", "discord"] as const;
+export type ConnectableBotProvider = (typeof CONNECTABLE_BOT_PROVIDERS)[number];
+
 const SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE: Readonly<Record<string, ReadonlySet<string>>> = {
 	hermes: new Set(["telegram", "discord"]),
 	openclaw: new Set(["telegram", "discord"]),
@@ -16,10 +19,17 @@ export function agentProviderHasSingleLinkLimit(
 	return Boolean(agentType && SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE[agentType]?.has(provider));
 }
 
-export function agentProviderLinkLimitDescription(provider: string): string {
-	const label =
-		provider === "telegram" ? "Telegram" : provider === "discord" ? "Discord" : provider;
-	return `This Agent already has a ${label} bot. Unlink it before connecting another.`;
+export function availableBotProvidersForAgent(
+	agentId: string | null | undefined,
+	agentType: string | null | undefined,
+	linkedProviders: ReadonlySet<string> | null | undefined,
+): ConnectableBotProvider[] {
+	return CONNECTABLE_BOT_PROVIDERS.filter(
+		(provider) =>
+			!agentId ||
+			!agentProviderHasSingleLinkLimit(agentType, provider) ||
+			!linkedProviders?.has(provider),
+	);
 }
 
 export function pairingCommand(code: string): string {
@@ -28,25 +38,6 @@ export function pairingCommand(code: string): string {
 
 export function pairingActionLabel(provider: string): string {
 	return provider === "discord" ? "Pair Discord" : "Pair chat";
-}
-
-export function discordPairingShouldSyncCommands(
-	visibility: "private" | "public" | undefined,
-): boolean {
-	return visibility === "private";
-}
-
-export async function prepareProviderPairing<T>({
-	provider,
-	syncCommands,
-	createPairCode,
-}: {
-	provider: string;
-	syncCommands?: () => Promise<unknown>;
-	createPairCode: () => Promise<T>;
-}): Promise<T> {
-	if (provider === "discord" && syncCommands) await syncCommands();
-	return createPairCode();
 }
 
 export function pairCodeExpired(expiresAt: string, nowMs: number): boolean {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -26,6 +26,29 @@ export function pairingCommand(code: string): string {
 	return `/bot_pair ${code}`;
 }
 
+export function pairingActionLabel(provider: string): string {
+	return provider === "discord" ? "Pair Discord" : "Pair chat";
+}
+
+export function discordPairingShouldSyncCommands(
+	visibility: "private" | "public" | undefined,
+): boolean {
+	return visibility === "private";
+}
+
+export async function prepareProviderPairing<T>({
+	provider,
+	syncCommands,
+	createPairCode,
+}: {
+	provider: string;
+	syncCommands?: () => Promise<unknown>;
+	createPairCode: () => Promise<T>;
+}): Promise<T> {
+	if (provider === "discord" && syncCommands) await syncCommands();
+	return createPairCode();
+}
+
 export function pairCodeExpired(expiresAt: string, nowMs: number): boolean {
 	const expiresAtMs = Date.parse(expiresAt);
 	return !Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs;

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -16,7 +16,11 @@ describe("channel mutation feedback", () => {
 	test("acknowledges bot connection before starting its request", () => {
 		const connect = source("./connect-bot-dialog.tsx");
 
-		expectFeedbackBeforeRequest(connect, "setSubmitting(true)", "await create.execute(body)");
+		expectFeedbackBeforeRequest(
+			connect,
+			"setSubmitting(true)",
+			"await create.execute(buildBody())",
+		);
 		expect(connect).toContain('{isSubmitting ? "Close" : "Cancel"}');
 		expect(connect).not.toContain("channelDialogOpenChangeAllowed");
 	});
@@ -46,12 +50,8 @@ describe("channel mutation feedback", () => {
 		expect(detail).toContain('"Pair Telegram"');
 		expect(detail).toContain("pairingActionLabel(provider)");
 		expect(pairDialog).toContain("Creating a secure Telegram link…");
-		expectFeedbackBeforeRequest(
-			discordPairDialog,
-			"setPreparing(true)",
-			"await prepareProviderPairing",
-		);
-		expect(discordPairDialog).toContain("Syncing commands and creating a pair code…");
+		expectFeedbackBeforeRequest(discordPairDialog, "setPreparing(true)", "await pair.execute");
+		expect(discordPairDialog).toContain("Preparing Discord and creating a pair code…");
 		expect(pairedChatRow).toContain("disabled={unpair.isPending}");
 		expect(pairedChatRow).toContain('"Unpairing…"');
 		expect(pairedChatRow).toContain('"Retry unpair"');

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -23,6 +23,7 @@ describe("channel mutation feedback", () => {
 
 	test("keeps agent-page link, unlink, and pair-code feedback scoped to the acting control", () => {
 		const detail = source("../../agents/hosted-agent-detail.tsx");
+		const discordPairDialog = source("./discord-pair-dialog.tsx");
 		const pairDialog = source("./telegram-pair-dialog.tsx");
 		const pairedChatRow = source("./paired-chat-row.tsx");
 
@@ -43,11 +44,17 @@ describe("channel mutation feedback", () => {
 		expect(detail).toContain('creatingPairCode ? <Spinner className="size-3.5" />');
 		expect(detail).toContain('"Generating…"');
 		expect(detail).toContain('"Pair Telegram"');
-		expect(detail).toContain('"Pair chat"');
+		expect(detail).toContain("pairingActionLabel(provider)");
 		expect(pairDialog).toContain("Creating a secure Telegram link…");
+		expectFeedbackBeforeRequest(
+			discordPairDialog,
+			"setPreparing(true)",
+			"await prepareProviderPairing",
+		);
+		expect(discordPairDialog).toContain("Syncing commands and creating a pair code…");
 		expect(pairedChatRow).toContain("disabled={unpair.isPending}");
-		expect(pairedChatRow).toContain('unpair.isPending ? "Unpairing…"');
-		expect(pairedChatRow).toContain('unpair.error ? "Retry unpair"');
+		expect(pairedChatRow).toContain('"Unpairing…"');
+		expect(pairedChatRow).toContain('"Retry unpair"');
 	});
 
 	test("uses per-action feedback for bot-owned detail mutations", () => {

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -50,25 +50,24 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).toContain("agentProviderHasSingleLinkLimit");
 		expect(agentDetail).toContain("linkedProviders={linkedProviders}");
 		expect(connectDialog).toContain("Already linked");
-		expect(connectDialog).toContain("agentProviderLinkLimitDescription");
+		expect(connectDialog).toContain("availableBotProvidersForAgent");
+		expect(connectDialog).toContain("This Agent already has a Telegram and Discord bot.");
 		expect(agentDetail).toContain('<details className="group border-t pt-4">');
 	});
 
 	test("provides a novice Discord connect, sync, and pair path in one compact dialog", () => {
-		expect(connectDialog).toContain("const linkTarget = { agent_id: agentId ?? null }");
+		expect(connectDialog).toContain("agent_id: agentId ?? null");
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setDiscordPairOpen(true)");
+		expect(agentDetail).toContain("setDiscordPair({ accountId: bot.id");
 		expect(agentDetail).toContain("<DiscordPairDialog");
-		expect(discordPairDialog).toContain("useSyncCommands(accountId)");
-		expect(discordPairDialog).toContain("prepareProviderPairing");
-		expect(discordPairDialog).toContain('provider: "discord"');
-		expect(discordPairDialog).toContain("syncCommandsBeforePairing");
-		expect(discordPairDialog).toContain("? () => syncCommands.mutateAsync()");
-		expect(discordPairDialog).toContain(": undefined");
-		expect(discordPairDialog).toContain("createPairCode: () =>");
+		expect(discordPairDialog).toContain("useCreatePairCode(accountId)");
+		expect(discordPairDialog).toContain("await pair.execute");
 		expect(discordPairDialog).toContain("run <code>/bot_pair</code>");
-		expect(discordPairDialog).toContain("server or direct message");
-		expect(discordPairDialog).toContain("Pairing a server requires Manage");
+		expect(discordPairDialog).toContain('data-discord-pair-path="server"');
+		expect(discordPairDialog).toContain('data-discord-pair-path="dm"');
+		expect(discordPairDialog).toContain("Manage");
+		expect(discordPairDialog).toContain("Add to server");
 		expect(discordPairDialog).toContain('label="pair code"');
 		expect(discordPairDialog).toContain("pairCodeExpiryLabel");
 		expect(discordPairDialog).toContain("Couldn't prepare Discord pairing");
@@ -76,12 +75,10 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).not.toContain("Paired servers and direct messages");
 	});
 
-	test("syncs owned private Discord bots but preserves public bot command ownership", () => {
-		expect(agentDetail).toContain("discordPairingShouldSyncCommands(account?.visibility)");
-		expect(agentDetail).toContain("syncCommandsBeforePairing={syncDiscordCommands}");
+	test("keeps Discord preparation server-owned for private and shared bots", () => {
 		expect(agentDetail).toContain("visibility: bot.visibility");
-		expect(discordPairDialog).toContain("syncCommandsBeforePairing");
-		expect(discordPairDialog).toContain("Creating a Discord pair code…");
+		expect(discordPairDialog).not.toContain("useSyncCommands");
+		expect(discordPairDialog).toContain("Preparing Discord and creating a pair code…");
 	});
 
 	test("opens the shared fixed-TTL Telegram flow immediately after a new link", () => {
@@ -127,7 +124,8 @@ describe("channel IA boundary", () => {
 		expect(pairedChatRow).toContain("<MessageCircle");
 		expect(pairedChatRow).toContain("<MessagesSquare");
 		expect(pairedChatRow).toContain("pairedChatTitle(binding, provider)");
-		expect(pairedChatRow).toContain("const confirmLabel = provider");
+		expect(pairedChatRow).toContain("pairedChatScopeLabel(provider, binding)");
+		expect(pairedChatRow).toContain("Run /bot_unpair in this");
 		expect(pairedChatRowLogic).toContain("external_chat_name?.trim()");
 		expect(pairedChatRowLogic).toContain("binding.external_chat_id");
 		expect(pairedChatRow).not.toContain("<ProviderChip");

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -7,6 +7,8 @@ function source(relativePath: string): string {
 
 const detail = source("./channel-detail-page.tsx");
 const pairDialog = source("./telegram-pair-dialog.tsx");
+const discordPairDialog = source("./discord-pair-dialog.tsx");
+const channelLinkingLogic = source("./channel-linking.logic.ts");
 const hooks = source("./channels-hooks.ts");
 const connectDialog = source("./connect-bot-dialog.tsx");
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
@@ -39,7 +41,8 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).not.toContain("data-agent-paired-chats");
 		expect(agentDetail).toContain("data-agent-add-channel");
 		expect(agentDetail).toContain("Pair Telegram");
-		expect(agentDetail).toContain("Pair chat");
+		expect(agentDetail).toContain("pairingActionLabel(provider)");
+		expect(channelLinkingLogic).toContain('provider === "discord" ? "Pair Discord" : "Pair chat"');
 		expect(agentDetail).toContain('confirmLabel="Unlink"');
 		expect(agentDetail).toContain("<PairedChatRow");
 		expect(pairedChatRow).toContain("Unpair");
@@ -49,6 +52,36 @@ describe("channel IA boundary", () => {
 		expect(connectDialog).toContain("Already linked");
 		expect(connectDialog).toContain("agentProviderLinkLimitDescription");
 		expect(agentDetail).toContain('<details className="group border-t pt-4">');
+	});
+
+	test("provides a novice Discord connect, sync, and pair path in one compact dialog", () => {
+		expect(connectDialog).toContain("const linkTarget = { agent_id: agentId ?? null }");
+		expect(agentDetail).toContain("body: { agent_id: environmentId }");
+		expect(agentDetail).toContain("setDiscordPairOpen(true)");
+		expect(agentDetail).toContain("<DiscordPairDialog");
+		expect(discordPairDialog).toContain("useSyncCommands(accountId)");
+		expect(discordPairDialog).toContain("prepareProviderPairing");
+		expect(discordPairDialog).toContain('provider: "discord"');
+		expect(discordPairDialog).toContain("syncCommandsBeforePairing");
+		expect(discordPairDialog).toContain("? () => syncCommands.mutateAsync()");
+		expect(discordPairDialog).toContain(": undefined");
+		expect(discordPairDialog).toContain("createPairCode: () =>");
+		expect(discordPairDialog).toContain("run <code>/bot_pair</code>");
+		expect(discordPairDialog).toContain("server or direct message");
+		expect(discordPairDialog).toContain("Pairing a server requires Manage");
+		expect(discordPairDialog).toContain('label="pair code"');
+		expect(discordPairDialog).toContain("pairCodeExpiryLabel");
+		expect(discordPairDialog).toContain("Couldn't prepare Discord pairing");
+		expect(agentDetail).not.toContain("Commands synced. In Discord");
+		expect(agentDetail).not.toContain("Paired servers and direct messages");
+	});
+
+	test("syncs owned private Discord bots but preserves public bot command ownership", () => {
+		expect(agentDetail).toContain("discordPairingShouldSyncCommands(account?.visibility)");
+		expect(agentDetail).toContain("syncCommandsBeforePairing={syncDiscordCommands}");
+		expect(agentDetail).toContain("visibility: bot.visibility");
+		expect(discordPairDialog).toContain("syncCommandsBeforePairing");
+		expect(discordPairDialog).toContain("Creating a Discord pair code…");
 	});
 
 	test("opens the shared fixed-TTL Telegram flow immediately after a new link", () => {
@@ -93,7 +126,8 @@ describe("channel IA boundary", () => {
 		expect(pairedChatRow).toContain("<IconChip");
 		expect(pairedChatRow).toContain("<MessageCircle");
 		expect(pairedChatRow).toContain("<MessagesSquare");
-		expect(pairedChatRow).toContain("pairedChatTitle(binding)");
+		expect(pairedChatRow).toContain("pairedChatTitle(binding, provider)");
+		expect(pairedChatRow).toContain("const confirmLabel = provider");
 		expect(pairedChatRowLogic).toContain("external_chat_name?.trim()");
 		expect(pairedChatRowLogic).toContain("binding.external_chat_id");
 		expect(pairedChatRow).not.toContain("<ProviderChip");

--- a/apps/web/src/hosted/v2/channels/channel-providers.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.test.ts
@@ -20,17 +20,9 @@ describe("channel provider registry", () => {
 		});
 	});
 
-	test("provides official setup links and complete bring-your-own steps", () => {
-		expect(providerMeta("telegram")).toMatchObject({
-			setupUrl: "https://t.me/BotFather",
-			setupLinkLabel: "Open @BotFather in Telegram",
-		});
-		expect(providerMeta("telegram").setupSteps).toHaveLength(3);
-		expect(providerMeta("discord")).toMatchObject({
-			setupUrl: "https://discord.com/developers/applications",
-			setupLinkLabel: "Open the Discord Developer Portal",
-		});
-		expect(providerMeta("discord").setupSteps).toHaveLength(3);
+	test("provides only the official setup links used by the compact connect form", () => {
+		expect(providerMeta("telegram").setupUrl).toBe("https://t.me/BotFather");
+		expect(providerMeta("discord").setupUrl).toBe("https://discord.com/developers/applications");
 	});
 
 	test("orders supported providers first and appends legacy providers from data", () => {

--- a/apps/web/src/hosted/v2/channels/channel-providers.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.ts
@@ -2,7 +2,7 @@
  * Native channel providers that can be created from the v2 channels UI. Each
  * takes different real connect inputs:
  *   - telegram:  bot token (BotFather)                → provider_token
- *   - discord:   bot token + application_id + public_key (+ optional guild_id)
+ *   - discord:   bot token + application_id + interactions public_key
  *                                                       → provider_token + config
  *   - whatsapp:  no token; agent/device linking is gated during the beta
  * Tints reuse the app identity palette so channel chips match the chrome.
@@ -18,13 +18,8 @@ export interface ChannelProviderMeta {
 	label: string;
 	tint: string;
 	connect?: ChannelConnectMode;
-	/** Label/placeholder for the single credential field (token / password). */
-	tokenLabel?: string;
 	tokenPlaceholder?: string;
-	hint: string;
 	setupUrl?: string;
-	setupLinkLabel?: string;
-	setupSteps?: readonly string[];
 	unavailable?: boolean;
 }
 
@@ -40,39 +35,22 @@ export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMe
 		label: "Telegram",
 		tint: "bg-identity-3-bg text-identity-3-fg",
 		connect: "token",
-		tokenLabel: "Bot token",
 		tokenPlaceholder: "123456:ABC-DEF…",
-		hint: "Telegram's official @BotFather creates the bot and gives you its token.",
 		setupUrl: "https://t.me/BotFather",
-		setupLinkLabel: "Open @BotFather in Telegram",
-		setupSteps: [
-			"Send /newbot to @BotFather and follow the prompts to choose a name and username.",
-			"Copy the HTTP API token from @BotFather.",
-			"Give the connection a friendly name below, then paste the token.",
-		],
 	},
 	discord: {
 		id: "discord",
 		label: "Discord",
 		tint: "bg-identity-5-bg text-identity-5-fg",
 		connect: "discord",
-		tokenLabel: "Bot token",
 		tokenPlaceholder: "Bot token",
-		hint: "Create a Discord application, add its bot to your server, then copy the credentials below.",
 		setupUrl: "https://discord.com/developers/applications",
-		setupLinkLabel: "Open the Discord Developer Portal",
-		setupSteps: [
-			"Create an application, open its Bot page, and copy or reset the bot token.",
-			"On General Information, copy the application ID and, if you use interactions, the public key.",
-			"Use the Installation page to add the bot to the Discord server where it should answer.",
-		],
 	},
 	whatsapp: {
 		id: "whatsapp",
 		label: "WhatsApp",
 		tint: "bg-identity-2-bg text-identity-2-fg",
 		connect: "whatsapp",
-		hint: "No bot token. WhatsApp agent linking is coming soon for hosted agents.",
 	},
 };
 
@@ -81,7 +59,6 @@ const LEGACY_PROVIDER_META: Record<string, ChannelProviderMeta> = {
 		id: "imessage",
 		label: "iMessage (unavailable)",
 		tint: "bg-muted text-muted-foreground",
-		hint: "iMessage native channels are no longer available in this surface.",
 		unavailable: true,
 	},
 };
@@ -91,7 +68,6 @@ function unknownProviderMeta(id: string): ChannelProviderMeta {
 		id,
 		label: id || "Channel",
 		tint: "bg-muted text-muted-foreground",
-		hint: "This channel provider is no longer available in this surface.",
 		unavailable: true,
 	};
 }

--- a/apps/web/src/hosted/v2/channels/channel-types.ts
+++ b/apps/web/src/hosted/v2/channels/channel-types.ts
@@ -16,4 +16,5 @@ export type ChannelCreated = Schemas["ChannelAccountCreatedResponse"];
 export type ChannelBotPoolItem = Schemas["ChannelBotPoolItem"];
 export type ChannelAgentLink = Schemas["ChannelAgentLinkResponse"];
 export type ChannelBinding = Schemas["ChannelBindingResponse"];
+export type ChannelPairCode = Schemas["ChannelPairCodeResponse"];
 export type ChannelActivityItem = Schemas["ChannelActivityItemResponse"];

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -15,7 +15,7 @@ import {
 	channelKeys as keys,
 	removeDeletedChannelQueries,
 } from "@/hosted/v2/channels/channel-query-cache";
-import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
+import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { whatsappCredentialMetadataForCache } from "@/hosted/v2/channels/whatsapp-credential-cache";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -162,9 +162,13 @@ export function useCreateChannel() {
 				id: result.id,
 				name: result.name,
 				provider: result.provider,
-				agentLinkId: result.agent_link_id ?? null,
-				agentId: result.agent_id ?? null,
-			};
+				webhook_url: result.webhook_url,
+				agent_link_id: result.agent_link_id ?? null,
+				agent_id: result.agent_id ?? null,
+			} satisfies Pick<
+				ChannelCreated,
+				"id" | "name" | "provider" | "webhook_url" | "agent_link_id" | "agent_id"
+			>;
 		} catch (error) {
 			toastApiError("Couldn't connect channel")(error);
 			throw error;
@@ -212,6 +216,7 @@ export function useCreatePairCode(accountId: string) {
 				bot_username: result.bot_username,
 				deep_link: result.deep_link,
 				qr_payload: result.qr_payload,
+				discord_install_url: result.discord_install_url,
 			};
 		} catch (error) {
 			toastApiError("Couldn't create pairing code")(error);

--- a/apps/web/src/hosted/v2/channels/channels-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channels-page.logic.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, test } from "bun:test";
+import type { ChannelBotPoolItem } from "./channel-types";
 import {
 	orderedChannelsForFilter,
 	providerCounts,
-	providersWithOwnedBots,
+	providersWithBots,
+	sharedBotsFromPool,
 } from "./channels-page.logic";
+
+function poolBot(
+	id: string,
+	provider: string,
+	access: ChannelBotPoolItem["access"],
+): ChannelBotPoolItem {
+	return {
+		id,
+		provider,
+		name: id,
+		status: "active",
+		visibility: access === "public" ? "public" : "private",
+		has_provider_token: true,
+		webhook_url: `https://example.test/${id}`,
+		created_at: "2026-07-31T00:00:00Z",
+		access,
+		capabilities: {
+			link_agent: access === "public",
+			pair_chat: false,
+			send_message: false,
+			manage_account: access === "owner",
+			sync_commands: false,
+		},
+		link_count: 0,
+		available: true,
+	};
+}
 
 describe("owned bot inventory", () => {
 	test("keeps canonical provider order and stable order within each provider", () => {
@@ -39,10 +68,22 @@ describe("owned bot inventory", () => {
 		]);
 
 		expect(counts).toEqual({ telegram: 2, discord: 1, whatsapp: 0 });
-		expect(providersWithOwnedBots(counts)).toEqual(["telegram", "discord"]);
+		expect(providersWithBots(counts)).toEqual(["telegram", "discord"]);
 	});
 
 	test("keeps an existing WhatsApp asset discoverable without showing empty providers", () => {
-		expect(providersWithOwnedBots({ telegram: 0, discord: 0, whatsapp: 1 })).toEqual(["whatsapp"]);
+		expect(providersWithBots({ telegram: 0, discord: 0, whatsapp: 1 })).toEqual(["whatsapp"]);
+	});
+
+	test("keeps public shared bots visible independently from owned inventory", () => {
+		const sharedDiscord = poolBot("shared-discord", "discord", "public");
+		const privateDiscord = poolBot("private-discord", "discord", "owner");
+		const sharedTelegram = poolBot("shared-telegram", "telegram", "public");
+		expect(
+			sharedBotsFromPool({
+				discord: [sharedDiscord, privateDiscord],
+				telegram: [sharedTelegram],
+			}),
+		).toEqual([sharedTelegram, sharedDiscord]);
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channels-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channels-page.logic.ts
@@ -3,7 +3,7 @@ import {
 	type ChannelProviderId,
 	orderedProviderIds,
 } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
+import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 
 export type ChannelProviderFilter = "all" | ChannelProviderId;
 
@@ -33,10 +33,19 @@ export function providerCounts(
 	return counts;
 }
 
-export function providersWithOwnedBots(
+export function providersWithBots(
 	counts: Readonly<Record<ChannelProviderId, number>>,
 ): ChannelProviderId[] {
 	return CHANNEL_PROVIDERS.filter((provider) => counts[provider] > 0);
+}
+
+export function sharedBotsFromPool(
+	providers: Readonly<Record<string, readonly ChannelBotPoolItem[]>> | undefined,
+): ChannelBotPoolItem[] {
+	if (!providers) return [];
+	return orderedProviderIds(Object.keys(providers)).flatMap((provider) =>
+		(providers[provider] ?? []).filter((item) => item.access === "public"),
+	);
 }
 
 function isKnownProvider(provider: string): provider is ChannelProviderId {

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -21,24 +21,25 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
+import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 import {
 	ChannelStatusBadge,
 	HealthBadge,
 	isNormalChannelHealth,
 	isNormalChannelStatus,
 } from "@/hosted/v2/channels/channel-ui";
-import { useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
+import { useBotPool, useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
 import {
 	type ChannelProviderFilter,
 	orderedChannelsForFilter,
 	providerCounts,
-	providersWithOwnedBots,
+	providersWithBots,
+	sharedBotsFromPool,
 } from "@/hosted/v2/channels/channels-page.logic";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Manage the bots you own and make available to your Agents.";
+const DESCRIPTION = "Manage your bots and discover shared bots for your Agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 
@@ -46,12 +47,20 @@ export function ChannelsPage() {
 	const [connectOpen, setConnectOpen] = useState(false);
 	const [filter, setFilter] = useState<ChannelProviderFilter>("all");
 	const channels = useChannels();
+	const botPool = useBotPool();
 	const health = useChannelHealth();
 
 	const channelItems = channels.data ?? [];
-	const counts = providerCounts(channelItems);
-	const visibleProviders = providersWithOwnedBots(counts);
-	const totalCount = channelItems.length;
+	const sharedItems = sharedBotsFromPool(botPool.data?.providers);
+	const counts = providerCounts([...channelItems, ...sharedItems]);
+	const visibleProviders = providersWithBots(counts);
+	const totalCount = channelItems.length + sharedItems.length;
+	const inventoryEmpty =
+		!channels.isLoading &&
+		!botPool.isLoading &&
+		!channels.error &&
+		!botPool.error &&
+		totalCount === 0;
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
@@ -84,25 +93,38 @@ export function ChannelsPage() {
 				}
 			/>
 
-			<OwnedBotsSection
-				channels={channelItems}
-				isLoading={channels.isLoading}
-				error={channels.error}
-				onRetry={() => channels.refetch()}
-				healthItems={health.data?.items ?? []}
-				healthError={health.error}
-				onRetryHealth={() => health.refetch()}
-				filter={filter}
-				onConnect={() => setConnectOpen(true)}
-			/>
+			{inventoryEmpty ? (
+				<EmptyState
+					icon={MessagesSquare}
+					title="No bots yet"
+					description="Connect a Telegram or Discord bot to make it available to your Agents."
+				/>
+			) : (
+				<>
+					<OwnedBotsSection
+						channels={channelItems}
+						isLoading={channels.isLoading}
+						error={channels.error}
+						onRetry={() => channels.refetch()}
+						healthItems={health.data?.items ?? []}
+						healthError={health.error}
+						onRetryHealth={() => health.refetch()}
+						filter={filter}
+					/>
+
+					<SharedBotsSection
+						bots={sharedItems}
+						isLoading={botPool.isLoading}
+						error={botPool.error}
+						onRetry={() => botPool.refetch()}
+						filter={filter}
+					/>
+				</>
+			)}
 
 			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
 		</div>
 	);
-}
-
-function providerLabel(filter: ChannelProviderFilter): string {
-	return filter === "all" ? "selected providers" : providerMeta(filter).label;
 }
 
 function OwnedBotsSection({
@@ -114,7 +136,6 @@ function OwnedBotsSection({
 	healthError,
 	onRetryHealth,
 	filter,
-	onConnect,
 }: {
 	channels: ChannelAccount[];
 	isLoading: boolean;
@@ -124,7 +145,6 @@ function OwnedBotsSection({
 	healthError: Error | null;
 	onRetryHealth: () => void;
 	filter: ChannelProviderFilter;
-	onConnect: () => void;
 }) {
 	const visibleChannels = orderedChannelsForFilter(channels, filter);
 	const visibleCount = visibleChannels.length;
@@ -141,34 +161,8 @@ function OwnedBotsSection({
 		);
 	} else if (error) {
 		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load channels" />;
-	} else if (channels.length === 0) {
-		content = (
-			<EmptyState
-				icon={MessagesSquare}
-				title="No bots yet"
-				description="Connect a Telegram or Discord bot to make it available to your Agents."
-				action={
-					<Button variant="outline" onClick={onConnect}>
-						<Plus />
-						Connect bot
-					</Button>
-				}
-			/>
-		);
 	} else if (visibleCount === 0) {
-		content = (
-			<EmptyState
-				icon={MessagesSquare}
-				title={`No ${providerLabel(filter)} channels`}
-				description="Try another provider filter, or connect your own bot."
-				action={
-					<Button variant="outline" onClick={onConnect}>
-						<Plus />
-						Connect bot
-					</Button>
-				}
-			/>
-		);
+		return null;
 	} else {
 		const healthByAccount = new Map(healthItems.map((h) => [h.account_id, h.health_status]));
 		content = (
@@ -186,7 +180,7 @@ function OwnedBotsSection({
 
 	return (
 		<section data-owned-bots-section className="flex flex-col gap-3">
-			<SectionLabel count={!isLoading ? visibleCount : undefined}>Bots</SectionLabel>
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Your bots</SectionLabel>
 			{healthError ? (
 				<ApiErrorPanel
 					error={healthError}
@@ -196,6 +190,69 @@ function OwnedBotsSection({
 			) : null}
 			{content}
 		</section>
+	);
+}
+
+function SharedBotsSection({
+	bots,
+	isLoading,
+	error,
+	onRetry,
+	filter,
+}: {
+	bots: ChannelBotPoolItem[];
+	isLoading: boolean;
+	error: Error | null;
+	onRetry: () => void;
+	filter: ChannelProviderFilter;
+}) {
+	const visibleBots = orderedChannelsForFilter(bots, filter);
+	let content: ReactNode;
+	if (isLoading) {
+		content = (
+			<div className={CHANNEL_GRID_CLASS}>
+				<EntityCardSkeleton trailingBadge />
+			</div>
+		);
+	} else if (error) {
+		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load shared bots" />;
+	} else if (visibleBots.length === 0) {
+		return null;
+	} else {
+		content = (
+			<div className={CHANNEL_GRID_CLASS}>
+				{visibleBots.map((bot) => (
+					<SharedBotCard key={bot.id} bot={bot} />
+				))}
+			</div>
+		);
+	}
+
+	return (
+		<section data-shared-bots-section className="flex flex-col gap-3">
+			<div>
+				<SectionLabel count={!isLoading ? visibleBots.length : undefined}>Shared bots</SectionLabel>
+				<p className="mt-1 text-xs text-muted-foreground">Connect them from Agent → Channels.</p>
+			</div>
+			{content}
+		</section>
+	);
+}
+
+function SharedBotCard({ bot }: { bot: ChannelBotPoolItem }) {
+	const meta = providerMeta(bot.provider);
+	return (
+		<div
+			data-shared-channel-account-id={bot.id}
+			className={cn(ENTITY_CARD_BASE, "flex h-full items-start gap-3")}
+		>
+			<EntityHeader
+				className="w-full"
+				align="start"
+				icon={<EntityIcon kind="channel" id={bot.provider} label={meta.label} />}
+				title={bot.name}
+			/>
+		</div>
 	);
 }
 

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
 	discordApplicationIdError,
 	discordBotTokenError,
-	discordGuildIdError,
 	discordPublicKeyError,
 } from "./connect-bot-dialog.logic";
 
@@ -35,12 +34,6 @@ describe("Discord snowflake fields", () => {
 		expect(discordApplicationIdError("99999999999999999999")).toBe(
 			"Enter a valid numeric application ID.",
 		);
-	});
-
-	test("allows an empty optional server ID but validates supplied values", () => {
-		expect(discordGuildIdError("   ")).toBeNull();
-		expect(discordGuildIdError("1234567890123456789")).toBeNull();
-		expect(discordGuildIdError("1234567890123456")).toBe("Enter a valid numeric server ID.");
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
@@ -27,12 +27,6 @@ export function discordApplicationIdError(value: string): string | null {
 	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric application ID.";
 }
 
-export function discordGuildIdError(value: string): string | null {
-	const trimmed = value.trim();
-	if (!trimmed) return null;
-	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric server ID.";
-}
-
 export function discordPublicKeyError(value: string): string | null {
 	const trimmed = value.trim();
 	if (!trimmed) return null;

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { ExternalLink } from "lucide-react";
+import { Check, ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,31 +17,19 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	agentProviderHasSingleLinkLimit,
-	agentProviderLinkLimitDescription,
-	WHATSAPP_LINKING_READY,
+	availableBotProvidersForAgent,
+	CONNECTABLE_BOT_PROVIDERS,
+	type ConnectableBotProvider,
 } from "@/hosted/v2/channels/channel-linking.logic";
-import {
-	CHANNEL_PROVIDERS,
-	type ChannelProviderId,
-	PROVIDER_META,
-} from "@/hosted/v2/channels/channel-providers";
-import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
-import { ProviderChip } from "@/hosted/v2/channels/channel-ui";
+import { PROVIDER_META } from "@/hosted/v2/channels/channel-providers";
+import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 import {
 	discordApplicationIdError,
 	discordBotTokenError,
-	discordGuildIdError,
 	discordPublicKeyError,
 } from "@/hosted/v2/channels/connect-bot-dialog.logic";
 
-/**
- * Connect a channel. Each provider takes its OWN real inputs (grounded in
- * cloud-api): Telegram = bot token; Discord = bot token + application_id +
- * public_key (+ guild_id); WhatsApp = no token (agent/device linking is
- * gated during the beta). Runtime credentials reconcile automatically.
- */
 export function ConnectBotDialog({
 	open,
 	onOpenChange,
@@ -64,118 +51,108 @@ export function ConnectBotDialog({
 	}) => void;
 }) {
 	const create = useCreateChannel();
-	const [provider, setProvider] = useState<ChannelProviderId>("telegram");
+	const [provider, setProvider] = useState<ConnectableBotProvider>("telegram");
 	const [name, setName] = useState("");
-	const [token, setToken] = useState(""); // Telegram / Discord bot token
-	// Discord
+	const [token, setToken] = useState("");
 	const [applicationId, setApplicationId] = useState("");
 	const [publicKey, setPublicKey] = useState("");
-	const [guildId, setGuildId] = useState("");
-	const [created, setCreated] = useState<{
-		id: string;
-		name: string;
-		provider: string;
-	} | null>(null);
+	const [created, setCreated] = useState<Pick<
+		ChannelCreated,
+		"id" | "name" | "provider" | "agent_link_id" | "agent_id"
+	> | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
 	const openRef = useRef(open);
 	const dialogSessionRef = useRef(0);
 	openRef.current = open;
 
+	const availableProviders = availableBotProvidersForAgent(agentId, agentType, linkedProviders);
+	const unavailableProviders = CONNECTABLE_BOT_PROVIDERS.filter(
+		(item) => !availableProviders.includes(item),
+	);
+
 	useEffect(() => {
 		if (!open) return;
-		setProvider("telegram");
+		setProvider(availableProviders[0] ?? "telegram");
 		setName("");
 		setToken("");
 		setApplicationId("");
 		setPublicKey("");
-		setGuildId("");
 		setCreated(null);
-	}, [open]);
+	}, [open, availableProviders[0]]);
 
 	const meta = PROVIDER_META[provider];
-	const providerAlreadyLinked = Boolean(
-		agentId &&
-			agentProviderHasSingleLinkLimit(agentType, provider) &&
-			linkedProviders?.has(provider),
-	);
-	const discordSelected = meta.connect === "discord";
+	const providerAlreadyLinked = !availableProviders.includes(provider);
+	const discordSelected = provider === "discord";
 	const tokenError = discordSelected ? discordBotTokenError(token) : null;
 	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
 	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
-	const guildIdError = discordSelected ? discordGuildIdError(guildId) : null;
 	const isSubmitting = submitting || create.isPending;
 
-	function changeProvider(next: ChannelProviderId) {
-		if (next === "whatsapp" && !WHATSAPP_LINKING_READY) return;
+	function changeProvider(next: ConnectableBotProvider) {
+		if (!availableProviders.includes(next)) return;
 		setProvider(next);
+		setName("");
 		setToken("");
 		setApplicationId("");
 		setPublicKey("");
-		setGuildId("");
 	}
 
 	const canSubmit =
 		!providerAlreadyLinked &&
 		name.trim().length > 0 &&
-		(meta.connect === "whatsapp"
-			? WHATSAPP_LINKING_READY
-			: meta.connect === "token"
-				? token.trim().length > 0
-				: meta.connect === "discord"
-					? token.trim().length > 0 &&
-						applicationId.trim().length > 0 &&
-						!tokenError &&
-						!applicationIdError &&
-						!publicKeyError &&
-						!guildIdError
-					: false);
+		token.trim().length > 0 &&
+		(!discordSelected ||
+			(applicationId.trim().length > 0 &&
+				publicKey.trim().length > 0 &&
+				!tokenError &&
+				!applicationIdError &&
+				!publicKeyError));
 
-	function buildBody(): ChannelCreate | null {
-		const trimmedName = name.trim();
-		const linkTarget = { agent_id: agentId ?? null };
-		if (meta.connect === "discord") {
-			const config: Record<string, unknown> = { application_id: applicationId.trim() };
-			if (publicKey.trim()) config.public_key = publicKey.trim();
-			if (guildId.trim()) config.guild_id = guildId.trim();
-			return { provider, name: trimmedName, provider_token: token.trim(), config, ...linkTarget };
-		}
-		if (meta.connect === "token") {
-			return { provider, name: trimmedName, provider_token: token.trim(), ...linkTarget };
-		}
-		if (!WHATSAPP_LINKING_READY) return null;
-		return { provider, name: trimmedName, ...linkTarget };
+	function buildBody(): ChannelCreate {
+		const base = {
+			provider,
+			name: name.trim(),
+			provider_token: token.trim(),
+			agent_id: agentId ?? null,
+		};
+		if (!discordSelected) return base;
+		return {
+			...base,
+			config: {
+				application_id: applicationId.trim(),
+				public_key: publicKey.trim(),
+			},
+		};
 	}
 
 	async function submit() {
 		if (!canSubmit || submitLocked.current) return;
-		const body = buildBody();
-		if (!body) return;
 		submitLocked.current = true;
 		setSubmitting(true);
 		const dialogSession = dialogSessionRef.current;
 		try {
-			const data = await create.execute(body);
+			const data = await create.execute(buildBody());
 			setToken("");
 			if (openRef.current && dialogSessionRef.current === dialogSession) {
-				if (agentId && data.agentLinkId && onAgentConnected) {
+				if (agentId && data.agent_link_id && onAgentConnected) {
 					handleOpenChange(false);
 					onAgentConnected({
 						id: data.id,
 						name: data.name,
 						provider: data.provider,
-						agentLinkId: data.agentLinkId,
+						agentLinkId: data.agent_link_id,
 					});
 					return;
 				}
-				setCreated({ id: data.id, name: data.name, provider: data.provider });
+				setCreated(data);
 			} else {
 				toast.success("Channel connected", {
 					description: `${data.name} is ready on the Channels page.`,
 				});
 			}
 		} catch {
-			// useCreateChannel already surfaces the API error; retain the token for retry.
+			// useCreateChannel surfaces the API error; retain inputs for retry.
 		} finally {
 			submitLocked.current = false;
 			setSubmitting(false);
@@ -184,6 +161,14 @@ export function ConnectBotDialog({
 
 	function handleOpenChange(nextOpen: boolean) {
 		if (!nextOpen) {
+			if (created?.agent_link_id && onAgentConnected) {
+				onAgentConnected({
+					id: created.id,
+					name: created.name,
+					provider: created.provider,
+					agentLinkId: created.agent_link_id,
+				});
+			}
 			dialogSessionRef.current += 1;
 			setToken("");
 			setCreated(null);
@@ -191,268 +176,189 @@ export function ConnectBotDialog({
 		onOpenChange(nextOpen);
 	}
 
-	const discordVerificationPending = created?.provider === "discord";
-
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
+			<DialogContent
+				data-hosted="true"
+				data-v2="true"
+				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-md"
+			>
 				{created ? (
 					<>
 						<DialogHeader>
-							<DialogTitle>
-								{discordVerificationPending
-									? "Discord setup saved — verification pending"
-									: "Channel connected"}
-							</DialogTitle>
+							<DialogTitle>Bot connected</DialogTitle>
 							<DialogDescription>
-								{discordVerificationPending ? (
-									<>
-										Credentials for <span className="font-medium">{created.name}</span> were saved,
-										but Clawdi does not verify them with Discord during setup.
-									</>
-								) : (
-									<>
-										<span className="font-medium">{created.name}</span> is connected. Clawdi handles
-										message delivery automatically.
-									</>
-								)}
+								<span className="font-medium">{created.name}</span> is ready to use.
 							</DialogDescription>
 						</DialogHeader>
-						{discordVerificationPending ? (
-							<div
-								role="status"
-								className="rounded-lg border border-warning/30 bg-warning-muted p-3 text-sm text-warning-muted-foreground"
-							>
-								<p className="font-medium">Verification pending</p>
-								<p className="mt-1 text-xs">
-									Send a test message to the bot, then review channel activity and health before
-									relying on it.
-								</p>
-							</div>
-						) : null}
 						<DialogFooter>
 							<Button variant="outline" onClick={() => handleOpenChange(false)}>
-								Close
+								Done
 							</Button>
 							<Button
 								render={<Link to="/channels/$id" params={{ id: created.id }} />}
 								nativeButton={false}
 							>
-								{discordVerificationPending ? "Open channel to verify" : "Open channel"}
+								View bot
 							</Button>
 						</DialogFooter>
 					</>
 				) : (
 					<>
 						<DialogHeader>
-							<DialogTitle>Connect a channel</DialogTitle>
-							<DialogDescription>
-								Each provider needs its own setup — pick one to see what it requires.
-							</DialogDescription>
+							<DialogTitle>Connect a bot</DialogTitle>
+							<DialogDescription>Use your own bot.</DialogDescription>
 						</DialogHeader>
 
-						<div className="flex flex-col gap-4">
-							<div className="flex flex-col gap-1.5">
-								<Label>Provider</Label>
-								<div className="grid grid-cols-2 gap-2">
-									{CHANNEL_PROVIDERS.map((p) => {
-										const comingSoon = p === "whatsapp" && !WHATSAPP_LINKING_READY;
-										const alreadyLinked = Boolean(
-											agentId &&
-												agentProviderHasSingleLinkLimit(agentType, p) &&
-												linkedProviders?.has(p),
-										);
-										return (
-											<EntityChoiceCard
-												key={p}
-												selected={provider === p}
-												onClick={() => changeProvider(p)}
-												disabled={comingSoon || alreadyLinked}
-												badge={
-													alreadyLinked ? (
-														<span className="text-xs text-muted-foreground">Already linked</span>
-													) : comingSoon ? (
-														<span className="text-xs text-muted-foreground">Coming soon</span>
-													) : undefined
-												}
-												icon={
+						{availableProviders.length === 0 ? (
+							<>
+								<p role="status" className="py-2 text-sm text-muted-foreground">
+									This Agent already has a Telegram and Discord bot.
+								</p>
+								<DialogFooter>
+									<Button onClick={() => handleOpenChange(false)}>Done</Button>
+								</DialogFooter>
+							</>
+						) : (
+							<>
+								<div className="flex flex-col gap-3">
+									<fieldset className="grid grid-cols-2 gap-2 border-0 p-0" aria-label="Provider">
+										{CONNECTABLE_BOT_PROVIDERS.map((item) => {
+											const alreadyLinked = !availableProviders.includes(item);
+											return (
+												<Button
+													key={item}
+													type="button"
+													variant={provider === item ? "secondary" : "outline"}
+													className="h-12 min-w-0 justify-start gap-2 px-2.5"
+													disabled={alreadyLinked}
+													aria-pressed={provider === item}
+													onClick={() => changeProvider(item)}
+												>
 													<EntityIcon
 														kind="channel"
-														id={p}
-														label={PROVIDER_META[p].label}
+														id={item}
+														label={PROVIDER_META[item].label}
 														size="sm"
 													/>
-												}
-												title={PROVIDER_META[p].label}
-												description={
-													alreadyLinked
-														? agentProviderLinkLimitDescription(p)
-														: comingSoon
-															? "Hosted agent linking is not ready yet."
-															: undefined
-												}
-											/>
-										);
-									})}
-								</div>
-							</div>
-
-							<div className="flex items-start gap-3 rounded-lg border bg-muted/30 p-3">
-								<ProviderChip provider={provider} />
-								<div className="space-y-2 text-xs text-muted-foreground">
-									<p>{meta.hint}</p>
-									{meta.setupSteps ? (
-										<ol className="list-decimal space-y-1 pl-4">
-											{meta.setupSteps.map((step) => (
-												<li key={step}>{step}</li>
-											))}
-										</ol>
+													<span className="min-w-0 text-left leading-tight">
+														<span className="block">{PROVIDER_META[item].label}</span>
+														{alreadyLinked ? (
+															<span className="flex items-center gap-1 whitespace-nowrap text-[10px] font-normal text-muted-foreground">
+																<Check className="size-3" /> Already linked
+															</span>
+														) : null}
+													</span>
+												</Button>
+											);
+										})}
+									</fieldset>
+									{unavailableProviders.length === 1 ? (
+										<p className="whitespace-normal text-xs text-muted-foreground">
+											Unlink {PROVIDER_META[unavailableProviders[0]].label} from this Agent first.
+										</p>
 									) : null}
-									{meta.setupUrl && meta.setupLinkLabel ? (
+									<p className="text-xs text-muted-foreground">
+										{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
 										<a
 											href={meta.setupUrl}
 											target="_blank"
 											rel="noreferrer"
 											className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4"
 										>
-											{meta.setupLinkLabel}
+											{provider === "telegram"
+												? "Create a bot with @BotFather"
+												: "Open Discord Developer Portal"}
 											<ExternalLink className="size-3" />
 										</a>
-									) : null}
-								</div>
-							</div>
+									</p>
 
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="connect-name">Name</Label>
-								<Input
-									id="connect-name"
-									value={name}
-									onChange={(e) => setName(e.target.value)}
-									placeholder="Support Bot"
-									autoComplete="off"
-								/>
-								<p className="text-xs text-muted-foreground">
-									This is the name shown in Clawdi; it does not rename the bot.
-								</p>
-							</div>
-
-							{/* Telegram / Discord bot token. */}
-							{meta.connect !== "whatsapp" ? (
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="connect-token">{meta.tokenLabel}</Label>
-									<Input
-										id="connect-token"
-										type="password"
-										value={token}
-										onChange={(e) => setToken(e.target.value)}
-										placeholder={meta.tokenPlaceholder}
-										autoComplete="off"
-										spellCheck={false}
-										required
-										aria-invalid={Boolean(tokenError)}
-										aria-describedby={tokenError ? "connect-token-err" : undefined}
-									/>
-									{tokenError ? (
-										<p id="connect-token-err" className="text-xs text-destructive">
-											{tokenError}
-										</p>
-									) : null}
-								</div>
-							) : null}
-
-							{/* Discord: application_id (+ public_key, guild_id). */}
-							{meta.connect === "discord" ? (
-								<>
 									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-app-id">Application ID</Label>
+										<Label htmlFor="connect-name">Name</Label>
 										<Input
-											id="connect-app-id"
-											value={applicationId}
-											onChange={(e) => setApplicationId(e.target.value)}
-											placeholder="Application (client) ID"
+											id="connect-name"
+											value={name}
+											onChange={(event) => setName(event.target.value)}
+											placeholder="Support Bot"
+											autoComplete="off"
+										/>
+									</div>
+
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="connect-token">Bot token</Label>
+										<Input
+											id="connect-token"
+											type="password"
+											value={token}
+											onChange={(event) => setToken(event.target.value)}
+											placeholder={meta.tokenPlaceholder}
 											autoComplete="off"
 											spellCheck={false}
 											required
-											aria-invalid={Boolean(applicationIdError)}
-											aria-describedby={
-												applicationIdError ? "connect-app-id-err" : "connect-app-id-help"
-											}
+											aria-invalid={Boolean(tokenError)}
+											aria-describedby={tokenError ? "connect-token-error" : undefined}
 										/>
-										{applicationIdError ? (
-											<p id="connect-app-id-err" className="text-xs text-destructive">
-												{applicationIdError}
+										{tokenError ? (
+											<p id="connect-token-error" className="text-xs text-destructive">
+												{tokenError}
 											</p>
-										) : (
-											<p id="connect-app-id-help" className="text-xs text-muted-foreground">
-												Find this on General Information in the Discord Developer Portal.
-											</p>
-										)}
+										) : null}
 									</div>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-public-key">
-											Public key <span className="text-muted-foreground">· recommended</span>
-										</Label>
-										<Input
-											id="connect-public-key"
-											value={publicKey}
-											onChange={(e) => setPublicKey(e.target.value)}
-											placeholder="Ed25519 public key (hex)"
-											autoComplete="off"
-											spellCheck={false}
-											aria-invalid={Boolean(publicKeyError)}
-											aria-describedby={
-												publicKeyError ? "connect-public-key-err" : "connect-public-key-help"
-											}
-										/>
-										{publicKeyError ? (
-											<p id="connect-public-key-err" className="text-xs text-destructive">
-												{publicKeyError}
-											</p>
-										) : (
-											<p id="connect-public-key-help" className="text-xs text-muted-foreground">
-												Find this on General Information. Leave it blank if you do not use Discord
-												interactions.
-											</p>
-										)}
-									</div>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-guild-id">
-											Server ID <span className="text-muted-foreground">· optional</span>
-										</Label>
-										<Input
-											id="connect-guild-id"
-											value={guildId}
-											onChange={(e) => setGuildId(e.target.value)}
-											placeholder="Discord server ID"
-											autoComplete="off"
-											spellCheck={false}
-											aria-invalid={Boolean(guildIdError)}
-											aria-describedby={
-												guildIdError ? "connect-guild-id-err" : "connect-server-id-help"
-											}
-										/>
-										{guildIdError ? (
-											<p id="connect-guild-id-err" className="text-xs text-destructive">
-												{guildIdError}
-											</p>
-										) : (
-											<p id="connect-server-id-help" className="text-xs text-muted-foreground">
-												Leave blank unless commands should be limited to one Discord server.
-											</p>
-										)}
-									</div>
-								</>
-							) : null}
-						</div>
 
-						<DialogFooter>
-							<Button variant="outline" onClick={() => handleOpenChange(false)}>
-								{isSubmitting ? "Close" : "Cancel"}
-							</Button>
-							<Button onClick={() => void submit()} disabled={!canSubmit || isSubmitting}>
-								{isSubmitting ? "Connecting…" : "Connect"}
-							</Button>
-						</DialogFooter>
+									{discordSelected ? (
+										<>
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-app-id">Application ID</Label>
+												<Input
+													id="connect-app-id"
+													value={applicationId}
+													onChange={(event) => setApplicationId(event.target.value)}
+													placeholder="Application ID"
+													autoComplete="off"
+													spellCheck={false}
+													required
+													aria-invalid={Boolean(applicationIdError)}
+													aria-describedby={applicationIdError ? "connect-app-id-error" : undefined}
+												/>
+												{applicationIdError ? (
+													<p id="connect-app-id-error" className="text-xs text-destructive">
+														{applicationIdError}
+													</p>
+												) : null}
+											</div>
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-public-key">Public key</Label>
+												<Input
+													id="connect-public-key"
+													value={publicKey}
+													onChange={(event) => setPublicKey(event.target.value)}
+													placeholder="64-character hex public key"
+													autoComplete="off"
+													spellCheck={false}
+													required
+													aria-invalid={Boolean(publicKeyError)}
+													aria-describedby={publicKeyError ? "connect-public-key-error" : undefined}
+												/>
+												{publicKeyError ? (
+													<p id="connect-public-key-error" className="text-xs text-destructive">
+														{publicKeyError}
+													</p>
+												) : null}
+											</div>
+										</>
+									) : null}
+								</div>
+
+								<DialogFooter>
+									<Button variant="outline" onClick={() => handleOpenChange(false)}>
+										{isSubmitting ? "Close" : "Cancel"}
+									</Button>
+									<Button onClick={() => void submit()} disabled={!canSubmit || isSubmitting}>
+										{isSubmitting ? "Connecting…" : "Connect"}
+									</Button>
+								</DialogFooter>
+							</>
+						)}
 					</>
 				)}
 			</DialogContent>

--- a/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RefreshCw } from "lucide-react";
+import { ExternalLink, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
@@ -14,34 +14,26 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
-import {
-	pairCodeExpired,
-	prepareProviderPairing,
-} from "@/hosted/v2/channels/channel-linking.logic";
+import { pairCodeExpired } from "@/hosted/v2/channels/channel-linking.logic";
+import type { ChannelPairCode } from "@/hosted/v2/channels/channel-types";
 import { CopyInline } from "@/hosted/v2/channels/channel-ui";
-import { useCreatePairCode, useSyncCommands } from "@/hosted/v2/channels/channels-hooks";
+import { useCreatePairCode } from "@/hosted/v2/channels/channels-hooks";
 
 const DISCORD_PAIR_TTL_SECONDS = 900;
 
-type DiscordPairResult = {
-	code: string;
-	expires_at: string;
-};
+type DiscordPairResult = Pick<ChannelPairCode, "code" | "expires_at" | "discord_install_url">;
 
 export function DiscordPairDialog({
 	open,
 	onOpenChange,
 	accountId,
 	agentLinkId,
-	syncCommandsBeforePairing,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	agentLinkId: string;
-	syncCommandsBeforePairing: boolean;
 }) {
-	const syncCommands = useSyncCommands(accountId);
 	const pair = useCreatePairCode(accountId);
 	const [result, setResult] = useState<DiscordPairResult | null>(null);
 	const [requestError, setRequestError] = useState<unknown>(null);
@@ -59,18 +51,18 @@ export function DiscordPairDialog({
 			setRequestError(null);
 			setResult(null);
 			try {
-				const data = await prepareProviderPairing({
-					provider: "discord",
-					syncCommands: syncCommandsBeforePairing ? () => syncCommands.mutateAsync() : undefined,
-					createPairCode: () =>
-						pair.execute({
-							agent_link_id: agentLinkId,
-							ttl_seconds: DISCORD_PAIR_TTL_SECONDS,
-						}),
+				if (sessionRef.current !== session) return;
+				const data = await pair.execute({
+					agent_link_id: agentLinkId,
+					ttl_seconds: DISCORD_PAIR_TTL_SECONDS,
 				});
 				if (sessionRef.current !== session) return;
 				setNowMs(Date.now());
-				setResult({ code: data.code, expires_at: data.expires_at });
+				setResult({
+					code: data.code,
+					expires_at: data.expires_at,
+					discord_install_url: data.discord_install_url,
+				});
 			} catch (error) {
 				if (sessionRef.current === session) setRequestError(error);
 			} finally {
@@ -78,7 +70,7 @@ export function DiscordPairDialog({
 				if (sessionRef.current === session) setPreparing(false);
 			}
 		},
-		[agentLinkId, pair.execute, syncCommands.mutateAsync, syncCommandsBeforePairing],
+		[agentLinkId, pair.execute],
 	);
 
 	useEffect(() => {
@@ -121,11 +113,7 @@ export function DiscordPairDialog({
 					{preparing ? (
 						<div className="flex min-h-36 flex-col items-center justify-center gap-3 text-muted-foreground">
 							<Spinner className="size-5" />
-							<p>
-								{syncCommandsBeforePairing
-									? "Syncing commands and creating a pair code…"
-									: "Creating a Discord pair code…"}
-							</p>
+							<p>Preparing Discord and creating a pair code…</p>
 						</div>
 					) : requestError ? (
 						<ApiErrorPanel
@@ -135,11 +123,34 @@ export function DiscordPairDialog({
 						/>
 					) : result ? (
 						<div className="space-y-4">
-							<p className="text-sm text-muted-foreground">
-								{syncCommandsBeforePairing ? "Commands synced. " : null}
-								In Discord, run <code>/bot_pair</code> and enter this code in the server or direct
-								message you want to connect. Pairing a server requires Manage Server.
-							</p>
+							<div data-discord-pair-path="server" className="space-y-1">
+								<p className="text-sm font-medium">Server</p>
+								<p className="text-sm text-muted-foreground">
+									Add the bot, then run <code>/bot_pair</code> in that server. You need Manage
+									Server.
+								</p>
+								{result.discord_install_url ? (
+									<Button
+										variant="outline"
+										size="sm"
+										render={
+											<a href={result.discord_install_url} target="_blank" rel="noreferrer" />
+										}
+										nativeButton={false}
+									>
+										Add to server
+										<ExternalLink className="size-3.5" />
+									</Button>
+								) : null}
+							</div>
+							<div data-discord-pair-path="dm" className="space-y-1 border-t pt-3">
+								<p className="text-sm font-medium">Direct message</p>
+								<p className="text-sm text-muted-foreground">
+									If you share a server with the bot or can already open its DM, message it and run{" "}
+									<code>/bot_pair</code>. No server permission is required.
+								</p>
+							</div>
+							<p className="text-sm text-muted-foreground">Enter this code when prompted:</p>
 							{expired ? null : <CopyInline value={result.code} label="pair code" />}
 							<p
 								role="status"

--- a/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
+import {
+	pairCodeExpired,
+	prepareProviderPairing,
+} from "@/hosted/v2/channels/channel-linking.logic";
+import { CopyInline } from "@/hosted/v2/channels/channel-ui";
+import { useCreatePairCode, useSyncCommands } from "@/hosted/v2/channels/channels-hooks";
+
+const DISCORD_PAIR_TTL_SECONDS = 900;
+
+type DiscordPairResult = {
+	code: string;
+	expires_at: string;
+};
+
+export function DiscordPairDialog({
+	open,
+	onOpenChange,
+	accountId,
+	agentLinkId,
+	syncCommandsBeforePairing,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	accountId: string;
+	agentLinkId: string;
+	syncCommandsBeforePairing: boolean;
+}) {
+	const syncCommands = useSyncCommands(accountId);
+	const pair = useCreatePairCode(accountId);
+	const [result, setResult] = useState<DiscordPairResult | null>(null);
+	const [requestError, setRequestError] = useState<unknown>(null);
+	const [preparing, setPreparing] = useState(false);
+	const [nowMs, setNowMs] = useState(() => Date.now());
+	const openKeyRef = useRef<string | null>(null);
+	const sessionRef = useRef(0);
+	const lockedSessionRef = useRef<number | null>(null);
+
+	const prepare = useCallback(
+		async (session = sessionRef.current) => {
+			if (lockedSessionRef.current === session) return;
+			lockedSessionRef.current = session;
+			setPreparing(true);
+			setRequestError(null);
+			setResult(null);
+			try {
+				const data = await prepareProviderPairing({
+					provider: "discord",
+					syncCommands: syncCommandsBeforePairing ? () => syncCommands.mutateAsync() : undefined,
+					createPairCode: () =>
+						pair.execute({
+							agent_link_id: agentLinkId,
+							ttl_seconds: DISCORD_PAIR_TTL_SECONDS,
+						}),
+				});
+				if (sessionRef.current !== session) return;
+				setNowMs(Date.now());
+				setResult({ code: data.code, expires_at: data.expires_at });
+			} catch (error) {
+				if (sessionRef.current === session) setRequestError(error);
+			} finally {
+				if (lockedSessionRef.current === session) lockedSessionRef.current = null;
+				if (sessionRef.current === session) setPreparing(false);
+			}
+		},
+		[agentLinkId, pair.execute, syncCommands.mutateAsync, syncCommandsBeforePairing],
+	);
+
+	useEffect(() => {
+		const openKey = open ? `${accountId}:${agentLinkId}` : null;
+		if (!openKey) {
+			openKeyRef.current = null;
+			sessionRef.current += 1;
+			lockedSessionRef.current = null;
+			setPreparing(false);
+			setRequestError(null);
+			setResult(null);
+			return;
+		}
+		if (openKeyRef.current === openKey) return;
+		openKeyRef.current = openKey;
+		const session = sessionRef.current + 1;
+		sessionRef.current = session;
+		lockedSessionRef.current = null;
+		void prepare(session);
+	}, [accountId, agentLinkId, open, prepare]);
+
+	useEffect(() => {
+		if (!open || !result) return;
+		setNowMs(Date.now());
+		const interval = window.setInterval(() => setNowMs(Date.now()), 1_000);
+		return () => window.clearInterval(interval);
+	}, [open, result]);
+
+	const expired = result ? pairCodeExpired(result.expires_at, nowMs) : false;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Pair Discord</DialogTitle>
+					<DialogDescription>Connect one server or direct message to this Agent.</DialogDescription>
+				</DialogHeader>
+
+				<div data-discord-pair-dialog-body className="min-h-36">
+					{preparing ? (
+						<div className="flex min-h-36 flex-col items-center justify-center gap-3 text-muted-foreground">
+							<Spinner className="size-5" />
+							<p>
+								{syncCommandsBeforePairing
+									? "Syncing commands and creating a pair code…"
+									: "Creating a Discord pair code…"}
+							</p>
+						</div>
+					) : requestError ? (
+						<ApiErrorPanel
+							error={requestError}
+							onRetry={() => void prepare()}
+							title="Couldn't prepare Discord pairing"
+						/>
+					) : result ? (
+						<div className="space-y-4">
+							<p className="text-sm text-muted-foreground">
+								{syncCommandsBeforePairing ? "Commands synced. " : null}
+								In Discord, run <code>/bot_pair</code> and enter this code in the server or direct
+								message you want to connect. Pairing a server requires Manage Server.
+							</p>
+							{expired ? null : <CopyInline value={result.code} label="pair code" />}
+							<p
+								role="status"
+								className={expired ? "text-sm text-destructive" : "text-sm text-muted-foreground"}
+							>
+								{pairCodeExpiryLabel(result.expires_at, nowMs)}
+							</p>
+						</div>
+					) : null}
+				</div>
+
+				{result && expired ? (
+					<DialogFooter>
+						<Button onClick={() => void prepare()}>
+							<RefreshCw className="size-4" />
+							Generate new code
+						</Button>
+					</DialogFooter>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { pairedChatTitle } from "@/hosted/v2/channels/paired-chat-row.logic";
+import { pairedChatScopeLabel, pairedChatTitle } from "@/hosted/v2/channels/paired-chat-row.logic";
 
 describe("pairedChatTitle", () => {
 	test("uses only the chat name when one is available", () => {
@@ -37,5 +37,23 @@ describe("pairedChatTitle", () => {
 				external_chat_type: null,
 			}),
 		).toBe("Chat · thread-abc");
+	});
+
+	test("distinguishes Discord server and direct-message bindings", () => {
+		const server = {
+			external_chat_id: "guild-123",
+			external_chat_name: "guild-123",
+			external_chat_type: "guild_text",
+		};
+		const directMessage = {
+			external_chat_id: "dm-456",
+			external_chat_name: null,
+			external_chat_type: "dm",
+		};
+
+		expect(pairedChatScopeLabel("discord", server)).toBe("server");
+		expect(pairedChatTitle(server, "discord")).toBe("Server · guild-123");
+		expect(pairedChatScopeLabel("discord", directMessage)).toBe("direct message");
+		expect(pairedChatTitle(directMessage, "discord")).toBe("Direct message · dm-456");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.logic.ts
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.logic.ts
@@ -4,8 +4,25 @@ type PairedChatIdentity = {
 	external_chat_type: string | null;
 };
 
-export function pairedChatTitle(binding: PairedChatIdentity): string {
+const DISCORD_DM_TYPES = new Set(["dm", "direct_messages", "group_dm", "private"]);
+
+export function pairedChatScopeLabel(
+	provider: string,
+	binding: PairedChatIdentity,
+): "server" | "direct message" | "chat" {
+	if (provider !== "discord") return "chat";
+	return DISCORD_DM_TYPES.has(binding.external_chat_type?.toLowerCase() ?? "")
+		? "direct message"
+		: "server";
+}
+
+export function pairedChatTitle(binding: PairedChatIdentity, provider = ""): string {
 	const name = binding.external_chat_name?.trim();
+	if (provider === "discord") {
+		const scope = pairedChatScopeLabel(provider, binding);
+		const label = scope === "server" ? "Server" : "Direct message";
+		return `${label} · ${name || binding.external_chat_id}`;
+	}
 	if (name) return name;
 
 	const chatType = binding.external_chat_type?.toLowerCase();

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -31,11 +31,7 @@ export function PairedChatRow({
 	const scope = pairedChatScopeLabel(provider, binding);
 	const privateChat = chatType === "private" || scope === "direct message";
 	const chatName = pairedChatTitle(binding, provider);
-	const discordDescription =
-		scope === "server"
-			? "This entire Discord server will be disconnected. Its channels and threads are not paired separately."
-			: "Only this Discord direct message will be disconnected. Paired servers stay active.";
-	const confirmLabel = provider === "discord" ? `Unpair ${scope}` : "Unpair chat";
+	const discordUnpairInstruction = `Run /bot_unpair in this ${scope}.`;
 
 	return (
 		<div
@@ -55,7 +51,7 @@ export function PairedChatRow({
 					...(isNormalChannelStatus(binding.status)
 						? []
 						: [<ChannelStatusBadge key="status" status={binding.status} />]),
-					...(unpair.error
+					...(provider !== "discord" && unpair.error
 						? [
 								<span key="error" className="font-medium text-destructive">
 									Couldn&apos;t unpair · Try again
@@ -65,32 +61,26 @@ export function PairedChatRow({
 				]}
 			/>
 			<div className="flex min-w-0 justify-end sm:shrink-0">
-				<ConfirmAction
-					title={`Unpair ${chatName}?`}
-					description={
-						provider === "discord"
-							? discordDescription
-							: "Only this chat will be disconnected. Other chats and the connected channel stay active."
-					}
-					confirmLabel={confirmLabel}
-					destructive
-					onConfirm={() => unpair.mutateAsync(binding.id)}
-				>
-					<Button variant="outline" size="sm" disabled={unpair.isPending}>
-						{unpair.isPending ? (
-							<Spinner className="size-3.5" />
-						) : (
-							<Link2Off className="size-3.5" />
-						)}
-						{unpair.isPending
-							? "Unpairing…"
-							: unpair.error
-								? "Retry unpair"
-								: provider === "discord"
-									? confirmLabel
-									: "Unpair"}
-					</Button>
-				</ConfirmAction>
+				{provider === "discord" ? (
+					<p className="text-right text-xs text-muted-foreground">{discordUnpairInstruction}</p>
+				) : (
+					<ConfirmAction
+						title={`Unpair ${chatName}?`}
+						description="Only this chat will be disconnected. Other chats and the connected channel stay active."
+						confirmLabel="Unpair chat"
+						destructive
+						onConfirm={() => unpair.mutateAsync(binding.id)}
+					>
+						<Button variant="outline" size="sm" disabled={unpair.isPending}>
+							{unpair.isPending ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<Link2Off className="size-3.5" />
+							)}
+							{unpair.isPending ? "Unpairing…" : unpair.error ? "Retry unpair" : "Unpair"}
+						</Button>
+					</ConfirmAction>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import { ChannelStatusBadge, isNormalChannelStatus } from "@/hosted/v2/channels/channel-ui";
 import { useDeleteChannelBinding } from "@/hosted/v2/channels/channels-hooks";
-import { pairedChatTitle } from "@/hosted/v2/channels/paired-chat-row.logic";
+import { pairedChatScopeLabel, pairedChatTitle } from "@/hosted/v2/channels/paired-chat-row.logic";
 import { cn } from "@/lib/utils";
 
 export const PAIRED_CHAT_ROW_CLASS =
@@ -28,8 +28,14 @@ export function PairedChatRow({
 }) {
 	const unpair = useDeleteChannelBinding(accountId);
 	const chatType = binding.external_chat_type?.toLowerCase();
-	const privateChat = chatType === "private";
-	const chatName = pairedChatTitle(binding);
+	const scope = pairedChatScopeLabel(provider, binding);
+	const privateChat = chatType === "private" || scope === "direct message";
+	const chatName = pairedChatTitle(binding, provider);
+	const discordDescription =
+		scope === "server"
+			? "This entire Discord server will be disconnected. Its channels and threads are not paired separately."
+			: "Only this Discord direct message will be disconnected. Paired servers stay active.";
+	const confirmLabel = provider === "discord" ? `Unpair ${scope}` : "Unpair chat";
 
 	return (
 		<div
@@ -61,8 +67,12 @@ export function PairedChatRow({
 			<div className="flex min-w-0 justify-end sm:shrink-0">
 				<ConfirmAction
 					title={`Unpair ${chatName}?`}
-					description="Only this chat will be disconnected. Other chats and the connected channel stay active."
-					confirmLabel="Unpair chat"
+					description={
+						provider === "discord"
+							? discordDescription
+							: "Only this chat will be disconnected. Other chats and the connected channel stay active."
+					}
+					confirmLabel={confirmLabel}
 					destructive
 					onConfirm={() => unpair.mutateAsync(binding.id)}
 				>
@@ -72,7 +82,13 @@ export function PairedChatRow({
 						) : (
 							<Link2Off className="size-3.5" />
 						)}
-						{unpair.isPending ? "Unpairing…" : unpair.error ? "Retry unpair" : "Unpair"}
+						{unpair.isPending
+							? "Unpairing…"
+							: unpair.error
+								? "Retry unpair"
+								: provider === "discord"
+									? confirmLabel
+									: "Unpair"}
 					</Button>
 				</ConfirmAction>
 			</div>

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -47,6 +47,7 @@ from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDERS,
+    CHANNEL_VISIBILITY_PUBLIC,
     ChannelAccount,
     ChannelBotAgentLink,
 )
@@ -105,10 +106,15 @@ from app.services.app_setting_registry import (
 )
 from app.services.app_settings import stage_app_setting_upsert
 from app.services.audit import record_control_plane_audit
-from app.services.channel_config import validate_channel_account_config_urls
+from app.services.channel_config import (
+    discord_interactions_config_error,
+    validate_channel_account_config_urls,
+    validate_required_discord_interactions_config,
+)
 from app.services.channels import (
     archive_channel_account,
     channel_webhook_url,
+    configure_discord_application,
     configure_telegram_provider_webhook,
     encrypt_optional_token,
     generate_webhook_secret,
@@ -1059,6 +1065,13 @@ async def admin_create_channel(
     db: AsyncSession = Depends(get_session),
 ) -> AdminChannelCreatedResponse:
     await validate_channel_account_config_urls(provider=body.provider, config=body.config)
+    if body.provider == CHANNEL_PROVIDER_DISCORD:
+        if body.provider_token is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Discord channels require a bot token.",
+            )
+        validate_required_discord_interactions_config(body.config)
     target = await _resolve_or_create_user(db, body.target_clerk_id)
     ciphertext, nonce = encrypt_optional_token(body.provider_token)
     webhook_secret = generate_webhook_secret()
@@ -1114,6 +1127,22 @@ async def admin_create_channel(
             status.HTTP_409_CONFLICT,
             "channel name already exists for this provider and owner",
         ) from exc
+    if (
+        account.provider == CHANNEL_PROVIDER_DISCORD
+        and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+    ):
+        # Discord validates the PATCH with a signed PING, so the account and
+        # public key must be committed and webhook-visible first. Bot-pool
+        # eligibility remains false until the readiness marker commits below.
+        await configure_discord_application(account)
+        await sync_channel_commands(
+            account=account,
+            use_configured_discord_guild=False,
+        )
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        config["discord_interactions_configured"] = True
+        account.config = config
+        await db.commit()
     await db.refresh(account)
     logger.info(
         "admin_channel_created target_clerk_id=%s channel_id=%s provider=%s visibility=%s",
@@ -1192,6 +1221,23 @@ async def admin_update_channel(
         elif telegram_bot_username is not None:
             config["bot_username"] = telegram_bot_username
         account.config = config
+    reconcile_public_discord = bool(
+        account.provider == CHANNEL_PROVIDER_DISCORD
+        and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+        and updates.intersection({"visibility", "provider_token", "config"})
+    )
+    if reconcile_public_discord:
+        if not account.encrypted_provider_token or not account.provider_token_nonce:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Public Discord channels require a bot token.",
+            )
+        config_error = discord_interactions_config_error(account.config)
+        if config_error is not None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=config_error)
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        config["discord_interactions_configured"] = False
+        account.config = config
     try:
         if "secrets" in updates:
             await upsert_channel_secrets(db, account=account, secrets_by_name=body.secrets)
@@ -1213,6 +1259,16 @@ async def admin_update_channel(
             status.HTTP_409_CONFLICT,
             "channel name already exists for this provider and owner",
         ) from exc
+    if reconcile_public_discord:
+        await configure_discord_application(account)
+        await sync_channel_commands(
+            account=account,
+            use_configured_discord_guild=False,
+        )
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        config["discord_interactions_configured"] = True
+        account.config = config
+        await db.commit()
     await db.refresh(account)
     return _admin_channel_response(account, owner)
 
@@ -1258,11 +1314,18 @@ async def admin_sync_channel_commands(
         if body.commands is not None
         else None
     )
+    if account.provider == CHANNEL_PROVIDER_DISCORD and commands is None:
+        await configure_discord_application(account)
     synced = await sync_channel_commands(
         account=account,
         commands=commands,
         guild_id=body.guild_id,
     )
+    if account.provider == CHANNEL_PROVIDER_DISCORD and commands is None:
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        config["discord_interactions_configured"] = True
+        account.config = config
+        await db.commit()
     return ChannelCommandSyncResponse(provider=account.provider, commands=synced)
 
 

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -31,10 +31,12 @@ from app.core.database import (
 )
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
+    BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     ChannelAccount,
     ChannelBinding,
     ChannelBindingAlias,
+    ChannelBotAgentLink,
 )
 from app.routes.channel_routers.shared import (
     _discord_application_id,
@@ -42,6 +44,7 @@ from app.routes.channel_routers.shared import (
     _discord_gateway_dispatch,
     _discord_interaction_content,
     _discord_message_result,
+    _DiscordProviderResult,
     _fan_out_discord_global_commands,
     _handle_discord_application_commands,
     _json_object_from_bytes,
@@ -49,6 +52,7 @@ from app.routes.channel_routers.shared import (
     _optional_str,
     _proxy_discord_request,
     _public_ws_url,
+    _request_discord_provider,
     _request_params,
     _require_bound_chat,
     _resolve_discord_agent_context,
@@ -64,12 +68,13 @@ from app.services.channels import (
     discord_channel_scope_from_payload,
     discord_chat_from_payload,
     discord_external_user_id_from_payload,
+    discord_guild_command_denied_reason,
     discord_message_id_from_payload,
     discord_pair_command_from_payload,
+    discord_pairing_reply_for_command,
     discord_text_from_payload,
     get_active_channel_account,
     get_channel_agent_reference,
-    pairing_reply_for_command,
     record_discord_interaction_references,
     record_inactive_bot_agent_link_event,
     record_inbound_messages_for_bindings,
@@ -240,12 +245,18 @@ async def discord_agent_rest(
         and request.method == "POST"
     ):
         channel_id = segments[1]
-        await _require_bound_chat(
-            db,
-            account=account,
-            external_chat_id=channel_id,
-            bot_agent_link_id=agent.link.id,
-        )
+        try:
+            await _authorize_discord_channel_request(
+                db,
+                agent=agent,
+                channel_id=channel_id,
+                request=request,
+                original_is_channel_get=False,
+            )
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_403_FORBIDDEN:
+                return _discord_rest_error("Missing Access", 50001, 403)
+            raise
         params = await _request_params(request)
         text = _optional_str(params.get("content")) or ""
         message = await send_channel_outbound_message(
@@ -258,12 +269,21 @@ async def discord_agent_rest(
         await db.commit()
         return _discord_message_result(message, channel_id=channel_id, content=text)
     if segments and segments[0] == "channels" and len(segments) >= 2:
-        await _require_bound_chat(
-            db,
-            account=account,
-            external_chat_id=segments[1],
-            bot_agent_link_id=agent.link.id,
-        )
+        original_is_channel_get = len(segments) == 2 and request.method == "GET"
+        try:
+            preflight = await _authorize_discord_channel_request(
+                db,
+                agent=agent,
+                channel_id=segments[1],
+                request=request,
+                original_is_channel_get=original_is_channel_get,
+            )
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_403_FORBIDDEN:
+                return _discord_rest_error("Missing Access", 50001, 403)
+            raise
+        if original_is_channel_get and preflight is not None:
+            return preflight.as_response()
         return await _proxy_discord_request(account=account, request=request, path=discord_path)
     if segments and segments[0] == "guilds" and len(segments) >= 2:
         if not await _discord_guild_is_bound(
@@ -275,6 +295,114 @@ async def discord_agent_rest(
             return _discord_rest_error("Missing Access", 50001, 403)
         return await _proxy_discord_request(account=account, request=request, path=discord_path)
     return _discord_rest_error("Missing Access", 50001, 403)
+
+
+async def _authorize_discord_channel_request(
+    db: AsyncSession,
+    *,
+    agent: ChannelAgentContext,
+    channel_id: str,
+    request: Request,
+    original_is_channel_get: bool,
+) -> _DiscordProviderResult | None:
+    """Resolve a physical Discord channel without making it a Binding.
+
+    Known channel aliases stay local. For an unobserved ID, Discord's own
+    Channel object is the authority for ``guild_id`` (threads are channels),
+    then the account and AgentLink are revalidated before the alias is cached.
+    A Channel without ``guild_id`` can only use a direct DM Binding.
+    """
+    try:
+        await _require_bound_chat(
+            db,
+            account=agent.account,
+            external_chat_id=channel_id,
+            bot_agent_link_id=agent.link.id,
+        )
+        return None
+    except HTTPException as exc:
+        if exc.status_code != status.HTTP_403_FORBIDDEN:
+            raise
+
+    path = f"channels/{channel_id}"
+    preflight = await _request_discord_provider(
+        account=agent.account,
+        method="GET",
+        path=path,
+        query_params=request.query_params if original_is_channel_get else None,
+    )
+    payload = preflight.json_object() if preflight.status_code == status.HTTP_200_OK else None
+    if payload is None or _optional_str(payload.get("id")) != channel_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="channel is not paired")
+    guild_id = _optional_str(payload.get("guild_id"))
+    binding = await _discord_revalidated_channel_binding(
+        db,
+        agent=agent,
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    if binding is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="channel is not paired")
+    if guild_id is not None and channel_id != binding.external_chat_id:
+        await upsert_binding_alias(
+            db,
+            binding=binding,
+            alias_external_chat_id=channel_id,
+            alias_kind="discord_channel",
+            require_same_binding=True,
+        )
+        await db.commit()
+    return preflight
+
+
+async def _discord_revalidated_channel_binding(
+    db: AsyncSession,
+    *,
+    agent: ChannelAgentContext,
+    channel_id: str,
+    guild_id: str | None,
+) -> ChannelBinding | None:
+    agent_token_hash = agent.link.agent_token_hash
+    if not agent_token_hash:
+        return None
+    await resolve_channel_agent_by_identity(
+        db,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        account_id=agent.account.id,
+        link_id=agent.link.id,
+        agent_token_hash=agent_token_hash,
+    )
+    result = await db.execute(
+        select(ChannelBinding)
+        .join(
+            ChannelBotAgentLink,
+            (ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
+            & (ChannelBotAgentLink.account_id == ChannelBinding.account_id)
+            & (ChannelBotAgentLink.user_id == ChannelBinding.user_id),
+        )
+        .where(
+            ChannelBinding.account_id == agent.account.id,
+            ChannelBinding.bot_agent_link_id == agent.link.id,
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+        )
+    )
+    candidates = list(result.scalars().all())
+    if guild_id is not None:
+        matching = [
+            binding for binding in candidates if _discord_binding_guild_id(binding) == guild_id
+        ]
+    else:
+        matching = [
+            binding
+            for binding in candidates
+            if binding.external_chat_id == channel_id
+            and _discord_binding_guild_id(binding) is None
+            and (binding.external_chat_type or "").lower()
+            in {"dm", "direct_messages", "group_dm", "private"}
+        ]
+    return matching[0] if len(matching) == 1 else None
 
 
 @router.websocket("/gateway")
@@ -611,6 +739,7 @@ async def discord_webhook(
         return {"ok": True}
     external_chat_id, external_chat_type, external_chat_name = chat
     command = discord_pair_command_from_payload(payload)
+    channel_id, guild_id = discord_channel_scope_from_payload(payload)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -620,6 +749,12 @@ async def discord_webhook(
         external_user_id=discord_external_user_id_from_payload(payload),
         text=discord_text_from_payload(payload),
         command=command,
+        command_denied_reason=discord_guild_command_denied_reason(
+            payload,
+            command=command,
+            guild_id=guild_id,
+        ),
+        command_actor_required=True,
     )
 
     messages = await record_inbound_messages_for_bindings(
@@ -631,7 +766,6 @@ async def discord_webhook(
         text=discord_text_from_payload(payload),
         payload=payload,
     )
-    channel_id, guild_id = discord_channel_scope_from_payload(payload)
     for message, binding in messages:
         if (
             binding is not None
@@ -644,6 +778,7 @@ async def discord_webhook(
                 binding=binding,
                 alias_external_chat_id=channel_id,
                 alias_kind="discord_channel",
+                require_same_binding=True,
             )
         await record_discord_interaction_references(
             db,
@@ -655,6 +790,7 @@ async def discord_webhook(
         await record_inactive_bot_agent_link_event(db, account=account, binding=binding)
     await db.commit()
     message = messages[0][0]
+    reply_text = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
     if payload.get("type") == 2:
         return {
             "type": 4,
@@ -663,7 +799,7 @@ async def discord_webhook(
                     command=command,
                     paired=binding_result.paired,
                     unpaired=binding_result.unpaired,
-                    reply=pairing_reply_for_command(command, binding_result),
+                    reply=reply_text,
                 ),
                 "flags": 64,
             },
@@ -682,6 +818,7 @@ async def discord_webhook(
         send_external_chat_id=channel_id,
         command=command,
         binding_result=binding_result,
+        reply=reply_text,
     )
     if reply is not None:
         await db.commit()

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import secrets
 import zlib
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from uuid import UUID
 import jwt
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Depends,
     Header,
     HTTPException,
@@ -22,6 +24,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -42,6 +45,7 @@ from app.routes.channel_routers.shared import (
     _discord_application_id,
     _discord_bot_user,
     _discord_gateway_dispatch,
+    _discord_guild_owner_principals,
     _discord_interaction_content,
     _discord_message_result,
     _DiscordProviderResult,
@@ -89,6 +93,7 @@ from app.services.channels import (
 )
 
 router = APIRouter(prefix="/channels/discord", tags=["channels"])
+log = logging.getLogger(__name__)
 
 _DISCORD_GATEWAY_RESUME_BUFFER_SIZE = 100
 _DISCORD_GATEWAY_SESSIONS: dict[str, dict[str, Any]] = {}
@@ -201,7 +206,7 @@ async def discord_agent_rest(
         return _discord_bot_user(account)
     command_response = await _handle_discord_application_commands(
         db,
-        account=account,
+        agent=agent,
         request=request,
         segments=segments,
     )
@@ -708,6 +713,7 @@ async def discord_agent_gateway(
 async def discord_webhook(
     account_id: UUID,
     request: Request,
+    background_tasks: BackgroundTasks,
     x_clawdi_channel_secret: str | None = Header(default=None),
     x_signature_ed25519: str | None = Header(default=None),
     x_signature_timestamp: str | None = Header(default=None),
@@ -792,6 +798,23 @@ async def discord_webhook(
     message = messages[0][0]
     reply_text = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
     if payload.get("type") == 2:
+        if binding_result.paired and guild_id is not None:
+            # Discord interactions have a short acknowledgement deadline. The
+            # binding commit is authoritative; replay the already-shadowed
+            # Agent commands once after the interaction response is available.
+            background_tasks.add_task(
+                _replay_discord_commands_for_paired_guild,
+                account_id=account.id,
+                bot_agent_link_id=binding_result.binding.bot_agent_link_id,
+                guild_id=guild_id,
+            )
+        if binding_result.unpaired and guild_id is not None and binding_result.bindings:
+            background_tasks.add_task(
+                _cleanup_discord_guild_commands_after_authority_revoked,
+                account_id=account.id,
+                bot_agent_link_id=binding_result.bindings[0].bot_agent_link_id,
+                guild_ids={guild_id},
+            )
         return {
             "type": 4,
             "data": {
@@ -807,6 +830,11 @@ async def discord_webhook(
     await _replay_discord_commands_on_pair(
         db,
         account=account,
+        link=(
+            await db.get(ChannelBotAgentLink, binding_result.binding.bot_agent_link_id)
+            if binding_result.binding is not None
+            else None
+        ),
         application_id=_discord_application_id(account),
         guild_id=guild_id,
         paired=binding_result.paired,
@@ -834,13 +862,21 @@ async def _replay_discord_commands_on_pair(
     db: AsyncSession,
     *,
     account: ChannelAccount,
+    link: ChannelBotAgentLink | None,
     application_id: str,
     guild_id: str | None,
     paired: bool,
 ) -> None:
-    if not paired or guild_id is None:
+    if (
+        not paired
+        or guild_id is None
+        or link is None
+        or link.account_id != account.id
+        or link.status != BOT_AGENT_LINK_STATUS_ACTIVE
+        or link.archived_at is not None
+    ):
         return
-    config = account.config if isinstance(account.config, dict) else {}
+    config = link.config if isinstance(link.config, dict) else {}
     shadow = config.get("discord_agent_commands")
     if not isinstance(shadow, dict):
         return
@@ -851,12 +887,104 @@ async def _replay_discord_commands_on_pair(
         await _fan_out_discord_global_commands(
             db,
             account=account,
+            bot_agent_link_id=link.id,
             application_id=application_id,
             commands=[command for command in commands if isinstance(command, dict)],
             guild_ids={guild_id},
         )
     except HTTPException:
         return
+
+
+async def _replay_discord_commands_for_paired_guild(
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+    guild_id: str,
+) -> None:
+    try:
+        async with async_session_factory() as db:
+            account = await get_active_channel_account(db, account_id=account_id)
+            link = await db.get(ChannelBotAgentLink, bot_agent_link_id)
+            await _replay_discord_commands_on_pair(
+                db,
+                account=account,
+                link=link,
+                application_id=_discord_application_id(account),
+                guild_id=guild_id,
+                paired=True,
+            )
+    except (HTTPException, SQLAlchemyError):
+        # The interaction has already acknowledged a durable pairing. Command
+        # fan-out is best effort and must not turn a provider/DB retry into an
+        # unhandled background-task failure.
+        log.exception(
+            "discord_command_replay_failed account_id=%s guild_id=%s",
+            account_id,
+            guild_id,
+        )
+
+
+async def _cleanup_discord_guild_commands_after_authority_revoked(
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+    guild_ids: set[str],
+) -> None:
+    """Best-effort cleanup after durable unpair/unlink authority revocation."""
+    try:
+        async with async_session_factory() as db:
+            account = await get_active_channel_account(db, account_id=account_id)
+            link = await db.get(ChannelBotAgentLink, bot_agent_link_id)
+            link_config = link.config if link is not None and isinstance(link.config, dict) else {}
+            command_shadow = link_config.get("discord_agent_commands")
+            if not isinstance(command_shadow, dict) or not any(
+                isinstance(commands, list) and commands for commands in command_shadow.values()
+            ):
+                return
+            application_id = _discord_application_id(account)
+            for guild_id in sorted(guild_ids):
+                # A new pairing can win after the revocation commit. Never erase its
+                # newly materialized commands.
+                if await _discord_guild_owner_principals(db, guild_id=guild_id):
+                    log.info(
+                        "discord_command_cleanup_skipped_active_owner "
+                        "account_id=%s link_id=%s guild_id=%s",
+                        account_id,
+                        bot_agent_link_id,
+                        guild_id,
+                    )
+                    continue
+                try:
+                    result = await _request_discord_provider(
+                        account=account,
+                        method="PUT",
+                        path=f"/applications/{application_id}/guilds/{guild_id}/commands",
+                        body=b"[]",
+                    )
+                    if result.status_code >= 400:
+                        log.warning(
+                            "discord_command_cleanup_rejected "
+                            "account_id=%s link_id=%s guild_id=%s status=%s",
+                            account_id,
+                            bot_agent_link_id,
+                            guild_id,
+                            result.status_code,
+                        )
+                except HTTPException:
+                    log.exception(
+                        "discord_command_cleanup_failed account_id=%s link_id=%s guild_id=%s",
+                        account_id,
+                        bot_agent_link_id,
+                        guild_id,
+                    )
+                    continue
+    except (HTTPException, SQLAlchemyError):
+        log.exception(
+            "discord_command_cleanup_setup_failed account_id=%s link_id=%s",
+            account_id,
+            bot_agent_link_id,
+        )
 
 
 async def _ack_discord_gateway_sequence(

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Depends,
     HTTPException,
     Query,
@@ -50,6 +51,7 @@ from app.models.session import AgentEnvironment
 from app.routes.channel_routers.shared import (
     _account_response,
     _binding_response,
+    _discord_binding_guild_id,
     _message_response,
 )
 from app.schemas.channel import (
@@ -81,16 +83,23 @@ from app.schemas.channel import (
 )
 from app.services.agent_bindings import get_owned_agent_or_404
 from app.services.audit import record_control_plane_audit
-from app.services.channel_config import validate_channel_account_config_urls
+from app.services.channel_config import (
+    discord_interactions_config_error,
+    discord_public_account_is_eligible,
+    validate_channel_account_config_urls,
+    validate_required_discord_interactions_config,
+)
 from app.services.channels import (
     archive_bot_agent_link,
     archive_channel_account,
     bot_agent_link_has_strict_v2_authority,
     channel_bot_link_limit,
     channel_webhook_url,
+    configure_discord_application,
     configure_telegram_provider_webhook,
     create_pair_code,
     decrypt_agent_link_token,
+    discord_bot_install_url,
     encrypt_optional_token,
     enqueue_channel_outbound_message,
     ensure_bot_agent_link_provider_cardinality_or_409,
@@ -528,6 +537,15 @@ async def list_channel_bot_pool(
         account_ids=[account.id for account in accounts],
     )
     for account in accounts:
+        if (
+            account.provider == CHANNEL_PROVIDER_DISCORD
+            and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+            and not discord_public_account_is_eligible(account)
+        ):
+            # Historical/incomplete shared Discord accounts remain manageable
+            # through admin APIs but are never offered as usable bot-pool
+            # infrastructure.
+            continue
         providers.setdefault(account.provider, []).append(
             _bot_pool_item(
                 account,
@@ -563,6 +581,13 @@ async def create_channel(
     if body.provider not in CHANNEL_PROVIDERS:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="unsupported provider")
     await validate_channel_account_config_urls(provider=body.provider, config=body.config)
+    if body.provider == CHANNEL_PROVIDER_DISCORD:
+        if body.provider_token is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Discord channels require a bot token.",
+            )
+        validate_required_discord_interactions_config(body.config)
     initial_agent_id = (
         None
         if "agent_id" in body.model_fields_set and body.agent_id is None
@@ -786,6 +811,25 @@ async def create_channel_pair_code(
     db: AsyncSession = Depends(get_session),
 ) -> ChannelPairCodeResponse:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    if account.provider == CHANNEL_PROVIDER_DISCORD:
+        config_error = discord_interactions_config_error(account.config)
+        if config_error is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Discord pairing is unavailable: {config_error}",
+            )
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        if config.get("discord_interactions_configured") is not True:
+            await configure_discord_application(account)
+            # Reserved control-plane commands are true account-global
+            # commands so they remain available before any Guild or DM is
+            # paired. Agent runtime commands are virtualized per Link.
+            await sync_channel_commands(
+                account=account,
+                use_configured_discord_guild=False,
+            )
+            config["discord_interactions_configured"] = True
+            account.config = config
     link, agent_token = await _resolve_pair_code_link(db, auth=auth, account=account, body=body)
     created = await create_pair_code(
         db,
@@ -833,6 +877,7 @@ async def create_channel_pair_code(
         bot_username=bot_username,
         deep_link=deep_link,
         qr_payload=deep_link,
+        discord_install_url=discord_bot_install_url(account),
     )
 
 
@@ -930,6 +975,7 @@ async def rotate_channel_agent_link_token(
 async def delete_channel_agent_link(
     account_id: UUID,
     link_id: UUID,
+    background_tasks: BackgroundTasks,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> None:
@@ -958,6 +1004,15 @@ async def delete_channel_agent_link(
             )
         ).scalars()
     )
+    discord_guild_ids = (
+        {
+            guild_id
+            for binding in bindings
+            if (guild_id := _discord_binding_guild_id(binding)) is not None
+        }
+        if account.provider == CHANNEL_PROVIDER_DISCORD
+        else set()
+    )
     for binding in sorted(bindings, key=lambda item: item.external_chat_id):
         await lock_channel_binding_identity(
             db,
@@ -980,7 +1035,18 @@ async def delete_channel_agent_link(
         details={"provider": account.provider, "agent_id": str(link.agent_id)},
     )
     await db.commit()
-    if account.provider == CHANNEL_PROVIDER_TELEGRAM and bindings:
+    if discord_guild_ids:
+        from app.routes.channel_routers.discord import (
+            _cleanup_discord_guild_commands_after_authority_revoked,
+        )
+
+        background_tasks.add_task(
+            _cleanup_discord_guild_commands_after_authority_revoked,
+            account_id=account.id,
+            bot_agent_link_id=link.id,
+            guild_ids=discord_guild_ids,
+        )
+    elif account.provider == CHANNEL_PROVIDER_TELEGRAM and bindings:
         from app.routes.channel_routers.telegram import reconcile_telegram_link_unlink
 
         cleaned = await reconcile_telegram_link_unlink(
@@ -1056,6 +1122,14 @@ async def delete_channel_binding(
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="binding not found")
     binding, link = row
+    if account.provider == CHANNEL_PROVIDER_DISCORD:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Run /bot_unpair in the paired Discord server or direct message. "
+                "Discord pairing authority cannot be verified from this API."
+            ),
+        )
     await lock_channel_binding_identity(
         db,
         account_id=account.id,

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -914,71 +915,113 @@ def _discord_gateway_dispatch(message: Any) -> dict[str, Any]:
     }
 
 
-async def _proxy_discord_request(
+@dataclass(frozen=True)
+class _DiscordProviderResult:
+    content: bytes
+    status_code: int
+    media_type: str
+    headers: dict[str, str] | None = None
+
+    def as_response(self) -> Response:
+        return Response(
+            content=self.content,
+            status_code=self.status_code,
+            media_type=self.media_type,
+            headers=self.headers,
+        )
+
+    def json_object(self) -> dict[str, Any] | None:
+        try:
+            payload = json.loads(self.content)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+
+async def _request_discord_provider(
     *,
     account: ChannelAccount,
-    request: Request,
+    method: str,
     path: str,
-) -> Response:
+    body: bytes | None = None,
+    content_type: str = "application/json",
+    query_params: Any = None,
+) -> _DiscordProviderResult:
     token = decrypt_provider_token(account)
     normalized_path = f"/{path.lstrip('/')}"
     base_url = settings.channel_discord_api_base_url.strip()
     await _validate_discord_provider_base_url(base_url)
     url = f"{base_url.rstrip('/')}{normalized_path}"
-    body = await request.body()
     headers = {
         "Authorization": f"Bot {token}",
-        "Content-Type": request.headers.get("content-type", "application/json"),
+        "Content-Type": content_type,
     }
-    decision = discord_rate_limiter.check(request.method, normalized_path)
+    decision = discord_rate_limiter.check(method, normalized_path)
     if not decision.allowed:
         rate_limit_rejects.labels(
             channel="discord",
             scope="bot" if decision.global_limit else "route",
         ).inc()
-        return Response(
+        return _DiscordProviderResult(
             content=json.dumps(
                 {
                     "message": "You are being rate limited.",
                     "retry_after": decision.retry_after_seconds,
                     "global": decision.global_limit,
                 }
-            ),
+            ).encode("utf-8"),
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             media_type="application/json",
             headers={"Retry-After": str(decision.retry_after_seconds or 1)},
         )
     try:
-        with track_proxy_latency("discord", request.method):
+        with track_proxy_latency("discord", method):
             async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(request.method, normalized_path)
+                discord_rate_limiter.consume(method, normalized_path)
                 response = await client.request(
-                    request.method,
+                    method,
                     url,
                     content=body if body else None,
                     headers=headers,
-                    params=request.query_params,
+                    params=query_params,
                 )
                 discord_rate_limiter.observe(
-                    request.method,
+                    method,
                     normalized_path,
                     response.headers,
                     response.status_code,
                 )
     except httpx.HTTPError as exc:
-        outbound_errors.labels(channel="discord", method=request.method).inc()
+        outbound_errors.labels(channel="discord", method=method).inc()
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="discord api unreachable",
         ) from exc
-    outbound_messages.labels(channel="discord", method=request.method).inc()
+    outbound_messages.labels(channel="discord", method=method).inc()
     if response.status_code >= 400:
-        outbound_errors.labels(channel="discord", method=request.method).inc()
-    return Response(
+        outbound_errors.labels(channel="discord", method=method).inc()
+    return _DiscordProviderResult(
         content=response.content,
         status_code=response.status_code,
         media_type=response.headers.get("content-type", "application/json"),
     )
+
+
+async def _proxy_discord_request(
+    *,
+    account: ChannelAccount,
+    request: Request,
+    path: str,
+) -> Response:
+    result = await _request_discord_provider(
+        account=account,
+        method=request.method,
+        path=path,
+        body=await request.body(),
+        content_type=request.headers.get("content-type", "application/json"),
+        query_params=request.query_params,
+    )
+    return result.as_response()
 
 
 async def _validate_discord_provider_base_url(base_url: str) -> None:

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
+    BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     ChannelAccount,
     ChannelBinding,
@@ -543,10 +544,12 @@ def _discord_message_result(message: Any, *, channel_id: str, content: str) -> d
 async def _handle_discord_application_commands(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
+    agent: ChannelAgentContext,
     request: Request,
     segments: list[str],
 ) -> Any:
+    account = agent.account
+    link = agent.link
     if not segments or segments[0] != "applications":
         return None
     application_id = segments[1] if len(segments) > 1 else None
@@ -568,14 +571,15 @@ async def _handle_discord_application_commands(
         return None
     if application_id != _discord_application_id(account):
         return _discord_command_error("Missing Access", 50001, 403)
-    if guild_id is not None and not await _discord_guild_owned_by_account(
+    if guild_id is not None and not await _discord_guild_owned_by_link(
         db,
         account=account,
+        bot_agent_link_id=link.id,
         guild_id=guild_id,
     ):
         return _discord_command_error("Missing Access", 50001, 403)
 
-    commands = _discord_command_shadow(account)
+    commands = _discord_command_shadow(link)
     if request.method == "GET" and command_id is None:
         return commands.get(scope_key, [])
     if request.method == "GET" and command_id is not None:
@@ -583,7 +587,15 @@ async def _handle_discord_application_commands(
         return command or _discord_command_error("Unknown application command", 10063, 404)
     if request.method == "DELETE" and command_id is None:
         commands.pop(scope_key, None)
-        await _store_discord_command_shadow(db, account=account, commands=commands)
+        await _store_discord_command_shadow(db, link=link, commands=commands)
+        await _materialize_discord_command_scope(
+            db,
+            account=account,
+            link=link,
+            application_id=application_id,
+            guild_id=guild_id,
+            commands=[],
+        )
         return {}
     if request.method == "DELETE" and command_id is not None:
         command_list = commands.get(scope_key, [])
@@ -593,7 +605,15 @@ async def _handle_discord_application_commands(
         if len(filtered) == len(command_list):
             return _discord_command_error("Unknown application command", 10063, 404)
         commands[scope_key] = filtered
-        await _store_discord_command_shadow(db, account=account, commands=commands)
+        await _store_discord_command_shadow(db, link=link, commands=commands)
+        await _materialize_discord_command_scope(
+            db,
+            account=account,
+            link=link,
+            application_id=application_id,
+            guild_id=guild_id,
+            commands=filtered,
+        )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     if request.method not in {"POST", "PUT", "PATCH"}:
         return None
@@ -607,14 +627,15 @@ async def _handle_discord_application_commands(
         else:
             command_list = _discord_command_list_shape([params], application_id=application_id)
         commands[scope_key] = command_list
-        await _store_discord_command_shadow(db, account=account, commands=commands)
-        if scope_key == "global":
-            await _fan_out_discord_global_commands(
-                db,
-                account=account,
-                application_id=application_id,
-                commands=command_list,
-            )
+        await _store_discord_command_shadow(db, link=link, commands=commands)
+        await _materialize_discord_command_scope(
+            db,
+            account=account,
+            link=link,
+            application_id=application_id,
+            guild_id=guild_id,
+            commands=command_list,
+        )
         return command_list
 
     if request.method == "PATCH" and command_id is not None:
@@ -629,14 +650,15 @@ async def _handle_discord_application_commands(
             if _discord_command_key_conflicts(command_list, command, ignored_id=command_id):
                 return _discord_command_error("Application command already exists", 30032, 400)
             command_list[index] = command
-            await _store_discord_command_shadow(db, account=account, commands=commands)
-            if scope_key == "global":
-                await _fan_out_discord_global_commands(
-                    db,
-                    account=account,
-                    application_id=application_id,
-                    commands=command_list,
-                )
+            await _store_discord_command_shadow(db, link=link, commands=commands)
+            await _materialize_discord_command_scope(
+                db,
+                account=account,
+                link=link,
+                application_id=application_id,
+                guild_id=guild_id,
+                commands=command_list,
+            )
             return command
         return _discord_command_error("Unknown application command", 10063, 404)
 
@@ -646,14 +668,15 @@ async def _handle_discord_application_commands(
     command = _discord_command_shape(params, application_id=application_id)
     command_list = commands.setdefault(scope_key, [])
     _discord_upsert_command(command_list, command)
-    await _store_discord_command_shadow(db, account=account, commands=commands)
-    if scope_key == "global":
-        await _fan_out_discord_global_commands(
-            db,
-            account=account,
-            application_id=application_id,
-            commands=command_list,
-        )
+    await _store_discord_command_shadow(db, link=link, commands=commands)
+    await _materialize_discord_command_scope(
+        db,
+        account=account,
+        link=link,
+        application_id=application_id,
+        guild_id=guild_id,
+        commands=command_list,
+    )
     return command
 
 
@@ -675,8 +698,8 @@ def _discord_command_error(message: str, code: int, status_code: int) -> Respons
     )
 
 
-def _discord_command_shadow(account: ChannelAccount) -> dict[str, list[dict[str, Any]]]:
-    config = account.config if isinstance(account.config, dict) else {}
+def _discord_command_shadow(link: ChannelBotAgentLink) -> dict[str, list[dict[str, Any]]]:
+    config = link.config if isinstance(link.config, dict) else {}
     commands = config.get("discord_agent_commands")
     if not isinstance(commands, dict):
         return {}
@@ -690,12 +713,12 @@ def _discord_command_shadow(account: ChannelAccount) -> dict[str, list[dict[str,
 async def _store_discord_command_shadow(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
+    link: ChannelBotAgentLink,
     commands: dict[str, list[dict[str, Any]]],
 ) -> None:
-    config = dict(account.config) if isinstance(account.config, dict) else {}
+    config = dict(link.config) if isinstance(link.config, dict) else {}
     config["discord_agent_commands"] = commands
-    account.config = config
+    link.config = config
     await db.commit()
 
 
@@ -799,53 +822,67 @@ def _discord_command_key_conflicts(
     return False
 
 
-async def _discord_guild_owned_by_account(
+async def _discord_guild_owned_by_link(
     db: AsyncSession,
     *,
     account: ChannelAccount,
+    bot_agent_link_id: UUID,
     guild_id: str,
 ) -> bool:
-    owners = await _discord_guild_owner_ids(db, guild_id=guild_id)
-    return owners == {account.id}
+    owners = await _discord_guild_owner_principals(db, guild_id=guild_id)
+    return owners == {(account.id, bot_agent_link_id)}
 
 
-async def _discord_uncontested_guilds_for_account(
+async def _discord_uncontested_guilds_for_link(
     db: AsyncSession,
     *,
     account: ChannelAccount,
+    bot_agent_link_id: UUID,
 ) -> list[str]:
     result = await db.execute(
-        select(ChannelBinding, ChannelAccount)
+        select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+        .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
         )
     )
-    owners_by_guild: dict[str, set[UUID]] = {}
-    for binding, owner_account in result.all():
+    owners_by_guild: dict[str, set[tuple[UUID, UUID]]] = {}
+    for binding, owner_account, owner_link in result.all():
         guild_id = _discord_binding_guild_id(binding)
         if guild_id is None:
             continue
-        owners_by_guild.setdefault(guild_id, set()).add(owner_account.id)
+        owners_by_guild.setdefault(guild_id, set()).add((owner_account.id, owner_link.id))
     return sorted(
-        guild_id for guild_id, owners in owners_by_guild.items() if owners == {account.id}
+        guild_id
+        for guild_id, owners in owners_by_guild.items()
+        if owners == {(account.id, bot_agent_link_id)}
     )
 
 
-async def _discord_guild_owner_ids(db: AsyncSession, *, guild_id: str) -> set[UUID]:
+async def _discord_guild_owner_principals(
+    db: AsyncSession,
+    *,
+    guild_id: str,
+) -> set[tuple[UUID, UUID]]:
     result = await db.execute(
-        select(ChannelBinding, ChannelAccount)
+        select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+        .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
         )
     )
-    owners: set[UUID] = set()
-    for binding, owner_account in result.all():
+    owners: set[tuple[UUID, UUID]] = set()
+    for binding, owner_account, owner_link in result.all():
         if _discord_binding_guild_id(binding) == guild_id:
-            owners.add(owner_account.id)
+            owners.add((owner_account.id, owner_link.id))
     return owners
 
 
@@ -862,39 +899,59 @@ async def _fan_out_discord_global_commands(
     db: AsyncSession,
     *,
     account: ChannelAccount,
+    bot_agent_link_id: UUID,
     application_id: str,
     commands: list[dict[str, Any]],
     guild_ids: set[str] | None = None,
 ) -> None:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
         return
-    token = decrypt_provider_token(account)
-    uncontested_guild_ids = await _discord_uncontested_guilds_for_account(db, account=account)
+    uncontested_guild_ids = await _discord_uncontested_guilds_for_link(
+        db,
+        account=account,
+        bot_agent_link_id=bot_agent_link_id,
+    )
     target_guild_ids = [
         guild_id for guild_id in uncontested_guild_ids if guild_ids is None or guild_id in guild_ids
     ]
     if not target_guild_ids:
         return
-    base_url = settings.channel_discord_api_base_url.strip()
-    await _validate_discord_provider_base_url(base_url)
-    base_url = base_url.rstrip("/")
-    headers = {
-        "Authorization": f"Bot {token}",
-        "Content-Type": "application/json",
-    }
-    try:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            for guild_id in target_guild_ids:
-                await client.put(
-                    f"{base_url}/applications/{application_id}/guilds/{guild_id}/commands",
-                    json=commands,
-                    headers=headers,
-                )
-    except httpx.HTTPError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="discord api unreachable",
-        ) from exc
+    body = json.dumps(commands).encode("utf-8")
+    for guild_id in target_guild_ids:
+        result = await _request_discord_provider(
+            account=account,
+            method="PUT",
+            path=f"/applications/{application_id}/guilds/{guild_id}/commands",
+            body=body,
+        )
+        if result.status_code >= 400:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="discord api rejected commands",
+            )
+
+
+async def _materialize_discord_command_scope(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+    application_id: str,
+    guild_id: str | None,
+    commands: list[dict[str, Any]],
+) -> None:
+    # Agent-facing global commands are virtualized per Link because a shared
+    # physical Discord application has only one true global command set.
+    # Materialize them only into that Link's active Guild bindings. Explicit
+    # guild-scoped requests use the same ownership-checked provider path.
+    await _fan_out_discord_global_commands(
+        db,
+        account=account,
+        bot_agent_link_id=link.id,
+        application_id=application_id,
+        commands=commands,
+        guild_ids={guild_id} if guild_id is not None else None,
+    )
 
 
 def _discord_gateway_dispatch(message: Any) -> dict[str, Any]:

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -143,6 +143,7 @@ class ChannelPairCodeResponse(BaseModel):
     bot_username: str | None = None
     deep_link: str | None = None
     qr_payload: str | None = None
+    discord_install_url: str | None = None
 
 
 class ChannelCommandSpec(BaseModel):

--- a/backend/app/services/channel_config.py
+++ b/backend/app/services/channel_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -8,12 +9,53 @@ from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_IMESSAGE,
     CHANNEL_PROVIDER_WHATSAPP,
+    ChannelAccount,
 )
 from app.services.url_security import (
     UnsafeOutboundUrlError,
     validate_channel_http_url,
     validate_channel_websocket_url,
 )
+
+_DISCORD_SNOWFLAKE_PATTERN = re.compile(r"^[0-9]{17,20}$")
+_DISCORD_PUBLIC_KEY_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+_DISCORD_MAX_SNOWFLAKE = (1 << 64) - 1
+
+
+def discord_interactions_config_error(config: dict[str, Any] | None) -> str | None:
+    """Return the first missing/invalid HTTP-interactions requirement."""
+    values = config if isinstance(config, dict) else {}
+    application_id = values.get("application_id")
+    if not isinstance(application_id, str) or not valid_discord_application_id(application_id):
+        return "Discord application_id must be a valid numeric application ID."
+    public_key = values.get("public_key")
+    if not isinstance(public_key, str) or _DISCORD_PUBLIC_KEY_PATTERN.fullmatch(public_key) is None:
+        return "Discord public_key must be a 64-character hexadecimal interactions public key."
+    return None
+
+
+def discord_public_account_is_eligible(account: ChannelAccount) -> bool:
+    config = account.config if isinstance(account.config, dict) else {}
+    return bool(
+        account.encrypted_provider_token
+        and account.provider_token_nonce
+        and discord_interactions_config_error(account.config) is None
+        and config.get("discord_interactions_configured") is True
+    )
+
+
+def validate_required_discord_interactions_config(config: dict[str, Any] | None) -> None:
+    detail = discord_interactions_config_error(config)
+    if detail is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+def valid_discord_application_id(value: str) -> bool:
+    return bool(
+        value == value.strip()
+        and _DISCORD_SNOWFLAKE_PATTERN.fullmatch(value)
+        and int(value, 10) <= _DISCORD_MAX_SNOWFLAKE
+    )
 
 
 async def validate_channel_account_config_urls(

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -65,6 +65,10 @@ from app.models.runtime_observation import (
 )
 from app.models.session import AgentEnvironment
 from app.schemas.runtime import validate_hosted_runtime_desired_state
+from app.services.channel_config import (
+    valid_discord_application_id,
+    validate_required_discord_interactions_config,
+)
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.discord_rate_limiter import discord_rate_limiter
 from app.services.imessage_routing import (
@@ -108,6 +112,12 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
 )
 DISCORD_ADMINISTRATOR_PERMISSION = 1 << 3
 DISCORD_MANAGE_GUILD_PERMISSION = 1 << 5
+# Discord API docs baseline b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+# ADD_REACTIONS, VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS, ATTACH_FILES,
+# READ_MESSAGE_HISTORY, and SEND_MESSAGES_IN_THREADS. Never request
+# ADMINISTRATOR or MANAGE_GUILD for the bot; pair mutation authority is the
+# invoking member's computed permissions.
+DISCORD_MINIMAL_BOT_PERMISSIONS = 274_878_024_768
 DISCORD_GUILD_PERMISSION_DENIED = "discord_guild_permission_denied"
 DISCORD_GUILD_USE_INTERACTION = "discord_guild_use_interaction"
 DISCORD_DM_CHAT_TYPES = frozenset({"dm", "direct_messages", "group_dm", "private"})
@@ -3261,7 +3271,9 @@ async def sync_channel_commands(
     account: ChannelAccount,
     commands: list[dict[str, Any]] | None = None,
     guild_id: str | None = None,
+    use_configured_discord_guild: bool | None = None,
 ) -> list[dict[str, Any]]:
+    using_default_commands = commands is None
     command_specs = commands or [dict(command) for command in DEFAULT_CHANNEL_COMMANDS]
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
         return await sync_telegram_commands(account=account, commands=command_specs)
@@ -3270,11 +3282,158 @@ async def sync_channel_commands(
             account=account,
             commands=command_specs,
             guild_id=guild_id,
+            use_configured_guild=(
+                not using_default_commands
+                if use_configured_discord_guild is None
+                else use_configured_discord_guild
+            ),
         )
     raise HTTPException(
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
         detail="channel provider command sync is not implemented",
     )
+
+
+async def configure_discord_application(account: ChannelAccount) -> dict[str, Any]:
+    """Configure and validate the account's Discord HTTP interaction endpoint.
+
+    The account row must already be committed before this runs: Discord
+    validates the PATCH by sending a signed PING to the generated webhook URL.
+    A GET identity check precedes mutation so a token for another application
+    can never silently configure the requested application.
+    """
+    if account.provider != CHANNEL_PROVIDER_DISCORD:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="not a discord channel")
+    validate_required_discord_interactions_config(account.config)
+    application_id = _account_config_str(account, "application_id")
+    if application_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Discord application_id is required.",
+        )
+    token = decrypt_provider_token(account)
+    base_url = (
+        _account_config_str(account, "api_base_url")
+        or settings.channel_discord_api_base_url.strip()
+    )
+    await _validate_provider_endpoint_url(
+        base_url,
+        channel=CHANNEL_PROVIDER_DISCORD,
+        method="application",
+        label="discord api base url",
+    )
+    url = f"{base_url.rstrip('/')}/applications/@me"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+    identity = await _discord_application_request(
+        method="GET",
+        url=url,
+        headers=headers,
+    )
+    _verify_discord_application_identity(identity, expected_application_id=application_id)
+    configured = await _discord_application_request(
+        method="PATCH",
+        url=url,
+        headers=headers,
+        json_payload={
+            "interactions_endpoint_url": channel_webhook_url(account.id, account.provider)
+        },
+    )
+    _verify_discord_application_identity(configured, expected_application_id=application_id)
+    return configured
+
+
+def discord_bot_install_url(account: ChannelAccount) -> str | None:
+    if account.provider != CHANNEL_PROVIDER_DISCORD:
+        return None
+    application_id = _account_config_str(account, "application_id")
+    if application_id is None or not valid_discord_application_id(application_id):
+        return None
+    return (
+        "https://discord.com/oauth2/authorize"
+        f"?client_id={application_id}"
+        f"&permissions={DISCORD_MINIMAL_BOT_PERMISSIONS}"
+        "&scope=bot%20applications.commands"
+    )
+
+
+async def _discord_application_request(
+    *,
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    path = "/applications/@me"
+    decision = discord_rate_limiter.check(method, path)
+    if not decision.allowed:
+        rate_limit_rejects.labels(
+            channel=CHANNEL_PROVIDER_DISCORD,
+            scope="bot" if decision.global_limit else "route",
+        ).inc()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord could not validate the interactions endpoint. Try again.",
+        )
+    try:
+        with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, method):
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                discord_rate_limiter.consume(method, path)
+                response = await client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=json_payload,
+                )
+                discord_rate_limiter.observe(
+                    method,
+                    path,
+                    response.headers,
+                    response.status_code,
+                )
+    except httpx.HTTPError as exc:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord could not validate the interactions endpoint. Try again.",
+        ) from exc
+    outbound_messages.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
+    if response.status_code >= 400:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                "Discord rejected the interactions endpoint. Check the application ID, "
+                "public key, and endpoint, then retry."
+            ),
+        )
+    payload = _response_json_or_text(response)
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord returned an invalid application response.",
+        )
+    return payload
+
+
+def _verify_discord_application_identity(
+    payload: dict[str, Any],
+    *,
+    expected_application_id: str,
+) -> None:
+    returned_id = _read_optional_str(payload.get("id"))
+    if returned_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord returned an application response without an ID.",
+        )
+    if returned_id != expected_application_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Discord bot token belongs to a different application.",
+        )
 
 
 async def send_telegram_message(
@@ -3496,6 +3655,7 @@ async def sync_discord_commands(
     account: ChannelAccount,
     commands: list[dict[str, Any]],
     guild_id: str | None,
+    use_configured_guild: bool = True,
 ) -> list[dict[str, Any]]:
     if account.provider != CHANNEL_PROVIDER_DISCORD:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="not a discord channel")
@@ -3509,7 +3669,9 @@ async def sync_discord_commands(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="discord application_id is required in channel config",
         )
-    scoped_guild_id = guild_id or _account_config_str(account, "guild_id")
+    scoped_guild_id = guild_id
+    if scoped_guild_id is None and use_configured_guild:
+        scoped_guild_id = _account_config_str(account, "guild_id")
     base_url = (
         _account_config_str(account, "api_base_url")
         or settings.channel_discord_api_base_url.strip()

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -106,6 +106,11 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
         "options": [],
     },
 )
+DISCORD_ADMINISTRATOR_PERMISSION = 1 << 3
+DISCORD_MANAGE_GUILD_PERMISSION = 1 << 5
+DISCORD_GUILD_PERMISSION_DENIED = "discord_guild_permission_denied"
+DISCORD_GUILD_USE_INTERACTION = "discord_guild_use_interaction"
+DISCORD_DM_CHAT_TYPES = frozenset({"dm", "direct_messages", "group_dm", "private"})
 DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
 DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
 HERMES_AGENT_TYPE = "hermes"
@@ -194,6 +199,10 @@ PAIRING_REPLY_FORBIDDEN = "Only the user who paired this chat can change its pai
 
 
 class BindingActorMismatchError(Exception):
+    pass
+
+
+class BindingAgentLinkMismatchError(Exception):
     pass
 
 
@@ -1329,6 +1338,8 @@ async def claim_pair_code(
                 external_chat_name=external_chat_name,
                 external_user_id=external_user_id,
             )
+    except BindingAgentLinkMismatchError:
+        return PairCodeClaimResult(reason="already_paired")
     except (BindingActorMismatchError, IntegrityError):
         return PairCodeClaimResult(reason="forbidden")
     pair_code.status = PAIR_CODE_STATUS_CLAIMED
@@ -1370,11 +1381,23 @@ async def get_or_create_binding(
     )
     binding = result.scalars().first()
     if binding is not None:
-        if binding.status == BINDING_STATUS_ACTIVE and not binding_is_controlled_by_actor(
-            binding,
-            external_user_id=external_user_id,
-        ):
-            raise BindingActorMismatchError
+        if binding.status == BINDING_STATUS_ACTIVE:
+            if not binding_is_controlled_by_actor(
+                binding,
+                external_user_id=external_user_id,
+            ):
+                raise BindingActorMismatchError
+            if account.provider == CHANNEL_PROVIDER_DISCORD:
+                if binding.bot_agent_link_id != bot_agent_link_id:
+                    # One active Discord guild/DM scope cannot be silently
+                    # moved between AgentLinks. Explicit unpair archives the
+                    # scope first, after which a new Link may claim it.
+                    raise BindingAgentLinkMismatchError
+                if not discord_binding_matches_chat_type(
+                    binding,
+                    external_chat_type=external_chat_type,
+                ):
+                    raise BindingActorMismatchError
         binding.bot_agent_link_id = bot_agent_link_id
         binding.user_id = user_id
         binding.external_chat_type = external_chat_type
@@ -1419,6 +1442,16 @@ def binding_is_controlled_by_actor(
     if binding.paired_external_user_id is None:
         return external_user_id is None
     return binding.paired_external_user_id == external_user_id
+
+
+def discord_binding_matches_chat_type(
+    binding: ChannelBinding,
+    *,
+    external_chat_type: str | None,
+) -> bool:
+    binding_is_dm = (binding.external_chat_type or "").lower() in DISCORD_DM_CHAT_TYPES
+    incoming_is_dm = (external_chat_type or "").lower() in DISCORD_DM_CHAT_TYPES
+    return binding_is_dm == incoming_is_dm
 
 
 async def find_binding(
@@ -1523,6 +1556,7 @@ async def upsert_binding_alias(
     binding: ChannelBinding,
     alias_external_chat_id: str,
     alias_kind: str,
+    require_same_binding: bool = False,
 ) -> ChannelBindingAlias:
     result = await db.execute(
         select(ChannelBindingAlias).where(
@@ -1532,6 +1566,13 @@ async def upsert_binding_alias(
     )
     alias = result.scalar_one_or_none()
     if alias is not None:
+        if require_same_binding and alias.binding_id != binding.id:
+            existing_binding = await db.get(ChannelBinding, alias.binding_id)
+            if existing_binding is not None and existing_binding.status == BINDING_STATUS_ACTIVE:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="channel binding alias does not match",
+                )
         alias.binding_id = binding.id
         alias.alias_kind = alias_kind
         alias.user_id = binding.user_id
@@ -1561,6 +1602,8 @@ async def resolve_inbound_binding(
     external_user_id: str | None,
     text: str | None,
     command: ChannelPairCommand | None = None,
+    command_denied_reason: str | None = None,
+    command_actor_required: bool = False,
 ) -> InboundBindingResult:
     parsed = command if command is not None else parse_pair_command(text)
     if parsed is not None and parsed.kind in {"pair", "unpair"}:
@@ -1570,6 +1613,15 @@ async def resolve_inbound_binding(
             external_chat_id=external_chat_id,
         )
     bindings = await find_bindings(db, account=account, external_chat_id=external_chat_id)
+    if account.provider == CHANNEL_PROVIDER_DISCORD:
+        bindings = [
+            active_binding
+            for active_binding in bindings
+            if discord_binding_matches_chat_type(
+                active_binding,
+                external_chat_type=external_chat_type,
+            )
+        ]
     binding = bindings[0] if bindings else None
     if parsed is None:
         authorized_bindings: list[ChannelBinding] = []
@@ -1604,7 +1656,16 @@ async def resolve_inbound_binding(
             binding=authorized_bindings[0] if authorized_bindings else None,
             bindings=tuple(authorized_bindings),
         )
-    if external_user_id is None and pairing_command_requires_actor(external_chat_type):
+    if command_denied_reason is not None:
+        return InboundBindingResult(
+            binding=binding,
+            bindings=tuple(bindings),
+            command_handled=True,
+            pair_failed_reason=command_denied_reason,
+        )
+    if external_user_id is None and (
+        command_actor_required or pairing_command_requires_actor(external_chat_type)
+    ):
         return InboundBindingResult(
             binding=binding,
             bindings=tuple(bindings),
@@ -1735,6 +1796,70 @@ def pairing_reply_for_command(
     return "Message received."
 
 
+def discord_guild_command_denied_reason(
+    payload: dict[str, Any],
+    *,
+    command: ChannelPairCommand | None,
+    guild_id: str | None,
+) -> str | None:
+    """Require Discord-computed guild permissions for pairing mutations.
+
+    Discord interaction ``member.permissions`` is the authoritative computed
+    decimal-string bitfield. MESSAGE_CREATE does not normally include it, so
+    text commands fail closed unless a trusted ingress supplied the same
+    computed field. Discord API docs baseline:
+    b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+    """
+    if command is None or command.kind not in {"pair", "unpair"} or guild_id is None:
+        return None
+    data = _discord_event_data(payload)
+    member = data.get("member")
+    raw_permissions = member.get("permissions") if isinstance(member, dict) else None
+    is_interaction = payload.get("type") == 2 or payload.get("t") == "INTERACTION_CREATE"
+    if not isinstance(raw_permissions, str) or re.fullmatch(r"[0-9]+", raw_permissions) is None:
+        return DISCORD_GUILD_PERMISSION_DENIED if is_interaction else DISCORD_GUILD_USE_INTERACTION
+    try:
+        permissions = int(raw_permissions, 10)
+    except ValueError:
+        return DISCORD_GUILD_PERMISSION_DENIED if is_interaction else DISCORD_GUILD_USE_INTERACTION
+    required = DISCORD_MANAGE_GUILD_PERMISSION | DISCORD_ADMINISTRATOR_PERMISSION
+    if permissions & required:
+        return None
+    return DISCORD_GUILD_PERMISSION_DENIED
+
+
+def discord_pairing_reply_for_command(
+    command: ChannelPairCommand | None,
+    result: InboundBindingResult,
+    *,
+    guild_id: str | None,
+) -> str:
+    if guild_id is None:
+        scope = "direct message"
+        scope_title = "Direct message"
+    else:
+        scope = "server"
+        scope_title = "Server"
+    if result.paired:
+        return f"{scope_title} paired. This Discord {scope} is now connected to your agent."
+    if result.unpaired:
+        return f"{scope_title} unpaired. This Discord {scope} is no longer connected to an agent."
+    if result.pair_failed_reason == DISCORD_GUILD_USE_INTERACTION:
+        return (
+            "Use the /bot_pair or /bot_unpair slash command; "
+            "pairing a server requires Manage Server permission."
+        )
+    if result.pair_failed_reason == DISCORD_GUILD_PERMISSION_DENIED:
+        return "You need Manage Server permission to pair or unpair this server."
+    if result.pair_failed_reason == "forbidden":
+        return f"Only the user who paired this {scope} can change its pairing."
+    if result.pair_failed_reason == "already_paired":
+        return f"This {scope} is already paired to another Agent. Unpair it first."
+    if command is not None and command.kind == "unpair" and not result.unpaired:
+        return f"This {scope} is not paired."
+    return pairing_reply_for_command(command, result)
+
+
 def extract_pair_code(text: str | None) -> str | None:
     command = parse_pair_command(text)
     return command.code if command is not None and command.kind == "pair" else None
@@ -1750,10 +1875,11 @@ async def send_pairing_command_reply(
     telegram_direct_messages_topic_id: int | None = None,
     command: ChannelPairCommand | None,
     binding_result: InboundBindingResult,
+    reply: str | None = None,
 ) -> ChannelMessage | None:
     if not binding_result.command_handled:
         return None
-    reply = pairing_reply_for_command(command, binding_result)
+    reply_text = reply or pairing_reply_for_command(command, binding_result)
     reply_link_id = (
         binding_result.binding.bot_agent_link_id
         if binding_result.binding is not None and (binding_result.paired or binding_result.unpaired)
@@ -1765,7 +1891,7 @@ async def send_pairing_command_reply(
             db,
             account=account,
             external_chat_id=send_external_chat_id or external_chat_id,
-            text=reply,
+            text=reply_text,
             bot_agent_link_id=reply_link_id,
             bind_to_existing=bind_reply_to_existing,
             telegram_message_thread_id=telegram_message_thread_id,
@@ -3991,6 +4117,8 @@ async def record_discord_dispatch(
     external_chat_id = key.chat_id if key is not None else chat[0]
     external_chat_type = key.chat_type if key is not None else chat[1]
     external_chat_name = chat[2] if chat is not None else key.scope_id
+    command = discord_pair_command_from_payload(frame)
+    guild_id = key.scope_id if key is not None else discord_channel_scope_from_payload(frame)[1]
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -3999,9 +4127,15 @@ async def record_discord_dispatch(
         external_chat_name=external_chat_name,
         external_user_id=discord_external_user_id_from_payload(frame),
         text=discord_text_from_payload(frame),
-        command=discord_pair_command_from_payload(frame),
+        command=command,
+        command_denied_reason=discord_guild_command_denied_reason(
+            frame,
+            command=command,
+            guild_id=guild_id,
+        ),
+        command_actor_required=True,
     )
-    if binding_result.binding is None:
+    if binding_result.binding is None and not binding_result.command_handled:
         return False
     data = frame.get("d")
     payload = frame if isinstance(data, dict) else {"d": data}
@@ -4027,6 +4161,7 @@ async def record_discord_dispatch(
                 binding=binding,
                 alias_external_chat_id=key.channel_id,
                 alias_kind="discord_channel",
+                require_same_binding=True,
             )
         await record_discord_interaction_references(
             db,
@@ -4036,6 +4171,17 @@ async def record_discord_dispatch(
             payload=payload,
         )
         await record_inactive_bot_agent_link_event(db, account=account, binding=binding)
+    if binding_result.command_handled:
+        reply = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
+        await send_pairing_command_reply(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            send_external_chat_id=key.channel_id if key is not None else None,
+            command=command,
+            binding_result=binding_result,
+            reply=reply,
+        )
     return True
 
 
@@ -4485,11 +4631,23 @@ def _command_description(command: dict[str, Any]) -> str:
 
 
 def _discord_command_payload(command: dict[str, Any]) -> dict[str, Any]:
+    name = _command_name(command)
     payload: dict[str, Any] = {
-        "name": _command_name(command),
+        "name": name,
         "description": _command_description(command),
         "type": 1,
     }
+    if name in {"bot_pair", "bot_unpair"}:
+        # Discord's provider-specific default keeps Telegram's command payload
+        # byte-for-byte unchanged. Server-side interaction checks remain the
+        # authority; this only makes Discord hide the commands by default from
+        # members without MANAGE_GUILD.
+        payload["default_member_permissions"] = str(DISCORD_MANAGE_GUILD_PERMISSION)
+        payload["description"] = (
+            "Pair this server or direct message with Clawdi."
+            if name == "bot_pair"
+            else "Disconnect this server or direct message from Clawdi."
+        )
     options = command.get("options")
     if isinstance(options, list):
         payload["options"] = [option for option in options if isinstance(option, dict)]

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -90,7 +90,15 @@ async def test_channel_debug_health_reports_pending_inbox_and_last_error(
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": "debug-discord"},
+            json={
+                "provider": "discord",
+                "name": "debug-discord",
+                "provider_token": "discord-debug-token",
+                "config": {
+                    "application_id": "123456789012345678",
+                    "public_key": "ab" * 32,
+                },
+            },
         )
     ).json()
     account = await db_session.get(ChannelAccount, UUID(created["id"]))

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -65,6 +65,7 @@ from app.routes.channel_routers.discord import (
     _discord_gateway_url,
     _discord_guild_create_payload,
 )
+from app.routes.channel_routers.shared import _discord_gateway_dispatch
 from app.services import channels as channel_service
 from app.services.bluebubbles_socket import BlueBubblesSocketManager
 from app.services.channel_debug_events import record_channel_debug_event
@@ -452,6 +453,10 @@ class _FailingProviderClient(_FakeProviderClient):
         self.calls.append({"url": url, **kwargs})
         raise httpx.ConnectError("network down")
 
+    async def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        raise httpx.ConnectError("network down")
+
 
 class _SequencedProviderClient(_FakeProviderClient):
     status_codes: list[int] = []
@@ -731,7 +736,7 @@ async def _create_paired_discord_channel(
             json={"ttl_seconds": 900},
         )
     ).json()
-    await client.post(
+    paired = await client.post(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
         json={
@@ -741,12 +746,19 @@ async def _create_paired_discord_channel(
             "application_id": application_id,
             "channel_id": channel_id,
             "guild_id": guild_id,
-            "member": {"user": {"id": "discord-pair-user"}},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-pair-user"},
+            },
             "data": {
                 "name": "bot_pair",
                 "options": [{"name": "code", "value": pair["code"]}],
             },
         },
+    )
+    assert paired.status_code == 200, paired.text
+    assert paired.json()["data"]["content"] == (
+        "Server paired. This Discord server is now connected to your agent."
     )
     return created
 
@@ -7907,6 +7919,7 @@ async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
                 "guild_id": "guild-replay",
                 "content": f"/bot_pair {pair['code']}",
                 "author": {"id": "discord-replay-user"},
+                "member": {"permissions": "32"},
             },
         },
     )
@@ -8192,6 +8205,132 @@ async def test_discord_channel_rest_accepts_bound_channel_alias(
     assert _FakeProviderClient.calls[0]["headers"]["Authorization"] == (
         "Bot discord-provider-token"
     )
+
+
+@pytest.mark.asyncio
+async def test_discord_channel_rest_resolves_caches_and_reuses_unobserved_guild_channel(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-unobserved-channel-rest",
+        channel_id="discord-observed-channel",
+        guild_id="discord-bound-guild",
+    )
+    _reset_fake_provider_client(
+        {
+            "id": "discord-unobserved-channel",
+            "guild_id": "discord-bound-guild",
+            "type": 11,
+            "parent_id": "discord-observed-channel",
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    headers = {"Authorization": f"Bot {created['agent_token']}"}
+
+    channel_get = await client.get(
+        "/v1/channels/discord/v10/channels/discord-unobserved-channel",
+        headers=headers,
+    )
+    cached_operation = await client.put(
+        "/v1/channels/discord/v10/channels/discord-unobserved-channel/permissions/role-1",
+        headers=headers,
+        json={"allow": "1024", "deny": "0", "type": 0},
+    )
+
+    assert channel_get.status_code == 200
+    assert channel_get.json()["guild_id"] == "discord-bound-guild"
+    assert cached_operation.status_code == 200
+    assert [(call["method"], urlparse(call["url"]).path) for call in _FakeProviderClient.calls] == [
+        ("GET", "/api/v10/channels/discord-unobserved-channel"),
+        ("PUT", "/api/v10/channels/discord-unobserved-channel/permissions/role-1"),
+    ]
+    alias = (
+        await db_session.execute(
+            select(ChannelBindingAlias).where(
+                ChannelBindingAlias.account_id == UUID(created["id"]),
+                ChannelBindingAlias.alias_external_chat_id == "discord-unobserved-channel",
+                ChannelBindingAlias.alias_kind == "discord_channel",
+            )
+        )
+    ).scalar_one()
+    assert alias.bot_agent_link_id == UUID(created["agent_link_id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_payload", "provider_status", "provider_content"),
+    [
+        ({"id": "unknown-channel", "guild_id": "wrong-guild"}, 200, None),
+        ({"id": "unknown-channel", "type": 1}, 200, None),
+        ({"id": "different-channel", "guild_id": "bound-guild"}, 200, None),
+        ({}, 200, b"not-json"),
+        ({"message": "upstream error"}, 500, None),
+    ],
+)
+async def test_discord_unobserved_channel_lookup_failures_do_not_authorize(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    provider_payload: dict[str, Any],
+    provider_status: int,
+    provider_content: bytes | None,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name=f"discord-unobserved-denied-{uuid4().hex}",
+        channel_id="observed-channel",
+        guild_id="bound-guild",
+    )
+    _reset_fake_provider_client(
+        provider_payload,
+        status_code=provider_status,
+        content=provider_content,
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    response = await client.get(
+        "/v1/channels/discord/v10/channels/unknown-channel",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"code": 50001, "message": "Missing Access"}
+    assert len(_FakeProviderClient.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_unobserved_channel_provider_network_error_fails_closed(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-unobserved-provider-error",
+        channel_id="observed-channel",
+        guild_id="bound-guild",
+    )
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FailingProviderClient,
+    )
+
+    response = await client.get(
+        "/v1/channels/discord/v10/channels/unknown-channel",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "discord api unreachable"}
+    assert len(_FailingProviderClient.calls) == 1
 
 
 @pytest.mark.asyncio
@@ -11489,6 +11628,7 @@ async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClie
                 "guild_id": "guild-1",
                 "content": f"/bot_pair {pair['code']}",
                 "author": {"id": "discord-msg-pair-user"},
+                "member": {"permissions": "32"},
                 "channel": {"id": "chan-1", "name": "ops"},
             },
         },
@@ -11605,6 +11745,7 @@ async def test_discord_message_pair_code_sends_user_reply(
                 "guild_id": "guild-1",
                 "content": f"/bot_pair {pair['code']}",
                 "author": {"id": "discord-msg-pair-user"},
+                "member": {"permissions": "32"},
                 "channel": {"id": "chan-1", "name": "ops"},
             },
         },
@@ -11619,9 +11760,362 @@ async def test_discord_message_pair_code_sends_user_reply(
     )
     assert reply_call["headers"]["Authorization"] == ("Bot discord-provider-token")
     assert reply_call["json"] == {
-        "content": "Paired! This chat is now connected to your agent.",
+        "content": "Server paired. This Discord server is now connected to your agent.",
         "allowed_mentions": {"parse": []},
     }
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_text_pair_without_computed_permissions_fails_closed(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"id": "discord-permission-instruction"})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-text-pair-permissions",
+                "provider_token": "discord-provider-token",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    denied = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "guild-text-pair-denied",
+                "channel_id": "guild-thread-invoking",
+                "guild_id": "guild-text-pair",
+                "channel_type": 11,
+                "content": f"/bot_pair {pair['code']}",
+                "author": {"id": "guild-text-actor"},
+            },
+        },
+    )
+
+    assert denied.status_code == 200
+    assert denied.json()["paired"] is False
+    assert (
+        await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    ).status == PAIR_CODE_STATUS_PENDING
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    reply_call = next(
+        call
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/channels/guild-thread-invoking/messages")
+    )
+    assert reply_call["json"]["content"] == (
+        "Use the /bot_pair or /bot_unpair slash command; "
+        "pairing a server requires Manage Server permission."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permissions", ["32", "8"])
+async def test_discord_guild_interaction_pair_allows_manage_guild_or_administrator(
+    client: httpx.AsyncClient,
+    permissions: str,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "discord", "name": f"discord-pair-authority-{permissions}"},
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    response = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": f"pair-authority-{permissions}",
+            "token": f"pair-authority-token-{permissions}",
+            "channel_id": "authority-channel",
+            "guild_id": f"authority-guild-{permissions}",
+            "member": {
+                "permissions": permissions,
+                "user": {"id": "authority-admin"},
+            },
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["content"].startswith("Server paired.")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permissions", ["0", None, "malformed", 32])
+async def test_discord_guild_interaction_pair_denies_non_authoritative_permissions(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    permissions: Any,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "discord", "name": f"discord-pair-denied-{uuid4().hex}"},
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    member: dict[str, Any] = {"user": {"id": "ordinary-member"}}
+    if permissions is not None:
+        member["permissions"] = permissions
+
+    response = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": f"pair-denied-{uuid4().hex}",
+            "token": f"pair-denied-token-{uuid4().hex}",
+            "channel_id": "denied-channel",
+            "guild_id": "denied-guild",
+            "member": member,
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["content"] == (
+        "You need Manage Server permission to pair or unpair this server."
+    )
+    assert (
+        await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    ).status == PAIR_CODE_STATUS_PENDING
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_unpair_requires_current_authority_and_pairing_actor(
+    client: httpx.AsyncClient,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-unpair-two-part-authority",
+        channel_id="unpair-authority-channel",
+        guild_id="unpair-authority-guild",
+    )
+
+    async def unpair(*, actor: str, permissions: str, suffix: str) -> httpx.Response:
+        return await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json={
+                "type": 2,
+                "id": f"unpair-authority-{suffix}",
+                "token": f"unpair-authority-token-{suffix}",
+                "channel_id": "unpair-authority-channel",
+                "guild_id": "unpair-authority-guild",
+                "member": {
+                    "permissions": permissions,
+                    "user": {"id": actor},
+                },
+                "data": {"name": "bot_unpair"},
+            },
+        )
+
+    no_permission = await unpair(
+        actor="discord-pair-user",
+        permissions="0",
+        suffix="no-permission",
+    )
+    wrong_actor = await unpair(
+        actor="different-admin",
+        permissions="32",
+        suffix="wrong-actor",
+    )
+    allowed = await unpair(
+        actor="discord-pair-user",
+        permissions="8",
+        suffix="allowed",
+    )
+
+    assert no_permission.json()["data"]["content"] == (
+        "You need Manage Server permission to pair or unpair this server."
+    )
+    assert wrong_actor.json()["data"]["content"] == (
+        "Only the user who paired this server can change its pairing."
+    )
+    assert allowed.json()["data"]["content"].startswith("Server unpaired.")
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_and_alias_repair(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-guild-link-conflict",
+        channel_id="link-a-channel",
+        guild_id="single-link-guild",
+        agent_id=channel_agent.id,
+    )
+    link_a_id = UUID(created["agent_link_id"])
+    link_b = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert link_b.status_code == 201, link_b.text
+    link_b_body = link_b.json()
+    pair_b = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"agent_link_id": link_b_body["id"], "ttl_seconds": 900},
+    )
+    assert pair_b.status_code == 201, pair_b.text
+    pair_b_body = pair_b.json()
+
+    conflict = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "link-b-conflicting-pair",
+            "token": "link-b-conflicting-pair-token",
+            "channel_id": "link-a-channel",
+            "guild_id": "single-link-guild",
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-pair-user"},
+            },
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair_b_body["code"]}],
+            },
+        },
+    )
+
+    assert conflict.status_code == 200
+    assert conflict.json()["data"]["content"] == (
+        "This server is already paired to another Agent. Unpair it first."
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.external_chat_id == "single-link-guild",
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+    binding_id = binding.id
+    assert binding.bot_agent_link_id == link_a_id
+    pair_code = await db_session.get(ChannelPairCode, UUID(pair_b_body["id"]))
+    assert pair_code is not None
+    assert pair_code.status == PAIR_CODE_STATUS_PENDING
+
+    unpaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "link-a-explicit-unpair",
+            "token": "link-a-explicit-unpair-token",
+            "channel_id": "link-a-channel",
+            "guild_id": "single-link-guild",
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-pair-user"},
+            },
+            "data": {"name": "bot_unpair"},
+        },
+    )
+    assert unpaired.json()["data"]["content"].startswith("Server unpaired.")
+
+    repaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "link-b-pair-after-unpair",
+            "token": "link-b-pair-after-unpair-token",
+            "channel_id": "link-b-channel",
+            "guild_id": "single-link-guild",
+            "member": {
+                "permissions": "32",
+                "user": {"id": "link-b-admin"},
+            },
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair_b_body["code"]}],
+            },
+        },
+    )
+    assert repaired.json()["data"]["content"].startswith("Server paired.")
+
+    await db_session.refresh(binding)
+    await db_session.refresh(pair_code)
+    assert binding.id == binding_id
+    assert binding.status == BINDING_STATUS_ACTIVE
+    assert binding.bot_agent_link_id == UUID(link_b_body["id"])
+    assert pair_code.status == "claimed"
+    stale_alias = (
+        await db_session.execute(
+            select(ChannelBindingAlias).where(
+                ChannelBindingAlias.account_id == UUID(created["id"]),
+                ChannelBindingAlias.alias_external_chat_id == "link-a-channel",
+            )
+        )
+    ).scalar_one()
+    assert stale_alias.binding_id == binding_id
+    assert stale_alias.bot_agent_link_id == link_a_id
+
+    _reset_fake_provider_client(
+        {
+            "id": "link-a-channel",
+            "guild_id": "single-link-guild",
+            "type": 0,
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    old_channel = await client.get(
+        "/v1/channels/discord/v10/channels/link-a-channel",
+        headers={"Authorization": f"Bot {link_b_body['agent_token']}"},
+    )
+
+    assert old_channel.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    await db_session.refresh(stale_alias)
+    assert stale_alias.binding_id == binding_id
+    assert stale_alias.bot_agent_link_id == UUID(link_b_body["id"])
 
 
 @pytest.mark.asyncio
@@ -11649,7 +12143,10 @@ async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncCl
             "channel_id": "chan-discord-unpair",
             "guild_id": "guild-discord-unpair",
             "channel": {"id": "chan-discord-unpair", "name": "ops", "type": 0},
-            "member": {"user": {"id": "discord-user-unpair"}},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-user-unpair"},
+            },
             "data": {
                 "name": "bot_pair",
                 "options": [{"name": "code", "value": pair["code"]}],
@@ -11667,7 +12164,10 @@ async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncCl
             "channel_id": "chan-discord-unpair",
             "guild_id": "guild-discord-unpair",
             "channel": {"id": "chan-discord-unpair", "name": "ops", "type": 0},
-            "member": {"user": {"id": "discord-user-unpair"}},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-user-unpair"},
+            },
             "data": {"name": "bot_unpair"},
         },
     )
@@ -11675,7 +12175,7 @@ async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncCl
     assert unpaired.status_code == 200
     assert (
         unpaired.json()["data"]["content"]
-        == "Unpaired. This chat is no longer connected to an agent."
+        == "Server unpaired. This Discord server is no longer connected to an agent."
     )
     bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
     assert bindings.status_code == 200
@@ -11700,6 +12200,215 @@ def test_discord_dispatch_routing_key_uses_guild_binding_and_channel_alias_sourc
     assert key.scope_id == "guild-2"
     assert key.channel_id == "chan-2"
     assert key.chat_type == "guild_text"
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_binding_routes_other_members_channels_and_threads(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-guild-trust-boundary",
+        channel_id="guild-channel-a",
+        guild_id="guild-shared",
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+
+    channel_frame = {
+        "op": 0,
+        "t": "MESSAGE_CREATE",
+        "s": 51,
+        "d": {
+            "id": "guild-message-b",
+            "channel_id": "guild-channel-b",
+            "guild_id": "guild-shared",
+            "channel_type": 0,
+            "content": "ordinary member in channel B",
+            "author": {"id": "ordinary-member-b"},
+            "member": {"roles": ["ordinary-role"]},
+            "clawdi_test_marker": {"preserved": True},
+        },
+    }
+    thread_frame = {
+        "op": 0,
+        "t": "MESSAGE_CREATE",
+        "s": 52,
+        "d": {
+            "id": "guild-thread-message",
+            "channel_id": "guild-thread-b-1",
+            "guild_id": "guild-shared",
+            "channel_type": 11,
+            "content": "thread reply",
+            "author": {"id": "ordinary-member-c"},
+        },
+    }
+
+    assert await record_discord_dispatch(db_session, account=account, frame=channel_frame)
+    assert await record_discord_dispatch(db_session, account=account, frame=thread_frame)
+    await db_session.commit()
+
+    messages = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage)
+                .where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.provider_message_id.in_(
+                        ["guild-message-b", "guild-thread-message"]
+                    ),
+                )
+                .order_by(ChannelMessage.provider_message_id)
+            )
+        ).scalars()
+    )
+    assert len(messages) == 2
+    assert {message.binding_id for message in messages} == {messages[0].binding_id}
+    assert {message.external_chat_id for message in messages} == {"guild-shared"}
+    dispatches = {
+        message.provider_message_id: _discord_gateway_dispatch(message) for message in messages
+    }
+    assert dispatches["guild-message-b"]["d"] == channel_frame["d"]
+    assert dispatches["guild-thread-message"]["d"] == thread_frame["d"]
+    assert {
+        dispatches["guild-message-b"]["d"]["channel_id"],
+        dispatches["guild-thread-message"]["d"]["channel_id"],
+    } == {"guild-channel-b", "guild-thread-b-1"}
+
+    aliases = list(
+        (
+            await db_session.execute(
+                select(ChannelBindingAlias).where(
+                    ChannelBindingAlias.account_id == account.id,
+                    ChannelBindingAlias.alias_external_chat_id.in_(
+                        ["guild-channel-b", "guild-thread-b-1"]
+                    ),
+                )
+            )
+        ).scalars()
+    )
+    assert len(aliases) == 2
+    assert {alias.binding_id for alias in aliases} == {messages[0].binding_id}
+
+
+@pytest.mark.asyncio
+async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-dm-boundary",
+                "provider_token": "discord-provider-token",
+                "config": {"application_id": "discord-dm-app"},
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "dm-pair-interaction",
+            "token": "dm-pair-token",
+            "application_id": "discord-dm-app",
+            "channel_id": "discord-dm-a",
+            "user": {"id": "discord-dm-actor"},
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert paired.status_code == 200
+    assert paired.json()["data"]["content"] == (
+        "Direct message paired. This Discord direct message is now connected to your agent."
+    )
+
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    dm_frame = {
+        "op": 0,
+        "t": "MESSAGE_CREATE",
+        "s": 61,
+        "d": {
+            "id": "discord-dm-message",
+            "channel_id": "discord-dm-a",
+            "channel_type": 1,
+            "content": "hello from the paired DM",
+            "author": {"id": "discord-dm-actor"},
+        },
+    }
+    assert await record_discord_dispatch(db_session, account=account, frame=dm_frame)
+    assert not await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame={
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "discord-other-dm-message",
+                "channel_id": "discord-dm-b",
+                "channel_type": 1,
+                "content": "unpaired DM",
+                "author": {"id": "discord-other-dm-actor"},
+            },
+        },
+    )
+    assert not await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame={
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "discord-guild-collision-message",
+                "channel_id": "guild-channel",
+                "guild_id": "discord-dm-a",
+                "channel_type": 0,
+                "content": "must not cross into the DM binding",
+                "author": {"id": "guild-member"},
+            },
+        },
+    )
+    await db_session.commit()
+
+    message = (
+        await db_session.execute(
+            select(ChannelMessage).where(ChannelMessage.provider_message_id == "discord-dm-message")
+        )
+    ).scalar_one()
+    assert message.external_chat_id == "discord-dm-a"
+    assert _discord_gateway_dispatch(message)["d"] == dm_frame["d"]
+
+    _reset_fake_provider_client(
+        {
+            "id": "discord-dm-reply",
+            "channel_id": "discord-dm-a",
+            "content": "DM reply",
+        }
+    )
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    reply = await client.post(
+        "/v1/channels/discord/v10/channels/discord-dm-a/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"content": "DM reply"},
+    )
+    assert reply.status_code == 200
+    assert reply.json()["channel_id"] == "discord-dm-a"
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith("/channels/discord-dm-a/messages")
 
 
 @pytest.mark.asyncio
@@ -11730,6 +12439,7 @@ async def test_discord_dispatch_records_bound_message(
                 "guild_id": "guild-dispatch",
                 "content": f"/bot_pair {pair['code']}",
                 "author": {"id": "discord-dispatch-pair-user"},
+                "member": {"permissions": "32"},
             },
         },
     )
@@ -11807,6 +12517,7 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
                 "guild_id": "guild-gateway",
                 "content": f"/bot_pair {pair['code']}",
                 "author": {"id": "discord-gateway-pair-user"},
+                "member": {"permissions": "32"},
             },
         },
     )
@@ -12146,6 +12857,7 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
             "id": "discord-shared-msg",
             "channel_id": shared_chat_id,
             "content": f"/bot_pair {pair_codes['discord']}",
+            "author": {"id": "shared-discord-sender"},
         },
     )
     imessage = created_by_provider["imessage"]
@@ -12967,8 +13679,10 @@ async def test_discord_command_sync_upserts_application_commands(
     )
     assert _FakeProviderClient.calls[0]["headers"]["Authorization"] == "Bot discord-token"
     assert _FakeProviderClient.calls[0]["json"]["name"] == "bot_pair"
+    assert _FakeProviderClient.calls[0]["json"]["default_member_permissions"] == "32"
     assert _FakeProviderClient.calls[0]["json"]["options"][0]["name"] == "code"
     assert _FakeProviderClient.calls[1]["json"]["name"] == "bot_unpair"
+    assert _FakeProviderClient.calls[1]["json"]["default_member_permissions"] == "32"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11695,11 +11695,19 @@ async def test_discord_gateway_early_heartbeat_does_not_ack_undispatched_low_inb
                 await db_session.commit()
 
                 websocket.send_json({"op": 1, "d": highest_guild_sequence})
-                assert websocket.receive_json() == {"op": 11, "d": None}
+                first_frame = websocket.receive_json()
+                if first_frame == {"op": 11, "d": None}:
+                    dispatch = websocket.receive_json()
+                else:
+                    # The gateway poll may observe the newly committed inbox row
+                    # before it processes the heartbeat. Frame ordering is not
+                    # the invariant under test: the stale heartbeat still must
+                    # not acknowledge this later dispatch sequence.
+                    dispatch = first_frame
+                    assert websocket.receive_json() == {"op": 11, "d": None}
                 await db_session.refresh(message)
                 assert message.delivered_at is None
 
-                dispatch = websocket.receive_json()
                 assert dispatch["t"] == "MESSAGE_CREATE"
                 assert dispatch["s"] > highest_guild_sequence
                 assert dispatch["d"]["content"] == "low inbox after guild create"

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -20,7 +20,8 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 from starlette.websockets import WebSocketDisconnect
 
 from app.core.auth import AuthContext, get_auth
@@ -110,6 +111,18 @@ from app.services.whatsapp_baileys import (
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 
 TELEGRAM_AGENT_TOKEN_RE = re.compile(r"^[1-9][0-9]{8}:[A-Za-z0-9_-]{32,}$")
+DISCORD_TEST_APPLICATION_ID = "123456789012345678"
+DISCORD_TEST_PUBLIC_KEY = "11" * 32
+
+
+def _discord_ready_config(
+    application_id: str = DISCORD_TEST_APPLICATION_ID,
+) -> dict[str, Any]:
+    return {
+        "application_id": application_id,
+        "public_key": DISCORD_TEST_PUBLIC_KEY,
+        "discord_interactions_configured": True,
+    }
 
 
 @asynccontextmanager
@@ -467,6 +480,28 @@ class _SequencedProviderClient(_FakeProviderClient):
         return _FakeProviderResponse({}, status_code=status_code)
 
 
+class _DiscordPreparationProviderClient(_FakeProviderClient):
+    responses: list[tuple[dict[str, Any], int]] = []
+
+    @classmethod
+    def reset(cls, responses: list[tuple[dict[str, Any], int]]) -> None:
+        cls.calls = []
+        cls.responses = list(responses)
+
+    @classmethod
+    def _next_response(cls) -> _FakeProviderResponse:
+        payload, status_code = cls.responses.pop(0)
+        return _FakeProviderResponse(payload, status_code=status_code)
+
+    async def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return self._next_response()
+
+    async def post(self, url, **kwargs):
+        self.calls.append({"method": "POST", "url": url, **kwargs})
+        return self._next_response()
+
+
 class _FakeDiscordGatewaySocket:
     def __init__(self, frames: list[dict[str, Any]], stop: asyncio.Event):
         self._frames = list(frames)
@@ -713,14 +748,14 @@ async def _create_paired_discord_channel(
     channel_id: str = "discord-chan-1",
     guild_id: str = "discord-guild-1",
     provider_token: str = "discord-provider-token",
-    application_id: str = "discord-app-1",
+    application_id: str = DISCORD_TEST_APPLICATION_ID,
     agent_id: UUID | None = None,
 ) -> dict[str, Any]:
     create_payload: dict[str, Any] = {
         "provider": "discord",
         "name": name,
         "provider_token": provider_token,
-        "config": {"application_id": application_id},
+        "config": _discord_ready_config(application_id),
     }
     if agent_id is not None:
         create_payload["agent_id"] = str(agent_id)
@@ -807,6 +842,79 @@ async def test_create_channel_masks_provider_token(client: httpx.AsyncClient):
     assert TELEGRAM_AGENT_TOKEN_RE.fullmatch(created["agent_token"])
     assert created["webhook_secret"]
     assert "telegram-secret" not in response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "provider": "discord",
+            "name": "discord-create-missing-token",
+            "config": _discord_ready_config(),
+        },
+        {
+            "provider": "discord",
+            "name": "discord-create-missing-application",
+            "provider_token": "discord-provider-token",
+            "config": {"public_key": DISCORD_TEST_PUBLIC_KEY},
+        },
+        {
+            "provider": "discord",
+            "name": "discord-create-missing-public-key",
+            "provider_token": "discord-provider-token",
+            "config": {"application_id": DISCORD_TEST_APPLICATION_ID},
+        },
+        {
+            "provider": "discord",
+            "name": "discord-create-invalid-public-key",
+            "provider_token": "discord-provider-token",
+            "config": {
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "public_key": "not-a-public-key",
+            },
+        },
+    ],
+)
+async def test_create_discord_channel_requires_http_interactions_credentials(
+    client: httpx.AsyncClient,
+    payload: dict[str, Any],
+):
+    response = await client.post("/v1/channels", json=payload)
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_historical_discord_without_public_key_is_readable_but_cannot_pair(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-historical-incomplete",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.config = {"application_id": DISCORD_TEST_APPLICATION_ID}
+    await db_session.commit()
+
+    readable = await client.get(f"/v1/channels/{created['id']}")
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert readable.status_code == 200
+    assert pair.status_code == 409
+    assert "public_key" in pair.json()["detail"]
 
     listed = await client.get("/v1/channels")
     assert listed.status_code == 200
@@ -1744,20 +1852,47 @@ async def test_hosted_agent_rejects_second_provider_account_but_keeps_existing_l
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
+    monkeypatch: pytest.MonkeyPatch,
     agent_type: str,
     provider: str,
 ):
+    if provider == CHANNEL_PROVIDER_DISCORD:
+
+        async def fake_configure_discord_application(account: ChannelAccount):
+            return {"id": DISCORD_TEST_APPLICATION_ID}
+
+        async def fake_sync_channel_commands(**kwargs):
+            return []
+
+        monkeypatch.setattr(
+            "app.routes.admin.configure_discord_application",
+            fake_configure_discord_application,
+        )
+        monkeypatch.setattr(
+            "app.routes.admin.sync_channel_commands",
+            fake_sync_channel_commands,
+        )
+    discord_credentials = (
+        {
+            "provider_token": f"discord-provider-token-{uuid4().hex}",
+            "config": _discord_ready_config(),
+        }
+        if provider == CHANNEL_PROVIDER_DISCORD
+        else {}
+    )
     first_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
         name=f"{agent_type}-{provider}-first-{uuid4().hex}",
+        **discord_credentials,
     )
     second_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
         name=f"{agent_type}-{provider}-second-{uuid4().hex}",
+        **discord_credentials,
     )
     assert first_account.status_code == 201, first_account.text
     assert second_account.status_code == 201, second_account.text
@@ -3127,6 +3262,8 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
             json={
                 "provider": "discord",
                 "name": f"agent-links-private-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
                 "agent_id": str(channel_agent.id),
             },
         )
@@ -3137,6 +3274,8 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
             json={
                 "provider": "discord",
                 "name": f"agent-links-other-{uuid4().hex}",
+                "provider_token": "discord-provider-token-2",
+                "config": _discord_ready_config("223456789012345678"),
                 "agent_id": str(second_channel_agent.id),
             },
         )
@@ -5082,7 +5221,10 @@ async def test_user_channel_config_rejects_insecure_discord_gateway_url(
             "provider": "discord",
             "name": "discord-insecure-gateway-url",
             "provider_token": "discord-token",
-            "config": {"gateway_url": "ws://gateway.discord.gg"},
+            "config": {
+                **_discord_ready_config(),
+                "gateway_url": "ws://gateway.discord.gg",
+            },
         },
     )
 
@@ -7566,7 +7708,8 @@ async def test_discord_rest_gateway_bot_uses_agent_token(client: httpx.AsyncClie
             json={
                 "provider": "discord",
                 "name": "discord-agent",
-                "config": {"application_id": "app-agent"},
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -7612,7 +7755,8 @@ async def test_discord_rest_accepts_preserve_path_mitm_alias(client: httpx.Async
             json={
                 "provider": "discord",
                 "name": "discord-agent-preserve-path",
-                "config": {"application_id": "app-agent"},
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -7638,22 +7782,24 @@ async def test_discord_rest_application_commands_are_tenant_shadowed(
             json={
                 "provider": "discord",
                 "name": "discord-command-shadow",
-                "config": {"application_id": "app-shadow"},
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
     headers = {"Authorization": f"Bot {created['agent_token']}"}
 
     updated = await client.put(
-        "/v1/channels/discord/v10/applications/app-shadow/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers=headers,
         json=[{"name": "deploy", "description": "Deploy a service"}],
     )
     listed = await client.get(
-        "/v1/channels/discord/v10/applications/app-shadow/commands", headers=headers
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
+        headers=headers,
     )
     reserved = await client.post(
-        "/v1/channels/discord/v10/applications/app-shadow/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers=headers,
         json={"name": "bot_pair", "description": "bad"},
     )
@@ -7668,40 +7814,47 @@ async def test_discord_rest_application_commands_are_tenant_shadowed(
 async def test_discord_application_command_lifecycle_is_tenant_shadowed(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    _reset_fake_provider_client({"id": "provider-command"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
     created = (
         await client.post(
             "/v1/channels",
             json={
                 "provider": "discord",
                 "name": "discord-command-lifecycle",
-                "config": {"application_id": "app-lifecycle"},
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
     headers = {"Authorization": f"Bot {created['agent_token']}"}
 
     created_command = await client.post(
-        "/v1/channels/discord/v10/applications/app-lifecycle/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers=headers,
         json={"name": "deploy", "description": "Deploy"},
     )
     command_id = created_command.json()["id"]
     edited = await client.patch(
-        f"/v1/channels/discord/v10/applications/app-lifecycle/commands/{command_id}",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands/{command_id}",
         headers=headers,
         json={"description": "Deploy service"},
     )
     listed = await client.get(
-        "/v1/channels/discord/v10/applications/app-lifecycle/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers=headers,
     )
     deleted = await client.delete(
-        f"/v1/channels/discord/v10/applications/app-lifecycle/commands/{command_id}",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands/{command_id}",
         headers=headers,
     )
     missing = await client.patch(
-        "/v1/channels/discord/v10/applications/app-lifecycle/commands/missing",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands/missing",
         headers=headers,
         json={"description": "missing"},
     )
@@ -7722,13 +7875,13 @@ async def test_discord_application_command_lifecycle_is_tenant_shadowed(
     )
     await db_session.commit()
     guild_created = await client.post(
-        "/v1/channels/discord/v10/applications/app-lifecycle/guilds/guild-1/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-1/commands",
         headers=headers,
         json={"name": "guilddeploy", "description": "Guild deploy"},
     )
     guild_id = guild_created.json()["id"]
     guild_edited = await client.patch(
-        f"/v1/channels/discord/v10/applications/app-lifecycle/guilds/guild-1/commands/{guild_id}",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-1/commands/{guild_id}",
         headers=headers,
         json={"description": "Guild deploy service"},
     )
@@ -7754,7 +7907,8 @@ async def test_discord_application_commands_validate_application_and_guild_scope
             json={
                 "provider": "discord",
                 "name": "discord-command-scope",
-                "config": {"application_id": "app-scope"},
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -7766,7 +7920,7 @@ async def test_discord_application_commands_validate_application_and_guild_scope
         json=[{"name": "deploy", "description": "Deploy"}],
     )
     unbound_guild = await client.put(
-        "/v1/channels/discord/v10/applications/app-scope/guilds/guild-404/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-404/commands",
         headers=headers,
         json=[{"name": "deploy", "description": "Deploy"}],
     )
@@ -7811,7 +7965,7 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
                 "provider": "discord",
                 "name": "discord-command-fanout",
                 "provider_token": "discord-provider-token",
-                "config": {"application_id": "app-fanout"},
+                "config": _discord_ready_config(),
                 "agent_id": str(channel_agent.id),
             },
         )
@@ -7822,7 +7976,8 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
             json={
                 "provider": "discord",
                 "name": "discord-command-contender",
-                "config": {"application_id": "app-contender"},
+                "provider_token": "discord-provider-token-2",
+                "config": _discord_ready_config("223456789012345678"),
                 "agent_id": str(second_channel_agent.id),
             },
         )
@@ -7855,20 +8010,148 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
     await db_session.commit()
 
     response = await client.put(
-        "/v1/channels/discord/v10/applications/app-fanout/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers={"Authorization": f"Bot {created['agent_token']}"},
         json=[{"name": "deploy", "description": "Deploy"}],
     )
 
     assert response.status_code == 200
-    assert response.json()[0]["application_id"] == "app-fanout"
+    assert response.json()[0]["application_id"] == DISCORD_TEST_APPLICATION_ID
     assert response.json()[0]["name"] == "deploy"
     assert len(_FakeProviderClient.calls) == 1
     call = _FakeProviderClient.calls[0]
     assert call["method"] == "PUT"
-    assert call["url"].endswith("/applications/app-fanout/guilds/guild-owned/commands")
+    assert call["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-owned/commands"
+    )
     assert call["headers"]["Authorization"] == "Bot discord-provider-token"
-    assert call["json"][0]["application_id"] == "app-fanout"
+    assert json.loads(call["content"])[0]["application_id"] == DISCORD_TEST_APPLICATION_ID
+
+
+@pytest.mark.asyncio
+async def test_shared_discord_account_command_shadows_and_fanout_are_link_scoped(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"id": "provider-command"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-shared-link-command-isolation",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    link_b_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert link_b_response.status_code == 201, link_b_response.text
+    link_b = link_b_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    db_session.add_all(
+        [
+            ChannelBinding(
+                account_id=account.id,
+                bot_agent_link_id=UUID(created["agent_link_id"]),
+                user_id=account.user_id,
+                external_chat_id="shared-link-channel-a",
+                external_chat_type="guild_text",
+                external_chat_name="shared-link-guild-a",
+            ),
+            ChannelBinding(
+                account_id=account.id,
+                bot_agent_link_id=UUID(link_b["id"]),
+                user_id=account.user_id,
+                external_chat_id="shared-link-channel-b",
+                external_chat_type="guild_text",
+                external_chat_name="shared-link-guild-b",
+            ),
+        ]
+    )
+    await db_session.commit()
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    headers_a = {"Authorization": f"Bot {created['agent_token']}"}
+    headers_b = {"Authorization": f"Bot {link_b['agent_token']}"}
+
+    stored_a = await client.put(
+        command_url,
+        headers=headers_a,
+        json=[{"name": "agent_a", "description": "Agent A command"}],
+    )
+    assert stored_a.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/shared-link-guild-a/commands"
+    )
+
+    _reset_fake_provider_client({"id": "provider-command"})
+    stored_b = await client.put(
+        command_url,
+        headers=headers_b,
+        json=[{"name": "agent_b", "description": "Agent B command"}],
+    )
+    assert stored_b.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/shared-link-guild-b/commands"
+    )
+    listed_a = await client.get(command_url, headers=headers_a)
+    listed_b = await client.get(command_url, headers=headers_b)
+    assert [command["name"] for command in listed_a.json()] == ["agent_a"]
+    assert [command["name"] for command in listed_b.json()] == ["agent_b"]
+    link_a_row = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    link_b_row = await db_session.get(ChannelBotAgentLink, UUID(link_b["id"]))
+    assert link_a_row is not None and link_b_row is not None
+    await db_session.refresh(link_a_row)
+    await db_session.refresh(link_b_row)
+    assert link_a_row.config["discord_agent_commands"]["global"][0]["name"] == "agent_a"
+    assert link_b_row.config["discord_agent_commands"]["global"][0]["name"] == "agent_b"
+
+    cross_guild = await client.put(
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}"
+        "/guilds/shared-link-guild-b/commands",
+        headers=headers_a,
+        json=[{"name": "cross", "description": "Must fail"}],
+    )
+    assert cross_guild.status_code == 403
+
+    _reset_fake_provider_client({"id": "provider-command"})
+    unlinked = await client.delete(
+        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}"
+    )
+    assert unlinked.status_code == 204
+    assert len(_FakeProviderClient.calls) == 1
+    cleanup_call = _FakeProviderClient.calls[0]
+    assert cleanup_call["method"] == "PUT"
+    assert cleanup_call["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/shared-link-guild-a/commands"
+    )
+    assert cleanup_call["content"] == b"[]"
+    assert "shared-link-guild-b" not in cleanup_call["url"]
+    _reset_fake_provider_client({"id": "provider-command"})
+    updated_b = await client.put(
+        command_url,
+        headers=headers_b,
+        json=[{"name": "agent_b_updated", "description": "Agent B updated"}],
+    )
+    assert updated_b.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert "shared-link-guild-b" in _FakeProviderClient.calls[0]["url"]
+    assert "shared-link-guild-a" not in _FakeProviderClient.calls[0]["url"]
 
 
 @pytest.mark.asyncio
@@ -7889,13 +8172,17 @@ async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
                 "provider": "discord",
                 "name": "discord-command-replay-on-pair",
                 "provider_token": "discord-provider-token",
-                "config": {"application_id": "app-replay"},
+                "config": {
+                    "application_id": DISCORD_TEST_APPLICATION_ID,
+                    "public_key": DISCORD_TEST_PUBLIC_KEY,
+                    "discord_interactions_configured": True,
+                },
             },
         )
     ).json()
     commands = [{"name": "deploy", "description": "Deploy"}]
     stored = await client.put(
-        "/v1/channels/discord/v10/applications/app-replay/commands",
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers={"Authorization": f"Bot {created['agent_token']}"},
         json=commands,
     )
@@ -7930,10 +8217,12 @@ async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
         call
         for call in _FakeProviderClient.calls
         if call.get("method") == "PUT"
-        and call["url"].endswith("/applications/app-replay/guilds/guild-replay/commands")
+        and call["url"].endswith(
+            f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-replay/commands"
+        )
     ]
     assert len(command_calls) == 1
-    assert command_calls[0]["json"][0]["name"] == "deploy"
+    assert json.loads(command_calls[0]["content"])[0]["name"] == "deploy"
 
 
 @pytest.mark.asyncio
@@ -7951,7 +8240,6 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
     created = await _create_paired_discord_channel(
         client,
         name="discord-interaction-ref",
-        application_id="discord-app-123",
         agent_id=channel_agent.id,
     )
     await _record_discord_interaction(
@@ -7959,7 +8247,7 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
         created=created,
         interaction_id="interaction-1",
         token="interaction-token-1",
-        application_id="discord-app-123",
+        application_id=DISCORD_TEST_APPLICATION_ID,
     )
     other = (
         await client.post(
@@ -7968,7 +8256,7 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
                 "provider": "discord",
                 "name": "discord-interaction-other",
                 "provider_token": "discord-provider-token-2",
-                "config": {"application_id": "discord-app-123"},
+                "config": _discord_ready_config(),
                 "agent_id": str(second_channel_agent.id),
             },
         )
@@ -7991,12 +8279,12 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
         json={"type": 4},
     )
     followup = await client.post(
-        "/v1/channels/discord/v10/webhooks/discord-app-123/interaction-token-1",
+        f"/v1/channels/discord/v10/webhooks/{DISCORD_TEST_APPLICATION_ID}/interaction-token-1",
         headers=headers,
         json={"content": "followup"},
     )
     edit_original = await client.patch(
-        "/v1/channels/discord/v10/webhooks/discord-app-123/interaction-token-1/messages/@original",
+        f"/v1/channels/discord/v10/webhooks/{DISCORD_TEST_APPLICATION_ID}/interaction-token-1/messages/@original",
         headers=headers,
         json={"content": "edited"},
     )
@@ -8028,7 +8316,7 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
         "Bot discord-provider-token"
     )
     assert _FakeProviderClient.calls[1]["url"].endswith(
-        "/webhooks/discord-app-123/interaction-token-1"
+        f"/webhooks/{DISCORD_TEST_APPLICATION_ID}/interaction-token-1"
     )
     assert _FakeProviderClient.calls[2]["method"] == "PATCH"
 
@@ -8045,7 +8333,8 @@ async def test_discord_bot_profile_shadow_is_account_scoped(
             json={
                 "provider": "discord",
                 "name": "discord-profile-a",
-                "config": {"application_id": "discord-app-profile-a"},
+                "provider_token": "discord-provider-token-a",
+                "config": _discord_ready_config(),
                 "agent_id": str(channel_agent.id),
             },
         )
@@ -8056,7 +8345,8 @@ async def test_discord_bot_profile_shadow_is_account_scoped(
             json={
                 "provider": "discord",
                 "name": "discord-profile-b",
-                "config": {"application_id": "discord-app-profile-b"},
+                "provider_token": "discord-provider-token-b",
+                "config": _discord_ready_config("223456789012345678"),
                 "agent_id": str(second_channel_agent.id),
             },
         )
@@ -8160,7 +8450,7 @@ async def test_discord_channel_rest_accepts_bound_channel_alias(
                 "provider": "discord",
                 "name": "discord-channel-alias-rest",
                 "provider_token": "discord-provider-token",
-                "config": {"application_id": "discord-app-alias"},
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -9409,6 +9699,7 @@ async def test_create_discord_channel_returns_provider_webhook(client: httpx.Asy
             "provider": "discord",
             "name": "discord-main",
             "provider_token": "discord-token",
+            "config": _discord_ready_config(),
         },
     )
 
@@ -10867,6 +11158,7 @@ async def test_discord_gateway_worker_resumes_and_falls_back_after_invalid_sessi
                 "provider": "discord",
                 "name": f"discord-worker-resume-{uuid4().hex}",
                 "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -11098,6 +11390,18 @@ def _install_discord_gateway_protocol_fakes(
     )
 
 
+def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep TestClient's worker loop off pytest's session-bound asyncpg pool."""
+    gateway_engine = create_async_engine(
+        settings.database_url,
+        poolclass=NullPool,
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord.async_session_factory",
+        async_sessionmaker(gateway_engine, expire_on_commit=False),
+    )
+
+
 def test_discord_gateway_rejects_unsupported_encoding_and_compress():
     with TestClient(app) as sync_client:
         with sync_client.websocket_connect(
@@ -11236,7 +11540,9 @@ def test_discord_gateway_resume_replays_buffered_dispatches(monkeypatch):
 async def test_discord_gateway_stateless_resume_replays_unacked_db_events(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    _install_discord_gateway_test_session_factory(monkeypatch)
     _DISCORD_GATEWAY_SESSIONS.clear()
     created = await _create_paired_discord_channel(
         client,
@@ -11312,7 +11618,9 @@ async def test_discord_gateway_stateless_resume_replays_unacked_db_events(
 async def test_discord_gateway_early_heartbeat_does_not_ack_undispatched_low_inbox(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    _install_discord_gateway_test_session_factory(monkeypatch)
     _DISCORD_GATEWAY_SESSIONS.clear()
     created = await _create_paired_discord_channel(
         client,
@@ -11607,7 +11915,12 @@ async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClie
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": "discord-pair"},
+            json={
+                "provider": "discord",
+                "name": "discord-pair",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -11640,6 +11953,146 @@ async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClie
     assert bindings.json()[0]["external_chat_id"] == "guild-1"
     assert bindings.json()[0]["external_chat_type"] == "guild_text"
     assert bindings.json()[0]["external_chat_name"] == "guild-1"
+
+
+@pytest.mark.asyncio
+async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild_only(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fan_out_calls: list[dict[str, Any]] = []
+
+    async def fake_fan_out(
+        _db: AsyncSession,
+        *,
+        account: ChannelAccount,
+        bot_agent_link_id: UUID,
+        application_id: str,
+        commands: list[dict[str, Any]],
+        guild_ids: set[str] | None = None,
+    ) -> None:
+        fan_out_calls.append(
+            {
+                "account_id": account.id,
+                "bot_agent_link_id": bot_agent_link_id,
+                "application_id": application_id,
+                "commands": commands,
+                "guild_ids": guild_ids,
+            }
+        )
+
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord._fan_out_discord_global_commands",
+        fake_fan_out,
+    )
+    shadowed_command = {
+        "id": "shadowed-agent-command",
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+        "name": "agent_status",
+        "description": "Show Agent status.",
+        "type": 1,
+    }
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-interaction-command-replay",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert link is not None
+    link.config = {"discord_agent_commands": {"global": [shadowed_command]}}
+    await db_session.commit()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    paired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "interaction-command-replay",
+            "token": "interaction-command-replay-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "interaction-replay-channel",
+            "guild_id": "interaction-replay-guild",
+            "member": {
+                "permissions": "32",
+                "user": {"id": "interaction-replay-admin"},
+            },
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+
+    assert paired.status_code == 200
+    assert paired.json()["data"]["content"].startswith("Server paired.")
+    assert fan_out_calls == [
+        {
+            "account_id": UUID(created["id"]),
+            "bot_agent_link_id": UUID(created["agent_link_id"]),
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "commands": [shadowed_command],
+            "guild_ids": {"interaction-replay-guild"},
+        }
+    ]
+
+    dm_created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-dm-no-command-fanout",
+                "provider_token": "discord-provider-token-2",
+                "config": _discord_ready_config("223456789012345678"),
+                "agent_id": str(second_channel_agent.id),
+            },
+        )
+    ).json()
+    dm_link = await db_session.get(ChannelBotAgentLink, UUID(dm_created["agent_link_id"]))
+    assert dm_link is not None
+    dm_link.config = {"discord_agent_commands": {"global": [shadowed_command]}}
+    await db_session.commit()
+    dm_pair = (
+        await client.post(
+            f"/v1/channels/{dm_created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    dm_paired = await client.post(
+        f"/v1/channels/discord/{dm_created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": dm_created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "dm-no-command-fanout",
+            "token": "dm-no-command-fanout-token",
+            "application_id": "223456789012345678",
+            "channel_id": "dm-no-fanout-channel",
+            "user": {"id": "dm-pairing-user"},
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": dm_pair["code"]}],
+            },
+        },
+    )
+
+    assert dm_paired.status_code == 200
+    assert dm_paired.json()["data"]["content"].startswith("Direct message paired.")
+    assert len(fan_out_calls) == 1
 
 
 @pytest.mark.asyncio
@@ -11724,6 +12177,7 @@ async def test_discord_message_pair_code_sends_user_reply(
                 "provider": "discord",
                 "name": "discord-message-pair-reply",
                 "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -11780,6 +12234,7 @@ async def test_discord_guild_text_pair_without_computed_permissions_fails_closed
                 "provider": "discord",
                 "name": "discord-text-pair-permissions",
                 "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -11832,7 +12287,12 @@ async def test_discord_guild_interaction_pair_allows_manage_guild_or_administrat
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": f"discord-pair-authority-{permissions}"},
+            json={
+                "provider": "discord",
+                "name": f"discord-pair-authority-{permissions}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -11876,7 +12336,12 @@ async def test_discord_guild_interaction_pair_denies_non_authoritative_permissio
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": f"discord-pair-denied-{uuid4().hex}"},
+            json={
+                "provider": "discord",
+                "name": f"discord-pair-denied-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -12119,11 +12584,20 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
 
 
 @pytest.mark.asyncio
-async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncClient):
+async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_commands(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": "discord-unpair"},
+            json={
+                "provider": "discord",
+                "name": "discord-unpair",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -12154,6 +12628,20 @@ async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncCl
         },
     )
 
+    link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"id": "provider-command"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
     unpaired = await client.post(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
@@ -12180,6 +12668,91 @@ async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncCl
     bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
     assert bindings.status_code == 200
     assert bindings.json() == []
+    assert len(_FakeProviderClient.calls) == 1
+    cleanup_call = _FakeProviderClient.calls[0]
+    assert cleanup_call["method"] == "PUT"
+    assert cleanup_call["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-discord-unpair/commands"
+    )
+    assert cleanup_call["content"] == b"[]"
+
+
+@pytest.mark.asyncio
+async def test_discord_unpair_command_cleanup_failure_keeps_authority_revoked(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-unpair-cleanup-failure",
+        channel_id="cleanup-failure-channel",
+        guild_id="cleanup-failure-guild",
+    )
+    link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"message": "provider failure"}, status_code=500)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    unpaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "cleanup-failure-unpair",
+            "token": "cleanup-failure-token",
+            "channel_id": "cleanup-failure-channel",
+            "guild_id": "cleanup-failure-guild",
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-pair-user"},
+            },
+            "data": {"name": "bot_unpair"},
+        },
+    )
+
+    assert unpaired.status_code == 200
+    assert unpaired.json()["data"]["content"].startswith("Server unpaired.")
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["content"] == b"[]"
+
+
+@pytest.mark.asyncio
+async def test_discord_binding_delete_requires_provider_authorized_unpair(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-control-plane-unpair-denied",
+        channel_id="discord-control-plane-channel",
+        guild_id="discord-control-plane-guild",
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+
+    response = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"].startswith("Run /bot_unpair")
+    await db_session.refresh(binding)
+    assert binding.status == BINDING_STATUS_ACTIVE
 
 
 def test_discord_dispatch_routing_key_uses_guild_binding_and_channel_alias_source():
@@ -12305,7 +12878,7 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
                 "provider": "discord",
                 "name": "discord-dm-boundary",
                 "provider_token": "discord-provider-token",
-                "config": {"application_id": "discord-dm-app"},
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -12322,7 +12895,7 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
             "type": 2,
             "id": "dm-pair-interaction",
             "token": "dm-pair-token",
-            "application_id": "discord-dm-app",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": "discord-dm-a",
             "user": {"id": "discord-dm-actor"},
             "data": {
@@ -12410,6 +12983,36 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
     assert len(_FakeProviderClient.calls) == 1
     assert _FakeProviderClient.calls[0]["url"].endswith("/channels/discord-dm-a/messages")
 
+    link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"id": "provider-command"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    unpaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "dm-unpair-interaction",
+            "token": "dm-unpair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "discord-dm-a",
+            "user": {"id": "discord-dm-actor"},
+            "data": {"name": "bot_unpair"},
+        },
+    )
+    assert unpaired.status_code == 200
+    assert unpaired.json()["data"]["content"].startswith("Direct message unpaired.")
+    assert _FakeProviderClient.calls == []
+
 
 @pytest.mark.asyncio
 async def test_discord_dispatch_records_bound_message(
@@ -12419,7 +13022,12 @@ async def test_discord_dispatch_records_bound_message(
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": "discord-dispatch"},
+            json={
+                "provider": "discord",
+                "name": "discord-dispatch",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -12493,7 +13101,12 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
     created = (
         await client.post(
             "/v1/channels",
-            json={"provider": "discord", "name": "discord-gateway-pair"},
+            json={
+                "provider": "discord",
+                "name": "discord-gateway-pair",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
         )
     ).json()
     pair = (
@@ -12795,7 +13408,7 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
                 "provider": "discord",
                 "name": "discord-shared-chat",
                 "provider_token": "discord-provider-token",
-                "config": {"application_id": "discord-shared-app"},
+                "config": _discord_ready_config(),
             },
         ),
         (
@@ -13647,6 +14260,132 @@ async def test_telegram_command_sync_uses_set_my_commands(
 
 
 @pytest.mark.asyncio
+async def test_discord_pair_preparation_configures_endpoint_then_global_commands_then_code(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _DiscordPreparationProviderClient.reset(
+        [
+            ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
+            ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
+            ({"id": "pair-command"}, 200),
+            ({"id": "unpair-command"}, 200),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.channels.httpx.AsyncClient",
+        _DiscordPreparationProviderClient,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-fresh-pair-preparation",
+                "provider_token": "discord-provider-token",
+                "config": {
+                    "application_id": DISCORD_TEST_APPLICATION_ID,
+                    "public_key": DISCORD_TEST_PUBLIC_KEY,
+                    "guild_id": "legacy-guild-must-not-scope-defaults",
+                },
+            },
+        )
+    ).json()
+
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert pair.status_code == 201, pair.text
+    assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
+        "GET",
+        "PATCH",
+        "POST",
+        "POST",
+    ]
+    get_call, patch_call, pair_command_call, unpair_command_call = (
+        _DiscordPreparationProviderClient.calls
+    )
+    assert get_call["url"].endswith("/applications/@me")
+    assert patch_call["json"] == {"interactions_endpoint_url": created["webhook_url"]}
+    expected_global_path = f"/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    assert pair_command_call["url"].endswith(expected_global_path)
+    assert unpair_command_call["url"].endswith(expected_global_path)
+    assert "legacy-guild-must-not-scope-defaults" not in pair_command_call["url"]
+    assert pair_command_call["json"]["default_member_permissions"] == "32"
+    assert unpair_command_call["json"]["default_member_permissions"] == "32"
+    install_url = pair.json()["discord_install_url"]
+    assert install_url == (
+        "https://discord.com/oauth2/authorize"
+        f"?client_id={DISCORD_TEST_APPLICATION_ID}"
+        "&permissions=274878024768"
+        "&scope=bot%20applications.commands"
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    assert account.config["discord_interactions_configured"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("responses", "expected_status"),
+    [
+        ([({"id": "223456789012345678"}, 200)], 409),
+        (
+            [
+                ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
+                ({"message": "invalid interactions endpoint"}, 400),
+            ],
+            502,
+        ),
+    ],
+)
+async def test_discord_pair_preparation_identity_or_validation_failure_creates_no_code(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[tuple[dict[str, Any], int]],
+    expected_status: int,
+):
+    _DiscordPreparationProviderClient.reset(responses)
+    monkeypatch.setattr(
+        "app.services.channels.httpx.AsyncClient",
+        _DiscordPreparationProviderClient,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-pair-preparation-failure-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": {
+                    "application_id": DISCORD_TEST_APPLICATION_ID,
+                    "public_key": DISCORD_TEST_PUBLIC_KEY,
+                },
+            },
+        )
+    ).json()
+
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert pair.status_code == expected_status
+    codes = list(
+        (
+            await db_session.execute(
+                select(ChannelPairCode).where(ChannelPairCode.account_id == UUID(created["id"]))
+            )
+        ).scalars()
+    )
+    assert codes == []
+
+
+@pytest.mark.asyncio
 async def test_discord_command_sync_upserts_application_commands(
     client: httpx.AsyncClient,
     monkeypatch,
@@ -13661,7 +14400,7 @@ async def test_discord_command_sync_upserts_application_commands(
                 "provider": "discord",
                 "name": "discord-commands",
                 "provider_token": "discord-token",
-                "config": {"application_id": "app-123"},
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -13675,7 +14414,7 @@ async def test_discord_command_sync_upserts_application_commands(
     assert response.json()["provider"] == "discord"
     assert len(_FakeProviderClient.calls) == 2
     assert _FakeProviderClient.calls[0]["url"].endswith(
-        "/applications/app-123/guilds/guild-123/commands"
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-123/commands"
     )
     assert _FakeProviderClient.calls[0]["headers"]["Authorization"] == "Bot discord-token"
     assert _FakeProviderClient.calls[0]["json"]["name"] == "bot_pair"
@@ -13701,6 +14440,7 @@ async def test_discord_send_uses_provider_rest_api(
                 "provider": "discord",
                 "name": "discord-send",
                 "provider_token": "discord-token",
+                "config": _discord_ready_config(),
             },
         )
     ).json()

--- a/packages/cli/src/runtime/managed-channel-session-contract.test.ts
+++ b/packages/cli/src/runtime/managed-channel-session-contract.test.ts
@@ -2,15 +2,36 @@ import { describe, expect, test } from "bun:test";
 
 // Fixed upstream contracts are used because this repository does not vendor or
 // execute either runtime. Keep these fixtures aligned with the audited sources:
-// OpenClaw npm 2026.7.1-2 (0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c)
-//   src/config/zod-schema.session.ts::SessionSchema
+// OpenClaw main (aaab981ab097749eef632f2601d5dca147a0e494)
 //   src/routing/session-key.ts::buildAgentPeerSessionKey
-// Hermes 0.19.1 main (f3cda0ceb18d8ba7465a6d223098ef0e56c8fee1)
+//   extensions/discord/src/monitor/route-resolution.ts::buildDiscordRoutePeer
+// Hermes main (1789e06ed8b1c68b6ebfb2fcd472534aedcff999)
 //   gateway/session.py::build_session_key
-//   gateway/platforms/telegram.py::TelegramAdapter._build_message_event
+//   plugins/platforms/telegram/adapter.py::TelegramAdapter._build_message_event
+//   plugins/platforms/discord/adapter.py (effective_channel.id source routing)
 
 function openClawDirectSessionKey(channel: string, accountId: string, peerId: string): string {
 	return `agent:main:${channel}:${accountId}:direct:${peerId}`;
+}
+
+function openClawDiscordSessionKey(source: {
+	accountId: string;
+	conversationId: string;
+	directUserId?: string;
+}): string {
+	return source.directUserId
+		? openClawDirectSessionKey("discord", source.accountId, source.directUserId)
+		: `agent:main:discord:channel:${source.conversationId}`;
+}
+
+function hermesDiscordSessionKey(source: {
+	chatType: "dm" | "group" | "thread";
+	chatId: string;
+	threadId?: string;
+}): string {
+	return ["agent:main", "discord", source.chatType, source.chatId, source.threadId]
+		.filter(Boolean)
+		.join(":");
 }
 
 function hermesTelegramThreadId(
@@ -137,5 +158,64 @@ describe("managed Telegram upstream session contracts", () => {
 				threadId: hermesTelegramThreadId("dm", "77", true, false),
 			}),
 		).toBe("agent:main:telegram:dm:101:77");
+	});
+});
+
+describe("managed Discord upstream session contracts", () => {
+	test("OpenClaw keys guild channels and threads by their physical conversation ids", () => {
+		const channelA = openClawDiscordSessionKey({
+			accountId: "managed-discord",
+			conversationId: "channel-a",
+		});
+		const channelB = openClawDiscordSessionKey({
+			accountId: "managed-discord",
+			conversationId: "channel-b",
+		});
+		const threadB = openClawDiscordSessionKey({
+			accountId: "managed-discord",
+			conversationId: "thread-b-1",
+		});
+
+		expect(channelA).toBe("agent:main:discord:channel:channel-a");
+		expect(new Set([channelA, channelB, threadB]).size).toBe(3);
+		for (const key of [channelA, channelB, threadB]) expect(key).not.toContain("guild-1");
+	});
+
+	test("Hermes keys guild channels, threads, and DMs by effective Discord channel ids", () => {
+		const channelA = hermesDiscordSessionKey({ chatType: "group", chatId: "channel-a" });
+		const channelB = hermesDiscordSessionKey({ chatType: "group", chatId: "channel-b" });
+		const threadB = hermesDiscordSessionKey({
+			chatType: "thread",
+			chatId: "thread-b-1",
+			threadId: "thread-b-1",
+		});
+		const dm = hermesDiscordSessionKey({ chatType: "dm", chatId: "dm-channel-1" });
+
+		expect(channelA).toBe("agent:main:discord:group:channel-a");
+		expect(threadB).toBe("agent:main:discord:thread:thread-b-1:thread-b-1");
+		expect(dm).toBe("agent:main:discord:dm:dm-channel-1");
+		expect(new Set([channelA, channelB, threadB, dm]).size).toBe(4);
+		for (const key of [channelA, channelB, threadB]) expect(key).not.toContain("guild-1");
+	});
+
+	test("OpenClaw keeps managed Discord DMs account- and user-scoped", () => {
+		const dmA = openClawDiscordSessionKey({
+			accountId: "managed-a",
+			conversationId: "dm-channel-a",
+			directUserId: "user-a",
+		});
+		const dmB = openClawDiscordSessionKey({
+			accountId: "managed-a",
+			conversationId: "dm-channel-b",
+			directUserId: "user-b",
+		});
+		const otherAccount = openClawDiscordSessionKey({
+			accountId: "managed-b",
+			conversationId: "dm-channel-a",
+			directUserId: "user-a",
+		});
+
+		expect(dmA).toBe("agent:main:discord:managed-a:direct:user-a");
+		expect(new Set([dmA, dmB, otherAccount]).size).toBe(3);
 	});
 });

--- a/packages/cli/src/runtime/managed-channel-session-contract.test.ts
+++ b/packages/cli/src/runtime/managed-channel-session-contract.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 // Fixed upstream contracts are used because this repository does not vendor or
 // execute either runtime. Keep these fixtures aligned with the audited sources:
-// OpenClaw main (aaab981ab097749eef632f2601d5dca147a0e494)
+// OpenClaw main (50771abc6aae8c9c4b95aa8c5a2b1b7a37eb80ef)
 //   src/routing/session-key.ts::buildAgentPeerSessionKey
 //   extensions/discord/src/monitor/route-resolution.ts::buildDiscordRoutePeer
-// Hermes main (1789e06ed8b1c68b6ebfb2fcd472534aedcff999)
+// Hermes main (126ff7071b6b755055879648f4e859b3187d0fac)
 //   gateway/session.py::build_session_key
 //   plugins/platforms/telegram/adapter.py::TelegramAdapter._build_message_event
 //   plugins/platforms/discord/adapter.py (effective_channel.id source routing)

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3265,6 +3265,8 @@ function hermesManagedChannelsPatch(
 ): Record<string, unknown> {
 	const baseUrl = stripTrailingSlash(cloudApiUrl);
 	const telegramEnabled = channelHasAccounts(channels.telegram);
+	const discordEnabled = channelHasAccounts(channels.discord);
+	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled;
 	const whatsapp = hermesWhatsAppProjection(channels, channelCredentials, baseUrl);
 	return {
 		telegram: telegramEnabled
@@ -3282,7 +3284,7 @@ function hermesManagedChannelsPatch(
 					},
 				}
 			: { enabled: false },
-		discord: channelHasAccounts(channels.discord)
+		discord: discordEnabled
 			? {
 					enabled: true,
 					dm_policy: "open",
@@ -3304,8 +3306,8 @@ function hermesManagedChannelsPatch(
 					require_mention: false,
 				}
 			: { enabled: false },
-		group_sessions_per_user: telegramEnabled ? false : null,
-		thread_sessions_per_user: telegramEnabled ? false : null,
+		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
+		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		platforms: {
 			telegram: {
 				extra: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12492,6 +12492,30 @@ exit 64
 		expect(profileBundle).toContain("/v1/channels/telegram");
 		expect(profileBundle).toContain("/v1/channels/discord");
 
+		const discordOnly = convergeRuntimeManifest(
+			applyRuntimeChannelsToManifestLoad(
+				load,
+				{
+					channels: [channels.channels[1]],
+					source: "remote-datasource",
+					sourcePath: "https://runtime.test/v1/channels",
+					etag: testBundleEtag("discord-only-hermes-channels"),
+				},
+				paths,
+			),
+			paths,
+		);
+		expect(discordOnly.installErrors).toEqual([]);
+		const discordOnlyHermesConfig = readHermesConfigYaml(home);
+		expect(discordOnlyHermesConfig.group_sessions_per_user).toBe(false);
+		expect(discordOnlyHermesConfig.thread_sessions_per_user).toBe(false);
+		expect(discordOnlyHermesConfig).not.toHaveProperty(
+			"platforms.telegram.extra.group_sessions_per_user",
+		);
+		expect(discordOnlyHermesConfig).not.toHaveProperty(
+			"platforms.telegram.extra.thread_sessions_per_user",
+		);
+
 		const removed = convergeRuntimeManifest(
 			applyRuntimeChannelsToManifestLoad(
 				load,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4343,6 +4343,8 @@ export interface components {
             deep_link?: string | null;
             /** Qr Payload */
             qr_payload?: string | null;
+            /** Discord Install Url */
+            discord_install_url?: string | null;
         };
         /** ChannelRuntimeAccountResponse */
         ChannelRuntimeAccountResponse: {


### PR DESCRIPTION
## Summary

- Make one active Discord Guild binding the trust boundary for every channel and thread in that server while preserving the real channel/thread payload and routing identity. Keep bot DM channels isolated as direct bindings.
- Require Discord-computed Manage Guild or Administrator permissions for Guild pair/unpair, retain pairing-actor protection for unpair, and set default_member_permissions to decimal 32 only for Discord default commands.
- Resolve unobserved channel REST operations through the centralized Discord provider path, validate the returned Channel guild_id against the same active account and AgentLink, cache aliases, reuse GET /channels/{id} preflight responses, and fail closed on mismatches/errors.
- Prevent active Guild bindings from moving to another AgentLink until explicit unpair, while allowing stale aliases from archived state to migrate on an intentional re-pair.
- Add a compact Pair Discord dialog and provider-aware Server / Direct message copy. Private owned bots sync default commands before code creation; public/shared bots do not call the owner-only sync endpoint and rely on centrally managed commands. Telegram behavior remains unchanged.
- Add OpenClaw and Hermes contract coverage proving physical Discord channel/thread/DM identities remain session identities rather than Guild IDs.

## Supported boundary

This PR supports Discord Guild-level trust and bot DM channel trust. A paired Guild authorizes messages throughout that server subject to the bot native Discord permissions; channels and threads are routing/session identities, not independently pairable bindings. It does not claim support for every Discord feature or interaction shape.

Discord API docs were audited at discord-api-docs b2f8adafc037242291b8f875d4cdf3adc4d48bb7. Runtime contracts were audited at OpenClaw aaab981ab097749eef632f2601d5dca147a0e494 and Hermes 1789e06ed8b1c68b6ebfb2fcd472534aedcff999.

## Verification

- `scripts/test.sh backend tests/test_channels.py -k discord`: 54 passed, 187 deselected (one existing SQLAlchemy connection-GC warning)
- Backend Ruff lint/format and Python compileall: passed
- `bun test --isolate src` in apps/web: 790 passed
- `bun run typecheck`: 4 workspace packages passed
- `bun run check`: 820 files passed Biome
- `bun run --cwd apps/web build:oss`: passed
- CLI managed Discord/Telegram session contract: 6 passed
- Shared package tests: 75 passed
- `git diff --check origin/main..HEAD`: passed

All provider and database verification used throwaway/local fakes and isolated Docker PostgreSQL. No real Discord, production, tenant data, credentials, deployment, or merge actions were used.

## Remaining risks

- Discord provider lookup and permission behavior are covered with local fake responses, not a real Discord account, by design.
- Public/shared Discord bots require centrally managed slash commands; the user-facing flow intentionally cannot mutate bot-global commands.
- OpenClaw/Hermes behavior is contract-tested against audited upstream source rather than executing those upstream runtimes in this repository.