### PR TITLE
fix(backend): type the Composio SDK boundary

### DIFF
--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -38,11 +38,12 @@ from app.core.config import settings
 if TYPE_CHECKING:
     from composio import Composio
     from composio_client import AsyncComposio
+    from composio_client.types import AuthConfigCreateParams, ConnectedAccountCreateParams
 
 logger = logging.getLogger(__name__)
 
-_client: Any = None
-_sdk_client: Any = None
+_client: AsyncComposio | None = None
+_sdk_client: Composio | None = None
 _tool_router_session_cache: dict[str, ComposioMcpSession] = {}
 
 _REDIRECT_AUTH_TYPES = {"oauth", "oauth1", "oauth2", "dcr_oauth", "composio_link"}
@@ -115,15 +116,10 @@ async def close_composio_client() -> None:
     global _client, _sdk_client
     _tool_router_session_cache.clear()
     if _client is not None:
-        close = getattr(_client, "close", None)
-        if callable(close):
-            await close()
+        await _client.close()
         _client = None
     if _sdk_client is not None:
-        sdk_http_client = getattr(_sdk_client, "client", None)
-        close = getattr(sdk_http_client, "close", None)
-        if callable(close):
-            await asyncio.to_thread(close)
+        await asyncio.to_thread(_sdk_client.client.close)
         _sdk_client = None
 
 
@@ -398,19 +394,13 @@ async def _create_non_oauth_connection(
         auth_type=auth_type,
         managed=False,
     )
-    result = await client.connected_accounts.create(
-        auth_config={"id": auth_config["id"]},
-        connection={
-            "user_id": user_id,
-            "state": {
-                "auth_scheme": auth_scheme,
-                "val": {
-                    "status": "ACTIVE",
-                    **credentials,
-                },
-            },
-        },
+    request = _connected_account_create_request(
+        auth_config_id=auth_config["id"],
+        user_id=user_id,
+        auth_scheme=auth_scheme,
+        credentials=credentials,
     )
+    result = await client.connected_accounts.create(**request)
     account_id = str(_value(result, "id", default=""))
     status = _normalize_status(_value(result, "status"))
     try:
@@ -499,24 +489,64 @@ async def _get_or_create_auth_config(
     if existing is not None:
         return existing
 
-    if managed:
-        auth_config: dict[str, Any] = {
+    request = _auth_config_create_request(
+        app_name=app_name,
+        auth_scheme=auth_scheme,
+        managed=managed,
+    )
+    created = await client.auth_configs.create(**request)
+    created_config = _value(created, "auth_config", default=created)
+    return _serialize_auth_config(created_config)
+
+
+def _connected_account_create_request(
+    *,
+    auth_config_id: str,
+    user_id: str,
+    auth_scheme: str,
+    credentials: dict[str, str],
+) -> ConnectedAccountCreateParams:
+    """Validate a complete request against the SDK's public generated type."""
+    from composio_client.types import ConnectedAccountCreateParams
+    from pydantic import TypeAdapter
+
+    return TypeAdapter(ConnectedAccountCreateParams).validate_python(
+        {
+            "auth_config": {"id": auth_config_id},
+            "connection": {
+                "user_id": user_id,
+                "state": {
+                    "auth_scheme": auth_scheme,
+                    "val": {"status": "ACTIVE", **credentials},
+                },
+            },
+        }
+    )
+
+
+def _auth_config_create_request(
+    *, app_name: str, auth_scheme: str, managed: bool
+) -> AuthConfigCreateParams:
+    """Validate a complete request against the SDK's public generated type."""
+    from composio_client.types import AuthConfigCreateParams
+    from pydantic import TypeAdapter
+
+    auth_config = (
+        {
             "type": "use_composio_managed_auth",
             "name": _auth_config_name(app_name, "managed"),
         }
-    else:
-        auth_config = {
+        if managed
+        else {
             "type": "use_custom_auth",
             "auth_scheme": auth_scheme,
             "credentials": {},
             "name": _auth_config_name(app_name, auth_scheme.lower()),
         }
-    created = await client.auth_configs.create(
-        toolkit={"slug": app_name},
-        auth_config=auth_config,
     )
-    created_config = _value(created, "auth_config", default=created)
-    return _serialize_auth_config(created_config)
+    return TypeAdapter(AuthConfigCreateParams).validate_python(
+        {"toolkit": {"slug": app_name}, "auth_config": auth_config}
+    )
 
 
 async def _get_redirect_auth_config(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,10 +23,10 @@ dependencies = [
     "sentry-sdk[fastapi]>=2.23",
     "websockets>=16.0",
     "pyyaml>=6.0",
-    # Keep the published pair exact: PyPI composio 0.18.0 metadata pins
-    # composio-client 1.42.0. https://pypi.org/pypi/composio/0.18.0/json
-    "composio==0.18.0",
-    "composio-client==1.42.0",
+    # Keep the published pair exact: PyPI composio 0.18.1 metadata pins
+    # composio-client 1.43.0. https://pypi.org/pypi/composio/0.18.1/json
+    "composio==0.18.1",
+    "composio-client==1.43.0",
     # Official Streamable HTTP client lifecycle for Composio Tool Router.
     "mcp==2.0.0",
     "prometheus-client>=0.25.0",
@@ -64,6 +64,7 @@ pythonVersion = "3.12"
 include = [
     "app/core/query_utils.py",
     "app/core/skill_key.py",
+    "app/services/composio.py",
 ]
 
 [tool.deptry]

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -17,7 +17,11 @@ CONFIG = BACKEND_ROOT / "pyproject.toml"
 EXPECTED_CONFIG = {
     "typeCheckingMode": "standard",
     "pythonVersion": "3.12",
-    "include": ["app/core/query_utils.py", "app/core/skill_key.py"],
+    "include": [
+        "app/core/query_utils.py",
+        "app/core/skill_key.py",
+        "app/services/composio.py",
+    ],
 }
 EXPECTED_VERSION = "1.39.9"
 INVENTORY_AREAS = ("app", "tests", "scripts", "alembic")

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -938,3 +938,63 @@ async def test_connect_route_rejects_unknown_auth_type_without_oauth_link(
 
     assert exc_info.value.status_code == 502
     assert exc_info.value.detail == "Connector auth metadata unavailable"
+
+
+def test_composio_request_boundary_validates_complete_public_request_types():
+    connected_account_request = composio._connected_account_create_request(
+        auth_config_id="ac_posthog",
+        user_id="user_123",
+        auth_scheme="API_KEY",
+        credentials={"api_key": "test-secret"},
+    )
+    auth_config_request = composio._auth_config_create_request(
+        app_name="posthog", auth_scheme="API_KEY", managed=False
+    )
+
+    assert connected_account_request == {
+        "auth_config": {"id": "ac_posthog"},
+        "connection": {
+            "user_id": "user_123",
+            "state": {
+                "auth_scheme": "API_KEY",
+                "val": {"status": "ACTIVE", "api_key": "test-secret"},
+            },
+        },
+    }
+    assert auth_config_request == {
+        "toolkit": {"slug": "posthog"},
+        "auth_config": {
+            "type": "use_custom_auth",
+            "auth_scheme": "API_KEY",
+            "credentials": {},
+            "name": "Clawdi posthog api_key",
+        },
+    }
+
+
+def test_composio_request_boundary_rejects_unknown_auth_scheme():
+    with pytest.raises(ValidationError):
+        composio._connected_account_create_request(
+            auth_config_id="ac_example",
+            user_id="user_123",
+            auth_scheme="UNKNOWN",
+            credentials={"token": "test-secret"},
+        )
+
+    with pytest.raises(ValidationError):
+        composio._auth_config_create_request(
+            app_name="example", auth_scheme="UNKNOWN", managed=False
+        )
+
+
+async def test_close_composio_client_uses_public_sdk_lifecycles():
+    from composio import Composio
+    from composio_client import AsyncComposio
+
+    composio._client = AsyncComposio(api_key="test-key")
+    composio._sdk_client = Composio(api_key="test-key")
+
+    await composio.close_composio_client()
+
+    assert composio._client is None
+    assert composio._sdk_client is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -378,8 +378,8 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.35" },
     { name = "botocore", specifier = ">=1.35" },
-    { name = "composio", specifier = "==0.18.0" },
-    { name = "composio-client", specifier = "==1.42.0" },
+    { name = "composio", specifier = "==0.18.1" },
+    { name = "composio-client", specifier = "==1.43.0" },
     { name = "cryptography", specifier = ">=44.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "fastembed", specifier = ">=0.3" },
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "composio"
-version = "0.18.0"
+version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "composio-client" },
@@ -446,14 +446,14 @@ dependencies = [
     { name = "pysher" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/80/0071e855e9b8e06d2a5f4d87b9f5a65e2a7b3573b72e707256c4b6ee4fc3/composio-0.18.0.tar.gz", hash = "sha256:d8277412eabbb29e357025f1611d59dbb8f410ded5a1bed9a3a8fad09c630366", size = 239594, upload-time = "2026-07-15T20:40:09.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/d4/62ba767d7632a4c78ee6d38f065994516f6f25fe431c3954254db29542d1/composio-0.18.1.tar.gz", hash = "sha256:8a48d30f861196825607467d623d0ac05cf8e25b5916c43607fed5ba1c71ee30", size = 245605, upload-time = "2026-07-30T11:03:17.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/8f/0f08f2698cfcdc03d53d8e4810256fbe16e4731c41b70b1fdbb9897f13f8/composio-0.18.0-py3-none-any.whl", hash = "sha256:8cf09b5f9494ae8b3f14103bab2a820a744e9007b0ed2cf9c36f575f9b63a522", size = 155940, upload-time = "2026-07-15T20:39:56.498Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fd/3873737f46b4229f50f6f453c699cb8764267fee1dcd485d0e9857a66c2d/composio-0.18.1-py3-none-any.whl", hash = "sha256:1632abac39ac82acc38c7358cf3a00529521c6f2edf72b912fe54819a4b819eb", size = 158101, upload-time = "2026-07-30T11:03:05.781Z" },
 ]
 
 [[package]]
 name = "composio-client"
-version = "1.42.0"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -463,9 +463,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/d3/c47df669397e672172ff31090d186ff36e2158d33cc6c07cf5ec7dd05c39/composio_client-1.42.0.tar.gz", hash = "sha256:74f4635befaa4761e0ca83ed68ff63b0a62312ebea08cf0a2088a47cfe9d5154", size = 246045, upload-time = "2026-06-30T18:14:22.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/4b/3789f4c1347fd01349b66ecaeffb5ef623434c3b1fa4f5c5993fddb69c68/composio_client-1.43.0.tar.gz", hash = "sha256:bb96700da0c2aabc394cebc954be0ebf419557cc42b40f5d148aac52a5aff6f9", size = 246767, upload-time = "2026-07-08T09:06:02.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/b5/f43e74632a91ae6516b713f7d2918391c98276967aa332bd8360457ec940/composio_client-1.42.0-py3-none-any.whl", hash = "sha256:4edfe2b3753fbf63fe2739a4f6705ffc8d4313f7fc98192efb12bac7990600a5", size = 277044, upload-time = "2026-06-30T18:14:20.857Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a2/3ae1f5471a52189ac558de6b0e088dc3575d695a0f91278cddf464274694/composio_client-1.43.0-py3-none-any.whl", hash = "sha256:3274d965b9efb6be90a51977f4c068ed24e2cad9160de4d40d3176d8bb4ce2d9", size = 277716, upload-time = "2026-07-08T09:06:01.007Z" },
 ]
 
 [[package]]

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -84,7 +84,7 @@ Warnings and information diagnostics are both zero in every area. This table
 records inventory, not accepted debt: no baseline or suppression file is
 used, and only the explicit zero-diagnostic owned paths gate existing code.
 
-Done: the `owned` command exits 0 with `filesAnalyzed` equal to 2 and all
+Done: the `owned` command exits 0 with `filesAnalyzed` equal to 3 and all
 diagnostic counts equal to 0; the `inventory` command reports all four areas.
 
 Backend tests require a real PostgreSQL database with `pgvector` and `pg_trgm`


### PR DESCRIPTION
## Summary

- upgrade the officially paired Composio Python cohort from `composio==0.18.0` / `composio-client==1.42.0` to `0.18.1` / `1.43.0`
- validate complete auth-config and connected-account create payloads against the SDK's public top-level `AuthConfigCreateParams` and `ConnectedAccountCreateParams` exports
- use the public async/sync client lifecycle directly and add the Composio service to the zero-diagnostic BasedPyright owned ratchet

## Evidence

- PyPI `composio 0.18.1` requires `composio-client==1.43.0` and Python `>=3.10,<4`
- PyPI `composio-client 1.43.0` supports Python `>=3.9`
- upstream `composio_client.types` publicly re-exports both complete request types; no generated leaf modules are imported
- `mcp==2.0.0` remains the latest stable release; its public `Client` + `streamable_http_client` lifecycle is unchanged here
- full BasedPyright inventory: 340 -> 337 errors (`app`: 157 -> 154; all other areas unchanged)

## Verification

- `uv sync --frozen`; `uv lock --check`
- `pytest tests/test_connectors.py -q` (31 passed); combined focused Composio/type-governance tests (45 passed)
- type governance owned (3 files, 0 diagnostics) and changed-from (1 production file, 0 diagnostics)
- dependency authority and `deptry app`
- Ruff, format, compileall
- generated OpenAPI client and strict hosted deploy-contract drift
- Docker-clean workspace suite: 1498 passed / 4 skipped; post-review backend rerun: 1706 passed / 7 skipped with fresh PostgreSQL and full migrations

No production or tenant operations were performed. This PR is intentionally unmerged.