### PR TITLE
refactor(web): simplify accepted deployment handoff

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1426,24 +1426,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				idempotencyKey: r.request().headers()["idempotency-key"] ?? null,
 			});
 			const response = options.createDeploymentResponse;
-			if (response) {
-				const operation = response.body as Partial<ReturnType<typeof completedDeploymentOperation>>;
-				const deploymentId = operation.metadata?.deploymentId;
-				if (
-					deploymentId &&
-					!deployments.some(
-						(candidate) => isDeploymentMutationFixture(candidate) && candidate.id === deploymentId,
-					)
-				) {
-					acceptedDeployments.set(deploymentId, {
-						...includedBasicDeployment,
-						id: deploymentId,
-						name: "Created included Basic",
-						status: "creating",
-					});
-				}
-				return fulfillJson(r, response.body, response.status);
-			}
+			if (response) return fulfillJson(r, response.body, response.status);
 			const createdDeployment: DeploymentMutationFixture = {
 				...includedBasicDeployment,
 				id: "hdep_included_created",
@@ -3981,7 +3964,7 @@ test("deploy form stays readable without stretching compact controls", async ({ 
 	}
 });
 
-test("free Basic Deploy submits the declarative create contract", async ({ page }) => {
+test("free Basic Deploy recovers hydration before authoritative first frame", async ({ page }) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
 	const convergencePollRequests: string[] = [];
 	page.on("request", (request) => {
@@ -4019,83 +4002,8 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 			},
 		},
 	};
-	const deploymentListRequests: string[] = [];
 	const deploymentDetailRequests: string[] = [];
 	const acceptedDetailGate = deferred();
-	await stubHostedApi(page, {
-		plans: [basicPlan],
-		deployments: [startingDeployment],
-		deploymentListResponses: [[]],
-		deploymentListRequests,
-		deploymentDetailRequests,
-		deploymentDetailResponseGates: [acceptedDetailGate.promise],
-		createDeploymentResponse: {
-			status: 202,
-			body: { ...acceptedCreate, done: false, response: null },
-		},
-		createDeploymentRequests,
-	});
-	await page.goto("/deploy");
-
-	await page.getByRole("button", { name: "Deploy", exact: true }).click();
-	await expect.poll(() => deploymentDetailRequests).toEqual(["hdep_included_created"]);
-	await expect(page).toHaveURL(/\/deploy$/);
-	await expect(page.getByRole("button", { name: "Loading agent details…" })).toBeDisabled();
-	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
-	acceptedDetailGate.resolve();
-	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
-	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
-	await expect(page.getByText("Agent not found", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
-	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
-	await expect(page.locator('[data-hosted="true"] [data-slot="skeleton"]')).toHaveCount(0);
-	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
-	await expect(page.locator("body")).toContainText("Created included Basic");
-	const detail = page.locator("main");
-	await expect(detail.getByText("Compute", { exact: true })).toBeVisible();
-	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(detail.getByText("Model", { exact: true })).toBeVisible();
-	await expect(detail.getByText("GPT-5.6 Luna", { exact: true })).toBeVisible();
-	await expect(detail.getByText("Resources", { exact: true })).toBeVisible();
-	await expect(detail.getByText("2 vCPU · 4 GiB", { exact: true })).toBeVisible();
-	await expect(detail.getByText("Some agent details are unavailable", { exact: true })).toHaveCount(
-		0,
-	);
-	await expect(detail.getByText("Some agent details are not ready", { exact: true })).toHaveCount(
-		0,
-	);
-	await expect(detail.getByText("Sessions unavailable", { exact: true })).toHaveCount(0);
-	await expect(detail.getByText("Recent sessions", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Agent actions", { exact: true })).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Delete", exact: true })).toHaveCount(0);
-	await expect(page.getByText("Agent unavailable", { exact: true })).toHaveCount(0);
-	await expect(page.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
-	await expect(page.locator("body")).not.toContainText("hdep_included_created");
-	expect(convergencePollRequests).toEqual([]);
-	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
-	expect(createDeploymentRequests).toHaveLength(1);
-	expect(createDeploymentRequests[0]?.idempotencyKey).toMatch(/^deployment-create-/);
-	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
-		compute_plan_slug: "compute_basic",
-		runtime: "hermes",
-		primary_model: {
-			provider_id: "clawdi",
-			model: "gpt-5.6-luna",
-		},
-	});
-});
-
-test("accepted create retries deployment hydration without issuing another create", async ({
-	page,
-}) => {
-	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
-	const deploymentDetailRequests: string[] = [];
-	const startingDeployment: DeploymentMutationFixture = {
-		...includedBasicDeployment,
-		id: "hdep_hydration_retry",
-		name: "Hydration retry agent",
-		status: "creating",
-	};
 	await stubHostedApi(page, {
 		plans: [basicPlan],
 		deployments: [startingDeployment],
@@ -4108,13 +4016,10 @@ test("accepted create retries deployment hydration without issuing another creat
 			},
 			{ status: 200, body: startingDeployment },
 		],
+		deploymentDetailResponseGates: [undefined, acceptedDetailGate.promise],
 		createDeploymentResponse: {
 			status: 202,
-			body: {
-				...completedDeploymentOperation(startingDeployment, "create"),
-				done: false,
-				response: null,
-			},
+			body: { ...acceptedCreate, done: false, response: null },
 		},
 		createDeploymentRequests,
 	});
@@ -4122,56 +4027,42 @@ test("accepted create retries deployment hydration without issuing another creat
 
 	await page.getByRole("button", { name: "Deploy", exact: true }).click();
 	const recovery = page.getByTestId("accepted-deployment-hydration-error");
-	await expect(recovery).toBeVisible();
 	await expect(recovery).toContainText("Deployment accepted; details couldn’t load");
 	await expect(recovery).toContainText("It won’t create another agent.");
 	await expect(recovery).not.toContainText("usr_secret");
 	await expect(page).toHaveURL(/\/deploy$/);
-	await expect(page.getByRole("button", { name: "Deploy", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Retry opening agent" })).toBeEnabled();
 	expect(createDeploymentRequests).toHaveLength(1);
-	expect(deploymentDetailRequests).toEqual(["hdep_hydration_retry"]);
+	expect(deploymentDetailRequests).toEqual(["hdep_included_created"]);
 
 	await page.getByRole("button", { name: "Retry opening agent" }).click();
-	await expect(page).toHaveURL(/\/agents\/hdep_hydration_retry/);
-	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
-	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
-	expect(deploymentDetailRequests).toEqual(["hdep_hydration_retry", "hdep_hydration_retry"]);
-	expect(createDeploymentRequests).toHaveLength(1);
-	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
-});
-
-test("checkout return hydrates its accepted deployment before replacing the deploy route", async ({
-	page,
-}) => {
-	const deploymentListRequests: string[] = [];
-	const deploymentDetailRequests: string[] = [];
-	const acceptedDetailGate = deferred();
-	const startingDeployment: DeploymentMutationFixture = {
-		...includedBasicDeployment,
-		id: "hdep_checkout_return",
-		name: "Checkout return agent",
-		status: "creating",
-	};
-	await stubHostedApi(page, {
-		plans: [basicPlan],
-		deployments: [startingDeployment],
-		deploymentListRequests,
-		deploymentListResponses: [[]],
-		deploymentDetailRequests,
-		deploymentDetailResponseGates: [acceptedDetailGate.promise],
-	});
-
-	await page.goto("/deploy?session_id=cs_checkout_return&deployment_id=hdep_checkout_return");
-	await expect.poll(() => deploymentDetailRequests).toEqual(["hdep_checkout_return"]);
-	await expect(page).toHaveURL(/\/deploy\?/);
+	await expect
+		.poll(() => deploymentDetailRequests)
+		.toEqual(["hdep_included_created", "hdep_included_created"]);
+	await expect(page).toHaveURL(/\/deploy$/);
 	await expect(page.getByRole("button", { name: "Loading agent details…" })).toBeDisabled();
-	expect(deploymentListRequests).toEqual(["/v2/deployments"]);
-
 	acceptedDetailGate.resolve();
-	await expect(page).toHaveURL(/\/agents\/hdep_checkout_return/);
-	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+
+	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
+	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
 	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
+	await expect(page.locator('[data-hosted="true"] [data-slot="skeleton"]')).toHaveCount(0);
+	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	const detail = page.locator("main");
+	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(detail.getByText("GPT-5.6 Luna", { exact: true })).toBeVisible();
+	await expect(detail.getByText("2 vCPU · 4 GiB", { exact: true })).toBeVisible();
+	expect(convergencePollRequests).toEqual([]);
+	expect(createDeploymentRequests).toHaveLength(1);
+	expect(deploymentDetailRequests).toHaveLength(2);
+	expect(createDeploymentRequests[0]?.idempotencyKey).toMatch(/^deployment-create-/);
+	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
+		compute_plan_slug: "compute_basic",
+		runtime: "hermes",
+		primary_model: {
+			provider_id: "clawdi",
+			model: "gpt-5.6-luna",
+		},
+	});
 });
 
 test("paid checkout navigates on deployment acceptance without LRO convergence", async ({

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3146,7 +3146,7 @@ function ComputeSettingsSections({
 	const queryClient = useQueryClient();
 	const billingClient = useBillingClient();
 	const navigateCheckoutReturn = useCallback(
-		(checkoutDeploymentId: string): false | undefined => {
+		async (checkoutDeploymentId: string): Promise<boolean> => {
 			if (checkoutDeploymentId === deployment.resource.id) return false;
 			const hydrateAndNavigate = async () => {
 				try {
@@ -3157,8 +3157,10 @@ function ComputeSettingsSections({
 						queryClient,
 						replace: true,
 					});
+					toast.dismiss(`checkout-deployment-${checkoutDeploymentId}`);
 				} catch {
 					toast.error("Deployment accepted; details couldn’t load", {
+						id: `checkout-deployment-${checkoutDeploymentId}`,
 						description: "Retrying only loads the accepted deployment. It won’t repeat checkout.",
 						duration: Number.POSITIVE_INFINITY,
 						action: {
@@ -3168,7 +3170,8 @@ function ComputeSettingsSections({
 					});
 				}
 			};
-			void hydrateAndNavigate();
+			await hydrateAndNavigate();
+			return true;
 		},
 		[billingClient.getDeployment, deployment.resource.id, queryClient, router],
 	);

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -36,13 +36,24 @@ export function checkoutReturnDeploymentId(searchStr: string): string | null {
 	return null;
 }
 
+type CheckoutReturnNavigationOwner = (deploymentId: string) => boolean | Promise<boolean>;
+
+export async function checkoutReturnHasNavigationOwner(
+	searchStr: string,
+	onNavigate: CheckoutReturnNavigationOwner,
+): Promise<boolean> {
+	if (checkoutReturnWasCanceled(searchStr)) return false;
+	const deploymentId = checkoutReturnDeploymentId(searchStr);
+	return deploymentId !== null && (await onNavigate(deploymentId));
+}
+
 export function useCheckoutReturnHandler({
 	onCancelCopy,
 	onNavigate,
 }: {
 	onCancelCopy: string;
-	/** Return false to keep the current page and show the refresh toast. */
-	onNavigate: (deploymentId: string) => false | undefined;
+	/** Return true when the callback owns navigation and deployment hydration. */
+	onNavigate: CheckoutReturnNavigationOwner;
 }): void {
 	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
@@ -53,30 +64,28 @@ export function useCheckoutReturnHandler({
 		if (!marker || handledMarkerRef.current === marker) return;
 		handledMarkerRef.current = marker;
 		const canceled = checkoutReturnWasCanceled(searchStr);
-		const deploymentId = canceled ? null : checkoutReturnDeploymentId(searchStr);
-		if (deploymentId && onNavigate(deploymentId) !== false) {
-			// The navigation owner hydrates the committed deployment by id. Refresh
-			// only ancillary billing state here so a stale list cannot erase it.
-			void refreshCheckoutReturn({ includeDeployments: false }).catch(() => {
-				toast.error("Couldn’t refresh checkout status", {
-					description: "Refresh the page to check your subscription and wallet.",
-				});
-			});
-			return;
-		}
-		void refreshCheckoutReturn()
-			.then(() => {
-				if (canceled) {
-					toast.message("Checkout canceled", { description: onCancelCopy });
+		void checkoutReturnHasNavigationOwner(searchStr, onNavigate)
+			.then(async (owned) => {
+				try {
+					await refreshCheckoutReturn(owned ? { includeDeployments: false } : undefined);
+				} catch {
+					toast.error("Couldn’t refresh checkout status", {
+						description: owned
+							? "Refresh the page to check your subscription and wallet."
+							: "Refresh the page to check your agents, subscription, and wallet.",
+					});
 					return;
 				}
-				toast.message("Checkout status refreshed", {
-					description: "We checked your agents, subscription, and wallet.",
+				if (owned) return;
+				toast.message(canceled ? "Checkout canceled" : "Checkout status refreshed", {
+					description: canceled
+						? onCancelCopy
+						: "We checked your agents, subscription, and wallet.",
 				});
 			})
 			.catch(() => {
-				toast.error("Couldn’t refresh checkout status", {
-					description: "Refresh the page to check your agents, subscription, and wallet.",
+				toast.error("Couldn’t open the checkout result", {
+					description: "Refresh the page to try again.",
 				});
 			});
 	}, [onCancelCopy, onNavigate, refreshCheckoutReturn, searchStr]);

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	type AcceptedDeploymentNavigate,
 	navigateToAcceptedDeployment,
-	upsertAuthoritativeDeployment,
 } from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -18,51 +17,30 @@ function deferred<T>() {
 }
 
 describe("accepted deployment navigation", () => {
-	test("immutably inserts and replaces authoritative deployment rows", () => {
-		const existing = hostedDeploymentFixture({ id: "hdep_existing" });
-		const created = hostedDeploymentFixture({ id: "hdep_created", status: "creating" });
-		const initial = [existing];
-
-		const inserted = upsertAuthoritativeDeployment(initial, created);
-		expect(inserted).not.toBe(initial);
-		expect(inserted).toEqual([existing, created]);
-		expect(initial).toEqual([existing]);
-
-		const refreshed = hostedDeploymentFixture({
-			id: "hdep_created",
-			name: "Committed name",
-			status: "starting",
-		});
-		const replaced = upsertAuthoritativeDeployment(inserted, refreshed);
-		expect(replaced).not.toBe(inserted);
-		expect(replaced[0]).toBe(existing);
-		expect(replaced[1]).toBe(refreshed);
-	});
-
-	test("cancels an in-flight stale list before upsert and navigates from the seeded authority", async () => {
+	test("cancels a stale list before authoritative cache handoff and navigation", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		const staleList = deferred<HostedDeployment[]>();
 		const existing = hostedDeploymentFixture({ id: "hdep_existing" });
+		const staleCreated = hostedDeploymentFixture({
+			id: "hdep_created",
+			name: "Stale agent",
+			status: "creating",
+		});
 		const authoritative = hostedDeploymentFixture({
 			id: "hdep_created",
 			name: "Committed agent",
-			status: "creating",
+			status: "starting",
 		});
 		const agentsProjection = [{ id: "agent_before_acceptance" }];
-		queryClient.setQueryData(billingKeys.deployments, [existing]);
+		queryClient.setQueryData(billingKeys.deployments, [existing, staleCreated]);
 		queryClient.setQueryData(["agents"], agentsProjection);
-		let inventoryRequests = 0;
-		const observer = new QueryObserver(queryClient, {
-			queryKey: billingKeys.deployments,
-			queryFn: () => {
-				inventoryRequests += 1;
-				return staleList.promise;
-			},
-			staleTime: 0,
-		});
-		const unsubscribe = observer.subscribe(() => undefined);
-		expect(inventoryRequests).toBe(1);
-		expect(observer.getCurrentResult().isFetching).toBe(true);
+		const inFlightStaleList = queryClient
+			.fetchQuery({
+				queryKey: billingKeys.deployments,
+				queryFn: () => staleList.promise,
+			})
+			.catch(() => undefined);
+		expect(queryClient.getQueryState(billingKeys.deployments)?.fetchStatus).toBe("fetching");
 
 		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
 		await navigateToAcceptedDeployment({
@@ -76,64 +54,22 @@ describe("accepted deployment navigation", () => {
 				navigations.push(options);
 			},
 			queryClient,
+			replace: true,
 		});
 
-		// This response began before acceptance and arrives after hydration and
-		// navigation. Cancellation must prevent it from replacing the committed row.
 		staleList.resolve([]);
 		await staleList.promise;
+		await inFlightStaleList;
 		await Promise.resolve();
 		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
 			existing,
 			authoritative,
 		]);
-		expect(navigations).toEqual([
-			{ href: "/agents/hdep_created?source=on-clawdi", replace: false },
-		]);
+		expect(navigations).toEqual([{ href: "/agents/hdep_created?source=on-clawdi", replace: true }]);
 		expect(queryClient.getQueryData<typeof agentsProjection>(["agents"])).toBe(agentsProjection);
 		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(1);
 
-		unsubscribe();
-		queryClient.clear();
-	});
-
-	test("a hydration retry only repeats the by-id read before replacing history", async () => {
-		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, []);
-		const authoritative = hostedDeploymentFixture({ id: "hdep_returned", status: "starting" });
-		let detailReads = 0;
-		const getDeployment = async () => {
-			detailReads += 1;
-			if (detailReads === 1) throw new Error("detail temporarily unavailable");
-			return authoritative;
-		};
-		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
-		const hydrate = () =>
-			navigateToAcceptedDeployment({
-				deploymentId: "hdep_returned",
-				getDeployment,
-				navigate: (options) => {
-					navigations.push(options);
-				},
-				queryClient,
-				replace: true,
-			});
-
-		await expect(hydrate()).rejects.toThrow("detail temporarily unavailable");
-		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([]);
-		expect(navigations).toEqual([]);
-
-		await hydrate();
-		expect(detailReads).toBe(2);
-		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
-			authoritative,
-		]);
-		expect(queryClient.getQueryData(["agents"])).toBeUndefined();
-		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(0);
-		expect(navigations).toEqual([
-			{ href: "/agents/hdep_returned?source=on-clawdi", replace: true },
-		]);
 		queryClient.clear();
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -8,7 +8,7 @@ export type AcceptedDeploymentNavigate = (options: {
 	replace: boolean;
 }) => void | Promise<void>;
 
-export function upsertAuthoritativeDeployment(
+function upsertAuthoritativeDeployment(
 	deployments: readonly HostedDeployment[] | undefined,
 	authoritative: HostedDeployment,
 ): HostedDeployment[] {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -87,9 +87,6 @@ describe("deploy wizard personalization", () => {
 		expect(wizardSource).toContain('aria-live="polite"');
 		expect(wizardSource).toContain('" — limit reached."');
 		expect(wizardSource).toContain("Name limit reached. You can enter up to");
-		expect(wizardSource).toContain(
-			'acceptedDeploymentHydrationFailed || walletTopUpAction ? "button" : "submit"',
-		);
 		expect(wizardSource).toContain("submitBlockingReason");
 	});
 });
@@ -229,8 +226,6 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("included Basic slot");
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
-		expect(wizardSource).toContain("await acceptDeployment(created.deploymentId)");
-		expect(wizardSource).toContain("await acceptDeployment(outcome.deploymentId)");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
 	});
 
@@ -240,7 +235,6 @@ describe("first Basic agent copy", () => {
 		);
 		expect(wizardSource).not.toContain("setup=accepted");
 		expect(wizardSource).not.toContain("waitForRuntime");
-		expect(wizardSource).toContain("getDeployment: billingClient.getDeployment");
 		expect(wizardSource).not.toContain("Agent deployment started");
 		expect(wizardSource).not.toContain("agent is getting ready now");
 		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
@@ -393,23 +387,6 @@ describe("deploy acceptance", () => {
 		);
 		expect(walletBranch).not.toContain("refreshCheckoutReturn");
 		expect(walletBranch).not.toContain("recheckCanCreateCloudAgents");
-		expect(wizardSource).toContain("await acceptDeployment(outcome.deploymentId)");
-	});
-
-	test("funnels every accepted create and activation through the same hydrated navigation", () => {
-		for (const acceptedId of [
-			"resolved.deploymentId",
-			"deploymentId",
-			"outcome.deploymentId",
-			"created.deploymentId",
-		]) {
-			expect(wizardSource).toContain(`await acceptDeployment(${acceptedId}`);
-		}
-		expect(wizardSource).toContain("navigateToAcceptedDeployment({");
-		expect(wizardSource).toContain("Deployment accepted; details couldn’t load");
-		expect(wizardSource).toContain("Retry opening agent");
-		expect(wizardSource).toContain("It won’t create");
-		expect(wizardSource).not.toContain("setup=accepted");
 	});
 
 	test("shows a scoped honest busy state and reports failures only through actionable toasts", () => {
@@ -418,8 +395,6 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain('"Opening secure checkout…"');
 		expect(wizardSource).toContain('"Creating agent…"');
 		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');
-		expect(wizardSource).toContain('? "Retry opening agent"');
-		expect(wizardSource).toContain(": deployLabel}");
 		expect(wizardSource).toContain('id: "deploy-submit-error"');
 		expect(wizardSource).toContain('label: "Retry"');
 		expect(wizardSource).toContain("deploySubmissionErrorPresentation(");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -178,10 +178,9 @@ type NativeDeployCheckout = {
 	summary: StripeCheckoutSummary;
 	tierLabel: "Basic" | "Performance";
 };
-type AcceptedDeploymentHandoff = {
+type AcceptedDeploymentRecovery = {
 	deploymentId: string;
 	replace: boolean;
-	error: string | null;
 };
 type PaidDeploySelection = {
 	billingTermMonths: number;
@@ -307,11 +306,11 @@ export function DeployWizard() {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const billingClient = useBillingClient();
-	const [acceptedDeploymentHandoff, setAcceptedDeploymentHandoff] =
-		useState<AcceptedDeploymentHandoff | null>(null);
+	const [acceptedDeploymentRecovery, setAcceptedDeploymentRecovery] =
+		useState<AcceptedDeploymentRecovery | null>(null);
 	const acceptDeployment = useCallback(
-		async (deploymentId: string, replace = false): Promise<boolean> => {
-			setAcceptedDeploymentHandoff({ deploymentId, replace, error: null });
+		async (deploymentId: string, replace = false): Promise<void> => {
+			setAcceptedDeploymentRecovery(null);
 			setSubmitBusyLabel("Loading agent details…");
 			setSubmitTakingLongCopy(
 				"Your deployment was accepted. Keep this page open while we load its committed details.",
@@ -326,23 +325,18 @@ export function DeployWizard() {
 					queryClient,
 					replace,
 				});
-				return true;
-			} catch (error) {
-				setAcceptedDeploymentHandoff({
-					deploymentId,
-					replace,
-					error: normalizeBillingError(error),
-				});
+			} catch {
+				setAcceptedDeploymentRecovery({ deploymentId, replace });
 				setSubmitting(false);
 				setSubmitTakingLong(false);
-				return false;
 			}
 		},
 		[billingClient.getDeployment, queryClient, router],
 	);
 	const navigateCheckoutReturn = useCallback(
-		(deploymentId: string): undefined => {
-			void acceptDeployment(deploymentId, true);
+		async (deploymentId: string) => {
+			await acceptDeployment(deploymentId, true);
+			return true;
 		},
 		[acceptDeployment],
 	);
@@ -354,7 +348,7 @@ export function DeployWizard() {
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
-	const createSubscription = useSensitiveCreateSubscription({ invalidateDeployments: false });
+	const createSubscription = useSensitiveCreateSubscription();
 	const resolveDeploymentRequest = useResolveDeploymentRequest();
 	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const runAction = useActionLock();
@@ -566,7 +560,7 @@ export function DeployWizard() {
 	const canSubmit =
 		!submitting &&
 		!postPaymentBlocked &&
-		acceptedDeploymentHandoff === null &&
+		acceptedDeploymentRecovery === null &&
 		submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
@@ -974,7 +968,7 @@ export function DeployWizard() {
 				: null;
 	const walletTopUpAction =
 		paidSelection !== null && paymentMethod === "wallet" && walletInsufficient;
-	const acceptedDeploymentHydrationFailed = Boolean(acceptedDeploymentHandoff?.error);
+	const acceptedDeploymentHydrationFailed = acceptedDeploymentRecovery !== null;
 	const primaryActionDisabled = acceptedDeploymentHydrationFailed
 		? submitting
 		: walletTopUpAction
@@ -1504,11 +1498,11 @@ export function DeployWizard() {
 										visibleSubmitBlockingReason ? "deploy-blocking-reason" : undefined
 									}
 									onClick={
-										acceptedDeploymentHydrationFailed && acceptedDeploymentHandoff
+										acceptedDeploymentHydrationFailed && acceptedDeploymentRecovery
 											? () =>
 													void acceptDeployment(
-														acceptedDeploymentHandoff.deploymentId,
-														acceptedDeploymentHandoff.replace,
+														acceptedDeploymentRecovery.deploymentId,
+														acceptedDeploymentRecovery.replace,
 													)
 											: walletTopUpAction
 												? () => walletTopUp.show(walletShortfallUsd)

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -5,7 +5,11 @@ import {
 	QueryClient,
 	QueryObserver,
 } from "@tanstack/react-query";
-import { checkoutReturnMarker, checkoutReturnWasCanceled } from "@/hosted/billing/checkout-return";
+import {
+	checkoutReturnHasNavigationOwner,
+	checkoutReturnMarker,
+	checkoutReturnWasCanceled,
+} from "@/hosted/billing/checkout-return";
 import type {
 	ComputeSubscriptionActionResult,
 	DeploymentOperation,
@@ -484,7 +488,36 @@ describe("reconcileDeploymentSnapshots", () => {
 	});
 });
 
-describe("checkout return parsing", () => {
+describe("checkout return", () => {
+	test("awaits an async navigation owner before choosing ancillary-only refresh", async () => {
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = () => resolve();
+		});
+		const navigated: string[] = [];
+		let settled = false;
+		const ownership = checkoutReturnHasNavigationOwner(
+			"?session_id=cs_return&deployment_id=hdep_returned",
+			async (deploymentId) => {
+				navigated.push(deploymentId);
+				await gate;
+				return true;
+			},
+		).then((owned) => {
+			settled = true;
+			return owned;
+		});
+
+		await Promise.resolve();
+		expect(navigated).toEqual(["hdep_returned"]);
+		expect(settled).toBe(false);
+		release();
+		expect(await ownership).toBe(true);
+		expect(await checkoutReturnHasNavigationOwner("?deployment_id=hdep_current", () => false)).toBe(
+			false,
+		);
+	});
+
 	test("recognizes Stripe cancel returns as checkout markers", () => {
 		expect(checkoutReturnWasCanceled("?checkout=cancel")).toBe(true);
 		expect(checkoutReturnWasCanceled("?settings=billing-plan&checkout=cancel")).toBe(true);

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -259,45 +259,31 @@ export function useCheckoutReturnRefresh() {
 	);
 }
 
-export type CheckoutReturnRefreshOptions = {
+type CheckoutReturnRefreshOptions = {
 	includeDeployments?: boolean;
 };
+
+async function refetchExactCheckoutQuery(qc: QueryClient, queryKey: readonly unknown[]) {
+	await qc.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+	await qc.refetchQueries({ queryKey, exact: true, type: "all" }, { throwOnError: true });
+}
 
 export async function refreshCheckoutReturnQueries(
 	qc: QueryClient,
 	{ includeDeployments = true }: CheckoutReturnRefreshOptions = {},
 ): Promise<HostedDeployment[] | undefined> {
-	const [deploymentsResult, walletResult] = await Promise.allSettled([
-		includeDeployments
-			? (async () => {
-					await qc.invalidateQueries({
-						queryKey: billingKeys.deployments,
-						exact: true,
-						refetchType: "none",
-					});
-					await qc.refetchQueries(
-						{ queryKey: billingKeys.deployments, exact: true, type: "all" },
-						{ throwOnError: true },
-					);
-				})()
-			: Promise.resolve(),
-		(async () => {
-			await qc.invalidateQueries({
-				queryKey: billingKeys.wallet,
-				exact: true,
-				refetchType: "none",
-			});
-			await qc.refetchQueries(
-				{ queryKey: billingKeys.wallet, exact: true, type: "all" },
-				{ throwOnError: true },
-			);
-		})(),
+	const requiredRefreshes = [refetchExactCheckoutQuery(qc, billingKeys.wallet)];
+	if (includeDeployments) {
+		requiredRefreshes.push(refetchExactCheckoutQuery(qc, billingKeys.deployments));
+	}
+	const results = await Promise.allSettled([
+		...requiredRefreshes,
 		qc.invalidateQueries({ queryKey: billingKeys.plans }),
 		qc.invalidateQueries({ queryKey: ["agents"] }),
 	]);
-	const requiredRefreshFailures = [deploymentsResult, walletResult].flatMap((result) =>
-		result.status === "rejected" ? [result.reason] : [],
-	);
+	const requiredRefreshFailures = results
+		.slice(0, requiredRefreshes.length)
+		.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
 	if (requiredRefreshFailures.length > 0) {
 		throw new AggregateError(
 			requiredRefreshFailures,

--- a/apps/web/src/hosted/billing/sensitive-actions.ts
+++ b/apps/web/src/hosted/billing/sensitive-actions.ts
@@ -16,16 +16,10 @@ import {
 } from "@/hosted/billing/subscription/subscription-create-adapter";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
-function useInvalidateBillingAfterCheckout({
-	invalidateDeployments,
-}: {
-	invalidateDeployments: boolean;
-}) {
+function useInvalidateBillingAfterCheckout() {
 	const queryClient = useQueryClient();
 	return () => {
-		if (invalidateDeployments) {
-			queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
-		}
+		queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
 		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 		queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
 		queryClient.invalidateQueries({ queryKey: ["agents"] });
@@ -45,13 +39,9 @@ export function useSensitiveSetAutoReload() {
 	return useSensitiveAction((body: WalletAutoReloadRequest) => client.setAutoReload(body));
 }
 
-export function useSensitiveCreateSubscription({
-	invalidateDeployments = true,
-}: {
-	invalidateDeployments?: boolean;
-} = {}) {
+export function useSensitiveCreateSubscription() {
 	const client = useBillingClient();
-	const invalidate = useInvalidateBillingAfterCheckout({ invalidateDeployments });
+	const invalidate = useInvalidateBillingAfterCheckout();
 	return useSensitiveAction(async (request: SubscriptionCreateRequestView) => {
 		const apiRequest = subscriptionCreateRequest(request);
 		const result = subscriptionCreateOutcome(


### PR DESCRIPTION
## Summary
- make checkout-return navigation natively async and wait for the authoritative deployment owner
- keep deployment inventory authoritative while removing the deploy-only subscription invalidation switch and redundant recovery state
- collapse accepted-deployment tests to a small behavioral spine

## Test cleanup
- removes every source-string assertion added by #703
- combines three new Hosted E2E scenarios into one recovery/loading/first-frame/idempotency chain
- keeps one cache race test, one async checkout-owner test, one ancillary refresh test, and one representative browser flow
- net change: +149/-332 (183 lines removed)

## Verification
- Docker web suite: 807 tests; typecheck and OSS build passed
- focused tests: 43 passed
- Docker Hosted Playwright: 5 representative flows passed
- Biome and diff-check passed
- focused tests and typecheck rerun after rebasing onto current main

No production, cluster, or tenant operations were performed.