### PR TITLE
fix(shared): refresh production deploy contract

### DIFF
--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1899,21 +1899,21 @@ export interface components {
             name: string;
             /** Price Cents */
             price_cents: number;
-            /**
-             * Signup Grant Usd
-             * @default 0
-             */
-            signup_grant_usd: string;
             /** Vcpu */
             vcpu: number;
             /** Ram Gb */
             ram_gb: number;
             /** Disk Size */
             disk_size: number;
-            /** Instance Type */
-            instance_type?: string | null;
             /** Offers */
             offers?: components["schemas"]["V2BillingOfferResponse"][];
+            /**
+             * Signup Grant Usd
+             * @default 0
+             */
+            signup_grant_usd: string;
+            /** Instance Type */
+            instance_type?: string | null;
         };
         /** V2PortalResponse */
         V2PortalResponse: {


### PR DESCRIPTION
Refresh the generated deploy client from the current production OpenAPI after Hosted #1239 changed the V2BillingPlanResponse field order. No runtime or schema semantics change.\n\nValidation:\n- production deploy contract check\n- shared typecheck\n- 25 focused shared tests\n- git diff check