### PR TITLE
fix(web): keep deploy overview useful during projection lag

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4007,6 +4007,20 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 		acceptedInventoryGate.resolve();
 	}
 	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	const detail = page.locator("main");
+	await expect(detail.getByText("Compute", { exact: true })).toBeVisible();
+	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(detail.getByText("Model", { exact: true })).toBeVisible();
+	await expect(detail.getByText("Resources", { exact: true })).toBeVisible();
+	await expect(detail.getByText("2 vCPU · 4 GiB", { exact: true })).toBeVisible();
+	await expect(detail.getByText("Some agent details are unavailable", { exact: true })).toHaveCount(
+		0,
+	);
+	await expect(detail.getByText("Some agent details are not ready", { exact: true })).toHaveCount(
+		0,
+	);
+	await expect(detail.getByText("Sessions unavailable", { exact: true })).toHaveCount(0);
+	await expect(detail.getByText("Recent sessions", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Agent actions", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Delete", exact: true })).toHaveCount(0);
 	await expect(page.getByText("Agent unavailable", { exact: true })).toHaveCount(0);
@@ -4745,7 +4759,8 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect.poll(() => new URL(page.url()).searchParams.get("d")).toBe("hdep_failed_projection");
-	await expect(main.getByText("Some agent details are not ready", { exact: true })).toBeVisible();
+	await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Recent sessions", { exact: true })).toHaveCount(0);
 	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toHaveCount(0);
 	await expect(
 		main.getByText("The Clawdi service could not complete this request.", { exact: true }),
@@ -4757,7 +4772,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Check again", exact: true })).toHaveCount(0);
 
 	expect(restartRequests).toEqual([]);
 
@@ -4939,14 +4954,14 @@ test("missing live projection recovers on Check again without losing deployment 
 		},
 	});
 
-	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
+	await page.goto(`/agents/${missingProjectionEnvironmentId}/sessions?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect(main.getByText("Some agent details are not ready", { exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
 	await main.getByRole("button", { name: "Check again", exact: true }).click();
 	await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(0);
-	await expect(main.getByRole("heading", { name: "Overview" })).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Sessions" })).toBeVisible();
 });
 
 test("projection service errors stay visible while deployment tools remain available", async ({
@@ -4961,7 +4976,7 @@ test("projection service errors stay visible while deployment tools remain avail
 		},
 	});
 
-	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
+	await page.goto(`/agents/${missingProjectionEnvironmentId}/sessions?source=on-clawdi`);
 	const main = page.locator("main");
 	await expect(main.getByText("Couldn’t load all agent details", { exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -24,11 +24,14 @@ type ProjectAcceptedDeploymentTransition =
 type OverviewReadinessPanel =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewReadinessPanel;
 type OverviewFailedPanel = typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailedPanel;
+type ShouldShowHostedProjectionNotice =
+	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowHostedProjectionNotice;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
 let overviewReadinessPanel: OverviewReadinessPanel | null = null;
 let overviewFailedPanel: OverviewFailedPanel | null = null;
+let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 
 function requiredDeploymentStatus(
 	deployment: HostedDeployment | undefined,
@@ -49,6 +52,7 @@ beforeAll(async () => {
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
 	overviewReadinessPanel = detailModule.OverviewReadinessPanel;
 	overviewFailedPanel = detailModule.OverviewFailedPanel;
+	shouldShowProjectionNotice = detailModule.shouldShowHostedProjectionNotice;
 });
 
 describe("deployment failure remediation rendering", () => {
@@ -132,16 +136,28 @@ describe("deployment failure remediation rendering", () => {
 });
 
 describe("deployment transition timeout rendering", () => {
-	test("keeps startup overview actions hidden until startup and projection resolve", () => {
+	test("keeps projection availability notices off the deployment-backed overview", () => {
+		if (!shouldShowProjectionNotice) throw new Error("agent detail was not loaded");
+
+		expect(shouldShowProjectionNotice("overview")).toBe(false);
+		expect(shouldShowProjectionNotice("console")).toBe(false);
+		expect(shouldShowProjectionNotice("terminal")).toBe(false);
+		expect(shouldShowProjectionNotice("ai")).toBe(false);
+		expect(shouldShowProjectionNotice("settings")).toBe(false);
+		expect(shouldShowProjectionNotice("sessions")).toBe(true);
+		expect(shouldShowProjectionNotice("skills")).toBe(true);
+	});
+
+	test("keeps overview actions status-authoritative when the projection is missing", () => {
 		const detailSource = readFileSync(
 			new URL("./hosted-agent-detail.tsx", import.meta.url),
 			"utf8",
 		);
-		expect(detailSource).toContain('projection.status === "resolved" &&');
-		expect(detailSource).toContain("!isStartingStatus(deploymentStatus)");
-		expect(detailSource).not.toContain(
-			'showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}',
+		expect(detailSource).toContain(
+			"showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}",
 		);
+		expect(detailSource).toContain("!isStartingStatus(deploymentStatus)");
+		expect(detailSource).not.toContain('projection.status === "resolved" &&');
 	});
 
 	test("keeps delayed startup copy truthful with automatic and manual checks", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -340,6 +340,11 @@ function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgent
 		: null;
 }
 
+/** Only surfaces whose primary content needs the cloud-agent projection own its notice. */
+export function shouldShowHostedProjectionNotice(section: AgentSectionId): boolean {
+	return section === "sessions" || section === "skills";
+}
+
 function LiveNote({ children }: { children: React.ReactNode }) {
 	return (
 		<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -574,7 +579,9 @@ export function HostedAgentDetail({
 						onRetry={onCheckDeploymentAgain}
 					/>
 				) : null}
-				{deploymentStatus.known && deploymentProjectionQueryable && activeTab !== "channels" ? (
+				{deploymentStatus.known &&
+				deploymentProjectionQueryable &&
+				shouldShowHostedProjectionNotice(activeTab) ? (
 					<HostedProjectionNotice
 						projection={projection}
 						isFetching={agentQuery.isFetching}
@@ -589,11 +596,7 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
-							showDeploymentActions={
-								projection.status === "resolved" &&
-								!deploymentRunning &&
-								!isStartingStatus(deploymentStatus)
-							}
+							showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}
 							onDeleteAccepted={onDeleteAccepted}
 							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}
@@ -1199,31 +1202,27 @@ function OverviewTab({
 					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)}`}
 				/>
 			</div>
-			<div>
-				<div className="mb-2 text-sm font-medium">Recent sessions</div>
-				{!projectionAvailable ? (
-					<EmptyState
-						variant="inset"
-						title="Sessions unavailable"
-						description="Sessions will appear when the rest of this agent is ready."
-					/>
-				) : sessionsError ? (
-					<ApiErrorPanel
-						error={sessionsError}
-						onRetry={onRetrySessions}
-						title="Couldn't load sessions"
-					/>
-				) : (
-					<SessionFeed
-						sessions={sessions}
-						isLoading={sessionsLoading}
-						emptyMessage={sessionsEmptyMessage}
-						emptyVariant="inset"
-						showAgent={false}
-						sessionLink={sessionLink}
-					/>
-				)}
-			</div>
+			{projectionAvailable ? (
+				<div>
+					<div className="mb-2 text-sm font-medium">Recent sessions</div>
+					{sessionsError ? (
+						<ApiErrorPanel
+							error={sessionsError}
+							onRetry={onRetrySessions}
+							title="Couldn't load sessions"
+						/>
+					) : (
+						<SessionFeed
+							sessions={sessions}
+							isLoading={sessionsLoading}
+							emptyMessage={sessionsEmptyMessage}
+							emptyVariant="inset"
+							showAgent={false}
+							sessionLink={sessionLink}
+						/>
+					)}
+				</div>
+			) : null}
 			{showDeploymentActions ? (
 				<OverviewDeploymentActions deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
 			) : null}


### PR DESCRIPTION
## Summary
- keep the accepted v2 deployment overview driven by authoritative deployment status/spec
- suppress projection-unavailable notices and unavailable session placeholders on Overview
- preserve projection recovery/error handling on projection-dependent tabs

## Verification
- Docker-isolated web test suite, typecheck, and OSS build
- focused unit tests: 32 passed
- focused Hosted Playwright scenarios: 4 passed
- Biome and git diff checks