### PR TITLE
fix(runtime): prepare Hermes dashboard artifact

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -3958,6 +3958,18 @@ describe("runtime manifest reconciliation invariants", () => {
 		);
 		expect(installedUserTargets).toContain(join(home, ".openclaw", "extensions", "discord"));
 		expect(installedUserTargets).not.toContain(largeInstalledTree);
+		manifest.runtimes.hermes.services.dashboard = runSettings("hermes", ["dashboard"]);
+		const dashboardTargets = runtimeUserMutationTargets(
+			manifest,
+			paths,
+			join(home, "clawdi"),
+			new Map([
+				["openclaw", { status: "present" as const }],
+				["hermes", { status: "present" as const }],
+			]),
+		);
+		expect(dashboardTargets).toContain(join(largeInstalledTree, "hermes_cli", "web_dist"));
+		expect(dashboardTargets).not.toContain(largeInstalledTree);
 		expect(
 			captureRuntimeLiveSnapshot({
 				rootTargets: [],

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -20,6 +20,10 @@ import {
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
+import {
+	planHermesDashboardArtifact,
+	prepareHermesDashboardArtifact,
+} from "./runtime-systemd-reconciliation";
 
 const originalEnv = { ...process.env };
 const originalConsoleWarn = console.warn;
@@ -340,6 +344,49 @@ exit ${input.exitCode ?? 0}
 	chmodSync(input.path, 0o700);
 }
 
+function writeFakeNpm(input: {
+	path: string;
+	logPath: string;
+	distIndex: string;
+	failBuild?: boolean;
+	version?: string;
+	mutateBeforeBuildFailure?: boolean;
+	environmentLogPath?: string;
+}): void {
+	mkdirSync(dirname(input.path), { recursive: true });
+	writeFileSync(
+		input.path,
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm %s\\n' "$*" >> '${input.logPath}'
+${input.environmentLogPath ? `printf '%s=%s\\n' "$*" "\${NODE_EXTRA_CA_CERTS-}" >> '${input.environmentLogPath}'` : ""}
+case "$*" in
+  "--version") printf '%s\\n' '${input.version ?? "12.0.2"}' ;;
+  "install --workspace web") ;;
+  "run build -w web")
+    ${
+			input.failBuild
+				? `${
+						input.mutateBeforeBuildFailure
+							? `mkdir -p '${dirname(input.distIndex)}'
+    printf '%s\\n' '<html>partial dashboard</html>' > '${input.distIndex}'
+    chmod 0777 '${dirname(input.distIndex)}'
+    chmod 0666 '${input.distIndex}'`
+							: ""
+					}
+    exit 71`
+				: `mkdir -p '${dirname(input.distIndex)}'
+    printf '%s\\n' '<html>Hermes dashboard</html>' > '${input.distIndex}'
+    printf '%s\\n' 'dashboard asset' > '${join(dirname(input.distIndex), "app.js")}'`
+		}
+    ;;
+  *) exit 64 ;;
+esac
+`,
+	);
+	chmodSync(input.path, 0o700);
+}
+
 afterEach(() => {
 	process.env = { ...originalEnv };
 	console.warn = originalConsoleWarn;
@@ -434,7 +481,7 @@ describe("runtime manifest services", () => {
 			"utf8",
 		);
 		expect(dashboardUnit).toContain(
-			'ExecStart="hermes" "dashboard" "--host" "127.0.0.1" "--port" "9119" "--no-open"',
+			'ExecStart="hermes" "dashboard" "--host" "127.0.0.1" "--port" "9119" "--no-open" "--skip-build"',
 		);
 		const openclawUnit = readUserServiceConfig(paths, "openclaw-gateway");
 		expect(openclawUnit).toContain('Environment="XDG_RUNTIME_DIR=%t"');
@@ -622,7 +669,7 @@ describe("runtime manifest services", () => {
 			"utf8",
 		);
 		expect(dashboardUnit).toContain(
-			'ExecStart="hermes" "dashboard" "--host" "0.0.0.0" "--port" "9119" "--no-open"',
+			'ExecStart="hermes" "dashboard" "--host" "0.0.0.0" "--port" "9119" "--no-open" "--skip-build"',
 		);
 		const dashboardEnv = readFileSync(
 			join(paths.systemdEnvRoot, "clawdi-hermes-dashboard.service.env"),
@@ -1128,6 +1175,409 @@ describe("runtime manifest services", () => {
 				),
 			);
 		}
+	});
+
+	test("prepares the Hermes dashboard artifact before activation and keeps ExecStart build-free", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-prerequisite.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(join(paths.userHome, ".hermes", "hermes-agent"), { recursive: true });
+		mkdirSync(dirname(distIndex), { recursive: true });
+		writeFileSync(distIndex, "<html>partial dashboard</html>\n");
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
+		writeFakeSystemctl({ path: systemctlCommand, logPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, [
+			"dashboard",
+			"--host",
+			"0.0.0.0",
+			"--port",
+			"9119",
+			"--no-open",
+		]);
+		let activations = 0;
+		const converge = () =>
+			convergeRuntimeManifest(
+				{ manifest, source: "remote-datasource", sourcePath: "inline-dashboard", offline: false },
+				paths,
+				{
+					systemdApply: {
+						activateEgressPrerequisite: () => ({
+							applied: true,
+							systemUnitsChanged: [],
+							userUnitsChanged: [],
+						}),
+						activate: () => {
+							expect(existsSync(distIndex)).toBe(true);
+							activations += 1;
+							return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+						},
+						rollback: () => {},
+					},
+				},
+			);
+
+		expect(converge().installErrors).toEqual([]);
+		expect(activations).toBe(1);
+		expect(readFileSync(logPath, "utf8")).toContain(
+			"hermes gateway install --force\nnpm --version\nnpm install --workspace web\nnpm run build -w web",
+		);
+		expect(readUserServiceConfig(paths, "clawdi-hermes-dashboard")).toContain(
+			`ExecStart="${hermesCommand}" "dashboard" "--host" "0.0.0.0" "--port" "9119" "--no-open" "--skip-build"`,
+		);
+		expect(converge().installErrors).toEqual([]);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
+		expect(
+			readRuntimeInstallReceipts(paths)?.officialServices["hermes-dashboard:artifact"],
+		).toBeDefined();
+
+		writeFileSync(join(dirname(distIndex), "app.js"), "drifted asset\n");
+		expect(converge().installErrors).toEqual([]);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(6);
+
+		rmSync(join(dirname(distIndex), "app.js"));
+		expect(converge().installErrors).toEqual([]);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(9);
+	});
+
+	test("passes the transparent-egress system CA to every Hermes dashboard npm command", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-egress.log");
+		const environmentLogPath = join(paths.runRoot, "hermes-dashboard-egress-env.log");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const appRoot = join(paths.userHome, ".hermes", "hermes-agent");
+		const distIndex = join(appRoot, "hermes_cli", "web_dist", "index.html");
+		mkdirSync(appRoot, { recursive: true });
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		writeFakeNpm({ path: npmCommand, logPath, distIndex, environmentLogPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		const plan = {
+			program: {
+				runtime: "hermes" as const,
+				service: "dashboard" as const,
+				command: hermesCommand,
+				args: ["dashboard"],
+				cwd: paths.userHome,
+				env: {},
+				resolvedSecretEnv: {},
+			},
+			receiptKey: "hermes-dashboard:artifact",
+			target: {
+				desiredRevision: "test-desired-revision",
+				currentRevision: () => null,
+				expectedCurrentRevision: null,
+			},
+		};
+
+		expect(prepareHermesDashboardArtifact(plan, paths, paths.egressSystemCaFile)).toBeNull();
+		expect(readFileSync(environmentLogPath, "utf8").trim().split("\n")).toEqual([
+			`--version=${paths.egressSystemCaFile}`,
+			`install --workspace web=${paths.egressSystemCaFile}`,
+			`run build -w web=${paths.egressSystemCaFile}`,
+		]);
+	});
+
+	test("binds a cold Hermes dashboard receipt after the installer creates the command", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-cold-receipt.log");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		const program = {
+			runtime: "hermes" as const,
+			service: "dashboard" as const,
+			command: hermesCommand,
+			args: ["dashboard"],
+			cwd: paths.userHome,
+			env: {},
+			resolvedSecretEnv: {},
+		};
+		mkdirSync(join(paths.userHome, ".hermes", "hermes-agent"), { recursive: true });
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const coldPlan = planHermesDashboardArtifact([program], paths, null, true);
+		expect(coldPlan.target?.desiredRevision).toBe("");
+		expect(prepareHermesDashboardArtifact(coldPlan, paths)).toContain(
+			"could not determine the installed Hermes command revision",
+		);
+		expect(existsSync(logPath)).toBe(false);
+
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		expect(prepareHermesDashboardArtifact(coldPlan, paths)).toBeNull();
+		expect(coldPlan.target?.desiredRevision).toMatch(/^[a-f0-9]{64}$/);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
+		const currentRevision = coldPlan.target?.expectedCurrentRevision;
+		expect(currentRevision).toMatch(/^[a-f0-9]{64}$/);
+
+		const receiptPlan = planHermesDashboardArtifact(
+			[program],
+			paths,
+			{
+				schemaVersion: "clawdi.runtimeInstallReceipts.v1",
+				officialServices: {
+					"hermes-dashboard:artifact": {
+						desiredRevision: coldPlan.target?.desiredRevision ?? "",
+						currentRevision: currentRevision ?? "",
+					},
+				},
+				channelPlugins: {},
+			},
+			true,
+		);
+		expect(prepareHermesDashboardArtifact(receiptPlan, paths)).toBeNull();
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
+	});
+
+	test("fails closed when the Hermes dashboard artifact build fails", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-failure.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(dirname(distIndex), { recursive: true });
+		writeFileSync(distIndex, "<html>old dashboard</html>\n");
+		chmodSync(dirname(distIndex), 0o750);
+		chmodSync(distIndex, 0o640);
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
+		writeFakeSystemctl({ path: systemctlCommand, logPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({
+			path: npmCommand,
+			logPath,
+			distIndex,
+			failBuild: true,
+			mutateBeforeBuildFailure: true,
+		});
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, ["dashboard"]);
+		let activations = 0;
+		let authorityCommits = 0;
+		let rollbacks = 0;
+		const result = convergeRuntimeManifest(
+			{
+				manifest,
+				source: "remote-datasource",
+				sourcePath: "inline-dashboard-fail",
+				offline: false,
+			},
+			paths,
+			{
+				commitAuthority: () => {
+					authorityCommits += 1;
+				},
+				systemdApply: {
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: () => {
+						activations += 1;
+						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					rollback: () => {
+						rollbacks += 1;
+					},
+				},
+			},
+		);
+		expect(result.installErrors).toEqual([
+			expect.stringContaining("Hermes dashboard prerequisite failed"),
+		]);
+		expect(activations).toBe(0);
+		expect(authorityCommits).toBe(0);
+		expect(rollbacks).toBe(1);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>old dashboard</html>\n");
+		expect(statSync(dirname(distIndex)).mode & 0o777).toBe(0o750);
+		expect(statSync(distIndex).mode & 0o777).toBe(0o640);
+		expect(existsSync(paths.appliedState)).toBe(false);
+		expect(existsSync(join(paths.instanceRoot, manifest.instanceId, "boot-finished"))).toBe(false);
+		expect(readRuntimeInstallReceipts(paths)).toBeNull();
+		expect(existsSync(join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"))).toBe(false);
+		expect(existsSync(join(paths.systemdUserRoot, "hermes-gateway.service"))).toBe(false);
+		expect(existsSync(join(paths.userHome, ".hermes", "config.yaml"))).toBe(false);
+	});
+
+	test("rejects an upstream-incompatible npm before dashboard mutation", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-npm-version.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(join(paths.userHome, ".hermes", "hermes-agent"), { recursive: true });
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
+		writeFakeSystemctl({ path: systemctlCommand, logPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({ path: npmCommand, logPath, distIndex, version: "11.10.0" });
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, ["dashboard"]);
+		const result = convergeRuntimeManifest(
+			{ manifest, source: "remote-datasource", sourcePath: "inline-npm-version", offline: false },
+			paths,
+			{
+				systemdApply: {
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
+					rollback: () => {},
+				},
+			},
+		);
+		expect(result.installErrors).toEqual([
+			expect.stringContaining("requires npm <11.10.0 or >=12.0.0; found 11.10.0"),
+		]);
+		expect(readFileSync(logPath, "utf8").match(/^npm .*$/gm)).toEqual(["npm --version"]);
+		expect(existsSync(distIndex)).toBe(false);
+	});
+
+	test("restores the previous Hermes dashboard artifact when final activation fails", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-activation-failure.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(dirname(distIndex), { recursive: true });
+		writeFileSync(distIndex, "<html>old dashboard</html>\n");
+		chmodSync(dirname(distIndex), 0o750);
+		chmodSync(distIndex, 0o640);
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
+		writeFakeSystemctl({ path: systemctlCommand, logPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, ["dashboard"]);
+		let authorityCommits = 0;
+		let activations = 0;
+		let rollbacks = 0;
+		const result = convergeRuntimeManifest(
+			{
+				manifest,
+				source: "remote-datasource",
+				sourcePath: "inline-dashboard-activation-fail",
+				offline: false,
+			},
+			paths,
+			{
+				commitAuthority: () => {
+					authorityCommits += 1;
+				},
+				systemdApply: {
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: () => {
+						activations += 1;
+						return { applied: false, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					rollback: () => {
+						rollbacks += 1;
+					},
+				},
+			},
+		);
+		expect(result.installErrors).toEqual([
+			expect.stringContaining("systemd runtime services did not reach required readiness"),
+		]);
+		expect(activations).toBe(1);
+		expect(authorityCommits).toBe(0);
+		expect(rollbacks).toBe(1);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>old dashboard</html>\n");
+		expect(statSync(dirname(distIndex)).mode & 0o777).toBe(0o750);
+		expect(statSync(distIndex).mode & 0o777).toBe(0o640);
+		expect(existsSync(paths.appliedState)).toBe(false);
+		expect(existsSync(join(paths.instanceRoot, manifest.instanceId, "boot-finished"))).toBe(false);
+		expect(readRuntimeInstallReceipts(paths)).toBeNull();
+		expect(existsSync(join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"))).toBe(false);
+		expect(existsSync(join(paths.userHome, ".hermes", "config.yaml"))).toBe(false);
 	});
 
 	test.each(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -154,8 +154,10 @@ import { runtimeImpactRevision, runtimeProgramRevision } from "./runtime-impact-
 import {
 	buildRuntimeSystemdUserProgram,
 	installOfficialRuntimeService,
+	planHermesDashboardArtifact,
 	planOfficialRuntimeServices,
 	planRuntimeSystemdUserMutations,
+	prepareHermesDashboardArtifact,
 	type RuntimeEgressSystemdProgram,
 	type RuntimeSystemdStaleFilePlan,
 	type RuntimeSystemdUserProgram,
@@ -4737,6 +4739,8 @@ export function runtimeUserMutationTargets(
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
 ): string[] {
 	const home = hostedRuntimeProjectionHome(manifest, paths);
+	const installerTargets = runtimeInstallerMutationTargets(manifest, home, observations);
+	const hermesAppRoot = join(home, ".hermes", "hermes-agent");
 	const openClawDatabase = join(openClawAgentDir(home), "openclaw-agent.sqlite");
 	const targets = new Set<string>([
 		join(home, ".openclaw", "openclaw.json"),
@@ -4750,9 +4754,16 @@ export function runtimeUserMutationTargets(
 		join(workspaceRoot, "SOUL.md"),
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
 		legacyHermesModelProviderPluginDir(home),
-		...runtimeInstallerMutationTargets(manifest, home, observations),
+		...installerTargets,
 		...hostedChannelCredentialMutationTargets(manifest, home),
 	]);
+	if (
+		manifest.runtimes.hermes?.enabled &&
+		manifest.runtimes.hermes.services?.dashboard &&
+		!installerTargets.includes(hermesAppRoot)
+	) {
+		targets.add(join(hermesAppRoot, "hermes_cli", "web_dist"));
+	}
 	for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
 		targets.add(join(paths.localEnvironments, `${agentType}.json`));
 	}
@@ -5491,8 +5502,22 @@ export function convergeRuntimeManifest(
 			opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
 		);
 		installReceiptTargets.officialServices = officialServicePlan.targets;
+		const hermesDashboardArtifactPlan = planHermesDashboardArtifact(
+			runtimeSystemdUserPrograms,
+			paths,
+			previousInstallReceipts,
+			opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
+		);
+		if (hermesDashboardArtifactPlan.receiptKey && hermesDashboardArtifactPlan.target) {
+			installReceiptTargets.officialServices.set(
+				hermesDashboardArtifactPlan.receiptKey,
+				hermesDashboardArtifactPlan.target,
+			);
+		}
 		if (
-			officialServicePlan.pending.length > 0 &&
+			(officialServicePlan.pending.length > 0 ||
+				(hermesDashboardArtifactPlan.program !== null &&
+					hermesDashboardArtifactPlan.target?.expectedCurrentRevision === null)) &&
 			systemdUnits.egressSidecarActive &&
 			opts.systemdApply
 		) {
@@ -5513,6 +5538,12 @@ export function convergeRuntimeManifest(
 			const error = installOfficialRuntimeService(item, paths);
 			if (error) throw new Error(error);
 		}
+		const artifactError = prepareHermesDashboardArtifact(
+			hermesDashboardArtifactPlan,
+			paths,
+			systemdUnits.egressSidecarActive ? egressSystemdProgram?.systemCaBundle : undefined,
+		);
+		if (artifactError) throw new Error(artifactError);
 
 		const bootFinished = join(instanceRoot, "boot-finished");
 		writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -110,6 +110,12 @@ export interface OfficialRuntimeServicePlan {
 	pending: Array<{ program: RuntimeSystemdUserProgram; target: RuntimeInstallReceiptTarget }>;
 }
 
+export interface HermesDashboardArtifactPlan {
+	program: RuntimeSystemdUserProgram | null;
+	receiptKey: string | null;
+	target: RuntimeInstallReceiptTarget | null;
+}
+
 export interface RuntimeSystemdUserMutationPlan {
 	targets: string[];
 	symlinkTargets: string[];
@@ -531,6 +537,167 @@ export function planOfficialRuntimeServices(
 		if (expectedCurrentRevision === null) pending.push({ program, target });
 	}
 	return { targets, pending };
+}
+
+// Hermes upstream bounds Node dependency installation at 600s and declares
+// npm "<11.10.0 || >=12.0.0" in its root package.json:
+// https://github.com/NousResearch/hermes-agent/blob/4b60979dc188655eb4fb81abf292890147ec2d4c/scripts/install.sh#L2797-L2803
+// https://github.com/NousResearch/hermes-agent/blob/4b60979dc188655eb4fb81abf292890147ec2d4c/package.json#L55-L58
+const HERMES_NPM_VERSION_TIMEOUT_MS = 30_000;
+const HERMES_NPM_INSTALL_TIMEOUT_MS = 600_000;
+const HERMES_DASHBOARD_BUILD_TIMEOUT_MS = 900_000;
+// This key deliberately reuses the existing officialServices receipt group:
+// the artifact is a prerequisite of Clawdi's compatibility dashboard service,
+// not a new install authority or receipt schema.
+const HERMES_DASHBOARD_ARTIFACT_RECEIPT = "hermes-dashboard:artifact";
+const HERMES_DASHBOARD_NPM_CONSTRAINT = "<11.10.0 || >=12.0.0";
+
+function isHermesDashboardProgram(program: RuntimeSystemdUserProgram): boolean {
+	return program.runtime === "hermes" && program.service === "dashboard";
+}
+
+function hermesDashboardArtifactIndex(paths: RuntimePaths): string {
+	return join(paths.userHome, ".hermes", "hermes-agent", "hermes_cli", "web_dist", "index.html");
+}
+
+function hermesDashboardArtifactCurrentRevision(paths: RuntimePaths): string | null {
+	const root = dirname(hermesDashboardArtifactIndex(paths));
+	try {
+		const rootStat = lstatSync(root);
+		if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return null;
+		const files: Array<{ path: string; contentSha256: string }> = [];
+		const visit = (directory: string, relativeDirectory: string): boolean => {
+			for (const entry of readdirSync(directory, { withFileTypes: true })) {
+				const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
+				const path = join(directory, entry.name);
+				if (entry.isSymbolicLink()) return false;
+				if (entry.isDirectory()) {
+					if (!visit(path, relativePath)) return false;
+					continue;
+				}
+				if (!entry.isFile()) return false;
+				files.push({
+					path: relativePath,
+					contentSha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
+				});
+			}
+			return true;
+		};
+		if (!visit(root, "") || !files.some((file) => file.path === "index.html")) return null;
+		return runtimeContentSha256(files.sort((left, right) => left.path.localeCompare(right.path)));
+	} catch {
+		return null;
+	}
+}
+
+function hermesDashboardArtifactDesiredRevision(commandRevision: string): string {
+	return runtimeContentSha256({
+		commandRevision,
+		npmConstraint: HERMES_DASHBOARD_NPM_CONSTRAINT,
+		commands: ["npm install --workspace web", "npm run build -w web"],
+		installTimeoutMs: HERMES_NPM_INSTALL_TIMEOUT_MS,
+		buildTimeoutMs: HERMES_DASHBOARD_BUILD_TIMEOUT_MS,
+	});
+}
+
+export function planHermesDashboardArtifact(
+	programs: RuntimeSystemdUserProgram[],
+	paths: RuntimePaths,
+	receipts: RuntimeInstallReceipts | null,
+	executePrerequisites: boolean,
+): HermesDashboardArtifactPlan {
+	if (!executePrerequisites) return { program: null, receiptKey: null, target: null };
+	const program = programs.find(isHermesDashboardProgram);
+	if (!program) return { program: null, receiptKey: null, target: null };
+	const command = runtimeCommandPath("hermes", paths.userHome) ?? program.command;
+	const commandRevision = runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
+	const desiredRevision = commandRevision
+		? hermesDashboardArtifactDesiredRevision(commandRevision)
+		: "";
+	const currentRevision = () => hermesDashboardArtifactCurrentRevision(paths);
+	const expectedCurrentRevision = commandRevision
+		? verifiedReceiptCurrentRevision(
+				receipts?.officialServices[HERMES_DASHBOARD_ARTIFACT_RECEIPT],
+				desiredRevision,
+				currentRevision,
+			)
+		: null;
+	return {
+		program,
+		receiptKey: HERMES_DASHBOARD_ARTIFACT_RECEIPT,
+		target: { desiredRevision, currentRevision, expectedCurrentRevision },
+	};
+}
+
+function supportedHermesNpmVersion(version: string): boolean {
+	const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version.trim());
+	if (!match) return false;
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	return major < 11 || (major === 11 && minor < 10) || major >= 12;
+}
+
+function validateHermesNpmVersion(
+	paths: RuntimePaths,
+	appRoot: string,
+	egressSystemCaFile?: string,
+): string | null {
+	const result = spawnRuntimeUserCommand("npm", ["--version"], paths.userHome, appRoot, {
+		timeoutMs: HERMES_NPM_VERSION_TIMEOUT_MS,
+		egressSystemCaFile,
+	});
+	if (result.status !== 0 || result.error) {
+		return `Hermes dashboard prerequisite could not determine npm version: ${
+			result.error?.message ?? `npm exited ${result.status ?? "without status"}`
+		}`;
+	}
+	const version = String(result.stdout ?? "").trim();
+	if (!supportedHermesNpmVersion(version)) {
+		return `Hermes dashboard prerequisite requires npm <11.10.0 or >=12.0.0; found ${
+			version || "an unrecognized version"
+		}`;
+	}
+	return null;
+}
+
+export function prepareHermesDashboardArtifact(
+	plan: HermesDashboardArtifactPlan,
+	paths: RuntimePaths,
+	egressSystemCaFile?: string,
+): string | null {
+	if (!plan.program || !plan.target || plan.target.expectedCurrentRevision) return null;
+	const appRoot = join(paths.userHome, ".hermes", "hermes-agent");
+	const command = runtimeCommandPath("hermes", paths.userHome) ?? plan.program.command;
+	const commandRevision = runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
+	if (!commandRevision) {
+		return `Hermes dashboard prerequisite could not determine the installed Hermes command revision: ${command}`;
+	}
+	plan.target.desiredRevision = hermesDashboardArtifactDesiredRevision(commandRevision);
+	if (!commandResolvable("npm")) {
+		return "Hermes dashboard prerequisite command is unavailable: npm";
+	}
+	const versionError = validateHermesNpmVersion(paths, appRoot, egressSystemCaFile);
+	if (versionError) return versionError;
+	try {
+		runRuntimeUserCommand("npm", ["install", "--workspace", "web"], "", paths.userHome, appRoot, {
+			timeoutMs: HERMES_NPM_INSTALL_TIMEOUT_MS,
+			egressSystemCaFile,
+		});
+		runRuntimeUserCommand("npm", ["run", "build", "-w", "web"], "", paths.userHome, appRoot, {
+			timeoutMs: HERMES_DASHBOARD_BUILD_TIMEOUT_MS,
+			egressSystemCaFile,
+		});
+		const currentRevision = hermesDashboardArtifactCurrentRevision(paths);
+		if (!currentRevision) {
+			return `Hermes dashboard prerequisite did not produce ${hermesDashboardArtifactIndex(paths)}`;
+		}
+		plan.target.expectedCurrentRevision = currentRevision;
+		return null;
+	} catch (error) {
+		return `Hermes dashboard prerequisite failed: ${
+			error instanceof Error ? error.message : String(error)
+		}`;
+	}
 }
 
 function writeSystemdEnvironmentFile(input: {
@@ -1084,6 +1251,10 @@ function writeRuntimeSystemdUserProgram(input: {
 	runtimeRevision: Parameters<typeof runtimeSystemdProgramRevision>[4];
 }): string {
 	const { program } = input;
+	const args =
+		isHermesDashboardProgram(program) && !program.args.includes("--skip-build")
+			? [...program.args, "--skip-build"]
+			: program.args;
 	const name = runtimeSystemdProgramName(program);
 	const unitName = systemdUnitFileName(name);
 	const env = {
@@ -1105,7 +1276,7 @@ function writeRuntimeSystemdUserProgram(input: {
 			paths: input.paths,
 			name,
 			command: program.command,
-			args: program.args,
+			args,
 			cwd: program.cwd,
 			env,
 		});
@@ -1115,7 +1286,7 @@ function writeRuntimeSystemdUserProgram(input: {
 		name,
 		description: `Clawdi hosted ${program.runtime}${program.service ? ` ${program.service}` : ""}`,
 		command: program.command,
-		args: program.args,
+		args,
 		cwd: program.cwd,
 		env,
 	});

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { runRuntimeUserCommand, spawnRuntimeUserCommand } from "./runtime-user-command";
+
+describe("runtime user command timeout", () => {
+	test("bounds synchronous runtime-user commands", () => {
+		expect(() =>
+			runRuntimeUserCommand("bash", ["-c", "while :; do :; done"], "", tmpdir(), tmpdir(), {
+				timeoutMs: 20,
+			}),
+		).toThrow();
+	});
+
+	test("reports a bounded runtime-user probe timeout", () => {
+		const result = spawnRuntimeUserCommand(
+			"bash",
+			["-c", "while :; do :; done"],
+			tmpdir(),
+			tmpdir(),
+			{ timeoutMs: 20 },
+		);
+		expect(result.status).toBeNull();
+		expect(result.error?.message).toContain("ETIMEDOUT");
+	});
+});

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -140,7 +140,7 @@ export function spawnRuntimeUserCommand(
 	args: string[],
 	home: string,
 	cwd: string,
-	options: { egressSystemCaFile?: string; input?: string } = {},
+	options: { egressSystemCaFile?: string; input?: string; timeoutMs?: number } = {},
 ): ReturnType<typeof spawnSync> {
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
@@ -151,20 +151,27 @@ export function spawnRuntimeUserCommand(
 				cwd,
 				encoding: "utf8",
 				input: options.input,
+				timeout: options.timeoutMs,
 			});
 		}
 		if (commandExists("runuser")) {
 			return spawnSync(
 				"runuser",
 				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ env, cwd, encoding: "utf8", input: options.input },
+				{ env, cwd, encoding: "utf8", input: options.input, timeout: options.timeoutMs },
 			);
 		}
 		throw new Error(
 			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
 		);
 	}
-	return spawnSync(command, args, { env, cwd, encoding: "utf8", input: options.input });
+	return spawnSync(command, args, {
+		env,
+		cwd,
+		encoding: "utf8",
+		input: options.input,
+		timeout: options.timeoutMs,
+	});
 }
 
 export function runRuntimeUserCommand(
@@ -173,7 +180,7 @@ export function runRuntimeUserCommand(
 	stdin: string,
 	home: string,
 	cwd: string,
-	options: { egressSystemCaFile?: string } = {},
+	options: { egressSystemCaFile?: string; timeoutMs?: number } = {},
 ): void {
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
@@ -184,6 +191,7 @@ export function runRuntimeUserCommand(
 				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
 				cwd,
 				stdio: "pipe",
+				timeout: options.timeoutMs,
 			});
 			return;
 		}
@@ -191,7 +199,7 @@ export function runRuntimeUserCommand(
 			execFileSync(
 				"runuser",
 				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ input: stdin, env, cwd, stdio: "pipe" },
+				{ input: stdin, env, cwd, stdio: "pipe", timeout: options.timeoutMs },
 			);
 			return;
 		}
@@ -199,5 +207,11 @@ export function runRuntimeUserCommand(
 			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
 		);
 	}
-	execFileSync(command, args, { input: stdin, env, cwd, stdio: "pipe" });
+	execFileSync(command, args, {
+		input: stdin,
+		env,
+		cwd,
+		stdio: "pipe",
+		timeout: options.timeoutMs,
+	});
 }

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8853,6 +8853,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousUmask = process.umask(0o022);
 		const previousExitCode = process.exitCode;
+		const previousPath = process.env.PATH;
 		let runtimeExitCode: number | undefined;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
@@ -8865,6 +8866,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_RUNTIME_USER = String(process.getuid?.() ?? 0);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		const paths = getRuntimePaths();
 		writeFakeSystemdManager({
 			path: join(bin, "systemctl"),
@@ -8877,7 +8879,9 @@ chmod +x "$prefix/bin/clawdi"
 			`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> '${installerLog}'
-if [ "$*" = "${installArgs}" ]; then
+if [ "$*" = "--version" ]; then
+  printf '%s\n' '${runtime}-test-version'
+elif [ "$*" = "${installArgs}" ]; then
   printf '%s\n' 'official ${runtime} installer' >> '${systemctlLog}'
   test -r '${paths.egressSystemCaFile}'
   test -s '${join(paths.systemdEnvRoot, `${serviceName}.service.env`)}'
@@ -8891,6 +8895,32 @@ exit 0
 `,
 		);
 		chmodSync(runtimeBin, 0o700);
+		if (runtime === "hermes") {
+			const distIndex = join(
+				home,
+				".hermes",
+				"hermes-agent",
+				"hermes_cli",
+				"web_dist",
+				"index.html",
+			);
+			mkdirSync(join(home, ".hermes", "hermes-agent"), { recursive: true });
+			writeFileSync(
+				join(bin, "npm"),
+				`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "npm $*" >> '${installerLog}'
+if [ "$*" = "--version" ]; then
+  printf '%s\n' '12.0.2'
+elif [ "$*" = "run build -w web" ]; then
+  mkdir -p '${dirname(distIndex)}'
+  printf '%s\n' '<html>Hermes dashboard</html>' > '${distIndex}'
+  printf '%s\n' 'official hermes dashboard artifact' >> '${systemctlLog}'
+fi
+`,
+			);
+			chmodSync(join(bin, "npm"), 0o700);
+		}
 		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const mitmproxy = seedMitmproxyCache(paths);
@@ -8913,6 +8943,8 @@ exit 0
 		} finally {
 			runtimeFetch.restore();
 			console.log = previousLog;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
 			process.umask(previousUmask);
 			process.exitCode = previousExitCode;
 		}
@@ -8939,12 +8971,15 @@ exit 0
 			/^(start|restart) .*clawdi-runtime-sidecar\.service/.test(call),
 		);
 		const officialInstaller = calls.indexOf(`official ${runtime} installer`);
+		const dashboardArtifact = calls.indexOf("official hermes dashboard artifact");
 		const finalSystemActivation = calls.findIndex(
 			(call) => call.startsWith("start") && call.includes("clawdi-daemon.service"),
 		);
 		expect(sidecarActivation).toBeGreaterThanOrEqual(0);
 		expect(officialInstaller).toBeGreaterThan(sidecarActivation);
+		if (runtime === "hermes") expect(dashboardArtifact).toBeGreaterThan(officialInstaller);
 		expect(finalSystemActivation).toBeGreaterThan(officialInstaller);
+		if (runtime === "hermes") expect(finalSystemActivation).toBeGreaterThan(dashboardArtifact);
 		expect(calls).not.toContain(`--user restart ${serviceName}.service`);
 		const installerCalls = readFileSync(installerLog, "utf8").trim().split("\n");
 		const installIndex = installerCalls.indexOf(installArgs);
@@ -8952,7 +8987,18 @@ exit 0
 			expect(installIndex).toBeGreaterThan(0);
 			expect(installerCalls.slice(installIndex + 1)).not.toContain("config patch --stdin");
 		} else {
-			expect(installIndex).toBe(0);
+			expect(installIndex).toBeGreaterThanOrEqual(0);
+			const postInstallCalls = installerCalls.slice(installIndex + 1);
+			expect(postInstallCalls.filter((call) => call.startsWith("npm "))).toEqual([
+				"npm --version",
+				"npm install --workspace web",
+				"npm run build -w web",
+			]);
+			expect(
+				postInstallCalls
+					.filter((call) => !call.startsWith("npm "))
+					.every((call) => call === "--version"),
+			).toBe(true);
 			expect(existsSync(join(home, ".hermes", "config.yaml"))).toBe(true);
 		}
 		expect(readRuntimeAppliedState(paths)).toMatchObject({


### PR DESCRIPTION
## Summary
- prepare and verify the upstream Hermes dashboard artifact before final systemd activation
- render the dashboard service with the public `--skip-build` contract
- reuse post-authority install receipts and the existing runtime-user snapshot for crash-safe convergence
- bound npm commands and propagate transparent-egress CA state

No new marker, journal, retry loop, service owner, or authority is introduced.

## Upstream contracts
- Hermes npm engine: `<11.10.0 || >=12.0.0`
- official installer installs web dependencies but does not build `web_dist`
- `dashboard --skip-build` is the public prebuilt-artifact mode

## Verification
- focused runtime tests: 347+ passed across review iterations
- isolated full CLI suite: 1505 passed, 4 skipped
- typecheck
- Biome
- git diff --check