### PR TITLE
fix(backend): type deletion counts with returning

### DIFF
--- a/backend/app/routes/sharing.py
+++ b/backend/app/routes/sharing.py
@@ -502,10 +502,17 @@ async def unshare_project(
     for link in active_links:
         link.revoked_at = now
 
-    invite_result = await db.execute(
-        sql_delete(ProjectInvitation).where(ProjectInvitation.project_id == project_id)
+    cancelled_invitation_ids = (
+        (
+            await db.execute(
+                sql_delete(ProjectInvitation)
+                .where(ProjectInvitation.project_id == project_id)
+                .returning(ProjectInvitation.id)
+            )
+        )
+        .scalars()
+        .all()
     )
-    invitations_cancelled = int(invite_result.rowcount or 0)
 
     members = (
         (
@@ -529,6 +536,6 @@ async def unshare_project(
     return UnshareResponse(
         links_revoked=len(active_links),
         members_removed=len(members),
-        invitations_cancelled=invitations_cancelled,
+        invitations_cancelled=len(cancelled_invitation_ids),
         agent_bindings_removed=agent_bindings_removed,
     )

--- a/backend/app/services/agent_bindings.py
+++ b/backend/app/services/agent_bindings.py
@@ -97,13 +97,21 @@ async def delete_project_bindings_for_users(
         return 0
 
     agent_ids = select(AgentEnvironment.id).where(AgentEnvironment.user_id.in_(user_ids))
-    result = await db.execute(
-        sql_delete(AgentProjectBinding).where(
-            AgentProjectBinding.project_id == project_id,
-            AgentProjectBinding.agent_id.in_(agent_ids),
+    deleted_binding_ids = (
+        (
+            await db.execute(
+                sql_delete(AgentProjectBinding)
+                .where(
+                    AgentProjectBinding.project_id == project_id,
+                    AgentProjectBinding.agent_id.in_(agent_ids),
+                )
+                .returning(AgentProjectBinding.id)
+            )
         )
+        .scalars()
+        .all()
     )
-    return int(result.rowcount or 0)
+    return len(deleted_binding_ids)
 
 
 async def _next_context_priority(db: AsyncSession, *, agent_id: UUID) -> int:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -70,6 +70,8 @@ include = [
     "app/core/query_utils.py",
     "app/core/sentry.py",
     "app/core/skill_key.py",
+    "app/routes/sharing.py",
+    "app/services/agent_bindings.py",
     "app/services/composio.py",
     "app/services/discord_gateway_worker.py",
     "app/services/embedding.py",

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -22,6 +22,8 @@ EXPECTED_CONFIG = {
         "app/core/query_utils.py",
         "app/core/sentry.py",
         "app/core/skill_key.py",
+        "app/routes/sharing.py",
+        "app/services/agent_bindings.py",
         "app/services/composio.py",
         "app/services/discord_gateway_worker.py",
         "app/services/embedding.py",


### PR DESCRIPTION
## Summary

- replace the two SQLAlchemy `Result.rowcount` reads with public `DELETE ... RETURNING(id)` statements
- count returned scalar identifiers while preserving the existing transaction, authorization, and response contracts
- promote both now-zero-diagnostic production files into the owned BasedPyright ratchet

## SQLAlchemy contract

This uses SQLAlchemy public APIs documented for [`Delete.returning()`](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Delete.returning), [`Result.scalars()`](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.scalars), and [`ScalarResult.all()`](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.ScalarResult.all). The upstream 2.0 source also defines the public DML returning implementation in [`sql/dml.py`](https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0/lib/sqlalchemy/sql/dml.py) and typed scalar result methods in [`engine/result.py`](https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0/lib/sqlalchemy/engine/result.py).

## Verification

- focused BasedPyright before: 2 errors (`Result[Any].rowcount`)
- focused BasedPyright after: 2 files, 0 diagnostics
- owned gate: 12 files, 0 diagnostics
- changed-from gate: 2 files, 0 diagnostics
- inventory: app 99 errors / 177 files; total 278 errors / 357 files (delta: -2 errors)
- focused throwaway PostgreSQL tests: 2 passed
- backend static checks: `uv lock --check`, dependency authority, Ruff lint/format, compileall passed
- hermetic Docker workspace suite: backend 1749 passed, 7 skipped; CLI 1514 passed, 4 skipped; all packages 0 failed
- `bun run check`: 829 files checked, no fixes

No dependency or lockfile changes.