### PR TITLE
Fix paired chats card expansion

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1116,13 +1116,16 @@ type HostedApiStubOptions = {
 	checkoutResponses?: StubResponse[];
 	channelAccount?: unknown;
 	channelAccounts?: unknown[];
+	channelAccountsResponses?: StubResponse[];
 	channelAgentLinks?: readonly unknown[];
 	channelBindings?: unknown[];
 	channelBindingResponses?: Record<string, StubResponse[]>;
 	channelBotPool?: unknown;
+	channelBotPoolResponses?: StubResponse[];
 	channelHealthItems?: unknown[];
 	linkAgentRequests?: Array<{ accountId: string; body: string }>;
 	linkAgentResponses?: StubResponse[];
+	linkAgentResponseGates?: Array<Promise<void> | undefined>;
 	unlinkAgentRequests?: string[];
 	unlinkAgentResponses?: StubResponse[];
 	onLinkAgent?: (response: unknown) => void;
@@ -1133,6 +1136,7 @@ type HostedApiStubOptions = {
 	onCreateChannel?: (response: unknown) => void;
 	pairCodeRequests?: string[];
 	pairCodeResponses?: StubResponse[];
+	pairCodeResponseGates?: Array<Promise<void> | undefined>;
 	cloudAgentOverrides?: Record<string, unknown>;
 	cloudAgents?: readonly unknown[];
 	cloudAgentsResponse?: StubResponse;
@@ -1894,6 +1898,11 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			});
 		}
 		if (p === "/v1/channels" && r.request().method() === "GET") {
+			const response = options.channelAccountsResponses?.shift();
+			if (response?.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
+			if (response) return fulfillJson(r, response.body, response.status);
 			return fulfillJson(
 				r,
 				options.channelAccounts ?? (options.channelAccount ? [options.channelAccount] : []),
@@ -1901,11 +1910,18 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v1/channels" && r.request().method() === "POST") {
 			options.createChannelRequests?.push(r.request().postData() ?? "");
-			const response = options.createChannelResponse ?? {};
-			options.onCreateChannel?.(response);
-			return fulfillJson(r, response, 201);
+			const configured = options.createChannelResponse ?? {};
+			const response = isStubResponse(configured) ? configured : { body: configured, status: 201 };
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			if (response.status < 400) options.onCreateChannel?.(response.body);
+			return fulfillJson(r, response.body, response.status);
 		}
 		if (p === "/v1/channels/bot-pool") {
+			const response = options.channelBotPoolResponses?.shift();
+			if (response?.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
+			if (response) return fulfillJson(r, response.body, response.status);
 			return fulfillJson(r, options.channelBotPool ?? { providers: {} });
 		}
 		if (p === "/v1/channels/health") {
@@ -1944,6 +1960,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				body: r.request().postData() ?? "",
 			});
 			const response = options.linkAgentResponses?.shift() ?? { body: {}, status: 201 };
+			const responseGate = options.linkAgentResponseGates?.shift();
+			await responseGate;
 			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
 			if (response.status < 400) options.onLinkAgent?.(response.body);
 			return fulfillJson(r, response.body, response.status);
@@ -1960,6 +1978,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p.endsWith("/pair-codes") && r.request().method() === "POST") {
 			options.pairCodeRequests?.push(r.request().postData() ?? "");
 			const response = options.pairCodeResponses?.shift() ?? { body: {}, status: 201 };
+			const responseGate = options.pairCodeResponseGates?.shift();
+			await responseGate;
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
 			return fulfillJson(r, response.body, response.status);
 		}
 		if (p.match(/\/bindings\/[^/]+$/) && r.request().method() === "DELETE") {
@@ -2205,11 +2226,88 @@ function collectBrowserErrors(page: Page): string[] {
 	return errors;
 }
 
-async function expectNonZeroBox(locator: ReturnType<Page["locator"]>, label: string) {
-	const box = await locator.boundingBox();
-	expect(box, `${label} should render a layout box`).not.toBeNull();
-	expect(box?.width, `${label} width`).toBeGreaterThan(0);
-	expect(box?.height, `${label} height`).toBeGreaterThan(0);
+async function expectNoHorizontalOverflow(locator: Locator, label: string) {
+	const metrics = await locator.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(metrics.scrollWidth, `${label} horizontal overflow`).toBeLessThanOrEqual(
+		metrics.clientWidth + 1,
+	);
+}
+
+async function expectContainedInOwnerAndViewport(
+	page: Page,
+	control: Locator,
+	owner: Locator,
+	label: string,
+) {
+	await expect(control, `${label} should be visible`).toBeVisible();
+	await control.scrollIntoViewIfNeeded();
+	const [controlBox, ownerBox] = await Promise.all([control.boundingBox(), owner.boundingBox()]);
+	expect(controlBox, `${label} control box`).not.toBeNull();
+	expect(ownerBox, `${label} owner box`).not.toBeNull();
+	if (!controlBox || !ownerBox) return;
+	const tolerance = 1;
+	const controlRight = controlBox.x + controlBox.width;
+	const controlBottom = controlBox.y + controlBox.height;
+	const ownerRight = ownerBox.x + ownerBox.width;
+	const ownerBottom = ownerBox.y + ownerBox.height;
+	expect(controlBox.x, `${label} left edge in owner`).toBeGreaterThanOrEqual(
+		ownerBox.x - tolerance,
+	);
+	expect(controlBox.y, `${label} top edge in owner`).toBeGreaterThanOrEqual(ownerBox.y - tolerance);
+	expect(controlRight, `${label} right edge in owner`).toBeLessThanOrEqual(ownerRight + tolerance);
+	expect(controlBottom, `${label} bottom edge in owner`).toBeLessThanOrEqual(
+		ownerBottom + tolerance,
+	);
+	const viewport = page.viewportSize();
+	if (!viewport) throw new Error("Playwright viewport is required for containment checks");
+	expect(controlBox.x, `${label} left edge in viewport`).toBeGreaterThanOrEqual(-tolerance);
+	expect(controlBox.y, `${label} top edge in viewport`).toBeGreaterThanOrEqual(-tolerance);
+	expect(controlRight, `${label} right edge in viewport`).toBeLessThanOrEqual(
+		viewport.width + tolerance,
+	);
+	expect(controlBottom, `${label} bottom edge in viewport`).toBeLessThanOrEqual(
+		viewport.height + tolerance,
+	);
+
+	if (await control.evaluate((element) => element.matches("button, [role=button]"))) {
+		const content = await control.evaluate((element) => ({
+			clientHeight: element.clientHeight,
+			clientWidth: element.clientWidth,
+			scrollHeight: element.scrollHeight,
+			scrollWidth: element.scrollWidth,
+		}));
+		expect(content.scrollWidth, `${label} button content width`).toBeLessThanOrEqual(
+			content.clientWidth + tolerance,
+		);
+		expect(content.scrollHeight, `${label} button content height`).toBeLessThanOrEqual(
+			content.clientHeight + tolerance,
+		);
+	}
+}
+
+async function expectControlsDoNotOverlap(controls: Locator[], label: string) {
+	const boxes = await Promise.all(controls.map((control) => control.boundingBox()));
+	for (let first = 0; first < boxes.length; first += 1) {
+		const firstBox = boxes[first];
+		if (!firstBox) continue;
+		for (let second = first + 1; second < boxes.length; second += 1) {
+			const secondBox = boxes[second];
+			if (!secondBox) continue;
+			const horizontalOverlap =
+				Math.min(firstBox.x + firstBox.width, secondBox.x + secondBox.width) -
+				Math.max(firstBox.x, secondBox.x);
+			const verticalOverlap =
+				Math.min(firstBox.y + firstBox.height, secondBox.y + secondBox.height) -
+				Math.max(firstBox.y, secondBox.y);
+			expect(
+				horizontalOverlap > 0 && verticalOverlap > 0,
+				`${label}: controls ${first + 1} and ${second + 1} overlap`,
+			).toBe(false);
+		}
+	}
 }
 
 async function expectPointerCursor(locator: ReturnType<Page["locator"]>, label: string) {
@@ -6796,7 +6894,7 @@ test("app 404 offers a working exit to the dashboard", async ({ page }) => {
 	expect(errors, `app 404: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("Channels separates owned and shared bots with compact connect forms", async ({
+test("Channels separates Custom and Clawdi bots with compact connect forms", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 1100 });
@@ -6814,6 +6912,16 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	const personalTelegramId = "10bbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 	const personalDiscordId = "10cccccc-cccc-4ccc-8ccc-cccccccccccc";
 	const globalCreatedBotId = "10dddddd-dddd-4ddd-8ddd-dddddddddddd";
+	const longCustomTelegramName = `Custom Telegram — ${"identity".repeat(36)}`.slice(0, 300);
+	const longCustomDiscordName = `Custom Discord — ${"localized channel name ".repeat(20)}`.slice(
+		0,
+		300,
+	);
+	const longClawdiTelegramName = `Clawdi Telegram — ${"sharedbot".repeat(36)}`.slice(0, 300);
+	const longClawdiDiscordName = `Clawdi Discord — ${"community server name ".repeat(20)}`.slice(
+		0,
+		300,
+	);
 	const createChannelRequests: string[] = [];
 	const cloudHermesDeployment = {
 		...runningMissingProjectionDeployment,
@@ -6846,7 +6954,7 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	const bot = {
 		id: accountId,
 		provider: "telegram",
-		name: "Clawdi Support Bot",
+		name: longClawdiTelegramName,
 		status: "active",
 		visibility: "public",
 		has_provider_token: true,
@@ -6868,14 +6976,14 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 		...bot,
 		id: discordBotId,
 		provider: "discord",
-		name: "Clawdi Community Bot",
+		name: longClawdiDiscordName,
 		webhook_url: "https://cloud.example.test/channels/community",
 		link_count: 91,
 	};
 	const personalTelegram = {
 		id: personalTelegramId,
 		provider: "telegram",
-		name: "Personal Telegram",
+		name: longCustomTelegramName,
 		status: "active",
 		visibility: "private",
 		has_provider_token: true,
@@ -6886,7 +6994,7 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 		...personalTelegram,
 		id: personalDiscordId,
 		provider: "discord",
-		name: "Personal Discord",
+		name: longCustomDiscordName,
 		status: "error",
 		webhook_url: "https://cloud.example.test/channels/personal-discord",
 		created_at: "2026-07-27T12:27:00Z",
@@ -6964,8 +7072,8 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	await page.goto("/channels");
 	const ownedSection = page.locator("[data-owned-bots-section]");
 	const sharedSection = page.locator("[data-shared-bots-section]");
-	await expect(ownedSection).toContainText(/Your bots\s*2/);
-	await expect(sharedSection).toContainText(/Shared bots\s*2/);
+	await expect(ownedSection).toContainText(/Custom bots\s*2/);
+	await expect(sharedSection).toContainText(/Clawdi bots\s*2/);
 	expect(
 		await ownedSection
 			.locator("[data-channel-account-id]")
@@ -6989,13 +7097,25 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	await expect(page.locator("[data-ready-bots-section]")).toHaveCount(0);
 	await expect(page.locator("[data-pool-account-id]")).toHaveCount(0);
 	await expect(page.getByText("Ready-to-go bots", { exact: true })).toHaveCount(0);
-	await expect(sharedSection.getByText("Clawdi Support Bot", { exact: true })).toBeVisible();
-	await expect(sharedSection.getByText("Clawdi Community Bot", { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText(longClawdiTelegramName, { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText(longClawdiDiscordName, { exact: true })).toBeVisible();
 	await expect(sharedSection.getByText("Shared", { exact: true })).toHaveCount(0);
 	await expect(sharedSection.getByText("Discord", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Link an agent", exact: true })).toHaveCount(0);
 	await expect(page.getByRole("dialog", { name: "Link an agent" })).toHaveCount(0);
 	const ownedCards = ownedSection.locator("[data-channel-account-id]");
+	for (const [card, name] of [
+		[ownedCards.nth(0), longCustomTelegramName],
+		[ownedCards.nth(1), longCustomDiscordName],
+		[sharedSection.locator("[data-shared-channel-account-id]").nth(0), longClawdiTelegramName],
+		[sharedSection.locator("[data-shared-channel-account-id]").nth(1), longClawdiDiscordName],
+	] as const) {
+		await expect(card.locator(`[title="${name}"]`)).toBeVisible();
+		await expectNoHorizontalOverflow(
+			card.locator("article"),
+			`desktop bot card ${name.slice(0, 24)}`,
+		);
+	}
 	const [firstOwnedBox, secondOwnedBox] = await Promise.all([
 		ownedCards.nth(0).boundingBox(),
 		ownedCards.nth(1).boundingBox(),
@@ -7012,8 +7132,8 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 		fullPage: true,
 	});
 
-	await page.getByRole("button", { name: "Connect bot", exact: true }).click();
-	let connectDialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await page.getByRole("button", { name: "Connect custom bot", exact: true }).click();
+	let connectDialog = page.getByRole("dialog", { name: "Connect custom bot" });
 	await expect(connectDialog.getByRole("button", { name: /^Telegram Telegram$/ })).toHaveAttribute(
 		"aria-pressed",
 		"true",
@@ -7028,11 +7148,31 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	await expect(connectDialog.getByLabel("Public key")).toBeVisible();
 	await expect(connectDialog.getByText(/Server ID/i)).toHaveCount(0);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-desktop.png") });
-	await connectDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }).click();
+	await connectDialog.getByLabel("Name").fill("Inventory Telegram");
+	await connectDialog.getByLabel("Bot token").fill("123456:console-inventory-token");
+	await connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(1);
+	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+		provider: "telegram",
+		name: "Inventory Telegram",
+		provider_token: "123456:console-inventory-token",
+		agent_id: null,
+	});
+	const successDialog = page.getByRole("dialog", { name: "Custom bot connected" });
+	await expect(successDialog).toBeVisible();
+	await expect(
+		successDialog.getByRole("button", { name: "View Custom bot", exact: true }),
+	).toBeVisible();
+	await expectNoHorizontalOverflow(successDialog, "Console Custom bot success Dialog");
+	await successDialog.screenshot({
+		path: testInfo.outputPath("connect-custom-bot-success-desktop.png"),
+	});
+	await successDialog.getByRole("button", { name: "Done", exact: true }).click();
 
 	await page.setViewportSize({ width: 320, height: 568 });
-	await expect(ownedSection.getByText("Personal Telegram", { exact: true })).toBeVisible();
-	await expect(sharedSection.getByText("Clawdi Community Bot", { exact: true })).toBeVisible();
+	await expect(ownedSection.getByText(longCustomTelegramName, { exact: true })).toBeVisible();
+	await expect(sharedSection.getByText(longClawdiDiscordName, { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /WhatsApp/ })).toHaveCount(0);
 	const [firstOwnedMobileBox, secondOwnedMobileBox] = await Promise.all([
 		ownedCards.nth(0).boundingBox(),
@@ -7040,19 +7180,56 @@ test("Channels separates owned and shared bots with compact connect forms", asyn
 	]);
 	expect(firstOwnedMobileBox?.x).toBe(secondOwnedMobileBox?.x);
 	expect(secondOwnedMobileBox?.y ?? 0).toBeGreaterThan(firstOwnedMobileBox?.y ?? 0);
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expectNoHorizontalOverflow(page.locator("html"), "Console Channels document at 320px");
+	for (const card of await ownedCards.all()) {
+		await expectNoHorizontalOverflow(card.locator("article"), "Custom bot card at 320px");
+	}
 	await page.screenshot({
 		path:
 			process.env.CHANNELS_HOME_MOBILE_SCREENSHOT_PATH ??
 			testInfo.outputPath("channels-owned-bot-inventory-320x568.png"),
 		fullPage: false,
 	});
-	await page.getByRole("button", { name: "Connect bot", exact: true }).click();
-	connectDialog = page.getByRole("dialog", { name: "Connect a bot" });
+	await page.getByRole("button", { name: "Connect custom bot", exact: true }).click();
+	connectDialog = page.getByRole("dialog", { name: "Connect custom bot" });
+	await expectNoHorizontalOverflow(connectDialog, "Telegram credentials dialog at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		connectDialog.getByRole("button", { name: "Cancel", exact: true }),
+		connectDialog,
+		"Telegram credentials Cancel",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }),
+		connectDialog,
+		"Telegram credentials Connect custom bot",
+	);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-320.png") });
 	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await connectDialog.getByLabel("Bot token").fill("!".repeat(300));
+	await connectDialog.getByLabel("Application ID").fill("9".repeat(300));
+	await connectDialog.getByLabel("Public key").fill("z".repeat(300));
 	await expect(connectDialog.getByLabel("Public key")).toBeVisible();
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expect(
+		connectDialog.getByText("Enter a valid Discord bot token.", { exact: true }),
+	).toBeVisible();
+	await expect(
+		connectDialog.getByText("Enter a valid numeric application ID.", { exact: true }),
+	).toBeVisible();
+	await expect(
+		connectDialog.getByText("Enter a 64-character hex public key.", { exact: true }),
+	).toBeVisible();
+	await expectNoHorizontalOverflow(connectDialog, "Discord credentials dialog at 320px");
+	for (const input of await connectDialog.locator("input").all()) {
+		await expectContainedInOwnerAndViewport(page, input, connectDialog, "Discord credential input");
+	}
+	await expectContainedInOwnerAndViewport(
+		page,
+		connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }),
+		connectDialog,
+		"Discord credentials Connect custom bot",
+	);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-320.png") });
 	expect(errors, `Channels inventory browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
@@ -7100,7 +7277,9 @@ test("Channels shared-only inventory stays primary without duplicate empty actio
 	await expect(sharedSection.getByText("Shared Discord", { exact: true })).toBeVisible();
 	await expect(sharedSection.getByRole("img", { name: "Discord" })).toBeVisible();
 	await expect(page.getByText("No bots yet", { exact: true })).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Connect bot", exact: true })).toHaveCount(1);
+	await expect(page.getByRole("button", { name: "Connect custom bot", exact: true })).toHaveCount(
+		1,
+	);
 	await expect(page.getByRole("button", { name: /Discord\s+1/ })).toBeVisible();
 	await page.screenshot({
 		path: testInfo.outputPath("channels-shared-only-desktop.png"),
@@ -7116,122 +7295,287 @@ test("Channels shared-only inventory stays primary without duplicate empty actio
 	expect(errors, `Channels shared-only browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("channel connect updates its auto-linked agent page without reload", async ({ page }) => {
-	const errors = collectBrowserErrors(page);
-	const channelId = "11111111-1111-4111-8111-111111111111";
-	const linkId = "22222222-2222-4222-8222-222222222222";
-	const channelAccounts: unknown[] = [];
-	const channelAgentLinks: unknown[] = [];
-	const createChannelRequests: string[] = [];
-	const pairCodeRequests: string[] = [];
-	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
-	const channelAccount = {
-		id: channelId,
-		provider: "telegram",
-		name: "Browser Telegram",
-		status: "active",
-		visibility: "private",
-		has_provider_token: true,
-		webhook_url: "https://cloud.example.test/channels/browser",
-		created_at: "2026-07-27T12:00:00Z",
-	};
-	const channelLink = {
-		id: linkId,
-		account_id: channelId,
-		agent_id: missingProjectionEnvironmentId,
-		status: "active",
-		created_at: "2026-07-27T12:00:00Z",
-		account: channelAccount,
-	};
-	await stubHostedApi(page, {
-		deployments: [runningMissingProjectionDeployment],
-		channelAccounts,
-		channelAgentLinks,
-		createChannelRequests,
-		createChannelResponse: {
-			...channelAccount,
-			webhook_secret: "one-time-webhook-secret",
-			agent_link_id: linkId,
-			agent_id: missingProjectionEnvironmentId,
-			agent_token: "one-time-agent-token",
-		},
-		onCreateChannel: () => {
-			channelAccounts.push(channelAccount);
-			channelAgentLinks.push(channelLink);
-		},
-		pairCodeRequests,
-		pairCodeResponses: [
-			{
-				status: 201,
-				body: {
-					id: "connected-bot-pair-code",
-					agent_link_id: linkId,
-					agent_id: missingProjectionEnvironmentId,
-					code: "CONNECTED123",
-					expires_at: validExpiry,
-					pairing_command: "/bot_pair CONNECTED123",
-					bot_username: "Browser_Telegram_Bot",
-					deep_link: "https://t.me/Browser_Telegram_Bot?start=CONNECTED123",
-					qr_payload: "https://t.me/Browser_Telegram_Bot?start=CONNECTED123",
-				},
-			},
-		],
-	});
-	await page.goto("/channels");
-	const globalConnect = page.getByRole("button", { name: "Connect bot", exact: true }).first();
-	await expect(globalConnect).toBeVisible();
-	await expect(page.locator('[data-slot="tabs-list"]')).toHaveCount(0);
-	await expect(page.getByText("Ready-to-go bots", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Bots", { exact: true })).toBeVisible();
-	await expectNonZeroBox(page.locator('[data-sidebar="separator"]').first(), "sidebar separator");
-	await globalConnect.click();
-	const globalDialog = page.getByRole("dialog");
-	await expect(globalDialog).toBeVisible();
-	await globalDialog.getByRole("button", { name: "Cancel", exact: true }).click();
-
-	await page.goto(
-		`/agents/${missingProjectionEnvironmentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
-	);
-
-	await expect(page.getByText("No connected channels", { exact: true })).toBeVisible();
-	await page.getByText("Use your own bot", { exact: true }).click();
-	const connect = page.getByRole("button", { name: "Connect a bot", exact: true }).first();
-	await expect(connect).toBeVisible();
-	await connect.click();
-	const dialog = page.getByRole("dialog");
-	await dialog.getByLabel("Name").fill("Browser Telegram");
-	await dialog.getByLabel("Bot token").fill("123456:browser-test-token");
-	await dialog.getByRole("button", { name: "Connect", exact: true }).click();
-
-	await expect.poll(() => createChannelRequests.length).toBe(1);
-	await expect.poll(() => pairCodeRequests.length).toBe(1);
-	const pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
-	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
-	await expect(page.locator("body")).not.toContainText("one-time-agent-token");
-	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
-	await expect(page.getByText("No connected channels", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Browser Telegram", { exact: true }).first()).toBeVisible();
-	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
-		provider: "telegram",
-		name: "Browser Telegram",
-		provider_token: "123456:browser-test-token",
-		agent_id: missingProjectionEnvironmentId,
-	});
-	expect(JSON.parse(pairCodeRequests[0] ?? "{}")).toEqual({
-		ttl_seconds: 900,
-		agent_link_id: linkId,
-	});
-	expect(errors, `channel connect convergence: ${errors.join(" | ")}`).toEqual([]);
-});
-
-test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
+test("Console Channels contains long inventory loading and error states at 320px", async ({
 	page,
 }, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
+	const customErrorText = `Custom inventory error ${"localizederror".repeat(25)}`;
+	const clawdiErrorText = `Clawdi inventory error ${"localizederror".repeat(25)}`;
+	await stubHostedApi(page, {
+		channelAccountsResponses: [
+			{ status: 400, delayMs: 1_500, body: { detail: customErrorText } },
+			{ status: 200, body: [] },
+		],
+		channelBotPoolResponses: [
+			{ status: 400, delayMs: 1_500, body: { detail: clawdiErrorText } },
+			{ status: 200, body: { providers: {} } },
+		],
+	});
+
+	await page.goto("/channels");
+	await expect(page.locator('[data-slot="skeleton"]').first()).toBeVisible();
+	await expectNoHorizontalOverflow(page.locator("html"), "loading Console Channels at 320px");
+	const customError = page.getByRole("alert").filter({ hasText: "Couldn't load channels" });
+	const clawdiError = page.getByRole("alert").filter({ hasText: "Couldn't load Clawdi bots" });
+	await expect(customError).toContainText(customErrorText);
+	await expect(clawdiError).toContainText(clawdiErrorText);
+	await expectNoHorizontalOverflow(customError, "long Console Custom error");
+	await expectNoHorizontalOverflow(clawdiError, "long Console Clawdi error");
+	for (const [errorPanel, label] of [
+		[customError, "Console Custom Retry"],
+		[clawdiError, "Console Clawdi Retry"],
+	] as const) {
+		await expectContainedInOwnerAndViewport(
+			page,
+			errorPanel.getByRole("button", { name: "Retry", exact: true }),
+			errorPanel,
+			label,
+		);
+	}
+	await page.screenshot({
+		path: testInfo.outputPath("console-channels-errors-320x568.png"),
+		fullPage: false,
+	});
+	await customError.getByRole("button", { name: "Retry", exact: true }).click();
+	await clawdiError.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect(page.getByText("No bots yet", { exact: true })).toBeVisible();
+});
+
+for (const firstTimeViewport of [
+	{ label: "desktop", size: { width: 1440, height: 900 } },
+	{ label: "320x568", size: { width: 320, height: 568 } },
+] as const) {
+	test(`first-time Agent connects, links, and pairs a Custom bot at ${firstTimeViewport.label}`, async ({
+		page,
+	}, testInfo) => {
+		await page.setViewportSize(firstTimeViewport.size);
+		const errors = collectBrowserErrors(page);
+		const channelId = "11111111-1111-4111-8111-111111111111";
+		const linkId = "22222222-2222-4222-8222-222222222222";
+		const channelAccounts: unknown[] = [];
+		const channelAgentLinks: unknown[] = [];
+		const channelBindings: unknown[] = [];
+		const createChannelRequests: string[] = [];
+		const linkAgentRequests: Array<{ accountId: string; body: string }> = [];
+		const pairCodeRequests: string[] = [];
+		const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
+		const channelAccount = {
+			id: channelId,
+			provider: "telegram",
+			name: "Browser Telegram",
+			status: "active",
+			visibility: "private",
+			has_provider_token: true,
+			webhook_url: "https://cloud.example.test/channels/browser",
+			created_at: "2026-07-27T12:00:00Z",
+		};
+		const channelLink = {
+			id: linkId,
+			account_id: channelId,
+			agent_id: missingProjectionEnvironmentId,
+			status: "active",
+			created_at: "2026-07-27T12:00:00Z",
+			account: channelAccount,
+		};
+		await stubHostedApi(page, {
+			deployments: [runningMissingProjectionDeployment],
+			channelAccounts,
+			channelAgentLinks,
+			channelBindings,
+			createChannelRequests,
+			createChannelResponse: {
+				status: 201,
+				delayMs: 1_500,
+				body: {
+					...channelAccount,
+					webhook_secret: "one-time-webhook-secret",
+					agent_link_id: linkId,
+					agent_id: missingProjectionEnvironmentId,
+					agent_token: "agent-custom-bot-token-must-not-render",
+				},
+			},
+			onCreateChannel: () => {
+				channelAccounts.push(channelAccount);
+				channelAgentLinks.push(channelLink);
+			},
+			linkAgentRequests,
+			pairCodeRequests,
+			pairCodeResponses: [
+				{
+					status: 201,
+					body: {
+						id: "connected-bot-pair-code",
+						agent_link_id: linkId,
+						agent_id: missingProjectionEnvironmentId,
+						code: "CONNECTED123",
+						expires_at: validExpiry,
+						pairing_command: "/bot_pair CONNECTED123",
+						bot_username: "Browser_Telegram_Bot",
+						deep_link: "https://t.me/Browser_Telegram_Bot?start=CONNECTED123",
+						qr_payload: "https://t.me/Browser_Telegram_Bot?start=CONNECTED123",
+					},
+				},
+			],
+		});
+
+		await page.goto(
+			`/agents/${missingProjectionEnvironmentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+		);
+		await expect(page.getByText("No connected channels", { exact: true })).toBeVisible();
+		const addChannel = page.getByRole("button", { name: "Add channel", exact: true });
+		await addChannel.click();
+		const addDialog = page.getByRole("dialog", { name: "Add channel" });
+		await expect(
+			addDialog.getByText("No Clawdi or Custom bots to add", { exact: true }),
+		).toBeVisible();
+		await expectNoHorizontalOverflow(page.locator("html"), `${firstTimeViewport.label} document`);
+		await expectNoHorizontalOverflow(addDialog, `${firstTimeViewport.label} Add channel Dialog`);
+		const connectCustom = addDialog.getByRole("button", {
+			name: "Connect custom bot",
+			exact: true,
+		});
+		await expect(connectCustom.locator("svg")).toHaveCount(1);
+		await expect(connectCustom.getByText("Connect custom bot", { exact: true })).toBeVisible();
+		await expectContainedInOwnerAndViewport(
+			page,
+			connectCustom,
+			addDialog,
+			`${firstTimeViewport.label} Add channel Connect custom bot`,
+		);
+		await addDialog.screenshot({
+			path: testInfo.outputPath(`agent-first-time-add-channel-${firstTimeViewport.label}.png`),
+		});
+
+		await connectCustom.click();
+		await expect(addDialog).toHaveCount(0);
+		const connectDialog = page.getByRole("dialog", { name: "Connect custom bot" });
+		await expect(connectDialog).toBeVisible();
+		await expect(page.getByRole("dialog")).toHaveCount(1);
+		await expect(connectDialog).toContainText("Connect a Custom bot you manage to this Agent.");
+		await connectDialog.getByLabel("Name").fill("Browser Telegram");
+		await connectDialog.getByLabel("Bot token").fill("123456:browser-test-token");
+		await expectNoHorizontalOverflow(
+			connectDialog,
+			`${firstTimeViewport.label} Connect custom bot Dialog`,
+		);
+		for (const input of await connectDialog.locator("input").all()) {
+			await expectContainedInOwnerAndViewport(
+				page,
+				input,
+				connectDialog,
+				`${firstTimeViewport.label} Custom bot credential input`,
+			);
+		}
+		const submitCustomBot = connectDialog.getByRole("button", {
+			name: "Connect custom bot",
+			exact: true,
+		});
+		await expectContainedInOwnerAndViewport(
+			page,
+			submitCustomBot,
+			connectDialog,
+			`${firstTimeViewport.label} Connect custom bot submit`,
+		);
+		await connectDialog.screenshot({
+			path: testInfo.outputPath(`agent-first-time-custom-bot-form-${firstTimeViewport.label}.png`),
+		});
+
+		await submitCustomBot.click();
+		const connecting = connectDialog.getByRole("button", { name: "Connecting…", exact: true });
+		await expect(connecting).toBeVisible();
+		await expectContainedInOwnerAndViewport(
+			page,
+			connecting,
+			connectDialog,
+			`${firstTimeViewport.label} pending Connect custom bot`,
+		);
+		await connectDialog.screenshot({
+			path: testInfo.outputPath(
+				`agent-first-time-custom-bot-pending-${firstTimeViewport.label}.png`,
+			),
+		});
+		await expect.poll(() => createChannelRequests.length).toBe(1);
+		expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+			provider: "telegram",
+			name: "Browser Telegram",
+			provider_token: "123456:browser-test-token",
+			agent_id: missingProjectionEnvironmentId,
+		});
+		expect(linkAgentRequests).toEqual([]);
+
+		await expect.poll(() => pairCodeRequests.length).toBe(1);
+		const pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+		await expect(connectDialog).toHaveCount(0);
+		await expect(page.getByRole("dialog")).toHaveCount(1);
+		await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+		await expectNoHorizontalOverflow(
+			pairDialog,
+			`${firstTimeViewport.label} first-time Telegram Pair Dialog`,
+		);
+		await expectContainedInOwnerAndViewport(
+			page,
+			pairDialog.getByRole("button", { name: "Open Telegram" }),
+			pairDialog,
+			`${firstTimeViewport.label} first-time Open Telegram`,
+		);
+		await pairDialog.screenshot({
+			path: testInfo.outputPath(`agent-first-time-pair-telegram-${firstTimeViewport.label}.png`),
+		});
+		expect(JSON.parse(pairCodeRequests[0] ?? "{}")).toEqual({
+			ttl_seconds: 900,
+			agent_link_id: linkId,
+		});
+		await expect(page.locator("body")).not.toContainText("agent-custom-bot-token-must-not-render");
+		channelBindings.push({
+			id: "33333333-3333-4333-8333-333333333333",
+			account_id: channelId,
+			agent_link_id: linkId,
+			external_chat_id: "first-time-private-chat",
+			external_chat_type: "private",
+			external_chat_name: "First-time private chat",
+			status: "active",
+			created_at: "2026-08-01T01:00:00Z",
+			last_message_at: null,
+		});
+		await expect(pairDialog).toHaveCount(0, { timeout: 5_000 });
+		const successToast = page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" });
+		await expect(successToast).toHaveCount(1);
+		await expect(successToast).toContainText("Telegram private chat is ready.");
+		await expectNoHorizontalOverflow(
+			successToast,
+			`${firstTimeViewport.label} first-time pair success toast`,
+		);
+		await expectContainedInOwnerAndViewport(
+			page,
+			successToast,
+			page.locator("html"),
+			`${firstTimeViewport.label} first-time pair success toast`,
+		);
+		await page.screenshot({
+			path: testInfo.outputPath(`agent-first-time-pair-success-${firstTimeViewport.label}.png`),
+			fullPage: false,
+		});
+		await expect(page.getByText("No connected channels", { exact: true })).toHaveCount(0);
+		await expect(page.getByText("Browser Telegram", { exact: true }).first()).toBeVisible();
+		await expect(
+			page.locator(`[data-agent-paired-chats-trigger="${linkId}"]`),
+		).toHaveAccessibleName("Paired chats · 1");
+		expect(
+			errors,
+			`${firstTimeViewport.label} first-time channel path: ${errors.join(" | ")}`,
+		).toEqual([]);
+	});
+}
+
+test("Agent Add channel offers only providers not already linked", async ({ page }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
 	const agentId = missingProjectionEnvironmentId;
 	const telegramId = "6aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 	const telegramLinkId = "6bbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+	const replacementTelegramId = "6ccccccc-cccc-4ccc-8ccc-cccccccccccc";
+	const discordId = "6ddddddd-dddd-4ddd-8ddd-dddddddddddd";
+	const clawdiDiscordId = "6eeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
 	const telegramAccount = {
 		id: telegramId,
 		provider: "telegram",
@@ -7242,9 +7586,37 @@ test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
 		webhook_url: "https://cloud.example.test/channels/linked-telegram",
 		created_at: "2026-07-31T00:00:00Z",
 	};
+	const replacementTelegram = {
+		...telegramAccount,
+		id: replacementTelegramId,
+		name: "Replacement Telegram",
+	};
+	const discordAccount = {
+		...telegramAccount,
+		id: discordId,
+		provider: "discord",
+		name: `Custom Discord — ${"long localized bot identity ".repeat(16)}`.slice(0, 300),
+	};
+	const clawdiDiscord = {
+		...discordAccount,
+		id: clawdiDiscordId,
+		name: `Clawdi Discord — ${"long localized bot identity ".repeat(16)}`.slice(0, 300),
+		visibility: "public",
+		access: "public",
+		available: true,
+		capabilities: {
+			link_agent: true,
+			pair_chat: true,
+			send_message: true,
+			manage_account: false,
+			sync_commands: true,
+		},
+		link_count: 0,
+		max_links: null,
+	};
 	await stubHostedApi(page, {
 		deployments: [runningMissingProjectionDeployment],
-		channelAccounts: [telegramAccount],
+		channelAccounts: [telegramAccount, replacementTelegram, discordAccount],
 		channelAgentLinks: [
 			{
 				id: telegramLinkId,
@@ -7255,52 +7627,182 @@ test("Agent Connect bot defaults to Discord after Telegram is linked", async ({
 				account: telegramAccount,
 			},
 		],
-		channelBotPool: { providers: {} },
+		channelBotPool: { providers: { discord: [clawdiDiscord] } },
 	});
 
 	await page.goto(
 		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 	);
-	await page.getByText("Use your own bot", { exact: true }).click();
-	await page.getByRole("button", { name: "Connect a bot", exact: true }).click();
-	let dialog = page.getByRole("dialog", { name: "Connect a bot" });
-	await expect(dialog.getByRole("button", { name: /Telegram.*Already linked/ })).toBeDisabled();
-	await expect(dialog.getByRole("button", { name: /^Discord Discord$/ })).toHaveAttribute(
-		"aria-pressed",
-		"true",
-	);
+	await page.getByRole("button", { name: "Add channel", exact: true }).click();
+	let dialog = page.getByRole("dialog", { name: "Add channel" });
+	await expect(dialog.locator(`[data-add-channel-id="${telegramId}"]`)).toHaveCount(0);
+	await expect(dialog.locator(`[data-add-channel-id="${replacementTelegramId}"]`)).toHaveCount(0);
+	const discordRow = dialog.locator(`[data-add-channel-id="${discordId}"]`);
+	const clawdiDiscordRow = dialog.locator(`[data-add-channel-id="${clawdiDiscordId}"]`);
+	await expect(dialog.getByText("Clawdi bots", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Custom bots", { exact: true })).toBeVisible();
+	await expect(discordRow).toBeVisible();
+	await expect(clawdiDiscordRow).toBeVisible();
+	await expect(discordRow.locator(`[title="${discordAccount.name}"]`)).toBeVisible();
+	await expect(clawdiDiscordRow.locator(`[title="${clawdiDiscord.name}"]`)).toBeVisible();
 	await expect(
-		dialog.getByText("Unlink Telegram from this Agent first.", { exact: true }),
+		dialog.getByRole("button", { name: "Connect custom bot", exact: true }),
 	).toBeVisible();
-	await expect(dialog.getByLabel("Application ID")).toBeVisible();
-	await dialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-default-desktop.png") });
+	await expect(dialog.getByLabel("Application ID")).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "desktop provider-limited Add channel dialog");
+	await dialog.screenshot({ path: testInfo.outputPath("add-channel-discord-only-desktop.png") });
 
-	await page.setViewportSize({ width: 320, height: 844 });
-	dialog = page.getByRole("dialog", { name: "Connect a bot" });
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
-	await expect(dialog.getByLabel("Public key")).toBeVisible();
-	await expect(dialog.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
-	await dialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-default-320.png") });
-	expect(errors, `Agent connect default browser errors: ${errors.join(" | ")}`).toEqual([]);
+	await page.setViewportSize({ width: 320, height: 568 });
+	dialog = page.getByRole("dialog", { name: "Add channel" });
+	await expectNoHorizontalOverflow(page.locator("html"), "provider-limited Agent at 320px");
+	await expectNoHorizontalOverflow(dialog, "provider-limited Add channel at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		discordRow.getByRole("button", { name: "Add", exact: true }),
+		dialog,
+		"Add Custom Discord at 320px",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		clawdiDiscordRow.getByRole("button", { name: "Add", exact: true }),
+		dialog,
+		"Add Clawdi Discord at 320px",
+	);
+	await dialog.screenshot({ path: testInfo.outputPath("add-channel-discord-only-320x568.png") });
+	expect(errors, `Agent Add channel provider limit errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Agent Add channel contains long loading and provider-error states at 320px", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
+	const agentId = missingProjectionEnvironmentId;
+	const customBotId = "60000000-1111-4111-8111-111111111111";
+	const clawdiBotId = "60000000-2222-4222-8222-222222222222";
+	const customName = `Custom Telegram — ${"longidentity".repeat(26)}`.slice(0, 300);
+	const clawdiName = `Clawdi Discord — ${"localized bot name ".repeat(18)}`.slice(0, 300);
+	const customBot = {
+		id: customBotId,
+		provider: "telegram",
+		name: customName,
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/custom-overflow",
+		created_at: "2026-07-31T00:10:00Z",
+	};
+	const clawdiBot = {
+		...customBot,
+		id: clawdiBotId,
+		provider: "discord",
+		name: clawdiName,
+		visibility: "public",
+		access: "public",
+		available: true,
+		capabilities: {
+			link_agent: true,
+			pair_chat: true,
+			send_message: true,
+			manage_account: false,
+			sync_commands: true,
+		},
+		link_count: 0,
+		max_links: null,
+	};
+	const longCustomError = `Custom bot provider error ${"localizederror".repeat(24)}`;
+	const longClawdiError = `Clawdi bot provider error ${"localizederror".repeat(24)}`;
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccountsResponses: [
+			{ status: 400, delayMs: 1_500, body: { detail: longCustomError } },
+			{ status: 200, body: [customBot] },
+		],
+		channelBotPoolResponses: [
+			{ status: 400, delayMs: 1_500, body: { detail: longClawdiError } },
+			{ status: 200, body: { providers: { discord: [clawdiBot] } } },
+		],
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await page.getByRole("button", { name: "Add channel", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Add channel" });
+	await expect(dialog.getByRole("status")).toContainText("Loading Clawdi and Custom bots");
+	await expectNoHorizontalOverflow(dialog, "loading Add channel Dialog at 320px");
+	await dialog.screenshot({ path: testInfo.outputPath("agent-add-channel-loading-320x568.png") });
+
+	const clawdiError = dialog.getByRole("alert").filter({ hasText: "Couldn't load Clawdi bots" });
+	const customError = dialog.getByRole("alert").filter({ hasText: "Couldn't load Custom bots" });
+	await expect(clawdiError).toContainText(longClawdiError);
+	await expect(customError).toContainText(longCustomError);
+	await expectNoHorizontalOverflow(dialog, "error Add channel Dialog at 320px");
+	await expectNoHorizontalOverflow(clawdiError, "long Clawdi provider error");
+	await expectNoHorizontalOverflow(customError, "long Custom provider error");
+	const clawdiRetry = clawdiError.getByRole("button", { name: "Retry", exact: true });
+	const customRetry = customError.getByRole("button", { name: "Retry", exact: true });
+	await expectContainedInOwnerAndViewport(
+		page,
+		clawdiRetry,
+		dialog,
+		"Clawdi provider Retry at 320px",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		customRetry,
+		dialog,
+		"Custom provider Retry at 320px",
+	);
+	await dialog.screenshot({ path: testInfo.outputPath("agent-add-channel-errors-320x568.png") });
+	await clawdiRetry.click();
+	await customRetry.click();
+	await expect(dialog.locator(`[data-add-channel-id="${clawdiBotId}"]`)).toBeVisible();
+	await expect(dialog.locator(`[data-add-channel-id="${customBotId}"]`)).toBeVisible();
+	await expectNoHorizontalOverflow(dialog, "recovered Add channel Dialog at 320px");
 });
 
 test("Agent Channel cards keep paired-chat loading and error recovery inside the owner", async ({
 	page,
-}) => {
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
 	const agentId = missingProjectionEnvironmentId;
 	const accountId = "61111111-1111-4111-8111-111111111111";
 	const linkId = "62222222-2222-4222-8222-222222222222";
 	const bindingId = "63333333-3333-4333-8333-333333333333";
+	const longRecoveryName = `Recovery Telegram — ${"channelidentity".repeat(24)}`.slice(0, 300);
 	const account = {
 		id: accountId,
 		provider: "telegram",
-		name: "Recovery Telegram",
+		name: longRecoveryName,
 		status: "active",
 		visibility: "private",
 		has_provider_token: true,
 		webhook_url: "https://cloud.example.test/channels/recovery-telegram",
 		created_at: "2026-07-30T09:00:00Z",
 	};
+	const recoveredBindingResponse: StubResponse = {
+		status: 200,
+		body: [
+			{
+				id: bindingId,
+				account_id: accountId,
+				agent_link_id: linkId,
+				external_chat_id: "recovered-chat",
+				external_chat_type: "private",
+				external_chat_name: "Recovered chat",
+				status: "active",
+				created_at: "2026-07-30T09:10:00Z",
+				last_message_at: "2026-07-30T09:11:00Z",
+			},
+		],
+	};
+	const bindingResponses: StubResponse[] = [
+		{
+			status: 400,
+			delayMs: 1_500,
+			body: { detail: `temporary binding read error ${"providererror".repeat(24)}` },
+		},
+	];
 	await stubHostedApi(page, {
 		deployments: [runningMissingProjectionDeployment],
 		cloudAgents: [
@@ -7323,25 +7825,7 @@ test("Agent Channel cards keep paired-chat loading and error recovery inside the
 			},
 		],
 		channelBindingResponses: {
-			[accountId]: [
-				{ status: 400, delayMs: 500, body: { detail: "temporary binding read error" } },
-				{
-					status: 200,
-					body: [
-						{
-							id: bindingId,
-							account_id: accountId,
-							agent_link_id: linkId,
-							external_chat_id: "recovered-chat",
-							external_chat_type: "private",
-							external_chat_name: "Recovered chat",
-							status: "active",
-							created_at: "2026-07-30T09:10:00Z",
-							last_message_at: "2026-07-30T09:11:00Z",
-						},
-					],
-				},
-			],
+			[accountId]: bindingResponses,
 		},
 	});
 
@@ -7349,20 +7833,384 @@ test("Agent Channel cards keep paired-chat loading and error recovery inside the
 		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 	);
 	const owner = page.locator(`[data-agent-channel-group-id="${linkId}"]`);
-	const disclosure = owner.getByRole("button", { name: /Paired chats · 0/ });
-	await expect(disclosure).toHaveAttribute("aria-expanded", "false");
-	await disclosure.click();
-	await expect(disclosure).toHaveAttribute("aria-expanded", "true");
+	const pairedChatsTrigger = owner.getByRole("button", { name: /Paired chats · 0/ });
+	await expect(pairedChatsTrigger).toHaveAttribute("aria-haspopup", "dialog");
+	await pairedChatsTrigger.click();
+	const pairedChatsDialog = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(pairedChatsDialog).toBeVisible();
+	await expect(pairedChatsDialog).toContainText("connected through this channel");
 	await expect(
-		owner.locator(`[data-agent-channel-chats-for="${linkId}"]`).getByRole("status"),
+		pairedChatsDialog.locator(
+			`[data-agent-paired-chats-channel-name][title="${longRecoveryName}"]`,
+		),
 	).toBeVisible();
-	const bindingError = owner.getByRole("alert");
+	await expect(pairedChatsDialog.getByRole("status")).toBeVisible();
+	const bindingError = pairedChatsDialog.getByRole("alert");
 	await expect(bindingError).toContainText("Couldn’t load paired chats");
+	await expectNoHorizontalOverflow(page.locator("html"), "paired-chat recovery document at 320px");
+	await expectNoHorizontalOverflow(pairedChatsDialog, "paired-chat recovery Sheet at 320px");
+	await expectNoHorizontalOverflow(
+		pairedChatsDialog.locator("[data-agent-paired-chats-list]"),
+		"paired-chat recovery list at 320px",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		bindingError.getByRole("button", { name: "Retry", exact: true }),
+		pairedChatsDialog,
+		"paired chats Retry at 320px",
+	);
+	await pairedChatsDialog.screenshot({
+		path: testInfo.outputPath("agent-channel-paired-chats-error-320x568.png"),
+	});
+	bindingResponses.push(recoveredBindingResponse);
 	await bindingError.getByRole("button", { name: "Retry", exact: true }).click();
-	await expect(owner.locator(`[data-channel-binding-id="${bindingId}"]`)).toContainText(
+	await expect(pairedChatsDialog.locator(`[data-channel-binding-id="${bindingId}"]`)).toContainText(
 		"Recovered chat",
 	);
 	await expect(bindingError).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await expect(pairedChatsDialog).toHaveCount(0);
+	await expect(pairedChatsTrigger).toBeFocused();
+});
+
+test("generic Channel pairing keeps pending, retry, errors, icons, and labels contained at 320px", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
+	const agentId = missingProjectionEnvironmentId;
+	const accountId = "64444444-4444-4444-8444-444444444444";
+	const linkId = "65555555-5555-4555-8555-555555555555";
+	const longChannelName = `WhatsApp Channel — ${"unbrokenidentity".repeat(24)}`.slice(0, 300);
+	const account = {
+		id: accountId,
+		provider: "whatsapp",
+		name: longChannelName,
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/whatsapp-overflow",
+		created_at: "2026-07-31T01:00:00Z",
+	};
+	const pairCodeRequests: string[] = [];
+	const pairResponseGate = deferred();
+	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: [account],
+		channelAgentLinks: [
+			{
+				id: linkId,
+				account_id: accountId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-07-31T01:01:00Z",
+				account,
+			},
+		],
+		pairCodeRequests,
+		pairCodeResponseGates: [pairResponseGate.promise],
+		pairCodeResponses: [
+			{
+				status: 503,
+				body: { detail: `provider pairing error ${"localizederror".repeat(24)}` },
+			},
+			{
+				status: 201,
+				body: {
+					id: "generic-pair-code",
+					agent_link_id: linkId,
+					agent_id: agentId,
+					code: "GENERIC123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair GENERIC123",
+				},
+			},
+		],
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const card = page.locator(`[data-agent-channel-link-id="${linkId}"]`);
+	const cardShell = card.locator("article");
+	await expect(card.locator(`[title="${longChannelName}"]`)).toBeVisible();
+	const pair = card.getByRole("button", { name: "Pair chat", exact: true });
+	const unlink = card.getByRole("button", {
+		name: `Unlink ${longChannelName} from Hosted agent`,
+		exact: true,
+	});
+	await expect(pair.locator("svg")).toHaveCount(1);
+	await expect(unlink.locator("svg")).toHaveCount(1);
+	await expect(unlink.getByText("Unlink", { exact: true })).toBeVisible();
+	await expectNoHorizontalOverflow(page.locator("html"), "generic Channel document at 320px");
+	await expectNoHorizontalOverflow(cardShell, "generic Channel card at 320px");
+	await expectContainedInOwnerAndViewport(page, pair, cardShell, "normal Pair chat");
+	await expectContainedInOwnerAndViewport(page, unlink, cardShell, "normal Unlink");
+	await expectControlsDoNotOverlap([pair, unlink], "generic Channel card actions");
+
+	const initialPairClick = pair.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(1);
+	const generating = card.locator("button", { hasText: "Generating…" });
+	await expect(generating).toBeVisible();
+	await expectContainedInOwnerAndViewport(page, generating, cardShell, "Generating pairing code");
+	pairResponseGate.resolve();
+	await initialPairClick;
+	const retry = card.getByRole("button", { name: "Retry pairing", exact: true });
+	await expect(retry).toBeVisible();
+	await expect(retry.locator("svg")).toHaveCount(1);
+	await expectContainedInOwnerAndViewport(page, retry, cardShell, "Retry pairing");
+	const errorToast = page.locator("[data-sonner-toast]").last();
+	await expect(errorToast).toBeVisible();
+	await expectNoHorizontalOverflow(errorToast, "long provider-error toast");
+	await expectContainedInOwnerAndViewport(
+		page,
+		errorToast,
+		page.locator("html"),
+		"long provider-error toast",
+	);
+	await page.screenshot({
+		path: testInfo.outputPath("agent-channel-generic-retry-320x568.png"),
+		fullPage: false,
+	});
+	await retry.click();
+	await expect.poll(() => pairCodeRequests.length).toBe(2);
+	await expect(card.getByRole("button", { name: "Copy pairing command" })).toBeVisible();
+});
+
+test("Telegram and Discord pairing acknowledge one newly active binding at 320px", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
+	const errors = collectBrowserErrors(page);
+	const agentId = missingProjectionEnvironmentId;
+	const telegramId = "67777777-7777-4777-8777-777777777777";
+	const telegramLinkId = "68888888-8888-4888-8888-888888888888";
+	const discordId = "69999999-9999-4999-8999-999999999999";
+	const discordLinkId = "6aaaaaaa-1111-4aaa-8aaa-111111111111";
+	const telegramExistingBindingId = "6bbbbbbb-1111-4bbb-8bbb-111111111111";
+	const discordExistingBindingId = "6ccccccc-1111-4ccc-8ccc-111111111111";
+	const telegramNewBindingId = "6ddddddd-1111-4ddd-8ddd-111111111111";
+	const discordNewBindingId = "6eeeeeee-1111-4eee-8eee-111111111111";
+	const telegramLateBindingId = "6fffffff-1111-4fff-8fff-111111111111";
+	const telegramAccount = {
+		id: telegramId,
+		provider: "telegram",
+		name: `Pair Success Telegram — ${"long channel identity ".repeat(16)}`.slice(0, 300),
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/pair-success-telegram",
+		created_at: "2026-08-01T02:00:00Z",
+	};
+	const discordAccount = {
+		...telegramAccount,
+		id: discordId,
+		provider: "discord",
+		name: `Pair Success Discord — ${"long channel identity ".repeat(16)}`.slice(0, 300),
+		webhook_url: "https://cloud.example.test/channels/pair-success-discord",
+	};
+	const channelBindings: unknown[] = [
+		{
+			id: telegramExistingBindingId,
+			account_id: telegramId,
+			agent_link_id: telegramLinkId,
+			external_chat_id: "telegram-existing",
+			external_chat_type: "private",
+			external_chat_name: "Existing Telegram chat",
+			status: "active",
+			created_at: "2026-08-01T02:01:00Z",
+			last_message_at: null,
+		},
+		{
+			id: discordExistingBindingId,
+			account_id: discordId,
+			agent_link_id: discordLinkId,
+			external_chat_id: "discord-existing",
+			external_chat_type: "guild",
+			external_chat_name: "Existing Discord server",
+			status: "active",
+			created_at: "2026-08-01T02:02:00Z",
+			last_message_at: null,
+		},
+	];
+	const pairCodeRequests: string[] = [];
+	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
+	const telegramPairResponse: StubResponse = {
+		status: 201,
+		body: {
+			id: "telegram-success-pair-code",
+			agent_link_id: telegramLinkId,
+			agent_id: agentId,
+			code: "TELEGRAMSUCCESS123",
+			expires_at: validExpiry,
+			pairing_command: "/bot_pair TELEGRAMSUCCESS123",
+			bot_username: "Pair_Success_Telegram_Bot",
+			deep_link: "https://t.me/Pair_Success_Telegram_Bot?start=TELEGRAMSUCCESS123",
+			qr_payload: "https://t.me/Pair_Success_Telegram_Bot?start=TELEGRAMSUCCESS123",
+		},
+	};
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: [telegramAccount, discordAccount],
+		channelAgentLinks: [
+			{
+				id: telegramLinkId,
+				account_id: telegramId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-08-01T02:03:00Z",
+				account: telegramAccount,
+			},
+			{
+				id: discordLinkId,
+				account_id: discordId,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-08-01T02:04:00Z",
+				account: discordAccount,
+			},
+		],
+		channelBindings,
+		pairCodeRequests,
+		pairCodeResponses: [
+			telegramPairResponse,
+			{
+				status: 201,
+				body: {
+					id: "discord-success-pair-code",
+					agent_link_id: discordLinkId,
+					agent_id: agentId,
+					code: "DISCORDSUCCESS123",
+					expires_at: validExpiry,
+					pairing_command: "/bot_pair DISCORDSUCCESS123",
+					discord_install_url:
+						"https://discord.com/oauth2/authorize?client_id=123&scope=bot&permissions=274878024768",
+				},
+			},
+			telegramPairResponse,
+		],
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const telegramCard = page.locator(`[data-agent-channel-link-id="${telegramLinkId}"]`);
+	const discordCard = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
+	const telegramChatsTrigger = page.locator(
+		`[data-agent-paired-chats-trigger="${telegramLinkId}"]`,
+	);
+	const discordChatsTrigger = page.locator(`[data-agent-paired-chats-trigger="${discordLinkId}"]`);
+	await expect(telegramChatsTrigger).toHaveAccessibleName("Paired chats · 1");
+	await expect(discordChatsTrigger).toHaveAccessibleName("Paired chats · 1");
+
+	await telegramCard.getByRole("button", { name: "Pair Telegram", exact: true }).click();
+	let pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	await page.waitForTimeout(3_200);
+	await expect(page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" })).toHaveCount(
+		0,
+	);
+
+	channelBindings.push({
+		id: telegramNewBindingId,
+		account_id: telegramId,
+		agent_link_id: telegramLinkId,
+		external_chat_id: "telegram-new",
+		external_chat_type: "private",
+		external_chat_name: "New Telegram private chat",
+		status: "active",
+		created_at: "2026-08-01T02:05:00Z",
+		last_message_at: null,
+	});
+	await expect(pairDialog).toHaveCount(0, { timeout: 5_000 });
+	const telegramSuccessToast = page
+		.locator("[data-sonner-toast]")
+		.filter({ hasText: "Chat paired" });
+	await expect(telegramSuccessToast).toHaveCount(1);
+	await expect(telegramSuccessToast).toContainText("Telegram private chat is ready.");
+	await expect(telegramChatsTrigger).toHaveAccessibleName("Paired chats · 2");
+	await expectNoHorizontalOverflow(page.locator("html"), "Telegram pair success document at 320px");
+	await expectNoHorizontalOverflow(telegramSuccessToast, "Telegram pair success toast at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		telegramSuccessToast,
+		page.locator("html"),
+		"Telegram pair success toast at 320px",
+	);
+	await page.screenshot({
+		path: testInfo.outputPath("agent-telegram-pair-success-320x568.png"),
+		fullPage: false,
+	});
+	await expect(telegramSuccessToast).toHaveCount(0, { timeout: 8_000 });
+	await page.waitForTimeout(3_200);
+	await expect(page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" })).toHaveCount(
+		0,
+	);
+
+	await discordCard.getByRole("button", { name: "Pair Discord", exact: true }).click();
+	pairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expect(pairDialog.getByText("DISCORDSUCCESS123", { exact: true })).toBeVisible();
+	await page.waitForTimeout(3_200);
+	await expect(page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" })).toHaveCount(
+		0,
+	);
+
+	channelBindings.push({
+		id: discordNewBindingId,
+		account_id: discordId,
+		agent_link_id: discordLinkId,
+		external_chat_id: "discord-new-dm",
+		external_chat_type: "private",
+		external_chat_name: "New Discord direct message",
+		status: "active",
+		created_at: "2026-08-01T02:06:00Z",
+		last_message_at: null,
+	});
+	await expect(pairDialog).toHaveCount(0, { timeout: 5_000 });
+	const discordSuccessToast = page
+		.locator("[data-sonner-toast]")
+		.filter({ hasText: "Chat paired" });
+	await expect(discordSuccessToast).toHaveCount(1);
+	await expect(discordSuccessToast).toContainText("Discord direct message is ready.");
+	await expect(discordChatsTrigger).toHaveAccessibleName("Paired chats · 2");
+	await expectNoHorizontalOverflow(page.locator("html"), "Discord pair success document at 320px");
+	await expectNoHorizontalOverflow(discordSuccessToast, "Discord pair success toast at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		discordSuccessToast,
+		page.locator("html"),
+		"Discord pair success toast at 320px",
+	);
+	await page.screenshot({
+		path: testInfo.outputPath("agent-discord-pair-success-320x568.png"),
+		fullPage: false,
+	});
+	await expect(discordSuccessToast).toHaveCount(0, { timeout: 8_000 });
+
+	await telegramCard.getByRole("button", { name: "Pair Telegram", exact: true }).click();
+	pairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(pairDialog.getByRole("img", { name: "Telegram pairing QR code" })).toBeVisible();
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
+	channelBindings.push({
+		id: telegramLateBindingId,
+		account_id: telegramId,
+		agent_link_id: telegramLinkId,
+		external_chat_id: "telegram-after-close",
+		external_chat_type: "group",
+		external_chat_name: "Paired after dialog close",
+		status: "active",
+		created_at: "2026-08-01T02:07:00Z",
+		last_message_at: null,
+	});
+	await expect(telegramChatsTrigger).toHaveAccessibleName("Paired chats · 3", {
+		timeout: 5_000,
+	});
+	await page.waitForTimeout(3_200);
+	await expect(page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" })).toHaveCount(
+		0,
+	);
+	expect(pairCodeRequests).toHaveLength(3);
+	expect(errors, `pair success feedback errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("Agent Channels uses compact task-ordered cards and the shared Telegram pair dialog", async ({
@@ -7391,6 +8239,11 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const discordOpsBindingId = "7eeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
 	const discordPartnersBindingId = "7fffffff-ffff-4fff-8fff-ffffffffffff";
 	const discordDmName = "Discord DM — urgent customer support escalation ".repeat(10).slice(0, 300);
+	const telegramChannelName = `Support Telegram — ${"agentchannel".repeat(26)}`.slice(0, 300);
+	const discordChannelName = `Community Discord — ${"localized server identity ".repeat(16)}`.slice(
+		0,
+		300,
+	);
 	const validExpiry = new Date(Date.now() + 15 * 60_000).toISOString();
 	const successfulPairResponse = (id: string, code: string): StubResponse => ({
 		status: 201,
@@ -7419,7 +8272,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const telegramAccount = {
 		id: telegramId,
 		provider: "telegram",
-		name: "Support Telegram",
+		name: telegramChannelName,
 		status: "active",
 		visibility: "private",
 		has_provider_token: true,
@@ -7429,7 +8282,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const discordAccount = {
 		id: discordId,
 		provider: "discord",
-		name: "Community Discord",
+		name: discordChannelName,
 		status: "active",
 		visibility: "private",
 		has_provider_token: true,
@@ -7449,6 +8302,24 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const pairCodeRequests: string[] = [];
 	const deleteBindingRequests: string[] = [];
 	const unlinkAgentRequests: string[] = [];
+	const extraDiscordBindings = [
+		"Engineering",
+		"Research",
+		"Field Support",
+		"Release Coordination",
+		"Documentation",
+		"Community Events",
+	].map((name, index) => ({
+		id: `80000000-0000-4000-8000-00000000000${index}`,
+		account_id: discordId,
+		agent_link_id: discordLinkId,
+		external_chat_id: `discord-guild-${index + 6}`,
+		external_chat_type: "guild",
+		external_chat_name: name,
+		status: "active",
+		created_at: `2026-07-30T10:${12 + index}:00Z`,
+		last_message_at: `2026-07-30T10:${22 + index}:00Z`,
+	}));
 	const channelBindings: unknown[] = [
 		{
 			id: currentBindingId,
@@ -7537,6 +8408,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 			created_at: "2026-07-30T10:11:00Z",
 			last_message_at: "2026-07-30T10:21:00Z",
 		},
+		...extraDiscordBindings,
 	];
 	await stubHostedApi(page, {
 		deployments: [agentChannelsDeployment],
@@ -7610,7 +8482,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 			{
 				account_id: telegramId,
 				provider: "telegram",
-				name: "Support Telegram",
+				name: telegramChannelName,
 				visibility: "private",
 				channel_status: "active",
 				health_status: "ok",
@@ -7623,7 +8495,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 			{
 				account_id: discordId,
 				provider: "discord",
-				name: "Community Discord",
+				name: discordChannelName,
 				visibility: "private",
 				channel_status: "active",
 				health_status: "ok",
@@ -7637,7 +8509,10 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		deleteBindingRequests,
 		unlinkAgentRequests,
 		deleteBindingResponses: [
-			{ status: 502, body: { detail: "temporary Telegram cleanup error" } },
+			{
+				status: 502,
+				body: { detail: `temporary Telegram cleanup error ${"localizederror".repeat(24)}` },
+			},
 			{
 				status: 200,
 				body: {
@@ -7664,7 +8539,10 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		pairCodeRequests,
 		pairCodeResponses: [
 			successfulPairResponse("agent-channel-pair-code", "AGENTPAIR123"),
-			{ status: 503, body: { detail: "temporary Telegram pair error" } },
+			{
+				status: 503,
+				body: { detail: `temporary Telegram pair error ${"localizederror".repeat(24)}` },
+			},
 			successfulPairResponse("agent-channel-pair-retry", "AGENTRETRY123"),
 			{
 				status: 201,
@@ -7696,7 +8574,10 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					qr_payload: "https://t.me/Clawdi_Ready_Bot?start=AGENTEXPIRED123",
 				},
 			},
-			{ status: 503, body: { detail: "temporary Discord preparation error" } },
+			{
+				status: 503,
+				body: { detail: `temporary Discord preparation error ${"localizederror".repeat(24)}` },
+			},
 			{
 				status: 201,
 				body: {
@@ -7760,21 +8641,47 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const discordRow = page.locator(`[data-agent-channel-link-id="${discordLinkId}"]`);
 	const telegramHeader = telegramRow.locator("[data-channel-card-header]");
 	const discordHeader = discordRow.locator("[data-channel-card-header]");
-	await expect(telegramRow).toContainText("Support Telegram");
+	await expect(telegramRow).toContainText(telegramChannelName);
 	await expect(telegramHeader).not.toContainText("Last activity");
 	await expect(telegramHeader).not.toContainText("No activity yet");
 	await expect(telegramHeader).not.toContainText("Checking activity");
-	await expect(discordRow).toContainText("Community Discord");
+	await expect(discordRow).toContainText(discordChannelName);
 	await expect(discordHeader).not.toContainText("Last activity");
 	const pairButton = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
 	await expect(pairButton).toBeVisible();
 	const discordPairButton = discordRow.getByRole("button", { name: "Pair Discord", exact: true });
 	await expect(discordPairButton).toBeVisible();
 	const telegramUnlinkButton = telegramRow.getByRole("button", {
-		name: "Unlink Support Telegram from Hosted agent",
+		name: `Unlink ${telegramChannelName} from Hosted agent`,
 		exact: true,
 	});
 	await expect(telegramUnlinkButton).toBeVisible();
+	await expect(telegramUnlinkButton.locator("svg")).toHaveCount(1);
+	await expect(telegramUnlinkButton.getByText("Unlink", { exact: true })).toBeVisible();
+	const discordUnlinkButton = discordRow.getByRole("button", {
+		name: `Unlink ${discordChannelName} from Hosted agent`,
+		exact: true,
+	});
+	await expect(discordUnlinkButton.locator("svg")).toHaveCount(1);
+	await expect(discordUnlinkButton.getByText("Unlink", { exact: true })).toBeVisible();
+	await expectNoHorizontalOverflow(telegramRow.locator("article"), "desktop Telegram Channel card");
+	await expectNoHorizontalOverflow(discordRow.locator("article"), "desktop Discord Channel card");
+	await expectContainedInOwnerAndViewport(
+		page,
+		pairButton,
+		telegramRow.locator("article"),
+		"desktop Pair Telegram",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		telegramUnlinkButton,
+		telegramRow.locator("article"),
+		"desktop Unlink Telegram",
+	);
+	await expectControlsDoNotOverlap(
+		[pairButton, telegramUnlinkButton],
+		"desktop Telegram card actions",
+	);
 	async function buttonColors(button: Locator) {
 		return button.evaluate((element) => {
 			const style = getComputedStyle(element);
@@ -7785,46 +8692,50 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 			};
 		});
 	}
-	const [telegramPairColors, discordPairColors, telegramPairBox, discordPairBox] =
-		await Promise.all([
-			buttonColors(pairButton),
-			buttonColors(discordPairButton),
-			pairButton.boundingBox(),
-			discordPairButton.boundingBox(),
-		]);
+	const [
+		telegramPairColors,
+		discordPairColors,
+		telegramPairBox,
+		discordPairBox,
+		unlinkColors,
+		unlinkBox,
+	] = await Promise.all([
+		buttonColors(pairButton),
+		buttonColors(discordPairButton),
+		pairButton.boundingBox(),
+		discordPairButton.boundingBox(),
+		buttonColors(telegramUnlinkButton),
+		telegramUnlinkButton.boundingBox(),
+	]);
 	expect(telegramPairColors).toEqual(discordPairColors);
 	expect(telegramPairBox?.height).toBe(discordPairBox?.height);
 	expect(telegramPairBox?.height).toBe(32);
 	await expect(page.locator(`[data-add-channel-id="${readyId}"]`)).toHaveCount(0);
 	await addChannelButton.click();
-	const fullSlotDialog = page.getByRole("dialog", { name: "Connect a bot" });
-	await expect(fullSlotDialog.getByRole("button", { name: /Telegram.*Connected/ })).toBeDisabled();
-	await expect(fullSlotDialog.getByRole("button", { name: /Discord.*Connected/ })).toBeDisabled();
+	const fullSlotDialog = page.getByRole("dialog", { name: "Add channel" });
 	await expect(
-		fullSlotDialog.getByText("This Agent already has one bot from each provider.", {
-			exact: false,
-		}),
+		fullSlotDialog.getByText("No Clawdi or Custom bots to add", { exact: true }),
 	).toBeVisible();
 	await expect(
-		fullSlotDialog.getByRole("button", { name: "Manage bots", exact: true }),
-	).toHaveAttribute("href", "/channels");
-	await fullSlotDialog.getByRole("button", { name: "Done", exact: true }).click();
+		fullSlotDialog.getByRole("button", { name: "Connect custom bot", exact: true }),
+	).toBeVisible();
+	await fullSlotDialog.getByRole("button", { name: "Close", exact: true }).click();
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);
 	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
-	const telegramChatsDisclosure = telegramGroup.getByRole("button", {
-		name: "Paired chats · 1",
-		exact: true,
-	});
-	const discordChatsDisclosure = discordGroup.getByRole("button", {
-		name: "Paired chats · 6",
-		exact: true,
-	});
-	await expect(telegramChatsDisclosure).toHaveAttribute("aria-expanded", "false");
-	await expect(discordChatsDisclosure).toHaveAttribute("aria-expanded", "false");
-	await expect(currentBindingRow).toBeHidden();
-	await expect(
-		discordGroup.locator(`[data-channel-binding-id="${discordServerBindingId}"]`),
-	).toBeHidden();
+	const telegramChatsTrigger = telegramGroup.locator(
+		`[data-agent-paired-chats-trigger="${telegramLinkId}"]`,
+	);
+	const discordChatsTrigger = discordGroup.locator(
+		`[data-agent-paired-chats-trigger="${discordLinkId}"]`,
+	);
+	await expect(telegramChatsTrigger).toHaveAccessibleName("Paired chats · 1");
+	await expect(discordChatsTrigger).toHaveAccessibleName("Paired chats · 12");
+	await expect(telegramChatsTrigger).toHaveAttribute("aria-haspopup", "dialog");
+	await expect(discordChatsTrigger).toHaveAttribute("aria-haspopup", "dialog");
+	await expect(currentBindingRow).toHaveCount(0);
+	await expect(page.locator(`[data-channel-binding-id="${discordServerBindingId}"]`)).toHaveCount(
+		0,
+	);
 	const defaultTelegramBox = await telegramGroup.boundingBox();
 	const defaultDiscordBox = await discordGroup.boundingBox();
 	expect(defaultTelegramBox?.y).toBe(defaultDiscordBox?.y);
@@ -7835,40 +8746,65 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	await page.screenshot({
 		path:
 			process.env.AGENT_CHANNELS_PAGE_SCREENSHOT_PATH ??
-			testInfo.outputPath("agent-channels-compact-page.png"),
-		fullPage: true,
+			testInfo.outputPath("agent-channel-paired-chats-closed-desktop.png"),
+		fullPage: false,
 	});
 
-	await telegramChatsDisclosure.click();
-	await expect(telegramChatsDisclosure).toHaveAttribute("aria-expanded", "true");
+	await telegramChatsTrigger.click();
+	let pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(pairedChatsPanel).toContainText("connected through this channel");
+	await expect(
+		pairedChatsPanel.locator(
+			`[data-agent-paired-chats-channel-name][title="${telegramChannelName}"]`,
+		),
+	).toBeVisible();
 	await expect(currentBindingRow).toContainText("Current Agent DM");
+	await expect(currentBindingRow.getByText("Private chat", { exact: true })).toBeVisible();
 	await expect(currentBindingRow).toContainText("Last activity");
 	const telegramUnpairButton = currentBindingRow.getByRole("button", {
 		name: "Unpair Current Agent DM",
 		exact: true,
 	});
-	const [unlinkColors, unpairColors, unlinkBox, unpairBox] = await Promise.all([
-		buttonColors(telegramUnlinkButton),
+	await expect(telegramUnpairButton.locator("svg")).toHaveCount(1);
+	await expect(telegramUnpairButton.getByText("Unpair", { exact: true })).toBeVisible();
+	await expectNoHorizontalOverflow(pairedChatsPanel, "desktop Telegram paired chats Dialog");
+	await expectNoHorizontalOverflow(
+		pairedChatsPanel.locator("[data-agent-paired-chats-list]"),
+		"desktop Telegram paired chats list",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		telegramUnpairButton,
+		currentBindingRow,
+		"desktop Telegram Unpair",
+	);
+	const [unpairColors, unpairBox] = await Promise.all([
 		buttonColors(telegramUnpairButton),
-		telegramUnlinkButton.boundingBox(),
 		telegramUnpairButton.boundingBox(),
 	]);
 	expect(unlinkColors).toEqual(unpairColors);
 	expect(unlinkBox?.height).toBe(32);
-	expect(unpairBox?.height).toBe(32);
+	expect(Math.abs((unpairBox?.height ?? 0) - (unlinkBox?.height ?? 0))).toBeLessThanOrEqual(1);
 	expect(unlinkBox?.width ?? 0).toBeGreaterThan(48);
 	expect(unpairBox?.width ?? 0).toBeGreaterThan(48);
+	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(pairedChatsPanel).toHaveCount(0);
+	await expect(telegramChatsTrigger).toBeFocused();
+
+	await discordChatsTrigger.click();
+	pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(pairedChatsPanel).toContainText("connected through this channel");
 	await expect(
-		telegramGroup.locator(`[data-channel-binding-id="${currentBindingId}"]`),
+		pairedChatsPanel.locator(
+			`[data-agent-paired-chats-channel-name][title="${discordChannelName}"]`,
+		),
 	).toBeVisible();
-	const discordServerRow = discordGroup.locator(
-		`[data-channel-binding-id="${discordServerBindingId}"]`,
-	);
-	const discordDmRow = discordGroup.locator(`[data-channel-binding-id="${discordDmBindingId}"]`);
-	await discordChatsDisclosure.click();
-	await expect(discordChatsDisclosure).toHaveAttribute("aria-expanded", "true");
-	await expect(discordServerRow).toContainText("Server · Clawdi Community");
-	await expect(discordDmRow).toContainText(`Direct message · ${discordDmName}`);
+	const discordServerRow = page.locator(`[data-channel-binding-id="${discordServerBindingId}"]`);
+	const discordDmRow = page.locator(`[data-channel-binding-id="${discordDmBindingId}"]`);
+	await expect(discordServerRow.getByText("Clawdi Community", { exact: true })).toBeVisible();
+	await expect(discordServerRow.getByText("Server", { exact: true })).toBeVisible();
+	await expect(discordDmRow.getByText(discordDmName, { exact: true })).toBeVisible();
+	await expect(discordDmRow.getByText("Direct message", { exact: true })).toBeVisible();
 	await expect(discordServerRow).toContainText("Last activity");
 	await expect(discordDmRow).not.toContainText("Last activity");
 	await expect(discordDmRow).not.toContainText("No activity yet");
@@ -7877,35 +8813,173 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	await expect(
 		discordServerRow.getByRole("button", { name: "Unpair Server · Clawdi Community" }),
 	).toBeVisible();
-	const hiddenDiscordChat = discordGroup.locator(
+	const discordServerUnpair = discordServerRow.getByRole("button", {
+		name: "Unpair Server · Clawdi Community",
+	});
+	await expect(discordServerUnpair.locator("svg")).toHaveCount(1);
+	await expect(discordServerUnpair.getByText("Unpair", { exact: true })).toBeVisible();
+	await expectNoHorizontalOverflow(pairedChatsPanel, "desktop Discord paired chats Dialog");
+	await expectNoHorizontalOverflow(
+		pairedChatsPanel.locator("[data-agent-paired-chats-list]"),
+		"desktop Discord paired chats list",
+	);
+	const lastDiscordChat = pairedChatsPanel.locator(
+		`[data-channel-binding-id="${extraDiscordBindings.at(-1)?.id}"]`,
+	);
+	await expect(lastDiscordChat).toContainText("Community Events");
+	const partnerDiscordChat = pairedChatsPanel.locator(
 		`[data-channel-binding-id="${discordPartnersBindingId}"]`,
 	);
-	await expect(hiddenDiscordChat).toBeHidden();
-	const showMoreChats = discordGroup.getByRole("button", { name: "Show more", exact: true });
-	await expect(showMoreChats).toHaveAttribute("aria-expanded", "false");
-	await showMoreChats.click();
-	await expect(hiddenDiscordChat).toContainText("Server · Partner Support");
-	await expect(
-		telegramGroup.locator(`[data-channel-binding-id="${discordPartnersBindingId}"]`),
-	).toHaveCount(0);
-	const showLessChats = discordGroup.getByRole("button", { name: "Show less", exact: true });
-	await expect(showLessChats).toHaveAttribute("aria-expanded", "true");
-	await showLessChats.click();
-	await expect(hiddenDiscordChat).toBeHidden();
-	await discordGroup.getByRole("button", { name: "Show more", exact: true }).click();
-	await expect(hiddenDiscordChat).toBeVisible();
-	await expect(currentBindingRow).not.toContainText("Support Telegram");
+	await expect(partnerDiscordChat).toContainText("Partner Support");
+	await expect(pairedChatsPanel.getByRole("button", { name: /Show (more|less)/ })).toHaveCount(0);
+	const desktopPairedChatsScroll = pairedChatsPanel.locator("[data-agent-paired-chats-scroll]");
+	const desktopScrollMetrics = await desktopPairedChatsScroll.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		overflowY: getComputedStyle(element).overflowY,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(desktopScrollMetrics.overflowY).toBe("auto");
+	expect(desktopScrollMetrics.scrollHeight).toBeGreaterThan(desktopScrollMetrics.clientHeight);
+	const openDesktopTelegramBox = await telegramGroup.boundingBox();
+	const openDesktopDiscordBox = await discordGroup.boundingBox();
+	expect(openDesktopTelegramBox?.height).toBe(defaultTelegramBox?.height);
+	expect(openDesktopDiscordBox?.height).toBe(defaultDiscordBox?.height);
 	await expect(page.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`)).toHaveCount(0);
 	await expect(page.getByText("Other Agent DM", { exact: true })).toHaveCount(0);
-	await expect(currentBindingRow).not.toContainText("101");
 	await expect(telegramHeader).not.toContainText("Active");
 	await expect(telegramHeader).not.toContainText("Healthy");
 	await expect(page.getByText("Waiting for channel activity", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Finish pairing", { exact: false })).toHaveCount(0);
 	await page.screenshot({
-		path: testInfo.outputPath("agent-channels-expanded-page.png"),
-		fullPage: true,
+		path: testInfo.outputPath("agent-channel-paired-chats-open-desktop.png"),
+		fullPage: false,
 	});
+	await page.keyboard.press("Escape");
+	await expect(pairedChatsPanel).toHaveCount(0);
+	await expect(discordChatsTrigger).toBeFocused();
+
+	await page.setViewportSize({ width: 320, height: 568 });
+	await discordGroup.evaluate((element) => element.scrollIntoView({ block: "center" }));
+	await expectNoHorizontalOverflow(page.locator("html"), "Agent Channels document at 320px");
+	await expectNoHorizontalOverflow(discordRow.locator("article"), "Discord Channel card at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		discordPairButton,
+		discordRow.locator("article"),
+		"mobile Pair Discord",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		discordUnlinkButton,
+		discordRow.locator("article"),
+		"mobile Unlink Discord",
+	);
+	await expectControlsDoNotOverlap(
+		[discordPairButton, discordUnlinkButton],
+		"mobile Discord card actions",
+	);
+	const closedMobileDiscordBox = await discordGroup.boundingBox();
+	await page.screenshot({
+		path: testInfo.outputPath("agent-channel-paired-chats-closed-320x568.png"),
+		fullPage: false,
+	});
+	await discordChatsTrigger.click();
+	pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(pairedChatsPanel).toBeVisible();
+	await expect(pairedChatsPanel).toHaveAttribute("data-slot", "sheet-content");
+	await expect
+		.poll(async () => {
+			const box = await pairedChatsPanel.boundingBox();
+			return (box?.y ?? 568) + (box?.height ?? 1);
+		})
+		.toBeLessThanOrEqual(568);
+	const mobilePanelBox = await pairedChatsPanel.boundingBox();
+	expect(mobilePanelBox?.y ?? -1).toBeGreaterThanOrEqual(0);
+	expect((mobilePanelBox?.y ?? 568) + (mobilePanelBox?.height ?? 1)).toBeLessThanOrEqual(568);
+	const openMobileDiscordBox = await discordGroup.boundingBox();
+	expect(openMobileDiscordBox?.height).toBe(closedMobileDiscordBox?.height);
+	const mobilePairedChatsScroll = pairedChatsPanel.locator("[data-agent-paired-chats-scroll]");
+	await expectNoHorizontalOverflow(pairedChatsPanel, "mobile paired chats Sheet");
+	await expectNoHorizontalOverflow(mobilePairedChatsScroll, "mobile paired chats scroll area");
+	const mobileScrollMetrics = await mobilePairedChatsScroll.evaluate((element) => ({
+		clientHeight: element.clientHeight,
+		overflowY: getComputedStyle(element).overflowY,
+		scrollHeight: element.scrollHeight,
+	}));
+	expect(mobileScrollMetrics.overflowY).toBe("auto");
+	expect(mobileScrollMetrics.scrollHeight).toBeGreaterThan(mobileScrollMetrics.clientHeight);
+	const mobileDiscordDmTitle = pairedChatsPanel.getByText(discordDmName, { exact: true });
+	const mobileDiscordScope = discordDmRow.getByText("Direct message", { exact: true });
+	await expect(mobileDiscordDmTitle).toBeVisible();
+	await expect(mobileDiscordDmTitle).toHaveAttribute("title", discordDmName);
+	await expect(mobileDiscordScope).toBeVisible();
+	const mobileDiscordDmTitleLayout = await mobileDiscordDmTitle.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return {
+			overflow: style.overflow,
+			textOverflow: style.textOverflow,
+			whiteSpace: style.whiteSpace,
+		};
+	});
+	expect(discordDmName).toHaveLength(300);
+	expect(mobileDiscordDmTitleLayout).toEqual({
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
+	});
+	const mobileDiscordDmUnpair = discordDmRow.getByRole("button", {
+		name: `Unpair Direct message · ${discordDmName}`,
+		exact: true,
+	});
+	await expect(mobileDiscordDmUnpair.locator("svg")).toHaveCount(1);
+	await expect(mobileDiscordDmUnpair.getByText("Unpair", { exact: true })).toBeVisible();
+	await expectContainedInOwnerAndViewport(
+		page,
+		mobileDiscordDmUnpair,
+		discordDmRow,
+		"mobile long-name Unpair",
+	);
+	await mobileDiscordDmUnpair.click();
+	const longNameConfirmation = page.getByRole("alertdialog", {
+		name: `Unpair Direct message · ${discordDmName}?`,
+		exact: true,
+	});
+	await expectNoHorizontalOverflow(longNameConfirmation, "long-name Unpair confirmation");
+	const cancelLongUnpair = longNameConfirmation.getByRole("button", {
+		name: "Cancel",
+		exact: true,
+	});
+	const confirmLongUnpair = longNameConfirmation.getByRole("button", {
+		name: "Unpair chat",
+		exact: true,
+	});
+	await expectContainedInOwnerAndViewport(
+		page,
+		cancelLongUnpair,
+		longNameConfirmation,
+		"long-name Unpair Cancel",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		confirmLongUnpair,
+		longNameConfirmation,
+		"long-name Unpair confirm",
+	);
+	await expectControlsDoNotOverlap(
+		[cancelLongUnpair, confirmLongUnpair],
+		"long-name Unpair confirmation actions",
+	);
+	await page.keyboard.press("Escape");
+	await expect(longNameConfirmation).toHaveCount(0);
+	await expect(mobileDiscordDmUnpair).toBeFocused();
+	await page.screenshot({
+		path: testInfo.outputPath("agent-channel-paired-chats-open-320x568.png"),
+		fullPage: false,
+	});
+	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(pairedChatsPanel).toHaveCount(0);
+	await expect(discordChatsTrigger).toBeFocused();
+	await page.setViewportSize({ width: 1440, height: 1100 });
 
 	await pairButton.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(1);
@@ -7917,7 +8991,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const telegramQr = pairDialog.getByRole("img", { name: "Telegram pairing QR code" });
 	await expect(telegramQr).toBeVisible();
 	await expect(pairDialog.getByRole("button", { name: "Copy link", exact: true })).toBeVisible();
-	await expect(pairDialog.getByRole("button", { name: "Open @Clawdi_Ready_Bot" })).toHaveAttribute(
+	await expect(pairDialog.getByRole("button", { name: "Open Telegram" })).toHaveAttribute(
 		"href",
 		"https://t.me/Clawdi_Ready_Bot?start=AGENTPAIR123",
 	);
@@ -7931,13 +9005,14 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const desktopTelegramQrBox = await telegramQr.boundingBox();
 	expect(desktopTelegramQrBox?.width ?? 0).toBeLessThanOrEqual(192);
 	await page.setViewportSize({ width: 320, height: 568 });
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expectNoHorizontalOverflow(page.locator("html"), "Telegram pairing document at 320px");
+	await expectNoHorizontalOverflow(pairDialog, "Telegram pairing Dialog at 320px");
 	await expect(telegramQr).toBeVisible();
 	const mobileTelegramQrBox = await telegramQr.boundingBox();
 	expect(mobileTelegramQrBox?.width ?? 0).toBeLessThanOrEqual(192);
 	const mobileTelegramDialogBox = await pairDialog.boundingBox();
 	const mobileTelegramActionBox = await pairDialog
-		.getByRole("button", { name: "Open @Clawdi_Ready_Bot" })
+		.getByRole("button", { name: "Open Telegram" })
 		.boundingBox();
 	expect(mobileTelegramDialogBox?.y ?? -1).toBeGreaterThanOrEqual(0);
 	expect(
@@ -7946,17 +9021,29 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	expect(
 		(mobileTelegramActionBox?.y ?? 568) + (mobileTelegramActionBox?.height ?? 1),
 	).toBeLessThanOrEqual(568);
+	const copyTelegramLink = pairDialog.getByRole("button", { name: "Copy link", exact: true });
+	const openTelegram = pairDialog.getByRole("button", { name: "Open Telegram" });
+	await expectContainedInOwnerAndViewport(
+		page,
+		copyTelegramLink,
+		pairDialog,
+		"mobile Copy Telegram link",
+	);
+	await expectContainedInOwnerAndViewport(page, openTelegram, pairDialog, "mobile Open Telegram");
+	await expectControlsDoNotOverlap(
+		[copyTelegramLink, openTelegram],
+		"mobile Telegram pairing actions",
+	);
 	await pairDialog.screenshot({
 		path: testInfo.outputPath("agent-telegram-pair-dialog-320x568.png"),
 	});
-	await pairDialog.getByRole("button", { name: "Copy link", exact: true }).click();
+	await copyTelegramLink.click();
 	await expect(pairDialog.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
-	await expectActionCenterUncovered(
-		pairDialog.getByRole("button", { name: "Open @Clawdi_Ready_Bot" }),
-	);
+	await expectActionCenterUncovered(pairDialog.getByRole("button", { name: "Open Telegram" }));
 	await page.setViewportSize({ width: 1440, height: 1100 });
 
+	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
 	channelBindings.push({
 		id: polledBindingId,
 		account_id: telegramId,
@@ -7967,28 +9054,40 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		status: "active",
 		created_at: "2026-07-30T10:10:00Z",
 	});
-	await pairDialog.getByRole("button", { name: "Close", exact: true }).click();
-	await expect(page.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toContainText(
-		"Newly Paired DM",
-		{ timeout: 5_000 },
-	);
-	await expect(
-		telegramGroup.locator(`[data-channel-binding-id="${polledBindingId}"]`),
-	).toBeVisible();
-	await expect(discordGroup.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toHaveCount(
+	await expect(telegramChatsTrigger).toHaveAccessibleName("Paired chats · 2", { timeout: 5_000 });
+	await expect(page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" })).toHaveCount(
 		0,
 	);
+	await expect(page.locator(`[data-channel-binding-id="${polledBindingId}"]`)).toHaveCount(0);
+	await telegramChatsTrigger.click();
+	pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(
+		pairedChatsPanel.locator(`[data-channel-binding-id="${polledBindingId}"]`),
+	).toContainText("Newly Paired DM");
+	await expect(
+		pairedChatsPanel.locator(`[data-channel-binding-id="${otherAgentBindingId}"]`),
+	).toHaveCount(0);
+	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();
 
 	await pairButton.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(2);
-	await expect(
-		page.getByRole("dialog", { name: "Pair Telegram" }).getByText("Couldn't create Telegram link"),
-	).toBeVisible();
+	let telegramErrorDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(telegramErrorDialog.getByText("Couldn't create Telegram link")).toBeVisible();
+	await page.setViewportSize({ width: 320, height: 568 });
+	telegramErrorDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expectNoHorizontalOverflow(telegramErrorDialog, "Telegram error Dialog at 320px");
+	const telegramRetry = telegramErrorDialog.getByRole("button", { name: "Retry", exact: true });
+	await expectContainedInOwnerAndViewport(
+		page,
+		telegramRetry,
+		telegramErrorDialog,
+		"Telegram error Retry",
+	);
+	await telegramErrorDialog.screenshot({
+		path: testInfo.outputPath("agent-telegram-pair-error-320x568.png"),
+	});
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
-	await page
-		.getByRole("dialog", { name: "Pair Telegram" })
-		.getByRole("button", { name: "Retry", exact: true })
-		.click();
+	await telegramRetry.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(3);
 	await expect(
 		page
@@ -7999,12 +9098,13 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	await expectActionCenterUncovered(
 		page
 			.getByRole("dialog", { name: "Pair Telegram" })
-			.getByRole("button", { name: "Open @Clawdi_Ready_Bot" }),
+			.getByRole("button", { name: "Open Telegram" }),
 	);
 	await page
 		.getByRole("dialog", { name: "Pair Telegram" })
 		.getByRole("button", { name: "Close", exact: true })
 		.click();
+	await page.setViewportSize({ width: 1440, height: 1100 });
 
 	await pairButton.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(4);
@@ -8036,12 +9136,23 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	await expect(
 		discordPairDialog.getByText("Couldn't prepare Discord pairing", { exact: true }),
 	).toBeVisible();
+	await page.setViewportSize({ width: 320, height: 568 });
+	discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expectNoHorizontalOverflow(discordPairDialog, "Discord error Dialog at 320px");
+	const discordRetry = discordPairDialog.getByRole("button", { name: "Retry", exact: true });
+	await expectContainedInOwnerAndViewport(
+		page,
+		discordRetry,
+		discordPairDialog,
+		"Discord error Retry",
+	);
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
 	await discordPairDialog.screenshot({
-		path: testInfo.outputPath("agent-discord-pair-error-desktop.png"),
+		path: testInfo.outputPath("agent-discord-pair-error-320x568.png"),
 	});
-	await discordPairDialog.getByRole("button", { name: "Retry", exact: true }).click();
+	await discordRetry.click();
 	await expect.poll(() => pairCodeRequests.length).toBe(7);
+	await page.setViewportSize({ width: 1440, height: 1100 });
 	discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
 	await expect(discordPairDialog.getByText("Server", { exact: true })).toBeVisible();
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
@@ -8073,7 +9184,8 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const desktopDiscordQrBox = await discordQr.boundingBox();
 	expect(desktopDiscordQrBox?.width ?? 0).toBeLessThanOrEqual(192);
 	await page.setViewportSize({ width: 320, height: 568 });
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
+	await expectNoHorizontalOverflow(page.locator("html"), "Discord pairing document at 320px");
+	await expectNoHorizontalOverflow(discordPairDialog, "Discord pairing Dialog at 320px");
 	const mobileDiscordQrBox = await discordQr.boundingBox();
 	expect(mobileDiscordQrBox?.width ?? 0).toBeLessThanOrEqual(192);
 	const mobileDiscordDialogBox = await discordPairDialog.boundingBox();
@@ -8087,6 +9199,23 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	expect(
 		(mobileDiscordActionBox?.y ?? 568) + (mobileDiscordActionBox?.height ?? 1),
 	).toBeLessThanOrEqual(568);
+	const addDiscordToServer = discordPairDialog.getByRole("button", { name: "Add to server" });
+	await expectContainedInOwnerAndViewport(
+		page,
+		copyDiscordCodeButton,
+		discordPairDialog,
+		"mobile Copy Discord code",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		addDiscordToServer,
+		discordPairDialog,
+		"mobile Add Discord to server",
+	);
+	await expectControlsDoNotOverlap(
+		[copyDiscordCodeButton, addDiscordToServer],
+		"mobile Discord pairing actions",
+	);
 	await expectActionCenterUncovered(
 		discordPairDialog.getByRole("button", { name: "Add to server" }),
 	);
@@ -8143,14 +9272,37 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	).toBeVisible();
 	await page.keyboard.press("Escape");
 
+	await page.setViewportSize({ width: 320, height: 568 });
+	await telegramChatsTrigger.click();
+	pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(currentBindingRow).toBeVisible();
 	await telegramUnpairButton.click();
 	const unpairConfirmation = page.getByRole("alertdialog", { name: "Unpair Current Agent DM?" });
-	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
+	await expectNoHorizontalOverflow(unpairConfirmation, "Telegram Unpair confirmation at 320px");
+	const telegramConfirmUnpair = unpairConfirmation.getByRole("button", {
+		name: "Unpair chat",
+		exact: true,
+	});
+	await expectContainedInOwnerAndViewport(
+		page,
+		telegramConfirmUnpair,
+		unpairConfirmation,
+		"Telegram Unpair confirmation action",
+	);
+	await telegramConfirmUnpair.click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(1);
 	await expect(page.getByText("Couldn't unpair chat", { exact: true })).toBeVisible();
+	const unpairErrorToast = page.locator("[data-sonner-toast]").last();
+	await expectNoHorizontalOverflow(unpairErrorToast, "long Unpair error toast at 320px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		unpairErrorToast,
+		page.locator("html"),
+		"long Unpair error toast at 320px",
+	);
 	await expect(currentBindingRow).toContainText("Couldn't unpair · Try again");
 	await expect(unpairConfirmation).toBeVisible();
-	await unpairConfirmation.getByRole("button", { name: "Unpair chat", exact: true }).click();
+	await telegramConfirmUnpair.click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(2);
 	expect(deleteBindingRequests.slice(0, 2)).toEqual([
 		`/v1/channels/${telegramId}/bindings/${currentBindingId}`,
@@ -8162,7 +9314,11 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	expect(
 		channelBindings.some((binding) => isRecord(binding) && binding.id === otherAgentBindingId),
 	).toBe(true);
+	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();
 
+	await discordChatsTrigger.click();
+	pairedChatsPanel = page.getByRole("dialog", { name: "Paired chats", exact: true });
+	await expect(discordServerRow).toBeVisible();
 	const discordUnpairButton = discordServerRow.getByRole("button", {
 		name: "Unpair Server · Clawdi Community",
 		exact: true,
@@ -8176,94 +9332,63 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		.getByRole("button", { name: "Unpair chat", exact: true })
 		.click();
 	await expect.poll(() => deleteBindingRequests.length).toBe(3);
-	await expect(discordServerRow.getByText("Unpairing…", { exact: true })).toBeVisible();
+	const pendingDiscordUnpair = discordServerRow.locator("button", { hasText: "Unpairing…" });
+	await expect(pendingDiscordUnpair).toBeVisible();
+	await expectContainedInOwnerAndViewport(
+		page,
+		pendingDiscordUnpair,
+		discordServerRow,
+		"pending Discord Unpair",
+	);
 	expect(deleteBindingRequests[2]).toBe(
 		`/v1/channels/${discordId}/bindings/${discordServerBindingId}`,
 	);
 	await discordUnpairClick;
 	await expect(discordServerRow).toHaveCount(0);
-
-	await page.setViewportSize({ width: 320, height: 568 });
-	const mobileChatRow = page.locator(`[data-channel-binding-id="${polledBindingId}"]`);
-	const mobileChatTitle = mobileChatRow.getByText("Newly Paired DM", { exact: true });
-	const mobileUnpair = mobileChatRow.getByRole("button", {
-		name: "Unpair Newly Paired DM",
-		exact: true,
-	});
-	await expect(mobileChatTitle).toBeVisible();
-	await expect(mobileUnpair).toBeVisible();
-	const mobileTitleBox = await mobileChatTitle.boundingBox();
-	const mobileActionBox = await mobileUnpair.boundingBox();
-	expect(mobileTitleBox?.width ?? 0).toBeGreaterThan(100);
-	expect(mobileActionBox?.y ?? 0).toBeGreaterThan(mobileTitleBox?.y ?? 0);
-	const mobileChannelTitle = telegramRow.getByText("Support Telegram", { exact: true });
-	const mobilePairAction = telegramRow.getByRole("button", { name: "Pair Telegram", exact: true });
-	const mobileChannelTitleBox = await mobileChannelTitle.boundingBox();
-	const mobilePairActionBox = await mobilePairAction.boundingBox();
-	expect(mobileChannelTitleBox?.width ?? 0).toBeGreaterThan(100);
-	expect(mobilePairActionBox?.y ?? 0).toBeGreaterThan(mobileChannelTitleBox?.y ?? 0);
-	const mobileDiscordDmTitle = discordDmRow.getByText(`Direct message · ${discordDmName}`, {
-		exact: true,
-	});
-	await expect(mobileDiscordDmTitle).toBeVisible();
-	const mobileDiscordDmTitleLayout = await mobileDiscordDmTitle.evaluate((element) => {
-		const style = getComputedStyle(element);
-		return {
-			height: element.getBoundingClientRect().height,
-			lineHeight: Number.parseFloat(style.lineHeight),
-			overflow: style.overflow,
-			textOverflow: style.textOverflow,
-			whiteSpace: style.whiteSpace,
-			webkitLineClamp: style.webkitLineClamp,
-		};
-	});
-	expect(discordDmName).toHaveLength(300);
-	expect(mobileDiscordDmTitleLayout).toMatchObject({
-		overflow: "hidden",
-		textOverflow: "clip",
-		whiteSpace: "normal",
-		webkitLineClamp: "2",
-	});
-	expect(mobileDiscordDmTitleLayout.height).toBeLessThanOrEqual(
-		mobileDiscordDmTitleLayout.lineHeight * 2 + 1,
-	);
-	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(320);
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
-	await discordGroup.evaluate((element) => {
-		element.scrollIntoView({ block: "start" });
-		let scrollParent = element.parentElement;
-		while (scrollParent && scrollParent.scrollHeight <= scrollParent.clientHeight) {
-			scrollParent = scrollParent.parentElement;
-		}
-		if (scrollParent) scrollParent.scrollTop = Math.max(0, scrollParent.scrollTop - 72);
-	});
-	await page.screenshot({
-		path:
-			process.env.AGENT_CHANNELS_MOBILE_SCREENSHOT_PATH ??
-			testInfo.outputPath("agent-channels-320x568.png"),
-		fullPage: false,
-	});
+	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(discordChatsTrigger).toHaveAccessibleName("Paired chats · 11");
 
-	await discordRow
-		.getByRole("button", {
-			name: "Unlink Community Discord from Hosted agent",
-			exact: true,
-		})
-		.click();
+	await discordRow.evaluate((element) => element.scrollIntoView({ block: "center" }));
+	await discordUnlinkButton.click();
 	const unlinkConfirmation = page.getByRole("alertdialog", {
-		name: "Unlink Community Discord?",
+		name: `Unlink ${discordChannelName}?`,
 		exact: true,
 	});
+	await expectNoHorizontalOverflow(unlinkConfirmation, "long-name Unlink confirmation at 320px");
+	const unlinkCancel = unlinkConfirmation.getByRole("button", { name: "Cancel", exact: true });
+	const unlinkConfirm = unlinkConfirmation.getByRole("button", { name: "Unlink", exact: true });
+	await expectContainedInOwnerAndViewport(
+		page,
+		unlinkCancel,
+		unlinkConfirmation,
+		"Unlink Cancel at 320px",
+	);
+	await expectContainedInOwnerAndViewport(
+		page,
+		unlinkConfirm,
+		unlinkConfirmation,
+		"Unlink confirm at 320px",
+	);
+	await expectControlsDoNotOverlap(
+		[unlinkCancel, unlinkConfirm],
+		"Unlink confirmation actions at 320px",
+	);
 	const unlinkClick = unlinkConfirmation
 		.getByRole("button", { name: "Unlink", exact: true })
 		.click();
 	await expect.poll(() => unlinkAgentRequests.length).toBe(1);
-	await expect(
-		discordRow.getByRole("button", {
-			name: "Unlinking Community Discord from Hosted agent",
-			exact: true,
-		}),
-	).toContainText("Unlinking…");
+	const pendingUnlink = discordRow.getByRole("button", {
+		name: `Unlinking ${discordChannelName} from Hosted agent`,
+		exact: true,
+	});
+	await expect(pendingUnlink).toContainText("Unlinking…");
+	await expectContainedInOwnerAndViewport(
+		page,
+		pendingUnlink,
+		discordRow.locator("article"),
+		"pending Discord Unlink at 320px",
+	);
 	await unlinkClick;
 	expect(unlinkAgentRequests).toEqual([`/v1/channels/${discordId}/agent-links/${discordLinkId}`]);
 	const unexpectedErrors = errors.filter(

--- a/apps/web/src/components/api-error-panel.tsx
+++ b/apps/web/src/components/api-error-panel.tsx
@@ -49,7 +49,7 @@ export function ApiErrorPanel({
 			<Icon />
 			<AlertTitle>{expired ? "Your session expired" : title}</AlertTitle>
 			<AlertDescription className="flex flex-col items-start gap-3">
-				<span>{normalizer.normalizeError(error)}</span>
+				<span className="min-w-0 [overflow-wrap:anywhere]">{normalizer.normalizeError(error)}</span>
 				<div className="flex flex-wrap gap-2">
 					{expired ? (
 						<Button size="sm" onClick={reauthenticate}>

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -171,6 +171,7 @@ export function EntityHeader({
 	align = "center",
 	className,
 	titleClassName,
+	titleAttribute,
 }: {
 	icon: ReactNode;
 	title: ReactNode;
@@ -180,6 +181,8 @@ export function EntityHeader({
 	align?: "center" | "start";
 	className?: string;
 	titleClassName?: string;
+	/** Full plain-text identity for a visually truncated title. */
+	titleAttribute?: string;
 }) {
 	return (
 		<div
@@ -192,7 +195,10 @@ export function EntityHeader({
 			{icon}
 			<div className="min-w-0 flex-1">
 				<div className="flex min-w-0 items-center gap-2">
-					<span className={cn("min-w-0 flex-1 truncate text-sm font-medium", titleClassName)}>
+					<span
+						className={cn("min-w-0 flex-1 truncate text-sm font-medium", titleClassName)}
+						title={titleAttribute}
+					>
 						{title}
 					</span>
 					{titleAdornment ? <span className="shrink-0">{titleAdornment}</span> : null}

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -44,7 +44,7 @@ function AlertDialogContent({
 				data-slot="alert-dialog-content"
 				data-size={size}
 				className={cn(
-					"group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					"group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full min-w-0 max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 overflow-x-hidden overflow-y-auto rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 [&>*]:min-w-0",
 					className,
 				)}
 				{...props}
@@ -100,7 +100,7 @@ function AlertDialogTitle({
 		<AlertDialogPrimitive.Title
 			data-slot="alert-dialog-title"
 			className={cn(
-				"text-lg font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+				"min-w-0 text-lg font-medium [overflow-wrap:anywhere] sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
 				className,
 			)}
 			{...props}
@@ -116,7 +116,7 @@ function AlertDialogDescription({
 		<AlertDialogPrimitive.Description
 			data-slot="alert-dialog-description"
 			className={cn(
-				"text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				"min-w-0 text-sm text-balance text-muted-foreground [overflow-wrap:anywhere] md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
 				className,
 			)}
 			{...props}

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-	"group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+	"group/alert relative grid w-full min-w-0 gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_minmax(0,1fr)] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
@@ -39,7 +39,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="alert-title"
 			className={cn(
-				"font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+				"min-w-0 font-medium [overflow-wrap:anywhere] group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
 				className,
 			)}
 			{...props}
@@ -52,7 +52,7 @@ function AlertDescription({ className, ...props }: React.ComponentProps<"div">) 
 		<div
 			data-slot="alert-description"
 			className={cn(
-				"text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+				"min-w-0 text-sm text-balance text-muted-foreground [overflow-wrap:anywhere] md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
 				className,
 			)}
 			{...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -47,7 +47,7 @@ function DialogContent({
 			<DialogPrimitive.Popup
 				data-slot="dialog-content"
 				className={cn(
-					"fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					"fixed top-1/2 left-1/2 z-50 grid w-full min-w-0 max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 [&>*]:min-w-0",
 					className,
 				)}
 				{...props}
@@ -99,7 +99,7 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
 	return (
 		<DialogPrimitive.Title
 			data-slot="dialog-title"
-			className={cn("leading-none font-medium", className)}
+			className={cn("min-w-0 leading-tight font-medium [overflow-wrap:anywhere]", className)}
 			{...props}
 		/>
 	);
@@ -110,7 +110,7 @@ function DialogDescription({ className, ...props }: DialogPrimitive.Description.
 		<DialogPrimitive.Description
 			data-slot="dialog-description"
 			className={cn(
-				"text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				"min-w-0 text-sm text-muted-foreground [overflow-wrap:anywhere] *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
 				className,
 			)}
 			{...props}

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -34,7 +34,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
 			}
 			toastOptions={{
 				classNames: {
-					toast: "cn-toast",
+					toast: "cn-toast max-w-[calc(100vw-2rem)] overflow-hidden",
+					content: "min-w-0",
+					title: "min-w-0 [overflow-wrap:anywhere]",
+					description: "min-w-0 [overflow-wrap:anywhere]",
+					actionButton: "shrink-0",
+					cancelButton: "shrink-0",
 				},
 			}}
 			{...props}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -6,7 +6,6 @@ import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
 	Check,
-	ChevronDown,
 	CircleCheck,
 	Copy,
 	Cpu,
@@ -80,7 +79,6 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
@@ -226,6 +224,7 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
+import { AddChannelDialog, type AddChannelOption } from "@/hosted/v2/channels/add-channel-dialog";
 import {
 	type AgentPairedChatItem,
 	activeAgentChannelLinks,
@@ -240,6 +239,7 @@ import {
 	channelProviderLinkingReady,
 	pairingActionLabel,
 } from "@/hosted/v2/channels/channel-linking.logic";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
 	ChannelStatusBadge,
@@ -259,7 +259,7 @@ import {
 } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { DiscordPairDialog } from "@/hosted/v2/channels/discord-pair-dialog";
-import { PairedChatRow } from "@/hosted/v2/channels/paired-chat-row";
+import { PairedChatsDialog } from "@/hosted/v2/channels/paired-chats-dialog";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentRouteSearch,
@@ -2255,11 +2255,8 @@ function ChannelsSyncState({
 	);
 }
 
-type LinkableChannel = { id: string } & ChannelAccountSummary;
-
 const AGENT_CHANNEL_PAIR_ACTIONS_CLASS =
-	"flex min-h-8 w-full flex-wrap items-center justify-end gap-2 sm:w-auto";
-const INITIAL_PAIRED_CHAT_COUNT = 3;
+	"grid min-h-8 w-full grid-cols-[minmax(0,1fr)_7rem] items-center gap-1.5 xl:flex xl:w-auto xl:gap-2";
 
 function ChannelsTab({
 	environmentId,
@@ -2288,7 +2285,9 @@ function ChannelsTab({
 		agentLinkId: string;
 		channelName: string;
 	} | null>(null);
-	const [connectOpen, setConnectOpen] = useState(false);
+	const [channelSetupDialog, setChannelSetupDialog] = useState<"add" | "connect-custom" | null>(
+		null,
+	);
 	const [linkingAccountId, setLinkingAccountId] = useState<string | null>(null);
 	const linkInFlightRef = useRef(false);
 	const unlinkingLinkIdsRef = useRef<Set<string>>(new Set());
@@ -2334,6 +2333,10 @@ function ChannelsTab({
 		[visibleActiveLinks],
 	);
 	const bindingQueries = useChannelBindingsForAccounts(activeAccountIds);
+	const bindingsForAccount = (accountId: string): readonly ChannelBinding[] | undefined => {
+		const index = activeAccountIds.indexOf(accountId);
+		return index >= 0 ? bindingQueries[index]?.data : undefined;
+	};
 	const pairedChats = selectAgentPairedChats({
 		visibleLinks: visibleActiveLinks,
 		bindingsByAccount: bindingQueries.flatMap((query, index) => {
@@ -2357,7 +2360,7 @@ function ChannelsTab({
 			),
 		[accountSummaries, visibleLinks],
 	);
-	const ownedChannels = useMemo(
+	const ownedChannels = useMemo<AddChannelOption[]>(
 		() =>
 			(channels.data ?? [])
 				.map((channel) => ({
@@ -2374,7 +2377,7 @@ function ChannelsTab({
 				),
 		[channels.data, linkedIds, linkedProviders, agentType],
 	);
-	const readyBots = useMemo(
+	const readyBots = useMemo<AddChannelOption[]>(
 		() =>
 			Object.values(botPool.data?.providers ?? {})
 				.flat()
@@ -2390,13 +2393,6 @@ function ChannelsTab({
 				.map((bot) => ({ id: bot.id, provider: bot.provider, name: bot.name })),
 		[botPool.data, linkedIds, linkedProviders, agentType],
 	);
-	const showAvailableBotsSection =
-		botPool.isLoading ||
-		Boolean(botPool.error) ||
-		channels.isLoading ||
-		Boolean(channels.error) ||
-		readyBots.length > 0 ||
-		ownedChannels.length > 0;
 	const healthByAccount = useMemo(
 		() => new Map((health.data?.items ?? []).map((item) => [item.account_id, item])),
 		[health.data],
@@ -2428,12 +2424,15 @@ function ChannelsTab({
 					agentLinkId: data.id,
 					channelName: account.name,
 				});
+			} else if (account?.provider === "discord") {
+				setDiscordPair({
+					accountId: data.account_id,
+					agentLinkId: data.id,
+					channelName: account.name,
+				});
 			} else {
 				toast.success("Channel linked", {
-					description:
-						account?.provider === "discord"
-							? "Use Pair Discord from the connected Discord Bot row."
-							: "Pair a chat from the connected channel row.",
+					description: "Pair a chat from the connected channel row.",
 				});
 			}
 			return data;
@@ -2443,14 +2442,16 @@ function ChannelsTab({
 		}
 	});
 
-	async function submitLink(channelId: string) {
-		if (!channelId || linkInFlightRef.current) return;
+	async function submitLink(channelId: string): Promise<boolean> {
+		if (!channelId || linkInFlightRef.current) return false;
 		linkInFlightRef.current = true;
 		setLinkingAccountId(channelId);
 		try {
 			await link.execute(channelId);
+			return true;
 		} catch {
 			// The action already surfaces the API error.
+			return false;
 		} finally {
 			linkInFlightRef.current = false;
 			setLinkingAccountId(null);
@@ -2488,7 +2489,7 @@ function ChannelsTab({
 						type="button"
 						variant="outline"
 						size="sm"
-						onClick={() => setConnectOpen(true)}
+						onClick={() => setChannelSetupDialog("add")}
 					>
 						<Plus className="size-3.5" />
 						Add channel
@@ -2507,9 +2508,8 @@ function ChannelsTab({
 					/>
 				) : visibleActiveLinks.length === 0 ? (
 					<EmptyState
-						variant="inset"
 						title="No connected channels"
-						description="Add a bot, then choose where this Agent should answer."
+						description="Add a channel, then pair where this Agent should answer."
 					/>
 				) : (
 					<div className={CHANNEL_CARD_GRID_CLASS}>
@@ -2520,6 +2520,7 @@ function ChannelsTab({
 									key={link.id}
 									link={link}
 									pairedChats={pairedChatsByLinkId.get(link.id) ?? []}
+									bindings={bindingQuery?.data}
 									bindingsLoading={Boolean(bindingQuery?.isFetching)}
 									bindingsError={Boolean(bindingQuery?.error)}
 									onBindingsRetry={() => void bindingQuery?.refetch()}
@@ -2549,63 +2550,27 @@ function ChannelsTab({
 				) : null}
 			</section>
 
-			{showAvailableBotsSection ? (
-				<section data-agent-available-channels className="flex flex-col gap-3 border-t pt-6">
-					<div className="space-y-1">
-						<SectionLabel>Available bots</SectionLabel>
-						<p className="px-0.5 text-sm text-muted-foreground">
-							Link a bot to this Agent, then choose where it should answer.
-						</p>
-					</div>
-					{botPool.error ? (
-						<ApiErrorPanel
-							error={botPool.error}
-							onRetry={() => botPool.refetch()}
-							title="Couldn't load shared bots"
-						/>
-					) : null}
-					{channels.error ? (
-						<ApiErrorPanel
-							error={channels.error}
-							onRetry={() => channels.refetch()}
-							title="Couldn't load your bots"
-						/>
-					) : null}
-					{botPool.isLoading || channels.isLoading ? (
-						<div className={CHANNEL_CARD_GRID_CLASS}>
-							<EntityCardSkeleton actions />
-						</div>
-					) : readyBots.length > 0 || ownedChannels.length > 0 ? (
-						<div className={CHANNEL_CARD_GRID_CLASS}>
-							{readyBots.map((bot) => (
-								<AddChannelRow
-									key={bot.id}
-									channel={bot}
-									kind="Shared bot"
-									linking={linkingAccountId === bot.id}
-									disabled={linkingAccountId !== null}
-									onLink={() => void submitLink(bot.id)}
-								/>
-							))}
-							{ownedChannels.map((channel) => (
-								<AddChannelRow
-									key={channel.id}
-									channel={channel}
-									kind="Your bot"
-									linking={linkingAccountId === channel.id}
-									disabled={linkingAccountId !== null}
-									onLink={() => void submitLink(channel.id)}
-									secondary
-								/>
-							))}
-						</div>
-					) : null}
-				</section>
-			) : null}
-
+			<AddChannelDialog
+				open={channelSetupDialog === "add"}
+				onOpenChange={(open) => {
+					if (!open) setChannelSetupDialog(null);
+				}}
+				clawdiBots={readyBots}
+				customBots={ownedChannels}
+				isLoading={botPool.isLoading || channels.isLoading}
+				clawdiError={botPool.error}
+				customError={channels.error}
+				onRetryClawdi={() => void botPool.refetch()}
+				onRetryCustom={() => void channels.refetch()}
+				addingAccountId={linkingAccountId}
+				onAdd={submitLink}
+				onConnectCustomBot={() => setChannelSetupDialog("connect-custom")}
+			/>
 			<ConnectBotDialog
-				open={connectOpen}
-				onOpenChange={setConnectOpen}
+				open={channelSetupDialog === "connect-custom"}
+				onOpenChange={(open) => {
+					if (!open) setChannelSetupDialog(null);
+				}}
 				agentId={environmentId}
 				agentType={agentType}
 				linkedProviders={linkedProviders}
@@ -2636,6 +2601,7 @@ function ChannelsTab({
 					accountId={telegramPair.accountId}
 					agentLinkId={telegramPair.agentLinkId}
 					channelName={telegramPair.channelName}
+					bindings={bindingsForAccount(telegramPair.accountId)}
 				/>
 			) : null}
 			{discordPair ? (
@@ -2647,6 +2613,7 @@ function ChannelsTab({
 					accountId={discordPair.accountId}
 					agentLinkId={discordPair.agentLinkId}
 					channelName={discordPair.channelName}
+					bindings={bindingsForAccount(discordPair.accountId)}
 				/>
 			) : null}
 		</div>
@@ -2656,6 +2623,7 @@ function ChannelsTab({
 function ConnectedChannelGroup({
 	link,
 	pairedChats,
+	bindings,
 	bindingsLoading,
 	bindingsError,
 	onBindingsRetry,
@@ -2667,6 +2635,7 @@ function ConnectedChannelGroup({
 }: {
 	link: AgentChannelLink;
 	pairedChats: AgentPairedChatItem[];
+	bindings: readonly ChannelBinding[] | undefined;
 	bindingsLoading: boolean;
 	bindingsError: boolean;
 	onBindingsRetry: () => void;
@@ -2677,12 +2646,7 @@ function ConnectedChannelGroup({
 	agentName: string;
 }) {
 	const provider = link.account?.provider ?? fallbackAccount?.provider ?? "";
-	const [chatsOpen, setChatsOpen] = useState(false);
-	const [showAllChats, setShowAllChats] = useState(false);
-	const visibleChats = showAllChats ? pairedChats : pairedChats.slice(0, INITIAL_PAIRED_CHAT_COUNT);
-	const chatsId = `paired-chats-${link.id}`;
-	const chatsListId = `${chatsId}-list`;
-	const pairedChatsLabel = `Paired chats · ${pairedChats.length}`;
+	const channelName = link.account?.name ?? fallbackAccount?.name ?? "Unnamed channel";
 
 	return (
 		<div data-agent-channel-group-id={link.id} className="min-w-0">
@@ -2691,139 +2655,20 @@ function ConnectedChannelGroup({
 				fallbackAccount={fallbackAccount}
 				health={health}
 				agentName={agentName}
+				bindings={bindings}
 				unlinking={unlinking}
 				onUnlink={onUnlink}
 			>
-				<div>
-					<button
-						type="button"
-						className="flex min-h-10 w-full items-center gap-2 px-4 py-2 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-						aria-expanded={chatsOpen}
-						aria-controls={chatsId}
-						onClick={() => {
-							setChatsOpen(!chatsOpen);
-							if (chatsOpen) setShowAllChats(false);
-						}}
-					>
-						<span className="min-w-0 flex-1">{pairedChatsLabel}</span>
-						{bindingsLoading ? (
-							<span role="status" className="inline-flex shrink-0">
-								<Spinner className="size-3.5" />
-								<span className="sr-only">Loading paired chats</span>
-							</span>
-						) : null}
-						{bindingsError ? (
-							<span className="inline-flex shrink-0 text-destructive">
-								<AlertCircle className="size-3.5" />
-								<span className="sr-only">Couldn’t load paired chats</span>
-							</span>
-						) : null}
-						<ChevronDown
-							className={`size-4 shrink-0 transition-transform ${chatsOpen ? "rotate-180" : ""}`}
-							aria-hidden="true"
-						/>
-					</button>
-					<div
-						data-agent-channel-chats-for={link.id}
-						id={chatsId}
-						hidden={!chatsOpen}
-						className="border-t px-3 py-2"
-					>
-						<div id={chatsListId} className="divide-y">
-							{visibleChats.map((item) => (
-								<PairedChatRow
-									key={item.binding.id}
-									accountId={item.accountId}
-									binding={item.binding}
-									provider={item.provider}
-								/>
-							))}
-							{bindingsLoading && pairedChats.length === 0 ? (
-								<div role="status" className="flex min-h-12 items-center gap-3 px-1 py-2">
-									<Skeleton className="size-8 shrink-0 rounded-md" />
-									<div className="space-y-1.5">
-										<Skeleton className="h-4 w-40 max-w-full" />
-										<span className="sr-only">Loading paired chats</span>
-									</div>
-								</div>
-							) : null}
-							{!bindingsLoading && !bindingsError && pairedChats.length === 0 ? (
-								<p className="px-1 py-2 text-sm text-muted-foreground">No paired chats yet.</p>
-							) : null}
-						</div>
-						{bindingsError ? (
-							<div
-								role="alert"
-								className="mt-1 flex min-h-12 flex-wrap items-center gap-2 rounded-md bg-destructive/5 px-3 py-2"
-							>
-								<AlertCircle className="size-4 shrink-0 text-destructive" />
-								<p className="min-w-0 flex-1 text-sm font-medium">
-									{provider === "discord"
-										? "Couldn’t load paired servers or direct messages"
-										: "Couldn’t load paired chats"}
-								</p>
-								<Button type="button" variant="outline" size="sm" onClick={onBindingsRetry}>
-									<RefreshCw className="size-3.5" />
-									Retry
-								</Button>
-							</div>
-						) : null}
-						{pairedChats.length > INITIAL_PAIRED_CHAT_COUNT ? (
-							<div className="border-t px-1 pt-2">
-								<Button
-									type="button"
-									variant="ghost"
-									size="sm"
-									className="h-8 px-2"
-									aria-expanded={showAllChats}
-									aria-controls={chatsListId}
-									onClick={() => setShowAllChats((showAll) => !showAll)}
-								>
-									{showAllChats ? "Show less" : "Show more"}
-								</Button>
-							</div>
-						) : null}
-					</div>
-				</div>
+				<PairedChatsDialog
+					linkId={link.id}
+					channelName={channelName}
+					provider={provider}
+					pairedChats={pairedChats}
+					bindingsLoading={bindingsLoading}
+					bindingsError={bindingsError}
+					onBindingsRetry={onBindingsRetry}
+				/>
 			</LinkedChannelRow>
-		</div>
-	);
-}
-
-function AddChannelRow({
-	channel,
-	kind,
-	linking,
-	disabled,
-	onLink,
-	secondary = false,
-}: {
-	channel: LinkableChannel;
-	kind?: string;
-	linking: boolean;
-	disabled: boolean;
-	onLink: () => void;
-	secondary?: boolean;
-}) {
-	return (
-		<div data-add-channel-id={channel.id} className="min-w-0">
-			<ChannelCard
-				provider={channel.provider}
-				title={channel.name}
-				state={kind}
-				actions={
-					<Button
-						type="button"
-						size="sm"
-						variant={secondary ? "outline" : "default"}
-						disabled={disabled}
-						onClick={onLink}
-					>
-						{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-						{linking ? "Linking…" : "Link"}
-					</Button>
-				}
-			/>
 		</div>
 	);
 }
@@ -2841,6 +2686,7 @@ function LinkedChannelRow({
 	fallbackAccount,
 	health,
 	agentName,
+	bindings,
 	children,
 }: {
 	link: AgentChannelLink;
@@ -2849,6 +2695,7 @@ function LinkedChannelRow({
 	fallbackAccount?: ChannelAccountSummary;
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	agentName: string;
+	bindings: readonly ChannelBinding[] | undefined;
 	children?: React.ReactNode;
 }) {
 	const pair = useCreatePairCode(link.account_id);
@@ -2921,7 +2768,7 @@ function LinkedChannelRow({
 								type="button"
 								variant="outline"
 								size="sm"
-								className="min-w-0 flex-1 sm:flex-none"
+								className="w-full min-w-0 xl:w-32"
 								disabled={provider !== "telegram" && creatingPairCode}
 								onClick={() => {
 									if (provider === "telegram") setTelegramPairOpen(true);
@@ -2952,7 +2799,7 @@ function LinkedChannelRow({
 								<Button
 									variant="ghost"
 									size="sm"
-									className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+									className={cn(CHANNEL_DESTRUCTIVE_ACTION_CLASS, "w-28 min-w-0")}
 									disabled={unlinking}
 									aria-label={`${unlinking ? "Unlinking" : "Unlink"} ${name} from ${agentName}`}
 								>
@@ -2962,7 +2809,10 @@ function LinkedChannelRow({
 											Unlinking…
 										</>
 									) : (
-										"Unlink"
+										<>
+											<Link2Off className="size-3.5" />
+											<span>Unlink</span>
+										</>
 									)}
 								</Button>
 							</ConfirmAction>
@@ -2979,6 +2829,7 @@ function LinkedChannelRow({
 					accountId={link.account_id}
 					agentLinkId={link.id}
 					channelName={name}
+					bindings={bindings}
 				/>
 			) : null}
 			{isDiscord ? (
@@ -2988,6 +2839,7 @@ function LinkedChannelRow({
 					accountId={link.account_id}
 					agentLinkId={link.id}
 					channelName={name}
+					bindings={bindings}
 				/>
 			) : null}
 		</>

--- a/apps/web/src/hosted/v2/channels/add-channel-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/add-channel-dialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Link2, Plus } from "lucide-react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { EntityHeader } from "@/components/entity-card";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { ProviderChip } from "@/hosted/v2/channels/channel-ui";
+
+export type AddChannelOption = {
+	id: string;
+	name: string;
+	provider: string;
+};
+
+export function AddChannelDialog({
+	open,
+	onOpenChange,
+	clawdiBots,
+	customBots,
+	isLoading,
+	clawdiError,
+	customError,
+	onRetryClawdi,
+	onRetryCustom,
+	addingAccountId,
+	onAdd,
+	onConnectCustomBot,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	clawdiBots: AddChannelOption[];
+	customBots: AddChannelOption[];
+	isLoading: boolean;
+	clawdiError: Error | null;
+	customError: Error | null;
+	onRetryClawdi: () => void;
+	onRetryCustom: () => void;
+	addingAccountId: string | null;
+	onAdd: (accountId: string) => Promise<boolean>;
+	onConnectCustomBot: () => void;
+}) {
+	const hasBots = clawdiBots.length > 0 || customBots.length > 0;
+
+	async function add(accountId: string) {
+		if (await onAdd(accountId)) onOpenChange(false);
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				data-hosted="true"
+				data-v2="true"
+				data-agent-add-channel-dialog
+				className="max-h-[calc(100dvh-2rem)] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0 sm:max-w-lg"
+			>
+				<DialogHeader className="border-b p-5 pr-14">
+					<DialogTitle>Add channel</DialogTitle>
+					<DialogDescription>Choose a bot for this Agent.</DialogDescription>
+				</DialogHeader>
+
+				<div className="min-h-0 min-w-0 space-y-4 overflow-y-auto overscroll-contain p-4 sm:p-5">
+					{clawdiError ? (
+						<ApiErrorPanel
+							error={clawdiError}
+							title="Couldn't load Clawdi bots"
+							onRetry={onRetryClawdi}
+						/>
+					) : null}
+					{customError ? (
+						<ApiErrorPanel
+							error={customError}
+							title="Couldn't load Custom bots"
+							onRetry={onRetryCustom}
+						/>
+					) : null}
+					{isLoading && !hasBots ? <AddChannelSkeleton /> : null}
+					<AddChannelSection
+						title="Clawdi bots"
+						bots={clawdiBots}
+						addingAccountId={addingAccountId}
+						onAdd={add}
+					/>
+					<AddChannelSection
+						title="Custom bots"
+						bots={customBots}
+						addingAccountId={addingAccountId}
+						onAdd={add}
+					/>
+					{!isLoading && !clawdiError && !customError && !hasBots ? (
+						<div className="py-6 text-center">
+							<p className="text-sm font-medium">No Clawdi or Custom bots to add</p>
+							<p className="mt-1 text-sm text-muted-foreground">
+								Connect a Custom bot, or unlink a channel to replace it.
+							</p>
+						</div>
+					) : null}
+				</div>
+
+				<DialogFooter className="border-t p-4 sm:p-5">
+					<Button
+						variant={hasBots ? "outline" : "default"}
+						className="min-w-0 whitespace-normal"
+						onClick={onConnectCustomBot}
+					>
+						<Plus className="size-4" />
+						Connect custom bot
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function AddChannelSection({
+	title,
+	bots,
+	addingAccountId,
+	onAdd,
+}: {
+	title: string;
+	bots: AddChannelOption[];
+	addingAccountId: string | null;
+	onAdd: (accountId: string) => Promise<void>;
+}) {
+	if (bots.length === 0) return null;
+	return (
+		<section className="min-w-0 space-y-2" data-agent-add-channel-section={title}>
+			<h3 className="text-xs font-medium text-muted-foreground">{title}</h3>
+			<div className="min-w-0 space-y-2">
+				{bots.map((bot) => {
+					const adding = addingAccountId === bot.id;
+					return (
+						<div
+							key={bot.id}
+							data-add-channel-id={bot.id}
+							className="grid min-w-0 grid-cols-[minmax(0,1fr)_6.5rem] items-center gap-2 rounded-lg border p-3"
+						>
+							<EntityHeader
+								className="min-w-0"
+								icon={<ProviderChip provider={bot.provider} size="sm" />}
+								title={bot.name}
+								titleAttribute={bot.name}
+							/>
+							<Button
+								type="button"
+								size="sm"
+								className="w-full min-w-0"
+								disabled={addingAccountId !== null}
+								onClick={() => void onAdd(bot.id)}
+							>
+								{adding ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+								<span>{adding ? "Adding…" : "Add"}</span>
+							</Button>
+						</div>
+					);
+				})}
+			</div>
+		</section>
+	);
+}
+
+function AddChannelSkeleton() {
+	return (
+		<div role="status" className="space-y-2">
+			<span className="sr-only">Loading Clawdi and Custom bots</span>
+			{[0, 1].map((index) => (
+				<div key={index} className="flex min-h-14 items-center gap-3 rounded-lg border p-3">
+					<Skeleton className="size-8 shrink-0 rounded-md" />
+					<Skeleton className="h-4 min-w-0 flex-1" />
+					<Skeleton className="h-8 w-26 shrink-0 rounded-md" />
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -11,6 +11,7 @@ function source(relativePath: string): string {
 const card = source("./channel-card.tsx");
 const consoleChannels = source("./channels-page.tsx");
 const agentChannels = source("../../agents/hosted-agent-detail.tsx");
+const pairedChatsDialog = source("./paired-chats-dialog.tsx");
 
 describe("shared Channel card", () => {
 	test("renders the hosted v2 Entity Card shell with aligned headers and composable content", () => {
@@ -53,5 +54,19 @@ describe("shared Channel card", () => {
 		expect(consoleChannels).not.toContain("Unpair");
 		expect(consoleChannels).not.toContain("Unlink");
 		expect(consoleChannels).toContain('to="/channels/$id"');
+	});
+
+	test("opens paired chats outside the card through responsive design-system overlays", () => {
+		expect(agentChannels).toContain("<PairedChatsDialog");
+		expect(pairedChatsDialog).toContain("<Dialog");
+		expect(pairedChatsDialog).toContain("<DialogTrigger");
+		expect(pairedChatsDialog).toContain("<Sheet");
+		expect(pairedChatsDialog).toContain("<SheetTrigger");
+		expect(pairedChatsDialog).toContain("useIsMobile()");
+		expect(pairedChatsDialog).toContain('side="bottom"');
+		expect(pairedChatsDialog).toContain("overflow-y-auto");
+		expect(pairedChatsDialog).toContain("h-10 min-h-10 max-h-10");
+		expect(pairedChatsDialog).not.toContain("Show more");
+		expect(pairedChatsDialog).not.toContain("Show less");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channel-card.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-card.tsx
@@ -36,12 +36,13 @@ export function ChannelCard({
 		>
 			<div
 				data-channel-card-header
-				className="grid min-h-20 min-w-0 gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+				className="grid min-h-20 min-w-0 gap-3 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center"
 			>
 				<EntityHeader
 					align="start"
 					icon={<ProviderChip provider={provider} />}
 					title={title}
+					titleAttribute={typeof title === "string" ? title : undefined}
 					meta={state}
 				/>
 				{actions ? (

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -6,14 +6,16 @@ function source(relativePath: string): string {
 }
 
 describe("global Channels inventory", () => {
-	test("separates owned and shared bot inventory without relationship actions", () => {
+	test("separates Custom and Clawdi bot inventory without relationship actions", () => {
 		const channelsPage = source("./channels-page.tsx");
 
 		expect(channelsPage).toContain("<OwnedBotsSection");
 		expect(channelsPage).toContain("data-owned-bots-section");
 		expect(channelsPage).toContain("<SharedBotsSection");
 		expect(channelsPage).toContain("data-shared-bots-section");
-		expect(channelsPage).toContain("Connect bot");
+		expect(channelsPage).toContain("Connect custom bot");
+		expect(channelsPage).toContain("Custom bots");
+		expect(channelsPage).toContain("Clawdi bots");
 		expect(channelsPage).toContain("orderedChannelsForFilter");
 		expect(channelsPage).toContain("useBotPool");
 		expect(channelsPage).not.toContain("ReadyBotsSection");
@@ -44,13 +46,22 @@ describe("global Channels inventory", () => {
 		expect(hooks).toContain("export function useUnlinkAgentChannel(");
 	});
 
-	test("creates an unlinked asset globally and targets the current Agent only in Agent context", () => {
+	test("reuses one Custom bot form for Console inventory and direct Agent setup", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
 		const agentDetail = source("../../agents/hosted-agent-detail.tsx");
+		const addChannelDialog = source("./add-channel-dialog.tsx");
 
 		expect(connectDialog).toContain("agent_id: agentId ?? null");
+		expect(connectDialog).toContain("onAgentConnected");
+		expect(connectDialog).toContain("availableBotProvidersForAgent");
+		expect(agentDetail).toContain("<AddChannelDialog");
+		expect(agentDetail).toContain("<ConnectBotDialog");
+		expect(agentDetail).toContain('channelSetupDialog === "connect-custom"');
 		expect(agentDetail).toContain("agentId={environmentId}");
-		expect(agentDetail).toContain("onAgentConnected={(bot)");
+		expect(agentDetail).toContain("linkedProviders={linkedProviders}");
+		expect(addChannelDialog).toContain("Choose a bot for this Agent.");
+		expect(addChannelDialog).toContain("Connect custom bot");
+		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setTelegramPair({");
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -7,6 +7,11 @@ const agentChannels = readFileSync(
 );
 const channelDetail = readFileSync(new URL("./channel-detail-page.tsx", import.meta.url), "utf8");
 const channelHooks = readFileSync(new URL("./channels-hooks.ts", import.meta.url), "utf8");
+const pairedChatsDialog = readFileSync(
+	new URL("./paired-chats-dialog.tsx", import.meta.url),
+	"utf8",
+);
+const addChannelDialog = readFileSync(new URL("./add-channel-dialog.tsx", import.meta.url), "utf8");
 const channelsTab = agentChannels.slice(
 	agentChannels.indexOf("function ChannelsTab"),
 	agentChannels.indexOf("// ── Settings / Compute"),
@@ -33,7 +38,8 @@ describe("hosted-agent channel finish line", () => {
 	});
 
 	test("separates linking a channel from pairing a chat with one short instruction", () => {
-		expect(channelsTab).toContain("Link a bot to this Agent, then choose where it should answer.");
+		expect(channelsTab).toContain("Add a channel, then pair where this Agent should answer.");
+		expect(addChannelDialog).toContain("Choose a bot for this Agent.");
 		expect(channelsTab).toContain("Pair Telegram");
 		expect(channelsTab).toContain("pairingActionLabel(provider)");
 		expect(channelsTab).toContain("<TelegramPairDialog");
@@ -45,50 +51,42 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).not.toContain("source revision");
 	});
 
-	test("keeps Add persistent and nests progressively disclosed chats inside their bot", () => {
+	test("keeps Add persistent and opens paired chats without expanding their bot", () => {
 		const connectedIndex = channelsTab.indexOf("<section data-agent-connected-channels");
 		const addIndex = channelsTab.indexOf("data-agent-add-channel");
 		const availableIndex = channelsTab.indexOf("<section data-agent-available-channels");
-		const readyBotIndex = channelsTab.indexOf('kind="Shared bot"');
 		expect(connectedIndex).toBeGreaterThanOrEqual(0);
 		expect(addIndex).toBeGreaterThan(connectedIndex);
-		expect(availableIndex).toBeGreaterThan(addIndex);
-		expect(readyBotIndex).toBeGreaterThan(availableIndex);
+		expect(availableIndex).toBe(-1);
 		expect(channelsTab).toContain("data-agent-connected-channels");
 		expect(channelsTab).toContain("data-agent-channel-group-id={link.id}");
-		expect(channelsTab).toContain("data-agent-channel-chats-for={link.id}");
+		expect(channelsTab).toContain("<PairedChatsDialog");
+		expect(pairedChatsDialog).toContain("data-agent-channel-chats-for={linkId}");
 		expect(channelsTab).not.toContain("data-agent-paired-chats");
-		expect(channelsTab).toContain("Paired chats");
+		expect(pairedChatsDialog).toContain("Paired chats");
 		expect(channelsTab).not.toContain("No chats paired");
 		expect(channelsTab).toContain("data-agent-add-channel");
-		expect(channelsTab).toContain("const showAvailableBotsSection =");
-		expect(channelsTab).toContain("{showAvailableBotsSection ? (");
-		const availableSectionGate = channelsTab.slice(
-			channelsTab.indexOf("const showAvailableBotsSection ="),
-			channelsTab.indexOf("const healthByAccount"),
-		);
-		expect(availableSectionGate).toContain("readyBots.length > 0");
-		expect(availableSectionGate).toContain("botPool.isLoading");
-		expect(availableSectionGate).toContain("botPool.error");
-		expect(addIndex).toBeLessThan(channelsTab.indexOf("{showAvailableBotsSection ? ("));
-		expect(channelsTab).toContain("data-add-channel-id");
+		expect(channelsTab).toContain("<AddChannelDialog");
+		expect(addChannelDialog).toContain("data-agent-add-channel-dialog");
+		expect(addChannelDialog).toContain("data-add-channel-id");
+		expect(addChannelDialog).toContain("Clawdi bots");
+		expect(addChannelDialog).toContain("Custom bots");
 		expect(channelsTab).not.toContain("No bot connected yet");
 		expect(channelsTab).not.toContain("View all channels");
 		expect(channelsTab).not.toContain("setAdvancedOpen");
 		expect(channelsTab).not.toContain('<details className="group border-t pt-4">');
 		expect(channelsTab).not.toContain("Fastest: use a ready-to-go bot");
 		expect(channelsTab).not.toContain("Use your own bot (advanced)");
-		expect(agentChannels).toContain("INITIAL_PAIRED_CHAT_COUNT = 3");
-		expect(channelsTab).toContain("pairedChats.slice(0, INITIAL_PAIRED_CHAT_COUNT)");
-		expect(channelsTab).toContain("const pairedChatsLabel =");
-		expect(channelsTab).toContain("Paired chats ·");
-		expect(channelsTab).toContain("aria-expanded={chatsOpen}");
-		expect(channelsTab).toContain("aria-controls={chatsId}");
-		expect(channelsTab).toContain("hidden={!chatsOpen}");
-		expect(channelsTab).toContain('showAllChats ? "Show less" : "Show more"');
-		expect(channelsTab).toContain("Show less");
+		expect(pairedChatsDialog).toContain("pairedChats.map");
+		expect(pairedChatsDialog).toContain("Paired chats ·");
+		expect(pairedChatsDialog).toContain("h-10 min-h-10 max-h-10");
+		expect(pairedChatsDialog).toContain("overflow-y-auto");
+		expect(pairedChatsDialog).toContain("<Dialog");
+		expect(pairedChatsDialog).toContain("<Sheet");
+		expect(pairedChatsDialog).not.toContain("Show more");
+		expect(pairedChatsDialog).not.toContain("Show less");
 		expect(channelsTab).toContain("onBindingsRetry");
-		expect(channelsTab).toContain("Loading paired chats");
+		expect(pairedChatsDialog).toContain("Loading paired chats");
 	});
 
 	test("replaces setup jargon with a bounded automatic wait and exits", () => {

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -27,6 +27,7 @@ describe("channel mutation feedback", () => {
 
 	test("keeps agent-page link, unlink, and pair-code feedback scoped to the acting control", () => {
 		const detail = source("../../agents/hosted-agent-detail.tsx");
+		const addChannelDialog = source("./add-channel-dialog.tsx");
 		const discordPairDialog = source("./discord-pair-dialog.tsx");
 		const pairDialog = source("./telegram-pair-dialog.tsx");
 		const pairedChatRow = source("./paired-chat-row.tsx");
@@ -45,7 +46,7 @@ describe("channel mutation feedback", () => {
 		expectFeedbackBeforeRequest(detail, "setCreatingPairCode(true)", "await pair.execute");
 		expectFeedbackBeforeRequest(pairDialog, "setGenerating(true)", "await pair.execute");
 		expect(detail).toContain("unlinking={unlinkingLinkIds.has(link.id)}");
-		expect(detail).toContain('linking ? "Linking…" : "Link"');
+		expect(addChannelDialog).toContain('adding ? "Adding…" : "Add"');
 		expect(detail).toContain('unlinking ? "Unlinking" : "Unlink"');
 		expect(detail).toContain("Unlinking…");
 		expect(detail).toContain("creatingPairCode ? (");

--- a/apps/web/src/hosted/v2/channels/channel-pairing-success.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-success.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
+import {
+	activeBindingsForPairingAttempt,
+	firstNewActivePairingBinding,
+	pairingSuccessDescription,
+} from "./channel-pairing-success";
+
+const existingBinding: ChannelBinding = {
+	id: "binding-existing",
+	account_id: "account-1",
+	agent_link_id: "link-1",
+	external_chat_id: "chat-existing",
+	external_chat_type: "private",
+	external_chat_name: "Existing chat",
+	status: "active",
+	created_at: "2026-08-01T00:00:00Z",
+	last_message_at: null,
+};
+
+describe("pairing success detection", () => {
+	test("finds only newly active bindings on the current account and link", () => {
+		const newlyActive = { ...existingBinding, id: "binding-new", external_chat_id: "chat-new" };
+		const inactive = { ...newlyActive, id: "binding-pending", status: "pending" };
+		const otherLink = { ...newlyActive, id: "binding-other-link", agent_link_id: "link-2" };
+		const otherAccount = { ...newlyActive, id: "binding-other-account", account_id: "account-2" };
+		const active = activeBindingsForPairingAttempt(
+			[existingBinding, inactive, otherLink, otherAccount, newlyActive],
+			"account-1",
+			"link-1",
+		);
+
+		expect(active.map((binding) => binding.id)).toEqual(["binding-existing", "binding-new"]);
+		expect(firstNewActivePairingBinding(active, new Set(["binding-existing"]))?.id).toBe(
+			"binding-new",
+		);
+	});
+
+	test("does not treat pre-existing bindings or ordinary refetches as success", () => {
+		const active = activeBindingsForPairingAttempt([existingBinding], "account-1", "link-1");
+		const initialIds = new Set(active.map((binding) => binding.id));
+
+		expect(firstNewActivePairingBinding(active, initialIds)).toBeNull();
+		expect(firstNewActivePairingBinding([...active], initialIds)).toBeNull();
+	});
+
+	test("describes Telegram and Discord success with provider and scope", () => {
+		expect(pairingSuccessDescription("telegram", existingBinding)).toBe(
+			"Telegram private chat is ready.",
+		);
+		expect(
+			pairingSuccessDescription("discord", {
+				...existingBinding,
+				external_chat_type: "guild",
+			}),
+		).toBe("Discord server is ready.");
+		expect(pairingSuccessDescription("discord", existingBinding)).toBe(
+			"Discord direct message is ready.",
+		);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-pairing-success.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-success.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { toast } from "sonner";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
+
+type PairingAttempt = {
+	key: string;
+	initialActiveBindingIds: ReadonlySet<string>;
+	completed: boolean;
+};
+
+export function activeBindingsForPairingAttempt(
+	bindings: readonly ChannelBinding[],
+	accountId: string,
+	agentLinkId: string,
+): ChannelBinding[] {
+	return bindings.filter(
+		(binding) =>
+			binding.account_id === accountId &&
+			binding.agent_link_id === agentLinkId &&
+			binding.status.toLowerCase() === "active",
+	);
+}
+
+export function firstNewActivePairingBinding(
+	activeBindings: readonly ChannelBinding[],
+	initialActiveBindingIds: ReadonlySet<string>,
+): ChannelBinding | null {
+	return activeBindings.find((binding) => !initialActiveBindingIds.has(binding.id)) ?? null;
+}
+
+export function pairingSuccessDescription(provider: string, binding: ChannelBinding): string {
+	const chatType = binding.external_chat_type?.toLowerCase();
+	if (provider === "discord") {
+		return ["dm", "direct_messages", "group_dm", "private"].includes(chatType ?? "")
+			? "Discord direct message is ready."
+			: "Discord server is ready.";
+	}
+	if (provider === "telegram") {
+		return chatType === "private"
+			? "Telegram private chat is ready."
+			: chatType === "group" || chatType === "supergroup"
+				? "Telegram group is ready."
+				: "Telegram chat is ready.";
+	}
+	return "The chat is ready.";
+}
+
+export function usePairingSuccess({
+	open,
+	onOpenChange,
+	accountId,
+	agentLinkId,
+	provider,
+	bindings,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	accountId: string;
+	agentLinkId: string;
+	provider: string;
+	bindings: readonly ChannelBinding[] | undefined;
+}) {
+	const attemptKey = `${accountId}:${agentLinkId}`;
+	const activeBindings = useMemo(
+		() =>
+			bindings ? activeBindingsForPairingAttempt(bindings, accountId, agentLinkId) : undefined,
+		[accountId, agentLinkId, bindings],
+	);
+	const attemptRef = useRef<PairingAttempt | null>(null);
+	const openRef = useRef(open);
+	openRef.current = open;
+	const handleOpenChange = useCallback(
+		(nextOpen: boolean) => {
+			openRef.current = nextOpen;
+			if (!nextOpen) attemptRef.current = null;
+			onOpenChange(nextOpen);
+		},
+		[onOpenChange],
+	);
+
+	// Snapshot before effects can interpret the same query payload as a new binding.
+	// Undefined means the parent binding query has not produced its first state yet.
+	if (!open) {
+		attemptRef.current = null;
+	} else if (activeBindings && attemptRef.current?.key !== attemptKey) {
+		attemptRef.current = {
+			key: attemptKey,
+			initialActiveBindingIds: new Set(activeBindings.map((binding) => binding.id)),
+			completed: false,
+		};
+	}
+
+	useEffect(() => {
+		const attempt = attemptRef.current;
+		if (
+			!open ||
+			!openRef.current ||
+			!activeBindings ||
+			!attempt ||
+			attempt.key !== attemptKey ||
+			attempt.completed
+		) {
+			return;
+		}
+		const binding = firstNewActivePairingBinding(activeBindings, attempt.initialActiveBindingIds);
+		if (!binding) return;
+
+		// Lock before closing so a refetch or parent rerender cannot duplicate feedback.
+		attempt.completed = true;
+		openRef.current = false;
+		onOpenChange(false);
+		toast.success("Chat paired", {
+			description: pairingSuccessDescription(provider, binding),
+		});
+	}, [activeBindings, attemptKey, onOpenChange, open, provider]);
+
+	return handleOpenChange;
+}

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -8,12 +8,15 @@ function source(relativePath: string): string {
 const detail = source("./channel-detail-page.tsx");
 const pairDialog = source("./telegram-pair-dialog.tsx");
 const discordPairDialog = source("./discord-pair-dialog.tsx");
+const pairingSuccess = source("./channel-pairing-success.ts");
 const channelLinkingLogic = source("./channel-linking.logic.ts");
 const hooks = source("./channels-hooks.ts");
 const connectDialog = source("./connect-bot-dialog.tsx");
+const addChannelDialog = source("./add-channel-dialog.tsx");
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 const pairedChatRow = source("./paired-chat-row.tsx");
 const pairedChatRowLogic = source("./paired-chat-row.logic.ts");
+const pairedChatsDialog = source("./paired-chats-dialog.tsx");
 const confirmAction = source("../../../components/ui/confirm-action.tsx");
 const agentBindingLogic = source("./agent-channel-bindings.logic.ts");
 const linkedChannelRow = agentDetail.slice(
@@ -38,31 +41,39 @@ describe("channel IA boundary", () => {
 		expect(detail).not.toContain("Link an agent");
 	});
 
-	test("keeps Link, Pair, Unpair, and Unlink on Agent Channels", () => {
+	test("keeps Add, Pair, Unpair, and Unlink on Agent Channels", () => {
 		expect(agentDetail).toContain("data-agent-connected-channels");
 		expect(agentDetail).toContain("data-agent-channel-group-id={link.id}");
-		expect(agentDetail).toContain("data-agent-channel-chats-for={link.id}");
+		expect(pairedChatsDialog).toContain("data-agent-channel-chats-for={linkId}");
 		expect(agentDetail).not.toContain("data-agent-paired-chats");
 		expect(agentDetail).toContain("data-agent-add-channel");
 		expect(agentDetail).toContain("Pair Telegram");
 		expect(agentDetail).toContain("pairingActionLabel(provider)");
 		expect(channelLinkingLogic).toContain('provider === "discord" ? "Pair Discord" : "Pair chat"');
 		expect(agentDetail).toContain('confirmLabel="Unlink"');
-		expect(agentDetail).toContain("<PairedChatRow");
+		expect(agentDetail).toContain("<PairedChatsDialog");
+		expect(pairedChatsDialog).toContain("<PairedChatRow");
 		expect(pairedChatRow).toContain("Unpair");
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("agentProviderHasSingleLinkLimit");
-		expect(agentDetail).toContain("linkedProviders={linkedProviders}");
-		expect(connectDialog).toContain("Connected");
-		expect(connectDialog).toContain("availableBotProvidersForAgent");
-		expect(connectDialog).toContain("This Agent already has one bot from each provider.");
-		expect(connectDialog).toContain("before connecting a replacement");
-		expect(connectDialog).toContain("Manage bots");
+		expect(agentDetail).toContain("<AddChannelDialog");
+		expect(addChannelDialog).toContain("Clawdi bots");
+		expect(addChannelDialog).toContain("Custom bots");
+		expect(addChannelDialog).toContain("No Clawdi or Custom bots to add");
+		expect(addChannelDialog).toContain("Connect custom bot");
+		expect(addChannelDialog).toContain("onConnectCustomBot");
+		expect(agentDetail).not.toContain("data-agent-available-channels");
+		expect(agentDetail).toContain("<ConnectBotDialog");
+		expect(agentDetail).toContain('setChannelSetupDialog("connect-custom")');
 		expect(agentDetail).not.toContain('<details className="group border-t pt-4">');
 	});
 
-	test("provides a novice Discord connect, sync, and pair path in one compact dialog", () => {
+	test("keeps Discord inventory in Console and Add/Pair actions on the Agent", () => {
 		expect(connectDialog).toContain("agent_id: agentId ?? null");
+		expect(connectDialog).toContain("Connect custom bot");
+		expect(connectDialog).toContain("onAgentConnected");
+		expect(addChannelDialog).toContain("Add channel");
+		expect(addChannelDialog).toContain('adding ? "Adding…" : "Add"');
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setDiscordPairOpen(true)");
 		expect(agentDetail).toContain("setDiscordPair({");
@@ -100,7 +111,7 @@ describe("channel IA boundary", () => {
 	test("opens the shared fixed-TTL Telegram flow immediately after a new link", () => {
 		expect(agentDetail).toContain("const [telegramPair, setTelegramPair]");
 		expect(agentDetail).toContain('account?.provider === "telegram"');
-		expect(agentDetail).toContain("onAgentConnected={(bot)");
+		expect(agentDetail).toContain("onAdd={submitLink}");
 		expect(agentDetail).toContain("<TelegramPairDialog");
 		expect(pairDialog).toContain("const TELEGRAM_PAIR_TTL_SECONDS = 900");
 		expect(pairDialog).toContain("agent_link_id: agentLinkId");
@@ -109,6 +120,23 @@ describe("channel IA boundary", () => {
 		expect(pairDialog).toContain("useCreatePairCode(accountId, { toastOnError: false })");
 		expect(pairDialog).toContain("success: false");
 		expect(pairDialog).not.toContain("Select");
+	});
+
+	test("acknowledges only a newly active binding from the current pairing attempt", () => {
+		expect(pairDialog).toContain("usePairingSuccess");
+		expect(discordPairDialog).toContain("usePairingSuccess");
+		expect(agentDetail).toContain("bindings={bindingQuery?.data}");
+		expect(agentDetail).toContain("bindings={bindingsForAccount(telegramPair.accountId)}");
+		expect(agentDetail).toContain("bindings={bindingsForAccount(discordPair.accountId)}");
+		expect(pairingSuccess).toContain("initialActiveBindingIds: new Set");
+		expect(pairingSuccess).toContain("binding.agent_link_id === agentLinkId");
+		expect(pairingSuccess).toContain('binding.status.toLowerCase() === "active"');
+		expect(pairingSuccess).toContain('toast.success("Chat paired"');
+		expect(pairingSuccess).toContain("attempt.completed = true");
+		expect(pairingSuccess).toContain("openRef.current = false");
+		expect(pairDialog).toContain("onOpenChange={handlePairingOpenChange}");
+		expect(discordPairDialog).toContain("onOpenChange={handlePairingOpenChange}");
+		expect(pairingSuccess).toContain("onOpenChange(false)");
 	});
 
 	test("makes the validated server deep link and QR primary with manual group recovery", () => {
@@ -126,7 +154,7 @@ describe("channel IA boundary", () => {
 		expect(pairDialog).toContain(
 			'<CopyInline value={result.pairing_command} label="pairing command" />',
 		);
-		expect(pairDialog).toContain("to pair with {botIdentity}");
+		expect(pairDialog).toContain("Scan the QR code or open Telegram to pair.");
 		expect(pairDialog).not.toContain("agentName");
 		expect(pairDialog).toContain('title="Couldn\'t create Telegram link"');
 	});
@@ -149,15 +177,14 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).not.toContain("Checking activity");
 		expect(agentDetail).not.toContain("No activity yet");
 		expect(agentDetail).not.toContain("Last activity");
-		expect(agentDetail).toContain("INITIAL_PAIRED_CHAT_COUNT = 3");
-		expect(agentDetail).toContain("Show less");
-		expect(agentDetail).toContain("const pairedChatsLabel =");
-		expect(agentDetail).toContain("Paired chats ·");
-		expect(agentDetail).toContain("aria-expanded={chatsOpen}");
-		expect(agentDetail).toContain("aria-controls={chatsId}");
-		expect(agentDetail).toContain("hidden={!chatsOpen}");
-		expect(agentDetail).toContain('role="status"');
-		expect(agentDetail).toContain('role="alert"');
+		expect(pairedChatsDialog).toContain("pairedChats.map");
+		expect(pairedChatsDialog).toContain("Paired chats ·");
+		expect(pairedChatsDialog).toContain("aria-controls={panelId}");
+		expect(pairedChatsDialog).toContain('role="status"');
+		expect(pairedChatsDialog).toContain('role="alert"');
+		expect(pairedChatsDialog).toContain("onBindingsRetry");
+		expect(pairedChatsDialog).not.toContain("pairedChats.slice");
+		expect(pairedChatsDialog).not.toContain("Show more");
 	});
 
 	test("keeps repeated row actions visually stable without provider variants", () => {
@@ -172,23 +199,25 @@ describe("channel IA boundary", () => {
 		expect(linkedChannelRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
 		expect(linkedChannelRow).toContain("Unlinking…");
 		expect(linkedChannelRow).toContain('"Unlink"');
+		expect(linkedChannelRow).toContain("<Link2Off");
 		expect(linkedChannelRow).not.toContain("<Tooltip>");
 		expect(pairedChatRow).toContain('variant="ghost"');
 		expect(pairedChatRow).toContain('size="sm"');
 		expect(pairedChatRow).toContain("CHANNEL_DESTRUCTIVE_ACTION_CLASS");
 		expect(pairedChatRow).toContain("Unpairing…");
 		expect(pairedChatRow).toContain('"Unpair"');
+		expect(pairedChatRow).toContain("<Link2Off");
 		expect(pairedChatRow).not.toContain('variant="outline"');
 	});
 
-	test("renders chats below channels without duplicating provider identity", () => {
+	test("renders compact identity-first chats without duplicating provider identity", () => {
 		expect(pairedChatRow).toContain("<IconChip");
 		expect(pairedChatRow).toContain("<MessageCircle");
 		expect(pairedChatRow).toContain("<MessagesSquare");
 		expect(pairedChatRow).toContain("pairedChatTitle(binding, provider)");
-		expect(pairedChatRow).toContain(
-			'titleClassName="line-clamp-2 whitespace-normal break-words text-clip"',
-		);
+		expect(pairedChatRow).toContain("binding.external_chat_name?.trim()");
+		expect(pairedChatRow).toContain('titleClassName="truncate"');
+		expect(pairedChatRow).toContain('<span className="shrink-0">{scopeLabel}</span>');
 		expect(pairedChatRow).not.toContain("overflow-visible");
 		expect(pairedChatRow).toContain("pairedChatScopeLabel(provider, binding)");
 		expect(pairedChatRow).not.toContain("Run /bot_unpair in this");
@@ -210,7 +239,7 @@ describe("channel IA boundary", () => {
 	});
 
 	test("never renders returned runtime credentials", () => {
-		for (const ui of [detail, pairDialog, connectDialog, agentDetail]) {
+		for (const ui of [detail, pairDialog, connectDialog, agentDetail, pairedChatsDialog]) {
 			expect(ui).not.toContain("TokenReveal");
 			expect(ui).not.toContain("agent_token");
 			expect(ui).not.toContain("Agent token");

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -170,7 +170,7 @@ export function useCreateChannel() {
 				"id" | "name" | "provider" | "webhook_url" | "agent_link_id" | "agent_id"
 			>;
 		} catch (error) {
-			toastApiError("Couldn't connect channel")(error);
+			toastApiError("Couldn't connect Custom bot")(error);
 			throw error;
 		}
 	});

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -36,7 +36,7 @@ import {
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Manage your bots and discover shared bots for your Agents.";
+const DESCRIPTION = "Manage Custom bots and discover Clawdi bots for your Agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 
 export function ChannelsPage() {
@@ -84,7 +84,7 @@ export function ChannelsPage() {
 				actions={
 					<Button size="sm" variant="outline" onClick={() => setConnectOpen(true)}>
 						<Plus />
-						Connect bot
+						Connect custom bot
 					</Button>
 				}
 			/>
@@ -93,7 +93,7 @@ export function ChannelsPage() {
 				<EmptyState
 					icon={MessagesSquare}
 					title="No bots yet"
-					description="Connect a Telegram or Discord bot to make it available to your Agents."
+					description="Connect a Custom Telegram or Discord bot you manage."
 				/>
 			) : (
 				<>
@@ -176,7 +176,7 @@ function OwnedBotsSection({
 
 	return (
 		<section data-owned-bots-section className="flex flex-col gap-3">
-			<SectionLabel count={!isLoading ? visibleCount : undefined}>Your bots</SectionLabel>
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Custom bots</SectionLabel>
 			{healthError ? (
 				<ApiErrorPanel
 					error={healthError}
@@ -211,7 +211,7 @@ function SharedBotsSection({
 			</div>
 		);
 	} else if (error) {
-		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load shared bots" />;
+		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load Clawdi bots" />;
 	} else if (visibleBots.length === 0) {
 		return null;
 	} else {
@@ -225,10 +225,12 @@ function SharedBotsSection({
 	}
 
 	return (
-		<section data-shared-bots-section className="flex flex-col gap-3">
+		<section data-shared-bots-section className="flex min-w-0 flex-col gap-3">
 			<div>
-				<SectionLabel count={!isLoading ? visibleBots.length : undefined}>Shared bots</SectionLabel>
-				<p className="mt-1 text-xs text-muted-foreground">Connect them from Agent → Channels.</p>
+				<SectionLabel count={!isLoading ? visibleBots.length : undefined}>Clawdi bots</SectionLabel>
+				<p className="mt-1 text-xs text-muted-foreground">
+					Add them from an Agent&apos;s Channels tab.
+				</p>
 			</div>
 			{content}
 		</section>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { Check, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EntityIcon } from "@/components/entity-icon";
@@ -65,7 +65,6 @@ export function ConnectBotDialog({
 	const openRef = useRef(open);
 	const dialogSessionRef = useRef(0);
 	openRef.current = open;
-
 	const availableProviders = availableBotProvidersForAgent(agentId, agentType, linkedProviders);
 	const unavailableProviders = CONNECTABLE_BOT_PROVIDERS.filter(
 		(item) => !availableProviders.includes(item),
@@ -147,8 +146,8 @@ export function ConnectBotDialog({
 				}
 				setCreated(data);
 			} else {
-				toast.success("Channel connected", {
-					description: `${data.name} is ready on the Channels page.`,
+				toast.success("Custom bot connected", {
+					description: `${data.name} is ready to use.`,
 				});
 			}
 		} catch {
@@ -161,14 +160,6 @@ export function ConnectBotDialog({
 
 	function handleOpenChange(nextOpen: boolean) {
 		if (!nextOpen) {
-			if (created?.agent_link_id && onAgentConnected) {
-				onAgentConnected({
-					id: created.id,
-					name: created.name,
-					provider: created.provider,
-					agentLinkId: created.agent_link_id,
-				});
-			}
 			dialogSessionRef.current += 1;
 			setToken("");
 			setCreated(null);
@@ -191,13 +182,8 @@ export function ConnectBotDialog({
 						onClick={() => changeProvider(item)}
 					>
 						<EntityIcon kind="channel" id={item} label={PROVIDER_META[item].label} size="sm" />
-						<span className="min-w-0 text-left leading-tight">
-							<span className="block">{PROVIDER_META[item].label}</span>
-							{alreadyLinked ? (
-								<span className="flex items-center gap-1 whitespace-nowrap text-[10px] font-normal text-muted-foreground">
-									<Check className="size-3" /> Connected
-								</span>
-							) : null}
+						<span className="min-w-0 truncate text-left leading-tight">
+							{PROVIDER_META[item].label}
 						</span>
 					</Button>
 				);
@@ -210,171 +196,183 @@ export function ConnectBotDialog({
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-md"
+				className="max-h-[calc(100dvh-2rem)] min-w-0 overflow-x-hidden overflow-y-auto sm:max-w-md [&>*]:min-w-0"
 			>
 				{created ? (
 					<>
 						<DialogHeader>
-							<DialogTitle>Bot connected</DialogTitle>
+							<DialogTitle>Custom bot connected</DialogTitle>
 							<DialogDescription>
-								<span className="font-medium">{created.name}</span> is ready to use.
+								<span className="font-medium [overflow-wrap:anywhere]" title={created.name}>
+									{created.name}
+								</span>{" "}
+								is ready to use.
 							</DialogDescription>
 						</DialogHeader>
 						<DialogFooter>
-							<Button variant="outline" onClick={() => handleOpenChange(false)}>
+							<Button
+								variant="outline"
+								className="min-w-0 whitespace-normal"
+								onClick={() => handleOpenChange(false)}
+							>
 								Done
 							</Button>
 							<Button
 								render={<Link to="/channels/$id" params={{ id: created.id }} />}
 								nativeButton={false}
+								className="min-w-0 whitespace-normal"
 							>
-								View bot
+								View Custom bot
 							</Button>
 						</DialogFooter>
 					</>
 				) : (
 					<>
 						<DialogHeader>
-							<DialogTitle>Connect a bot</DialogTitle>
+							<DialogTitle>Connect custom bot</DialogTitle>
 							<DialogDescription>
-								{agentId ? "Connect a bot you manage to this Agent." : "Add a bot you manage."}
+								{agentId
+									? "Connect a Custom bot you manage to this Agent."
+									: "Connect a Custom bot you manage."}
 							</DialogDescription>
 						</DialogHeader>
 
 						{availableProviders.length === 0 ? (
-							<>
-								<div className="space-y-3">
-									{providerChoices}
-									<p role="status" className="text-sm text-muted-foreground">
-										This Agent already has one bot from each provider. Unlink one from its card
-										before connecting a replacement.
-									</p>
-								</div>
-								<DialogFooter>
-									<Button render={<Link to="/channels" />} nativeButton={false} variant="outline">
-										Manage bots
-									</Button>
-									<Button onClick={() => handleOpenChange(false)}>Done</Button>
-								</DialogFooter>
-							</>
+							<div className="space-y-3">
+								{providerChoices}
+								<p role="status" className="text-sm text-muted-foreground">
+									This Agent already has a channel from each provider. Unlink one before connecting
+									a Custom bot.
+								</p>
+							</div>
 						) : (
-							<>
-								<div className="flex flex-col gap-3">
-									{providerChoices}
-									{unavailableProviders.length === 1 ? (
-										<p className="whitespace-normal text-xs text-muted-foreground">
-											Unlink {PROVIDER_META[unavailableProviders[0]].label} from its card to replace
-											it. You can also{" "}
-											<Link
-												to="/channels"
-												className="font-medium text-foreground underline underline-offset-4"
-											>
-												manage bots
-											</Link>
-											.
+							<div className="flex flex-col gap-3">
+								{providerChoices}
+								{unavailableProviders.length === 1 ? (
+									<p className="text-xs text-muted-foreground">
+										{PROVIDER_META[unavailableProviders[0]].label} is already linked to this Agent.
+										Unlink it to connect another Custom bot from that provider.
+									</p>
+								) : null}
+								<p className="min-w-0 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
+									{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
+									<a
+										href={meta.setupUrl}
+										target="_blank"
+										rel="noreferrer"
+										className="inline-flex min-w-0 flex-wrap items-center gap-1 font-medium text-foreground underline underline-offset-4"
+									>
+										{provider === "telegram"
+											? "Create a bot with @BotFather"
+											: "Open Discord Developer Portal"}
+										<ExternalLink className="size-3" />
+									</a>
+								</p>
+
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="connect-name">Name</Label>
+									<Input
+										id="connect-name"
+										value={name}
+										onChange={(event) => setName(event.target.value)}
+										placeholder="Support Bot"
+										autoComplete="off"
+									/>
+								</div>
+
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="connect-token">Bot token</Label>
+									<Input
+										id="connect-token"
+										type="password"
+										value={token}
+										onChange={(event) => setToken(event.target.value)}
+										placeholder={meta.tokenPlaceholder}
+										autoComplete="off"
+										spellCheck={false}
+										required
+										aria-invalid={Boolean(tokenError)}
+										aria-describedby={tokenError ? "connect-token-error" : undefined}
+									/>
+									{tokenError ? (
+										<p
+											id="connect-token-error"
+											className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+										>
+											{tokenError}
 										</p>
 									) : null}
-									<p className="text-xs text-muted-foreground">
-										{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
-										<a
-											href={meta.setupUrl}
-											target="_blank"
-											rel="noreferrer"
-											className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4"
-										>
-											{provider === "telegram"
-												? "Create a bot with @BotFather"
-												: "Open Discord Developer Portal"}
-											<ExternalLink className="size-3" />
-										</a>
-									</p>
-
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-name">Name</Label>
-										<Input
-											id="connect-name"
-											value={name}
-											onChange={(event) => setName(event.target.value)}
-											placeholder="Support Bot"
-											autoComplete="off"
-										/>
-									</div>
-
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-token">Bot token</Label>
-										<Input
-											id="connect-token"
-											type="password"
-											value={token}
-											onChange={(event) => setToken(event.target.value)}
-											placeholder={meta.tokenPlaceholder}
-											autoComplete="off"
-											spellCheck={false}
-											required
-											aria-invalid={Boolean(tokenError)}
-											aria-describedby={tokenError ? "connect-token-error" : undefined}
-										/>
-										{tokenError ? (
-											<p id="connect-token-error" className="text-xs text-destructive">
-												{tokenError}
-											</p>
-										) : null}
-									</div>
-
-									{discordSelected ? (
-										<>
-											<div className="flex flex-col gap-1.5">
-												<Label htmlFor="connect-app-id">Application ID</Label>
-												<Input
-													id="connect-app-id"
-													value={applicationId}
-													onChange={(event) => setApplicationId(event.target.value)}
-													placeholder="Application ID"
-													autoComplete="off"
-													spellCheck={false}
-													required
-													aria-invalid={Boolean(applicationIdError)}
-													aria-describedby={applicationIdError ? "connect-app-id-error" : undefined}
-												/>
-												{applicationIdError ? (
-													<p id="connect-app-id-error" className="text-xs text-destructive">
-														{applicationIdError}
-													</p>
-												) : null}
-											</div>
-											<div className="flex flex-col gap-1.5">
-												<Label htmlFor="connect-public-key">Public key</Label>
-												<Input
-													id="connect-public-key"
-													value={publicKey}
-													onChange={(event) => setPublicKey(event.target.value)}
-													placeholder="64-character hex public key"
-													autoComplete="off"
-													spellCheck={false}
-													required
-													aria-invalid={Boolean(publicKeyError)}
-													aria-describedby={publicKeyError ? "connect-public-key-error" : undefined}
-												/>
-												{publicKeyError ? (
-													<p id="connect-public-key-error" className="text-xs text-destructive">
-														{publicKeyError}
-													</p>
-												) : null}
-											</div>
-										</>
-									) : null}
 								</div>
 
-								<DialogFooter>
-									<Button variant="outline" onClick={() => handleOpenChange(false)}>
-										{isSubmitting ? "Close" : "Cancel"}
-									</Button>
-									<Button onClick={() => void submit()} disabled={!canSubmit || isSubmitting}>
-										{isSubmitting ? "Connecting…" : "Connect"}
-									</Button>
-								</DialogFooter>
-							</>
+								{discordSelected ? (
+									<>
+										<div className="flex flex-col gap-1.5">
+											<Label htmlFor="connect-app-id">Application ID</Label>
+											<Input
+												id="connect-app-id"
+												value={applicationId}
+												onChange={(event) => setApplicationId(event.target.value)}
+												placeholder="Application ID"
+												autoComplete="off"
+												spellCheck={false}
+												required
+												aria-invalid={Boolean(applicationIdError)}
+												aria-describedby={applicationIdError ? "connect-app-id-error" : undefined}
+											/>
+											{applicationIdError ? (
+												<p
+													id="connect-app-id-error"
+													className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+												>
+													{applicationIdError}
+												</p>
+											) : null}
+										</div>
+										<div className="flex flex-col gap-1.5">
+											<Label htmlFor="connect-public-key">Public key</Label>
+											<Input
+												id="connect-public-key"
+												value={publicKey}
+												onChange={(event) => setPublicKey(event.target.value)}
+												placeholder="64-character hex public key"
+												autoComplete="off"
+												spellCheck={false}
+												required
+												aria-invalid={Boolean(publicKeyError)}
+												aria-describedby={publicKeyError ? "connect-public-key-error" : undefined}
+											/>
+											{publicKeyError ? (
+												<p
+													id="connect-public-key-error"
+													className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+												>
+													{publicKeyError}
+												</p>
+											) : null}
+										</div>
+									</>
+								) : null}
+							</div>
 						)}
+
+						<DialogFooter>
+							<Button
+								variant="outline"
+								className="min-w-0 whitespace-normal"
+								onClick={() => handleOpenChange(false)}
+							>
+								{isSubmitting ? "Close" : "Cancel"}
+							</Button>
+							{availableProviders.length > 0 ? (
+								<Button
+									className="min-w-0 whitespace-normal"
+									onClick={() => void submit()}
+									disabled={!canSubmit || isSubmitting}
+								>
+									{isSubmitting ? "Connecting…" : "Connect custom bot"}
+								</Button>
+							) : null}
+						</DialogFooter>
 					</>
 				)}
 			</DialogContent>

--- a/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
@@ -18,7 +18,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { pairCodeExpired } from "@/hosted/v2/channels/channel-linking.logic";
-import type { ChannelPairCode } from "@/hosted/v2/channels/channel-types";
+import { usePairingSuccess } from "@/hosted/v2/channels/channel-pairing-success";
+import type { ChannelBinding, ChannelPairCode } from "@/hosted/v2/channels/channel-types";
 import { useCreatePairCode } from "@/hosted/v2/channels/channels-hooks";
 
 const DISCORD_PAIR_TTL_SECONDS = 900;
@@ -31,12 +32,14 @@ export function DiscordPairDialog({
 	accountId,
 	agentLinkId,
 	channelName,
+	bindings,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	agentLinkId: string;
 	channelName?: string;
+	bindings?: readonly ChannelBinding[];
 }) {
 	const pair = useCreatePairCode(accountId, { toastOnError: false });
 	const { copied, copy } = useCopyToClipboard({
@@ -51,6 +54,14 @@ export function DiscordPairDialog({
 	const openKeyRef = useRef<string | null>(null);
 	const sessionRef = useRef(0);
 	const lockedSessionRef = useRef<number | null>(null);
+	const handlePairingOpenChange = usePairingSuccess({
+		open,
+		onOpenChange,
+		accountId,
+		agentLinkId,
+		provider: "discord",
+		bindings,
+	});
 
 	const prepare = useCallback(
 		async (session = sessionRef.current) => {
@@ -113,22 +124,23 @@ export function DiscordPairDialog({
 	const botIdentity = channelName?.trim() || "this bot";
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handlePairingOpenChange}>
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
+				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
 			>
 				<DialogHeader>
 					<DialogTitle>Pair Discord</DialogTitle>
-					<DialogDescription>
-						Choose a server or direct message for {botIdentity}.
-					</DialogDescription>
+					<p className="min-w-0 truncate text-sm font-medium" title={botIdentity}>
+						{botIdentity}
+					</p>
+					<DialogDescription>Choose a server or direct message to pair.</DialogDescription>
 				</DialogHeader>
 
 				<div
 					data-discord-pair-dialog-body
-					className="min-h-0 overflow-y-auto overscroll-contain pr-1"
+					className="min-h-0 min-w-0 break-words overflow-y-auto overscroll-contain pr-1 [overflow-wrap:anywhere]"
 				>
 					{preparing ? (
 						<div className="flex min-h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
@@ -196,9 +208,7 @@ export function DiscordPairDialog({
 											</div>
 										)}
 										<div className="space-y-2 border-t pt-3 text-sm">
-											<p>
-												1. Add {botIdentity} to the server. You need Manage Server or Administrator.
-											</p>
+											<p>1. Add the bot to the server. You need Manage Server or Administrator.</p>
 											<p>
 												2. In that server, run <code>/bot_pair</code> and paste this code into the
 												required <code>code</code> option.
@@ -208,7 +218,7 @@ export function DiscordPairDialog({
 									</TabsContent>
 									<TabsContent value="dm" data-discord-pair-path="dm" className="mt-2 space-y-3">
 										<p className="text-sm text-muted-foreground">
-											If you can already open a direct message with {botIdentity}, run{" "}
+											If you can already open a direct message with the bot, run{" "}
 											<code>/bot_pair</code> and paste this code into the required <code>code</code>{" "}
 											option. No server permission is required.
 										</p>
@@ -227,6 +237,7 @@ export function DiscordPairDialog({
 					<DialogFooter>
 						<Button
 							variant={path === "server" ? "outline" : "default"}
+							className="min-w-0 whitespace-normal"
 							onClick={() => void copy(result.code)}
 						>
 							{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
@@ -238,6 +249,7 @@ export function DiscordPairDialog({
 									<a href={result.discord_install_url} target="_blank" rel="noopener noreferrer" />
 								}
 								nativeButton={false}
+								className="min-w-0 whitespace-normal"
 							>
 								Add to server
 								<ExternalLink className="size-4" />
@@ -246,7 +258,7 @@ export function DiscordPairDialog({
 					</DialogFooter>
 				) : result && expired ? (
 					<DialogFooter>
-						<Button onClick={() => void prepare()}>
+						<Button className="min-w-0 whitespace-normal" onClick={() => void prepare()}>
 							<RefreshCw className="size-4" />
 							Generate new code
 						</Button>

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageCircle, MessagesSquare } from "lucide-react";
+import { Link2Off, MessageCircle, MessagesSquare } from "lucide-react";
 import { EntityHeader } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
@@ -17,7 +17,7 @@ import { pairedChatScopeLabel, pairedChatTitle } from "@/hosted/v2/channels/pair
 import { cn, relativeTime } from "@/lib/utils";
 
 export const PAIRED_CHAT_ROW_CLASS =
-	"grid min-h-14 grid-cols-[minmax(0,1fr)] items-center gap-2 px-1 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3";
+	"grid min-h-14 min-w-0 grid-cols-[minmax(0,1fr)_7rem] items-center gap-1.5 px-1 py-2.5";
 
 export function PairedChatRow({
 	accountId,
@@ -35,6 +35,24 @@ export function PairedChatRow({
 	const scope = pairedChatScopeLabel(provider, binding);
 	const privateChat = chatType === "private" || scope === "direct message";
 	const chatName = pairedChatTitle(binding, provider);
+	const displayName = binding.external_chat_name?.trim() || binding.external_chat_id;
+	const scopeLabel =
+		provider === "discord"
+			? scope === "direct message"
+				? "Direct message"
+				: "Server"
+			: chatType === "private"
+				? "Private chat"
+				: chatType === "group" || chatType === "supergroup"
+					? "Group chat"
+					: "Chat";
+	const metaDetail = unpair.error ? (
+		<span className="font-medium text-destructive">Couldn&apos;t unpair · Try again</span>
+	) : !isNormalChannelStatus(binding.status) ? (
+		<ChannelStatusBadge status={binding.status} />
+	) : binding.last_message_at ? (
+		<span>Last activity {relativeTime(binding.last_message_at)}</span>
+	) : null;
 
 	return (
 		<div
@@ -49,25 +67,22 @@ export function PairedChatRow({
 			<EntityHeader
 				className="min-w-0"
 				icon={<IconChip size="sm">{privateChat ? <MessageCircle /> : <MessagesSquare />}</IconChip>}
-				title={chatName}
-				titleClassName="line-clamp-2 whitespace-normal break-words text-clip"
-				meta={[
-					...(binding.last_message_at
-						? [<span key="activity">Last activity {relativeTime(binding.last_message_at)}</span>]
-						: []),
-					...(isNormalChannelStatus(binding.status)
-						? []
-						: [<ChannelStatusBadge key="status" status={binding.status} />]),
-					...(unpair.error
-						? [
-								<span key="error" className="font-medium text-destructive">
-									Couldn&apos;t unpair · Try again
-								</span>,
-							]
-						: []),
-				]}
+				title={displayName}
+				titleClassName="truncate"
+				titleAttribute={displayName}
+				meta={
+					<span className="flex min-w-0 items-center">
+						<span className="shrink-0">{scopeLabel}</span>
+						{metaDetail ? (
+							<>
+								<span className="mx-1.5 shrink-0 text-muted-foreground/40">·</span>
+								<span className="min-w-0 truncate">{metaDetail}</span>
+							</>
+						) : null}
+					</span>
+				}
 			/>
-			<div className="flex min-h-8 min-w-0 justify-end sm:shrink-0">
+			<div className="flex min-h-8 min-w-0 justify-end">
 				<ConfirmAction
 					title={`Unpair ${chatName}?`}
 					description="Only this chat will be disconnected. Other chats and the connected channel stay active."
@@ -78,7 +93,7 @@ export function PairedChatRow({
 					<Button
 						variant="ghost"
 						size="sm"
-						className={CHANNEL_DESTRUCTIVE_ACTION_CLASS}
+						className={cn(CHANNEL_DESTRUCTIVE_ACTION_CLASS, "w-full min-w-0")}
 						disabled={unpair.isPending}
 						aria-label={`${unpair.isPending ? "Unpairing" : "Unpair"} ${chatName}`}
 					>
@@ -88,7 +103,10 @@ export function PairedChatRow({
 								Unpairing…
 							</>
 						) : (
-							"Unpair"
+							<>
+								<Link2Off className="size-3.5" />
+								<span>Unpair</span>
+							</>
 						)}
 					</Button>
 				</ConfirmAction>

--- a/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { AlertCircle, ChevronRight, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { AgentPairedChatItem } from "@/hosted/v2/channels/agent-channel-bindings.logic";
+import { PairedChatRow } from "@/hosted/v2/channels/paired-chat-row";
+
+export function PairedChatsDialog({
+	linkId,
+	channelName,
+	provider,
+	pairedChats,
+	bindingsLoading,
+	bindingsError,
+	onBindingsRetry,
+}: {
+	linkId: string;
+	channelName: string;
+	provider: string;
+	pairedChats: AgentPairedChatItem[];
+	bindingsLoading: boolean;
+	bindingsError: boolean;
+	onBindingsRetry: () => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const isMobile = useIsMobile();
+	const panelId = `paired-chats-${linkId}`;
+	const label = `Paired chats · ${pairedChats.length}`;
+	const description = `${pairedChats.length} ${pairedChats.length === 1 ? "chat" : "chats"} connected through this channel. Unpairing affects only the selected chat.`;
+	const trigger = (
+		<button
+			type="button"
+			data-agent-paired-chats-trigger={linkId}
+			className="flex h-10 min-h-10 max-h-10 w-full items-center gap-2 px-4 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+			aria-controls={panelId}
+		>
+			<span className="min-w-0 flex-1 truncate">{label}</span>
+			{bindingsLoading ? (
+				<span role="status" className="inline-flex shrink-0">
+					<Spinner className="size-3.5" />
+					<span className="sr-only">Loading paired chats</span>
+				</span>
+			) : null}
+			{bindingsError ? (
+				<span className="inline-flex shrink-0 text-destructive">
+					<AlertCircle className="size-3.5" />
+					<span className="sr-only">Couldn’t load paired chats</span>
+				</span>
+			) : null}
+			<ChevronRight className="size-4 shrink-0" aria-hidden="true" />
+		</button>
+	);
+	const list = (
+		<PairedChatsList
+			linkId={linkId}
+			provider={provider}
+			pairedChats={pairedChats}
+			bindingsLoading={bindingsLoading}
+			bindingsError={bindingsError}
+			onBindingsRetry={onBindingsRetry}
+		/>
+	);
+
+	if (isMobile) {
+		return (
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetTrigger render={trigger} />
+				<SheetContent
+					id={panelId}
+					data-hosted="true"
+					data-v2="true"
+					data-agent-channel-chats-for={linkId}
+					side="bottom"
+					className="top-2 min-w-0 gap-0 overflow-hidden rounded-t-xl pb-[env(safe-area-inset-bottom)] [&>*]:min-w-0"
+				>
+					<SheetHeader className="shrink-0 border-b p-4 pr-12">
+						<SheetTitle>Paired chats</SheetTitle>
+						<p
+							data-agent-paired-chats-channel-name
+							className="min-w-0 truncate text-sm font-medium"
+							title={channelName}
+						>
+							{channelName}
+						</p>
+						<SheetDescription className="min-w-0 break-words [overflow-wrap:anywhere]">
+							{description}
+						</SheetDescription>
+					</SheetHeader>
+					<div
+						data-agent-paired-chats-scroll
+						className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-3 py-2"
+					>
+						{list}
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger render={trigger} />
+			<DialogContent
+				id={panelId}
+				data-hosted="true"
+				data-v2="true"
+				data-agent-channel-chats-for={linkId}
+				className="max-h-[calc(100dvh-2rem)] min-w-0 grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden p-0 sm:max-w-xl"
+			>
+				<DialogHeader className="border-b p-5 pr-14">
+					<DialogTitle>Paired chats</DialogTitle>
+					<p
+						data-agent-paired-chats-channel-name
+						className="min-w-0 truncate text-sm font-medium"
+						title={channelName}
+					>
+						{channelName}
+					</p>
+					<DialogDescription>{description}</DialogDescription>
+				</DialogHeader>
+				<div
+					data-agent-paired-chats-scroll
+					className="min-h-0 max-h-[min(28rem,calc(100dvh-10rem))] overflow-x-hidden overflow-y-auto overscroll-contain px-4 py-2"
+				>
+					{list}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function PairedChatsList({
+	linkId,
+	provider,
+	pairedChats,
+	bindingsLoading,
+	bindingsError,
+	onBindingsRetry,
+}: {
+	linkId: string;
+	provider: string;
+	pairedChats: AgentPairedChatItem[];
+	bindingsLoading: boolean;
+	bindingsError: boolean;
+	onBindingsRetry: () => void;
+}) {
+	return (
+		<div data-agent-paired-chats-list={linkId} className="min-w-0 divide-y">
+			{bindingsError ? (
+				<div
+					role="alert"
+					className="grid min-h-14 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-2 px-1 py-2.5 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
+				>
+					<AlertCircle className="size-4 shrink-0 text-destructive" />
+					<p className="min-w-0 break-words text-sm font-medium [overflow-wrap:anywhere]">
+						{provider === "discord"
+							? "Couldn’t load paired servers or direct messages"
+							: "Couldn’t load paired chats"}
+					</p>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="col-start-2 justify-self-start sm:col-start-3"
+						onClick={onBindingsRetry}
+					>
+						<RefreshCw className="size-3.5" />
+						Retry
+					</Button>
+				</div>
+			) : null}
+			{pairedChats.map((item) => (
+				<PairedChatRow
+					key={item.binding.id}
+					accountId={item.accountId}
+					binding={item.binding}
+					provider={item.provider}
+				/>
+			))}
+			{bindingsLoading && pairedChats.length === 0 ? (
+				<div role="status" className="divide-y">
+					<span className="sr-only">Loading paired chats</span>
+					{[0, 1, 2].map((index) => (
+						<div key={index} className="flex min-h-14 items-center gap-3 px-1 py-2.5">
+							<Skeleton className="size-8 shrink-0 rounded-md" />
+							<div className="min-w-0 flex-1 space-y-1.5">
+								<Skeleton className="h-4 w-40 max-w-full" />
+								<Skeleton className="h-3 w-24 max-w-2/3" />
+							</div>
+							<Skeleton className="h-8 w-28 shrink-0 rounded-md" />
+						</div>
+					))}
+				</div>
+			) : null}
+			{!bindingsLoading && !bindingsError && pairedChats.length === 0 ? (
+				<p className="px-1 py-6 text-center text-sm text-muted-foreground">No paired chats yet.</p>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/telegram-pair-dialog.tsx
@@ -20,6 +20,8 @@ import {
 	telegramPairDeepLink,
 } from "@/hosted/v2/channels/channel-detail-page.logic";
 import { pairCodeExpired } from "@/hosted/v2/channels/channel-linking.logic";
+import { usePairingSuccess } from "@/hosted/v2/channels/channel-pairing-success";
+import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import { CopyInline } from "@/hosted/v2/channels/channel-ui";
 import { useCreatePairCode } from "@/hosted/v2/channels/channels-hooks";
 import { cn } from "@/lib/utils";
@@ -41,12 +43,14 @@ export function TelegramPairDialog({
 	accountId,
 	agentLinkId,
 	channelName,
+	bindings,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	agentLinkId: string;
 	channelName?: string;
+	bindings?: readonly ChannelBinding[];
 }) {
 	const pair = useCreatePairCode(accountId, { toastOnError: false });
 	const { copied, copy } = useCopyToClipboard({
@@ -60,6 +64,14 @@ export function TelegramPairDialog({
 	const openKeyRef = useRef<string | null>(null);
 	const sessionRef = useRef(0);
 	const lockedSessionRef = useRef<number | null>(null);
+	const handlePairingOpenChange = usePairingSuccess({
+		open,
+		onOpenChange,
+		accountId,
+		agentLinkId,
+		provider: "telegram",
+		bindings,
+	});
 
 	const generate = useCallback(
 		async (session = sessionRef.current) => {
@@ -134,22 +146,23 @@ export function TelegramPairDialog({
 		: channelName?.trim() || "this bot";
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handlePairingOpenChange}>
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
+				className="h-[min(40rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:h-auto sm:max-w-md"
 			>
 				<DialogHeader>
 					<DialogTitle>Pair Telegram</DialogTitle>
-					<DialogDescription>
-						Scan the QR code or open Telegram to pair with {botIdentity}.
-					</DialogDescription>
+					<p className="min-w-0 truncate text-sm font-medium" title={botIdentity}>
+						{botIdentity}
+					</p>
+					<DialogDescription>Scan the QR code or open Telegram to pair.</DialogDescription>
 				</DialogHeader>
 
 				<div
 					data-telegram-pair-dialog-body
-					className="min-h-0 overflow-y-auto overscroll-contain pr-1"
+					className="min-h-0 min-w-0 break-words overflow-y-auto overscroll-contain pr-1 [overflow-wrap:anywhere]"
 				>
 					{generating ? (
 						<div className="flex min-h-64 flex-col items-center justify-center gap-3 text-muted-foreground">
@@ -166,10 +179,11 @@ export function TelegramPairDialog({
 						<div className="flex flex-col gap-4">
 							{validLink ? (
 								<div className="flex justify-center">
-									<div className="rounded-md border bg-white p-3 shadow-sm">
+									<div className="max-w-full rounded-md border bg-white p-3 shadow-sm">
 										<QRCodeSVG
 											value={validLink}
 											size={192}
+											className="h-auto w-full max-w-48"
 											role="img"
 											aria-label="Telegram pairing QR code"
 										/>
@@ -213,23 +227,26 @@ export function TelegramPairDialog({
 
 				{validLink ? (
 					<DialogFooter>
-						<Button variant="outline" onClick={() => void copy(validLink)}>
+						<Button
+							variant="outline"
+							className="min-w-0 whitespace-normal"
+							onClick={() => void copy(validLink)}
+						>
 							{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
 							{copied ? "Copied" : "Copy link"}
 						</Button>
 						<Button
 							render={<a href={validLink} target="_blank" rel="noopener noreferrer" />}
 							nativeButton={false}
+							className="min-w-0 whitespace-normal"
 						>
-							{result?.bot_username
-								? `Open @${result.bot_username.replace(/^@/, "")}`
-								: "Open Telegram"}
+							Open Telegram
 							<ExternalLink className="size-4" />
 						</Button>
 					</DialogFooter>
 				) : result && !generating ? (
 					<DialogFooter>
-						<Button onClick={() => void generate()}>
+						<Button className="min-w-0 whitespace-normal" onClick={() => void generate()}>
 							<QrCode className="size-4" />
 							{expired ? "Generate new link" : "Try again"}
 						</Button>


### PR DESCRIPTION
## Summary

- keep Console and Agent Channel cards at the same compact height while paired chats are open
- open Paired chats from a bounded desktop Dialog and a viewport-filling mobile Sheet
- keep identity, scope, loading/error retry, visible Unpair, confirmation, pending, and mutation-isolation behavior
- remove the nested Show more/less flow and use one bounded scrolling list

## Verification

- bun run --cwd apps/web typecheck
- bun test apps/web/src/hosted/v2/channels/channel-card.test.ts apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts apps/web/src/hosted/v2/channels/channel-finish-line.test.ts (20 passed)
- bunx biome check apps/web/src
- bunx biome check apps/web/e2e/hosted-smoke.pw.ts
- bun run --cwd apps/web test src/hosted/oss-clean.test.ts (15 passed; includes OSS build)
- bun run --cwd apps/web e2e:hosted -- --grep "Agent Channel cards keep|Agent Channels uses compact" (2 passed)

## Playwright screenshots

- agent-channel-paired-chats-closed-desktop.png
- agent-channel-paired-chats-open-desktop.png
- agent-channel-paired-chats-closed-320x568.png
- agent-channel-paired-chats-open-320x568.png

Follow-up to #693. No backend or production changes.