### PR TITLE
chore(backend): pin and type Sentry SDK boundary

### DIFF
--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -11,9 +11,12 @@ scrub a conservative set of sensitive keys before events are sent.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
 
 from app.core.config import settings
+
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
 
 logger = logging.getLogger(__name__)
 
@@ -65,13 +68,13 @@ def init_sentry() -> None:
     )
 
 
-def _scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any]:
+def _scrub_event(event: Event, _hint: Hint) -> Event:
     """Walk the event and redact anything that looks like a credential."""
     _scrub(event)
     return event
 
 
-def _scrub(obj: Any) -> None:
+def _scrub(obj: object) -> None:
     if isinstance(obj, dict):
         for key, value in list(obj.items()):
             if _is_sensitive_key(key):
@@ -83,7 +86,7 @@ def _scrub(obj: Any) -> None:
             _scrub(item)
 
 
-def _is_sensitive_key(key: Any) -> bool:
+def _is_sensitive_key(key: object) -> bool:
     if not isinstance(key, str):
         return False
     lowered = key.lower()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pgvector>=0.2.5",
     "openai>=2.52.0",
     "fastembed>=0.3",
-    "sentry-sdk[fastapi]>=2.23",
+    "sentry-sdk[fastapi]==2.66.1",
     # https://pypi.org/pypi/websockets/17.0.1/json
     "websockets==17.0.1",
     "pyyaml>=6.0",
@@ -67,6 +67,7 @@ typeCheckingMode = "standard"
 pythonVersion = "3.12"
 include = [
     "app/core/query_utils.py",
+    "app/core/sentry.py",
     "app/core/skill_key.py",
     "app/services/composio.py",
     "app/services/discord_gateway_worker.py",

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -19,6 +19,7 @@ EXPECTED_CONFIG = {
     "pythonVersion": "3.12",
     "include": [
         "app/core/query_utils.py",
+        "app/core/sentry.py",
         "app/core/skill_key.py",
         "app/services/composio.py",
         "app/services/discord_gateway_worker.py",

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sentry_sdk.types import Event, Hint
+
+from app.core.sentry import _scrub_event
+
+
+def test_scrub_event_redacts_nested_credentials_without_changing_shape() -> None:
+    payload: dict[object, object] = {
+        "authorization": "exact-secret",
+        "service_api_key": "suffix-secret",
+        "items": [
+            {"CLIENT_SECRET": "case-insensitive-secret", "label": "visible"},
+            {7: {"access_token": "nested-secret", "display_name": "visible"}},
+        ],
+        "public_key_id": "visible",
+    }
+    event: Event = {"extra": {"payload": payload}}
+    hint: Hint = {}
+
+    result = _scrub_event(event, hint)
+
+    assert result is event
+    assert payload == {
+        "authorization": "[redacted]",
+        "service_api_key": "[redacted]",
+        "items": [
+            {"CLIENT_SECRET": "[redacted]", "label": "visible"},
+            {7: {"access_token": "[redacted]", "display_name": "visible"}},
+        ],
+        "public_key_id": "visible",
+    }
+
+
+def test_disabled_sentry_does_not_import_sdk() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "importtime",
+            "-c",
+            "from app.core.sentry import init_sentry; init_sentry()",
+        ],
+        check=False,
+        capture_output=True,
+        cwd=Path(__file__).resolve().parents[1],
+        env=os.environ | {"SENTRY_DSN": ""},
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "sentry_sdk" not in completed.stderr

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -396,7 +396,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.23" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.66.1" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
     { name = "websockets", specifier = "==17.0.1" },


### PR DESCRIPTION
## Summary

- pin `sentry-sdk[fastapi]` exactly to reviewed release `2.66.1`; the resolved version is unchanged and the lockfile only updates the direct specifier
- type the Sentry event processor with public `sentry_sdk.types.Event` / `Hint`, removing explicit `Any` while preserving recursive credential redaction
- preserve the original zero-argument `init_sentry() -> None`, strict DSN opt-in, FastAPI/Starlette integrations, environment/release/traces configuration, and `send_default_pii=False`
- admit `app/core/sentry.py` to the zero-diagnostic owned ratchet

Base: `4f624a279861e73cd18dd344810fb07355ff24f7`  
Head: `2cd02fa6671a7c7929c5236c3f287ee8523f4b84`

## Reviewer follow-up

Removed the production-only `Transport` injection parameter and its postponed annotation. The enabled-initialization/custom-transport test was deleted rather than replaced with socket patching or client-options inspection. The remaining tests protect only two product behaviors: nested recursive credential scrubbing and DSN-empty initialization without importing Sentry.

## Official upstream evidence

- [PyPI project JSON](https://pypi.org/pypi/sentry-sdk/json) reports `2.66.1` as the current Production/Stable release, advertises the `fastapi` extra, and marks its wheel/sdist non-yanked.
- Tagged [`2.66.1` setup.py](https://github.com/getsentry/sentry-python/blob/2.66.1/setup.py) defines the `fastapi` extra as `fastapi>=0.79.0`, compatible with this repository's `fastapi>=0.115` requirement.
- Tagged public [`sentry_sdk.types`](https://github.com/getsentry/sentry-python/blob/2.66.1/sentry_sdk/types.py) provides `Event` and `Hint`.
- Tagged [`sentry_sdk.__init__`](https://github.com/getsentry/sentry-python/blob/2.66.1/sentry_sdk/__init__.py) confirms the public top-level export list; it does not export `close()`. No lifecycle test depends on a non-exported top-level API or private client state.

## Type inventory

- task baseline: 356 files / 309 errors
- final inventory: 357 files / 302 errors
- current base-to-head delta: 356 / 303 → 357 / 302
- owned ratchet: 8 files / 0 diagnostics
- changed-production gate: 1 file / 0 diagnostics

## Verification

- focused Sentry + type-governance tests: 16 passed
- full backend suite in the Docker clean runner against migrated throwaway PostgreSQL: 1744 passed, 7 skipped
- Ruff lint/format, Python compileall, `uv lock --check`, and deptry: passed
- generated OpenAPI and local/offline deploy-contract drift checks from the original cohort: passed

No production, tenant, hosted-control-plane, real Sentry telemetry, merge, or deploy operation was performed. This PR remains open for review.
