### PR TITLE
fix(runtime): migrate hosted MCP ownership ledger

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -860,7 +860,7 @@ outputs include:
 | `managed-cli/bin/clawdi` | Root-only active managed CLI link used by system services |
 | `npm/` | Root-only managed CLI package prefixes and active targets |
 | `config/projections/<runtime>.json` | Runtime projection payload |
-| `config/projections/managed-mcp-servers.json` | Canonical last-applied MCP server map per runtime, written atomically only after the full native-config apply succeeds |
+| `config/projections/managed-mcp-servers.json` | Canonical v2 managed MCP server-name ownership ledger per runtime, written atomically only after the full native-config apply succeeds |
 | `config/run/<runtime>.json`, `config/run/<runtime>+<service>.json` | `clawdi run` launch config for runtime main processes and internal runtime-owned services |
 | `$CLAWDI_RUN_DIR/secrets/*` | Short-lived token and secret files for the current runtime session |
 | `$CLAWDI_RUN_DIR/systemd/env/*.service.env` | Ephemeral env files for local systemd services, including short-lived runtime secrets |
@@ -883,10 +883,14 @@ a real, root-owned directory without group/world write permission before Apply
 begins.
 
 Generic MCP reconciliation compares desired servers, the previous managed
-last-applied map, and the current native map. OpenClaw current state is the
+server-name ownership ledger, and the current native map. The ledger never
+stores desired or native config values. A retained v1 ledger is migrated by
+strictly validating its schema, runtime keys, server-map boundaries, and server
+names, then discarding every legacy config value; all desired native config is
+derived from the current manifest. OpenClaw current state is the
 canonical `mcp.servers` object in `~/.openclaw/openclaw.json`; Hermes uses
 `mcp_servers` in `~/.hermes/config.yaml`. A desired name that already exists
-without last-applied ownership fails closed. Native absence already satisfies a
+without ledger ownership fails closed. Native absence already satisfies a
 managed deletion. The runtime apply snapshots both complete native configs and
 the ledger, preserves unrelated entries, writes the ledger last, and restores
 the exact previous files and metadata if any later mutation fails.

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -48,7 +48,11 @@ import {
 	OFFICIAL_INSTALL_ARGS,
 	OFFICIAL_INSTALL_URLS,
 } from "./manifest-contract";
-import { hostedManifestToRuntimeManifest, type RuntimeManifestLoad } from "./manifest-source";
+import {
+	hostedManifestToRuntimeManifest,
+	loadCommittedRuntimeManifest,
+	type RuntimeManifestLoad,
+} from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
@@ -3313,6 +3317,155 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionB);
 		expect(convergeLegacy().installErrors).toEqual([]);
 		expect(legacySignals).toEqual([true, false]);
+	});
+
+	test("replaces an unverifiable legacy secret cache after a successful online upgrade", () => {
+		const paths = tempRuntimePaths();
+		const engine = installCachedTestEgressEngine(paths, "12.2.3");
+		const canonicalSecretRef = "secret://tool.codex.apiKey";
+		const base = egressRuntimeManifest(paths, {
+			generation: 19,
+			engine,
+			profile: "enabled",
+		});
+		const profile = base.egressProfiles?.profiles[0];
+		if (!profile) throw new Error("expected enabled egress profile fixture");
+		const currentManifest = manifestSchema.parse({
+			...base,
+			issuedAt: "2026-07-01T00:19:00.000Z",
+			egressProfiles: {
+				profiles: [
+					{
+						...profile,
+						rewrite: {
+							...profile.rewrite,
+							setHeaders: {
+								authorization: {
+									type: "secretRef",
+									secretRef: canonicalSecretRef,
+									prefix: "Bearer ",
+								},
+							},
+						},
+					},
+				],
+			},
+		});
+		const retainedManifest = {
+			...currentManifest,
+			generation: 15,
+			issuedAt: "2026-07-01T00:15:00.000Z",
+			egressProfiles: {
+				profiles: [
+					profile,
+					{
+						...profile,
+						id: "legacy-env-ref",
+						rewrite: {
+							...profile.rewrite,
+							setHeaders: {
+								authorization: {
+									type: "secretRef",
+									secretRef: "env://REDACTED_LEGACY_NAME",
+									prefix: "Bearer ",
+								},
+							},
+						},
+					},
+				],
+			},
+		};
+		const retainedSecretValues = {
+			...TEST_HOSTED_SECRET_VALUES,
+			"clawdi/auth-token": TEST_HOSTED_SECRET_VALUES["secret://clawdi/auth-token"],
+			"runtime/openclaw/gateway-token":
+				TEST_HOSTED_SECRET_VALUES["secret://runtime/openclaw/gateway-token"],
+			"tool.codex.apiKey": TEST_HOSTED_SECRET_VALUES[canonicalSecretRef],
+		};
+		const currentSecretValues = {
+			"secret://clawdi/auth-token": "generation-19-auth-token",
+			"secret://runtime/openclaw/gateway-token": "canonical-generation-19-gateway",
+			[canonicalSecretRef]: "generation-19-egress-token",
+		};
+		const currentLoad = manifestLoad(
+			currentManifest,
+			"inline-generation-19-online-upgrade",
+			currentSecretValues,
+		);
+		if (!currentLoad.applyContext) throw new Error("expected apply context fixture");
+
+		mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
+		writeFileSync(paths.manifestLastGood, `${JSON.stringify(retainedManifest, null, 2)}\n`);
+		writeFileSync(
+			paths.managedSecretCacheFile,
+			`${JSON.stringify(retainedSecretValues, null, 2)}\n`,
+		);
+		writeRuntimeAppliedState(
+			{
+				schemaVersion: "clawdi.runtimeAppliedState.v2",
+				appliedAt: "2026-07-01T00:15:00.000Z",
+				instanceId: currentManifest.instanceId,
+				etag: '"generation-15"',
+				sourceRevision: runtimeContentSha256({ generation: 15 }),
+				generation: 15,
+				contentIdentity: {
+					sourcePath: "retained-generation-15",
+					sha256: runtimeContentSha256({
+						manifest: retainedManifest,
+						secretValues: retainedSecretValues,
+					}),
+				},
+				providerIds: [],
+				projectedProviderIds: {},
+			},
+			paths,
+		);
+		expect(loadCommittedRuntimeManifest(paths, currentLoad.applyContext)).toHaveProperty("errors");
+
+		let activations = 0;
+		let rollbacks = 0;
+		const convergence = convergeRuntimeManifest(currentLoad, paths, {
+			cacheLastGood: false,
+			commitAuthority: (committedConvergence, authority) =>
+				commitTestRuntimeAuthority(currentLoad, paths, committedConvergence, authority),
+			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
+				activate: ({ restartEgressSidecar }) => {
+					expect(restartEgressSidecar).toBe(true);
+					expect(
+						readFileSync(join(paths.managedSecretRoot, "egress-secrets.json"), "utf-8"),
+					).toContain("generation-19-egress-token");
+					activations++;
+					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+				},
+				rollback: () => {
+					rollbacks++;
+				},
+			},
+		});
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(activations).toBe(1);
+		expect(rollbacks).toBe(0);
+		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf-8"))).toEqual(currentManifest);
+		expect(JSON.parse(readFileSync(paths.managedSecretCacheFile, "utf-8"))).toEqual({
+			"secret://runtime/openclaw/gateway-token": "canonical-generation-19-gateway",
+			[canonicalSecretRef]: "generation-19-egress-token",
+		});
+		expect(readRuntimeAppliedState(paths)).toMatchObject({
+			generation: 19,
+			egressSidecarSecretRevision: expect.stringMatching(/^[a-f0-9]{64}$/),
+		});
+		const committedSecretCache = readFileSync(paths.managedSecretCacheFile, "utf-8");
+		const committedCache = [
+			readFileSync(paths.manifestLastGood, "utf-8"),
+			committedSecretCache,
+		].join("\n");
+		expect(committedCache).not.toContain("env://");
+		expect(committedCache).not.toContain("legacy-env-ref");
+		expect(committedSecretCache).not.toContain(': "test-auth-token"');
+		expect(committedSecretCache).not.toContain(': "gateway-token"');
+		expect(committedSecretCache).not.toContain(': "test-codex-provider-key"');
 	});
 
 	test("advances last-good manifest only after a clean converge", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -106,7 +106,6 @@ import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-
 import {
 	type HostedMcpServerDesiredState,
 	hostedMcpDesiredStateSchema,
-	hostedMcpServerDesiredStateSchema,
 } from "./manifest-resources";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
 
@@ -3380,14 +3379,14 @@ interface HostedMcpIntent {
 }
 
 const HOSTED_RUNTIME_TARGETS = ["openclaw", "hermes"] as const satisfies readonly RuntimeName[];
-const HOSTED_MCP_LEDGER_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v1";
+const HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v1";
+const HOSTED_MCP_LEDGER_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v2";
 const HOSTED_MCP_LEDGER_FILE = "managed-mcp-servers.json";
+const HOSTED_MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 
 interface HostedMcpManagedLedger {
 	schemaVersion: typeof HOSTED_MCP_LEDGER_SCHEMA_VERSION;
-	runtimes: Partial<
-		Record<(typeof HOSTED_RUNTIME_TARGETS)[number], Record<string, HostedMcpServerDesiredState>>
-	>;
+	runtimes: Partial<Record<(typeof HOSTED_RUNTIME_TARGETS)[number], string[]>>;
 }
 
 function hostedMcpIntent(manifest: RuntimeManifest): HostedMcpIntent {
@@ -3415,8 +3414,19 @@ function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger
 			}`,
 		);
 	}
-	if (!isPlainRecord(payload) || payload.schemaVersion !== HOSTED_MCP_LEDGER_SCHEMA_VERSION) {
+	if (
+		!isPlainRecord(payload) ||
+		(payload.schemaVersion !== HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION &&
+			payload.schemaVersion !== HOSTED_MCP_LEDGER_SCHEMA_VERSION)
+	) {
 		throw new Error("hosted MCP last-applied ledger has an unsupported schema");
+	}
+	if (
+		Object.keys(payload).length !== 2 ||
+		!Object.hasOwn(payload, "schemaVersion") ||
+		!Object.hasOwn(payload, "runtimes")
+	) {
+		throw new Error("hosted MCP last-applied ledger has invalid fields");
 	}
 	const runtimes = recordValue(payload.runtimes);
 	if (
@@ -3427,23 +3437,31 @@ function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger
 	}
 	const normalized: HostedMcpManagedLedger["runtimes"] = {};
 	for (const runtime of HOSTED_RUNTIME_TARGETS) {
-		const servers = runtimes[runtime];
-		if (servers === undefined) continue;
-		if (!isPlainRecord(servers)) {
+		const runtimeOwnership = runtimes[runtime];
+		if (runtimeOwnership === undefined) continue;
+		// V1 values are untrusted legacy desired state. Migrate ownership by name only.
+		const names =
+			payload.schemaVersion === HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION
+				? isPlainRecord(runtimeOwnership)
+					? Object.keys(runtimeOwnership)
+					: null
+				: Array.isArray(runtimeOwnership)
+					? runtimeOwnership
+					: null;
+		if (!names) {
 			throw new Error(`hosted MCP last-applied ledger has invalid ${runtime} servers`);
 		}
-		const normalizedServers: Record<string, HostedMcpServerDesiredState> = {};
-		for (const [name, server] of Object.entries(servers).sort(([a], [b]) => a.localeCompare(b))) {
-			if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(name)) {
+		const normalizedNames = new Set<string>();
+		for (const name of names) {
+			if (typeof name !== "string" || !HOSTED_MCP_SERVER_NAME_PATTERN.test(name)) {
 				throw new Error(`hosted MCP last-applied ledger has invalid ${runtime} server name`);
 			}
-			const parsed = hostedMcpServerDesiredStateSchema.safeParse(server);
-			if (!parsed.success) {
-				throw new Error(`hosted MCP last-applied ledger has invalid ${runtime} server ${name}`);
+			if (normalizedNames.has(name)) {
+				throw new Error(`hosted MCP last-applied ledger has duplicate ${runtime} server name`);
 			}
-			normalizedServers[name] = parsed.data;
+			normalizedNames.add(name);
 		}
-		if (Object.keys(normalizedServers).length > 0) normalized[runtime] = normalizedServers;
+		if (normalizedNames.size > 0) normalized[runtime] = [...normalizedNames].sort();
 	}
 	return { schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION, runtimes: normalized };
 }
@@ -3453,15 +3471,8 @@ function writeHostedMcpManagedLedger(paths: RuntimePaths, ledger: HostedMcpManag
 		schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION,
 		runtimes: Object.fromEntries(
 			HOSTED_RUNTIME_TARGETS.flatMap((runtime) => {
-				const servers = ledger.runtimes[runtime];
-				return servers && Object.keys(servers).length > 0
-					? [
-							[
-								runtime,
-								Object.fromEntries(Object.entries(servers).sort(([a], [b]) => a.localeCompare(b))),
-							],
-						]
-					: [];
+				const names = ledger.runtimes[runtime];
+				return names && names.length > 0 ? [[runtime, [...names].sort()]] : [];
 			}),
 		),
 	});
@@ -3690,16 +3701,16 @@ function buildHostedMcpReconciliationPlan(
 	};
 	const runtimes = HOSTED_RUNTIME_TARGETS.map((name) => {
 		const desiredServers = manifest.runtimes[name]?.enabled === true ? intent.servers : {};
-		const previousServers = ledger.runtimes[name] ?? {};
+		const previousServerNames = new Set(ledger.runtimes[name] ?? []);
 		const native = readHostedMcpNativeState(name, home);
 		for (const serverName of Object.keys(desiredServers).sort()) {
-			if (Object.hasOwn(previousServers, serverName)) continue;
+			if (previousServerNames.has(serverName)) continue;
 			if (Object.hasOwn(native.servers, serverName)) {
 				throw new Error(`refusing to replace unmanaged ${name} MCP server ${serverName}`);
 			}
 		}
 		const mutations: HostedMcpMutation[] = [];
-		for (const serverName of Object.keys(previousServers).sort()) {
+		for (const serverName of [...previousServerNames].sort()) {
 			if (!Object.hasOwn(desiredServers, serverName) && Object.hasOwn(native.servers, serverName)) {
 				// The ledger owns this name even if its native value drifted. Native
 				// absence, however, already satisfies deletion and must not invoke an
@@ -3716,9 +3727,7 @@ function buildHostedMcpReconciliationPlan(
 			}
 		}
 		if (Object.keys(desiredServers).length > 0) {
-			nextLedger.runtimes[name] = Object.fromEntries(
-				Object.entries(desiredServers).sort(([a], [b]) => a.localeCompare(b)),
-			);
+			nextLedger.runtimes[name] = Object.keys(desiredServers).sort();
 		}
 		const observation = observations.get(name);
 		const hasSet = mutations.some((mutation) => mutation.kind === "set");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13656,8 +13656,9 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			command: "user-owned",
 			args: ["keep"],
 		});
-		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
-			openclaw: initialServers,
+		expect(JSON.parse(readFileSync(ledgerPath, "utf-8"))).toEqual({
+			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
+			runtimes: { openclaw: ["clawdi", "search-proxy"] },
 		});
 		expect(existsSync(join(openclawSkill, ".clawdi-managed.json"))).toBe(true);
 
@@ -13697,7 +13698,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(hermesAfterSwitch.clawdi).toEqual(initialServers.clawdi);
 		expect(hermesAfterSwitch["search-proxy"]).toEqual(updatedServers["search-proxy"]);
 		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
-			hermes: updatedServers,
+			hermes: ["clawdi", "search-proxy"],
 		});
 		const hermesSkill = join(home, ".hermes", "skills", "clawdi");
 		expect(existsSync(join(hermesSkill, ".clawdi-managed.json"))).toBe(true);
@@ -13727,7 +13728,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			args: ["keep"],
 		});
 		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
-			hermes: { clawdi: initialServers.clawdi },
+			hermes: ["clawdi"],
 		});
 		expect(existsSync(hermesSkill)).toBe(false);
 		mkdirSync(hermesSkill, { recursive: true });
@@ -13749,6 +13750,207 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			"user-owned canonical skill\n",
 		);
 		expect(readFileSync(openclawCalls, "utf-8")).toContain("unset search-proxy");
+	});
+
+	it("migrates retained v1 MCP ownership without copying legacy config values", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "workspace");
+		const ledgerPath = join(state, "config", "projections", "managed-mcp-servers.json");
+		const hermesConfigPath = join(home, ".hermes", "config.yaml");
+		const legacySecretRef = "env://REDACTED_LEGACY_NAME";
+		const legacyPrefix = "Bearer ";
+		const legacyServer = {
+			url: "https://legacy.example.test/mcp",
+			transport: "streamable-http",
+			headers: {
+				Authorization: { secretRef: legacySecretRef, prefix: legacyPrefix },
+			},
+		};
+		const retainedV1Ledger = {
+			schemaVersion: "clawdi.hostedManagedMcpServers.v1",
+			runtimes: { hermes: { clawdi: legacyServer } },
+		};
+		writeHermesVersionBinary(home, "0.18.0");
+		mkdirSync(dirname(hermesConfigPath), { recursive: true });
+		writeFileSync(
+			hermesConfigPath,
+			`${JSON.stringify({ mcp_servers: { clawdi: legacyServer } }, null, 2)}\n`,
+		);
+		mkdirSync(dirname(ledgerPath), { recursive: true });
+		writeFileSync(ledgerPath, `${JSON.stringify(retainedV1Ledger, null, 2)}\n`);
+		expect(legacyPrefix).toHaveLength(7);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const load = (generation: number, includeServer: boolean): RuntimeManifestLoad => ({
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_mcp_ledger_migration",
+				environmentId: "env_mcp_ledger_migration",
+				instanceId: "iid_mcp_ledger_migration",
+				generation,
+				issuedAt: "2026-07-31T00:00:00Z",
+				workspaceRoot: workspace,
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					hermes: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://hermes-agent.nousresearch.com/install.sh",
+							home,
+							args: [],
+						},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+					mcp: {
+						servers: includeServer
+							? {
+									clawdi: {
+										url: "https://current.example.test/mcp",
+										transport: "sse",
+										headers: { "X-Manifest": "current-only" },
+									},
+								}
+							: {},
+					},
+				},
+				recovery: {},
+			},
+			source: "remote-datasource",
+			sourcePath: `test://mcp-ledger-migration-${generation}`,
+			offline: false,
+			secretValues: {},
+		});
+
+		const migrated = convergeRuntimeManifest(load(1, true), getRuntimePaths());
+		expect(migrated.installErrors).toEqual([]);
+		expect(readHermesConfigYaml(home).mcp_servers).toEqual({
+			clawdi: {
+				url: "https://current.example.test/mcp",
+				transport: "sse",
+				headers: { "X-Manifest": "current-only" },
+			},
+		});
+		const migratedLedgerPayload = JSON.parse(readFileSync(ledgerPath, "utf-8"));
+		expect(migratedLedgerPayload).toEqual({
+			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
+			runtimes: { hermes: ["clawdi"] },
+		});
+		const migratedNative = readFileSync(hermesConfigPath, "utf-8");
+		const migratedLedger = readFileSync(ledgerPath, "utf-8");
+		for (const legacyValue of [
+			legacyServer.url,
+			legacyServer.transport,
+			legacySecretRef,
+			legacyPrefix,
+		]) {
+			expect(migratedNative).not.toContain(legacyValue);
+			expect(migratedLedger).not.toContain(legacyValue);
+		}
+		expect(migratedLedger).not.toContain("env://");
+		expect(JSON.stringify(migratedLedgerPayload)).not.toContain(JSON.stringify(legacyServer));
+
+		const roundTripped = convergeRuntimeManifest(load(2, true), getRuntimePaths());
+		expect(roundTripped.installErrors).toEqual([]);
+		expect(readFileSync(hermesConfigPath, "utf-8")).toBe(migratedNative);
+		expect(readFileSync(ledgerPath, "utf-8")).toBe(migratedLedger);
+
+		const removed = convergeRuntimeManifest(load(3, false), getRuntimePaths());
+		expect(removed.installErrors).toEqual([]);
+		expect(readHermesConfigYaml(home).mcp_servers).toEqual({});
+		expect(JSON.parse(readFileSync(ledgerPath, "utf-8"))).toEqual({
+			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
+			runtimes: {},
+		});
+	});
+
+	it.each([
+		[
+			"unsupported schema",
+			{ schemaVersion: "clawdi.hostedManagedMcpServers.v3", runtimes: {} },
+			"unsupported schema",
+		],
+		[
+			"unsupported runtime",
+			{ schemaVersion: "clawdi.hostedManagedMcpServers.v2", runtimes: { codex: ["clawdi"] } },
+			"invalid runtimes",
+		],
+		[
+			"invalid v1 server name",
+			{
+				schemaVersion: "clawdi.hostedManagedMcpServers.v1",
+				runtimes: {
+					hermes: {
+						"Invalid Name": {
+							url: "https://legacy.example.test/mcp",
+							transport: "streamable-http",
+							headers: {
+								Authorization: {
+									secretRef: "env://REDACTED_LEGACY_NAME",
+									prefix: "Bearer ",
+								},
+							},
+						},
+					},
+				},
+			},
+			"invalid hermes server name",
+		],
+		[
+			"invalid v2 server name",
+			{
+				schemaVersion: "clawdi.hostedManagedMcpServers.v2",
+				runtimes: { hermes: ["Invalid Name"] },
+			},
+			"invalid hermes server name",
+		],
+	] as const)("rejects an MCP ownership ledger with %s", (_case, ledger, expectedError) => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "workspace");
+		const ledgerPath = join(state, "config", "projections", "managed-mcp-servers.json");
+		const originalLedger = `${JSON.stringify(ledger, null, 2)}\n`;
+		mkdirSync(dirname(ledgerPath), { recursive: true });
+		writeFileSync(ledgerPath, originalLedger);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		expect(() =>
+			convergeRuntimeManifest(
+				{
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "dep_invalid_mcp_ledger",
+						environmentId: "env_invalid_mcp_ledger",
+						instanceId: "iid_invalid_mcp_ledger",
+						generation: 1,
+						issuedAt: "2026-07-31T00:00:00Z",
+						workspaceRoot: workspace,
+						controlPlane: { apiUrl: "https://cloud-api.test" },
+						runtimes: {},
+						projection: { system: { home, workspace }, mcp: { servers: {} } },
+						recovery: {},
+					},
+					source: "remote-datasource",
+					sourcePath: "test://invalid-mcp-ledger",
+					offline: false,
+					secretValues: {},
+				},
+				getRuntimePaths(),
+			),
+		).toThrow(expectedError);
+		expect(readFileSync(ledgerPath, "utf-8")).toBe(originalLedger);
 	});
 
 	it("claims MCP ownership only after successful mutations and retries failed cleanup", () => {
@@ -13851,7 +14053,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		);
 		expect(managed.installErrors).toEqual([]);
 		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
-			openclaw: { "owned-server": { command: "owned", args: ["serve"] } },
+			openclaw: ["owned-server"],
 		});
 		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual({
 			command: "owned",
@@ -13861,7 +14063,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		const failedRemoval = convergeRuntimeManifest(load(5, {}), getRuntimePaths());
 		expect(failedRemoval.installErrors.join("\n")).toContain("runtime MCP projection failed");
 		expect(JSON.parse(readFileSync(ledgerPath, "utf-8")).runtimes).toEqual({
-			openclaw: { "owned-server": { command: "owned", args: ["serve"] } },
+			openclaw: ["owned-server"],
 		});
 		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual({
 			command: "owned",


### PR DESCRIPTION
## Summary
- replace the hosted MCP last-applied config copy with a names-only ownership ledger
- migrate retained v1 ledgers by validating only their ownership envelope and discarding all legacy config values
- preserve fail-closed collision, mutation, rollback, and post-success ledger commit semantics

## Production failure addressed
A retained v1 Hermes ledger can contain legacy `env://` credential references. Current canonical desired-state validation must not reinterpret that historical value. The reconciler now extracts only validated server names and rebuilds native state exclusively from the current manifest.

## Verification
- MCP focused tests: 11 passed
- egress rollback/online-upgrade tests: 2 passed
- isolated CLI suite: 1513 passed, 4 skipped
- CLI typecheck
- Biome check
- git diff --check