### PR TITLE
fix(web): recover Stripe deploy returns by request lineage

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -102,7 +102,10 @@ import {
 } from "@/hosted/agents/runtime-ui-credentials";
 import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import { useBillingClient } from "@/hosted/billing/billing-client";
-import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
+import {
+	type CheckoutReturnNavigationTarget,
+	useCheckoutReturnHandler,
+} from "@/hosted/billing/checkout-return";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import type {
 	ComputePlanChangeQuoteRequest,
@@ -3113,7 +3116,9 @@ function ComputeSettingsSections({
 	const queryClient = useQueryClient();
 	const billingClient = useBillingClient();
 	const navigateCheckoutReturn = useCallback(
-		async (checkoutDeploymentId: string): Promise<boolean> => {
+		async (target: CheckoutReturnNavigationTarget): Promise<boolean> => {
+			if (target.kind !== "deployment") return false;
+			const checkoutDeploymentId = target.deploymentId;
 			if (checkoutDeploymentId === deployment.resource.id) return false;
 			const hydrateAndNavigate = async () => {
 				try {

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -8,6 +8,7 @@ import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
 import {
 	BillingApiError,
+	BillingNetworkError,
 	DEPLOYMENT_CONFLICT_MESSAGE,
 	DeploymentConflictError,
 	DeploymentRequestTerminalError,
@@ -254,6 +255,12 @@ describe("declarative deployment mutations", () => {
 			if (path === `/v2/deployments/by-request/${intentKey}`) {
 				requestStatusReads += 1;
 				if (requestStatusReads === 1) {
+					return jsonResponse({ detail: "Deploy request not visible yet" }, 404);
+				}
+				if (requestStatusReads === 2) {
+					return jsonResponse({ detail: "Temporary gateway failure" }, 503);
+				}
+				if (requestStatusReads === 3) {
 					return jsonResponse({
 						deploy_request_id: intentKey,
 						request_status: "ready",
@@ -313,7 +320,36 @@ describe("declarative deployment mutations", () => {
 			"/v2/subscription/checkout",
 			`/v2/deployments/by-request/${intentKey}`,
 			`/v2/deployments/by-request/${intentKey}`,
+			`/v2/deployments/by-request/${intentKey}`,
+			`/v2/deployments/by-request/${intentKey}`,
 		]);
+	});
+
+	it("bounds an initial by-request not-found race", async () => {
+		const requests: Request[] = [];
+		const deployRequestId = "checkout/race:stable";
+		let sleeps = 0;
+		const client = createBillingClient(async () => "test-token", {
+			fetch: async (request) => {
+				requests.push(request.clone());
+				return jsonResponse({ detail: "Deploy request not visible yet" }, 404);
+			},
+			operationPollLimit: 2,
+			sleep: async () => {
+				sleeps += 1;
+			},
+		});
+
+		await expect(client.waitForDeploymentRequest(deployRequestId)).rejects.toBeInstanceOf(
+			BillingNetworkError,
+		);
+		expect(requests.map((request) => new URL(request.url).pathname)).toEqual(
+			Array.from(
+				{ length: 3 },
+				() => `/v2/deployments/by-request/${encodeURIComponent(deployRequestId)}`,
+			),
+		);
+		expect(sleeps).toBe(2);
 	});
 
 	it("surfaces a checkout deployment request that fails before acceptance", async () => {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -36,6 +36,7 @@ import {
 	BillingNetworkError,
 	DeploymentConflictError,
 	DeploymentRequestTerminalError,
+	isRetryableError,
 	PlanChangePendingError,
 	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
@@ -164,6 +165,14 @@ function terminalDeployRequestError(status: HostedDeployRequestStatus): BillingA
 			? "This agent creation was superseded by a newer attempt."
 			: "The agent could not be created.",
 		status,
+	);
+}
+
+function isTransientDeployRequestRead(error: unknown): boolean {
+	return (
+		isRetryableError(error) ||
+		(error instanceof BillingApiError &&
+			(error.status === 404 || error.status === 408 || error.status === 425))
 	);
 }
 
@@ -319,8 +328,18 @@ export function createBillingClient(
 		);
 
 	const waitForDeploymentRequest = async (deployRequestId: string) => {
+		let lastTransientError: unknown;
 		for (let poll = 0; poll <= pollLimit; poll += 1) {
-			const status = await getDeploymentByRequest(deployRequestId);
+			let status: HostedDeployRequestStatus;
+			try {
+				status = await getDeploymentByRequest(deployRequestId);
+			} catch (error) {
+				if (!isTransientDeployRequestRead(error)) throw error;
+				lastTransientError = error;
+				if (poll === pollLimit) break;
+				await sleep(pollIntervalMs);
+				continue;
+			}
 			const projection = projectHostedDeployRequest(status);
 			if (projection.kind === "terminal") {
 				throw terminalDeployRequestError(status);
@@ -346,10 +365,11 @@ export function createBillingClient(
 			if (projection.kind === "invalid_success") {
 				return acceptDeclarativeOperation({ deploymentId: null, operation: null });
 			}
+			lastTransientError = undefined;
 			if (poll === pollLimit) break;
 			await sleep(pollIntervalMs);
 		}
-		throw new BillingNetworkError("timeout");
+		throw new BillingNetworkError("timeout", { cause: lastTransientError });
 	};
 
 	const acceptDeploymentMutation = async (

--- a/apps/web/src/hosted/billing/checkout-return.test.ts
+++ b/apps/web/src/hosted/billing/checkout-return.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type CheckoutReturnNavigationTarget,
+	checkoutReturnHasNavigationOwner,
+	checkoutReturnMarker,
+	checkoutReturnNavigationTarget,
+	checkoutReturnWasCanceled,
+} from "@/hosted/billing/checkout-return";
+
+describe("checkout return navigation", () => {
+	test("prefers the URL-decoded deploy request lineage and awaits its navigation owner", async () => {
+		let release: () => void = () => undefined;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const targets: CheckoutReturnNavigationTarget[] = [];
+		let settled = false;
+		const ownership = checkoutReturnHasNavigationOwner(
+			"?session_id=cs_return&deploy_request_id=checkout%2Fstable%3Akey&deployment_id=hdep_legacy",
+			async (target) => {
+				targets.push(target);
+				await gate;
+				return true;
+			},
+		).then((owned) => {
+			settled = true;
+			return owned;
+		});
+
+		await Promise.resolve();
+		expect(targets).toEqual([{ kind: "deploy_request", deployRequestId: "checkout/stable:key" }]);
+		expect(settled).toBe(false);
+		release();
+		expect(await ownership).toBe(true);
+	});
+
+	test("preserves legacy deployment return targets", () => {
+		expect(checkoutReturnNavigationTarget("?deployment_id=hdep_current")).toEqual({
+			kind: "deployment",
+			deploymentId: "hdep_current",
+		});
+		expect(checkoutReturnNavigationTarget("?upgrade_deployment_id=hdep_upgrade")).toEqual({
+			kind: "deployment",
+			deploymentId: "hdep_upgrade",
+		});
+	});
+
+	test("keeps cancellation non-navigating even when lineage is present", async () => {
+		let navigationCalls = 0;
+		const owned = await checkoutReturnHasNavigationOwner(
+			"?deploy_request_id=checkout-key&checkout=cancel",
+			() => {
+				navigationCalls += 1;
+				return true;
+			},
+		);
+
+		expect(owned).toBe(false);
+		expect(navigationCalls).toBe(0);
+		expect(checkoutReturnWasCanceled("?checkout=cancel")).toBe(true);
+		expect(checkoutReturnMarker("?checkout=cancel")).toBe("checkout=cancel");
+	});
+
+	test("does not treat passive checkout success copy as a refresh marker", () => {
+		expect(checkoutReturnWasCanceled("?checkout=success")).toBe(false);
+		expect(checkoutReturnMarker("?checkout=success")).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -9,9 +9,14 @@ const DEPLOYMENT_PARAMS = ["deployment_id", "upgrade_deployment_id"] as const;
 const MARKER_PARAMS = [
 	"session_id",
 	"checkout_session_id",
+	"deploy_request_id",
 	...DEPLOYMENT_PARAMS,
 	"mockCheckout",
 ] as const;
+
+export type CheckoutReturnNavigationTarget =
+	| { kind: "deploy_request"; deployRequestId: string }
+	| { kind: "deployment"; deploymentId: string };
 
 export function checkoutReturnWasCanceled(searchStr: string): boolean {
 	return new URLSearchParams(searchStr).get("checkout") === "cancel";
@@ -36,15 +41,27 @@ export function checkoutReturnDeploymentId(searchStr: string): string | null {
 	return null;
 }
 
-type CheckoutReturnNavigationOwner = (deploymentId: string) => boolean | Promise<boolean>;
+export function checkoutReturnNavigationTarget(
+	searchStr: string,
+): CheckoutReturnNavigationTarget | null {
+	const params = new URLSearchParams(searchStr);
+	const deployRequestId = params.get("deploy_request_id")?.trim();
+	if (deployRequestId) return { kind: "deploy_request", deployRequestId };
+	const deploymentId = checkoutReturnDeploymentId(searchStr);
+	return deploymentId ? { kind: "deployment", deploymentId } : null;
+}
+
+type CheckoutReturnNavigationOwner = (
+	target: CheckoutReturnNavigationTarget,
+) => boolean | Promise<boolean>;
 
 export async function checkoutReturnHasNavigationOwner(
 	searchStr: string,
 	onNavigate: CheckoutReturnNavigationOwner,
 ): Promise<boolean> {
 	if (checkoutReturnWasCanceled(searchStr)) return false;
-	const deploymentId = checkoutReturnDeploymentId(searchStr);
-	return deploymentId !== null && (await onNavigate(deploymentId));
+	const target = checkoutReturnNavigationTarget(searchStr);
+	return target !== null && (await onNavigate(target));
 }
 
 export function useCheckoutReturnHandler({

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -5,9 +5,7 @@ import {
 	checkoutRedirectUrl,
 	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
-	findNewDeploymentId,
 } from "@/hosted/billing/components/stripe-checkout.logic";
-import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 describe("stripe checkout logic", () => {
 	function checkoutResult(
@@ -47,15 +45,5 @@ describe("stripe checkout logic", () => {
 	test("starts with hosted Checkout when Stripe.js cannot be configured", () => {
 		expect(checkoutUiModeForPublishableKey(undefined)).toBe("hosted");
 		expect(checkoutUiModeForPublishableKey("pk_test_browser")).toBe("custom");
-	});
-
-	test("finds a deployment created after checkout completes", () => {
-		const deployments = [
-			hostedDeploymentFixture({ id: "dep_old" }),
-			hostedDeploymentFixture({ id: "dep_new" }),
-		];
-
-		expect(findNewDeploymentId(["dep_old"], deployments)).toBe("dep_new");
-		expect(findNewDeploymentId(["dep_old", "dep_new"], deployments)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
@@ -1,5 +1,4 @@
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
 
 export { checkoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 
@@ -16,14 +15,4 @@ export function checkoutRedirectUrl(result: CheckoutOperationResult): string | n
 	return result.flow_type === "checkout_session"
 		? result.action_url || result.checkout_url || null
 		: result.checkout_url || null;
-}
-
-export function findNewDeploymentId(
-	previousDeploymentIds: readonly string[],
-	deployments: readonly HostedDeployment[] | undefined,
-): string | null {
-	if (!deployments?.length) return null;
-	const previousIds = new Set(previousDeploymentIds);
-	const created = deployments.find((deployment) => !previousIds.has(deployment.resource.id));
-	return created?.resource.id ?? null;
 }

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -4,6 +4,7 @@ import type { HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	type AcceptedDeploymentNavigate,
 	navigateToAcceptedDeployment,
+	navigateToAcceptedDeploymentRequest,
 } from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -20,6 +21,7 @@ describe("accepted deployment navigation", () => {
 	test("cancels a stale list before authoritative cache handoff and navigation", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		const staleList = deferred<HostedDeployment[]>();
+		const relatedRead = deferred<HostedDeployment>();
 		const existing = hostedDeploymentFixture({ id: "hdep_existing" });
 		const staleCreated = hostedDeploymentFixture({
 			id: "hdep_created",
@@ -40,6 +42,12 @@ describe("accepted deployment navigation", () => {
 				queryFn: () => staleList.promise,
 			})
 			.catch(() => undefined);
+		const inFlightRelatedRead = queryClient
+			.fetchQuery({
+				queryKey: [...billingKeys.deployments, "hdep_created"],
+				queryFn: () => relatedRead.promise,
+			})
+			.catch(() => undefined);
 		expect(queryClient.getQueryState(billingKeys.deployments)?.fetchStatus).toBe("fetching");
 
 		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
@@ -50,6 +58,9 @@ describe("accepted deployment navigation", () => {
 				const cached = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 				expect(cached).toEqual([existing, authoritative]);
 				expect(queryClient.getQueryState(billingKeys.deployments)?.fetchStatus).toBe("idle");
+				expect(
+					queryClient.getQueryState([...billingKeys.deployments, "hdep_created"])?.fetchStatus,
+				).toBe("fetching");
 				expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
 				navigations.push(options);
 			},
@@ -58,8 +69,11 @@ describe("accepted deployment navigation", () => {
 		});
 
 		staleList.resolve([]);
+		relatedRead.resolve(authoritative);
 		await staleList.promise;
+		await relatedRead.promise;
 		await inFlightStaleList;
+		await inFlightRelatedRead;
 		await Promise.resolve();
 		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
 			existing,
@@ -70,6 +84,48 @@ describe("accepted deployment navigation", () => {
 		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(1);
 
+		queryClient.clear();
+	});
+
+	test("resolves request lineage before the authoritative handoff and awaits navigation", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const authoritative = hostedDeploymentFixture({ id: "hdep_from_request", status: "creating" });
+		const navigationGate = deferred<void>();
+		const events: string[] = [];
+		let settled = false;
+
+		const handoff = navigateToAcceptedDeploymentRequest({
+			deployRequestId: "checkout/stable:key",
+			resolveDeploymentRequest: async (deployRequestId) => {
+				events.push(`resolve:${deployRequestId}`);
+				return { deploymentId: authoritative.resource.id };
+			},
+			getDeployment: async (deploymentId) => {
+				events.push(`get:${deploymentId}`);
+				return authoritative;
+			},
+			navigate: async () => {
+				events.push("navigate");
+				expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
+					authoritative,
+				]);
+				await navigationGate.promise;
+			},
+			queryClient,
+			replace: true,
+		}).then(() => {
+			settled = true;
+		});
+
+		for (let turn = 0; turn < 10 && !events.includes("navigate"); turn += 1) {
+			await Promise.resolve();
+		}
+		expect(events).toEqual(["resolve:checkout/stable:key", "get:hdep_from_request", "navigate"]);
+		expect(settled).toBe(false);
+
+		navigationGate.resolve();
+		await handoff;
+		expect(settled).toBe(true);
 		queryClient.clear();
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -8,6 +8,10 @@ export type AcceptedDeploymentNavigate = (options: {
 	replace: boolean;
 }) => void | Promise<void>;
 
+type AcceptedDeploymentRequestResolver = (
+	deployRequestId: string,
+) => Promise<{ deploymentId: string }>;
+
 function upsertAuthoritativeDeployment(
 	deployments: readonly HostedDeployment[] | undefined,
 	authoritative: HostedDeployment,
@@ -54,4 +58,17 @@ export async function navigateToAcceptedDeployment({
 		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
 		replace,
 	});
+}
+
+/** Resolve the durable checkout lineage, then reuse the canonical deployment handoff. */
+export async function navigateToAcceptedDeploymentRequest({
+	deployRequestId,
+	resolveDeploymentRequest,
+	...navigation
+}: Omit<Parameters<typeof navigateToAcceptedDeployment>[0], "deploymentId"> & {
+	deployRequestId: string;
+	resolveDeploymentRequest: AcceptedDeploymentRequestResolver;
+}): Promise<void> {
+	const { deploymentId } = await resolveDeploymentRequest(deployRequestId);
+	await navigateToAcceptedDeployment({ ...navigation, deploymentId });
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -176,13 +176,6 @@ describe("deploy wizard product copy and flow", () => {
 		expect(runtimesSource).not.toContain("The agent that grows with you.");
 		expect(runtimesSource).not.toContain("DEFAULT_HOSTED_RUNTIME");
 	});
-
-	test("links unresolved post-payment recovery to the agents list", () => {
-		expect(wizardSource).toContain('id: "deploy-post-payment-error"');
-		expect(wizardSource).toContain("duration: Number.POSITIVE_INFINITY");
-		expect(wizardSource).toContain("View agents");
-		expect(wizardSource).toContain('router.navigate({ href: "/agents" })');
-	});
 });
 
 describe("hosted agent security and copy", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -43,13 +43,15 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { useBillingClient } from "@/hosted/billing/billing-client";
-import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
+import {
+	type CheckoutReturnNavigationTarget,
+	useCheckoutReturnHandler,
+} from "@/hosted/billing/checkout-return";
 import {
 	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
 	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
-	findNewDeploymentId,
 } from "@/hosted/billing/components/stripe-checkout.logic";
 import {
 	StripeCheckoutDialog,
@@ -62,7 +64,10 @@ import type {
 	DeployRequest,
 	Plan,
 } from "@/hosted/billing/contracts";
-import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
+import {
+	navigateToAcceptedDeployment,
+	navigateToAcceptedDeploymentRequest,
+} from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import {
 	DEFAULT_DEPLOY_AI_ACCESS_MODE,
 	DEFAULT_DEPLOY_PRIMARY_MODEL,
@@ -97,14 +102,12 @@ import {
 } from "@/hosted/billing/deploy/language-timezone-controls";
 import {
 	billingErrorNormalizer,
-	DeploymentRequestTerminalError,
 	deploySubmissionErrorPresentation,
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
 import {
-	useCheckoutReturnRefresh,
 	useHostedDeployments,
 	useManagedModelCatalog,
 	usePlans,
@@ -173,14 +176,13 @@ type Compute = "basic" | "performance";
 type DeployPaymentMethod = "card" | "wallet";
 type NativeDeployCheckout = {
 	clientSecret: CheckoutSessionClientSecret;
-	previousDeploymentIds: string[];
 	request: SubscriptionCreateRequestView;
 	summary: StripeCheckoutSummary;
 	tierLabel: "Basic" | "Performance";
 };
 type AcceptedDeploymentRecovery = {
-	deploymentId: string;
 	replace: boolean;
+	target: CheckoutReturnNavigationTarget;
 };
 type PaidDeploySelection = {
 	billingTermMonths: number;
@@ -310,10 +312,11 @@ export function DeployWizard() {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const billingClient = useBillingClient();
+	const resolveDeploymentRequest = useResolveDeploymentRequest().mutateAsync;
 	const [acceptedDeploymentRecovery, setAcceptedDeploymentRecovery] =
 		useState<AcceptedDeploymentRecovery | null>(null);
 	const acceptDeployment = useCallback(
-		async (deploymentId: string, replace = false): Promise<void> => {
+		async (target: CheckoutReturnNavigationTarget, replace = false): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
 			setSubmitBusyLabel("Loading agent details…");
 			setSubmitTakingLongCopy(
@@ -322,24 +325,37 @@ export function DeployWizard() {
 			setSubmitTakingLong(false);
 			setSubmitting(true);
 			try {
-				await navigateToAcceptedDeployment({
-					deploymentId,
+				const navigation = {
 					getDeployment: billingClient.getDeployment,
-					navigate: (options) => router.navigate(options),
+					navigate: (options: { href: string; replace: boolean }) => router.navigate(options),
 					queryClient,
 					replace,
-				});
+				};
+				if (target.kind === "deploy_request") {
+					await navigateToAcceptedDeploymentRequest({
+						...navigation,
+						deployRequestId: target.deployRequestId,
+						resolveDeploymentRequest,
+					});
+				} else {
+					await navigateToAcceptedDeployment({
+						...navigation,
+						deploymentId: target.deploymentId,
+					});
+				}
+				return true;
 			} catch {
-				setAcceptedDeploymentRecovery({ deploymentId, replace });
+				setAcceptedDeploymentRecovery({ replace, target });
 				setSubmitting(false);
 				setSubmitTakingLong(false);
+				return false;
 			}
 		},
-		[billingClient.getDeployment, queryClient, router],
+		[billingClient.getDeployment, queryClient, resolveDeploymentRequest, router],
 	);
 	const navigateCheckoutReturn = useCallback(
-		async (deploymentId: string) => {
-			await acceptDeployment(deploymentId, true);
+		async (target: CheckoutReturnNavigationTarget) => {
+			await acceptDeployment(target, true);
 			return true;
 		},
 		[acceptDeployment],
@@ -353,8 +369,6 @@ export function DeployWizard() {
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
 	const createSubscription = useSensitiveCreateSubscription();
-	const resolveDeploymentRequest = useResolveDeploymentRequest();
-	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const runAction = useActionLock();
 	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
@@ -372,7 +386,6 @@ export function DeployWizard() {
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
-	const [postPaymentBlocked, setPostPaymentBlocked] = useState(false);
 	const [submitTakingLong, setSubmitTakingLong] = useState(false);
 	const [submitBusyLabel, setSubmitBusyLabel] = useState("Creating agent…");
 	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState(
@@ -562,10 +575,7 @@ export function DeployWizard() {
 		return null;
 	})();
 	const canSubmit =
-		!submitting &&
-		!postPaymentBlocked &&
-		acceptedDeploymentRecovery === null &&
-		submitBlockingReason === null;
+		!submitting && acceptedDeploymentRecovery === null && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId);
@@ -632,19 +642,6 @@ export function DeployWizard() {
 		}
 	}
 
-	function showPostPaymentError(title: string, description: string) {
-		setPostPaymentBlocked(true);
-		toast.error(title, {
-			id: "deploy-post-payment-error",
-			description,
-			duration: Number.POSITIVE_INFINITY,
-			action: {
-				label: "View agents",
-				onClick: () => void router.navigate({ href: "/agents" }),
-			},
-		});
-	}
-
 	function showDeploySubmissionError(error: unknown) {
 		const presentation = deploySubmissionErrorPresentation(
 			error,
@@ -692,12 +689,9 @@ export function DeployWizard() {
 
 	async function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
 		setCheckoutSession(null);
-		await acceptDeployment(deploymentId);
+		await acceptDeployment({ kind: "deployment", deploymentId });
 	}
-	async function handleCheckoutComplete(
-		previousDeploymentIds: readonly string[],
-		request: SubscriptionCreateRequestView | null,
-	) {
+	async function handleCheckoutComplete(request: SubscriptionCreateRequestView) {
 		setCheckoutSession(null);
 		setSubmitTakingLong(false);
 		setSubmitBusyLabel("Creating agent…");
@@ -705,57 +699,19 @@ export function DeployWizard() {
 			"Payment was confirmed and agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
 		);
 		setSubmitting(true);
-		let requestFingerprint: string | null = null;
 		try {
-			if (request) {
-				requestFingerprint = idempotencyFingerprint({
-					selection: request.selection,
-					target: request.target,
-				});
-				try {
-					const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
-					forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
-					checkoutAttemptRef.current = null;
-					await acceptDeployment(resolved.deploymentId, true);
-					return;
-				} catch (error) {
-					if (error instanceof DeploymentRequestTerminalError) {
-						forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
-						checkoutAttemptRef.current = null;
-						const normalized = normalizeBillingError(error);
-						showPostPaymentError(
-							"Payment succeeded, but the agent could not be started",
-							`${normalized} Don’t submit another payment; check Agents for the latest state.`,
-						);
-						return;
-					}
-					// Stripe may complete before its deployment request is visible. Fall back
-					// to one inventory refresh after the bounded request-status watch ends.
-				}
-			}
-			let refreshedDeployments: Awaited<ReturnType<typeof refreshCheckoutReturn>>;
-			try {
-				refreshedDeployments = await refreshCheckoutReturn();
-			} catch {
-				showPostPaymentError(
-					"Payment succeeded; agent status is unavailable",
-					"We couldn’t refresh your agent list. Don’t submit another payment; open Agents and check again in a moment.",
-				);
-				return;
-			}
-			const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
-			if (!deploymentId) {
-				showPostPaymentError(
-					"Payment succeeded; your agent is not visible yet",
-					"Don’t submit another payment. Open Agents and check again in a moment while the accepted request appears.",
-				);
-				return;
-			}
-			if (requestFingerprint) {
+			const requestFingerprint = idempotencyFingerprint({
+				selection: request.selection,
+				target: request.target,
+			});
+			const accepted = await acceptDeployment(
+				{ kind: "deploy_request", deployRequestId: request.idempotencyKey },
+				true,
+			);
+			if (accepted) {
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
 			}
-			await acceptDeployment(deploymentId, true);
 		} finally {
 			setSubmitting(false);
 			setSubmitTakingLong(false);
@@ -835,7 +791,10 @@ export function DeployWizard() {
 							? formatUsdExact(walletDebit.debitAmountUsd)
 							: formatCents(paidSelection.offer.price_cents),
 					);
-					await acceptDeployment(outcome.deploymentId);
+					await acceptDeployment({
+						kind: "deployment",
+						deploymentId: outcome.deploymentId,
+					});
 					return;
 				}
 				const checkoutFingerprint = idempotencyFingerprint({ selection, target });
@@ -871,9 +830,6 @@ export function DeployWizard() {
 				if (cardCheckoutUiMode === CHECKOUT_ELEMENTS_UI_MODE && clientSecret) {
 					setCheckoutSession({
 						clientSecret,
-						previousDeploymentIds: (deployments.data ?? []).map(
-							(deployment) => deployment.resource.id,
-						),
 						request: {
 							selection,
 							target,
@@ -916,7 +872,7 @@ export function DeployWizard() {
 				});
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
-			await acceptDeployment(created.deploymentId);
+			await acceptDeployment({ kind: "deployment", deploymentId: created.deploymentId });
 		} catch (e) {
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();
@@ -976,7 +932,7 @@ export function DeployWizard() {
 	const primaryActionDisabled = acceptedDeploymentHydrationFailed
 		? submitting
 		: walletTopUpAction
-			? submitting || postPaymentBlocked || !wallet.data
+			? submitting || !wallet.data
 			: !canSubmit;
 	const amountExplainsBlocking =
 		paidSelection !== null &&
@@ -1445,10 +1401,11 @@ export function DeployWizard() {
 							className="mb-3"
 						>
 							<TriangleAlert />
-							<AlertTitle>Deployment accepted; details couldn’t load</AlertTitle>
+							<AlertTitle>Agent couldn’t be opened</AlertTitle>
 							<AlertDescription>
-								Retrying only loads the accepted deployment and opens its page. It won’t create
-								another agent.
+								{acceptedDeploymentRecovery?.target.kind === "deploy_request"
+									? "Retrying resumes this checkout’s existing deployment request and opens the agent. It won’t create or charge for another one."
+									: "Retrying only loads the accepted deployment and opens its page. It won’t create another agent."}
 							</AlertDescription>
 						</Alert>
 					) : null}
@@ -1509,7 +1466,7 @@ export function DeployWizard() {
 										acceptedDeploymentHydrationFailed && acceptedDeploymentRecovery
 											? () =>
 													void acceptDeployment(
-														acceptedDeploymentRecovery.deploymentId,
+														acceptedDeploymentRecovery.target,
 														acceptedDeploymentRecovery.replace,
 													)
 											: walletTopUpAction
@@ -1579,12 +1536,9 @@ export function DeployWizard() {
 				title={`Complete ${checkoutSession?.tierLabel ?? "compute"} checkout`}
 				description="Enter payment details without leaving this page. Redirect-based payment methods return here after confirmation."
 				summary={checkoutSession?.summary ?? null}
-				onComplete={() =>
-					void handleCheckoutComplete(
-						checkoutSession?.previousDeploymentIds ?? [],
-						checkoutSession?.request ?? null,
-					)
-				}
+				onComplete={() => {
+					if (checkoutSession) void handleCheckoutComplete(checkoutSession.request);
+				}}
 			/>
 		</div>
 	);

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -5,11 +5,6 @@ import {
 	QueryClient,
 	QueryObserver,
 } from "@tanstack/react-query";
-import {
-	checkoutReturnHasNavigationOwner,
-	checkoutReturnMarker,
-	checkoutReturnWasCanceled,
-} from "@/hosted/billing/checkout-return";
 import type {
 	ComputeSubscriptionActionResult,
 	DeploymentOperation,
@@ -485,47 +480,5 @@ describe("reconcileDeploymentSnapshots", () => {
 
 		expect(reconciled?.resource.status).toBeNull();
 		expect(reconciled?.accepted_operation).toEqual(accepted);
-	});
-});
-
-describe("checkout return", () => {
-	test("awaits an async navigation owner before choosing ancillary-only refresh", async () => {
-		let release: () => void = () => undefined;
-		const gate = new Promise<void>((resolve) => {
-			release = () => resolve();
-		});
-		const navigated: string[] = [];
-		let settled = false;
-		const ownership = checkoutReturnHasNavigationOwner(
-			"?session_id=cs_return&deployment_id=hdep_returned",
-			async (deploymentId) => {
-				navigated.push(deploymentId);
-				await gate;
-				return true;
-			},
-		).then((owned) => {
-			settled = true;
-			return owned;
-		});
-
-		await Promise.resolve();
-		expect(navigated).toEqual(["hdep_returned"]);
-		expect(settled).toBe(false);
-		release();
-		expect(await ownership).toBe(true);
-		expect(await checkoutReturnHasNavigationOwner("?deployment_id=hdep_current", () => false)).toBe(
-			false,
-		);
-	});
-
-	test("recognizes Stripe cancel returns as checkout markers", () => {
-		expect(checkoutReturnWasCanceled("?checkout=cancel")).toBe(true);
-		expect(checkoutReturnWasCanceled("?settings=billing-plan&checkout=cancel")).toBe(true);
-		expect(checkoutReturnMarker("?checkout=cancel")).toBe("checkout=cancel");
-	});
-
-	test("does not treat passive checkout success copy as a refresh marker", () => {
-		expect(checkoutReturnWasCanceled("?checkout=success")).toBe(false);
-		expect(checkoutReturnMarker("?checkout=success")).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- recover redirect-based Stripe deploys through the existing owner-scoped by-request endpoint
- reuse the authoritative by-ID deployment cache handoff before navigation
- remove the unsafe deployment list-diff fallback
- keep retries on the same checkout lineage so they cannot recreate or recharge

## Verification

- Docker web suite: 815 passed
- focused tests: 66 passed
- typecheck, production build, Biome, and git diff --check passed

## Backend

Requires Clawdi-AI/clawdi-hosted#1287 before or alongside rollout. No production or tenant operations were performed.