### PR TITLE
fix(api): restore legacy MCP compatibility

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -926,6 +926,17 @@ async def require_user_auth(auth: AuthContext = Depends(get_auth)) -> AuthContex
     return auth
 
 
+def require_clerk_id(auth: AuthContext) -> str:
+    """Return the Clerk id required by user-scoped integrations."""
+    clerk_id = auth.user.clerk_id
+    if not clerk_id:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Clerk user authentication is required",
+        )
+    return clerk_id
+
+
 async def require_user_auth_unbound(
     auth: AuthContext = Depends(require_user_auth),
 ) -> AuthContext:

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.core.auth import AuthContext, require_user_auth
+from app.core.auth import AuthContext, require_clerk_id, require_user_auth
 from app.core.config import settings
 from app.schemas.common import Paginated
 from app.schemas.connector import (
@@ -144,8 +144,9 @@ async def list_connections(
     """List user's connected services."""
     if not settings.composio_api_key:
         return []
+    clerk_id = require_clerk_id(auth)
     try:
-        accounts = await get_connected_accounts(auth.user.clerk_id)
+        accounts = await get_connected_accounts(clerk_id)
     except Exception as exc:
         if _is_composio_auth_error(exc):
             log.warning("composio_key_invalid path=connectors_list")
@@ -155,7 +156,7 @@ async def list_connections(
     # Composio Tool Router sessions capture the active account set, so
     # observing the latest connected-account state should force the next
     # MCP bridge call to create a fresh session.
-    invalidate_tool_router_mcp_session(auth.user.clerk_id)
+    invalidate_tool_router_mcp_session(clerk_id)
     return [ConnectorConnectionResponse.model_validate(account) for account in accounts]
 
 
@@ -242,7 +243,7 @@ async def connect_app(
             )
         if auth_type not in _REDIRECT_AUTH_TYPES:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Connector requires credentials")
-        result = await create_connect_link(auth.user.clerk_id, app_name, redirect_url)
+        result = await create_connect_link(require_clerk_id(auth), app_name, redirect_url)
     except HTTPException:
         raise
     except Exception as exc:
@@ -387,7 +388,7 @@ async def connect_credentials(
     if any(not v.strip() for v in body.credentials.values()):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Credential values cannot be empty")
     try:
-        result = await connect_with_credentials(auth.user.clerk_id, app_name, body.credentials)
+        result = await connect_with_credentials(require_clerk_id(auth), app_name, body.credentials)
     except TimeoutError as exc:
         # `connect_with_credentials` polls Composio with a bounded
         # timeout after creating the connected account. Surface that
@@ -423,14 +424,15 @@ async def disconnect(
     if not settings.composio_api_key:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
 
-    accounts = await get_connected_accounts(auth.user.clerk_id)
+    clerk_id = require_clerk_id(auth)
+    accounts = await get_connected_accounts(clerk_id)
     if not any(a.get("id") == connection_id for a in accounts):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Connection not found")
 
     success = await disconnect_account(connection_id)
     if not success:
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to disconnect")
-    invalidate_tool_router_mcp_session(auth.user.clerk_id)
+    invalidate_tool_router_mcp_session(clerk_id)
     return ConnectorDisconnectResponse(status="disconnected")
 
 
@@ -444,7 +446,7 @@ async def get_mcp_config(
 
     return ConnectorMcpConfigResponse(
         mcp_url=f"{settings.public_api_url.rstrip('/')}/v1/mcp/composio",
-        mcp_token=create_mcp_bridge_token(auth.user.clerk_id),
+        mcp_token=create_mcp_bridge_token(require_clerk_id(auth)),
     )
 
 

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -13,6 +13,7 @@ from app.schemas.connector import (
     ConnectorCredentialsConnectRequest,
     ConnectorCredentialsConnectResponse,
     ConnectorDisconnectResponse,
+    ConnectorMcpConfigResponse,
     ConnectorToolResponse,
     ConnectRequest,
 )
@@ -21,6 +22,7 @@ from app.services.composio import (
     ConnectorCustomAuthConfigRequired,
     connect_with_credentials,
     create_connect_link,
+    create_mcp_bridge_token,
     disconnect_account,
     get_app_by_name,
     get_app_tools,
@@ -430,6 +432,20 @@ async def disconnect(
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to disconnect")
     invalidate_tool_router_mcp_session(auth.user.clerk_id)
     return ConnectorDisconnectResponse(status="disconnected")
+
+
+@router.get("/mcp-config", response_model=ConnectorMcpConfigResponse)
+async def get_mcp_config(
+    auth: AuthContext = Depends(require_user_auth),
+) -> ConnectorMcpConfigResponse:
+    """Return the deprecated MCP bridge config required by CLI 0.12.7."""
+    if not settings.composio_api_key:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
+
+    return ConnectorMcpConfigResponse(
+        mcp_url=f"{settings.public_api_url.rstrip('/')}/v1/mcp/composio",
+        mcp_token=create_mcp_bridge_token(auth.user.clerk_id),
+    )
 
 
 @router.get("/{app_name}/tools")

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -18,6 +18,7 @@ from app.core.auth import (
     _is_scoped_api_key,
     get_auth,
     is_runtime_deployment_principal,
+    require_clerk_id,
 )
 from app.core.database import get_session
 from app.core.query_utils import like_needle
@@ -417,19 +418,20 @@ async def _connector_mcp_tools(auth: AuthContext) -> list[dict[str, Any]]:
             _require_scope(auth, "connectors:read")
         except HTTPException:
             return []
+    clerk_id = require_clerk_id(auth)
     now = time.monotonic()
-    cached = _connector_tools_cache.get(auth.user.clerk_id)
+    cached = _connector_tools_cache.get(clerk_id)
     if cached and cached[0] > now:
         return cached[1]
     tools: list[dict[str, Any]] = []
     try:
-        session = await get_tool_router_mcp_session(auth.user.clerk_id)
+        session = await get_tool_router_mcp_session(clerk_id)
         result = await list_tool_router_mcp_tools(session)
         serialized = result.model_dump(by_alias=True, exclude_none=True)
         raw_tools = serialized.get("tools")
         if isinstance(raw_tools, list):
             tools = [tool for tool in raw_tools if isinstance(tool, dict)]
-        _connector_tools_cache[auth.user.clerk_id] = (
+        _connector_tools_cache[clerk_id] = (
             now + _CONNECTOR_TOOLS_CACHE_TTL_SECONDS,
             tools,
         )
@@ -661,7 +663,7 @@ async def _tool_connector_call(
         )
     if is_runtime_deployment_principal(auth):
         _require_scope(auth, "connectors:invoke")
-    session = await get_tool_router_mcp_session(auth.user.clerk_id)
+    session = await get_tool_router_mcp_session(require_clerk_id(auth))
     response = await call_tool_router_mcp_tool(session, name, arguments)
     result = response.model_dump(by_alias=True, exclude_none=True)
     if isinstance(result, dict):

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -274,11 +274,14 @@ async def mcp_composio_post(request: Request):
 
     rpc_id = body.get("id")
     method = body.get("method")
+    if method not in {"tools/list", "tools/call"}:
+        return _mcp_error(rpc_id, -32601, "Method not found")
+
     try:
         session = await get_tool_router_mcp_session(user_id)
         if method == "tools/list":
             result = await list_tool_router_mcp_tools(session)
-        elif method == "tools/call":
+        else:
             params = body.get("params")
             if not isinstance(params, dict):
                 return _mcp_error(rpc_id, -32602, "Invalid params")
@@ -287,8 +290,6 @@ async def mcp_composio_post(request: Request):
             if not isinstance(name, str) or not isinstance(arguments, dict):
                 return _mcp_error(rpc_id, -32602, "Invalid params")
             result = await call_tool_router_mcp_tool(session, name, arguments)
-        else:
-            return _mcp_error(rpc_id, -32601, "Method not found")
     except Exception as exc:
         logger.error(
             "Legacy Composio MCP error: method=%s error_type=%s", method, type(exc).__name__

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -28,6 +28,7 @@ from app.services.composio import (
     call_tool_router_mcp_tool,
     get_tool_router_mcp_session,
     list_tool_router_mcp_tools,
+    verify_mcp_bridge_token,
 )
 from app.services.file_store import get_file_store
 from app.services.memory_provider import get_memory_provider
@@ -250,6 +251,51 @@ _MEMORY_EXTRACT_INSTRUCTIONS = (
     "(unless they demonstrate a preferred pattern); anything readable from the current code "
     "state; conversational noise."
 )
+
+
+def _extract_legacy_mcp_user_id(request: Request) -> str:
+    authorization = request.headers.get("authorization", "")
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Missing auth token")
+    try:
+        return verify_mcp_bridge_token(authorization[7:])
+    except Exception:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token") from None
+
+
+# Deprecated compatibility bridge for CLI 0.12.7. Keep hidden from OpenAPI;
+# new clients authenticate normally and use POST /v1/mcp/clawdi.
+@router.post("/composio", include_in_schema=False)
+async def mcp_composio_post(request: Request):
+    user_id = _extract_legacy_mcp_user_id(request)
+    body = await request.json()
+    if not isinstance(body, dict):
+        return _mcp_error(None, -32600, "Invalid Request")
+
+    rpc_id = body.get("id")
+    method = body.get("method")
+    try:
+        session = await get_tool_router_mcp_session(user_id)
+        if method == "tools/list":
+            result = await list_tool_router_mcp_tools(session)
+        elif method == "tools/call":
+            params = body.get("params")
+            if not isinstance(params, dict):
+                return _mcp_error(rpc_id, -32602, "Invalid params")
+            name = params.get("name")
+            arguments = params.get("arguments") or {}
+            if not isinstance(name, str) or not isinstance(arguments, dict):
+                return _mcp_error(rpc_id, -32602, "Invalid params")
+            result = await call_tool_router_mcp_tool(session, name, arguments)
+        else:
+            return _mcp_error(rpc_id, -32601, "Method not found")
+    except Exception as exc:
+        logger.error(
+            "Legacy Composio MCP error: method=%s error_type=%s", method, type(exc).__name__
+        )
+        return _mcp_error(rpc_id, -32000, "internal error")
+
+    return _mcp_result(rpc_id, result.model_dump(by_alias=True, exclude_none=True))
 
 
 @router.post("/clawdi", include_in_schema=False)

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -155,6 +155,11 @@ class ConnectorDisconnectResponse(BaseModel):
     status: Literal["disconnected"]
 
 
+class ConnectorMcpConfigResponse(BaseModel):
+    mcp_url: str
+    mcp_token: str
+
+
 class ConnectorToolParametersResponse(BaseModel):
     properties: dict
     required: list[str]

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import httpx2
+import jwt
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult, ListToolsResult
@@ -121,6 +122,34 @@ async def close_composio_client() -> None:
     if _sdk_client is not None:
         await asyncio.to_thread(_sdk_client.client.close)
         _sdk_client = None
+
+
+def _jwt_signing_key() -> str:
+    key = settings.encryption_key
+    if not key:
+        raise RuntimeError(
+            "ENCRYPTION_KEY is not configured. Generate a 32-byte hex value and "
+            "set it in backend/.env; it must be distinct from VAULT_ENCRYPTION_KEY."
+        )
+    return key
+
+
+def create_mcp_bridge_token(user_id: str) -> str:
+    """Create the short-lived credential used by legacy CLI MCP config."""
+    payload = {
+        "sub": "mcp",
+        "user_id": user_id,
+        "exp": datetime.now(UTC) + timedelta(days=30),
+    }
+    return jwt.encode(payload, _jwt_signing_key(), algorithm="HS256")
+
+
+def verify_mcp_bridge_token(token: str) -> str:
+    """Verify a legacy MCP bridge credential and return its user id."""
+    payload = jwt.decode(token, _jwt_signing_key(), algorithms=["HS256"])
+    if payload.get("sub") != "mcp" or not isinstance(payload.get("user_id"), str):
+        raise ValueError("Invalid MCP bridge token")
+    return payload["user_id"]
 
 
 async def get_tool_router_mcp_session(user_id: str) -> ComposioMcpSession:

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -86,7 +86,7 @@ async def test_project_migration_banner_dismiss_persists(client: httpx.AsyncClie
     assert body["project_migration_banner_dismissed_at"] == dismissed_at
 
 
-def test_clawdi_is_the_only_public_mcp_contract():
+def test_legacy_mcp_compatibility_routes_and_schema():
     route_methods = {
         (route.path, method)
         for route in iter_route_contexts(app.routes)
@@ -94,9 +94,118 @@ def test_clawdi_is_the_only_public_mcp_contract():
     }
 
     for prefix in ("/v1", "/api"):
-        assert (f"{prefix}/connectors/mcp-config", "GET") not in route_methods
-        assert (f"{prefix}/mcp/composio", "POST") not in route_methods
+        assert (f"{prefix}/connectors/mcp-config", "GET") in route_methods
+        assert (f"{prefix}/mcp/composio", "POST") in route_methods
         assert (f"{prefix}/mcp/clawdi", "POST") in route_methods
+
+    paths = app.openapi()["paths"]
+    assert "/v1/connectors/mcp-config" in paths
+    assert "/v1/mcp/composio" not in paths
+    assert "/api/connectors/mcp-config" not in paths
+    assert "/api/mcp/composio" not in paths
+
+
+@pytest.mark.asyncio
+async def test_legacy_mcp_config_preserves_cli_response_for_both_aliases(monkeypatch):
+    from app.core.auth import AuthContext, get_auth
+    from app.core.config import settings
+    from app.models.user import User
+    from app.services.composio import verify_mcp_bridge_token
+
+    async def fake_auth() -> AuthContext:
+        return AuthContext(
+            user=User(
+                email="mcp-config-test@clawdi.local",
+                name="MCP Config Test",
+                clerk_id="clerk_user_123",
+            )
+        )
+
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
+    monkeypatch.setattr(settings, "public_api_url", "https://api.example.test/")
+    app.dependency_overrides[get_auth] = fake_auth
+    try:
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            responses = [
+                await ac.get("/v1/connectors/mcp-config"),
+                await ac.get("/api/connectors/mcp-config"),
+            ]
+    finally:
+        app.dependency_overrides.clear()
+
+    for response in responses:
+        assert response.status_code == 200, response.text
+        assert set(response.json()) == {"mcp_url", "mcp_token"}
+        assert response.json()["mcp_url"] == "https://api.example.test/v1/mcp/composio"
+        assert verify_mcp_bridge_token(response.json()["mcp_token"]) == "clerk_user_123"
+
+
+@pytest.mark.asyncio
+async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
+    from mcp.types import CallToolResult, ListToolsResult
+
+    from app.core.config import settings
+    from app.routes import mcp_bridge
+    from app.services.composio import ComposioMcpSession, create_mcp_bridge_token
+
+    seen: list[tuple[str, object]] = []
+    session = ComposioMcpSession(
+        url="https://composio.example.test/mcp",
+        headers={"x-session": "secret"},
+        expires_at=datetime.now(UTC) + timedelta(minutes=30),
+    )
+
+    async def fake_session(user_id: str) -> ComposioMcpSession:
+        seen.append(("session", user_id))
+        return session
+
+    async def fake_list(value: ComposioMcpSession) -> ListToolsResult:
+        assert value is session
+        return ListToolsResult.model_validate(
+            {"tools": [{"name": "COMPOSIO_SEARCH_TOOLS", "inputSchema": {"type": "object"}}]}
+        )
+
+    async def fake_call(value: ComposioMcpSession, name: str, arguments: dict) -> CallToolResult:
+        assert value is session
+        seen.append((name, arguments))
+        return CallToolResult.model_validate(
+            {"content": [{"type": "text", "text": "called"}], "isError": False}
+        )
+
+    monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
+    monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_session", fake_session)
+    monkeypatch.setattr(mcp_bridge, "list_tool_router_mcp_tools", fake_list)
+    monkeypatch.setattr(mcp_bridge, "call_tool_router_mcp_tool", fake_call)
+    token = create_mcp_bridge_token("clerk_user_123")
+    headers = {"Authorization": f"Bearer {token}"}
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        for prefix in ("/v1", "/api"):
+            listed = await ac.post(
+                f"{prefix}/mcp/composio",
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+            )
+            called = await ac.post(
+                f"{prefix}/mcp/composio",
+                headers=headers,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "COMPOSIO_SEARCH_TOOLS", "arguments": {"query": "mail"}},
+                },
+            )
+            assert listed.status_code == 200, listed.text
+            assert listed.json()["result"]["tools"][0]["name"] == "COMPOSIO_SEARCH_TOOLS"
+            assert called.status_code == 200, called.text
+            assert called.json()["result"]["content"] == [{"type": "text", "text": "called"}]
+            assert called.json()["result"]["isError"] is False
+
+    assert seen.count(("session", "clerk_user_123")) == 4
+    assert seen.count(("COMPOSIO_SEARCH_TOOLS", {"query": "mail"})) == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -143,6 +143,58 @@ async def test_legacy_mcp_config_preserves_cli_response_for_both_aliases(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_legacy_composio_bridge_rejects_missing_and_invalid_bearer_tokens(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        missing = await ac.post("/v1/mcp/composio", json={"method": "tools/list"})
+        invalid = await ac.post(
+            "/v1/mcp/composio",
+            headers={"Authorization": "Bearer not.a.valid.jwt"},
+            json={"method": "tools/list"},
+        )
+
+    assert missing.status_code == 401, missing.text
+    assert missing.json() == {"detail": "Missing auth token"}
+    assert invalid.status_code == 401, invalid.text
+    assert invalid.json() == {"detail": "Invalid token"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_composio_bridge_rejects_unknown_methods_without_upstream_session(monkeypatch):
+    from app.core.config import settings
+    from app.routes import mcp_bridge
+    from app.services.composio import create_mcp_bridge_token
+
+    async def unexpected_session(_user_id: str):
+        raise AssertionError("unsupported methods must not create an upstream session")
+
+    monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
+    monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_session", unexpected_session)
+    token = create_mcp_bridge_token("clerk_user_123")
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        responses = [
+            await ac.post(
+                "/v1/mcp/composio",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"jsonrpc": "2.0", "id": rpc_id, "method": method},
+            )
+            for rpc_id, method in ((1, "resources/list"), (2, 42))
+        ]
+
+    for rpc_id, response in enumerate(responses, start=1):
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "error": {"code": -32601, "message": "Method not found"},
+        }
+
+
+@pytest.mark.asyncio
 async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
     from mcp.types import CallToolResult, ListToolsResult
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2408,6 +2408,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/connectors/mcp-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Mcp Config
+         * @description Return the deprecated MCP bridge config required by CLI 0.12.7.
+         */
+        get: operations["get_mcp_config_v1_connectors_mcp_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/connectors/{app_name}/tools": {
         parameters: {
             query?: never;
@@ -4587,6 +4607,13 @@ export interface components {
              * @constant
              */
             status: "disconnected";
+        };
+        /** ConnectorMcpConfigResponse */
+        ConnectorMcpConfigResponse: {
+            /** Mcp Url */
+            mcp_url: string;
+            /** Mcp Token */
+            mcp_token: string;
         };
         /** ConnectorToolParametersResponse */
         ConnectorToolParametersResponse: {
@@ -12216,6 +12243,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_mcp_config_v1_connectors_mcp_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorMcpConfigResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- restore the authenticated MCP config and Composio bridge used by Clawdi CLI 0.12.7
- retain `/v1/mcp/clawdi` as the canonical MCP contract
- reuse the current standard Composio MCP client and limit the legacy bridge to `tools/list` and `tools/call`
- preserve hidden `/api` aliases and regenerate the public API client

## Verification

- `bun run test` (Docker): 1746 passed, 7 skipped
- focused Docker backend compatibility tests: 3 passed
- API alias tests: 13 passed
- Ruff lint and format checks
- generated API consistency check

## Security

The compatibility credential preserves the historical user-bound HS256 payload and 30-day expiry. Composio project credentials remain server-side. Unsupported JSON-RPC methods are rejected before opening an upstream session.