### PR TITLE
fix(web): hydrate accepted deployments before navigation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1150,6 +1150,9 @@ type HostedApiStubOptions = {
 	completedDeleteIds?: Set<string>;
 	failedDeleteRetryability?: Map<string, boolean>;
 	deleteResponses?: StubResponse[];
+	deploymentDetailRequests?: string[];
+	deploymentDetailResponses?: StubResponse[];
+	deploymentDetailResponseGates?: Array<Promise<void> | undefined>;
 	deploymentListRequests?: string[];
 	deploymentListResponses?: unknown[][];
 	deploymentListResponseGates?: Array<Promise<void> | undefined>;
@@ -1318,6 +1321,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	const plans = options.plans ?? [];
 	let currentWallet = options.walletState ?? walletState;
 	const deploymentRequests = new Map<string, DeploymentMutationFixture>();
+	const acceptedDeployments = new Map<string, DeploymentMutationFixture>();
 	// Deploy API (/me, /v2/*).
 	await page.route(`${DEPLOY_API}/**`, async (r) => {
 		const p = new URL(r.request().url()).pathname;
@@ -1422,20 +1426,32 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				idempotencyKey: r.request().headers()["idempotency-key"] ?? null,
 			});
 			const response = options.createDeploymentResponse;
-			if (response) return fulfillJson(r, response.body, response.status);
-			return fulfillJson(
-				r,
-				completedDeploymentOperation(
-					{
+			if (response) {
+				const operation = response.body as Partial<ReturnType<typeof completedDeploymentOperation>>;
+				const deploymentId = operation.metadata?.deploymentId;
+				if (
+					deploymentId &&
+					!deployments.some(
+						(candidate) => isDeploymentMutationFixture(candidate) && candidate.id === deploymentId,
+					)
+				) {
+					acceptedDeployments.set(deploymentId, {
 						...includedBasicDeployment,
-						id: "hdep_included_created",
+						id: deploymentId,
 						name: "Created included Basic",
-						status: "running",
-					},
-					"create",
-				),
-				202,
-			);
+						status: "creating",
+					});
+				}
+				return fulfillJson(r, response.body, response.status);
+			}
+			const createdDeployment: DeploymentMutationFixture = {
+				...includedBasicDeployment,
+				id: "hdep_included_created",
+				name: "Created included Basic",
+				status: "creating",
+			};
+			acceptedDeployments.set(createdDeployment.id, createdDeployment);
+			return fulfillJson(r, completedDeploymentOperation(createdDeployment, "create"), 202);
 		}
 		if (p.startsWith("/v2/deployments/by-request/") && r.request().method() === "GET") {
 			const deployRequestId = decodeURIComponent(p.slice("/v2/deployments/by-request/".length));
@@ -1461,10 +1477,21 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p.startsWith("/v2/deployments/") && r.request().method() === "GET") {
 			const deploymentId = decodeURIComponent(p.slice("/v2/deployments/".length));
-			const deployment = deployments.find(
-				(candidate): candidate is DeploymentMutationFixture =>
-					isDeploymentMutationFixture(candidate) && candidate.id === deploymentId,
-			);
+			options.deploymentDetailRequests?.push(deploymentId);
+			const response = options.deploymentDetailResponses?.shift();
+			const responseGate = options.deploymentDetailResponseGates?.shift();
+			await responseGate;
+			if (response) {
+				if (response.delayMs) {
+					await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+				}
+				return fulfillJson(r, readDeploymentFixture(response.body), response.status);
+			}
+			const deployment =
+				deployments.find(
+					(candidate): candidate is DeploymentMutationFixture =>
+						isDeploymentMutationFixture(candidate) && candidate.id === deploymentId,
+				) ?? acceptedDeployments.get(deploymentId);
 			return deployment
 				? fulfillJson(r, readDeploymentFixture(deployment))
 				: fulfillJson(r, { detail: "Deployment not found" }, 404);
@@ -3977,15 +4004,31 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 		id: "hdep_included_created",
 		name: "Created included Basic",
 		status: "creating",
+		config_info: {
+			...includedBasicDeployment.config_info,
+			runtime_configuration: {
+				providers: [
+					{
+						provider_id: "clawdi",
+						auth_kind: "managed" as const,
+						models: ["gpt-5.6-luna"],
+					},
+				],
+				primary_model: { provider_id: "clawdi", model: "gpt-5.6-luna" },
+				features: [],
+			},
+		},
 	};
 	const deploymentListRequests: string[] = [];
-	const acceptedInventoryGate = deferred();
+	const deploymentDetailRequests: string[] = [];
+	const acceptedDetailGate = deferred();
 	await stubHostedApi(page, {
 		plans: [basicPlan],
 		deployments: [startingDeployment],
-		deploymentListResponses: [[], [startingDeployment]],
-		deploymentListResponseGates: [undefined, acceptedInventoryGate.promise],
+		deploymentListResponses: [[]],
 		deploymentListRequests,
+		deploymentDetailRequests,
+		deploymentDetailResponseGates: [acceptedDetailGate.promise],
 		createDeploymentResponse: {
 			status: 202,
 			body: { ...acceptedCreate, done: false, response: null },
@@ -3995,22 +4038,24 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 	await page.goto("/deploy");
 
 	await page.getByRole("button", { name: "Deploy", exact: true }).click();
+	await expect.poll(() => deploymentDetailRequests).toEqual(["hdep_included_created"]);
+	await expect(page).toHaveURL(/\/deploy$/);
+	await expect(page.getByRole("button", { name: "Loading agent details…" })).toBeDisabled();
+	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
+	acceptedDetailGate.resolve();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
-	await expect.poll(() => deploymentListRequests.length).toBeGreaterThanOrEqual(2);
 	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
-	try {
-		await expect(page.getByText("Agent not found", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
-		await expect(page.getByLabel("Agent ownership loading")).toBeVisible();
-		await expect(page.locator('[data-hosted="true"] [data-slot="skeleton"]').first()).toBeVisible();
-	} finally {
-		acceptedInventoryGate.resolve();
-	}
+	await expect(page.getByText("Agent not found", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
+	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
+	await expect(page.locator('[data-hosted="true"] [data-slot="skeleton"]')).toHaveCount(0);
 	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.locator("body")).toContainText("Created included Basic");
 	const detail = page.locator("main");
 	await expect(detail.getByText("Compute", { exact: true })).toBeVisible();
 	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
 	await expect(detail.getByText("Model", { exact: true })).toBeVisible();
+	await expect(detail.getByText("GPT-5.6 Luna", { exact: true })).toBeVisible();
 	await expect(detail.getByText("Resources", { exact: true })).toBeVisible();
 	await expect(detail.getByText("2 vCPU · 4 GiB", { exact: true })).toBeVisible();
 	await expect(detail.getByText("Some agent details are unavailable", { exact: true })).toHaveCount(
@@ -4038,6 +4083,95 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 			model: "gpt-5.6-luna",
 		},
 	});
+});
+
+test("accepted create retries deployment hydration without issuing another create", async ({
+	page,
+}) => {
+	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
+	const deploymentDetailRequests: string[] = [];
+	const startingDeployment: DeploymentMutationFixture = {
+		...includedBasicDeployment,
+		id: "hdep_hydration_retry",
+		name: "Hydration retry agent",
+		status: "creating",
+	};
+	await stubHostedApi(page, {
+		plans: [basicPlan],
+		deployments: [startingDeployment],
+		deploymentListResponses: [[]],
+		deploymentDetailRequests,
+		deploymentDetailResponses: [
+			{
+				status: 503,
+				body: { detail: "internal deployment replica unavailable tenant=usr_secret" },
+			},
+			{ status: 200, body: startingDeployment },
+		],
+		createDeploymentResponse: {
+			status: 202,
+			body: {
+				...completedDeploymentOperation(startingDeployment, "create"),
+				done: false,
+				response: null,
+			},
+		},
+		createDeploymentRequests,
+	});
+	await page.goto("/deploy");
+
+	await page.getByRole("button", { name: "Deploy", exact: true }).click();
+	const recovery = page.getByTestId("accepted-deployment-hydration-error");
+	await expect(recovery).toBeVisible();
+	await expect(recovery).toContainText("Deployment accepted; details couldn’t load");
+	await expect(recovery).toContainText("It won’t create another agent.");
+	await expect(recovery).not.toContainText("usr_secret");
+	await expect(page).toHaveURL(/\/deploy$/);
+	await expect(page.getByRole("button", { name: "Deploy", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Retry opening agent" })).toBeEnabled();
+	expect(createDeploymentRequests).toHaveLength(1);
+	expect(deploymentDetailRequests).toEqual(["hdep_hydration_retry"]);
+
+	await page.getByRole("button", { name: "Retry opening agent" }).click();
+	await expect(page).toHaveURL(/\/agents\/hdep_hydration_retry/);
+	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
+	expect(deploymentDetailRequests).toEqual(["hdep_hydration_retry", "hdep_hydration_retry"]);
+	expect(createDeploymentRequests).toHaveLength(1);
+	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
+});
+
+test("checkout return hydrates its accepted deployment before replacing the deploy route", async ({
+	page,
+}) => {
+	const deploymentListRequests: string[] = [];
+	const deploymentDetailRequests: string[] = [];
+	const acceptedDetailGate = deferred();
+	const startingDeployment: DeploymentMutationFixture = {
+		...includedBasicDeployment,
+		id: "hdep_checkout_return",
+		name: "Checkout return agent",
+		status: "creating",
+	};
+	await stubHostedApi(page, {
+		plans: [basicPlan],
+		deployments: [startingDeployment],
+		deploymentListRequests,
+		deploymentListResponses: [[]],
+		deploymentDetailRequests,
+		deploymentDetailResponseGates: [acceptedDetailGate.promise],
+	});
+
+	await page.goto("/deploy?session_id=cs_checkout_return&deployment_id=hdep_checkout_return");
+	await expect.poll(() => deploymentDetailRequests).toEqual(["hdep_checkout_return"]);
+	await expect(page).toHaveURL(/\/deploy\?/);
+	await expect(page.getByRole("button", { name: "Loading agent details…" })).toBeDisabled();
+	expect(deploymentListRequests).toEqual(["/v2/deployments"]);
+
+	acceptedDetailGate.resolve();
+	await expect(page).toHaveURL(/\/agents\/hdep_checkout_return/);
+	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
 });
 
 test("paid checkout navigates on deployment acceptance without LRO convergence", async ({

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -112,6 +112,7 @@ import type {
 	DeploymentUpdateRequest,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
+import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import {
 	fallbackTimezones,
 	LANGUAGE_OPTIONS,
@@ -2970,15 +2971,34 @@ function ComputeSettingsSections({
 	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const router = useRouter();
+	const queryClient = useQueryClient();
+	const billingClient = useBillingClient();
 	const navigateCheckoutReturn = useCallback(
 		(checkoutDeploymentId: string): false | undefined => {
 			if (checkoutDeploymentId === deployment.resource.id) return false;
-			void router.navigate({
-				href: agentSectionHref(checkoutDeploymentId, "overview", "source=on-clawdi"),
-				replace: true,
-			});
+			const hydrateAndNavigate = async () => {
+				try {
+					await navigateToAcceptedDeployment({
+						deploymentId: checkoutDeploymentId,
+						getDeployment: billingClient.getDeployment,
+						navigate: (options) => router.navigate(options),
+						queryClient,
+						replace: true,
+					});
+				} catch {
+					toast.error("Deployment accepted; details couldn’t load", {
+						description: "Retrying only loads the accepted deployment. It won’t repeat checkout.",
+						duration: Number.POSITIVE_INFINITY,
+						action: {
+							label: "Retry",
+							onClick: () => void hydrateAndNavigate(),
+						},
+					});
+				}
+			};
+			void hydrateAndNavigate();
 		},
-		[deployment.resource.id, router],
+		[billingClient.getDeployment, deployment.resource.id, queryClient, router],
 	);
 	useCheckoutReturnHandler({
 		onCancelCopy: "You were not charged. Your compute plan is unchanged.",

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -55,9 +55,11 @@ export function useCheckoutReturnHandler({
 		const canceled = checkoutReturnWasCanceled(searchStr);
 		const deploymentId = canceled ? null : checkoutReturnDeploymentId(searchStr);
 		if (deploymentId && onNavigate(deploymentId) !== false) {
-			void refreshCheckoutReturn().catch(() => {
+			// The navigation owner hydrates the committed deployment by id. Refresh
+			// only ancillary billing state here so a stale list cannot erase it.
+			void refreshCheckoutReturn({ includeDeployments: false }).catch(() => {
 				toast.error("Couldn’t refresh checkout status", {
-					description: "Refresh the page to check your agents, subscription, and wallet.",
+					description: "Refresh the page to check your subscription and wallet.",
 				});
 			});
 			return;

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -1,55 +1,136 @@
 import { describe, expect, test } from "bun:test";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	type AcceptedDeploymentNavigate,
 	navigateToAcceptedDeployment,
+	upsertAuthoritativeDeployment,
 } from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import { billingKeys } from "@/hosted/billing/query-keys";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
+
+function deferred<T>() {
+	let resolve: (value: T) => void = () => undefined;
+	const promise = new Promise<T>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
+}
 
 describe("accepted deployment navigation", () => {
-	test("starts the stale inventory refresh and navigates without waiting for it", async () => {
-		let inventoryRequests = 0;
+	test("immutably inserts and replaces authoritative deployment rows", () => {
+		const existing = hostedDeploymentFixture({ id: "hdep_existing" });
+		const created = hostedDeploymentFixture({ id: "hdep_created", status: "creating" });
+		const initial = [existing];
+
+		const inserted = upsertAuthoritativeDeployment(initial, created);
+		expect(inserted).not.toBe(initial);
+		expect(inserted).toEqual([existing, created]);
+		expect(initial).toEqual([existing]);
+
+		const refreshed = hostedDeploymentFixture({
+			id: "hdep_created",
+			name: "Committed name",
+			status: "starting",
+		});
+		const replaced = upsertAuthoritativeDeployment(inserted, refreshed);
+		expect(replaced).not.toBe(inserted);
+		expect(replaced[0]).toBe(existing);
+		expect(replaced[1]).toBe(refreshed);
+	});
+
+	test("cancels an in-flight stale list before upsert and navigates from the seeded authority", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		queryClient.setQueryData(billingKeys.deployments, []);
-		queryClient.setQueryData(["agents"], []);
+		const staleList = deferred<HostedDeployment[]>();
+		const existing = hostedDeploymentFixture({ id: "hdep_existing" });
+		const authoritative = hostedDeploymentFixture({
+			id: "hdep_created",
+			name: "Committed agent",
+			status: "creating",
+		});
+		const agentsProjection = [{ id: "agent_before_acceptance" }];
+		queryClient.setQueryData(billingKeys.deployments, [existing]);
+		queryClient.setQueryData(["agents"], agentsProjection);
+		let inventoryRequests = 0;
 		const observer = new QueryObserver(queryClient, {
 			queryKey: billingKeys.deployments,
 			queryFn: () => {
 				inventoryRequests += 1;
-				return new Promise<never[]>(() => undefined);
+				return staleList.promise;
 			},
+			staleTime: 0,
 		});
 		const unsubscribe = observer.subscribe(() => undefined);
-		const requestsBeforeAcceptance = inventoryRequests;
-		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
+		expect(inventoryRequests).toBe(1);
+		expect(observer.getCurrentResult().isFetching).toBe(true);
 
-		navigateToAcceptedDeployment({
-			deploymentId: "hdep_created",
-			navigate: (options) => navigations.push(options),
+		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
+		await navigateToAcceptedDeployment({
+			deploymentId: authoritative.resource.id,
+			getDeployment: async () => authoritative,
+			navigate: async (options) => {
+				const cached = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+				expect(cached).toEqual([existing, authoritative]);
+				expect(queryClient.getQueryState(billingKeys.deployments)?.fetchStatus).toBe("idle");
+				expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+				navigations.push(options);
+			},
 			queryClient,
 		});
 
-		expect(inventoryRequests).toBe(requestsBeforeAcceptance + 1);
-		expect(observer.getCurrentResult().isFetching).toBe(true);
+		// This response began before acceptance and arrives after hydration and
+		// navigation. Cancellation must prevent it from replacing the committed row.
+		staleList.resolve([]);
+		await staleList.promise;
+		await Promise.resolve();
+		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
+			existing,
+			authoritative,
+		]);
 		expect(navigations).toEqual([
 			{ href: "/agents/hdep_created?source=on-clawdi", replace: false },
 		]);
+		expect(queryClient.getQueryData<typeof agentsProjection>(["agents"])).toBe(agentsProjection);
 		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(1);
 
-		await queryClient.cancelQueries({ queryKey: billingKeys.deployments });
 		unsubscribe();
 		queryClient.clear();
 	});
 
-	test("supports replacing redirect-return history without changing the canonical route", () => {
-		const queryClient = new QueryClient();
+	test("a hydration retry only repeats the by-id read before replacing history", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, []);
+		const authoritative = hostedDeploymentFixture({ id: "hdep_returned", status: "starting" });
+		let detailReads = 0;
+		const getDeployment = async () => {
+			detailReads += 1;
+			if (detailReads === 1) throw new Error("detail temporarily unavailable");
+			return authoritative;
+		};
 		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
-		navigateToAcceptedDeployment({
-			deploymentId: "hdep_returned",
-			navigate: (options) => navigations.push(options),
-			queryClient,
-			replace: true,
-		});
+		const hydrate = () =>
+			navigateToAcceptedDeployment({
+				deploymentId: "hdep_returned",
+				getDeployment,
+				navigate: (options) => {
+					navigations.push(options);
+				},
+				queryClient,
+				replace: true,
+			});
+
+		await expect(hydrate()).rejects.toThrow("detail temporarily unavailable");
+		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([]);
+		expect(navigations).toEqual([]);
+
+		await hydrate();
+		expect(detailReads).toBe(2);
+		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
+			authoritative,
+		]);
+		expect(queryClient.getQueryData(["agents"])).toBeUndefined();
+		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(0);
 		expect(navigations).toEqual([
 			{ href: "/agents/hdep_returned?source=on-clawdi", replace: true },
 		]);

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -1,21 +1,57 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { invalidateDeploymentSnapshots } from "@/hosted/agents/deployment-hooks";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { billingKeys } from "@/hosted/billing/query-keys";
 import { agentSectionHref } from "@/lib/agent-routes";
 
-export type AcceptedDeploymentNavigate = (options: { href: string; replace: boolean }) => void;
+export type AcceptedDeploymentNavigate = (options: {
+	href: string;
+	replace: boolean;
+}) => void | Promise<void>;
 
-/** Refresh committed deployment membership and immediately open its canonical route. */
-export function navigateToAcceptedDeployment({
+export function upsertAuthoritativeDeployment(
+	deployments: readonly HostedDeployment[] | undefined,
+	authoritative: HostedDeployment,
+): HostedDeployment[] {
+	if (!deployments) return [authoritative];
+	const deploymentId = authoritative.resource.id;
+	const existingIndex = deployments.findIndex(
+		(deployment) => deployment.resource.id === deploymentId,
+	);
+	if (existingIndex === -1) return [...deployments, authoritative];
+	return deployments.map((deployment, index) =>
+		index === existingIndex ? authoritative : deployment,
+	);
+}
+
+/** Hydrate committed deployment authority before opening its canonical route. */
+export async function navigateToAcceptedDeployment({
 	deploymentId,
+	getDeployment,
 	navigate,
 	queryClient,
 	replace = false,
 }: {
 	deploymentId: string;
+	getDeployment: (deploymentId: string) => Promise<HostedDeployment>;
 	navigate: AcceptedDeploymentNavigate;
 	queryClient: QueryClient;
 	replace?: boolean;
-}): void {
-	invalidateDeploymentSnapshots(queryClient);
-	navigate({ href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace });
+}): Promise<void> {
+	const authoritative = await getDeployment(deploymentId);
+	if (authoritative.resource.id !== deploymentId) {
+		throw new Error("The deployment service returned a different deployment.");
+	}
+
+	// A list read that started before acceptance can be older than the committed
+	// by-id row. Cancel it before the upsert so it cannot erase this handoff.
+	await queryClient.cancelQueries({ queryKey: billingKeys.deployments, exact: true });
+	queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
+		upsertAuthoritativeDeployment(deployments, authoritative),
+	);
+	void queryClient.invalidateQueries({ queryKey: ["agents"] });
+
+	await navigate({
+		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
+		replace,
+	});
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -87,7 +87,9 @@ describe("deploy wizard personalization", () => {
 		expect(wizardSource).toContain('aria-live="polite"');
 		expect(wizardSource).toContain('" — limit reached."');
 		expect(wizardSource).toContain("Name limit reached. You can enter up to");
-		expect(wizardSource).toContain('type={walletTopUpAction ? "button" : "submit"}');
+		expect(wizardSource).toContain(
+			'acceptedDeploymentHydrationFailed || walletTopUpAction ? "button" : "submit"',
+		);
 		expect(wizardSource).toContain("submitBlockingReason");
 	});
 });
@@ -227,8 +229,8 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("included Basic slot");
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
-		expect(wizardSource).toContain("acceptDeployment(created.deploymentId)");
-		expect(wizardSource).toContain("acceptDeployment(outcome.deploymentId)");
+		expect(wizardSource).toContain("await acceptDeployment(created.deploymentId)");
+		expect(wizardSource).toContain("await acceptDeployment(outcome.deploymentId)");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
 	});
 
@@ -238,7 +240,7 @@ describe("first Basic agent copy", () => {
 		);
 		expect(wizardSource).not.toContain("setup=accepted");
 		expect(wizardSource).not.toContain("waitForRuntime");
-		expect(wizardSource).not.toContain("getDeployment(created.deploymentId)");
+		expect(wizardSource).toContain("getDeployment: billingClient.getDeployment");
 		expect(wizardSource).not.toContain("Agent deployment started");
 		expect(wizardSource).not.toContain("agent is getting ready now");
 		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
@@ -391,19 +393,22 @@ describe("deploy acceptance", () => {
 		);
 		expect(walletBranch).not.toContain("refreshCheckoutReturn");
 		expect(walletBranch).not.toContain("recheckCanCreateCloudAgents");
-		expect(wizardSource).toContain("acceptDeployment(outcome.deploymentId)");
+		expect(wizardSource).toContain("await acceptDeployment(outcome.deploymentId)");
 	});
 
-	test("funnels every accepted create and activation through the same immediate navigation", () => {
+	test("funnels every accepted create and activation through the same hydrated navigation", () => {
 		for (const acceptedId of [
 			"resolved.deploymentId",
 			"deploymentId",
 			"outcome.deploymentId",
 			"created.deploymentId",
 		]) {
-			expect(wizardSource).toContain(`acceptDeployment(${acceptedId}`);
+			expect(wizardSource).toContain(`await acceptDeployment(${acceptedId}`);
 		}
 		expect(wizardSource).toContain("navigateToAcceptedDeployment({");
+		expect(wizardSource).toContain("Deployment accepted; details couldn’t load");
+		expect(wizardSource).toContain("Retry opening agent");
+		expect(wizardSource).toContain("It won’t create");
 		expect(wizardSource).not.toContain("setup=accepted");
 	});
 
@@ -413,7 +418,8 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain('"Opening secure checkout…"');
 		expect(wizardSource).toContain('"Creating agent…"');
 		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');
-		expect(wizardSource).toContain("{submitting ? submitBusyLabel : deployLabel}");
+		expect(wizardSource).toContain('? "Retry opening agent"');
+		expect(wizardSource).toContain(": deployLabel}");
 		expect(wizardSource).toContain('id: "deploy-submit-error"');
 		expect(wizardSource).toContain('label: "Retry"');
 		expect(wizardSource).toContain("deploySubmissionErrorPresentation(");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -178,6 +178,11 @@ type NativeDeployCheckout = {
 	summary: StripeCheckoutSummary;
 	tierLabel: "Basic" | "Performance";
 };
+type AcceptedDeploymentHandoff = {
+	deploymentId: string;
+	replace: boolean;
+	error: string | null;
+};
 type PaidDeploySelection = {
 	billingTermMonths: number;
 	computePlanSlug: ComputePlanSlug;
@@ -301,20 +306,43 @@ function DeploySectionSkeleton() {
 export function DeployWizard() {
 	const router = useRouter();
 	const queryClient = useQueryClient();
+	const billingClient = useBillingClient();
+	const [acceptedDeploymentHandoff, setAcceptedDeploymentHandoff] =
+		useState<AcceptedDeploymentHandoff | null>(null);
 	const acceptDeployment = useCallback(
-		(deploymentId: string, replace = false): void => {
-			navigateToAcceptedDeployment({
-				deploymentId,
-				navigate: (options) => void router.navigate(options),
-				queryClient,
-				replace,
-			});
+		async (deploymentId: string, replace = false): Promise<boolean> => {
+			setAcceptedDeploymentHandoff({ deploymentId, replace, error: null });
+			setSubmitBusyLabel("Loading agent details…");
+			setSubmitTakingLongCopy(
+				"Your deployment was accepted. Keep this page open while we load its committed details.",
+			);
+			setSubmitTakingLong(false);
+			setSubmitting(true);
+			try {
+				await navigateToAcceptedDeployment({
+					deploymentId,
+					getDeployment: billingClient.getDeployment,
+					navigate: (options) => router.navigate(options),
+					queryClient,
+					replace,
+				});
+				return true;
+			} catch (error) {
+				setAcceptedDeploymentHandoff({
+					deploymentId,
+					replace,
+					error: normalizeBillingError(error),
+				});
+				setSubmitting(false);
+				setSubmitTakingLong(false);
+				return false;
+			}
 		},
-		[queryClient, router],
+		[billingClient.getDeployment, queryClient, router],
 	);
 	const navigateCheckoutReturn = useCallback(
 		(deploymentId: string): undefined => {
-			acceptDeployment(deploymentId, true);
+			void acceptDeployment(deploymentId, true);
 		},
 		[acceptDeployment],
 	);
@@ -326,8 +354,7 @@ export function DeployWizard() {
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
-	const createSubscription = useSensitiveCreateSubscription();
-	const billingClient = useBillingClient();
+	const createSubscription = useSensitiveCreateSubscription({ invalidateDeployments: false });
 	const resolveDeploymentRequest = useResolveDeploymentRequest();
 	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const runAction = useActionLock();
@@ -536,7 +563,11 @@ export function DeployWizard() {
 		}
 		return null;
 	})();
-	const canSubmit = !submitting && !postPaymentBlocked && submitBlockingReason === null;
+	const canSubmit =
+		!submitting &&
+		!postPaymentBlocked &&
+		acceptedDeploymentHandoff === null &&
+		submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId);
@@ -661,9 +692,9 @@ export function DeployWizard() {
 		return false;
 	}
 
-	function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
+	async function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
 		setCheckoutSession(null);
-		acceptDeployment(deploymentId);
+		await acceptDeployment(deploymentId);
 	}
 	async function handleCheckoutComplete(
 		previousDeploymentIds: readonly string[],
@@ -687,7 +718,7 @@ export function DeployWizard() {
 					const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
 					forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 					checkoutAttemptRef.current = null;
-					acceptDeployment(resolved.deploymentId, true);
+					await acceptDeployment(resolved.deploymentId, true);
 					return;
 				} catch (error) {
 					if (error instanceof DeploymentRequestTerminalError) {
@@ -726,7 +757,7 @@ export function DeployWizard() {
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
 			}
-			acceptDeployment(deploymentId, true);
+			await acceptDeployment(deploymentId, true);
 		} finally {
 			setSubmitting(false);
 			setSubmitTakingLong(false);
@@ -806,7 +837,7 @@ export function DeployWizard() {
 							? formatUsdExact(walletDebit.debitAmountUsd)
 							: formatCents(paidSelection.offer.price_cents),
 					);
-					acceptDeployment(outcome.deploymentId);
+					await acceptDeployment(outcome.deploymentId);
 					return;
 				}
 				const checkoutFingerprint = idempotencyFingerprint({ selection, target });
@@ -834,7 +865,7 @@ export function DeployWizard() {
 				if (outcome.flowType === "subscription_activation") {
 					forgetIdempotencyAttempt("subscription-checkout", checkoutFingerprint);
 					checkoutAttemptRef.current = null;
-					navigateToReusedSubscription(outcome);
+					await navigateToReusedSubscription(outcome);
 					return;
 				}
 				const result = outcome.checkout;
@@ -887,7 +918,7 @@ export function DeployWizard() {
 				});
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
-			acceptDeployment(created.deploymentId);
+			await acceptDeployment(created.deploymentId);
 		} catch (e) {
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();
@@ -943,9 +974,12 @@ export function DeployWizard() {
 				: null;
 	const walletTopUpAction =
 		paidSelection !== null && paymentMethod === "wallet" && walletInsufficient;
-	const primaryActionDisabled = walletTopUpAction
-		? submitting || postPaymentBlocked || !wallet.data
-		: !canSubmit;
+	const acceptedDeploymentHydrationFailed = Boolean(acceptedDeploymentHandoff?.error);
+	const primaryActionDisabled = acceptedDeploymentHydrationFailed
+		? submitting
+		: walletTopUpAction
+			? submitting || postPaymentBlocked || !wallet.data
+			: !canSubmit;
 	const amountExplainsBlocking =
 		paidSelection !== null &&
 		paymentMethod === "wallet" &&
@@ -1402,6 +1436,20 @@ export function DeployWizard() {
 					data-testid="deploy-action-bar"
 					className="sticky bottom-0 z-10 -mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur lg:-mx-6 lg:px-6"
 				>
+					{acceptedDeploymentHydrationFailed ? (
+						<Alert
+							data-testid="accepted-deployment-hydration-error"
+							variant="destructive"
+							className="mb-3"
+						>
+							<TriangleAlert />
+							<AlertTitle>Deployment accepted; details couldn’t load</AlertTitle>
+							<AlertDescription>
+								Retrying only loads the accepted deployment and opens its page. It won’t create
+								another agent.
+							</AlertDescription>
+						</Alert>
+					) : null}
 					<div className="flex flex-col gap-2 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
 						<div
 							data-testid="deploy-configuration-summary"
@@ -1447,23 +1495,39 @@ export function DeployWizard() {
 							) : null}
 							<div className="flex min-w-0 flex-col gap-1 @2xl/main:items-end">
 								<Button
-									type={walletTopUpAction ? "button" : "submit"}
+									type={
+										acceptedDeploymentHydrationFailed || walletTopUpAction ? "button" : "submit"
+									}
 									size="lg"
 									disabled={primaryActionDisabled}
 									aria-describedby={
 										visibleSubmitBlockingReason ? "deploy-blocking-reason" : undefined
 									}
 									onClick={
-										walletTopUpAction ? () => walletTopUp.show(walletShortfallUsd) : undefined
+										acceptedDeploymentHydrationFailed && acceptedDeploymentHandoff
+											? () =>
+													void acceptDeployment(
+														acceptedDeploymentHandoff.deploymentId,
+														acceptedDeploymentHandoff.replace,
+													)
+											: walletTopUpAction
+												? () => walletTopUp.show(walletShortfallUsd)
+												: undefined
 									}
 									className="w-full shrink-0 @2xl/main:w-auto"
 								>
 									{submitting ? (
 										<Spinner data-icon="inline-start" />
+									) : acceptedDeploymentHydrationFailed ? (
+										<RefreshCw data-icon="inline-start" />
 									) : (
 										<Rocket data-icon="inline-start" />
 									)}
-									{submitting ? submitBusyLabel : deployLabel}
+									{submitting
+										? submitBusyLabel
+										: acceptedDeploymentHydrationFailed
+											? "Retry opening agent"
+											: deployLabel}
 								</Button>
 								{submitTakingLong ? (
 									<p

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -185,6 +185,37 @@ describe("refreshCheckoutReturnQueries", () => {
 		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
 	});
 
+	test("refreshes ancillary checkout state without invalidating a seeded deployment handoff", async () => {
+		const qc = new QueryClient({
+			defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+		});
+		const authoritative = hostedDeploymentFixture({ id: "hdep_accepted", status: "creating" });
+		let deploymentsCalls = 0;
+		let walletCalls = 0;
+		await qc.prefetchQuery({
+			queryKey: billingKeys.deployments,
+			queryFn: async () => {
+				deploymentsCalls += 1;
+				return [authoritative];
+			},
+		});
+		await qc.prefetchQuery({
+			queryKey: billingKeys.wallet,
+			queryFn: async () => {
+				walletCalls += 1;
+				return { balance_cents: walletCalls };
+			},
+		});
+
+		const result = await refreshCheckoutReturnQueries(qc, { includeDeployments: false });
+
+		expect(deploymentsCalls).toBe(1);
+		expect(walletCalls).toBe(2);
+		expect(result).toEqual([authoritative]);
+		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+		qc.clear();
+	});
+
 	test("rejects instead of claiming success when the required wallet refresh fails", async () => {
 		const qc = new QueryClient({
 			defaultOptions: { queries: { retry: false } },

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -253,24 +253,34 @@ export function useResumeSubscription() {
 
 export function useCheckoutReturnRefresh() {
 	const queryClient = useQueryClient();
-	return useCallback(() => refreshCheckoutReturnQueries(queryClient), [queryClient]);
+	return useCallback(
+		(options?: CheckoutReturnRefreshOptions) => refreshCheckoutReturnQueries(queryClient, options),
+		[queryClient],
+	);
 }
+
+export type CheckoutReturnRefreshOptions = {
+	includeDeployments?: boolean;
+};
 
 export async function refreshCheckoutReturnQueries(
 	qc: QueryClient,
+	{ includeDeployments = true }: CheckoutReturnRefreshOptions = {},
 ): Promise<HostedDeployment[] | undefined> {
 	const [deploymentsResult, walletResult] = await Promise.allSettled([
-		(async () => {
-			await qc.invalidateQueries({
-				queryKey: billingKeys.deployments,
-				exact: true,
-				refetchType: "none",
-			});
-			await qc.refetchQueries(
-				{ queryKey: billingKeys.deployments, exact: true, type: "all" },
-				{ throwOnError: true },
-			);
-		})(),
+		includeDeployments
+			? (async () => {
+					await qc.invalidateQueries({
+						queryKey: billingKeys.deployments,
+						exact: true,
+						refetchType: "none",
+					});
+					await qc.refetchQueries(
+						{ queryKey: billingKeys.deployments, exact: true, type: "all" },
+						{ throwOnError: true },
+					);
+				})()
+			: Promise.resolve(),
 		(async () => {
 			await qc.invalidateQueries({
 				queryKey: billingKeys.wallet,

--- a/apps/web/src/hosted/billing/sensitive-actions.ts
+++ b/apps/web/src/hosted/billing/sensitive-actions.ts
@@ -16,10 +16,16 @@ import {
 } from "@/hosted/billing/subscription/subscription-create-adapter";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
-function useInvalidateBillingAfterCheckout() {
+function useInvalidateBillingAfterCheckout({
+	invalidateDeployments,
+}: {
+	invalidateDeployments: boolean;
+}) {
 	const queryClient = useQueryClient();
 	return () => {
-		queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
+		if (invalidateDeployments) {
+			queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
+		}
 		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 		queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
 		queryClient.invalidateQueries({ queryKey: ["agents"] });
@@ -39,9 +45,13 @@ export function useSensitiveSetAutoReload() {
 	return useSensitiveAction((body: WalletAutoReloadRequest) => client.setAutoReload(body));
 }
 
-export function useSensitiveCreateSubscription() {
+export function useSensitiveCreateSubscription({
+	invalidateDeployments = true,
+}: {
+	invalidateDeployments?: boolean;
+} = {}) {
 	const client = useBillingClient();
-	const invalidate = useInvalidateBillingAfterCheckout();
+	const invalidate = useInvalidateBillingAfterCheckout({ invalidateDeployments });
 	return useSensitiveAction(async (request: SubscriptionCreateRequestView) => {
 		const apiRequest = subscriptionCreateRequest(request);
 		const result = subscriptionCreateOutcome(


### PR DESCRIPTION
## Summary
- keep Deploy loading until the accepted deployment is hydrated by ID
- upsert the authoritative deployment into the shared React Query deployment inventory before navigation
- keep runtime agents as projection-only data and provide a safe hydration retry that never repeats create or checkout

## Verification
- Docker full web tests, typecheck, and OSS build
- focused unit tests: 45/45
- focused hosted Playwright flows, including stale-list race and hydration retry
- Biome and git diff check

No production or tenant operations were performed.