### PR TITLE
fix(channels): secure Discord gateway relay and lock Telegram typing semantics

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -670,6 +670,12 @@ async def discord_agent_gateway(
         await websocket.close(code=4012)
         return
     raw_capability = path_capability or websocket.query_params.get("capability")
+    authorization = websocket.headers.get("authorization")
+    link_token = None
+    if authorization:
+        scheme, separator, credential = authorization.partition(" ")
+        if separator and scheme.lower() == "bearer" and credential and " " not in credential:
+            link_token = credential
     try:
         capability = _decode_discord_gateway_capability(raw_capability) if raw_capability else None
     except HTTPException:
@@ -773,13 +779,13 @@ async def discord_agent_gateway(
                 return
             async with async_session_factory() as db:
                 try:
-                    if capability is None:
+                    if capability is None and link_token is None:
                         resolved_agent = await resolve_channel_agent_by_token(
                             db,
                             provider=CHANNEL_PROVIDER_DISCORD,
                             token=token,
                         )
-                    else:
+                    elif capability is not None:
                         expected_placeholder = channel_runtime_placeholder_token(
                             CHANNEL_PROVIDER_DISCORD,
                             channel_runtime_account_key(capability.account_id),
@@ -796,6 +802,21 @@ async def discord_agent_gateway(
                             link_id=capability.link_id,
                             agent_token_hash=capability.agent_token_hash,
                         )
+                    else:
+                        resolved_agent = await resolve_channel_agent_by_token(
+                            db,
+                            provider=CHANNEL_PROVIDER_DISCORD,
+                            token=link_token,
+                        )
+                        expected_placeholder = channel_runtime_placeholder_token(
+                            CHANNEL_PROVIDER_DISCORD,
+                            channel_runtime_account_key(resolved_agent.account.id),
+                        )
+                        if not secrets.compare_digest(token, expected_placeholder):
+                            raise HTTPException(
+                                status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="invalid discord gateway placeholder",
+                            )
                 except HTTPException:
                     if op == 6:
                         await send_gateway_frame({"op": 9, "d": False}, record=False)
@@ -888,7 +909,7 @@ async def discord_agent_gateway(
                             "session_id": session_id,
                             "resume_gateway_url": (
                                 _discord_gateway_url(resolved_agent)
-                                if capability is not None
+                                if capability is not None or link_token is not None
                                 else _public_ws_url("/v1/channels/discord/gateway")
                             ),
                             "user": _discord_bot_user(account),

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -779,35 +779,46 @@ async def discord_agent_gateway(
                 return
             async with async_session_factory() as db:
                 try:
-                    if capability is None and link_token is None:
-                        resolved_agent = await resolve_channel_agent_by_token(
-                            db,
-                            provider=CHANNEL_PROVIDER_DISCORD,
-                            token=token,
-                        )
-                    elif capability is not None:
-                        expected_placeholder = channel_runtime_placeholder_token(
-                            CHANNEL_PROVIDER_DISCORD,
-                            channel_runtime_account_key(capability.account_id),
-                        )
-                        if not secrets.compare_digest(token, expected_placeholder):
-                            raise HTTPException(
-                                status_code=status.HTTP_401_UNAUTHORIZED,
-                                detail="invalid discord gateway placeholder",
-                            )
-                        resolved_agent = await resolve_channel_agent_by_identity(
+                    capability_agent = (
+                        await resolve_channel_agent_by_identity(
                             db,
                             provider=CHANNEL_PROVIDER_DISCORD,
                             account_id=capability.account_id,
                             link_id=capability.link_id,
                             agent_token_hash=capability.agent_token_hash,
                         )
-                    else:
-                        resolved_agent = await resolve_channel_agent_by_token(
+                        if capability is not None
+                        else None
+                    )
+                    bearer_agent = (
+                        await resolve_channel_agent_by_token(
                             db,
                             provider=CHANNEL_PROVIDER_DISCORD,
                             token=link_token,
                         )
+                        if link_token is not None
+                        else None
+                    )
+                    if (
+                        capability_agent is not None
+                        and bearer_agent is not None
+                        and (
+                            capability_agent.account.id != bearer_agent.account.id
+                            or capability_agent.link.id != bearer_agent.link.id
+                        )
+                    ):
+                        raise HTTPException(
+                            status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="discord gateway credentials do not match",
+                        )
+                    resolved_agent = capability_agent or bearer_agent
+                    if resolved_agent is None:
+                        resolved_agent = await resolve_channel_agent_by_token(
+                            db,
+                            provider=CHANNEL_PROVIDER_DISCORD,
+                            token=token,
+                        )
+                    else:
                         expected_placeholder = channel_runtime_placeholder_token(
                             CHANNEL_PROVIDER_DISCORD,
                             channel_runtime_account_key(resolved_agent.account.id),
@@ -909,8 +920,12 @@ async def discord_agent_gateway(
                             "session_id": session_id,
                             "resume_gateway_url": (
                                 _discord_gateway_url(resolved_agent)
-                                if capability is not None or link_token is not None
-                                else _public_ws_url("/v1/channels/discord/gateway")
+                                if capability is not None
+                                else (
+                                    settings.channel_discord_gateway_url.strip().rstrip("/")
+                                    if link_token is not None
+                                    else _public_ws_url("/v1/channels/discord/gateway")
+                                )
                             ),
                             "user": _discord_bot_user(account),
                             "application": {"id": _discord_application_id(account)},

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6828,7 +6828,7 @@ async def test_telegram_private_and_forum_thread_methods_preserve_message_thread
         chat_type="supergroup",
     )
     _reset_fake_provider_client({"ok": True, "result": True})
-    requests = (
+    json_requests = (
         (
             "sendMessageDraft",
             b'{ "chat_id": 42, "message_thread_id": 7, "draft_id": 1, "text": "draft" }\n',
@@ -6847,7 +6847,7 @@ async def test_telegram_private_and_forum_thread_methods_preserve_message_thread
         ),
     )
 
-    for method, body in requests:
+    for method, body in json_requests:
         response = await client.post(
             _telegram_bot_path(created, method),
             headers={**_telegram_agent_headers(created), "content-type": "application/json"},
@@ -6855,11 +6855,33 @@ async def test_telegram_private_and_forum_thread_methods_preserve_message_thread
         )
         assert response.status_code == 200
 
+    private_form = b"chat_id=42&message_thread_id=8&action=typing&future_hint=preserved"
+    form_response = await client.post(
+        _telegram_bot_path(created, "sendChatAction"),
+        headers={
+            **_telegram_agent_headers(created),
+            "content-type": "application/x-www-form-urlencoded",
+        },
+        content=private_form,
+    )
+    ordinary_private = b'{ "chat_id": 42, "action": "typing", "future_hint": true }\n'
+    ordinary_response = await client.post(
+        _telegram_bot_path(created, "sendChatAction"),
+        headers={**_telegram_agent_headers(created), "content-type": "application/json"},
+        content=ordinary_private,
+    )
+    assert form_response.status_code == 200
+    assert ordinary_response.status_code == 200
+
     assert [call["content"] for call in _FakeProviderClient.calls] == [
-        body for _method, body in requests
+        *[body for _method, body in json_requests],
+        private_form,
+        ordinary_private,
     ]
     assert [call["url"].rsplit("/", 1)[-1] for call in _FakeProviderClient.calls] == [
-        method for method, _body in requests
+        *[method for method, _body in json_requests],
+        "sendChatAction",
+        "sendChatAction",
     ]
     assert all(
         b"direct_messages_topic_id" not in call["content"] for call in _FakeProviderClient.calls
@@ -8264,6 +8286,58 @@ def test_discord_gateway_capability_accepts_runtime_placeholder(monkeypatch):
     resume_url = urlparse(ready["d"]["resume_gateway_url"])
     assert resume_url.path.startswith("/v1/channels/discord/gateway/")
     assert resume_url.path.rpartition("/")[2]
+
+
+def test_discord_gateway_link_authorization_accepts_runtime_placeholder(monkeypatch):
+    _install_discord_gateway_protocol_fakes(monkeypatch)
+    agent = _discord_gateway_protocol_agent()
+    placeholder = channel_runtime_placeholder_token(
+        CHANNEL_PROVIDER_DISCORD,
+        channel_runtime_account_key(agent.account.id),
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(
+            "/v1/channels/discord/gateway?v=10&encoding=json",
+            headers={"Authorization": "Bearer valid-discord-token"},
+        ) as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+            ready = websocket.receive_json()
+            session_id = ready["d"]["session_id"]
+            guild = websocket.receive_json()
+
+    assert ready["t"] == "READY"
+    assert guild["t"] == "GUILD_CREATE"
+    resume_path = urlparse(ready["d"]["resume_gateway_url"]).path
+    assert resume_path.startswith("/v1/channels/discord/gateway/")
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(resume_path) as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {"token": placeholder, "session_id": session_id, "seq": guild["s"]},
+                }
+            )
+            assert websocket.receive_json()["t"] == "RESUMED"
+
+
+def test_discord_gateway_link_authorization_rejects_wrong_placeholder(monkeypatch):
+    _install_discord_gateway_protocol_fakes(monkeypatch)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(
+            "/v1/channels/discord/gateway?v=10&encoding=json",
+            headers={"Authorization": "Bearer valid-discord-token"},
+        ) as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": "clawdi_wrong-placeholder", "intents": 0}})
+            with pytest.raises(WebSocketDisconnect) as raised:
+                websocket.receive_json()
+
+    assert raised.value.code == 4004
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -8309,11 +8309,15 @@ def test_discord_gateway_link_authorization_accepts_runtime_placeholder(monkeypa
 
     assert ready["t"] == "READY"
     assert guild["t"] == "GUILD_CREATE"
-    resume_path = urlparse(ready["d"]["resume_gateway_url"]).path
-    assert resume_path.startswith("/v1/channels/discord/gateway/")
+    assert ready["d"]["resume_gateway_url"] == settings.channel_discord_gateway_url
 
+    # discord.py reconnects to the external URL, which the egress sidecar rewrites
+    # back to this canonical endpoint and authenticates with the same Link header.
     with TestClient(app) as sync_client:
-        with sync_client.websocket_connect(resume_path) as websocket:
+        with sync_client.websocket_connect(
+            "/v1/channels/discord/gateway",
+            headers={"Authorization": "Bearer valid-discord-token"},
+        ) as websocket:
             assert websocket.receive_json()["op"] == 10
             websocket.send_json(
                 {
@@ -8338,6 +8342,160 @@ def test_discord_gateway_link_authorization_rejects_wrong_placeholder(monkeypatc
                 websocket.receive_json()
 
     assert raised.value.code == 4004
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_shared_account_link_bearers_are_isolated(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _DISCORD_GATEWAY_SESSIONS.clear()
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-shared-gateway-isolation",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    second_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert second_response.status_code == 201, second_response.text
+    second = second_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    link_a = await db_session.get(ChannelBotAgentLink, UUID(created["agent_link_id"]))
+    link_b = await db_session.get(ChannelBotAgentLink, UUID(second["id"]))
+    assert account is not None and link_a is not None and link_b is not None
+    account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    binding_a = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=link_a.id,
+        user_id=account.user_id,
+        external_chat_id="shared-gateway-channel-a",
+        external_chat_type="guild_text",
+        external_chat_name="shared-gateway-guild-a",
+    )
+    binding_b = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=link_b.id,
+        user_id=account.user_id,
+        external_chat_id="shared-gateway-channel-b",
+        external_chat_type="guild_text",
+        external_chat_name="shared-gateway-guild-b",
+    )
+    db_session.add_all([binding_a, binding_b])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            ChannelBindingAlias(
+                account_id=account.id,
+                bot_agent_link_id=link_a.id,
+                user_id=account.user_id,
+                binding_id=binding_a.id,
+                alias_kind="discord_channel",
+                alias_external_chat_id="shared-gateway-channel-a",
+            ),
+            ChannelBindingAlias(
+                account_id=account.id,
+                bot_agent_link_id=link_b.id,
+                user_id=account.user_id,
+                binding_id=binding_b.id,
+                alias_kind="discord_channel",
+                alias_external_chat_id="shared-gateway-channel-b",
+            ),
+        ]
+    )
+    await db_session.commit()
+    _install_discord_gateway_test_session_factory(monkeypatch)
+    placeholder = channel_runtime_placeholder_token(
+        CHANNEL_PROVIDER_DISCORD,
+        channel_runtime_account_key(account.id),
+    )
+
+    def identify(bearer: str) -> tuple[dict[str, Any], dict[str, Any]]:
+        with TestClient(app) as sync_client:
+            with sync_client.websocket_connect(
+                "/v1/channels/discord/gateway?v=10&encoding=json",
+                headers={"Authorization": f"Bearer {bearer}"},
+            ) as websocket:
+                assert websocket.receive_json()["op"] == 10
+                websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+                return websocket.receive_json(), websocket.receive_json()
+
+    ready_a, guild_a = identify(created["agent_token"])
+    ready_b, guild_b = identify(second["agent_token"])
+
+    assert ready_a["d"]["resume_gateway_url"] == settings.channel_discord_gateway_url
+    assert ready_b["d"]["resume_gateway_url"] == settings.channel_discord_gateway_url
+    assert ready_a["d"]["guilds"] == [{"id": "shared-gateway-guild-a", "unavailable": False}]
+    assert ready_b["d"]["guilds"] == [{"id": "shared-gateway-guild-b", "unavailable": False}]
+    assert [channel["id"] for channel in guild_a["d"]["channels"]] == ["shared-gateway-channel-a"]
+    assert [channel["id"] for channel in guild_b["d"]["channels"]] == ["shared-gateway-channel-b"]
+    assert "/v1/channels/discord/gateway" not in ready_a["d"]["resume_gateway_url"]
+
+    # Simulate discord.py reconnecting to the external resume URL: egress rewrites
+    # it to /gateway and re-injects the same Link bearer. Session ownership then
+    # proves the resumed connection cannot cross-select the sibling Link.
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(
+            "/v1/channels/discord/gateway",
+            headers={"Authorization": f"Bearer {created['agent_token']}"},
+        ) as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {
+                        "token": placeholder,
+                        "session_id": ready_a["d"]["session_id"],
+                        "seq": guild_a["s"],
+                    },
+                }
+            )
+            assert websocket.receive_json()["t"] == "RESUMED"
+
+    capability_a_path = urlparse(
+        _discord_gateway_url(ChannelAgentContext(account=account, link=link_a))
+    ).path
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(
+            capability_a_path,
+            headers={"Authorization": f"Bearer {second['agent_token']}"},
+        ) as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+            with pytest.raises(WebSocketDisconnect) as raised:
+                websocket.receive_json()
+    assert raised.value.code == 4004
+
+    rotated = await client.post(
+        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}/token"
+    )
+    assert rotated.status_code == 200, rotated.text
+    for rejected_bearer in (created["agent_token"], "wrong-link-bearer", second["agent_token"]):
+        if rejected_bearer == second["agent_token"]:
+            link_b.status = BOT_AGENT_LINK_STATUS_ARCHIVED
+            link_b.archived_at = datetime.now(UTC)
+            await db_session.commit()
+        with TestClient(app) as sync_client:
+            with sync_client.websocket_connect(
+                "/v1/channels/discord/gateway",
+                headers={"Authorization": f"Bearer {rejected_bearer}"},
+            ) as websocket:
+                assert websocket.receive_json()["op"] == 10
+                websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+                with pytest.raises(WebSocketDisconnect) as raised:
+                    websocket.receive_json()
+        assert raised.value.code == 4004
 
 
 @pytest.mark.asyncio

--- a/packages/cli/egress-addon/clawdi_egress_addon.py
+++ b/packages/cli/egress-addon/clawdi_egress_addon.py
@@ -476,7 +476,12 @@ def apply_http_rewrite(flow: Any, profile: dict[str, Any], secrets: dict[str, st
     flow.request.port = parsed.port or default_port(parsed.scheme)
     header_set(flow.request.headers, "host", parsed.netloc)
     preserve_path = bool(rewrite.get("preservePath", True))
-    flow.request.path = combine_paths(parsed.path or "/", original_path if preserve_path else "")
+    if preserve_path:
+        flow.request.path = combine_paths(parsed.path or "/", original_path)
+    else:
+        original_query = urlsplit(original_path).query
+        target_path = parsed.path or "/"
+        flow.request.path = f"{target_path}?{original_query}" if original_query else target_path
     apply_rewrite_headers(flow, profile, secrets)
 
 

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -527,15 +527,26 @@ function buildManagedChannelEgressProfiles(
 				owner: "clawdi-native-channels",
 			});
 			profiles.push({
-				id: `native-${idSuffix}-gateway-passthrough`,
+				id: `native-${idSuffix}-gateway-managed`,
 				enabled: true,
-				kind: "passthrough",
+				kind: "websocket",
 				match: {
 					scheme: "wss",
 					host: "gateway.discord.gg",
 					pathPrefix: "/",
 					headers: {},
 					query: {},
+				},
+				rewrite: {
+					upstreamBaseUrl: `${toWebSocketUrl(baseUrl)}/v1/channels/discord/gateway`,
+					preservePath: false,
+					setHeaders: {
+						authorization: {
+							type: "secretRef",
+							secretRef: link.secretRef,
+							prefix: "Bearer ",
+						},
+					},
 				},
 				logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
 				priority: 201,

--- a/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
+++ b/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
@@ -556,16 +556,28 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                     "enabled": True,
                     "kind": "websocket",
                     "match": {"scheme": "wss", "host": "socket.test", "pathPrefix": "/ws"},
-                    "rewrite": {"upstreamBaseUrl": "wss://relay.test/session"},
+                    "rewrite": {
+                        "upstreamBaseUrl": "wss://relay.test/session",
+                        "preservePath": False,
+                        "setHeaders": {
+                            "authorization": {
+                                "type": "secretRef",
+                                "secretRef": "secret://link-token",
+                                "prefix": "Bearer ",
+                            }
+                        },
+                    },
+                    "logging": {"redactHeaders": ["authorization"]},
                     "priority": 10,
                 }
-            ]
+            ],
+            {"secret://link-token": "link-secret"},
         )
 
         flow = Flow(
             scheme="https",
             host="socket.test",
-            path="/ws/chat",
+            path="/ws/chat?v=10&encoding=json",
             headers={"Upgrade": "websocket"},
         )
         decision = egress.apply_to_flow(flow)
@@ -573,7 +585,23 @@ class AddonProfileInterpreterTest(unittest.TestCase):
         self.assertEqual(decision.action, "websocket")
         self.assertEqual(flow.request.scheme, "https")
         self.assertEqual(flow.request.host, "relay.test")
-        self.assertEqual(flow.request.path, "/session/ws/chat")
+        self.assertEqual(flow.request.path, "/session?v=10&encoding=json")
+        self.assertEqual(flow.request.headers["Upgrade"], "websocket")
+        self.assertEqual(flow.request.headers["authorization"], "Bearer link-secret")
+
+        profile = egress.profiles[0]
+        self.assertEqual(
+            addon.redacted_headers(flow.request.headers, profile)["authorization"],
+            "[redacted]",
+        )
+        messages = []
+        original_info = addon.ctx.log.info
+        addon.ctx.log.info = messages.append
+        try:
+            egress.log_decision(flow, decision)
+        finally:
+            addon.ctx.log.info = original_info
+        self.assertNotIn("link-secret", "\n".join(messages))
 
     def test_deny_profile_sets_safe_response(self):
         egress = self.load(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6458,6 +6458,26 @@ exit 64
 		expect(
 			projected.secretValues?.["secret://channels/discord/clawdi_acctdiscord1/placeholder-token"],
 		).toMatch(/^clawdi_[a-f0-9]{32}$/);
+		const discordGateway = projected.manifest.egressProfiles?.profiles.find(
+			(profile) => profile.id === "native-discord-clawdi_acctdiscord1-gateway-managed",
+		);
+		expect(discordGateway).toMatchObject({
+			kind: "websocket",
+			match: { scheme: "wss", host: "gateway.discord.gg", pathPrefix: "/" },
+			rewrite: {
+				upstreamBaseUrl: "wss://cloud-api.test/v1/channels/discord/gateway",
+				preservePath: false,
+				setHeaders: {
+					authorization: {
+						type: "secretRef",
+						secretRef:
+							"secret://channels/discord/clawdi_acctdiscord1/links/link-discord-1/agent-token",
+						prefix: "Bearer ",
+					},
+				},
+			},
+			logging: { redactHeaders: ["authorization"] },
+		});
 		expect(
 			projected.secretValues?.["secret://channels/whatsapp/clawdi_acctwhatsapp/agent-token"],
 		).toBeUndefined();


### PR DESCRIPTION
## Summary

- rewrite discord.py's hard-coded `wss://gateway.discord.gg/` connection through the managed Clawdi WebSocket egress profile
- inject the AgentLink bearer only in the WebSocket upgrade, resolve the exact active account/link server-side, and require the account-scoped placeholder in Identify/Resume
- keep capability resume URLs only for capability-authenticated compatibility clients; bearer-egress clients receive the configured canonical Discord Gateway URL so resume traverses the same rewrite and Link-header boundary
- require capability and Authorization identities to select the same account/link when both are present
- preserve WebSocket upgrade headers and query parameters when replacing the path; keep link credentials and bearer-equivalent capabilities out of managed-egress URLs and logs
- lock Telegram `sendChatAction` to the upstream Bot API contract: private-chat and forum `message_thread_id` pass through unchanged for JSON/form, ordinary DMs remain unthreaded, and channel direct-message translation stays limited to supported send methods

## Isolation coverage

A real-DB shared/public Discord account test now proves:

- two active AgentLinks authenticate with distinct bearers and the same account placeholder
- READY guilds and GUILD_CREATE channels are filtered by the resolved Link
- bearer-authenticated resume through the rewritten endpoint remains on the original Link
- mismatched capability + sibling bearer, rotated/stale bearer, random bearer, and archived bearer are rejected with 4004
- managed-egress READY contains only the canonical external Gateway URL, with no capability or internal route

## Upstream contracts checked

- Hermes Agent 0.19.0 metadata pins `discord.py[voice]==2.7.1`; discord.py 2.7.1 defines `DiscordWebSocket.DEFAULT_GATEWAY = wss://gateway.discord.gg/`
- Hermes 0.19.0 Telegram adapter derives topic identity from `message_thread_id` plus `is_topic_message`, and calls `send_chat_action(..., message_thread_id=...)`
- Telegram Bot API 10.x distinguishes private/forum `message_thread_id` from channel `direct_messages_topic_id`; the proxy does not invent or interchange these fields for typing

## Verification

- `bun test --isolate --max-concurrency=1` in `packages/cli`
- `bun run --cwd packages/cli typecheck`
- Python egress addon unittest suite: 17 passed
- throwaway pgvector/Postgres: `tests/test_channels.py tests/test_discord_gateway_websockets.py`: 282 passed
- Ruff check/format, Biome check, Python compileall
- `git diff --check origin/main..HEAD`

No production operations, tenant data access, deployment, or merge performed.