### PR TITLE
Fix Discord install, pairing authority, and command reconciliation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -8717,7 +8717,7 @@ test("Telegram and Discord pairing acknowledge one newly active binding at 320px
 					expires_at: validExpiry,
 					pairing_command: "/clawdi_pair DISCORDSUCCESS123",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123&scope=bot&permissions=274878024768",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9223,7 +9223,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: validExpiry,
 					pairing_command: "/bot_pair DISCORDLEGACY123",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9238,7 +9238,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: validExpiry,
 					pairing_command: "/clawdi_pair DISCORDPAIR123",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9253,7 +9253,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: "2000-01-01T00:00:00Z",
 					pairing_command: "/clawdi_pair DISCORDEXPIRED123",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9895,10 +9895,11 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	).toContainText("/clawdi_pair");
 	await expect(discordPairDialog).not.toContainText("/bot_pair");
 	await expect(discordPairDialog.getByText(/required code option/)).toBeVisible();
-	await expect(discordPairDialog.getByRole("button", { name: "Add to server" })).toHaveAttribute(
-		"href",
-		/permissions=274878024768/,
-	);
+	const discordServerInstallLink = discordPairDialog.getByRole("button", {
+		name: "Add to server",
+	});
+	await expect(discordServerInstallLink).toHaveAttribute("href", /integration_type=0/);
+	await expect(discordServerInstallLink).toHaveAttribute("href", /permissions=274878024768/);
 	await discordDmTab.click();
 	await expect(discordPairDialog.locator('[data-discord-pair-path="dm"]')).toBeVisible();
 	const discordUserInstallQr = discordPairDialog.getByRole("img", {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -7,6 +7,7 @@ import {
 	pairingActionLabel,
 	pairingCommand,
 	verifiedDiscordPairingCommand,
+	verifiedDiscordServerInstallUrl,
 	verifiedDiscordUserInstallUrl,
 } from "./channel-linking.logic";
 
@@ -44,6 +45,22 @@ describe("hosted channel instructions and gates", () => {
 			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands&permissions=8",
 		]) {
 			expect(verifiedDiscordUserInstallUrl(unsupported)).toBeNull();
+		}
+	});
+
+	test("accepts only the explicit Discord Guild Install bot contract", () => {
+		const supported =
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands";
+		expect(verifiedDiscordServerInstallUrl(supported)).toBe(supported);
+		for (const unsupported of [
+			null,
+			undefined,
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&permissions=274878024768&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=0&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=applications.commands",
+		]) {
+			expect(verifiedDiscordServerInstallUrl(unsupported)).toBeNull();
 		}
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -41,6 +41,38 @@ export function verifiedDiscordPairingCommand(pairingCommand: string, code: stri
 	return pairingCommand === expected ? pairingCommand : null;
 }
 
+export function verifiedDiscordServerInstallUrl(value: string | null | undefined): string | null {
+	if (!value) return null;
+	try {
+		const url = new URL(value);
+		const clientId = url.searchParams.get("client_id");
+		const scopes = new Set((url.searchParams.get("scope") ?? "").split(" "));
+		if (
+			url.origin !== "https://discord.com" ||
+			url.pathname !== "/oauth2/authorize" ||
+			url.username ||
+			url.password ||
+			url.hash ||
+			!clientId ||
+			!/^[0-9]{17,20}$/.test(clientId) ||
+			url.searchParams.getAll("client_id").length !== 1 ||
+			url.searchParams.get("integration_type") !== "0" ||
+			url.searchParams.getAll("integration_type").length !== 1 ||
+			url.searchParams.get("permissions") !== "274878024768" ||
+			url.searchParams.getAll("permissions").length !== 1 ||
+			url.searchParams.getAll("scope").length !== 1 ||
+			scopes.size !== 2 ||
+			!scopes.has("applications.commands") ||
+			!scopes.has("bot")
+		) {
+			return null;
+		}
+		return value;
+	} catch {
+		return null;
+	}
+}
+
 export function verifiedDiscordUserInstallUrl(value: string | null | undefined): string | null {
 	if (!value) return null;
 	try {

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -90,6 +90,9 @@ describe("channel IA boundary", () => {
 		);
 		expect(discordPairDialog).toContain("pairing_command: pairingCommand");
 		expect(discordPairDialog).toContain("discord_user_install_url: verifiedDiscordUserInstallUrl(");
+		expect(discordPairDialog).toContain(
+			"verifiedDiscordServerInstallUrl(data.discord_install_url)",
+		);
 		expect(discordPairDialog).toContain('result.pairing_command.split(" ", 1)[0]');
 		expect(discordPairDialog).toContain('data-discord-pair-path="server"');
 		expect(discordPairDialog).toContain('data-discord-pair-path="dm"');
@@ -103,6 +106,8 @@ describe("channel IA boundary", () => {
 		expect(discordPairDialog).toContain("Use Server pairing");
 		expect(discordPairDialog).toContain("enable User Install");
 		expect(discordPairDialog).toContain("applications.commands");
+		expect(discordPairDialog).toContain("Agent-defined slash commands are server-only");
+		expect(discordPairDialog).toContain("not per-Agent command menus");
 		expect(discordPairDialog).toContain("Manage");
 		expect(discordPairDialog).toContain("Add to server");
 		expect(discordPairDialog).toContain("value={result.discord_install_url}");

--- a/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/discord-pair-dialog.tsx
@@ -10,6 +10,7 @@ import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.lo
 import {
 	pairCodeExpired,
 	verifiedDiscordPairingCommand,
+	verifiedDiscordServerInstallUrl,
 	verifiedDiscordUserInstallUrl,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import { usePairingSuccess } from "@/hosted/v2/channels/channel-pairing-success";
@@ -87,12 +88,18 @@ export function DiscordPairDialog({
 				if (pairingCommand === null) {
 					throw new Error("Discord pairing instructions are out of date. Refresh and try again.");
 				}
+				const serverInstallUrl = verifiedDiscordServerInstallUrl(data.discord_install_url);
+				if (serverInstallUrl === null) {
+					throw new Error(
+						"Discord server install settings are out of date. Refresh and try again.",
+					);
+				}
 				setNowMs(Date.now());
 				setResult({
 					code: data.code,
 					expires_at: data.expires_at,
 					pairing_command: pairingCommand,
-					discord_install_url: data.discord_install_url,
+					discord_install_url: serverInstallUrl,
 					discord_user_install_url: verifiedDiscordUserInstallUrl(data.discord_user_install_url),
 				});
 			} catch (error) {
@@ -240,6 +247,10 @@ export function DiscordPairDialog({
 											</div>
 											<CopyablePairingCode value={result.code} label="Discord pair code" />
 										</PairingInstructionPanel>
+										<p className="text-xs text-muted-foreground">
+											The default install grants only Clawdi&apos;s text, attachment, reaction, and
+											thread baseline. Voice and advanced server-management actions are not enabled.
+										</p>
 									</TabsContent>
 
 									{result.discord_user_install_url ? (
@@ -275,6 +286,10 @@ export function DiscordPairDialog({
 												/>
 												<span>in the Discord Developer Portal.</span>
 											</div>
+											<p className="text-xs text-muted-foreground">
+												Agent-defined slash commands are server-only. Direct messages support
+												pairing and message routing, not per-Agent command menus.
+											</p>
 										</TabsContent>
 									) : null}
 								</Tabs>

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -117,15 +117,20 @@ from app.services.channels import (
     channel_webhook_url,
     configure_discord_application,
     configure_telegram_provider_webhook,
+    discord_application_id_from_config,
+    discord_config_without_unverified_install_state,
     encrypt_optional_token,
+    ensure_discord_application_identity_available,
     generate_webhook_secret,
     get_telegram_bot_username,
     hash_token,
     mark_discord_reserved_commands_current,
     normalize_telegram_bot_username,
+    require_unchanged_discord_application_identity,
     store_channel_secrets,
     sync_channel_commands,
     upsert_channel_secrets,
+    verify_discord_application_token_identity,
 )
 from app.services.hosted_runtime_secrets import (
     hosted_runtime_secret_values_changed,
@@ -1070,6 +1075,11 @@ async def admin_create_channel(
     target = await _resolve_or_create_user(db, body.target_clerk_id)
     ciphertext, nonce = encrypt_optional_token(body.provider_token)
     webhook_secret = generate_webhook_secret()
+    account_config = (
+        discord_config_without_unverified_install_state(body.config)
+        if body.provider == CHANNEL_PROVIDER_DISCORD
+        else body.config
+    )
     account = ChannelAccount(
         user_id=target.id,
         provider=body.provider,
@@ -1078,7 +1088,7 @@ async def admin_create_channel(
         encrypted_provider_token=ciphertext,
         provider_token_nonce=nonce,
         webhook_secret_hash=hash_token(webhook_secret),
-        config=body.config,
+        config=account_config,
     )
     db.add(account)
     try:
@@ -1129,6 +1139,7 @@ async def admin_create_channel(
         # Discord validates the PATCH with a signed PING, so the account and
         # public key must be committed and webhook-visible first. Bot-pool
         # eligibility remains false until the readiness marker commits below.
+        await ensure_discord_application_identity_available(db, account=account)
         await configure_discord_application(account)
         await sync_channel_commands(
             account=account,
@@ -1186,6 +1197,24 @@ async def admin_update_channel(
         else None
     )
     telegram_bot_username = current_telegram_bot_username
+    if account.provider == CHANNEL_PROVIDER_DISCORD and "config" in updates:
+        require_unchanged_discord_application_identity(account, body.config)
+    if (
+        account.provider == CHANNEL_PROVIDER_DISCORD
+        and "provider_token" in updates
+        and body.provider_token is not None
+    ):
+        application_id = discord_application_id_from_config(account.config)
+        if application_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Discord application identity is missing; recreate the channel.",
+            )
+        await verify_discord_application_token_identity(
+            application_id=application_id,
+            provider_token=body.provider_token,
+            config=account.config,
+        )
     if "provider_token" in updates:
         if account.provider == CHANNEL_PROVIDER_TELEGRAM and body.provider_token:
             if current_telegram_bot_username is None:
@@ -1207,7 +1236,16 @@ async def admin_update_channel(
         account.provider_token_nonce = nonce
     if "config" in updates:
         await validate_channel_account_config_urls(provider=account.provider, config=body.config)
-        account.config = body.config
+        account.config = (
+            discord_config_without_unverified_install_state(body.config)
+            if account.provider == CHANNEL_PROVIDER_DISCORD
+            else body.config
+        )
+    elif account.provider == CHANNEL_PROVIDER_DISCORD and "provider_token" in updates:
+        # A replacement token may belong to a different application. Force the
+        # next pairing request through /applications/@me identity and install
+        # capability verification before exposing install URLs or commands.
+        account.config = discord_config_without_unverified_install_state(account.config)
     if account.provider == CHANNEL_PROVIDER_TELEGRAM and (
         "provider_token" in updates or "config" in updates
     ):
@@ -1234,6 +1272,7 @@ async def admin_update_channel(
         config = dict(account.config) if isinstance(account.config, dict) else {}
         config["discord_interactions_configured"] = False
         account.config = config
+        await ensure_discord_application_identity_available(db, account=account)
     try:
         if "secrets" in updates:
             await upsert_channel_secrets(db, account=account, secrets_by_name=body.secrets)
@@ -1312,6 +1351,7 @@ async def admin_sync_channel_commands(
         else None
     )
     if account.provider == CHANNEL_PROVIDER_DISCORD and commands is None:
+        await ensure_discord_application_identity_available(db, account=account)
         await configure_discord_application(account)
     synced = await sync_channel_commands(
         account=account,

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -126,6 +126,7 @@ from app.services.channels import (
     hash_token,
     mark_discord_reserved_commands_current,
     normalize_telegram_bot_username,
+    rearm_discord_command_reconciliation,
     require_unchanged_discord_application_identity,
     store_channel_secrets,
     sync_channel_commands,
@@ -1141,6 +1142,7 @@ async def admin_create_channel(
         # eligibility remains false until the readiness marker commits below.
         await ensure_discord_application_identity_available(db, account=account)
         await configure_discord_application(account)
+        await rearm_discord_command_reconciliation(db, account=account)
         await sync_channel_commands(
             account=account,
             use_configured_discord_guild=False,
@@ -1234,6 +1236,8 @@ async def admin_update_channel(
         ciphertext, nonce = encrypt_optional_token(body.provider_token)
         account.encrypted_provider_token = ciphertext
         account.provider_token_nonce = nonce
+        if account.provider == CHANNEL_PROVIDER_DISCORD and body.provider_token is not None:
+            await rearm_discord_command_reconciliation(db, account=account)
     if "config" in updates:
         await validate_channel_account_config_urls(provider=account.provider, config=body.config)
         account.config = (
@@ -1296,6 +1300,7 @@ async def admin_update_channel(
         ) from exc
     if reconcile_public_discord:
         await configure_discord_application(account)
+        await rearm_discord_command_reconciliation(db, account=account)
         await sync_channel_commands(
             account=account,
             use_configured_discord_guild=False,
@@ -1353,6 +1358,7 @@ async def admin_sync_channel_commands(
     if account.provider == CHANNEL_PROVIDER_DISCORD and commands is None:
         await ensure_discord_application_identity_available(db, account=account)
         await configure_discord_application(account)
+        await rearm_discord_command_reconciliation(db, account=account)
     synced = await sync_channel_commands(
         account=account,
         commands=commands,

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -45,10 +45,10 @@ from app.models.channel import (
     ChannelBotAgentLink,
 )
 from app.routes.channel_routers.shared import (
+    _clear_discord_guild_commands,
     _discord_application_id,
     _discord_bot_user,
     _discord_gateway_dispatch,
-    _discord_guild_owner_principals,
     _discord_interaction_content,
     _DiscordProviderResult,
     _fan_out_discord_global_commands,
@@ -74,9 +74,10 @@ from app.services.channels import (
     discord_channel_scope_from_payload,
     discord_chat_from_payload,
     discord_external_user_id_from_payload,
-    discord_guild_command_denied_reason,
     discord_message_id_from_payload,
     discord_pair_command_from_payload,
+    discord_pairing_command_denied_reason,
+    discord_pairing_command_event_was_handled,
     discord_pairing_reply_for_command,
     discord_text_from_payload,
     get_active_channel_account,
@@ -1004,14 +1005,15 @@ async def discord_webhook(
     if account.provider != CHANNEL_PROVIDER_DISCORD:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     body = await request.body()
+    signature_verified = verify_discord_signature(
+        account=account,
+        body=body,
+        signature=x_signature_ed25519,
+        timestamp=x_signature_timestamp,
+    )
     if not (
         verify_webhook_secret(x_clawdi_channel_secret, account.webhook_secret_hash)
-        or verify_discord_signature(
-            account=account,
-            body=body,
-            signature=x_signature_ed25519,
-            timestamp=x_signature_timestamp,
-        )
+        or signature_verified
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -1027,19 +1029,40 @@ async def discord_webhook(
     external_chat_id, external_chat_type, external_chat_name = chat
     command = discord_pair_command_from_payload(payload)
     channel_id, guild_id = discord_channel_scope_from_payload(payload)
+    provider_event_id = discord_message_id_from_payload(payload)
+    if await discord_pairing_command_event_was_handled(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        provider_event_id=provider_event_id,
+        command=command,
+    ):
+        if payload.get("type") == 2:
+            return {
+                "type": 4,
+                "data": {
+                    "content": "This interaction was already handled.",
+                    "flags": 64,
+                },
+            }
+        return {"ok": True}
+    external_user_id = discord_external_user_id_from_payload(payload)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
         external_chat_id=external_chat_id,
         external_chat_type=external_chat_type,
         external_chat_name=external_chat_name,
-        external_user_id=discord_external_user_id_from_payload(payload),
+        external_user_id=external_user_id,
         text=discord_text_from_payload(payload),
         command=command,
-        command_denied_reason=discord_guild_command_denied_reason(
+        command_denied_reason=await discord_pairing_command_denied_reason(
+            account,
             payload,
             command=command,
             guild_id=guild_id,
+            external_user_id=external_user_id,
+            trusted_interaction=signature_verified,
         ),
         command_actor_required=True,
     )
@@ -1049,7 +1072,7 @@ async def discord_webhook(
         account=account,
         binding_result=binding_result,
         external_chat_id=external_chat_id,
-        provider_message_id=discord_message_id_from_payload(payload),
+        provider_message_id=provider_event_id,
         text=discord_text_from_payload(payload),
         payload=payload,
     )
@@ -1172,6 +1195,7 @@ async def _replay_discord_commands_on_pair(
             application_id=application_id,
             commands=[command for command in commands if isinstance(command, dict)],
             guild_ids={guild_id},
+            force=True,
         )
     except HTTPException:
         return
@@ -1212,62 +1236,20 @@ async def cleanup_discord_guild_commands_after_authority_revoked(
     bot_agent_link_id: UUID,
     guild_ids: set[str],
 ) -> bool:
-    """Best-effort cleanup after durable unpair/unlink authority revocation."""
-    cleanup_succeeded = True
+    """Durably reconcile Guild command cleanup after authority revocation."""
     try:
         async with async_session_factory() as db:
             account = await get_active_channel_account(db, account_id=account_id)
             link = await db.get(ChannelBotAgentLink, bot_agent_link_id)
-            link_config = link.config if link is not None and isinstance(link.config, dict) else {}
-            command_shadow = link_config.get("discord_agent_commands")
-            if not isinstance(command_shadow, dict) or not any(
-                isinstance(commands, list) and commands for commands in command_shadow.values()
-            ):
-                return True
-            application_id = _discord_application_id(account)
-            for guild_id in sorted(guild_ids):
-                # A new pairing can win after the revocation commit. Never erase its
-                # newly materialized commands.
-                if await _discord_guild_owner_principals(
-                    db,
-                    account_id=account.id,
-                    guild_id=guild_id,
-                ):
-                    log.info(
-                        "discord_command_cleanup_skipped_active_owner "
-                        "account_id=%s link_id=%s guild_id=%s",
-                        account_id,
-                        bot_agent_link_id,
-                        guild_id,
-                    )
-                    continue
-                try:
-                    result = await _request_discord_provider(
-                        account=account,
-                        method="PUT",
-                        path=f"/applications/{application_id}/guilds/{guild_id}/commands",
-                        body=b"[]",
-                    )
-                    if result.status_code >= 400:
-                        cleanup_succeeded = False
-                        log.warning(
-                            "discord_command_cleanup_rejected "
-                            "account_id=%s link_id=%s guild_id=%s status=%s",
-                            account_id,
-                            bot_agent_link_id,
-                            guild_id,
-                            result.status_code,
-                        )
-                except HTTPException:
-                    cleanup_succeeded = False
-                    log.exception(
-                        "discord_command_cleanup_failed account_id=%s link_id=%s guild_id=%s",
-                        account_id,
-                        bot_agent_link_id,
-                        guild_id,
-                    )
-                    continue
-        return cleanup_succeeded
+            if link is None or link.account_id != account.id:
+                return False
+            return await _clear_discord_guild_commands(
+                db,
+                account=account,
+                link=link,
+                application_id=_discord_application_id(account),
+                guild_ids=guild_ids,
+            )
     except (HTTPException, SQLAlchemyError):
         log.exception(
             "discord_command_cleanup_setup_failed account_id=%s link_id=%s",

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -102,11 +102,14 @@ from app.services.channels import (
     create_pair_code,
     decrypt_agent_link_token,
     discord_bot_install_url,
+    discord_config_without_unverified_install_state,
+    discord_install_config_is_current,
     discord_reserved_commands_are_current,
     discord_user_install_url,
     encrypt_optional_token,
     enqueue_channel_outbound_message,
     ensure_bot_agent_link_provider_cardinality_or_409,
+    ensure_discord_application_identity_available,
     ensure_hosted_agent_provider_link_available,
     generate_agent_token,
     generate_webhook_secret,
@@ -606,6 +609,11 @@ async def create_channel(
 
     ciphertext, nonce = encrypt_optional_token(body.provider_token)
     webhook_secret = generate_webhook_secret()
+    account_config = (
+        discord_config_without_unverified_install_state(body.config)
+        if body.provider == CHANNEL_PROVIDER_DISCORD
+        else body.config
+    )
     account = ChannelAccount(
         user_id=auth.user_id,
         provider=body.provider,
@@ -613,7 +621,7 @@ async def create_channel(
         encrypted_provider_token=ciphertext,
         provider_token_nonce=nonce,
         webhook_secret_hash=hash_token(webhook_secret),
-        config=body.config,
+        config=account_config,
     )
     if initial_agent_id is not None:
         # Runtime authority and provider support checks must precede Telegram
@@ -817,6 +825,7 @@ async def create_channel_pair_code(
 ) -> ChannelPairCodeResponse:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     if account.provider == CHANNEL_PROVIDER_DISCORD:
+        await ensure_discord_application_identity_available(db, account=account)
         config_error = discord_interactions_config_error(account.config)
         if config_error is not None:
             raise HTTPException(
@@ -826,9 +835,11 @@ async def create_channel_pair_code(
         config = dict(account.config) if isinstance(account.config, dict) else {}
         interactions_configured = config.get("discord_interactions_configured") is True
         commands_current = discord_reserved_commands_are_current(account)
-        if not interactions_configured:
+        install_config_current = discord_install_config_is_current(account)
+        if not interactions_configured or not install_config_current:
             await configure_discord_application(account)
-        if not interactions_configured or not commands_current:
+            config = dict(account.config) if isinstance(account.config, dict) else {}
+        if not interactions_configured or not install_config_current or not commands_current:
             # Reserved control-plane commands are true account-global
             # commands so they remain available before any Guild or DM is
             # paired. Agent runtime commands are virtualized per Link.

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -126,6 +126,7 @@ from app.services.channels import (
     lock_channel_binding_identity,
     mark_discord_reserved_commands_current,
     normalize_telegram_bot_username,
+    rearm_discord_command_reconciliation,
     rotate_bot_agent_link_token,
     store_channel_secrets,
     sync_channel_commands,
@@ -838,6 +839,7 @@ async def create_channel_pair_code(
         install_config_current = discord_install_config_is_current(account)
         if not interactions_configured or not install_config_current:
             await configure_discord_application(account)
+            await rearm_discord_command_reconciliation(db, account=account)
             config = dict(account.config) if isinstance(account.config, dict) else {}
         if not interactions_configured or not install_config_current or not commands_current:
             # Reserved control-plane commands are true account-global

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -18,7 +19,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -91,6 +92,9 @@ _DISCORD_RESPONSE_HEADER_ALLOWLIST = (
     "x-ratelimit-scope",
     "x-request-id",
 )
+_DISCORD_AGENT_COMMANDS_CONFIG_KEY = "discord_agent_commands"
+_DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY = "discord_command_materializations"
+_DISCORD_COMMAND_RETRIES_CONFIG_KEY = "discord_command_retries"
 
 
 def _channel_visibility(account: ChannelAccount) -> ChannelVisibility:
@@ -612,15 +616,42 @@ async def _handle_discord_application_commands(
         guild_id=guild_id,
     ):
         return _discord_command_error("Missing Access", 50001, 403)
+    if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+        # Pair claims lock this Link row too. Take the same lock before the DM
+        # boundary check so a concurrent User Install cannot make a rejected
+        # mutation commit a hidden shadow.
+        await db.refresh(link, with_for_update=True)
+        await _assert_discord_command_mutation_supported(
+            db,
+            account=account,
+            link=link,
+            guild_id=guild_id,
+        )
+        # Serialize desired-shadow mutations with provider receipts/retries.
+        # The subsequent shadow commit releases this row lock before network I/O.
 
     commands = _discord_command_shadow(link)
     if request.method == "GET" and command_id is None:
-        return commands.get(scope_key, [])
+        return await _discord_materialized_command_list(
+            db,
+            account=account,
+            link=link,
+            guild_id=guild_id,
+        )
     if request.method == "GET" and command_id is not None:
-        command = _find_discord_command(commands.get(scope_key, []), command_id)
+        materialized_commands = await _discord_materialized_command_list(
+            db,
+            account=account,
+            link=link,
+            guild_id=guild_id,
+        )
+        command = _find_discord_command(materialized_commands, command_id)
         return command or _discord_command_error("Unknown application command", 10063, 404)
     if request.method == "DELETE" and command_id is None:
-        commands.pop(scope_key, None)
+        # Keep an explicit empty desired scope as a durable tombstone. If the
+        # provider call fails, the worker can still converge the physical Guild
+        # command set after the client observes an error or retries to a 404.
+        commands[scope_key] = []
         await _store_discord_command_shadow(db, link=link, commands=commands)
         await _materialize_discord_command_scope(
             db,
@@ -734,7 +765,7 @@ def _discord_command_error(message: str, code: int, status_code: int) -> Respons
 
 def _discord_command_shadow(link: ChannelBotAgentLink) -> dict[str, list[dict[str, Any]]]:
     config = link.config if isinstance(link.config, dict) else {}
-    commands = config.get("discord_agent_commands")
+    commands = config.get(_DISCORD_AGENT_COMMANDS_CONFIG_KEY)
     if not isinstance(commands, dict):
         return {}
     clean: dict[str, list[dict[str, Any]]] = {}
@@ -744,6 +775,170 @@ def _discord_command_shadow(link: ChannelBotAgentLink) -> dict[str, list[dict[st
     return clean
 
 
+def _discord_command_materializations(link: ChannelBotAgentLink) -> dict[str, str]:
+    config = link.config if isinstance(link.config, dict) else {}
+    raw = config.get(_DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        guild_id: fingerprint
+        for guild_id, fingerprint in raw.items()
+        if isinstance(guild_id, str) and guild_id and isinstance(fingerprint, str) and fingerprint
+    }
+
+
+def _discord_command_retries(link: ChannelBotAgentLink) -> dict[str, dict[str, Any]]:
+    config = link.config if isinstance(link.config, dict) else {}
+    raw = config.get(_DISCORD_COMMAND_RETRIES_CONFIG_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        guild_id: dict(value)
+        for guild_id, value in raw.items()
+        if isinstance(guild_id, str) and guild_id and isinstance(value, dict)
+    }
+
+
+def _discord_retry_is_due(retry: dict[str, Any] | None, *, fingerprint: str) -> bool:
+    if retry is None or retry.get("fingerprint") != fingerprint:
+        return True
+    if retry.get("blocked") is True:
+        return False
+    next_retry_at = retry.get("next_retry_at")
+    if not isinstance(next_retry_at, str):
+        return True
+    try:
+        due_at = datetime.fromisoformat(next_retry_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return due_at <= datetime.now(UTC)
+
+
+def _discord_retry_after_seconds(result: _DiscordProviderResult) -> float | None:
+    raw_header = next(
+        (value for key, value in (result.headers or {}).items() if key.lower() == "retry-after"),
+        None,
+    )
+    if raw_header is not None:
+        try:
+            value = float(raw_header)
+        except ValueError:
+            value = -1
+        if value >= 0:
+            return value
+    payload = result.json_object()
+    raw_body = payload.get("retry_after") if payload is not None else None
+    if isinstance(raw_body, (int, float)) and not isinstance(raw_body, bool) and raw_body >= 0:
+        return float(raw_body)
+    return None
+
+
+def _discord_command_retry_state(
+    *,
+    previous: dict[str, Any] | None,
+    fingerprint: str,
+    status_code: int,
+    result: _DiscordProviderResult | None,
+) -> dict[str, Any]:
+    previous_attempts = previous.get("attempts") if isinstance(previous, dict) else None
+    attempts = (
+        previous_attempts + 1
+        if isinstance(previous_attempts, int)
+        and not isinstance(previous_attempts, bool)
+        and previous_attempts >= 0
+        and previous.get("fingerprint") == fingerprint
+        else 1
+    )
+    retry_after = _discord_retry_after_seconds(result) if result is not None else None
+    blocked = 400 <= status_code < 500 and (
+        status_code != status.HTTP_429_TOO_MANY_REQUESTS or retry_after is None
+    )
+    if status_code == status.HTTP_429_TOO_MANY_REQUESTS and retry_after is not None:
+        delay_seconds = retry_after
+    else:
+        delay_seconds = min(30.0 * (2 ** (attempts - 1)), 3600.0)
+    return {
+        "fingerprint": fingerprint,
+        "attempts": attempts,
+        "status_code": status_code,
+        "blocked": blocked,
+        "next_retry_at": (
+            None if blocked else (datetime.now(UTC) + timedelta(seconds=delay_seconds)).isoformat()
+        ),
+    }
+
+
+def _discord_effective_guild_commands(
+    shadow: dict[str, list[dict[str, Any]]],
+    *,
+    guild_id: str,
+) -> list[dict[str, Any]]:
+    guild_commands = shadow.get(f"guild:{guild_id}")
+    return guild_commands if guild_commands is not None else shadow.get("global", [])
+
+
+def _discord_guild_command_fingerprint(
+    commands: list[dict[str, Any]],
+    *,
+    application_id: str,
+) -> str:
+    provider_commands = [_discord_guild_command_provider_payload(command) for command in commands]
+    encoded = json.dumps(
+        {
+            "application_id": application_id,
+            "commands": provider_commands,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+async def _discord_materialized_command_list(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+    guild_id: str | None,
+) -> list[dict[str, Any]]:
+    shadow = _discord_command_shadow(link)
+    materializations = _discord_command_materializations(link)
+    application_id = _discord_application_id(account)
+    if guild_id is not None:
+        desired = _discord_effective_guild_commands(shadow, guild_id=guild_id)
+        expected = _discord_guild_command_fingerprint(
+            desired,
+            application_id=application_id,
+        )
+        return desired if materializations.get(guild_id) == expected else []
+    guild_ids = await _discord_uncontested_guilds_for_link(
+        db,
+        account=account,
+        bot_agent_link_id=link.id,
+    )
+    global_commands = shadow.get("global", [])
+    global_targets = [
+        target_guild_id for target_guild_id in guild_ids if f"guild:{target_guild_id}" not in shadow
+    ]
+    if not guild_ids:
+        # Before any chat is paired, the shadow is a durable desired state for
+        # a future server. Once the Link is DM-only, returning an empty list is
+        # the explicit boundary: per-Link global commands are not materialized
+        # into Discord's shared application-global DM namespace.
+        bindings = await _discord_active_bindings_for_link(db, account=account, link=link)
+        return global_commands if not bindings else []
+    if not global_targets:
+        return global_commands
+    expected = _discord_guild_command_fingerprint(
+        global_commands,
+        application_id=application_id,
+    )
+    if all(materializations.get(target) == expected for target in global_targets):
+        return global_commands
+    return []
+
+
 async def _store_discord_command_shadow(
     db: AsyncSession,
     *,
@@ -751,7 +946,7 @@ async def _store_discord_command_shadow(
     commands: dict[str, list[dict[str, Any]]],
 ) -> None:
     config = dict(link.config) if isinstance(link.config, dict) else {}
-    config["discord_agent_commands"] = commands
+    config[_DISCORD_AGENT_COMMANDS_CONFIG_KEY] = commands
     link.config = config
     await db.commit()
 
@@ -878,7 +1073,7 @@ async def _discord_guild_owned_by_link(
 ) -> bool:
     owners = await _discord_guild_owner_principals(
         db,
-        account_id=account.id,
+        application_id=_discord_application_id(account),
         guild_id=guild_id,
     )
     return owners == {(account.id, bot_agent_link_id)}
@@ -890,13 +1085,13 @@ async def _discord_uncontested_guilds_for_link(
     account: ChannelAccount,
     bot_agent_link_id: UUID,
 ) -> list[str]:
+    application_id = _discord_application_id(account)
     result = await db.execute(
         select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
         .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
-            ChannelBinding.account_id == account.id,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
             ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
             ChannelBotAgentLink.archived_at.is_(None),
@@ -904,6 +1099,8 @@ async def _discord_uncontested_guilds_for_link(
     )
     owners_by_guild: dict[str, set[tuple[UUID, UUID]]] = {}
     for binding, owner_account, owner_link in result.all():
+        if _discord_application_id(owner_account) != application_id:
+            continue
         guild_id = _discord_binding_guild_id(binding)
         if guild_id is None:
             continue
@@ -915,20 +1112,62 @@ async def _discord_uncontested_guilds_for_link(
     )
 
 
+async def _discord_active_bindings_for_link(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> list[ChannelBinding]:
+    result = await db.execute(
+        select(ChannelBinding).where(
+            ChannelBinding.account_id == account.id,
+            ChannelBinding.bot_agent_link_id == link.id,
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+        )
+    )
+    return list(result.scalars())
+
+
+async def _assert_discord_command_mutation_supported(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+    guild_id: str | None,
+) -> None:
+    if guild_id is not None:
+        return
+    guild_ids = await _discord_uncontested_guilds_for_link(
+        db,
+        account=account,
+        bot_agent_link_id=link.id,
+    )
+    if guild_ids:
+        return
+    bindings = await _discord_active_bindings_for_link(db, account=account, link=link)
+    if bindings:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "agent-defined Discord commands require a paired server; "
+                "per-Link commands are unavailable in direct messages"
+            ),
+        )
+
+
 async def _discord_guild_owner_principals(
     db: AsyncSession,
     *,
-    account_id: UUID,
+    application_id: str,
     guild_id: str,
 ) -> set[tuple[UUID, UUID]]:
-    """Return active Link owners within one physical Discord account namespace."""
+    """Return active Link owners within one physical Discord app namespace."""
     result = await db.execute(
         select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
         .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
         .where(
             ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
-            ChannelBinding.account_id == account_id,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
             ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
             ChannelBotAgentLink.archived_at.is_(None),
@@ -936,7 +1175,10 @@ async def _discord_guild_owner_principals(
     )
     owners: set[tuple[UUID, UUID]] = set()
     for binding, owner_account, owner_link in result.all():
-        if _discord_binding_guild_id(binding) == guild_id:
+        if (
+            _discord_application_id(owner_account) == application_id
+            and _discord_binding_guild_id(binding) == guild_id
+        ):
             owners.add((owner_account.id, owner_link.id))
     return owners
 
@@ -950,6 +1192,60 @@ def _discord_binding_guild_id(binding: ChannelBinding) -> str | None:
     return None
 
 
+async def _lock_discord_command_projection(
+    db: AsyncSession,
+    *,
+    application_id: str,
+    guild_id: str,
+) -> None:
+    """Serialize every physical command overwrite for one app/Guild namespace."""
+    lock_name = f"discord-command-projection:{application_id}:{guild_id}"
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
+
+
+def _discord_retry_exception(retry: dict[str, Any]) -> HTTPException:
+    status_code = retry.get("status_code")
+    if status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        headers: dict[str, str] | None = None
+        next_retry_at = retry.get("next_retry_at")
+        if isinstance(next_retry_at, str):
+            try:
+                due_at = datetime.fromisoformat(next_retry_at.replace("Z", "+00:00"))
+            except ValueError:
+                pass
+            else:
+                remaining = max(0.0, (due_at - datetime.now(UTC)).total_seconds())
+                headers = {"Retry-After": f"{remaining:.3f}"}
+        return HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="discord command sync is rate limited",
+            headers=headers,
+        )
+    if retry.get("blocked") is True:
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="discord api rejected commands",
+        )
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="discord command reconciliation is deferred",
+    )
+
+
+def _discord_provider_failure_exception(result: _DiscordProviderResult) -> HTTPException:
+    if result.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        retry_after = _discord_retry_after_seconds(result)
+        return HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="discord command sync is rate limited",
+            headers=({"Retry-After": f"{retry_after:.3f}"} if retry_after is not None else None),
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="discord api rejected commands",
+    )
+
+
 async def _fan_out_discord_global_commands(
     db: AsyncSession,
     *,
@@ -958,9 +1254,25 @@ async def _fan_out_discord_global_commands(
     application_id: str,
     commands: list[dict[str, Any]],
     guild_ids: set[str] | None = None,
-) -> None:
+    automatic: bool = False,
+    force: bool = False,
+) -> int:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
-        return
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="discord bot credential unavailable",
+        )
+    link = await db.get(ChannelBotAgentLink, bot_agent_link_id)
+    if (
+        link is None
+        or link.account_id != account.id
+        or link.status != BOT_AGENT_LINK_STATUS_ACTIVE
+        or link.archived_at is not None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="discord agent link unavailable",
+        )
     uncontested_guild_ids = await _discord_uncontested_guilds_for_link(
         db,
         account=account,
@@ -970,22 +1282,200 @@ async def _fan_out_discord_global_commands(
         guild_id for guild_id in uncontested_guild_ids if guild_ids is None or guild_id in guild_ids
     ]
     if not target_guild_ids:
-        return
-    body = json.dumps(
-        [_discord_guild_command_provider_payload(command) for command in commands]
-    ).encode("utf-8")
+        return 0
+    reconciled = 0
+    first_error: HTTPException | None = None
     for guild_id in target_guild_ids:
-        result = await _request_discord_provider(
-            account=account,
-            method="PUT",
-            path=f"/applications/{application_id}/guilds/{guild_id}/commands",
-            body=body,
+        await _lock_discord_command_projection(
+            db,
+            application_id=application_id,
+            guild_id=guild_id,
         )
-        if result.status_code >= 400:
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail="discord api rejected commands",
+        await db.refresh(link, with_for_update=True)
+        if not await _discord_guild_owned_by_link(
+            db,
+            account=account,
+            bot_agent_link_id=link.id,
+            guild_id=guild_id,
+        ):
+            await db.commit()
+            continue
+        desired_shadow = _discord_command_shadow(link)
+        materializations = _discord_command_materializations(link)
+        retries = _discord_command_retries(link)
+        desired_commands = _discord_effective_guild_commands(
+            desired_shadow,
+            guild_id=guild_id,
+        )
+        fingerprint = _discord_guild_command_fingerprint(
+            desired_commands,
+            application_id=application_id,
+        )
+        if not force and materializations.get(guild_id) == fingerprint:
+            await db.commit()
+            continue
+        retry = retries.get(guild_id)
+        if not force and not _discord_retry_is_due(retry, fingerprint=fingerprint):
+            await db.commit()
+            if not automatic and first_error is None and retry is not None:
+                first_error = _discord_retry_exception(retry)
+            continue
+        body = json.dumps(
+            [_discord_guild_command_provider_payload(command) for command in desired_commands]
+        ).encode("utf-8")
+        try:
+            result = await _request_discord_provider(
+                account=account,
+                method="PUT",
+                path=f"/applications/{application_id}/guilds/{guild_id}/commands",
+                body=body,
             )
+        except HTTPException as exc:
+            retries[guild_id] = _discord_command_retry_state(
+                previous=retries.get(guild_id),
+                fingerprint=fingerprint,
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                result=None,
+            )
+            config = dict(link.config) if isinstance(link.config, dict) else {}
+            config[_DISCORD_COMMAND_RETRIES_CONFIG_KEY] = retries
+            link.config = config
+            await db.commit()
+            if not automatic and first_error is None:
+                first_error = exc
+            continue
+        if not 200 <= result.status_code < 300:
+            retries[guild_id] = _discord_command_retry_state(
+                previous=retries.get(guild_id),
+                fingerprint=fingerprint,
+                status_code=result.status_code,
+                result=result,
+            )
+            config = dict(link.config) if isinstance(link.config, dict) else {}
+            config[_DISCORD_COMMAND_RETRIES_CONFIG_KEY] = retries
+            link.config = config
+            await db.commit()
+            if not automatic and first_error is None:
+                first_error = _discord_provider_failure_exception(result)
+            continue
+        materializations[guild_id] = fingerprint
+        retries.pop(guild_id, None)
+        config = dict(link.config) if isinstance(link.config, dict) else {}
+        config[_DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY] = materializations
+        config[_DISCORD_COMMAND_RETRIES_CONFIG_KEY] = retries
+        link.config = config
+        await db.commit()
+        reconciled += 1
+    if first_error is not None:
+        raise first_error
+    return reconciled
+
+
+async def _discord_historical_guilds_for_link(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> set[str]:
+    result = await db.execute(
+        select(ChannelBinding).where(
+            ChannelBinding.account_id == account.id,
+            ChannelBinding.bot_agent_link_id == link.id,
+        )
+    )
+    return {
+        guild_id
+        for binding in result.scalars()
+        if (guild_id := _discord_binding_guild_id(binding)) is not None
+    }
+
+
+async def _clear_discord_guild_commands(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+    application_id: str,
+    guild_ids: set[str],
+    force: bool = False,
+) -> bool:
+    """Converge stale physical Guild scopes to an explicit empty tombstone."""
+    if not account.encrypted_provider_token or not account.provider_token_nonce:
+        return False
+    empty_fingerprint = _discord_guild_command_fingerprint(
+        [],
+        application_id=application_id,
+    )
+    succeeded = True
+    for guild_id in sorted(guild_ids):
+        await _lock_discord_command_projection(
+            db,
+            application_id=application_id,
+            guild_id=guild_id,
+        )
+        await db.refresh(link, with_for_update=True)
+        materializations = _discord_command_materializations(link)
+        retries = _discord_command_retries(link)
+        owners = await _discord_guild_owner_principals(
+            db,
+            application_id=application_id,
+            guild_id=guild_id,
+        )
+        if len(owners) == 1:
+            # A new active Link owns the physical namespace. Retire only this
+            # stale Link's receipt; its owner will reconcile the desired set.
+            materializations[guild_id] = empty_fingerprint
+            retries.pop(guild_id, None)
+            config = dict(link.config) if isinstance(link.config, dict) else {}
+            config[_DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY] = materializations
+            config[_DISCORD_COMMAND_RETRIES_CONFIG_KEY] = retries
+            link.config = config
+            await db.commit()
+            continue
+        # Multiple owners are a legacy/invalid collision in the same physical
+        # app+Guild namespace. No Link may claim materialization; converge the
+        # namespace to empty until identity admission is repaired.
+        retry = retries.get(guild_id)
+        if not force and materializations.get(guild_id) == empty_fingerprint and retry is None:
+            await db.commit()
+            continue
+        if not force and not _discord_retry_is_due(retry, fingerprint=empty_fingerprint):
+            succeeded = False
+            await db.commit()
+            continue
+        try:
+            result = await _request_discord_provider(
+                account=account,
+                method="PUT",
+                path=f"/applications/{application_id}/guilds/{guild_id}/commands",
+                body=b"[]",
+            )
+        except HTTPException:
+            retries[guild_id] = _discord_command_retry_state(
+                previous=retry,
+                fingerprint=empty_fingerprint,
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                result=None,
+            )
+            succeeded = False
+        else:
+            if 200 <= result.status_code < 300:
+                materializations[guild_id] = empty_fingerprint
+                retries.pop(guild_id, None)
+            else:
+                retries[guild_id] = _discord_command_retry_state(
+                    previous=retry,
+                    fingerprint=empty_fingerprint,
+                    status_code=result.status_code,
+                    result=result,
+                )
+                succeeded = False
+        config = dict(link.config) if isinstance(link.config, dict) else {}
+        config[_DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY] = materializations
+        config[_DISCORD_COMMAND_RETRIES_CONFIG_KEY] = retries
+        link.config = config
+        await db.commit()
+    return succeeded
 
 
 async def _materialize_discord_command_scope(
@@ -1001,13 +1491,38 @@ async def _materialize_discord_command_scope(
     # physical global command set or DMs; only materialize them into this
     # Link's Guild bindings. Built-in reserved commands use the separate
     # account-level sync path and remain physical global commands.
+    target_guild_ids = await _discord_uncontested_guilds_for_link(
+        db,
+        account=account,
+        bot_agent_link_id=link.id,
+    )
+    selected_guild_ids = (
+        [target for target in target_guild_ids if target == guild_id]
+        if guild_id is not None
+        else target_guild_ids
+    )
+    if not selected_guild_ids:
+        bindings = await _discord_active_bindings_for_link(
+            db,
+            account=account,
+            link=link,
+        )
+        if bindings:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "agent-defined Discord commands require a paired server; "
+                    "per-Link commands are unavailable in direct messages"
+                ),
+            )
+        return
     await _fan_out_discord_global_commands(
         db,
         account=account,
         bot_agent_link_id=link.id,
         application_id=application_id,
         commands=commands,
-        guild_ids={guild_id} if guild_id is not None else None,
+        guild_ids=set(selected_guild_ids),
     )
 
 
@@ -1122,7 +1637,7 @@ async def _request_discord_provider(
                 discord_rate_limiter.observe(
                     method,
                     normalized_path,
-                    response.headers,
+                    _discord_rate_limit_response_headers(response),
                     response.status_code,
                 )
     except httpx.HTTPError as exc:
@@ -1138,7 +1653,7 @@ async def _request_discord_provider(
         content=response.content,
         status_code=response.status_code,
         media_type=response.headers.get("content-type", "application/json"),
-        headers=_discord_response_headers(response.headers),
+        headers=_discord_response_headers(_discord_rate_limit_response_headers(response)),
     )
 
 
@@ -1174,6 +1689,24 @@ def _discord_response_headers(headers: Any) -> dict[str, str]:
     return {
         name: value for name in _DISCORD_RESPONSE_HEADER_ALLOWLIST if (value := headers.get(name))
     }
+
+
+def _discord_rate_limit_response_headers(response: httpx.Response) -> dict[str, str]:
+    headers = {str(key).lower(): str(value) for key, value in response.headers.items()}
+    if response.status_code != status.HTTP_429_TOO_MANY_REQUESTS or "retry-after" in headers:
+        return headers
+    try:
+        payload = response.json()
+    except ValueError:
+        return headers
+    raw_retry_after = payload.get("retry_after") if isinstance(payload, dict) else None
+    if (
+        isinstance(raw_retry_after, (int, float))
+        and not isinstance(raw_retry_after, bool)
+        and raw_retry_after >= 0
+    ):
+        headers["retry-after"] = str(raw_retry_after)
+    return headers
 
 
 async def _validate_discord_provider_base_url(base_url: str) -> None:

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -841,12 +841,13 @@ def _discord_command_retry_state(
     result: _DiscordProviderResult | None,
 ) -> dict[str, Any]:
     previous_attempts = previous.get("attempts") if isinstance(previous, dict) else None
+    previous_fingerprint = previous.get("fingerprint") if isinstance(previous, dict) else None
     attempts = (
         previous_attempts + 1
         if isinstance(previous_attempts, int)
         and not isinstance(previous_attempts, bool)
         and previous_attempts >= 0
-        and previous.get("fingerprint") == fingerprint
+        and previous_fingerprint == fingerprint
         else 1
     )
     retry_after = _discord_retry_after_seconds(result) if result is not None else None

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -72,7 +72,7 @@ from app.services.metrics import (
 )
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_http_url
 
-# Discord API docs baseline b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+# Discord API docs baseline 07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3.
 # Keep both directions explicit: runtime credentials and hop-by-hop headers
 # never cross into Discord, while documented rate-limit state remains usable.
 _DISCORD_REQUEST_HEADER_ALLOWLIST = ("x-audit-log-reason",)
@@ -850,9 +850,10 @@ def _discord_command_retry_state(
         else 1
     )
     retry_after = _discord_retry_after_seconds(result) if result is not None else None
-    blocked = 400 <= status_code < 500 and (
-        status_code != status.HTTP_429_TOO_MANY_REQUESTS or retry_after is None
-    )
+    # A 429 is always transient. Discord normally supplies Retry-After, but a
+    # missing/malformed value must fall back to bounded exponential backoff
+    # instead of turning a temporary rate limit into a permanent tombstone.
+    blocked = 400 <= status_code < 500 and status_code != status.HTTP_429_TOO_MANY_REQUESTS
     if status_code == status.HTTP_429_TOO_MANY_REQUESTS and retry_after is not None:
         delay_seconds = retry_after
     else:
@@ -1311,7 +1312,11 @@ async def _fan_out_discord_global_commands(
             desired_commands,
             application_id=application_id,
         )
-        if not force and materializations.get(guild_id) == fingerprint:
+        # GUILD_CREATE is also emitted for every available Guild on READY and
+        # reconnect. A verified recovery trigger may bypass blocked/not-due
+        # retry state, but an application-aware current receipt is converged
+        # and must never cause another bulk overwrite.
+        if materializations.get(guild_id) == fingerprint:
             await db.commit()
             continue
         retry = retries.get(guild_id)
@@ -1436,7 +1441,7 @@ async def _clear_discord_guild_commands(
         # app+Guild namespace. No Link may claim materialization; converge the
         # namespace to empty until identity admission is repaired.
         retry = retries.get(guild_id)
-        if not force and materializations.get(guild_id) == empty_fingerprint and retry is None:
+        if materializations.get(guild_id) == empty_fingerprint and retry is None:
             await db.commit()
             continue
         if not force and not _discord_retry_is_due(retry, fingerprint=empty_fingerprint):

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -130,7 +130,7 @@ DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
 DISCORD_INSTALL_CONFIG_VERSION = 1
 DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
 DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY = "discord_user_install_supported"
-# Discord API docs baseline b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+# Discord API docs baseline 07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3.
 # ADD_REACTIONS, VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS, ATTACH_FILES,
 # READ_MESSAGE_HISTORY, and SEND_MESSAGES_IN_THREADS. Never request
 # ADMINISTRATOR or MANAGE_GUILD for the bot; pair mutation authority is the
@@ -1844,7 +1844,7 @@ def discord_guild_command_denied_reason(
     decimal-string bitfield. The installation admission check separately
     requires an application-command interaction, so MESSAGE_CREATE cannot
     manufacture authority by copying this field. Discord API docs baseline:
-    b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
+    07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3.
     """
     if command is None or command.kind not in {"pair", "unpair"} or guild_id is None:
         return None
@@ -3647,16 +3647,66 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
         },
     )
     _verify_discord_application_identity(configured, expected_application_id=application_id)
-    configured_integration_types = configured.get("integration_types_config")
-    verified_user_install = isinstance(configured_integration_types, dict) and isinstance(
-        configured_integration_types.get(str(DISCORD_USER_INSTALL)),
-        dict,
-    )
+    verified_user_install = _verify_discord_install_configuration(configured)
     config = dict(account.config) if isinstance(account.config, dict) else {}
     config[DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY] = DISCORD_INSTALL_CONFIG_VERSION
     config[DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY] = verified_user_install
     account.config = config
     return configured
+
+
+def _verify_discord_install_configuration(payload: dict[str, Any]) -> bool:
+    """Verify the exact install defaults Discord persisted after PATCH."""
+    integration_types = payload.get("integration_types_config")
+    if not isinstance(integration_types, dict):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord returned an invalid Guild Install configuration.",
+        )
+    guild_config = integration_types.get(str(DISCORD_GUILD_INSTALL))
+    if not _discord_install_params_match(
+        guild_config,
+        expected_scopes={"applications.commands", "bot"},
+        expected_permissions=str(DISCORD_MINIMAL_BOT_PERMISSIONS),
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord returned an invalid Guild Install configuration.",
+        )
+    user_config = integration_types.get(str(DISCORD_USER_INSTALL))
+    if user_config is None:
+        return False
+    if not _discord_install_params_match(
+        user_config,
+        expected_scopes={"applications.commands"},
+        expected_permissions="0",
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Discord returned an invalid User Install configuration.",
+        )
+    return True
+
+
+def _discord_install_params_match(
+    config: Any,
+    *,
+    expected_scopes: set[str],
+    expected_permissions: str,
+) -> bool:
+    if not isinstance(config, dict):
+        return False
+    install_params = config.get("oauth2_install_params")
+    if not isinstance(install_params, dict):
+        return False
+    scopes = install_params.get("scopes")
+    return (
+        isinstance(scopes, list)
+        and len(scopes) == len(expected_scopes)
+        and all(isinstance(scope, str) for scope in scopes)
+        and set(scopes) == expected_scopes
+        and install_params.get("permissions") == expected_permissions
+    )
 
 
 async def verify_discord_application_token_identity(
@@ -3814,6 +3864,40 @@ def discord_config_without_unverified_install_state(
     sanitized.pop(DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY, None)
     sanitized.pop(DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY, None)
     return sanitized
+
+
+async def rearm_discord_command_reconciliation(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+) -> int:
+    """Make blocked command retries due after verified credential/setup repair."""
+    result = await db.execute(
+        select(ChannelBotAgentLink).where(ChannelBotAgentLink.account_id == account.id)
+    )
+    rearmed = 0
+    for link in result.scalars():
+        config = dict(link.config) if isinstance(link.config, dict) else {}
+        raw_retries = config.get("discord_command_retries")
+        if not isinstance(raw_retries, dict):
+            continue
+        retries = {
+            guild_id: dict(retry)
+            for guild_id, retry in raw_retries.items()
+            if isinstance(guild_id, str) and isinstance(retry, dict)
+        }
+        changed = False
+        for retry in retries.values():
+            if retry.get("blocked") is not True:
+                continue
+            retry["blocked"] = False
+            retry["next_retry_at"] = datetime.now(UTC).isoformat()
+            changed = True
+            rearmed += 1
+        if changed:
+            config["discord_command_retries"] = retries
+            link.config = config
+    return rearmed
 
 
 def discord_reserved_commands_are_current(account: ChannelAccount) -> bool:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -4425,12 +4425,10 @@ async def _discord_command_request(
             headers={"Retry-After": str(retry_after)} if retry_after is not None else None,
         )
     discord_rate_limiter.consume(method, path)
-    response = await client.request(
-        method,
-        url,
-        headers=headers,
-        **({"json": json_payload} if json_payload is not None else {}),
-    )
+    if json_payload is None:
+        response = await client.request(method, url, headers=headers)
+    else:
+        response = await client.request(method, url, headers=headers, json=json_payload)
     discord_rate_limiter.observe(
         method,
         path,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -125,16 +125,27 @@ DISCORD_GUILD_INSTALL = 0
 DISCORD_USER_INSTALL = 1
 DISCORD_GUILD_INTERACTION_CONTEXT = 0
 DISCORD_BOT_DM_INTERACTION_CONTEXT = 1
-DISCORD_RESERVED_COMMAND_VERSION = 2
+DISCORD_RESERVED_COMMAND_VERSION = 3
 DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
+DISCORD_INSTALL_CONFIG_VERSION = 1
+DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
+DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY = "discord_user_install_supported"
 # Discord API docs baseline b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
 # ADD_REACTIONS, VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS, ATTACH_FILES,
 # READ_MESSAGE_HISTORY, and SEND_MESSAGES_IN_THREADS. Never request
 # ADMINISTRATOR or MANAGE_GUILD for the bot; pair mutation authority is the
-# invoking member's computed permissions.
+# invoking member's computed permissions. The managed OpenClaw projection
+# disables advanced actions that need excluded role permissions; Gateway
+# intents are a separate capability and never widen the bot role. The default
+# install deliberately excludes CONNECT, SPEAK, MANAGE_MESSAGES, MANAGE_EVENTS,
+# and MANAGE_GUILD_EXPRESSIONS.
 DISCORD_MINIMAL_BOT_PERMISSIONS = 274_878_024_768
 DISCORD_GUILD_PERMISSION_DENIED = "discord_guild_permission_denied"
 DISCORD_GUILD_USE_INTERACTION = "discord_guild_use_interaction"
+DISCORD_GUILD_INSTALL_REQUIRED = "discord_guild_install_required"
+DISCORD_USER_INSTALL_REQUIRED = "discord_user_install_required"
+DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED = "discord_bot_guild_membership_required"
+DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE = "discord_bot_guild_membership_unavailable"
 DISCORD_DM_CHAT_TYPES = frozenset({"dm", "direct_messages", "group_dm", "private"})
 DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
 DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
@@ -636,7 +647,7 @@ async def bot_agent_link_allows_new_pairing(
                 AgentEnvironment.user_id == user_id,
             )
             .execution_options(populate_existing=True)
-            .with_for_update(of=V2RuntimeEnvironmentFence)
+            .with_for_update(of=(ChannelBotAgentLink, V2RuntimeEnvironmentFence))
         )
     ).one_or_none()
     if row is None:
@@ -1830,9 +1841,9 @@ def discord_guild_command_denied_reason(
     """Require Discord-computed guild permissions for pairing mutations.
 
     Discord interaction ``member.permissions`` is the authoritative computed
-    decimal-string bitfield. MESSAGE_CREATE does not normally include it, so
-    text commands fail closed unless a trusted ingress supplied the same
-    computed field. Discord API docs baseline:
+    decimal-string bitfield. The installation admission check separately
+    requires an application-command interaction, so MESSAGE_CREATE cannot
+    manufacture authority by copying this field. Discord API docs baseline:
     b2f8adafc037242291b8f875d4cdf3adc4d48bb7.
     """
     if command is None or command.kind not in {"pair", "unpair"} or guild_id is None:
@@ -1851,6 +1862,194 @@ def discord_guild_command_denied_reason(
     if permissions & required:
         return None
     return DISCORD_GUILD_PERMISSION_DENIED
+
+
+def discord_pair_install_denied_reason(
+    payload: dict[str, Any],
+    *,
+    command: ChannelPairCommand | None,
+    guild_id: str | None,
+    external_user_id: str | None,
+    trusted_interaction: bool,
+) -> str | None:
+    """Require the Discord installation that owns a pairing mutation.
+
+    ``authorizing_integration_owners`` is Discord's authoritative mapping from
+    installation context to owner. Both pair and unpair require an authentic
+    application-command interaction in the matching context. For backward
+    compatible cleanup after an uninstall, unpair alone may proceed when the
+    required owner key is absent; the binding resolver still requires an exact
+    active scope and the original pairing actor. A present-but-mismatched owner
+    is never accepted.
+    """
+    denied_reason, _cleanup_owner_missing = _discord_pair_install_admission(
+        payload,
+        command=command,
+        guild_id=guild_id,
+        external_user_id=external_user_id,
+        trusted_interaction=trusted_interaction,
+    )
+    return denied_reason
+
+
+def _discord_pair_install_admission(
+    payload: dict[str, Any],
+    *,
+    command: ChannelPairCommand | None,
+    guild_id: str | None,
+    external_user_id: str | None,
+    trusted_interaction: bool,
+) -> tuple[str | None, bool]:
+    if command is None or command.kind not in {"pair", "unpair"}:
+        return None, False
+    data = _discord_event_data(payload)
+    interaction_type = data.get("type")
+    interaction_data = data.get("data")
+    is_http_interaction = data is payload
+    is_gateway_interaction = payload.get("t") == "INTERACTION_CREATE" and data is not payload
+    is_application_command = (
+        isinstance(interaction_type, int)
+        and not isinstance(interaction_type, bool)
+        and interaction_type == 2
+        and isinstance(interaction_data, dict)
+        and (is_http_interaction or is_gateway_interaction)
+    )
+    expected_context = (
+        DISCORD_GUILD_INTERACTION_CONTEXT
+        if guild_id is not None
+        else DISCORD_BOT_DM_INTERACTION_CONTEXT
+    )
+    raw_context = data.get("context")
+    if (
+        not trusted_interaction
+        or not is_application_command
+        or not isinstance(raw_context, int)
+        or isinstance(raw_context, bool)
+        or raw_context != expected_context
+    ):
+        return (
+            (
+                DISCORD_GUILD_INSTALL_REQUIRED
+                if guild_id is not None
+                else DISCORD_USER_INSTALL_REQUIRED
+            ),
+            False,
+        )
+    raw_owners = data.get("authorizing_integration_owners")
+    if raw_owners is None and "authorizing_integration_owners" not in data:
+        owners: dict[str, Any] = {}
+    elif isinstance(raw_owners, dict):
+        owners = raw_owners
+    else:
+        return (
+            (
+                DISCORD_GUILD_INSTALL_REQUIRED
+                if guild_id is not None
+                else DISCORD_USER_INSTALL_REQUIRED
+            ),
+            False,
+        )
+    if guild_id is not None:
+        owner_key = str(DISCORD_GUILD_INSTALL)
+        if owner_key not in owners:
+            return (
+                (None, True)
+                if command.kind == "unpair"
+                else (DISCORD_GUILD_INSTALL_REQUIRED, False)
+            )
+        raw_guild_owner = owners.get(owner_key)
+        guild_owner = raw_guild_owner.strip() if isinstance(raw_guild_owner, str) else None
+        return (None, False) if guild_owner == guild_id else (DISCORD_GUILD_INSTALL_REQUIRED, False)
+    owner_key = str(DISCORD_USER_INSTALL)
+    if owner_key not in owners:
+        return (None, True) if command.kind == "unpair" else (DISCORD_USER_INSTALL_REQUIRED, False)
+    raw_user_owner = owners.get(owner_key)
+    user_owner = raw_user_owner.strip() if isinstance(raw_user_owner, str) else None
+    if external_user_id is not None and user_owner == external_user_id:
+        return None, False
+    return DISCORD_USER_INSTALL_REQUIRED, False
+
+
+async def discord_bot_guild_membership_denied_reason(
+    account: ChannelAccount,
+    *,
+    guild_id: str,
+) -> str | None:
+    """Verify bot membership with Discord before a guild pair code is claimed."""
+    token = decrypt_provider_token(account)
+    base_url = (
+        _account_config_str(account, "api_base_url")
+        or settings.channel_discord_api_base_url.strip()
+    )
+    await _validate_provider_endpoint_url(
+        base_url,
+        channel=CHANNEL_PROVIDER_DISCORD,
+        method="GET",
+        label="discord api base url",
+    )
+    path = f"/guilds/{guild_id}"
+    decision = discord_rate_limiter.check("GET", path)
+    if not decision.allowed:
+        return DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE
+    try:
+        with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, "GET"):
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                discord_rate_limiter.consume("GET", path)
+                response = await client.get(
+                    f"{base_url.rstrip('/')}{path}",
+                    headers={"Authorization": f"Bot {token}"},
+                )
+                discord_rate_limiter.observe(
+                    "GET",
+                    path,
+                    _discord_rate_limit_response_headers(response),
+                    response.status_code,
+                )
+    except httpx.HTTPError:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="GET").inc()
+        return DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE
+    outbound_messages.labels(channel=CHANNEL_PROVIDER_DISCORD, method="GET").inc()
+    if response.status_code in {status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND}:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="GET").inc()
+        return DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED
+    if not 200 <= response.status_code < 300:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="GET").inc()
+        return DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE
+    response_payload = _response_json_or_text(response)
+    if _read_optional_str(response_payload.get("id")) != guild_id:
+        return DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE
+    return None
+
+
+async def discord_pairing_command_denied_reason(
+    account: ChannelAccount,
+    payload: dict[str, Any],
+    *,
+    command: ChannelPairCommand | None,
+    guild_id: str | None,
+    external_user_id: str | None,
+    trusted_interaction: bool,
+) -> str | None:
+    install_reason, cleanup_owner_missing = _discord_pair_install_admission(
+        payload,
+        command=command,
+        guild_id=guild_id,
+        external_user_id=external_user_id,
+        trusted_interaction=trusted_interaction,
+    )
+    if install_reason is not None:
+        return install_reason
+    if not cleanup_owner_missing:
+        permission_reason = discord_guild_command_denied_reason(
+            payload,
+            command=command,
+            guild_id=guild_id,
+        )
+        if permission_reason is not None:
+            return permission_reason
+    if command is not None and command.kind == "pair" and guild_id is not None:
+        return await discord_bot_guild_membership_denied_reason(account, guild_id=guild_id)
+    return None
 
 
 def discord_pairing_reply_for_command(
@@ -1876,6 +2075,14 @@ def discord_pairing_reply_for_command(
         )
     if result.pair_failed_reason == DISCORD_GUILD_PERMISSION_DENIED:
         return "You need Manage Server permission to pair or unpair this server."
+    if result.pair_failed_reason == DISCORD_GUILD_INSTALL_REQUIRED:
+        return "Discord could not verify this app installation for this server command."
+    if result.pair_failed_reason == DISCORD_USER_INSTALL_REQUIRED:
+        return "Discord could not verify User Install for this direct-message command."
+    if result.pair_failed_reason == DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED:
+        return "Add the Discord bot to this server before pairing it."
+    if result.pair_failed_reason == DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE:
+        return "Discord could not verify that the bot is in this server. Try again."
     if result.pair_failed_reason == "forbidden":
         return f"Only the user who paired this {scope} can change its pairing."
     if result.pair_failed_reason == "already_paired":
@@ -2271,6 +2478,35 @@ async def find_existing_inbound_provider_event(
         .limit(1)
     )
     return result.scalar_one_or_none()
+
+
+async def discord_pairing_command_event_was_handled(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    external_chat_id: str,
+    provider_event_id: str | None,
+    command: ChannelPairCommand | None,
+) -> bool:
+    """Serialize pairing mutations and reject a previously handled Discord event."""
+    if provider_event_id is None or command is None or command.kind not in {"pair", "unpair"}:
+        return False
+    # The same transaction-level scope lock is acquired again by
+    # resolve_inbound_binding. Taking it before the event lookup closes the
+    # replay race where a duplicate unpair waits behind a new pair and then
+    # archives the replacement binding.
+    await lock_channel_binding_identity(
+        db,
+        account_id=account.id,
+        external_chat_id=external_chat_id,
+    )
+    existing = await find_existing_inbound_provider_event(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        provider_event_id=provider_event_id,
+    )
+    return existing is not None
 
 
 async def record_inbound_messages_for_bindings(
@@ -3355,6 +3591,36 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
             detail="Discord application_id is required.",
         )
     token = decrypt_provider_token(account)
+    identity = await verify_discord_application_token_identity(
+        application_id=application_id,
+        provider_token=token,
+        config=account.config,
+    )
+    raw_integration_config = identity.get("integration_types_config")
+    integration_config = (
+        {
+            str(key): dict(value)
+            for key, value in raw_integration_config.items()
+            if isinstance(key, str) and isinstance(value, dict)
+        }
+        if isinstance(raw_integration_config, dict)
+        else {}
+    )
+    guild_install_params = {
+        "scopes": ["applications.commands", "bot"],
+        "permissions": str(DISCORD_MINIMAL_BOT_PERMISSIONS),
+    }
+    guild_install_config = dict(integration_config.get(str(DISCORD_GUILD_INSTALL), {}))
+    guild_install_config["oauth2_install_params"] = guild_install_params
+    integration_config[str(DISCORD_GUILD_INSTALL)] = guild_install_config
+    user_install_supported = str(DISCORD_USER_INSTALL) in integration_config
+    if user_install_supported:
+        user_install_config = dict(integration_config[str(DISCORD_USER_INSTALL)])
+        user_install_config["oauth2_install_params"] = {
+            "scopes": ["applications.commands"],
+            "permissions": "0",
+        }
+        integration_config[str(DISCORD_USER_INSTALL)] = user_install_config
     base_url = (
         _account_config_str(account, "api_base_url")
         or settings.channel_discord_api_base_url.strip()
@@ -3370,22 +3636,114 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
         "Authorization": f"Bot {token}",
         "Content-Type": "application/json",
     }
-    identity = await _discord_application_request(
-        method="GET",
-        url=url,
-        headers=headers,
-    )
-    _verify_discord_application_identity(identity, expected_application_id=application_id)
     configured = await _discord_application_request(
         method="PATCH",
         url=url,
         headers=headers,
         json_payload={
-            "interactions_endpoint_url": channel_webhook_url(account.id, account.provider)
+            "interactions_endpoint_url": channel_webhook_url(account.id, account.provider),
+            "install_params": guild_install_params,
+            "integration_types_config": integration_config,
         },
     )
     _verify_discord_application_identity(configured, expected_application_id=application_id)
+    configured_integration_types = configured.get("integration_types_config")
+    verified_user_install = isinstance(configured_integration_types, dict) and isinstance(
+        configured_integration_types.get(str(DISCORD_USER_INSTALL)),
+        dict,
+    )
+    config = dict(account.config) if isinstance(account.config, dict) else {}
+    config[DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY] = DISCORD_INSTALL_CONFIG_VERSION
+    config[DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY] = verified_user_install
+    account.config = config
     return configured
+
+
+async def verify_discord_application_token_identity(
+    *,
+    application_id: str,
+    provider_token: str,
+    config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Verify a Discord credential without mutating the Developer Portal."""
+    raw_base_url = config.get("api_base_url") if isinstance(config, dict) else None
+    base_url = (
+        raw_base_url.strip()
+        if isinstance(raw_base_url, str) and raw_base_url.strip()
+        else settings.channel_discord_api_base_url.strip()
+    )
+    await _validate_provider_endpoint_url(
+        base_url,
+        channel=CHANNEL_PROVIDER_DISCORD,
+        method="application",
+        label="discord api base url",
+    )
+    identity = await _discord_application_request(
+        method="GET",
+        url=f"{base_url.rstrip('/')}/applications/@me",
+        headers={
+            "Authorization": f"Bot {provider_token}",
+            "Content-Type": "application/json",
+        },
+    )
+    _verify_discord_application_identity(identity, expected_application_id=application_id)
+    return identity
+
+
+def discord_application_id_from_config(config: dict[str, Any] | None) -> str | None:
+    if not isinstance(config, dict):
+        return None
+    return _read_optional_str(config.get("application_id")) or _read_optional_str(
+        config.get("app_id")
+    )
+
+
+def require_unchanged_discord_application_identity(
+    account: ChannelAccount,
+    config: dict[str, Any] | None,
+) -> None:
+    """Prevent replacing an identity whose old projections cannot be retired."""
+    current_application_id = discord_application_id_from_config(account.config)
+    replacement_application_id = discord_application_id_from_config(config)
+    if replacement_application_id != current_application_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Discord application identity cannot be changed in place; "
+                "recreate the channel instead."
+            ),
+        )
+
+
+async def ensure_discord_application_identity_available(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+) -> None:
+    """Fail closed if another verified account owns the same Discord app."""
+    application_id = discord_application_id_from_config(account.config)
+    if application_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Discord application_id is required.",
+        )
+    lock_name = f"discord-application-identity:{application_id}"
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
+    result = await db.execute(
+        select(ChannelAccount).where(
+            ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+            ChannelAccount.id != account.id,
+            ChannelAccount.archived_at.is_(None),
+        )
+    )
+    for existing in result.scalars():
+        if discord_application_id_from_config(
+            existing.config
+        ) == application_id and discord_install_config_is_current(existing):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This Discord application is already connected to another channel.",
+            )
 
 
 def discord_bot_install_url(account: ChannelAccount) -> str | None:
@@ -3397,6 +3755,7 @@ def discord_bot_install_url(account: ChannelAccount) -> str | None:
     return (
         "https://discord.com/oauth2/authorize"
         f"?client_id={application_id}"
+        "&integration_type=0"
         f"&permissions={DISCORD_MINIMAL_BOT_PERMISSIONS}"
         "&scope=bot%20applications.commands"
     )
@@ -3408,6 +3767,8 @@ def discord_user_install_url(account: ChannelAccount) -> str | None:
     application_id = _account_config_str(account, "application_id")
     if application_id is None or not valid_discord_application_id(application_id):
         return None
+    if not discord_user_install_is_supported(account):
+        return None
     # USER_INSTALL supports applications.commands without the bot scope or
     # guild bot permissions. The application owner must enable User Install in
     # Discord's Installation settings for this authorize URL to succeed.
@@ -3418,6 +3779,41 @@ def discord_user_install_url(account: ChannelAccount) -> str | None:
         "&integration_type=1"
         "&scope=applications.commands"
     )
+
+
+def discord_install_config_is_current(account: ChannelAccount) -> bool:
+    if not isinstance(account.config, dict):
+        return False
+    version = account.config.get(DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY)
+    return (
+        isinstance(version, int)
+        and not isinstance(version, bool)
+        and version == DISCORD_INSTALL_CONFIG_VERSION
+        and isinstance(
+            account.config.get(DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY),
+            bool,
+        )
+    )
+
+
+def discord_user_install_is_supported(account: ChannelAccount) -> bool:
+    return (
+        discord_install_config_is_current(account)
+        and isinstance(account.config, dict)
+        and account.config.get(DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY) is True
+    )
+
+
+def discord_config_without_unverified_install_state(
+    config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Remove Discord capability state that only provider verification may set."""
+    if not isinstance(config, dict):
+        return None
+    sanitized = dict(config)
+    sanitized.pop(DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY, None)
+    sanitized.pop(DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY, None)
+    return sanitized
 
 
 def discord_reserved_commands_are_current(account: ChannelAccount) -> bool:
@@ -3452,8 +3848,13 @@ async def _discord_application_request(
             scope="bot" if decision.global_limit else "route",
         ).inc()
         raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Discord could not validate the interactions endpoint. Try again.",
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Discord application configuration is rate limited.",
+            headers=(
+                {"Retry-After": str(decision.retry_after_seconds)}
+                if decision.retry_after_seconds is not None
+                else None
+            ),
         )
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, method):
@@ -3468,7 +3869,7 @@ async def _discord_application_request(
                 discord_rate_limiter.observe(
                     method,
                     path,
-                    response.headers,
+                    _discord_rate_limit_response_headers(response),
                     response.status_code,
                 )
     except httpx.HTTPError as exc:
@@ -3478,6 +3879,14 @@ async def _discord_application_request(
             detail="Discord could not validate the interactions endpoint. Try again.",
         ) from exc
     outbound_messages.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
+    if response.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
+        retry_after = _discord_rate_limit_response_headers(response).get("retry-after")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Discord application configuration is rate limited.",
+            headers={"Retry-After": retry_after} if retry_after is not None else None,
+        )
     if response.status_code >= 400:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
         raise HTTPException(
@@ -3794,6 +4203,7 @@ async def sync_discord_commands(
     command_payloads = [
         _discord_command_payload(
             command,
+            account=account,
             global_command=scoped_guild_id is None,
         )
         for command in commands
@@ -3816,7 +4226,13 @@ async def sync_discord_commands(
                     "Authorization": f"Bot {token}",
                     "Content-Type": "application/json",
                 }
-                response = await client.request("GET", url, headers=headers)
+                response = await _discord_command_request(
+                    client,
+                    method="GET",
+                    url=url,
+                    path=f"{path}/commands",
+                    headers=headers,
+                )
                 _raise_for_discord_command_sync_response(response)
                 existing_commands = _response_json_or_text(response).get("data")
                 if not isinstance(existing_commands, list) or not all(
@@ -3847,11 +4263,13 @@ async def sync_discord_commands(
                         )
                     legacy_command_ids.append(command_id)
                 for command_payload in command_payloads:
-                    response = await client.request(
-                        "POST",
-                        url,
+                    response = await _discord_command_request(
+                        client,
+                        method="POST",
+                        url=url,
+                        path=f"{path}/commands",
                         headers=headers,
-                        json=command_payload,
+                        json_payload=command_payload,
                     )
                     _raise_for_discord_command_sync_response(response)
                     synced_command = _response_json_or_text(response)
@@ -3868,9 +4286,11 @@ async def sync_discord_commands(
                         )
                     synced.append(synced_command)
                 for command_id in legacy_command_ids:
-                    response = await client.request(
-                        "DELETE",
-                        f"{url}/{command_id}",
+                    response = await _discord_command_request(
+                        client,
+                        method="DELETE",
+                        url=f"{url}/{command_id}",
+                        path=f"{path}/commands/{command_id}",
                         headers=headers,
                     )
                     # A concurrent reconciliation can delete the exact ID
@@ -3882,13 +4302,16 @@ async def sync_discord_commands(
                     )
                 return synced
             for command_payload in command_payloads:
-                response = await client.post(
-                    url,
+                response = await _discord_command_request(
+                    client,
+                    method="POST",
+                    url=url,
+                    path=f"{path}/commands",
                     headers={
                         "Authorization": f"Bot {token}",
                         "Content-Type": "application/json",
                     },
-                    json=command_payload,
+                    json_payload=command_payload,
                 )
                 _raise_for_discord_command_sync_response(response)
                 synced.append(_response_json_or_text(response))
@@ -3900,6 +4323,53 @@ async def sync_discord_commands(
     return synced
 
 
+async def _discord_command_request(
+    client: httpx.AsyncClient,
+    *,
+    method: str,
+    url: str,
+    path: str,
+    headers: dict[str, str],
+    json_payload: dict[str, Any] | None = None,
+) -> httpx.Response:
+    decision = discord_rate_limiter.check(method, path)
+    if not decision.allowed:
+        retry_after = decision.retry_after_seconds
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="discord command sync is rate limited",
+            headers={"Retry-After": str(retry_after)} if retry_after is not None else None,
+        )
+    discord_rate_limiter.consume(method, path)
+    response = await client.request(
+        method,
+        url,
+        headers=headers,
+        **({"json": json_payload} if json_payload is not None else {}),
+    )
+    discord_rate_limiter.observe(
+        method,
+        path,
+        _discord_rate_limit_response_headers(response),
+        response.status_code,
+    )
+    return response
+
+
+def _discord_rate_limit_response_headers(response: httpx.Response) -> dict[str, str]:
+    headers = {str(key).lower(): str(value) for key, value in response.headers.items()}
+    if response.status_code != status.HTTP_429_TOO_MANY_REQUESTS or "retry-after" in headers:
+        return headers
+    raw_retry_after = _response_json_or_text(response).get("retry_after")
+    if (
+        isinstance(raw_retry_after, (int, float))
+        and not isinstance(raw_retry_after, bool)
+        and raw_retry_after >= 0
+    ):
+        headers["retry-after"] = str(raw_retry_after)
+    return headers
+
+
 def _raise_for_discord_command_sync_response(
     response: httpx.Response,
     *,
@@ -3908,9 +4378,11 @@ def _raise_for_discord_command_sync_response(
     if allow_not_found and response.status_code == status.HTTP_404_NOT_FOUND:
         return
     if response.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        retry_after = _discord_rate_limit_response_headers(response).get("retry-after")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="discord command sync is temporarily rate limited",
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="discord command sync is rate limited",
+            headers={"Retry-After": retry_after} if retry_after is not None else None,
         )
     if not status.HTTP_200_OK <= response.status_code < status.HTTP_300_MULTIPLE_CHOICES:
         raise HTTPException(
@@ -4520,19 +4992,32 @@ async def record_discord_dispatch(
     else:
         return False
     command = discord_pair_command_from_payload(frame)
+    provider_event_id = discord_message_id_from_payload(frame)
+    if await discord_pairing_command_event_was_handled(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        provider_event_id=provider_event_id,
+        command=command,
+    ):
+        return True
+    external_user_id = discord_external_user_id_from_payload(frame)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
         external_chat_id=external_chat_id,
         external_chat_type=external_chat_type,
         external_chat_name=external_chat_name,
-        external_user_id=discord_external_user_id_from_payload(frame),
+        external_user_id=external_user_id,
         text=discord_text_from_payload(frame),
         command=command,
-        command_denied_reason=discord_guild_command_denied_reason(
+        command_denied_reason=await discord_pairing_command_denied_reason(
+            account,
             frame,
             command=command,
             guild_id=guild_id,
+            external_user_id=external_user_id,
+            trusted_interaction=True,
         ),
         command_actor_required=True,
     )
@@ -4545,7 +5030,7 @@ async def record_discord_dispatch(
         account=account,
         binding_result=binding_result,
         external_chat_id=external_chat_id,
-        provider_message_id=_read_optional_str(data.get("id")) if isinstance(data, dict) else None,
+        provider_message_id=provider_event_id,
         text=_read_optional_str(data.get("content")) if isinstance(data, dict) else None,
         payload=payload,
     )
@@ -5036,6 +5521,7 @@ def _command_description(command: dict[str, Any]) -> str:
 def _discord_command_payload(
     command: dict[str, Any],
     *,
+    account: ChannelAccount,
     global_command: bool,
 ) -> dict[str, Any]:
     name = _command_name(command)
@@ -5050,25 +5536,31 @@ def _discord_command_payload(
         # authority; this only makes Discord hide the commands by default from
         # guild members without MANAGE_GUILD.
         payload["default_member_permissions"] = str(DISCORD_MANAGE_GUILD_PERMISSION)
-        payload["description"] = (
-            "Pair this server or direct message with Clawdi."
-            if name == DISCORD_PAIR_COMMAND_NAME
-            else "Disconnect this server or direct message from Clawdi."
-        )
+        if name == DISCORD_PAIR_COMMAND_NAME:
+            payload["description"] = (
+                "Pair this server or direct message with Clawdi."
+                if discord_user_install_is_supported(account)
+                else "Pair this server with Clawdi."
+            )
+        else:
+            payload["description"] = (
+                "Disconnect this server or direct message from Clawdi."
+                if discord_user_install_is_supported(account)
+                else "Disconnect this server from Clawdi."
+            )
         if global_command:
-            # The configured Discord application supports both Guild Install
-            # and User Install. BOT_DM is the user-installed app DM context;
-            # PRIVATE_CHANNEL is intentionally excluded because pairing does
-            # not need user-installed commands in other users' DMs.
+            # Guild Install is always configured. USER_INSTALL and BOT_DM are
+            # included only after /applications/@me verified that the app
+            # supports User Install. Unknown capability fails closed.
             # These are global-command fields and are intentionally omitted
             # from guild-scoped writes.
             # https://discord.com/developers/docs/resources/application#application-object-application-integration-types
             # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types
-            payload["integration_types"] = [DISCORD_GUILD_INSTALL, DISCORD_USER_INSTALL]
-            payload["contexts"] = [
-                DISCORD_GUILD_INTERACTION_CONTEXT,
-                DISCORD_BOT_DM_INTERACTION_CONTEXT,
-            ]
+            payload["integration_types"] = [DISCORD_GUILD_INSTALL]
+            payload["contexts"] = [DISCORD_GUILD_INTERACTION_CONTEXT]
+            if discord_user_install_is_supported(account):
+                payload["integration_types"].append(DISCORD_USER_INSTALL)
+                payload["contexts"].append(DISCORD_BOT_DM_INTERACTION_CONTEXT)
     options = command.get("options")
     if isinstance(options, list):
         payload["options"] = [option for option in options if isinstance(option, dict)]

--- a/backend/app/services/discord_command_reconciliation_worker.py
+++ b/backend/app/services/discord_command_reconciliation_worker.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.channel import (
+    BOT_AGENT_LINK_STATUS_ACTIVE,
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_STATUS_ACTIVE,
+    ChannelAccount,
+    ChannelBotAgentLink,
+)
+from app.routes.channel_routers.shared import (
+    _clear_discord_guild_commands,
+    _discord_command_materializations,
+    _discord_command_retries,
+    _discord_guild_command_fingerprint,
+    _discord_guild_owned_by_link,
+    _discord_historical_guilds_for_link,
+    _discord_uncontested_guilds_for_link,
+    _fan_out_discord_global_commands,
+)
+
+log = logging.getLogger(__name__)
+
+
+async def reconcile_discord_guild_commands(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    account_id: UUID,
+    guild_id: str,
+) -> int:
+    """Reconcile one Guild after Discord explicitly reports the bot joined."""
+    async with sessionmaker() as db:
+        account = await db.get(ChannelAccount, account_id)
+        if account is None:
+            await db.rollback()
+            return 0
+        link_ids = list(
+            (
+                await db.execute(
+                    select(ChannelBotAgentLink.id).where(
+                        ChannelBotAgentLink.account_id == account_id,
+                    )
+                )
+            ).scalars()
+        )
+    reconciled = 0
+    for link_id in link_ids:
+        async with sessionmaker() as db:
+            account = await db.get(ChannelAccount, account_id)
+            link = await db.get(ChannelBotAgentLink, link_id)
+            if account is None or link is None or link.account_id != account.id:
+                await db.rollback()
+                continue
+            try:
+                if await _discord_guild_owned_by_link(
+                    db,
+                    account=account,
+                    bot_agent_link_id=link.id,
+                    guild_id=guild_id,
+                ):
+                    reconciled += await _fan_out_discord_global_commands(
+                        db,
+                        account=account,
+                        bot_agent_link_id=link.id,
+                        application_id=_discord_application_id(account),
+                        commands=[],
+                        guild_ids={guild_id},
+                        automatic=False,
+                        force=True,
+                    )
+                else:
+                    known_guilds = await _discord_historical_guilds_for_link(
+                        db,
+                        account=account,
+                        link=link,
+                    )
+                    known_guilds.update(_discord_command_materializations(link))
+                    known_guilds.update(_discord_command_retries(link))
+                    if guild_id in known_guilds:
+                        await _clear_discord_guild_commands(
+                            db,
+                            account=account,
+                            link=link,
+                            application_id=_discord_application_id(account),
+                            guild_ids={guild_id},
+                            force=True,
+                        )
+            except HTTPException as exc:
+                await db.rollback()
+                log.warning(
+                    "discord_command_join_reconciliation_deferred "
+                    "account_id=%s link_id=%s guild_id=%s status=%s",
+                    account_id,
+                    link_id,
+                    guild_id,
+                    exc.status_code,
+                )
+    return reconciled
+
+
+class DiscordCommandReconciliationWorker:
+    """Retry durable Link command shadows until their Guild projections converge."""
+
+    def __init__(
+        self,
+        sessionmaker: async_sessionmaker[AsyncSession],
+        *,
+        poll_interval_seconds: float = 30.0,
+    ) -> None:
+        self._sessionmaker = sessionmaker
+        self._poll_interval_seconds = poll_interval_seconds
+
+    async def run_once(self) -> int:
+        async with self._sessionmaker() as db:
+            rows = list(
+                (
+                    await db.execute(
+                        select(ChannelBotAgentLink.id, ChannelAccount.id)
+                        .join(ChannelAccount, ChannelAccount.id == ChannelBotAgentLink.account_id)
+                        .where(
+                            ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+                            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                            ChannelAccount.archived_at.is_(None),
+                        )
+                    )
+                ).all()
+            )
+        reconciled = 0
+        for link_id, account_id in rows:
+            reconciled += await self._reconcile_link(link_id=link_id, account_id=account_id)
+        return reconciled
+
+    async def _reconcile_link(self, *, link_id: UUID, account_id: UUID) -> int:
+        async with self._sessionmaker() as db:
+            account = await db.get(ChannelAccount, account_id)
+            link = await db.get(ChannelBotAgentLink, link_id)
+            if account is None or link is None or link.account_id != account.id:
+                await db.rollback()
+                return 0
+            try:
+                application_id = _discord_application_id(account)
+                reconciled = 0
+                active_link = (
+                    link.status == BOT_AGENT_LINK_STATUS_ACTIVE and link.archived_at is None
+                )
+                if active_link:
+                    reconciled += await _fan_out_discord_global_commands(
+                        db,
+                        account=account,
+                        bot_agent_link_id=link.id,
+                        application_id=application_id,
+                        commands=[],
+                        automatic=True,
+                    )
+                    await db.refresh(link)
+                active_guilds = (
+                    set(
+                        await _discord_uncontested_guilds_for_link(
+                            db,
+                            account=account,
+                            bot_agent_link_id=link.id,
+                        )
+                    )
+                    if active_link
+                    else set()
+                )
+                historical_guilds = await _discord_historical_guilds_for_link(
+                    db,
+                    account=account,
+                    link=link,
+                )
+                materializations = _discord_command_materializations(link)
+                retries = _discord_command_retries(link)
+                empty_fingerprint = _discord_guild_command_fingerprint(
+                    [],
+                    application_id=application_id,
+                )
+                cleanup_guilds = {
+                    guild_id
+                    for guild_id in historical_guilds | set(materializations) | set(retries)
+                    if guild_id not in active_guilds
+                    and (materializations.get(guild_id) != empty_fingerprint or guild_id in retries)
+                }
+                if cleanup_guilds:
+                    await _clear_discord_guild_commands(
+                        db,
+                        account=account,
+                        link=link,
+                        application_id=application_id,
+                        guild_ids=cleanup_guilds,
+                    )
+                return reconciled
+            except HTTPException as exc:
+                await db.rollback()
+                log.warning(
+                    "discord_command_reconciliation_deferred account_id=%s link_id=%s status=%s",
+                    account_id,
+                    link_id,
+                    exc.status_code,
+                )
+                return 0
+
+    async def run_forever(self, stop: asyncio.Event | None = None) -> None:
+        stop_event = stop or asyncio.Event()
+        while not stop_event.is_set():
+            try:
+                await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            # One failed scan must not stop future durable retries.
+            except Exception:
+                log.exception("discord command reconciliation worker failed")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval_seconds)
+            except TimeoutError:
+                pass
+
+
+def _discord_application_id(account: ChannelAccount) -> str:
+    config = account.config if isinstance(account.config, dict) else {}
+    for key in ("application_id", "app_id"):
+        value = config.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise HTTPException(status_code=400, detail="discord application id unavailable")

--- a/backend/app/services/discord_command_reconciliation_worker.py
+++ b/backend/app/services/discord_command_reconciliation_worker.py
@@ -9,14 +9,18 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
+    BINDING_STATUS_ACTIVE,
+    BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_STATUS_ACTIVE,
     ChannelAccount,
+    ChannelBinding,
     ChannelBotAgentLink,
 )
 from app.routes.channel_routers.shared import (
     _clear_discord_guild_commands,
+    _discord_binding_guild_id,
     _discord_command_materializations,
     _discord_command_retries,
     _discord_guild_command_fingerprint,
@@ -25,8 +29,12 @@ from app.routes.channel_routers.shared import (
     _discord_uncontested_guilds_for_link,
     _fan_out_discord_global_commands,
 )
+from app.services.channels import lock_channel_binding_identity
 
 log = logging.getLogger(__name__)
+
+_DISCORD_GATEWAY_LIFECYCLE_EVENTS_CONFIG_KEY = "discord_gateway_lifecycle_events"
+_DISCORD_GATEWAY_LIFECYCLE_EVENT_LIMIT = 256
 
 
 async def reconcile_discord_guild_commands(
@@ -103,6 +111,86 @@ async def reconcile_discord_guild_commands(
                     exc.status_code,
                 )
     return reconciled
+
+
+async def reconcile_discord_guild_departure(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    account_id: UUID,
+    guild_id: str,
+    lifecycle_event_id: str,
+) -> int:
+    """Archive a departed Guild exactly once, then durably clear commands."""
+    async with sessionmaker() as db:
+        account = await db.get(ChannelAccount, account_id)
+        if account is None:
+            await db.rollback()
+            return 0
+        await lock_channel_binding_identity(
+            db,
+            account_id=account.id,
+            external_chat_id=guild_id,
+        )
+        await db.refresh(account, with_for_update=True)
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        raw_events = config.get(_DISCORD_GATEWAY_LIFECYCLE_EVENTS_CONFIG_KEY)
+        events = (
+            [event for event in raw_events if isinstance(event, str)]
+            if isinstance(raw_events, list)
+            else []
+        )
+        if lifecycle_event_id in events:
+            await db.commit()
+            return 0
+        bindings = list(
+            (
+                await db.execute(
+                    select(ChannelBinding).where(
+                        ChannelBinding.account_id == account.id,
+                        ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    )
+                )
+            ).scalars()
+        )
+        departed = [
+            binding for binding in bindings if _discord_binding_guild_id(binding) == guild_id
+        ]
+        link_ids = {binding.bot_agent_link_id for binding in departed}
+        for binding in departed:
+            binding.status = BINDING_STATUS_ARCHIVED
+        config[_DISCORD_GATEWAY_LIFECYCLE_EVENTS_CONFIG_KEY] = (events + [lifecycle_event_id])[
+            -_DISCORD_GATEWAY_LIFECYCLE_EVENT_LIMIT:
+        ]
+        account.config = config
+        await db.commit()
+
+    for link_id in sorted(link_ids, key=str):
+        async with sessionmaker() as db:
+            account = await db.get(ChannelAccount, account_id)
+            link = await db.get(ChannelBotAgentLink, link_id)
+            if account is None or link is None or link.account_id != account.id:
+                await db.rollback()
+                continue
+            try:
+                await _clear_discord_guild_commands(
+                    db,
+                    account=account,
+                    link=link,
+                    application_id=_discord_application_id(account),
+                    guild_ids={guild_id},
+                    force=True,
+                )
+            except HTTPException as exc:
+                await db.rollback()
+                log.warning(
+                    "discord_command_departure_cleanup_deferred "
+                    "account_id=%s link_id=%s guild_id=%s status=%s",
+                    account_id,
+                    link_id,
+                    guild_id,
+                    exc.status_code,
+                )
+    return len(departed)
 
 
 class DiscordCommandReconciliationWorker:

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -29,6 +29,7 @@ from app.models.channel import (
 from app.services.channels import decrypt_provider_token, record_discord_dispatch
 from app.services.discord_command_reconciliation_worker import (
     reconcile_discord_guild_commands,
+    reconcile_discord_guild_departure,
 )
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_websocket_url
 
@@ -315,7 +316,12 @@ class DiscordGatewayWorker:
         op = frame.get("op")
         if op == 0:
             _update_gateway_session_state(state, frame)
-            await record_discord_gateway_dispatch(self._sessionmaker, account_id, frame)
+            await record_discord_gateway_dispatch(
+                self._sessionmaker,
+                account_id,
+                frame,
+                gateway_session_id=state.session_id,
+            )
         elif op == 1:
             await _send_heartbeat(websocket, state)
         elif op == 7:
@@ -376,12 +382,35 @@ async def record_discord_gateway_dispatch(
     sessionmaker: async_sessionmaker[AsyncSession],
     account_id: UUID,
     frame: GatewayFrame,
+    *,
+    gateway_session_id: str | None = None,
 ) -> bool:
     async with sessionmaker() as db:
         account = await _load_active_discord_account(db, account_id)
         if account is None:
             await db.rollback()
             return False
+        if frame.get("t") == "GUILD_DELETE":
+            await db.rollback()
+            guild_id = _discord_departed_guild_id(frame)
+            if guild_id is None:
+                # unavailable=true is a temporary outage, not a departure.
+                return True
+            # Do not acknowledge an authority-loss event until its binding
+            # mutation is durable. A database failure must reconnect/resume so
+            # Discord can replay the sequence; provider cleanup itself is
+            # persisted as retry state and does not raise for normal failures.
+            await reconcile_discord_guild_departure(
+                sessionmaker,
+                account_id=account_id,
+                guild_id=guild_id,
+                lifecycle_event_id=_discord_lifecycle_event_id(
+                    frame,
+                    gateway_session_id=gateway_session_id,
+                    guild_id=guild_id,
+                ),
+            )
+            return True
         recorded = await record_discord_dispatch(db, account=account, frame=frame)
         if recorded:
             await db.commit()
@@ -413,6 +442,31 @@ def _discord_available_guild_id(frame: GatewayFrame) -> str | None:
         return None
     guild_id = data.get("id")
     return guild_id if isinstance(guild_id, str) and guild_id else None
+
+
+def _discord_departed_guild_id(frame: GatewayFrame) -> str | None:
+    data = frame.get("d")
+    if not isinstance(data, dict) or data.get("unavailable") is True:
+        return None
+    guild_id = data.get("id")
+    return guild_id if isinstance(guild_id, str) and guild_id else None
+
+
+def _discord_lifecycle_event_id(
+    frame: GatewayFrame,
+    *,
+    gateway_session_id: str | None,
+    guild_id: str,
+) -> str:
+    sequence = frame.get("s")
+    sequence_key = (
+        str(sequence)
+        if isinstance(sequence, int) and not isinstance(sequence, bool)
+        else hashlib.sha256(
+            json.dumps(frame, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+    )
+    return f"{gateway_session_id or 'unknown'}:{sequence_key}:GUILD_DELETE:{guild_id}"
 
 
 async def _load_active_discord_account(

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -27,6 +27,9 @@ from app.models.channel import (
     ChannelAccount,
 )
 from app.services.channels import decrypt_provider_token, record_discord_dispatch
+from app.services.discord_command_reconciliation_worker import (
+    reconcile_discord_guild_commands,
+)
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_websocket_url
 
 log = logging.getLogger(__name__)
@@ -382,9 +385,34 @@ async def record_discord_gateway_dispatch(
         recorded = await record_discord_dispatch(db, account=account, frame=frame)
         if recorded:
             await db.commit()
-            return True
-        await db.rollback()
-        return False
+        else:
+            await db.rollback()
+        guild_id = _discord_available_guild_id(frame)
+        if guild_id is not None:
+            try:
+                await reconcile_discord_guild_commands(
+                    sessionmaker,
+                    account_id=account_id,
+                    guild_id=guild_id,
+                )
+            # Reconciliation failures must not reconnect the healthy Gateway.
+            except Exception:
+                log.exception(
+                    "discord_command_guild_create_reconciliation_failed account_id=%s guild_id=%s",
+                    account_id,
+                    guild_id,
+                )
+        return recorded
+
+
+def _discord_available_guild_id(frame: GatewayFrame) -> str | None:
+    if frame.get("t") != "GUILD_CREATE":
+        return None
+    data = frame.get("d")
+    if not isinstance(data, dict) or data.get("unavailable") is True:
+        return None
+    guild_id = data.get("id")
+    return guild_id if isinstance(guild_id, str) and guild_id else None
 
 
 async def _load_active_discord_account(

--- a/backend/app/services/discord_rate_limiter.py
+++ b/backend/app/services/discord_rate_limiter.py
@@ -35,11 +35,19 @@ class DiscordRateLimiter:
         self._global_per_second = global_per_second
         self._global_window_started_at = 0.0
         self._global_count = 0
+        self._global_blocked_until = 0.0
         self._buckets: dict[str, DiscordBucketState] = {}
         self._now = now or time.monotonic
 
     def check(self, method: str, path: str) -> DiscordRateLimitDecision:
         now = self._now()
+        if self._global_blocked_until > now:
+            return DiscordRateLimitDecision(
+                allowed=False,
+                retry_after_seconds=self._global_blocked_until - now,
+                global_limit=True,
+            )
+        self._global_blocked_until = 0.0
         if now - self._global_window_started_at >= 1:
             self._global_window_started_at = now
             self._global_count = 0
@@ -86,14 +94,21 @@ class DiscordRateLimiter:
         global_header = (headers.get("x-ratelimit-global") or "").lower() == "true"
 
         if status_code == 429 and global_header:
-            self._global_window_started_at = now
-            self._global_count = self._global_per_second
+            delay = retry_after if retry_after is not None else reset_after
+            if delay is not None:
+                self._global_blocked_until = max(
+                    self._global_blocked_until,
+                    now + max(0.0, delay),
+                )
             return
 
         if status_code == 429:
+            delay = retry_after if retry_after is not None else reset_after
+            if delay is None:
+                return
             self._buckets[self.route_key(method, path)] = DiscordBucketState(
                 remaining=0,
-                reset_at=now + (retry_after or reset_after or 1.0),
+                reset_at=now + max(0.0, delay),
                 limit=limit,
                 bucket_id=bucket_id,
             )

--- a/backend/app/services/discord_rate_limiter.py
+++ b/backend/app/services/discord_rate_limiter.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Protocol
-
-
-class HeaderReader(Protocol):
-    def get(self, key: str, default: str | None = None) -> str | None: ...
 
 
 @dataclass
@@ -84,7 +79,13 @@ class DiscordRateLimiter:
         if bucket and bucket.reset_at > now and bucket.remaining > 0:
             bucket.remaining -= 1
 
-    def observe(self, method: str, path: str, headers: HeaderReader, status_code: int) -> None:
+    def observe(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, str],
+        status_code: int,
+    ) -> None:
         now = self._now()
         reset_after = _float_header(headers, "x-ratelimit-reset-after")
         retry_after = _float_header(headers, "retry-after")
@@ -148,7 +149,7 @@ class DiscordRateLimiter:
         return self._buckets.get(self.route_key(method, path))
 
 
-def _float_header(headers: HeaderReader, key: str) -> float | None:
+def _float_header(headers: Mapping[str, str], key: str) -> float | None:
     raw = headers.get(key)
     if raw is None:
         return None
@@ -158,7 +159,7 @@ def _float_header(headers: HeaderReader, key: str) -> float | None:
         return None
 
 
-def _int_header(headers: HeaderReader, key: str) -> int | None:
+def _int_header(headers: Mapping[str, str], key: str) -> int | None:
     raw = headers.get(key)
     if raw is None:
         return None

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -12,6 +12,9 @@ from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWo
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
+from app.services.discord_command_reconciliation_worker import (
+    DiscordCommandReconciliationWorker,
+)
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 
@@ -114,6 +117,7 @@ def build_channel_workers() -> tuple[
     AiProviderOAuthRevokeWorker,
     ChannelDeliveryWorker,
     ChannelWebhookDeliveryWorker,
+    DiscordCommandReconciliationWorker,
     DiscordGatewayWorker,
     ChannelMessageRetentionWorker,
     RuntimeObservationRetentionWorker,
@@ -127,6 +131,7 @@ def build_channel_workers() -> tuple[
         AiProviderOAuthRevokeWorker(async_session_factory),
         ChannelDeliveryWorker(async_session_factory),
         ChannelWebhookDeliveryWorker(async_session_factory),
+        DiscordCommandReconciliationWorker(async_session_factory),
         DiscordGatewayWorker(async_session_factory, lock_engine=engine),
         ChannelMessageRetentionWorker(async_session_factory),
         RuntimeObservationRetentionWorker(async_session_factory),

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -8,6 +8,9 @@ from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWo
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
+from app.services.discord_command_reconciliation_worker import (
+    DiscordCommandReconciliationWorker,
+)
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 from app.workers.channels import ChannelWorkerHealth, _handle_health_request, build_channel_workers
@@ -22,6 +25,7 @@ def test_channel_worker_stack_runs_revoke_delivery_webhook_gateway_and_retention
         AiProviderOAuthRevokeWorker,
         ChannelDeliveryWorker,
         ChannelWebhookDeliveryWorker,
+        DiscordCommandReconciliationWorker,
         DiscordGatewayWorker,
         ChannelMessageRetentionWorker,
         RuntimeObservationRetentionWorker,

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -60,6 +60,10 @@ from app.models.channel import (
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
+from app.routes import admin as admin_router
+from app.routes.channel_routers import discord as discord_router
+from app.routes.channel_routers import public as public_router
+from app.routes.channel_routers import shared as shared_router
 from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
     _discord_bound_guild_channels,
@@ -93,6 +97,10 @@ from app.services.channels import (
     telegram_message_thread_id_from_update,
     wait_for_telegram_updates,
 )
+from app.services.discord_command_reconciliation_worker import (
+    DiscordCommandReconciliationWorker,
+    reconcile_discord_guild_commands,
+)
 from app.services.discord_gateway_worker import (
     DISCORD_DEFAULT_INTENTS,
     DiscordGatewayWorker,
@@ -117,6 +125,9 @@ pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db
 TELEGRAM_AGENT_TOKEN_RE = re.compile(r"^[1-9][0-9]{8}:[A-Za-z0-9_-]{32,}$")
 DISCORD_TEST_APPLICATION_ID = "123456789012345678"
 DISCORD_TEST_PUBLIC_KEY = "11" * 32
+_REAL_DISCORD_BOT_GUILD_MEMBERSHIP_DENIED_REASON = (
+    channel_service.discord_bot_guild_membership_denied_reason
+)
 
 
 def _discord_ready_config(
@@ -126,8 +137,92 @@ def _discord_ready_config(
         "application_id": application_id,
         "public_key": DISCORD_TEST_PUBLIC_KEY,
         "discord_interactions_configured": True,
+        "discord_install_config_version": channel_service.DISCORD_INSTALL_CONFIG_VERSION,
+        "discord_user_install_supported": True,
         "discord_reserved_command_version": channel_service.DISCORD_RESERVED_COMMAND_VERSION,
+        "_test_discord_server_state": True,
     }
+
+
+@pytest.fixture(autouse=True)
+def _verified_discord_guild_membership(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_configure = public_router.configure_discord_application
+    original_sync = public_router.sync_channel_commands
+    original_verify_token = admin_router.verify_discord_application_token_identity
+
+    async def verified_membership(
+        _account: ChannelAccount,
+        *,
+        guild_id: str,
+    ) -> str | None:
+        assert guild_id
+        return None
+
+    async def configure_test_discord_application(account: ChannelAccount) -> dict[str, Any]:
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        if config.get("_test_discord_server_state") is not True:
+            return await original_configure(account)
+        config["discord_install_config_version"] = channel_service.DISCORD_INSTALL_CONFIG_VERSION
+        config["discord_user_install_supported"] = True
+        account.config = config
+        return {
+            "id": config.get("application_id"),
+            "integration_types_config": {"0": {}, "1": {}},
+        }
+
+    async def sync_test_discord_commands(
+        *,
+        account: ChannelAccount,
+        commands: list[dict[str, Any]] | None = None,
+        guild_id: str | None = None,
+        use_configured_discord_guild: bool | None = None,
+    ) -> list[dict[str, Any]]:
+        config = account.config if isinstance(account.config, dict) else {}
+        if (
+            config.get("_test_discord_server_state") is True
+            and channel_service.discord_reserved_commands_are_current(account)
+            and commands is None
+            and use_configured_discord_guild is False
+        ):
+            return []
+        return await original_sync(
+            account=account,
+            commands=commands,
+            guild_id=guild_id,
+            use_configured_discord_guild=use_configured_discord_guild,
+        )
+
+    async def verify_test_discord_token_identity(
+        *,
+        application_id: str,
+        provider_token: str,
+        config: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if isinstance(config, dict) and config.get("_test_discord_server_state") is True:
+            return {"id": application_id}
+        return await original_verify_token(
+            application_id=application_id,
+            provider_token=provider_token,
+            config=config,
+        )
+
+    monkeypatch.setattr(
+        channel_service,
+        "discord_bot_guild_membership_denied_reason",
+        verified_membership,
+    )
+    monkeypatch.setattr(
+        public_router,
+        "configure_discord_application",
+        configure_test_discord_application,
+    )
+    monkeypatch.setattr(public_router, "sync_channel_commands", sync_test_discord_commands)
+    monkeypatch.setattr(
+        admin_router,
+        "verify_discord_application_token_identity",
+        verify_test_discord_token_identity,
+    )
+    monkeypatch.setattr(discord_router, "verify_discord_signature", lambda **_kwargs: True)
 
 
 @asynccontextmanager
@@ -558,6 +653,12 @@ class _StatefulDiscordCommandClient(_FakeProviderClient):
                     # Simulate another reconciler deleting the ID between this
                     # client's GET and DELETE.
                     self.commands_by_path[scope_path] = remaining
+                if status_code == 429:
+                    return _FakeProviderResponse(
+                        {"retry_after": 0},
+                        status_code=status_code,
+                        headers={"Retry-After": "0"},
+                    )
                 return _FakeProviderResponse({}, status_code=status_code)
             if len(remaining) == len(commands):
                 return _FakeProviderResponse({}, status_code=404)
@@ -872,6 +973,8 @@ async def _create_paired_discord_channel(
             "application_id": application_id,
             "channel_id": channel_id,
             "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
             "member": {
                 "permissions": "32",
                 "user": {"id": "discord-pair-user"},
@@ -9242,14 +9345,7 @@ async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
                 "provider": "discord",
                 "name": "discord-command-replay-on-pair",
                 "provider_token": "discord-provider-token",
-                "config": {
-                    "application_id": DISCORD_TEST_APPLICATION_ID,
-                    "public_key": DISCORD_TEST_PUBLIC_KEY,
-                    "discord_interactions_configured": True,
-                    "discord_reserved_command_version": (
-                        channel_service.DISCORD_RESERVED_COMMAND_VERSION
-                    ),
-                },
+                "config": _discord_ready_config(),
             },
         )
     ).json()
@@ -9272,20 +9368,27 @@ async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
         json={
-            "t": "MESSAGE_CREATE",
-            "d": {
-                "id": "msg-pair-replay",
-                "channel_id": "chan-replay",
-                "guild_id": "guild-replay",
-                "content": f"/clawdi_pair {pair['code']}",
-                "author": {"id": "discord-replay-user"},
-                "member": {"permissions": "32"},
+            "type": 2,
+            "id": "interaction-pair-replay",
+            "token": "interaction-pair-replay-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "chan-replay",
+            "guild_id": "guild-replay",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "guild-replay"},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-replay-user"},
+            },
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
             },
         },
     )
 
     assert paired.status_code == 200
-    assert paired.json()["paired"] is True
+    assert paired.json()["data"]["content"].startswith("Server paired.")
     command_calls = [
         call
         for call in _FakeProviderClient.calls
@@ -14028,7 +14131,10 @@ async def test_telegram_pairing_same_agent_is_idempotent_and_consumes_code(
 
 
 @pytest.mark.asyncio
-async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClient):
+async def test_discord_message_pair_code_cannot_forge_interaction_authority(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
     created = (
         await client.post(
             "/v1/channels",
@@ -14059,17 +14165,21 @@ async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClie
                 "content": f"/clawdi_pair {pair['code']}",
                 "author": {"id": "discord-msg-pair-user"},
                 "member": {"permissions": "32"},
+                "type": 2,
+                "context": 0,
+                "authorizing_integration_owners": {"0": "guild-1"},
                 "channel": {"id": "chan-1", "name": "ops"},
             },
         },
     )
 
     assert webhook.status_code == 200
-    assert webhook.json()["paired"] is True
+    assert webhook.json()["paired"] is False
+    pair_code = await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    assert pair_code is not None
+    assert pair_code.status == PAIR_CODE_STATUS_PENDING
     bindings = await client.get(f"/v1/channels/{created['id']}/bindings")
-    assert bindings.json()[0]["external_chat_id"] == "guild-1"
-    assert bindings.json()[0]["external_chat_type"] == "guild_text"
-    assert bindings.json()[0]["external_chat_name"] == "guild-1"
+    assert bindings.json() == []
 
 
 @pytest.mark.asyncio
@@ -14090,6 +14200,8 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
         application_id: str,
         commands: list[dict[str, Any]],
         guild_ids: set[str] | None = None,
+        automatic: bool = False,
+        force: bool = False,
     ) -> None:
         fan_out_calls.append(
             {
@@ -14098,6 +14210,8 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
                 "application_id": application_id,
                 "commands": commands,
                 "guild_ids": guild_ids,
+                "automatic": automatic,
+                "force": force,
             }
         )
 
@@ -14145,6 +14259,8 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
             "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": "interaction-replay-channel",
             "guild_id": "interaction-replay-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "interaction-replay-guild"},
             "member": {
                 "permissions": "32",
                 "user": {"id": "interaction-replay-admin"},
@@ -14165,6 +14281,8 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
             "application_id": DISCORD_TEST_APPLICATION_ID,
             "commands": [shadowed_command],
             "guild_ids": {"interaction-replay-guild"},
+            "automatic": False,
+            "force": True,
         }
     ]
 
@@ -14200,6 +14318,8 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
             "application_id": "223456789012345678",
             "channel_id": "dm-no-fanout-channel",
             "user": {"id": "dm-pairing-user"},
+            "context": 1,
+            "authorizing_integration_owners": {"1": "dm-pairing-user"},
             "data": {
                 "name": "clawdi_pair",
                 "options": [{"name": "code", "value": dm_pair["code"]}],
@@ -14323,7 +14443,7 @@ async def test_discord_message_pair_code_sends_user_reply(
     )
 
     assert webhook.status_code == 200
-    assert webhook.json()["paired"] is True
+    assert webhook.json()["paired"] is False
     reply_call = next(
         call
         for call in _FakeProviderClient.calls
@@ -14331,7 +14451,7 @@ async def test_discord_message_pair_code_sends_user_reply(
     )
     assert reply_call["headers"]["Authorization"] == ("Bot discord-provider-token")
     assert reply_call["json"] == {
-        "content": "Server paired. This Discord server is now connected to your agent.",
+        "content": "Discord could not verify this app installation for this server command.",
         "allowed_mentions": {"parse": []},
     }
 
@@ -14390,8 +14510,7 @@ async def test_discord_guild_text_pair_without_computed_permissions_fails_closed
         if call["url"].endswith("/channels/guild-thread-invoking/messages")
     )
     assert reply_call["json"]["content"] == (
-        "Use the /clawdi_pair or /clawdi_unpair slash command; "
-        "pairing a server requires Manage Server permission."
+        "Discord could not verify this app installation for this server command."
     )
 
 
@@ -14428,6 +14547,8 @@ async def test_discord_guild_interaction_pair_allows_manage_guild_or_administrat
             "token": f"pair-authority-token-{permissions}",
             "channel_id": "authority-channel",
             "guild_id": f"authority-guild-{permissions}",
+            "context": 0,
+            "authorizing_integration_owners": {"0": f"authority-guild-{permissions}"},
             "member": {
                 "permissions": permissions,
                 "user": {"id": "authority-admin"},
@@ -14480,6 +14601,8 @@ async def test_discord_guild_interaction_pair_denies_non_authoritative_permissio
             "token": f"pair-denied-token-{uuid4().hex}",
             "channel_id": "denied-channel",
             "guild_id": "denied-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "denied-guild"},
             "member": member,
             "data": {
                 "name": "clawdi_pair",
@@ -14519,6 +14642,8 @@ async def test_discord_guild_unpair_requires_current_authority_and_pairing_actor
                 "token": f"unpair-authority-token-{suffix}",
                 "channel_id": "unpair-authority-channel",
                 "guild_id": "unpair-authority-guild",
+                "context": 0,
+                "authorizing_integration_owners": {"0": "unpair-authority-guild"},
                 "member": {
                     "permissions": permissions,
                     "user": {"id": actor},
@@ -14591,6 +14716,8 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
             "token": "link-b-conflicting-pair-token",
             "channel_id": "link-a-channel",
             "guild_id": "single-link-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "single-link-guild"},
             "member": {
                 "permissions": "32",
                 "user": {"id": "discord-pair-user"},
@@ -14630,6 +14757,7 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
             "token": "link-a-explicit-unpair-token",
             "channel_id": "link-a-channel",
             "guild_id": "single-link-guild",
+            "context": 0,
             "member": {
                 "permissions": "32",
                 "user": {"id": "discord-pair-user"},
@@ -14648,6 +14776,8 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
             "token": "link-b-pair-after-unpair-token",
             "channel_id": "link-b-channel",
             "guild_id": "single-link-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "single-link-guild"},
             "member": {
                 "permissions": "32",
                 "user": {"id": "link-b-admin"},
@@ -14734,6 +14864,8 @@ async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_comm
             "token": "token-pair",
             "channel_id": "chan-discord-unpair",
             "guild_id": "guild-discord-unpair",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "guild-discord-unpair"},
             "channel": {"id": "chan-discord-unpair", "name": "ops", "type": 0},
             "member": {
                 "permissions": "32",
@@ -14798,6 +14930,8 @@ async def test_discord_interaction_unpair_archives_binding_and_cleans_guild_comm
             "token": "token-unpair",
             "channel_id": "chan-discord-unpair",
             "guild_id": "guild-discord-unpair",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "guild-discord-unpair"},
             "channel": {"id": "chan-discord-unpair", "name": "ops", "type": 0},
             "member": {
                 "permissions": "32",
@@ -14866,6 +15000,8 @@ async def test_discord_unpair_command_cleanup_failure_keeps_authority_revoked(
             "token": "cleanup-failure-token",
             "channel_id": "cleanup-failure-channel",
             "guild_id": "cleanup-failure-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "cleanup-failure-guild"},
             "member": {
                 "permissions": "32",
                 "user": {"id": "discord-pair-user"},
@@ -14971,6 +15107,8 @@ async def test_discord_dm_binding_delete_revokes_without_guild_cleanup(
             "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": "discord-control-plane-dm",
             "user": {"id": "discord-control-plane-dm-user"},
+            "context": 1,
+            "authorizing_integration_owners": {"1": "discord-control-plane-dm-user"},
             "data": {
                 "name": "clawdi_pair",
                 "options": [{"name": "code", "value": pair["code"]}],
@@ -15287,6 +15425,8 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
             "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": "discord-dm-a",
             "user": {"id": "discord-dm-actor"},
+            "context": 1,
+            "authorizing_integration_owners": {"1": "discord-dm-actor"},
             "data": {
                 "name": "clawdi_pair",
                 "options": [{"name": "code", "value": pair["code"]}],
@@ -15413,6 +15553,8 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
             "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": "discord-dm-a",
             "user": {"id": "discord-dm-actor"},
+            "context": 1,
+            "authorizing_integration_owners": {"1": "discord-dm-actor"},
             "data": {"name": "clawdi_unpair"},
         },
     )
@@ -15447,14 +15589,21 @@ async def test_discord_dispatch_records_bound_message(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
         json={
-            "t": "MESSAGE_CREATE",
-            "d": {
-                "id": "msg-pair",
-                "channel_id": "chan-dispatch",
-                "guild_id": "guild-dispatch",
-                "content": f"/clawdi_pair {pair['code']}",
-                "author": {"id": "discord-dispatch-pair-user"},
-                "member": {"permissions": "32"},
+            "type": 2,
+            "id": "interaction-dispatch-pair",
+            "token": "interaction-dispatch-pair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "chan-dispatch",
+            "guild_id": "guild-dispatch",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "guild-dispatch"},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-dispatch-pair-user"},
+            },
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
             },
         },
     )
@@ -15529,15 +15678,25 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
         UUID(created["id"]),
         {
             "op": 0,
-            "t": "MESSAGE_CREATE",
+            "t": "INTERACTION_CREATE",
             "s": 42,
             "d": {
-                "id": "msg-gateway-pair",
+                "type": 2,
+                "id": "interaction-gateway-pair",
+                "token": "interaction-gateway-pair-token",
+                "application_id": DISCORD_TEST_APPLICATION_ID,
                 "channel_id": "chan-gateway-pair",
                 "guild_id": "guild-gateway",
-                "content": f"/clawdi_pair {pair['code']}",
-                "author": {"id": "discord-gateway-pair-user"},
-                "member": {"permissions": "32"},
+                "context": 0,
+                "authorizing_integration_owners": {"0": "guild-gateway"},
+                "member": {
+                    "permissions": "32",
+                    "user": {"id": "discord-gateway-pair-user"},
+                },
+                "data": {
+                    "name": "clawdi_pair",
+                    "options": [{"name": "code", "value": pair["code"]}],
+                },
             },
         },
     )
@@ -15554,7 +15713,9 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
     assert binding.status == "active"
     message = (
         await db_session.execute(
-            select(ChannelMessage).where(ChannelMessage.provider_message_id == "msg-gateway-pair")
+            select(ChannelMessage).where(
+                ChannelMessage.provider_message_id == "interaction-gateway-pair"
+            )
         )
     ).scalar_one()
     assert message.binding_id == binding.id
@@ -15874,10 +16035,18 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
         f"/v1/channels/discord/{discord['id']}/webhook",
         headers={"x-clawdi-channel-secret": discord["webhook_secret"]},
         json={
+            "type": 2,
             "id": "discord-shared-msg",
+            "token": "discord-shared-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
             "channel_id": shared_chat_id,
-            "content": f"/clawdi_pair {pair_codes['discord']}",
-            "author": {"id": "shared-discord-sender"},
+            "context": 1,
+            "authorizing_integration_owners": {"1": "shared-discord-sender"},
+            "user": {"id": "shared-discord-sender"},
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair_codes["discord"]}],
+            },
         },
     )
     imessage = created_by_provider["imessage"]
@@ -16674,8 +16843,46 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
 ):
     _DiscordPreparationProviderClient.reset(
         [
-            ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
-            ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": {
+                        "0": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands"],
+                                "permissions": "0",
+                            }
+                        },
+                        "1": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands"],
+                                "permissions": "0",
+                            }
+                        },
+                    },
+                },
+                200,
+            ),
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": {
+                        "0": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands", "bot"],
+                                "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+                            }
+                        },
+                        "1": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands"],
+                                "permissions": "0",
+                            }
+                        },
+                    },
+                },
+                200,
+            ),
             (
                 [
                     {
@@ -16731,7 +16938,27 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     ]
     get_call, patch_call, list_call, *reconciliation_calls = _DiscordPreparationProviderClient.calls
     assert get_call["url"].endswith("/applications/@me")
-    assert patch_call["json"] == {"interactions_endpoint_url": created["webhook_url"]}
+    assert patch_call["json"] == {
+        "interactions_endpoint_url": created["webhook_url"],
+        "install_params": {
+            "scopes": ["applications.commands", "bot"],
+            "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+        },
+        "integration_types_config": {
+            "0": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands", "bot"],
+                    "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+                }
+            },
+            "1": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands"],
+                    "permissions": "0",
+                }
+            },
+        },
+    }
     expected_global_path = f"/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
     assert list_call["url"].endswith(expected_global_path)
     assert "legacy-guild-must-not-scope-defaults" not in list_call["url"]
@@ -16761,6 +16988,7 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     assert install_url == (
         "https://discord.com/oauth2/authorize"
         f"?client_id={DISCORD_TEST_APPLICATION_ID}"
+        "&integration_type=0"
         "&permissions=274878024768"
         "&scope=bot%20applications.commands"
     )
@@ -16777,6 +17005,8 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
     assert account.config["discord_interactions_configured"] is True
+    assert account.config["discord_install_config_version"] == 1
+    assert account.config["discord_user_install_supported"] is True
     assert (
         account.config["discord_reserved_command_version"]
         == channel_service.DISCORD_RESERVED_COMMAND_VERSION
@@ -17058,7 +17288,7 @@ async def test_discord_reserved_delete_not_found_is_idempotent_success(
     ("delete_status", "expected_status", "expected_detail"),
     [
         (500, 502, "discord api rejected commands"),
-        (429, 503, "discord command sync is temporarily rate limited"),
+        (429, 429, "discord command sync is rate limited"),
     ],
 )
 async def test_discord_reserved_delete_failure_retries_to_convergence(
@@ -17069,6 +17299,12 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
     expected_status: int,
     expected_detail: str,
 ):
+    clock = [1_000.0]
+    monkeypatch.setattr(
+        channel_service,
+        "discord_rate_limiter",
+        DiscordRateLimiter(now=lambda: clock[0]),
+    )
     global_path = f"/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
     _StatefulDiscordCommandClient.reset(
         {
@@ -17105,6 +17341,8 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
 
     assert failed_pair.status_code == expected_status
     assert failed_pair.json()["detail"] == expected_detail
+    if delete_status == 429:
+        assert failed_pair.headers["Retry-After"] == "0"
     assert [call["method"] for call in _StatefulDiscordCommandClient.calls] == [
         "GET",
         "POST",
@@ -17132,6 +17370,8 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
     )
     assert pair_codes == []
 
+    if delete_status == 429:
+        clock[0] += 1.1
     converged_pair = await client.post(
         f"/v1/channels/{created['id']}/pair-codes",
         json={"ttl_seconds": 900},
@@ -17165,6 +17405,11 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    monkeypatch.setattr(
+        channel_service,
+        "discord_rate_limiter",
+        DiscordRateLimiter(now=lambda: 1_000.0),
+    )
     _DiscordPreparationProviderClient.reset(
         [
             (
@@ -17178,7 +17423,7 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
             ({"id": "850000000000000004", "name": "clawdi_unpair", "type": 1}, 200),
             ({}, 204),
             ({}, 204),
-            ({"message": "rate limited"}, 429),
+            ({"message": "rate limited", "retry_after": 0}, 429),
         ]
     )
     monkeypatch.setattr(
@@ -17205,8 +17450,9 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
         json={"ttl_seconds": 900},
     )
 
-    assert pair.status_code == 503
-    assert pair.json()["detail"] == "discord command sync is temporarily rate limited"
+    assert pair.status_code == 429
+    assert pair.json()["detail"] == "discord command sync is rate limited"
+    assert pair.headers["Retry-After"] == "0"
     assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
         "GET",
         "POST",
@@ -17719,3 +17965,1864 @@ async def test_imessage_send_uses_bluebubbles_api(
     )
     assert _FakeProviderClient.calls[0]["params"] == {"password": "bb-password"}
     assert _FakeProviderClient.calls[0]["json"]["chatGuid"] == "iMessage;-;+15551234567"
+
+
+@pytest.mark.parametrize(
+    ("payload", "guild_id", "external_user_id", "expected"),
+    [
+        (
+            {
+                "type": 2,
+                "context": 0,
+                "authorizing_integration_owners": {"0": "guild-contract"},
+                "data": {"name": "clawdi_pair"},
+            },
+            "guild-contract",
+            "guild-actor",
+            None,
+        ),
+        (
+            {
+                "type": 2,
+                "context": 1,
+                "authorizing_integration_owners": {"1": "dm-actor"},
+                "data": {"name": "clawdi_pair"},
+            },
+            None,
+            "dm-actor",
+            None,
+        ),
+        (
+            {"type": 2, "context": 2, "data": {"name": "clawdi_pair"}},
+            "guild-contract",
+            "guild-actor",
+            channel_service.DISCORD_GUILD_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "authorizing_integration_owners": {"0": "guild-contract"},
+                "data": {"name": "clawdi_pair"},
+            },
+            "guild-contract",
+            "guild-actor",
+            channel_service.DISCORD_GUILD_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "context": "0",
+                "authorizing_integration_owners": {"0": "guild-contract"},
+                "data": {"name": "clawdi_pair"},
+            },
+            "guild-contract",
+            "guild-actor",
+            channel_service.DISCORD_GUILD_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "context": 0,
+                "authorizing_integration_owners": {"1": "guild-actor"},
+                "data": {"name": "clawdi_pair"},
+            },
+            "guild-contract",
+            "guild-actor",
+            channel_service.DISCORD_GUILD_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "context": 0,
+                "authorizing_integration_owners": {"0": "other-guild"},
+                "data": {"name": "clawdi_pair"},
+            },
+            "guild-contract",
+            "guild-actor",
+            channel_service.DISCORD_GUILD_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "context": 1,
+                "authorizing_integration_owners": {"0": "some-guild"},
+                "data": {"name": "clawdi_pair"},
+            },
+            None,
+            "dm-actor",
+            channel_service.DISCORD_USER_INSTALL_REQUIRED,
+        ),
+        (
+            {
+                "type": 2,
+                "context": 1,
+                "authorizing_integration_owners": {"1": "other-user"},
+                "data": {"name": "clawdi_pair"},
+            },
+            None,
+            "dm-actor",
+            channel_service.DISCORD_USER_INSTALL_REQUIRED,
+        ),
+    ],
+)
+def test_discord_pair_install_contract_requires_matching_context_and_owner(
+    payload: dict[str, Any],
+    guild_id: str | None,
+    external_user_id: str,
+    expected: str | None,
+) -> None:
+    command = channel_service.ChannelPairCommand(kind="pair", code="PAIRCODE")
+
+    assert (
+        channel_service.discord_pair_install_denied_reason(
+            payload,
+            command=command,
+            guild_id=guild_id,
+            external_user_id=external_user_id,
+            trusted_interaction=True,
+        )
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_secret_only_interaction_cannot_claim_pair_code(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(discord_router, "verify_discord_signature", lambda **_kwargs: False)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-secret-only-admission",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    response = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "forged-secret-only-interaction",
+            "token": "forged-secret-only-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "forged-secret-only-channel",
+            "guild_id": "forged-secret-only-guild",
+            "context": 0,
+            "authorizing_integration_owners": {"0": "forged-secret-only-guild"},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "forged-secret-only-user"},
+            },
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["content"] == (
+        "Discord could not verify this app installation for this server command."
+    )
+    pair_code = await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    assert pair_code is not None
+    assert pair_code.status == PAIR_CODE_STATUS_PENDING
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_pair_membership_preflight_fails_closed_without_claim(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-membership-preflight",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+
+    for suffix, denied_reason in (
+        ("absent", channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED),
+        ("unavailable", channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE),
+    ):
+
+        async def denied_membership(
+            _account: ChannelAccount,
+            *,
+            guild_id: str,
+            reason: str = denied_reason,
+        ) -> str:
+            assert guild_id == f"membership-{suffix}-guild"
+            return reason
+
+        monkeypatch.setattr(
+            channel_service,
+            "discord_bot_guild_membership_denied_reason",
+            denied_membership,
+        )
+        pair = (
+            await client.post(
+                f"/v1/channels/{created['id']}/pair-codes",
+                json={"ttl_seconds": 900},
+            )
+        ).json()
+        response = await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json={
+                "type": 2,
+                "id": f"membership-{suffix}-interaction",
+                "token": f"membership-{suffix}-token",
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "channel_id": f"membership-{suffix}-channel",
+                "guild_id": f"membership-{suffix}-guild",
+                "context": 0,
+                "authorizing_integration_owners": {"0": f"membership-{suffix}-guild"},
+                "member": {
+                    "permissions": "32",
+                    "user": {"id": "membership-admin"},
+                },
+                "data": {
+                    "name": "clawdi_pair",
+                    "options": [{"name": "code", "value": pair["code"]}],
+                },
+            },
+        )
+        assert response.status_code == 200
+        pair_code = await db_session.get(ChannelPairCode, UUID(pair["id"]))
+        assert pair_code is not None
+        assert pair_code.status == PAIR_CODE_STATUS_PENDING
+
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "payload", "headers", "expected"),
+    [
+        (200, {"id": "membership-real-guild"}, {}, None),
+        (
+            200,
+            {"id": "wrong-guild"},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE,
+        ),
+        (
+            302,
+            {},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE,
+        ),
+        (
+            403,
+            {},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED,
+        ),
+        (
+            404,
+            {},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_REQUIRED,
+        ),
+        (
+            429,
+            {"retry_after": 17.0},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE,
+        ),
+        (
+            503,
+            {},
+            {},
+            channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE,
+        ),
+    ],
+)
+async def test_discord_membership_helper_classifies_real_provider_responses(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    expected: str | None,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-membership-helper-{status_code}-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    limiter = DiscordRateLimiter(now=lambda: 100.0)
+
+    class MembershipClient(_FakeProviderClient):
+        async def get(self, url, **kwargs):
+            self.calls.append({"method": "GET", "url": url, **kwargs})
+            return _FakeProviderResponse(
+                payload,
+                status_code=status_code,
+                headers=headers,
+            )
+
+    MembershipClient.calls = []
+    monkeypatch.setattr(channel_service, "discord_rate_limiter", limiter)
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", MembershipClient)
+
+    result = await _REAL_DISCORD_BOT_GUILD_MEMBERSHIP_DENIED_REASON(
+        account,
+        guild_id="membership-real-guild",
+    )
+
+    assert result == expected
+    assert len(MembershipClient.calls) == 1
+    if status_code == 429:
+        decision = limiter.check("GET", "/guilds/membership-real-guild")
+        assert decision.allowed is False
+        assert decision.retry_after_seconds == pytest.approx(17.0)
+
+
+@pytest.mark.asyncio
+async def test_discord_membership_helper_network_failure_is_unavailable(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-membership-network",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+
+    class NetworkFailureClient(_FakeProviderClient):
+        async def get(self, url, **kwargs):
+            raise httpx.ConnectError("membership network failure")
+
+    monkeypatch.setattr(channel_service, "discord_rate_limiter", DiscordRateLimiter())
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", NetworkFailureClient)
+
+    assert (
+        await _REAL_DISCORD_BOT_GUILD_MEMBERSHIP_DENIED_REASON(
+            account,
+            guild_id="membership-network-guild",
+        )
+        == channel_service.DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_owner_missing_unpair_cleanup_skips_manage_guild_and_membership(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-owner-missing-cleanup",
+        channel_id="owner-missing-channel",
+        guild_id="owner-missing-guild",
+    )
+
+    async def membership_must_not_run(
+        _account: ChannelAccount,
+        *,
+        guild_id: str,
+    ) -> str | None:
+        raise AssertionError(f"unpair attempted membership check for {guild_id}")
+
+    monkeypatch.setattr(
+        channel_service,
+        "discord_bot_guild_membership_denied_reason",
+        membership_must_not_run,
+    )
+
+    async def provider_success(**_kwargs: Any) -> shared_router._DiscordProviderResult:
+        return shared_router._DiscordProviderResult(
+            content=b"[]",
+            status_code=200,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", provider_success)
+
+    async def unpair(actor: str, owners: dict[str, str] | None) -> httpx.Response:
+        payload: dict[str, Any] = {
+            "type": 2,
+            "id": f"owner-missing-unpair-{actor}-{uuid4().hex}",
+            "token": f"owner-missing-token-{uuid4().hex}",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "owner-missing-channel",
+            "guild_id": "owner-missing-guild",
+            "context": 0,
+            "member": {"permissions": "0", "user": {"id": actor}},
+            "data": {"name": "clawdi_unpair"},
+        }
+        if owners is not None:
+            payload["authorizing_integration_owners"] = owners
+        return await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json=payload,
+        )
+
+    wrong_actor = await unpair("other-actor", None)
+    mismatched_owner = await unpair("discord-pair-user", {"0": "different-guild"})
+    cleanup = await unpair("discord-pair-user", None)
+
+    assert wrong_actor.json()["data"]["content"] == (
+        "Only the user who paired this server can change its pairing."
+    )
+    assert mismatched_owner.json()["data"]["content"] == (
+        "Discord could not verify this app installation for this server command."
+    )
+    assert cleanup.json()["data"]["content"].startswith("Server unpaired.")
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_discord_replayed_unpair_cannot_archive_a_replacement_binding(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "replayed-unpair-guild"
+    channel_id = "replayed-unpair-channel"
+    actor_id = "discord-pair-user"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-replayed-unpair",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+
+    async def provider_success(**_kwargs: Any) -> shared_router._DiscordProviderResult:
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", provider_success)
+    original_unpair = {
+        "type": 2,
+        "id": "replayed-unpair-interaction",
+        "token": "replayed-unpair-token",
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+        "channel_id": channel_id,
+        "guild_id": guild_id,
+        "context": 0,
+        "authorizing_integration_owners": {"0": guild_id},
+        "member": {
+            "permissions": "32",
+            "user": {"id": actor_id},
+        },
+        "data": {"name": "clawdi_unpair"},
+    }
+    first_unpair = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json=original_unpair,
+    )
+    assert first_unpair.json()["data"]["content"].startswith("Server unpaired.")
+
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    replacement_pair = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "replacement-pair-interaction",
+            "token": "replacement-pair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
+            "member": {
+                "permissions": "32",
+                "user": {"id": actor_id},
+            },
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert replacement_pair.json()["data"]["content"].startswith("Server paired.")
+
+    replay = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json=original_unpair,
+    )
+
+    assert replay.json()["data"]["content"] == "This interaction was already handled."
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert bindings[0]["external_chat_id"] == guild_id
+
+
+@pytest.mark.asyncio
+async def test_discord_concurrent_replayed_unpair_waits_for_event_commit_and_repair(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "concurrent-replayed-unpair-guild"
+    channel_id = "concurrent-replayed-unpair-channel"
+    actor_id = "discord-pair-user"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-concurrent-replayed-unpair",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    original_unpair = {
+        "type": 2,
+        "id": "concurrent-replayed-unpair-interaction",
+        "token": "concurrent-replayed-unpair-token",
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+        "channel_id": channel_id,
+        "guild_id": guild_id,
+        "context": 0,
+        "authorizing_integration_owners": {"0": guild_id},
+        "member": {"permissions": "32", "user": {"id": actor_id}},
+        "data": {"name": "clawdi_unpair"},
+    }
+    replacement_pair = {
+        "type": 2,
+        "id": "concurrent-replacement-pair-interaction",
+        "token": "concurrent-replacement-pair-token",
+        "application_id": DISCORD_TEST_APPLICATION_ID,
+        "channel_id": channel_id,
+        "guild_id": guild_id,
+        "context": 0,
+        "authorizing_integration_owners": {"0": guild_id},
+        "member": {"permissions": "32", "user": {"id": actor_id}},
+        "data": {
+            "name": "clawdi_pair",
+            "options": [{"name": "code", "value": pair["code"]}],
+        },
+    }
+    original_record = discord_router.record_inbound_messages_for_bindings
+    unpair_before_event_commit = asyncio.Event()
+    release_unpair_commit = asyncio.Event()
+    paused = False
+
+    async def pause_first_unpair_before_event_commit(**kwargs: Any):
+        nonlocal paused
+        binding_result = kwargs["binding_result"]
+        if binding_result.unpaired and not paused:
+            paused = True
+            unpair_before_event_commit.set()
+            await release_unpair_commit.wait()
+        return await original_record(**kwargs)
+
+    monkeypatch.setattr(
+        discord_router,
+        "record_inbound_messages_for_bindings",
+        pause_first_unpair_before_event_commit,
+    )
+
+    async def post_interaction(payload: dict[str, Any]) -> httpx.Response:
+        return await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json=payload,
+        )
+
+    first_unpair_task = asyncio.create_task(post_interaction(original_unpair))
+    await asyncio.wait_for(unpair_before_event_commit.wait(), timeout=2)
+    replacement_pair_task = asyncio.create_task(post_interaction(replacement_pair))
+    await asyncio.sleep(0.05)
+    replay_task = asyncio.create_task(post_interaction(original_unpair))
+    await asyncio.sleep(0.05)
+    release_unpair_commit.set()
+
+    first_unpair, repaired, replay = await asyncio.gather(
+        first_unpair_task,
+        replacement_pair_task,
+        replay_task,
+    )
+    assert first_unpair.json()["data"]["content"].startswith("Server unpaired.")
+    assert repaired.json()["data"]["content"].startswith("Server paired.")
+    assert replay.json()["data"]["content"] == "This interaction was already handled."
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert bindings[0]["external_chat_id"] == guild_id
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_replayed_unpair_cannot_archive_replacement_binding(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    guild_id = "gateway-replayed-unpair-guild"
+    channel_id = "gateway-replayed-unpair-channel"
+    actor_id = "discord-pair-user"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-gateway-replayed-unpair",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    original_unpair = {
+        "op": 0,
+        "t": "INTERACTION_CREATE",
+        "s": 801,
+        "d": {
+            "type": 2,
+            "id": "gateway-replayed-unpair-interaction",
+            "token": "gateway-replayed-unpair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
+            "member": {
+                "permissions": "32",
+                "user": {"id": actor_id},
+            },
+            "data": {"name": "clawdi_unpair"},
+        },
+    }
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            original_unpair,
+        )
+        is True
+    )
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    replacement_pair = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "gateway-replacement-pair-interaction",
+            "token": "gateway-replacement-pair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
+            "member": {
+                "permissions": "32",
+                "user": {"id": actor_id},
+            },
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert replacement_pair.json()["data"]["content"].startswith("Server paired.")
+
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            original_unpair,
+        )
+        is True
+    )
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert bindings[0]["external_chat_id"] == guild_id
+
+
+@pytest.mark.asyncio
+async def test_discord_dm_owner_missing_unpair_cleanup_requires_original_actor(
+    client: httpx.AsyncClient,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-dm-owner-missing-cleanup",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "dm-owner-missing-pair",
+            "token": "dm-owner-missing-pair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "dm-owner-missing-channel",
+            "context": 1,
+            "authorizing_integration_owners": {"1": "dm-owner"},
+            "user": {"id": "dm-owner"},
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert paired.json()["data"]["content"].startswith("Direct message paired.")
+
+    async def unpair(actor: str, owners: dict[str, str] | None) -> httpx.Response:
+        payload: dict[str, Any] = {
+            "type": 2,
+            "id": f"dm-owner-missing-unpair-{uuid4().hex}",
+            "token": f"dm-owner-missing-unpair-token-{uuid4().hex}",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "dm-owner-missing-channel",
+            "context": 1,
+            "user": {"id": actor},
+            "data": {"name": "clawdi_unpair"},
+        }
+        if owners is not None:
+            payload["authorizing_integration_owners"] = owners
+        return await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json=payload,
+        )
+
+    wrong_actor = await unpair("other-dm-user", None)
+    mismatched_owner = await unpair("dm-owner", {"1": "other-dm-user"})
+    cleanup = await unpair("dm-owner", None)
+
+    assert wrong_actor.json()["data"]["content"] == (
+        "Only the user who paired this direct message can change its pairing."
+    )
+    assert mismatched_owner.json()["data"]["content"] == (
+        "Discord could not verify User Install for this direct-message command."
+    )
+    assert cleanup.json()["data"]["content"].startswith("Direct message unpaired.")
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_discord_guild_only_install_capability_stays_guild_only(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _DiscordPreparationProviderClient.reset(
+        [
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": {
+                        "0": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands"],
+                                "permissions": "0",
+                            },
+                            "preserved_field": True,
+                        }
+                    },
+                },
+                200,
+            ),
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": {
+                        "0": {
+                            "oauth2_install_params": {
+                                "scopes": ["applications.commands", "bot"],
+                                "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+                            },
+                            "preserved_field": True,
+                        }
+                    },
+                },
+                200,
+            ),
+            ([], 200),
+            ({"id": "910000000000000001", "name": "clawdi_pair", "type": 1}, 200),
+            ({"id": "910000000000000002", "name": "clawdi_unpair", "type": 1}, 200),
+        ]
+    )
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", _DiscordPreparationProviderClient)
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "discord",
+            "name": "discord-guild-only-capability",
+            "provider_token": "discord-provider-token",
+            "config": {
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "public_key": DISCORD_TEST_PUBLIC_KEY,
+                "discord_install_config_version": (channel_service.DISCORD_INSTALL_CONFIG_VERSION),
+                "discord_user_install_supported": True,
+            },
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    assert channel_service.discord_user_install_url(account) is None
+
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert pair.status_code == 201, pair.text
+    patch_call = _DiscordPreparationProviderClient.calls[1]
+    assert patch_call["method"] == "PATCH"
+    assert set(patch_call["json"]["integration_types_config"]) == {"0"}
+    assert patch_call["json"]["integration_types_config"]["0"]["preserved_field"] is True
+    assert pair.json()["discord_user_install_url"] is None
+    await db_session.refresh(account)
+    assert account.config["discord_user_install_supported"] is False
+    post_calls = [
+        call for call in _DiscordPreparationProviderClient.calls if call["method"] == "POST"
+    ]
+    assert len(post_calls) == 2
+    for call in post_calls:
+        assert call["json"]["integration_types"] == [0]
+        assert call["json"]["contexts"] == [0]
+        assert "direct message" not in call["json"]["description"]
+
+
+@pytest.mark.asyncio
+async def test_discord_pair_code_rejects_duplicate_verified_application_identity(
+    client: httpx.AsyncClient,
+) -> None:
+    await _create_paired_discord_channel(
+        client,
+        name="discord-application-owner",
+        channel_id="application-owner-channel",
+        guild_id="application-owner-guild",
+    )
+    duplicate = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-application-duplicate",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+
+    pair_code = await client.post(
+        f"/v1/channels/{duplicate['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert pair_code.status_code == 409
+    assert pair_code.json()["detail"] == (
+        "This Discord application is already connected to another channel."
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_legacy_duplicate_application_is_contested_across_accounts(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    guild_id = "legacy-duplicate-application-guild"
+    first = await _create_paired_discord_channel(
+        client,
+        name="discord-legacy-application-first",
+        channel_id="legacy-application-first-channel",
+        guild_id=guild_id,
+    )
+    second_application_id = "223456789012345678"
+    second = await _create_paired_discord_channel(
+        client,
+        name="discord-legacy-application-second",
+        channel_id="legacy-application-second-channel",
+        guild_id=guild_id,
+        application_id=second_application_id,
+    )
+    second_account = await db_session.get(ChannelAccount, UUID(second["id"]))
+    assert second_account is not None
+    config = dict(second_account.config) if isinstance(second_account.config, dict) else {}
+    config["application_id"] = DISCORD_TEST_APPLICATION_ID
+    second_account.config = config
+    await db_session.commit()
+
+    first_account = await db_session.get(ChannelAccount, UUID(first["id"]))
+    first_link = await db_session.get(ChannelBotAgentLink, UUID(first["agent_link_id"]))
+    second_link = await db_session.get(ChannelBotAgentLink, UUID(second["agent_link_id"]))
+    assert first_account is not None
+    assert first_link is not None
+    assert second_link is not None
+    owners = await shared_router._discord_guild_owner_principals(
+        db_session,
+        application_id=DISCORD_TEST_APPLICATION_ID,
+        guild_id=guild_id,
+    )
+
+    assert owners == {
+        (UUID(first["id"]), first_link.id),
+        (UUID(second["id"]), second_link.id),
+    }
+    assert not await shared_router._discord_guild_owned_by_link(
+        db_session,
+        account=first_account,
+        bot_agent_link_id=first_link.id,
+        guild_id=guild_id,
+    )
+    assert (
+        await shared_router._discord_uncontested_guilds_for_link(
+            db_session,
+            account=first_account,
+            bot_agent_link_id=first_link.id,
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_admin_token_change_invalidates_verified_install_capability(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    created_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        name="discord-token-capability-invalidation",
+        visibility="private",
+        provider_token="discord-provider-token",
+        config=_discord_ready_config(),
+    )
+    assert created_response.status_code == 201, created_response.text
+    account = await db_session.get(ChannelAccount, UUID(created_response.json()["id"]))
+    assert account is not None
+    config = dict(account.config) if isinstance(account.config, dict) else {}
+    config["discord_install_config_version"] = channel_service.DISCORD_INSTALL_CONFIG_VERSION
+    config["discord_user_install_supported"] = True
+    account.config = config
+    await db_session.commit()
+
+    admin_key = f"admin-{uuid4().hex}"
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = admin_key
+    try:
+        replaced = await client.patch(
+            f"/v1/admin/channels/{account.id}",
+            headers={"X-Admin-Key": admin_key},
+            json={"provider_token": "replacement-discord-provider-token"},
+        )
+    finally:
+        settings.admin_api_key = original_admin_key
+
+    assert replaced.status_code == 200, replaced.text
+    await db_session.refresh(account)
+    assert channel_service.discord_install_config_is_current(account) is False
+    assert channel_service.discord_user_install_url(account) is None
+    assert "discord_install_config_version" not in account.config
+    assert "discord_user_install_supported" not in account.config
+
+
+def test_discord_minimal_bot_permissions_are_exact_text_baseline() -> None:
+    permissions = channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS
+
+    assert permissions == sum(1 << bit for bit in (6, 10, 11, 14, 15, 16, 38))
+    excluded_bits = (3, 4, 5, 13, 17, 20, 21, 28, 29, 30, 31, 33, 34, 35, 36, 40, 43, 44, 49)
+    for excluded_bit in excluded_bits:
+        assert permissions & (1 << excluded_bit) == 0
+
+
+def _discord_provider_result(
+    status_code: int,
+    payload: Any,
+    *,
+    headers: dict[str, str] | None = None,
+) -> shared_router._DiscordProviderResult:
+    return shared_router._DiscordProviderResult(
+        content=json.dumps(payload).encode("utf-8"),
+        status_code=status_code,
+        media_type="application/json",
+        headers=headers,
+    )
+
+
+async def _make_discord_retry_due(
+    db_session: AsyncSession,
+    *,
+    link_id: UUID,
+    guild_id: str,
+) -> None:
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    await db_session.refresh(link, with_for_update=True)
+    config = dict(link.config) if isinstance(link.config, dict) else {}
+    retries = dict(config.get("discord_command_retries", {}))
+    retry = dict(retries[guild_id])
+    retry["next_retry_at"] = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    retries[guild_id] = retry
+    config["discord_command_retries"] = retries
+    link.config = config
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_discord_prod_timeline_reconciles_shadow_after_guild_create(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "prod-timeline-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-prod-timeline",
+        channel_id="prod-timeline-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+    responses = [
+        _discord_provider_result(502, {"message": "temporary upstream failure"}),
+        _discord_provider_result(200, []),
+    ]
+
+    async def sequenced_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", sequenced_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    commands = [
+        {"name": f"agent_command_{index}", "description": f"Agent command {index}"}
+        for index in range(9)
+    ]
+
+    failed = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=commands,
+    )
+    stale_get = await client.get(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+
+    assert failed.status_code == 502
+    assert stale_get.status_code == 200
+    assert stale_get.json() == []
+    link_id = UUID(created["agent_link_id"])
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    assert len(link.config["discord_agent_commands"]["global"]) == 9
+    assert guild_id not in link.config.get("discord_command_materializations", {})
+    assert link.config["discord_command_retries"][guild_id]["status_code"] == 502
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 1
+
+    assert (
+        await reconcile_discord_guild_commands(
+            sessionmaker,
+            account_id=UUID(created["id"]),
+            guild_id=guild_id,
+        )
+        == 1
+    )
+    materialized_get = await client.get(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+    assert [command["name"] for command in materialized_get.json()] == [
+        command["name"] for command in commands
+    ]
+    assert len(provider_calls) == 2
+    assert json.loads(provider_calls[1]["body"]) == [
+        shared_router._discord_guild_command_provider_payload(command)
+        for command in materialized_get.json()
+    ]
+
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_discord_delete_tombstone_recovers_after_provider_failure(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "delete-tombstone-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-delete-tombstone",
+        channel_id="delete-tombstone-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+    responses = [
+        _discord_provider_result(200, []),
+        _discord_provider_result(502, {"message": "temporary delete failure"}),
+        _discord_provider_result(200, []),
+    ]
+
+    async def sequenced_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", sequenced_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    stored = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "ephemeral", "description": "Ephemeral command"}],
+    )
+    command_id = stored.json()[0]["id"]
+
+    failed_delete = await client.delete(
+        f"{command_url}/{command_id}",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+    retry_delete = await client.delete(
+        f"{command_url}/{command_id}",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+
+    assert failed_delete.status_code == 502
+    assert retry_delete.status_code == 404
+    assert len(provider_calls) == 2
+    link_id = UUID(created["agent_link_id"])
+    await _make_discord_retry_due(
+        db_session,
+        link_id=link_id,
+        guild_id=guild_id,
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 1
+    assert len(provider_calls) == 3
+    assert provider_calls[2]["body"] == b"[]"
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    empty_fingerprint = shared_router._discord_guild_command_fingerprint(
+        [],
+        application_id=DISCORD_TEST_APPLICATION_ID,
+    )
+    assert link.config["discord_agent_commands"]["global"] == []
+    assert link.config["discord_command_materializations"][guild_id] == empty_fingerprint
+    assert guild_id not in link.config["discord_command_retries"]
+
+
+@pytest.mark.asyncio
+async def test_discord_429_retry_after_blocks_poll_until_due(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "rate-limited-command-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-command-rate-limit",
+        channel_id="rate-limited-command-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+    responses = [
+        _discord_provider_result(
+            429,
+            {"retry_after": 17.0},
+            headers={"Retry-After": "41"},
+        ),
+        _discord_provider_result(200, []),
+    ]
+
+    async def sequenced_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", sequenced_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    rate_limited = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "rate_limited", "description": "Rate limited command"}],
+    )
+
+    assert rate_limited.status_code == 429
+    assert float(rate_limited.headers["Retry-After"]) == pytest.approx(41.0)
+    link_id = UUID(created["agent_link_id"])
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    retry = link.config["discord_command_retries"][guild_id]
+    due_at = datetime.fromisoformat(retry["next_retry_at"])
+    assert due_at - datetime.now(UTC) > timedelta(seconds=39)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 1
+    await _make_discord_retry_due(db_session, link_id=link_id, guild_id=guild_id)
+    assert await worker.run_once() == 1
+    assert len(provider_calls) == 2
+
+    body_only = _discord_provider_result(429, {"retry_after": 23.5})
+    assert shared_router._discord_retry_after_seconds(body_only) == pytest.approx(23.5)
+
+
+@pytest.mark.asyncio
+async def test_discord_403_command_retry_is_blocked_without_tight_poll(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "blocked-command-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-command-blocked",
+        channel_id="blocked-command-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+
+    async def forbidden_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return _discord_provider_result(403, {"message": "Missing Access"})
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", forbidden_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    rejected = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "blocked", "description": "Blocked command"}],
+    )
+
+    assert rejected.status_code == 502
+    link_id = UUID(created["agent_link_id"])
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    retry = link.config["discord_command_retries"][guild_id]
+    assert retry["status_code"] == 403
+    assert retry["blocked"] is True
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 0
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_multi_guild_partial_failure_converges_independently(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_a = "multi-command-guild-a"
+    guild_b = "multi-command-guild-b"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-command-multi-guild",
+        channel_id="multi-command-channel-a",
+        guild_id=guild_a,
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    db_session.add(
+        ChannelBinding(
+            account_id=account.id,
+            bot_agent_link_id=UUID(created["agent_link_id"]),
+            user_id=account.user_id,
+            external_chat_id=guild_b,
+            external_chat_type="guild_text",
+            external_chat_name=guild_b,
+            paired_external_user_id="discord-pair-user",
+        )
+    )
+    await db_session.commit()
+    provider_calls: list[dict[str, Any]] = []
+    guild_b_attempts = 0
+
+    async def partial_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        nonlocal guild_b_attempts
+        provider_calls.append(kwargs)
+        path = kwargs["path"]
+        if guild_b in path:
+            guild_b_attempts += 1
+            if guild_b_attempts == 1:
+                return _discord_provider_result(502, {"message": "temporary guild failure"})
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", partial_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    partially_failed = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "multi", "description": "Multi guild command"}],
+    )
+
+    assert partially_failed.status_code == 502
+    link_id = UUID(created["agent_link_id"])
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    assert guild_a in link.config["discord_command_materializations"]
+    assert guild_b not in link.config["discord_command_materializations"]
+    assert guild_b in link.config["discord_command_retries"]
+    await _make_discord_retry_due(db_session, link_id=link_id, guild_id=guild_b)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 1
+    assert [guild_a in call["path"] for call in provider_calls].count(True) == 1
+    assert [guild_b in call["path"] for call in provider_calls].count(True) == 2
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+async def test_discord_dm_only_command_mutations_leave_shadow_unchanged(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    method: str,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-dm-command-boundary-{method.lower()}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": f"dm-command-boundary-pair-{method}",
+            "token": f"dm-command-boundary-token-{method}",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": f"dm-command-boundary-{method.lower()}",
+            "context": 1,
+            "authorizing_integration_owners": {"1": "dm-command-owner"},
+            "user": {"id": "dm-command-owner"},
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert paired.json()["data"]["content"].startswith("Direct message paired.")
+    link_id = UUID(created["agent_link_id"])
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    before = json.loads(json.dumps(link.config)) if isinstance(link.config, dict) else None
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    request_url = f"{command_url}/missing" if method == "PATCH" else command_url
+    response = await client.request(
+        method,
+        request_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"name": "dm_only", "description": "Must not be stored"},
+    )
+
+    assert response.status_code == 409
+    await db_session.refresh(link)
+    assert link.config == before
+
+
+@pytest.mark.asyncio
+async def test_discord_reserved_command_429_preserves_retry_after_and_limiter(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-reserved-command-rate-limit",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+
+    class ReservedRateLimitClient(_FakeProviderClient):
+        async def request(self, method, url, **kwargs):
+            self.calls.append({"method": method, "url": url, **kwargs})
+            return _FakeProviderResponse(
+                {"retry_after": 29.0},
+                status_code=429,
+                headers={},
+            )
+
+    ReservedRateLimitClient.calls = []
+    monkeypatch.setattr(channel_service, "discord_rate_limiter", DiscordRateLimiter())
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", ReservedRateLimitClient)
+
+    first = await client.post(f"/v1/channels/{created['id']}/commands/sync", json={})
+    second = await client.post(f"/v1/channels/{created['id']}/commands/sync", json={})
+
+    assert first.status_code == 429
+    assert first.headers["Retry-After"] == "29.0"
+    assert second.status_code == 429
+    assert float(second.headers["Retry-After"]) > 28
+    assert len(ReservedRateLimitClient.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_projection_lock_prevents_stale_put_after_new_desired_state(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "projection-lock-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-projection-lock",
+        channel_id="projection-lock-channel",
+        guild_id=guild_id,
+    )
+    link_id = UUID(created["agent_link_id"])
+    account_id = UUID(created["id"])
+    v1 = [{"name": "version_one", "description": "Version one"}]
+    v2 = [{"name": "version_two", "description": "Version two"}]
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    link.config = {"discord_agent_commands": {"global": v1}}
+    await db_session.commit()
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    provider_versions: list[str] = []
+
+    async def blocked_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        commands = json.loads(kwargs["body"])
+        provider_versions.append(commands[0]["name"])
+        if commands[0]["name"] == "version_one":
+            first_started.set()
+            await release_first.wait()
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", blocked_provider)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    async def materialize_current() -> int:
+        async with sessionmaker() as session:
+            account = await session.get(ChannelAccount, account_id)
+            assert account is not None
+            return await shared_router._fan_out_discord_global_commands(
+                session,
+                account=account,
+                bot_agent_link_id=link_id,
+                application_id=DISCORD_TEST_APPLICATION_ID,
+                commands=[],
+                force=True,
+            )
+
+    async def store_v2_and_materialize() -> int:
+        async with sessionmaker() as session:
+            current_link = await session.get(ChannelBotAgentLink, link_id)
+            assert current_link is not None
+            await session.refresh(current_link, with_for_update=True)
+            config = dict(current_link.config) if isinstance(current_link.config, dict) else {}
+            config["discord_agent_commands"] = {"global": v2}
+            current_link.config = config
+            await session.commit()
+        return await materialize_current()
+
+    first_task = asyncio.create_task(materialize_current())
+    await asyncio.wait_for(first_started.wait(), timeout=2)
+    second_task = asyncio.create_task(store_v2_and_materialize())
+    await asyncio.sleep(0.05)
+    assert provider_versions == ["version_one"]
+    release_first.set()
+
+    assert await first_task == 1
+    assert await second_task == 1
+    assert provider_versions == ["version_one", "version_two"]
+    await db_session.rollback()
+    final_link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert final_link is not None
+    await db_session.refresh(final_link)
+    desired = final_link.config["discord_agent_commands"]["global"]
+    assert desired == v2
+    assert final_link.config["discord_command_materializations"][guild_id] == (
+        shared_router._discord_guild_command_fingerprint(
+            v2,
+            application_id=DISCORD_TEST_APPLICATION_ID,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_admin_rejects_application_identity_change(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    replacement_application_id = "223456789012345678"
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-application-change",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    original_config = dict(account.config) if isinstance(account.config, dict) else None
+
+    admin_key = f"admin-{uuid4().hex}"
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = admin_key
+    try:
+        replaced = await client.patch(
+            f"/v1/admin/channels/{account_id}",
+            headers={"X-Admin-Key": admin_key},
+            json={"config": _discord_ready_config(replacement_application_id)},
+        )
+    finally:
+        settings.admin_api_key = original_admin_key
+
+    assert replaced.status_code == 409
+    assert replaced.json()["detail"] == (
+        "Discord application identity cannot be changed in place; recreate the channel instead."
+    )
+    await db_session.rollback()
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    assert account.config == original_config
+
+
+@pytest.mark.asyncio
+async def test_discord_admin_rejects_token_for_different_application(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-token-identity-change",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    original_ciphertext = account.encrypted_provider_token
+    original_nonce = account.provider_token_nonce
+
+    async def reject_replacement_token(**_kwargs: Any) -> dict[str, Any]:
+        raise HTTPException(
+            status_code=409,
+            detail="Discord bot token belongs to a different application.",
+        )
+
+    monkeypatch.setattr(
+        admin_router,
+        "verify_discord_application_token_identity",
+        reject_replacement_token,
+    )
+    admin_key = f"admin-{uuid4().hex}"
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = admin_key
+    try:
+        replaced = await client.patch(
+            f"/v1/admin/channels/{account_id}",
+            headers={"X-Admin-Key": admin_key},
+            json={"provider_token": "different-application-token"},
+        )
+    finally:
+        settings.admin_api_key = original_admin_key
+
+    assert replaced.status_code == 409
+    await db_session.rollback()
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    assert account.encrypted_provider_token == original_ciphertext
+    assert account.provider_token_nonce == original_nonce
+
+
+def test_discord_materialization_fingerprint_is_application_bound() -> None:
+    commands = [{"name": "application_bound", "description": "Application-bound command"}]
+
+    first = shared_router._discord_guild_command_fingerprint(
+        commands,
+        application_id=DISCORD_TEST_APPLICATION_ID,
+    )
+    second = shared_router._discord_guild_command_fingerprint(
+        commands,
+        application_id="223456789012345678",
+    )
+
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_discord_archived_binding_cleanup_is_recovered_by_worker(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "archived-cleanup-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-archived-cleanup",
+        channel_id="archived-cleanup-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+    responses = [
+        _discord_provider_result(200, []),
+        _discord_provider_result(502, {"message": "temporary cleanup failure"}),
+        _discord_provider_result(200, []),
+    ]
+
+    async def sequenced_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", sequenced_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    stored = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "cleanup_me", "description": "Cleanup command"}],
+    )
+    assert stored.status_code == 200
+
+    unpaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "archived-cleanup-unpair",
+            "token": "archived-cleanup-unpair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": "archived-cleanup-channel",
+            "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
+            "member": {
+                "permissions": "32",
+                "user": {"id": "discord-pair-user"},
+            },
+            "data": {"name": "clawdi_unpair"},
+        },
+    )
+
+    assert unpaired.json()["data"]["content"].startswith("Server unpaired.")
+    assert len(provider_calls) == 2
+    link_id = UUID(created["agent_link_id"])
+    await _make_discord_retry_due(db_session, link_id=link_id, guild_id=guild_id)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 3
+    assert provider_calls[-1]["body"] == b"[]"
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    assert link.config["discord_command_materializations"][guild_id] == (
+        shared_router._discord_guild_command_fingerprint(
+            [],
+            application_id=DISCORD_TEST_APPLICATION_ID,
+        )
+    )
+    assert guild_id not in link.config["discord_command_retries"]
+
+
+@pytest.mark.asyncio
+async def test_discord_worker_recovers_cleanup_when_crash_left_no_link_state(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "cleanup-without-link-state-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-cleanup-without-link-state",
+        channel_id="cleanup-without-link-state-channel",
+        guild_id=guild_id,
+    )
+    link_id = UUID(created["agent_link_id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.bot_agent_link_id == link_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+        )
+    ).scalar_one()
+    binding.status = BINDING_STATUS_ARCHIVED
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    link.config = None
+    await db_session.commit()
+    provider_calls: list[dict[str, Any]] = []
+
+    async def provider_success(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", provider_success)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 1
+    assert provider_calls[0]["body"] == b"[]"
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_guild_create_triggers_reconcile_without_reconnect(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-guild-create-trigger",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    calls: list[tuple[UUID, str]] = []
+
+    async def record_reconcile(
+        _sessionmaker: async_sessionmaker[AsyncSession],
+        *,
+        account_id: UUID,
+        guild_id: str,
+    ) -> int:
+        calls.append((account_id, guild_id))
+        return 1
+
+    monkeypatch.setattr(
+        "app.services.discord_gateway_worker.reconcile_discord_guild_commands",
+        record_reconcile,
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    recorded = await record_discord_gateway_dispatch(
+        sessionmaker,
+        UUID(created["id"]),
+        {
+            "op": 0,
+            "t": "GUILD_CREATE",
+            "s": 77,
+            "d": {"id": "guild-create-trigger", "unavailable": False},
+        },
+    )
+
+    assert recorded is False
+    assert calls == [(UUID(created["id"]), "guild-create-trigger")]
+
+    async def failed_reconcile(
+        _sessionmaker: async_sessionmaker[AsyncSession],
+        *,
+        account_id: UUID,
+        guild_id: str,
+    ) -> int:
+        raise RuntimeError(f"reconcile failed for {account_id}/{guild_id}")
+
+    monkeypatch.setattr(
+        "app.services.discord_gateway_worker.reconcile_discord_guild_commands",
+        failed_reconcile,
+    )
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            {
+                "op": 0,
+                "t": "GUILD_CREATE",
+                "s": 78,
+                "d": {"id": "guild-create-trigger", "unavailable": False},
+            },
+        )
+        is False
+    )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -17532,6 +17532,121 @@ async def test_discord_pair_preparation_identity_or_validation_failure_creates_n
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "patched_integration_types",
+    [
+        {},
+        {
+            "0": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands"],
+                    "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+                }
+            }
+        },
+        {
+            "0": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands", "bot"],
+                    "permissions": "0",
+                }
+            }
+        },
+        {
+            "0": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands", "bot"],
+                    "permissions": str(channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS),
+                }
+            },
+            "1": {
+                "oauth2_install_params": {
+                    "scopes": ["applications.commands", "bot"],
+                    "permissions": "0",
+                }
+            },
+        },
+    ],
+)
+async def test_discord_pair_preparation_requires_exact_persisted_install_contract(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    patched_integration_types: dict[str, Any],
+) -> None:
+    initial_integration_types = {
+        "0": {
+            "oauth2_install_params": {
+                "scopes": ["applications.commands"],
+                "permissions": "0",
+            }
+        },
+        "1": {
+            "oauth2_install_params": {
+                "scopes": ["applications.commands"],
+                "permissions": "0",
+            }
+        },
+    }
+    _DiscordPreparationProviderClient.reset(
+        [
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": initial_integration_types,
+                },
+                200,
+            ),
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "integration_types_config": patched_integration_types,
+                },
+                200,
+            ),
+        ]
+    )
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", _DiscordPreparationProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-install-contract-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": {
+                    "application_id": DISCORD_TEST_APPLICATION_ID,
+                    "public_key": DISCORD_TEST_PUBLIC_KEY,
+                },
+            },
+        )
+    ).json()
+
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert pair.status_code == 502
+    assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
+        "GET",
+        "PATCH",
+    ]
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    assert channel_service.discord_install_config_is_current(account) is False
+    assert channel_service.discord_user_install_url(account) is None
+    pair_codes = list(
+        (
+            await db_session.execute(
+                select(ChannelPairCode).where(ChannelPairCode.account_id == UUID(created["id"]))
+            )
+        ).scalars()
+    )
+    assert pair_codes == []
+
+
+@pytest.mark.asyncio
 async def test_discord_default_command_sync_reconciles_only_reserved_commands(
     client: httpx.AsyncClient,
     monkeypatch,
@@ -18499,6 +18614,7 @@ async def test_discord_replayed_unpair_cannot_archive_a_replacement_binding(
 @pytest.mark.asyncio
 async def test_discord_concurrent_replayed_unpair_waits_for_event_commit_and_repair(
     client: httpx.AsyncClient,
+    db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     guild_id = "concurrent-replayed-unpair-guild"
@@ -18548,20 +18664,29 @@ async def test_discord_concurrent_replayed_unpair_waits_for_event_commit_and_rep
     release_unpair_commit = asyncio.Event()
     paused = False
 
-    async def pause_first_unpair_before_event_commit(**kwargs: Any):
+    async def pause_first_unpair_before_event_commit(*args: Any, **kwargs: Any):
         nonlocal paused
         binding_result = kwargs["binding_result"]
         if binding_result.unpaired and not paused:
             paused = True
             unpair_before_event_commit.set()
             await release_unpair_commit.wait()
-        return await original_record(**kwargs)
+        return await original_record(*args, **kwargs)
 
     monkeypatch.setattr(
         discord_router,
         "record_inbound_messages_for_bindings",
         pause_first_unpair_before_event_commit,
     )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    original_get_session_override = app.dependency_overrides[get_session]
+
+    async def independent_request_session() -> AsyncIterator[AsyncSession]:
+        async with sessionmaker() as request_db:
+            yield request_db
+
+    await db_session.rollback()
+    app.dependency_overrides[get_session] = independent_request_session
 
     async def post_interaction(payload: dict[str, Any]) -> httpx.Response:
         return await client.post(
@@ -18570,25 +18695,38 @@ async def test_discord_concurrent_replayed_unpair_waits_for_event_commit_and_rep
             json=payload,
         )
 
-    first_unpair_task = asyncio.create_task(post_interaction(original_unpair))
-    await asyncio.wait_for(unpair_before_event_commit.wait(), timeout=2)
-    replacement_pair_task = asyncio.create_task(post_interaction(replacement_pair))
-    await asyncio.sleep(0.05)
-    replay_task = asyncio.create_task(post_interaction(original_unpair))
-    await asyncio.sleep(0.05)
-    release_unpair_commit.set()
+    try:
+        first_unpair_task = asyncio.create_task(post_interaction(original_unpair))
+        await asyncio.wait_for(unpair_before_event_commit.wait(), timeout=2)
+        replacement_pair_task = asyncio.create_task(post_interaction(replacement_pair))
+        await asyncio.sleep(0.05)
+        replay_task = asyncio.create_task(post_interaction(original_unpair))
+        await asyncio.sleep(0.05)
+        release_unpair_commit.set()
 
-    first_unpair, repaired, replay = await asyncio.gather(
-        first_unpair_task,
-        replacement_pair_task,
-        replay_task,
-    )
+        first_unpair, repaired, replay = await asyncio.gather(
+            first_unpair_task,
+            replacement_pair_task,
+            replay_task,
+        )
+    finally:
+        app.dependency_overrides[get_session] = original_get_session_override
     assert first_unpair.json()["data"]["content"].startswith("Server unpaired.")
     assert repaired.json()["data"]["content"].startswith("Server paired.")
     assert replay.json()["data"]["content"] == "This interaction was already handled."
-    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
-    assert len(bindings) == 1
-    assert bindings[0]["external_chat_id"] == guild_id
+    async with sessionmaker() as verification_db:
+        active_bindings = list(
+            (
+                await verification_db.execute(
+                    select(ChannelBinding).where(
+                        ChannelBinding.account_id == UUID(created["id"]),
+                        ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    )
+                )
+            ).scalars()
+        )
+    assert len(active_bindings) == 1
+    assert active_bindings[0].external_chat_id == guild_id
 
 
 @pytest.mark.asyncio
@@ -18877,6 +19015,8 @@ async def test_discord_pair_code_rejects_duplicate_verified_application_identity
 async def test_discord_legacy_duplicate_application_is_contested_across_accounts(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
 ) -> None:
     guild_id = "legacy-duplicate-application-guild"
     first = await _create_paired_discord_channel(
@@ -18884,6 +19024,7 @@ async def test_discord_legacy_duplicate_application_is_contested_across_accounts
         name="discord-legacy-application-first",
         channel_id="legacy-application-first-channel",
         guild_id=guild_id,
+        agent_id=channel_agent.id,
     )
     second_application_id = "223456789012345678"
     second = await _create_paired_discord_channel(
@@ -18892,6 +19033,7 @@ async def test_discord_legacy_duplicate_application_is_contested_across_accounts
         channel_id="legacy-application-second-channel",
         guild_id=guild_id,
         application_id=second_application_id,
+        agent_id=second_channel_agent.id,
     )
     second_account = await db_session.get(ChannelAccount, UUID(second["id"]))
     assert second_account is not None
@@ -19096,6 +19238,24 @@ async def test_discord_prod_timeline_reconciles_shadow_after_guild_create(
         for command in materialized_get.json()
     ]
 
+    # Discord emits GUILD_CREATE for all available Guilds after READY and
+    # reconnect. A current receipt must make that lifecycle replay a no-op.
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            {
+                "op": 0,
+                "t": "GUILD_CREATE",
+                "s": 902,
+                "d": {"id": guild_id, "unavailable": False},
+            },
+            gateway_session_id="prod-timeline-reconnect",
+        )
+        is False
+    )
+    assert len(provider_calls) == 2
+
     assert await worker.run_once() == 0
     assert len(provider_calls) == 2
 
@@ -19226,6 +19386,26 @@ async def test_discord_429_retry_after_blocks_poll_until_due(
     assert shared_router._discord_retry_after_seconds(body_only) == pytest.approx(23.5)
 
 
+def test_discord_429_without_valid_retry_after_uses_bounded_backoff() -> None:
+    before = datetime.now(UTC)
+    retry = shared_router._discord_command_retry_state(
+        previous=None,
+        fingerprint="rate-limit-without-delay",
+        status_code=429,
+        result=_discord_provider_result(
+            429,
+            {"retry_after": "invalid"},
+            headers={"Retry-After": "invalid"},
+        ),
+    )
+    after = datetime.now(UTC)
+
+    assert retry["blocked"] is False
+    assert retry["attempts"] == 1
+    due_at = datetime.fromisoformat(retry["next_retry_at"])
+    assert before + timedelta(seconds=30) <= due_at <= after + timedelta(seconds=30)
+
+
 @pytest.mark.asyncio
 async def test_discord_403_command_retry_is_blocked_without_tight_poll(
     client: httpx.AsyncClient,
@@ -19267,6 +19447,68 @@ async def test_discord_403_command_retry_is_blocked_without_tight_poll(
     assert await worker.run_once() == 0
     assert await worker.run_once() == 0
     assert len(provider_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_verified_token_repair_rearms_blocked_command_retry(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "credential-repair-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-credential-repair",
+        channel_id="credential-repair-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+    responses = [
+        _discord_provider_result(403, {"message": "Missing Access"}),
+        _discord_provider_result(200, []),
+    ]
+
+    async def sequenced_provider(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", sequenced_provider)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    rejected = await client.put(
+        command_url,
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=[{"name": "repairable", "description": "Repairable command"}],
+    )
+    assert rejected.status_code == 502
+
+    admin_key = f"admin-{uuid4().hex}"
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = admin_key
+    try:
+        repaired = await client.patch(
+            f"/v1/admin/channels/{created['id']}",
+            headers={"X-Admin-Key": admin_key},
+            json={"provider_token": "replacement-discord-provider-token"},
+        )
+    finally:
+        settings.admin_api_key = original_admin_key
+    assert repaired.status_code == 200, repaired.text
+
+    link_id = UUID(created["agent_link_id"])
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    retry = link.config["discord_command_retries"][guild_id]
+    assert retry["blocked"] is False
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 1
+    assert len(provider_calls) == 2
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    assert guild_id not in link.config["discord_command_retries"]
 
 
 @pytest.mark.asyncio
@@ -19826,3 +20068,129 @@ async def test_discord_gateway_guild_create_triggers_reconcile_without_reconnect
         )
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_guild_delete_unavailable_does_nothing(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "temporarily-unavailable-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-temporarily-unavailable-guild",
+        channel_id="temporarily-unavailable-channel",
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+
+    async def provider_must_not_run(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", provider_must_not_run)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            {
+                "op": 0,
+                "t": "GUILD_DELETE",
+                "s": 101,
+                "d": {"id": guild_id, "unavailable": True},
+            },
+            gateway_session_id="guild-delete-unavailable-session",
+        )
+        is True
+    )
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_guild_delete_archives_cleans_and_is_replay_safe(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_id = "departed-guild"
+    channel_id = "departed-guild-channel"
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-departed-guild",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    provider_calls: list[dict[str, Any]] = []
+
+    async def provider_success(**kwargs: Any) -> shared_router._DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "_request_discord_provider", provider_success)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    deleted = {
+        "op": 0,
+        "t": "GUILD_DELETE",
+        "s": 202,
+        "d": {"id": guild_id, "unavailable": False},
+    }
+
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            deleted,
+            gateway_session_id="guild-delete-session",
+        )
+        is True
+    )
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    assert len(provider_calls) == 1
+    assert provider_calls[0]["body"] == b"[]"
+
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    repaired = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 2,
+            "id": "departed-guild-repair",
+            "token": "departed-guild-repair-token",
+            "application_id": DISCORD_TEST_APPLICATION_ID,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "context": 0,
+            "authorizing_integration_owners": {"0": guild_id},
+            "member": {"permissions": "32", "user": {"id": "discord-pair-user"}},
+            "data": {
+                "name": "clawdi_pair",
+                "options": [{"name": "code", "value": pair["code"]}],
+            },
+        },
+    )
+    assert repaired.json()["data"]["content"].startswith("Server paired.")
+    provider_calls.clear()
+
+    assert (
+        await record_discord_gateway_dispatch(
+            sessionmaker,
+            UUID(created["id"]),
+            deleted,
+            gateway_session_id="guild-delete-session",
+        )
+        is True
+    )
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert bindings[0]["external_chat_id"] == guild_id
+    assert provider_calls == []

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -19320,6 +19320,7 @@ async def test_discord_delete_tombstone_recovers_after_provider_failure(
     await db_session.rollback()
     link = await db_session.get(ChannelBotAgentLink, link_id)
     assert link is not None
+    await db_session.refresh(link)
     empty_fingerprint = shared_router._discord_guild_command_fingerprint(
         [],
         application_id=DISCORD_TEST_APPLICATION_ID,

--- a/backend/tests/test_discord_rate_limiter.py
+++ b/backend/tests/test_discord_rate_limiter.py
@@ -115,6 +115,16 @@ def test_discord_limiter_honors_retry_after_on_429():
     assert blocked.retry_after_seconds == 5.0
 
 
+def test_discord_limiter_treats_zero_retry_after_as_immediately_due():
+    now = 0.0
+    limiter = DiscordRateLimiter(now=lambda: now)
+    path = "/channels/111111111111111111/messages"
+
+    limiter.observe("POST", path, _headers({"retry-after": "0"}), 429)
+
+    assert limiter.check("POST", path).allowed is True
+
+
 def test_discord_limiter_consume_decrements_remaining_for_in_flight_requests():
     now = 0.0
     limiter = DiscordRateLimiter(now=lambda: now)
@@ -160,6 +170,16 @@ def test_discord_limiter_upstream_global_429_clamps_window():
         429,
     )
     blocked = limiter.check("POST", "/channels/111111111111111111/messages")
+    now = 1.001
+    still_blocked = limiter.check("GET", "/applications/222222222222222222/commands")
+    now = 2.001
+    after = limiter.check("GET", "/applications/222222222222222222/commands")
 
     assert blocked.allowed is False
     assert blocked.global_limit is True
+    assert blocked.retry_after_seconds == 2.0
+    assert still_blocked.allowed is False
+    assert still_blocked.global_limit is True
+    assert still_blocked.retry_after_seconds is not None
+    assert 0.99 < still_blocked.retry_after_seconds < 1.0
+    assert after.allowed is True

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -201,17 +201,54 @@ Pair flow:
    external actor id.
 8. The provider adapter sends a best-effort visible reply to the same external
    chat, such as `Paired! This chat is now connected to your agent.`.
-9. If the provider has persistent bot command menus, the adapter replays the
+9. If the provider has persistent bot command menus, the adapter reconciles the
    link's stored broad-scope command state onto the newly paired chat. Telegram
-   replays broad `setMyCommands` scopes to a per-chat scope. Discord replays
-   stored global application commands to the newly paired guild when the guild
-   is uncontested.
+   replays broad `setMyCommands` scopes to a per-chat scope. Discord stores the
+   Link shadow as desired state and materializes it only into uncontested Guild
+   bindings. A per-Guild fingerprint is written only after Discord accepts the
+   idempotent bulk overwrite; the channel worker retries missing or stale
+   fingerprints after transient failures and after the bot joins later.
 
 The visible reply is not part of the database transaction that claims the pair
 code. If the provider send fails, the claimed binding remains valid and the
 webhook still succeeds. This prevents a transient provider outage from rolling
-back a pairing operation that was already accepted by Clawdi. Command replay is
-also best-effort and must not roll back the binding.
+back a pairing operation that was already accepted by Clawdi. Discord command
+materialization does not roll back the binding, but it is not silent best
+effort: failed desired state remains pending for durable worker reconciliation
+and is not returned to the Agent as materialized state.
+
+Discord pairing claims fail closed on Discord-signed HTTP interactions or the
+backend's Discord Gateway `INTERACTION_CREATE` ingress. A server pair requires
+interaction context `0`, `authorizing_integration_owners["0"]` equal to the
+interaction `guild_id`, sufficient member permissions, and a successful
+bot-authenticated `GET /guilds/{guild_id}` membership check before the code is
+claimed. A direct-message pair requires interaction context `1` and
+`authorizing_integration_owners["1"]` equal to the invoking user. Context `2`
+(`PRIVATE_CHANNEL`), message-shaped payloads, and webhook-secret-only requests
+cannot claim pair codes.
+
+Normal unpair follows the same context and installation-owner checks; a Guild
+unpair with a valid owner also requires current Manage Server authority. If
+Discord has removed the required owner key after uninstall, a cleanup-only
+fallback is allowed for a verified application-command interaction only when
+an active binding exactly matches the scope and the invoker is the original
+pairing actor. That fallback does not require current Manage Server permission
+or bot membership. A present-but-mismatched owner never falls back.
+
+Agent-defined Discord commands are Guild-only. Discord's global User Install
+command namespace belongs to the shared application, so per-Link command menus
+cannot be safely materialized in DMs. User Install DMs support Clawdi's
+account-global reserved pair/unpair commands and routed messages only.
+
+The managed server install requests only Add Reactions, View Channels, Send
+Messages, Embed Links, Attach Files, Read Message History, and Send Messages in
+Threads (`274878024768`). Voice, moderation, event, expression, channel, role,
+pin, poll, sticker, and optional thread-tool actions are not granted by
+default. Managed OpenClaw projections explicitly gate those optional action
+surfaces; ordinary replies in existing threads continue through normal message
+sending. Managed Hermes projections leave user allowlists empty instead of
+writing a `"*"` username, so they do not accidentally request Server Members
+intent while preserving the adapter's documented allow-everyone behavior.
 
 Unpair flow:
 

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -226,6 +226,24 @@ function buildOpenClawChannelsProjection(
 				groupPolicy: "open",
 				allowFrom: ["*"],
 				guilds: { "*": { requireMention: false, users: ["*"] } },
+				// The managed invite grants the text/reaction/attachment baseline only.
+				// OpenClaw groups thread creation/list/reply behind one gate, so disable
+				// that optional tool surface while ordinary replies in existing threads
+				// continue through the normal message send path.
+				actions: {
+					stickers: false,
+					polls: false,
+					threads: false,
+					pins: false,
+					roles: false,
+					voiceStatus: false,
+					events: false,
+					moderation: false,
+					emojiUploads: false,
+					stickerUploads: false,
+					channels: false,
+					presence: false,
+				},
 			};
 			continue;
 		}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3291,8 +3291,6 @@ function hermesManagedChannelsPatch(
 					enabled: true,
 					dm_policy: "open",
 					group_policy: "open",
-					allow_from: ["*"],
-					group_allow_from: ["*"],
 					require_mention: false,
 					thread_require_mention: false,
 					bots_require_inline_mention: false,

--- a/packages/cli/tests/commands/channel.test.ts
+++ b/packages/cli/tests/commands/channel.test.ts
@@ -366,7 +366,7 @@ describe("channel commands", () => {
 							expires_at: new Date().toISOString(),
 							pairing_command: "/clawdi_pair PAIRDISCORD123",
 							discord_install_url:
-								"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
+								"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
 							discord_user_install_url:
 								"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 						},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6631,7 +6631,27 @@ exit 64
 		).toBeUndefined();
 		expect(projected.manifest.projection?.channels).toMatchObject({
 			telegram: { enabled: true },
-			discord: { enabled: true },
+			discord: {
+				enabled: true,
+				accounts: {
+					clawdi_acctdiscord1: {
+						actions: {
+							stickers: false,
+							polls: false,
+							threads: false,
+							pins: false,
+							roles: false,
+							voiceStatus: false,
+							events: false,
+							moderation: false,
+							emojiUploads: false,
+							stickerUploads: false,
+							channels: false,
+							presence: false,
+						},
+					},
+				},
+			},
 		});
 		expect(JSON.stringify(projected.manifest.projection?.channels ?? {})).not.toContain("whatsapp");
 	});
@@ -12177,6 +12197,9 @@ exit 64
 				"custom_root: keep",
 				"streaming:",
 				"  enabled: false",
+				"discord:",
+				'  allow_from: ["*"]',
+				'  group_allow_from: ["*"]',
 				"display:",
 				"  theme: user-theme",
 				"  platforms:",
@@ -12304,6 +12327,8 @@ exit 64
 		expect(parsedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(parsedHermesConfig.group_sessions_per_user).toBe(false);
 		expect(parsedHermesConfig.thread_sessions_per_user).toBe(false);
+		expect(parsedHermesConfig).not.toHaveProperty("discord.allow_from");
+		expect(parsedHermesConfig).not.toHaveProperty("discord.group_allow_from");
 		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
 		expect(parsedHermesConfig).toMatchObject({
 			custom_root: "keep",


### PR DESCRIPTION
## Summary
- repair Discord Guild/User Install defaults and validate the persisted application contract
- enforce signed interaction context, authorizing installation owner, guild authority, and bot membership before pairing
- make per-guild agent command materialization durable, retryable, lifecycle-aware, and honest to clients
- align OpenClaw/Hermes projections with the minimal permission and intent contract
- clarify Server Install versus DM command behavior in the hosted UI

## Verification
- final hermetic full suite run by implementation agent
- reviewer backend Discord matrix: 173 passed, 199 deselected
- reviewer CLI runtime projection suite: 164 passed
- reviewer Web install/pairing tests: 22 passed
- reviewer Web OSS production build: passed
- git diff --check: passed

## Rollout safety
This PR is intentionally unmerged. No production, Discord Developer Portal, tenant data, or deployment mutation was performed during implementation or review.