### PR TITLE
refactor(backend): type OpenAI SDK boundaries

### DIFF
--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -73,20 +73,25 @@ class ApiEmbedder:
         base_url: str | None = None,
         model: str = "text-embedding-3-small",
     ) -> None:
-        from openai import AsyncOpenAI
-
-        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url or None)
+        self.api_key = api_key
+        self.base_url = base_url
         self.model = model
 
     async def embed(self, text: str) -> list[float]:
+        from openai import AsyncOpenAI
+
         # `dimensions=768` truncates via Matryoshka (supported by
         # text-embedding-3-*). Providers that don't support it will
         # surface an explicit error rather than silently mismatch dims.
-        resp = await self.client.embeddings.create(
-            input=text,
-            model=self.model,
-            dimensions=EMBEDDING_DIM,
-        )
+        async with AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url or None,
+        ) as client:
+            resp = await client.embeddings.create(
+                input=text,
+                model=self.model,
+                dimensions=EMBEDDING_DIM,
+            )
         return list(resp.data[0].embedding)
 
 

--- a/backend/app/services/memory_extraction.py
+++ b/backend/app/services/memory_extraction.py
@@ -22,10 +22,16 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Literal
+from typing import Literal
 
 from openai import AsyncOpenAI
-from pydantic import BaseModel, Field
+from openai.types.chat import (
+    ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionUserMessageParam,
+)
+from openai.types.shared_params import ResponseFormatJSONSchema
+from pydantic import BaseModel, Field, JsonValue
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +56,11 @@ class ExtractionResult(BaseModel):
     # for selectivity ("most sessions yield 0-5"). 20 only catches a
     # model that's gone off the rails (one memory per message, etc.).
     memories: list[ExtractedMemory] = Field(default_factory=list, max_length=20)
+
+
+class _SessionMessage(BaseModel):
+    role: str = "?"
+    content: JsonValue = ""
 
 
 # json_schema for OpenAI structured output. Mirrored from `ExtractionResult`
@@ -161,7 +172,7 @@ Return JSON only. Do not explain why the array is empty. Do not narrate your rea
 
 
 def _format_messages_for_prompt(
-    messages: list[dict[str, Any]],
+    messages: list[object],
     project_path: str | None,
     total: int,
 ) -> str:
@@ -169,9 +180,10 @@ def _format_messages_for_prompt(
     header = f"project: {project_path or 'unknown'}\nmessages: {len(messages)} of {total} (tail-truncated, oldest dropped)"
     lines.append(header)
     lines.append("")
-    for m in messages:
-        role = str(m.get("role", "?"))
-        content = m.get("content", "")
+    for raw_message in messages:
+        message = _SessionMessage.model_validate(raw_message)
+        role = str(message.role)
+        content = message.content
         # Some messages may have non-string content (tool_use blocks etc).
         # Stringify defensively — the LLM is fine with JSON snippets in-line.
         if not isinstance(content, str):
@@ -184,7 +196,7 @@ def _format_messages_for_prompt(
 
 
 async def extract_memories_from_session(
-    messages: list[dict[str, Any]],
+    messages: list[object],
     *,
     project_path: str | None,
     client: AsyncOpenAI,
@@ -194,33 +206,37 @@ async def extract_memories_from_session(
 
     Tail-truncates to `MAX_MESSAGES` and asks the LLM for a JSON-schema
     constrained `ExtractionResult`. Returns the parsed list, possibly
-    empty. Any LLM/network/parsing error propagates to the caller.
+    empty. This function takes ownership of `client` and closes it before
+    returning. Any LLM/network/parsing error propagates to the caller.
     """
-    if not messages:
-        return []
+    async with client:
+        if not messages:
+            return []
 
-    total = len(messages)
-    truncated = messages[-MAX_MESSAGES:] if total > MAX_MESSAGES else messages
+        total = len(messages)
+        truncated = messages[-MAX_MESSAGES:] if total > MAX_MESSAGES else messages
 
-    user_content = _format_messages_for_prompt(truncated, project_path, total)
+        user_content = _format_messages_for_prompt(truncated, project_path, total)
 
-    response = await client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": _SYSTEM_PROMPT},
-            {"role": "user", "content": user_content},
-        ],
-        response_format={
-            "type": "json_schema",
-            "json_schema": {
+        request_messages: list[ChatCompletionMessageParam] = [
+            ChatCompletionSystemMessageParam(role="system", content=_SYSTEM_PROMPT),
+            ChatCompletionUserMessageParam(role="user", content=user_content),
+        ]
+        response_format = ResponseFormatJSONSchema(
+            type="json_schema",
+            json_schema={
                 "name": "ExtractionResult",
                 "strict": True,
                 "schema": _RESPONSE_SCHEMA,
             },
-        },
-        temperature=0.2,
-    )
+        )
+        response = await client.chat.completions.create(
+            model=model,
+            messages=request_messages,
+            response_format=response_format,
+            temperature=0.2,
+        )
 
-    raw = response.choices[0].message.content or "{}"
-    parsed = ExtractionResult.model_validate_json(raw)
-    return parsed.memories
+        raw = response.choices[0].message.content or "{}"
+        parsed = ExtractionResult.model_validate_json(raw)
+        return parsed.memories

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiofiles>=24.1",
     "psycopg2-binary>=2.9.11",
     "pgvector>=0.2.5",
-    "openai>=1.40",
+    "openai>=2.52.0",
     "fastembed>=0.3",
     "sentry-sdk[fastapi]>=2.23",
     "websockets>=16.0",
@@ -65,6 +65,8 @@ include = [
     "app/core/query_utils.py",
     "app/core/skill_key.py",
     "app/services/composio.py",
+    "app/services/embedding.py",
+    "app/services/memory_extraction.py",
 ]
 
 [tool.deptry]

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -21,6 +21,8 @@ EXPECTED_CONFIG = {
         "app/core/query_utils.py",
         "app/core/skill_key.py",
         "app/services/composio.py",
+        "app/services/embedding.py",
+        "app/services/memory_extraction.py",
     ],
 }
 EXPECTED_VERSION = "1.39.9"

--- a/backend/tests/test_ai_provider_connection.py
+++ b/backend/tests/test_ai_provider_connection.py
@@ -122,12 +122,17 @@ async def test_connection_probe_verifies_protocol_model_and_credential_shape(
     base_url: str,
     expected_path: str,
     header_name: str,
-):
-    captured: dict[str, object] = {}
+) -> None:
+    captured_request: ai_provider_connection._ProbeRequest | None = None
+    captured_address: str | None = None
 
-    async def fake_send(request, address: str) -> ai_provider_connection._ProbeHttpResponse:
-        captured["request"] = request
-        captured["address"] = address
+    async def fake_send(
+        request: ai_provider_connection._ProbeRequest,
+        address: str,
+    ) -> ai_provider_connection._ProbeHttpResponse:
+        nonlocal captured_request, captured_address
+        captured_request = request
+        captured_address = address
         return _successful_inference_response(api_mode)
 
     _mock_public_dns(monkeypatch)
@@ -142,10 +147,11 @@ async def test_connection_probe_verifies_protocol_model_and_credential_shape(
 
     assert result.ok is True
     assert result.error is None
-    request = captured["request"]
+    request = captured_request
+    assert request is not None
     assert request.url.path == expected_path
     assert header_name in request.headers
-    assert captured["address"] == "8.8.8.8"
+    assert captured_address == "8.8.8.8"
     if api_mode == "openai_responses":
         assert request.body["max_output_tokens"] == 16
         assert request.body["store"] is False

--- a/backend/tests/test_openai_sdk_boundary.py
+++ b/backend/tests/test_openai_sdk_boundary.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from openai import AsyncOpenAI
+from pydantic import ValidationError
+
+from app.services.embedding import ApiEmbedder
+from app.services.memory_extraction import extract_memories_from_session
+
+
+class _OpenAICompatibleHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, bytes]] = []
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        content_length = int(self.headers["Content-Length"])
+        self.requests.append((self.path, self.rfile.read(content_length)))
+        if self.path == "/v1/embeddings":
+            payload = {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.25, 0.75]}],
+                "model": "compatible-embedding-model",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        else:
+            payload = {
+                "id": "chatcmpl-local",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "compatible-chat-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "memories": [
+                                        {
+                                            "content": "Uses hermetic SDK boundary tests",
+                                            "category": "pattern",
+                                            "tags": ["testing"],
+                                        }
+                                    ]
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+        body = json.dumps(payload).encode()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@contextmanager
+def _openai_compatible_server() -> Iterator[str]:
+    _OpenAICompatibleHandler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAICompatibleHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.asyncio
+async def test_public_sdk_surface_supports_openai_compatible_boundaries() -> None:
+    with _openai_compatible_server() as base_url:
+        embedder = ApiEmbedder("test-key", base_url, "compatible-embedding-model")
+        client = AsyncOpenAI(api_key="test-key", base_url=base_url)
+        assert await embedder.embed("hello") == [0.25, 0.75]
+        memories = await extract_memories_from_session(
+            [{"role": "user", "content": ["keep", {"nested": True}]}],
+            project_path="/workspace",
+            client=client,
+            model="compatible-chat-model",
+        )
+
+    assert memories[0].content == "Uses hermetic SDK boundary tests"
+    assert client.is_closed
+    assert [path for path, _body in _OpenAICompatibleHandler.requests] == [
+        "/v1/embeddings",
+        "/v1/chat/completions",
+    ]
+    embedding_body = _OpenAICompatibleHandler.requests[0][1]
+    completion_body = _OpenAICompatibleHandler.requests[1][1]
+    assert b'"dimensions":768' in embedding_body
+    assert b'"type":"json_schema"' in completion_body
+    assert b'"strict":true' in completion_body
+
+
+@pytest.mark.asyncio
+async def test_memory_extraction_validates_dynamic_session_messages() -> None:
+    client = AsyncOpenAI(api_key="test-key", base_url="http://127.0.0.1:1/v1")
+    with pytest.raises(ValidationError):
+        await extract_memories_from_session(
+            [{"role": "user", "content": object()}],
+            project_path=None,
+            client=client,
+            model="compatible-chat-model",
+        )
+    assert client.is_closed

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -388,7 +388,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.10" },
     { name = "mcp", specifier = "==2.0.0" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1" },
-    { name = "openai", specifier = ">=1.40" },
+    { name = "openai", specifier = ">=2.52.0" },
     { name = "pgvector", specifier = ">=0.2.5" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.50.0"
+version = "2.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1377,9 +1377,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/f5/e7735f2af272ee179a287911a698b3cbdb59d7a4ac4874571363adf1e4de/openai-2.50.0.tar.gz", hash = "sha256:5128f7caf4a6b01aefd6e7e93efe170a2c3427b8de286b9af5cdff3aa47e02c8", size = 1081965, upload-time = "2026-07-28T22:16:31.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5a/c45fa035cd72c70ebe67c6e079e3adf871492382634f69e3dff62c43597d/openai-2.52.0.tar.gz", hash = "sha256:7c736d592f81471ce1f734838390983c4d8c8aecff23dcd36e600a58e5032d9c", size = 1098876, upload-time = "2026-07-31T15:13:03.228Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/ca/db315b3bb748c26c644a3f85b7d509e774354d6518d47080b1446005ee41/openai-2.50.0-py3-none-any.whl", hash = "sha256:90bdddcc5a2fa529b350fac9c5780d87e5c361dcc6090ab57b0d470b0d7af7fa", size = 1650721, upload-time = "2026-07-28T22:16:29.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/ceb40c995df49533ad4dcff6c37f0d85cf14446a212363fc9d2f927e60b4/openai-2.52.0-py3-none-any.whl", hash = "sha256:f97e231d9a8fa69ab55897df1080f02d99913fb0a30e3ee56ea16a1eb6c2d434", size = 1659569, upload-time = "2026-07-31T15:13:01.145Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade the direct OpenAI Python SDK floor and lock from 2.50.0 to the current stable 2.52.0 without changing any transitive dependency
- validate session-message JSON at Clawdi's owned boundary and build Chat Completions inputs from the SDK's public generated parameter exports
- add a hermetic loopback HTTP test for embeddings, structured Chat Completions, OpenAI-compatible `base_url`, and explicit async client closure
- add both changed production services to the explicit zero-diagnostic BasedPyright ratchet and remove four existing diagnostics from the OpenAI-compatible connection-probe test

## Design

`sessions.py` remains unchanged: its existing 14 diagnostics are outside this cohort. The extraction service now accepts the dynamic decoded value as `list[object]`, validates each item with Pydantic (`str` role plus JSON-valued content), and only then formats it. SDK request dictionaries are replaced by the public generated `ChatCompletion*MessageParam` and `ResponseFormatJSONSchema` exports. No cast, ignore, reflection, compatibility shim, SDK-internal import, or handwritten SDK duplicate type is introduced.

`ApiEmbedder` stores only constructor inputs; each `embed()` operation creates `AsyncOpenAI` inside the public async context manager and closes that operation pool before returning. The existing session route transfers its freshly created client to the single extraction function, which enters the same public async context manager and closes the client on success, validation failure, or network failure. This keeps `sessions.py` unchanged because the full route module has 14 unrelated existing diagnostics, while fixing the real production lifetime without a provider-wide close protocol, singleton, or test-only helper. The loopback test runs both production boundaries against a local stdlib HTTP server, verifies that the extraction client is closed, and checks the exact OpenAI-compatible paths and structured request fields; it performs no external API call.

## Official upstream evidence

- Official PyPI reports 2.52.0 as the stable release: https://pypi.org/project/openai/2.52.0/
- OpenAI's official v2.52.0 release (published 2026-07-31) and changelog: https://github.com/openai/openai-python/releases/tag/v2.52.0
- `AsyncOpenAI`, `await`, and construction are documented in the official README: https://github.com/openai/openai-python/blob/v2.52.0/README.md#async-usage
- `base_url` and custom HTTP client configuration are documented publicly: https://github.com/openai/openai-python/blob/v2.52.0/README.md#configuring-the-http-client
- explicit `.close()` / context-manager lifecycle is documented publicly: https://github.com/openai/openai-python/blob/v2.52.0/README.md#managing-http-resources
- the generated Chat Completions parameter types are public package exports: https://github.com/openai/openai-python/blob/v2.52.0/src/openai/types/chat/__init__.py
- `ResponseFormatJSONSchema` is a public shared-parameter export: https://github.com/openai/openai-python/blob/v2.52.0/src/openai/types/shared_params/__init__.py

## Type inventory

Before (`main@53a32f57`, BasedPyright 1.39.9 standard):

- app: 177 files / 154 errors
- tests: 111 files / 177 errors
- scripts: 11 files / 2 errors
- alembic: 54 files / 4 errors
- total: 353 files / 337 errors
- owned zero-diagnostic ratchet: 3 files

After (`fe84bdda`):

- app: 177 files / 154 errors
- tests: 112 files / 173 errors
- scripts: 11 files / 2 errors
- alembic: 54 files / 4 errors
- total: 354 files / 333 errors
- owned zero-diagnostic ratchet: 5 files

Delta: +1 analyzed test file, -4 real diagnostics, and +2 production files protected at zero diagnostics.

## Verification

- `bun run --cwd backend test` — pass; clean Docker runner, client 1498 passed / 4 skipped, backend 1708 passed / 7 skipped, PostgreSQL created from scratch and all migrations applied
- final focused OpenAI/provider tests after reviewer simplification — 21 passed; the preceding full focused boundary/governance set passed 35 tests
- owned type gate — 5 files / 0 diagnostics
- changed-production type gate — 2 files / 0 diagnostics
- new and touched test files — 2 files / 0 diagnostics
- full non-gating inventory — 354 files / 333 errors
- `uv lock --check` and `uv sync --locked --check` — pass
- dependency authority and `deptry` — pass
- Ruff lint and format — pass
- `compileall app scripts tests alembic` — pass
- generated OpenAPI/client drift — pass
- strict deploy-contract drift against the published spec — pass
- `git diff --check origin/main..HEAD` — pass

## Diff review

Reviewed all seven files in `git diff origin/main..HEAD` after the semantic commit. The lock changes only the direct OpenAI constraint, version, hashes, sizes, and upload timestamps; no transitive package changed.