### PR TITLE
fix(channels): finish pairing UX

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1,5 +1,5 @@
 import type { DeploymentRead } from "@clawdi/shared/api";
-import { expect, type Page, type Route, test } from "@playwright/test";
+import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
 import type { ManagedModelCatalogItem } from "../src/hosted/billing/contracts";
 import {
 	presetCatalogToProviderModels,
@@ -2001,6 +2001,17 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 async function expectNoQuarterlyCopy(page: Page) {
 	await expect(page.getByText("Quarterly", { exact: true })).toHaveCount(0);
 	await expect(page.getByText(/\/qtr/)).toHaveCount(0);
+}
+
+async function expectActionCenterUncovered(action: Locator) {
+	await expect(action).toBeVisible();
+	expect(
+		await action.evaluate((element) => {
+			const rect = element.getBoundingClientRect();
+			const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+			return hit !== null && (hit === element || element.contains(hit));
+		}),
+	).toBe(true);
 }
 
 async function capturePricingScreenshot(page: Page, path: string) {
@@ -7326,7 +7337,9 @@ test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
 
 test("Agent Channels uses compact task-ordered rows and the shared Telegram pair dialog", async ({
 	page,
+	context,
 }, testInfo) => {
+	await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 	await page.setViewportSize({ width: 1440, height: 1100 });
 	const errors = collectBrowserErrors(page);
 	const agentId = missingProjectionEnvironmentId;
@@ -7343,6 +7356,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const polledBindingId = "79999999-9999-4999-8999-999999999999";
 	const discordServerBindingId = "7aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 	const discordDmBindingId = "7bbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+	const discordDmName = "Discord DM — urgent customer support escalation ".repeat(10).slice(0, 300);
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const successfulPairResponse = (id: string, code: string): StubResponse => ({
 		status: 201,
@@ -7411,6 +7425,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			external_chat_name: "Current Agent DM",
 			status: "active",
 			created_at: "2026-07-30T10:00:00Z",
+			last_message_at: "2026-07-30T10:12:00Z",
 		},
 		{
 			id: otherAgentBindingId,
@@ -7431,6 +7446,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			external_chat_name: "Clawdi Community",
 			status: "active",
 			created_at: "2026-07-30T10:06:00Z",
+			last_message_at: "2026-07-30T10:16:00Z",
 		},
 		{
 			id: discordDmBindingId,
@@ -7438,9 +7454,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			agent_link_id: discordLinkId,
 			external_chat_id: "discord-dm-1",
 			external_chat_type: "private",
-			external_chat_name: "Discord DM",
+			external_chat_name: discordDmName,
 			status: "active",
 			created_at: "2026-07-30T10:07:00Z",
+			last_message_at: null,
 		},
 	];
 	await stubHostedApi(page, {
@@ -7603,6 +7620,32 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
 				},
 			},
+			{
+				status: 201,
+				body: {
+					id: "agent-channel-discord-pair-expired",
+					agent_link_id: discordLinkId,
+					agent_id: agentId,
+					code: "DISCORDEXPIRED123",
+					expires_at: "2000-01-01T00:00:00Z",
+					pairing_command: "/bot_pair DISCORDEXPIRED123",
+					discord_install_url:
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+				},
+			},
+			{
+				status: 201,
+				body: {
+					id: "agent-channel-discord-pair-regenerated",
+					agent_link_id: discordLinkId,
+					agent_id: agentId,
+					code: "DISCORDNEW123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair DISCORDNEW123",
+					discord_install_url:
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+				},
+			},
 		],
 	});
 
@@ -7614,25 +7657,72 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect(connectedSection.getByText("Connected channels", { exact: true })).toBeVisible();
 	await expect(page.locator("[data-agent-paired-chats]")).toHaveCount(0);
 	await expect(page.getByText("Paired chats", { exact: true })).toHaveCount(0);
-	await expect(addSection.getByText("Add a channel", { exact: true })).toBeVisible();
+	await expect(addSection).toHaveCount(0);
+	await expect(page.getByText("Add a channel", { exact: true })).toHaveCount(0);
+	await expect(
+		page.getByText("Link a bot to this Agent, then choose where it should answer.", {
+			exact: true,
+		}),
+	).toHaveCount(0);
 	const telegramGroup = page.locator(`[data-agent-channel-group-id="${telegramLinkId}"]`);
 	const discordGroup = page.locator(`[data-agent-channel-group-id="${discordLinkId}"]`);
 	const telegramRow = page.locator(`[data-agent-channel-link-id="${telegramLinkId}"]`);
 	const discordRow = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
 	await expect(telegramRow).toContainText("Support Telegram");
-	await expect(telegramRow).toContainText("Last activity");
+	await expect(telegramRow).not.toContainText("Last activity");
+	await expect(telegramRow).not.toContainText("No activity yet");
+	await expect(telegramRow).not.toContainText("Checking activity");
 	await expect(discordRow).toContainText("Community Discord");
+	await expect(discordRow).not.toContainText("Last activity");
 	const pairButton = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
 	await expect(pairButton).toBeVisible();
 	const discordPairButton = discordRow.getByRole("button", { name: "Pair Discord", exact: true });
 	await expect(discordPairButton).toBeVisible();
-	await expect(telegramRow.getByRole("button", { name: "Unlink", exact: true })).toBeVisible();
+	const telegramUnlinkButton = telegramRow.getByRole("button", {
+		name: "Unlink Support Telegram from Hosted agent",
+		exact: true,
+	});
+	await expect(telegramUnlinkButton).toBeVisible();
+	async function buttonColors(button: Locator) {
+		return button.evaluate((element) => {
+			const style = getComputedStyle(element);
+			return {
+				backgroundColor: style.backgroundColor,
+				borderColor: style.borderColor,
+				color: style.color,
+			};
+		});
+	}
+	const [telegramPairColors, discordPairColors, telegramPairBox, discordPairBox] =
+		await Promise.all([
+			buttonColors(pairButton),
+			buttonColors(discordPairButton),
+			pairButton.boundingBox(),
+			discordPairButton.boundingBox(),
+		]);
+	expect(telegramPairColors).toEqual(discordPairColors);
+	expect(telegramPairBox?.height).toBe(discordPairBox?.height);
+	expect(telegramPairBox?.height).toBe(32);
 	await expect(addSection.locator(`[data-add-channel-id="${readyId}"]`)).toHaveCount(0);
 	await expect(addSection.getByText("Use your own bot", { exact: true })).toHaveCount(0);
 	await expect(addSection.locator("details")).toHaveCount(0);
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);
 	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
 	await expect(currentBindingRow).toContainText("Current Agent DM");
+	await expect(currentBindingRow).toContainText("Last activity");
+	const telegramUnpairButton = currentBindingRow.getByRole("button", {
+		name: "Unpair Current Agent DM",
+		exact: true,
+	});
+	const [unlinkColors, unpairColors, unlinkBox, unpairBox] = await Promise.all([
+		buttonColors(telegramUnlinkButton),
+		buttonColors(telegramUnpairButton),
+		telegramUnlinkButton.boundingBox(),
+		telegramUnpairButton.boundingBox(),
+	]);
+	expect(unlinkColors).toEqual(unpairColors);
+	expect({ width: unlinkBox?.width, height: unlinkBox?.height }).toEqual({ width: 32, height: 32 });
+	expect({ width: unpairBox?.width, height: unpairBox?.height }).toEqual({ width: 32, height: 32 });
 	await expect(
 		telegramGroup.locator(`[data-channel-binding-id="${currentBindingId}"]`),
 	).toBeVisible();
@@ -7641,7 +7731,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	);
 	const discordDmRow = discordGroup.locator(`[data-channel-binding-id="${discordDmBindingId}"]`);
 	await expect(discordServerRow).toContainText("Server · Clawdi Community");
-	await expect(discordDmRow).toContainText("Direct message · Discord DM");
+	await expect(discordDmRow).toContainText(`Direct message · ${discordDmName}`);
+	await expect(discordServerRow).toContainText("Last activity");
+	await expect(discordDmRow).not.toContainText("Last activity");
+	await expect(discordDmRow).not.toContainText("No activity yet");
 	await expect(discordServerRow).toContainText("Run /bot_unpair in this server.");
 	await expect(discordDmRow).toContainText("Run /bot_unpair in this direct message.");
 	await expect(discordGroup.getByRole("button", { name: /Unpair/ })).toHaveCount(0);
@@ -7670,7 +7763,8 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		agent_link_id: telegramLinkId,
 	});
 	const pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
-	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	const telegramQr = pairDialog.getByRole("img", { name: "Telegram pairing QR code" });
+	await expect(telegramQr).toBeVisible();
 	await expect(pairDialog.getByRole("button", { name: "Copy link", exact: true })).toBeVisible();
 	await expect(pairDialog.getByRole("button", { name: "Open @Clawdi_Ready_Bot" })).toHaveAttribute(
 		"href",
@@ -7683,6 +7777,34 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			testInfo.outputPath("agent-channels-pair-dialog.png"),
 		fullPage: true,
 	});
+	const desktopTelegramQrBox = await telegramQr.boundingBox();
+	expect(desktopTelegramQrBox?.width ?? 0).toBeLessThanOrEqual(192);
+	await page.setViewportSize({ width: 320, height: 568 });
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expect(telegramQr).toBeVisible();
+	const mobileTelegramQrBox = await telegramQr.boundingBox();
+	expect(mobileTelegramQrBox?.width ?? 0).toBeLessThanOrEqual(192);
+	const mobileTelegramDialogBox = await pairDialog.boundingBox();
+	const mobileTelegramActionBox = await pairDialog
+		.getByRole("button", { name: "Open @Clawdi_Ready_Bot" })
+		.boundingBox();
+	expect(mobileTelegramDialogBox?.y ?? -1).toBeGreaterThanOrEqual(0);
+	expect(
+		(mobileTelegramDialogBox?.y ?? 568) + (mobileTelegramDialogBox?.height ?? 1),
+	).toBeLessThanOrEqual(568);
+	expect(
+		(mobileTelegramActionBox?.y ?? 568) + (mobileTelegramActionBox?.height ?? 1),
+	).toBeLessThanOrEqual(568);
+	await pairDialog.screenshot({
+		path: testInfo.outputPath("agent-telegram-pair-dialog-320x568.png"),
+	});
+	await pairDialog.getByRole("button", { name: "Copy link", exact: true }).click();
+	await expect(pairDialog.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await expectActionCenterUncovered(
+		pairDialog.getByRole("button", { name: "Open @Clawdi_Ready_Bot" }),
+	);
+	await page.setViewportSize({ width: 1440, height: 1100 });
 
 	channelBindings.push({
 		id: polledBindingId,
@@ -7711,6 +7833,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect(
 		page.getByRole("dialog", { name: "Pair Telegram" }).getByText("Couldn't create Telegram link"),
 	).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
 	await page
 		.getByRole("dialog", { name: "Pair Telegram" })
 		.getByRole("button", { name: "Retry", exact: true })
@@ -7721,6 +7844,12 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			.getByRole("dialog", { name: "Pair Telegram" })
 			.getByRole("img", { name: "Telegram pairing QR code" }),
 	).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await expectActionCenterUncovered(
+		page
+			.getByRole("dialog", { name: "Pair Telegram" })
+			.getByRole("button", { name: "Open @Clawdi_Ready_Bot" }),
+	);
 	await page
 		.getByRole("dialog", { name: "Pair Telegram" })
 		.getByRole("button", { name: "Close", exact: true })
@@ -7733,6 +7862,9 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		recoveryDialog.getByText("Telegram link unavailable", { exact: true }),
 	).toBeVisible();
 	await recoveryDialog.getByText("Pair a group manually", { exact: true }).click();
+	await expect(
+		recoveryDialog.getByText("Add @Clawdi_Ready_Bot to the group, then send:", { exact: true }),
+	).toBeVisible();
 	await expect(recoveryDialog.getByText("/bot_pair AGENTMANUAL123", { exact: true })).toBeVisible();
 	await recoveryDialog.getByRole("button", { name: "Close", exact: true }).click();
 
@@ -7753,6 +7885,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect(
 		discordPairDialog.getByText("Couldn't prepare Discord pairing", { exact: true }),
 	).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
 	await discordPairDialog.screenshot({
 		path: testInfo.outputPath("agent-discord-pair-error-desktop.png"),
 	});
@@ -7760,24 +7893,106 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect.poll(() => pairCodeRequests.length).toBe(7);
 	discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
 	await expect(discordPairDialog.getByText("Server", { exact: true })).toBeVisible();
-	await expect(discordPairDialog.getByText("Direct message", { exact: true })).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	const directMessageTab = discordPairDialog.getByRole("tab", {
+		name: "Direct message",
+		exact: true,
+	});
+	await expect(directMessageTab).toBeVisible();
 	await expect(discordPairDialog.getByText("DISCORDPAIR123", { exact: true })).toBeVisible();
+	const discordQr = discordPairDialog.getByRole("img", { name: "Discord server install QR code" });
+	await expect(discordQr).toBeVisible();
+	const copyDiscordCodeButton = discordPairDialog.getByRole("button", {
+		name: "Copy code",
+		exact: true,
+	});
+	await expect(copyDiscordCodeButton).toBeVisible();
+	await expect(discordPairDialog.getByText(/required code option/)).toBeVisible();
 	await expect(discordPairDialog.getByRole("button", { name: "Add to server" })).toHaveAttribute(
 		"href",
 		/permissions=274878024768/,
 	);
+	await expectActionCenterUncovered(copyDiscordCodeButton);
+	await expectActionCenterUncovered(
+		discordPairDialog.getByRole("button", { name: "Add to server" }),
+	);
 	await discordPairDialog.screenshot({
 		path: testInfo.outputPath("agent-discord-pair-code-desktop.png"),
 	});
-	await page.setViewportSize({ width: 320, height: 844 });
+	const desktopDiscordQrBox = await discordQr.boundingBox();
+	expect(desktopDiscordQrBox?.width ?? 0).toBeLessThanOrEqual(192);
+	await page.setViewportSize({ width: 320, height: 568 });
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	const mobileDiscordQrBox = await discordQr.boundingBox();
+	expect(mobileDiscordQrBox?.width ?? 0).toBeLessThanOrEqual(192);
+	const mobileDiscordDialogBox = await discordPairDialog.boundingBox();
+	const mobileDiscordActionBox = await discordPairDialog
+		.getByRole("button", { name: "Add to server" })
+		.boundingBox();
+	expect(mobileDiscordDialogBox?.y ?? -1).toBeGreaterThanOrEqual(0);
+	expect(
+		(mobileDiscordDialogBox?.y ?? 568) + (mobileDiscordDialogBox?.height ?? 1),
+	).toBeLessThanOrEqual(568);
+	expect(
+		(mobileDiscordActionBox?.y ?? 568) + (mobileDiscordActionBox?.height ?? 1),
+	).toBeLessThanOrEqual(568);
+	await expectActionCenterUncovered(
+		discordPairDialog.getByRole("button", { name: "Add to server" }),
+	);
 	await discordPairDialog.screenshot({
-		path: testInfo.outputPath("agent-discord-pair-code-320.png"),
+		path: testInfo.outputPath("agent-discord-pair-code-320x568.png"),
+	});
+	await copyDiscordCodeButton.click();
+	await expect(
+		discordPairDialog.getByRole("button", { name: "Code copied", exact: true }),
+	).toBeVisible();
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await expectActionCenterUncovered(
+		discordPairDialog.getByRole("button", { name: "Add to server" }),
+	);
+	await expect(
+		discordPairDialog.getByRole("button", { name: "Copy code", exact: true }),
+	).toBeVisible({ timeout: 2_500 });
+	await directMessageTab.click();
+	await expect(
+		discordPairDialog.getByText("No server permission is required.", { exact: false }),
+	).toBeVisible();
+	await expect(
+		discordPairDialog.getByRole("img", { name: "Discord server install QR code" }),
+	).toHaveCount(0);
+	await expect(discordPairDialog.getByRole("button", { name: "Add to server" })).toHaveCount(0);
+	await expect(discordPairDialog.locator('a[href^="discord:"]')).toHaveCount(0);
+	const mobileDiscordDmActionBox = await discordPairDialog
+		.getByRole("button", { name: "Copy code", exact: true })
+		.boundingBox();
+	expect(
+		(mobileDiscordDmActionBox?.y ?? 568) + (mobileDiscordDmActionBox?.height ?? 1),
+	).toBeLessThanOrEqual(568);
+	await expectActionCenterUncovered(copyDiscordCodeButton);
+	await discordPairDialog.screenshot({
+		path: testInfo.outputPath("agent-discord-pair-dm-320x568.png"),
 	});
 	await page.keyboard.press("Escape");
 	await page.setViewportSize({ width: 1440, height: 1100 });
 
-	await currentBindingRow.getByRole("button", { name: "Unpair", exact: true }).click();
+	await discordPairButton.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(8);
+	discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expect(
+		discordPairDialog.getByText("This Discord pair code has expired", { exact: true }),
+	).toBeVisible();
+	await expect(
+		discordPairDialog.getByRole("button", { name: "Copy code", exact: true }),
+	).toHaveCount(0);
+	await discordPairDialog.getByRole("button", { name: "Generate new code", exact: true }).click();
+	await expect.poll(() => pairCodeRequests.length).toBe(9);
+	await expect(discordPairDialog.getByText("DISCORDNEW123", { exact: true })).toBeVisible();
+	await expect(
+		discordPairDialog.getByRole("img", { name: "Discord server install QR code" }),
+	).toBeVisible();
+	await page.keyboard.press("Escape");
+
+	await telegramUnpairButton.click();
 	const unpairConfirmation = page.getByRole("alertdialog", { name: "Unpair Current Agent DM?" });
 	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(1);
@@ -7800,7 +8015,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await page.setViewportSize({ width: 320, height: 844 });
 	const mobileChatRow = page.locator(`[data-channel-binding-id="${polledBindingId}"]`);
 	const mobileChatTitle = mobileChatRow.getByText("Newly Paired DM", { exact: true });
-	const mobileUnpair = mobileChatRow.getByRole("button", { name: "Unpair", exact: true });
+	const mobileUnpair = mobileChatRow.getByRole("button", {
+		name: "Unpair Newly Paired DM",
+		exact: true,
+	});
 	await expect(mobileChatTitle).toBeVisible();
 	await expect(mobileUnpair).toBeVisible();
 	const mobileTitleBox = await mobileChatTitle.boundingBox();
@@ -7813,8 +8031,33 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const mobilePairActionBox = await mobilePairAction.boundingBox();
 	expect(mobileChannelTitleBox?.width ?? 0).toBeGreaterThan(100);
 	expect(mobilePairActionBox?.y ?? 0).toBeGreaterThan(mobileChannelTitleBox?.y ?? 0);
+	const mobileDiscordDmTitle = discordDmRow.getByText(`Direct message · ${discordDmName}`, {
+		exact: true,
+	});
+	await expect(mobileDiscordDmTitle).toBeVisible();
+	const mobileDiscordDmTitleLayout = await mobileDiscordDmTitle.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return {
+			height: element.getBoundingClientRect().height,
+			lineHeight: Number.parseFloat(style.lineHeight),
+			overflow: style.overflow,
+			textOverflow: style.textOverflow,
+			whiteSpace: style.whiteSpace,
+			webkitLineClamp: style.webkitLineClamp,
+		};
+	});
+	expect(discordDmName).toHaveLength(300);
+	expect(mobileDiscordDmTitleLayout).toMatchObject({
+		overflow: "hidden",
+		textOverflow: "clip",
+		whiteSpace: "normal",
+		webkitLineClamp: "2",
+	});
+	expect(mobileDiscordDmTitleLayout.height).toBeLessThanOrEqual(
+		mobileDiscordDmTitleLayout.lineHeight * 2 + 1,
+	);
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
-	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0, { timeout: 7_000 });
+	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
 	await page.screenshot({
 		path:
 			process.env.AGENT_CHANNELS_MOBILE_SCREENSHOT_PATH ??
@@ -7822,8 +8065,16 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		fullPage: true,
 	});
 
-	await discordRow.getByRole("button", { name: "Unlink", exact: true }).click();
-	const unlinkConfirmation = page.getByRole("alertdialog", { name: "Unlink this channel?" });
+	await discordRow
+		.getByRole("button", {
+			name: "Unlink Community Discord from Hosted agent",
+			exact: true,
+		})
+		.click();
+	const unlinkConfirmation = page.getByRole("alertdialog", {
+		name: "Unlink Community Discord?",
+		exact: true,
+	});
 	await unlinkConfirmation.getByRole("button", { name: "Unlink", exact: true }).click();
 	await expect.poll(() => unlinkAgentRequests.length).toBe(1);
 	expect(unlinkAgentRequests).toEqual([`/v1/channels/${discordId}/agent-links/${discordLinkId}`]);

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -170,6 +170,7 @@ export function EntityHeader({
 	meta,
 	align = "center",
 	className,
+	titleClassName,
 }: {
 	icon: ReactNode;
 	title: ReactNode;
@@ -178,6 +179,7 @@ export function EntityHeader({
 	/** `start` aligns the icon to the top for multi-line bodies. */
 	align?: "center" | "start";
 	className?: string;
+	titleClassName?: string;
 }) {
 	return (
 		<div
@@ -190,7 +192,9 @@ export function EntityHeader({
 			{icon}
 			<div className="min-w-0 flex-1">
 				<div className="flex min-w-0 items-center gap-2">
-					<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+					<span className={cn("min-w-0 flex-1 truncate text-sm font-medium", titleClassName)}>
+						{title}
+					</span>
 					{titleAdornment ? <span className="shrink-0">{titleAdornment}</span> : null}
 				</div>
 				{meta !== undefined ? <EntityMeta items={meta} /> : null}

--- a/apps/web/src/hooks/use-copy-to-clipboard.ts
+++ b/apps/web/src/hooks/use-copy-to-clipboard.ts
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 interface CopyToastCopy {
-	/** Success toast title. Defaults to "Copied to clipboard". */
-	success?: string;
+	/** Success toast title. Defaults to "Copied to clipboard"; false suppresses it. */
+	success?: string | false;
 	/** Failure toast title (clipboard blocked / insecure context). */
 	error?: string;
 }
@@ -23,7 +23,7 @@ export function useCopyToClipboard(toasts: CopyToastCopy = {}) {
 		try {
 			await navigator.clipboard.writeText(value);
 			setCopied(true);
-			toast.success(toasts.success ?? "Copied to clipboard");
+			if (toasts.success !== false) toast.success(toasts.success ?? "Copied to clipboard");
 			setTimeout(() => setCopied(false), 1500);
 		} catch {
 			toast.error(toasts.error ?? "Couldn’t copy — select and copy manually.");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -82,6 +82,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -237,11 +238,11 @@ import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client"
 import {
 	agentProviderHasSingleLinkLimit,
 	availableBotProvidersForAgent,
-	channelActivityAfterLink,
 	channelProviderLinkingReady,
 	pairingActionLabel,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import {
+	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
 	ChannelStatusBadge,
 	CopyInline,
 	HealthBadge,
@@ -277,7 +278,7 @@ import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
-import { cn, relativeTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 type Runtime = HostedRuntime;
 type HostedAgentTab =
@@ -2308,6 +2309,8 @@ const AGENT_CHANNEL_ROW_CLASS =
 	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]";
 const AGENT_CHANNEL_ACTIONS_CLASS =
 	"col-span-2 flex min-w-0 items-center justify-end gap-2 sm:col-span-1 sm:col-start-3 sm:row-start-1";
+const AGENT_CHANNEL_PAIR_ACTIONS_CLASS =
+	"col-span-2 grid min-h-8 w-full grid-cols-[minmax(0,1fr)_2rem] items-center gap-2 sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:w-48";
 
 function ChannelsTab({
 	environmentId,
@@ -2334,6 +2337,7 @@ function ChannelsTab({
 	const [discordPair, setDiscordPair] = useState<{
 		accountId: string;
 		agentLinkId: string;
+		channelName: string;
 	} | null>(null);
 	const [connectOpen, setConnectOpen] = useState(false);
 	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
@@ -2437,6 +2441,11 @@ function ChannelsTab({
 				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
 		[botPool.data, linkedIds, linkedProviders, agentType],
 	);
+	const availableBotProviders = useMemo(
+		() => availableBotProvidersForAgent(environmentId, agentType, linkedProviders),
+		[agentType, environmentId, linkedProviders],
+	);
+	const showAddChannelSection = readyBots.length > 0 || availableBotProviders.length > 0;
 	const healthByAccount = useMemo(
 		() => new Map((health.data?.items ?? []).map((item) => [item.account_id, item])),
 		[health.data],
@@ -2561,9 +2570,7 @@ function ChannelsTab({
 									onBindingsRetry={() => void bindingQuery?.refetch()}
 									fallbackAccount={accountSummaries.get(link.account_id)}
 									health={healthByAccount.get(link.account_id)}
-									healthLoading={health.isLoading}
-									healthError={Boolean(health.error)}
-									onHealthRetry={() => void health.refetch()}
+									agentName={agentName}
 									unlinking={unlinkingLinkIds.has(link.id)}
 									onUnlink={() => startUnlink(link.account_id, link.id)}
 								/>
@@ -2578,95 +2585,104 @@ function ChannelsTab({
 						title="Couldn't refresh every linked channel"
 					/>
 				) : null}
+				{health.error && visibleActiveLinks.length > 0 ? (
+					<ApiErrorPanel
+						error={health.error}
+						onRetry={() => void health.refetch()}
+						title="Couldn't refresh channel health"
+					/>
+				) : null}
 			</section>
 
-			<section data-agent-add-channel className="flex flex-col gap-3 border-t pt-6">
-				<div className="space-y-1">
-					<SectionLabel>Add a channel</SectionLabel>
-					<p className="px-0.5 text-sm text-muted-foreground">
-						Link a bot to this Agent, then choose where it should answer.
-					</p>
-				</div>
-				{botPool.isLoading ? (
-					<div className={AGENT_CHANNEL_LIST_CLASS}>
-						<div className={AGENT_CHANNEL_ROW_CLASS}>
-							<Skeleton className="size-8 shrink-0 rounded-md" />
-							<Skeleton className="h-4 min-w-0 flex-1 max-w-48" />
-							<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
-								<Skeleton className="h-8 w-16 rounded-md" />
+			{showAddChannelSection ? (
+				<section data-agent-add-channel className="flex flex-col gap-3 border-t pt-6">
+					<div className="space-y-1">
+						<SectionLabel>Add a channel</SectionLabel>
+						<p className="px-0.5 text-sm text-muted-foreground">
+							Link a bot to this Agent, then choose where it should answer.
+						</p>
+					</div>
+					{botPool.isLoading ? (
+						<div className={AGENT_CHANNEL_LIST_CLASS}>
+							<div className={AGENT_CHANNEL_ROW_CLASS}>
+								<Skeleton className="size-8 shrink-0 rounded-md" />
+								<Skeleton className="h-4 min-w-0 flex-1 max-w-48" />
+								<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+									<Skeleton className="h-8 w-16 rounded-md" />
+								</div>
 							</div>
 						</div>
-					</div>
-				) : botPool.error ? (
-					<ApiErrorPanel
-						error={botPool.error}
-						onRetry={() => botPool.refetch()}
-						title="Couldn't load ready-to-go bots"
-					/>
-				) : readyBots.length > 0 ? (
-					<div className={AGENT_CHANNEL_LIST_CLASS}>
-						{readyBots.map((bot) => (
-							<AddChannelRow
-								key={bot.id}
-								channel={bot}
-								kind="Shared bot"
-								linking={linkingAccountId === bot.id}
-								disabled={linkingAccountId !== null}
-								onLink={() => void submitLink(bot.id)}
-							/>
-						))}
-					</div>
-				) : null}
-
-				{availableBotProvidersForAgent(environmentId, agentType, linkedProviders).length > 0 ? (
-					<details className="group border-t pt-4">
-						<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
-						<div className="mt-3 space-y-3">
-							{channels.isLoading ? (
-								<Skeleton className="h-16 w-full rounded-lg" />
-							) : channels.error ? (
-								<ApiErrorPanel
-									error={channels.error}
-									onRetry={() => channels.refetch()}
-									title="Couldn't load your bots"
+					) : botPool.error ? (
+						<ApiErrorPanel
+							error={botPool.error}
+							onRetry={() => botPool.refetch()}
+							title="Couldn't load ready-to-go bots"
+						/>
+					) : readyBots.length > 0 ? (
+						<div className={AGENT_CHANNEL_LIST_CLASS}>
+							{readyBots.map((bot) => (
+								<AddChannelRow
+									key={bot.id}
+									channel={bot}
+									kind="Shared bot"
+									linking={linkingAccountId === bot.id}
+									disabled={linkingAccountId !== null}
+									onLink={() => void submitLink(bot.id)}
 								/>
-							) : ownedChannels.length > 0 ? (
-								<div className={AGENT_CHANNEL_LIST_CLASS}>
-									{ownedChannels.map((channel) => (
-										<AddChannelRow
-											key={channel.id}
-											channel={channel}
-											kind={undefined}
-											linking={linkingAccountId === channel.id}
-											disabled={linkingAccountId !== null}
-											onLink={() => void submitLink(channel.id)}
-											secondary
-										/>
-									))}
-								</div>
-							) : (
-								<Button size="sm" onClick={() => setConnectOpen(true)}>
-									<Plus className="size-3.5" />
-									Connect a bot
-								</Button>
-							)}
-							{ownedChannels.length > 0 ? (
-								<div className="flex flex-wrap gap-2">
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										onClick={() => setConnectOpen(true)}
-									>
+							))}
+						</div>
+					) : null}
+
+					{availableBotProviders.length > 0 ? (
+						<details className="group border-t pt-4">
+							<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
+							<div className="mt-3 space-y-3">
+								{channels.isLoading ? (
+									<Skeleton className="h-16 w-full rounded-lg" />
+								) : channels.error ? (
+									<ApiErrorPanel
+										error={channels.error}
+										onRetry={() => channels.refetch()}
+										title="Couldn't load your bots"
+									/>
+								) : ownedChannels.length > 0 ? (
+									<div className={AGENT_CHANNEL_LIST_CLASS}>
+										{ownedChannels.map((channel) => (
+											<AddChannelRow
+												key={channel.id}
+												channel={channel}
+												kind={undefined}
+												linking={linkingAccountId === channel.id}
+												disabled={linkingAccountId !== null}
+												onLink={() => void submitLink(channel.id)}
+												secondary
+											/>
+										))}
+									</div>
+								) : (
+									<Button size="sm" onClick={() => setConnectOpen(true)}>
 										<Plus className="size-3.5" />
 										Connect a bot
 									</Button>
-								</div>
-							) : null}
-						</div>
-					</details>
-				) : null}
-			</section>
+								)}
+								{ownedChannels.length > 0 ? (
+									<div className="flex flex-wrap gap-2">
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											onClick={() => setConnectOpen(true)}
+										>
+											<Plus className="size-3.5" />
+											Connect a bot
+										</Button>
+									</div>
+								) : null}
+							</div>
+						</details>
+					) : null}
+				</section>
+			) : null}
 
 			<ConnectBotDialog
 				open={connectOpen}
@@ -2684,7 +2700,11 @@ function ChannelsTab({
 						return;
 					}
 					if (bot.provider === "discord") {
-						setDiscordPair({ accountId: bot.id, agentLinkId: bot.agentLinkId });
+						setDiscordPair({
+							accountId: bot.id,
+							agentLinkId: bot.agentLinkId,
+							channelName: bot.name,
+						});
 					}
 				}}
 			/>
@@ -2696,7 +2716,6 @@ function ChannelsTab({
 					}}
 					accountId={telegramPair.accountId}
 					agentLinkId={telegramPair.agentLinkId}
-					agentName={agentName}
 					channelName={telegramPair.channelName}
 				/>
 			) : null}
@@ -2708,6 +2727,7 @@ function ChannelsTab({
 					}}
 					accountId={discordPair.accountId}
 					agentLinkId={discordPair.agentLinkId}
+					channelName={discordPair.channelName}
 				/>
 			) : null}
 		</div>
@@ -2724,9 +2744,7 @@ function ConnectedChannelGroup({
 	unlinking,
 	fallbackAccount,
 	health,
-	healthLoading,
-	healthError,
-	onHealthRetry,
+	agentName,
 }: {
 	link: AgentChannelLink;
 	pairedChats: AgentPairedChatItem[];
@@ -2737,9 +2755,7 @@ function ConnectedChannelGroup({
 	unlinking: boolean;
 	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
-	healthLoading: boolean;
-	healthError: boolean;
-	onHealthRetry: () => void;
+	agentName: string;
 }) {
 	const showChats = pairedChats.length > 0 || bindingsLoading || bindingsError;
 	const provider = link.account?.provider ?? fallbackAccount?.provider ?? "";
@@ -2750,9 +2766,7 @@ function ConnectedChannelGroup({
 				link={link}
 				fallbackAccount={fallbackAccount}
 				health={health}
-				healthLoading={healthLoading}
-				healthError={healthError}
-				onHealthRetry={onHealthRetry}
+				agentName={agentName}
 				unlinking={unlinking}
 				onUnlink={onUnlink}
 			/>
@@ -2845,18 +2859,14 @@ function LinkedChannelRow({
 	unlinking,
 	fallbackAccount,
 	health,
-	healthLoading,
-	healthError,
-	onHealthRetry,
+	agentName,
 }: {
 	link: AgentChannelLink;
 	onUnlink: () => void;
 	unlinking: boolean;
 	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
-	healthLoading: boolean;
-	healthError: boolean;
-	onHealthRetry: () => void;
+	agentName: string;
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
@@ -2872,7 +2882,6 @@ function LinkedChannelRow({
 	const provider = account?.provider ?? "";
 	const isDiscord = provider === "discord";
 	const name = account?.name ?? "Unnamed channel";
-	const hasActivity = channelActivityAfterLink(health?.last_message_at, link.created_at);
 	useEffect(() => {
 		if (!code) return;
 		setNowMs(Date.now());
@@ -2907,23 +2916,6 @@ function LinkedChannelRow({
 					{health && !isNormalChannelHealth(health.health_status) ? (
 						<HealthBadge status={health.health_status} />
 					) : null}
-					{healthLoading ? (
-						<span className="inline-flex items-center gap-1">
-							<Spinner className="size-3" /> Checking activity…
-						</span>
-					) : healthError ? (
-						<button
-							type="button"
-							className="font-medium text-destructive underline-offset-2 hover:underline"
-							onClick={onHealthRetry}
-						>
-							Activity unavailable · Retry
-						</button>
-					) : hasActivity ? (
-						<span>Last activity {relativeTime(health?.last_message_at)}</span>
-					) : (
-						<span>No activity yet</span>
-					)}
 				</div>
 				{provider !== "telegram" && !isDiscord && pair.error ? (
 					<p className="mt-1 text-xs font-medium text-destructive">Pair failed · Try again</p>
@@ -2937,11 +2929,12 @@ function LinkedChannelRow({
 					</div>
 				) : null}
 			</div>
-			<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
+			<div className={AGENT_CHANNEL_PAIR_ACTIONS_CLASS}>
 				<Button
 					type="button"
-					variant={provider === "telegram" ? "default" : "outline"}
+					variant="outline"
 					size="sm"
+					className="w-full"
 					disabled={provider !== "telegram" && creatingPairCode}
 					onClick={() => {
 						if (provider === "telegram") setTelegramPairOpen(true);
@@ -2958,23 +2951,30 @@ function LinkedChannelRow({
 								? "Retry pairing"
 								: pairingActionLabel(provider)}
 				</Button>
-				<ConfirmAction
-					title="Unlink this channel?"
-					description={<p>This Agent will stop answering through {name}.</p>}
-					confirmLabel="Unlink"
-					destructive
-					onConfirm={onUnlink}
-				>
-					<Button
-						variant="ghost"
-						size="sm"
-						className="text-muted-foreground hover:text-destructive"
-						disabled={unlinking}
-					>
-						{unlinking ? <Spinner className="size-3.5" /> : <Link2Off className="size-3.5" />}
-						{unlinking ? "Unlinking…" : "Unlink"}
-					</Button>
-				</ConfirmAction>
+				<Tooltip>
+					<TooltipTrigger render={<span className="inline-flex size-8" />}>
+						<ConfirmAction
+							title={`Unlink ${name}?`}
+							description={<p>{agentName} will stop answering through this bot.</p>}
+							confirmLabel="Unlink"
+							destructive
+							onConfirm={onUnlink}
+						>
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+								disabled={unlinking}
+								aria-label={`Unlink ${name} from ${agentName}`}
+							>
+								{unlinking ? <Spinner className="size-3.5" /> : <Link2Off className="size-3.5" />}
+							</Button>
+						</ConfirmAction>
+					</TooltipTrigger>
+					<TooltipContent>
+						Unlink {name} from {agentName}
+					</TooltipContent>
+				</Tooltip>
 			</div>
 
 			{provider === "telegram" ? (
@@ -2992,6 +2992,7 @@ function LinkedChannelRow({
 					onOpenChange={setDiscordPairOpen}
 					accountId={link.account_id}
 					agentLinkId={link.id}
+					channelName={name}
 				/>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -171,7 +171,7 @@ describe("structural secret boundaries without the denylist", () => {
 				"hosted/v2/channels/channels-hooks.ts",
 				[
 					"export function useCreateChannel()",
-					"export function useCreatePairCode(accountId: string)",
+					"export function useCreatePairCode(",
 					"export function useCreateWhatsappTenantCred(accountId: string)",
 					"return useSensitiveAction",
 				],

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -15,12 +15,15 @@ const channelsTab = agentChannels.slice(
 describe("hosted-agent channel finish line", () => {
 	test("keeps diagnosis compact inside a shared connected-channel row", () => {
 		expect(channelsTab).toContain("const health = useChannelHealth()");
-		expect(channelsTab).toContain("channelActivityAfterLink(");
 		expect(channelsTab).toContain("AGENT_CHANNEL_LIST_CLASS");
 		expect(channelsTab).toContain("AGENT_CHANNEL_ROW_CLASS");
-		expect(channelsTab).toContain("Last activity");
-		expect(channelsTab).toContain("No activity yet");
-		expect(channelsTab).toContain("Activity unavailable · Retry");
+		expect(channelsTab).not.toContain("channelActivityAfterLink(");
+		expect(channelsTab).not.toContain("Last activity");
+		expect(channelsTab).not.toContain("No activity yet");
+		expect(channelsTab).not.toContain("Checking activity");
+		expect(channelsTab).toContain("health.error && visibleActiveLinks.length > 0");
+		expect(channelsTab).toContain('title="Couldn\'t refresh channel health"');
+		expect(channelsTab).toContain("onRetry={() => void health.refetch()}");
 		expect(channelsTab).toContain("<ChannelStatusBadge status={link.status} />");
 		expect(channelsTab).toContain("<HealthBadge");
 		expect(channelsTab).not.toContain("Waiting for channel activity");
@@ -56,6 +59,17 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).not.toContain(">Paired chats<");
 		expect(channelsTab).not.toContain("No chats paired");
 		expect(channelsTab).toContain("data-agent-add-channel");
+		expect(channelsTab).toContain("const availableBotProviders = useMemo(");
+		expect(channelsTab).toContain("const showAddChannelSection =");
+		expect(channelsTab).toContain("{showAddChannelSection ? (");
+		expect(channelsTab).toContain("availableBotProviders.length > 0");
+		const addSectionGate = channelsTab.slice(
+			channelsTab.indexOf("const showAddChannelSection ="),
+			channelsTab.indexOf("const healthByAccount"),
+		);
+		expect(addSectionGate).toContain("readyBots.length > 0");
+		expect(addSectionGate).not.toContain("botPool.isLoading");
+		expect(addSectionGate).not.toContain("botPool.error");
 		expect(channelsTab).toContain("data-add-channel-id");
 		expect(channelsTab).not.toContain("No bot connected yet");
 		expect(channelsTab).toContain("Connect a bot");

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
 	agentProviderHasSingleLinkLimit,
 	availableBotProvidersForAgent,
-	channelActivityAfterLink,
 	channelProviderLinkingReady,
 	pairCodeExpired,
 	pairingActionLabel,
@@ -56,12 +55,5 @@ describe("hosted channel instructions and gates", () => {
 		}
 		expect(agentProviderHasSingleLinkLimit("openclaw", "whatsapp")).toBe(false);
 		expect(agentProviderHasSingleLinkLimit("codex", "telegram")).toBe(false);
-	});
-
-	test("only treats real account activity after linking as new channel activity", () => {
-		expect(channelActivityAfterLink(null, "2026-07-26T09:00:00Z")).toBe(false);
-		expect(channelActivityAfterLink("2026-07-26T08:59:59Z", "2026-07-26T09:00:00Z")).toBe(false);
-		expect(channelActivityAfterLink("2026-07-26T09:00:01Z", "2026-07-26T09:00:00Z")).toBe(true);
-		expect(channelActivityAfterLink("not-a-date", "2026-07-26T09:00:00Z")).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -44,14 +44,3 @@ export function pairCodeExpired(expiresAt: string, nowMs: number): boolean {
 	const expiresAtMs = Date.parse(expiresAt);
 	return !Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs;
 }
-
-/** Account-level activity is useful, but it is not proof of agent-runtime delivery. */
-export function channelActivityAfterLink(
-	lastMessageAt: string | null | undefined,
-	linkCreatedAt: string,
-): boolean {
-	if (!lastMessageAt) return false;
-	const messageTime = Date.parse(lastMessageAt);
-	const linkTime = Date.parse(linkCreatedAt);
-	return Number.isFinite(messageTime) && Number.isFinite(linkTime) && messageTime >= linkTime;
-}

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -30,6 +30,7 @@ describe("channel mutation feedback", () => {
 		const discordPairDialog = source("./discord-pair-dialog.tsx");
 		const pairDialog = source("./telegram-pair-dialog.tsx");
 		const pairedChatRow = source("./paired-chat-row.tsx");
+		const clipboardHook = source("../../../hooks/use-copy-to-clipboard.ts");
 
 		expectFeedbackBeforeRequest(
 			detail,
@@ -50,11 +51,20 @@ describe("channel mutation feedback", () => {
 		expect(detail).toContain('"Pair Telegram"');
 		expect(detail).toContain("pairingActionLabel(provider)");
 		expect(pairDialog).toContain("Creating a secure Telegram link…");
+		expect(pairDialog).toContain("useCreatePairCode(accountId, { toastOnError: false })");
 		expectFeedbackBeforeRequest(discordPairDialog, "setPreparing(true)", "await pair.execute");
-		expect(discordPairDialog).toContain("Preparing Discord and creating a pair code…");
+		expect(discordPairDialog).toContain("Creating a Discord pair code…");
+		expect(discordPairDialog).toContain("useCreatePairCode(accountId, { toastOnError: false })");
+		expect(pairDialog).toContain("success: false");
+		expect(discordPairDialog).toContain("success: false");
+		expect(clipboardHook).toContain("success?: string | false");
+		expect(clipboardHook).toContain("if (toasts.success !== false)");
+		expect(clipboardHook).toContain("toast.error(toasts.error ??");
 		expect(pairedChatRow).toContain("disabled={unpair.isPending}");
-		expect(pairedChatRow).toContain('"Unpairing…"');
-		expect(pairedChatRow).toContain('"Retry unpair"');
+		expect(pairedChatRow).toContain("unpair.isPending ? (");
+		expect(pairedChatRow).toContain("Couldn&apos;t unpair · Try again");
+		expect(pairedChatRow).not.toContain('"Unpairing…"');
+		expect(pairedChatRow).not.toContain('"Retry unpair"');
 	});
 
 	test("uses per-action feedback for bot-owned detail mutations", () => {

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -16,6 +16,10 @@ const pairedChatRow = source("./paired-chat-row.tsx");
 const pairedChatRowLogic = source("./paired-chat-row.logic.ts");
 const confirmAction = source("../../../components/ui/confirm-action.tsx");
 const agentBindingLogic = source("./agent-channel-bindings.logic.ts");
+const linkedChannelRow = agentDetail.slice(
+	agentDetail.indexOf("function LinkedChannelRow"),
+	agentDetail.indexOf("// ── Settings / Compute"),
+);
 
 describe("channel IA boundary", () => {
 	test("keeps bot detail read-only for Agent relationships and navigates to Agent Channels", () => {
@@ -59,18 +63,28 @@ describe("channel IA boundary", () => {
 		expect(connectDialog).toContain("agent_id: agentId ?? null");
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setDiscordPairOpen(true)");
-		expect(agentDetail).toContain("setDiscordPair({ accountId: bot.id");
+		expect(agentDetail).toContain("setDiscordPair({");
 		expect(agentDetail).toContain("<DiscordPairDialog");
-		expect(discordPairDialog).toContain("useCreatePairCode(accountId)");
+		expect(discordPairDialog).toContain("useCreatePairCode(accountId, { toastOnError: false })");
 		expect(discordPairDialog).toContain("await pair.execute");
 		expect(discordPairDialog).toContain("run <code>/bot_pair</code>");
 		expect(discordPairDialog).toContain('data-discord-pair-path="server"');
 		expect(discordPairDialog).toContain('data-discord-pair-path="dm"');
 		expect(discordPairDialog).toContain("Manage");
 		expect(discordPairDialog).toContain("Add to server");
-		expect(discordPairDialog).toContain('label="pair code"');
+		expect(discordPairDialog).toContain("value={result.discord_install_url}");
+		expect(discordPairDialog).toContain('aria-label="Discord server install QR code"');
+		expect(discordPairDialog).toContain("paste this code into the");
+		expect(discordPairDialog).toContain("required <code>code</code> option");
+		expect(discordPairDialog).toContain('"Copy code"');
+		expect(discordPairDialog).not.toContain("/bot_pair ${");
+		expect(discordPairDialog).not.toContain("discord://");
 		expect(discordPairDialog).toContain("pairCodeExpiryLabel");
+		expect(discordPairDialog).toContain("This Discord pair code has expired");
+		expect(discordPairDialog).toContain("Generate new code");
 		expect(discordPairDialog).toContain("Couldn't prepare Discord pairing");
+		expect(discordPairDialog).toContain("success: false");
+		expect(hooks).toContain("if (toastOnError) toastApiError");
 		expect(agentDetail).not.toContain("Commands synced. In Discord");
 		expect(agentDetail).not.toContain("Paired servers and direct messages");
 	});
@@ -78,7 +92,7 @@ describe("channel IA boundary", () => {
 	test("keeps Discord preparation server-owned for private and shared bots", () => {
 		expect(agentDetail).toContain("visibility: bot.visibility");
 		expect(discordPairDialog).not.toContain("useSyncCommands");
-		expect(discordPairDialog).toContain("Preparing Discord and creating a pair code…");
+		expect(discordPairDialog).toContain("Creating a Discord pair code…");
 	});
 
 	test("opens the shared fixed-TTL Telegram flow immediately after a new link", () => {
@@ -90,6 +104,8 @@ describe("channel IA boundary", () => {
 		expect(pairDialog).toContain("agent_link_id: agentLinkId");
 		expect(pairDialog).toContain("ttl_seconds: TELEGRAM_PAIR_TTL_SECONDS");
 		expect(pairDialog).toContain("openKeyRef.current === openKey");
+		expect(pairDialog).toContain("useCreatePairCode(accountId, { toastOnError: false })");
+		expect(pairDialog).toContain("success: false");
 		expect(pairDialog).not.toContain("Select");
 	});
 
@@ -102,6 +118,14 @@ describe("channel IA boundary", () => {
 		expect(pairDialog).toContain("Telegram link unavailable");
 		expect(pairDialog).toContain("This Telegram link has expired");
 		expect(pairDialog).toContain("Pair a group manually");
+		expect(pairDialog).toContain("!expired && result.bot_username");
+		expect(pairDialog).toContain("Add @{result.bot_username.replace");
+		expect(pairDialog).toContain("to the group, then send:");
+		expect(pairDialog).toContain(
+			'<CopyInline value={result.pairing_command} label="pairing command" />',
+		);
+		expect(pairDialog).toContain("to pair with {botIdentity}");
+		expect(pairDialog).not.toContain("agentName");
 		expect(pairDialog).toContain('title="Couldn\'t create Telegram link"');
 	});
 
@@ -117,6 +141,30 @@ describe("channel IA boundary", () => {
 		expect(hooks).toContain("keys.bindings(accountId)");
 		expect(hooks).toContain('toastApiError("Couldn\'t unpair chat")');
 		expect(hooks).toContain("refetchInterval: 3_000");
+		expect(pairedChatRow).toContain("binding.last_message_at");
+		expect(pairedChatRow).toContain("Last activity {relativeTime(binding.last_message_at)}");
+		expect(pairedChatRow).not.toContain("No activity yet");
+		expect(agentDetail).not.toContain("Checking activity");
+		expect(agentDetail).not.toContain("No activity yet");
+		expect(agentDetail).not.toContain("Last activity");
+	});
+
+	test("keeps repeated row actions visually stable without provider variants", () => {
+		expect(linkedChannelRow).toContain('variant="outline"');
+		expect(linkedChannelRow).toContain('size="sm"');
+		expect(linkedChannelRow).toContain('<QrCode className="size-3.5" />');
+		expect(linkedChannelRow).toContain("AGENT_CHANNEL_PAIR_ACTIONS_CLASS");
+		expect(linkedChannelRow).not.toContain('variant={provider === "telegram"');
+		expect(linkedChannelRow).not.toContain('provider === "telegram" ? "default"');
+		expect(linkedChannelRow).toContain('variant="ghost"');
+		expect(linkedChannelRow).toContain('size="icon-sm"');
+		expect(linkedChannelRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
+		expect(linkedChannelRow).toContain("aria-label={`Unlink ");
+		expect(pairedChatRow).toContain('variant="ghost"');
+		expect(pairedChatRow).toContain('size="icon-sm"');
+		expect(pairedChatRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
+		expect(pairedChatRow).toContain("aria-label={`Unpair ");
+		expect(pairedChatRow).not.toContain('variant="outline"');
 	});
 
 	test("renders chats below channels without duplicating provider identity", () => {
@@ -124,6 +172,10 @@ describe("channel IA boundary", () => {
 		expect(pairedChatRow).toContain("<MessageCircle");
 		expect(pairedChatRow).toContain("<MessagesSquare");
 		expect(pairedChatRow).toContain("pairedChatTitle(binding, provider)");
+		expect(pairedChatRow).toContain(
+			'titleClassName="line-clamp-2 whitespace-normal break-words text-clip"',
+		);
+		expect(pairedChatRow).not.toContain("overflow-visible");
 		expect(pairedChatRow).toContain("pairedChatScopeLabel(provider, binding)");
 		expect(pairedChatRow).toContain("Run /bot_unpair in this");
 		expect(pairedChatRowLogic).toContain("external_chat_name?.trim()");

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -7,6 +7,9 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import { cn } from "@/lib/utils";
 
+export const CHANNEL_DESTRUCTIVE_ACTION_CLASS =
+	"text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:text-destructive";
+
 /** Real app-icon for a channel provider (delegates to the unified EntityIcon). */
 export function ProviderChip({
 	provider,

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -194,7 +194,10 @@ export function useDeleteChannel() {
 	});
 }
 
-export function useCreatePairCode(accountId: string) {
+export function useCreatePairCode(
+	accountId: string,
+	{ toastOnError = true }: { toastOnError?: boolean } = {},
+) {
 	const api = useApi();
 	const qc = useQueryClient();
 	return useSensitiveAction(async (vars: { agent_link_id: string; ttl_seconds?: number }) => {
@@ -219,7 +222,7 @@ export function useCreatePairCode(accountId: string) {
 				discord_install_url: result.discord_install_url,
 			};
 		} catch (error) {
-			toastApiError("Couldn't create pairing code")(error);
+			if (toastOnError) toastApiError("Couldn't create pairing code")(error);
 			throw error;
 		}
 	});

--- a/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { Check, Copy, ExternalLink, MessageCircle, RefreshCw, Server } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
@@ -13,10 +14,11 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { pairCodeExpired } from "@/hosted/v2/channels/channel-linking.logic";
 import type { ChannelPairCode } from "@/hosted/v2/channels/channel-types";
-import { CopyInline } from "@/hosted/v2/channels/channel-ui";
 import { useCreatePairCode } from "@/hosted/v2/channels/channels-hooks";
 
 const DISCORD_PAIR_TTL_SECONDS = 900;
@@ -28,16 +30,23 @@ export function DiscordPairDialog({
 	onOpenChange,
 	accountId,
 	agentLinkId,
+	channelName,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	agentLinkId: string;
+	channelName?: string;
 }) {
-	const pair = useCreatePairCode(accountId);
+	const pair = useCreatePairCode(accountId, { toastOnError: false });
+	const { copied, copy } = useCopyToClipboard({
+		success: false,
+		error: "Couldn't copy Discord pair code",
+	});
 	const [result, setResult] = useState<DiscordPairResult | null>(null);
 	const [requestError, setRequestError] = useState<unknown>(null);
 	const [preparing, setPreparing] = useState(false);
+	const [path, setPath] = useState<"server" | "dm">("server");
 	const [nowMs, setNowMs] = useState(() => Date.now());
 	const openKeyRef = useRef<string | null>(null);
 	const sessionRef = useRef(0);
@@ -79,6 +88,7 @@ export function DiscordPairDialog({
 			openKeyRef.current = null;
 			sessionRef.current += 1;
 			lockedSessionRef.current = null;
+			setPath("server");
 			setPreparing(false);
 			setRequestError(null);
 			setResult(null);
@@ -100,20 +110,30 @@ export function DiscordPairDialog({
 	}, [open, result]);
 
 	const expired = result ? pairCodeExpired(result.expires_at, nowMs) : false;
+	const botIdentity = channelName?.trim() || "this bot";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
+			<DialogContent
+				data-hosted="true"
+				data-v2="true"
+				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
+			>
 				<DialogHeader>
 					<DialogTitle>Pair Discord</DialogTitle>
-					<DialogDescription>Connect one server or direct message to this Agent.</DialogDescription>
+					<DialogDescription>
+						Choose a server or direct message for {botIdentity}.
+					</DialogDescription>
 				</DialogHeader>
 
-				<div data-discord-pair-dialog-body className="min-h-36">
+				<div
+					data-discord-pair-dialog-body
+					className="min-h-0 overflow-y-auto overscroll-contain pr-1"
+				>
 					{preparing ? (
-						<div className="flex min-h-36 flex-col items-center justify-center gap-3 text-muted-foreground">
+						<div className="flex min-h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
 							<Spinner className="size-5" />
-							<p>Preparing Discord and creating a pair code…</p>
+							<p>Creating a Discord pair code…</p>
 						</div>
 					) : requestError ? (
 						<ApiErrorPanel
@@ -122,47 +142,109 @@ export function DiscordPairDialog({
 							title="Couldn't prepare Discord pairing"
 						/>
 					) : result ? (
-						<div className="space-y-4">
-							<div data-discord-pair-path="server" className="space-y-1">
-								<p className="text-sm font-medium">Server</p>
-								<p className="text-sm text-muted-foreground">
-									Add the bot, then run <code>/bot_pair</code> in that server. You need Manage
-									Server.
+						expired ? (
+							<div role="alert" className="rounded-lg border border-warning/40 bg-muted/20 p-4">
+								<p className="text-sm font-medium">This Discord pair code has expired</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									Create a new code before pairing a server or direct message.
 								</p>
-								{result.discord_install_url ? (
-									<Button
-										variant="outline"
-										size="sm"
-										render={
-											<a href={result.discord_install_url} target="_blank" rel="noreferrer" />
-										}
-										nativeButton={false}
+							</div>
+						) : (
+							<div className="space-y-4">
+								<Tabs
+									value={path}
+									onValueChange={(value) => {
+										if (value === "server" || value === "dm") setPath(value);
+									}}
+								>
+									<TabsList className="grid w-full grid-cols-2">
+										<TabsTrigger value="server" className="px-1 text-xs sm:px-2 sm:text-sm">
+											<Server className="size-3.5" />
+											Server
+										</TabsTrigger>
+										<TabsTrigger value="dm" className="px-1 text-xs sm:px-2 sm:text-sm">
+											<MessageCircle className="size-3.5" />
+											Direct message
+										</TabsTrigger>
+									</TabsList>
+									<TabsContent
+										value="server"
+										data-discord-pair-path="server"
+										className="mt-2 space-y-4"
 									>
-										Add to server
-										<ExternalLink className="size-3.5" />
-									</Button>
-								) : null}
-							</div>
-							<div data-discord-pair-path="dm" className="space-y-1 border-t pt-3">
-								<p className="text-sm font-medium">Direct message</p>
-								<p className="text-sm text-muted-foreground">
-									If you share a server with the bot or can already open its DM, message it and run{" "}
-									<code>/bot_pair</code>. No server permission is required.
+										{result.discord_install_url ? (
+											<div className="flex justify-center">
+												<div className="max-w-full rounded-md border bg-white p-3 shadow-sm">
+													<QRCodeSVG
+														value={result.discord_install_url}
+														size={192}
+														className="h-auto w-full max-w-48"
+														role="img"
+														aria-label="Discord server install QR code"
+													/>
+												</div>
+											</div>
+										) : (
+											<div
+												role="alert"
+												className="rounded-lg border border-warning/40 bg-muted/20 p-3"
+											>
+												<p className="text-sm font-medium">Server install unavailable</p>
+												<p className="mt-1 text-xs text-muted-foreground">
+													Use an existing server installation or choose Direct message.
+												</p>
+											</div>
+										)}
+										<div className="space-y-2 border-t pt-3 text-sm">
+											<p>
+												1. Add {botIdentity} to the server. You need Manage Server or Administrator.
+											</p>
+											<p>
+												2. In that server, run <code>/bot_pair</code> and paste this code into the
+												required <code>code</code> option.
+											</p>
+											<DiscordPairCode code={result.code} />
+										</div>
+									</TabsContent>
+									<TabsContent value="dm" data-discord-pair-path="dm" className="mt-2 space-y-3">
+										<p className="text-sm text-muted-foreground">
+											If you can already open a direct message with {botIdentity}, run{" "}
+											<code>/bot_pair</code> and paste this code into the required <code>code</code>{" "}
+											option. No server permission is required.
+										</p>
+										<DiscordPairCode code={result.code} />
+									</TabsContent>
+								</Tabs>
+								<p role="status" className="text-center text-sm text-muted-foreground">
+									{pairCodeExpiryLabel(result.expires_at, nowMs)}
 								</p>
 							</div>
-							<p className="text-sm text-muted-foreground">Enter this code when prompted:</p>
-							{expired ? null : <CopyInline value={result.code} label="pair code" />}
-							<p
-								role="status"
-								className={expired ? "text-sm text-destructive" : "text-sm text-muted-foreground"}
-							>
-								{pairCodeExpiryLabel(result.expires_at, nowMs)}
-							</p>
-						</div>
+						)
 					) : null}
 				</div>
 
-				{result && expired ? (
+				{result && !expired ? (
+					<DialogFooter>
+						<Button
+							variant={path === "server" ? "outline" : "default"}
+							onClick={() => void copy(result.code)}
+						>
+							{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+							{copied ? "Code copied" : "Copy code"}
+						</Button>
+						{path === "server" && result.discord_install_url ? (
+							<Button
+								render={
+									<a href={result.discord_install_url} target="_blank" rel="noopener noreferrer" />
+								}
+								nativeButton={false}
+							>
+								Add to server
+								<ExternalLink className="size-4" />
+							</Button>
+						) : null}
+					</DialogFooter>
+				) : result && expired ? (
 					<DialogFooter>
 						<Button onClick={() => void prepare()}>
 							<RefreshCw className="size-4" />
@@ -172,5 +254,14 @@ export function DiscordPairDialog({
 				) : null}
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+function DiscordPairCode({ code }: { code: string }) {
+	return (
+		<div className="flex min-w-0 items-center justify-between gap-3 border-y py-3">
+			<span className="text-xs font-medium text-muted-foreground">Required code</span>
+			<code className="min-w-0 break-all text-right text-sm font-medium">{code}</code>
+		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -6,11 +6,16 @@ import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
-import { ChannelStatusBadge, isNormalChannelStatus } from "@/hosted/v2/channels/channel-ui";
+import {
+	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
+	ChannelStatusBadge,
+	isNormalChannelStatus,
+} from "@/hosted/v2/channels/channel-ui";
 import { useDeleteChannelBinding } from "@/hosted/v2/channels/channels-hooks";
 import { pairedChatScopeLabel, pairedChatTitle } from "@/hosted/v2/channels/paired-chat-row.logic";
-import { cn } from "@/lib/utils";
+import { cn, relativeTime } from "@/lib/utils";
 
 export const PAIRED_CHAT_ROW_CLASS =
 	"ml-4 grid min-h-12 grid-cols-[minmax(0,1fr)] items-center gap-2 border-l-2 border-muted py-2 pr-0 pl-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3";
@@ -47,7 +52,11 @@ export function PairedChatRow({
 				className="min-w-0"
 				icon={<IconChip size="sm">{privateChat ? <MessageCircle /> : <MessagesSquare />}</IconChip>}
 				title={chatName}
+				titleClassName="line-clamp-2 whitespace-normal break-words text-clip"
 				meta={[
+					...(binding.last_message_at
+						? [<span key="activity">Last activity {relativeTime(binding.last_message_at)}</span>]
+						: []),
 					...(isNormalChannelStatus(binding.status)
 						? []
 						: [<ChannelStatusBadge key="status" status={binding.status} />]),
@@ -60,26 +69,38 @@ export function PairedChatRow({
 						: []),
 				]}
 			/>
-			<div className="flex min-w-0 justify-end sm:shrink-0">
+			<div className="flex min-h-8 min-w-0 justify-end sm:w-28 sm:shrink-0">
 				{provider === "discord" ? (
-					<p className="text-right text-xs text-muted-foreground">{discordUnpairInstruction}</p>
+					<p className="w-full text-right text-xs text-muted-foreground">
+						{discordUnpairInstruction}
+					</p>
 				) : (
-					<ConfirmAction
-						title={`Unpair ${chatName}?`}
-						description="Only this chat will be disconnected. Other chats and the connected channel stay active."
-						confirmLabel="Unpair chat"
-						destructive
-						onConfirm={() => unpair.mutateAsync(binding.id)}
-					>
-						<Button variant="outline" size="sm" disabled={unpair.isPending}>
-							{unpair.isPending ? (
-								<Spinner className="size-3.5" />
-							) : (
-								<Link2Off className="size-3.5" />
-							)}
-							{unpair.isPending ? "Unpairing…" : unpair.error ? "Retry unpair" : "Unpair"}
-						</Button>
-					</ConfirmAction>
+					<Tooltip>
+						<TooltipTrigger render={<span className="inline-flex size-8" />}>
+							<ConfirmAction
+								title={`Unpair ${chatName}?`}
+								description="Only this chat will be disconnected. Other chats and the connected channel stay active."
+								confirmLabel="Unpair chat"
+								destructive
+								onConfirm={() => unpair.mutateAsync(binding.id)}
+							>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+									disabled={unpair.isPending}
+									aria-label={`Unpair ${chatName}`}
+								>
+									{unpair.isPending ? (
+										<Spinner className="size-3.5" />
+									) : (
+										<Link2Off className="size-3.5" />
+									)}
+								</Button>
+							</ConfirmAction>
+						</TooltipTrigger>
+						<TooltipContent>Unpair {chatName}</TooltipContent>
+					</Tooltip>
 				)}
 			</div>
 		</div>

--- a/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
@@ -40,19 +40,17 @@ export function TelegramPairDialog({
 	onOpenChange,
 	accountId,
 	agentLinkId,
-	agentName,
 	channelName,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	agentLinkId: string;
-	agentName?: string;
 	channelName?: string;
 }) {
-	const pair = useCreatePairCode(accountId);
+	const pair = useCreatePairCode(accountId, { toastOnError: false });
 	const { copied, copy } = useCopyToClipboard({
-		success: "Telegram link copied",
+		success: false,
 		error: "Couldn't copy Telegram link",
 	});
 	const [result, setResult] = useState<TelegramPairResult | null>(null);
@@ -131,19 +129,28 @@ export function TelegramPairDialog({
 					code: result.code,
 				})
 			: null;
-	const context = [agentName, channelName].filter(Boolean).join(" · ");
+	const botIdentity = result?.bot_username
+		? `@${result.bot_username.replace(/^@/, "")}`
+		: channelName?.trim() || "this bot";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
+			<DialogContent
+				data-hosted="true"
+				data-v2="true"
+				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
+			>
 				<DialogHeader>
 					<DialogTitle>Pair Telegram</DialogTitle>
 					<DialogDescription>
-						Scan the QR code or open Telegram{context ? ` for ${context}` : ""}.
+						Scan the QR code or open Telegram to pair with {botIdentity}.
 					</DialogDescription>
 				</DialogHeader>
 
-				<div data-telegram-pair-dialog-body className="min-h-64">
+				<div
+					data-telegram-pair-dialog-body
+					className="min-h-0 overflow-y-auto overscroll-contain pr-1"
+				>
 					{generating ? (
 						<div className="flex min-h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
 							<Spinner className="size-5" />
@@ -159,7 +166,7 @@ export function TelegramPairDialog({
 						<div className="flex flex-col gap-4">
 							{validLink ? (
 								<div className="flex justify-center">
-									<div className="rounded-xl border bg-white p-3 shadow-sm">
+									<div className="rounded-md border bg-white p-3 shadow-sm">
 										<QRCodeSVG
 											value={validLink}
 											size={192}
@@ -187,12 +194,15 @@ export function TelegramPairDialog({
 							>
 								{pairCodeExpiryLabel(result.expires_at, nowMs)}
 							</p>
-							{!expired ? (
+							{!expired && result.bot_username ? (
 								<details className="rounded-md border bg-muted/20 px-3 py-2">
 									<summary className="cursor-pointer text-xs font-medium text-muted-foreground">
 										Pair a group manually
 									</summary>
-									<div className="mt-2">
+									<div className="mt-2 space-y-2">
+										<p className="text-sm">
+											Add @{result.bot_username.replace(/^@/, "")} to the group, then send:
+										</p>
 										<CopyInline value={result.pairing_command} label="pairing command" />
 									</div>
 								</details>

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -51,6 +51,7 @@ from app.models.session import AgentEnvironment
 from app.routes.channel_routers.shared import (
     _account_response,
     _binding_response,
+    _channel_visibility,
     _discord_binding_guild_id,
     _message_response,
 )
@@ -1607,7 +1608,7 @@ async def _channel_health_item(
         account_id=account.id,
         provider=account.provider,
         name=account.name,
-        visibility=account.visibility,
+        visibility=_channel_visibility(account),
         channel_status=account.status,
         health_status=health_status,
         reasons=reasons,

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -1078,8 +1078,22 @@ async def list_channel_bindings(
     db: AsyncSession = Depends(get_session),
 ) -> list[ChannelBindingResponse]:
     account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    binding_activity = (
+        select(
+            ChannelMessage.binding_id.label("binding_id"),
+            func.max(ChannelMessage.created_at).label("last_message_at"),
+        )
+        .where(
+            ChannelMessage.account_id == account.id,
+            ChannelMessage.user_id == auth.user_id,
+            ChannelMessage.binding_id.is_not(None),
+        )
+        .group_by(ChannelMessage.binding_id)
+        .subquery()
+    )
     result = await db.execute(
-        select(ChannelBinding)
+        select(ChannelBinding, binding_activity.c.last_message_at)
+        .outerjoin(binding_activity, binding_activity.c.binding_id == ChannelBinding.id)
         .where(
             ChannelBinding.account_id == account.id,
             ChannelBinding.user_id == auth.user_id,
@@ -1087,7 +1101,10 @@ async def list_channel_bindings(
         )
         .order_by(ChannelBinding.created_at.desc())
     )
-    return [_binding_response(binding) for binding in result.scalars().all()]
+    return [
+        _binding_response(binding, last_message_at=last_message_at)
+        for binding, last_message_at in result.all()
+    ]
 
 
 @router.delete("/{account_id}/bindings/{binding_id}")

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -1229,7 +1230,11 @@ def _whatsapp_graph_text(params: dict[str, Any]) -> str:
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="text.body is required")
 
 
-def _binding_response(binding: ChannelBinding) -> ChannelBindingResponse:
+def _binding_response(
+    binding: ChannelBinding,
+    *,
+    last_message_at: datetime | None = None,
+) -> ChannelBindingResponse:
     return ChannelBindingResponse(
         id=binding.id,
         account_id=binding.account_id,
@@ -1239,6 +1244,7 @@ def _binding_response(binding: ChannelBinding) -> ChannelBindingResponse:
         external_chat_name=binding.external_chat_name,
         status=binding.status,
         created_at=binding.created_at,
+        last_message_at=last_message_at,
     )
 
 

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -26,6 +26,8 @@ from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_VISIBILITY_PRIVATE,
+    CHANNEL_VISIBILITY_PUBLIC,
     ChannelAccount,
     ChannelBinding,
     ChannelBindingAlias,
@@ -90,20 +92,21 @@ _DISCORD_RESPONSE_HEADER_ALLOWLIST = (
 )
 
 
+def _channel_visibility(account: ChannelAccount) -> ChannelVisibility:
+    if account.visibility == CHANNEL_VISIBILITY_PRIVATE:
+        return "private"
+    if account.visibility == CHANNEL_VISIBILITY_PUBLIC:
+        return "public"
+    raise ValueError("invalid channel account visibility")
+
+
 def _account_response(account: ChannelAccount) -> ChannelAccountResponse:
-    visibility: ChannelVisibility
-    if account.visibility == "private":
-        visibility = "private"
-    elif account.visibility == "public":
-        visibility = "public"
-    else:
-        raise ValueError("invalid channel account visibility")
     return ChannelAccountResponse(
         id=account.id,
         provider=account.provider,
         name=account.name,
         status=account.status,
-        visibility=visibility,
+        visibility=_channel_visibility(account),
         has_provider_token=bool(account.encrypted_provider_token and account.provider_token_nonce),
         webhook_url=channel_webhook_url(account.id, account.provider),
         created_at=account.created_at,

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -192,6 +192,7 @@ class ChannelBindingResponse(BaseModel):
     external_chat_name: str | None
     status: str
     created_at: datetime
+    last_message_at: datetime | None = None
 
 
 class ChannelBindingDeleteResponse(BaseModel):

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11302,6 +11302,83 @@ async def test_telegram_webhook_pair_code_creates_binding(client: httpx.AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_channel_bindings_include_binding_scoped_last_message_at(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": "binding-activity"},
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    agent_link_id = UUID(created["agent_link_id"])
+    active_binding = ChannelBinding(
+        account_id=account_id,
+        bot_agent_link_id=agent_link_id,
+        user_id=seed_user.id,
+        external_chat_id="active-chat",
+        external_chat_type="private",
+        external_chat_name="Active chat",
+    )
+    quiet_binding = ChannelBinding(
+        account_id=account_id,
+        bot_agent_link_id=agent_link_id,
+        user_id=seed_user.id,
+        external_chat_id="quiet-chat",
+        external_chat_type="private",
+        external_chat_name="Quiet chat",
+    )
+    db_session.add_all([active_binding, quiet_binding])
+    await db_session.flush()
+    earlier = datetime(2026, 7, 30, 9, 0, tzinfo=UTC)
+    latest = datetime(2026, 7, 30, 10, 0, tzinfo=UTC)
+    db_session.add_all(
+        [
+            ChannelMessage(
+                account_id=account_id,
+                bot_agent_link_id=agent_link_id,
+                binding_id=active_binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=active_binding.external_chat_id,
+                text="earlier bound message",
+                created_at=earlier,
+            ),
+            ChannelMessage(
+                account_id=account_id,
+                bot_agent_link_id=agent_link_id,
+                binding_id=active_binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_OUTBOUND,
+                external_chat_id=active_binding.external_chat_id,
+                text="latest bound message",
+                created_at=latest,
+            ),
+            ChannelMessage(
+                account_id=account_id,
+                bot_agent_link_id=agent_link_id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=quiet_binding.external_chat_id,
+                text="newer unbound account message",
+                created_at=latest + timedelta(hours=1),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get(f"/v1/channels/{created['id']}/bindings")
+
+    assert response.status_code == 200, response.text
+    bindings = {item["external_chat_id"]: item for item in response.json()}
+    assert datetime.fromisoformat(bindings["active-chat"]["last_message_at"]) == latest
+    assert bindings["quiet-chat"]["last_message_at"] is None
+
+
+@pytest.mark.asyncio
 async def test_telegram_pairing_threads_share_one_chat_binding(client: httpx.AsyncClient):
     created = (
         await client.post(

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4124,6 +4124,8 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+            /** Last Message At */
+            last_message_at?: string | null;
         };
         /** ChannelBotPoolCapabilities */
         ChannelBotPoolCapabilities: {


### PR DESCRIPTION
## Summary
- tighten Discord and Telegram pairing flows with accurate QR, install, command, copy, expiry, retry, and mobile behavior
- align Pair, Unlink, and Unpair row actions; remove empty add-channel UI and cap long paired-chat titles
- move activity ownership to bindings via grouped last-message aggregation while preserving shared channel-health errors
- suppress duplicate pairing/copy toasts so inline errors and footer actions remain usable

## Verification
- apps/web typecheck
- focused and relevant Bun tests, including OSS boundary coverage
- Biome check and OSS build
- hosted stub Playwright on desktop and 320x568, including computed action styles, viewport bounds, toast behavior, long names, and screenshots
- backend Ruff, compileall, generated-client freshness, and focused PostgreSQL pytest

## Safety
- OSS code only; clawdi-hosted was inspected read-only and not modified
- no production, tenant, real provider, secrets, or deployment operations
- do not merge before review