### PR TITLE
fix(backend): pin and type PyJWT auth boundary

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -514,8 +514,8 @@ def _decode_clerk_oauth_access_jwt(
 
 
 async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | None:
-    oauth_cli = _is_oauth_access_jwt(token)
-    if oauth_cli:
+    oauth_setting: ClerkCliOAuthSetting | None = None
+    if _is_oauth_access_jwt(token):
         try:
             oauth_setting = await resolve_app_setting(db, CLERK_CLI_OAUTH_SPEC)
         except AppSettingUnavailable as error:
@@ -531,11 +531,10 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
     signing_key = await _resolve_clerk_signing_key(token)
     if signing_key is None:
         return None
-    payload = (
-        _decode_clerk_oauth_access_jwt(token, signing_key, oauth_setting)
-        if oauth_cli
-        else _decode_clerk_session_jwt(token, signing_key)
-    )
+    if oauth_setting is None:
+        payload = _decode_clerk_session_jwt(token, signing_key)
+    else:
+        payload = _decode_clerk_oauth_access_jwt(token, signing_key, oauth_setting)
     if payload is None:
         return None
 
@@ -718,6 +717,7 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             # of being silently swallowed.
             await db.rollback()
 
+    oauth_cli = oauth_setting is not None
     oauth_access_expires_at: datetime | None = None
     if oauth_cli:
         expires_at = payload.get("exp")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "asyncpg>=0.30",
     "alembic>=1.14",
     "pydantic-settings>=2.14.0",
-    "pyjwt[crypto]>=2.10",
+    "pyjwt[crypto]==2.13.0",
     "cryptography>=44.0",
     "httpx>=0.28.1",
     "httpx2>=2.5.0,<3.0.0",
@@ -66,6 +66,7 @@ dev = [
 typeCheckingMode = "standard"
 pythonVersion = "3.12"
 include = [
+    "app/core/auth.py",
     "app/core/query_utils.py",
     "app/core/sentry.py",
     "app/core/skill_key.py",

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -18,6 +18,7 @@ EXPECTED_CONFIG = {
     "typeCheckingMode": "standard",
     "pythonVersion": "3.12",
     "include": [
+        "app/core/auth.py",
         "app/core/query_utils.py",
         "app/core/sentry.py",
         "app/core/skill_key.py",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -393,7 +393,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
+    { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.66.1" },


### PR DESCRIPTION
## Summary

- Pin `pyjwt[crypto]` to the reviewed `2.13.0` release; the existing lock already selected the same wheel/sdist and crypto extra.
- Model Clerk access-token auth with one optional OAuth setting, resolved and validated before the single signing-key lookup, then select OAuth or browser-session decode from setting presence.
- Add the now-clean `app/core/auth.py` to the fail-closed zero-diagnostic BasedPyright owned ratchet.

## Public upstream evidence

- [Official PyPI metadata](https://pypi.org/pypi/PyJWT/json) currently reports `2.13.0`; its 2.13.0 wheel and sdist are both non-yanked and their SHA-256 hashes match `uv.lock`.
- The exact [PyJWT 2.13.0 tag](https://github.com/jpadilla/pyjwt/tree/2.13.0) resolves to `7144e4534c34810f4525dc4578a32addd8212cff`.
- The tagged [package metadata](https://github.com/jpadilla/pyjwt/blob/2.13.0/pyproject.toml#L63-L68) requires Python `>=3.9` and defines `crypto` as `cryptography>=3.4.0`; the tagged [installation docs](https://github.com/jpadilla/pyjwt/blob/2.13.0/docs/installation.rst#L13-L26) recommend `pyjwt[crypto]` for RSA.
- Tagged public contracts cover [PyJWKClient and its PyJWK return](https://github.com/jpadilla/pyjwt/blob/2.13.0/jwt/jwks_client.py#L15-L220), [top-level exports and exceptions](https://github.com/jpadilla/pyjwt/blob/2.13.0/jwt/__init__.py#L1-L78), and the documented [JWKS to decode flow](https://github.com/jpadilla/pyjwt/blob/2.13.0/docs/usage.rst#L476-L512).

## Security behavior

The decode helpers and their validation profiles are unchanged. OAuth unavailable or disabled still returns 503 before token verification; JWKS connection failure remains 503; unknown keys and invalid tokens remain unauthenticated. OAuth issuer, exp, iat, nbf, client_id, aud, and azp checks and browser issuer/audience behavior are preserved. `PyJWKClient` remains off the event loop and tokens/secrets are not logged.

## Rebase evidence

- Base: `main@8b2a4b88ca004742ce894f62497cb0dd0bde6704`
- Previous head: `aaa4a92f86a07088aea258db058287a109bf6d08`
- Rebased head: `54a26954f704334202b0dc5465a9c7895ce47ee5`
- Stable patch-id before and after: `616aa5cef5325a8e4602797aeee8d09df1709960`
- Four-file diff SHA-256 before and after: `ea012eb56446df64280c3e82534a7d022617466b7522d709619c08f15b3b78a3`
- `git range-diff`: `aaa4a92f = 54a26954`
- `origin/main..HEAD`: one semantic commit; exactly 4 modified files, 11 insertions, 9 deletions, 0 added files
- All four cohort files are byte-equivalent to the reviewed pre-rebase head

## Verification on rebased head

- Fresh throwaway PostgreSQL 16 + pgvector migration to the single Alembic head
- Focused auth/JWKS/OAuth/email-rebind suites: 61 passed
- Hermetic Docker backend suite: 1744 passed, 7 skipped
- Hermetic CLI Clerk OAuth suite: 56 passed
- Workspace typecheck: 4/4 tasks passed
- BasedPyright owned: 9 files / 0 diagnostics; changed: 1 / 0; inventory: 357 files / 301 errors
- Ruff lint/format, compileall, `uv sync --frozen`, `uv lock --check`, dependency authority, deptry, generated OpenAPI drift, generated-client byte drift, and diff-check passed

No production, tenant, real Clerk, hosted deploy API, telemetry, merge, or deploy access was used.