### PR TITLE
chore(backend): tighten S3 file store boundary

### DIFF
--- a/backend/app/services/file_store.py
+++ b/backend/app/services/file_store.py
@@ -1,11 +1,12 @@
 import asyncio
 from functools import lru_cache
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import boto3
 from botocore.client import Config as BotoConfig
 from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
 
 from app.core.config import settings
 
@@ -15,6 +16,24 @@ class FileStore(Protocol):
     async def get(self, key: str) -> bytes: ...
     async def delete(self, key: str) -> None: ...
     async def exists(self, key: str) -> bool: ...
+
+
+@runtime_checkable
+class _S3Client(Protocol):
+    """The small public boto3 S3 surface owned by this consumer."""
+
+    def put_object(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        ContentType: str | None = None,
+    ) -> object: ...
+    def get_object(self, *, Bucket: str, Key: str) -> object: ...
+    def delete_object(self, *, Bucket: str, Key: str) -> object: ...
+    def head_object(self, *, Bucket: str, Key: str) -> object: ...
+    def close(self) -> None: ...
 
 
 class LocalFileStore:
@@ -85,39 +104,56 @@ class S3FileStore:
         config = BotoConfig(
             s3={"addressing_style": "path" if force_path_style else "auto"},
         )
-        kwargs = {
-            "service_name": "s3",
-            "region_name": region or None,
-            "endpoint_url": endpoint_url or None,
-            "config": config,
-        }
         if access_key_id or secret_access_key:
-            kwargs["aws_access_key_id"] = access_key_id
-            kwargs["aws_secret_access_key"] = secret_access_key
-        self.client = boto3.client(**kwargs)
+            client = boto3.client(
+                "s3",
+                region_name=region or None,
+                endpoint_url=endpoint_url or None,
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+                config=config,
+            )
+        else:
+            client = boto3.client(
+                "s3",
+                region_name=region or None,
+                endpoint_url=endpoint_url or None,
+                config=config,
+            )
+        if not isinstance(client, _S3Client):
+            raise RuntimeError("boto3 returned an invalid S3 client")
+        self.client = client
 
     async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
-        extra: dict[str, str] = {}
         if content_type:
-            extra["ContentType"] = content_type
-        await asyncio.to_thread(
-            self.client.put_object,
-            Bucket=self.bucket,
-            Key=key,
-            Body=data,
-            **extra,
-        )
+            await asyncio.to_thread(
+                self.client.put_object,
+                Bucket=self.bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+            )
+        else:
+            await asyncio.to_thread(
+                self.client.put_object,
+                Bucket=self.bucket,
+                Key=key,
+                Body=data,
+            )
 
     async def get(self, key: str) -> bytes:
         def _read() -> bytes:
             try:
                 response = self.client.get_object(Bucket=self.bucket, Key=key)
             except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code")
-                if code in {"404", "NoSuchKey", "NotFound"}:
+                if _is_not_found(exc):
                     raise FileNotFoundError(key) from exc
                 raise
-            body = response["Body"]
+            if not isinstance(response, dict):
+                raise RuntimeError("S3 get_object returned a non-object response")
+            body = response.get("Body")
+            if not isinstance(body, StreamingBody):
+                raise RuntimeError("S3 get_object returned an invalid Body")
             try:
                 return body.read()
             finally:
@@ -134,12 +170,22 @@ class S3FileStore:
                 self.client.head_object(Bucket=self.bucket, Key=key)
                 return True
             except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code")
-                if code in {"404", "NoSuchKey", "NotFound"}:
+                if _is_not_found(exc):
                     return False
                 raise
 
         return await asyncio.to_thread(_exists)
+
+
+def _is_not_found(exc: ClientError) -> bool:
+    response = exc.response
+    if not isinstance(response, dict):
+        return False
+    error = response.get("Error")
+    if not isinstance(error, dict):
+        return False
+    code = error.get("Code")
+    return isinstance(code, str) and code in {"404", "NoSuchKey", "NotFound"}
 
 
 @lru_cache(maxsize=1)
@@ -149,7 +195,7 @@ def get_file_store() -> FileStore:
     Single factory read from `Settings`. Cached so route modules reuse
     the same local path / S3 client.
     """
-    kind = getattr(settings, "file_store_type", "local")
+    kind = settings.file_store_type
     if kind == "local":
         return LocalFileStore(settings.file_store_local_path)
     if kind == "s3":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,8 +30,11 @@ dependencies = [
     # Official Streamable HTTP client lifecycle for Composio Tool Router.
     "mcp==2.0.0",
     "prometheus-client>=0.25.0",
-    "boto3>=1.35",
-    "botocore>=1.35",
+    # Keep boto3 and botocore on the same published release. boto3 1.43.62
+    # requires botocore>=1.43.62,<1.44.0.
+    # https://pypi.org/pypi/boto3/1.43.62/json
+    "boto3==1.43.62",
+    "botocore==1.43.62",
 ]
 
 [project.optional-dependencies]
@@ -66,6 +69,7 @@ include = [
     "app/core/skill_key.py",
     "app/services/composio.py",
     "app/services/embedding.py",
+    "app/services/file_store.py",
     "app/services/memory_extraction.py",
 ]
 

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -22,6 +22,7 @@ EXPECTED_CONFIG = {
         "app/core/skill_key.py",
         "app/services/composio.py",
         "app/services/embedding.py",
+        "app/services/file_store.py",
         "app/services/memory_extraction.py",
     ],
 }

--- a/backend/tests/test_file_store_s3.py
+++ b/backend/tests/test_file_store_s3.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote, urlsplit
+
+import pytest
+from botocore.exceptions import ClientError, ResponseStreamingError
+
+from app.services.file_store import S3FileStore
+
+
+class _S3CompatibleHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    objects: dict[str, tuple[bytes, str | None]] = {}
+    requests: list[tuple[str, str, str | None]] = []
+    lock = threading.Lock()
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+    def _record(self) -> str:
+        path = unquote(urlsplit(self.path).path)
+        authorization = self.headers.get("Authorization")
+        with self.lock:
+            self.requests.append((self.command, path, authorization))
+        return path
+
+    def _send_empty(self, status: HTTPStatus) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _send_error(self, status: HTTPStatus, code: str) -> None:
+        payload = (
+            f"<Error><Code>{code}</Code><Message>contract response</Message></Error>"
+        ).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/xml")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(payload)
+
+    def do_PUT(self) -> None:
+        path = self._record()
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length)
+        with self.lock:
+            self.objects[path] = (data, self.headers.get("Content-Type"))
+        self._send_empty(HTTPStatus.OK)
+
+    def do_GET(self) -> None:
+        path = self._record()
+        if path.endswith("/truncated"):
+            payload = b"short"
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Length", str(len(payload) + 1))
+            self.end_headers()
+            self.wfile.write(payload)
+            self.close_connection = True
+            return
+        if path.endswith("/denied"):
+            self._send_error(HTTPStatus.FORBIDDEN, "AccessDenied")
+            return
+        with self.lock:
+            stored = self.objects.get(path)
+        if stored is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "NoSuchKey")
+            return
+        data, content_type = stored
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Length", str(len(data)))
+        if content_type is not None:
+            self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_HEAD(self) -> None:
+        path = self._record()
+        if path.endswith("/denied"):
+            self._send_error(HTTPStatus.FORBIDDEN, "AccessDenied")
+            return
+        with self.lock:
+            stored = self.objects.get(path)
+        if stored is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "NoSuchKey")
+            return
+        data, content_type = stored
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Length", str(len(data)))
+        if content_type is not None:
+            self.send_header("Content-Type", content_type)
+        self.end_headers()
+
+    def do_DELETE(self) -> None:
+        path = self._record()
+        with self.lock:
+            self.objects.pop(path, None)
+        self._send_empty(HTTPStatus.NO_CONTENT)
+
+
+@pytest.fixture
+def s3_endpoint() -> Iterator[tuple[str, type[_S3CompatibleHandler]]]:
+    handler = _S3CompatibleHandler
+    handler.objects = {}
+    handler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", handler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _store(endpoint: str) -> S3FileStore:
+    return S3FileStore(
+        bucket="contract-bucket",
+        region="us-east-1",
+        endpoint_url=endpoint,
+        access_key_id="contract-access-key",
+        secret_access_key="contract-secret-key",
+        force_path_style=True,
+    )
+
+
+@pytest.fixture
+def s3_store(
+    s3_endpoint: tuple[str, type[_S3CompatibleHandler]],
+) -> Iterator[tuple[S3FileStore, type[_S3CompatibleHandler]]]:
+    endpoint, handler = s3_endpoint
+    store = _store(endpoint)
+    try:
+        yield store, handler
+    finally:
+        store.client.close()
+
+
+@pytest.mark.asyncio
+async def test_real_boto3_s3_transport_contract(
+    s3_store: tuple[S3FileStore, type[_S3CompatibleHandler]],
+) -> None:
+    store, handler = s3_store
+
+    await store.put("folder/object.txt", b"contract body", content_type="text/plain")
+    assert handler.objects["/contract-bucket/folder/object.txt"] == (
+        b"contract body",
+        "text/plain",
+    )
+    assert await store.exists("folder/object.txt") is True
+    assert await store.get("folder/object.txt") == b"contract body"
+
+    await store.delete("folder/object.txt")
+    assert await store.exists("folder/object.txt") is False
+    with pytest.raises(FileNotFoundError, match="folder/object.txt"):
+        await store.get("folder/object.txt")
+
+    methods = [method for method, _, _ in handler.requests]
+    assert methods == ["PUT", "HEAD", "GET", "DELETE", "HEAD", "GET"]
+    for _, path, authorization in handler.requests:
+        assert path.startswith("/contract-bucket/")
+        assert authorization is not None
+        assert authorization.startswith("AWS4-HMAC-SHA256 Credential=contract-access-key/")
+
+
+@pytest.mark.asyncio
+async def test_non_not_found_client_errors_propagate(
+    s3_store: tuple[S3FileStore, type[_S3CompatibleHandler]],
+) -> None:
+    store, _ = s3_store
+
+    with pytest.raises(ClientError, match="AccessDenied"):
+        await store.get("denied")
+    with pytest.raises(ClientError, match="403"):
+        await store.exists("denied")
+
+
+@pytest.mark.asyncio
+async def test_streaming_body_closes_after_read_failure(
+    s3_store: tuple[S3FileStore, type[_S3CompatibleHandler]],
+) -> None:
+    store, handler = s3_store
+
+    with pytest.raises(ResponseStreamingError, match="response stream"):
+        await store.get("truncated")
+
+    await store.put("after-truncated", b"ok")
+    assert await store.exists("after-truncated") is True
+    assert [method for method, _, _ in handler.requests] == ["GET", "PUT", "HEAD"]
+
+
+@pytest.mark.asyncio
+async def test_default_credential_chain(
+    s3_endpoint: tuple[str, type[_S3CompatibleHandler]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint, handler = s3_endpoint
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "chain-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "chain-secret-key")
+    store = S3FileStore(
+        bucket="contract-bucket",
+        region="us-east-1",
+        endpoint_url=endpoint,
+        access_key_id="",
+        secret_access_key="",
+        force_path_style=True,
+    )
+    try:
+        await store.put("default-chain", b"credential chain")
+    finally:
+        store.client.close()
+
+    _, path, authorization = handler.requests[-1]
+    assert path == "/contract-bucket/default-chain"
+    assert authorization is not None
+    assert authorization.startswith("AWS4-HMAC-SHA256 Credential=chain-access-key/")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -142,30 +142,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.58"
+version = "1.43.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/95/bd6276870084c9c1a94e17d1dc73b2de275e59bd7a0ad8bfff0a1598cec4/boto3-1.43.58.tar.gz", hash = "sha256:12871fb50c383f1b9aa4ed6dd386ba689062baef730552e79d5a9cd782b53058", size = 112685, upload-time = "2026-07-28T19:35:09.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/c7/f7732c5e1abf7270a6bbbce47338d25ea66a30df658cffd1d17bb5f735fb/boto3-1.43.62.tar.gz", hash = "sha256:0bf920e0739346e81c7310b685a3f783bf1fcc62ce7d5c7016508fa25c0d261f", size = 112668, upload-time = "2026-07-31T19:35:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/85/b0709066efb4ce7b86aba4092c739ad0e458be9d62cf32550fc4c130c93f/boto3-1.43.58-py3-none-any.whl", hash = "sha256:ce1a20cbcfaa1d0b3c8f568e2b6c7fbd34b842ea00e729d49a4b4de522828db9", size = 140026, upload-time = "2026-07-28T19:35:06.993Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f0/5e1a392c817e395b140c18c12a00c0c65c69f8d63da26ad4387aebf2172b/boto3-1.43.62-py3-none-any.whl", hash = "sha256:0bb298e7ffd72b91615df44bf71c417df80a29d844971e5d665b8bd743a4bb35", size = 140025, upload-time = "2026-07-31T19:35:15.347Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.58"
+version = "1.43.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/64/5cd46a7e72b0647e6d78fc8da016259ad66b9ae0818f4c5d629c75e7ca49/botocore-1.43.58.tar.gz", hash = "sha256:e110ca53f65c128fe98df4d6d36a459b1db17c6114671c8a18becf151bf20909", size = 15742412, upload-time = "2026-07-28T19:34:57.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/36af6d99269a701f83809b87a01f4728699eb825ebdedee3a3d515b18f61/botocore-1.43.62.tar.gz", hash = "sha256:94efc419c9f0f41dc2415e4b6b62f04ae21b3ce3930fac47214c4d3f361ea8b8", size = 15818261, upload-time = "2026-07-31T19:35:06.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/82/6f8fbbea47b773734ba0199643d2d851e5c2f75bc3699fe99db8af344d96/botocore-1.43.58-py3-none-any.whl", hash = "sha256:f516159f0732da8249206163ccea3bd1f82ad2a9d184fe6ed447e1abdba4330e", size = 15426503, upload-time = "2026-07-28T19:34:53.508Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/65/d5dae96de68ffc55acf87c3bae76e9dabeeca92aadf1223f20e9a7860aef/botocore-1.43.62-py3-none-any.whl", hash = "sha256:76de153de1ba3e242b2e6df6a13ab8a3fb35d17db562462969e661457b63166e", size = 15502622, upload-time = "2026-07-31T19:35:02.697Z" },
 ]
 
 [[package]]
@@ -376,8 +376,8 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.1" },
     { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.30" },
-    { name = "boto3", specifier = ">=1.35" },
-    { name = "botocore", specifier = ">=1.35" },
+    { name = "boto3", specifier = "==1.43.62" },
+    { name = "botocore", specifier = "==1.43.62" },
     { name = "composio", specifier = "==0.18.1" },
     { name = "composio-client", specifier = "==1.43.0" },
     { name = "cryptography", specifier = ">=44.0" },


### PR DESCRIPTION
## Summary
- Pin the current compatible `boto3==1.43.62` / `botocore==1.43.62` pair.
- Define only the public S3 operations Clawdi consumes through a minimal owned Protocol, narrow dynamic responses and ClientError payloads, and preserve off-event-loop calls plus StreamingBody closure.
- Exercise signed path-style PUT/GET/HEAD/DELETE against a local HTTP S3-compatible server, including Content-Type, default credentials, not-found mapping, non-404 propagation, and read-failure cleanup.
- Keep the process-cached production client alive for process lifetime; tests explicitly close the public clients they create. No lifecycle registry, atexit callback, shim, or app/main.py change.

## Base / head
- Base: `main@ddeaa4392a34a9ddea1fc2a45f99111d1b45a110` (the reviewer-requested rebase first landed cleanly on `8c5782d8471915456220b4fc4a1cc134eecad840`; main advanced again during verification).
- Head: `3a5207205068a51aae615ddd694e9af2a198816f`.
- One semantic commit.

## Exact two-dot diff
- 5 files changed, 307 insertions, 35 deletions.
- `backend/app/services/file_store.py`: +71/-25
- `backend/tests/test_file_store_s3.py`: +221/-0
- `backend/pyproject.toml`: +6/-2
- `backend/scripts/type_governance.py`: +1/-0
- `backend/uv.lock`: +8/-8

## Type inventory
- Baseline: 354 files / 333 errors.
- Final: 355 files / 333 errors (`app` 177/154, `tests` 113/173, `scripts` 11/2, `alembic` 54/4).
- Delta: +1 zero-diagnostic test file / +0 errors.
- Production + touched test check: 2 files / 0 diagnostics; owned: 6/0; changed production: 1/0.

## Official evidence
- boto3 1.43.62 metadata requires `botocore>=1.43.62,<1.44.0`: https://pypi.org/pypi/boto3/1.43.62/json
- boto3 upstream dependency declaration: https://github.com/boto/boto3/blob/develop/setup.py
- Public boto3 client factory: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client
- Public botocore StreamingBody: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/response.html
- Public botocore ClientError: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/error-handling.html

## Verification
- Focused S3 transport: 4 passed.
- Latest-base backend/PostgreSQL/migrations: 1712 passed, 7 skipped.
- Full clean workspace suite on the reviewer-requested `8c5782d8` base: all client packages passed; backend 1712 passed, 7 skipped.
- Latest-base full-workspace rerun reached isolated `bun install --frozen-lockfile` and stalled without output; it was terminated and cleaned up. Latest-base backend full suite and all focused/static gates passed.
- uv locked sync/lock, dependency authority, deptry, Ruff lint/format, compileall, owned/changed type gates, generated OpenAPI client, strict deploy-contract drift, and diff-check passed.

## Rebase equivalence
- Pre-rebase original stable patch-id: `c3eb29707657ac84a81240abb46c99c3625ca5b8`.
- Rebased-before-review-fixes stable patch-id: identical `c3eb29707657ac84a81240abb46c99c3625ca5b8`.
- Final stable patch-id: `89c94ca7c5d9664ae0970b47f4d4796ad423bcaf`; range-diff differs only by removing atexit lifecycle registration, typing the server endpoint without tuple unpacking, explicit test-client cleanup, and stronger default-chain transport coverage.