### PR TITLE
fix: align hosted agent resource surfaces

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1102,6 +1102,9 @@ function isStubResponse(value: unknown): value is StubResponse {
 
 type HostedApiStubOptions = {
 	aiProviders?: readonly unknown[];
+	agentProjectBindings?: readonly unknown[];
+	agentProjectBindingRequests?: string[];
+	agentProjects?: readonly unknown[];
 	agentResourceFixtures?: boolean;
 	agentOrderRequests?: string[];
 	autoReloadRequests?: string[];
@@ -1188,6 +1191,8 @@ type HostedApiStubOptions = {
 	runtimeUiRedemptionRequests?: string[];
 	runtimeUiRedemptionResponses?: StubResponse[];
 	runtimeUiResetRequests?: Array<{ idempotencyKey: string | null; ifMatch: string | null }>;
+	skillRequests?: string[];
+	skillsByProjectId?: Readonly<Record<string, readonly unknown[]>>;
 	resumeRequests?: string[];
 	subscriptionQuoteRequests?: string[];
 	subscriptionQuoteResponses?: unknown[];
@@ -1827,8 +1832,10 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			);
 		}
 		if (p.match(/^\/v1\/agents\/[^/]+\/project-bindings$/) && r.request().method() === "GET") {
-			if (!options.agentResourceFixtures) return fulfillJson(r, []);
 			const agentId = decodeURIComponent(p.split("/")[3] ?? "");
+			options.agentProjectBindingRequests?.push(r.request().url());
+			if (options.agentProjectBindings) return fulfillJson(r, options.agentProjectBindings);
+			if (!options.agentResourceFixtures) return fulfillJson(r, []);
 			return fulfillJson(r, [
 				{
 					id: `binding-${agentId}`,
@@ -2055,6 +2062,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, { items: [] });
 		}
 		if (p === "/v1/projects") {
+			if (options.agentProjects) return fulfillJson(r, options.agentProjects);
 			if (!options.agentResourceFixtures) return fulfillJson(r, []);
 			return fulfillJson(r, [
 				{
@@ -2070,6 +2078,20 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					owner_handle: "hosted-user",
 				},
 			]);
+		}
+		if (p === "/v1/skills") {
+			options.skillRequests?.push(r.request().url());
+			const projectId = url.searchParams.get("project_id") ?? "";
+			const page = Number(url.searchParams.get("page") ?? "1");
+			const pageSize = Number(url.searchParams.get("page_size") ?? "25");
+			const projectSkills = options.skillsByProjectId?.[projectId] ?? [];
+			const start = (page - 1) * pageSize;
+			return fulfillJson(r, {
+				items: projectSkills.slice(start, start + pageSize),
+				total: projectSkills.length,
+				page,
+				page_size: pageSize,
+			});
 		}
 		if (p === "/v1/vault") {
 			if (!options.agentResourceFixtures) {
@@ -2796,22 +2818,90 @@ test("agent cards stay action-free and brand marks fill their tiles", async ({
 	});
 });
 
-test("hosted Skills hide private platform resources", async ({ page }) => {
+test("hosted Skills do not resolve Project scope before the agent projection", async ({ page }) => {
+	const agentProjectBindingRequests: string[] = [];
+	const skillRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		cloudAgentNotFoundIds: [missingProjectionEnvironmentId],
+		agentProjectBindingRequests,
+		skillRequests,
+	});
+
+	await page.goto(
+		`/agents/${missingProjectionEnvironmentId}/skills?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await expect(page.locator("main").getByText("Skills unavailable", { exact: true })).toBeVisible();
+	expect(agentProjectBindingRequests).toEqual([]);
+	expect(skillRequests).toEqual([]);
+});
+
+test("hosted Hermes Skills include context Projects without exposing runtime infrastructure", async ({
+	page,
+}) => {
+	const skillRequests: string[] = [];
+	const contextProjectId = "project-hermes-context";
 	await stubHostedApi(page, {
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
-	});
-	await page.route(`${CLOUD_API}/v1/skills**`, (route) =>
-		fulfillJson(route, {
-			items: [
+		agentProjectBindings: [
+			{
+				id: "binding-hermes-context",
+				agent_id: railHostedEnvironmentId,
+				project_id: contextProjectId,
+				binding_type: "context",
+				priority: 1,
+				default_write_enabled: false,
+				created_at: "2026-07-15T00:01:00Z",
+			},
+			{
+				id: "binding-hermes-primary",
+				agent_id: railHostedEnvironmentId,
+				project_id: "project-hosted",
+				binding_type: "primary",
+				priority: 0,
+				default_write_enabled: true,
+				created_at: "2026-07-15T00:00:00Z",
+			},
+		],
+		agentProjects: [
+			{
+				id: "project-hosted",
+				name: "Rail Cloud Agent Project",
+				slug: "rail-cloud-agent-project",
+				kind: "environment",
+				origin_environment_id: railHostedEnvironmentId,
+				archived_at: null,
+				created_at: "2026-07-15T00:00:00Z",
+				is_owner: true,
+				owner_display: "Hosted User",
+				owner_handle: "hosted-user",
+			},
+			{
+				id: contextProjectId,
+				name: "Hermes Shared Skills",
+				slug: "hermes-shared-skills",
+				kind: "workspace",
+				origin_environment_id: null,
+				archived_at: null,
+				created_at: "2026-07-15T00:00:00Z",
+				is_owner: false,
+				owner_display: "Platform Team",
+				owner_handle: "platform-team",
+			},
+		],
+		skillRequests,
+		skillsByProjectId: {
+			"project-hosted": [],
+			[contextProjectId]: [
 				{
-					id: "skill-filesystem-docs",
-					skill_key: "filesystem-docs",
-					name: "Filesystem docs",
-					description: "Projected from the Agent filesystem",
+					id: "skill-context-workflow",
+					skill_key: "context-workflow",
+					name: "Context workflow",
+					description: "Available through an added Project",
 					version: 3,
-					source: "agent_sync",
-					authority: "agent_sync",
+					source: "cloud",
+					authority: "cloud",
 					source_repo: null,
 					agent_types: ["hermes"],
 					file_count: 2,
@@ -2819,18 +2909,13 @@ test("hosted Skills hide private platform resources", async ({ page }) => {
 					is_active: true,
 					created_at: "2026-07-15T00:00:00Z",
 					updated_at: "2026-07-15T00:00:00Z",
-					project_id: "project-hosted",
-					project_name: "Rail Cloud Agent Project",
-					project_kind: "environment",
-					machine_name: "rail-cloud.local",
-					environment_id: railHostedEnvironmentId,
+					project_id: contextProjectId,
+					project_name: "Hermes Shared Skills",
+					project_kind: "workspace",
 				},
 			],
-			total: 1,
-			page: 1,
-			page_size: 200,
-		}),
-	);
+		},
+	});
 	await page.route(`${CLOUD_API}/v1/agents/${railHostedEnvironmentId}/runtime-observed`, (route) =>
 		fulfillJson(route, {
 			environment: { ...railHostedCloudAgent, hosted_managed: true },
@@ -2854,10 +2939,57 @@ test("hosted Skills hide private platform resources", async ({ page }) => {
 	const main = page.locator("main");
 	await expect(main.getByText("Clawdi", { exact: true })).toHaveCount(0);
 	await expect(main.getByText("Manifest", { exact: true })).toHaveCount(0);
-	await expect(main.getByText("Filesystem docs", { exact: true })).toBeVisible();
-	await expect(main.getByText("Agent synced · Read-only", { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: /Send Filesystem docs/ })).toHaveCount(0);
+	await expect(main.getByText("Context workflow", { exact: true })).toBeVisible();
+	await expect(main.getByText("Hermes Shared Skills", { exact: true })).toBeVisible();
+	await expect(main.getByText("Shared · Read-only", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: /Send Context workflow/ })).toHaveCount(0);
 	await expect(page.getByRole("link", { name: "MCP", exact: true })).toHaveCount(0);
+	await expect.poll(() => skillRequests.length).toBe(2);
+	const requestedProjects = skillRequests.map((request) => {
+		const url = new URL(request);
+		expect(url.searchParams.get("page")).toBe("1");
+		expect(url.searchParams.get("page_size")).toBe("200");
+		return url.searchParams.get("project_id");
+	});
+	expect(requestedProjects).toEqual(["project-hosted", contextProjectId]);
+});
+
+test("hosted Skills empty state stays neutral and excludes infrastructure summaries", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentProjectBindings: [
+			{
+				id: "binding-hermes-primary-empty",
+				agent_id: railHostedEnvironmentId,
+				project_id: "project-hosted",
+				binding_type: "primary",
+				priority: 0,
+				default_write_enabled: true,
+				created_at: "2026-07-15T00:00:00Z",
+			},
+		],
+		skillsByProjectId: { "project-hosted": [] },
+	});
+	await page.route(`${CLOUD_API}/v1/agents/${railHostedEnvironmentId}/runtime-observed`, (route) =>
+		fulfillJson(route, {
+			desired: { managed_skills: [{ id: "clawdi", enabled: true, version: 1 }] },
+			observed: null,
+		}),
+	);
+
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}/skills?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+	const main = page.locator("main");
+	await expect(
+		main.getByText("No user-visible Skills are available through this agent's Projects yet.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(main.getByText("Clawdi", { exact: true })).toHaveCount(0);
 });
 
 test("transient inventory withholds connected tiles until membership resolves", async ({
@@ -5213,6 +5345,44 @@ test("deployment detail stays put, becomes running, and keeps manual Runtime UI 
 	await expect(
 		main.getByRole("button", { name: "Open Hermes Dashboard in new window" }),
 	).toBeVisible();
+});
+
+test("hosted Agent Interface and Terminal fill the available main width on desktop and mobile", async ({
+	page,
+}) => {
+	await stubHostedApi(page, { deployments: [runningMissingProjectionDeployment] });
+	const query = `?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`;
+	const liveSections = ["console", "terminal"] as const;
+
+	for (const viewport of [
+		{ width: 2000, height: 1000, minimumSurfaceWidth: 1281 },
+		{ width: 390, height: 844, minimumSurfaceWidth: 380 },
+	]) {
+		await page.setViewportSize(viewport);
+		for (const section of liveSections) {
+			await page.goto(`/agents/${missingProjectionEnvironmentId}/${section}${query}`);
+			const surface = page.getByTestId("hosted-agent-live-surface");
+			await expect(surface).toBeVisible();
+			const geometry = await surface.evaluate((element) => {
+				const surfaceRect = element.getBoundingClientRect();
+				const parentRect = element.parentElement?.getBoundingClientRect();
+				return {
+					left: surfaceRect.left,
+					right: surfaceRect.right,
+					width: surfaceRect.width,
+					parentLeft: parentRect?.left ?? -1,
+					parentWidth: parentRect?.width ?? -1,
+				};
+			});
+			expect(geometry.width, `${section} width at ${viewport.width}px`).toBeGreaterThanOrEqual(
+				viewport.minimumSurfaceWidth,
+			);
+			expect(geometry.width).toBeCloseTo(geometry.parentWidth, 0);
+			expect(geometry.left).toBeCloseTo(geometry.parentLeft, 0);
+			expect(geometry.left).toBeGreaterThanOrEqual(0);
+			expect(geometry.right).toBeLessThanOrEqual(viewport.width + 1);
+		}
+	}
 });
 
 test("Runtime UI Access shows Hermes username, masks password, and submits one declarative reset", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -163,18 +163,28 @@ const sessions = {
 	page_size: 25,
 };
 
-async function fulfillJson(route: Route, body: unknown) {
+async function fulfillJson(route: Route, body: unknown, status = 200) {
 	await route.fulfill({
-		status: 200,
+		status,
 		contentType: "application/json",
 		body: JSON.stringify(body),
 	});
 }
 
+type DashboardApiStubOptions = {
+	projectBindings?: readonly unknown[];
+	projectBindingsError?: { status: number; detail: string };
+	projectBindingsGate?: Promise<void>;
+	projects?: readonly unknown[];
+	skillRequests?: string[];
+	skillsByProjectId?: Readonly<Record<string, readonly unknown[]>>;
+	vaultRequests?: string[];
+};
+
 async function stubDashboardApi(
 	page: Page,
 	agentOrderRequests: string[] = [],
-	options: { projectBindingsGate?: Promise<void>; vaultRequests?: string[] } = {},
+	options: DashboardApiStubOptions = {},
 ) {
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
@@ -203,7 +213,15 @@ async function stubDashboardApi(
 		}
 		if (url.pathname === "/v1/agents/agent-smoke-1/project-bindings") {
 			await options.projectBindingsGate;
-			await fulfillJson(route, projectBindings);
+			if (options.projectBindingsError) {
+				await fulfillJson(
+					route,
+					{ detail: options.projectBindingsError.detail },
+					options.projectBindingsError.status,
+				);
+				return;
+			}
+			await fulfillJson(route, options.projectBindings ?? projectBindings);
 			return;
 		}
 		if (url.pathname === "/v1/dashboard/stats") {
@@ -211,7 +229,22 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/projects") {
-			await fulfillJson(route, projects);
+			await fulfillJson(route, options.projects ?? projects);
+			return;
+		}
+		if (url.pathname === "/v1/skills") {
+			options.skillRequests?.push(route.request().url());
+			const projectId = url.searchParams.get("project_id") ?? "";
+			const pageNumber = Number(url.searchParams.get("page") ?? "1");
+			const pageSize = Number(url.searchParams.get("page_size") ?? "25");
+			const projectSkills = options.skillsByProjectId?.[projectId] ?? [];
+			const start = (pageNumber - 1) * pageSize;
+			await fulfillJson(route, {
+				items: projectSkills.slice(start, start + pageSize),
+				total: projectSkills.length,
+				page: pageNumber,
+				page_size: pageSize,
+			});
 			return;
 		}
 		if (url.pathname === "/v1/vault") {
@@ -362,7 +395,61 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	page,
 }) => {
 	const vaultRequests: string[] = [];
-	await stubDashboardApi(page, [], { vaultRequests });
+	const projectAccessBindings = [
+		{
+			...projectBindings[0],
+		},
+		{
+			id: "binding-context-later",
+			agent_id: "agent-smoke-1",
+			project_id: "project-context-later",
+			binding_type: "context",
+			priority: 2,
+			default_write_enabled: false,
+			created_at: "2026-07-04T12:02:00.000Z",
+		},
+		{
+			id: "binding-context-first",
+			agent_id: "agent-smoke-1",
+			project_id: "project-context-first",
+			binding_type: "context",
+			priority: 1,
+			default_write_enabled: false,
+			created_at: "2026-07-04T12:01:00.000Z",
+		},
+	];
+	const projectAccessProjects = [
+		...projects,
+		{
+			id: "project-context-first",
+			name: "Team Knowledge",
+			slug: "team-knowledge",
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: now.toISOString(),
+			is_owner: false,
+			owner_display: "Teammate",
+			owner_handle: "teammate",
+		},
+		{
+			id: "project-context-later",
+			name: "Automation Library",
+			slug: "automation-library",
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: now.toISOString(),
+			is_owner: true,
+			owner_display: "Dev User",
+			owner_handle: "dev-user",
+		},
+	];
+	await stubDashboardApi(page, [], {
+		projectBindings: projectAccessBindings,
+		projects: projectAccessProjects,
+		vaultRequests,
+	});
 
 	await page.goto("/agents/agent-smoke-1/connectors?q=gmail&page=2");
 	const main = page.locator("main");
@@ -375,9 +462,34 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await expect(page).toHaveURL(/\/agents\/agent-smoke-1\/connectors\?q=gmail&page=2/);
 
 	await page.goto("/agents/agent-smoke-1/project-access");
-	await expect(main.getByRole("heading", { name: "Projects", level: 1 })).toBeVisible();
-	await expect(main.getByRole("heading", { name: "Agent Project", level: 2 })).toBeVisible();
-	await expect(main.getByText("Smoke Project", { exact: true })).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Projects", level: 1 })).toBeVisible({
+		timeout: 15_000,
+	});
+	const projectStack = main.getByTestId("agent-project-stack");
+	const projectRows = projectStack.locator('ol[aria-label="Effective Project read order"] > li');
+	await expect(projectRows).toHaveCount(3);
+	await expect(projectRows.nth(0)).toContainText("Smoke Project");
+	await expect(projectRows.nth(0)).toContainText("Fixed");
+	await expect(projectRows.nth(0)).toContainText("Default writes · Reads Skills and Vaults");
+	await expect(projectRows.nth(0).getByRole("button")).toHaveCount(0);
+	await expect(projectRows.nth(1)).toContainText("Team Knowledge");
+	await expect(projectRows.nth(1)).toContainText("Viewer");
+	await expect(projectRows.nth(1)).toContainText("Read access · Skills and Vaults");
+	await expect(projectRows.nth(2)).toContainText("Automation Library");
+	await expect(
+		projectRows.nth(1).getByRole("button", { name: "Move Team Knowledge up" }),
+	).toBeDisabled();
+	await expect(
+		projectRows.nth(1).getByRole("button", { name: "Remove Team Knowledge" }),
+	).toBeVisible();
+	await expect(projectStack.getByTestId("agent-project-add")).toBeVisible();
+	await expect(projectStack.getByLabel("Add a Project")).toBeVisible();
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(projectRows.nth(2)).toBeVisible();
+	expect(
+		await projectStack.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
 
 	await page.goto("/agents/agent-smoke-1/vaults");
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();
@@ -421,6 +533,45 @@ test("agent Vaults wait for effective Project bindings before requesting invento
 	const vaultRequest = vaultRequests[0];
 	if (!vaultRequest) throw new Error("Agent Vault inventory was not requested after bindings");
 	expect(new URL(vaultRequest).searchParams.get("project_id")).toBe("project-smoke");
+});
+
+test("agent Skills wait for effective Project bindings and fail closed on binding errors", async ({
+	page,
+}) => {
+	let releaseBindings: (() => void) | undefined;
+	const projectBindingsGate = new Promise<void>((resolve) => {
+		releaseBindings = resolve;
+	});
+	const skillRequests: string[] = [];
+	await stubDashboardApi(page, [], { projectBindingsGate, skillRequests });
+
+	await page.goto("/agents/agent-smoke-1/skills");
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
+	await expect(main.getByTestId("agent-skills-inventory")).toBeVisible();
+	expect(skillRequests).toEqual([]);
+	if (!releaseBindings) throw new Error("Project binding gate was not initialized");
+	releaseBindings();
+	await expect(
+		main.getByText("No Skills are available through this agent's Projects yet.", { exact: true }),
+	).toBeVisible();
+	expect(skillRequests).toHaveLength(1);
+
+	const errorPage = await page.context().newPage();
+	const errorSkillRequests: string[] = [];
+	try {
+		await stubDashboardApi(errorPage, [], {
+			projectBindingsError: { status: 503, detail: "bindings unavailable" },
+			skillRequests: errorSkillRequests,
+		});
+		await errorPage.goto("/agents/agent-smoke-1/skills");
+		await expect(
+			errorPage.locator("main").getByText("Couldn't load agent Skills", { exact: true }),
+		).toBeVisible({ timeout: 15_000 });
+		expect(errorSkillRequests).toEqual([]);
+	} finally {
+		await errorPage.close();
+	}
 });
 
 test("every agent rail tile button navigates on click", async ({ page }) => {

--- a/apps/web/src/components/dashboard/agent-project-bindings-query.ts
+++ b/apps/web/src/components/dashboard/agent-project-bindings-query.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { AgentProjectBinding } from "@/components/dashboard/agent-project-scope";
+import { unwrap, useApi } from "@/lib/api";
+
+export function agentProjectBindingsQueryKey(agentId: string | null | undefined) {
+	return ["agent-project-bindings", agentId ?? ""] as const;
+}
+
+export function useAgentProjectBindings(
+	agentId: string | null | undefined,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	const api = useApi();
+	return useQuery({
+		queryKey: agentProjectBindingsQueryKey(agentId),
+		queryFn: async (): Promise<AgentProjectBinding[]> => {
+			if (!agentId) throw new Error("Agent identity is not resolved");
+			return unwrap(
+				await api.GET("/v1/agents/{agent_id}/project-bindings", {
+					params: { path: { agent_id: agentId } },
+				}),
+			);
+		},
+		enabled: enabled && Boolean(agentId),
+	});
+}

--- a/apps/web/src/components/dashboard/agent-project-scope.test.ts
+++ b/apps/web/src/components/dashboard/agent-project-scope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import type { components } from "@/lib/api-schemas";
+import {
+	effectiveAgentProjectIds,
+	orderedAgentProjectBindings,
+	resolveAgentProjectScope,
+} from "./agent-project-scope";
+
+type Binding = components["schemas"]["AgentProjectBindingResponse"];
+
+function binding(
+	id: string,
+	projectId: string,
+	bindingType: "primary" | "context",
+	priority: number,
+): Binding {
+	return {
+		id,
+		agent_id: "agent_1",
+		project_id: projectId,
+		binding_type: bindingType,
+		priority,
+		default_write_enabled: bindingType === "primary",
+		created_at: `2026-08-01T00:00:0${priority}Z`,
+	};
+}
+
+describe("effective Agent Project scope", () => {
+	test("orders the fixed primary before context bindings in priority order", () => {
+		const bindings = [
+			binding("context-2", "project_context_2", "context", 2),
+			binding("primary", "project_primary", "primary", 0),
+			binding("context-1", "project_context_1", "context", 1),
+		];
+
+		expect(orderedAgentProjectBindings(bindings).map((item) => item.id)).toEqual([
+			"primary",
+			"context-1",
+			"context-2",
+		]);
+		expect(effectiveAgentProjectIds(bindings)).toEqual([
+			"project_primary",
+			"project_context_1",
+			"project_context_2",
+		]);
+	});
+
+	test("uses AgentResponse.default_project_id only as a consistency fence", () => {
+		const bindings = [
+			binding("primary", "project_primary", "primary", 0),
+			binding("context", "project_context", "context", 1),
+		];
+
+		expect(resolveAgentProjectScope(bindings, "project_primary").projectIds).toEqual([
+			"project_primary",
+			"project_context",
+		]);
+		expect(() => resolveAgentProjectScope(bindings, "project_stale")).toThrow(
+			"Agent Project is still syncing",
+		);
+		expect(() => resolveAgentProjectScope([], "project_primary")).toThrow(
+			"Agent Project is not available",
+		);
+		expect(() =>
+			resolveAgentProjectScope(
+				[binding("context", "project_primary", "context", 1)],
+				"project_primary",
+			),
+		).toThrow("Agent Project is not available");
+		expect(() =>
+			resolveAgentProjectScope(
+				[
+					binding("primary-1", "project_primary", "primary", 0),
+					binding("primary-2", "project_other", "primary", 0),
+				],
+				"project_primary",
+			),
+		).toThrow("Agent Project is not available");
+	});
+});

--- a/apps/web/src/components/dashboard/agent-project-scope.ts
+++ b/apps/web/src/components/dashboard/agent-project-scope.ts
@@ -1,0 +1,54 @@
+import type { components } from "@/lib/api-schemas";
+
+export type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
+
+/** Primary first, followed by context Projects in the agent's effective read order. */
+export function orderedAgentProjectBindings(
+	bindings: readonly AgentProjectBinding[],
+): AgentProjectBinding[] {
+	return [
+		...bindings.filter((binding) => binding.binding_type === "primary"),
+		...bindings
+			.filter((binding) => binding.binding_type === "context")
+			.sort(
+				(left, right) =>
+					left.priority - right.priority ||
+					left.created_at.localeCompare(right.created_at) ||
+					left.id.localeCompare(right.id),
+			),
+	];
+}
+
+export function effectiveAgentProjectIds(bindings: readonly AgentProjectBinding[]): string[] {
+	return Array.from(
+		new Set(orderedAgentProjectBindings(bindings).map((binding) => binding.project_id)),
+	);
+}
+
+/**
+ * Bindings are the effective-access authority. AgentResponse.default_project_id
+ * is only a consistency fence: when present it must match the single primary
+ * binding and never expands scope when bindings are missing or stale.
+ */
+export function resolveAgentProjectScope(
+	bindings: readonly AgentProjectBinding[],
+	expectedPrimaryProjectId?: string | null,
+): { bindings: AgentProjectBinding[]; projectIds: string[] } {
+	const primaryBindings = bindings.filter((binding) => binding.binding_type === "primary");
+	if (primaryBindings.length !== 1) {
+		throw new Error("The Agent Project is not available yet. Refresh and try again.");
+	}
+	const primary = primaryBindings[0];
+	if (!primary) {
+		throw new Error("The Agent Project is not available yet. Refresh and try again.");
+	}
+	if (expectedPrimaryProjectId && primary.project_id !== expectedPrimaryProjectId) {
+		throw new Error("The Agent Project is still syncing. Refresh and try again.");
+	}
+
+	const orderedBindings = orderedAgentProjectBindings(bindings);
+	return {
+		bindings: orderedBindings,
+		projectIds: Array.from(new Set(orderedBindings.map((binding) => binding.project_id))),
+	};
+}

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, Home, Layers, Plus, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { DetailPanel } from "@/components/detail/layout";
+import {
+	agentProjectBindingsQueryKey,
+	useAgentProjectBindings,
+} from "@/components/dashboard/agent-project-bindings-query";
+import {
+	type AgentProjectBinding,
+	orderedAgentProjectBindings,
+} from "@/components/dashboard/agent-project-scope";
 import { EmptyState } from "@/components/empty-state";
 import {
 	isCustomProject,
@@ -21,26 +28,6 @@ import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
-export type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
-
-export function useAgentProjectBindings(
-	agentId: string | null | undefined,
-	{ enabled = true }: { enabled?: boolean } = {},
-) {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["agent-project-bindings", agentId ?? ""],
-		queryFn: async (): Promise<AgentProjectBinding[]> => {
-			if (!agentId) throw new Error("Agent identity is not resolved");
-			return unwrap(
-				await api.GET("/v1/agents/{agent_id}/project-bindings", {
-					params: { path: { agent_id: agentId } },
-				}),
-			);
-		},
-		enabled: enabled && Boolean(agentId),
-	});
-}
 
 export function AgentProjectsTab({
 	agentId,
@@ -63,7 +50,7 @@ export function AgentProjectsTab({
 			agentId={agentId}
 			bindings={bindings.data ?? []}
 			projects={projects.data ?? []}
-			isLoading={bindings.isLoading}
+			isLoading={bindings.isLoading || projects.isLoading}
 			bindingsError={bindings.error}
 			onRetryBindings={() => {
 				void bindings.refetch();
@@ -73,7 +60,7 @@ export function AgentProjectsTab({
 				void projects.refetch();
 			}}
 			onChanged={() => {
-				void queryClient.invalidateQueries({ queryKey: ["agent-project-bindings", agentId] });
+				void queryClient.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) });
 				void queryClient.invalidateQueries({ queryKey: ["projects"] });
 			}}
 		/>
@@ -103,10 +90,10 @@ function AgentProjectsPanel({
 }) {
 	const api = useApi();
 	const [contextProjectId, setContextProjectId] = useState("");
-	const primary = bindings.find((binding) => binding.binding_type === "primary") ?? null;
-	const contexts = bindings
-		.filter((binding) => binding.binding_type === "context")
-		.sort((a, b) => a.priority - b.priority);
+	const orderedBindings = orderedAgentProjectBindings(bindings);
+	const primary = orderedBindings.find((binding) => binding.binding_type === "primary") ?? null;
+	const contexts = orderedBindings.filter((binding) => binding.binding_type === "context");
+	const effectiveBindings = primary ? [primary, ...contexts] : [];
 	const projectsById = useMemo(
 		() => new Map(projects.map((project) => [project.id, project])),
 		[projects],
@@ -175,7 +162,14 @@ function AgentProjectsPanel({
 		reorder.mutate(next.map((binding, idx) => ({ binding_id: binding.id, priority: idx + 1 })));
 	};
 
-	if (isLoading) return <Skeleton className="h-40 w-full" />;
+	if (isLoading) {
+		return (
+			<div className="space-y-3" data-testid="agent-projects-loading">
+				<Skeleton className="h-4 w-96 max-w-full" />
+				<Skeleton className="h-52 w-full rounded-lg" />
+			</div>
+		);
+	}
 
 	if (bindingsError) {
 		return (
@@ -198,155 +192,124 @@ function AgentProjectsPanel({
 	}
 
 	return (
-		<div className="space-y-4">
-			<DetailPanel>
-				<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:items-start">
-					<div className="space-y-3">
-						<div className="flex items-center gap-2">
-							<Home className="size-4 text-muted-foreground" />
-							<h2 className="text-sm font-semibold">Agent Project</h2>
-						</div>
-						<p className="text-xs text-muted-foreground">
-							This Project is created with the agent and is always its writable default. It cannot
-							be replaced, shared, or removed from here.
-						</p>
-						{primary ? (
-							<ProjectUseLine binding={primary} project={projectsById.get(primary.project_id)} />
-						) : (
-							<EmptyState variant="inset" description="Agent Project is not loaded yet." />
-						)}
-					</div>
-					<div className="rounded-md border bg-background/60 p-3 text-xs text-muted-foreground">
-						Create Projects to share resources with teammates and across agents. This agent&apos;s
-						main Project stays private to this agent; other agents cannot see it.
-					</div>
-				</div>
-			</DetailPanel>
+		<div className="space-y-4" data-testid="agent-project-stack">
+			<section className="overflow-hidden rounded-lg border bg-card/60">
+				{effectiveBindings.length === 0 ? (
+					<EmptyState
+						variant="inset"
+						className="rounded-none border-0"
+						description="The Agent Project is not available yet."
+					/>
+				) : (
+					<ol className="divide-y" aria-label="Effective Project read order">
+						{effectiveBindings.map((binding, position) => {
+							const project = projectsById.get(binding.project_id);
+							const projectName = project?.name || binding.project_id;
+							const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
+							const contextIndex = binding.binding_type === "context" ? position - 1 : -1;
+							return (
+								<li
+									key={binding.id}
+									className="grid gap-3 px-3 py-3 sm:px-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+									data-binding-type={binding.binding_type}
+								>
+									<div className="flex min-w-0 items-start gap-3">
+										<div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-background text-xs font-semibold tabular-nums">
+											<span className="sr-only">Position </span>
+											{position + 1}
+										</div>
+										<ProjectUseLine binding={binding} project={project} />
+									</div>
+									{binding.binding_type === "context" ? (
+										<div className="flex items-center justify-end gap-1">
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												disabled={contextIndex === 0 || reorder.isPending}
+												onClick={() => moveContext(binding.id, -1)}
+												title="Move up"
+												aria-label={`Move ${projectName} up`}
+											>
+												<ArrowUp className="size-3.5" />
+											</Button>
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												disabled={contextIndex === contexts.length - 1 || reorder.isPending}
+												onClick={() => moveContext(binding.id, 1)}
+												title="Move down"
+												aria-label={`Move ${projectName} down`}
+											>
+												<ArrowDown className="size-3.5" />
+											</Button>
+											<ConfirmAction
+												title="Remove this Project?"
+												description={
+													<>
+														<p>{projectName} will no longer be available to this agent.</p>
+														<p>The Project and its resources are not deleted.</p>
+													</>
+												}
+												confirmLabel="Remove Project"
+												destructive
+												onConfirm={() => removeBinding.mutate(binding.id)}
+											>
+												<Button
+													variant="ghost"
+													size="icon-sm"
+													disabled={isRemoving}
+													title="Remove"
+													aria-label={`Remove ${projectName}`}
+												>
+													{isRemoving ? (
+														<Spinner className="size-3.5" />
+													) : (
+														<Trash2 className="size-3.5 text-destructive" />
+													)}
+												</Button>
+											</ConfirmAction>
+										</div>
+									) : null}
+								</li>
+							);
+						})}
+					</ol>
+				)}
 
-			<DetailPanel>
-				<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:items-start">
+				<div
+					className="grid gap-3 border-t bg-background/40 p-3 sm:p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end"
+					data-testid="agent-project-add"
+				>
 					<div className="space-y-2">
-						<div className="flex items-center gap-2">
-							<Layers className="size-4 text-muted-foreground" />
-							<h2 className="text-sm font-semibold">Added Projects</h2>
-						</div>
-						<p className="text-xs text-muted-foreground">
-							Added Projects are read after the Agent Project. Use the list below to adjust read
-							order after adding one.
-						</p>
-					</div>
-					<div className="grid gap-3">
 						<ProjectScopePicker
 							projects={contextChoices}
 							value={contextProjectId}
 							onValueChange={setContextProjectId}
-							label="Project to Add"
-							placeholder="Choose a Project…"
+							label="Add a Project"
+							placeholder="Choose a Custom or shared Project…"
 							layout="stacked"
-							disabled={contextChoices.length === 0}
+							disabled={!primary || contextChoices.length === 0}
 						/>
 						{contextChoices.length === 0 ? (
 							<p className="text-xs text-muted-foreground">
 								No Custom or shared Projects are available to add.
 							</p>
 						) : null}
-						<Button
-							size="sm"
-							disabled={!contextProjectId || addContext.isPending}
-							variant={contextProjectId ? "default" : "outline"}
-							onClick={() => addContext.mutate()}
-						>
-							{addContext.isPending ? (
-								<Spinner className="size-3.5" />
-							) : (
-								<Plus className="size-3.5" />
-							)}
-							Add Project
-						</Button>
 					</div>
+					<Button
+						size="sm"
+						disabled={!primary || !contextProjectId || addContext.isPending}
+						variant={contextProjectId ? "default" : "outline"}
+						onClick={() => addContext.mutate()}
+					>
+						{addContext.isPending ? (
+							<Spinner className="size-3.5" />
+						) : (
+							<Plus className="size-3.5" />
+						)}
+						Add Project
+					</Button>
 				</div>
-			</DetailPanel>
-
-			<section className="space-y-2">
-				<div className="flex items-center justify-between gap-2">
-					<h2 className="text-sm font-semibold">Added Project Order</h2>
-					<Badge variant="secondary">{contexts.length}</Badge>
-				</div>
-				{contexts.length === 0 ? (
-					<EmptyState
-						variant="inset"
-						description="No added Projects yet. Add a Custom or shared Project to make it available to this agent."
-					/>
-				) : (
-					<div className="divide-y rounded-lg border bg-card/60">
-						{contexts.map((binding, index) => {
-							const project = projectsById.get(binding.project_id);
-							const projectName = project?.name || binding.project_id;
-							const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
-							return (
-								<div
-									key={binding.id}
-									className="grid gap-3 px-3 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
-								>
-									<div className="flex min-w-0 items-start gap-3">
-										<div className="flex size-7 shrink-0 items-center justify-center rounded-md border bg-background text-xs font-medium">
-											{index + 1}
-										</div>
-										<ProjectUseLine binding={binding} project={project} />
-									</div>
-									<div className="flex items-center justify-end gap-1">
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											disabled={index === 0 || reorder.isPending}
-											onClick={() => moveContext(binding.id, -1)}
-											title="Move up"
-											aria-label="Move project up"
-										>
-											<ArrowUp className="size-3.5" />
-										</Button>
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											disabled={index === contexts.length - 1 || reorder.isPending}
-											onClick={() => moveContext(binding.id, 1)}
-											title="Move down"
-											aria-label="Move project down"
-										>
-											<ArrowDown className="size-3.5" />
-										</Button>
-										<ConfirmAction
-											title="Remove this Project?"
-											description={
-												<>
-													<p>{projectName} will no longer be available to this agent.</p>
-													<p>The Project and its resources are not deleted.</p>
-												</>
-											}
-											confirmLabel="Remove Project"
-											destructive
-											onConfirm={() => removeBinding.mutate(binding.id)}
-										>
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												disabled={isRemoving}
-												title="Remove"
-												aria-label={`Remove ${projectName}`}
-											>
-												{isRemoving ? (
-													<Spinner className="size-3.5" />
-												) : (
-													<Trash2 className="size-3.5 text-destructive" />
-												)}
-											</Button>
-										</ConfirmAction>
-									</div>
-								</div>
-							);
-						})}
-					</div>
-				)}
 			</section>
 		</div>
 	);
@@ -359,7 +322,11 @@ function ProjectUseLine({
 	binding: AgentProjectBinding;
 	project: ProjectRow | undefined;
 }) {
-	const bindingLabel = binding.binding_type === "primary" ? "Agent Project" : "Added";
+	const bindingLabel = binding.binding_type === "primary" ? "Primary" : "Added";
+	const resourceAccess =
+		binding.binding_type === "primary"
+			? "Default writes · Reads Skills and Vaults"
+			: "Read access · Skills and Vaults";
 	if (!project) {
 		return (
 			<div className="min-w-0">
@@ -368,10 +335,9 @@ function ProjectUseLine({
 					<Badge variant={binding.binding_type === "primary" ? "secondary" : "outline"}>
 						{bindingLabel}
 					</Badge>
+					<Badge variant="outline">Access unavailable</Badge>
 				</div>
-				{binding.binding_type === "context" ? (
-					<div className="mt-1 text-xs text-muted-foreground">Read order {binding.priority}</div>
-				) : null}
+				<div className="mt-1 text-xs text-muted-foreground">{resourceAccess}</div>
 			</div>
 		);
 	}
@@ -379,17 +345,16 @@ function ProjectUseLine({
 		<div className="min-w-0">
 			<ProjectIdentity
 				project={project}
-				showKind={false}
-				showAccess={false}
 				badges={
-					<Badge variant={binding.binding_type === "primary" ? "secondary" : "outline"}>
-						{bindingLabel}
-					</Badge>
+					<>
+						<Badge variant={binding.binding_type === "primary" ? "secondary" : "outline"}>
+							{bindingLabel}
+						</Badge>
+						{binding.binding_type === "primary" ? <Badge variant="outline">Fixed</Badge> : null}
+					</>
 				}
 			/>
-			{binding.binding_type === "context" ? (
-				<div className="mt-0.5 text-xs text-muted-foreground">Read order {binding.priority}</div>
-			) : null}
+			<div className="mt-0.5 text-xs text-muted-foreground">{resourceAccess}</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-skill-inventory.test.ts
+++ b/apps/web/src/components/dashboard/agent-skill-inventory.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { components } from "@/lib/api-schemas";
+import { fetchAgentProjectSkills } from "./agent-skill-inventory";
+
+type Skill = components["schemas"]["SkillSummaryResponse"];
+
+function skill(id: string, skillKey: string, projectId: string): Skill {
+	return {
+		id,
+		skill_key: skillKey,
+		name: skillKey,
+		description: null,
+		version: 1,
+		source: "cloud",
+		authority: "cloud",
+		source_repo: null,
+		agent_types: null,
+		file_count: 1,
+		content_hash: "a".repeat(64),
+		is_active: true,
+		created_at: "2026-08-01T00:00:00Z",
+		updated_at: "2026-08-01T00:00:00Z",
+		project_id: projectId,
+		project_name: projectId,
+		project_kind: projectId === "project_primary" ? "environment" : "workspace",
+	};
+}
+
+describe("Agent effective Project Skill inventory", () => {
+	test("finds a context-only Skill and keeps effective Project ordering", async () => {
+		const calls: string[] = [];
+		const result = await fetchAgentProjectSkills(
+			["project_primary", "project_context_1", "project_context_2"],
+			async (projectId, page, pageSize) => {
+				calls.push(`${projectId}:${page}:${pageSize}`);
+				const items =
+					projectId === "project_context_1"
+						? [skill("context-1", "context-only", projectId)]
+						: projectId === "project_context_2"
+							? [skill("context-2", "later-context", projectId)]
+							: [];
+				return { items, total: items.length, page, page_size: pageSize };
+			},
+		);
+
+		expect(calls).toEqual([
+			"project_primary:1:200",
+			"project_context_1:1:200",
+			"project_context_2:1:200",
+		]);
+		expect(result.map((item) => item.skill_key)).toEqual(["context-only", "later-context"]);
+	});
+
+	test("preserves the same Skill key in two Projects by project identity", async () => {
+		const result = await fetchAgentProjectSkills(
+			["project_primary", "project_context"],
+			async (projectId, page, pageSize) => ({
+				items: [skill(`skill-${projectId}`, "shared-key", projectId)],
+				total: 1,
+				page,
+				page_size: pageSize,
+			}),
+		);
+
+		expect(result.map((item) => `${item.project_id}:${item.skill_key}`)).toEqual([
+			"project_primary:shared-key",
+			"project_context:shared-key",
+		]);
+	});
+
+	test("walks every server-filtered page", async () => {
+		const calls: number[] = [];
+		const result = await fetchAgentProjectSkills(
+			["project_primary"],
+			async (projectId, page, pageSize) => {
+				calls.push(page);
+				return {
+					items:
+						page === 1
+							? [skill("one", "one", projectId), skill("two", "two", projectId)]
+							: [skill("three", "three", projectId)],
+					total: 3,
+					page,
+					page_size: pageSize,
+				};
+			},
+			{ pageSize: 2 },
+		);
+
+		expect(calls).toEqual([1, 2]);
+		expect(result.map((item) => item.skill_key)).toEqual(["one", "two", "three"]);
+	});
+
+	test("fails closed on leaked rows, invalid pagination, or a truncated inventory", async () => {
+		await expect(
+			fetchAgentProjectSkills(["project_primary"], async (_projectId, page, pageSize) => ({
+				items: [skill("leaked", "leaked", "project_other")],
+				total: 1,
+				page,
+				page_size: pageSize,
+			})),
+		).rejects.toThrow("did not match the requested Project");
+
+		await expect(
+			fetchAgentProjectSkills(["project_primary"], async (projectId, page, pageSize) => ({
+				items: [skill("one", "one", projectId)],
+				page,
+				page_size: pageSize,
+			})),
+		).rejects.toThrow("valid pagination metadata");
+
+		await expect(
+			fetchAgentProjectSkills(["project_primary"], async (projectId, page, pageSize) => ({
+				items: page === 1 ? [skill("one", "one", projectId)] : [],
+				total: 2,
+				page,
+				page_size: pageSize,
+			})),
+		).rejects.toThrow("ended before every Project row was loaded");
+
+		await expect(
+			fetchAgentProjectSkills(
+				["project_primary"],
+				async (projectId, page, pageSize) => ({
+					items: [skill(`page-${page}`, `page-${page}`, projectId)],
+					total: 2,
+					page,
+					page_size: pageSize,
+				}),
+				{ pageSize: 1, maxPages: 1 },
+			),
+		).rejects.toThrow("Too many agent Skill pages");
+	});
+});

--- a/apps/web/src/components/dashboard/agent-skill-inventory.ts
+++ b/apps/web/src/components/dashboard/agent-skill-inventory.ts
@@ -1,0 +1,56 @@
+import { type FetchAllPagesOptions, fetchAllPages, type PaginatedPage } from "@/lib/api-pagination";
+import type { components } from "@/lib/api-schemas";
+
+export type AgentSkillSummary = components["schemas"]["SkillSummaryResponse"];
+
+type FetchSkillPage = (
+	projectId: string,
+	page: number,
+	pageSize: number,
+) => Promise<PaginatedPage<AgentSkillSummary>>;
+
+/**
+ * Fetch every user-visible Skill from the Agent's effective Projects. Each
+ * Project is filtered by the API before pagination. Rows retain their
+ * `(project_id, skill_key)` identity, so equal keys in different Projects are
+ * distinct resources and stay in effective Project read order.
+ */
+export async function fetchAgentProjectSkills(
+	projectIds: readonly string[],
+	fetchPage: FetchSkillPage,
+	options: Pick<FetchAllPagesOptions, "pageSize" | "maxPages"> = {},
+): Promise<AgentSkillSummary[]> {
+	const orderedProjectIds = Array.from(new Set(projectIds));
+	const skills: AgentSkillSummary[] = [];
+
+	for (const projectId of orderedProjectIds) {
+		let loadedForProject = 0;
+		const result = await fetchAllPages<AgentSkillSummary>(
+			async (page, pageSize) => {
+				const response = await fetchPage(projectId, page, pageSize);
+				if (!Number.isSafeInteger(response.total) || (response.total ?? -1) < 0) {
+					throw new Error("A Skill response did not include valid pagination metadata.");
+				}
+				if (response.items.length === 0 && loadedForProject < (response.total ?? 0)) {
+					throw new Error("A Skill inventory ended before every Project row was loaded.");
+				}
+				loadedForProject += response.items.length;
+				return response;
+			},
+			{
+				pageSize: options.pageSize ?? 200,
+				maxPages: options.maxPages ?? 50,
+				resourceName: "agent Skill",
+			},
+		);
+
+		for (const skill of result.items) {
+			if (skill.project_id !== projectId) {
+				throw new Error("A Skill response did not match the requested Project.");
+			}
+			skills.push(skill);
+		}
+	}
+
+	return skills;
+}

--- a/apps/web/src/components/dashboard/agent-skills-query.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-query.test.ts
@@ -26,7 +26,7 @@ describe("Agent Project Skills query lifecycle", () => {
 		] as const;
 		let calls = 0;
 		const observer = new QueryObserver(queryClient, {
-			queryKey: agentProjectSkillsQueryKey("agent-1", "project-1", "fence-1"),
+			queryKey: agentProjectSkillsQueryKey("agent-1", ["project-1"], "fence-1"),
 			queryFn: async () => {
 				const snapshot = snapshots[Math.min(calls, snapshots.length - 1)];
 				calls += 1;
@@ -60,9 +60,9 @@ describe("Agent Project Skills query lifecycle", () => {
 		}
 	});
 
-	test("partitions cached rows by Agent, Project, and projection fence", () => {
+	test("partitions cached rows by Agent, effective Project order, and projection fence", () => {
 		const queryClient = new QueryClient();
-		const currentKey = agentProjectSkillsQueryKey("agent-1", "project-1", "fence-1");
+		const currentKey = agentProjectSkillsQueryKey("agent-1", ["project-1", "project-2"], "fence-1");
 		queryClient.setQueryData<Array<{ skill_key: string; version: number }>>(currentKey, [
 			{ skill_key: "alpha", version: 1 },
 		]);
@@ -71,18 +71,25 @@ describe("Agent Project Skills query lifecycle", () => {
 			queryClient.getQueryData<Array<{ skill_key: string; version: number }>>(currentKey),
 		).toEqual([{ skill_key: "alpha", version: 1 }]);
 		expect(
-			queryClient.getQueryData(agentProjectSkillsQueryKey("agent-1", "project-2", "fence-1")),
+			queryClient.getQueryData(agentProjectSkillsQueryKey("agent-1", ["project-1"], "fence-1")),
 		).toBeUndefined();
 		expect(
-			queryClient.getQueryData(agentProjectSkillsQueryKey("agent-1", "project-1", "fence-2")),
+			queryClient.getQueryData(
+				agentProjectSkillsQueryKey("agent-1", ["project-2", "project-1"], "fence-1"),
+			),
 		).toBeUndefined();
 		expect(
-			queryClient.getQueryData(agentProjectSkillsQueryKey("agent-2", "project-1", "fence-1")),
+			queryClient.getQueryData(
+				agentProjectSkillsQueryKey("agent-1", ["project-1", "project-2"], "fence-2"),
+			),
 		).toBeUndefined();
 		expect(
-			queryClient.getQueryData(agentProjectSkillsQueryKey("agent-1", null, "fence-1")),
+			queryClient.getQueryData(
+				agentProjectSkillsQueryKey("agent-2", ["project-1", "project-2"], "fence-1"),
+			),
 		).toBeUndefined();
-		expect(agentProjectSkillsQueryEnabled("project-1")).toBe(true);
-		expect(agentProjectSkillsQueryEnabled(null)).toBe(false);
+		expect(agentProjectSkillsQueryEnabled(true, ["project-1"])).toBe(true);
+		expect(agentProjectSkillsQueryEnabled(false, ["project-1"])).toBe(false);
+		expect(agentProjectSkillsQueryEnabled(true, [])).toBe(false);
 	});
 });

--- a/apps/web/src/components/dashboard/agent-skills-query.ts
+++ b/apps/web/src/components/dashboard/agent-skills-query.ts
@@ -13,14 +13,15 @@ export function agentSkillForegroundRefetchInterval(enabled: boolean): number | 
 
 export function agentProjectSkillsQueryKey(
 	agentId: string,
-	projectId: string | null | undefined,
+	projectIds: readonly string[],
 	projectionFence: string,
 ) {
-	return ["skills", "agent-project", agentId, projectId ?? "unavailable", projectionFence] as const;
+	return ["skills", "agent-projects", agentId, projectionFence, ...projectIds] as const;
 }
 
 export function agentProjectSkillsQueryEnabled(
-	projectId: string | null | undefined,
-): projectId is string {
-	return Boolean(projectId);
+	bindingsResolved: boolean,
+	projectIds: readonly string[],
+): boolean {
+	return bindingsResolved && projectIds.length > 0;
 }

--- a/apps/web/src/components/dashboard/agent-skills-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-skills-tab.test.ts
@@ -3,28 +3,29 @@ import { readFileSync } from "node:fs";
 import { AGENT_SECTION_NAVIGATION_ITEMS, agentNavigationGroups } from "@/lib/navigation-model";
 
 describe("agent Skills resource boundary", () => {
-	test("keeps persisted Agent Project rows read-only without cleanup mutations", () => {
+	test("keeps effective Project rows scoped and platform infrastructure out of inventory", () => {
 		const source = readFileSync(new URL("./agent-skills-tab.tsx", import.meta.url), "utf8");
-		const normalizedSource = source.replace(/\s+/g, " ");
 
-		expect(source).toContain('kind: "environment"');
-		expect(normalizedSource).toContain("No empty filesystem inventory is being inferred");
+		expect(source).toContain("resolveAgentProjectScope");
+		expect(source).toContain("fetchAgentProjectSkills");
+		expect(source).toContain("sourceLabelFor");
 		expect(source).not.toContain("cleanupOnly");
 		expect(source).not.toMatch(/api\.DELETE|useMutation/);
 		expect(source).toContain("AGENT_PROJECT_SKILLS_REFRESH_POLICY");
 		expect(source).not.toMatch(/manifest|reservedSkill|leadingCards/i);
 		expect(source).not.toMatch(/managed_resources|mcp_server|MCP servers/i);
 		expect(source).not.toMatch(/has_mcp|Deployment MCP/i);
+		expect(source).not.toMatch(/runtime-observed|managed_skills/i);
 	});
 
-	test("describes both Agent Skill surfaces as filesystem projections", () => {
+	test("describes both Agent Skill surfaces as effective availability", () => {
 		const connectedSkills = agentNavigationGroups("connected").flatMap((group) => group.items);
 		const hostedSkills = agentNavigationGroups("hosted").flatMap((group) => group.items);
 
 		expect(connectedSkills).toContain(AGENT_SECTION_NAVIGATION_ITEMS.skills);
 		expect(hostedSkills).toContain(AGENT_SECTION_NAVIGATION_ITEMS.skills);
 		expect(AGENT_SECTION_NAVIGATION_ITEMS.skills.description).toBe(
-			"Skills synced from this agent's filesystem.",
+			"Skills available through this agent's Projects.",
 		);
 		expect(AGENT_SECTION_NAVIGATION_ITEMS.skills.description).not.toContain(
 			"Manifest configuration",

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { resolveAgentProjectScope } from "@/components/dashboard/agent-project-scope";
+import { fetchAgentProjectSkills } from "@/components/dashboard/agent-skill-inventory";
 import {
 	AGENT_PROJECT_SKILLS_REFRESH_POLICY,
 	agentProjectSkillsQueryEnabled,
@@ -9,54 +13,78 @@ import {
 	agentSkillForegroundRefetchInterval,
 } from "@/components/dashboard/agent-skills-query";
 import { SkillCardGrid } from "@/components/skills/skill-card";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { type AgentRouteSearch, agentSkillDetailLink } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
-import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
+import { identityFor } from "@/lib/identity";
 import { skillCapabilities } from "@/lib/skill-authority";
 
-type SkillSummary = components["schemas"]["SkillSummaryResponse"];
+type ProjectRow = components["schemas"]["ProjectResponse"];
 
 export function useAgentProjectSkills(
 	agentId: string,
 	agentProjectId: string | null | undefined,
 	projectionFence: string,
 	foregroundRefresh = true,
+	enabled = true,
 ) {
 	const api = useApi();
-	const projectAvailable = agentProjectSkillsQueryEnabled(agentProjectId);
+	const bindings = useAgentProjectBindings(agentId, { enabled });
+	const scope = useMemo<{ projectIds: string[]; error: unknown | null }>(() => {
+		if (!bindings.data) return { projectIds: [], error: null };
+		try {
+			return {
+				projectIds: resolveAgentProjectScope(bindings.data, agentProjectId).projectIds,
+				error: null,
+			};
+		} catch (error) {
+			return { projectIds: [], error };
+		}
+	}, [agentProjectId, bindings.data]);
+	const queryEnabled =
+		enabled && agentProjectSkillsQueryEnabled(bindings.isSuccess, scope.projectIds) && !scope.error;
 
-	// Fetch only this agent's Agent Project. The `project_id` query pushes the
-	// filter into the database, then we walk every page so a large agent library
-	// does not silently lose rows beyond the first page.
+	// Bindings are resolved before any Skill request. Each effective Project is
+	// server-filtered and fully paginated, then rows remain in Project read order.
 	const query = useQuery({
-		queryKey: agentProjectSkillsQueryKey(agentId, agentProjectId, projectionFence),
+		queryKey: agentProjectSkillsQueryKey(agentId, scope.projectIds, projectionFence),
 		queryFn: async () => {
-			if (!agentProjectId) throw new Error("Agent Project is unavailable");
-			return fetchAllPages<SkillSummary>(
-				async (page, pageSize) =>
+			return fetchAgentProjectSkills(
+				scope.projectIds,
+				async (projectId, page, pageSize) =>
 					unwrap(
 						await api.GET("/v1/skills", {
 							params: {
 								query: {
 									page,
 									page_size: pageSize,
-									project_id: agentProjectId,
+									project_id: projectId,
 								},
 							},
 						}),
 					),
-				{ pageSize: 200, resourceName: "agent skills" },
+				{ pageSize: 200 },
 			);
 		},
-		enabled: projectAvailable,
+		enabled: queryEnabled,
 		...AGENT_PROJECT_SKILLS_REFRESH_POLICY,
-		refetchInterval: agentSkillForegroundRefetchInterval(foregroundRefresh && projectAvailable),
+		refetchInterval: agentSkillForegroundRefetchInterval(foregroundRefresh && queryEnabled),
 	});
 
-	const skills = query.data?.items;
-	return { ...query, skills };
+	const skills = query.data;
+	const error = bindings.error ?? scope.error ?? query.error;
+	const isLoading =
+		enabled &&
+		(bindings.isLoading ||
+			(bindings.isSuccess && !scope.error && scope.projectIds.length > 0 && query.isLoading));
+	const refetch = async () => {
+		if (!bindings.data || bindings.error || scope.error) {
+			await bindings.refetch();
+			return;
+		}
+		await query.refetch();
+	};
+	return { ...query, skills, error, isLoading, refetch, projectIds: scope.projectIds };
 }
 
 export function AgentSkillsTab({
@@ -65,31 +93,37 @@ export function AgentSkillsTab({
 	routeSearch,
 	isResolvingAgentProject = false,
 	projectionFence = agentId,
+	hosted = false,
 }: {
 	agentId: string;
 	agentProjectId: string | null | undefined;
 	routeSearch: AgentRouteSearch;
 	isResolvingAgentProject?: boolean;
 	projectionFence?: string;
+	hosted?: boolean;
 }) {
+	const api = useApi();
 	const {
 		skills,
 		isLoading: skillsLoading,
 		error: skillsError,
 		refetch: refetchSkills,
-	} = useAgentProjectSkills(agentId, agentProjectId, projectionFence);
-	if (!agentProjectId && !isResolvingAgentProject) {
-		return (
-			<div>
-				<Alert>
-					<AlertTitle>Agent-synced Skills are unavailable</AlertTitle>
-					<AlertDescription>
-						The Agent Project is not available. No empty filesystem inventory is being inferred.
-					</AlertDescription>
-				</Alert>
-			</div>
-		);
-	}
+	} = useAgentProjectSkills(
+		agentId,
+		agentProjectId,
+		projectionFence,
+		true,
+		!isResolvingAgentProject,
+	);
+	const projects = useQuery({
+		queryKey: ["projects"],
+		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
+		enabled: !isResolvingAgentProject,
+	});
+	const projectsById = useMemo(
+		() => new Map((projects.data ?? []).map((project) => [project.id, project])),
+		[projects.data],
+	);
 
 	if (skillsError) {
 		return (
@@ -99,21 +133,46 @@ export function AgentSkillsTab({
 					onRetry={() => {
 						void refetchSkills();
 					}}
-					title="Couldn't load agent-synced skills"
+					title="Couldn't load agent Skills"
 				/>
 			</div>
 		);
 	}
 
 	return (
-		<div>
+		<div className="space-y-4" data-testid="agent-skills-inventory">
+			<p className="text-sm text-muted-foreground">
+				Skills appear here through this agent&apos;s Agent Project and added Projects, in read
+				order. Open a Skill to manage it in its source Project when allowed.
+			</p>
+			{projects.error ? (
+				<ApiErrorPanel
+					error={projects.error}
+					onRetry={() => {
+						void projects.refetch();
+					}}
+					title="Couldn't load Project labels"
+				/>
+			) : null}
 			<SkillCardGrid
 				skills={skills ?? []}
 				isLoading={isResolvingAgentProject || skillsLoading}
-				emptyMessage="No skills installed on this agent yet."
-				capabilitiesFor={(skill) =>
-					skillCapabilities(skill, { kind: "environment", is_owner: true })
+				emptyMessage={
+					hosted
+						? "No user-visible Skills are available through this agent's Projects yet."
+						: "No Skills are available through this agent's Projects yet."
 				}
+				capabilitiesFor={(skill) =>
+					skillCapabilities(
+						skill,
+						skill.project_id ? projectsById.get(skill.project_id) : undefined,
+					)
+				}
+				sourceLabelFor={(skill) => {
+					const project = skill.project_id ? projectsById.get(skill.project_id) : undefined;
+					const name = project?.name ?? skill.project_name ?? skill.project_id;
+					return name ? { name, emoji: identityFor(name).emoji } : null;
+				}}
 				skillLink={(skill) =>
 					agentSkillDetailLink(agentId, skill.skill_key, skill.project_id, routeSearch)
 				}

--- a/apps/web/src/components/dashboard/agent-vaults-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-vaults-tab.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { useAgentProjectBindings } from "@/components/dashboard/agent-projects-tab";
+import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
 import { Skeleton } from "@/components/ui/skeleton";
-import { effectiveAgentProjectIds } from "@/components/vault/vault-scope";
 import { VaultsSurface } from "@/components/vault/vaults-surface";
 
 export function AgentVaultsTab({ agentId }: { agentId: string }) {

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -8,10 +8,8 @@ import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
 } from "@/components/dashboard/agent-label";
-import {
-	AgentProjectsTab,
-	useAgentProjectBindings,
-} from "@/components/dashboard/agent-projects-tab";
+import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { AgentVaultsTab } from "@/components/dashboard/agent-vaults-tab";
@@ -96,7 +94,7 @@ export function ConnectedAgentDetail({
 		skills: skillsForThisEnv,
 		error: skillsError,
 		refetch: refetchSkills,
-	} = useAgentProjectSkills(id, agentProjectId, id, false);
+	} = useAgentProjectSkills(id, agentProjectId, id, false, Boolean(agent));
 
 	const sessionTotal = sessionsError ? "—" : (sessionsPage?.total ?? 0);
 	const activeTabMeta = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];

--- a/apps/web/src/components/vault/vault-scope.ts
+++ b/apps/web/src/components/vault/vault-scope.ts
@@ -1,7 +1,8 @@
 import { type FetchAllPagesOptions, fetchAllPages, type PaginatedPage } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 
-type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
+export { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
+
 type VaultSummary = components["schemas"]["VaultResponse"];
 
 type FetchVaultPage = (
@@ -9,17 +10,6 @@ type FetchVaultPage = (
 	page: number,
 	pageSize: number,
 ) => Promise<PaginatedPage<VaultSummary>>;
-
-/** Primary first, followed by context Projects in the agent's effective read order. */
-export function effectiveAgentProjectIds(bindings: readonly AgentProjectBinding[]): string[] {
-	const ordered = [
-		...bindings.filter((binding) => binding.binding_type === "primary"),
-		...bindings
-			.filter((binding) => binding.binding_type === "context")
-			.sort((left, right) => left.priority - right.priority),
-	];
-	return Array.from(new Set(ordered.map((binding) => binding.project_id)));
-}
 
 /** Never return a Vault unless it is attached to at least one effective Agent Project. */
 export function vaultsForProjectIds(

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -525,11 +525,11 @@ export function HostedAgentDetail({
 	return (
 		<div
 			data-hosted="true"
+			data-testid={isLiveToolTab ? "hosted-agent-live-surface" : undefined}
 			className={cn(
-				CENTERED_PAGE_WIDTH_CLASS.page,
 				isLiveToolTab
-					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
-					: "flex flex-col gap-6 px-4 lg:px-6",
+					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] w-full flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
+					: cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6"),
 			)}
 		>
 			{isLiveToolTab ? <h1 className="sr-only">{agentTitle}</h1> : null}
@@ -622,6 +622,7 @@ export function HostedAgentDetail({
 								agentProjectId={agent?.default_project_id}
 								routeSearch={routeSearch}
 								projectionFence={deployment.resource.metadata.resourceVersion}
+								hosted
 							/>
 						) : (
 							<ProjectionDependentUnavailable label="Skills" />

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -307,8 +307,8 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 		id: "skills",
 		...CANONICAL_NAVIGATION_IDENTITIES.skills,
 		tint: RESOURCE_TINT_CLASSES.skills,
-		description: "Skills synced from this agent's filesystem.",
-		tooltip: "Skills synced from this agent's filesystem",
+		description: "Skills available through this agent's Projects.",
+		tooltip: "View Skills available through this agent's Projects",
 		variants: ["connected", "hosted"],
 	},
 	projects: {

--- a/packages/cli/src/runtime/manifest-contract.test.ts
+++ b/packages/cli/src/runtime/manifest-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { OFFICIAL_INSTALL_ARGS } from "./manifest-contract";
+
+describe("official runtime installer arguments", () => {
+	test("keeps new Hermes installs on the upstream bundled-Skill defaults", () => {
+		expect(OFFICIAL_INSTALL_ARGS.hermes).toEqual([
+			"--skip-setup",
+			"--skip-browser",
+			"--non-interactive",
+		]);
+		expect(OFFICIAL_INSTALL_ARGS.hermes).not.toContain("--no-skills");
+	});
+});

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -18,7 +18,7 @@ export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
 
 export const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 	openclaw: ["--json", "--no-onboard"],
-	hermes: ["--skip-setup", "--skip-browser", "--no-skills", "--non-interactive"],
+	hermes: ["--skip-setup", "--skip-browser", "--non-interactive"],
 };
 
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);


### PR DESCRIPTION
## Summary

- restore the official Hermes installer arguments for new/reprovisioned Hosted installs to `--skip-setup --skip-browser --non-interactive`, allowing upstream bundled Skills again; existing `.no-bundled-skills` markers are intentionally untouched
- let Hosted Agent Interface and Terminal fill the available main content width at desktop and mobile sizes while retaining centered widths for non-live tabs
- resolve Agent Skills from the authoritative effective Project binding order (primary, then context), server-filter and fully paginate every Project, preserve cross-Project duplicate keys, and show source/authority labels without exposing runtime-managed infrastructure summaries
- redesign Agent Projects as one effective read-order stack with the fixed primary Project first and inline add/reorder/remove controls

## Verification

- `bun run --cwd packages/cli test` (1486 passed, 4 skipped)
- `bun run --cwd apps/web test` (Docker-backed full Web test, typecheck, and OSS build)
- `bun run --cwd apps/web typecheck`
- focused CLI/Web Bun tests (16 passed)
- `bunx biome check packages/cli/src/runtime/manifest-contract.ts packages/cli/src/runtime/manifest-contract.test.ts apps/web/src apps/web/e2e`
- OSS Playwright `sidebar-runtime-smoke.pw.ts` (9 passed)
- focused Hosted Playwright for sidebar resources, projection gating, Hermes context Skills, neutral empty state, and live-surface width (5 passed)

## Scope note

This changes installer arguments only for new/reprovisioned Hermes installs. It does not migrate or delete existing `.no-bundled-skills` markers, alter the separate Clawdi infrastructure Skill authority, deploy anything, or touch tenant data.