### PR TITLE
fix(web): normalize framework icon optics

### DIFF
--- a/apps/web/e2e/brand-icon-geometry.pw.ts
+++ b/apps/web/e2e/brand-icon-geometry.pw.ts
@@ -76,24 +76,20 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 			};
 		}),
 	);
-
 	for (const measurement of measurements) {
-		expect(measurement.widthAttribute, `${measurement.id} width`).toBe("84%");
-		expect(measurement.heightAttribute, `${measurement.id} height`).toBe("84%");
+		const expectedSize =
+			measurement.kind === "framework"
+				? measurement.id === "openclaw" || measurement.id === "hermes"
+					? "75%"
+					: "70%"
+				: "84%";
+		expect(measurement.widthAttribute, `${measurement.id} width`).toBe(expectedSize);
+		expect(measurement.heightAttribute, `${measurement.id} height`).toBe(expectedSize);
 		expect(measurement.contained, `${measurement.id} artwork containment`).toBe(true);
 		expect(measurement.noOverflow, `${measurement.id} tile overflow`).toBe(true);
-		expect(measurement.iconWidth, `${measurement.id} visible fill`).toBeGreaterThan(
-			measurement.tileWidth * 0.75,
-		);
-		expect(measurement.iconHeight, `${measurement.id} visible fill`).toBeGreaterThan(
-			measurement.tileHeight * 0.75,
-		);
-		expect(measurement.iconWidth, `${measurement.id} safety space`).toBeLessThan(
-			measurement.tileWidth * 0.81,
-		);
-		expect(measurement.iconHeight, `${measurement.id} safety space`).toBeLessThan(
-			measurement.tileHeight * 0.81,
-		);
+		const expectedRatio = Number.parseInt(expectedSize, 10) / 100;
+		expect(measurement.iconWidth).toBeCloseTo((measurement.tileWidth - 2) * expectedRatio, 1);
+		expect(measurement.iconHeight).toBeCloseTo((measurement.tileHeight - 2) * expectedRatio, 1);
 		expect(measurement.minimumMargin, `${measurement.id} edge margin`).toBeGreaterThan(2.5);
 	}
 
@@ -114,7 +110,7 @@ test("keeps every shared LobeHub brand mark full and contained", async ({ page }
 	}
 
 	await page.screenshot({
-		path: testInfo.outputPath("brand-icon-geometry-84.png"),
+		path: testInfo.outputPath("brand-icon-geometry.png"),
 		fullPage: true,
 	});
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -67,14 +67,13 @@ async function expectVisibleLobeHubIconsContained(page: Page, minimumCount: numb
 		}),
 	);
 	for (const measurement of measurements) {
-		expect(measurement.width).toBe("84%");
-		expect(measurement.height).toBe("84%");
+		expect(["70%", "75%", "84%"]).toContain(measurement.width);
+		expect(measurement.height).toBe(measurement.width);
 		expect(measurement.contained).toBe(true);
 		expect(measurement.noOverflow).toBe(true);
-		expect(measurement.iconWidth).toBeGreaterThan(measurement.tileWidth * 0.75);
-		expect(measurement.iconHeight).toBeGreaterThan(measurement.tileHeight * 0.75);
-		expect(measurement.iconWidth).toBeLessThan(measurement.tileWidth * 0.81);
-		expect(measurement.iconHeight).toBeLessThan(measurement.tileHeight * 0.81);
+		const expectedRatio = Number.parseInt(measurement.width ?? "", 10) / 100;
+		expect(measurement.iconWidth).toBeCloseTo((measurement.tileWidth - 2) * expectedRatio, 1);
+		expect(measurement.iconHeight).toBeCloseTo((measurement.tileHeight - 2) * expectedRatio, 1);
 	}
 }
 

--- a/apps/web/src/components/agent-framework-icon.test.tsx
+++ b/apps/web/src/components/agent-framework-icon.test.tsx
@@ -5,17 +5,17 @@ import { FRAMEWORK_BRAND_ICON_IDS } from "@/components/entity-brand-icon-ids";
 import { frameworkBrandIcon } from "@/components/entity-brand-icons";
 
 const FRAMEWORKS = {
-	openclaw: "OpenClaw",
-	hermes: "Hermes Agent",
-	"claude-code": "Claude Code",
-	codex: "Codex",
+	openclaw: { label: "OpenClaw", size: "75%" },
+	hermes: { label: "Hermes Agent", size: "75%" },
+	"claude-code": { label: "Claude Code", size: "70%" },
+	codex: { label: "Codex", size: "70%" },
 } as const;
 
 describe("AgentFrameworkIcon", () => {
 	test("renders all supported framework IDs as accessible official LobeHub SVG components", () => {
 		expect(Object.keys(FRAMEWORKS)).toEqual([...FRAMEWORK_BRAND_ICON_IDS]);
 		for (const id of FRAMEWORK_BRAND_ICON_IDS) {
-			const label = FRAMEWORKS[id];
+			const { label, size } = FRAMEWORKS[id];
 			expect(frameworkBrandIcon(id)?.label).toBe(label);
 			const markup = renderToStaticMarkup(
 				<AgentFrameworkIcon agent={id} pixelSize={40} boxClassName="size-10" />,
@@ -25,9 +25,9 @@ describe("AgentFrameworkIcon", () => {
 			expect(markup).toContain(`aria-label="${label}"`);
 			expect(markup).toContain(`<title>${label}</title>`);
 			expect(markup).toContain('data-icon-source="lobehub"');
-			expect(markup).toContain('width="84%"');
-			expect(markup).toContain('height="84%"');
-			expect(markup).toContain("width:84%;height:84%");
+			expect(markup).toContain(`width="${size}"`);
+			expect(markup).toContain(`height="${size}"`);
+			expect(markup).toContain(`width:${size};height:${size}`);
 			expect(markup).not.toContain("<img");
 		}
 	});
@@ -42,6 +42,22 @@ describe("AgentFrameworkIcon", () => {
 		);
 		expect(markup).toContain("bg-white");
 		expect(markup).toContain("text-black");
+	});
+
+	test("uses LobeHub's lightweight official avatar presentation for every framework", () => {
+		const openClaw = renderToStaticMarkup(
+			<AgentFrameworkIcon agent="openclaw" pixelSize={40} boxClassName="size-10" />,
+		);
+		const claudeCode = renderToStaticMarkup(
+			<AgentFrameworkIcon agent="claude-code" pixelSize={40} boxClassName="size-10" />,
+		);
+		const codex = renderToStaticMarkup(
+			<AgentFrameworkIcon agent="codex" pixelSize={40} boxClassName="size-10" />,
+		);
+		expect(openClaw).toContain("bg-black");
+		expect(claudeCode).toContain("bg-[#09090B]");
+		expect(claudeCode).toContain("text-[#D97757]");
+		expect(codex).toContain("bg-white");
 	});
 
 	test("keeps custom avatars as object-cover images instead of scaling them like brand marks", () => {

--- a/apps/web/src/components/agent-framework-icon.test.tsx
+++ b/apps/web/src/components/agent-framework-icon.test.tsx
@@ -44,7 +44,7 @@ describe("AgentFrameworkIcon", () => {
 		expect(markup).toContain("text-black");
 	});
 
-	test("uses LobeHub's lightweight official avatar presentation for every framework", () => {
+	test("keeps colored framework marks on the shared neutral tile without forced dark backplates", () => {
 		const openClaw = renderToStaticMarkup(
 			<AgentFrameworkIcon agent="openclaw" pixelSize={40} boxClassName="size-10" />,
 		);
@@ -54,9 +54,8 @@ describe("AgentFrameworkIcon", () => {
 		const codex = renderToStaticMarkup(
 			<AgentFrameworkIcon agent="codex" pixelSize={40} boxClassName="size-10" />,
 		);
-		expect(openClaw).toContain("bg-black");
-		expect(claudeCode).toContain("bg-[#09090B]");
-		expect(claudeCode).toContain("text-[#D97757]");
+		expect(openClaw).not.toContain("bg-black");
+		expect(claudeCode).not.toContain("bg-[#09090B]");
 		expect(codex).toContain("bg-white");
 	});
 

--- a/apps/web/src/components/agent-framework-icon.tsx
+++ b/apps/web/src/components/agent-framework-icon.tsx
@@ -66,6 +66,7 @@ export function AgentFrameworkIcon({
 			<BrandIconTile
 				icon={brand.icon}
 				iconClassName={brand.iconClassName}
+				iconScale={brand.iconScale}
 				label={alt || brand.label}
 				boxClassName={boxClassName}
 				className={cn(brand.tileClassName, className)}

--- a/apps/web/src/components/brand-icon-tile.tsx
+++ b/apps/web/src/components/brand-icon-tile.tsx
@@ -5,22 +5,24 @@ export type BrandIconComponent = ComponentType<
 	Omit<SVGProps<SVGSVGElement>, "size"> & { size?: number | string }
 >;
 
-const BRAND_ICON_SIZE = "84%";
-const BRAND_ICON_STYLE = { width: BRAND_ICON_SIZE, height: BRAND_ICON_SIZE };
+const DEFAULT_BRAND_ICON_SCALE = 0.84;
 
 export function BrandIconTile({
 	icon: Icon,
 	label,
 	boxClassName,
 	iconClassName,
+	iconScale = DEFAULT_BRAND_ICON_SCALE,
 	className,
 }: {
 	icon: BrandIconComponent;
 	label: string;
 	boxClassName: string;
 	iconClassName?: string;
+	iconScale?: number;
 	className?: string;
 }) {
+	const iconSize = `${iconScale * 100}%`;
 	return (
 		<span
 			role="img"
@@ -32,8 +34,8 @@ export function BrandIconTile({
 			)}
 		>
 			<Icon
-				size={BRAND_ICON_SIZE}
-				style={BRAND_ICON_STYLE}
+				size={iconSize}
+				style={{ width: iconSize, height: iconSize }}
 				aria-hidden
 				className={cn("shrink-0", iconClassName)}
 				data-icon-source="lobehub"

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@lobehub/icons/es/Anthropic/components/Mono.js";
-import ClaudeCode from "@lobehub/icons/es/ClaudeCode/components/Mono.js";
+import ClaudeCode from "@lobehub/icons/es/ClaudeCode/components/Color.js";
 import Codex from "@lobehub/icons/es/Codex/components/Inner.js";
 import DeepSeek from "@lobehub/icons/es/DeepSeek/components/Color.js";
 import Gemini from "@lobehub/icons/es/Gemini/components/Color.js";
@@ -29,7 +29,7 @@ export type BrandIconMetadata = {
 };
 
 const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
-	openclaw: { icon: OpenClaw, iconScale: 0.75, label: "OpenClaw", tileClassName: "bg-black" },
+	openclaw: { icon: OpenClaw, iconScale: 0.75, label: "OpenClaw" },
 	hermes: {
 		icon: HermesAgent,
 		// LobeHub's Hermes avatar is intentionally a black mark on white.
@@ -40,10 +40,8 @@ const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
 	},
 	"claude-code": {
 		icon: ClaudeCode,
-		iconClassName: "text-[#D97757]",
 		iconScale: 0.7,
 		label: "Claude Code",
-		tileClassName: "bg-[#09090B]",
 	},
 	codex: { icon: Codex, iconScale: 0.7, label: "Codex", tileClassName: "bg-white" },
 } satisfies Readonly<Record<FrameworkBrandIconId, BrandIconMetadata>>;

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -1,6 +1,6 @@
 import Anthropic from "@lobehub/icons/es/Anthropic/components/Mono.js";
-import ClaudeCode from "@lobehub/icons/es/ClaudeCode/components/Color.js";
-import Codex from "@lobehub/icons/es/Codex/components/Color.js";
+import ClaudeCode from "@lobehub/icons/es/ClaudeCode/components/Mono.js";
+import Codex from "@lobehub/icons/es/Codex/components/Inner.js";
 import DeepSeek from "@lobehub/icons/es/DeepSeek/components/Color.js";
 import Gemini from "@lobehub/icons/es/Gemini/components/Color.js";
 import Grok from "@lobehub/icons/es/Grok/components/Mono.js";
@@ -23,21 +23,29 @@ import type { FrameworkBrandIconId, ProviderBrandIconId } from "@/components/ent
 export type BrandIconMetadata = {
 	icon: BrandIconComponent;
 	iconClassName?: string;
+	iconScale?: number;
 	label: string;
 	tileClassName?: string;
 };
 
 const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
-	openclaw: { icon: OpenClaw, label: "OpenClaw" },
+	openclaw: { icon: OpenClaw, iconScale: 0.75, label: "OpenClaw", tileClassName: "bg-black" },
 	hermes: {
 		icon: HermesAgent,
 		// LobeHub's Hermes avatar is intentionally a black mark on white.
 		iconClassName: "text-black",
+		iconScale: 0.75,
 		label: "Hermes Agent",
 		tileClassName: "bg-white",
 	},
-	"claude-code": { icon: ClaudeCode, label: "Claude Code" },
-	codex: { icon: Codex, label: "Codex" },
+	"claude-code": {
+		icon: ClaudeCode,
+		iconClassName: "text-[#D97757]",
+		iconScale: 0.7,
+		label: "Claude Code",
+		tileClassName: "bg-[#09090B]",
+	},
+	codex: { icon: Codex, iconScale: 0.7, label: "Codex", tileClassName: "bg-white" },
 } satisfies Readonly<Record<FrameworkBrandIconId, BrandIconMetadata>>;
 
 const FRAMEWORK_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {

--- a/apps/web/src/components/entity-icon.test.tsx
+++ b/apps/web/src/components/entity-icon.test.tsx
@@ -14,8 +14,14 @@ describe("EntityIcon LobeHub brands", () => {
 			for (const size of SIZES) {
 				const markup = renderToStaticMarkup(<EntityIcon {...kindAndId} size={size} />);
 				expect(markup).toContain('data-icon-source="lobehub"');
-				expect(markup).toContain('width="84%"');
-				expect(markup).toContain('height="84%"');
+				const expectedIconSize =
+					kindAndId.kind === "provider"
+						? "84%"
+						: kindAndId.id === "openclaw" || kindAndId.id === "hermes"
+							? "75%"
+							: "70%";
+				expect(markup).toContain(`width="${expectedIconSize}"`);
+				expect(markup).toContain(`height="${expectedIconSize}"`);
 			}
 		}
 	});

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -126,6 +126,7 @@ export function EntityIcon({
 				<BrandIconTile
 					icon={providerBrand.icon}
 					iconClassName={providerBrand.iconClassName}
+					iconScale={providerBrand.iconScale}
 					label={alt}
 					boxClassName={s.box}
 					className={cn(providerBrand.tileClassName, className)}

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -16,7 +16,7 @@ describe("AI provider icon coverage", () => {
 		expect(iconSource).not.toMatch(/from\s+["']@lobehub\/icons["']/);
 		expect(iconSource).toContain("@lobehub/icons/es/OpenClaw/components/Color.js");
 		expect(iconSource).toContain("@lobehub/icons/es/HermesAgent/components/Mono.js");
-		expect(iconSource).toContain("@lobehub/icons/es/ClaudeCode/components/Mono.js");
+		expect(iconSource).toContain("@lobehub/icons/es/ClaudeCode/components/Color.js");
 		expect(iconSource).toContain("@lobehub/icons/es/Codex/components/Inner.js");
 		expect(viteSource).toContain('noExternal: ["@lobehub/icons"]');
 		expect(viteSource).not.toContain("noExternal: [/^@lobehub");

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -16,6 +16,8 @@ describe("AI provider icon coverage", () => {
 		expect(iconSource).not.toMatch(/from\s+["']@lobehub\/icons["']/);
 		expect(iconSource).toContain("@lobehub/icons/es/OpenClaw/components/Color.js");
 		expect(iconSource).toContain("@lobehub/icons/es/HermesAgent/components/Mono.js");
+		expect(iconSource).toContain("@lobehub/icons/es/ClaudeCode/components/Mono.js");
+		expect(iconSource).toContain("@lobehub/icons/es/Codex/components/Inner.js");
 		expect(viteSource).toContain('noExternal: ["@lobehub/icons"]');
 		expect(viteSource).not.toContain("noExternal: [/^@lobehub");
 		expect(viteSource).not.toContain("optimizeDeps");


### PR DESCRIPTION
## Summary
- normalize framework artwork with LobeHub optical scales: 75% for OpenClaw/Hermes and 70% for Claude Code/Codex
- keep OpenClaw and Claude Code color marks on the shared neutral tile; preserve white contrast surfaces only for Hermes and Codex
- keep one BrandIconTile path across sidebar, Agent cards, and Deploy cards
- preserve provider/model marks at 84% and avoid @lobehub/ui/antd bundle expansion

## Verification
- 13 focused tests
- Web typecheck and Biome
- dark gallery geometry: 42 icon/surface combinations
- real hosted sidebar/Agent card/Deploy Playwright in desktop and mobile layouts
- OSS client + SSR build
- git diff --check