### PR TITLE
fix(web): refine AI provider setup flow

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2441,6 +2441,18 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	const choiceButtons = choiceGrid.locator(":scope > button");
 	await expect(choiceButtons).toHaveCount(17);
 	await expect(choiceButtons.locator("button, a, input, select, textarea")).toHaveCount(0);
+	await expect(
+		chooserDialog.getByRole("button", {
+			name: "OpenAI API key or ChatGPT sign-in",
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(
+		chooserDialog.getByRole("button", {
+			name: "Anthropic Claude model access",
+			exact: true,
+		}),
+	).toBeVisible();
 	await expect(chooserDialog.getByRole("button", { name: /^Custom endpoint/ })).toBeVisible();
 	const providerSearch = chooserDialog.getByRole("textbox", { name: "Search providers" });
 	const mobileOpenAiBox = await chooserDialog
@@ -2677,8 +2689,14 @@ test("AI Provider OAuth and destructive confirmations keep dialog semantics on m
 	await chooserDialog.getByRole("button", { name: /^OpenAI/ }).click();
 	const configureDialog = page.getByRole("dialog");
 	await expect(configureDialog).toHaveAccessibleName("Set up OpenAI");
-	const apiKeyAuth = configureDialog.getByRole("button", { name: /^Sign in with an API key/ });
-	const chatGptAuth = configureDialog.getByRole("button", { name: /^Sign in with ChatGPT/ });
+	const apiKeyAuth = configureDialog.getByRole("button", {
+		name: "Sign in with an API key For usage-based access",
+		exact: true,
+	});
+	const chatGptAuth = configureDialog.getByRole("button", {
+		name: "Sign in with ChatGPT For subscription access",
+		exact: true,
+	});
 	await expect(apiKeyAuth).toHaveAttribute("aria-pressed", "true");
 	await expect(chatGptAuth).toHaveAttribute("aria-pressed", "false");
 	const openAiApiKey = configureDialog.getByRole("textbox", { name: "API key", exact: true });
@@ -2735,6 +2753,125 @@ test("AI Provider OAuth and destructive confirmations keep dialog semantics on m
 	await expect(removeProvider).toBeEnabled();
 	await removeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 
+	const documentWidth = await page.evaluate(() => ({
+		clientWidth: document.documentElement.clientWidth,
+		scrollWidth: document.documentElement.scrollWidth,
+	}));
+	expect(documentWidth.scrollWidth).toBe(documentWidth.clientWidth);
+});
+
+test("AI provider chooser and auth dialogs preserve hierarchy in dark mode", async ({
+	page,
+}, testInfo) => {
+	const providerAcceptRequests: string[] = [];
+	const pendingOpenAiProvider = {
+		...deepSeekProvider,
+		id: "row-dark-openai",
+		provider_id: "openai-dark",
+		type: "openai",
+		label: "OpenAI",
+		base_url: "https://api.openai.com/v1",
+		models: [{ id: "gpt-5.5", label: "GPT-5.5" }],
+		api_mode: "openai_responses",
+		auth: { type: "agent_profile", tool: "codex", profile: "default" },
+		runtime_env_name: null,
+	};
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.addInitScript(() => window.localStorage.setItem("clawdi-theme", "dark"));
+	await stubHostedApi(page, {
+		aiProviders: [],
+		deployments: [],
+		providerAcceptRequests,
+		providerAcceptResponses: [
+			{
+				status: 200,
+				body: {
+					status: "pending",
+					provider: pendingOpenAiProvider,
+					authorization: {
+						flow: "device_code",
+						state: "dark-mode-state",
+						verification_url: "https://auth.openai.com/codex/device",
+						user_code: "DARK-CODE",
+						expires_at: "2099-01-01T00:00:00Z",
+						poll_interval_seconds: 60,
+					},
+				},
+			},
+		],
+	});
+	await page.goto("/ai-providers");
+	await expect(page.locator("html")).toHaveClass(/dark/);
+
+	const main = page.locator("main");
+	await main.getByRole("button", { name: "Add provider", exact: true }).first().click();
+	const chooserDialog = page.getByRole("dialog", { name: "Add a provider" });
+	const providerSearch = chooserDialog.getByRole("textbox", { name: "Search providers" });
+	await expect(providerSearch).toBeFocused();
+	const openAiChoice = chooserDialog.getByRole("button", {
+		name: "OpenAI API key or ChatGPT sign-in",
+		exact: true,
+	});
+	const anthropicChoice = chooserDialog.getByRole("button", {
+		name: "Anthropic Claude model access",
+		exact: true,
+	});
+	await expect(openAiChoice).toBeVisible();
+	await expect(anthropicChoice).toBeVisible();
+	await expect(openAiChoice.locator(':scope > [aria-hidden="true"]')).toHaveCount(1);
+	const anthropicIcon = anthropicChoice.locator(':scope > [aria-hidden="true"]');
+	await expect(anthropicIcon).toHaveCount(1);
+	await expect(anthropicIcon.locator("img")).toHaveAttribute("alt", "Anthropic");
+	const chooserBody = chooserDialog.getByTestId("provider-dialog-body");
+	const mobileScroll = await chooserBody.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(mobileScroll.scrollHeight).toBeGreaterThan(mobileScroll.clientHeight);
+	await chooserDialog.screenshot({ path: testInfo.outputPath("provider-dark-chooser-mobile.png") });
+
+	await page.setViewportSize({ width: 1000, height: 800 });
+	const openAiBox = await openAiChoice.boundingBox();
+	const anthropicBox = await anthropicChoice.boundingBox();
+	expect(Math.abs((openAiBox?.y ?? 0) - (anthropicBox?.y ?? 0))).toBeLessThanOrEqual(1);
+	expect(anthropicBox?.x ?? 0).toBeGreaterThan(openAiBox?.x ?? 0);
+	await chooserDialog.screenshot({
+		path: testInfo.outputPath("provider-dark-chooser-desktop.png"),
+	});
+
+	await openAiChoice.click();
+	const configureDialog = page.getByRole("dialog", { name: "Set up OpenAI" });
+	const apiKeyAuth = configureDialog.getByRole("button", {
+		name: "Sign in with an API key For usage-based access",
+		exact: true,
+	});
+	const chatGptAuth = configureDialog.getByRole("button", {
+		name: "Sign in with ChatGPT For subscription access",
+		exact: true,
+	});
+	await expect(apiKeyAuth).toHaveAttribute("aria-pressed", "true");
+	await expect(chatGptAuth).toHaveAttribute("aria-pressed", "false");
+	await expect(configureDialog.locator('[data-slot="dialog-footer"]')).toBeVisible();
+	await configureDialog.screenshot({
+		path: testInfo.outputPath("provider-dark-api-key-desktop.png"),
+	});
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await configureDialog.screenshot({
+		path: testInfo.outputPath("provider-dark-api-key-mobile.png"),
+	});
+	await chatGptAuth.click();
+	const oauthConfigureDialog = page.getByRole("dialog", { name: "Set up ChatGPT (Codex)" });
+	await oauthConfigureDialog
+		.getByRole("button", { name: "Continue to ChatGPT", exact: true })
+		.click();
+	await expect.poll(() => providerAcceptRequests.length).toBe(1);
+	const oauthDialog = page.getByRole("dialog", { name: "Sign in with ChatGPT" });
+	await expect(oauthDialog.getByText("DARK-CODE", { exact: true })).toBeVisible();
+	await oauthDialog.screenshot({ path: testInfo.outputPath("provider-dark-oauth-mobile.png") });
+
+	await page.setViewportSize({ width: 1000, height: 800 });
+	await oauthDialog.screenshot({ path: testInfo.outputPath("provider-dark-oauth-desktop.png") });
 	const documentWidth = await page.evaluate(() => ({
 		clientWidth: document.documentElement.clientWidth,
 		scrollWidth: document.documentElement.scrollWidth,

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -964,6 +964,14 @@ type HostedApiStubOptions = {
 	planChangeResponses?: unknown[];
 	planQuoteRequests?: string[];
 	planQuoteResponses?: unknown[];
+	providerAcceptRequests?: string[];
+	providerAcceptResponses?: StubResponse[];
+	providerDraftTestRequests?: string[];
+	providerDraftTestResponses?: StubResponse[];
+	providerOAuthStartRequests?: string[];
+	providerOAuthStartResponses?: StubResponse[];
+	providerPatchRequests?: string[];
+	providerPatchResponses?: StubResponse[];
 	providerTestRequests?: string[];
 	restartRequests?: string[];
 	runtimeUiRedemptionRequests?: string[];
@@ -1634,6 +1642,42 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p === "/v1/ai-providers") {
 			return fulfillJson(r, { providers: options.aiProviders ?? [] });
 		}
+		if (p === "/v1/ai-providers/accept" && r.request().method() === "POST") {
+			options.providerAcceptRequests?.push(r.request().postData() ?? "");
+			const response = options.providerAcceptResponses?.shift() ?? {
+				status: 500,
+				body: { detail: "No provider accept response configured" },
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (p.match(/^\/v1\/ai-providers\/[^/]+$/) && r.request().method() === "PATCH") {
+			options.providerPatchRequests?.push(r.request().postData() ?? "");
+			const response = options.providerPatchResponses?.shift() ?? {
+				status: 200,
+				body: deepSeekProvider,
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (p === "/v1/ai-providers/test" && r.request().method() === "POST") {
+			options.providerDraftTestRequests?.push(r.request().postData() ?? "");
+			const response = options.providerDraftTestResponses?.shift() ?? {
+				status: 200,
+				body: { ok: true, readiness: deepSeekProvider.readiness, error: null },
+			};
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (
+			p.match(/^\/v1\/ai-providers\/[^/]+\/auth\/oauth\/device\/start$/) &&
+			r.request().method() === "POST"
+		) {
+			options.providerOAuthStartRequests?.push(r.request().postData() ?? "");
+			const response = options.providerOAuthStartResponses?.shift() ?? {
+				status: 500,
+				body: { detail: "No provider OAuth response configured" },
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
 		if (p.match(/^\/v1\/ai-providers\/[^/]+\/test$/) && r.request().method() === "POST") {
 			options.providerTestRequests?.push(r.request().url());
 			return fulfillJson(r, {
@@ -2235,16 +2279,54 @@ test("deploy keeps AI providers expanded and provider selection exclusive", asyn
 });
 
 test("AI Providers preserves provider identity and keeps technical details progressive", async ({
+	context,
 	page,
-}) => {
+}, testInfo) => {
+	const providerAcceptRequests: string[] = [];
 	const providerTestRequests: string[] = [];
+	const providerDraftTestRequests: string[] = [];
+	const providerPatchRequests: string[] = [];
 	await page.setViewportSize({ width: 390, height: 844 });
 	await stubHostedApi(page, {
 		aiProviders: [deepSeekProvider, deepSeekProxyProvider],
 		deployments: [],
+		providerAcceptRequests,
+		providerAcceptResponses: [
+			{
+				status: 503,
+				body: { detail: "upstream tenant=internal replacement_key=must-not-render" },
+			},
+			{
+				status: 200,
+				body: { status: "ready", provider: deepSeekProvider },
+			},
+		],
+		providerDraftTestRequests,
+		providerDraftTestResponses: [
+			{
+				status: 200,
+				delayMs: 1_000,
+				body: {
+					ok: false,
+					readiness: deepSeekProvider.readiness,
+					error: {
+						category: "authentication",
+						code: "invalid_api_key",
+						message: "upstream tenant=internal api_key=must-not-render",
+						retryable: false,
+					},
+				},
+			},
+			{
+				status: 200,
+				body: { ok: true, readiness: deepSeekProvider.readiness, error: null },
+			},
+		],
+		providerPatchRequests,
 		providerTestRequests,
 	});
 	await page.goto("/ai-providers");
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
 	const main = page.locator("main");
 	await expect(main.getByRole("heading", { name: "AI Providers", level: 1 })).toBeVisible();
@@ -2289,6 +2371,17 @@ test("AI Providers preserves provider identity and keeps technical details progr
 
 	await main.getByRole("button", { name: "Edit Research DeepSeek" }).click();
 	const editDialog = page.getByRole("dialog", { name: "Edit provider" });
+	const savedApiKey = editDialog.getByRole("textbox", { name: "API key", exact: true });
+	await expect(savedApiKey).toHaveAttribute("type", "password");
+	await expect(savedApiKey).toHaveValue("");
+	await expect(savedApiKey).toHaveAttribute("placeholder", "Leave blank to keep current key");
+	await expect(
+		editDialog.getByText("Leave blank to keep the current key.", { exact: true }),
+	).toBeVisible();
+	await editDialog.getByRole("button", { name: "Show API key" }).click();
+	await expect(savedApiKey).toHaveAttribute("type", "text");
+	await editDialog.getByRole("button", { name: "Hide API key" }).click();
+	await expect(savedApiKey).toHaveAttribute("type", "password");
 	const advanced = editDialog.locator("details");
 	await expect(advanced).not.toHaveAttribute("open", "");
 	await expect(editDialog.getByLabel("Base URL")).not.toBeVisible();
@@ -2296,7 +2389,38 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	await expect(editDialog.getByLabel("Name")).toHaveValue("Research DeepSeek");
 	await expect(editDialog.getByLabel("Base URL")).toHaveValue("https://api.deepseek.com/v1");
 	await expect(editDialog.getByText("deepseek-primary", { exact: true })).toBeVisible();
-	await editDialog.getByRole("button", { name: "Cancel" }).click();
+	await editDialog.getByRole("button", { name: "Save settings", exact: true }).click();
+	await expect.poll(() => providerPatchRequests.length).toBe(1);
+	const preservedCredentialPatch = JSON.parse(providerPatchRequests[0] ?? "{}");
+	expect(preservedCredentialPatch).not.toHaveProperty("credential");
+	expect(preservedCredentialPatch).not.toHaveProperty("api_key");
+	await expect(editDialog).toHaveCount(0);
+
+	await main.getByRole("button", { name: "Edit Research DeepSeek" }).click();
+	const replacementDialog = page.getByRole("dialog", { name: "Edit provider" });
+	const replacementApiKey = replacementDialog.getByRole("textbox", {
+		name: "API key",
+		exact: true,
+	});
+	await replacementApiKey.fill("  replacement-key  ");
+	await replacementDialog.getByRole("button", { name: "Save settings", exact: true }).click();
+	await expect.poll(() => providerAcceptRequests.length).toBe(1);
+	const failedReplacement = page.locator("[data-sonner-toast]").filter({
+		hasText: "Couldn't save provider",
+	});
+	await expect(failedReplacement).toContainText("The service is having trouble right now.");
+	await expect(failedReplacement).not.toContainText("tenant=internal");
+	await expect(replacementDialog).toBeVisible();
+	await replacementDialog.getByRole("button", { name: "Save settings", exact: true }).click();
+	await expect.poll(() => providerAcceptRequests.length).toBe(2);
+	for (const request of providerAcceptRequests) {
+		expect(JSON.parse(request)).toMatchObject({
+			credential: { type: "api_key", value: "replacement-key" },
+			replace: true,
+		});
+	}
+	await expect(replacementDialog).toHaveCount(0);
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0, { timeout: 7_000 });
 
 	await main.getByRole("button", { name: "Edit DeepSeek proxy" }).click();
 	const proxyEditDialog = page.getByRole("dialog", { name: "Edit provider" });
@@ -2309,14 +2433,75 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	const chooserDialog = page.getByRole("dialog", { name: "Add a provider" });
 	await expect(chooserDialog.getByText("Providers", { exact: true })).toBeVisible();
 	await expect(chooserDialog.getByText("Popular", { exact: true })).toHaveCount(0);
-	await expect(chooserDialog.getByText("More providers", { exact: true })).toBeVisible();
+	await expect(chooserDialog.getByText("More providers", { exact: true })).toHaveCount(0);
+	await expect(chooserDialog.locator("details")).toHaveCount(0);
+	await expect(chooserDialog.locator('[data-slot="dialog-footer"]')).toHaveCount(0);
+	await expect(chooserDialog.getByRole("button", { name: "Close" })).toBeVisible();
+	const choiceGrid = chooserDialog.getByTestId("provider-choice-grid");
+	const choiceButtons = choiceGrid.locator(":scope > button");
+	await expect(choiceButtons).toHaveCount(17);
+	await expect(choiceButtons.locator("button, a, input, select, textarea")).toHaveCount(0);
+	await expect(chooserDialog.getByRole("button", { name: /^Custom endpoint/ })).toBeVisible();
 	const providerSearch = chooserDialog.getByRole("textbox", { name: "Search providers" });
+	const mobileOpenAiBox = await chooserDialog
+		.getByRole("button", { name: /^OpenAI/ })
+		.boundingBox();
+	const mobileAnthropicBox = await chooserDialog
+		.getByRole("button", { name: /^Anthropic/ })
+		.boundingBox();
+	expect(Math.abs((mobileOpenAiBox?.x ?? 0) - (mobileAnthropicBox?.x ?? 0))).toBeLessThanOrEqual(1);
+	expect(mobileAnthropicBox?.y ?? 0).toBeGreaterThan(mobileOpenAiBox?.y ?? 0);
+	const mobileScroll = await chooserDialog
+		.getByTestId("provider-dialog-body")
+		.evaluate((element) => ({
+			clientHeight: element.clientHeight,
+			scrollHeight: element.scrollHeight,
+		}));
+	expect(mobileScroll.scrollHeight).toBeGreaterThan(mobileScroll.clientHeight);
+	await chooserDialog.screenshot({
+		path:
+			process.env.PROVIDER_CHOOSER_MOBILE_SCREENSHOT_PATH ??
+			testInfo.outputPath("provider-chooser-mobile.png"),
+	});
+
+	await page.setViewportSize({ width: 1000, height: 800 });
+	const desktopOpenAiBox = await chooserDialog
+		.getByRole("button", { name: /^OpenAI/ })
+		.boundingBox();
+	const desktopAnthropicBox = await chooserDialog
+		.getByRole("button", { name: /^Anthropic/ })
+		.boundingBox();
+	expect(Math.abs((desktopOpenAiBox?.y ?? 0) - (desktopAnthropicBox?.y ?? 0))).toBeLessThanOrEqual(
+		1,
+	);
+	expect(desktopAnthropicBox?.x ?? 0).toBeGreaterThan(desktopOpenAiBox?.x ?? 0);
+	await chooserDialog.screenshot({
+		path:
+			process.env.PROVIDER_CHOOSER_DESKTOP_SCREENSHOT_PATH ??
+			testInfo.outputPath("provider-chooser-desktop.png"),
+	});
+	await page.setViewportSize({ width: 390, height: 844 });
+
+	await providerSearch.focus();
+	await page.keyboard.press("Tab");
+	await expect(chooserDialog.getByRole("button", { name: /^OpenAI/ })).toBeFocused();
+	await providerSearch.focus();
 	await providerSearch.fill("Moonshot");
 	await expect(chooserDialog.getByRole("button", { name: /^Kimi API/ })).toBeVisible();
-	await providerSearch.fill("");
+	await chooserDialog.getByRole("button", { name: "Clear search" }).click();
+	await expect(choiceGrid.locator(":scope > button")).toHaveCount(17);
+	await providerSearch.fill("not-a-listed-provider");
+	const noMatchGrid = chooserDialog.getByTestId("provider-choice-grid");
+	await expect(noMatchGrid.locator(":scope > button")).toHaveCount(1);
+	await expect(noMatchGrid.getByRole("button", { name: /^Use a custom endpoint/ })).toBeVisible();
+	await chooserDialog.getByRole("button", { name: "Clear search" }).click();
 	await chooserDialog.getByRole("button", { name: /^DeepSeek/ }).click();
 	const presetDialog = page.getByRole("dialog");
 	await expect(presetDialog).toHaveAccessibleName("Set up DeepSeek");
+	await expect(presetDialog.getByRole("link", { name: /Get API key/ })).toHaveAttribute(
+		"href",
+		"https://platform.deepseek.com/api_keys",
+	);
 	const presetAdvanced = presetDialog.locator("details");
 	await expect(presetAdvanced).not.toHaveAttribute("open", "");
 	await expect(presetDialog.getByLabel("Name")).not.toBeVisible();
@@ -2324,6 +2509,42 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	await presetDialog.getByLabel("Name").fill("Research DeepSeek East");
 	await expect(presetDialog).toHaveAccessibleName("Set up Research DeepSeek East");
 	await expect(presetDialog.getByText("deepseek", { exact: true })).toBeVisible();
+	const presetApiKey = presetDialog.getByRole("textbox", { name: "API key", exact: true });
+	await expect(presetApiKey).toHaveAttribute("type", "password");
+	await page.evaluate(() => navigator.clipboard.writeText("  pasted-key-with-whitespace  "));
+	await presetApiKey.focus();
+	await page.keyboard.press("Control+V");
+	await presetDialog.getByRole("button", { name: "Show API key" }).click();
+	await expect(presetApiKey).toHaveAttribute("type", "text");
+	await expect(presetApiKey).toHaveValue("  pasted-key-with-whitespace  ");
+	await presetDialog.getByRole("button", { name: "Hide API key" }).click();
+	await expect(presetApiKey).toHaveAttribute("type", "password");
+	await expect(presetDialog).not.toContainText("pasted-key-with-whitespace");
+	await expect(
+		presetDialog.getByRole("button", { name: "Add provider", exact: true }),
+	).toBeEnabled();
+	const draftTestButton = presetDialog.getByRole("button", {
+		name: "Test connection",
+		exact: true,
+	});
+	await draftTestButton.click();
+	await expect.poll(() => providerDraftTestRequests.length).toBe(1);
+	expect(JSON.parse(providerDraftTestRequests[0] ?? "{}")).toMatchObject({
+		credential: { type: "api_key", value: "pasted-key-with-whitespace" },
+	});
+	await expect(
+		presetDialog.getByText("The provider rejected the API key. Check it and try again.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(presetDialog).not.toContainText("tenant=internal");
+	await draftTestButton.click();
+	await expect.poll(() => providerDraftTestRequests.length).toBe(2);
+	await expect(
+		presetDialog.getByText("Connection verified. The provider accepted the test request.", {
+			exact: true,
+		}),
+	).toBeVisible();
 	await presetDialog.getByRole("button", { name: "Back" }).click();
 	await expect(chooserDialog).toBeVisible();
 	await chooserDialog.getByRole("button", { name: /^Custom endpoint/ }).click();
@@ -2338,7 +2559,7 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	await expect(customDialog.locator("details")).toHaveAttribute("open", "");
 	const customName = customDialog.getByLabel("Name");
 	await expect(customName).toHaveAttribute("required", "");
-	await customDialog.getByLabel("API key").fill("test-api-key");
+	await customDialog.getByRole("textbox", { name: "API key", exact: true }).fill("test-api-key");
 	await customDialog.getByLabel("Base URL").fill("https://proxy.example.com/v1");
 	await expect(
 		customDialog.getByRole("button", { name: "Add provider", exact: true }),
@@ -2348,6 +2569,171 @@ test("AI Providers preserves provider identity and keeps technical details progr
 	await expect(
 		customDialog.getByRole("button", { name: "Add provider", exact: true }),
 	).toBeEnabled();
+
+	const documentWidth = await page.evaluate(() => ({
+		clientWidth: document.documentElement.clientWidth,
+		scrollWidth: document.documentElement.scrollWidth,
+	}));
+	expect(documentWidth.scrollWidth).toBe(documentWidth.clientWidth);
+});
+
+test("AI Provider OAuth and destructive confirmations keep dialog semantics on mobile and desktop", async ({
+	page,
+}, testInfo) => {
+	const oauthProvider = {
+		...deepSeekProvider,
+		id: "row-openai-codex",
+		provider_id: "openai-codex",
+		type: "openai",
+		label: "ChatGPT (Codex)",
+		base_url: "https://api.openai.com/v1",
+		models: [{ id: "gpt-5.5", label: "GPT-5.5" }],
+		api_mode: "openai_responses",
+		auth: { type: "agent_profile", tool: "codex", profile: "default" },
+		runtime_env_name: null,
+	};
+	const providerAcceptRequests: string[] = [];
+	const providerOAuthStartRequests: string[] = [];
+	await page.setViewportSize({ width: 390, height: 844 });
+	await stubHostedApi(page, {
+		aiProviders: [oauthProvider],
+		deploymentsResponse: {
+			status: 403,
+			body: { detail: "internal deployment tenant=must-not-render" },
+		},
+		providerAcceptRequests,
+		providerAcceptResponses: [
+			{
+				status: 200,
+				body: {
+					status: "pending",
+					provider: oauthProvider,
+					authorization: {
+						flow: "device_code",
+						state: "expired-state",
+						verification_url: "https://auth.openai.com/codex/device",
+						user_code: "OLD-CODE",
+						expires_at: "2000-01-01T00:00:00Z",
+						poll_interval_seconds: 60,
+					},
+				},
+			},
+			{
+				status: 200,
+				body: {
+					status: "pending",
+					provider: oauthProvider,
+					authorization: {
+						flow: "device_code",
+						state: "replacement-state",
+						verification_url: "https://auth.openai.com/codex/device",
+						user_code: "NEW-CODE",
+						expires_at: "2099-01-01T00:00:00Z",
+						poll_interval_seconds: 60,
+					},
+				},
+			},
+		],
+		providerOAuthStartRequests,
+		providerOAuthStartResponses: [
+			{
+				status: 200,
+				body: {
+					state: "reconnect-state",
+					verification_url: "https://auth.openai.com/codex/device",
+					user_code: "RECONNECT",
+					expires_at: "2099-01-01T00:00:00Z",
+					poll_interval_seconds: 60,
+				},
+			},
+		],
+	});
+	await page.goto("/ai-providers");
+
+	const main = page.locator("main");
+	await main.getByRole("button", { name: "Edit ChatGPT (Codex)", exact: true }).click();
+	const editDialog = page.getByRole("dialog", { name: "Edit provider" });
+	await expect(editDialog.getByText("ChatGPT sign-in", { exact: true })).toBeVisible();
+	await expect(editDialog.locator('[data-slot="dialog-footer"]')).toBeVisible();
+	await editDialog.getByRole("button", { name: "Reconnect", exact: true }).click();
+	await expect.poll(() => providerOAuthStartRequests.length).toBe(1);
+	const reconnectDialog = page.getByRole("dialog", { name: "Sign in with ChatGPT" });
+	await expect(reconnectDialog.getByText("RECONNECT", { exact: true })).toBeVisible();
+	await expect(
+		reconnectDialog.getByRole("link", { name: /Open ChatGPT and enter code/ }),
+	).toHaveAttribute("href", "https://auth.openai.com/codex/device");
+	await expect(
+		reconnectDialog.getByText("Waiting for ChatGPT authorization…", { exact: true }),
+	).toBeVisible();
+	await reconnectDialog.screenshot({
+		path:
+			process.env.PROVIDER_OAUTH_MOBILE_SCREENSHOT_PATH ??
+			testInfo.outputPath("provider-oauth-mobile.png"),
+	});
+	await reconnectDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+	await main.getByRole("button", { name: "Add provider", exact: true }).click();
+	const chooserDialog = page.getByRole("dialog", { name: "Add a provider" });
+	await chooserDialog.getByRole("button", { name: /^OpenAI/ }).click();
+	const configureDialog = page.getByRole("dialog");
+	await expect(configureDialog).toHaveAccessibleName("Set up OpenAI");
+	const apiKeyAuth = configureDialog.getByRole("button", { name: /^Sign in with an API key/ });
+	const chatGptAuth = configureDialog.getByRole("button", { name: /^Sign in with ChatGPT/ });
+	await expect(apiKeyAuth).toHaveAttribute("aria-pressed", "true");
+	await expect(chatGptAuth).toHaveAttribute("aria-pressed", "false");
+	const openAiApiKey = configureDialog.getByRole("textbox", { name: "API key", exact: true });
+	await configureDialog.getByRole("button", { name: "Show API key" }).click();
+	await expect(openAiApiKey).toHaveAttribute("type", "text");
+	await chatGptAuth.click();
+	await expect(chatGptAuth).toHaveAttribute("aria-pressed", "true");
+	await expect(apiKeyAuth).toHaveAttribute("aria-pressed", "false");
+	await apiKeyAuth.click();
+	await expect(openAiApiKey).toHaveAttribute("type", "password");
+	await chatGptAuth.click();
+	await configureDialog.getByRole("button", { name: "Continue to ChatGPT", exact: true }).click();
+	await expect.poll(() => providerAcceptRequests.length).toBe(1);
+	expect(JSON.parse(providerAcceptRequests[0] ?? "{}")).toMatchObject({
+		credential: { type: "oauth", provider: "codex", flow: "device_code" },
+		replace: false,
+	});
+
+	const oauthDialog = page.getByRole("dialog", { name: "Sign in with ChatGPT" });
+	await expect(
+		oauthDialog.getByText("This code expired. Start again for a new code.", { exact: true }),
+	).toBeVisible();
+	await oauthDialog.getByRole("button", { name: "Get a new code", exact: true }).click();
+	await expect.poll(() => providerAcceptRequests.length).toBe(2);
+	await expect(oauthDialog.getByText("NEW-CODE", { exact: true })).toBeVisible();
+	await expect(
+		oauthDialog.getByText("Waiting for ChatGPT authorization…", { exact: true }),
+	).toBeVisible();
+	await page.setViewportSize({ width: 1000, height: 800 });
+	await oauthDialog.screenshot({
+		path:
+			process.env.PROVIDER_OAUTH_DESKTOP_SCREENSHOT_PATH ??
+			testInfo.outputPath("provider-oauth-desktop.png"),
+	});
+	await page.keyboard.press("Escape");
+	await expect(oauthDialog).toHaveCount(0);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await main.getByRole("button", { name: "Remove ChatGPT (Codex)", exact: true }).click();
+	const removeDialog = page.getByRole("alertdialog", { name: "Remove ChatGPT (Codex)?" });
+	await expect(removeDialog).not.toContainText("tenant=must-not-render");
+	await expect(
+		removeDialog.getByText(/couldn't check whether any agents use this provider/i),
+	).toBeVisible();
+	const acknowledgement = removeDialog.getByRole("checkbox", {
+		name: /affected agents will lose model access/i,
+	});
+	const removeProvider = removeDialog.getByRole("button", {
+		name: "Remove provider",
+		exact: true,
+	});
+	await expect(removeProvider).toBeDisabled();
+	await acknowledgement.check();
+	await expect(removeProvider).toBeEnabled();
+	await removeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 
 	const documentWidth = await page.evaluate(() => ({
 		clientWidth: document.documentElement.clientWidth,

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -376,6 +376,7 @@ export function EntityChoiceCard({
 	selected,
 	onClick,
 	disabled,
+	variant = "card",
 	className,
 }: {
 	icon: ReactNode;
@@ -390,6 +391,8 @@ export function EntityChoiceCard({
 	selected?: boolean;
 	onClick?: () => void;
 	disabled?: boolean;
+	/** Compact, low-chrome treatment for dense chooser grids. */
+	variant?: "card" | "compact";
 	className?: string;
 }) {
 	const content = (
@@ -407,7 +410,14 @@ export function EntityChoiceCard({
 						{badge ? <span className="shrink-0">{badge}</span> : null}
 					</div>
 					{description ? (
-						<p className="mt-0.5 break-words text-sm text-muted-foreground">{description}</p>
+						<p
+							className={cn(
+								"mt-0.5 text-muted-foreground",
+								variant === "compact" ? "truncate text-xs leading-4" : "break-words text-sm",
+							)}
+						>
+							{description}
+						</p>
 					) : null}
 				</div>
 				{details ? (
@@ -429,12 +439,15 @@ export function EntityChoiceCard({
 		</>
 	);
 	const cardClass = cn(
-		ENTITY_CARD_BASE,
-		"flex w-full items-start gap-3 text-left transition-colors",
+		variant === "compact"
+			? "min-w-0 rounded-md border border-transparent bg-muted/30 p-2.5"
+			: ENTITY_CARD_BASE,
+		"flex w-full text-left transition-colors",
+		variant === "compact" ? "items-center gap-2.5" : "items-start gap-3",
 		onClick && ENTITY_CARD_BUTTON_FOCUS_CLASS,
 		selected
 			? "border-primary bg-primary/5 ring-1 ring-primary/30"
-			: onClick && "hover:bg-muted/50",
+			: onClick && (variant === "compact" ? "hover:bg-muted/60" : "hover:bg-muted/50"),
 		disabled && "pointer-events-none opacity-60",
 		className,
 	);

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -397,7 +397,9 @@ export function EntityChoiceCard({
 }) {
 	const content = (
 		<>
-			{icon}
+			<span aria-hidden="true" className="flex shrink-0">
+				{icon}
+			</span>
 			<div
 				className={cn(
 					"min-w-0 flex-1",

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -16,8 +16,8 @@ import { cn } from "@/lib/utils";
  *   - channel   → full-color app-icon PNG on Clawdi's CDN
  *   - framework → local app-icon PNG in /public/agents
  *   - provider  → colored brand logo from simpleicons (the CDN has no
- *                 provider PNGs) on a white tile so the brand color reads in
- *                 both themes; ids without a configured mark → monogram
+ *                 provider PNGs) in the same neutral tile used by monogram
+ *                 fallbacks; ids without a configured mark → monogram
  *   - anything unresolved → neutral monogram tile
  *
  * Uses plain image rendering — these are tiny/vector brand assets that don't
@@ -37,8 +37,8 @@ const CHANNEL_PNG: Record<string, string> = {
 
 /**
  * AI providers: no CDN PNG (those 404) → colored simpleicons brand logo. The
- * hex is pinned to a vivid, mid-tone brand color so it reads on a white tile
- * in both themes. `null` → neutral monogram (OpenAI isn't in simpleicons;
+ * hex is pinned to a vivid, mid-tone brand color so it reads in both themes.
+ * `null` → neutral monogram (OpenAI isn't in simpleicons;
  * custom endpoints have no brand).
  */
 const PROVIDER_SIMPLEICON: Record<string, { slug: string; hex: string } | null> = {
@@ -61,6 +61,7 @@ export type EntityIconSize = keyof typeof SIZE;
 export type EntityKind = "channel" | "provider" | "framework";
 
 const SHADOW = "shadow-[0_2px_6px_rgba(0,0,0,0.1)] dark:shadow-none";
+const PROVIDER_TILE = "border border-border/60 bg-muted/40 shadow-none";
 
 function NeutralMonogram({
 	label,
@@ -100,17 +101,14 @@ function ProviderBrandIcon({
 	className?: string;
 }) {
 	const [failed, setFailed] = useState(false);
-	if (failed) return <NeutralMonogram label={label} size={size} className={className} />;
+	if (failed) {
+		return <NeutralMonogram label={label} size={size} className={cn(PROVIDER_TILE, className)} />;
+	}
 
 	const s = SIZE[size];
 	return (
 		<span
-			className={cn(
-				s.box,
-				"flex shrink-0 items-center justify-center border border-border bg-white",
-				SHADOW,
-				className,
-			)}
+			className={cn(s.box, "flex shrink-0 items-center justify-center", PROVIDER_TILE, className)}
 		>
 			<img
 				src={src}
@@ -185,8 +183,9 @@ export function EntityIcon({
 				/>
 			);
 		}
+		return <NeutralMonogram label={alt} size={size} className={cn(PROVIDER_TILE, className)} />;
 	}
 
-	// Neutral fallback: a monogram tile (OpenAI, custom endpoints, unknown ids).
+	// Neutral fallback for unresolved channels/frameworks.
 	return <NeutralMonogram label={alt} size={size} className={className} />;
 }

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { codexProviderBody } from "@/hosted/v2/ai-providers/codex-oauth";
 import { type ProviderChoice, ProviderChooser } from "@/hosted/v2/ai-providers/provider-chooser";
+import { providerConnectionIssueMessage } from "@/hosted/v2/ai-providers/provider-connection-feedback";
 import { ProviderFieldsForm } from "@/hosted/v2/ai-providers/provider-fields-form";
 import { ProviderOAuthFlow } from "@/hosted/v2/ai-providers/provider-oauth-flow";
 import {
@@ -447,7 +448,7 @@ export function AddProviderDialog({
 				data-v2="true"
 				className="flex max-h-[min(92vh,calc(100dvh-1rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
 			>
-				<DialogHeader className="shrink-0 px-5 pt-5 sm:px-6 sm:pt-6">
+				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
 					<DialogTitle>
 						{oauth
 							? "Sign in with ChatGPT"
@@ -477,7 +478,10 @@ export function AddProviderDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="min-h-0 flex-1 overflow-y-auto px-5 py-4 sm:px-6">
+				<div
+					data-testid="provider-dialog-body"
+					className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4 sm:px-6"
+				>
 					{oauth ? (
 						<ProviderOAuthFlow
 							issue={oauthIssue}
@@ -533,66 +537,64 @@ export function AddProviderDialog({
 								>
 									{draftTestResult.ok
 										? "Connection verified. The provider accepted the test request."
-										: (draftTestResult.error?.message ?? "Connection test failed.")}
+										: providerConnectionIssueMessage(draftTestResult.error)}
 								</div>
 							) : null}
 						</div>
 					)}
 				</div>
 
-				<DialogFooter className="shrink-0 border-t bg-background px-5 py-3 sm:px-6 sm:py-4">
-					{oauth ? (
-						<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
-							Cancel
-						</Button>
-					) : step === "choose" && !isEdit ? (
-						<Button variant="outline" onClick={() => requestClose(false)}>
-							Cancel
-						</Button>
-					) : isOAuthEdit ? (
-						<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
-							Close
-						</Button>
-					) : (
-						<>
-							<Button
-								variant="outline"
-								onClick={() => {
-									if (isEdit) requestClose(false);
-									else setStep("choose");
-								}}
-								disabled={busy}
-							>
-								{isEdit ? null : <ArrowLeft />}
-								{isEdit ? "Cancel" : "Back"}
+				{step === "choose" && !isEdit && !oauth ? null : (
+					<DialogFooter className="shrink-0 border-t bg-popover px-5 py-3 sm:px-6 sm:py-4">
+						{oauth ? (
+							<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
+								Cancel
 							</Button>
-							{form.authMethod === "api_key" ? (
+						) : isOAuthEdit ? (
+							<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
+								Close
+							</Button>
+						) : (
+							<>
 								<Button
 									variant="outline"
-									onClick={() => void runAction(testDraftConnection)}
-									disabled={!form.apiKey.trim() || busy}
+									onClick={() => {
+										if (isEdit) requestClose(false);
+										else setStep("choose");
+									}}
+									disabled={busy}
 								>
-									{testDraft.isPending ? <Spinner data-icon="inline-start" /> : null}
-									Test connection
+									{isEdit ? null : <ArrowLeft />}
+									{isEdit ? "Cancel" : "Back"}
 								</Button>
-							) : null}
-							<Button onClick={() => void runAction(submit)} disabled={!canSubmit || busy}>
-								{busy ? <Spinner data-icon="inline-start" /> : null}
-								{form.authMethod === "oauth" && !isEdit
-									? busy
-										? "Opening sign-in…"
-										: "Continue to ChatGPT"
-									: isEdit
+								{form.authMethod === "api_key" ? (
+									<Button
+										variant="outline"
+										onClick={() => void runAction(testDraftConnection)}
+										disabled={!form.apiKey.trim() || busy}
+									>
+										{testDraft.isPending ? <Spinner data-icon="inline-start" /> : null}
+										Test connection
+									</Button>
+								) : null}
+								<Button onClick={() => void runAction(submit)} disabled={!canSubmit || busy}>
+									{busy ? <Spinner data-icon="inline-start" /> : null}
+									{form.authMethod === "oauth" && !isEdit
 										? busy
-											? "Saving settings…"
-											: "Save settings"
-										: busy
-											? "Adding provider…"
-											: "Add provider"}
-							</Button>
-						</>
-					)}
-				</DialogFooter>
+											? "Opening sign-in…"
+											: "Continue to ChatGPT"
+										: isEdit
+											? busy
+												? "Saving settings…"
+												: "Save settings"
+											: busy
+												? "Adding provider…"
+												: "Add provider"}
+								</Button>
+							</>
+						)}
+					</DialogFooter>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -233,23 +233,23 @@ function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>Remove {providerLabel}?</AlertDialogTitle>
-					<AlertDialogDescription render={<div className="space-y-3" />}>
+					<AlertDialogDescription render={<div className="space-y-2" />}>
 						<p>This provider will be removed from your account and cannot be restored.</p>
 						<p>{impact.warning}</p>
-						{impact.acknowledgementRequired ? (
-							<div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
-								<Checkbox
-									id={acknowledgementId}
-									checked={acknowledged}
-									onCheckedChange={(checked) => setAcknowledged(checked === true)}
-								/>
-								<Label htmlFor={acknowledgementId} className="text-sm font-normal leading-snug">
-									I understand that affected agents will lose model access until reconfigured.
-								</Label>
-							</div>
-						) : null}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
+				{impact.acknowledgementRequired ? (
+					<div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
+						<Checkbox
+							id={acknowledgementId}
+							checked={acknowledged}
+							onCheckedChange={(checked) => setAcknowledged(checked === true)}
+						/>
+						<Label htmlFor={acknowledgementId} className="text-sm font-normal leading-snug">
+							I understand that affected agents will lose model access until reconfigured.
+						</Label>
+					</div>
+				) : null}
 				<AlertDialogFooter>
 					<AlertDialogCancel disabled={del.isPending}>Cancel</AlertDialogCancel>
 					<AlertDialogAction

--- a/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
 import { useMemo, useState } from "react";
 import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
@@ -23,16 +22,6 @@ interface ChoiceEntry {
 }
 
 const FIRST_CLASS_TYPES: readonly ProviderTypeId[] = ["openai", "anthropic", "gemini"];
-const INITIAL_PROVIDER_IDS = new Set([
-	"type:openai",
-	"type:anthropic",
-	"preset:openrouter",
-	"type:gemini",
-	"preset:deepseek",
-	"preset:moonshot",
-	"type:custom_openai_compatible",
-]);
-
 function typeDescription(type: ProviderTypeId): string {
 	if (type === "openai") return "API key or ChatGPT sign-in";
 	if (type === "anthropic") return "Claude model access";
@@ -53,12 +42,21 @@ function typeEntry(type: ProviderTypeId): ChoiceEntry {
 }
 
 function presetEntry(preset: ProviderPreset): ChoiceEntry {
+	const description = providerPresetSummary(preset);
 	return {
 		id: `preset:${preset.id}`,
 		label: preset.label,
-		description: providerPresetSummary(preset),
+		description,
 		iconId: preset.id,
-		searchText: `${preset.label} ${preset.id} ${preset.api_mode}`.toLowerCase(),
+		searchText: [
+			preset.label,
+			preset.id,
+			preset.api_mode,
+			description,
+			...preset.catalog.flatMap((model) => [model.id, model.alias ?? ""]),
+		]
+			.join(" ")
+			.toLowerCase(),
 		choice: { kind: "preset", preset },
 	};
 }
@@ -77,7 +75,7 @@ function ChoiceGrid({
 	onSelect: (choice: ProviderChoice) => void;
 }) {
 	return (
-		<div className="grid gap-2 sm:grid-cols-2">
+		<div data-testid="provider-choice-grid" className="grid gap-1.5 sm:grid-cols-2">
 			{entries.map((entry) => (
 				<EntityChoiceCard
 					key={entry.id}
@@ -85,6 +83,7 @@ function ChoiceGrid({
 					icon={<EntityIcon kind="provider" id={entry.iconId} label={entry.label} size="sm" />}
 					title={entry.label}
 					description={entry.description}
+					variant="compact"
 				/>
 			))}
 		</div>
@@ -101,11 +100,8 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 				: [],
 		[normalizedQuery],
 	);
-	const initialProviders = ALL_ENTRIES.filter((entry) => INITIAL_PROVIDER_IDS.has(entry.id));
-	const moreProviders = ALL_ENTRIES.filter((entry) => !INITIAL_PROVIDER_IDS.has(entry.id));
-
 	return (
-		<div data-hosted="true" data-v2="true" className="flex flex-col gap-4">
+		<div data-hosted="true" data-v2="true" className="flex flex-col gap-3">
 			<SearchInput
 				name="provider-search"
 				ariaLabel="Search providers"
@@ -122,40 +118,29 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 					{searchResults.length > 0 ? (
 						<ChoiceGrid entries={searchResults} onSelect={onSelect} />
 					) : (
-						<EntityChoiceCard
-							onClick={() => onSelect({ kind: "type", type: "custom_openai_compatible" })}
-							icon={
-								<EntityIcon
-									kind="provider"
-									id="custom_openai_compatible"
-									label="Custom endpoint"
-									size="sm"
-								/>
-							}
-							title="Use a custom endpoint"
-							description={`No matches for “${query.trim()}”. Configure it manually.`}
-						/>
+						<div data-testid="provider-choice-grid" className="grid gap-1.5 sm:grid-cols-2">
+							<EntityChoiceCard
+								onClick={() => onSelect({ kind: "type", type: "custom_openai_compatible" })}
+								icon={
+									<EntityIcon
+										kind="provider"
+										id="custom_openai_compatible"
+										label="Custom endpoint"
+										size="sm"
+									/>
+								}
+								title="Use a custom endpoint"
+								description={`No matches for “${query.trim()}”. Configure it manually.`}
+								variant="compact"
+							/>
+						</div>
 					)}
 				</div>
 			) : (
-				<>
-					<div className="flex flex-col gap-2">
-						<p className="text-xs font-medium text-muted-foreground">Providers</p>
-						<ChoiceGrid entries={initialProviders} onSelect={onSelect} />
-					</div>
-					<details className="group rounded-lg border bg-muted/20">
-						<summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium marker:hidden">
-							More providers
-							<ChevronDown
-								className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
-								aria-hidden
-							/>
-						</summary>
-						<div className="border-t px-3 py-3">
-							<ChoiceGrid entries={moreProviders} onSelect={onSelect} />
-						</div>
-					</details>
-				</>
+				<div className="flex flex-col gap-2">
+					<p className="text-xs font-medium text-muted-foreground">Providers</p>
+					<ChoiceGrid entries={ALL_ENTRIES} onSelect={onSelect} />
+				</div>
 			)}
 		</div>
 	);

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-feedback.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-feedback.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+	providerConnectionIssueMessage,
+	providerConnectionIssueTitle,
+} from "@/hosted/v2/ai-providers/provider-connection-feedback";
+
+describe("provider connection feedback", () => {
+	test("turns typed failure categories into actionable copy", () => {
+		const error = {
+			category: "authentication" as const,
+			code: "invalid_api_key",
+			message: "upstream tenant=internal api_key=must-not-render",
+			retryable: false,
+		};
+
+		expect(providerConnectionIssueTitle(error)).toBe("Authentication");
+		expect(providerConnectionIssueMessage(error)).toBe(
+			"The provider rejected the API key. Check it and try again.",
+		);
+		expect(providerConnectionIssueMessage(error)).not.toContain(error.message);
+	});
+
+	test("keeps an internal-free fallback when no structured error is present", () => {
+		expect(providerConnectionIssueTitle(null)).toBe("Connection");
+		expect(providerConnectionIssueMessage(null)).toBe(
+			"The provider did not accept the test request.",
+		);
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-feedback.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-feedback.ts
@@ -1,0 +1,47 @@
+import type { AiProviderConnectionTestResponse } from "@/hosted/v2/ai-providers/types";
+
+type ConnectionError = NonNullable<AiProviderConnectionTestResponse["error"]>;
+
+const CATEGORY_LABEL: Record<ConnectionError["category"], string> = {
+	validation: "Provider setup",
+	credential: "Credential",
+	ssrf: "Endpoint safety",
+	dns: "DNS",
+	timeout: "Timeout",
+	tls: "TLS",
+	network: "Network",
+	authentication: "Authentication",
+	authorization: "Authorization",
+	rate_limit: "Rate limit",
+	redirect: "Redirect",
+	endpoint: "Endpoint",
+	protocol_model: "Protocol or model",
+	upstream: "Provider",
+};
+
+const CATEGORY_GUIDANCE: Record<ConnectionError["category"], string> = {
+	validation: "Review the required provider settings and try again.",
+	credential: "Check the API key and try again.",
+	ssrf: "This endpoint isn't allowed. Review the Base URL and try again.",
+	dns: "The endpoint hostname couldn't be resolved. Check the Base URL and try again.",
+	timeout: "The endpoint took too long to respond. Try again in a moment.",
+	tls: "The endpoint's secure connection couldn't be verified. Check the Base URL.",
+	network: "The provider couldn't be reached. Check the Base URL and try again.",
+	authentication: "The provider rejected the API key. Check it and try again.",
+	authorization: "This API key doesn't have access to the configured model.",
+	rate_limit: "The provider is rate limiting requests. Try again in a moment.",
+	redirect: "The endpoint redirected unexpectedly. Check the Base URL.",
+	endpoint: "The provider endpoint didn't accept the request. Check the Base URL.",
+	protocol_model: "Check the API mode and first configured model, then try again.",
+	upstream: "The provider returned an error. Try again in a moment.",
+};
+
+export function providerConnectionIssueTitle(error: ConnectionError | null | undefined): string {
+	return error ? CATEGORY_LABEL[error.category] : "Connection";
+}
+
+export function providerConnectionIssueMessage(error: ConnectionError | null | undefined): string {
+	return error
+		? CATEGORY_GUIDANCE[error.category]
+		: "The provider did not accept the test request.";
+}

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
@@ -10,30 +10,15 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	DialogTrigger,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { useTestProviderConnection } from "@/hosted/v2/ai-providers/ai-providers-hooks";
-import type { AiProvider, AiProviderConnectionTestResponse } from "@/hosted/v2/ai-providers/types";
-
-const CATEGORY_LABEL: Record<
-	NonNullable<AiProviderConnectionTestResponse["error"]>["category"],
-	string
-> = {
-	validation: "Provider setup",
-	credential: "Credential",
-	ssrf: "Endpoint safety",
-	dns: "DNS",
-	timeout: "Timeout",
-	tls: "TLS",
-	network: "Network",
-	authentication: "Authentication",
-	authorization: "Authorization",
-	rate_limit: "Rate limit",
-	redirect: "Redirect",
-	endpoint: "Endpoint",
-	protocol_model: "Protocol or model",
-	upstream: "Provider",
-};
+import {
+	providerConnectionIssueMessage,
+	providerConnectionIssueTitle,
+} from "@/hosted/v2/ai-providers/provider-connection-feedback";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 export function ProviderConnectionTest({
 	provider,
@@ -63,15 +48,14 @@ export function ProviderConnectionTest({
 	const result = testConnection.data;
 	return (
 		<Dialog open={open} onOpenChange={changeOpen}>
-			<Button
-				variant="ghost"
-				size="sm"
-				onClick={() => changeOpen(true)}
-				aria-label={`Test connection for ${providerLabel}`}
+			<DialogTrigger
+				render={
+					<Button variant="ghost" size="sm" aria-label={`Test connection for ${providerLabel}`} />
+				}
 			>
 				<FlaskConical />
 				Test connection
-			</Button>
+			</DialogTrigger>
 			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
 				<DialogHeader>
 					<DialogTitle>Test connection</DialogTitle>
@@ -112,11 +96,10 @@ export function ProviderConnectionTest({
 							<CircleAlert className="mt-0.5 size-5 shrink-0 text-warning-muted-foreground" />
 							<div>
 								<p className="text-sm font-medium">
-									{result.error ? CATEGORY_LABEL[result.error.category] : "Connection"} needs
-									attention
+									{providerConnectionIssueTitle(result.error)} needs attention
 								</p>
 								<p className="mt-1 text-xs text-muted-foreground">
-									{result.error?.message ?? "The provider did not accept the test request."}
+									{providerConnectionIssueMessage(result.error)}
 								</p>
 							</div>
 						</div>

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import { ChevronDown, ExternalLink, KeyRound, RefreshCw, UserRound } from "lucide-react";
-import { useCallback } from "react";
+import {
+	ChevronDown,
+	ExternalLink,
+	Eye,
+	EyeOff,
+	KeyRound,
+	RefreshCw,
+	UserRound,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { EntityChoiceCard } from "@/components/entity-card";
+import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+} from "@/components/ui/input-group";
 import { Label } from "@/components/ui/label";
 import {
 	Select,
@@ -68,6 +83,7 @@ export function ProviderFieldsForm({
 	const isEdit = editing !== null;
 	const isOAuthEdit =
 		editing?.auth.type === "agent_profile" || editing?.auth.type === "oauth_profile";
+	const savedCredentialAvailable = editing !== null && editing.auth.type !== "none";
 	const apiModes = meta.apiModes;
 	const regions = preset?.region_variants ?? [];
 	const isCustomEndpoint = meta.custom === true && preset === null;
@@ -75,6 +91,10 @@ export function ProviderFieldsForm({
 	const showAdvancedName = preset !== null || (!showPrimaryName && isEdit);
 	const showRuntimeEnv = !isOAuthEdit && form.authMethod === "api_key";
 	const defaultAdvancedOpen = isCustomEndpoint;
+	const [apiKeyVisible, setApiKeyVisible] = useState(false);
+	useEffect(() => {
+		setApiKeyVisible(false);
+	}, [form.authMethod]);
 	// React has no defaultOpen prop for native details. Initialize once through a
 	// stable ref so later renders leave the user's disclosure state untouched.
 	const initializeAdvancedDetails = useCallback(
@@ -110,7 +130,7 @@ export function ProviderFieldsForm({
 							if (value) onRegionChange(value);
 						}}
 					>
-						<SelectTrigger id="provider-region">
+						<SelectTrigger id="provider-region" className="w-full">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
@@ -131,16 +151,26 @@ export function ProviderFieldsForm({
 						<EntityChoiceCard
 							selected={form.authMethod === "api_key"}
 							onClick={() => onAuthMethodChange("api_key")}
-							icon={<KeyRound className="size-4" />}
+							icon={
+								<IconChip size="sm" className="size-6">
+									<KeyRound />
+								</IconChip>
+							}
 							title="Sign in with an API key"
 							description="For usage-based access"
+							variant="compact"
 						/>
 						<EntityChoiceCard
 							selected={form.authMethod === "oauth"}
 							onClick={() => onAuthMethodChange("oauth")}
-							icon={<UserRound className="size-4" />}
+							icon={
+								<IconChip size="sm" className="size-6">
+									<UserRound />
+								</IconChip>
+							}
 							title="Sign in with ChatGPT"
 							description="For subscription access"
+							variant="compact"
 						/>
 					</div>
 				</fieldset>
@@ -163,18 +193,35 @@ export function ProviderFieldsForm({
 			) : form.authMethod === "api_key" ? (
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="provider-key">API key</Label>
-					<div>
-						<Input
+					<InputGroup>
+						<InputGroupInput
 							id="provider-key"
-							type="password"
+							type={apiKeyVisible ? "text" : "password"}
 							value={form.apiKey}
 							onChange={(event) => onUpdate({ apiKey: event.target.value })}
-							placeholder="Enter API key"
+							placeholder={
+								isEdit && savedCredentialAvailable
+									? "Leave blank to keep current key"
+									: "Enter API key"
+							}
 							autoComplete="off"
+							autoCapitalize="none"
+							autoCorrect="off"
 							spellCheck={false}
+							aria-describedby="provider-key-help"
 						/>
-					</div>
-					<p className="text-xs text-muted-foreground">
+						<InputGroupAddon align="inline-end">
+							<InputGroupButton
+								size="icon-xs"
+								onClick={() => setApiKeyVisible((visible) => !visible)}
+								aria-label={apiKeyVisible ? "Hide API key" : "Show API key"}
+								aria-pressed={apiKeyVisible}
+							>
+								{apiKeyVisible ? <EyeOff /> : <Eye />}
+							</InputGroupButton>
+						</InputGroupAddon>
+					</InputGroup>
+					<p id="provider-key-help" className="text-xs text-muted-foreground">
 						{isEdit
 							? editing?.auth.type === "none"
 								? "Enter an API key to finish setup."
@@ -255,7 +302,7 @@ export function ProviderFieldsForm({
 										if (isApiMode(value)) onUpdate({ apiMode: value });
 									}}
 								>
-									<SelectTrigger id="provider-mode">
+									<SelectTrigger id="provider-mode" className="w-full">
 										<SelectValue />
 									</SelectTrigger>
 									<SelectContent>

--- a/apps/web/src/hosted/v2/ai-providers/provider-oauth-flow.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-oauth-flow.tsx
@@ -3,7 +3,7 @@
 import { Check, CircleAlert, Copy, ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 
 export type OAuthIssue = "expired" | "failed";
@@ -56,13 +56,14 @@ export function ProviderOAuthFlow({
 				</div>
 			</div>
 
-			<Button
-				render={<a href={verificationUrl} target="_blank" rel="noreferrer" />}
-				nativeButton={false}
-				className="w-full"
+			<a
+				href={verificationUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				className={buttonVariants({ className: "w-full" })}
 			>
 				Open ChatGPT and enter code <ExternalLink />
-			</Button>
+			</a>
 
 			<div aria-live="polite">
 				{issue === "expired" ? (


### PR DESCRIPTION
## Summary
- replace the nested provider chooser with a compact, flat responsive grid
- align API-key, OAuth, connection-test, and removal dialogs with existing Base UI/shadcn primitives
- improve secret handling feedback, accessible names, and safe connection-test errors
- add mocked light/dark desktop and mobile browser coverage

## Scope
- Core Web only
- no backend, runtime, Hosted, v1, installer, version, or protocol changes

## Verification
- 84 focused provider tests
- 4 Playwright provider-flow scenarios across light/dark desktop/mobile
- Web typecheck
- Biome
- OSS production build
- git diff --check
- independent final review: GO