### PR TITLE
fix(web): enlarge shared brand icons

### DIFF
--- a/apps/web/e2e/brand-icon-gallery.browser.tsx
+++ b/apps/web/e2e/brand-icon-gallery.browser.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
+import {
+	FRAMEWORK_BRAND_ICON_IDS,
+	PROVIDER_BRAND_ICON_IDS,
+} from "@/components/entity-brand-icon-ids";
+import { EntityIcon } from "@/components/entity-icon";
+import "@/styles/globals.css";
+
+function GalleryCell({
+	kind,
+	id,
+	surface,
+	children,
+}: {
+	kind: "framework" | "provider";
+	id: string;
+	surface: string;
+	children: ReactNode;
+}) {
+	return (
+		<div
+			data-brand-cell
+			data-brand-kind={kind}
+			data-brand-id={id}
+			data-brand-surface={surface}
+			className="flex min-h-20 items-center gap-3 rounded-lg border border-border bg-background p-3"
+		>
+			{children}
+			<span className="text-xs text-muted-foreground">
+				{id} · {surface}
+			</span>
+		</div>
+	);
+}
+
+function BrandIconGallery() {
+	return (
+		<main className="min-h-screen bg-background p-6 text-foreground">
+			<section className="grid grid-cols-3 gap-3" aria-label="Framework brand icon geometry">
+				{FRAMEWORK_BRAND_ICON_IDS.flatMap((id) => [
+					<GalleryCell key={`${id}-rail`} kind="framework" id={id} surface="sidebar-rail">
+						<AgentIcon agent={id} size="rail" />
+					</GalleryCell>,
+					<GalleryCell key={`${id}-card`} kind="framework" id={id} surface="agent-card">
+						<AgentIcon agent={id} size="lg" />
+					</GalleryCell>,
+					<GalleryCell key={`${id}-deploy`} kind="framework" id={id} surface="deploy-card">
+						<EntityIcon kind="framework" id={id} size="md" />
+					</GalleryCell>,
+				])}
+			</section>
+
+			<section className="mt-6 grid grid-cols-4 gap-3" aria-label="Provider brand icon geometry">
+				{PROVIDER_BRAND_ICON_IDS.flatMap((id) => [
+					<GalleryCell key={`${id}-card`} kind="provider" id={id} surface="provider-card">
+						<EntityIcon kind="provider" id={id} size="sm" />
+					</GalleryCell>,
+					<GalleryCell key={`${id}-model`} kind="provider" id={id} surface="model-card">
+						<EntityIcon kind="provider" id={id} size="sm" />
+					</GalleryCell>,
+				])}
+			</section>
+		</main>
+	);
+}
+
+const galleryRoot = document.querySelector("#brand-icon-gallery");
+if (!(galleryRoot instanceof HTMLElement)) {
+	throw new Error("Brand icon gallery root is missing.");
+}
+
+createRoot(galleryRoot).render(<BrandIconGallery />);

--- a/apps/web/e2e/brand-icon-geometry.pw.ts
+++ b/apps/web/e2e/brand-icon-geometry.pw.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import {
+	FRAMEWORK_BRAND_ICON_IDS,
+	PROVIDER_BRAND_ICON_IDS,
+} from "../src/components/entity-brand-icon-ids";
+
+test("keeps every shared LobeHub brand mark full and contained", async ({ page }, testInfo) => {
+	await page.setViewportSize({ width: 1440, height: 2400 });
+	await page.goto("/");
+	await page.setContent(`<!doctype html>
+		<html lang="en">
+			<head><meta name="viewport" content="width=device-width, initial-scale=1" /></head>
+			<body><div id="brand-icon-gallery"></div><script type="module" src="/e2e/brand-icon-gallery.browser.tsx"></script></body>
+		</html>`);
+
+	const icons = page.locator('[data-icon-source="lobehub"]');
+	const expectedIconCount =
+		FRAMEWORK_BRAND_ICON_IDS.length * 3 + PROVIDER_BRAND_ICON_IDS.length * 2;
+	await expect(icons).toHaveCount(expectedIconCount);
+
+	const measurements = await icons.evaluateAll((elements) =>
+		elements.map((element) => {
+			if (!(element instanceof SVGSVGElement) || !(element.parentElement instanceof HTMLElement)) {
+				throw new Error("Expected an SVG brand mark inside an HTML tile.");
+			}
+			const icon = element.getBoundingClientRect();
+			const tile = element.parentElement.getBoundingClientRect();
+			const artwork = element.getBBox();
+			const matrix = element.getScreenCTM();
+			if (!matrix) throw new Error("Expected the brand mark to have a screen transform.");
+			const artworkCorners = [
+				new DOMPoint(artwork.x, artwork.y).matrixTransform(matrix),
+				new DOMPoint(artwork.x + artwork.width, artwork.y).matrixTransform(matrix),
+				new DOMPoint(artwork.x, artwork.y + artwork.height).matrixTransform(matrix),
+				new DOMPoint(artwork.x + artwork.width, artwork.y + artwork.height).matrixTransform(matrix),
+			];
+			const artworkLeft = Math.min(...artworkCorners.map((point) => point.x));
+			const artworkRight = Math.max(...artworkCorners.map((point) => point.x));
+			const artworkTop = Math.min(...artworkCorners.map((point) => point.y));
+			const artworkBottom = Math.max(...artworkCorners.map((point) => point.y));
+			const cell = element.closest("[data-brand-cell]");
+			return {
+				id: cell?.getAttribute("data-brand-id"),
+				kind: cell?.getAttribute("data-brand-kind"),
+				surface: cell?.getAttribute("data-brand-surface"),
+				iconWidth: icon.width,
+				iconHeight: icon.height,
+				tileWidth: tile.width,
+				tileHeight: tile.height,
+				artworkWidth: artworkRight - artworkLeft,
+				artworkHeight: artworkBottom - artworkTop,
+				widthAttribute: element.getAttribute("width"),
+				heightAttribute: element.getAttribute("height"),
+				contained:
+					icon.left >= tile.left &&
+					icon.top >= tile.top &&
+					icon.right <= tile.right &&
+					icon.bottom <= tile.bottom &&
+					artworkLeft >= tile.left &&
+					artworkTop >= tile.top &&
+					artworkRight <= tile.right &&
+					artworkBottom <= tile.bottom,
+				noOverflow:
+					element.parentElement.scrollWidth <= element.parentElement.clientWidth &&
+					element.parentElement.scrollHeight <= element.parentElement.clientHeight,
+				minimumMargin: Math.min(
+					icon.left - tile.left,
+					icon.top - tile.top,
+					tile.right - icon.right,
+					tile.bottom - icon.bottom,
+				),
+			};
+		}),
+	);
+
+	for (const measurement of measurements) {
+		expect(measurement.widthAttribute, `${measurement.id} width`).toBe("84%");
+		expect(measurement.heightAttribute, `${measurement.id} height`).toBe("84%");
+		expect(measurement.contained, `${measurement.id} artwork containment`).toBe(true);
+		expect(measurement.noOverflow, `${measurement.id} tile overflow`).toBe(true);
+		expect(measurement.iconWidth, `${measurement.id} visible fill`).toBeGreaterThan(
+			measurement.tileWidth * 0.75,
+		);
+		expect(measurement.iconHeight, `${measurement.id} visible fill`).toBeGreaterThan(
+			measurement.tileHeight * 0.75,
+		);
+		expect(measurement.iconWidth, `${measurement.id} safety space`).toBeLessThan(
+			measurement.tileWidth * 0.81,
+		);
+		expect(measurement.iconHeight, `${measurement.id} safety space`).toBeLessThan(
+			measurement.tileHeight * 0.81,
+		);
+		expect(measurement.minimumMargin, `${measurement.id} edge margin`).toBeGreaterThan(2.5);
+	}
+
+	const frameworkMeasurements = measurements.filter(({ kind }) => kind === "framework");
+	const providerMeasurements = measurements.filter(({ kind }) => kind === "provider");
+	for (const id of FRAMEWORK_BRAND_ICON_IDS) {
+		expect(frameworkMeasurements.filter((measurement) => measurement.id === id)).toHaveLength(3);
+	}
+	for (const id of PROVIDER_BRAND_ICON_IDS) {
+		expect(providerMeasurements.filter((measurement) => measurement.id === id)).toHaveLength(2);
+	}
+
+	await page.screenshot({
+		path: testInfo.outputPath("brand-icon-geometry-84.png"),
+		fullPage: true,
+	});
+});

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -47,6 +47,10 @@ async function expectVisibleLobeHubIconsContained(page: Page, minimumCount: numb
 			return {
 				width: element.getAttribute("width"),
 				height: element.getAttribute("height"),
+				iconWidth: icon.width,
+				iconHeight: icon.height,
+				tileWidth: tile?.width ?? 0,
+				tileHeight: tile?.height ?? 0,
 				contained: Boolean(
 					tile &&
 						icon.left >= tile.left &&
@@ -54,11 +58,23 @@ async function expectVisibleLobeHubIconsContained(page: Page, minimumCount: numb
 						icon.right <= tile.right &&
 						icon.bottom <= tile.bottom,
 				),
+				noOverflow: Boolean(
+					element.parentElement &&
+						element.parentElement.scrollWidth <= element.parentElement.clientWidth &&
+						element.parentElement.scrollHeight <= element.parentElement.clientHeight,
+				),
 			};
 		}),
 	);
 	for (const measurement of measurements) {
-		expect(measurement).toEqual({ width: "72%", height: "72%", contained: true });
+		expect(measurement.width).toBe("84%");
+		expect(measurement.height).toBe("84%");
+		expect(measurement.contained).toBe(true);
+		expect(measurement.noOverflow).toBe(true);
+		expect(measurement.iconWidth).toBeGreaterThan(measurement.tileWidth * 0.75);
+		expect(measurement.iconHeight).toBeGreaterThan(measurement.tileHeight * 0.75);
+		expect(measurement.iconWidth).toBeLessThan(measurement.tileWidth * 0.81);
+		expect(measurement.iconHeight).toBeLessThan(measurement.tileHeight * 0.81);
 	}
 }
 
@@ -4163,7 +4179,7 @@ test("rejected detail delete stays on the current agent without accepted cleanup
 
 test("deploy managed model picker preserves featured and overflow order and submits overflow", async ({
 	page,
-}) => {
+}, testInfo) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
 	await stubHostedApi(page, {
 		plans: [basicPlan],
@@ -4193,8 +4209,8 @@ test("deploy managed model picker preserves featured and overflow order and subm
 	await expect(kimiBrand).toBeVisible();
 	for (const icon of [openAiIcon, kimiIcon]) {
 		await expect(icon.locator("svg")).toHaveCount(1);
-		await expect(icon.locator('[data-icon-source="lobehub"]')).toHaveAttribute("width", "72%");
-		await expect(icon.locator('[data-icon-source="lobehub"]')).toHaveAttribute("height", "72%");
+		await expect(icon.locator('[data-icon-source="lobehub"]')).toHaveAttribute("width", "84%");
+		await expect(icon.locator('[data-icon-source="lobehub"]')).toHaveAttribute("height", "84%");
 	}
 	await expect(featuredCards.nth(0).getByText("O", { exact: true })).toHaveCount(0);
 	await expect(featuredCards.nth(0).getByText("S", { exact: true })).toHaveCount(0);
@@ -4249,21 +4265,25 @@ test("deploy managed model picker preserves featured and overflow order and subm
 	const screenshotStyle = await page.addStyleTag({
 		content: ".sticky.bottom-0 { display: none !important; }",
 	});
-	await expectResponsiveAiChoiceLayout(
-		page,
-		"deploy",
-		(width) => `/tmp/deploy-ai-provider-layout-${width}.png`,
+	await expectResponsiveAiChoiceLayout(page, "deploy", (width) =>
+		testInfo.outputPath(`deploy-ai-provider-layout-${width}.png`),
 	);
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.locator("html").evaluate((element) => element.classList.add("dark"));
 	await expect(page.locator("html")).toHaveClass(/dark/);
-	await page.getByTestId("provider-choice-grid").locator("..").screenshot({
-		path: "/tmp/deploy-ai-provider-layout-dark-1280.png",
-	});
+	await page
+		.getByTestId("provider-choice-grid")
+		.locator("..")
+		.screenshot({
+			path: testInfo.outputPath("deploy-ai-provider-layout-dark-1280.png"),
+		});
 	await page.setViewportSize({ width: 390, height: 844 });
-	await page.getByTestId("provider-choice-grid").locator("..").screenshot({
-		path: "/tmp/deploy-ai-provider-layout-dark-390.png",
-	});
+	await page
+		.getByTestId("provider-choice-grid")
+		.locator("..")
+		.screenshot({
+			path: testInfo.outputPath("deploy-ai-provider-layout-dark-390.png"),
+		});
 	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
 	await screenshotStyle.evaluate((element) => element.parentNode?.removeChild(element));
 
@@ -4446,7 +4466,7 @@ test("hosted AI provider Apply submits canonical deployment PATCH", async ({ pag
 
 test("agent settings shares the responsive managed model layout and accepts its catalog default", async ({
 	page,
-}) => {
+}, testInfo) => {
 	const updateDeploymentRequests: Array<{
 		body: string;
 		idempotencyKey: string | null;
@@ -4477,21 +4497,25 @@ test("agent settings shares the responsive managed model layout and accepts its 
 	await expect(page.locator("#agent-primary-model")).toHaveCount(0);
 	await expect(page.locator("#agent-primary-provider")).toHaveCount(0);
 	await expect(page.getByText("Primary provider", { exact: true })).toHaveCount(0);
-	await expectResponsiveAiChoiceLayout(
-		page,
-		"agent",
-		(width) => `/tmp/agent-ai-provider-layout-${width}.png`,
+	await expectResponsiveAiChoiceLayout(page, "agent", (width) =>
+		testInfo.outputPath(`agent-ai-provider-layout-${width}.png`),
 	);
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.locator("html").evaluate((element) => element.classList.add("dark"));
 	await expect(page.locator("html")).toHaveClass(/dark/);
-	await page.getByTestId("provider-choice-grid").locator("..").screenshot({
-		path: "/tmp/agent-ai-provider-layout-dark-1280.png",
-	});
+	await page
+		.getByTestId("provider-choice-grid")
+		.locator("..")
+		.screenshot({
+			path: testInfo.outputPath("agent-ai-provider-layout-dark-1280.png"),
+		});
 	await page.setViewportSize({ width: 390, height: 844 });
-	await page.getByTestId("provider-choice-grid").locator("..").screenshot({
-		path: "/tmp/agent-ai-provider-layout-dark-390.png",
-	});
+	await page
+		.getByTestId("provider-choice-grid")
+		.locator("..")
+		.screenshot({
+			path: testInfo.outputPath("agent-ai-provider-layout-dark-390.png"),
+		});
 	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
 	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);

--- a/apps/web/src/components/agent-framework-icon.test.tsx
+++ b/apps/web/src/components/agent-framework-icon.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { AgentFrameworkIcon } from "@/components/agent-framework-icon";
+import { FRAMEWORK_BRAND_ICON_IDS } from "@/components/entity-brand-icon-ids";
 import { frameworkBrandIcon } from "@/components/entity-brand-icons";
 
 const FRAMEWORKS = {
@@ -12,7 +13,9 @@ const FRAMEWORKS = {
 
 describe("AgentFrameworkIcon", () => {
 	test("renders all supported framework IDs as accessible official LobeHub SVG components", () => {
-		for (const [id, label] of Object.entries(FRAMEWORKS)) {
+		expect(Object.keys(FRAMEWORKS)).toEqual([...FRAMEWORK_BRAND_ICON_IDS]);
+		for (const id of FRAMEWORK_BRAND_ICON_IDS) {
+			const label = FRAMEWORKS[id];
 			expect(frameworkBrandIcon(id)?.label).toBe(label);
 			const markup = renderToStaticMarkup(
 				<AgentFrameworkIcon agent={id} pixelSize={40} boxClassName="size-10" />,
@@ -22,13 +25,33 @@ describe("AgentFrameworkIcon", () => {
 			expect(markup).toContain(`aria-label="${label}"`);
 			expect(markup).toContain(`<title>${label}</title>`);
 			expect(markup).toContain('data-icon-source="lobehub"');
-			expect(markup).toContain('width="72%"');
-			expect(markup).toContain('height="72%"');
+			expect(markup).toContain('width="84%"');
+			expect(markup).toContain('height="84%"');
+			expect(markup).toContain("width:84%;height:84%");
 			expect(markup).not.toContain("<img");
 		}
 	});
 
 	test("preserves the claude_code wire alias", () => {
 		expect(frameworkBrandIcon("claude_code")?.icon).toBe(frameworkBrandIcon("claude-code")?.icon);
+	});
+
+	test("keeps custom avatars as object-cover images instead of scaling them like brand marks", () => {
+		const markup = renderToStaticMarkup(
+			<AgentFrameworkIcon
+				agent="codex"
+				pixelSize={32}
+				boxClassName="size-8 rounded-md"
+				avatarUrl="https://example.test/avatar.png"
+				alt="Custom avatar"
+			/>,
+		);
+		expect(markup).toContain('<img src="https://example.test/avatar.png"');
+		expect(markup).toContain('alt="Custom avatar"');
+		expect(markup).toContain('width="32"');
+		expect(markup).toContain('height="32"');
+		expect(markup).toContain("object-cover");
+		expect(markup).not.toContain("<svg");
+		expect(markup).not.toContain('data-icon-source="lobehub"');
 	});
 });

--- a/apps/web/src/components/brand-icon-tile.tsx
+++ b/apps/web/src/components/brand-icon-tile.tsx
@@ -5,6 +5,9 @@ export type BrandIconComponent = ComponentType<
 	Omit<SVGProps<SVGSVGElement>, "size"> & { size?: number | string }
 >;
 
+const BRAND_ICON_SIZE = "84%";
+const BRAND_ICON_STYLE = { width: BRAND_ICON_SIZE, height: BRAND_ICON_SIZE };
+
 export function BrandIconTile({
 	icon: Icon,
 	label,
@@ -29,7 +32,8 @@ export function BrandIconTile({
 			)}
 		>
 			<Icon
-				size="72%"
+				size={BRAND_ICON_SIZE}
+				style={BRAND_ICON_STYLE}
 				aria-hidden
 				className={cn("shrink-0", iconClassName)}
 				data-icon-source="lobehub"

--- a/apps/web/src/components/entity-brand-icon-ids.ts
+++ b/apps/web/src/components/entity-brand-icon-ids.ts
@@ -1,0 +1,21 @@
+export const FRAMEWORK_BRAND_ICON_IDS = ["openclaw", "hermes", "claude-code", "codex"] as const;
+export type FrameworkBrandIconId = (typeof FRAMEWORK_BRAND_ICON_IDS)[number];
+
+export const PROVIDER_BRAND_ICON_IDS = [
+	"anthropic",
+	"deepseek",
+	"gemini",
+	"grok",
+	"groq",
+	"kimi",
+	"minimax",
+	"mistral",
+	"openai",
+	"openrouter",
+	"qwen",
+	"stepfun",
+	"together",
+	"xai",
+	"zhipu",
+] as const;
+export type ProviderBrandIconId = (typeof PROVIDER_BRAND_ICON_IDS)[number];

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -18,21 +18,26 @@ import Together from "@lobehub/icons/es/Together/components/Color.js";
 import XAI from "@lobehub/icons/es/XAI/components/Mono.js";
 import Zhipu from "@lobehub/icons/es/Zhipu/components/Color.js";
 import type { BrandIconComponent } from "@/components/brand-icon-tile";
+import type { FrameworkBrandIconId, ProviderBrandIconId } from "@/components/entity-brand-icon-ids";
 
 export type BrandIconMetadata = {
 	icon: BrandIconComponent;
 	label: string;
 };
 
-const FRAMEWORK_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {
+const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
 	openclaw: { icon: OpenClaw, label: "OpenClaw" },
 	hermes: { icon: HermesAgent, label: "Hermes Agent" },
 	"claude-code": { icon: ClaudeCode, label: "Claude Code" },
-	claude_code: { icon: ClaudeCode, label: "Claude Code" },
 	codex: { icon: Codex, label: "Codex" },
+} satisfies Readonly<Record<FrameworkBrandIconId, BrandIconMetadata>>;
+
+const FRAMEWORK_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {
+	...FRAMEWORK_BRAND_ICON_DEFINITIONS,
+	claude_code: FRAMEWORK_BRAND_ICON_DEFINITIONS["claude-code"],
 };
 
-const PROVIDER_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {
+const PROVIDER_BRAND_ICON_DEFINITIONS = {
 	anthropic: { icon: Anthropic, label: "Anthropic" },
 	deepseek: { icon: DeepSeek, label: "DeepSeek" },
 	gemini: { icon: Gemini, label: "Gemini" },
@@ -48,7 +53,10 @@ const PROVIDER_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {
 	together: { icon: Together, label: "Together AI" },
 	xai: { icon: XAI, label: "xAI" },
 	zhipu: { icon: Zhipu, label: "Zhipu" },
-};
+} satisfies Readonly<Record<ProviderBrandIconId, BrandIconMetadata>>;
+
+const PROVIDER_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> =
+	PROVIDER_BRAND_ICON_DEFINITIONS;
 
 const PROVIDER_ICON_ALIASES: Readonly<Record<string, string>> = {
 	"google-gemini-openai": "gemini",

--- a/apps/web/src/components/entity-icon.test.tsx
+++ b/apps/web/src/components/entity-icon.test.tsx
@@ -1,23 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { FRAMEWORK_BRAND_ICON_IDS } from "@/components/entity-brand-icon-ids";
 import { EntityIcon } from "@/components/entity-icon";
 
-const FRAMEWORKS = ["openclaw", "hermes", "claude-code", "codex"] as const;
 const SIZES = ["sm", "md", "lg"] as const;
 
 describe("EntityIcon LobeHub brands", () => {
 	test("uses the shared larger mark without clipping framework or provider tiles", () => {
 		for (const kindAndId of [
-			...FRAMEWORKS.map((id) => ({ kind: "framework" as const, id })),
+			...FRAMEWORK_BRAND_ICON_IDS.map((id) => ({ kind: "framework" as const, id })),
 			{ kind: "provider" as const, id: "openai" },
 		]) {
 			for (const size of SIZES) {
 				const markup = renderToStaticMarkup(<EntityIcon {...kindAndId} size={size} />);
 				expect(markup).toContain('data-icon-source="lobehub"');
-				expect(markup).toContain('width="72%"');
-				expect(markup).toContain('height="72%"');
+				expect(markup).toContain('width="84%"');
+				expect(markup).toContain('height="84%"');
 			}
 		}
+	});
+
+	test("keeps unknown frameworks on the existing monogram fallback", () => {
+		const markup = renderToStaticMarkup(
+			<EntityIcon kind="framework" id="custom-agent" label="Custom agent" size="sm" />,
+		);
+		expect(markup).toContain(">C</div>");
+		expect(markup).not.toContain("<svg");
+		expect(markup).not.toContain("<img");
 	});
 });
 

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -2,26 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { PROVIDER_BRAND_ICON_IDS } from "@/components/entity-brand-icon-ids";
 import { providerBrandIcon } from "@/components/entity-brand-icons";
 import { EntityIcon } from "@/components/entity-icon";
-
-const BRANDED_PROVIDER_IDS = [
-	"anthropic",
-	"deepseek",
-	"gemini",
-	"grok",
-	"groq",
-	"kimi",
-	"minimax",
-	"mistral",
-	"openai",
-	"openrouter",
-	"qwen",
-	"stepfun",
-	"together",
-	"xai",
-	"zhipu",
-] as const;
 
 describe("AI provider icon coverage", () => {
 	test("imports official leaf components without the compounded root or broad SSR transform", () => {
@@ -39,15 +22,15 @@ describe("AI provider icon coverage", () => {
 	});
 
 	test("renders every current branded provider through the official LobeHub React API", () => {
-		for (const id of BRANDED_PROVIDER_IDS) {
+		for (const id of PROVIDER_BRAND_ICON_IDS) {
 			const brand = providerBrandIcon(id);
 			expect(brand).toBeDefined();
 			const markup = renderToStaticMarkup(createElement(EntityIcon, { kind: "provider", id }));
 			expect(markup).toContain("<svg");
 			expect(markup).toContain('data-icon-source="lobehub"');
 			expect(markup).toContain(`aria-label="${brand?.label}"`);
-			expect(markup).toContain('width="72%"');
-			expect(markup).toContain('height="72%"');
+			expect(markup).toContain('width="84%"');
+			expect(markup).toContain('height="84%"');
 			expect(markup).not.toContain("<img");
 		}
 	});


### PR DESCRIPTION
## Summary

- Enlarge every official framework/provider SVG through the shared `BrandIconTile`, from 72% to 84%, with no sidebar/provider/model/brand special cases.
- Apply the shared size as both the LobeHub component size and inline dimensions so the sidebar descendant SVG utility cannot collapse the percentage mark to 16px.
- Keep custom avatar `object-cover`, unknown monograms, channel PNGs, LobeHub leaf imports, SSR exclusions, and bundle behavior unchanged.
- Add exhaustive shared brand ID coverage plus browser geometry checks for all 4 frameworks and 15 branded providers across 42 rendered surface instances.

## Sizing evidence

Compared 72%, 80%, and 84% in the browser. 84% was the smallest option that was clearly fuller across the affected surfaces while retaining visible safety space:

- 24px provider/model tile: SVG 18.47px, minimum edge margin about 2.77px
- 32px Agent card tile: SVG 25.19px, minimum edge margin about 3.41px
- 36px sidebar rail tile: SVG 28.55px, minimum edge margin about 3.72px

Every tested SVG and its internal artwork bounding box remains contained with no clipping or overflow.

## Visual coverage

Reviewed generated screenshots for:

- desktop sidebar rail and Agent cards
- mobile Agent card/sidebar
- deploy framework, provider, and managed model cards
- Agent Settings provider/model cards
- key desktop/mobile scenes in light and dark themes

## Verification

- focused icon/provider unit tests: 10 passed
- `bun run check`
- `bun run typecheck`
- `bun run --cwd apps/web build:oss`
- browser geometry Playwright: 1 passed
- relevant hosted Playwright scenarios passed, including the managed deploy case on an isolated E2E port after a batched Vite dev-server fetch flake
- `bun run test` Docker clean runner: exit 0 (TypeScript/CLI/shared 1506 passed, 4 skipped; backend 1712 passed, 7 skipped)

## Release impact

- Head SHA: c34d789e8bee10c0f83449f7c69655ab699116d9
- Web-only visual fix
- Migration: none
- No backend, generated contract, Hosted repository, runtime, or deployment changes
