### PR TITLE
fix(skills): restore legacy CLI sync compatibility

### DIFF
--- a/backend/app/core/skill_sync_protocol.py
+++ b/backend/app/core/skill_sync_protocol.py
@@ -1,18 +1,29 @@
-"""Explicit mixed-version gate for Agent-authoritative Skill sync."""
+"""Mixed-version compatibility for Agent Skill sync clients."""
 
 from __future__ import annotations
 
 import re
+from enum import StrEnum
 
 from fastapi import HTTPException, status
 
 SKILL_SYNC_PROTOCOL_HEADER = "X-Clawdi-Skill-Sync-Protocol"
+SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0 = "agent-authoritative-v0"
 SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1 = "agent-authoritative-v1"
 _PROTOCOL_VALUE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 
 
-def require_agent_authoritative_skill_sync(protocol: str | None) -> None:
-    """Fail closed unless the caller explicitly speaks the one-way protocol."""
+class SkillSyncProtocol(StrEnum):
+    LEGACY = "legacy"
+    AGENT_AUTHORITATIVE_V1 = SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1
+
+
+def resolve_skill_sync_protocol(protocol: str | None) -> SkillSyncProtocol:
+    """Validate the wire value and resolve its compatibility behavior."""
+    if protocol is None or protocol == SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0:
+        return SkillSyncProtocol.LEGACY
+    if protocol == SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1:
+        return SkillSyncProtocol.AGENT_AUTHORITATIVE_V1
     if protocol is not None and not _PROTOCOL_VALUE.fullmatch(protocol):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
@@ -21,15 +32,10 @@ def require_agent_authoritative_skill_sync(protocol: str | None) -> None:
                 "message": "The Agent Skill sync protocol header is malformed.",
             },
         )
-    if protocol != SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1:
-        raise HTTPException(
-            status.HTTP_426_UPGRADE_REQUIRED,
-            detail={
-                "code": "agent_skill_sync_upgrade_required",
-                "message": (
-                    "Upgrade Clawdi before syncing Agent Project Skills; older clients "
-                    "are paused to protect the Agent filesystem."
-                ),
-            },
-            headers={"Upgrade": SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1},
-        )
+    raise HTTPException(
+        status.HTTP_400_BAD_REQUEST,
+        detail={
+            "code": "unsupported_skill_sync_protocol",
+            "message": "The Agent Skill sync protocol is not supported.",
+        },
+    )

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -54,6 +54,8 @@ from app.models.skill import (
 from app.models.user import User
 from app.schemas.common import Paginated
 from app.schemas.skill import (
+    PersistedProjectKind,
+    PersistedSkillAuthority,
     SkillContentUpdateRequest,
     SkillDeleteResponse,
     SkillDetailResponse,
@@ -114,6 +116,24 @@ log = logging.getLogger(__name__)
 file_store = get_file_store()
 _SKILLS_LIST_CACHE_CONTROL = "no-transform"
 _SKILLS_ETAG_VERSION = "skills-v2"
+
+
+def _persisted_skill_authority(value: str) -> PersistedSkillAuthority:
+    if value == SKILL_AUTHORITY_AGENT_SYNC:
+        return "agent_sync"
+    if value == SKILL_AUTHORITY_CLOUD:
+        return "cloud"
+    raise ValueError(f"Unsupported persisted Skill authority: {value}")
+
+
+def _persisted_project_kind(value: str) -> PersistedProjectKind:
+    if value == "environment":
+        return "environment"
+    if value == "personal":
+        return "personal"
+    if value == "workspace":
+        return "workspace"
+    raise ValueError(f"Unsupported persisted Project kind: {value}")
 
 
 def _file_key(user_id, project_id, skill_key: str) -> str:
@@ -240,7 +260,7 @@ def _compute_file_tree_hash(tar_bytes: bytes, skill_key: str | None = None) -> s
 # ---------------------------------------------------------------------------
 
 
-@router.get("")
+@router.get("", response_model=Paginated[SkillSummaryResponse])
 async def list_skills(
     auth: AuthContext = Depends(require_scope_short_session("skills:read")),
     q: str | None = Query(default=None, description="Search name / description / skill_key"),
@@ -260,7 +280,7 @@ async def list_skills(
     ),
     if_none_match: str | None = Header(default=None, alias="If-None-Match"),
     skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
-) -> Paginated[SkillSummaryResponse]:
+) -> Paginated[SkillSummaryResponse] | Response:
     if (
         (auth.is_cli or auth.oauth_cli)
         and auth.api_key is not None
@@ -292,7 +312,7 @@ async def _list_skills_with_db(
     project_id: UUID | None,
     if_none_match: str | None,
     skill_sync_protocol: str | None,
-) -> Paginated[SkillSummaryResponse]:
+) -> Paginated[SkillSummaryResponse] | Response:
     # Keep every query that contributes to the strong collection ETag and its
     # response body in one snapshot. Cross-page consistency remains fenced by
     # the shared collection revision because released CLI 0.13.13 performs a
@@ -426,7 +446,7 @@ async def _list_skills_with_db(
                 description=s.description,
                 version=s.version,
                 source=s.source,
-                authority=s.authority,
+                authority=_persisted_skill_authority(s.authority),
                 source_repo=s.source_repo,
                 agent_types=s.agent_types,
                 file_count=s.file_count,
@@ -679,7 +699,7 @@ async def _build_skill_detail(skill: Skill, db: AsyncSession | None = None) -> S
     description = skill.description
     version = skill.version
     source = skill.source
-    authority = skill.authority
+    authority = _persisted_skill_authority(skill.authority)
     source_repo = skill.source_repo
     file_count = skill.file_count
     agent_types = skill.agent_types
@@ -709,7 +729,7 @@ async def _build_skill_detail(skill: Skill, db: AsyncSession | None = None) -> S
         ).first()
         if project_row is not None:
             project_name = project_row.name
-            project_kind = project_row.kind
+            project_kind = _persisted_project_kind(project_row.kind)
             if project_row.origin_environment_id is not None:
                 environment_id = str(project_row.origin_environment_id)
                 env_row = (

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -40,7 +40,8 @@ from app.core.skill_key import (
 )
 from app.core.skill_sync_protocol import (
     SKILL_SYNC_PROTOCOL_HEADER,
-    require_agent_authoritative_skill_sync,
+    SkillSyncProtocol,
+    resolve_skill_sync_protocol,
 )
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.project_membership import ProjectMembership
@@ -265,7 +266,7 @@ async def list_skills(
         and auth.api_key is not None
         and auth.api_key.environment_id is not None
     ):
-        require_agent_authoritative_skill_sync(skill_sync_protocol)
+        resolve_skill_sync_protocol(skill_sync_protocol)
     async with async_session_factory() as db:
         return await _list_skills_with_db(
             auth=auth,
@@ -363,7 +364,7 @@ async def _list_skills_with_db(
             meta["kind"] == PROJECT_KIND_ENVIRONMENT for meta in project_meta.values()
         )
         if has_agent_project:
-            require_agent_authoritative_skill_sync(skill_sync_protocol)
+            resolve_skill_sync_protocol(skill_sync_protocol)
     etag = _skills_collection_etag(
         revision=revision,
         selected_project_id=selected_project_id,
@@ -795,7 +796,8 @@ async def upload_skill_legacy(
     route. New CLIs and the dashboard call
     `POST /v1/projects/{project_id}/skills/upload` directly.
 
-    Asymmetric with `delete_skill_legacy` (which 410s) by design:
+    Asymmetric with `delete_skill_legacy` (which only accepts an env-bound
+    API key) by design:
     a wrong-project upload creates a stray row visible in the
     dashboard listing, recoverable in 30s by re-uploading to the
     correct project. A wrong-project DELETE is permanent data loss.
@@ -947,7 +949,7 @@ async def _project_upload_authority(
                 "message": "Change this Skill in the Agent filesystem and sync it.",
             },
         )
-    require_agent_authoritative_skill_sync(skill_sync_protocol)
+    resolve_skill_sync_protocol(skill_sync_protocol)
     agent_id = project.origin_environment_id
     if agent_id is None:
         raise HTTPException(
@@ -1418,6 +1420,7 @@ async def _do_upload_skill(
 @router.get("/{skill_key:path}/download")
 async def download_skill_legacy(
     skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:read")),
     db: AsyncSession = Depends(get_session),
 ):
@@ -1426,7 +1429,12 @@ async def download_skill_legacy(
     `/v1/projects/{project_id}/skills/{skill_key}/download`."""
     visible_project_ids = await project_ids_visible_to(db, auth)
     skill = await _resolve_legacy_skill(db, auth, visible_project_ids, skill_key)
-    await _assert_cli_agent_project_download_blocked(db, auth, skill.project_id)
+    await _enforce_agent_project_download_protocol(
+        db,
+        auth,
+        skill.project_id,
+        skill_sync_protocol,
+    )
     return await _build_skill_download(skill, skill_key, db)
 
 
@@ -1434,6 +1442,7 @@ async def download_skill_legacy(
 async def download_skill_project(
     project_id: UUID = Path(...),
     skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:read")),
     db: AsyncSession = Depends(get_session),
 ):
@@ -1453,6 +1462,7 @@ async def download_skill_project(
         auth=auth,
         project_id=project_id,
         skill_key=skill_key,
+        skill_sync_protocol=skill_sync_protocol,
     )
 
 
@@ -1460,6 +1470,7 @@ async def download_skill_project(
 async def download_skill_scope_compat(
     scope_id: UUID = Path(...),
     skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:read")),
     db: AsyncSession = Depends(get_session),
 ):
@@ -1468,6 +1479,7 @@ async def download_skill_scope_compat(
         auth=auth,
         project_id=scope_id,
         skill_key=skill_key,
+        skill_sync_protocol=skill_sync_protocol,
     )
 
 
@@ -1537,8 +1549,14 @@ async def _get_project_skill_download(
     auth: AuthContext,
     project_id: UUID,
     skill_key: str,
+    skill_sync_protocol: str | None,
 ) -> Response:
-    await _assert_cli_agent_project_download_blocked(db, auth, project_id)
+    await _enforce_agent_project_download_protocol(
+        db,
+        auth,
+        project_id,
+        skill_sync_protocol,
+    )
     skill = await _get_project_skill(
         db=db,
         auth=auth,
@@ -1548,17 +1566,22 @@ async def _get_project_skill_download(
     return await _build_skill_download(skill, skill_key, db)
 
 
-async def _assert_cli_agent_project_download_blocked(
+async def _enforce_agent_project_download_protocol(
     db: AsyncSession,
     auth: AuthContext,
     project_id: UUID,
+    skill_sync_protocol: str | None,
 ) -> None:
     if not auth.is_cli and not auth.oauth_cli:
         return
     project_kind = (
         await db.execute(select(Project.kind).where(Project.id == project_id))
     ).scalar_one_or_none()
-    if project_kind == PROJECT_KIND_ENVIRONMENT:
+    if (
+        project_kind == PROJECT_KIND_ENVIRONMENT
+        and resolve_skill_sync_protocol(skill_sync_protocol)
+        == SkillSyncProtocol.AGENT_AUTHORITATIVE_V1
+    ):
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             detail={
@@ -1741,36 +1764,37 @@ async def _do_delete_agent_synced_skill(
 @router.delete("/{skill_key:path}")
 async def delete_skill_legacy(
     skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
     db: AsyncSession = Depends(get_session),
 ) -> SkillDeleteResponse:
-    """Legacy delete by slug-only is gone in phase 2. Resolving
-    via `resolve_default_write_project` would silently delete
-    the wrong project's copy when the caller's account holds the
-    same `skill_key` in multiple projects (which the cross-project
-    listing now exposes), or 404 with no useful hint when
-    their default project doesn't have that key. The CLI and
-    dashboard both migrated to
-    `DELETE /v1/projects/{project_id}/skills/{skill_key}` and
-    pass the row's own project_id; force any stale client onto
-    that path with 410 instead of guessing.
+    """Safely serve released slug-only clients with an Agent-bound identity.
 
-    Argument unused — kept so FastAPI still parses the path
-    param uniformly with sibling routes.
+    Only an env-bound API key identifies exactly one Agent and its current
+    Agent Project. User-level API keys, OAuth CLI sessions, and browser sessions
+    remain ambiguous and receive the historical 410 instead of resolving a
+    most-recently-active Project.
     """
-    del skill_key
-    del auth
-    del db
-    raise HTTPException(
-        status.HTTP_410_GONE,
-        detail={
-            "code": "project_explicit_route_required",
-            "message": (
-                "Use DELETE /v1/projects/{project_id}/skills/{skill_key} — "
-                "call GET /v1/skills to find the project_id of the row "
-                "you want to delete."
-            ),
-        },
+    key = auth.api_key
+    if not auth.is_cli or key is None or key.environment_id is None:
+        raise HTTPException(
+            status.HTTP_410_GONE,
+            detail={
+                "code": "project_explicit_route_required",
+                "message": (
+                    "Use DELETE /v1/projects/{project_id}/skills/{skill_key} — "
+                    "call GET /v1/skills to find the project_id of the row "
+                    "you want to delete."
+                ),
+            },
+        )
+    resolve_skill_sync_protocol(skill_sync_protocol)
+    return await _do_delete_agent_synced_skill(
+        db=db,
+        auth=auth,
+        agent_id=key.environment_id,
+        project_id=None,
+        skill_key=skill_key,
     )
 
 

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -38,6 +38,7 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -135,8 +136,9 @@ async def _stream(
         )
         for task in pending:
             task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        for task in pending:
+            with suppress(asyncio.CancelledError):
+                await task
         if revoked_task in done or revoked.is_set():
             return
         if event_task not in done:

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -48,7 +48,7 @@ from app.core.database import async_session_factory
 from app.core.project import project_ids_visible_to
 from app.core.skill_sync_protocol import (
     SKILL_SYNC_PROTOCOL_HEADER,
-    require_agent_authoritative_skill_sync,
+    resolve_skill_sync_protocol,
 )
 from app.services import sync_events
 
@@ -195,7 +195,7 @@ async def events(
     query returns. With many connected daemons this keeps the
     pool free for normal request traffic.
     """
-    require_agent_authoritative_skill_sync(skill_sync_protocol)
+    resolve_skill_sync_protocol(skill_sync_protocol)
     user_id = auth.user_id
     if _oauth_cli_access_expired(auth):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "OAuth access token has expired")

--- a/backend/tests/test_skill_authority.py
+++ b/backend/tests/test_skill_authority.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth, get_auth_short_session
 from app.core.skill_sync_protocol import (
+    SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
     SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
     SKILL_SYNC_PROTOCOL_HEADER,
 )
@@ -241,35 +242,56 @@ async def test_agent_sync_mutations_emit_additive_rolling_safe_events(
 
 
 @pytest.mark.asyncio
-async def test_generic_agent_project_upload_is_cli_compatibility_alias(
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        None,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+    ],
+)
+@pytest.mark.parametrize("route_kind", ["legacy", "project_explicit"])
+async def test_generic_agent_project_upload_and_delete_support_mixed_cli_versions(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
     environment_project,
+    protocol: str | None,
+    route_kind: str,
 ):
-    data, files = _skill_upload("legacy-cli-upload")
+    protocol_label = protocol or "missing"
+    skill_key = f"{route_kind}-{protocol_label}"
+    upload_path = (
+        "/v1/skills/upload"
+        if route_kind == "legacy"
+        else f"/v1/projects/{environment_project.id}/skills/upload"
+    )
+    headers = {} if protocol is None else {SKILL_SYNC_PROTOCOL_HEADER: protocol}
+
+    data, files = _skill_upload(skill_key)
     browser = await client.post(
-        f"/v1/projects/{environment_project.id}/skills/upload",
+        upload_path,
         data=data,
         files=files,
+        headers=headers,
     )
     assert browser.status_code == 409, browser.text
     assert browser.json()["detail"]["code"] == "agent_project_skills_read_only"
 
     _set_auth(_api_key_auth(seed_user))
-    data, files = _skill_upload("legacy-cli-upload")
+    data, files = _skill_upload(skill_key)
     cli = await client.post(
-        f"/v1/projects/{environment_project.id}/skills/upload",
+        upload_path,
         data=data,
         files=files,
-        headers=_AGENT_SYNC_HEADERS,
+        headers=headers,
     )
     assert cli.status_code == 200, cli.text
     row = (
         await db_session.execute(
             select(Skill).where(
                 Skill.project_id == environment_project.id,
-                Skill.skill_key == "legacy-cli-upload",
+                Skill.skill_key == skill_key,
                 Skill.is_active,
             )
         )
@@ -277,17 +299,24 @@ async def test_generic_agent_project_upload_is_cli_compatibility_alias(
     assert row.authority == SKILL_AUTHORITY_AGENT_SYNC
     assert row.authority_agent_id == environment_project.origin_environment_id
 
+    deleted = await client.delete(
+        f"/v1/projects/{environment_project.id}/skills/{skill_key}",
+        headers=headers,
+    )
+    assert deleted.status_code == 200, deleted.text
+    await db_session.refresh(row)
+    assert row.is_active is False
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("protocol", "expected_status", "expected_code"),
     [
-        (None, 426, "agent_skill_sync_upgrade_required"),
-        ("agent-authoritative-v0", 426, "agent_skill_sync_upgrade_required"),
+        ("agent-authoritative-v2", 400, "unsupported_skill_sync_protocol"),
         ("Agent authoritative", 400, "invalid_skill_sync_protocol"),
     ],
 )
-async def test_generic_agent_project_upload_pauses_old_or_malformed_cli(
+async def test_generic_agent_project_upload_rejects_unknown_or_malformed_protocol(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
@@ -319,10 +348,19 @@ async def test_generic_agent_project_upload_pauses_old_or_malformed_cli(
 
 
 @pytest.mark.asyncio
-async def test_agent_project_listing_gates_old_daemon_before_conditional_304(
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        None,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+    ],
+)
+async def test_agent_project_listing_supports_mixed_cli_versions_and_conditional_304(
     client: httpx.AsyncClient,
     seed_user: User,
     environment_project,
+    protocol: str | None,
 ):
     agent_id = environment_project.origin_environment_id
     _set_auth(
@@ -333,24 +371,15 @@ async def test_agent_project_listing_gates_old_daemon_before_conditional_304(
         )
     )
     params = {"project_id": str(environment_project.id)}
-    old = await client.get("/v1/skills", params=params)
-    assert old.status_code == 426, old.text
-    assert old.json()["detail"]["code"] == "agent_skill_sync_upgrade_required"
-
-    current = await client.get("/v1/skills", params=params, headers=_AGENT_SYNC_HEADERS)
-    assert current.status_code == 200, current.text
-    conditional_old = await client.get(
+    headers = {} if protocol is None else {SKILL_SYNC_PROTOCOL_HEADER: protocol}
+    listing = await client.get("/v1/skills", params=params, headers=headers)
+    assert listing.status_code == 200, listing.text
+    conditional = await client.get(
         "/v1/skills",
         params=params,
-        headers={"If-None-Match": current.headers["etag"]},
+        headers={**headers, "If-None-Match": listing.headers["etag"]},
     )
-    assert conditional_old.status_code == 426, conditional_old.text
-    conditional_current = await client.get(
-        "/v1/skills",
-        params=params,
-        headers={**_AGENT_SYNC_HEADERS, "If-None-Match": current.headers["etag"]},
-    )
-    assert conditional_current.status_code == 304, conditional_current.text
+    assert conditional.status_code == 304, conditional.text
 
 
 @pytest.mark.asyncio
@@ -415,11 +444,20 @@ async def test_agent_project_cloud_content_and_install_mutations_fail_closed(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        None,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+    ],
+)
 async def test_generic_agent_project_delete_treats_local_absence_as_legacy_migration_evidence(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
     environment_project,
+    protocol: str | None,
 ):
     legacy = Skill(
         user_id=seed_user.id,
@@ -433,19 +471,157 @@ async def test_generic_agent_project_delete_treats_local_absence_as_legacy_migra
     db_session.add(legacy)
     await db_session.commit()
     _set_auth(_api_key_auth(seed_user))
+    headers = {} if protocol is None else {SKILL_SYNC_PROTOCOL_HEADER: protocol}
 
     deleted = await client.delete(
         f"/v1/projects/{environment_project.id}/skills/legacy-absence",
-        headers=_AGENT_SYNC_HEADERS,
+        headers=headers,
     )
     assert deleted.status_code == 200, deleted.text
     replay = await client.delete(
         f"/v1/projects/{environment_project.id}/skills/legacy-absence",
-        headers=_AGENT_SYNC_HEADERS,
+        headers=headers,
     )
     assert replay.status_code == 200, replay.text
     await db_session.refresh(legacy)
     assert legacy.is_active is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        None,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
+        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+    ],
+)
+async def test_slug_only_delete_uses_bound_agent_project_for_mixed_cli_versions(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    environment_project,
+    protocol: str | None,
+):
+    skill = Skill(
+        user_id=seed_user.id,
+        project_id=environment_project.id,
+        skill_key="bound-legacy-delete",
+        name="Bound legacy delete",
+        description="Released slug-only compatibility",
+        content_hash="e" * 64,
+        authority=SKILL_AUTHORITY_CLOUD,
+    )
+    db_session.add(skill)
+    await db_session.commit()
+    _set_auth(
+        _api_key_auth(
+            seed_user,
+            environment_id=environment_project.origin_environment_id,
+            scopes=["skills:write"],
+        )
+    )
+    headers = {} if protocol is None else {SKILL_SYNC_PROTOCOL_HEADER: protocol}
+
+    response = await client.delete(
+        "/v1/skills/bound-legacy-delete",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "deleted"}
+    await db_session.refresh(skill)
+    assert skill.is_active is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("principal", ["browser", "unbound_api_key", "oauth_cli"])
+async def test_slug_only_delete_keeps_ambiguous_callers_on_410(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    environment_project,
+    principal: str,
+):
+    skill = Skill(
+        user_id=seed_user.id,
+        project_id=environment_project.id,
+        skill_key="ambiguous-legacy-delete",
+        name="Ambiguous legacy delete",
+        description="Must remain project-explicit",
+        content_hash="f" * 64,
+        authority=SKILL_AUTHORITY_CLOUD,
+    )
+    db_session.add(skill)
+    await db_session.commit()
+    if principal == "unbound_api_key":
+        _set_auth(_api_key_auth(seed_user))
+    elif principal == "oauth_cli":
+        _set_auth(_oauth_auth(seed_user))
+
+    response = await client.delete("/v1/skills/ambiguous-legacy-delete")
+
+    assert response.status_code == 410, response.text
+    assert response.json()["detail"]["code"] == "project_explicit_route_required"
+    await db_session.refresh(skill)
+    assert skill.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_agent_project_download_preserves_legacy_access_and_current_cli_protection(
+    client: httpx.AsyncClient,
+    seed_user: User,
+    environment_project,
+    channel_agent,
+):
+    agent_id = environment_project.origin_environment_id
+    _set_auth(_api_key_auth(seed_user))
+    data, files = _skill_upload("download-compat")
+    uploaded = await client.post(
+        f"/v1/agents/{agent_id}/skills/sync/upload",
+        data=data,
+        files=files,
+    )
+    assert uploaded.status_code == 200, uploaded.text
+
+    project_download = f"/v1/projects/{environment_project.id}/skills/download-compat/download"
+    for protocol in (None, SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0):
+        headers = {} if protocol is None else {SKILL_SYNC_PROTOCOL_HEADER: protocol}
+        legacy = await client.get(project_download, headers=headers)
+        assert legacy.status_code == 200, legacy.text
+        assert legacy.headers["content-type"].startswith("application/gzip")
+
+    legacy_route = await client.get("/v1/skills/download-compat/download")
+    assert legacy_route.status_code == 200, legacy_route.text
+
+    current = await client.get(project_download, headers=_AGENT_SYNC_HEADERS)
+    assert current.status_code == 409, current.text
+    assert current.json()["detail"]["code"] == "agent_project_download_forbidden"
+
+    for protocol, expected_code in (
+        ("agent-authoritative-v2", "unsupported_skill_sync_protocol"),
+        ("Agent authoritative", "invalid_skill_sync_protocol"),
+    ):
+        rejected = await client.get(
+            project_download,
+            headers={SKILL_SYNC_PROTOCOL_HEADER: protocol},
+        )
+        assert rejected.status_code == 400, rejected.text
+        assert rejected.json()["detail"]["code"] == expected_code
+
+    _set_auth(AuthContext(user=seed_user))
+    dashboard = await client.get(project_download, headers=_AGENT_SYNC_HEADERS)
+    assert dashboard.status_code == 200, dashboard.text
+
+    _set_auth(
+        _api_key_auth(
+            seed_user,
+            environment_id=channel_agent.id,
+            scopes=["skills:read", "skills:write"],
+        )
+    )
+    fenced = await client.get(project_download)
+    assert fenced.status_code == 404, fenced.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1218,10 +1218,10 @@ async def test_legacy_upload_resolves_default_project_with_deprecation_header(
     legacy `POST /api/skills/upload` route. Round-3 originally
     410'd it for safety, but every user has a deterministic
     default project after the migration (`resolve_default_write_project`
-    never returns None). Asymmetric with DELETE: a wrong-project
-    upload creates a stray row that's recoverable in 30s; a
-    wrong-project DELETE is permanent loss. So upload soft-
-    deprecates and continues to function — old CLIs keep
+    never returns None). A wrong-project upload creates a stray row
+    that's recoverable in 30s, while slug-only DELETE remains restricted
+    to env-bound keys that identify exactly one Agent Project. Upload
+    therefore soft-deprecates and continues to function so old CLIs keep
     pushing skills.
 
     Pinned by: legacy upload returns 200 with the skill landed
@@ -1258,14 +1258,11 @@ async def test_legacy_upload_resolves_default_project_with_deprecation_header(
 
 
 @pytest.mark.asyncio
-async def test_legacy_delete_still_410s(client: httpx.AsyncClient, project_id: str):
-    """Round-r6: round-3's 410-on-DELETE design preserved.
-    DELETE remains hard-410 (not soft-deprecated like upload)
-    because a wrong-project delete is permanent data loss — the
-    asymmetry that justifies the back-compat split. Clients
-    must use the project-explicit `DELETE /api/projects/{sid}/
-    skills/{key}` so they pick which row to delete on multi-
-    project accounts.
+async def test_legacy_delete_still_410s_for_browser(client: httpx.AsyncClient, project_id: str):
+    """Slug-only DELETE remains ambiguous for browser sessions.
+
+    Only an env-bound API key can identify one Agent Project without guessing;
+    dashboard and other user-level callers must use the project-explicit route.
     """
     # Upload via the new route to make sure there's a row to
     # potentially-delete; the 410 must fire BEFORE we look up

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -29,8 +29,10 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.skill_sync_protocol import (
+    SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
     SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
-    require_agent_authoritative_skill_sync,
+    SkillSyncProtocol,
+    resolve_skill_sync_protocol,
 )
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -47,20 +49,38 @@ pytestmark = pytest.mark.committed_db
 
 
 @pytest.mark.parametrize(
-    ("protocol", "expected_status"),
-    [(None, 426), ("agent-authoritative-v0", 426), ("Agent authoritative", 400)],
+    ("protocol", "expected"),
+    [
+        (None, SkillSyncProtocol.LEGACY),
+        (SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0, SkillSyncProtocol.LEGACY),
+        (
+            SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+            SkillSyncProtocol.AGENT_AUTHORITATIVE_V1,
+        ),
+    ],
 )
-def test_sse_protocol_gate_pauses_old_or_malformed_daemons(
+def test_skill_sync_protocol_accepts_legacy_and_current_clients(
     protocol: str | None,
-    expected_status: int,
+    expected: SkillSyncProtocol,
+) -> None:
+    assert resolve_skill_sync_protocol(protocol) is expected
+
+
+@pytest.mark.parametrize(
+    ("protocol", "expected_code"),
+    [
+        ("Agent authoritative", "invalid_skill_sync_protocol"),
+        ("agent-authoritative-v2", "unsupported_skill_sync_protocol"),
+    ],
+)
+def test_skill_sync_protocol_rejects_malformed_and_unknown_values(
+    protocol: str,
+    expected_code: str,
 ) -> None:
     with pytest.raises(HTTPException) as rejected:
-        require_agent_authoritative_skill_sync(protocol)
-    assert rejected.value.status_code == expected_status
-
-
-def test_sse_protocol_gate_accepts_current_one_way_daemon() -> None:
-    require_agent_authoritative_skill_sync(SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1)
+        resolve_skill_sync_protocol(protocol)
+    assert rejected.value.status_code == 400
+    assert rejected.value.detail["code"] == expected_code
 
 
 def test_oauth_cli_sse_handshake_uses_verified_utc_expiry_only():
@@ -156,7 +176,7 @@ async def test_oauth_cli_sse_expiry_rechecks_clock_at_heartbeat_cadence():
 
 
 @pytest.mark.asyncio
-async def test_oauth_cli_events_route_subscribes_then_closes_at_verified_expiry(
+async def test_oauth_cli_sse_without_protocol_header_subscribes_then_closes_at_expiry(
     monkeypatch: pytest.MonkeyPatch,
 ):
     from unittest.mock import Mock
@@ -209,7 +229,7 @@ async def test_oauth_cli_events_route_subscribes_then_closes_at_verified_expiry(
     response = await sync_route.events(
         request,
         oauth,
-        SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+        None,
     )
     assert response.media_type == "text/event-stream"
     assert response.headers["x-accel-buffering"] == "no"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,23 +166,24 @@ old environment metadata are not ownership evidence. A live authenticated
 Agent upload may atomically claim the matching row as `agent_sync`, including
 when its bytes are unchanged. Current CLIs use only the dedicated Agent sync
 boundary; a missing dedicated route or an unproven Agent identity fails closed
-without issuing a generic Project mutation. Browser writes, old clients without
-the explicit capability, and orphan Agent Projects also fail closed.
+without issuing a generic Project mutation. Compatibility writes still require
+a proven CLI Agent and Agent Project; browser writes and orphan Agent Projects
+fail closed. Slug-only delete is accepted only for an environment-bound API key,
+whose bound Agent resolves exactly one current Agent Project.
 
-Mixed-version safety uses the explicit
-`X-Clawdi-Skill-Sync-Protocol: agent-authoritative-v1` capability, never a
-User-Agent guess. Every Clawdi backend worker must serve the gate and dedicated
-endpoints and old SSE connections must be drained before CLI 0.13.13 is rolled
-out; Web follows the CLI. An old CLI reaching a current backend receives 426
-on Agent-Project sync surfaces. A current CLI reaching an old backend receives
-a dedicated-route 404, retains its local operation, and does not create a Cloud
-mutation. Projection may pause during that window, but the Agent filesystem
-remains unchanged. Additive
+Mixed-version behavior is selected by `X-Clawdi-Skill-Sync-Protocol`, never a
+User-Agent guess. A missing header or explicit `agent-authoritative-v0` selects
+the released legacy listing, SSE, upload, delete, and download behavior;
+`agent-authoritative-v1` selects the current one-way behavior. Malformed and
+unknown values return 400. Current CLIs use the dedicated Agent routes and do
+not download Agent Project projections; an explicit v1 download remains
+blocked. A current CLI reaching an old backend receives a dedicated-route 404,
+retains its local operation, and does not create a generic Project mutation.
+Additive
 `agent_skill_changed`/`agent_skill_deleted` invalidations protect mutations
 created by current backend workers from already-connected released parsers;
-they do not make an old mutation worker safe. Current daemons treat both event
-families as rescan hints. Cloud-owned Project events retain their released
-names.
+current daemons treat both event families as rescan hints. Cloud-owned Project
+events retain their released names.
 
 The bundled `clawdi` Skill is private platform infrastructure, not a third
 inventory authority and not a user Skill. Its private runtime entry reserves

--- a/docs/clawdi-daemon-test-guide.md
+++ b/docs/clawdi-daemon-test-guide.md
@@ -153,10 +153,12 @@ reflects the new content_hash on refresh.
 
 ### Verify a Cloud event cannot overwrite local state
 
-The backend's protocol-gated generic Agent-Project route remains a direct
+The backend's protocol-aware generic Agent-Project route remains a direct
 compatibility-boundary test surface, but the current CLI uses only the
-dedicated Agent sync route. A current daemon uses its SSE event only to rescan
-the local filesystem and project the local bytes back; it never downloads the
+dedicated Agent sync route. Missing protocol and `agent-authoritative-v0`
+requests retain legacy download behavior; the explicit v1 request below keeps
+the one-way boundary. A current daemon uses its SSE event only to rescan the
+local filesystem and project the local bytes back; it never downloads the
 uploaded bytes. `PROJECT_ID` is the Agent's `default_project_id`:
 
 ```sh

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -556,20 +556,21 @@ an upload baseline but cannot authorize deletion. The current CLI uses only
 the dedicated Agent sync boundary. A 404 from that boundary is ambiguous
 between a backend without the route and an identity the caller cannot prove,
 so both cases fail closed: the durable operation and exact claim remain, and
-no generic Project mutation is attempted. Dashboard writes, old clients
-without the explicit capability, and orphan projects also fail closed.
+no generic Project mutation is attempted. Dashboard writes and orphan projects
+also fail closed. Compatibility writes still prove CLI Agent and Agent Project
+identity; slug-only delete additionally requires an environment-bound API key.
 
 The CLI declares `X-Clawdi-Skill-Sync-Protocol: agent-authoritative-v1` on
-Agent-Project listing, SSE, and writes. Every Clawdi backend worker plus
-drainage of old SSE connections precedes CLI 0.13.13, then Web. Old CLIs
-receive 426 from a current backend; a current CLI receives a dedicated 404
-from an old backend and leaves its filesystem and durable projection state
-intact. Additive
+Agent-Project listing, SSE, and writes. A missing header or explicit
+`agent-authoritative-v0` selects the supported legacy behavior, including
+Agent Project downloads; malformed and unknown values return 400. Explicit v1
+keeps the one-way boundary and rejects Agent Project downloads. A current CLI
+receives a dedicated 404 from an old backend and leaves its filesystem and
+durable projection state intact. Additive
 `agent_skill_changed`/`agent_skill_deleted` events protect only mutations
 created by current backend workers from released parsers on older connections;
-they do not make an old mutation worker safe. Current daemons treat both event
-families only as local-rescan hints. Workspace and personal Project events keep
-their released Cloud-owned behavior.
+current daemons treat both event families only as local-rescan hints. Workspace
+and personal Project events keep their released Cloud-owned behavior.
 
 An enabled private bundled-Skill entry reserves its key ahead of managed target
 installation. Conforming CLI/daemon uploads fail closed at that reservation

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -12,6 +12,10 @@ import { parseModules } from "../lib/prompts";
 import { sanitizeMetadata } from "../lib/sanitize";
 import { adapterForType, resolveTargetAgentTypes } from "../lib/select-adapter";
 import {
+	SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+	SKILL_SYNC_PROTOCOL_HEADER,
+} from "../lib/skill-sync-protocol";
+import {
 	readSkillsLock,
 	type SkillsLock,
 	skillCacheKey,
@@ -311,6 +315,9 @@ async function applyOneAgentPull(
 					// The explicit Cloud-owned source Project selects the import bytes.
 					const tarBytes = await api.getBytes(
 						`/v1/projects/${encodeURIComponent(scan.skillProjectId)}/skills/${encodeURIComponent(skill.skill_key)}/download`,
+						{
+							[SKILL_SYNC_PROTOCOL_HEADER]: SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+						},
 					);
 					if (scan.sharedOwnerHandle) {
 						await adapter.writeSharedSkillArchive(

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -551,10 +551,13 @@ export class ApiClient {
 		return await readJson<T>(res, path);
 	}
 
-	async getBytes(path: string): Promise<Buffer> {
+	async getBytes(path: string, extraHeaders?: Record<string, string>): Promise<Buffer> {
 		const accessToken = await this.getAccessToken();
 		const req = new Request(`${this.baseUrl}${path}`, {
-			headers: { Authorization: `Bearer ${accessToken}` },
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				...(extraHeaders ?? {}),
+			},
 		});
 		const res = await retryingFetch(req, DEFAULT_TIMEOUT_MS, this.abortSignal);
 		if (!res.ok) {

--- a/packages/cli/tests/api-client.test.ts
+++ b/packages/cli/tests/api-client.test.ts
@@ -307,6 +307,28 @@ describe("ApiClient error classification", () => {
 });
 
 describe("Agent-authoritative Skill sync rollout", () => {
+	it("marks binary downloads with the current Skill sync protocol", async () => {
+		fakeLogin("http://127.0.0.1:0");
+		const originalFetch = globalThis.fetch;
+		let request: Request | undefined;
+		globalThis.fetch = async (input, init) => {
+			request = input instanceof Request ? input : new Request(input, init);
+			return new Response("archive");
+		};
+		try {
+			const { ApiClient } = await import("../src/lib/api-client");
+			await new ApiClient().getBytes("/v1/projects/project-1/skills/demo/download", {
+				[SKILL_SYNC_PROTOCOL_HEADER]: SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+
+		expect(request?.headers.get(SKILL_SYNC_PROTOCOL_HEADER)).toBe(
+			SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+		);
+	});
+
 	const notFoundCases = [
 		{
 			name: "route-not-found from an older backend",

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1539,7 +1539,8 @@ export interface paths {
          *     route. New CLIs and the dashboard call
          *     `POST /v1/projects/{project_id}/skills/upload` directly.
          *
-         *     Asymmetric with `delete_skill_legacy` (which 410s) by design:
+         *     Asymmetric with `delete_skill_legacy` (which only accepts an env-bound
+         *     API key) by design:
          *     a wrong-project upload creates a stray row visible in the
          *     dashboard listing, recoverable in 30s by re-uploading to the
          *     correct project. A wrong-project DELETE is permanent data loss.
@@ -1592,19 +1593,12 @@ export interface paths {
         post?: never;
         /**
          * Delete Skill Legacy
-         * @description Legacy delete by slug-only is gone in phase 2. Resolving
-         *     via `resolve_default_write_project` would silently delete
-         *     the wrong project's copy when the caller's account holds the
-         *     same `skill_key` in multiple projects (which the cross-project
-         *     listing now exposes), or 404 with no useful hint when
-         *     their default project doesn't have that key. The CLI and
-         *     dashboard both migrated to
-         *     `DELETE /v1/projects/{project_id}/skills/{skill_key}` and
-         *     pass the row's own project_id; force any stale client onto
-         *     that path with 410 instead of guessing.
+         * @description Safely serve released slug-only clients with an Agent-bound identity.
          *
-         *     Argument unused — kept so FastAPI still parses the path
-         *     param uniformly with sibling routes.
+         *     Only an env-bound API key identifies exactly one Agent and its current
+         *     Agent Project. User-level API keys, OAuth CLI sessions, and browser sessions
+         *     remain ambiguous and receive the historical 410 instead of resolving a
+         *     most-recently-active Project.
          */
         delete: operations["delete_skill_legacy_v1_skills__skill_key__delete"];
         options?: never;
@@ -10610,7 +10604,9 @@ export interface operations {
     download_skill_legacy_v1_skills__skill_key__download_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+            };
             path: {
                 skill_key: string;
             };
@@ -10672,7 +10668,9 @@ export interface operations {
     delete_skill_legacy_v1_skills__skill_key__delete: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+            };
             path: {
                 skill_key: string;
             };
@@ -10809,7 +10807,9 @@ export interface operations {
     download_skill_project_v1_projects__project_id__skills__skill_key__download_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+            };
             path: {
                 project_id: string;
                 skill_key: string;


### PR DESCRIPTION
## Summary

- Treat a missing Skill sync protocol header and explicit agent-authoritative-v0 as supported legacy clients.
- Restore legacy SSE, list, upload, download, and safely fenced delete behavior while preserving v1 Agent-authoritative semantics.
- Keep slug-only delete limited to environment-bound CLI/API keys and preserve dashboard/OAuth/project identity fences.
- Send the v1 header only on current CLI Skill archive downloads.

## Why

Released older CLIs do not send X-Clawdi-Skill-Sync-Protocol, so the backend returned HTTP 426 from /v1/sync/events and continuously logged sse_disconnect:http_426. Those binaries cannot all be upgraded immediately.

## Verification

- Backend focused tests: 98 passed (Docker).
- CLI focused tests: 22 passed (Docker).
- CLI typecheck: passed (Docker).
- Ruff lint/format and Python compileall: passed.
- Biome: passed.
- Generated OpenAPI stale check: passed (existing discriminator warnings only).
- git diff --check origin/main..HEAD: passed.

## Safety

- Malformed and unknown protocol values return 400.
- Explicit v1 Agent Project download remains 409.
- Browser, OAuth, and unbound/ambiguous slug-only delete callers remain 410.
- No database migration or production/tenant data operation.