### PR TITLE
fix(hosted): align compute resource displays

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4050,7 +4050,7 @@ test("free Basic Deploy recovers hydration before authoritative first frame", as
 	const detail = page.locator("main");
 	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
 	await expect(detail.getByText("GPT-5.6 Luna", { exact: true })).toBeVisible();
-	await expect(detail.getByText("2 vCPU · 4 GiB", { exact: true })).toBeVisible();
+	await expect(detail.getByText("2 vCPU · 4 GiB · 20 GiB storage", { exact: true })).toBeVisible();
 	expect(convergencePollRequests).toEqual([]);
 	expect(createDeploymentRequests).toHaveLength(1);
 	expect(deploymentDetailRequests).toHaveLength(2);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1204,7 +1204,7 @@ function OverviewTab({
 				<StatCard label="Model" value={model} />
 				<StatCard
 					label="Resources"
-					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)}`}
+					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)} · ${spec.resources.disk_gib} GiB storage`}
 				/>
 			</div>
 			{projectionAvailable ? (

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -117,6 +117,13 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource.match(/className="items-center p-3"/g)).toHaveLength(2);
 		expect(wizardSource).toContain('testId="basic-ram-resource"');
 		expect(wizardSource).toContain('testId="performance-ram-resource"');
+		expect(wizardSource).toContain("diskGb={basicPlan.disk_size}");
+		expect(wizardSource).toContain("diskGb={perfPlan.disk_size}");
+		expect(wizardSource).toContain("{diskGb} GB storage");
+		expect(wizardSource).toContain("Basic plan unavailable");
+		expect(wizardSource).not.toContain("basicPlan?.vcpu ?? 2");
+		expect(wizardSource).not.toContain("basicPlan?.ram_gb ?? 4");
+		expect(agentDetailSource).toContain("disk_gib} GiB storage");
 		expect(wizardSource).toContain('className="whitespace-nowrap" data-testid={testId}');
 		expect(wizardSource).toMatch(/data-testid=\{`\$\{testId\}-savings`\}/);
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -268,10 +268,12 @@ function ComputeResources({
 	testId,
 	vcpu,
 	ramGb,
+	diskGb,
 }: {
 	testId: string;
 	vcpu: number;
 	ramGb: number;
+	diskGb: number;
 }) {
 	return (
 		<span className="text-xs">
@@ -280,6 +282,8 @@ function ComputeResources({
 			<span className="whitespace-nowrap" data-testid={testId}>
 				{ramGb} GB RAM
 			</span>
+			{" · "}
+			<span className="whitespace-nowrap">{diskGb} GB storage</span>
 		</span>
 	);
 }
@@ -1215,12 +1219,15 @@ export function DeployWizard() {
 												? "Basic availability couldn't be checked"
 												: "Checking free Basic slot availability"}
 										</span>
-									) : (
+									) : basicPlan ? (
 										<ComputeResources
 											testId="basic-ram-resource"
-											vcpu={basicPlan?.vcpu ?? 2}
-											ramGb={basicPlan?.ram_gb ?? 4}
+											vcpu={basicPlan.vcpu}
+											ramGb={basicPlan.ram_gb}
+											diskGb={basicPlan.disk_size}
 										/>
+									) : (
+										<span className="text-xs">Basic plan unavailable</span>
 									)
 								}
 								detailsPlacement="trailing"
@@ -1272,6 +1279,7 @@ export function DeployWizard() {
 											testId="performance-ram-resource"
 											vcpu={perfPlan.vcpu}
 											ramGb={perfPlan.ram_gb}
+											diskGb={perfPlan.disk_size}
 										/>
 									) : (
 										<span className="text-xs">Performance plan unavailable</span>


### PR DESCRIPTION
## Summary
- show API-sourced disk entitlement beside CPU and RAM in the deploy selector
- remove the hardcoded Basic CPU/RAM fallback
- show actual disk entitlement in hosted agent details

## Verification
- focused Bun tests: 35 passed
- Web TypeScript typecheck passed
- Biome checks passed
- focused Hosted Playwright Chromium scenario passed