### PR TITLE
docs: trim generic agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,14 @@
 iCloud for AI Agents: CLI, FastAPI backend, TanStack dashboard, shared types,
 agent adapters, memory, vault, skills, channels, and sync.
 
-## Start Here
+Maintain agent-facing repository docs with
+[`docs/agent-docs-guide.md`](docs/agent-docs-guide.md).
 
-1. Keep code, comments, docs, file names, and identifiers in English.
-2. Keep OSS boundaries clean. Hosted infrastructure is owned outside this repo
-   by first-party hosted control planes; this repo must not contain hosted
-   service runbooks, private addresses, or internal deployment details.
-3. Maintain agent docs with [`docs/agent-docs-guide.md`](docs/agent-docs-guide.md).
-4. Prefer repo-local conventions over new abstractions.
+## OSS Boundary
+
+Hosted infrastructure is owned outside this repo by first-party hosted control
+planes. Do not add hosted service runbooks, private addresses, or internal
+deployment details here.
 
 ## Repository Map
 
@@ -173,6 +173,7 @@ host-local workspace loop. Done: command output reports passing tests/typechecks
 
 ## Owner Docs
 
+- Agent documentation: [`docs/agent-docs-guide.md`](docs/agent-docs-guide.md)
 - Backend: [`docs/backend-development.md`](docs/backend-development.md)
 - Frontend: [`docs/frontend-development.md`](docs/frontend-development.md)
 - CLI: [`docs/cli-development.md`](docs/cli-development.md)
@@ -199,20 +200,15 @@ host-local workspace loop. Done: command output reports passing tests/typechecks
 Done: compatibility changes include focused backend tests for canonical and
 legacy paths.
 
-## Package Managers
+## Toolchain
 
-- Use Bun for JavaScript/TypeScript; the repo declares `packageManager:
-  bun@1.3.14`.
-- Do not introduce Yarn/Corepack globally.
-- Use `uv` and PDM scripts for backend workflows.
+- JavaScript and TypeScript commands use the declared `bun@1.3.14` toolchain.
+- JavaScript and TypeScript formatting and linting use Biome.
+- Backend dependency management uses `uv`; operational commands use the PDM
+  scripts in `backend/pyproject.toml`.
+- Python formatting and linting use Ruff.
 
-## Conventions
+## Directory Ownership
 
-- Use Biome for JS/TS formatting and linting.
-- Use Ruff for Python linting and formatting.
 - Keep UI primitives under `apps/web/src/components/ui/`.
 - Keep shared public types under `packages/shared/src/types/`.
-- Store local MCP launch wrappers in `~/.agents/mcp`; Codex and Claude Code
-  registrations should point at those wrappers.
-- Do not store plaintext tokens or private keys in shell startup files,
-  dotfiles, or repo files.


### PR DESCRIPTION
## Summary

- trim generic agent preferences from `AGENTS.md`
- keep Clawdi architecture, ownership, toolchain, generated-contract, and compatibility guidance
- retain links to the project-specific agent documentation guide

## Verification

- `git diff --check origin/main..HEAD`
- verified the linked agent documentation guide exists