### PR TITLE
chore(backend): establish uv-only Python type governance

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -87,6 +87,8 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
@@ -96,6 +98,10 @@ jobs:
         with:
           bun-version: "1.3.14"
       - run: uv sync --frozen --no-install-project
+      - name: uv lock is current
+        run: uv lock --check
+      - name: Dependency authority
+        run: uv run python scripts/check_dependency_authority.py
       - name: Ruff lint
         run: uv run ruff check app scripts
       - name: Ruff format (check-only)
@@ -111,6 +117,15 @@ jobs:
       # and flags drift. Config in `pyproject.toml [tool.deptry]`.
       - name: Dependency drift check
         run: uv run deptry app
+      - name: Owned-path type ratchet
+        run: uv run python scripts/type_governance.py owned
+      - name: Changed-production type gate
+        env:
+          TYPE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          TYPE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: uv run python scripts/type_governance.py changed-from "$TYPE_BASE_SHA" "$TYPE_HEAD_SHA"
+      - name: Complete BasedPyright inventory (non-gating diagnostics)
+        run: uv run python scripts/type_governance.py inventory
       - name: Generated OpenAPI client is current
         run: uv run python scripts/check_generated_api.py
   test:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,7 @@ mem0 = ["mem0ai>=0.1"]
 
 [dependency-groups]
 dev = [
+    "basedpyright==1.39.9",
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "aiosqlite>=0.20",
@@ -55,6 +56,14 @@ dev = [
     # the same class of bug that let mem0/mem0ai stay
     # undeclared for months without CI noticing.
     "deptry>=0.20",
+]
+
+[tool.basedpyright]
+typeCheckingMode = "standard"
+pythonVersion = "3.12"
+include = [
+    "app/core/query_utils.py",
+    "app/core/skill_key.py",
 ]
 
 [tool.deptry]
@@ -95,6 +104,8 @@ migrate = "alembic upgrade head"
 audit-ai-provider-models = "python -m scripts.audit_ai_provider_models"
 lint = "ruff check ."
 format = "ruff format ."
+typecheck = "python scripts/type_governance.py owned"
+type-inventory = "python scripts/type_governance.py inventory"
 test = { shell = "../scripts/test.sh backend" }
 
 [tool.ruff]

--- a/backend/scripts/check_dependency_authority.py
+++ b/backend/scripts/check_dependency_authority.py
@@ -1,0 +1,21 @@
+"""Enforce uv as the backend's sole dependency and lock authority."""
+
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    required = BACKEND_ROOT / "uv.lock"
+    forbidden = ("pdm.lock", "poetry.lock", "Pipfile.lock", "requirements.txt")
+    if not required.is_file():
+        raise SystemExit("dependency-authority: backend/uv.lock is required")
+    present = [name for name in forbidden if (BACKEND_ROOT / name).exists()]
+    if present:
+        raise SystemExit(f"dependency-authority: non-uv lock authority found: {', '.join(present)}")
+    print("dependency-authority: uv.lock is the sole backend lock authority")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -1,0 +1,212 @@
+"""Fail-closed BasedPyright gates and a complete non-gating inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TypedDict
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parent
+CONFIG = BACKEND_ROOT / "pyproject.toml"
+EXPECTED_CONFIG = {
+    "typeCheckingMode": "standard",
+    "pythonVersion": "3.12",
+    "include": ["app/core/query_utils.py", "app/core/skill_key.py"],
+}
+EXPECTED_VERSION = "1.39.9"
+INVENTORY_AREAS = ("app", "tests", "scripts", "alembic")
+PRODUCTION_PATHSPEC = ":(top,glob)backend/app/**/*.py"
+
+
+class Summary(TypedDict):
+    filesAnalyzed: int
+    errorCount: int
+    warningCount: int
+    informationCount: int
+
+
+class Analysis(TypedDict):
+    version: str
+    generalDiagnostics: list[object]
+    summary: Summary
+
+
+def validate_config() -> None:
+    with CONFIG.open("rb") as handle:
+        document = tomllib.load(handle)
+    configured = document.get("tool", {}).get("basedpyright")
+    if configured != EXPECTED_CONFIG:
+        raise ValueError(
+            "BasedPyright configuration mismatch; expected exactly "
+            f"{json.dumps(EXPECTED_CONFIG, sort_keys=True)}"
+        )
+
+
+def production_paths(raw_paths: Sequence[str]) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for raw_path in raw_paths:
+        path = Path(raw_path)
+        if path.is_absolute():
+            raise ValueError(f"absolute paths are not allowed: {raw_path}")
+        normalized = path.as_posix()
+        if normalized.startswith("backend/"):
+            normalized = normalized.removeprefix("backend/")
+        candidate = Path(normalized)
+        if candidate.parts[:1] != ("app",) or candidate.suffix != ".py" or ".." in candidate.parts:
+            raise ValueError(f"not an owned production Python path: {raw_path}")
+        resolved = (BACKEND_ROOT / candidate).resolve()
+        if not resolved.is_relative_to(BACKEND_ROOT / "app") or not resolved.is_file():
+            raise ValueError(f"production path does not resolve to a file: {raw_path}")
+        canonical = resolved.relative_to(BACKEND_ROOT).as_posix()
+        if canonical not in seen:
+            seen.add(canonical)
+            paths.append(canonical)
+    if not paths:
+        raise ValueError("changed-production analysis requires at least one Python file")
+    return paths
+
+
+def discover_changed_production_paths(
+    base: str, head: str, *, repo_root: Path = REPO_ROOT
+) -> list[str]:
+    completed = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=ACMR",
+            "--name-only",
+            "-z",
+            base,
+            head,
+            "--",
+            PRODUCTION_PATHSPEC,
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            f"changed-path discovery exited {completed.returncode}: "
+            f"{completed.stderr.strip() or 'no stderr'}"
+        )
+    return list(dict.fromkeys(path for path in completed.stdout.split("\0") if path))
+
+
+def parse_analysis(stdout: str, expected_files: int) -> Analysis:
+    try:
+        payload = json.loads(stdout)
+        version = payload["version"]
+        diagnostics = payload["generalDiagnostics"]
+        summary = payload["summary"]
+        counts = {
+            key: summary[key]
+            for key in ("filesAnalyzed", "errorCount", "warningCount", "informationCount")
+        }
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError("analyzer returned malformed or incomplete JSON") from exc
+    if version != EXPECTED_VERSION:
+        raise ValueError(f"analyzer version mismatch: {version!r}")
+    if not isinstance(diagnostics, list) or any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+        for value in counts.values()
+    ):
+        raise ValueError("analyzer returned invalid diagnostics or summary counts")
+    if counts["filesAnalyzed"] != expected_files:
+        raise ValueError(
+            f"partial analysis: expected {expected_files} files, analyzed {counts['filesAnalyzed']}"
+        )
+    return payload
+
+
+def analyze(paths: Sequence[str], *, gating: bool) -> Analysis:
+    completed = subprocess.run(
+        ["basedpyright", "--outputjson", "--project", str(CONFIG), *paths],
+        cwd=BACKEND_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    analysis = parse_analysis(completed.stdout, len(paths))
+    if completed.returncode not in ({0} if gating else {0, 1}):
+        raise ValueError(
+            f"analyzer exited {completed.returncode}: {completed.stderr.strip() or 'no stderr'}"
+        )
+    if gating:
+        summary = analysis["summary"]
+        if analysis["generalDiagnostics"] or any(
+            summary[key] for key in ("errorCount", "warningCount", "informationCount")
+        ):
+            raise ValueError("gating analysis reported diagnostics")
+    return analysis
+
+
+def inventory() -> dict[str, object]:
+    areas: dict[str, Summary] = {}
+    total: Summary = {
+        "filesAnalyzed": 0,
+        "errorCount": 0,
+        "warningCount": 0,
+        "informationCount": 0,
+    }
+    for area in INVENTORY_AREAS:
+        paths = sorted(
+            path.relative_to(BACKEND_ROOT).as_posix()
+            for path in (BACKEND_ROOT / area).rglob("*.py")
+        )
+        if not paths:
+            raise ValueError(f"inventory area is unexpectedly empty: {area}")
+        summary = analyze(paths, gating=False)["summary"]
+        areas[area] = summary
+        for key in total:
+            total[key] += summary[key]
+    return {
+        "basedpyrightVersion": EXPECTED_VERSION,
+        "mode": "standard",
+        "areas": areas,
+        "total": total,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("owned")
+    changed = subparsers.add_parser("changed")
+    changed.add_argument("paths", nargs="*")
+    changed_from = subparsers.add_parser("changed-from")
+    changed_from.add_argument("base")
+    changed_from.add_argument("head")
+    subparsers.add_parser("inventory")
+    args = parser.parse_args(argv)
+    try:
+        validate_config()
+        if args.command == "owned":
+            result: object = analyze(EXPECTED_CONFIG["include"], gating=True)["summary"]
+        elif args.command == "changed":
+            result = analyze(production_paths(args.paths), gating=True)["summary"]
+        elif args.command == "changed-from":
+            paths = discover_changed_production_paths(args.base, args.head)
+            if paths:
+                result = analyze(production_paths(paths), gating=True)["summary"]
+            else:
+                result = {"filesAnalyzed": 0, "message": "no changed production Python files"}
+        else:
+            result = inventory()
+    except ValueError as exc:
+        print(f"type-governance: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_dependency_authority.py
+++ b/backend/tests/test_dependency_authority.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+
+from scripts import check_dependency_authority
+
+
+def test_dependency_authority_accepts_uv_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "uv.lock").touch()
+    monkeypatch.setattr(check_dependency_authority, "BACKEND_ROOT", tmp_path)
+
+    assert check_dependency_authority.main() == 0
+
+
+def test_dependency_authority_rejects_second_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "uv.lock").touch()
+    (tmp_path / "pdm.lock").touch()
+    monkeypatch.setattr(check_dependency_authority, "BACKEND_ROOT", tmp_path)
+
+    with pytest.raises(SystemExit, match="non-uv lock authority"):
+        check_dependency_authority.main()

--- a/backend/tests/test_type_governance.py
+++ b/backend/tests/test_type_governance.py
@@ -1,0 +1,140 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import type_governance
+
+
+def run_git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def analysis(*, files: int = 1, errors: int = 0, diagnostics: list[object] | None = None) -> str:
+    return json.dumps(
+        {
+            "version": type_governance.EXPECTED_VERSION,
+            "generalDiagnostics": diagnostics or [],
+            "summary": {
+                "filesAnalyzed": files,
+                "errorCount": errors,
+                "warningCount": 0,
+                "informationCount": 0,
+            },
+        }
+    )
+
+
+def test_changed_paths_preserve_first_seen_order_and_deduplicate() -> None:
+    paths = type_governance.production_paths(
+        [
+            "backend/app/core/skill_key.py",
+            "app/core/query_utils.py",
+            "app/core/skill_key.py",
+        ]
+    )
+
+    assert paths == ["app/core/skill_key.py", "app/core/query_utils.py"]
+
+
+def test_changed_path_discovery_includes_direct_and_nested_app_files(tmp_path: Path) -> None:
+    direct = tmp_path / "backend/app/main.py"
+    nested = tmp_path / "backend/app/services/nested.py"
+    nonproduction = tmp_path / "backend/tests/test_example.py"
+    for path in (direct, nested, nonproduction):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("INITIAL = True\n", encoding="utf-8")
+    run_git(tmp_path, "init")
+    run_git(tmp_path, "config", "user.email", "type-governance@example.invalid")
+    run_git(tmp_path, "config", "user.name", "Type Governance")
+    run_git(tmp_path, "add", ".")
+    run_git(tmp_path, "commit", "-m", "initial")
+    base = run_git(tmp_path, "rev-parse", "HEAD")
+
+    for path in (direct, nested, nonproduction):
+        path.write_text("CHANGED = True\n", encoding="utf-8")
+    run_git(tmp_path, "commit", "-am", "change files")
+    head = run_git(tmp_path, "rev-parse", "HEAD")
+
+    assert type_governance.discover_changed_production_paths(base, head, repo_root=tmp_path) == [
+        "backend/app/main.py",
+        "backend/app/services/nested.py",
+    ]
+
+
+@pytest.mark.parametrize(
+    "paths",
+    [[], ["tests/test_smoke.py"], ["app/core/query_utils.txt"], ["app/../tests/test_smoke.py"]],
+)
+def test_changed_paths_reject_empty_or_nonproduction_input(paths: list[str]) -> None:
+    with pytest.raises(ValueError):
+        type_governance.production_paths(paths)
+
+
+def test_analysis_rejects_empty_analysis() -> None:
+    with pytest.raises(ValueError, match="partial analysis"):
+        type_governance.parse_analysis(analysis(files=0), expected_files=1)
+
+
+def test_analysis_rejects_partial_analysis() -> None:
+    with pytest.raises(ValueError, match="partial analysis"):
+        type_governance.parse_analysis(analysis(files=1), expected_files=2)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["", "{}", json.dumps({"version": type_governance.EXPECTED_VERSION})],
+)
+def test_analysis_rejects_malformed_output(payload: str) -> None:
+    with pytest.raises(ValueError, match="malformed or incomplete JSON"):
+        type_governance.parse_analysis(payload, expected_files=1)
+
+
+def test_config_mismatch_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "pyproject.toml"
+    config.write_text('[tool.basedpyright]\ntypeCheckingMode = "basic"\n', encoding="utf-8")
+    monkeypatch.setattr(type_governance, "CONFIG", config)
+
+    with pytest.raises(ValueError, match="configuration mismatch"):
+        type_governance.validate_config()
+
+
+def install_analyzer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    payload: str,
+    exit_code: int,
+) -> None:
+    executable = tmp_path / "basedpyright"
+    executable.write_text(
+        f"#!/bin/sh\nprintf '%s' '{payload}'\nexit {exit_code}\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+
+def test_gate_rejects_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = analysis(files=1, errors=1, diagnostics=[{"severity": "error"}])
+    install_analyzer(tmp_path, monkeypatch, payload=payload, exit_code=0)
+
+    with pytest.raises(ValueError, match="reported diagnostics"):
+        type_governance.analyze(["app/core/query_utils.py"], gating=True)
+
+
+def test_gate_rejects_nonzero_exit_without_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_analyzer(tmp_path, monkeypatch, payload=analysis(), exit_code=2)
+
+    with pytest.raises(ValueError, match="analyzer exited 2"):
+        type_governance.analyze(["app/core/query_utils.py"], gating=True)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,6 +129,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/4b/c1f4e211e50389304d6af32b9280e026a7133e3ad59bbdf8f7a3250f8bee/basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901", size = 24412216, upload-time = "2026-06-27T02:19:49.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c", size = 13374276, upload-time = "2026-06-27T02:19:54.431Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.58"
 source = { registry = "https://pypi.org/simple" }
@@ -352,6 +364,7 @@ mem0 = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
+    { name = "basedpyright" },
     { name = "deptry" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -393,6 +406,7 @@ provides-extras = ["mem0"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "basedpyright", specifier = "==1.39.9" },
     { name = "deptry", specifier = ">=0.20" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
@@ -1248,6 +1262,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -47,10 +47,45 @@ Run these before sending backend changes for review:
 
 ```bash
 cd backend
+uv lock --check
+uv run python scripts/check_dependency_authority.py
+uv run python scripts/type_governance.py owned
 uv run ruff check .
 uv run ruff format --check .
 uv run python -m compileall app scripts tests alembic
 ```
+
+## Python type governance
+
+BasedPyright runs in standard mode from the uv development environment. The
+owned-path gate is a zero-diagnostic ratchet for the small explicit `include`
+list in `pyproject.toml`. CI also sends every changed `backend/app/**/*.py`
+file to the fail-closed exact-path gate. The gate rejects empty, missing,
+partial, or malformed analysis rather than treating it as success.
+
+Generate the complete non-gating inventory with:
+
+```bash
+cd backend
+uv run python scripts/type_governance.py inventory
+```
+
+The inventory at the initial BasedPyright 1.39.9 standard-mode baseline is:
+
+| Area | Files | Errors |
+| --- | ---: | ---: |
+| `app` | 177 | 157 |
+| `tests` | 111 | 177 |
+| `scripts` | 11 | 2 |
+| `alembic` | 54 | 4 |
+| **Total** | **353** | **340** |
+
+Warnings and information diagnostics are both zero in every area. This table
+records inventory, not accepted debt: no baseline or suppression file is
+used, and only the explicit zero-diagnostic owned paths gate existing code.
+
+Done: the `owned` command exits 0 with `filesAnalyzed` equal to 2 and all
+diagnostic counts equal to 0; the `inventory` command reports all four areas.
 
 Backend tests require a real PostgreSQL database with `pgvector` and `pg_trgm`
 available. The pytest fixtures read `DATABASE_URL` and do not create or migrate


### PR DESCRIPTION
## Summary

- add BasedPyright 1.39.9 in standard mode through the existing uv development authority, with no third-party SDK upgrades
- establish a two-file zero-diagnostic owned-path ratchet and a fail-closed exact changed-production path gate
- centralize changed-file discovery in the governance script with the explicit Git pathspec `:(top,glob)backend/app/**/*.py`; it selects all 177 tracked app Python files, including direct children
- enforce uv.lock as the sole backend dependency authority while preserving useful tool.pdm.scripts
- generate and document the complete non-gating app, tests, scripts, and alembic inventory

## Type inventory

| Area | Files | Errors |
| --- | ---: | ---: |
| app | 177 | 157 |
| tests | 111 | 177 |
| scripts | 11 | 2 |
| alembic | 54 | 4 |
| Total | 353 | 340 |

Warnings and information diagnostics are zero in every area. The owned ratchet analyzes 2 files with zero diagnostics.

## Verification

- uv lock --check
- fresh uv sync --frozen --no-install-project in an isolated environment
- dependency authority check and deptry app
- focused governance suite: 16 passed, including a real temporary Git repository contract for direct-child and nested app path discovery, plus empty and partial analysis, exact path order and deduplication, malformed output, diagnostics, nonzero exit, and config mismatch cases
- explicit repository contract: the production pathspec selects 177/177 tracked app Python files and includes `backend/app/__init__.py`, `backend/app/main.py`, and `backend/app/runtime_entrypoint.py`
- Docker-backed PostgreSQL backend suite: 1691 passed, 7 skipped, 9 upstream deprecation warnings
- Alembic upgrade head, downgrade to 62bdb2921f5f, upgrade head round trip
- Ruff lint and format checks; compileall for app, scripts, tests, and alembic
- generated OpenAPI client drift check
- complete BasedPyright inventory regenerated unchanged
- git diff --check and full `origin/main..HEAD` review

Base: b403607e3c39af00f629e9e438215e58438ac3b7
Head: 0175172ba1e23c6461c93e1caa2c6d181d044fe6

No production or tenant access, external writes, deploy, SDK upgrade, generated output change, or runtime refactor.