### PR TITLE
fix(web): unify model choice card styling

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4233,6 +4233,27 @@ test("deploy managed model picker preserves featured and overflow order and subm
 	await expect(featuredModels.nth(1)).not.toBeChecked();
 	await expect(featuredModels.nth(2)).not.toBeChecked();
 	await expect(featuredModels.nth(3)).not.toBeChecked();
+	const choiceSurfaceStyle = async (locator: ReturnType<Page["locator"]>) =>
+		locator.evaluate((element) => {
+			const style = getComputedStyle(element);
+			return {
+				backgroundColor: style.backgroundColor,
+				borderColor: style.borderColor,
+				borderRadius: style.borderRadius,
+				borderStyle: style.borderStyle,
+				borderWidth: style.borderWidth,
+				boxShadow: style.boxShadow,
+			};
+		});
+	const providerCards = page
+		.getByTestId("provider-choice-grid")
+		.locator(":scope > button, :scope > a");
+	expect(await choiceSurfaceStyle(featuredCards.nth(0))).toEqual(
+		await choiceSurfaceStyle(providerCards.nth(0)),
+	);
+	expect(await choiceSurfaceStyle(featuredCards.nth(1))).toEqual(
+		await choiceSurfaceStyle(providerCards.nth(1)),
+	);
 	await expect(page.locator("#deploy-primary-model")).toHaveCount(0);
 	await expect(managedModels).toContainText("Higher cost for complex work.");
 	await expect(managedModels).toContainText("Variable cost for long, detailed work.");

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -50,6 +50,36 @@ export const HERO_STRETCHED_LINK_CLASS =
 export const ENTITY_CARD_BUTTON_FOCUS_CLASS =
 	"focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
+type EntityChoiceCardVariant = "card" | "compact";
+
+export function entityChoiceCardClass({
+	variant = "card",
+	selected = false,
+	interactive = false,
+	disabled = false,
+	className,
+}: {
+	variant?: EntityChoiceCardVariant;
+	selected?: boolean;
+	interactive?: boolean;
+	disabled?: boolean;
+	className?: string;
+}) {
+	return cn(
+		variant === "compact"
+			? "min-w-0 rounded-md border border-transparent bg-muted/30 p-2.5"
+			: ENTITY_CARD_BASE,
+		"flex w-full text-left transition-colors",
+		variant === "compact" ? "items-center gap-2.5" : "items-start gap-3",
+		interactive && ENTITY_CARD_BUTTON_FOCUS_CLASS,
+		selected
+			? "border-primary bg-primary/5 ring-1 ring-primary/30"
+			: interactive && (variant === "compact" ? "hover:bg-muted/60" : "hover:bg-muted/50"),
+		disabled && "pointer-events-none opacity-60",
+		className,
+	);
+}
+
 /** Shared loading shape for entity cards and selectable entity options. */
 export function EntityCardSkeleton({
 	iconSize = "md",
@@ -446,19 +476,13 @@ export function EntityChoiceCard({
 			) : null}
 		</>
 	);
-	const cardClass = cn(
-		variant === "compact"
-			? "min-w-0 rounded-md border border-transparent bg-muted/30 p-2.5"
-			: ENTITY_CARD_BASE,
-		"flex w-full text-left transition-colors",
-		variant === "compact" ? "items-center gap-2.5" : "items-start gap-3",
-		(onClick || href) && ENTITY_CARD_BUTTON_FOCUS_CLASS,
-		selected
-			? "border-primary bg-primary/5 ring-1 ring-primary/30"
-			: (onClick || href) && (variant === "compact" ? "hover:bg-muted/60" : "hover:bg-muted/50"),
-		disabled && "pointer-events-none opacity-60",
+	const cardClass = entityChoiceCardClass({
+		variant,
+		selected,
+		interactive: Boolean(onClick || href),
+		disabled,
 		className,
-	);
+	});
 	if (href) {
 		return (
 			<Link to={href} className={cardClass}>

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -3,6 +3,7 @@
 import { Check } from "lucide-react";
 import type { ApiErrorNormalizer } from "@/components/api-error-panel";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { entityChoiceCardClass } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -99,11 +100,16 @@ export function ModelBindingPicker({
 									const radioId = `${catalogInputId}-featured-${index}`;
 									const titleId = `${catalogInputId}-featured-${index}-title`;
 									const descriptionId = `${catalogInputId}-featured-${index}-description`;
+									const selected = primaryModel === item.value;
 									return (
 										<Label
 											key={item.value}
 											htmlFor={radioId}
-											className="w-full min-w-0 cursor-pointer items-start gap-2 rounded-md border border-border/70 bg-transparent px-2.5 py-2 shadow-xs transition-[color,box-shadow] hover:bg-muted/60 has-data-checked:border-primary/50 has-data-checked:bg-muted"
+											className={entityChoiceCardClass({
+												selected,
+												interactive: true,
+												className: "cursor-pointer gap-2 px-2.5 py-2",
+											})}
 										>
 											<RadioGroupItem
 												id={radioId}
@@ -133,7 +139,7 @@ export function ModelBindingPicker({
 												aria-hidden
 												className={cn(
 													"size-4 shrink-0 text-primary transition-opacity",
-													primaryModel === item.value ? "opacity-100" : "opacity-0",
+													selected ? "opacity-100" : "opacity-0",
 												)}
 											/>
 										</Label>


### PR DESCRIPTION
## Summary

- reuse the shared entity choice-card surface and selection states for managed model cards
- keep the denser model-card spacing and responsive four/two/one-column layout
- verify selected and unselected model surfaces match provider cards exactly

## Verification

- focused Web tests (47 passed)
- Web typecheck
- hosted Playwright: Deploy and Agent Settings managed model layouts
- OSS production build
- responsive light/dark screenshots at 1280/800/700/390
- git diff --check