### PR TITLE
test: avoid ordering audit events by transaction timestamp

### DIFF
--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -991,17 +991,16 @@ async def test_observation_consumer_identity_is_bound_to_admin_actor(
     expiry_audits = list(
         (
             await db_session.execute(
-                select(ControlPlaneAuditEvent)
-                .where(
+                select(ControlPlaneAuditEvent).where(
                     ControlPlaneAuditEvent.source == "api.v2.runtime",
                     ControlPlaneAuditEvent.action == "runtime_observation.cursor_expired",
                     ControlPlaneAuditEvent.resource_id == str(environment.id),
                 )
-                .order_by(ControlPlaneAuditEvent.created_at)
             )
         ).scalars()
     )
-    assert [event.details["operation"] for event in expiry_audits] == ["read", "ack"]
+    assert len(expiry_audits) == 2
+    assert {event.details["operation"] for event in expiry_audits} == {"read", "ack"}
     assert all(event.actor_type == "admin" for event in expiry_audits)
     assert all(event.details["auth_method"] == "x_admin_key" for event in expiry_audits)
     assert all(event.details["consumer_id"] == "hosted-controller" for event in expiry_audits)


### PR DESCRIPTION
## Summary

- remove an invalid ordering assumption for audit events created in the same PostgreSQL transaction
- verify the exact event count and operation set instead

## Root cause

`TimestampMixin.created_at` uses a PostgreSQL `server_default=func.now()`. Events inserted in one transaction may share the same timestamp, so ordering only by `created_at` is not deterministic. Both `read` and `ack` orders are valid.

## Verification

- `bash scripts/test.sh backend`: 1706 passed, 7 skipped
- Ruff check/format
- `git diff --check`

No production code, dependencies, schemas, migrations, tenant access, or external writes.