### PR TITLE
fix(web): balance agent channel card sections

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -7737,23 +7737,58 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await expect(discordRow.locator(`[title="${discordAccount.name}"]`)).toBeVisible();
 	await expect(clawdiDiscordRow.locator(`[title="${clawdiDiscord.name}"]`)).toBeVisible();
 	const linkedTelegramHeader = linkedTelegramRow.locator("[data-channel-card-header]");
+	const unlinkedDiscordHeader = discordRow.locator("[data-channel-card-header]");
+	const linkedTelegramFooter = linkedTelegramRow.locator("[data-channel-card-footer]");
+	const unlinkedDiscordFooter = discordRow.locator("[data-channel-card-footer]");
 	const linkedTelegramChats = linkedTelegramRow.locator(
 		`[data-agent-paired-chats-trigger="${telegramLinkId}"]`,
 	);
-	await expect(linkedTelegramHeader.getByText("Paired", { exact: true })).toBeVisible();
 	await expect(linkedTelegramHeader.getByText("Warning", { exact: true })).toBeVisible();
 	await expect(linkedTelegramHeader).not.toContainText("1 chat");
+	await expect(linkedTelegramHeader).not.toContainText("Paired");
+	await expect(unlinkedDiscordHeader).not.toContainText("Paired");
 	await expect(linkedTelegramChats).toHaveAccessibleName("Manage paired chats · 1");
+	await expect(linkedTelegramFooter).toContainText("Manage paired chats · 1");
+	await expect(unlinkedDiscordFooter).toContainText("Link to start pairing chats");
+	await expect(
+		unlinkedDiscordHeader.getByRole("button", { name: "Link", exact: true }),
+	).toBeVisible();
+	await expect(
+		unlinkedDiscordFooter.getByRole("button", { name: "Link", exact: true }),
+	).toHaveCount(0);
 	await expect(discordRow.locator("[data-agent-paired-chats-trigger]")).toHaveCount(0);
-	const [linkedTelegramBox, unlinkedDiscordBox] = await Promise.all([
+	const [
+		linkedTelegramBox,
+		unlinkedDiscordBox,
+		linkedTelegramHeaderBox,
+		unlinkedDiscordHeaderBox,
+		linkedTelegramFooterBox,
+		unlinkedDiscordFooterBox,
+	] = await Promise.all([
 		linkedTelegramRow.locator("article").boundingBox(),
 		discordRow.locator("article").boundingBox(),
+		linkedTelegramHeader.boundingBox(),
+		unlinkedDiscordHeader.boundingBox(),
+		linkedTelegramFooter.boundingBox(),
+		unlinkedDiscordFooter.boundingBox(),
 	]);
-	if (!linkedTelegramBox || !unlinkedDiscordBox) {
-		throw new Error("Expected linked Telegram and unlinked Discord card bounds");
+	if (
+		!linkedTelegramBox ||
+		!unlinkedDiscordBox ||
+		!linkedTelegramHeaderBox ||
+		!unlinkedDiscordHeaderBox ||
+		!linkedTelegramFooterBox ||
+		!unlinkedDiscordFooterBox
+	) {
+		throw new Error("Expected linked Telegram and unlinked Discord two-section card bounds");
 	}
 	expect(linkedTelegramBox.y).toBe(unlinkedDiscordBox.y);
 	expect(linkedTelegramBox.height).toBe(unlinkedDiscordBox.height);
+	expect(linkedTelegramHeaderBox.y).toBe(unlinkedDiscordHeaderBox.y);
+	expect(linkedTelegramHeaderBox.height).toBe(unlinkedDiscordHeaderBox.height);
+	expect(linkedTelegramFooterBox.y).toBe(unlinkedDiscordFooterBox.y);
+	expect(linkedTelegramFooterBox.height).toBe(unlinkedDiscordFooterBox.height);
+	expect(linkedTelegramFooterBox.height).toBeGreaterThan(0);
 	await expect(
 		customSection.getByRole("button", { name: "Add custom bot", exact: true }),
 	).toBeVisible();
@@ -7780,6 +7815,41 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 		clawdiDiscordRow,
 		"Link Clawdi Discord at 320px",
 	);
+	const [
+		mobileLinkedTelegramBox,
+		mobileUnlinkedDiscordBox,
+		mobileLinkedTelegramHeaderBox,
+		mobileUnlinkedDiscordHeaderBox,
+		mobileLinkedTelegramFooterBox,
+		mobileUnlinkedDiscordFooterBox,
+	] = await Promise.all([
+		linkedTelegramRow.locator("article").boundingBox(),
+		discordRow.locator("article").boundingBox(),
+		linkedTelegramHeader.boundingBox(),
+		unlinkedDiscordHeader.boundingBox(),
+		linkedTelegramFooter.boundingBox(),
+		unlinkedDiscordFooter.boundingBox(),
+	]);
+	if (
+		!mobileLinkedTelegramBox ||
+		!mobileUnlinkedDiscordBox ||
+		!mobileLinkedTelegramHeaderBox ||
+		!mobileUnlinkedDiscordHeaderBox ||
+		!mobileLinkedTelegramFooterBox ||
+		!mobileUnlinkedDiscordFooterBox
+	) {
+		throw new Error("Expected mobile linked and unlinked two-section card bounds");
+	}
+	expect(mobileLinkedTelegramBox.height).toBe(mobileUnlinkedDiscordBox.height);
+	expect(mobileLinkedTelegramHeaderBox.height).toBe(mobileUnlinkedDiscordHeaderBox.height);
+	expect(mobileLinkedTelegramHeaderBox.y - mobileLinkedTelegramBox.y).toBe(
+		mobileUnlinkedDiscordHeaderBox.y - mobileUnlinkedDiscordBox.y,
+	);
+	expect(mobileLinkedTelegramFooterBox.height).toBe(mobileUnlinkedDiscordFooterBox.height);
+	expect(mobileLinkedTelegramFooterBox.y - mobileLinkedTelegramBox.y).toBe(
+		mobileUnlinkedDiscordFooterBox.y - mobileUnlinkedDiscordBox.y,
+	);
+	await discordRow.evaluate((element) => element.scrollIntoView({ block: "start" }));
 	await page.screenshot({
 		path: testInfo.outputPath("agent-bot-groups-provider-limits-320x568.png"),
 		fullPage: false,

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -29,7 +29,7 @@ import {
 	X,
 	Zap,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
@@ -2262,6 +2262,18 @@ function ChannelsSyncState({
 const AGENT_CHANNEL_PAIR_ACTIONS_CLASS =
 	"grid min-h-8 w-full grid-cols-[minmax(0,1fr)_7rem] items-center gap-1.5 xl:flex xl:w-auto xl:gap-2";
 
+const AGENT_CHANNEL_CARD_HEADER_CLASS =
+	"h-[7.5rem] flex-none grid-rows-[2.75rem_2rem] xl:h-20 xl:grid-rows-1";
+
+function AgentChannelCard({ headerClassName, ...props }: ComponentProps<typeof ChannelCard>) {
+	return (
+		<ChannelCard
+			{...props}
+			headerClassName={cn(AGENT_CHANNEL_CARD_HEADER_CLASS, headerClassName)}
+		/>
+	);
+}
+
 function agentChannelLinkUnavailableReason({
 	bot,
 	agentType,
@@ -2762,7 +2774,7 @@ function AgentChannelBotCard({
 					onUnlink={onUnlink}
 				/>
 			) : (
-				<ChannelCard
+				<AgentChannelCard
 					provider={bot.provider}
 					title={bot.name}
 					state={unavailableReason}
@@ -2778,7 +2790,14 @@ function AgentChannelBotCard({
 							{linking ? "Linking…" : "Link"}
 						</Button>
 					}
-				/>
+				>
+					<p
+						data-agent-channel-link-guidance
+						className="flex h-10 min-h-10 max-h-10 min-w-0 items-center px-4 text-sm text-muted-foreground"
+					>
+						<span className="min-w-0 truncate">Link to start pairing chats</span>
+					</p>
+				</AgentChannelCard>
 			)}
 		</div>
 	);
@@ -2820,7 +2839,6 @@ function ConnectedChannelGroup({
 				health={health}
 				agentName={agentName}
 				bindings={bindings}
-				hasPairedChats={pairedChats.length > 0}
 				unlinking={unlinking}
 				onUnlink={onUnlink}
 			>
@@ -2852,7 +2870,6 @@ function LinkedChannelRow({
 	health,
 	agentName,
 	bindings,
-	hasPairedChats,
 	children,
 }: {
 	link: AgentChannelLink;
@@ -2862,7 +2879,6 @@ function LinkedChannelRow({
 	health?: components["schemas"]["ChannelHealthItemResponse"];
 	agentName: string;
 	bindings: readonly ChannelBinding[] | undefined;
-	hasPairedChats: boolean;
 	children?: React.ReactNode;
 }) {
 	const pair = useCreatePairCode(link.account_id);
@@ -2904,11 +2920,6 @@ function LinkedChannelRow({
 		}
 	}
 	const exceptionalState = [
-		hasPairedChats ? (
-			<span key="paired" className="font-medium text-foreground">
-				Paired
-			</span>
-		) : null,
 		isNormalChannelStatus(link.status) ? null : (
 			<ChannelStatusBadge key="status" status={link.status} />
 		),
@@ -2930,7 +2941,7 @@ function LinkedChannelRow({
 	return (
 		<>
 			<div data-agent-channel-link-id={link.id} className="h-full min-w-0">
-				<ChannelCard
+				<AgentChannelCard
 					provider={provider}
 					title={name}
 					state={exceptionalState}
@@ -2992,7 +3003,7 @@ function LinkedChannelRow({
 					}
 				>
 					{children}
-				</ChannelCard>
+				</AgentChannelCard>
 			</div>
 			{provider === "telegram" ? (
 				<TelegramPairDialog

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -27,6 +27,7 @@ describe("shared Channel card", () => {
 		expect(markup).toContain('data-hosted="true"');
 		expect(markup).toContain('data-v2="true"');
 		expect(markup).toContain("data-channel-card-header");
+		expect(markup).toContain("data-channel-card-footer");
 		expect(markup).toContain("min-h-20");
 		expect(markup).toContain("data-channel-card-actions");
 		expect(markup).toContain("h-full");
@@ -41,7 +42,7 @@ describe("shared Channel card", () => {
 		expect(card).toContain('"items-stretch xl:grid-cols-2"');
 	});
 
-	test("stretches the real header instead of rendering an empty footer", () => {
+	test("keeps optional content out of Console-style inventory cards", () => {
 		const markup = renderToStaticMarkup(
 			createElement(ChannelCard, {
 				provider: "discord",
@@ -52,7 +53,7 @@ describe("shared Channel card", () => {
 
 		expect(markup).toContain("data-channel-card-header");
 		expect(markup).toContain("flex-1");
-		expect(markup).not.toContain("border-t");
+		expect(markup).not.toContain("data-channel-card-footer");
 	});
 
 	test("is reused by Console inventory and Agent channel cards", () => {
@@ -60,7 +61,7 @@ describe("shared Channel card", () => {
 		expect(consoleChannels).toContain("CHANNEL_CARD_GRID_CLASS");
 		expect(consoleChannels).toContain("<SharedChannelCard");
 		expect(agentChannels).toContain('from "@/hosted/v2/channels/channel-card"');
-		expect(agentChannels).toContain("<ChannelCard");
+		expect(agentChannels).toContain("<AgentChannelCard");
 		expect(agentChannels).toContain("CHANNEL_CARD_GRID_CLASS");
 	});
 
@@ -69,7 +70,17 @@ describe("shared Channel card", () => {
 		expect(consoleChannels).not.toContain("Pair Discord");
 		expect(consoleChannels).not.toContain("Unpair");
 		expect(consoleChannels).not.toContain("Unlink");
+		expect(consoleChannels).not.toContain("Link to start pairing chats");
 		expect(consoleChannels).toContain('to="/channels/$id"');
+	});
+
+	test("composes a real equal-height footer for every Agent channel card", () => {
+		expect(agentChannels).toContain("data-agent-channel-link-guidance");
+		expect(agentChannels).toContain("Link to start pairing chats");
+		expect(agentChannels).toContain("h-10 min-h-10 max-h-10");
+		expect(agentChannels).toContain("h-[7.5rem] flex-none grid-rows-[2.75rem_2rem]");
+		expect(agentChannels).toContain("xl:h-20 xl:grid-rows-1");
+		expect(agentChannels).not.toContain('key="paired"');
 	});
 
 	test("opens paired chats outside the card through responsive design-system overlays", () => {

--- a/apps/web/src/hosted/v2/channels/channel-card.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-card.tsx
@@ -20,6 +20,7 @@ export function ChannelCard({
 	actions,
 	children,
 	className,
+	headerClassName,
 }: {
 	provider: string;
 	title: ReactNode;
@@ -27,6 +28,7 @@ export function ChannelCard({
 	actions?: ReactNode;
 	children?: ReactNode;
 	className?: string;
+	headerClassName?: string;
 }) {
 	return (
 		<article
@@ -36,7 +38,10 @@ export function ChannelCard({
 		>
 			<div
 				data-channel-card-header
-				className="grid min-h-20 min-w-0 flex-1 content-center gap-3 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center"
+				className={cn(
+					"grid min-h-20 min-w-0 flex-1 content-center gap-3 p-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-center",
+					headerClassName,
+				)}
 			>
 				<EntityHeader
 					align="start"
@@ -51,7 +56,11 @@ export function ChannelCard({
 					</div>
 				) : null}
 			</div>
-			{children ? <div className="shrink-0 border-t">{children}</div> : null}
+			{children ? (
+				<div data-channel-card-footer className="shrink-0 border-t">
+					{children}
+				</div>
+			) : null}
 		</article>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -20,7 +20,7 @@ describe("hosted-agent channel finish line", () => {
 	test("keeps diagnosis compact inside shared equal-height channel cards", () => {
 		expect(channelsTab).toContain("const health = useChannelHealth()");
 		expect(channelsTab).toContain("CHANNEL_CARD_GRID_CLASS");
-		expect(channelsTab).toContain("<ChannelCard");
+		expect(channelsTab).toContain("<AgentChannelCard");
 		expect(channelsTab).not.toContain("AGENT_CHANNEL_LIST_CLASS");
 		expect(channelsTab).not.toContain("AGENT_CHANNEL_ROW_CLASS");
 		expect(channelsTab).not.toContain("channelActivityAfterLink(");
@@ -32,7 +32,8 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).toContain("onRetry={() => void health.refetch()}");
 		expect(channelsTab).toContain('<ChannelStatusBadge key="status" status={link.status} />');
 		expect(channelsTab).toContain("<HealthBadge");
-		expect(channelsTab).toContain("hasPairedChats={pairedChats.length > 0}");
+		expect(channelsTab).toContain("Link to start pairing chats");
+		expect(channelsTab).not.toContain('key="paired"');
 		expect(channelsTab).not.toContain("pairedChatCount");
 		expect(channelsTab).not.toContain('1 ? "chat" : "chats"');
 		expect(channelsTab).not.toContain("Waiting for channel activity");


### PR DESCRIPTION
## Summary

- keep Link in the Agent card header while aligning linked and unlinked header geometry
- give every Agent card a real 40px footer: guidance before linking, paired-chat management after linking
- remove redundant Paired/header chat-count copy while preserving real health and unavailable states
- keep Console inventory free of Agent-only guidance

## Verification

- Docker-isolated Web typecheck
- 23 focused channel tests
- Docker-isolated production Web build
- focused Chromium Hosted E2E on an isolated port
- exact desktop and 320px outer/header/footer geometry assertions
- desktop and mobile screenshot inspection