### PR TITLE
fix(channels): transparently proxy Discord messages

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -6,6 +6,9 @@ import logging
 import secrets
 import zlib
 from dataclasses import dataclass
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
 from typing import Any
 from urllib.parse import quote
 from uuid import UUID
@@ -47,7 +50,6 @@ from app.routes.channel_routers.shared import (
     _discord_gateway_dispatch,
     _discord_guild_owner_principals,
     _discord_interaction_content,
-    _discord_message_result,
     _DiscordProviderResult,
     _fan_out_discord_global_commands,
     _handle_discord_application_commands,
@@ -80,12 +82,12 @@ from app.services.channels import (
     get_active_channel_account,
     get_channel_agent_reference,
     record_discord_interaction_references,
+    record_discord_outbound_message,
     record_inactive_bot_agent_link_event,
     record_inbound_messages_for_bindings,
     resolve_channel_agent_by_identity,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
-    send_channel_outbound_message,
     send_pairing_command_reply,
     upsert_binding_alias,
     verify_discord_signature,
@@ -106,6 +108,26 @@ class _DiscordGatewayCapability:
     account_id: UUID
     link_id: UUID
     agent_token_hash: str
+
+
+@dataclass(frozen=True)
+class _DiscordChannelAuthorization:
+    binding: ChannelBinding
+    preflight: _DiscordProviderResult | None = None
+
+
+@dataclass(frozen=True)
+class _DiscordMessageReferenceIdentity:
+    guild_id: str | None
+    channel_id: str | None
+
+
+class _DiscordCreateMessageParseError(ValueError):
+    pass
+
+
+class _DiscordJsonObject(list[tuple[str, Any]]):
+    pass
 
 
 def _discord_gateway_capability(agent: ChannelAgentContext) -> str:
@@ -180,6 +202,8 @@ async def discord_agent_rest(
 ) -> Any:
     agent = await _resolve_discord_agent_context(db, authorization)
     account = agent.account
+    account_id = account.id
+    link_id = agent.link.id
     segments = [segment for segment in discord_path.strip("/").split("/") if segment]
     if segments in (["gateway"], ["gateway", "bot"]):
         return {
@@ -250,8 +274,20 @@ async def discord_agent_rest(
         and request.method == "POST"
     ):
         channel_id = segments[1]
+        raw_body = await request.body()
+        content_types = request.headers.getlist("content-type")
+        if len(content_types) > 1:
+            return _discord_rest_error("Invalid Form Body", 50035, 400)
+        content_type = content_types[0] if content_types else "application/json"
         try:
-            await _authorize_discord_channel_request(
+            reference = _discord_create_message_reference(
+                raw_body,
+                content_type=content_type,
+            )
+        except _DiscordCreateMessageParseError:
+            return _discord_rest_error("Invalid Form Body", 50035, 400)
+        try:
+            channel_authorization = await _authorize_discord_channel_request(
                 db,
                 agent=agent,
                 channel_id=channel_id,
@@ -262,21 +298,73 @@ async def discord_agent_rest(
             if exc.status_code == status.HTTP_403_FORBIDDEN:
                 return _discord_rest_error("Missing Access", 50001, 403)
             raise
-        params = await _request_params(request)
-        text = _optional_str(params.get("content")) or ""
-        message = await send_channel_outbound_message(
+        if not await _discord_message_reference_is_authorized(
             db,
+            agent=agent,
+            binding=channel_authorization.binding,
+            reference=reference,
+            request=request,
+        ):
+            return _discord_rest_error("Unknown Message", 10008, 404)
+        provider_result = await _request_discord_provider(
             account=account,
-            external_chat_id=channel_id,
-            text=text,
-            bot_agent_link_id=agent.link.id,
+            method=request.method,
+            path=discord_path,
+            body=raw_body,
+            content_type=content_type,
+            query_params=request.query_params,
+            request_headers=request.headers,
         )
-        await db.commit()
-        return _discord_message_result(message, channel_id=channel_id, content=text)
+        if 200 <= provider_result.status_code < 300:
+            provider_payload = provider_result.json_object()
+            if provider_payload is None:
+                log.warning(
+                    "discord_outbound_record_skipped_invalid_response account_id=%s "
+                    "link_id=%s channel_id=%s",
+                    account_id,
+                    link_id,
+                    channel_id,
+                )
+            else:
+                try:
+                    await record_discord_outbound_message(
+                        db,
+                        account=account,
+                        binding=channel_authorization.binding,
+                        external_chat_id=channel_id,
+                        provider_response=provider_payload,
+                    )
+                    await db.commit()
+                except ValueError:
+                    log.warning(
+                        "discord_outbound_record_skipped_invalid_metadata account_id=%s "
+                        "link_id=%s channel_id=%s",
+                        account_id,
+                        link_id,
+                        channel_id,
+                    )
+                except Exception:
+                    log.exception(
+                        "discord_outbound_record_failed account_id=%s link_id=%s channel_id=%s",
+                        account_id,
+                        link_id,
+                        channel_id,
+                    )
+                    try:
+                        await db.rollback()
+                    except Exception:
+                        log.exception(
+                            "discord_outbound_record_rollback_failed account_id=%s "
+                            "link_id=%s channel_id=%s",
+                            account_id,
+                            link_id,
+                            channel_id,
+                        )
+        return provider_result.as_response()
     if segments and segments[0] == "channels" and len(segments) >= 2:
         original_is_channel_get = len(segments) == 2 and request.method == "GET"
         try:
-            preflight = await _authorize_discord_channel_request(
+            channel_authorization = await _authorize_discord_channel_request(
                 db,
                 agent=agent,
                 channel_id=segments[1],
@@ -287,8 +375,8 @@ async def discord_agent_rest(
             if exc.status_code == status.HTTP_403_FORBIDDEN:
                 return _discord_rest_error("Missing Access", 50001, 403)
             raise
-        if original_is_channel_get and preflight is not None:
-            return preflight.as_response()
+        if original_is_channel_get and channel_authorization.preflight is not None:
+            return channel_authorization.preflight.as_response()
         return await _proxy_discord_request(account=account, request=request, path=discord_path)
     if segments and segments[0] == "guilds" and len(segments) >= 2:
         if not await _discord_guild_is_bound(
@@ -309,7 +397,7 @@ async def _authorize_discord_channel_request(
     channel_id: str,
     request: Request,
     original_is_channel_get: bool,
-) -> _DiscordProviderResult | None:
+) -> _DiscordChannelAuthorization:
     """Resolve a physical Discord channel without making it a Binding.
 
     Known channel aliases stay local. For an unobserved ID, Discord's own
@@ -318,13 +406,13 @@ async def _authorize_discord_channel_request(
     A Channel without ``guild_id`` can only use a direct DM Binding.
     """
     try:
-        await _require_bound_chat(
+        binding = await _require_bound_chat(
             db,
             account=agent.account,
             external_chat_id=channel_id,
             bot_agent_link_id=agent.link.id,
         )
-        return None
+        return _DiscordChannelAuthorization(binding=binding)
     except HTTPException as exc:
         if exc.status_code != status.HTTP_403_FORBIDDEN:
             raise
@@ -357,7 +445,165 @@ async def _authorize_discord_channel_request(
             require_same_binding=True,
         )
         await db.commit()
-    return preflight
+    return _DiscordChannelAuthorization(binding=binding, preflight=preflight)
+
+
+def _discord_create_message_reference(
+    body: bytes,
+    *,
+    content_type: str,
+) -> _DiscordMessageReferenceIdentity | None:
+    """Extract only Create Message identities while preserving ``body`` unchanged."""
+    media_type = _discord_media_type(content_type)
+    if media_type == "application/json":
+        payload = _discord_json_object(body)
+    elif media_type == "multipart/form-data":
+        payload = _discord_multipart_payload_json(body, content_type=content_type)
+    else:
+        raise _DiscordCreateMessageParseError
+    reference = _discord_unique_json_member(payload, "message_reference")
+    if reference is None:
+        return None
+    if not isinstance(reference, _DiscordJsonObject):
+        raise _DiscordCreateMessageParseError
+    return _DiscordMessageReferenceIdentity(
+        guild_id=_discord_reference_identity(reference, "guild_id"),
+        channel_id=_discord_reference_identity(reference, "channel_id"),
+    )
+
+
+def _discord_media_type(content_type: str) -> str:
+    if "\r" in content_type or "\n" in content_type:
+        raise _DiscordCreateMessageParseError
+    message = Message()
+    message["content-type"] = content_type
+    return message.get_content_type().lower()
+
+
+def _discord_json_object(body: bytes) -> _DiscordJsonObject:
+    def reject_nonstandard_constant(_value: str) -> None:
+        raise ValueError
+
+    try:
+        payload = json.loads(
+            body.decode("utf-8"),
+            object_pairs_hook=_DiscordJsonObject,
+            parse_constant=reject_nonstandard_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise _DiscordCreateMessageParseError from exc
+    if not isinstance(payload, _DiscordJsonObject):
+        raise _DiscordCreateMessageParseError
+    return payload
+
+
+def _discord_unique_json_member(payload: _DiscordJsonObject, name: str) -> Any:
+    values = [value for key, value in payload if key == name]
+    if len(values) > 1:
+        raise _DiscordCreateMessageParseError
+    return values[0] if values else None
+
+
+def _discord_reference_identity(reference: _DiscordJsonObject, name: str) -> str | None:
+    value = _discord_unique_json_member(reference, name)
+    if value is None:
+        return None
+    identity = _optional_str(value) if not isinstance(value, bool) else None
+    if identity is None:
+        raise _DiscordCreateMessageParseError
+    return identity
+
+
+def _discord_multipart_payload_json(
+    body: bytes,
+    *,
+    content_type: str,
+) -> _DiscordJsonObject:
+    content_type_message = Message()
+    content_type_message["content-type"] = content_type
+    content_type_params = (
+        content_type_message.get_params(
+            header="content-type",
+            unquote=True,
+        )
+        or []
+    )
+    boundary_params = [
+        value for name, value in content_type_params[1:] if name.lower() == "boundary"
+    ]
+    if len(boundary_params) != 1 or not boundary_params[0]:
+        raise _DiscordCreateMessageParseError
+    try:
+        message = BytesParser(policy=policy.default).parsebytes(
+            b"Content-Type: "
+            + content_type.encode("ascii")
+            + b"\r\nMIME-Version: 1.0\r\n\r\n"
+            + body
+        )
+    except (UnicodeEncodeError, ValueError) as exc:
+        raise _DiscordCreateMessageParseError from exc
+    if not message.is_multipart() or any(part.defects for part in message.walk()):
+        raise _DiscordCreateMessageParseError
+
+    payload_parts: list[Message] = []
+    for part in message.iter_parts():
+        dispositions = part.get_all("content-disposition", [])
+        if len(dispositions) != 1 or part.get_content_disposition() != "form-data":
+            raise _DiscordCreateMessageParseError
+        disposition_params = (
+            part.get_params(
+                header="content-disposition",
+                unquote=True,
+            )
+            or []
+        )
+        names = [value for name, value in disposition_params[1:] if name.lower() == "name"]
+        if len(names) != 1 or not names[0]:
+            raise _DiscordCreateMessageParseError
+        if names[0] == "payload_json":
+            payload_parts.append(part)
+    if len(payload_parts) > 1:
+        raise _DiscordCreateMessageParseError
+    if not payload_parts:
+        return _DiscordJsonObject()
+    payload_part = payload_parts[0]
+    if payload_part.is_multipart() or payload_part.get("content-transfer-encoding") is not None:
+        raise _DiscordCreateMessageParseError
+    payload_body = payload_part.get_payload(decode=True)
+    if not isinstance(payload_body, bytes):
+        raise _DiscordCreateMessageParseError
+    return _discord_json_object(payload_body)
+
+
+async def _discord_message_reference_is_authorized(
+    db: AsyncSession,
+    *,
+    agent: ChannelAgentContext,
+    binding: ChannelBinding,
+    reference: _DiscordMessageReferenceIdentity | None,
+    request: Request,
+) -> bool:
+    if reference is None:
+        return True
+    binding_guild_id = _discord_binding_guild_id(binding)
+    if reference.guild_id is not None and reference.guild_id != binding_guild_id:
+        return False
+    if reference.channel_id is not None:
+        try:
+            reference_authorization = await _authorize_discord_channel_request(
+                db,
+                agent=agent,
+                channel_id=reference.channel_id,
+                request=request,
+                original_is_channel_get=False,
+            )
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_403_FORBIDDEN:
+                return False
+            raise
+        if reference_authorization.binding.id != binding.id:
+            return False
+    return True
 
 
 async def _discord_revalidated_channel_binding(
@@ -570,13 +816,12 @@ async def discord_agent_gateway(
                 )
             if op == 6:
                 resume_session_id = _optional_str(data.get("session_id"))
-                resume_state = (
-                    _DISCORD_GATEWAY_SESSIONS.get(resume_session_id)
-                    if resume_session_id is not None
-                    else None
-                )
+                if resume_session_id is None:
+                    await send_gateway_frame({"op": 9, "d": False}, record=False)
+                    continue
+                resume_state = _DISCORD_GATEWAY_SESSIONS.get(resume_session_id)
                 if resume_state is None:
-                    if resume_session_id is None or _DISCORD_GATEWAY_SESSIONS:
+                    if _DISCORD_GATEWAY_SESSIONS:
                         await send_gateway_frame({"op": 9, "d": False}, record=False)
                         continue
                     resume_state = {
@@ -798,7 +1043,7 @@ async def discord_webhook(
     message = messages[0][0]
     reply_text = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
     if payload.get("type") == 2:
-        if binding_result.paired and guild_id is not None:
+        if binding_result.paired and binding_result.binding is not None and guild_id is not None:
             # Discord interactions have a short acknowledgement deadline. The
             # binding commit is authoritative; replay the already-shadowed
             # Agent commands once after the interaction response is available.
@@ -946,7 +1191,11 @@ async def _cleanup_discord_guild_commands_after_authority_revoked(
             for guild_id in sorted(guild_ids):
                 # A new pairing can win after the revocation commit. Never erase its
                 # newly materialized commands.
-                if await _discord_guild_owner_principals(db, guild_id=guild_id):
+                if await _discord_guild_owner_principals(
+                    db,
+                    account_id=account.id,
+                    guild_id=guild_id,
+                ):
                     log.info(
                         "discord_command_cleanup_skipped_active_owner "
                         "account_id=%s link_id=%s guild_id=%s",

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -35,6 +35,7 @@ from app.schemas.channel import (
     ChannelAccountResponse,
     ChannelBindingResponse,
     ChannelMessageResponse,
+    ChannelVisibility,
 )
 from app.services.bluebubbles_compat import (
     bluebubbles_message_client_payload,
@@ -66,14 +67,42 @@ from app.services.metrics import (
 )
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_http_url
 
+# Discord API docs baseline b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+# Keep both directions explicit: runtime credentials and hop-by-hop headers
+# never cross into Discord, while documented rate-limit state remains usable.
+_DISCORD_REQUEST_HEADER_ALLOWLIST = ("x-audit-log-reason",)
+_DISCORD_RESPONSE_HEADER_ALLOWLIST = (
+    "cache-control",
+    "cf-ray",
+    "etag",
+    "last-modified",
+    "retry-after",
+    "x-correlation-id",
+    "x-ratelimit-bucket",
+    "x-ratelimit-global",
+    "x-ratelimit-limit",
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "x-ratelimit-reset-after",
+    "x-ratelimit-scope",
+    "x-request-id",
+)
+
 
 def _account_response(account: ChannelAccount) -> ChannelAccountResponse:
+    visibility: ChannelVisibility
+    if account.visibility == "private":
+        visibility = "private"
+    elif account.visibility == "public":
+        visibility = "public"
+    else:
+        raise ValueError("invalid channel account visibility")
     return ChannelAccountResponse(
         id=account.id,
         provider=account.provider,
         name=account.name,
         status=account.status,
-        visibility=account.visibility,
+        visibility=visibility,
         has_provider_token=bool(account.encrypted_provider_token and account.provider_token_nonce),
         webhook_url=channel_webhook_url(account.id, account.provider),
         created_at=account.created_at,
@@ -569,7 +598,7 @@ async def _handle_discord_application_commands(
         command_id = segments[5]
     else:
         return None
-    if application_id != _discord_application_id(account):
+    if application_id is None or application_id != _discord_application_id(account):
         return _discord_command_error("Missing Access", 50001, 403)
     if guild_id is not None and not await _discord_guild_owned_by_link(
         db,
@@ -743,7 +772,12 @@ def _discord_command_list_shape(
 
 
 def _discord_command_shape(command: Any, *, application_id: str) -> dict[str, Any]:
-    source = command if isinstance(command, dict) else {}
+    if not isinstance(command, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="application command object required",
+        )
+    source = command
     name = _optional_str(source.get("name"))
     if name is None:
         raise HTTPException(
@@ -755,42 +789,50 @@ def _discord_command_shape(command: Any, *, application_id: str) -> dict[str, An
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='command names starting with "bot_" are reserved',
         )
-    command_type = source.get("type") if isinstance(source.get("type"), int) else 1
-    description = _optional_str(source.get("description"))
-    if command_type == 1 and description is None:
+    raw_command_type = source.get("type")
+    if isinstance(raw_command_type, bool):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="command type is invalid",
+        )
+    command_type = raw_command_type if isinstance(raw_command_type, int) else 1
+    description = source.get("description")
+    if command_type == 1 and (not isinstance(description, str) or not description.strip()):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="command description is required",
         )
-    shaped = {
-        "id": _optional_str(source.get("id"))
-        or str(
-            abs(
-                hash(
-                    json.dumps(
-                        {
-                            "application_id": application_id,
-                            "name": name,
-                            "type": command_type,
-                        },
-                        sort_keys=True,
+    shaped = dict(source)
+    shaped.update(
+        {
+            "id": _optional_str(source.get("id"))
+            or str(
+                abs(
+                    hash(
+                        json.dumps(
+                            {
+                                "application_id": application_id,
+                                "name": name,
+                                "type": command_type,
+                            },
+                            sort_keys=True,
+                        )
                     )
                 )
-            )
-        ),
-        "application_id": application_id,
-        "name": name,
-        "description": description or "",
-        "type": command_type,
-    }
-    options = source.get("options")
-    if isinstance(options, list):
-        shaped["options"] = [option for option in options if isinstance(option, dict)]
+            ),
+            "application_id": application_id,
+            "name": name,
+            "type": command_type,
+        }
+    )
     return shaped
 
 
 def _discord_command_key(command: dict[str, Any]) -> tuple[int, str]:
-    command_type = command.get("type") if isinstance(command.get("type"), int) else 1
+    raw_command_type = command.get("type")
+    command_type = 1
+    if isinstance(raw_command_type, int) and not isinstance(raw_command_type, bool):
+        command_type = raw_command_type
     return command_type, _optional_str(command.get("name")) or ""
 
 
@@ -829,7 +871,11 @@ async def _discord_guild_owned_by_link(
     bot_agent_link_id: UUID,
     guild_id: str,
 ) -> bool:
-    owners = await _discord_guild_owner_principals(db, guild_id=guild_id)
+    owners = await _discord_guild_owner_principals(
+        db,
+        account_id=account.id,
+        guild_id=guild_id,
+    )
     return owners == {(account.id, bot_agent_link_id)}
 
 
@@ -845,6 +891,7 @@ async def _discord_uncontested_guilds_for_link(
         .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+            ChannelBinding.account_id == account.id,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
             ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
             ChannelBotAgentLink.archived_at.is_(None),
@@ -866,14 +913,17 @@ async def _discord_uncontested_guilds_for_link(
 async def _discord_guild_owner_principals(
     db: AsyncSession,
     *,
+    account_id: UUID,
     guild_id: str,
 ) -> set[tuple[UUID, UUID]]:
+    """Return active Link owners within one physical Discord account namespace."""
     result = await db.execute(
         select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
         .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+            ChannelBinding.account_id == account_id,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
             ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
             ChannelBotAgentLink.archived_at.is_(None),
@@ -916,7 +966,9 @@ async def _fan_out_discord_global_commands(
     ]
     if not target_guild_ids:
         return
-    body = json.dumps(commands).encode("utf-8")
+    body = json.dumps(
+        [_discord_guild_command_provider_payload(command) for command in commands]
+    ).encode("utf-8")
     for guild_id in target_guild_ids:
         result = await _request_discord_provider(
             account=account,
@@ -940,10 +992,10 @@ async def _materialize_discord_command_scope(
     guild_id: str | None,
     commands: list[dict[str, Any]],
 ) -> None:
-    # Agent-facing global commands are virtualized per Link because a shared
-    # physical Discord application has only one true global command set.
-    # Materialize them only into that Link's active Guild bindings. Explicit
-    # guild-scoped requests use the same ownership-checked provider path.
+    # Agent-defined commands are Link shadows. Never write them to the shared
+    # physical global command set or DMs; only materialize them into this
+    # Link's Guild bindings. Built-in reserved commands use the separate
+    # account-level sync path and remain physical global commands.
     await _fan_out_discord_global_commands(
         db,
         account=account,
@@ -952,6 +1004,24 @@ async def _materialize_discord_command_scope(
         commands=commands,
         guild_ids={guild_id} if guild_id is not None else None,
     )
+
+
+def _discord_guild_command_provider_payload(command: dict[str, Any]) -> dict[str, Any]:
+    """Project a virtual response object onto Discord's guild write contract."""
+    payload = dict(command)
+    for field in (
+        "id",
+        "application_id",
+        "guild_id",
+        "version",
+        "name_localized",
+        "description_localized",
+        "contexts",
+        "integration_types",
+        "dm_permission",
+    ):
+        payload.pop(field, None)
+    return payload
 
 
 def _discord_gateway_dispatch(message: Any) -> dict[str, Any]:
@@ -1003,6 +1073,7 @@ async def _request_discord_provider(
     body: bytes | None = None,
     content_type: str = "application/json",
     query_params: Any = None,
+    request_headers: Any = None,
 ) -> _DiscordProviderResult:
     token = decrypt_provider_token(account)
     normalized_path = f"/{path.lstrip('/')}"
@@ -1013,6 +1084,7 @@ async def _request_discord_provider(
         "Authorization": f"Bot {token}",
         "Content-Type": content_type,
     }
+    headers.update(_discord_request_headers(request_headers))
     decision = discord_rate_limiter.check(method, normalized_path)
     if not decision.allowed:
         rate_limit_rejects.labels(
@@ -1038,7 +1110,7 @@ async def _request_discord_provider(
                 response = await client.request(
                     method,
                     url,
-                    content=body if body else None,
+                    content=body,
                     headers=headers,
                     params=query_params,
                 )
@@ -1061,6 +1133,7 @@ async def _request_discord_provider(
         content=response.content,
         status_code=response.status_code,
         media_type=response.headers.get("content-type", "application/json"),
+        headers=_discord_response_headers(response.headers),
     )
 
 
@@ -1077,8 +1150,25 @@ async def _proxy_discord_request(
         body=await request.body(),
         content_type=request.headers.get("content-type", "application/json"),
         query_params=request.query_params,
+        request_headers=request.headers,
     )
     return result.as_response()
+
+
+def _discord_request_headers(headers: Any) -> dict[str, str]:
+    if headers is None:
+        return {}
+    return {
+        name: value for name in _DISCORD_REQUEST_HEADER_ALLOWLIST if (value := headers.get(name))
+    }
+
+
+def _discord_response_headers(headers: Any) -> dict[str, str]:
+    if headers is None:
+        return {}
+    return {
+        name: value for name in _DISCORD_RESPONSE_HEADER_ALLOWLIST if (value := headers.get(name))
+    }
 
 
 async def _validate_discord_provider_base_url(base_url: str) -> None:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -966,7 +966,7 @@ async def list_owned_active_bot_agent_links_for_agent(
             ChannelBotAgentLink.created_at,
         )
     )
-    return list(result.all())
+    return [(link, account) for link, account in result.all()]
 
 
 async def rotate_bot_agent_link_token(
@@ -3585,6 +3585,33 @@ async def send_discord_message(
     )
 
 
+async def record_discord_outbound_message(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    binding: ChannelBinding,
+    external_chat_id: str,
+    provider_response: dict[str, Any],
+) -> ChannelMessage:
+    _require_channel_provider(account, CHANNEL_PROVIDER_DISCORD)
+    if binding.account_id != account.id:
+        raise ValueError("channel binding does not belong to channel account")
+    provider_message_id = _read_optional_str(provider_response.get("id"))
+    if provider_message_id is None:
+        raise ValueError("discord message response has no id")
+    if _read_optional_str(provider_response.get("channel_id")) != external_chat_id:
+        raise ValueError("discord message response channel does not match target")
+    return await _record_outbound_channel_message(
+        db,
+        account=account,
+        binding=binding,
+        external_chat_id=external_chat_id,
+        provider_message_id=provider_message_id,
+        text=_read_optional_str(provider_response.get("content")) or "",
+        payload=None,
+    )
+
+
 async def _send_discord_provider_payload(
     *,
     account: ChannelAccount,
@@ -3631,8 +3658,7 @@ async def _send_discord_provider_payload(
                     headers={"Authorization": f"Bot {token}"},
                     json=payload,
                 )
-                response_headers = getattr(response, "headers", {})
-                discord_rate_limiter.observe("POST", path, response_headers, response.status_code)
+                discord_rate_limiter.observe("POST", path, response.headers, response.status_code)
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
         raise HTTPException(
@@ -3874,7 +3900,15 @@ def _whatsapp_cloud_media_payload(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"whatsapp {media_type} payload requires exactly one of id or link",
         )
-    media: dict[str, str] = {"id": media_id} if media_id is not None else {"link": media_link}
+    if media_id is not None:
+        media: dict[str, str] = {"id": media_id}
+    elif media_link is not None:
+        media = {"link": media_link}
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"whatsapp {media_type} payload requires exactly one of id or link",
+        )
     caption = _read_optional_str(media_payload.get("caption"))
     if media_type == "image" and caption is not None:
         media["caption"] = caption
@@ -4274,13 +4308,19 @@ async def record_discord_dispatch(
 ) -> bool:
     key = extract_discord_routing_key(frame)
     chat = discord_chat_from_payload(frame)
-    if key is None and chat is None:
+    if key is not None:
+        external_chat_id = key.chat_id
+        external_chat_type = key.chat_type
+        external_chat_name = chat[2] if chat is not None else key.scope_id
+        guild_id = key.scope_id
+    elif chat is not None:
+        external_chat_id = chat[0]
+        external_chat_type = chat[1]
+        external_chat_name = chat[2]
+        guild_id = discord_channel_scope_from_payload(frame)[1]
+    else:
         return False
-    external_chat_id = key.chat_id if key is not None else chat[0]
-    external_chat_type = key.chat_type if key is not None else chat[1]
-    external_chat_name = chat[2] if chat is not None else key.scope_id
     command = discord_pair_command_from_payload(frame)
-    guild_id = key.scope_id if key is not None else discord_channel_scope_from_payload(frame)[1]
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -4538,6 +4578,8 @@ def _discord_event_data(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _discord_channel_type_name(value: int | None, fallback: str) -> str:
+    if value is None:
+        return fallback
     return {
         0: "guild_text",
         1: "dm",

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -19,7 +19,7 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 from starlette.websockets import WebSocketDisconnect
@@ -61,6 +61,7 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
+    _cleanup_discord_guild_commands_after_authority_revoked,
     _discord_bound_guild_channels,
     _discord_bound_guilds,
     _discord_gateway_url,
@@ -8306,11 +8307,30 @@ async def test_discord_rest_application_commands_are_tenant_shadowed(
         )
     ).json()
     headers = {"Authorization": f"Bot {created['agent_token']}"}
+    rich_command = {
+        "id": "virtual-command-id",
+        "application_id": "untrusted-application-id",
+        "guild_id": "response-only-guild",
+        "version": "response-only-version",
+        "name": "deploy",
+        "name_localizations": {"de": "bereitstellen"},
+        "name_localized": "localized response only",
+        "description": "Deploy a service",
+        "description_localizations": {"de": "Dienst bereitstellen"},
+        "description_localized": "localized description response only",
+        "default_member_permissions": "32",
+        "nsfw": True,
+        "integration_types": [0, 1],
+        "contexts": [0, 1, 2],
+        "dm_permission": False,
+        "handler": 1,
+        "future_command_field": {"preserved": True},
+    }
 
     updated = await client.put(
         f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers=headers,
-        json=[{"name": "deploy", "description": "Deploy a service"}],
+        json=[rich_command],
     )
     listed = await client.get(
         f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
@@ -8321,11 +8341,86 @@ async def test_discord_rest_application_commands_are_tenant_shadowed(
         headers=headers,
         json={"name": "bot_pair", "description": "bad"},
     )
+    invalid_object = await client.put(
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
+        headers=headers,
+        json=["not-an-object"],
+    )
 
     assert updated.status_code == 200
-    assert updated.json()[0]["name"] == "deploy"
-    assert listed.json()[0]["description"] == "Deploy a service"
+    shadowed = updated.json()[0]
+    assert shadowed == {
+        **rich_command,
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+        "type": 1,
+    }
+    assert listed.json() == [shadowed]
     assert reserved.status_code == 400
+    assert invalid_object.status_code == 400
+    assert invalid_object.json() == {"detail": "application command object required"}
+
+
+@pytest.mark.asyncio
+async def test_discord_application_command_identity_validation_is_type_aware(
+    client: httpx.AsyncClient,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-command-identity-validation",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    headers = {"Authorization": f"Bot {created['agent_token']}"}
+
+    missing_description = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "missing_description", "type": 1},
+    )
+    empty_description = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "empty_description", "type": 1, "description": "   "},
+    )
+    boolean_type = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "boolean_type", "type": True, "description": "Invalid type"},
+    )
+    user_context = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "inspect_user", "type": 2},
+    )
+    message_context = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "inspect_message", "type": 3},
+    )
+    listed = await client.get(command_url, headers=headers)
+
+    assert missing_description.status_code == 400
+    assert missing_description.json() == {"detail": "command description is required"}
+    assert empty_description.status_code == 400
+    assert empty_description.json() == {"detail": "command description is required"}
+    assert boolean_type.status_code == 400
+    assert boolean_type.json() == {"detail": "command type is invalid"}
+    assert user_context.status_code == 200
+    assert user_context.json()["type"] == 2
+    assert "description" not in user_context.json()
+    assert message_context.status_code == 200
+    assert message_context.json()["type"] == 3
+    assert "description" not in message_context.json()
+    assert [command["name"] for command in listed.json()] == [
+        "inspect_user",
+        "inspect_message",
+    ]
 
 
 @pytest.mark.asyncio
@@ -8464,14 +8559,15 @@ async def test_discord_application_commands_validate_application_and_guild_scope
 
 
 @pytest.mark.asyncio
-async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
+async def test_discord_command_materialization_and_guild_management_are_application_scoped(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     channel_agent,
     second_channel_agent,
     monkeypatch,
 ):
-    _reset_fake_provider_client([])
+    other_application_id = "223456789012345678"
+    _reset_fake_provider_client({"id": "provider-command"})
     monkeypatch.setattr(
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FakeProviderClient,
@@ -8495,7 +8591,7 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
                 "provider": "discord",
                 "name": "discord-command-contender",
                 "provider_token": "discord-provider-token-2",
-                "config": _discord_ready_config("223456789012345678"),
+                "config": _discord_ready_config(other_application_id),
                 "agent_id": str(second_channel_agent.id),
             },
         )
@@ -8526,24 +8622,98 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
             )
         )
     await db_session.commit()
+    rich_command = {
+        "id": "virtual-response-id",
+        "application_id": "stale-application-id",
+        "guild_id": "stale-guild-id",
+        "version": "stale-version",
+        "name": "deploy",
+        "name_localizations": {"de": "bereitstellen"},
+        "name_localized": "response-only-name",
+        "description": "Deploy",
+        "description_localizations": {"de": "Bereitstellen"},
+        "description_localized": "response-only-description",
+        "default_member_permissions": "32",
+        "nsfw": True,
+        "integration_types": [0, 1],
+        "contexts": [0, 1, 2],
+        "dm_permission": False,
+        "handler": 1,
+        "type": 1,
+        "future_command_field": {"preserved": True},
+    }
 
-    response = await client.put(
+    first_global = await client.put(
         f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands",
         headers={"Authorization": f"Bot {created['agent_token']}"},
-        json=[{"name": "deploy", "description": "Deploy"}],
+        json=[rich_command],
     )
 
-    assert response.status_code == 200
-    assert response.json()[0]["application_id"] == DISCORD_TEST_APPLICATION_ID
-    assert response.json()[0]["name"] == "deploy"
-    assert len(_FakeProviderClient.calls) == 1
-    call = _FakeProviderClient.calls[0]
-    assert call["method"] == "PUT"
-    assert call["url"].endswith(
-        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-owned/commands"
+    assert first_global.status_code == 200
+    assert first_global.json()[0] == {
+        **rich_command,
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+    }
+    assert {urlparse(call["url"]).path for call in _FakeProviderClient.calls} == {
+        f"/api/v10/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-owned/commands",
+        f"/api/v10/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-contested/commands",
+    }
+    expected_provider_command = {
+        "name": "deploy",
+        "name_localizations": {"de": "bereitstellen"},
+        "description": "Deploy",
+        "description_localizations": {"de": "Bereitstellen"},
+        "default_member_permissions": "32",
+        "nsfw": True,
+        "handler": 1,
+        "type": 1,
+        "future_command_field": {"preserved": True},
+    }
+    for call in _FakeProviderClient.calls:
+        assert call["method"] == "PUT"
+        assert call["headers"]["Authorization"] == "Bot discord-provider-token"
+        assert json.loads(call["content"]) == [expected_provider_command]
+
+    _reset_fake_provider_client({"id": "other-provider-command"})
+    second_global = await client.put(
+        f"/v1/channels/discord/v10/applications/{other_application_id}/commands",
+        headers={"Authorization": f"Bot {other['agent_token']}"},
+        json=[{"name": "other_deploy", "description": "Other deploy"}],
     )
-    assert call["headers"]["Authorization"] == "Bot discord-provider-token"
-    assert json.loads(call["content"])[0]["application_id"] == DISCORD_TEST_APPLICATION_ID
+    assert second_global.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        f"/applications/{other_application_id}/guilds/guild-contested/commands"
+    )
+    assert _FakeProviderClient.calls[0]["headers"]["Authorization"] == (
+        "Bot discord-provider-token-2"
+    )
+
+    _reset_fake_provider_client({"id": "first-guild-command"})
+    first_guild = await client.put(
+        f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}"
+        "/guilds/guild-contested/commands",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "first_guild", "description": "First guild"}],
+    )
+    assert first_guild.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-contested/commands"
+    )
+
+    _reset_fake_provider_client({"id": "second-guild-command"})
+    second_guild = await client.put(
+        f"/v1/channels/discord/v10/applications/{other_application_id}"
+        "/guilds/guild-contested/commands",
+        headers={"Authorization": f"Bot {other['agent_token']}"},
+        json=[{"name": "second_guild", "description": "Second guild"}],
+    )
+    assert second_guild.status_code == 200
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        f"/applications/{other_application_id}/guilds/guild-contested/commands"
+    )
 
 
 @pytest.mark.asyncio
@@ -8670,6 +8840,66 @@ async def test_shared_discord_account_command_shadows_and_fanout_are_link_scoped
     assert len(_FakeProviderClient.calls) == 1
     assert "shared-link-guild-b" in _FakeProviderClient.calls[0]["url"]
     assert "shared-link-guild-a" not in _FakeProviderClient.calls[0]["url"]
+
+
+@pytest.mark.asyncio
+async def test_discord_stale_cleanup_does_not_erase_same_account_new_link_winner(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-stale-command-cleanup",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    link_b_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert link_b_response.status_code == 201, link_b_response.text
+    link_b = link_b_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    link_a = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    assert account is not None and link_a is not None
+    link_a.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "stale_agent", "description": "Stale Agent command"}]
+        }
+    }
+    db_session.add(
+        ChannelBinding(
+            account_id=account.id,
+            bot_agent_link_id=UUID(link_b["id"]),
+            user_id=account.user_id,
+            external_chat_id="winner-channel",
+            external_chat_type="guild_text",
+            external_chat_name="same-account-winner-guild",
+        )
+    )
+    await db_session.commit()
+    _reset_fake_provider_client({"id": "must-not-clean"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    await _cleanup_discord_guild_commands_after_authority_revoked(
+        account_id=account.id,
+        bot_agent_link_id=link_a.id,
+        guild_ids={"same-account-winner-guild"},
+    )
+
+    assert _FakeProviderClient.calls == []
 
 
 @pytest.mark.asyncio
@@ -8940,7 +9170,7 @@ async def test_discord_guild_rest_requires_bound_guild_scope(
 
     assert allowed.status_code == 200
     assert channel_send.status_code == 200
-    assert channel_send.json()["channel_id"] == "discord-chan-1"
+    assert channel_send.json()["id"] == "guild-channel"
     assert blocked.status_code == 403
     assert blocked.json() == {"code": 50001, "message": "Missing Access"}
     assert _FakeProviderClient.calls[0]["url"].endswith("/guilds/discord-guild-1/channels")
@@ -8948,6 +9178,787 @@ async def test_discord_guild_rest_requires_bound_guild_scope(
         "Bot discord-provider-token"
     )
     assert _FakeProviderClient.calls[1]["url"].endswith("/channels/discord-chan-1/messages")
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_preserves_rich_json_query_response_and_ownership(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-rich-message-proxy",
+        channel_id="discord-rich-channel",
+        guild_id="discord-rich-guild",
+    )
+    provider_payload = {
+        "id": "discord-rich-message",
+        "channel_id": "discord-rich-channel",
+        "content": "rich message",
+        "embeds": [{"title": "Deployment", "color": 0x5865F2}],
+        "components": [{"type": 1, "components": []}],
+        "attachments": [{"id": "attachment-1", "filename": "report.txt"}],
+        "future_response_field": {"preserved": True},
+    }
+    _reset_fake_provider_client(
+        provider_payload,
+        headers={
+            "content-type": "application/json; charset=utf-8",
+            "cache-control": "no-cache",
+            "cf-ray": "discord-ray-1",
+            "retry-after": "2.5",
+            "x-ratelimit-bucket": "bucket-1",
+            "x-ratelimit-limit": "5",
+            "x-ratelimit-remaining": "4",
+            "x-ratelimit-reset": "1900000000.25",
+            "x-ratelimit-reset-after": "1.0",
+            "set-cookie": "provider-session=must-not-leak",
+            "server": "provider-internal",
+            "x-discord-features": "provider-internal-feature",
+        },
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    request_body = (
+        b'{  "content": "rich message", "embeds": [{"title": "Deployment"}], '
+        b'"components": [{"type": 1, "components": []}], "sticker_ids": ["1"], '
+        b'"poll": {"question": {"text": "Ship?"}}, "flags": 4096, '
+        b'"future_message_field": {"nested": [1, 2, 3]} }'
+    )
+
+    response = await client.post(
+        "/v1/channels/discord/v10/channels/discord-rich-channel/messages"
+        "?wait=true&future=first&future=second",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": "application/json; charset=utf-8",
+            "Cookie": "runtime-session=must-not-forward",
+            "Proxy-Authorization": "Basic must-not-forward",
+            "X-Future-Runtime-Header": "must-not-forward",
+        },
+        content=request_body,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == provider_payload
+    assert response.headers["cache-control"] == "no-cache"
+    assert response.headers["cf-ray"] == "discord-ray-1"
+    assert response.headers["retry-after"] == "2.5"
+    assert response.headers["x-ratelimit-bucket"] == "bucket-1"
+    assert response.headers["x-ratelimit-remaining"] == "4"
+    assert "set-cookie" not in response.headers
+    assert "server" not in response.headers
+    assert "x-discord-features" not in response.headers
+
+    assert len(_FakeProviderClient.calls) == 1
+    call = _FakeProviderClient.calls[0]
+    assert call["method"] == "POST"
+    assert call["content"] == request_body
+    assert list(call["params"].multi_items()) == [
+        ("wait", "true"),
+        ("future", "first"),
+        ("future", "second"),
+    ]
+    forwarded_headers = {key.lower(): value for key, value in call["headers"].items()}
+    assert forwarded_headers == {
+        "authorization": "Bot discord-provider-token",
+        "content-type": "application/json; charset=utf-8",
+    }
+
+    message = (
+        await db_session.execute(
+            select(ChannelMessage).where(
+                ChannelMessage.account_id == UUID(created["id"]),
+                ChannelMessage.provider_message_id == "discord-rich-message",
+            )
+        )
+    ).scalar_one()
+    assert message.bot_agent_link_id == UUID(created["agent_link_id"])
+    assert message.binding_id is not None
+    assert message.external_chat_id == "discord-rich-channel"
+    assert message.text == "rich message"
+    assert message.payload is None
+
+
+@pytest.mark.asyncio
+async def test_discord_proxy_forwards_only_allowlisted_protocol_request_headers(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-header-boundary",
+        channel_id="discord-header-channel",
+        guild_id="discord-header-guild",
+    )
+    _reset_fake_provider_client({"id": "permission-overwrite"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    response = await client.put(
+        "/v1/channels/discord/v10/channels/discord-header-channel/permissions/role-1",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": "application/json",
+            "X-Audit-Log-Reason": "rotate%20on-call",
+            "Cookie": "runtime-session=must-not-forward",
+            "Host": "runtime.invalid",
+            "Proxy-Authorization": "Basic must-not-forward",
+            "Connection": "keep-alive",
+            "X-Forwarded-For": "127.0.0.1",
+        },
+        json={"allow": "1024", "deny": "0", "type": 0},
+    )
+
+    assert response.status_code == 200
+    forwarded_headers = {
+        key.lower(): value for key, value in _FakeProviderClient.calls[0]["headers"].items()
+    }
+    assert forwarded_headers == {
+        "authorization": "Bot discord-provider-token",
+        "content-type": "application/json",
+        "x-audit-log-reason": "rotate%20on-call",
+    }
+
+    empty_body_response = await client.delete(
+        "/v1/channels/discord/v10/channels/discord-header-channel/permissions/role-1",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+    assert empty_body_response.status_code == 200
+    assert _FakeProviderClient.calls[1]["content"] == b""
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_preserves_multipart_attachment_and_unrecorded_reply(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-multipart-message-proxy",
+        channel_id="discord-multipart-channel",
+        guild_id="discord-multipart-guild",
+    )
+    _reset_fake_provider_client(
+        {
+            "id": "discord-multipart-message",
+            "channel_id": "discord-multipart-channel",
+            "content": "with attachment",
+            "attachments": [{"id": "0", "filename": "report.bin"}],
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    boundary = "discord-thin-proxy-boundary"
+    payload_json = json.dumps(
+        {
+            "content": "with attachment",
+            "embeds": [{"image": {"url": "attachment://report.bin"}}],
+            "attachments": [{"id": 0, "filename": "report.bin"}],
+            "message_reference": {
+                "message_id": "discord-unrecorded-reference",
+                "channel_id": "discord-multipart-channel",
+                "guild_id": "discord-multipart-guild",
+            },
+            "future_multipart_field": {"preserved": True},
+        },
+        separators=(",", ":"),
+    ).encode()
+    file_bytes = b"\x00DISCORD-ATTACHMENT\xff\r\n"
+    multipart_body = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="payload_json"\r\n',
+            b"Content-Type: application/json\r\n\r\n",
+            payload_json,
+            b"\r\n",
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="files[0]"; filename="report.bin"\r\n',
+            b"Content-Type: application/octet-stream\r\n\r\n",
+            file_bytes,
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    content_type = f"multipart/form-data; boundary={boundary}"
+
+    response = await client.post(
+        "/v1/channels/discord/v10/channels/discord-multipart-channel/messages",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": content_type,
+        },
+        content=multipart_body,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["attachments"][0]["filename"] == "report.bin"
+    assert len(_FakeProviderClient.calls) == 1
+    call = _FakeProviderClient.calls[0]
+    assert call["content"] == multipart_body
+    assert call["headers"]["Content-Type"] == content_type
+    assert file_bytes in call["content"]
+    message = (
+        await db_session.execute(
+            select(ChannelMessage).where(
+                ChannelMessage.provider_message_id == "discord-multipart-message"
+            )
+        )
+    ).scalar_one()
+    assert message.bot_agent_link_id == UUID(created["agent_link_id"])
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_preserves_files_only_multipart_without_payload_json(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-files-only-message-proxy",
+        channel_id="discord-files-only-channel",
+        guild_id="discord-files-only-guild",
+    )
+    provider_body = (
+        b'{"id":"discord-files-only-message",'
+        b'"channel_id":"discord-files-only-channel",'
+        b'"attachments":[{"id":"0","filename":"future.bin"}],'
+        b'"future_response_field":{"preserved":true}}'
+    )
+    _reset_fake_provider_client(
+        content=provider_body,
+        status_code=201,
+        headers={
+            "content-type": "application/json",
+            "x-ratelimit-bucket": "files-only-bucket",
+        },
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    boundary = "discord-files-only-boundary"
+    file_bytes = b"\x00FILES-ONLY-DISCORD\xff"
+    multipart_body = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="files[0]"; filename="future.bin"\r\n',
+            b"Content-Type: application/octet-stream\r\n\r\n",
+            file_bytes,
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    content_type = f"multipart/form-data; boundary={boundary}"
+
+    response = await client.post(
+        "/v1/channels/discord/v10/channels/discord-files-only-channel/messages",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": content_type,
+        },
+        content=multipart_body,
+    )
+
+    assert response.status_code == 201
+    assert response.content == provider_body
+    assert response.headers["x-ratelimit-bucket"] == "files-only-bucket"
+    assert len(_FakeProviderClient.calls) == 1
+    call = _FakeProviderClient.calls[0]
+    assert call["content"] == multipart_body
+    assert call["headers"]["Content-Type"] == content_type
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_authorizes_unobserved_same_guild_reference_channel(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-reference-channel-preflight",
+        channel_id="discord-reference-target",
+        guild_id="discord-reference-guild",
+    )
+    _DiscordPreparationProviderClient.reset(
+        [
+            (
+                {
+                    "id": "discord-unobserved-reference-channel",
+                    "guild_id": "discord-reference-guild",
+                    "type": 0,
+                },
+                200,
+            ),
+            (
+                {
+                    "id": "discord-reference-reply",
+                    "channel_id": "discord-reference-target",
+                    "content": "reply across channels",
+                },
+                201,
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _DiscordPreparationProviderClient,
+    )
+
+    response = await client.post(
+        "/v1/channels/discord/v10/channels/discord-reference-target/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={
+            "content": "reply across channels",
+            "message_reference": {
+                "message_id": "discord-unrecorded-cross-channel-message",
+                "channel_id": "discord-unobserved-reference-channel",
+                "guild_id": "discord-reference-guild",
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
+        "GET",
+        "POST",
+    ]
+    assert _DiscordPreparationProviderClient.calls[0]["url"].endswith(
+        "/channels/discord-unobserved-reference-channel"
+    )
+    alias = (
+        await db_session.execute(
+            select(ChannelBindingAlias).where(
+                ChannelBindingAlias.account_id == UUID(created["id"]),
+                ChannelBindingAlias.alias_external_chat_id
+                == "discord-unobserved-reference-channel",
+            )
+        )
+    ).scalar_one()
+    assert alias.bot_agent_link_id == UUID(created["agent_link_id"])
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_rejects_ambiguous_or_malformed_reference_forms(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-reference-parser-boundary",
+        channel_id="discord-parser-channel",
+        guild_id="discord-parser-guild",
+    )
+    _reset_fake_provider_client(
+        {
+            "id": "must-not-send",
+            "channel_id": "discord-parser-channel",
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    boundary = "discord-parser-boundary"
+    duplicate_payload_json = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="payload_json"\r\n\r\n',
+            b"{}\r\n",
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="payload_json"\r\n\r\n',
+            b"{}\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    malformed_payload_json = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="payload_json"\r\n\r\n',
+            b'{"message_reference":\r\n',
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    missing_close_boundary = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="payload_json"\r\n\r\n',
+            b"{}\r\n",
+        ]
+    )
+    cases = [
+        (
+            "application/json",
+            b'{"message_reference":',
+        ),
+        (
+            "application/json",
+            b'{"message_reference":{},"message_reference":{}}',
+        ),
+        (
+            "application/json",
+            b'{"message_reference":{"channel_id":"first","channel_id":"second"}}',
+        ),
+        (
+            f"multipart/form-data; boundary={boundary}",
+            duplicate_payload_json,
+        ),
+        (
+            f"multipart/form-data; boundary={boundary}",
+            malformed_payload_json,
+        ),
+        (
+            f"multipart/form-data; boundary={boundary}",
+            missing_close_boundary,
+        ),
+    ]
+
+    for content_type, body in cases:
+        response = await client.post(
+            "/v1/channels/discord/v10/channels/discord-parser-channel/messages",
+            headers={
+                "Authorization": f"Bot {created['agent_token']}",
+                "Content-Type": content_type,
+            },
+            content=body,
+        )
+        assert response.status_code == 400
+        assert response.json() == {"code": 50035, "message": "Invalid Form Body"}
+
+    unobserved_target = await client.post(
+        "/v1/channels/discord/v10/channels/discord-unobserved-parser-channel/messages",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": "application/json",
+        },
+        content=b'{"message_reference":',
+    )
+    assert unobserved_target.status_code == 400
+    assert _FakeProviderClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_keeps_provider_success_when_recording_fails(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.discord_rate_limiter",
+        DiscordRateLimiter(),
+    )
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-best-effort-outbound-record",
+        channel_id="discord-best-effort-channel",
+        guild_id="discord-best-effort-guild",
+    )
+    _reset_fake_provider_client(
+        {
+            "id": "discord-mismatched-response",
+            "channel_id": "discord-other-channel",
+            "content": "provider accepted",
+        },
+        status_code=201,
+        headers={
+            "content-type": "application/json",
+            "x-ratelimit-bucket": "discord-request-mismatch",
+        },
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    mismatched = await client.post(
+        "/v1/channels/discord/v10/channels/discord-best-effort-channel/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"content": "provider accepted"},
+    )
+    assert mismatched.status_code == 201
+    assert mismatched.json()["channel_id"] == "discord-other-channel"
+    assert mismatched.headers["x-ratelimit-bucket"] == "discord-request-mismatch"
+    assert (
+        await db_session.execute(
+            select(ChannelMessage.id).where(
+                ChannelMessage.provider_message_id == "discord-mismatched-response"
+            )
+        )
+    ).scalar_one_or_none() is None
+
+    async def fail_recording(*_args, **_kwargs):
+        raise SQLAlchemyError("local recording unavailable")
+
+    _reset_fake_provider_client(
+        {
+            "id": "discord-unrecorded-success",
+            "channel_id": "discord-best-effort-channel",
+            "content": "provider accepted once",
+        },
+        status_code=202,
+        headers={
+            "content-type": "application/json",
+            "x-ratelimit-bucket": "discord-request-db-failure",
+        },
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord.record_discord_outbound_message",
+        fail_recording,
+    )
+    failed_record = await client.post(
+        "/v1/channels/discord/v10/channels/discord-best-effort-channel/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"content": "provider accepted once"},
+    )
+
+    assert failed_record.status_code == 202
+    assert failed_record.json()["id"] == "discord-unrecorded-success"
+    assert failed_record.headers["x-ratelimit-bucket"] == "discord-request-db-failure"
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_transparently_returns_provider_error_and_safe_failure(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.discord_rate_limiter",
+        DiscordRateLimiter(),
+    )
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-provider-error-proxy",
+        channel_id="discord-error-channel",
+        guild_id="discord-error-guild",
+    )
+    provider_error = {
+        "id": "must-not-be-recorded",
+        "code": 50035,
+        "message": "Invalid Form Body",
+        "errors": {"future_field": {"_errors": [{"code": "UNKNOWN_FIELD"}]}},
+    }
+    _reset_fake_provider_client(
+        provider_error,
+        status_code=400,
+        headers={
+            "content-type": "application/json",
+            "retry-after": "3",
+            "x-ratelimit-scope": "user",
+        },
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    rejected = await client.post(
+        "/v1/channels/discord/v10/channels/discord-error-channel/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"future_field": "provider validates this"},
+    )
+
+    assert rejected.status_code == 400
+    assert rejected.json() == provider_error
+    assert rejected.headers["retry-after"] == "3"
+    assert rejected.headers["x-ratelimit-scope"] == "user"
+    assert (
+        await db_session.execute(
+            select(ChannelMessage.id).where(
+                ChannelMessage.provider_message_id == "must-not-be-recorded"
+            )
+        )
+    ).scalar_one_or_none() is None
+
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FailingProviderClient,
+    )
+    unreachable = await client.post(
+        "/v1/channels/discord/v10/channels/discord-error-channel/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"content": "network failure"},
+    )
+
+    assert unreachable.status_code == 502
+    assert unreachable.json() == {"detail": "discord api unreachable"}
+    assert created["agent_token"] not in unreachable.text
+    assert "discord-provider-token" not in unreachable.text
+    assert "network down" not in unreachable.text
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_authorizes_unobserved_thread_then_proxies_raw_request(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-thread-message-proxy",
+        channel_id="discord-parent-channel",
+        guild_id="discord-thread-guild",
+    )
+    _DiscordPreparationProviderClient.reset(
+        [
+            (
+                {
+                    "id": "discord-unobserved-thread",
+                    "guild_id": "discord-thread-guild",
+                    "parent_id": "discord-parent-channel",
+                    "type": 11,
+                },
+                200,
+            ),
+            (
+                {
+                    "id": "discord-thread-message",
+                    "channel_id": "discord-unobserved-thread",
+                    "content": "thread payload",
+                },
+                200,
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _DiscordPreparationProviderClient,
+    )
+    raw_body = b'{"content":"thread payload","future_thread_field":true}'
+
+    response = await client.post(
+        "/v1/channels/discord/v10/channels/discord-unobserved-thread/messages?future=1",
+        headers={
+            "Authorization": f"Bot {created['agent_token']}",
+            "Content-Type": "application/json",
+        },
+        content=raw_body,
+    )
+
+    assert response.status_code == 200
+    assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
+        "GET",
+        "POST",
+    ]
+    assert _DiscordPreparationProviderClient.calls[1]["content"] == raw_body
+    assert list(_DiscordPreparationProviderClient.calls[1]["params"].multi_items()) == [
+        ("future", "1")
+    ]
+    alias = (
+        await db_session.execute(
+            select(ChannelBindingAlias).where(
+                ChannelBindingAlias.account_id == UUID(created["id"]),
+                ChannelBindingAlias.alias_external_chat_id == "discord-unobserved-thread",
+            )
+        )
+    ).scalar_one()
+    assert alias.bot_agent_link_id == UUID(created["agent_link_id"])
+
+
+@pytest.mark.asyncio
+async def test_discord_create_message_rejects_cross_link_target_and_message_reference(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-create-message-link-boundary",
+        channel_id="discord-link-channel-a",
+        guild_id="discord-link-guild-a",
+        agent_id=channel_agent.id,
+    )
+    link_b_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert link_b_response.status_code == 201, link_b_response.text
+    link_b = link_b_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    binding_b = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=UUID(link_b["id"]),
+        user_id=account.user_id,
+        external_chat_id="discord-link-guild-b",
+        external_chat_type="guild_text",
+        external_chat_name="discord-link-guild-b",
+    )
+    db_session.add(binding_b)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            ChannelBindingAlias(
+                account_id=account.id,
+                bot_agent_link_id=UUID(link_b["id"]),
+                binding_id=binding_b.id,
+                user_id=account.user_id,
+                alias_external_chat_id="discord-link-channel-b",
+                alias_kind="discord_channel",
+            ),
+        ]
+    )
+    await db_session.commit()
+    _reset_fake_provider_client(
+        {
+            "id": "discord-link-channel-b",
+            "guild_id": "discord-link-guild-b",
+            "type": 0,
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    headers_a = {"Authorization": f"Bot {created['agent_token']}"}
+
+    cross_reference = await client.post(
+        "/v1/channels/discord/v10/channels/discord-link-channel-a/messages",
+        headers=headers_a,
+        json={
+            "content": "must fail",
+            "message_reference": {
+                "message_id": "discord-unrecorded-link-message-b",
+                "channel_id": "discord-link-channel-b",
+                "guild_id": "discord-link-guild-b",
+            },
+        },
+    )
+    cross_link_channel_only = await client.post(
+        "/v1/channels/discord/v10/channels/discord-link-channel-a/messages",
+        headers=headers_a,
+        json={
+            "content": "must fail",
+            "message_reference": {
+                "message_id": "discord-unrecorded-link-message-b",
+                "channel_id": "discord-link-channel-b",
+            },
+        },
+    )
+    cross_target = await client.post(
+        "/v1/channels/discord/v10/channels/discord-link-channel-b/messages",
+        headers=headers_a,
+        json={"content": "must also fail"},
+    )
+
+    assert cross_reference.status_code == 404
+    assert cross_reference.json() == {"code": 10008, "message": "Unknown Message"}
+    assert cross_link_channel_only.status_code == 404
+    assert cross_link_channel_only.json() == {"code": 10008, "message": "Unknown Message"}
+    assert cross_target.status_code == 403
+    assert cross_target.json() == {"code": 50001, "message": "Missing Access"}
+    assert [call["method"] for call in _FakeProviderClient.calls] == ["GET", "GET"]
 
 
 @pytest.mark.asyncio
@@ -13170,6 +14181,7 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
 async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_commands(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    channel_agent,
     monkeypatch: pytest.MonkeyPatch,
 ):
     created = (
@@ -13209,6 +14221,35 @@ async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_comm
                 "options": [{"name": "code", "value": pair["code"]}],
             },
         },
+    )
+    other_application_id = "223456789012345678"
+    other = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-unpair-other-application",
+                "provider_token": "discord-other-provider-token",
+                "config": _discord_ready_config(other_application_id),
+            },
+        )
+    ).json()
+    await _seed_created_channel_link(
+        db_session,
+        created=other,
+        agent=channel_agent,
+    )
+    other_account = await db_session.get(ChannelAccount, UUID(other["id"]))
+    assert other_account is not None
+    db_session.add(
+        ChannelBinding(
+            account_id=other_account.id,
+            bot_agent_link_id=UUID(other["agent_link_id"]),
+            user_id=other_account.user_id,
+            external_chat_id="other-app-channel-same-guild",
+            external_chat_type="guild_text",
+            external_chat_name="guild-discord-unpair",
+        )
     )
 
     link = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
@@ -13251,12 +14292,19 @@ async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_comm
     bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
     assert bindings.status_code == 200
     assert bindings.json() == []
+    other_bindings = await client.get(f"/v1/channels/{other['id']}/bindings")
+    assert other_bindings.status_code == 200
+    assert len(other_bindings.json()) == 1
+    assert other_bindings.json()[0]["external_chat_id"] == "other-app-channel-same-guild"
+    assert other_bindings.json()[0]["external_chat_name"] == "guild-discord-unpair"
     assert len(_FakeProviderClient.calls) == 1
     cleanup_call = _FakeProviderClient.calls[0]
     assert cleanup_call["method"] == "PUT"
     assert cleanup_call["url"].endswith(
         f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/guild-discord-unpair/commands"
     )
+    assert other_application_id not in cleanup_call["url"]
+    assert cleanup_call["headers"]["Authorization"] == "Bot discord-provider-token"
     assert cleanup_call["content"] == b"[]"
 
 
@@ -13555,7 +14603,25 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
             "content": "DM reply",
         }
     )
-    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    cross_guild_reply = await client.post(
+        "/v1/channels/discord/v10/channels/discord-dm-a/messages",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={
+            "content": "must not cross from DM to guild",
+            "message_reference": {
+                "message_id": "unrecorded-guild-message",
+                "guild_id": "discord-guild-other",
+            },
+        },
+    )
+    assert cross_guild_reply.status_code == 404
+    assert cross_guild_reply.json() == {"code": 10008, "message": "Unknown Message"}
+    assert _FakeProviderClient.calls == []
+
     reply = await client.post(
         "/v1/channels/discord/v10/channels/discord-dm-a/messages",
         headers={"Authorization": f"Bot {created['agent_token']}"},


### PR DESCRIPTION
## Summary

- Replace the Discord Create Message content-only reconstruction with a thin proxy that preserves the original JSON or multipart body, repeated query parameters, and content type.
- Preserve Discord response bodies and statuses, plus an explicit safe response-header allowlist for rate limits, retries, cache validators, and correlation. Forward only the documented `X-Audit-Log-Reason` functional request header; runtime `Authorization`, `Host`, `Cookie`, proxy credentials, and hop-by-hop headers never cross the boundary.
- Keep account -> AgentLink -> Binding authorization fail-closed for guild channels, threads, and exact DM bindings. Replies and forwards may reference only messages recorded for the same Link and Binding.
- Record only the successful outbound message ID/content and ownership columns needed for future resource checks. Provider/network/internal failures return sanitized local errors without exposing credentials.
- Audit the ordinary Telegram Bot API proxy. It already forwards raw body/query and only rewrites direct-topic and attach references at required ownership/compatibility boundaries, so no Telegram code change was needed.

This naturally enables Discord rich messages, embeds, components, attachments, stickers, polls, flags, replies/forwards, nonce options, and future Create Message fields without maintaining a Clawdi protocol-field allowlist.

## Official contract baseline

Verified against `discord/discord-api-docs@b2f8adafc037242291b8f875d4cdf3adc4d48bb7`:

- [Create Message JSON/Form parameters](https://github.com/discord/discord-api-docs/blob/b2f8adafc037242291b8f875d4cdf3adc4d48bb7/developers/resources/message.mdx#create-message)
- [Uploading Files: `payload_json` and `files[n]`](https://github.com/discord/discord-api-docs/blob/b2f8adafc037242291b8f875d4cdf3adc4d48bb7/developers/reference.mdx#uploading-files)
- [`X-Audit-Log-Reason`](https://github.com/discord/discord-api-docs/blob/b2f8adafc037242291b8f875d4cdf3adc4d48bb7/developers/resources/audit-log.mdx#audit-log-entry-object)
- [Rate-limit response headers and `Retry-After`](https://github.com/discord/discord-api-docs/blob/b2f8adafc037242291b8f875d4cdf3adc4d48bb7/developers/topics/rate-limits.mdx#header-format)

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
- `uv run pytest -q tests/test_discord_fixture_replay.py tests/test_discord_routing.py tests/test_discord_rate_limiter.py` (22 passed)
- Migrated throwaway `pgvector/pgvector:pg16` plus focused `tests/test_channels.py` Discord and Telegram proxy/ownership coverage (79 passed)

All provider calls in tests are fake/local. No live provider, production cluster, tenant data, deployment, or merge was used.