### PR TITLE
Unify Console and Agent channel cards

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1118,11 +1118,13 @@ type HostedApiStubOptions = {
 	channelAccounts?: unknown[];
 	channelAgentLinks?: readonly unknown[];
 	channelBindings?: unknown[];
+	channelBindingResponses?: Record<string, StubResponse[]>;
 	channelBotPool?: unknown;
 	channelHealthItems?: unknown[];
 	linkAgentRequests?: Array<{ accountId: string; body: string }>;
 	linkAgentResponses?: StubResponse[];
 	unlinkAgentRequests?: string[];
+	unlinkAgentResponses?: StubResponse[];
 	onLinkAgent?: (response: unknown) => void;
 	createChannelRequests?: string[];
 	createChannelResponse?: unknown;
@@ -1948,7 +1950,12 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p.match(/\/agent-links\/[^/]+$/) && r.request().method() === "DELETE") {
 			options.unlinkAgentRequests?.push(p);
-			return fulfillJson(r, { unlinked: true });
+			const response = options.unlinkAgentResponses?.shift() ?? {
+				body: { unlinked: true },
+				status: 200,
+			};
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			return fulfillJson(r, response.body, response.status);
 		}
 		if (p.endsWith("/pair-codes") && r.request().method() === "POST") {
 			options.pairCodeRequests?.push(r.request().postData() ?? "");
@@ -1967,6 +1974,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				},
 				status: 200,
 			};
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
 			if (response.status < 400) {
 				const bindingId = p.slice(p.lastIndexOf("/") + 1);
 				const index = options.channelBindings?.findIndex(
@@ -1979,6 +1987,13 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p.endsWith("/bindings") && r.request().method() === "GET") {
 			const match = p.match(/^\/v1\/channels\/([^/]+)\/bindings$/);
 			const accountId = match?.[1] ? decodeURIComponent(match[1]) : null;
+			const response = accountId
+				? options.channelBindingResponses?.[accountId]?.shift()
+				: undefined;
+			if (response?.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
+			if (response) return fulfillJson(r, response.body, response.status);
 			return fulfillJson(
 				r,
 				accountId
@@ -5718,7 +5733,7 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 					effectiveAt: "2026-07-16T00:00:00Z",
 				}),
 				status: 200,
-				delayMs: 1_500,
+				delayMs: 3_000,
 			},
 		],
 		planQuoteRequests,
@@ -6955,6 +6970,7 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 		id: personalDiscordId,
 		provider: "discord",
 		name: "Personal Discord",
+		status: "error",
 		webhook_url: "https://cloud.example.test/channels/personal-discord",
 		created_at: "2026-07-27T12:27:00Z",
 	};
@@ -7062,6 +7078,16 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	await expect(sharedSection.getByText("Discord", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Link an agent", exact: true })).toHaveCount(0);
 	await expect(page.getByRole("dialog", { name: "Link an agent" })).toHaveCount(0);
+	const ownedCards = ownedSection.locator("[data-channel-account-id]");
+	const [firstOwnedBox, secondOwnedBox] = await Promise.all([
+		ownedCards.nth(0).boundingBox(),
+		ownedCards.nth(1).boundingBox(),
+	]);
+	expect(firstOwnedBox?.y).toBe(secondOwnedBox?.y);
+	expect(secondOwnedBox?.x ?? 0).toBeGreaterThan(firstOwnedBox?.x ?? 0);
+	expect(
+		Math.abs((firstOwnedBox?.height ?? 0) - (secondOwnedBox?.height ?? 0)),
+	).toBeLessThanOrEqual(1);
 	await page.screenshot({
 		path:
 			process.env.CHANNELS_HOME_SCREENSHOT_PATH ??
@@ -7087,16 +7113,22 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-desktop.png") });
 	await connectDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 
-	await page.setViewportSize({ width: 320, height: 844 });
+	await page.setViewportSize({ width: 320, height: 568 });
 	await expect(ownedSection.getByText("Personal Telegram", { exact: true })).toBeVisible();
 	await expect(sharedSection.getByText("Clawdi Community Bot", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /WhatsApp/ })).toHaveCount(0);
+	const [firstOwnedMobileBox, secondOwnedMobileBox] = await Promise.all([
+		ownedCards.nth(0).boundingBox(),
+		ownedCards.nth(1).boundingBox(),
+	]);
+	expect(firstOwnedMobileBox?.x).toBe(secondOwnedMobileBox?.x);
+	expect(secondOwnedMobileBox?.y ?? 0).toBeGreaterThan(firstOwnedMobileBox?.y ?? 0);
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
 	await page.screenshot({
 		path:
 			process.env.CHANNELS_HOME_MOBILE_SCREENSHOT_PATH ??
-			testInfo.outputPath("channels-owned-bot-inventory-320.png"),
-		fullPage: true,
+			testInfo.outputPath("channels-owned-bot-inventory-320x568.png"),
+		fullPage: false,
 	});
 	await page.getByRole("button", { name: "Connect bot", exact: true }).click();
 	connectDialog = page.getByRole("dialog", { name: "Connect a bot" });
@@ -7158,7 +7190,7 @@ test("Channels shared-only inventory stays primary without duplicate empty actio
 		fullPage: true,
 	});
 
-	await page.setViewportSize({ width: 320, height: 844 });
+	await page.setViewportSize({ width: 320, height: 568 });
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
 	await page.screenshot({
 		path: testInfo.outputPath("channels-shared-only-320.png"),
@@ -7335,7 +7367,88 @@ test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
 	expect(errors, `Agent connect default browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("Agent Channels uses compact task-ordered rows and the shared Telegram pair dialog", async ({
+test("Agent Channel cards keep paired-chat loading and error recovery inside the owner", async ({
+	page,
+}) => {
+	const agentId = missingProjectionEnvironmentId;
+	const accountId = "61111111-1111-4111-8111-111111111111";
+	const linkId = "62222222-2222-4222-8222-222222222222";
+	const bindingId = "63333333-3333-4333-8333-333333333333";
+	const account = {
+		id: accountId,
+		provider: "telegram",
+		name: "Recovery Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/recovery-telegram",
+		created_at: "2026-07-30T09:00:00Z",
+	};
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		cloudAgents: [
+			{
+				...sharedLegacyCloudAgent,
+				id: agentId,
+				default_name: "Recovery Agent",
+				display_name: "Recovery Agent",
+			},
+		],
+		channelAccounts: [account],
+		channelAgentLinks: [
+			{
+				id: linkId,
+				account_id: accountId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-07-30T09:05:00Z",
+				account,
+			},
+		],
+		channelBindingResponses: {
+			[accountId]: [
+				{ status: 400, delayMs: 500, body: { detail: "temporary binding read error" } },
+				{
+					status: 200,
+					body: [
+						{
+							id: bindingId,
+							account_id: accountId,
+							agent_link_id: linkId,
+							external_chat_id: "recovered-chat",
+							external_chat_type: "private",
+							external_chat_name: "Recovered chat",
+							status: "active",
+							created_at: "2026-07-30T09:10:00Z",
+							last_message_at: "2026-07-30T09:11:00Z",
+						},
+					],
+				},
+			],
+		},
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const owner = page.locator(`[data-agent-channel-group-id="${linkId}"]`);
+	const disclosure = owner.getByRole("button", { name: /Paired chats · 0/ });
+	await expect(disclosure).toHaveAttribute("aria-expanded", "false");
+	await disclosure.click();
+	await expect(disclosure).toHaveAttribute("aria-expanded", "true");
+	await expect(
+		owner.locator(`[data-agent-channel-chats-for="${linkId}"]`).getByRole("status"),
+	).toBeVisible();
+	const bindingError = owner.getByRole("alert");
+	await expect(bindingError).toContainText("Couldn’t load paired chats");
+	await bindingError.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect(owner.locator(`[data-channel-binding-id="${bindingId}"]`)).toContainText(
+		"Recovered chat",
+	);
+	await expect(bindingError).toHaveCount(0);
+});
+
+test("Agent Channels uses compact task-ordered cards and the shared Telegram pair dialog", async ({
 	page,
 	context,
 }, testInfo) => {
@@ -7356,6 +7469,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const polledBindingId = "79999999-9999-4999-8999-999999999999";
 	const discordServerBindingId = "7aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 	const discordDmBindingId = "7bbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+	const discordEscalationsBindingId = "7ccccccc-cccc-4ccc-8ccc-cccccccccccc";
+	const discordDesignBindingId = "7ddddddd-dddd-4ddd-8ddd-dddddddddddd";
+	const discordOpsBindingId = "7eeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+	const discordPartnersBindingId = "7fffffff-ffff-4fff-8fff-ffffffffffff";
 	const discordDmName = "Discord DM — urgent customer support escalation ".repeat(10).slice(0, 300);
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const successfulPairResponse = (id: string, code: string): StubResponse => ({
@@ -7458,6 +7575,50 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 			status: "active",
 			created_at: "2026-07-30T10:07:00Z",
 			last_message_at: null,
+		},
+		{
+			id: discordEscalationsBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-guild-2",
+			external_chat_type: "guild",
+			external_chat_name: "Customer Escalations",
+			status: "active",
+			created_at: "2026-07-30T10:08:00Z",
+			last_message_at: "2026-07-30T10:18:00Z",
+		},
+		{
+			id: discordDesignBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-guild-3",
+			external_chat_type: "guild",
+			external_chat_name: "Product Design",
+			status: "active",
+			created_at: "2026-07-30T10:09:00Z",
+			last_message_at: "2026-07-30T10:19:00Z",
+		},
+		{
+			id: discordOpsBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-guild-4",
+			external_chat_type: "guild",
+			external_chat_name: "Operations",
+			status: "active",
+			created_at: "2026-07-30T10:10:00Z",
+			last_message_at: "2026-07-30T10:20:00Z",
+		},
+		{
+			id: discordPartnersBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-guild-5",
+			external_chat_type: "guild",
+			external_chat_name: "Partner Support",
+			status: "active",
+			created_at: "2026-07-30T10:11:00Z",
+			last_message_at: "2026-07-30T10:21:00Z",
 		},
 	];
 	await stubHostedApi(page, {
@@ -7570,7 +7731,19 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 					warning: null,
 				},
 			},
+			{
+				status: 200,
+				delayMs: 1_500,
+				body: {
+					binding_id: discordServerBindingId,
+					unpaired: true,
+					notification_status: "not_applicable",
+					provider_cleanup_status: "succeeded",
+					warning: null,
+				},
+			},
 		],
+		unlinkAgentResponses: [{ status: 200, delayMs: 3_000, body: { unlinked: true } }],
 		pairCodeRequests,
 		pairCodeResponses: [
 			successfulPairResponse("agent-channel-pair-code", "AGENTPAIR123"),
@@ -7653,12 +7826,12 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		`/agents/${agentId}/channel-links?source=on-clawdi&d=${agentChannelsDeployment.id}`,
 	);
 	const connectedSection = page.locator("[data-agent-connected-channels]");
-	const addSection = page.locator("[data-agent-add-channel]");
+	const addChannelButton = page.locator("[data-agent-add-channel]");
+	const availableSection = page.locator("[data-agent-available-channels]");
 	await expect(connectedSection.getByText("Connected channels", { exact: true })).toBeVisible();
 	await expect(page.locator("[data-agent-paired-chats]")).toHaveCount(0);
-	await expect(page.getByText("Paired chats", { exact: true })).toHaveCount(0);
-	await expect(addSection).toHaveCount(0);
-	await expect(page.getByText("Add a channel", { exact: true })).toHaveCount(0);
+	await expect(addChannelButton).toBeVisible();
+	await expect(availableSection).toHaveCount(0);
 	await expect(
 		page.getByText("Link a bot to this Agent, then choose where it should answer.", {
 			exact: true,
@@ -7668,12 +7841,14 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	const discordGroup = page.locator(`[data-agent-channel-group-id="${discordLinkId}"]`);
 	const telegramRow = page.locator(`[data-agent-channel-link-id="${telegramLinkId}"]`);
 	const discordRow = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
+	const telegramHeader = telegramRow.locator("[data-channel-card-header]");
+	const discordHeader = discordRow.locator("[data-channel-card-header]");
 	await expect(telegramRow).toContainText("Support Telegram");
-	await expect(telegramRow).not.toContainText("Last activity");
-	await expect(telegramRow).not.toContainText("No activity yet");
-	await expect(telegramRow).not.toContainText("Checking activity");
+	await expect(telegramHeader).not.toContainText("Last activity");
+	await expect(telegramHeader).not.toContainText("No activity yet");
+	await expect(telegramHeader).not.toContainText("Checking activity");
 	await expect(discordRow).toContainText("Community Discord");
-	await expect(discordRow).not.toContainText("Last activity");
+	await expect(discordHeader).not.toContainText("Last activity");
 	const pairButton = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
 	await expect(pairButton).toBeVisible();
 	const discordPairButton = discordRow.getByRole("button", { name: "Pair Discord", exact: true });
@@ -7703,11 +7878,52 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	expect(telegramPairColors).toEqual(discordPairColors);
 	expect(telegramPairBox?.height).toBe(discordPairBox?.height);
 	expect(telegramPairBox?.height).toBe(32);
-	await expect(addSection.locator(`[data-add-channel-id="${readyId}"]`)).toHaveCount(0);
-	await expect(addSection.getByText("Use your own bot", { exact: true })).toHaveCount(0);
-	await expect(addSection.locator("details")).toHaveCount(0);
+	await expect(page.locator(`[data-add-channel-id="${readyId}"]`)).toHaveCount(0);
+	await addChannelButton.click();
+	const fullSlotDialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await expect(fullSlotDialog.getByRole("button", { name: /Telegram.*Connected/ })).toBeDisabled();
+	await expect(fullSlotDialog.getByRole("button", { name: /Discord.*Connected/ })).toBeDisabled();
+	await expect(
+		fullSlotDialog.getByText("This Agent already has one bot from each provider.", {
+			exact: false,
+		}),
+	).toBeVisible();
+	await expect(
+		fullSlotDialog.getByRole("button", { name: "Manage bots", exact: true }),
+	).toHaveAttribute("href", "/channels");
+	await fullSlotDialog.getByRole("button", { name: "Done", exact: true }).click();
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);
 	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
+	const telegramChatsDisclosure = telegramGroup.getByRole("button", {
+		name: "Paired chats · 1",
+		exact: true,
+	});
+	const discordChatsDisclosure = discordGroup.getByRole("button", {
+		name: "Paired chats · 6",
+		exact: true,
+	});
+	await expect(telegramChatsDisclosure).toHaveAttribute("aria-expanded", "false");
+	await expect(discordChatsDisclosure).toHaveAttribute("aria-expanded", "false");
+	await expect(currentBindingRow).toBeHidden();
+	await expect(
+		discordGroup.locator(`[data-channel-binding-id="${discordServerBindingId}"]`),
+	).toBeHidden();
+	const defaultTelegramBox = await telegramGroup.boundingBox();
+	const defaultDiscordBox = await discordGroup.boundingBox();
+	expect(defaultTelegramBox?.y).toBe(defaultDiscordBox?.y);
+	expect(defaultDiscordBox?.x ?? 0).toBeGreaterThan(defaultTelegramBox?.x ?? 0);
+	expect(
+		Math.abs((defaultTelegramBox?.height ?? 0) - (defaultDiscordBox?.height ?? 0)),
+	).toBeLessThanOrEqual(1);
+	await page.screenshot({
+		path:
+			process.env.AGENT_CHANNELS_PAGE_SCREENSHOT_PATH ??
+			testInfo.outputPath("agent-channels-compact-page.png"),
+		fullPage: true,
+	});
+
+	await telegramChatsDisclosure.click();
+	await expect(telegramChatsDisclosure).toHaveAttribute("aria-expanded", "true");
 	await expect(currentBindingRow).toContainText("Current Agent DM");
 	await expect(currentBindingRow).toContainText("Last activity");
 	const telegramUnpairButton = currentBindingRow.getByRole("button", {
@@ -7721,8 +7937,10 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		telegramUnpairButton.boundingBox(),
 	]);
 	expect(unlinkColors).toEqual(unpairColors);
-	expect({ width: unlinkBox?.width, height: unlinkBox?.height }).toEqual({ width: 32, height: 32 });
-	expect({ width: unpairBox?.width, height: unpairBox?.height }).toEqual({ width: 32, height: 32 });
+	expect(unlinkBox?.height).toBe(32);
+	expect(unpairBox?.height).toBe(32);
+	expect(unlinkBox?.width ?? 0).toBeGreaterThan(48);
+	expect(unpairBox?.width ?? 0).toBeGreaterThan(48);
 	await expect(
 		telegramGroup.locator(`[data-channel-binding-id="${currentBindingId}"]`),
 	).toBeVisible();
@@ -7730,29 +7948,45 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		`[data-channel-binding-id="${discordServerBindingId}"]`,
 	);
 	const discordDmRow = discordGroup.locator(`[data-channel-binding-id="${discordDmBindingId}"]`);
+	await discordChatsDisclosure.click();
+	await expect(discordChatsDisclosure).toHaveAttribute("aria-expanded", "true");
 	await expect(discordServerRow).toContainText("Server · Clawdi Community");
 	await expect(discordDmRow).toContainText(`Direct message · ${discordDmName}`);
 	await expect(discordServerRow).toContainText("Last activity");
 	await expect(discordDmRow).not.toContainText("Last activity");
 	await expect(discordDmRow).not.toContainText("No activity yet");
-	await expect(discordServerRow).toContainText("Run /bot_unpair in this server.");
-	await expect(discordDmRow).toContainText("Run /bot_unpair in this direct message.");
-	await expect(discordGroup.getByRole("button", { name: /Unpair/ })).toHaveCount(0);
+	await expect(discordServerRow).not.toContainText("Run /bot_unpair");
+	await expect(discordDmRow).not.toContainText("Run /bot_unpair");
+	await expect(
+		discordServerRow.getByRole("button", { name: "Unpair Server · Clawdi Community" }),
+	).toBeVisible();
+	const hiddenDiscordChat = discordGroup.locator(
+		`[data-channel-binding-id="${discordPartnersBindingId}"]`,
+	);
+	await expect(hiddenDiscordChat).toBeHidden();
+	const showMoreChats = discordGroup.getByRole("button", { name: "Show more", exact: true });
+	await expect(showMoreChats).toHaveAttribute("aria-expanded", "false");
+	await showMoreChats.click();
+	await expect(hiddenDiscordChat).toContainText("Server · Partner Support");
+	await expect(
+		telegramGroup.locator(`[data-channel-binding-id="${discordPartnersBindingId}"]`),
+	).toHaveCount(0);
+	const showLessChats = discordGroup.getByRole("button", { name: "Show less", exact: true });
+	await expect(showLessChats).toHaveAttribute("aria-expanded", "true");
+	await showLessChats.click();
+	await expect(hiddenDiscordChat).toBeHidden();
+	await discordGroup.getByRole("button", { name: "Show more", exact: true }).click();
+	await expect(hiddenDiscordChat).toBeVisible();
 	await expect(currentBindingRow).not.toContainText("Support Telegram");
 	await expect(page.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`)).toHaveCount(0);
 	await expect(page.getByText("Other Agent DM", { exact: true })).toHaveCount(0);
 	await expect(currentBindingRow).not.toContainText("101");
-	await expect(telegramRow).not.toContainText("Active");
-	await expect(telegramRow).not.toContainText("Healthy");
+	await expect(telegramHeader).not.toContainText("Active");
+	await expect(telegramHeader).not.toContainText("Healthy");
 	await expect(page.getByText("Waiting for channel activity", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Finish pairing", { exact: false })).toHaveCount(0);
-	const telegramBox = await telegramRow.boundingBox();
-	const discordBox = await discordRow.boundingBox();
-	expect(Math.abs((telegramBox?.height ?? 0) - (discordBox?.height ?? 0))).toBeLessThanOrEqual(1);
 	await page.screenshot({
-		path:
-			process.env.AGENT_CHANNELS_PAGE_SCREENSHOT_PATH ??
-			testInfo.outputPath("agent-channels-compact-page.png"),
+		path: testInfo.outputPath("agent-channels-expanded-page.png"),
 		fullPage: true,
 	});
 
@@ -8001,7 +8235,7 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	await expect(unpairConfirmation).toBeVisible();
 	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(2);
-	expect(deleteBindingRequests).toEqual([
+	expect(deleteBindingRequests.slice(0, 2)).toEqual([
 		`/v1/channels/${telegramId}/bindings/${currentBindingId}`,
 		`/v1/channels/${telegramId}/bindings/${currentBindingId}`,
 	]);
@@ -8012,7 +8246,27 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		channelBindings.some((binding) => isRecord(binding) && binding.id === otherAgentBindingId),
 	).toBe(true);
 
-	await page.setViewportSize({ width: 320, height: 844 });
+	const discordUnpairButton = discordServerRow.getByRole("button", {
+		name: "Unpair Server · Clawdi Community",
+		exact: true,
+	});
+	await discordUnpairButton.click();
+	const discordUnpairConfirmation = page.getByRole("alertdialog", {
+		name: "Unpair Server · Clawdi Community?",
+		exact: true,
+	});
+	const discordUnpairClick = discordUnpairConfirmation
+		.getByRole("button", { name: "Unpair chat", exact: true })
+		.click();
+	await expect.poll(() => deleteBindingRequests.length).toBe(3);
+	await expect(discordServerRow.getByText("Unpairing…", { exact: true })).toBeVisible();
+	expect(deleteBindingRequests[2]).toBe(
+		`/v1/channels/${discordId}/bindings/${discordServerBindingId}`,
+	);
+	await discordUnpairClick;
+	await expect(discordServerRow).toHaveCount(0);
+
+	await page.setViewportSize({ width: 320, height: 568 });
 	const mobileChatRow = page.locator(`[data-channel-binding-id="${polledBindingId}"]`);
 	const mobileChatTitle = mobileChatRow.getByText("Newly Paired DM", { exact: true });
 	const mobileUnpair = mobileChatRow.getByRole("button", {
@@ -8058,11 +8312,19 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 	);
 	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	await discordGroup.evaluate((element) => {
+		element.scrollIntoView({ block: "start" });
+		let scrollParent = element.parentElement;
+		while (scrollParent && scrollParent.scrollHeight <= scrollParent.clientHeight) {
+			scrollParent = scrollParent.parentElement;
+		}
+		if (scrollParent) scrollParent.scrollTop = Math.max(0, scrollParent.scrollTop - 72);
+	});
 	await page.screenshot({
 		path:
 			process.env.AGENT_CHANNELS_MOBILE_SCREENSHOT_PATH ??
-			testInfo.outputPath("agent-channels-320.png"),
-		fullPage: true,
+			testInfo.outputPath("agent-channels-320x568.png"),
+		fullPage: false,
 	});
 
 	await discordRow
@@ -8075,8 +8337,17 @@ test("Agent Channels uses compact task-ordered rows and the shared Telegram pair
 		name: "Unlink Community Discord?",
 		exact: true,
 	});
-	await unlinkConfirmation.getByRole("button", { name: "Unlink", exact: true }).click();
+	const unlinkClick = unlinkConfirmation
+		.getByRole("button", { name: "Unlink", exact: true })
+		.click();
 	await expect.poll(() => unlinkAgentRequests.length).toBe(1);
+	await expect(
+		discordRow.getByRole("button", {
+			name: "Unlinking Community Discord from Hosted agent",
+			exact: true,
+		}),
+	).toContainText("Unlinking…");
+	await unlinkClick;
 	expect(unlinkAgentRequests).toEqual([`/v1/channels/${discordId}/agent-links/${discordLinkId}`]);
 	const unexpectedErrors = errors.filter(
 		(error) =>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -6,6 +6,7 @@ import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
 	Check,
+	ChevronDown,
 	CircleCheck,
 	Copy,
 	Cpu,
@@ -82,7 +83,6 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -233,11 +233,11 @@ import {
 	type ChannelAccountSummary,
 	selectAgentPairedChats,
 } from "@/hosted/v2/channels/agent-channel-bindings.logic";
+import { CHANNEL_CARD_GRID_CLASS, ChannelCard } from "@/hosted/v2/channels/channel-card";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import {
 	agentProviderHasSingleLinkLimit,
-	availableBotProvidersForAgent,
 	channelProviderLinkingReady,
 	pairingActionLabel,
 } from "@/hosted/v2/channels/channel-linking.logic";
@@ -248,7 +248,6 @@ import {
 	HealthBadge,
 	isNormalChannelHealth,
 	isNormalChannelStatus,
-	ProviderChip,
 } from "@/hosted/v2/channels/channel-ui";
 import {
 	useAgentChannelLinks,
@@ -2304,13 +2303,9 @@ function ChannelsSyncState({
 
 type LinkableChannel = { id: string } & ChannelAccountSummary;
 
-const AGENT_CHANNEL_LIST_CLASS = "divide-y overflow-hidden rounded-lg border bg-card";
-const AGENT_CHANNEL_ROW_CLASS =
-	"grid min-h-16 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 px-4 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]";
-const AGENT_CHANNEL_ACTIONS_CLASS =
-	"col-span-2 flex min-w-0 items-center justify-end gap-2 sm:col-span-1 sm:col-start-3 sm:row-start-1";
 const AGENT_CHANNEL_PAIR_ACTIONS_CLASS =
-	"col-span-2 grid min-h-8 w-full grid-cols-[minmax(0,1fr)_2rem] items-center gap-2 sm:col-span-1 sm:col-start-3 sm:row-start-1 sm:w-48";
+	"flex min-h-8 w-full flex-wrap items-center justify-end gap-2 sm:w-auto";
+const INITIAL_PAIRED_CHAT_COUNT = 3;
 
 function ChannelsTab({
 	environmentId,
@@ -2441,11 +2436,13 @@ function ChannelsTab({
 				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
 		[botPool.data, linkedIds, linkedProviders, agentType],
 	);
-	const availableBotProviders = useMemo(
-		() => availableBotProvidersForAgent(environmentId, agentType, linkedProviders),
-		[agentType, environmentId, linkedProviders],
-	);
-	const showAddChannelSection = readyBots.length > 0 || availableBotProviders.length > 0;
+	const showAvailableBotsSection =
+		botPool.isLoading ||
+		Boolean(botPool.error) ||
+		channels.isLoading ||
+		Boolean(channels.error) ||
+		readyBots.length > 0 ||
+		ownedChannels.length > 0;
 	const healthByAccount = useMemo(
 		() => new Map((health.data?.items ?? []).map((item) => [item.account_id, item])),
 		[health.data],
@@ -2530,19 +2527,23 @@ function ChannelsTab({
 	return (
 		<div className="flex flex-col gap-6">
 			<section data-agent-connected-channels className="flex flex-col gap-3">
-				<SectionLabel count={visibleActiveLinks.length}>Connected channels</SectionLabel>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<SectionLabel count={visibleActiveLinks.length}>Connected channels</SectionLabel>
+					<Button
+						data-agent-add-channel
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={() => setConnectOpen(true)}
+					>
+						<Plus className="size-3.5" />
+						Add channel
+					</Button>
+				</div>
 				{linked.isLoading && visibleActiveLinks.length === 0 ? (
-					<div className={AGENT_CHANNEL_LIST_CLASS}>
-						<div className={AGENT_CHANNEL_ROW_CLASS}>
-							<Skeleton className="size-8 shrink-0 rounded-md" />
-							<div className="min-w-0 flex-1 space-y-2">
-								<Skeleton className="h-4 w-40" />
-								<Skeleton className="h-3 w-64 max-w-full" />
-							</div>
-							<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
-								<Skeleton className="h-8 w-28 rounded-md" />
-							</div>
-						</div>
+					<div className={CHANNEL_CARD_GRID_CLASS}>
+						<EntityCardSkeleton actions />
+						<EntityCardSkeleton actions />
 					</div>
 				) : linked.error && visibleActiveLinks.length === 0 ? (
 					<ApiErrorPanel
@@ -2554,10 +2555,10 @@ function ChannelsTab({
 					<EmptyState
 						variant="inset"
 						title="No connected channels"
-						description="Add a channel below to get started."
+						description="Add a bot, then choose where this Agent should answer."
 					/>
 				) : (
-					<div className={AGENT_CHANNEL_LIST_CLASS}>
+					<div className={CHANNEL_CARD_GRID_CLASS}>
 						{visibleActiveLinks.map((link) => {
 							const bindingQuery = bindingQueries[activeAccountIds.indexOf(link.account_id)];
 							return (
@@ -2565,7 +2566,7 @@ function ChannelsTab({
 									key={link.id}
 									link={link}
 									pairedChats={pairedChatsByLinkId.get(link.id) ?? []}
-									bindingsLoading={Boolean(bindingQuery?.isLoading)}
+									bindingsLoading={Boolean(bindingQuery?.isFetching)}
 									bindingsError={Boolean(bindingQuery?.error)}
 									onBindingsRetry={() => void bindingQuery?.refetch()}
 									fallbackAccount={accountSummaries.get(link.account_id)}
@@ -2594,32 +2595,34 @@ function ChannelsTab({
 				) : null}
 			</section>
 
-			{showAddChannelSection ? (
-				<section data-agent-add-channel className="flex flex-col gap-3 border-t pt-6">
+			{showAvailableBotsSection ? (
+				<section data-agent-available-channels className="flex flex-col gap-3 border-t pt-6">
 					<div className="space-y-1">
-						<SectionLabel>Add a channel</SectionLabel>
+						<SectionLabel>Available bots</SectionLabel>
 						<p className="px-0.5 text-sm text-muted-foreground">
 							Link a bot to this Agent, then choose where it should answer.
 						</p>
 					</div>
-					{botPool.isLoading ? (
-						<div className={AGENT_CHANNEL_LIST_CLASS}>
-							<div className={AGENT_CHANNEL_ROW_CLASS}>
-								<Skeleton className="size-8 shrink-0 rounded-md" />
-								<Skeleton className="h-4 min-w-0 flex-1 max-w-48" />
-								<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
-									<Skeleton className="h-8 w-16 rounded-md" />
-								</div>
-							</div>
-						</div>
-					) : botPool.error ? (
+					{botPool.error ? (
 						<ApiErrorPanel
 							error={botPool.error}
 							onRetry={() => botPool.refetch()}
-							title="Couldn't load ready-to-go bots"
+							title="Couldn't load shared bots"
 						/>
-					) : readyBots.length > 0 ? (
-						<div className={AGENT_CHANNEL_LIST_CLASS}>
+					) : null}
+					{channels.error ? (
+						<ApiErrorPanel
+							error={channels.error}
+							onRetry={() => channels.refetch()}
+							title="Couldn't load your bots"
+						/>
+					) : null}
+					{botPool.isLoading || channels.isLoading ? (
+						<div className={CHANNEL_CARD_GRID_CLASS}>
+							<EntityCardSkeleton actions />
+						</div>
+					) : readyBots.length > 0 || ownedChannels.length > 0 ? (
+						<div className={CHANNEL_CARD_GRID_CLASS}>
 							{readyBots.map((bot) => (
 								<AddChannelRow
 									key={bot.id}
@@ -2630,56 +2633,18 @@ function ChannelsTab({
 									onLink={() => void submitLink(bot.id)}
 								/>
 							))}
+							{ownedChannels.map((channel) => (
+								<AddChannelRow
+									key={channel.id}
+									channel={channel}
+									kind="Your bot"
+									linking={linkingAccountId === channel.id}
+									disabled={linkingAccountId !== null}
+									onLink={() => void submitLink(channel.id)}
+									secondary
+								/>
+							))}
 						</div>
-					) : null}
-
-					{availableBotProviders.length > 0 ? (
-						<details className="group border-t pt-4">
-							<summary className="cursor-pointer text-sm font-medium">Use your own bot</summary>
-							<div className="mt-3 space-y-3">
-								{channels.isLoading ? (
-									<Skeleton className="h-16 w-full rounded-lg" />
-								) : channels.error ? (
-									<ApiErrorPanel
-										error={channels.error}
-										onRetry={() => channels.refetch()}
-										title="Couldn't load your bots"
-									/>
-								) : ownedChannels.length > 0 ? (
-									<div className={AGENT_CHANNEL_LIST_CLASS}>
-										{ownedChannels.map((channel) => (
-											<AddChannelRow
-												key={channel.id}
-												channel={channel}
-												kind={undefined}
-												linking={linkingAccountId === channel.id}
-												disabled={linkingAccountId !== null}
-												onLink={() => void submitLink(channel.id)}
-												secondary
-											/>
-										))}
-									</div>
-								) : (
-									<Button size="sm" onClick={() => setConnectOpen(true)}>
-										<Plus className="size-3.5" />
-										Connect a bot
-									</Button>
-								)}
-								{ownedChannels.length > 0 ? (
-									<div className="flex flex-wrap gap-2">
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											onClick={() => setConnectOpen(true)}
-										>
-											<Plus className="size-3.5" />
-											Connect a bot
-										</Button>
-									</div>
-								) : null}
-							</div>
-						</details>
 					) : null}
 				</section>
 			) : null}
@@ -2757,8 +2722,13 @@ function ConnectedChannelGroup({
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	agentName: string;
 }) {
-	const showChats = pairedChats.length > 0 || bindingsLoading || bindingsError;
 	const provider = link.account?.provider ?? fallbackAccount?.provider ?? "";
+	const [chatsOpen, setChatsOpen] = useState(false);
+	const [showAllChats, setShowAllChats] = useState(false);
+	const visibleChats = showAllChats ? pairedChats : pairedChats.slice(0, INITIAL_PAIRED_CHAT_COUNT);
+	const chatsId = `paired-chats-${link.id}`;
+	const chatsListId = `${chatsId}-list`;
+	const pairedChatsLabel = `Paired chats · ${pairedChats.length}`;
 
 	return (
 		<div data-agent-channel-group-id={link.id} className="min-w-0">
@@ -2769,42 +2739,99 @@ function ConnectedChannelGroup({
 				agentName={agentName}
 				unlinking={unlinking}
 				onUnlink={onUnlink}
-			/>
-			{showChats ? (
-				<div data-agent-channel-chats-for={link.id} className="divide-y border-t px-4">
-					{pairedChats.map((item) => (
-						<PairedChatRow
-							key={item.binding.id}
-							accountId={item.accountId}
-							binding={item.binding}
-							provider={item.provider}
+			>
+				<div>
+					<button
+						type="button"
+						className="flex min-h-10 w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+						aria-expanded={chatsOpen}
+						aria-controls={chatsId}
+						onClick={() => {
+							setChatsOpen(!chatsOpen);
+							if (chatsOpen) setShowAllChats(false);
+						}}
+					>
+						<span className="min-w-0 flex-1">{pairedChatsLabel}</span>
+						{bindingsLoading ? (
+							<span role="status" className="inline-flex shrink-0">
+								<Spinner className="size-3.5" />
+								<span className="sr-only">Loading paired chats</span>
+							</span>
+						) : null}
+						{bindingsError ? (
+							<span className="inline-flex shrink-0 text-destructive">
+								<AlertCircle className="size-3.5" />
+								<span className="sr-only">Couldn’t load paired chats</span>
+							</span>
+						) : null}
+						<ChevronDown
+							className={`size-4 shrink-0 transition-transform ${chatsOpen ? "rotate-180" : ""}`}
+							aria-hidden="true"
 						/>
-					))}
-					{bindingsLoading && pairedChats.length === 0 ? (
-						<div className="ml-4 flex min-h-12 items-center gap-3 border-l-2 border-muted py-2 pl-3">
-							<Skeleton className="size-8 shrink-0 rounded-md" />
-							<Skeleton className="h-4 w-40 max-w-full" />
+					</button>
+					<div
+						data-agent-channel-chats-for={link.id}
+						id={chatsId}
+						hidden={!chatsOpen}
+						className="border-t px-3 py-2"
+					>
+						<div id={chatsListId} className="divide-y">
+							{visibleChats.map((item) => (
+								<PairedChatRow
+									key={item.binding.id}
+									accountId={item.accountId}
+									binding={item.binding}
+									provider={item.provider}
+								/>
+							))}
+							{bindingsLoading && pairedChats.length === 0 ? (
+								<div role="status" className="flex min-h-12 items-center gap-3 px-1 py-2">
+									<Skeleton className="size-8 shrink-0 rounded-md" />
+									<div className="space-y-1.5">
+										<Skeleton className="h-4 w-40 max-w-full" />
+										<span className="sr-only">Loading paired chats</span>
+									</div>
+								</div>
+							) : null}
+							{!bindingsLoading && !bindingsError && pairedChats.length === 0 ? (
+								<p className="px-1 py-2 text-sm text-muted-foreground">No paired chats yet.</p>
+							) : null}
 						</div>
-					) : null}
-					{bindingsError ? (
-						<div
-							role="alert"
-							className="ml-4 flex min-h-12 flex-wrap items-center gap-2 border-l-2 border-muted py-2 pl-3"
-						>
-							<AlertCircle className="size-4 shrink-0 text-destructive" />
-							<p className="min-w-0 flex-1 text-sm font-medium">
-								{provider === "discord"
-									? "Couldn’t load paired servers or direct messages"
-									: "Couldn’t load paired chats"}
-							</p>
-							<Button type="button" variant="outline" size="sm" onClick={onBindingsRetry}>
-								<RefreshCw className="size-3.5" />
-								Retry
-							</Button>
-						</div>
-					) : null}
+						{bindingsError ? (
+							<div
+								role="alert"
+								className="mt-1 flex min-h-12 flex-wrap items-center gap-2 rounded-md bg-destructive/5 px-3 py-2"
+							>
+								<AlertCircle className="size-4 shrink-0 text-destructive" />
+								<p className="min-w-0 flex-1 text-sm font-medium">
+									{provider === "discord"
+										? "Couldn’t load paired servers or direct messages"
+										: "Couldn’t load paired chats"}
+								</p>
+								<Button type="button" variant="outline" size="sm" onClick={onBindingsRetry}>
+									<RefreshCw className="size-3.5" />
+									Retry
+								</Button>
+							</div>
+						) : null}
+						{pairedChats.length > INITIAL_PAIRED_CHAT_COUNT ? (
+							<div className="border-t px-1 pt-2">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-8 px-2"
+									aria-expanded={showAllChats}
+									aria-controls={chatsListId}
+									onClick={() => setShowAllChats((showAll) => !showAll)}
+								>
+									{showAllChats ? "Show less" : "Show more"}
+								</Button>
+							</div>
+						) : null}
+					</div>
 				</div>
-			) : null}
+			</LinkedChannelRow>
 		</div>
 	);
 }
@@ -2825,24 +2852,24 @@ function AddChannelRow({
 	secondary?: boolean;
 }) {
 	return (
-		<div data-add-channel-id={channel.id} className={AGENT_CHANNEL_ROW_CLASS}>
-			<ProviderChip provider={channel.provider} size="sm" />
-			<div className="min-w-0">
-				<p className="truncate text-sm font-medium">{channel.name}</p>
-				{kind ? <p className="truncate text-xs text-muted-foreground">{kind}</p> : null}
-			</div>
-			<div className={AGENT_CHANNEL_ACTIONS_CLASS}>
-				<Button
-					type="button"
-					size="sm"
-					variant={secondary ? "outline" : "default"}
-					disabled={disabled}
-					onClick={onLink}
-				>
-					{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-					{linking ? "Linking…" : "Link"}
-				</Button>
-			</div>
+		<div data-add-channel-id={channel.id} className="min-w-0">
+			<ChannelCard
+				provider={channel.provider}
+				title={channel.name}
+				state={kind}
+				actions={
+					<Button
+						type="button"
+						size="sm"
+						variant={secondary ? "outline" : "default"}
+						disabled={disabled}
+						onClick={onLink}
+					>
+						{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+						{linking ? "Linking…" : "Link"}
+					</Button>
+				}
+			/>
 		</div>
 	);
 }
@@ -2860,6 +2887,7 @@ function LinkedChannelRow({
 	fallbackAccount,
 	health,
 	agentName,
+	children,
 }: {
 	link: AgentChannelLink;
 	onUnlink: () => void;
@@ -2867,6 +2895,7 @@ function LinkedChannelRow({
 	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	agentName: string;
+	children?: React.ReactNode;
 }) {
 	const pair = useCreatePairCode(link.account_id);
 	const [code, setCode] = useState<AgentPairCodeResult | null>(null);
@@ -2906,77 +2935,89 @@ function LinkedChannelRow({
 			setCreatingPairCode(false);
 		}
 	}
+	const exceptionalState = [
+		isNormalChannelStatus(link.status) ? null : (
+			<ChannelStatusBadge key="status" status={link.status} />
+		),
+		health && !isNormalChannelHealth(health.health_status) ? (
+			<HealthBadge key="health" status={health.health_status} />
+		) : null,
+		provider !== "telegram" && !isDiscord && pair.error ? (
+			<span key="pair-error" className="font-medium text-destructive">
+				Pair failed · Try again
+			</span>
+		) : null,
+		code && provider !== "telegram" && !isDiscord ? (
+			<span key="pair-code" className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+				<CopyInline value={code.pairing_command} label="pairing command" />
+				<span className="text-muted-foreground">{pairCodeExpiryLabel(code.expires_at, nowMs)}</span>
+			</span>
+		) : null,
+	];
 	return (
-		<div data-agent-channel-link-id={link.id} className={AGENT_CHANNEL_ROW_CLASS}>
-			<ProviderChip provider={provider} size="sm" />
-			<div className="min-w-0">
-				<p className="truncate text-sm font-medium">{name}</p>
-				<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-					{isNormalChannelStatus(link.status) ? null : <ChannelStatusBadge status={link.status} />}
-					{health && !isNormalChannelHealth(health.health_status) ? (
-						<HealthBadge status={health.health_status} />
-					) : null}
-				</div>
-				{provider !== "telegram" && !isDiscord && pair.error ? (
-					<p className="mt-1 text-xs font-medium text-destructive">Pair failed · Try again</p>
-				) : null}
-				{code && provider !== "telegram" && !isDiscord ? (
-					<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-						<CopyInline value={code.pairing_command} label="pairing command" />
-						<span className="text-muted-foreground">
-							{pairCodeExpiryLabel(code.expires_at, nowMs)}
-						</span>
-					</div>
-				) : null}
-			</div>
-			<div className={AGENT_CHANNEL_PAIR_ACTIONS_CLASS}>
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					className="w-full"
-					disabled={provider !== "telegram" && creatingPairCode}
-					onClick={() => {
-						if (provider === "telegram") setTelegramPairOpen(true);
-						else if (isDiscord) setDiscordPairOpen(true);
-						else void createPairCode();
-					}}
-				>
-					{creatingPairCode ? <Spinner className="size-3.5" /> : <QrCode className="size-3.5" />}
-					{creatingPairCode
-						? "Generating…"
-						: provider === "telegram"
-							? "Pair Telegram"
-							: pair.error
-								? "Retry pairing"
-								: pairingActionLabel(provider)}
-				</Button>
-				<Tooltip>
-					<TooltipTrigger render={<span className="inline-flex size-8" />}>
-						<ConfirmAction
-							title={`Unlink ${name}?`}
-							description={<p>{agentName} will stop answering through this bot.</p>}
-							confirmLabel="Unlink"
-							destructive
-							onConfirm={onUnlink}
-						>
+		<>
+			<div data-agent-channel-link-id={link.id} className="min-w-0">
+				<ChannelCard
+					provider={provider}
+					title={name}
+					state={exceptionalState}
+					actions={
+						<div className={AGENT_CHANNEL_PAIR_ACTIONS_CLASS}>
 							<Button
-								variant="ghost"
-								size="icon-sm"
-								className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
-								disabled={unlinking}
-								aria-label={`Unlink ${name} from ${agentName}`}
+								type="button"
+								variant="outline"
+								size="sm"
+								className="min-w-0 flex-1 sm:flex-none"
+								disabled={provider !== "telegram" && creatingPairCode}
+								onClick={() => {
+									if (provider === "telegram") setTelegramPairOpen(true);
+									else if (isDiscord) setDiscordPairOpen(true);
+									else void createPairCode();
+								}}
 							>
-								{unlinking ? <Spinner className="size-3.5" /> : <Link2Off className="size-3.5" />}
+								{creatingPairCode ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<QrCode className="size-3.5" />
+								)}
+								{creatingPairCode
+									? "Generating…"
+									: provider === "telegram"
+										? "Pair Telegram"
+										: pair.error
+											? "Retry pairing"
+											: pairingActionLabel(provider)}
 							</Button>
-						</ConfirmAction>
-					</TooltipTrigger>
-					<TooltipContent>
-						Unlink {name} from {agentName}
-					</TooltipContent>
-				</Tooltip>
+							<ConfirmAction
+								title={`Unlink ${name}?`}
+								description={<p>{agentName} will stop answering through this bot.</p>}
+								confirmLabel="Unlink"
+								destructive
+								onConfirm={onUnlink}
+							>
+								<Button
+									variant="ghost"
+									size="sm"
+									className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+									disabled={unlinking}
+									aria-label={`${unlinking ? "Unlinking" : "Unlink"} ${name} from ${agentName}`}
+								>
+									{unlinking ? (
+										<>
+											<Spinner className="size-3.5" />
+											Unlinking…
+										</>
+									) : (
+										"Unlink"
+									)}
+								</Button>
+							</ConfirmAction>
+						</div>
+					}
+				>
+					{children}
+				</ChannelCard>
 			</div>
-
 			{provider === "telegram" ? (
 				<TelegramPairDialog
 					open={telegramPairOpen}
@@ -2995,7 +3036,7 @@ function LinkedChannelRow({
 					channelName={name}
 				/>
 			) : null}
-		</div>
+		</>
 	);
 }
 

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChannelCard } from "./channel-card";
+
+function source(relativePath: string): string {
+	return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}
+
+const card = source("./channel-card.tsx");
+const consoleChannels = source("./channels-page.tsx");
+const agentChannels = source("../../agents/hosted-agent-detail.tsx");
+
+describe("shared Channel card", () => {
+	test("renders the hosted v2 Entity Card shell with aligned headers and composable content", () => {
+		const markup = renderToStaticMarkup(
+			createElement(ChannelCard, {
+				provider: "telegram",
+				title: "Support Telegram",
+				actions: createElement("button", { type: "button" }, "Pair"),
+				children: createElement("p", null, "Paired chats · 2"),
+			}),
+		);
+
+		expect(markup).toContain('data-hosted="true"');
+		expect(markup).toContain('data-v2="true"');
+		expect(markup).toContain("data-channel-card-header");
+		expect(markup).toContain("min-h-20");
+		expect(markup).toContain("data-channel-card-actions");
+		expect(markup).toContain(">Support Telegram<");
+		expect(markup).toContain(">Pair<");
+		expect(markup).toContain("Paired chats · 2");
+
+		expect(card).toContain("ENTITY_CARD_BASE");
+		expect(card).toContain("ENTITY_GRID_CLASS");
+		expect(card).toContain('"items-start xl:grid-cols-2"');
+		expect(card).not.toContain("h-full");
+	});
+
+	test("is reused by Console inventory and Agent channel cards", () => {
+		expect(consoleChannels).toContain("ChannelCard as SharedChannelCard");
+		expect(consoleChannels).toContain("CHANNEL_CARD_GRID_CLASS");
+		expect(consoleChannels).toContain("<SharedChannelCard");
+		expect(agentChannels).toContain('from "@/hosted/v2/channels/channel-card"');
+		expect(agentChannels).toContain("<ChannelCard");
+		expect(agentChannels).toContain("CHANNEL_CARD_GRID_CLASS");
+	});
+
+	test("keeps relationship actions off Console Channels", () => {
+		expect(consoleChannels).not.toContain("Pair Telegram");
+		expect(consoleChannels).not.toContain("Pair Discord");
+		expect(consoleChannels).not.toContain("Unpair");
+		expect(consoleChannels).not.toContain("Unlink");
+		expect(consoleChannels).toContain('to="/channels/$id"');
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-card.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-card.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityHeader } from "@/components/entity-card";
+import { ProviderChip } from "@/hosted/v2/channels/channel-ui";
+import { cn } from "@/lib/utils";
+
+/** Channel cards stay content-height so a long chat list never stretches its neighbour. */
+export const CHANNEL_CARD_GRID_CLASS = cn(ENTITY_GRID_CLASS, "items-start xl:grid-cols-2");
+
+/**
+ * Shared visual shell for bot inventory and Agent channel cards. Provider
+ * identity and responsive header layout live here; navigation, mutations, and
+ * nested chat content remain composed by each surface.
+ */
+export function ChannelCard({
+	provider,
+	title,
+	state,
+	actions,
+	children,
+	className,
+}: {
+	provider: string;
+	title: ReactNode;
+	state?: ReactNode | ReactNode[];
+	actions?: ReactNode;
+	children?: ReactNode;
+	className?: string;
+}) {
+	return (
+		<article
+			data-hosted="true"
+			data-v2="true"
+			className={cn(ENTITY_CARD_BASE, "overflow-hidden p-0", className)}
+		>
+			<div
+				data-channel-card-header
+				className="grid min-h-20 min-w-0 gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+			>
+				<EntityHeader
+					align="start"
+					icon={<ProviderChip provider={provider} />}
+					title={title}
+					meta={state}
+				/>
+				{actions ? (
+					<div data-channel-card-actions className="flex min-w-0 items-center justify-end gap-2">
+						{actions}
+					</div>
+				) : null}
+			</div>
+			{children ? <div className="border-t">{children}</div> : null}
+		</article>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -13,10 +13,12 @@ const channelsTab = agentChannels.slice(
 );
 
 describe("hosted-agent channel finish line", () => {
-	test("keeps diagnosis compact inside a shared connected-channel row", () => {
+	test("keeps diagnosis compact inside shared content-height channel cards", () => {
 		expect(channelsTab).toContain("const health = useChannelHealth()");
-		expect(channelsTab).toContain("AGENT_CHANNEL_LIST_CLASS");
-		expect(channelsTab).toContain("AGENT_CHANNEL_ROW_CLASS");
+		expect(channelsTab).toContain("CHANNEL_CARD_GRID_CLASS");
+		expect(channelsTab).toContain("<ChannelCard");
+		expect(channelsTab).not.toContain("AGENT_CHANNEL_LIST_CLASS");
+		expect(channelsTab).not.toContain("AGENT_CHANNEL_ROW_CLASS");
 		expect(channelsTab).not.toContain("channelActivityAfterLink(");
 		expect(channelsTab).not.toContain("Last activity");
 		expect(channelsTab).not.toContain("No activity yet");
@@ -24,7 +26,7 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).toContain("health.error && visibleActiveLinks.length > 0");
 		expect(channelsTab).toContain('title="Couldn\'t refresh channel health"');
 		expect(channelsTab).toContain("onRetry={() => void health.refetch()}");
-		expect(channelsTab).toContain("<ChannelStatusBadge status={link.status} />");
+		expect(channelsTab).toContain('<ChannelStatusBadge key="status" status={link.status} />');
 		expect(channelsTab).toContain("<HealthBadge");
 		expect(channelsTab).not.toContain("Waiting for channel activity");
 		expect(channelsTab).not.toContain("This page checks automatically every 20 seconds");
@@ -43,41 +45,50 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).not.toContain("source revision");
 	});
 
-	test("nests paired chats under their channel before channel addition", () => {
+	test("keeps Add persistent and nests progressively disclosed chats inside their bot", () => {
 		const connectedIndex = channelsTab.indexOf("<section data-agent-connected-channels");
-		const addIndex = channelsTab.indexOf("<section data-agent-add-channel");
+		const addIndex = channelsTab.indexOf("data-agent-add-channel");
+		const availableIndex = channelsTab.indexOf("<section data-agent-available-channels");
 		const readyBotIndex = channelsTab.indexOf('kind="Shared bot"');
-		const advancedIndex = channelsTab.indexOf("Use your own bot");
 		expect(connectedIndex).toBeGreaterThanOrEqual(0);
 		expect(addIndex).toBeGreaterThan(connectedIndex);
-		expect(readyBotIndex).toBeGreaterThan(addIndex);
-		expect(advancedIndex).toBeGreaterThan(readyBotIndex);
+		expect(availableIndex).toBeGreaterThan(addIndex);
+		expect(readyBotIndex).toBeGreaterThan(availableIndex);
 		expect(channelsTab).toContain("data-agent-connected-channels");
 		expect(channelsTab).toContain("data-agent-channel-group-id={link.id}");
 		expect(channelsTab).toContain("data-agent-channel-chats-for={link.id}");
 		expect(channelsTab).not.toContain("data-agent-paired-chats");
-		expect(channelsTab).not.toContain(">Paired chats<");
+		expect(channelsTab).toContain("Paired chats");
 		expect(channelsTab).not.toContain("No chats paired");
 		expect(channelsTab).toContain("data-agent-add-channel");
-		expect(channelsTab).toContain("const availableBotProviders = useMemo(");
-		expect(channelsTab).toContain("const showAddChannelSection =");
-		expect(channelsTab).toContain("{showAddChannelSection ? (");
-		expect(channelsTab).toContain("availableBotProviders.length > 0");
-		const addSectionGate = channelsTab.slice(
-			channelsTab.indexOf("const showAddChannelSection ="),
+		expect(channelsTab).toContain("const showAvailableBotsSection =");
+		expect(channelsTab).toContain("{showAvailableBotsSection ? (");
+		const availableSectionGate = channelsTab.slice(
+			channelsTab.indexOf("const showAvailableBotsSection ="),
 			channelsTab.indexOf("const healthByAccount"),
 		);
-		expect(addSectionGate).toContain("readyBots.length > 0");
-		expect(addSectionGate).not.toContain("botPool.isLoading");
-		expect(addSectionGate).not.toContain("botPool.error");
+		expect(availableSectionGate).toContain("readyBots.length > 0");
+		expect(availableSectionGate).toContain("botPool.isLoading");
+		expect(availableSectionGate).toContain("botPool.error");
+		expect(addIndex).toBeLessThan(channelsTab.indexOf("{showAvailableBotsSection ? ("));
 		expect(channelsTab).toContain("data-add-channel-id");
 		expect(channelsTab).not.toContain("No bot connected yet");
-		expect(channelsTab).toContain("Connect a bot");
 		expect(channelsTab).not.toContain("View all channels");
 		expect(channelsTab).not.toContain("setAdvancedOpen");
-		expect(channelsTab).toContain('<details className="group border-t pt-4">');
+		expect(channelsTab).not.toContain('<details className="group border-t pt-4">');
 		expect(channelsTab).not.toContain("Fastest: use a ready-to-go bot");
 		expect(channelsTab).not.toContain("Use your own bot (advanced)");
+		expect(agentChannels).toContain("INITIAL_PAIRED_CHAT_COUNT = 3");
+		expect(channelsTab).toContain("pairedChats.slice(0, INITIAL_PAIRED_CHAT_COUNT)");
+		expect(channelsTab).toContain("const pairedChatsLabel =");
+		expect(channelsTab).toContain("Paired chats ·");
+		expect(channelsTab).toContain("aria-expanded={chatsOpen}");
+		expect(channelsTab).toContain("aria-controls={chatsId}");
+		expect(channelsTab).toContain("hidden={!chatsOpen}");
+		expect(channelsTab).toContain('showAllChats ? "Show less" : "Show more"');
+		expect(channelsTab).toContain("Show less");
+		expect(channelsTab).toContain("onBindingsRetry");
+		expect(channelsTab).toContain("Loading paired chats");
 	});
 
 	test("replaces setup jargon with a bounded automatic wait and exits", () => {

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -46,7 +46,10 @@ describe("channel mutation feedback", () => {
 		expectFeedbackBeforeRequest(pairDialog, "setGenerating(true)", "await pair.execute");
 		expect(detail).toContain("unlinking={unlinkingLinkIds.has(link.id)}");
 		expect(detail).toContain('linking ? "Linking…" : "Link"');
-		expect(detail).toContain('creatingPairCode ? <Spinner className="size-3.5" />');
+		expect(detail).toContain('unlinking ? "Unlinking" : "Unlink"');
+		expect(detail).toContain("Unlinking…");
+		expect(detail).toContain("creatingPairCode ? (");
+		expect(detail).toContain('<Spinner className="size-3.5" />');
 		expect(detail).toContain('"Generating…"');
 		expect(detail).toContain('"Pair Telegram"');
 		expect(detail).toContain("pairingActionLabel(provider)");
@@ -63,7 +66,8 @@ describe("channel mutation feedback", () => {
 		expect(pairedChatRow).toContain("disabled={unpair.isPending}");
 		expect(pairedChatRow).toContain("unpair.isPending ? (");
 		expect(pairedChatRow).toContain("Couldn&apos;t unpair · Try again");
-		expect(pairedChatRow).not.toContain('"Unpairing…"');
+		expect(pairedChatRow).toContain("Unpairing…");
+		expect(pairedChatRow).toContain('"Unpair"');
 		expect(pairedChatRow).not.toContain('"Retry unpair"');
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -53,10 +53,12 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("agentProviderHasSingleLinkLimit");
 		expect(agentDetail).toContain("linkedProviders={linkedProviders}");
-		expect(connectDialog).toContain("Already linked");
+		expect(connectDialog).toContain("Connected");
 		expect(connectDialog).toContain("availableBotProvidersForAgent");
-		expect(connectDialog).toContain("This Agent already has a Telegram and Discord bot.");
-		expect(agentDetail).toContain('<details className="group border-t pt-4">');
+		expect(connectDialog).toContain("This Agent already has one bot from each provider.");
+		expect(connectDialog).toContain("before connecting a replacement");
+		expect(connectDialog).toContain("Manage bots");
+		expect(agentDetail).not.toContain('<details className="group border-t pt-4">');
 	});
 
 	test("provides a novice Discord connect, sync, and pair path in one compact dialog", () => {
@@ -147,6 +149,15 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).not.toContain("Checking activity");
 		expect(agentDetail).not.toContain("No activity yet");
 		expect(agentDetail).not.toContain("Last activity");
+		expect(agentDetail).toContain("INITIAL_PAIRED_CHAT_COUNT = 3");
+		expect(agentDetail).toContain("Show less");
+		expect(agentDetail).toContain("const pairedChatsLabel =");
+		expect(agentDetail).toContain("Paired chats ·");
+		expect(agentDetail).toContain("aria-expanded={chatsOpen}");
+		expect(agentDetail).toContain("aria-controls={chatsId}");
+		expect(agentDetail).toContain("hidden={!chatsOpen}");
+		expect(agentDetail).toContain('role="status"');
+		expect(agentDetail).toContain('role="alert"');
 	});
 
 	test("keeps repeated row actions visually stable without provider variants", () => {
@@ -157,13 +168,16 @@ describe("channel IA boundary", () => {
 		expect(linkedChannelRow).not.toContain('variant={provider === "telegram"');
 		expect(linkedChannelRow).not.toContain('provider === "telegram" ? "default"');
 		expect(linkedChannelRow).toContain('variant="ghost"');
-		expect(linkedChannelRow).toContain('size="icon-sm"');
+		expect(linkedChannelRow).toContain('size="sm"');
 		expect(linkedChannelRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
-		expect(linkedChannelRow).toContain("aria-label={`Unlink ");
+		expect(linkedChannelRow).toContain("Unlinking…");
+		expect(linkedChannelRow).toContain('"Unlink"');
+		expect(linkedChannelRow).not.toContain("<Tooltip>");
 		expect(pairedChatRow).toContain('variant="ghost"');
-		expect(pairedChatRow).toContain('size="icon-sm"');
+		expect(pairedChatRow).toContain('size="sm"');
 		expect(pairedChatRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
-		expect(pairedChatRow).toContain("aria-label={`Unpair ");
+		expect(pairedChatRow).toContain("Unpairing…");
+		expect(pairedChatRow).toContain('"Unpair"');
 		expect(pairedChatRow).not.toContain('variant="outline"');
 	});
 
@@ -177,13 +191,15 @@ describe("channel IA boundary", () => {
 		);
 		expect(pairedChatRow).not.toContain("overflow-visible");
 		expect(pairedChatRow).toContain("pairedChatScopeLabel(provider, binding)");
-		expect(pairedChatRow).toContain("Run /bot_unpair in this");
+		expect(pairedChatRow).not.toContain("Run /bot_unpair in this");
 		expect(pairedChatRowLogic).toContain("external_chat_name?.trim()");
 		expect(pairedChatRowLogic).toContain("binding.external_chat_id");
 		expect(pairedChatRow).not.toContain("<ProviderChip");
 		expect(pairedChatRow).not.toContain("CopyInline");
 		expect(pairedChatRow).not.toContain("Paired to");
 		expect(pairedChatRow).not.toContain("Through");
+		expect(pairedChatRow).not.toContain("border-l-2");
+		expect(pairedChatRow).not.toContain("ml-4");
 	});
 
 	test("filters Agent-page chats by the visible active link and account", () => {

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -6,20 +6,17 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
-import {
-	ENTITY_CARD_BASE,
-	ENTITY_GRID_CLASS,
-	ENTITY_STRETCHED_LINK_CLASS,
-	EntityCardSkeleton,
-	EntityHeader,
-} from "@/components/entity-card";
-import { EntityIcon } from "@/components/entity-icon";
+import { ENTITY_STRETCHED_LINK_CLASS, EntityCardSkeleton } from "@/components/entity-card";
 import { FilterChip } from "@/components/filter-chip";
 import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
+import {
+	CHANNEL_CARD_GRID_CLASS,
+	ChannelCard as SharedChannelCard,
+} from "@/hosted/v2/channels/channel-card";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 import {
@@ -41,7 +38,6 @@ import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Manage your bots and discover shared bots for your Agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
-const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function ChannelsPage() {
 	const [connectOpen, setConnectOpen] = useState(false);
@@ -153,7 +149,7 @@ function OwnedBotsSection({
 
 	if (isLoading) {
 		content = (
-			<div className={CHANNEL_GRID_CLASS}>
+			<div className={CHANNEL_CARD_GRID_CLASS}>
 				{[0, 1, 2].map((i) => (
 					<EntityCardSkeleton key={i} trailingBadge />
 				))}
@@ -166,7 +162,7 @@ function OwnedBotsSection({
 	} else {
 		const healthByAccount = new Map(healthItems.map((h) => [h.account_id, h.health_status]));
 		content = (
-			<div className={CHANNEL_GRID_CLASS}>
+			<div className={CHANNEL_CARD_GRID_CLASS}>
 				{visibleChannels.map((channel) => (
 					<ChannelCard
 						key={channel.id}
@@ -210,7 +206,7 @@ function SharedBotsSection({
 	let content: ReactNode;
 	if (isLoading) {
 		content = (
-			<div className={CHANNEL_GRID_CLASS}>
+			<div className={CHANNEL_CARD_GRID_CLASS}>
 				<EntityCardSkeleton trailingBadge />
 			</div>
 		);
@@ -220,7 +216,7 @@ function SharedBotsSection({
 		return null;
 	} else {
 		content = (
-			<div className={CHANNEL_GRID_CLASS}>
+			<div className={CHANNEL_CARD_GRID_CLASS}>
 				{visibleBots.map((bot) => (
 					<SharedBotCard key={bot.id} bot={bot} />
 				))}
@@ -240,48 +236,29 @@ function SharedBotsSection({
 }
 
 function SharedBotCard({ bot }: { bot: ChannelBotPoolItem }) {
-	const meta = providerMeta(bot.provider);
 	return (
-		<div
-			data-shared-channel-account-id={bot.id}
-			className={cn(ENTITY_CARD_BASE, "flex h-full items-start gap-3")}
-		>
-			<EntityHeader
-				className="w-full"
-				align="start"
-				icon={<EntityIcon kind="channel" id={bot.provider} label={meta.label} />}
-				title={bot.name}
-			/>
+		<div data-shared-channel-account-id={bot.id} className="min-w-0">
+			<SharedChannelCard provider={bot.provider} title={bot.name} />
 		</div>
 	);
 }
 
 function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: string }) {
-	const meta = providerMeta(channel.provider);
-
 	return (
-		<div data-channel-account-id={channel.id} className="group relative z-0 h-full min-w-0">
-			<div
-				className={cn(
-					ENTITY_CARD_BASE,
-					"flex h-full items-start gap-3 transition-colors group-hover:bg-muted/50",
-				)}
-			>
-				<EntityHeader
-					className="w-full"
-					align="start"
-					icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
-					title={channel.name}
-					titleAdornment={
-						health && !isNormalChannelHealth(health) ? <HealthBadge status={health} /> : undefined
-					}
-					meta={
-						isNormalChannelStatus(channel.status) ? undefined : (
-							<ChannelStatusBadge status={channel.status} />
-						)
-					}
-				/>
-			</div>
+		<div data-channel-account-id={channel.id} className="group relative z-0 min-w-0">
+			<SharedChannelCard
+				provider={channel.provider}
+				title={channel.name}
+				className="transition-colors group-hover:bg-muted/50"
+				state={[
+					health && !isNormalChannelHealth(health) ? (
+						<HealthBadge key="health" status={health} />
+					) : null,
+					isNormalChannelStatus(channel.status) ? null : (
+						<ChannelStatusBadge key="status" status={channel.status} />
+					),
+				]}
+			/>
 			<Link to="/channels/$id" params={{ id: channel.id }} className={ENTITY_STRETCHED_LINK_CLASS}>
 				<span className="sr-only">Open {channel.name}</span>
 			</Link>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -176,6 +176,35 @@ export function ConnectBotDialog({
 		onOpenChange(nextOpen);
 	}
 
+	const providerChoices = (
+		<fieldset className="grid grid-cols-2 gap-2 border-0 p-0" aria-label="Provider">
+			{CONNECTABLE_BOT_PROVIDERS.map((item) => {
+				const alreadyLinked = !availableProviders.includes(item);
+				return (
+					<Button
+						key={item}
+						type="button"
+						variant={!alreadyLinked && provider === item ? "secondary" : "outline"}
+						className="h-12 min-w-0 justify-start gap-2 px-2.5"
+						disabled={alreadyLinked}
+						aria-pressed={!alreadyLinked && provider === item}
+						onClick={() => changeProvider(item)}
+					>
+						<EntityIcon kind="channel" id={item} label={PROVIDER_META[item].label} size="sm" />
+						<span className="min-w-0 text-left leading-tight">
+							<span className="block">{PROVIDER_META[item].label}</span>
+							{alreadyLinked ? (
+								<span className="flex items-center gap-1 whitespace-nowrap text-[10px] font-normal text-muted-foreground">
+									<Check className="size-3" /> Connected
+								</span>
+							) : null}
+						</span>
+					</Button>
+				);
+			})}
+		</fieldset>
+	);
+
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent
@@ -207,55 +236,42 @@ export function ConnectBotDialog({
 					<>
 						<DialogHeader>
 							<DialogTitle>Connect a bot</DialogTitle>
-							<DialogDescription>Use your own bot.</DialogDescription>
+							<DialogDescription>
+								{agentId ? "Connect a bot you manage to this Agent." : "Add a bot you manage."}
+							</DialogDescription>
 						</DialogHeader>
 
 						{availableProviders.length === 0 ? (
 							<>
-								<p role="status" className="py-2 text-sm text-muted-foreground">
-									This Agent already has a Telegram and Discord bot.
-								</p>
+								<div className="space-y-3">
+									{providerChoices}
+									<p role="status" className="text-sm text-muted-foreground">
+										This Agent already has one bot from each provider. Unlink one from its card
+										before connecting a replacement.
+									</p>
+								</div>
 								<DialogFooter>
+									<Button render={<Link to="/channels" />} nativeButton={false} variant="outline">
+										Manage bots
+									</Button>
 									<Button onClick={() => handleOpenChange(false)}>Done</Button>
 								</DialogFooter>
 							</>
 						) : (
 							<>
 								<div className="flex flex-col gap-3">
-									<fieldset className="grid grid-cols-2 gap-2 border-0 p-0" aria-label="Provider">
-										{CONNECTABLE_BOT_PROVIDERS.map((item) => {
-											const alreadyLinked = !availableProviders.includes(item);
-											return (
-												<Button
-													key={item}
-													type="button"
-													variant={provider === item ? "secondary" : "outline"}
-													className="h-12 min-w-0 justify-start gap-2 px-2.5"
-													disabled={alreadyLinked}
-													aria-pressed={provider === item}
-													onClick={() => changeProvider(item)}
-												>
-													<EntityIcon
-														kind="channel"
-														id={item}
-														label={PROVIDER_META[item].label}
-														size="sm"
-													/>
-													<span className="min-w-0 text-left leading-tight">
-														<span className="block">{PROVIDER_META[item].label}</span>
-														{alreadyLinked ? (
-															<span className="flex items-center gap-1 whitespace-nowrap text-[10px] font-normal text-muted-foreground">
-																<Check className="size-3" /> Already linked
-															</span>
-														) : null}
-													</span>
-												</Button>
-											);
-										})}
-									</fieldset>
+									{providerChoices}
 									{unavailableProviders.length === 1 ? (
 										<p className="whitespace-normal text-xs text-muted-foreground">
-											Unlink {PROVIDER_META[unavailableProviders[0]].label} from this Agent first.
+											Unlink {PROVIDER_META[unavailableProviders[0]].label} from its card to replace
+											it. You can also{" "}
+											<Link
+												to="/channels"
+												className="font-medium text-foreground underline underline-offset-4"
+											>
+												manage bots
+											</Link>
+											.
 										</p>
 									) : null}
 									<p className="text-xs text-muted-foreground">

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { Link2Off, MessageCircle, MessagesSquare } from "lucide-react";
+import { MessageCircle, MessagesSquare } from "lucide-react";
 import { EntityHeader } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
@@ -18,7 +17,7 @@ import { pairedChatScopeLabel, pairedChatTitle } from "@/hosted/v2/channels/pair
 import { cn, relativeTime } from "@/lib/utils";
 
 export const PAIRED_CHAT_ROW_CLASS =
-	"ml-4 grid min-h-12 grid-cols-[minmax(0,1fr)] items-center gap-2 border-l-2 border-muted py-2 pr-0 pl-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3";
+	"grid min-h-14 grid-cols-[minmax(0,1fr)] items-center gap-2 px-1 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3";
 
 export function PairedChatRow({
 	accountId,
@@ -36,7 +35,6 @@ export function PairedChatRow({
 	const scope = pairedChatScopeLabel(provider, binding);
 	const privateChat = chatType === "private" || scope === "direct message";
 	const chatName = pairedChatTitle(binding, provider);
-	const discordUnpairInstruction = `Run /bot_unpair in this ${scope}.`;
 
 	return (
 		<div
@@ -60,7 +58,7 @@ export function PairedChatRow({
 					...(isNormalChannelStatus(binding.status)
 						? []
 						: [<ChannelStatusBadge key="status" status={binding.status} />]),
-					...(provider !== "discord" && unpair.error
+					...(unpair.error
 						? [
 								<span key="error" className="font-medium text-destructive">
 									Couldn&apos;t unpair · Try again
@@ -69,39 +67,31 @@ export function PairedChatRow({
 						: []),
 				]}
 			/>
-			<div className="flex min-h-8 min-w-0 justify-end sm:w-28 sm:shrink-0">
-				{provider === "discord" ? (
-					<p className="w-full text-right text-xs text-muted-foreground">
-						{discordUnpairInstruction}
-					</p>
-				) : (
-					<Tooltip>
-						<TooltipTrigger render={<span className="inline-flex size-8" />}>
-							<ConfirmAction
-								title={`Unpair ${chatName}?`}
-								description="Only this chat will be disconnected. Other chats and the connected channel stay active."
-								confirmLabel="Unpair chat"
-								destructive
-								onConfirm={() => unpair.mutateAsync(binding.id)}
-							>
-								<Button
-									variant="ghost"
-									size="icon-sm"
-									className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
-									disabled={unpair.isPending}
-									aria-label={`Unpair ${chatName}`}
-								>
-									{unpair.isPending ? (
-										<Spinner className="size-3.5" />
-									) : (
-										<Link2Off className="size-3.5" />
-									)}
-								</Button>
-							</ConfirmAction>
-						</TooltipTrigger>
-						<TooltipContent>Unpair {chatName}</TooltipContent>
-					</Tooltip>
-				)}
+			<div className="flex min-h-8 min-w-0 justify-end sm:shrink-0">
+				<ConfirmAction
+					title={`Unpair ${chatName}?`}
+					description="Only this chat will be disconnected. Other chats and the connected channel stay active."
+					confirmLabel="Unpair chat"
+					destructive
+					onConfirm={() => unpair.mutateAsync(binding.id)}
+				>
+					<Button
+						variant="ghost"
+						size="sm"
+						className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+						disabled={unpair.isPending}
+						aria-label={`${unpair.isPending ? "Unpairing" : "Unpair"} ${chatName}`}
+					>
+						{unpair.isPending ? (
+							<>
+								<Spinner className="size-3.5" />
+								Unpairing…
+							</>
+						) : (
+							"Unpair"
+						)}
+					</Button>
+				</ConfirmAction>
 			</div>
 		</div>
 	);

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -1091,7 +1091,7 @@ async def discord_webhook(
             )
         if binding_result.unpaired and guild_id is not None and binding_result.bindings:
             background_tasks.add_task(
-                _cleanup_discord_guild_commands_after_authority_revoked,
+                cleanup_discord_guild_commands_after_authority_revoked,
                 account_id=account.id,
                 bot_agent_link_id=binding_result.bindings[0].bot_agent_link_id,
                 guild_ids={guild_id},
@@ -1206,13 +1206,14 @@ async def _replay_discord_commands_for_paired_guild(
         )
 
 
-async def _cleanup_discord_guild_commands_after_authority_revoked(
+async def cleanup_discord_guild_commands_after_authority_revoked(
     *,
     account_id: UUID,
     bot_agent_link_id: UUID,
     guild_ids: set[str],
-) -> None:
+) -> bool:
     """Best-effort cleanup after durable unpair/unlink authority revocation."""
+    cleanup_succeeded = True
     try:
         async with async_session_factory() as db:
             account = await get_active_channel_account(db, account_id=account_id)
@@ -1222,7 +1223,7 @@ async def _cleanup_discord_guild_commands_after_authority_revoked(
             if not isinstance(command_shadow, dict) or not any(
                 isinstance(commands, list) and commands for commands in command_shadow.values()
             ):
-                return
+                return True
             application_id = _discord_application_id(account)
             for guild_id in sorted(guild_ids):
                 # A new pairing can win after the revocation commit. Never erase its
@@ -1248,6 +1249,7 @@ async def _cleanup_discord_guild_commands_after_authority_revoked(
                         body=b"[]",
                     )
                     if result.status_code >= 400:
+                        cleanup_succeeded = False
                         log.warning(
                             "discord_command_cleanup_rejected "
                             "account_id=%s link_id=%s guild_id=%s status=%s",
@@ -1257,6 +1259,7 @@ async def _cleanup_discord_guild_commands_after_authority_revoked(
                             result.status_code,
                         )
                 except HTTPException:
+                    cleanup_succeeded = False
                     log.exception(
                         "discord_command_cleanup_failed account_id=%s link_id=%s guild_id=%s",
                         account_id,
@@ -1264,12 +1267,14 @@ async def _cleanup_discord_guild_commands_after_authority_revoked(
                         guild_id,
                     )
                     continue
+        return cleanup_succeeded
     except (HTTPException, SQLAlchemyError):
         log.exception(
             "discord_command_cleanup_setup_failed account_id=%s link_id=%s",
             account_id,
             bot_agent_link_id,
         )
+        return False
 
 
 async def _ack_discord_gateway_sequence(

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -1038,11 +1038,11 @@ async def delete_channel_agent_link(
     await db.commit()
     if discord_guild_ids:
         from app.routes.channel_routers.discord import (
-            _cleanup_discord_guild_commands_after_authority_revoked,
+            cleanup_discord_guild_commands_after_authority_revoked,
         )
 
         background_tasks.add_task(
-            _cleanup_discord_guild_commands_after_authority_revoked,
+            cleanup_discord_guild_commands_after_authority_revoked,
             account_id=account.id,
             bot_agent_link_id=link.id,
             guild_ids=discord_guild_ids,
@@ -1139,15 +1139,7 @@ async def delete_channel_binding(
     ).one_or_none()
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="binding not found")
-    binding, link = row
-    if account.provider == CHANNEL_PROVIDER_DISCORD:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                "Run /bot_unpair in the paired Discord server or direct message. "
-                "Discord pairing authority cannot be verified from this API."
-            ),
-        )
+    binding, _link = row
     await lock_channel_binding_identity(
         db,
         account_id=account.id,
@@ -1180,6 +1172,9 @@ async def delete_channel_binding(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="binding not found")
     binding, link = row
     await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=link.agent_id)
+    discord_guild_id = (
+        _discord_binding_guild_id(binding) if account.provider == CHANNEL_PROVIDER_DISCORD else None
+    )
 
     if binding.status != BINDING_STATUS_ACTIVE:
         return ChannelBindingDeleteResponse(
@@ -1207,8 +1202,8 @@ async def delete_channel_binding(
             "external_chat_id": binding.external_chat_id,
         },
     )
-    # The archive commits before any provider I/O. A failed Telegram cleanup or
-    # notification can never roll back a completed unpair.
+    # Authority commits before any provider I/O. Notification or provider cleanup
+    # failure can never roll back a completed unpair.
     await db.commit()
 
     notification_status = "not_applicable"
@@ -1247,6 +1242,37 @@ async def delete_channel_binding(
             source="api.channels",
             details={
                 "notification_status": notification_status,
+                "provider_cleanup_status": provider_cleanup_status,
+            },
+        )
+        await db.commit()
+    elif account.provider == CHANNEL_PROVIDER_DISCORD and discord_guild_id is not None:
+        from app.routes.channel_routers.discord import (
+            cleanup_discord_guild_commands_after_authority_revoked,
+        )
+
+        cleanup_succeeded = await cleanup_discord_guild_commands_after_authority_revoked(
+            account_id=account.id,
+            bot_agent_link_id=link.id,
+            guild_ids={discord_guild_id},
+        )
+        provider_cleanup_status = "succeeded" if cleanup_succeeded else "failed"
+        if not cleanup_succeeded:
+            warning = "Chat was unpaired, but Discord server command cleanup did not complete."
+        record_control_plane_audit(
+            db,
+            actor_type="user",
+            actor_user_id=auth.user_id,
+            target_user_id=auth.user_id,
+            action="channel.binding.discord_cleanup",
+            resource_type="channel_binding",
+            resource_id=str(binding.id),
+            environment_id=link.agent_id,
+            channel_account_id=account.id,
+            channel_agent_link_id=link.id,
+            source="api.channels",
+            details={
+                "guild_id": discord_guild_id,
                 "provider_cleanup_status": provider_cleanup_status,
             },
         )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -32,6 +32,7 @@ from app.models.api_key import ApiKey
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
+    BOT_AGENT_LINK_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ARCHIVED,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_IMESSAGE,
@@ -61,11 +62,11 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
-    _cleanup_discord_guild_commands_after_authority_revoked,
     _discord_bound_guild_channels,
     _discord_bound_guilds,
     _discord_gateway_url,
     _discord_guild_create_payload,
+    cleanup_discord_guild_commands_after_authority_revoked,
 )
 from app.routes.channel_routers.shared import _discord_gateway_dispatch
 from app.services import channels as channel_service
@@ -9125,7 +9126,7 @@ async def test_discord_stale_cleanup_does_not_erase_same_account_new_link_winner
         _FakeProviderClient,
     )
 
-    await _cleanup_discord_guild_commands_after_authority_revoked(
+    await cleanup_discord_guild_commands_after_authority_revoked(
         account_id=account.id,
         bot_agent_link_id=link_a.id,
         guild_ids={"same-account-winner-guild"},
@@ -14668,14 +14669,15 @@ async def test_discord_unpair_command_cleanup_failure_keeps_authority_revoked(
 
 
 @pytest.mark.asyncio
-async def test_discord_binding_delete_requires_provider_authorized_unpair(
+async def test_discord_guild_binding_delete_revokes_authority_then_cleans_commands(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     created = await _create_paired_discord_channel(
         client,
-        name="discord-control-plane-unpair-denied",
-        channel_id="discord-control-plane-channel",
+        name="discord-control-plane-guild-unpair",
+        channel_id="discord-control-plane-guild-channel",
         guild_id="discord-control-plane-guild",
     )
     binding = (
@@ -14686,11 +14688,245 @@ async def test_discord_binding_delete_requires_provider_authorized_unpair(
             )
         )
     ).scalar_one()
+    link = await db_session.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"id": "discord-control-plane-cleanup"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
 
     response = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
 
-    assert response.status_code == 409
-    assert response.json()["detail"].startswith("Run /bot_unpair")
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "binding_id": str(binding.id),
+        "unpaired": True,
+        "notification_status": "not_applicable",
+        "provider_cleanup_status": "succeeded",
+        "warning": None,
+    }
+    await db_session.refresh(binding)
+    assert binding.status == BINDING_STATUS_ARCHIVED
+    assert len(_FakeProviderClient.calls) == 1
+    cleanup_call = _FakeProviderClient.calls[0]
+    assert cleanup_call["method"] == "PUT"
+    assert cleanup_call["url"].endswith(
+        f"/applications/{DISCORD_TEST_APPLICATION_ID}/guilds/discord-control-plane-guild/commands"
+    )
+    assert cleanup_call["content"] == b"[]"
+
+
+@pytest.mark.asyncio
+async def test_discord_dm_binding_delete_revokes_without_guild_cleanup(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-control-plane-dm-unpair",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": created["agent_link_id"], "ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "discord-control-plane-dm-pair",
+            "token": "discord-control-plane-dm-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "discord-control-plane-dm",
+            "user": {"id": "discord-control-plane-dm-user"},
+            "data": {
+                "name": "bot_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert paired.status_code == 200, paired.text
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+    link = await db_session.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"id": "must-not-run-for-dm"})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    response = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "binding_id": str(binding.id),
+        "unpaired": True,
+        "notification_status": "not_applicable",
+        "provider_cleanup_status": "not_applicable",
+        "warning": None,
+    }
+    await db_session.refresh(binding)
+    assert binding.status == BINDING_STATUS_ARCHIVED
+    assert _FakeProviderClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_binding_delete_cleanup_failure_warns_after_durable_revocation(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-control-plane-cleanup-failure",
+        channel_id="discord-control-plane-cleanup-channel",
+        guild_id="discord-control-plane-cleanup-guild",
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+    link = await db_session.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    assert link is not None
+    link.config = {
+        "discord_agent_commands": {
+            "global": [{"name": "agent_status", "description": "Agent status"}]
+        }
+    }
+    await db_session.commit()
+    _reset_fake_provider_client({"message": "provider failure"}, status_code=500)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+
+    response = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "binding_id": str(binding.id),
+        "unpaired": True,
+        "notification_status": "not_applicable",
+        "provider_cleanup_status": "failed",
+        "warning": "Chat was unpaired, but Discord server command cleanup did not complete.",
+    }
+    await db_session.refresh(binding)
+    assert binding.status == BINDING_STATUS_ARCHIVED
+    audit = await client.get(
+        "/v1/audit/events",
+        params={"channel_account_id": created["id"], "limit": 20},
+    )
+    cleanup_event = next(
+        item
+        for item in audit.json()["items"]
+        if item["action"] == "channel.binding.discord_cleanup"
+    )
+    assert cleanup_event["details"] == {
+        "guild_id": "discord-control-plane-cleanup-guild",
+        "provider_cleanup_status": "failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_discord_binding_delete_denies_cross_user_account_inactive_link_and_unowned_agent(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-control-plane-authority-boundary",
+        channel_id="discord-control-plane-authority-channel",
+        guild_id="discord-control-plane-authority-guild",
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+    link = await db_session.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    assert link is not None
+    wrong_account = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-control-plane-wrong-account",
+                "provider_token": "discord-provider-token-2",
+                "config": _discord_ready_config("223456789012345678"),
+            },
+        )
+    ).json()
+    other_user, other_agent = await _create_user_with_channel_agent(
+        db_session,
+        label="discord-control-plane-other-user",
+    )
+
+    wrong_account_response = await client.delete(
+        f"/v1/channels/{wrong_account['id']}/bindings/{binding.id}"
+    )
+    async with _client_for_user(db_session, other_user) as other_client:
+        cross_user_response = await other_client.delete(
+            f"/v1/channels/{created['id']}/bindings/{binding.id}"
+        )
+
+    link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
+    link.archived_at = datetime.now(UTC)
+    await db_session.commit()
+    inactive_link_response = await client.delete(
+        f"/v1/channels/{created['id']}/bindings/{binding.id}"
+    )
+
+    link.status = BOT_AGENT_LINK_STATUS_ACTIVE
+    link.archived_at = None
+    link.agent_id = other_agent.id
+    await db_session.commit()
+    unowned_agent_response = await client.delete(
+        f"/v1/channels/{created['id']}/bindings/{binding.id}"
+    )
+
+    assert wrong_account_response.status_code == 404
+    assert cross_user_response.status_code == 404
+    assert inactive_link_response.status_code == 404
+    assert unowned_agent_response.status_code == 404
     await db_session.refresh(binding)
     assert binding.status == BINDING_STATUS_ACTIVE
 


### PR DESCRIPTION
## Summary

- add a small shared Channel card shell built on the existing Entity Card family and reuse it across Console and Agent Channels
- keep Console focused on bot inventory/navigation while Agent cards retain Link, Pair, Unpair, and Unlink ownership
- make Add channel persistent, explain full provider slots in ConnectBotDialog, and provide replacement/Manage bots paths
- nest paired chats inside their bot card with loading/error recovery and accessible three-item progressive disclosure
- replace the divided channel list with content-height two-column cards that collapse cleanly at 320px

## Verification

- `bun run --cwd apps/web typecheck`
- `bun test apps/web/src/hosted/v2/channels` (63 passed)
- `bunx biome check apps/web/src`
- `bun run --cwd apps/web build:oss`
- focused hosted Playwright: Console card/responsive layout; paired-chat loading/error recovery; Agent long-list/full-slot/320x568 flow
- inspected desktop and 320x568 screenshots for Console and Agent Channels

No backend changes. No deployment or production/provider access.