### PR TITLE
fix(runtime): isolate CLI activation self-check

### DIFF
--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	accessSync,
@@ -7,6 +7,7 @@ import {
 	constants,
 	existsSync,
 	mkdirSync,
+	mkdtempSync,
 	readdirSync,
 	readFileSync,
 	readlinkSync,
@@ -15,6 +16,7 @@ import {
 	statSync,
 	symlinkSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -803,15 +805,24 @@ function smokeCliVersion(command: string): string {
 }
 
 function verifyCliRuntime(command: string): void {
-	const result = spawnSync(command, ["runtime", "verify", "--json"], {
-		encoding: "utf8",
-		timeout: RUNTIME_VERIFY_TIMEOUT_MS,
-		env: {
-			...process.env,
-			CLAWDI_NO_AUTO_UPDATE: "1",
-			CLAWDI_NO_UPDATE_CHECK: "1",
-		},
-	});
+	const verifyRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-verify-"));
+	let result: SpawnSyncReturns<string>;
+	try {
+		result = spawnSync(command, ["runtime", "verify", "--json"], {
+			encoding: "utf8",
+			timeout: RUNTIME_VERIFY_TIMEOUT_MS,
+			env: {
+				...process.env,
+				HOME: join(verifyRoot, "home"),
+				CLAWDI_SERVICE_STATE_DIR: join(verifyRoot, "state"),
+				CLAWDI_RUN_DIR: join(verifyRoot, "run"),
+				CLAWDI_NO_AUTO_UPDATE: "1",
+				CLAWDI_NO_UPDATE_CHECK: "1",
+			},
+		});
+	} finally {
+		rmSync(verifyRoot, { recursive: true, force: true });
+	}
 	if (result.status !== 0) {
 		throw new Error(
 			`installed clawdi did not pass runtime verify self-check${

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -9590,6 +9590,8 @@ if [ "\${1:-}" = "--version" ]; then
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  test "\${CLAWDI_SERVICE_STATE_DIR:-}" != "${state}"
+  test "\${CLAWDI_RUN_DIR:-}" != "${run}"
   echo '{"status":"ok"}'
   exit 0
 fi


### PR DESCRIPTION
## Summary

- run candidate CLI verification in an isolated empty runtime-state namespace
- prevent an incompatible prior manifest cache from blocking a compatible CLI upgrade
- preserve ordinary runtime verify cache validation and exact downgrade support

## Verification

- focused runtime tests: 174 passed
- isolated CLI suite: 1498 passed, 4 skipped, 0 failed
- CLI typecheck
- Biome
- git diff --check