### PR TITLE
fix(web): preserve official Hermes contrast

### DIFF
--- a/apps/web/e2e/brand-icon-geometry.pw.ts
+++ b/apps/web/e2e/brand-icon-geometry.pw.ts
@@ -8,7 +8,7 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 	await page.setViewportSize({ width: 1440, height: 2400 });
 	await page.goto("/");
 	await page.setContent(`<!doctype html>
-		<html lang="en">
+		<html lang="en" class="dark">
 			<head><meta name="viewport" content="width=device-width, initial-scale=1" /></head>
 			<body><div id="brand-icon-gallery"></div><script type="module" src="/e2e/brand-icon-gallery.browser.tsx"></script></body>
 		</html>`);
@@ -26,6 +26,8 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 			const icon = element.getBoundingClientRect();
 			const tile = element.parentElement.getBoundingClientRect();
 			const artwork = element.getBBox();
+			const iconStyle = getComputedStyle(element);
+			const tileStyle = getComputedStyle(element.parentElement);
 			const matrix = element.getScreenCTM();
 			if (!matrix) throw new Error("Expected the brand mark to have a screen transform.");
 			const artworkCorners = [
@@ -45,8 +47,10 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 				surface: cell?.getAttribute("data-brand-surface"),
 				iconWidth: icon.width,
 				iconHeight: icon.height,
+				iconColor: iconStyle.color,
 				tileWidth: tile.width,
 				tileHeight: tile.height,
+				tileBackground: tileStyle.backgroundColor,
 				artworkWidth: artworkRight - artworkLeft,
 				artworkHeight: artworkBottom - artworkTop,
 				widthAttribute: element.getAttribute("width"),
@@ -96,7 +100,14 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 	const frameworkMeasurements = measurements.filter(({ kind }) => kind === "framework");
 	const providerMeasurements = measurements.filter(({ kind }) => kind === "provider");
 	for (const id of FRAMEWORK_BRAND_ICON_IDS) {
-		expect(frameworkMeasurements.filter((measurement) => measurement.id === id)).toHaveLength(3);
+		const frameworkIcons = frameworkMeasurements.filter((measurement) => measurement.id === id);
+		expect(frameworkIcons).toHaveLength(3);
+		if (id === "hermes") {
+			for (const icon of frameworkIcons) {
+				expect(icon.iconColor).toBe("rgb(0, 0, 0)");
+				expect(icon.tileBackground).toBe("rgb(255, 255, 255)");
+			}
+		}
 	}
 	for (const id of PROVIDER_BRAND_ICON_IDS) {
 		expect(providerMeasurements.filter((measurement) => measurement.id === id)).toHaveLength(2);

--- a/apps/web/src/components/agent-framework-icon.test.tsx
+++ b/apps/web/src/components/agent-framework-icon.test.tsx
@@ -36,6 +36,14 @@ describe("AgentFrameworkIcon", () => {
 		expect(frameworkBrandIcon("claude_code")?.icon).toBe(frameworkBrandIcon("claude-code")?.icon);
 	});
 
+	test("keeps the official Hermes black mark on white instead of theme-inverting it", () => {
+		const markup = renderToStaticMarkup(
+			<AgentFrameworkIcon agent="hermes" pixelSize={40} boxClassName="size-10" />,
+		);
+		expect(markup).toContain("bg-white");
+		expect(markup).toContain("text-black");
+	});
+
 	test("keeps custom avatars as object-cover images instead of scaling them like brand marks", () => {
 		const markup = renderToStaticMarkup(
 			<AgentFrameworkIcon

--- a/apps/web/src/components/agent-framework-icon.tsx
+++ b/apps/web/src/components/agent-framework-icon.tsx
@@ -65,9 +65,10 @@ export function AgentFrameworkIcon({
 		return (
 			<BrandIconTile
 				icon={brand.icon}
+				iconClassName={brand.iconClassName}
 				label={alt || brand.label}
 				boxClassName={boxClassName}
-				className={className}
+				className={cn(brand.tileClassName, className)}
 			/>
 		);
 	}

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -22,12 +22,20 @@ import type { FrameworkBrandIconId, ProviderBrandIconId } from "@/components/ent
 
 export type BrandIconMetadata = {
 	icon: BrandIconComponent;
+	iconClassName?: string;
 	label: string;
+	tileClassName?: string;
 };
 
 const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
 	openclaw: { icon: OpenClaw, label: "OpenClaw" },
-	hermes: { icon: HermesAgent, label: "Hermes Agent" },
+	hermes: {
+		icon: HermesAgent,
+		// LobeHub's Hermes avatar is intentionally a black mark on white.
+		iconClassName: "text-black",
+		label: "Hermes Agent",
+		tileClassName: "bg-white",
+	},
 	"claude-code": { icon: ClaudeCode, label: "Claude Code" },
 	codex: { icon: Codex, label: "Codex" },
 } satisfies Readonly<Record<FrameworkBrandIconId, BrandIconMetadata>>;

--- a/apps/web/src/components/entity-icon.test.tsx
+++ b/apps/web/src/components/entity-icon.test.tsx
@@ -28,6 +28,14 @@ describe("EntityIcon LobeHub brands", () => {
 		expect(markup).not.toContain("<svg");
 		expect(markup).not.toContain("<img");
 	});
+
+	test("uses the official Hermes black-on-white treatment at every entity size", () => {
+		for (const size of SIZES) {
+			const markup = renderToStaticMarkup(<EntityIcon kind="framework" id="hermes" size={size} />);
+			expect(markup).toContain("bg-white");
+			expect(markup).toContain("text-black");
+		}
+	});
 });
 
 describe("EntityIcon channels", () => {

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -125,9 +125,10 @@ export function EntityIcon({
 			return (
 				<BrandIconTile
 					icon={providerBrand.icon}
+					iconClassName={providerBrand.iconClassName}
 					label={alt}
 					boxClassName={s.box}
-					className={className}
+					className={cn(providerBrand.tileClassName, className)}
 				/>
 			);
 		}


### PR DESCRIPTION
## Summary
- render Hermes as the official black mark on white across every shared brand-icon surface
- keep the lightweight LobeHub Mono leaf import instead of pulling the heavy Avatar UI graph
- add dark-theme geometry coverage for sidebar, Agent card, and deploy card sizes

## Verification
- 12 focused tests
- Web typecheck and Biome
- Playwright brand geometry in dark mode
- OSS client + SSR build
- `git diff --check`