### PR TITLE
Refine runtime observation persistence types

### DIFF
--- a/backend/app/models/runtime_observation.py
+++ b/backend/app/models/runtime_observation.py
@@ -94,7 +94,7 @@ class V2RuntimeEnvironmentFence(Base, TimestampMixin):
         nullable=False,
     )
     replay_floor_advanced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    replay_floor_session_high_waters: Mapped[JsonValue] = mapped_column(
+    replay_floor_session_high_waters: Mapped[dict[str, int]] = mapped_column(
         JSONB(none_as_null=True),
         default=dict,
         server_default="{}",
@@ -106,7 +106,9 @@ class V2RuntimeEnvironmentFence(Base, TimestampMixin):
     retired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     final_cursor: Mapped[str | None] = mapped_column(String(2000))
     final_stream_position: Mapped[int | None] = mapped_column(BigInteger)
-    final_session_high_waters: Mapped[JsonValue | None] = mapped_column(JSONB(none_as_null=True))
+    final_session_high_waters: Mapped[dict[str, int] | None] = mapped_column(
+        JSONB(none_as_null=True)
+    )
 
 
 class V2RuntimeObservationInbox(Base):
@@ -340,6 +342,8 @@ class V2RuntimeObservationConsumerCursor(Base, TimestampMixin):
     expired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     expiry_boundary_stream_position: Mapped[int | None] = mapped_column(BigInteger)
     expiry_boundary_cursor: Mapped[str | None] = mapped_column(String(2000))
-    expiry_session_high_waters: Mapped[JsonValue | None] = mapped_column(JSONB(none_as_null=True))
+    expiry_session_high_waters: Mapped[dict[str, int] | None] = mapped_column(
+        JSONB(none_as_null=True)
+    )
     reset_barrier_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     reset_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -386,22 +386,19 @@ async def ingest_runtime_observation(
                 )
             )
         ).scalar_one_or_none()
-        existing = existing_by_event or existing_by_sequence
-        exact_duplicate = (
-            existing is not None
-            and existing_by_event is not None
+        if (
+            existing_by_event is not None
             and existing_by_sequence is not None
             and existing_by_event.id == existing_by_sequence.id
-            and existing.environment_id == environment_id
-            and existing.boot_session_id == value.boot_session_id
-            and existing.sequence == value.sequence
-            and existing.event_id == value.event_id
-            and existing.payload_hash == payload_hash
-        )
-        if exact_duplicate:
+            and existing_by_event.environment_id == environment_id
+            and existing_by_event.boot_session_id == value.boot_session_id
+            and existing_by_event.sequence == value.sequence
+            and existing_by_event.event_id == value.event_id
+            and existing_by_event.payload_hash == payload_hash
+        ):
             return RuntimeObservationIngestResult(
-                event_id=existing.event_id,
-                stream_position=existing.id,
+                event_id=existing_by_event.event_id,
+                stream_position=existing_by_event.id,
                 duplicate=True,
                 outcome="duplicate_replay",
             )
@@ -1516,16 +1513,19 @@ async def expire_runtime_observation_payloads(
                         "session_high_water_marks": high_waters,
                     },
                 )
-        result = await db.execute(
-            update(V2RuntimeObservationInbox)
-            .where(
-                V2RuntimeObservationInbox.id.in_(ids),
-                V2RuntimeObservationInbox.received_at < replay_cutoff,
-                V2RuntimeObservationInbox.payload_purged_at.is_(None),
+        compacted_ids = (
+            await db.scalars(
+                update(V2RuntimeObservationInbox)
+                .where(
+                    V2RuntimeObservationInbox.id.in_(ids),
+                    V2RuntimeObservationInbox.received_at < replay_cutoff,
+                    V2RuntimeObservationInbox.payload_purged_at.is_(None),
+                )
+                .values(diagnostics={}, payload_purged_at=current)
+                .returning(V2RuntimeObservationInbox.id)
             )
-            .values(diagnostics={}, payload_purged_at=current)
-        )
-        compacted = result.rowcount or 0
+        ).all()
+        compacted = len(compacted_ids)
         if compacted:
             floor_position = max(ids)
             if floor_position > fence.replay_floor_stream_position:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -75,6 +75,7 @@ include = [
     "app/services/embedding.py",
     "app/services/file_store.py",
     "app/services/memory_extraction.py",
+    "app/services/runtime_observation.py",
 ]
 
 [tool.deptry]

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -27,6 +27,7 @@ EXPECTED_CONFIG = {
         "app/services/embedding.py",
         "app/services/file_store.py",
         "app/services/memory_extraction.py",
+        "app/services/runtime_observation.py",
     ],
 }
 EXPECTED_VERSION = "1.39.9"


### PR DESCRIPTION
## Summary
- narrow runtime observation JSONB ORM annotations to their persisted session high-water shape
- remove redundant duplicate-replay narrowing and count compactions through SQLAlchemy UPDATE RETURNING
- add `runtime_observation.py` to the fail-closed BasedPyright owned ratchet and mirrored config

## Type inventory
- Before: 291 errors total (app 112, tests 173, scripts 2, alembic 4); target file 10
- After: 281 errors total (app 102, tests 173, scripts 2, alembic 4); target file 0
- Owned gate: 10 files, 0 diagnostics
- Changed production gate: 2 files, 0 diagnostics

## Verification
- `uv run basedpyright --outputjson --project pyproject.toml app/services/runtime_observation.py app/models/runtime_observation.py scripts/type_governance.py`
- `uv run python scripts/type_governance.py owned`
- `uv run python scripts/type_governance.py changed app/services/runtime_observation.py app/models/runtime_observation.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
- `uv run python scripts/check_dependency_authority.py`
- `uv sync --frozen --check`
- `uv lock --check`
- `uv run deptry .`
- PostgreSQL focused runtime observation and hardening migration tests: 30 passed
- PostgreSQL duplicate replay recheck after final deletion: 1 passed
- `uv run python scripts/check_generated_api.py`
- `bun run typecheck`
- `bun run check`
- `bun run test` Docker clean runner: JS/TS 1513 passed, 4 skipped; backend 1748 passed, 7 skipped
- `git diff --check origin/main..HEAD`

## Contract references
- SQLAlchemy typed declarative mapping: https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html#orm-annotated-declarative-complete-guide
- SQLAlchemy UPDATE RETURNING / rowcount behavior: https://docs.sqlalchemy.org/en/20/tutorial/data_update.html#using-returning-with-update-delete and https://docs.sqlalchemy.org/en/20/tutorial/data_update.html#getting-affected-row-count-from-update-delete

Base: `Clawdi-AI/clawdi:main` at `e97d37f615a858887a77a0e5f41bda9b8922e178`
Head: `Clawdi-AI/clawdi:refactor/oss-runtime-observation-types-clean` at `90dd6591`