### PR TITLE
fix(backend): validate resolved socket addresses

### DIFF
--- a/backend/app/services/private_ip.py
+++ b/backend/app/services/private_ip.py
@@ -51,6 +51,8 @@ async def has_private_resolved_ip(hostname: str | None) -> bool:
         return True
     for info in infos:
         address = info[4][0]
+        if not isinstance(address, str):
+            return True
         if is_private_hostname(address):
             return True
     return False

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,6 +77,7 @@ include = [
     "app/services/embedding.py",
     "app/services/file_store.py",
     "app/services/memory_extraction.py",
+    "app/services/private_ip.py",
     "app/services/runtime_observation.py",
 ]
 

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -29,6 +29,7 @@ EXPECTED_CONFIG = {
         "app/services/embedding.py",
         "app/services/file_store.py",
         "app/services/memory_extraction.py",
+        "app/services/private_ip.py",
         "app/services/runtime_observation.py",
     ],
 }


### PR DESCRIPTION
## Summary

- fail closed when the public `getaddrinfo()` sockaddr address union contains a non-string value
- pass only a runtime-verified string into the private-hostname security check
- add the now-zero-diagnostic production file to the existing BasedPyright owned ratchet

## Runtime contract

Python documents `socket.getaddrinfo()` as returning five-tuples `(family, type, proto, canonname, sockaddr)`, with the sockaddr representation depending on the address family: https://docs.python.org/3/library/socket.html#socket.getaddrinfo

The official CPython 3.12 wrapper destructures each result into those five fields and preserves the underlying `sa` value as the result sockaddr: https://github.com/python/cpython/blob/3.12/Lib/socket.py#L961-L982

The implementation relies on that public shape and performs only the required runtime check at the typed `str | int` address boundary.

## Verification

- `uv run basedpyright --outputjson app/services/private_ip.py` (1 file, 0 diagnostics; before: 1 error)
- `uv run python scripts/type_governance.py owned` (13 files, 0 diagnostics)
- `uv run python scripts/type_governance.py changed-from e7c44bad5131719c4a0e63fe674da5e4de8c0ef1 HEAD` (1 file, 0 diagnostics)
- `uv run pytest -q tests/test_private_ip.py` (42 passed; existing suite unchanged)
- `uv run ruff check app/services/private_ip.py tests/test_private_ip.py scripts/type_governance.py`
- `uv run ruff format --check app/services/private_ip.py tests/test_private_ip.py scripts/type_governance.py`
- `git diff --check`
- `bun run test backend tests/test_private_ip.py` (isolated Docker runner, migrated throwaway PostgreSQL, 42 passed)

Diff: 3 files, 4 insertions. Inventory: 357 files / 278 errors before; 357 files / 277 errors after (app 99 -> 98; all other areas unchanged).

No production or tenant operations were performed.