### PR TITLE
fix(web): align agent channel card states

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -7666,6 +7666,19 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await stubHostedApi(page, {
 		deployments: [runningMissingProjectionDeployment],
 		channelAccounts: [telegramAccount, replacementTelegram, discordAccount],
+		channelBindings: [
+			{
+				id: "6fffffff-ffff-4fff-8fff-ffffffffffff",
+				account_id: telegramId,
+				agent_link_id: telegramLinkId,
+				external_chat_id: "linked-telegram-chat",
+				external_chat_type: "private",
+				external_chat_name: "Linked Telegram chat",
+				status: "active",
+				created_at: "2026-07-31T00:02:00Z",
+				last_message_at: null,
+			},
+		],
 		channelAgentLinks: [
 			{
 				id: telegramLinkId,
@@ -7677,6 +7690,21 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 			},
 		],
 		channelBotPool: { providers: { discord: [clawdiDiscord] } },
+		channelHealthItems: [
+			{
+				account_id: telegramId,
+				provider: "telegram",
+				name: telegramAccount.name,
+				visibility: "private",
+				channel_status: "active",
+				health_status: "warning",
+				pending_inbox: 0,
+				pending_deliveries: 0,
+				in_progress_deliveries: 0,
+				failed_deliveries: 0,
+				last_message_at: null,
+			},
+		],
 	});
 
 	await page.goto(
@@ -7708,6 +7736,24 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await expect(clawdiDiscordRow).toBeVisible();
 	await expect(discordRow.locator(`[title="${discordAccount.name}"]`)).toBeVisible();
 	await expect(clawdiDiscordRow.locator(`[title="${clawdiDiscord.name}"]`)).toBeVisible();
+	const linkedTelegramHeader = linkedTelegramRow.locator("[data-channel-card-header]");
+	const linkedTelegramChats = linkedTelegramRow.locator(
+		`[data-agent-paired-chats-trigger="${telegramLinkId}"]`,
+	);
+	await expect(linkedTelegramHeader.getByText("Paired", { exact: true })).toBeVisible();
+	await expect(linkedTelegramHeader.getByText("Warning", { exact: true })).toBeVisible();
+	await expect(linkedTelegramHeader).not.toContainText("1 chat");
+	await expect(linkedTelegramChats).toHaveAccessibleName("Manage paired chats · 1");
+	await expect(discordRow.locator("[data-agent-paired-chats-trigger]")).toHaveCount(0);
+	const [linkedTelegramBox, unlinkedDiscordBox] = await Promise.all([
+		linkedTelegramRow.locator("article").boundingBox(),
+		discordRow.locator("article").boundingBox(),
+	]);
+	if (!linkedTelegramBox || !unlinkedDiscordBox) {
+		throw new Error("Expected linked Telegram and unlinked Discord card bounds");
+	}
+	expect(linkedTelegramBox.y).toBe(unlinkedDiscordBox.y);
+	expect(linkedTelegramBox.height).toBe(unlinkedDiscordBox.height);
 	await expect(
 		customSection.getByRole("button", { name: "Add custom bot", exact: true }),
 	).toBeVisible();

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2695,7 +2695,7 @@ function AgentChannelBotsSection({
 			) : bots.length > 0 ? (
 				<div className={CHANNEL_CARD_GRID_CLASS}>
 					{bots.map((bot) => (
-						<div key={bot.id} className="min-w-0">
+						<div key={bot.id} className="h-full min-w-0">
 							{renderBot(bot)}
 						</div>
 					))}
@@ -2742,7 +2742,7 @@ function AgentChannelBotCard({
 }) {
 	const unavailableReason = agentChannelLinkUnavailableReason({ bot, agentType, linkedProviders });
 	return (
-		<div data-agent-channel-account-id={bot.id} className="min-w-0">
+		<div data-agent-channel-account-id={bot.id} className="h-full min-w-0">
 			{bot.link ? (
 				<ConnectedChannelGroup
 					link={bot.link}
@@ -2813,14 +2813,14 @@ function ConnectedChannelGroup({
 	const channelName = link.account?.name ?? fallbackAccount?.name ?? "Unnamed channel";
 
 	return (
-		<div data-agent-channel-group-id={link.id} className="min-w-0">
+		<div data-agent-channel-group-id={link.id} className="h-full min-w-0">
 			<LinkedChannelRow
 				link={link}
 				fallbackAccount={fallbackAccount}
 				health={health}
 				agentName={agentName}
 				bindings={bindings}
-				pairedChatCount={pairedChats.length}
+				hasPairedChats={pairedChats.length > 0}
 				unlinking={unlinking}
 				onUnlink={onUnlink}
 			>
@@ -2852,7 +2852,7 @@ function LinkedChannelRow({
 	health,
 	agentName,
 	bindings,
-	pairedChatCount,
+	hasPairedChats,
 	children,
 }: {
 	link: AgentChannelLink;
@@ -2862,7 +2862,7 @@ function LinkedChannelRow({
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	agentName: string;
 	bindings: readonly ChannelBinding[] | undefined;
-	pairedChatCount: number;
+	hasPairedChats: boolean;
 	children?: React.ReactNode;
 }) {
 	const pair = useCreatePairCode(link.account_id);
@@ -2904,9 +2904,9 @@ function LinkedChannelRow({
 		}
 	}
 	const exceptionalState = [
-		pairedChatCount > 0 ? (
+		hasPairedChats ? (
 			<span key="paired" className="font-medium text-foreground">
-				Paired · {pairedChatCount} {pairedChatCount === 1 ? "chat" : "chats"}
+				Paired
 			</span>
 		) : null,
 		isNormalChannelStatus(link.status) ? null : (
@@ -2929,7 +2929,7 @@ function LinkedChannelRow({
 	];
 	return (
 		<>
-			<div data-agent-channel-link-id={link.id} className="min-w-0">
+			<div data-agent-channel-link-id={link.id} className="h-full min-w-0">
 				<ChannelCard
 					provider={provider}
 					title={name}

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -29,14 +29,30 @@ describe("shared Channel card", () => {
 		expect(markup).toContain("data-channel-card-header");
 		expect(markup).toContain("min-h-20");
 		expect(markup).toContain("data-channel-card-actions");
+		expect(markup).toContain("h-full");
+		expect(markup).toContain("flex-1");
+		expect(markup).toContain("content-center");
 		expect(markup).toContain(">Support Telegram<");
 		expect(markup).toContain(">Pair<");
 		expect(markup).toContain("Paired chats · 2");
 
 		expect(card).toContain("ENTITY_CARD_BASE");
 		expect(card).toContain("ENTITY_GRID_CLASS");
-		expect(card).toContain('"items-start xl:grid-cols-2"');
-		expect(card).not.toContain("h-full");
+		expect(card).toContain('"items-stretch xl:grid-cols-2"');
+	});
+
+	test("stretches the real header instead of rendering an empty footer", () => {
+		const markup = renderToStaticMarkup(
+			createElement(ChannelCard, {
+				provider: "discord",
+				title: "Community Discord",
+				actions: createElement("button", { type: "button" }, "Link"),
+			}),
+		);
+
+		expect(markup).toContain("data-channel-card-header");
+		expect(markup).toContain("flex-1");
+		expect(markup).not.toContain("border-t");
 	});
 
 	test("is reused by Console inventory and Agent channel cards", () => {

--- a/apps/web/src/hosted/v2/channels/channel-card.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-card.tsx
@@ -5,8 +5,8 @@ import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityHeader } from "@/components/
 import { ProviderChip } from "@/hosted/v2/channels/channel-ui";
 import { cn } from "@/lib/utils";
 
-/** Channel cards stay content-height so a long chat list never stretches its neighbour. */
-export const CHANNEL_CARD_GRID_CLASS = cn(ENTITY_GRID_CLASS, "items-start xl:grid-cols-2");
+/** Channel cards in the same grid row share a stable outer height. */
+export const CHANNEL_CARD_GRID_CLASS = cn(ENTITY_GRID_CLASS, "items-stretch xl:grid-cols-2");
 
 /**
  * Shared visual shell for bot inventory and Agent channel cards. Provider
@@ -32,11 +32,11 @@ export function ChannelCard({
 		<article
 			data-hosted="true"
 			data-v2="true"
-			className={cn(ENTITY_CARD_BASE, "overflow-hidden p-0", className)}
+			className={cn(ENTITY_CARD_BASE, "flex h-full flex-col overflow-hidden p-0", className)}
 		>
 			<div
 				data-channel-card-header
-				className="grid min-h-20 min-w-0 gap-3 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center"
+				className="grid min-h-20 min-w-0 flex-1 content-center gap-3 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center"
 			>
 				<EntityHeader
 					align="start"
@@ -51,7 +51,7 @@ export function ChannelCard({
 					</div>
 				) : null}
 			</div>
-			{children ? <div className="border-t">{children}</div> : null}
+			{children ? <div className="shrink-0 border-t">{children}</div> : null}
 		</article>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -17,7 +17,7 @@ const channelsTab = agentChannels.slice(
 );
 
 describe("hosted-agent channel finish line", () => {
-	test("keeps diagnosis compact inside shared content-height channel cards", () => {
+	test("keeps diagnosis compact inside shared equal-height channel cards", () => {
 		expect(channelsTab).toContain("const health = useChannelHealth()");
 		expect(channelsTab).toContain("CHANNEL_CARD_GRID_CLASS");
 		expect(channelsTab).toContain("<ChannelCard");
@@ -32,6 +32,9 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).toContain("onRetry={() => void health.refetch()}");
 		expect(channelsTab).toContain('<ChannelStatusBadge key="status" status={link.status} />');
 		expect(channelsTab).toContain("<HealthBadge");
+		expect(channelsTab).toContain("hasPairedChats={pairedChats.length > 0}");
+		expect(channelsTab).not.toContain("pairedChatCount");
+		expect(channelsTab).not.toContain('1 ? "chat" : "chats"');
 		expect(channelsTab).not.toContain("Waiting for channel activity");
 		expect(channelsTab).not.toContain("This page checks automatically every 20 seconds");
 	});

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -239,7 +239,7 @@ function SharedBotsSection({
 
 function SharedBotCard({ bot }: { bot: ChannelBotPoolItem }) {
 	return (
-		<div data-shared-channel-account-id={bot.id} className="min-w-0">
+		<div data-shared-channel-account-id={bot.id} className="h-full min-w-0">
 			<SharedChannelCard provider={bot.provider} title={bot.name} />
 		</div>
 	);
@@ -247,7 +247,7 @@ function SharedBotCard({ bot }: { bot: ChannelBotPoolItem }) {
 
 function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: string }) {
 	return (
-		<div data-channel-account-id={channel.id} className="group relative z-0 min-w-0">
+		<div data-channel-account-id={channel.id} className="group relative z-0 h-full min-w-0">
 			<SharedChannelCard
 				provider={channel.provider}
 				title={channel.name}


### PR DESCRIPTION
## Summary

- remove the duplicated paired-chat count from the card header while keeping it on the manage-chats action
- make linked, unlinked, warning, and unavailable channel cards share a stable equal-height shell
- let the real header absorb extra height instead of rendering an empty footer
- preserve responsive behavior and shared Console/Agent card styling

## Verification

- Docker-isolated Web typecheck
- 22 focused channel tests
- Docker-isolated production Web build
- focused Chromium Hosted E2E, including non-null layout bounds and exact equal-height assertions
- desktop and 320px screenshot inspection