### PR TITLE
fix(runtime): authenticate managed model discovery

### DIFF
--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -160,6 +160,7 @@ function managedGatewayPrimaryModelTarget(
 	runtimeName: string,
 ): {
 	baseUrl: string;
+	credential: string;
 	providerId: string;
 	seedModel: string | null;
 } | null {
@@ -179,8 +180,12 @@ function managedGatewayPrimaryModelTarget(
 	if (!baseUrl) return null;
 	const apiMode = hostedProviderApiMode(provider);
 	if (!managedProviderSupportsLiveModelProbe(apiMode)) return null;
+	const runtimeEnvName = hostedProviderRuntimeEnvName(selectedProviderId, provider);
+	const credential = hostedProviderPlaceholderEnv(manifest, runtimeName)[runtimeEnvName];
+	if (!credential) return null;
 	return {
 		baseUrl,
+		credential,
 		providerId: selectedProviderId,
 		seedModel:
 			currentPrimary && currentPrimary.provider_id === selectedProviderId
@@ -196,6 +201,7 @@ interface ManagedGatewayModelOverrides {
 
 interface ManagedGatewayModelFetchInput {
 	baseUrl: string;
+	credential: string;
 	home: string;
 	egressSystemCaFile: string | null;
 	providerId: string;
@@ -210,6 +216,15 @@ type ManagedGatewayModelFetchResult =
 export type ManagedGatewayModelListFetcher = (
 	input: ManagedGatewayModelFetchInput,
 ) => ManagedGatewayModelFetchResult;
+
+export function requiresManagedGatewayModelProbe(
+	manifest: RuntimeManifest,
+	enabledRuntimes: readonly string[],
+): boolean {
+	return enabledRuntimes.some(
+		(runtimeName) => managedGatewayPrimaryModelTarget(manifest, runtimeName) !== null,
+	);
+}
 
 export function resolveManagedGatewayModelOverrides(
 	manifest: RuntimeManifest,
@@ -229,6 +244,7 @@ export function resolveManagedGatewayModelOverrides(
 		if (!fetchResult) {
 			fetchResult = fetcher({
 				baseUrl: target.baseUrl,
+				credential: target.credential,
 				home,
 				egressSystemCaFile,
 				providerId: target.providerId,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -24,7 +24,9 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "./applied-state";
+import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import { loadHostedBundledSkill } from "./hosted-bundled-skill";
+import { hostedManifestEgressProfiles } from "./hosted-egress-profiles";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import {
 	captureRuntimeLiveSnapshot,
@@ -2648,6 +2650,121 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(readRuntimeAppliedState(paths)?.generation).toBe(1);
 		expect(existsSync(paths.manifestLastGood)).toBe(true);
 		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(true);
+	});
+
+	test("activates transparent egress before authenticated managed-model discovery", () => {
+		const paths = tempRuntimePaths();
+		const commandPath = join(paths.userHome, ".openclaw", "bin", "openclaw");
+		const officialUnitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+		mkdirSync(dirname(commandPath), { recursive: true });
+		writeFileSync(
+			commandPath,
+			[
+				"#!/usr/bin/env sh",
+				'if [ "$1" = "--version" ]; then printf "0.13.26\\n"; exit 0; fi',
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then cat >/dev/null; exit 0; fi',
+				'if [ "$1 $2 $3" = "gateway install --force" ]; then',
+				`  mkdir -p ${JSON.stringify(dirname(officialUnitPath))}`,
+				`  printf '[Unit]\\nDescription=Official gateway\\n\\n[Service]\\nExecStart=openclaw gateway run\\n' > ${JSON.stringify(officialUnitPath)}`,
+				"  exit 0",
+				"fi",
+				"exit 2",
+				"",
+			].join("\n"),
+		);
+		chmodSync(commandPath, 0o700);
+		const providerSecretRef = "secret://provider.clawdi.apiKey";
+		const providers = {
+			clawdi: {
+				kind: "openai-compatible",
+				baseUrl: "https://ai-gateway.clawdi.ai/v1",
+				models: [{ id: "gpt-5.5" }],
+				apiMode: "openai_responses",
+				managed_by: "clawdi",
+				runtimeEnvName: "OPENAI_API_KEY",
+				apiKeySecretRef: providerSecretRef,
+			},
+		};
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings(commandPath, ["gateway", "run"]),
+					services: {},
+					provider_ids: ["clawdi"],
+					primary_model: { provider_id: "clawdi", model: "gpt-5.5" },
+				},
+			},
+			{
+				openclawGatewayAuth: hostedOpenClawNativeAuth(),
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					system: hostedSystemFixture(),
+					providers,
+				},
+				egressProfiles: hostedManifestEgressProfiles({ providers }),
+				egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-model-probe"),
+			},
+		);
+		const load = manifestLoad(manifest, "managed-model-probe", {
+			...TEST_HOSTED_SECRET_VALUES,
+			[providerSecretRef]: "test-managed-provider-key",
+		});
+		const prerequisiteSignals: Array<{ restartEgressSidecar: boolean }> = [];
+		const activationSignals: Array<{ restartEgressSidecar: boolean }> = [];
+		let probeCalls = 0;
+		const converge = () =>
+			convergeRuntimeManifest(load, paths, {
+				cacheLastGood: false,
+				commitAuthority: (convergence, authority) =>
+					commitTestRuntimeAuthority(load, paths, convergence, authority),
+				managedGatewayModelListFetcher: (input) => {
+					probeCalls += 1;
+					expect(input.credential).toBe(MANAGED_EGRESS_PLACEHOLDER_VALUE);
+					expect(input.egressSystemCaFile).toBe(paths.egressSystemCaFile);
+					expect(existsSync(paths.egressSystemCaFile)).toBe(true);
+					return {
+						status: "ok",
+						endpoint: `${input.baseUrl}/models`,
+						models: [{ id: "gpt-5.5" }, { id: "gpt-5.6" }],
+					};
+				},
+				systemdApply: {
+					activateEgressPrerequisite: (signal) => {
+						prerequisiteSignals.push(signal);
+						expect(existsSync(paths.egressProfileBundle)).toBe(true);
+						expect(existsSync(join(paths.managedSecretRoot, "egress-secrets.json"))).toBe(true);
+						expect(
+							existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service")),
+						).toBe(true);
+						expect(readFileSync(paths.egressProfileBundle, "utf8")).toContain(
+							MANAGED_EGRESS_PLACEHOLDER_VALUE,
+						);
+						writeFileSync(paths.egressSystemCaFile, "test-ca\n", { mode: 0o644 });
+						return successfulPrerequisiteActivation();
+					},
+					activate: (signal) => {
+						activationSignals.push(signal);
+						return successfulPrerequisiteActivation();
+					},
+					rollback: () => {},
+				},
+			});
+
+		const first = converge();
+		expect(first.installErrors).toEqual([]);
+		expect(probeCalls).toBe(1);
+		expect(prerequisiteSignals).toHaveLength(1);
+		expect(prerequisiteSignals[0]?.restartEgressSidecar).toBe(true);
+		expect(activationSignals[0]?.restartEgressSidecar).toBe(true);
+
+		const refresh = converge();
+		expect(refresh.installErrors).toEqual([]);
+		expect(probeCalls).toBe(2);
+		expect(prerequisiteSignals).toHaveLength(1);
+		expect(activationSignals).toHaveLength(2);
+		expect(activationSignals[1]?.restartEgressSidecar).toBe(false);
 	});
 
 	test.each([

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -79,6 +79,7 @@ import {
 	type ManagedGatewayModelListFetcher,
 	mergeRuntimeEnvWithProviderPlaceholders,
 	mergeRuntimeServiceEnvWithProviderPlaceholders,
+	requiresManagedGatewayModelProbe,
 	resolveManagedGatewayModelOverrides,
 } from "./hosted-provider-resolution";
 import {
@@ -165,6 +166,7 @@ import {
 	runtimeSystemdCommonEnvironment,
 	uninstallStaleOfficialRuntimeServices,
 	validateRuntimeSystemdPlan,
+	writeRuntimeSidecarSystemdUnit,
 	writeRuntimeSystemdState,
 } from "./runtime-systemd-reconciliation";
 import {
@@ -1453,7 +1455,7 @@ function applyHostedLocaleProjection(
 const MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS = 3_000;
 
 const MANAGED_GATEWAY_MODEL_FETCH_SCRIPT = [
-	"const [url, timeoutRaw] = process.argv.slice(1);",
+	"const [url, timeoutRaw, credential] = process.argv.slice(1);",
 	"const timeoutMs = Number.parseInt(timeoutRaw ?? '', 10) || 3000;",
 	"const controller = new AbortController();",
 	"const timer = setTimeout(() => controller.abort(), timeoutMs);",
@@ -1461,7 +1463,7 @@ const MANAGED_GATEWAY_MODEL_FETCH_SCRIPT = [
 	"  try {",
 	"    const response = await fetch(url, {",
 	"      method: 'GET',",
-	"      headers: { accept: 'application/json' },",
+	"      headers: { accept: 'application/json', authorization: 'Bearer ' + credential },",
 	"      signal: controller.signal,",
 	"    });",
 	"    const body = await response.text();",
@@ -1497,6 +1499,7 @@ function fetchManagedGatewayModelList(
 			MANAGED_GATEWAY_MODEL_FETCH_SCRIPT,
 			endpoint,
 			String(MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS),
+			input.credential,
 		],
 		input.home,
 		input.workspaceRoot,
@@ -5014,6 +5017,7 @@ export function convergeRuntimeManifest(
 	let rollbackEgressSecretOverride: RuntimeEgressSecretMaterial | undefined;
 	let rollbackEgressSecretRevision: string | undefined;
 	let egressRollbackAuthorityVerified = true;
+	let egressPrerequisiteActivated = false;
 	let staleSystemdFiles: RuntimeSystemdStaleFilePlan = {
 		files: [],
 		systemUnits: [],
@@ -5090,24 +5094,6 @@ export function convergeRuntimeManifest(
 			}
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
-
-		const managedModelOverrides = resolveManagedGatewayModelOverrides(
-			manifest,
-			enabledRuntimes,
-			projectionHome,
-			workspaceRoot,
-			plannedEgressProfileBundlePath ? paths.egressSystemCaFile : null,
-			opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
-		);
-		validateRuntimeProjectionPlan({
-			manifest,
-			paths,
-			workspaceRoot,
-			secretValues,
-			observations,
-			previousProjectedProviderIds,
-			managedModelOverrides,
-		});
 
 		ensureRuntimeUserHome(paths.userHome);
 		withRuntimeUserFileAccess(() => {
@@ -5253,6 +5239,91 @@ export function convergeRuntimeManifest(
 				egress: egressSystemdProgram,
 			}),
 		);
+		const egressSidecarActive =
+			egressSystemdProgram !== null &&
+			egressIdentity !== null &&
+			runtimeSystemdUserPrograms.length > 0;
+		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
+		if (egressSidecarActive) {
+			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
+			restartEgressSidecar =
+				egressSecretWrite.changed ||
+				committedEgressSidecarSecretRevision === undefined ||
+				committedEgressSidecarSecretRevision !== desiredEgressSidecarSecretRevision;
+			if (committedEgressSidecarSecretRevision === undefined) {
+				// Legacy applied state has no private egress revision. An exact
+				// applied content identity can still prove complete last-good material
+				// for rollback, but its absence must not block loading the desired
+				// material. If desired activation later fails, unverified live bytes
+				// must never be loaded by a rollback restart.
+				rollbackEgressSecretOverride =
+					verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
+				egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
+			} else if (
+				restartEgressSidecar &&
+				egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
+			) {
+				if (desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
+					rollbackEgressSecretOverride = egressSecretWrite.material;
+				} else {
+					// A crash may have already advanced both the live file and last-good
+					// cache while the applied authority still describes the loaded secret.
+					// Do not require rollback material until activation actually fails:
+					// successfully restarting the desired material can safely commit it.
+					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
+				}
+			}
+		}
+		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(paths);
+		const egressCaUnavailable = !existsSync(paths.egressSystemCaFile);
+		if (
+			requiresManagedGatewayModelProbe(manifest, enabledRuntimes) &&
+			egressCaUnavailable &&
+			egressSystemdProgram &&
+			egressIdentity &&
+			runtimeSystemdUserPrograms.length > 0 &&
+			opts.systemdApply
+		) {
+			writeRuntimeSidecarSystemdUnit({
+				program: egressSystemdProgram,
+				identity: egressIdentity,
+				manifest,
+				paths,
+				workspaceRoot,
+				commonEnvironment: commonSystemdEnvironment,
+			});
+			restartEgressSidecar = restartEgressSidecar || egressCaUnavailable;
+			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
+				restartDaemon,
+				restartEgressSidecar,
+				stopEgressSidecar: false,
+				reconcileUserUnits: mutationPlan.systemdUserUnits,
+				staleSystemUnits: [],
+				staleUserUnits: [],
+			});
+			if (!prerequisite.applied) {
+				throw new Error("transparent-egress system prerequisites did not reach readiness");
+			}
+			egressPrerequisiteActivated = true;
+		}
+
+		const managedModelOverrides = resolveManagedGatewayModelOverrides(
+			manifest,
+			enabledRuntimes,
+			projectionHome,
+			workspaceRoot,
+			egressProfileBundlePath ? paths.egressSystemCaFile : null,
+			opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
+		);
+		validateRuntimeProjectionPlan({
+			manifest,
+			paths,
+			workspaceRoot,
+			secretValues,
+			observations,
+			previousProjectedProviderIds,
+			managedModelOverrides,
+		});
 		const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
 		for (const [name] of runtimeEntries) {
 			const observation = observations.get(name);
@@ -5266,7 +5337,6 @@ export function convergeRuntimeManifest(
 				managedModelOverrides,
 			);
 		}
-		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(paths);
 		try {
 			const codexProjection = withRuntimeUserFileAccess(() =>
 				applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
@@ -5473,37 +5543,6 @@ export function convergeRuntimeManifest(
 			commonEnvironment: commonSystemdEnvironment,
 		});
 		staleSystemdFiles = systemdUnits.staleFiles;
-		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
-		if (systemdUnits.egressSidecarActive) {
-			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
-			restartEgressSidecar =
-				egressSecretWrite.changed ||
-				committedEgressSidecarSecretRevision === undefined ||
-				committedEgressSidecarSecretRevision !== desiredEgressSidecarSecretRevision;
-			if (committedEgressSidecarSecretRevision === undefined) {
-				// Legacy applied state has no private egress revision. An exact
-				// applied content identity can still prove complete last-good material
-				// for rollback, but its absence must not block loading the desired
-				// material. If desired activation later fails, unverified live bytes
-				// must never be loaded by a rollback restart.
-				rollbackEgressSecretOverride =
-					verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
-				egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
-			} else if (
-				restartEgressSidecar &&
-				egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
-			) {
-				if (desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
-					rollbackEgressSecretOverride = egressSecretWrite.material;
-				} else {
-					// A crash may have already advanced both the live file and last-good
-					// cache while the applied authority still describes the loaded secret.
-					// Do not require rollback material until activation actually fails:
-					// successfully restarting the desired material can safely commit it.
-					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
-				}
-			}
-		}
 		const officialServicePlan = planOfficialRuntimeServices(
 			runtimeSystemdUserPrograms,
 			paths,
@@ -5528,6 +5567,7 @@ export function convergeRuntimeManifest(
 				(hermesDashboardArtifactPlan.program !== null &&
 					hermesDashboardArtifactPlan.target?.expectedCurrentRevision === null)) &&
 			systemdUnits.egressSidecarActive &&
+			!egressPrerequisiteActivated &&
 			opts.systemdApply
 		) {
 			const prerequisite = opts.systemdApply.activateEgressPrerequisite({

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1305,6 +1305,37 @@ function officialRuntimeSystemdPrograms(
 		.map(([, program]) => program);
 }
 
+export function writeRuntimeSidecarSystemdUnit(input: {
+	program: RuntimeEgressSystemdProgram;
+	identity: RuntimeEgressIdentity;
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	workspaceRoot: string;
+	commonEnvironment: Record<string, string>;
+}): string {
+	return writeSystemdSystemUnit({
+		paths: input.paths,
+		name: "clawdi-runtime-sidecar",
+		description: "Clawdi hosted runtime sidecar",
+		command: input.paths.cliManagedBin,
+		args: ["runtime", "sidecar"],
+		cwd: input.workspaceRoot,
+		env: {
+			...input.commonEnvironment,
+			CLAWDI_AUTH_TOKEN: "",
+			CLAWDI_EGRESS_ENV_FILE: input.program.envFilePath,
+			CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
+				input.manifest,
+				input.program,
+				input.identity,
+			),
+		},
+		serviceType: "notify",
+		extraUnitLines: [`Before=user@${input.identity.runtimeUid}.service`],
+		extraServiceLines: ["NotifyAccess=main"],
+	});
+}
+
 export function writeRuntimeSystemdState(input: {
 	runtimePrograms: RuntimeSystemdUserProgram[];
 	egressProgram: RuntimeEgressSystemdProgram | null;
@@ -1336,13 +1367,11 @@ export function writeRuntimeSystemdState(input: {
 		runtimeRevision,
 		commonEnvironment,
 	} = input;
-	const runtimeUser = commonEnvironment.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const systemUnits: string[] = [];
 	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
 	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
 	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const userUnits: string[] = [];
-	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
 	const desiredSystemUnitNames = [
 		...(daemonAuthTokenFile ? ["clawdi-runtime-watch.service", "clawdi-daemon.service"] : []),
 		...(activeEgressProgram ? ["clawdi-runtime-sidecar.service"] : []),
@@ -1406,27 +1435,17 @@ export function writeRuntimeSystemdState(input: {
 	}
 
 	if (activeEgressProgram) {
+		if (!activeEgressIdentity) {
+			throw new Error("runtime sidecar egress revision requires the configured numeric identity");
+		}
 		systemUnits.push(
-			writeSystemdSystemUnit({
+			writeRuntimeSidecarSystemdUnit({
+				program: activeEgressProgram,
+				identity: activeEgressIdentity,
+				manifest,
 				paths,
-				name: "clawdi-runtime-sidecar",
-				description: "Clawdi hosted runtime sidecar",
-				command: paths.cliManagedBin,
-				args: ["runtime", "sidecar"],
-				cwd: workspaceRoot,
-				env: {
-					...commonEnvironment,
-					CLAWDI_AUTH_TOKEN: "",
-					CLAWDI_EGRESS_ENV_FILE: activeEgressProgram.envFilePath,
-					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
-						manifest,
-						activeEgressProgram,
-						activeEgressIdentity,
-					),
-				},
-				serviceType: "notify",
-				extraUnitLines: runtimeUid === null ? undefined : [`Before=user@${runtimeUid}.service`],
-				extraServiceLines: ["NotifyAccess=main"],
+				workspaceRoot,
+				commonEnvironment,
 			}),
 		);
 	}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -47,6 +47,7 @@ import {
 	rollbackPendingRuntimeCliUpgrade,
 } from "../src/runtime/cli-update";
 import { withRuntimeConvergeLock } from "../src/runtime/converge-lock";
+import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "../src/runtime/egress-env";
 import {
 	deniedCommandReason,
 	evaluateHostPolicyForCommand,
@@ -3921,6 +3922,7 @@ exit 0
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths(), {
 			managedGatewayModelListFetcher: (input) => {
 				expect(input.providerId).toBe(agentProviderId);
+				expect(input.credential).toBe(MANAGED_EGRESS_PLACEHOLDER_VALUE);
 				return {
 					status: "ok",
 					endpoint: `${input.baseUrl}/models`,
@@ -8954,7 +8956,9 @@ fi
 			expect(event.status).toBe("error");
 			expect(event.error).toContain("prerequisite activation failed");
 			expect(readRuntimeAppliedState(paths)).toBeNull();
-			expect(readFileSync(installerLog, "utf8")).not.toContain(installArgs);
+			expect(existsSync(installerLog) ? readFileSync(installerLog, "utf8") : "").not.toContain(
+				installArgs,
+			);
 			const failedManagerCalls = readFileSync(systemctlLog, "utf8").trim().split("\n");
 			expect(
 				failedManagerCalls.some((call) => /^(start|restart) .*clawdi-daemon\.service/.test(call)),


### PR DESCRIPTION
## Summary
- derive the existing managed-egress placeholder credential from the canonical provider projection and send it on `/v1/models`
- publish and activate the existing transparent-egress prerequisite before first managed model discovery when the CA is absent
- reuse the single sidecar unit renderer and keep unchanged full refreshes restart-free

## Validation
- focused reconciliation/model/egress ordering tests
- CLI typecheck and Biome
- isolated Docker CLI suite: 1514 passed, 4 existing native skips, 0 failures
- `git diff --check origin/main..HEAD`

No retry, env fallback, real credential exposure, egress bypass, warning suppression, production, tenant, publish, or deployment operation.