### PR TITLE
fix(web): fill agent channel card identity meta

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -7737,16 +7737,24 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await expect(discordRow.locator(`[title="${discordAccount.name}"]`)).toBeVisible();
 	await expect(clawdiDiscordRow.locator(`[title="${clawdiDiscord.name}"]`)).toBeVisible();
 	const linkedTelegramHeader = linkedTelegramRow.locator("[data-channel-card-header]");
+	const unavailableTelegramHeader = replacementTelegramRow.locator("[data-channel-card-header]");
 	const unlinkedDiscordHeader = discordRow.locator("[data-channel-card-header]");
 	const linkedTelegramFooter = linkedTelegramRow.locator("[data-channel-card-footer]");
 	const unlinkedDiscordFooter = discordRow.locator("[data-channel-card-footer]");
 	const linkedTelegramChats = linkedTelegramRow.locator(
 		`[data-agent-paired-chats-trigger="${telegramLinkId}"]`,
 	);
+	await expect(linkedTelegramHeader.getByText("Linked", { exact: true })).toBeVisible();
 	await expect(linkedTelegramHeader.getByText("Warning", { exact: true })).toBeVisible();
 	await expect(linkedTelegramHeader).not.toContainText("1 chat");
 	await expect(linkedTelegramHeader).not.toContainText("Paired");
+	await expect(unlinkedDiscordHeader.getByText("Available", { exact: true })).toBeVisible();
+	await expect(unlinkedDiscordHeader).not.toContainText("1 chat");
 	await expect(unlinkedDiscordHeader).not.toContainText("Paired");
+	await expect(unavailableTelegramHeader).toContainText(
+		"Another bot from this provider is already linked",
+	);
+	await expect(unavailableTelegramHeader).not.toContainText("Available");
 	await expect(linkedTelegramChats).toHaveAccessibleName("Manage paired chats · 1");
 	await expect(linkedTelegramFooter).toContainText("Manage paired chats · 1");
 	await expect(unlinkedDiscordFooter).toContainText("Link to start pairing chats");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2777,7 +2777,7 @@ function AgentChannelBotCard({
 				<AgentChannelCard
 					provider={bot.provider}
 					title={bot.name}
-					state={unavailableReason}
+					state={unavailableReason ?? "Available"}
 					actions={
 						<Button
 							type="button"
@@ -2919,8 +2919,10 @@ function LinkedChannelRow({
 			setCreatingPairCode(false);
 		}
 	}
-	const exceptionalState = [
-		isNormalChannelStatus(link.status) ? null : (
+	const relationshipState = [
+		isNormalChannelStatus(link.status) ? (
+			"Linked"
+		) : (
 			<ChannelStatusBadge key="status" status={link.status} />
 		),
 		health && !isNormalChannelHealth(health.health_status) ? (
@@ -2944,7 +2946,7 @@ function LinkedChannelRow({
 				<AgentChannelCard
 					provider={provider}
 					title={name}
-					state={exceptionalState}
+					state={relationshipState}
 					actions={
 						<div className={AGENT_CHANNEL_PAIR_ACTIONS_CLASS}>
 							<Button

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -54,6 +54,8 @@ describe("shared Channel card", () => {
 		expect(markup).toContain("data-channel-card-header");
 		expect(markup).toContain("flex-1");
 		expect(markup).not.toContain("data-channel-card-footer");
+		expect(markup).not.toContain("Available");
+		expect(markup).not.toContain("Linked");
 	});
 
 	test("is reused by Console inventory and Agent channel cards", () => {
@@ -80,7 +82,11 @@ describe("shared Channel card", () => {
 		expect(agentChannels).toContain("h-10 min-h-10 max-h-10");
 		expect(agentChannels).toContain("h-[7.5rem] flex-none grid-rows-[2.75rem_2rem]");
 		expect(agentChannels).toContain("xl:h-20 xl:grid-rows-1");
+		expect(agentChannels).toContain('state={unavailableReason ?? "Available"}');
+		expect(agentChannels).toContain('isNormalChannelStatus(link.status) ? (\n\t\t\t"Linked"');
 		expect(agentChannels).not.toContain('key="paired"');
+		expect(consoleChannels).not.toContain('state="Available"');
+		expect(consoleChannels).not.toContain('state="Linked"');
 	});
 
 	test("opens paired chats outside the card through responsive design-system overlays", () => {

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -32,6 +32,8 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).toContain("onRetry={() => void health.refetch()}");
 		expect(channelsTab).toContain('<ChannelStatusBadge key="status" status={link.status} />');
 		expect(channelsTab).toContain("<HealthBadge");
+		expect(channelsTab).toContain('state={unavailableReason ?? "Available"}');
+		expect(channelsTab).toContain('isNormalChannelStatus(link.status) ? (\n\t\t\t"Linked"');
 		expect(channelsTab).toContain("Link to start pairing chats");
 		expect(channelsTab).not.toContain('key="paired"');
 		expect(channelsTab).not.toContain("pairedChatCount");


### PR DESCRIPTION
## Summary
- fill the Agent channel identity line with `Available` or `Linked`
- preserve real unavailable and exceptional lifecycle states
- keep `Link` in the header and the existing equal-height footer layout
- keep redundant `Paired` and header chat counts removed

## Verification
- Docker-isolated web typecheck, 23 focused tests, and production build
- Biome
- Hosted Chromium E2E with desktop and 320px geometry assertions
- manual desktop and 320px screenshot review