### PR TITLE
refactor(web): unify sidebar information architecture

### DIFF
--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -166,6 +166,22 @@ async function expectNoBrowserErrors(page: Page, errors: string[], label: string
 	expect(errors, label).toEqual([]);
 }
 
+async function expectSidebarNavigationGroups(
+	page: Page,
+	expected: Array<{ label: string; items: string[] }>,
+) {
+	const groups = page
+		.getByTestId("app-sidebar")
+		.locator('[data-slot="sidebar-content"] > [data-slot="sidebar-group"]');
+	await expect(groups).toHaveCount(expected.length);
+	for (const [index, group] of expected.entries()) {
+		await expect(groups.nth(index).locator('[data-slot="sidebar-group-label"]')).toHaveText(
+			group.label,
+		);
+		await expect(groups.nth(index).getByRole("link")).toHaveText(group.items);
+	}
+}
+
 test("dashboard sidebar primitives run without browser errors", async ({ page }) => {
 	const browserErrors: string[] = [];
 	page.on("console", (message) => {
@@ -217,6 +233,25 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await page.getByTestId("settings-theme-select").click();
 	await expect(page.getByRole("option", { name: "Dark" })).toBeVisible();
 	await expectNoBrowserErrors(page, browserErrors, "settings select");
+});
+
+test("Console and connected agents use the scoped navigation grammar", async ({ page }) => {
+	await stubDashboardApi(page);
+	await page.goto("/");
+	await expectSidebarNavigationGroups(page, [
+		{ label: "Primary", items: ["Overview", "Agents"] },
+		{ label: "Projects", items: ["Projects", "Skills", "Vaults"] },
+		{ label: "Activity", items: ["Sessions", "Memories"] },
+		{ label: "Integrations", items: ["Connectors"] },
+	]);
+
+	await page.goto("/agents/agent-smoke-1");
+	await expectSidebarNavigationGroups(page, [
+		{ label: "Primary", items: ["Overview"] },
+		{ label: "Activity", items: ["Sessions"] },
+		{ label: "Context", items: ["Skills", "Projects"] },
+		{ label: "Manage", items: ["Settings"] },
+	]);
 });
 
 test("every agent rail tile button navigates on click", async ({ page }) => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -30,20 +30,12 @@ import {
 	Cloud,
 	ExternalLink,
 	History,
-	Layers,
 	LayoutDashboard,
-	Link2,
 	type LucideIcon,
 	Mail,
 	MessageCircle,
-	MessageSquare,
-	MessagesSquare,
-	MonitorPlay,
 	Search,
 	Settings,
-	Sparkles,
-	TerminalSquare,
-	Zap,
 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -68,7 +60,6 @@ import {
 import { DaemonStatusBadge, type DaemonStatusSource } from "@/components/dashboard/daemon-status";
 import { NewAgentButton } from "@/components/dashboard/new-agent-button";
 import { IconChip } from "@/components/icon-chip";
-import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -106,7 +97,6 @@ import {
 	agentDeploymentRouteQuery,
 	agentDeploymentSelector,
 	agentSectionHref,
-	agentSectionLabel,
 	parseAgentPathname,
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
@@ -119,11 +109,12 @@ import {
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
+import type { AgentNavigationVariant } from "@/lib/navigation-model";
 import {
-	PROJECT_RESOURCE_GROUPS,
-	projectResourceDefinitionsForGroup,
-	projectResourceScopeLabel,
-} from "@/lib/project-resource-model";
+	AGENT_SECTION_NAVIGATION_ITEMS,
+	agentNavigationGroups,
+	consoleNavigationGroups,
+} from "@/lib/navigation-model";
 import { RESOURCE_TINT_CLASSES } from "@/lib/resource-identity";
 import { DEFAULT_SETTINGS_SECTION, type SettingsSectionId } from "@/lib/settings-routes";
 import { useHydrated } from "@/lib/use-hydrated";
@@ -149,101 +140,6 @@ function useAgentChromeKind(
 	return agentOwnershipKindFromId(agent.id, ownership);
 }
 
-const CONNECTED_AGENT_SECTIONS: {
-	id: AgentSectionId;
-	icon: LucideIcon;
-	tooltip: string;
-}[] = [
-	{
-		id: "overview",
-		icon: LayoutDashboard,
-		tooltip: "Agent overview",
-	},
-	{
-		id: "sessions",
-		icon: MessageSquare,
-		tooltip: "Sessions from this agent",
-	},
-	{
-		id: "skills",
-		icon: Sparkles,
-		tooltip: "Skills synced from this Agent filesystem",
-	},
-	{
-		id: "projects",
-		icon: Layers,
-		tooltip: "Agent Project and added Projects",
-	},
-	{
-		id: "settings",
-		icon: Settings,
-		tooltip: "Name and avatar for this agent",
-	},
-];
-
-const HOSTED_AGENT_SECTIONS: {
-	id: AgentSectionId;
-	icon: LucideIcon;
-	tooltip: string;
-}[] = [
-	{
-		id: "overview",
-		icon: LayoutDashboard,
-		tooltip: "Agent overview",
-	},
-	{
-		id: "console",
-		icon: MonitorPlay,
-		tooltip: "Open this agent's browser interface",
-	},
-	{
-		id: "terminal",
-		icon: TerminalSquare,
-		tooltip: "Open a terminal for this agent",
-	},
-	{
-		id: "sessions",
-		icon: MessageSquare,
-		tooltip: "Sessions from this agent",
-	},
-	{
-		id: "skills",
-		icon: Sparkles,
-		tooltip: "Skills synced from this Agent filesystem",
-	},
-	{
-		id: "ai",
-		icon: Zap,
-		tooltip: "AI providers and primary model",
-	},
-	{
-		id: "channels",
-		icon: Link2,
-		tooltip: "Channels linked to this agent",
-	},
-	{
-		id: "settings",
-		icon: Settings,
-		tooltip: "Name, preferences, plan, and lifecycle",
-	},
-];
-
-const HOSTED_AGENT_FALLBACK_SECTIONS = HOSTED_AGENT_SECTIONS.filter(
-	(section) => section.id === "overview" || section.id === "skills",
-);
-
-const AGENT_SECTION_TINTS = {
-	overview: RESOURCE_TINT_CLASSES.overview,
-	sessions: RESOURCE_TINT_CLASSES.sessions,
-	skills: RESOURCE_TINT_CLASSES.skills,
-	projects: RESOURCE_TINT_CLASSES.projects,
-	console: "bg-identity-6-bg text-identity-6-fg",
-	terminal: "bg-identity-7-bg text-identity-7-fg",
-	ai: "bg-identity-2-bg text-identity-2-fg",
-	channels: "bg-identity-5-bg text-identity-5-fg",
-	settings: "bg-identity-4-bg text-identity-4-fg",
-} satisfies Record<AgentSectionId, string>;
-
 const LEGACY_DASHBOARD_TINT = "bg-warning-muted text-warning-muted-foreground";
 
 type SidebarEnvironment = components["schemas"]["AgentResponse"];
@@ -259,12 +155,6 @@ type SidebarNavItem = {
 	active: boolean;
 	external?: boolean;
 	prefetch?: () => void;
-};
-
-type AgentSectionDefinition = {
-	id: AgentSectionId;
-	icon: LucideIcon;
-	tooltip: string;
 };
 
 const RAIL_DRAG_ACTIVATION_DISTANCE = 10;
@@ -373,38 +263,7 @@ function SidebarNavSection({
 	);
 }
 
-function ConsolePrimarySection({
-	pathname,
-	onNavigate,
-}: {
-	pathname: string;
-	onNavigate?: () => void;
-}) {
-	const items: SidebarNavItem[] = [
-		{
-			id: "overview",
-			label: "Overview",
-			href: "/",
-			icon: LayoutDashboard,
-			tint: RESOURCE_TINT_CLASSES.overview,
-			tooltip: "Console overview",
-			active: pathname === "/",
-		},
-		{
-			id: "agents",
-			label: "Agents",
-			href: "/agents",
-			icon: MonitorPlay,
-			tint: "bg-identity-6-bg text-identity-6-fg",
-			tooltip: "All agents",
-			active: pathname === "/agents",
-		},
-	];
-
-	return <SidebarNavSection label="Primary" items={items} onNavigate={onNavigate} />;
-}
-
-function ConsoleResourcesSection({
+function ConsoleNavigationSections({
 	pathname,
 	showCloudFeatures,
 	onNavigate,
@@ -424,105 +283,70 @@ function ConsoleResourcesSection({
 		);
 		void queryClient.prefetchQuery(connectionsQueryOptions(api));
 	}, [api, queryClient]);
-	const resourceItems: SidebarNavItem[] = PROJECT_RESOURCE_GROUPS.flatMap((group) =>
-		projectResourceDefinitionsForGroup(group.id).map((definition) => {
-			const Icon = PROJECT_RESOURCE_ICONS[definition.id];
-			return {
-				id: definition.id,
-				label: definition.navLabel,
-				href: definition.href,
-				icon: Icon,
-				tint: RESOURCE_TINT_CLASSES[definition.id],
-				tooltip: `${definition.navLabel} - ${projectResourceScopeLabel(definition.projectScope)}`,
-				active: pathname === definition.href || pathname.startsWith(`${definition.href}/`),
-				prefetch: definition.id === "connectors" ? prefetchConnectorsCatalog : undefined,
-			};
-		}),
-	);
-
-	if (showCloudFeatures) {
-		resourceItems.push(
-			{
-				id: "channels",
-				label: "Channels",
-				href: "/channels",
-				icon: MessagesSquare,
-				tint: "bg-identity-5-bg text-identity-5-fg",
-				tooltip: "Channels - Account resources",
-				active: pathname === "/channels" || pathname.startsWith("/channels/"),
-			},
-			{
-				id: "model-providers",
-				label: "AI Providers",
-				href: "/ai-providers",
-				icon: Sparkles,
-				tint: "bg-identity-2-bg text-identity-2-fg",
-				tooltip: "AI Providers - Account resources",
-				active: pathname === "/ai-providers" || pathname.startsWith("/ai-providers/"),
-			},
-		);
-	}
-
-	return <SidebarNavSection label="Resources" items={resourceItems} onNavigate={onNavigate} />;
+	return consoleNavigationGroups(showCloudFeatures).map((group) => (
+		<SidebarNavSection
+			key={group.id}
+			label={group.label}
+			items={group.items.map((item) => ({
+				...item,
+				active:
+					item.href === "/"
+						? pathname === item.href
+						: pathname === item.href || pathname.startsWith(`${item.href}/`),
+				prefetch: item.id === "connectors" ? prefetchConnectorsCatalog : undefined,
+			}))}
+			onNavigate={onNavigate}
+		/>
+	));
 }
 
 function AgentSectionList({
 	agentId,
-	sections,
+	variant,
+	visibleSectionIds,
 	activeSection,
 	extraPrimaryItems = [],
 	onNavigate,
 }: {
 	agentId: string;
-	sections: readonly AgentSectionDefinition[];
+	variant: AgentNavigationVariant;
+	visibleSectionIds?: readonly AgentSectionId[];
 	activeSection: AgentSectionId;
 	extraPrimaryItems?: SidebarNavItem[];
 	onNavigate?: () => void;
 }) {
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const routeQuery = agentDeploymentRouteQuery(searchStr);
-	const normalizedActiveSection = sections.some((section) => section.id === activeSection)
+	const groups = agentNavigationGroups(variant, visibleSectionIds);
+	const normalizedActiveSection = groups.some((group) =>
+		group.items.some((item) => item.id === activeSection),
+	)
 		? activeSection
 		: "overview";
-	const primarySections = sections.filter(
-		(section) => section.id === "overview" || section.id === "console" || section.id === "terminal",
-	);
-	const resourceSections = sections.filter(
-		(section) => section.id !== "overview" && section.id !== "console" && section.id !== "terminal",
-	);
-
-	const primaryItems = [
-		...primarySections.map((section): SidebarNavItem => {
-			const Icon = section.icon;
-			return {
-				id: section.id,
-				label: agentSectionLabel(section.id),
-				href: agentSectionHref(agentId, section.id, routeQuery),
-				icon: Icon,
-				tint: AGENT_SECTION_TINTS[section.id],
-				tooltip: section.tooltip,
-				active: normalizedActiveSection === section.id,
-			};
-		}),
-		...extraPrimaryItems,
-	];
-	const resourceItems = resourceSections.map((section): SidebarNavItem => {
-		const Icon = section.icon;
-		return {
-			id: section.id,
-			label: agentSectionLabel(section.id),
-			href: agentSectionHref(agentId, section.id, routeQuery),
-			icon: Icon,
-			tint: AGENT_SECTION_TINTS[section.id],
-			tooltip: section.tooltip,
-			active: normalizedActiveSection === section.id,
-		};
-	});
 
 	return (
 		<>
-			<SidebarNavSection label="Primary" items={primaryItems} onNavigate={onNavigate} />
-			<SidebarNavSection label="Resources" items={resourceItems} onNavigate={onNavigate} />
+			{groups.map((group) => (
+				<SidebarNavSection
+					key={group.id}
+					label={group.label}
+					items={[
+						...group.items.map(
+							(item): SidebarNavItem => ({
+								id: item.id,
+								label: item.label,
+								href: agentSectionHref(agentId, item.id, routeQuery),
+								icon: item.icon,
+								tint: item.tint,
+								tooltip: item.tooltip,
+								active: normalizedActiveSection === item.id,
+							}),
+						),
+						...(group.id === "primary" ? extraPrimaryItems : []),
+					]}
+					onNavigate={onNavigate}
+				/>
+			))}
 		</>
 	);
 }
@@ -556,7 +380,7 @@ function AgentFocusSections({
 	return (
 		<AgentSectionList
 			agentId={agentId}
-			sections={kind === "cloud" ? HOSTED_AGENT_SECTIONS : CONNECTED_AGENT_SECTIONS}
+			variant={kind === "cloud" ? "hosted" : "connected"}
 			activeSection={activeSection}
 			extraPrimaryItems={extraPrimaryItems}
 			onNavigate={onNavigate}
@@ -576,7 +400,8 @@ function AgentFocusHostedFallbackSections({
 	return (
 		<AgentSectionList
 			agentId={agentId}
-			sections={HOSTED_AGENT_FALLBACK_SECTIONS}
+			variant="hosted"
+			visibleSectionIds={["overview", "skills"]}
 			activeSection={activeSection}
 			onNavigate={onNavigate}
 		/>
@@ -594,13 +419,14 @@ function AgentFocusLoadingSections({
 }) {
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const routeQuery = agentDeploymentRouteQuery(searchStr);
+	const overviewMetadata = AGENT_SECTION_NAVIGATION_ITEMS.overview;
 	const overviewItem: SidebarNavItem = {
-		id: "overview",
-		label: "Overview",
+		id: overviewMetadata.id,
+		label: overviewMetadata.label,
 		href: agentSectionHref(agentId, "overview", routeQuery),
-		icon: LayoutDashboard,
-		tint: RESOURCE_TINT_CLASSES.overview,
-		tooltip: "Agent overview",
+		icon: overviewMetadata.icon,
+		tint: overviewMetadata.tint,
+		tooltip: overviewMetadata.tooltip,
 		active: activeSection === "overview",
 	};
 
@@ -608,7 +434,7 @@ function AgentFocusLoadingSections({
 		<>
 			<SidebarNavSection label="Primary" items={[overviewItem]} onNavigate={onNavigate} />
 			<SidebarGroup className="pt-0">
-				<SidebarGroupLabel>Resources</SidebarGroupLabel>
+				<SidebarGroupLabel>Loading navigation</SidebarGroupLabel>
 				<SidebarGroupContent>
 					<SidebarMenu>
 						{["70%", "58%", "64%"].map((width) => (
@@ -685,14 +511,11 @@ function SidebarMainNavigation({
 	}
 
 	return (
-		<>
-			<ConsolePrimarySection pathname={pathname} onNavigate={onNavigate} />
-			<ConsoleResourcesSection
-				pathname={pathname}
-				showCloudFeatures={showCloudFeatures}
-				onNavigate={onNavigate}
-			/>
-		</>
+		<ConsoleNavigationSections
+			pathname={pathname}
+			showCloudFeatures={showCloudFeatures}
+			onNavigate={onNavigate}
+		/>
 	);
 }
 

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -2,18 +2,8 @@
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import {
-	Brain,
-	Key,
-	LayoutDashboard,
-	type LucideIcon,
-	MessageSquare,
-	MessagesSquare,
-	Settings,
-	Sparkles,
-} from "lucide-react";
+import { Brain, Key, type LucideIcon, MessageSquare, Settings, Sparkles } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
 import {
 	Command,
 	CommandDialog,
@@ -29,12 +19,7 @@ import { unwrap, useApi } from "@/lib/api";
 import type { SearchHit } from "@/lib/api-schemas";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
-import {
-	PROJECT_RESOURCE_GROUPS,
-	projectResourceDefinitionsForGroup,
-	projectResourcePathLabel,
-	projectResourceScopeLabel,
-} from "@/lib/project-resource-model";
+import { consoleCommandPaletteItems } from "@/lib/navigation-model";
 import type { SettingsSectionId } from "@/lib/settings-routes";
 import { useDebouncedValue } from "@/lib/use-debounced";
 
@@ -46,45 +31,6 @@ interface NavShortcut {
 	subtitle: string;
 	searchText: string;
 }
-
-const BASE_NAV_SHORTCUTS: NavShortcut[] = [
-	{
-		label: "Overview",
-		href: "/",
-		icon: LayoutDashboard,
-		subtitle: "Dashboard",
-		searchText: "overview dashboard",
-	},
-	...PROJECT_RESOURCE_GROUPS.flatMap((group) =>
-		projectResourceDefinitionsForGroup(group.id).map((definition) => ({
-			label: definition.navLabel,
-			href: definition.href,
-			icon: PROJECT_RESOURCE_ICONS[definition.id],
-			subtitle: projectResourcePathLabel(definition),
-			searchText: `${definition.navLabel} ${definition.label} ${group.label} ${projectResourceScopeLabel(
-				definition.projectScope,
-			)} ${projectResourcePathLabel(definition)}`,
-		})),
-	),
-];
-
-const CLOUD_NAV_SHORTCUTS: NavShortcut[] = [
-	{
-		label: "Channels",
-		href: "/channels",
-		icon: MessagesSquare,
-		subtitle: "Account resources",
-		searchText: "channels telegram discord whatsapp bots messaging",
-	},
-	{
-		label: "AI Providers",
-		href: "/ai-providers",
-		icon: Sparkles,
-		subtitle: "Account resources",
-		searchText:
-			"model providers ai providers models openai anthropic openrouter gemini mistral byok api key",
-	},
-];
 
 const TYPE_ICON: Record<SearchHit["type"], LucideIcon> = {
 	session: MessageSquare,
@@ -160,6 +106,13 @@ function CommandPalette({
 	const [query, setQuery] = useState("");
 	const debounced = useDebouncedValue(query, 180);
 	const navShortcuts = useMemo(() => {
+		const shortcuts: NavShortcut[] = consoleCommandPaletteItems(false).map((item) => ({
+			label: item.label,
+			href: item.href,
+			icon: item.icon,
+			subtitle: item.commandPalette.subtitle,
+			searchText: item.commandPalette.searchText,
+		}));
 		const settingsShortcut: NavShortcut = {
 			label: "Settings",
 			href: ".",
@@ -168,9 +121,19 @@ function CommandPalette({
 			subtitle: "General, Profile, API Keys",
 			searchText: "settings general profile api keys model providers billing preferences account",
 		};
-		const shortcuts = [...BASE_NAV_SHORTCUTS, settingsShortcut];
+		shortcuts.push(settingsShortcut);
 		if (IS_HOSTED && hostedAccess.canCreateCloudAgents) {
-			shortcuts.push(...CLOUD_NAV_SHORTCUTS);
+			shortcuts.push(
+				...consoleCommandPaletteItems(true)
+					.filter((item) => item.availability === "cloud")
+					.map((item) => ({
+						label: item.label,
+						href: item.href,
+						icon: item.icon,
+						subtitle: item.commandPalette.subtitle,
+						searchText: item.commandPalette.searchText,
+					})),
+			);
 		}
 		return shortcuts;
 	}, [hostedAccess.canCreateCloudAgents]);

--- a/apps/web/src/components/dashboard/agent-skills-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-tab.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { AGENT_SECTION_NAVIGATION_ITEMS, agentNavigationGroups } from "@/lib/navigation-model";
 
 describe("agent Skills resource boundary", () => {
 	test("keeps persisted Agent Project rows read-only without cleanup mutations", () => {
@@ -17,15 +18,16 @@ describe("agent Skills resource boundary", () => {
 	});
 
 	test("describes both Agent Skill surfaces as filesystem projections", () => {
-		const sidebar = readFileSync(new URL("../app-sidebar.tsx", import.meta.url), "utf8");
-		const hostedStart = sidebar.indexOf("const HOSTED_AGENT_SECTIONS");
-		expect(hostedStart).toBeGreaterThan(-1);
-		const connected = sidebar.slice(0, hostedStart);
-		const hosted = sidebar.slice(hostedStart);
+		const connectedSkills = agentNavigationGroups("connected").flatMap((group) => group.items);
+		const hostedSkills = agentNavigationGroups("hosted").flatMap((group) => group.items);
 
-		expect(connected).toContain("Skills synced from this Agent filesystem");
-		expect(connected).not.toContain("Manifest configuration");
-		expect(hosted).toContain("Skills synced from this Agent filesystem");
-		expect(hosted).not.toContain("Manifest configuration");
+		expect(connectedSkills).toContain(AGENT_SECTION_NAVIGATION_ITEMS.skills);
+		expect(hostedSkills).toContain(AGENT_SECTION_NAVIGATION_ITEMS.skills);
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.skills.description).toBe(
+			"Skills synced from this agent's filesystem.",
+		);
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.skills.description).not.toContain(
+			"Manifest configuration",
+		);
 	});
 });

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -1,17 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-	ArrowDown,
-	ArrowUp,
-	Home,
-	Layers,
-	MessageSquare,
-	Plus,
-	Settings,
-	Sparkles,
-	Trash2,
-} from "lucide-react";
+import { ArrowDown, ArrowUp, Home, Layers, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -22,7 +12,7 @@ import {
 } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
-import { DetailNotFound, DetailPanel, type DetailSectionMeta } from "@/components/detail/layout";
+import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { PageHeader } from "@/components/page-header";
@@ -49,6 +39,7 @@ import {
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
+import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -56,29 +47,6 @@ type AgentTab = "overview" | "sessions" | "skills" | "projects" | "settings";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type ProjectBindingRow = components["schemas"]["AgentProjectBindingResponse"];
-
-const AGENT_DETAIL_NAV_META: Record<AgentTab, DetailSectionMeta> = {
-	overview: {
-		icon: Home,
-		description: "Status, inventory, and recent activity for this agent.",
-	},
-	sessions: {
-		icon: MessageSquare,
-		description: "History synced by this agent.",
-	},
-	skills: {
-		icon: Sparkles,
-		description: "Installed in this agent's Agent Project.",
-	},
-	projects: {
-		icon: Layers,
-		description: "Agent Project, added Projects, and read order.",
-	},
-	settings: {
-		icon: Settings,
-		description: "Name and avatar used across the dashboard.",
-	},
-};
 
 export function ConnectedAgentDetail({
 	environmentId,
@@ -155,7 +123,7 @@ export function ConnectedAgentDetail({
 	} = useAgentProjectSkills(id, agentProjectId, id, false);
 
 	const sessionTotal = sessionsError ? "—" : (sessionsPage?.total ?? 0);
-	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
+	const activeTabMeta = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
 	const ownershipKind = agent ? agentOwnershipKindFromId(agent.id, ownership) : "connected";

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -22,7 +22,6 @@ import {
 	QrCode,
 	RefreshCw,
 	Settings,
-	Sparkles,
 	TerminalSquare,
 	Trash2,
 	WalletCards,
@@ -36,7 +35,6 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
-import type { DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CHOICE_GRID_CLASS,
@@ -278,6 +276,7 @@ import { ApiError, toastApiError, unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -293,54 +292,9 @@ type HostedAgentTab =
 	| "ai"
 	| "channels"
 	| "settings";
-const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
-	"overview",
-	"console",
-	"terminal",
-	"sessions",
-	"skills",
-	"ai",
-	"channels",
-	"settings",
-]);
-const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
-	overview: {
-		description: "Status, model, resources, and recent sessions.",
-		icon: Info,
-	},
-	console: {
-		description: "Open this agent's browser interface.",
-		icon: MonitorPlay,
-	},
-	terminal: {
-		description: "Open a terminal for this agent.",
-		icon: TerminalSquare,
-	},
-	sessions: {
-		description: "Conversation history from this agent.",
-		icon: RefreshCw,
-	},
-	skills: {
-		description: "Read-only projections from this Agent's filesystem.",
-		icon: Sparkles,
-	},
-	ai: {
-		description: "AI providers and the primary model used by this agent.",
-		icon: Zap,
-	},
-	channels: {
-		description: "Channels this Agent can use.",
-		icon: Link2,
-	},
-	settings: {
-		description: "Name, preferences, plan, and lifecycle controls.",
-		icon: Settings,
-	},
-};
 function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgentTab | null {
 	if (!value) return null;
-	return HOSTED_AGENT_SECTION_IDS.includes(value as HostedAgentTab) &&
-		HOSTED_AGENT_TABS.has(value as HostedAgentTab)
+	return HOSTED_AGENT_SECTION_IDS.includes(value as HostedAgentTab)
 		? (value as HostedAgentTab)
 		: null;
 }
@@ -553,7 +507,7 @@ export function HostedAgentDetail({
 		enabled: deploymentRunning && projection.status === "resolved",
 	});
 
-	const activeNavItem = HOSTED_AGENT_NAV_META[activeTab];
+	const activeNavItem = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -149,6 +149,33 @@ describe("agent routes", () => {
 		expect(parseAgentSectionSegment("bad")).toBeNull();
 	});
 
+	it("keeps every released agent section segment backward-compatible", () => {
+		const sections = [
+			"overview",
+			"sessions",
+			"skills",
+			"projects",
+			"console",
+			"terminal",
+			"ai",
+			"channels",
+			"settings",
+		] as const;
+		expect(
+			Object.fromEntries(sections.map((section) => [section, agentSectionSegment(section)])),
+		).toEqual({
+			overview: "",
+			sessions: "sessions",
+			skills: "skills",
+			projects: "project-access",
+			console: "console",
+			terminal: "terminal",
+			ai: "model-provider",
+			channels: "channel-links",
+			settings: "settings",
+		});
+	});
+
 	it("keeps canonical labels while preserving backward-compatible URL segments", () => {
 		expect(agentSectionLabel("projects")).toBe("Projects");
 		expect(agentSectionLabel("console")).toBe("Agent Interface");

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -149,13 +149,13 @@ describe("agent routes", () => {
 		expect(parseAgentSectionSegment("bad")).toBeNull();
 	});
 
-	it("keeps labels and URL segments in one route table", () => {
-		expect(agentSectionLabel("projects")).toBe("Project Access");
+	it("keeps canonical labels while preserving backward-compatible URL segments", () => {
+		expect(agentSectionLabel("projects")).toBe("Projects");
 		expect(agentSectionLabel("console")).toBe("Agent Interface");
 		expect(agentSectionLabel("channels")).toBe("Channels");
-		expect(agentSectionLabelFromSegment("project-access")).toBe("Project Access");
+		expect(agentSectionLabelFromSegment("project-access")).toBe("Projects");
 		expect(agentSectionLabelFromSegment("console")).toBe("Agent Interface");
-		expect(agentSectionLabelFromSegment("model-provider")).toBe("AI Providers");
+		expect(agentSectionLabelFromSegment("model-provider")).toBe("AI & Model");
 		expect(agentSectionLabelFromSegment("settings")).toBe("Settings");
 		expect(agentSectionLabelFromSegment("bad")).toBeNull();
 	});

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -1,15 +1,9 @@
 import { defaultParseSearch, defaultStringifySearch, linkOptions } from "@tanstack/react-router";
+import type { AgentSectionId } from "@/lib/navigation-model";
+import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 
-export type AgentSectionId =
-	| "overview"
-	| "sessions"
-	| "skills"
-	| "projects"
-	| "console"
-	| "terminal"
-	| "ai"
-	| "channels"
-	| "settings";
+export type { AgentSectionId } from "@/lib/navigation-model";
+export { CONNECTED_AGENT_SECTION_IDS, HOSTED_AGENT_SECTION_IDS } from "@/lib/navigation-model";
 
 export type RouteSearchParamsRecord = Record<string, string | string[] | undefined>;
 export type AgentRouteSearch = Record<string, unknown> & {
@@ -28,25 +22,6 @@ export type AgentRouteQuery =
 
 export const AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY = "d";
 
-export const CONNECTED_AGENT_SECTION_IDS = [
-	"overview",
-	"sessions",
-	"skills",
-	"projects",
-	"settings",
-] as const satisfies readonly AgentSectionId[];
-
-export const HOSTED_AGENT_SECTION_IDS = [
-	"overview",
-	"console",
-	"terminal",
-	"sessions",
-	"skills",
-	"ai",
-	"channels",
-	"settings",
-] as const satisfies readonly AgentSectionId[];
-
 const AGENT_SECTION_SEGMENTS = {
 	overview: "",
 	sessions: "sessions",
@@ -57,18 +32,6 @@ const AGENT_SECTION_SEGMENTS = {
 	ai: "model-provider",
 	channels: "channel-links",
 	settings: "settings",
-} as const satisfies Record<AgentSectionId, string>;
-
-const AGENT_SECTION_LABELS = {
-	overview: "Overview",
-	sessions: "Sessions",
-	skills: "Skills",
-	projects: "Project Access",
-	console: "Agent Interface",
-	terminal: "Terminal",
-	ai: "AI Providers",
-	channels: "Channels",
-	settings: "Settings",
 } as const satisfies Record<AgentSectionId, string>;
 
 const AGENT_SEGMENT_TO_SECTION = Object.fromEntries(
@@ -89,7 +52,7 @@ export function agentSectionSegment(section: AgentSectionId): string {
 }
 
 export function agentSectionLabel(section: AgentSectionId): string {
-	return AGENT_SECTION_LABELS[section];
+	return AGENT_SECTION_NAVIGATION_ITEMS[section].label;
 }
 
 export function agentSectionLabelFromSegment(segment: string): string | null {

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -141,6 +141,9 @@ describe("sidebar navigation model", () => {
 	});
 
 	test("keeps labels, icons, and descriptions canonical across navigation and page headers", () => {
+		for (const item of Object.values(AGENT_SECTION_NAVIGATION_ITEMS)) {
+			expect(item).not.toHaveProperty("href");
+		}
 		expect(AGENT_SECTION_NAVIGATION_ITEMS.overview).toMatchObject({
 			label: "Overview",
 			icon: LayoutDashboard,

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { FolderKanban, LayoutDashboard, MessageSquare, Settings, Zap } from "lucide-react";
+import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
+import {
+	AGENT_SECTION_NAVIGATION_ITEMS,
+	agentNavigationGroups,
+	CONNECTED_AGENT_SECTION_IDS,
+	CONSOLE_NAVIGATION_ITEMS,
+	consoleCommandPaletteItems,
+	consoleNavigationGroups,
+	HOSTED_AGENT_SECTION_IDS,
+} from "@/lib/navigation-model";
+
+function groupShape(
+	groups: ReadonlyArray<{
+		id: string;
+		label: string;
+		items: ReadonlyArray<{ id: string; label: string }>;
+	}>,
+) {
+	return groups.map((group) => ({
+		id: group.id,
+		label: group.label,
+		items: group.items.map((item) => ({ id: item.id, label: item.label })),
+	}));
+}
+
+describe("sidebar navigation model", () => {
+	test("groups the full Console inventory by account semantics", () => {
+		expect(groupShape(consoleNavigationGroups(true))).toEqual([
+			{
+				id: "primary",
+				label: "Primary",
+				items: [
+					{ id: "overview", label: "Overview" },
+					{ id: "agents", label: "Agents" },
+				],
+			},
+			{
+				id: "projects",
+				label: "Projects",
+				items: [
+					{ id: "projects", label: "Projects" },
+					{ id: "skills", label: "Skills" },
+					{ id: "vaults", label: "Vaults" },
+				],
+			},
+			{
+				id: "activity",
+				label: "Activity",
+				items: [
+					{ id: "sessions", label: "Sessions" },
+					{ id: "memories", label: "Memories" },
+				],
+			},
+			{
+				id: "integrations",
+				label: "Integrations",
+				items: [
+					{ id: "connectors", label: "Connectors" },
+					{ id: "channels", label: "Channels" },
+					{ id: "ai-providers", label: "AI Providers" },
+				],
+			},
+		]);
+	});
+
+	test("preserves hosted gating in the Console and command palette", () => {
+		const ossGroups = consoleNavigationGroups(false);
+		expect(ossGroups.at(-1)?.items.map((item) => item.id)).toEqual(["connectors"]);
+		expect(consoleCommandPaletteItems(false).map((item) => item.id)).toEqual([
+			"overview",
+			"projects",
+			"skills",
+			"vaults",
+			"sessions",
+			"memories",
+			"connectors",
+		]);
+		expect(
+			consoleCommandPaletteItems(true)
+				.filter((item) => item.availability === "cloud")
+				.map((item) => item.id),
+		).toEqual(["channels", "ai-providers"]);
+	});
+
+	test("uses one ordered grammar for connected and hosted agents", () => {
+		expect(groupShape(agentNavigationGroups("connected"))).toEqual([
+			{ id: "primary", label: "Primary", items: [{ id: "overview", label: "Overview" }] },
+			{ id: "activity", label: "Activity", items: [{ id: "sessions", label: "Sessions" }] },
+			{
+				id: "context",
+				label: "Context",
+				items: [
+					{ id: "skills", label: "Skills" },
+					{ id: "projects", label: "Projects" },
+				],
+			},
+			{ id: "manage", label: "Manage", items: [{ id: "settings", label: "Settings" }] },
+		]);
+		expect(groupShape(agentNavigationGroups("hosted"))).toEqual([
+			{ id: "primary", label: "Primary", items: [{ id: "overview", label: "Overview" }] },
+			{
+				id: "runtime",
+				label: "Runtime",
+				items: [
+					{ id: "console", label: "Agent Interface" },
+					{ id: "terminal", label: "Terminal" },
+				],
+			},
+			{ id: "activity", label: "Activity", items: [{ id: "sessions", label: "Sessions" }] },
+			{ id: "context", label: "Context", items: [{ id: "skills", label: "Skills" }] },
+			{
+				id: "integrations",
+				label: "Integrations",
+				items: [
+					{ id: "ai", label: "AI & Model" },
+					{ id: "channels", label: "Channels" },
+				],
+			},
+			{ id: "manage", label: "Manage", items: [{ id: "settings", label: "Settings" }] },
+		]);
+		expect(CONNECTED_AGENT_SECTION_IDS).toEqual([
+			"overview",
+			"sessions",
+			"skills",
+			"projects",
+			"settings",
+		]);
+		expect(HOSTED_AGENT_SECTION_IDS).toEqual([
+			"overview",
+			"console",
+			"terminal",
+			"sessions",
+			"skills",
+			"ai",
+			"channels",
+			"settings",
+		]);
+	});
+
+	test("keeps labels, icons, and descriptions canonical across navigation and page headers", () => {
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.overview).toMatchObject({
+			label: "Overview",
+			icon: LayoutDashboard,
+			description: "Status, resources, and recent activity for this agent.",
+		});
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.sessions.icon).toBe(MessageSquare);
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.projects).toMatchObject({
+			label: "Projects",
+			icon: FolderKanban,
+		});
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.ai).toMatchObject({
+			label: "AI & Model",
+			icon: Zap,
+			description: "Provider binding and primary model used by this agent.",
+		});
+		expect(AGENT_SECTION_NAVIGATION_ITEMS.settings.icon).toBe(Settings);
+		expect(CONSOLE_NAVIGATION_ITEMS.projects.icon).toBe(PROJECT_RESOURCE_ICONS.projects);
+
+		const connectedDetail = readFileSync(
+			new URL("../components/dashboard/connected-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		const hostedDetail = readFileSync(
+			new URL("../hosted/agents/hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(connectedDetail).toContain("AGENT_SECTION_NAVIGATION_ITEMS[activeTab]");
+		expect(hostedDetail).toContain("AGENT_SECTION_NAVIGATION_ITEMS[activeTab]");
+		expect(connectedDetail).not.toContain("AGENT_DETAIL_NAV_META");
+		expect(hostedDetail).not.toContain("HOSTED_AGENT_NAV_META");
+	});
+});

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -216,7 +216,7 @@ type AgentNavigationGroupId =
 	| "integrations"
 	| "manage";
 
-export type AgentNavigationItemMetadata = NavigationItemMetadata<AgentSectionId> & {
+export type AgentNavigationItemMetadata = Omit<NavigationItemMetadata<AgentSectionId>, "href"> & {
 	variants: readonly AgentNavigationVariant[];
 };
 
@@ -231,7 +231,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	overview: {
 		id: "overview",
 		label: "Overview",
-		href: "",
 		icon: LayoutDashboard,
 		tint: RESOURCE_TINT_CLASSES.overview,
 		description: "Status, resources, and recent activity for this agent.",
@@ -241,7 +240,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	console: {
 		id: "console",
 		label: "Agent Interface",
-		href: "console",
 		icon: MonitorPlay,
 		tint: "bg-identity-6-bg text-identity-6-fg",
 		description: "Open this agent's browser interface.",
@@ -251,7 +249,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	terminal: {
 		id: "terminal",
 		label: "Terminal",
-		href: "terminal",
 		icon: TerminalSquare,
 		tint: "bg-identity-7-bg text-identity-7-fg",
 		description: "Open a terminal for this agent.",
@@ -261,7 +258,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	sessions: {
 		id: "sessions",
 		label: "Sessions",
-		href: "sessions",
 		icon: MessageSquare,
 		tint: RESOURCE_TINT_CLASSES.sessions,
 		description: "Conversation history from this agent.",
@@ -271,7 +267,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	skills: {
 		id: "skills",
 		label: "Skills",
-		href: "skills",
 		icon: Sparkles,
 		tint: RESOURCE_TINT_CLASSES.skills,
 		description: "Skills synced from this agent's filesystem.",
@@ -281,7 +276,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	projects: {
 		id: "projects",
 		label: "Projects",
-		href: "project-access",
 		icon: PROJECT_RESOURCE_ICONS.projects,
 		tint: RESOURCE_TINT_CLASSES.projects,
 		description: "Agent Project, added Projects, and read order.",
@@ -291,7 +285,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	ai: {
 		id: "ai",
 		label: "AI & Model",
-		href: "model-provider",
 		icon: Zap,
 		tint: "bg-identity-2-bg text-identity-2-fg",
 		description: "Provider binding and primary model used by this agent.",
@@ -301,7 +294,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	channels: {
 		id: "channels",
 		label: "Channels",
-		href: "channel-links",
 		icon: Link2,
 		tint: "bg-identity-5-bg text-identity-5-fg",
 		description: "Channels linked to this agent.",
@@ -311,7 +303,6 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	settings: {
 		id: "settings",
 		label: "Settings",
-		href: "settings",
 		icon: Settings,
 		tint: "bg-identity-4-bg text-identity-4-fg",
 		description: "Name, preferences, and agent controls.",

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -1,0 +1,362 @@
+import {
+	LayoutDashboard,
+	Link2,
+	type LucideIcon,
+	MessageSquare,
+	MessagesSquare,
+	MonitorPlay,
+	Settings,
+	Sparkles,
+	TerminalSquare,
+	Zap,
+} from "lucide-react";
+import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
+import {
+	getProjectResourceDefinition,
+	projectResourcePathLabel,
+	projectResourceScopeLabel,
+} from "@/lib/project-resource-model";
+import { RESOURCE_TINT_CLASSES } from "@/lib/resource-identity";
+
+export type AgentSectionId =
+	| "overview"
+	| "sessions"
+	| "skills"
+	| "projects"
+	| "console"
+	| "terminal"
+	| "ai"
+	| "channels"
+	| "settings";
+
+export type AgentNavigationVariant = "connected" | "hosted";
+
+export type NavigationItemMetadata<Id extends string> = {
+	id: Id;
+	label: string;
+	href: string;
+	icon: LucideIcon;
+	tint: string;
+	description: string;
+	tooltip: string;
+};
+
+export type NavigationGroupMetadata<GroupId extends string, ItemId extends string> = {
+	id: GroupId;
+	label: string;
+	items: readonly NavigationItemMetadata<ItemId>[];
+};
+
+type ConsoleNavigationItemId =
+	| "overview"
+	| "agents"
+	| "projects"
+	| "skills"
+	| "vaults"
+	| "sessions"
+	| "memories"
+	| "connectors"
+	| "channels"
+	| "ai-providers";
+
+type ConsoleNavigationGroupId = "primary" | "projects" | "activity" | "integrations";
+
+type ConsoleCommandPaletteMetadata = {
+	subtitle: string;
+	searchText: string;
+};
+
+export type ConsoleNavigationItemMetadata = NavigationItemMetadata<ConsoleNavigationItemId> & {
+	availability: "all" | "cloud";
+	commandPalette?: ConsoleCommandPaletteMetadata;
+};
+
+export type ConsoleNavigationGroup = Omit<
+	NavigationGroupMetadata<ConsoleNavigationGroupId, ConsoleNavigationItemId>,
+	"items"
+> & {
+	items: readonly ConsoleNavigationItemMetadata[];
+};
+
+function projectResourceNavigationItem(
+	id: "projects" | "skills" | "vaults" | "sessions" | "memories" | "connectors",
+): ConsoleNavigationItemMetadata {
+	const definition = getProjectResourceDefinition(id);
+	const commandGroupLabel =
+		id === "projects"
+			? "Projects"
+			: id === "skills" || id === "vaults"
+				? "Project resources"
+				: "Account resources";
+	return {
+		id,
+		label: definition.navLabel,
+		href: definition.href,
+		icon: PROJECT_RESOURCE_ICONS[id],
+		tint: RESOURCE_TINT_CLASSES[id],
+		description: definition.managementDescription,
+		tooltip: `${definition.navLabel} — ${projectResourceScopeLabel(definition.projectScope)}`,
+		availability: "all",
+		commandPalette: {
+			subtitle: projectResourcePathLabel(definition),
+			searchText: `${definition.navLabel} ${definition.label} ${commandGroupLabel} ${projectResourceScopeLabel(definition.projectScope)} ${projectResourcePathLabel(definition)}`,
+		},
+	};
+}
+
+export const CONSOLE_NAVIGATION_ITEMS: Record<
+	ConsoleNavigationItemId,
+	ConsoleNavigationItemMetadata
+> = {
+	overview: {
+		id: "overview",
+		label: "Overview",
+		href: "/",
+		icon: LayoutDashboard,
+		tint: RESOURCE_TINT_CLASSES.overview,
+		description: "Account inventory and recent activity.",
+		tooltip: "Console overview",
+		availability: "all",
+		commandPalette: {
+			subtitle: "Dashboard",
+			searchText: "overview dashboard",
+		},
+	},
+	agents: {
+		id: "agents",
+		label: "Agents",
+		href: "/agents",
+		icon: MonitorPlay,
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		description: "Every agent connected to this account.",
+		tooltip: "All agents",
+		availability: "all",
+	},
+	projects: projectResourceNavigationItem("projects"),
+	skills: projectResourceNavigationItem("skills"),
+	vaults: projectResourceNavigationItem("vaults"),
+	sessions: projectResourceNavigationItem("sessions"),
+	memories: projectResourceNavigationItem("memories"),
+	connectors: projectResourceNavigationItem("connectors"),
+	channels: {
+		id: "channels",
+		label: "Channels",
+		href: "/channels",
+		icon: MessagesSquare,
+		tint: "bg-identity-5-bg text-identity-5-fg",
+		description: "Account channel inventory and connections.",
+		tooltip: "Channels — Account integrations",
+		availability: "cloud",
+		commandPalette: {
+			subtitle: "Account resources",
+			searchText: "channels telegram discord whatsapp bots messaging",
+		},
+	},
+	"ai-providers": {
+		id: "ai-providers",
+		label: "AI Providers",
+		href: "/ai-providers",
+		icon: Sparkles,
+		tint: "bg-identity-2-bg text-identity-2-fg",
+		description: "Account AI provider connections and credentials.",
+		tooltip: "AI Providers — Account integrations",
+		availability: "cloud",
+		commandPalette: {
+			subtitle: "Account resources",
+			searchText:
+				"model providers ai providers models openai anthropic openrouter gemini mistral byok api key",
+		},
+	},
+} satisfies Record<ConsoleNavigationItemId, ConsoleNavigationItemMetadata>;
+
+const CONSOLE_NAVIGATION_GROUPS = [
+	{ id: "primary", label: "Primary", itemIds: ["overview", "agents"] },
+	{ id: "projects", label: "Projects", itemIds: ["projects", "skills", "vaults"] },
+	{ id: "activity", label: "Activity", itemIds: ["sessions", "memories"] },
+	{
+		id: "integrations",
+		label: "Integrations",
+		itemIds: ["connectors", "channels", "ai-providers"],
+	},
+] as const satisfies readonly {
+	id: ConsoleNavigationGroupId;
+	label: string;
+	itemIds: readonly ConsoleNavigationItemId[];
+}[];
+
+export function consoleNavigationGroups(showCloudFeatures: boolean): ConsoleNavigationGroup[] {
+	return CONSOLE_NAVIGATION_GROUPS.map((group) => ({
+		id: group.id,
+		label: group.label,
+		items: group.itemIds
+			.map((id) => CONSOLE_NAVIGATION_ITEMS[id])
+			.filter((item) => item.availability === "all" || showCloudFeatures),
+	}));
+}
+
+export function consoleCommandPaletteItems(
+	showCloudFeatures: boolean,
+): Array<ConsoleNavigationItemMetadata & { commandPalette: ConsoleCommandPaletteMetadata }> {
+	return consoleNavigationGroups(showCloudFeatures)
+		.flatMap((group) => group.items)
+		.filter(
+			(
+				item,
+			): item is ConsoleNavigationItemMetadata & {
+				commandPalette: ConsoleCommandPaletteMetadata;
+			} => Boolean(item.commandPalette),
+		);
+}
+
+type AgentNavigationGroupId =
+	| "primary"
+	| "runtime"
+	| "activity"
+	| "context"
+	| "integrations"
+	| "manage";
+
+export type AgentNavigationItemMetadata = NavigationItemMetadata<AgentSectionId> & {
+	variants: readonly AgentNavigationVariant[];
+};
+
+export type AgentNavigationGroup = Omit<
+	NavigationGroupMetadata<AgentNavigationGroupId, AgentSectionId>,
+	"items"
+> & {
+	items: readonly AgentNavigationItemMetadata[];
+};
+
+export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigationItemMetadata> = {
+	overview: {
+		id: "overview",
+		label: "Overview",
+		href: "",
+		icon: LayoutDashboard,
+		tint: RESOURCE_TINT_CLASSES.overview,
+		description: "Status, resources, and recent activity for this agent.",
+		tooltip: "Agent overview",
+		variants: ["connected", "hosted"],
+	},
+	console: {
+		id: "console",
+		label: "Agent Interface",
+		href: "console",
+		icon: MonitorPlay,
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		description: "Open this agent's browser interface.",
+		tooltip: "Open this agent's browser interface",
+		variants: ["hosted"],
+	},
+	terminal: {
+		id: "terminal",
+		label: "Terminal",
+		href: "terminal",
+		icon: TerminalSquare,
+		tint: "bg-identity-7-bg text-identity-7-fg",
+		description: "Open a terminal for this agent.",
+		tooltip: "Open a terminal for this agent",
+		variants: ["hosted"],
+	},
+	sessions: {
+		id: "sessions",
+		label: "Sessions",
+		href: "sessions",
+		icon: MessageSquare,
+		tint: RESOURCE_TINT_CLASSES.sessions,
+		description: "Conversation history from this agent.",
+		tooltip: "Sessions from this agent",
+		variants: ["connected", "hosted"],
+	},
+	skills: {
+		id: "skills",
+		label: "Skills",
+		href: "skills",
+		icon: Sparkles,
+		tint: RESOURCE_TINT_CLASSES.skills,
+		description: "Skills synced from this agent's filesystem.",
+		tooltip: "Skills synced from this agent's filesystem",
+		variants: ["connected", "hosted"],
+	},
+	projects: {
+		id: "projects",
+		label: "Projects",
+		href: "project-access",
+		icon: PROJECT_RESOURCE_ICONS.projects,
+		tint: RESOURCE_TINT_CLASSES.projects,
+		description: "Agent Project, added Projects, and read order.",
+		tooltip: "Projects available to this agent",
+		variants: ["connected"],
+	},
+	ai: {
+		id: "ai",
+		label: "AI & Model",
+		href: "model-provider",
+		icon: Zap,
+		tint: "bg-identity-2-bg text-identity-2-fg",
+		description: "Provider binding and primary model used by this agent.",
+		tooltip: "Configure this agent's provider binding and primary model",
+		variants: ["hosted"],
+	},
+	channels: {
+		id: "channels",
+		label: "Channels",
+		href: "channel-links",
+		icon: Link2,
+		tint: "bg-identity-5-bg text-identity-5-fg",
+		description: "Channels linked to this agent.",
+		tooltip: "Channels linked to this agent",
+		variants: ["hosted"],
+	},
+	settings: {
+		id: "settings",
+		label: "Settings",
+		href: "settings",
+		icon: Settings,
+		tint: "bg-identity-4-bg text-identity-4-fg",
+		description: "Name, preferences, and agent controls.",
+		tooltip: "Manage this agent",
+		variants: ["connected", "hosted"],
+	},
+};
+
+const AGENT_NAVIGATION_GROUPS = [
+	{ id: "primary", label: "Primary", itemIds: ["overview"] },
+	{ id: "runtime", label: "Runtime", itemIds: ["console", "terminal"] },
+	{ id: "activity", label: "Activity", itemIds: ["sessions"] },
+	{ id: "context", label: "Context", itemIds: ["skills", "projects"] },
+	{ id: "integrations", label: "Integrations", itemIds: ["ai", "channels"] },
+	{ id: "manage", label: "Manage", itemIds: ["settings"] },
+] as const satisfies readonly {
+	id: AgentNavigationGroupId;
+	label: string;
+	itemIds: readonly AgentSectionId[];
+}[];
+
+export function agentNavigationSectionIds(variant: AgentNavigationVariant): AgentSectionId[] {
+	return AGENT_NAVIGATION_GROUPS.flatMap((group) =>
+		group.itemIds.filter((id) => AGENT_SECTION_NAVIGATION_ITEMS[id].variants.includes(variant)),
+	);
+}
+
+export const CONNECTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
+	agentNavigationSectionIds("connected");
+export const HOSTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
+	agentNavigationSectionIds("hosted");
+
+export function agentNavigationGroups(
+	variant: AgentNavigationVariant,
+	visibleSectionIds?: readonly AgentSectionId[],
+): AgentNavigationGroup[] {
+	const visibleSections = visibleSectionIds ? new Set(visibleSectionIds) : null;
+	return AGENT_NAVIGATION_GROUPS.map((group) => ({
+		id: group.id,
+		label: group.label,
+		items: group.itemIds
+			.map((id) => AGENT_SECTION_NAVIGATION_ITEMS[id])
+			.filter(
+				(item) =>
+					item.variants.includes(variant) && (!visibleSections || visibleSections.has(item.id)),
+			),
+	})).filter((group) => group.items.length > 0);
+}

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -72,7 +72,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { vaultDetailSearch } from "@/components/vault/vault-detail-identity";
-import { agentSectionHref } from "@/lib/agent-routes";
+import { agentSectionHref, agentSectionLabel } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError, isApiNotFoundError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
@@ -91,6 +91,8 @@ type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type Member = components["schemas"]["MemberResponse"];
 type CountValue = number | "unavailable";
+
+const AGENT_PROJECTS_SECTION_LABEL = agentSectionLabel("projects");
 
 export default function ProjectDetailPage({ projectId }: { projectId: string }) {
 	const api = useApi();
@@ -944,8 +946,8 @@ function UseProjectWithAgentDialog({
 						<Bot className="size-4" />
 						<AlertTitle>No agents connected</AlertTitle>
 						<AlertDescription>
-							Add an agent from Overview first, then add this Project here or from the agent&apos;s
-							Project Access section.
+							Add an agent from Overview first, then add this Project here or from the agent&apos;s{" "}
+							{AGENT_PROJECTS_SECTION_LABEL} section.
 						</AlertDescription>
 					</Alert>
 				) : (
@@ -1014,8 +1016,8 @@ function UseProjectWithAgentDialog({
 									<div>
 										<div className="font-medium">This Is the Agent&apos;s Main Project</div>
 										<p className="mt-1 text-xs text-muted-foreground">
-											No extra step is needed. Open the agent&apos;s Project Access section to
-											review its read order.
+											No extra step is needed. Open the agent&apos;s {AGENT_PROJECTS_SECTION_LABEL}{" "}
+											section to review its read order.
 										</p>
 									</div>
 								</div>
@@ -1025,8 +1027,8 @@ function UseProjectWithAgentDialog({
 									<div>
 										<div className="font-medium">Already Added as Extra</div>
 										<p className="mt-1 text-xs text-muted-foreground">
-											Open the agent&apos;s Project Access section to review its read order or
-											remove it.
+											Open the agent&apos;s {AGENT_PROJECTS_SECTION_LABEL} section to review its
+											read order or remove it.
 										</p>
 									</div>
 								</div>

--- a/apps/web/src/pages/dashboard/projects/project-navigation-copy.test.ts
+++ b/apps/web/src/pages/dashboard/projects/project-navigation-copy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { agentSectionLabel } from "@/lib/agent-routes";
+
+const projectDetailSource = readFileSync(new URL("./[id]/page.tsx", import.meta.url), "utf8");
+
+describe("Project navigation instructions", () => {
+	test("derive every agent Projects reference from the canonical navigation label", () => {
+		expect(agentSectionLabel("projects")).toBe("Projects");
+		expect(projectDetailSource).toContain(
+			'const AGENT_PROJECTS_SECTION_LABEL = agentSectionLabel("projects");',
+		);
+		expect(projectDetailSource.match(/\{AGENT_PROJECTS_SECTION_LABEL\}/g)).toHaveLength(3);
+		expect(projectDetailSource).not.toContain("Project Access section");
+	});
+});


### PR DESCRIPTION
## Summary

- introduce one declarative navigation model for Console, connected agents, and hosted agents
- group account and agent navigation by semantic scope while preserving routes, gates, active states, fallbacks, mobile behavior, legacy links, and command palette behavior
- share canonical labels, icons, and descriptions between sidebars and agent page headers; rename agent Project Access to Projects and agent AI Providers to AI & Model
- add exact model tests plus rendered sidebar browser coverage

## Verification

- `bun run --cwd apps/web test src/lib/navigation-model.test.ts src/lib/agent-routes.test.ts src/components/dashboard/agent-skills-tab.test.ts` (Docker clean runner: 20 passed; typecheck and OSS build passed)
- `bun run --cwd apps/web test` (Docker clean runner: full Web suite, typecheck, and OSS build passed)
- `bunx biome check apps/web/src apps/web/e2e/sidebar-runtime-smoke.pw.ts` (passed)
- `bun run --cwd apps/web typecheck` (passed)
- `bun run --cwd apps/web e2e sidebar-runtime-smoke.pw.ts` (6 passed)

No production, deployment, live-cluster, or tenant-data operations were performed.