### PR TITLE
Redesign agent overview around capabilities

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2711,7 +2711,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
-	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Tools", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="projects"]')).not.toHaveClass(
 		/md:col-span-2/,
@@ -2935,7 +2935,7 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
-	await expect(main.getByRole("heading", { name: "Operate", exact: true })).toHaveCount(0);
+	await expect(main.getByRole("heading", { name: "Tools", exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1000 });
 	await page.screenshot({
@@ -2963,7 +2963,7 @@ test("hosted unavailable status stays inside Compute", async ({ page }, testInfo
 	const overview = main.locator('[data-agent-overview="hosted"]');
 	const compute = main.locator('[data-overview-status="compute"]');
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
-	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Tools", exact: true })).toBeVisible();
 	await expect(compute).toContainText("Status unavailable");
 	await expect(compute).toContainText("Clawdi cannot confirm the current compute status.");
 	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2575,10 +2575,50 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 });
 
 test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
+	const telegramAccount = {
+		id: "channel-overview-telegram",
+		provider: "telegram",
+		name: "Research Telegram",
+		status: "active",
+		created_at: "2026-07-15T00:00:00Z",
+	};
 	await stubHostedApi(page, {
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		agentResourceFixtures: true,
+		skillsByProjectId: {
+			"project-hosted": [
+				{
+					id: "skill-hosted-briefing",
+					skill_key: "briefing",
+					name: "Daily briefing",
+					description: "Prepare daily briefings",
+					version: 1,
+					source: "cloud",
+					authority: "cloud",
+					source_repo: null,
+					agent_types: ["hermes"],
+					file_count: 1,
+					content_hash: "b".repeat(64),
+					is_active: true,
+					created_at: "2026-07-15T00:00:00Z",
+					updated_at: "2026-07-15T00:00:00Z",
+					project_id: "project-hosted",
+					project_name: "Hosted Agent Project",
+					project_kind: "environment",
+				},
+			],
+		},
+		channelAgentLinks: [
+			{
+				id: "link-overview-telegram",
+				account_id: telegramAccount.id,
+				agent_id: railHostedEnvironmentId,
+				status: "active",
+				created_at: "2026-07-15T00:00:00Z",
+				account: telegramAccount,
+			},
+		],
 	});
 	await page.goto(
 		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
@@ -2593,12 +2633,38 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
-	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveClass(
-		/bg-identity-6-bg\/20/,
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
+		"UI ready",
+	);
+	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Running");
+	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Basic");
+	await expect(page.getByText("Your agent is running", { exact: true })).toHaveCount(0);
+	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Daily briefing");
+	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
+		"Research Telegram",
 	);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
+});
+
+test("hosted starting status and actions stay inside Compute", async ({ page }) => {
+	const startingDeployment = { ...railHostedDeployment, status: "starting" };
+	await stubHostedApi(page, {
+		deployments: [startingDeployment],
+		cloudAgents: [railHostedCloudAgent],
+	});
+	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${startingDeployment.id}`);
+
+	const main = page.locator("main");
+	const compute = main.locator('[data-overview-module="compute"]');
+	await expect(compute).toContainText("Starting");
+	await expect(compute).toContainText("Startup is still in progress.");
+	await expect(compute.getByRole("link", { name: "Compute", exact: true })).toBeVisible();
+	await expect(main.getByText("Starting your agent…", { exact: true })).toHaveCount(0);
+	await expect(
+		compute.getByText("Startup is still in progress.", { exact: false }),
+	).toHaveAttribute("role", "status");
 });
 
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2643,9 +2643,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 				models_used: ["gpt-5"],
 				summary: [
 					"Prepare launch brief",
-					"Research customer feedback",
-					"Update project plan",
-					"Review release risks",
+					"Research customer feedback before the product planning review",
+					"Investigate a long-running customer issue across several projects and write a detailed plan for the next release",
+					"Review risks",
 					"Fifth hosted session",
 				][index],
 				tags: [],
@@ -2722,6 +2722,35 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
 	await expect(recentSessions.locator("article")).toHaveCount(4);
 	await expect(recentSessions).not.toContainText("Fifth hosted session");
+	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
+		cards.map((card) => {
+			const rect = card.getBoundingClientRect();
+			return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+		}),
+	);
+	expect(
+		Math.max(...sessionBoxes.map((box) => box.height)) -
+			Math.min(...sessionBoxes.map((box) => box.height)),
+	).toBeLessThanOrEqual(2);
+	for (let index = 1; index < sessionBoxes.length; index += 1) {
+		expect(Math.abs(sessionBoxes[index].x - sessionBoxes[0].x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(sessionBoxes[index].width - sessionBoxes[0].width)).toBeLessThanOrEqual(1);
+		expect(sessionBoxes[index].y).toBeGreaterThanOrEqual(
+			sessionBoxes[index - 1].y + sessionBoxes[index - 1].height,
+		);
+	}
+	const [recentSessionsBox, computeBox] = await Promise.all([
+		recentSessions.boundingBox(),
+		page.locator('[data-overview-status="compute"]').boundingBox(),
+	]);
+	expect(Math.abs((computeBox?.y ?? 0) - (recentSessionsBox?.y ?? 0))).toBeLessThanOrEqual(2);
+	expect(
+		Math.abs(
+			(computeBox?.y ?? 0) +
+				(computeBox?.height ?? 0) -
+				((recentSessionsBox?.y ?? 0) + (recentSessionsBox?.height ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Open Agent Interface" })).toHaveAttribute(
 		"href",
@@ -2747,11 +2776,14 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const connectors = overview.locator('[data-overview-module="connectors"]');
-	await expect(connectors).toContainText("2 connected apps");
-	await expect(connectors.getByRole("link", { name: "Connected: Github" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Connected: Slack" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Popular: Github" })).toHaveCount(0);
+	await expect(connectors).not.toHaveClass(/md:col-span-2/);
+	await expect(connectors).toContainText("2 connected");
+	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
+	await expect(connectorLinks).toHaveCount(5);
+	await expect(connectorLinks.nth(0)).toHaveAccessibleName("Connected app: Github");
+	await expect(connectorLinks.nth(1)).toHaveAccessibleName("Connected app: Slack");
+	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
+	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2668,6 +2668,13 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("CPU");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Memory");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Storage");
+	for (const moduleId of ["memories", "vaults", "connectors"]) {
+		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toHaveCount(0);
+	}
+	const sidebar = page.getByTestId("app-sidebar");
+	for (const section of ["Memories", "Vaults", "Connectors"]) {
+		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
+	}
 	await expect(overview.getByText("Scope", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Access", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Managed", { exact: true })).toHaveCount(0);
@@ -2691,7 +2698,7 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
-	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(5);
+	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(4);
 	await expect(overview.getByText("Details pending", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Loading…", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
@@ -2755,9 +2762,7 @@ test("hosted overview keeps project count when names fail", async ({ page }) => 
 	await expect(projectsCard).toContainText("Can’t load project names");
 	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
 	await expect(projectsCard).not.toContainText("No projects added");
-	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
-		"Available through 1 project",
-	);
+	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
 });
 
 test("hosted overview keeps project count while names load", async ({ page }) => {
@@ -2774,9 +2779,7 @@ test("hosted overview keeps project count while names load", async ({ page }) =>
 	const projectsCard = page.locator('[data-overview-module="projects"]');
 	await expect(projectsCard).toContainText("1 project");
 	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
-	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
-		"Available through 1 project",
-	);
+	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
 });
 
 test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3220,7 +3220,9 @@ for (const deploymentStatus of ["creating", "starting"] as const) {
 			await expect(segment).toHaveAttribute("data-stage-state", state);
 			if (state === "active") await expect(segment).toHaveAttribute("aria-current", "step");
 		}
-		await expect(panel.locator('[data-slot="spinner"]')).toHaveCount(0);
+		const spinner = panel.locator('[data-slot="spinner"]');
+		await expect(spinner).toHaveCount(1);
+		await expect(spinner.locator("..")).toHaveAttribute("aria-hidden", "true");
 		for (const detail of ["Plan", "CPU", "Memory", "Storage"])
 			await expect(panel.getByText(detail, { exact: true })).toHaveCount(0);
 		await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -15,6 +15,40 @@ declare global {
 	}
 }
 
+async function expectOverviewResourceGeometry(grid: Locator, expectedRows: readonly number[]) {
+	const [gridBox, cards] = await Promise.all([
+		grid.boundingBox(),
+		grid
+			.locator("article")
+			.evaluateAll((elements) =>
+				elements.map((element) => element.getBoundingClientRect().toJSON()),
+			),
+	]);
+	expect(gridBox).not.toBeNull();
+	expect(cards).toHaveLength(5);
+	const rowYs = [...new Set(cards.map((card) => Math.round(card.y)))];
+	const rows = rowYs.map((rowY) => cards.filter((card) => Math.abs(card.y - rowY) <= 2));
+	expect(rows.map((row) => row.length)).toEqual(expectedRows);
+	expect(
+		Math.max(...cards.map((card) => card.width)) - Math.min(...cards.map((card) => card.width)),
+	).toBeLessThanOrEqual(2);
+	for (const row of rows) {
+		expect(
+			Math.max(...row.map((card) => card.height)) - Math.min(...row.map((card) => card.height)),
+		).toBeLessThanOrEqual(2);
+	}
+	for (const card of cards) {
+		expect(card.x).toBeGreaterThanOrEqual((gridBox?.x ?? 0) - 1);
+		expect(card.x + card.width).toBeLessThanOrEqual((gridBox?.x ?? 0) + (gridBox?.width ?? 0) + 1);
+	}
+	const finalRow = rows.at(-1) ?? [];
+	const finalLeft = Math.min(...finalRow.map((card) => card.x));
+	const finalRight = Math.max(...finalRow.map((card) => card.x + card.width));
+	expect(
+		Math.abs((finalLeft + finalRight) / 2 - ((gridBox?.x ?? 0) + (gridBox?.width ?? 0) / 2)),
+	).toBeLessThanOrEqual(2);
+}
+
 // HOSTED (Clawdi Cloud) smoke against the vite dev server with dev-auth-bypass
 // (NO Clerk key needed) + deploy-api enabled so /deploy renders. Exercises the
 // deploy wizard's Base UI Select asserting ZERO browser console/page errors.
@@ -2853,6 +2887,13 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			.locator("article")
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
+	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);
+	await page.setViewportSize({ width: 1024, height: 1200 });
+	await expectOverviewResourceGeometry(resourceGrid, [2, 2, 1]);
+	await page.setViewportSize({ width: 768, height: 1200 });
+	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
+	await page.setViewportSize({ width: 390, height: 1200 });
+	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
 });
@@ -2923,6 +2964,80 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 		fullPage: true,
 	});
 });
+
+for (const projectionFailure of [
+	{ name: "missing", response: { status: 404, body: { detail: "Agent not found" } } },
+	{ name: "error", response: { status: 500, body: { detail: "projection gateway failed" } } },
+] as const) {
+	test(`hosted overview keeps ${projectionFailure.name} projection unknown until one agent retry resolves`, async ({
+		page,
+	}) => {
+		const sessionRequests: string[] = [];
+		const agentProjectBindingRequests: string[] = [];
+		const skillRequests: string[] = [];
+		const projectionRequests: string[] = [];
+		page.on("request", (request) => {
+			const url = new URL(request.url());
+			if (
+				url.origin === CLOUD_API &&
+				url.pathname === `/v1/agents/${missingProjectionEnvironmentId}`
+			)
+				projectionRequests.push(url.pathname);
+		});
+		await stubHostedApi(page, {
+			deployments: [runningMissingProjectionDeployment],
+			cloudAgentResponses:
+				projectionFailure.name === "missing"
+					? { [missingProjectionEnvironmentId]: [projectionFailure.response] }
+					: undefined,
+			cloudAgentErrors:
+				projectionFailure.name === "error"
+					? {
+							[missingProjectionEnvironmentId]: {
+								status: 500,
+								detail: "projection gateway failed",
+							},
+						}
+					: undefined,
+			sessionRequests,
+			agentProjectBindingRequests,
+			skillRequests,
+		});
+		await page.goto(
+			`/agents/${missingProjectionEnvironmentId}?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+		);
+		const main = page.locator("main");
+		await expect(
+			main.getByText("Agent details are unavailable right now.", { exact: true }),
+		).toBeVisible();
+		await expect(main.getByText("No sessions from this agent yet.", { exact: true })).toHaveCount(
+			0,
+		);
+		await expect(main.getByText("No recent sessions", { exact: true })).toHaveCount(0);
+		await expect(main.getByText("Unavailable right now", { exact: true })).toHaveCount(4);
+		await expect(main.getByRole("button", { name: "Check again", exact: true })).toHaveCount(1);
+		expect(sessionRequests).toEqual([]);
+		expect(agentProjectBindingRequests).toEqual([]);
+		expect(skillRequests).toEqual([]);
+		const requestsBeforeRetry = projectionRequests.length;
+		await main.getByRole("button", { name: "Check again", exact: true }).click();
+		await expect.poll(() => projectionRequests.length).toBeGreaterThan(requestsBeforeRetry);
+		if (projectionFailure.name === "missing") {
+			await expect(
+				main.getByText("Agent details are unavailable right now.", { exact: true }),
+			).toHaveCount(0);
+			await expect.poll(() => sessionRequests.length).toBe(1);
+			await expect.poll(() => agentProjectBindingRequests.length).toBe(1);
+		} else {
+			await expect(
+				main.getByText("Agent details are unavailable right now.", { exact: true }),
+			).toBeVisible();
+			expect(sessionRequests).toEqual([]);
+			expect(agentProjectBindingRequests).toEqual([]);
+		}
+		await expect(main).not.toContainText("projection gateway failed");
+	});
+}
 
 test("hosted Sessions tab uses its own pagination without the Overview request", async ({
 	page,
@@ -3051,6 +3166,21 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	});
 });
 
+test("starting with an existing projection keeps lifecycle status in Compute", async ({ page }) => {
+	const restartingDeployment = { ...railHostedDeployment, status: "starting" };
+	await stubHostedApi(page, {
+		deployments: [restartingDeployment],
+		cloudAgents: [railHostedCloudAgent],
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${restartingDeployment.id}`,
+	);
+	const main = page.locator("main");
+	await expect(main.locator('[data-overview-status="compute"]')).toContainText("Starting");
+	await expect(main.getByTestId("hosted-initial-deployment-panel")).toHaveCount(0);
+	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
+});
+
 test("hosted unavailable status stays inside Compute", async ({ page }, testInfo) => {
 	const sessionRequests: string[] = [];
 	const runningRead = mutationDeploymentReadFixture(railHostedDeployment);
@@ -3077,18 +3207,61 @@ test("hosted unavailable status stays inside Compute", async ({ page }, testInfo
 	await expect(compute).toContainText("Clawdi cannot confirm the current compute status.");
 	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="vaults"]')).toContainText(
-		"Can’t load vaults",
+		"Unavailable right now",
 	);
 	await expect(overview.locator('[data-overview-module="vaults"]')).not.toContainText(
 		"No vaults available",
 	);
 	await expect(main.getByTestId("deployment-status-unavailable")).toHaveCount(0);
 	expect(sessionRequests).toEqual([]);
+	await expect(main.getByText("No sessions from this agent yet.", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-unavailable.png"),
 		fullPage: true,
 	});
+});
+
+test("raw offline stays a Compute-only status and does not become status unavailable", async ({
+	page,
+}) => {
+	const sessionRequests: string[] = [];
+	const cloudRequests: string[] = [];
+	page.on("request", (request) => {
+		const url = new URL(request.url());
+		if (url.origin === CLOUD_API) cloudRequests.push(url.pathname);
+	});
+	const runningDeployment = mutationDeploymentReadFixture(railHostedDeployment);
+	if (!runningDeployment.resource.status) throw new Error("Expected deployment status fixture");
+	const offlineDeployment = {
+		...runningDeployment,
+		resource: {
+			...runningDeployment.resource,
+			status: { ...runningDeployment.resource.status, summary_state: "offline" },
+		},
+	};
+	await stubHostedApi(page, {
+		deployments: [offlineDeployment],
+		deploymentDetailResponses: [{ body: offlineDeployment, status: 200 }],
+		sessionRequests,
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${offlineDeployment.resource.id}`,
+	);
+	const main = page.locator("main");
+	const compute = main.locator('[data-overview-status="compute"]');
+	await expect(compute).toContainText("Offline");
+	await expect(compute).not.toContainText("Status unavailable");
+	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
+	await expect(main.getByTestId("deployment-status-unavailable")).toHaveCount(0);
+	await expect(
+		main.getByText("Agent details are unavailable right now.", { exact: true }),
+	).toBeVisible();
+	await expect(main.getByText("No sessions from this agent yet.", { exact: true })).toHaveCount(0);
+	expect(sessionRequests).toEqual([]);
+	expect(cloudRequests.filter((path) => path === `/v1/agents/${railHostedEnvironmentId}`)).toEqual(
+		[],
+	);
 });
 
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {
@@ -5874,6 +6047,8 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 		main.getByText("The Clawdi service could not complete this request.", { exact: true }),
 	).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
+	await expect(main.locator('[data-overview-status="compute"]')).toContainText("Failed");
+	await expect(main.getByRole("alert")).toHaveCount(0);
 	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
@@ -5938,9 +6113,19 @@ test("stopped detail stays recoverable without querying its removed projection",
 	for (const section of ["", "/sessions", "/channel-links", "/console"]) {
 		await page.goto(`${detailPath}${section}${detailQuery}`);
 		const main = page.locator("main");
-		await expect(
-			main.locator('[data-slot="empty-title"]').getByText("Stopped", { exact: true }),
-		).toBeVisible();
+		if (section === "") {
+			await expect(main.locator('[data-overview-status="compute"]')).toContainText("Stopped");
+			await expect(
+				main.getByText("Agent details are unavailable right now.", { exact: true }),
+			).toBeVisible();
+			await expect(main.getByText("No sessions from this agent yet.", { exact: true })).toHaveCount(
+				0,
+			);
+		} else {
+			await expect(
+				main.locator('[data-slot="empty-title"]').getByText("Stopped", { exact: true }),
+			).toBeVisible();
+		}
 		await expect(main.getByRole("button", { name: "Start", exact: true })).toBeVisible();
 		await expect(main.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
 		await expect(main.getByText("Some agent details are not ready", { exact: true })).toHaveCount(

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1870,7 +1870,10 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
 			const response = options.cloudAgentResponses?.[id]?.shift();
-			if (response) return fulfillJson(r, response.body, response.status);
+			if (response) {
+				if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+				return fulfillJson(r, response.body, response.status);
+			}
 			const error = options.cloudAgentErrors?.[id];
 			if (error) return fulfillJson(r, { detail: error.detail }, error.status);
 			if (options.cloudAgentNotFoundIds?.includes(id)) {
@@ -2633,11 +2636,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText("Ready");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
-		"UI ready",
-	);
-	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
-		"Managed interface available",
+		"Managed interface",
 	);
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Running");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Basic");
@@ -2650,10 +2651,75 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText(
 		"Managed by Clawdi",
 	);
+	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText("Model");
+	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("CPU");
+	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Memory");
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
+});
+
+test("hosted projection loading uses module skeletons", async ({ page }, testInfo) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		cloudAgentResponses: {
+			[railHostedEnvironmentId]: [{ body: railHostedCloudAgent, status: 200, delayMs: 5_000 }],
+		},
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const overview = page.locator('[data-agent-overview="hosted"]');
+	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
+	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(5);
+	await expect(overview.getByText("Details pending", { exact: true })).toHaveCount(0);
+	await expect(overview.getByText("Loading…", { exact: true })).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1600 });
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-loading.png"),
+		fullPage: true,
+	});
+});
+
+test("hosted overview distinguishes empty skills and channels from loading", async ({ page }) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentResourceFixtures: true,
+		skillsByProjectId: { "project-hosted": [] },
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const overview = page.locator('[data-agent-overview="hosted"]');
+	await expect(overview.locator('[data-overview-module="skills"]')).toContainText(
+		"No skills available",
+	);
+	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
+		"No channels linked",
+	);
+	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(0);
+});
+
+test("hosted overview shows a true empty Projects state", async ({ page }) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentProjectBindings: [],
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	await expect(
+		page
+			.locator('[data-overview-module="projects"]')
+			.getByText("No projects bound", { exact: true }),
+	).toBeVisible();
 });
 
 test("hosted starting status and actions stay inside Compute", async ({ page }) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1132,6 +1132,7 @@ type HostedApiStubOptions = {
 		connect_disabled_reason: null;
 	}[];
 	aiProviders?: readonly unknown[];
+	aiProviderRequests?: string[];
 	agentProjectBindings?: readonly unknown[];
 	agentProjectBindingRequests?: string[];
 	agentProjects?: readonly unknown[];
@@ -1200,6 +1201,7 @@ type HostedApiStubOptions = {
 	ledgerResponses?: unknown[];
 	legacyAgentEnvironmentIds?: readonly string[];
 	managedModels?: typeof managedModelCatalog;
+	managedModelRequests?: string[];
 	planRequests?: string[];
 	mutationOrder?: string[];
 	plans?: readonly unknown[];
@@ -1383,6 +1385,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, plans);
 		}
 		if (p === "/v2/ai-providers/managed/models") {
+			options.managedModelRequests?.push(r.request().url());
 			return fulfillJson(r, options.managedModels ?? managedModelCatalog);
 		}
 		if (p === "/v2/wallet" && r.request().method() === "GET") {
@@ -1916,6 +1919,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			});
 		}
 		if (p === "/v1/ai-providers") {
+			options.aiProviderRequests?.push(r.request().url());
 			return fulfillJson(r, { providers: options.aiProviders ?? [] });
 		}
 		if (p === "/v1/ai-providers/accept" && r.request().method() === "POST") {
@@ -2614,6 +2618,8 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 
 test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
 	const sessionRequests: string[] = [];
+	const aiProviderRequests: string[] = [];
+	const managedModelRequests: string[] = [];
 	const telegramAccount = {
 		id: "channel-overview-telegram",
 		provider: "telegram",
@@ -2623,6 +2629,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	};
 	await stubHostedApi(page, {
 		sessionRequests,
+		aiProviderRequests,
+		managedModelRequests,
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		agentResourceFixtures: true,
@@ -2797,6 +2805,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		"Managed by Clawdi",
 	);
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText("Model");
+	expect(aiProviderRequests).toEqual([]);
+	await expect.poll(() => managedModelRequests.length).toBe(1);
 	await expect(compute).toContainText("CPU");
 	await expect(compute).toContainText("Memory");
 	await expect(compute).toContainText("Storage");
@@ -2832,11 +2842,60 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		Math.max(...resourceGeometry.map((box) => box.width)) -
 			Math.min(...resourceGeometry.map((box) => box.width)),
 	).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[0].y - resourceGeometry[1].y)).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[1].y - resourceGeometry[2].y)).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[3].y - resourceGeometry[4].y)).toBeLessThanOrEqual(2);
+	for (const rowY of new Set(resourceGeometry.map((box) => Math.round(box.y)))) {
+		const row = resourceGeometry.filter((box) => Math.abs(box.y - rowY) <= 2);
+		expect(
+			Math.max(...row.map((box) => box.height)) - Math.min(...row.map((box) => box.height)),
+		).toBeLessThanOrEqual(2);
+	}
+	expect(
+		await resourceGrid
+			.locator("article")
+			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
+	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
+});
+
+test("hosted overview shows a custom provider label and gates provider catalogs", async ({
+	page,
+}) => {
+	const aiProviderRequests: string[] = [];
+	const managedModelRequests: string[] = [];
+	const deployment: DeploymentMutationFixture = {
+		...railHostedDeployment,
+		id: "hdep_overview_custom_provider",
+		config_info: {
+			...railHostedDeployment.config_info,
+			ai_provider_auth_kind: "api_key",
+			clawdi_cloud_environments: { hermes: railHostedEnvironmentId },
+			runtime_configuration: {
+				providers: [
+					{
+						provider_id: deepSeekProvider.provider_id,
+						auth_kind: "secret_reference",
+						base_url: deepSeekProvider.base_url,
+						models: ["deepseek-v4-flash"],
+					},
+				],
+				primary_model: { provider_id: deepSeekProvider.provider_id, model: "deepseek-v4-flash" },
+				features: [],
+			},
+		},
+	};
+	await stubHostedApi(page, {
+		deployments: [deployment],
+		cloudAgents: [railHostedCloudAgent],
+		aiProviders: [deepSeekProvider],
+		aiProviderRequests,
+		managedModelRequests,
+	});
+	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${deployment.id}`);
+	const card = page.locator('[data-overview-module="model-provider"]');
+	await expect(card).toContainText("Research DeepSeek");
+	await expect(card).not.toContainText(deepSeekProvider.provider_id);
+	await expect.poll(() => aiProviderRequests.length).toBe(1);
+	expect(managedModelRequests).toEqual([]);
 });
 
 test("hosted projection loading uses module skeletons", async ({ page }, testInfo) => {
@@ -2853,7 +2912,9 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
-	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
+	await expect(overview.locator('[data-overview-module="vaults"]')).not.toContainText(
+		"No vaults available",
+	);
 	await expect(overview.getByText("Details pending", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Loading…", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
@@ -2916,6 +2977,9 @@ test("hosted overview shows a true empty Projects state", async ({ page }) => {
 			.locator('[data-overview-module="projects"]')
 			.getByText("No projects added", { exact: true }),
 	).toBeVisible();
+	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
+		"No vaults available",
+	);
 });
 
 test("hosted overview keeps project count when names fail", async ({ page }) => {
@@ -3012,6 +3076,12 @@ test("hosted unavailable status stays inside Compute", async ({ page }, testInfo
 	await expect(compute).toContainText("Status unavailable");
 	await expect(compute).toContainText("Clawdi cannot confirm the current compute status.");
 	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
+	await expect(overview.locator('[data-overview-module="vaults"]')).toContainText(
+		"Can’t load vaults",
+	);
+	await expect(overview.locator('[data-overview-module="vaults"]')).not.toContainText(
+		"No vaults available",
+	);
 	await expect(main.getByTestId("deployment-status-unavailable")).toHaveCount(0);
 	expect(sessionRequests).toEqual([]);
 	await page.setViewportSize({ width: 1280, height: 1600 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2713,9 +2713,6 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.getByRole("heading", { name: "Tools", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
-	await expect(overview.locator('[data-overview-module="projects"]')).not.toHaveClass(
-		/md:col-span-2/,
-	);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
@@ -2799,7 +2796,6 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const connectors = overview.locator('[data-overview-module="connectors"]');
-	await expect(connectors).not.toHaveClass(/md:col-span-2/);
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
 	await expect(connectorLinks).toHaveCount(5);
@@ -2808,6 +2804,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
 	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
+	await expect(sidebar.getByText("Running", { exact: true })).toBeVisible();
+	await expect(sidebar.getByText("Paused", { exact: true })).toHaveCount(0);
+	await expect(sidebar.getByText(/last seen/i)).toHaveCount(0);
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
 	}
@@ -2816,6 +2815,18 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.getByText("Managed", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
+	const resourceGrid = overview.locator('[data-overview-layout="balanced-five"]');
+	const resourceGeometry = await resourceGrid
+		.locator("article")
+		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
+	expect(resourceGeometry).toHaveLength(5);
+	expect(
+		Math.max(...resourceGeometry.map((box) => box.width)) -
+			Math.min(...resourceGeometry.map((box) => box.width)),
+	).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[0].y - resourceGeometry[1].y)).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[1].y - resourceGeometry[2].y)).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[3].y - resourceGeometry[4].y)).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
 });
@@ -2937,6 +2948,10 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Tools", exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+	const sidebar = page.getByTestId("app-sidebar");
+	await expect(sidebar.getByText("Starting", { exact: true })).toBeVisible();
+	await expect(sidebar.getByText("Paused", { exact: true })).toHaveCount(0);
+	await expect(sidebar.getByText(/last seen/i)).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1000 });
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-provisioning.png"),

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1123,6 +1123,7 @@ type HostedApiStubOptions = {
 	agentProjectBindings?: readonly unknown[];
 	agentProjectBindingRequests?: string[];
 	agentProjects?: readonly unknown[];
+	agentProjectsResponse?: StubResponse;
 	agentResourceFixtures?: boolean;
 	agentOrderRequests?: string[];
 	autoReloadRequests?: string[];
@@ -2094,6 +2095,18 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, { items: [] });
 		}
 		if (p === "/v1/projects") {
+			if (options.agentProjectsResponse) {
+				if (options.agentProjectsResponse.delayMs) {
+					await new Promise((resolve) =>
+						setTimeout(resolve, options.agentProjectsResponse?.delayMs),
+					);
+				}
+				return fulfillJson(
+					r,
+					options.agentProjectsResponse.body,
+					options.agentProjectsResponse.status,
+				);
+			}
 			if (options.agentProjects) return fulfillJson(r, options.agentProjects);
 			if (!options.agentResourceFixtures) return fulfillJson(r, []);
 			return fulfillJson(r, [
@@ -2638,7 +2651,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	);
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText("Ready");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
-		"Managed interface",
+		"Hermes",
 	);
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Running");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Basic");
@@ -2654,6 +2667,10 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText("Model");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("CPU");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Memory");
+	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Storage");
+	await expect(overview.getByText("Scope", { exact: true })).toHaveCount(0);
+	await expect(overview.getByText("Access", { exact: true })).toHaveCount(0);
+	await expect(overview.getByText("Managed", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
@@ -2700,7 +2717,7 @@ test("hosted overview distinguishes empty skills and channels from loading", asy
 		"No skills available",
 	);
 	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
-		"No channels linked",
+		"No channels connected",
 	);
 	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(0);
 });
@@ -2718,27 +2735,81 @@ test("hosted overview shows a true empty Projects state", async ({ page }) => {
 	await expect(
 		page
 			.locator('[data-overview-module="projects"]')
-			.getByText("No projects bound", { exact: true }),
+			.getByText("No projects added", { exact: true }),
 	).toBeVisible();
 });
 
-test("hosted starting status and actions stay inside Compute", async ({ page }) => {
+test("hosted overview keeps project count when names fail", async ({ page }) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentResourceFixtures: true,
+		agentProjectsResponse: { status: 500, body: { detail: "project list failed" } },
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const projectsCard = page.locator('[data-overview-module="projects"]');
+	await expect(projectsCard).toContainText("1 project");
+	await expect(projectsCard).toContainText("Can’t load project names");
+	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
+	await expect(projectsCard).not.toContainText("No projects added");
+	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
+		"Available through 1 project",
+	);
+});
+
+test("hosted overview keeps project count while names load", async ({ page }) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentResourceFixtures: true,
+		agentProjectsResponse: { status: 200, body: [], delayMs: 5_000 },
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const projectsCard = page.locator('[data-overview-module="projects"]');
+	await expect(projectsCard).toContainText("1 project");
+	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
+	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
+		"Available through 1 project",
+	);
+});
+
+test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) => {
 	const startingDeployment = { ...railHostedDeployment, status: "starting" };
 	await stubHostedApi(page, {
 		deployments: [startingDeployment],
 		cloudAgents: [railHostedCloudAgent],
+		cloudAgentNotFoundIds: [railHostedEnvironmentId],
 	});
 	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${startingDeployment.id}`);
 
 	const main = page.locator("main");
 	const compute = main.locator('[data-overview-module="compute"]');
 	await expect(compute).toContainText("Starting");
+	await expect(compute).toContainText("Plan");
+	await expect(compute).toContainText("CPU");
+	await expect(compute).toContainText("Memory");
+	await expect(compute).toContainText("Storage");
 	await expect(compute).toContainText("Startup is still in progress.");
 	await expect(compute.getByRole("link", { name: "Compute", exact: true })).toBeVisible();
 	await expect(main.getByText("Starting your agent…", { exact: true })).toHaveCount(0);
 	await expect(
 		compute.getByText("Startup is still in progress.", { exact: false }),
 	).toHaveAttribute("role", "status");
+	await expect(main.getByTestId("hosted-overview-provisioning-placeholder")).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
+	await expect(main.getByRole("heading", { name: "Operate", exact: true })).toHaveCount(0);
+	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1000 });
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-provisioning.png"),
+		fullPage: true,
+	});
 });
 
 test("hosted unavailable status stays inside Compute", async ({ page }, testInfo) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2820,10 +2820,18 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			sessionBoxes[index - 1].y + sessionBoxes[index - 1].height,
 		);
 	}
-	const [recentSessionsBox, computeBox] = await Promise.all([
+	const [recentSessionsBox, computeBox, viewAllBox] = await Promise.all([
 		recentSessions.boundingBox(),
 		page.locator('[data-overview-status="compute"]').boundingBox(),
+		viewAllSessions.boundingBox(),
 	]);
+	expect(
+		Math.abs(
+			(viewAllBox?.x ?? 0) +
+				(viewAllBox?.width ?? 0) -
+				((recentSessionsBox?.x ?? 0) + (recentSessionsBox?.width ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	expect(Math.abs((computeBox?.y ?? 0) - (recentSessionsBox?.y ?? 0))).toBeLessThanOrEqual(2);
 	expect(
 		Math.abs(
@@ -2920,6 +2928,20 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await page.setViewportSize({ width: 390, height: 1200 });
 	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
 	await expectOverviewResourceGeometry(toolsGrid, [1, 1]);
+	const [mobileSessionsBox, mobileViewAllBox] = await Promise.all([
+		recentSessions.boundingBox(),
+		viewAllSessions.boundingBox(),
+	]);
+	expect((mobileViewAllBox?.y ?? 0) + (mobileViewAllBox?.height ?? 0)).toBeLessThanOrEqual(
+		(mobileSessionsBox?.y ?? 0) + 1,
+	);
+	expect(
+		Math.abs(
+			(mobileViewAllBox?.x ?? 0) +
+				(mobileViewAllBox?.width ?? 0) -
+				((mobileSessionsBox?.x ?? 0) + (mobileSessionsBox?.width ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
 });
@@ -3159,42 +3181,65 @@ test("hosted overview keeps project count while names load", async ({ page }) =>
 	await expect(page.locator('[data-overview-module="vaults"]')).toBeVisible();
 });
 
-test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) => {
-	const startingDeployment = { ...railHostedDeployment, status: "starting" };
-	const sessionRequests: string[] = [];
-	await stubHostedApi(page, {
-		sessionRequests,
-		deployments: [startingDeployment],
-		cloudAgents: [railHostedCloudAgent],
-		cloudAgentNotFoundIds: [railHostedEnvironmentId],
-	});
-	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${startingDeployment.id}`);
+for (const deploymentStatus of ["creating", "starting"] as const) {
+	test(`hosted initial ${deploymentStatus} stays concise and status-grounded`, async ({
+		page,
+	}, testInfo) => {
+		const deployment = { ...railHostedDeployment, status: deploymentStatus };
+		const sessionRequests: string[] = [];
+		await stubHostedApi(page, {
+			sessionRequests,
+			deployments: [deployment],
+			cloudAgents: [railHostedCloudAgent],
+			cloudAgentNotFoundIds: [railHostedEnvironmentId],
+		});
+		await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${deployment.id}`);
 
-	const main = page.locator("main");
-	const panel = main.getByTestId("hosted-initial-deployment-panel");
-	await expect(panel).toContainText("Starting your agent");
-	await expect(panel).toContainText("Current status");
-	await expect(panel).toContainText("Starting");
-	await expect(panel).toContainText("This page updates automatically while your agent starts.");
-	await expect(panel.getByRole("status", { name: "Loading" })).toBeVisible();
-	for (const detail of ["Plan", "CPU", "Memory", "Storage"])
-		await expect(panel.getByText(detail, { exact: true })).toHaveCount(0);
-	await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
-	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
-	await expect(main.getByRole("heading", { name: "Tools", exact: true })).toHaveCount(0);
-	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
-	expect(sessionRequests).toEqual([]);
-	const sidebar = page.getByTestId("app-sidebar");
-	await expect(sidebar.getByText("Starting", { exact: true })).toBeVisible();
-	await expect(sidebar.getByText("Paused", { exact: true })).toHaveCount(0);
-	await expect(sidebar.getByText(/last seen/i)).toHaveCount(0);
-	await page.setViewportSize({ width: 1280, height: 1000 });
-	await page.screenshot({
-		path: testInfo.outputPath("hosted-agent-overview-provisioning.png"),
-		fullPage: true,
+		const main = page.locator("main");
+		const panel = main.getByTestId("hosted-initial-deployment-panel");
+		const activeLabel =
+			deploymentStatus === "creating" ? "Preparing your environment" : "Installing Hermes";
+		const stepLabel = deploymentStatus === "creating" ? "Step 1 of 3" : "Step 2 of 3";
+		const expectedStates =
+			deploymentStatus === "creating"
+				? { creating: "active", starting: "pending", running: "pending" }
+				: { creating: "completed", starting: "active", running: "pending" };
+		await expect(panel.getByRole("heading", { name: "Setting up Hermes" })).toBeVisible();
+		await expect(panel).not.toContainText("Current status");
+		await expect(panel).toContainText("This page updates automatically as setup progresses.");
+		await expect(panel.getByText(stepLabel, { exact: true })).toBeVisible();
+		const progress = panel.getByRole("list", { name: "Deployment progress" });
+		await expect(progress).toBeVisible();
+		for (const shortLabel of ["Environment", "Install", "Ready"])
+			await expect(progress.getByText(shortLabel, { exact: true })).toBeVisible();
+		await expect(progress).not.toContainText("Preparing your environment");
+		await expect(progress).not.toContainText("Installing Hermes");
+		await expect(panel.getByRole("status").filter({ hasText: activeLabel })).toHaveCount(1);
+		for (const [stage, state] of Object.entries(expectedStates)) {
+			const segment = panel.locator(`[data-deployment-stage="${stage}"]`);
+			await expect(segment).toHaveAttribute("data-stage-state", state);
+			if (state === "active") await expect(segment).toHaveAttribute("aria-current", "step");
+		}
+		await expect(panel.locator('[data-slot="spinner"]')).toHaveCount(0);
+		for (const detail of ["Plan", "CPU", "Memory", "Storage"])
+			await expect(panel.getByText(detail, { exact: true })).toHaveCount(0);
+		await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);
+		await expect(main.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
+		await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
+		await expect(main.getByRole("heading", { name: "Tools", exact: true })).toHaveCount(0);
+		await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+		expect(sessionRequests).toEqual([]);
+		const sidebar = page.getByTestId("app-sidebar");
+		await expect(sidebar.getByText("Starting", { exact: true })).toBeVisible();
+		await expect(sidebar.getByText("Paused", { exact: true })).toHaveCount(0);
+		await expect(sidebar.getByText(/last seen/i)).toHaveCount(0);
+		await page.setViewportSize({ width: 1280, height: 1000 });
+		await page.screenshot({
+			path: testInfo.outputPath(`hosted-agent-overview-initial-${deploymentStatus}.png`),
+			fullPage: true,
+		});
 	});
-});
+}
 
 test("starting with an existing projection keeps lifecycle status in Compute", async ({ page }) => {
 	const restartingDeployment = { ...railHostedDeployment, status: "starting" };
@@ -5332,7 +5377,7 @@ test("free Basic Deploy recovers hydration before authoritative first frame", as
 	expect(new URL(page.url()).searchParams.has("setup")).toBe(false);
 	await expect(page.getByLabel("Agent ownership loading")).toHaveCount(0);
 	await expect(page.locator('[data-hosted="true"] [data-slot="skeleton"]')).toHaveCount(0);
-	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByText("Setting up Hermes", { exact: true })).toBeVisible();
 	const detail = page.locator("main");
 	await expect(detail.getByText("Basic", { exact: true })).toBeVisible();
 	await expect(detail.getByText("GPT-5.6 Luna", { exact: true })).toBeVisible();
@@ -5397,7 +5442,7 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	await checkoutDialog.getByRole("button", { name: "Subscribe", exact: true }).click();
 
 	await expect(page).toHaveURL(/\/agents\/hdep_created/);
-	await expect(page.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(page.getByText("Setting up Hermes", { exact: true })).toBeVisible();
 	await expect(
 		page.getByText("This step should finish within five minutes.", { exact: false }),
 	).toBeVisible();
@@ -6262,7 +6307,7 @@ test("terminal provider failure replaces Starting with provider recovery", async
 			exact: true,
 		}),
 	).toBeVisible();
-	await expect(main.getByText("Starting your agent…", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Setting up Hermes", { exact: true })).toHaveCount(0);
 	await main.getByRole("button", { name: "Fix provider", exact: true }).click();
 	await expect(page).toHaveURL(new RegExp(`/agents/${starting.id}/model-provider`));
 });
@@ -6342,7 +6387,7 @@ test("deployment detail stays put, becomes running, and keeps manual Runtime UI 
 
 	await page.goto(`/agents/${pendingRuntimeUiDeployment.id}?source=on-clawdi`);
 	const main = page.locator("main");
-	await expect(main.getByText("Starting your agent…", { exact: true })).toBeVisible();
+	await expect(main.getByText("Setting up Hermes", { exact: true })).toBeVisible();
 	await expect(page).toHaveURL(
 		(url) => url.pathname === `/agents/${pendingRuntimeUiDeployment.id}`,
 	);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -25,7 +25,7 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 			),
 	]);
 	expect(gridBox).not.toBeNull();
-	expect(cards).toHaveLength(5);
+	expect(cards).toHaveLength(expectedRows.reduce((total, count) => total + count, 0));
 	const rowYs = [...new Set(cards.map((card) => Math.round(card.y)))];
 	const rows = rowYs.map((rowY) => cards.filter((card) => Math.abs(card.y - rowY) <= 2));
 	expect(rows.map((row) => row.length)).toEqual(expectedRows);
@@ -2704,7 +2704,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			})),
 			total: 5,
 			page: 1,
-			page_size: 20,
+			page_size: 3,
 		},
 		connectorConnections: [
 			{ id: "hosted-conn-github", app_name: "github", status: "ACTIVE" },
@@ -2759,7 +2759,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
 	);
 	await expect.poll(() => sessionRequests.length).toBe(1);
-	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("4");
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("3");
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
@@ -2768,9 +2768,18 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
+	const viewAllSessions = page
+		.locator("#hosted-recent-sessions")
+		.locator("..")
+		.getByRole("button", { name: "View all", exact: true });
+	const viewAllHref = await viewAllSessions.getAttribute("href");
+	const viewAllUrl = new URL(viewAllHref ?? "", page.url());
+	expect(viewAllUrl.pathname).toBe(`/agents/${railHostedEnvironmentId}/sessions`);
+	expect(viewAllUrl.searchParams.get("source")).toBe("on-clawdi");
+	expect(viewAllUrl.searchParams.get("d")).toBe(railHostedDeployment.id);
 	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
-	await expect(recentSessions.locator("article")).toHaveCount(4);
-	await expect(recentSessions).not.toContainText("Fifth hosted session");
+	await expect(recentSessions.locator("article")).toHaveCount(3);
+	await expect(recentSessions).not.toContainText("Review risks");
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
@@ -2869,7 +2878,12 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.getByText("Managed", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
-	const resourceGrid = overview.locator('[data-overview-layout="three-column"]');
+	const resourceGrid = overview.locator(
+		'section[aria-labelledby="agent-overview-resources"] [data-overview-layout="three-column"]',
+	);
+	const toolsGrid = overview.locator(
+		'section[aria-labelledby="agent-overview-operate"] [data-overview-layout="three-column"]',
+	);
 	const resourceGeometry = await resourceGrid
 		.locator("[data-overview-module]")
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
@@ -2890,12 +2904,22 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);
+	await expectOverviewResourceGeometry(toolsGrid, [2]);
+	expect(
+		Math.abs(
+			(resourceGeometry[0]?.width ?? 0) -
+				((await toolsGrid.locator("[data-overview-module]").first().boundingBox())?.width ?? 0),
+		),
+	).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 1024, height: 1200 });
 	await expectOverviewResourceGeometry(resourceGrid, [2, 2, 1]);
+	await expectOverviewResourceGeometry(toolsGrid, [2]);
 	await page.setViewportSize({ width: 768, height: 1200 });
 	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
+	await expectOverviewResourceGeometry(toolsGrid, [1, 1]);
 	await page.setViewportSize({ width: 390, height: 1200 });
 	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
+	await expectOverviewResourceGeometry(toolsGrid, [1, 1]);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
 });
@@ -3149,8 +3173,12 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	const main = page.locator("main");
 	const panel = main.getByTestId("hosted-initial-deployment-panel");
 	await expect(panel).toContainText("Starting your agent");
-	for (const detail of ["Starting", "Plan", "CPU", "Memory", "Storage"])
-		await expect(panel).toContainText(detail);
+	await expect(panel).toContainText("Current status");
+	await expect(panel).toContainText("Starting");
+	await expect(panel).toContainText("This page updates automatically while your agent starts.");
+	await expect(panel.getByRole("status", { name: "Loading" })).toBeVisible();
+	for (const detail of ["Plan", "CPU", "Memory", "Storage"])
+		await expect(panel.getByText(detail, { exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2574,6 +2574,33 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 	await expect(page.getByRole("dialog", { name: "Add agent" })).toBeVisible();
 });
 
+test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
+	await stubHostedApi(page, {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		agentResourceFixtures: true,
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const overview = page.locator('[data-agent-overview="hosted"]');
+	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
+	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="projects"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
+		"Hosted Agent Project",
+	);
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveClass(
+		/bg-identity-6-bg\/20/,
+	);
+	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1600 });
+	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
+});
+
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {
 	await stubHostedApi(page, {
 		canCreateCloudAgents: false,

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2792,7 +2792,10 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${startingDeployment.id}`);
 
 	const main = page.locator("main");
+	const agentInterface = main.locator('[data-overview-module="agent-interface"]');
 	const compute = main.locator('[data-overview-module="compute"]');
+	await expect(agentInterface).toHaveClass(/md:col-span-2/);
+	await expect(compute).toHaveClass(/md:col-span-2/);
 	await expect(compute).toContainText("Starting");
 	await expect(compute).toContainText("Plan");
 	await expect(compute).toContainText("CPU");
@@ -2804,11 +2807,31 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await expect(
 		compute.getByText("Startup is still in progress.", { exact: false }),
 	).toHaveAttribute("role", "status");
-	await expect(main.getByTestId("hosted-overview-provisioning-placeholder")).toBeVisible();
+	const placeholder = main.getByTestId("hosted-overview-provisioning-placeholder");
+	await expect(placeholder).toContainText("More details will appear here");
+	await expect(placeholder).toContainText(
+		"This page will fill in automatically when your agent is ready.",
+	);
+	for (const removedModule of ["memories", "vaults", "connectors"]) {
+		await expect(placeholder).not.toContainText(removedModule);
+	}
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Operate", exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1000 });
+	const [gridBox, interfaceBox, computeBox] = await Promise.all([
+		agentInterface.locator("..").boundingBox(),
+		agentInterface.boundingBox(),
+		compute.boundingBox(),
+	]);
+	expect(gridBox).not.toBeNull();
+	expect(interfaceBox).not.toBeNull();
+	expect(computeBox).not.toBeNull();
+	if (gridBox && interfaceBox && computeBox) {
+		expect(Math.abs(interfaceBox.width - computeBox.width)).toBeLessThan(2);
+		expect(interfaceBox.x).toBeCloseTo(gridBox.x, 0);
+		expect(computeBox.x + computeBox.width).toBeCloseTo(gridBox.x + gridBox.width, 0);
+	}
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-provisioning.png"),
 		fullPage: true,

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2929,7 +2929,7 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 
 	const main = page.locator("main");
 	const panel = main.getByTestId("hosted-initial-deployment-panel");
-	await expect(panel).toContainText("Setting up your agent");
+	await expect(panel).toContainText("Starting your agent");
 	for (const detail of ["Starting", "Plan", "CPU", "Memory", "Storage"])
 		await expect(panel).toContainText(detail);
 	await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1120,6 +1120,7 @@ function isStubResponse(value: unknown): value is StubResponse {
 
 type HostedApiStubOptions = {
 	sessionsPage?: unknown;
+	sessionRequests?: string[];
 	connectorConnections?: readonly unknown[];
 	connectorCatalog?: readonly {
 		name: string;
@@ -2210,7 +2211,10 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				page_size: 24,
 			});
 		}
-		if (p === "/v1/sessions") return fulfillJson(r, options.sessionsPage ?? emptyPage);
+		if (p === "/v1/sessions") {
+			options.sessionRequests?.push(r.request().url());
+			return fulfillJson(r, options.sessionsPage ?? emptyPage);
+		}
 		if (p === "/v1/memories") return fulfillJson(r, hostedMemories);
 		if (p === "/v1/settings") {
 			return fulfillJson(r, { memory_provider: "builtin", mem0_api_key: null });
@@ -2609,6 +2613,7 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 });
 
 test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
+	const sessionRequests: string[] = [];
 	const telegramAccount = {
 		id: "channel-overview-telegram",
 		provider: "telegram",
@@ -2617,6 +2622,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		created_at: "2026-07-15T00:00:00Z",
 	};
 	await stubHostedApi(page, {
+		sessionRequests,
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		agentResourceFixtures: true,
@@ -2708,6 +2714,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await page.goto(
 		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
 	);
+	await expect.poll(() => sessionRequests.length).toBe(1);
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("4");
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
@@ -2855,6 +2863,23 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 	});
 });
 
+test("hosted Sessions tab uses its own pagination without the Overview request", async ({
+	page,
+}) => {
+	const sessionRequests: string[] = [];
+	await stubHostedApi(page, {
+		sessionRequests,
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}/sessions?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+	await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
+	await expect.poll(() => sessionRequests.length).toBe(1);
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("20");
+});
+
 test("hosted overview distinguishes empty skills and channels from loading", async ({ page }) => {
 	await stubHostedApi(page, {
 		deployments: [railHostedDeployment],
@@ -2931,7 +2956,9 @@ test("hosted overview keeps project count while names load", async ({ page }) =>
 
 test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) => {
 	const startingDeployment = { ...railHostedDeployment, status: "starting" };
+	const sessionRequests: string[] = [];
 	await stubHostedApi(page, {
+		sessionRequests,
 		deployments: [startingDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		cloudAgentNotFoundIds: [railHostedEnvironmentId],
@@ -2948,6 +2975,7 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Tools", exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+	expect(sessionRequests).toEqual([]);
 	const sidebar = page.getByTestId("app-sidebar");
 	await expect(sidebar.getByText("Starting", { exact: true })).toBeVisible();
 	await expect(sidebar.getByText("Paused", { exact: true })).toHaveCount(0);
@@ -2960,12 +2988,14 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 });
 
 test("hosted unavailable status stays inside Compute", async ({ page }, testInfo) => {
+	const sessionRequests: string[] = [];
 	const runningRead = mutationDeploymentReadFixture(railHostedDeployment);
 	const unavailableDeployment = {
 		...runningRead,
 		resource: { ...runningRead.resource, status: null },
 	};
 	await stubHostedApi(page, {
+		sessionRequests,
 		deployments: [unavailableDeployment],
 		deploymentDetailResponses: [{ body: unavailableDeployment, status: 200 }],
 		cloudAgents: [railHostedCloudAgent],
@@ -2983,6 +3013,7 @@ test("hosted unavailable status stays inside Compute", async ({ page }, testInfo
 	await expect(compute).toContainText("Clawdi cannot confirm the current compute status.");
 	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
 	await expect(main.getByTestId("deployment-status-unavailable")).toHaveCount(0);
+	expect(sessionRequests).toEqual([]);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-unavailable.png"),

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2661,7 +2661,7 @@ test("global Hosted Wallet balance lives in chrome and reuses its cached query",
 
 	const walletEntry = page.getByTestId("global-wallet-balance");
 	await expect(walletEntry).toHaveCount(1);
-	await expect(walletEntry).toContainText("Wallet");
+	await expect(walletEntry).not.toContainText("Wallet");
 	await expect(walletEntry).toContainText("$25.00");
 	await expect(walletEntry).toHaveAccessibleName("Wallet balance $25.00. Open Wallet settings");
 	await expect.poll(() => walletRequests.length).toBe(1);
@@ -2875,6 +2875,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const compute = page.locator('[data-overview-status="compute"]');
 	await expect(compute).toContainText("Running");
 	await expect(compute).toContainText("Basic plan");
+	await expect(compute.getByTestId("overview-compute-summary")).not.toHaveClass(
+		/rounded|border|bg-/,
+	);
 	await expect(
 		compute.getByRole("list", {
 			name: "Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage",
@@ -2901,6 +2904,10 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
+	const flatResourceSummaries = overview.getByTestId("overview-summary-list");
+	await expect(flatResourceSummaries).toHaveCount(3);
+	for (const summary of await flatResourceSummaries.all())
+		await expect(summary).not.toHaveClass(/rounded|border|divide-y|bg-/);
 	const connectors = overview.locator('[data-overview-module="connectors"]');
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2652,6 +2652,33 @@ test("returning users can deploy on Clawdi or connect another machine", async ({
 	await expect(page.getByRole("dialog", { name: "Add agent" })).toBeVisible();
 });
 
+test("global Hosted Wallet balance lives in chrome and reuses its cached query", async ({
+	page,
+}, testInfo) => {
+	const walletRequests: string[] = [];
+	await stubHostedApi(page, { deployments: [], walletRequests });
+	await page.goto("/channels");
+
+	const walletEntry = page.getByTestId("global-wallet-balance");
+	await expect(walletEntry).toHaveCount(1);
+	await expect(walletEntry).toContainText("Wallet");
+	await expect(walletEntry).toContainText("$25.00");
+	await expect(walletEntry).toHaveAccessibleName("Wallet balance $25.00. Open Wallet settings");
+	await expect.poll(() => walletRequests.length).toBe(1);
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-global-wallet-channels.png"),
+		fullPage: true,
+	});
+
+	await walletEntry.click();
+	await expect(page).toHaveURL(/settings=billing-wallet/);
+	const settingsDialog = page.getByTestId("settings-dialog");
+	await expect(settingsDialog.getByRole("heading", { name: "Wallet", level: 1 })).toBeVisible();
+	await expect(settingsDialog.getByText("$25.00", { exact: true })).toBeVisible();
+	await page.waitForTimeout(250);
+	expect(walletRequests).toHaveLength(1);
+});
+
 test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
 	const sessionRequests: string[] = [];
 	const aiProviderRequests: string[] = [];
@@ -2847,7 +2874,12 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	);
 	const compute = page.locator('[data-overview-status="compute"]');
 	await expect(compute).toContainText("Running");
-	await expect(compute).toContainText("Basic");
+	await expect(compute).toContainText("Basic plan");
+	await expect(
+		compute.getByRole("list", {
+			name: "Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage",
+		}),
+	).toBeVisible();
 	await expect(page.getByText("Your agent is running", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Daily briefing");
 	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
@@ -2860,9 +2892,12 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText("Model");
 	expect(aiProviderRequests).toEqual([]);
 	await expect.poll(() => managedModelRequests.length).toBe(1);
-	await expect(compute).toContainText("CPU");
-	await expect(compute).toContainText("Memory");
-	await expect(compute).toContainText("Storage");
+	for (const configuration of ["2 vCPU", "4 GiB memory", "20 GiB storage"])
+		await expect(compute.getByText(configuration, { exact: true })).toBeVisible();
+	await expect(compute.getByText("Plan", { exact: true })).toHaveCount(0);
+	await expect(compute.getByText("CPU", { exact: true })).toHaveCount(0);
+	await expect(compute.getByText("Memory", { exact: true })).toHaveCount(0);
+	await expect(compute.getByText("Storage", { exact: true })).toHaveCount(0);
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
@@ -3342,13 +3377,17 @@ test("raw offline stays a Compute-only status and does not become status unavail
 });
 
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {
+	const walletRequests: string[] = [];
 	await stubHostedApi(page, {
 		canCreateCloudAgents: false,
 		deployments: [],
 		cloudAgents: [],
+		walletRequests,
 	});
 	await page.goto("/");
 
+	await expect(page.getByTestId("global-wallet-balance")).toHaveCount(0);
+	expect(walletRequests).toEqual([]);
 	await expect(page.getByText("Let's connect your first agent", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Deploy on Clawdi", exact: true })).toHaveCount(0);
 	await expect(page.getByText("Node.js 22.5+ is required.", { exact: true })).toHaveCount(0);
@@ -4099,13 +4138,17 @@ test("whole agent tile drag does not navigate and the next click does", async ({
 test("existing Cloud customers keep billing settings when new deploys are disabled", async ({
 	page,
 }) => {
+	const walletRequests: string[] = [];
 	await stubHostedApi(page, {
 		canCreateCloudAgents: false,
 		deployments: [includedBasicDeployment],
+		walletRequests,
 	});
 	await page.goto("/channels");
 	await page.waitForLoadState("networkidle");
 
+	await expect(page.getByTestId("global-wallet-balance")).toContainText("$25.00");
+	await expect.poll(() => walletRequests.length).toBe(1);
 	await page.getByRole("button", { name: "Settings", exact: true }).click();
 	const dialog = page.getByTestId("settings-dialog");
 	await expect(dialog).toBeVisible();
@@ -6126,7 +6169,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
 	await expect(main.locator('[data-overview-status="compute"]')).toContainText("Failed");
 	await expect(main.getByRole("alert")).toHaveCount(0);
-	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(main.getByText("Basic plan", { exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
@@ -6249,7 +6292,7 @@ test("failed deployment with a retained projection keeps status-authoritative na
 		main.getByText("The Clawdi service could not complete this request.", { exact: true }),
 	).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
-	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(main.getByText("Basic plan", { exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2636,6 +2636,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
 		"UI ready",
 	);
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
+		"Managed interface available",
+	);
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Running");
 	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Basic");
 	await expect(page.getByText("Your agent is running", { exact: true })).toHaveCount(0);
@@ -2643,6 +2646,11 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
 		"Research Telegram",
 	);
+	await expect(overview.locator('[data-overview-module="channels"]')).toContainText("Telegram");
+	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText(
+		"Managed by Clawdi",
+	);
+	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
@@ -2665,6 +2673,38 @@ test("hosted starting status and actions stay inside Compute", async ({ page }) 
 	await expect(
 		compute.getByText("Startup is still in progress.", { exact: false }),
 	).toHaveAttribute("role", "status");
+});
+
+test("hosted unavailable status stays inside Compute", async ({ page }, testInfo) => {
+	const runningRead = mutationDeploymentReadFixture(railHostedDeployment);
+	const unavailableDeployment = {
+		...runningRead,
+		resource: { ...runningRead.resource, status: null },
+	};
+	await stubHostedApi(page, {
+		deployments: [unavailableDeployment],
+		deploymentDetailResponses: [{ body: unavailableDeployment, status: 200 }],
+		cloudAgents: [railHostedCloudAgent],
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${unavailableDeployment.resource.id}`,
+	);
+
+	const main = page.locator("main");
+	const overview = main.locator('[data-agent-overview="hosted"]');
+	const compute = overview.locator('[data-overview-module="compute"]');
+	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
+	await expect(compute).toContainText("Status unavailable");
+	await expect(compute).toContainText("Clawdi cannot confirm the current compute status.");
+	await expect(compute.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
+	await expect(main.getByTestId("deployment-status-unavailable")).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1600 });
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-unavailable.png"),
+		fullPage: true,
+	});
 });
 
 test("empty accounts without deploy access only get the connected-agent path", async ({ page }) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1119,6 +1119,17 @@ function isStubResponse(value: unknown): value is StubResponse {
 }
 
 type HostedApiStubOptions = {
+	sessionsPage?: unknown;
+	connectorConnections?: readonly unknown[];
+	connectorCatalog?: readonly {
+		name: string;
+		display_name: string;
+		logo: string;
+		description: string;
+		auth_type: string;
+		connect_disabled: boolean;
+		connect_disabled_reason: null;
+	}[];
 	aiProviders?: readonly unknown[];
 	agentProjectBindings?: readonly unknown[];
 	agentProjectBindingRequests?: string[];
@@ -2170,13 +2181,20 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				page_size: Number(url.searchParams.get("page_size") ?? "25"),
 			});
 		}
-		if (p === "/v1/connectors") return fulfillJson(r, []);
+		if (p === "/v1/connectors") return fulfillJson(r, options.connectorConnections ?? []);
+		const connectorAppMatch = p.match(/^\/v1\/connectors\/available\/([^/]+)$/);
+		if (connectorAppMatch) {
+			const app = options.connectorCatalog?.find(
+				(item) => item.name === decodeURIComponent(connectorAppMatch[1] ?? ""),
+			);
+			return fulfillJson(r, app ?? { detail: "App not found" }, app ? 200 : 404);
+		}
 		if (p === "/v1/connectors/available") {
 			if (!options.agentResourceFixtures) {
 				return fulfillJson(r, { items: [], total: 0, page: 1, page_size: 24 });
 			}
 			return fulfillJson(r, {
-				items: [
+				items: options.connectorCatalog ?? [
 					{
 						name: "github",
 						display_name: "GitHub",
@@ -2192,7 +2210,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				page_size: 24,
 			});
 		}
-		if (p === "/v1/sessions") return fulfillJson(r, emptyPage);
+		if (p === "/v1/sessions") return fulfillJson(r, options.sessionsPage ?? emptyPage);
 		if (p === "/v1/memories") return fulfillJson(r, hostedMemories);
 		if (p === "/v1/settings") {
 			return fulfillJson(r, { memory_provider: "builtin", mem0_api_key: null });
@@ -2602,6 +2620,57 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		agentResourceFixtures: true,
+		sessionsPage: {
+			items: Array.from({ length: 5 }, (_, index) => ({
+				id: `hosted-overview-session-${index + 1}`,
+				local_session_id: `hosted-local-${index + 1}`,
+				project_path: "/hosted",
+				agent_name: "rail-cloud",
+				agent_display_name: "Rail Cloud",
+				agent_default_name: "Rail Cloud",
+				agent_type: "hermes",
+				machine_name: "rail-cloud",
+				started_at: `2026-07-15T0${index}:00:00Z`,
+				ended_at: null,
+				updated_at: `2026-07-15T0${index}:30:00Z`,
+				last_activity_at: `2026-07-15T0${index}:30:00Z`,
+				duration_seconds: 1800,
+				message_count: index + 3,
+				input_tokens: (index + 1) * 200,
+				output_tokens: (index + 1) * 100,
+				cache_read_tokens: 0,
+				model: "gpt-5",
+				models_used: ["gpt-5"],
+				summary: [
+					"Prepare launch brief",
+					"Research customer feedback",
+					"Update project plan",
+					"Review release risks",
+					"Fifth hosted session",
+				][index],
+				tags: [],
+				status: "active",
+				content_hash: `hosted-hash-${index}`,
+			})),
+			total: 5,
+			page: 1,
+			page_size: 20,
+		},
+		connectorConnections: [
+			{ id: "hosted-conn-github", app_name: "github", status: "ACTIVE" },
+			{ id: "hosted-conn-slack", app_name: "slack", status: "ACTIVE" },
+		],
+		connectorCatalog: ["github", "slack", "gmail", "notion", "linear", "dropbox", "calendar"].map(
+			(name) => ({
+				name,
+				display_name: name[0]?.toUpperCase() + name.slice(1),
+				logo: "",
+				description: `${name} connector`,
+				auth_type: "oauth",
+				connect_disabled: false,
+				connect_disabled_reason: null,
+			}),
+		),
 		skillsByProjectId: {
 			"project-hosted": [
 				{
@@ -2650,6 +2719,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
+	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
+	await expect(recentSessions.locator("article")).toHaveCount(4);
+	await expect(recentSessions).not.toContainText("Fifth hosted session");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Open Agent Interface" })).toHaveAttribute(
 		"href",
@@ -2674,6 +2746,12 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
+	const connectors = overview.locator('[data-overview-module="connectors"]');
+	await expect(connectors).toContainText("2 connected apps");
+	await expect(connectors.getByRole("link", { name: "Connected: Github" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Connected: Slack" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Popular: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2644,7 +2644,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 				summary: [
 					"Prepare launch brief",
 					"Research customer feedback before the product planning review",
-					"Investigate a long-running customer issue across several projects and write a detailed plan for the next release",
+					"Investigate a long-running customer issue across several projects and write a detailed plan for the next release review with every regional owner and support lead",
 					"Review risks",
 					"Fifth hosted session",
 				][index],
@@ -2725,13 +2725,36 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
-			return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+			const title = card.querySelector<HTMLElement>('[data-testid="overview-session-title"]');
+			const meta = card.querySelector<HTMLElement>('[data-testid="overview-session-meta"]');
+			const titleStyle = title ? getComputedStyle(title) : null;
+			return {
+				x: rect.x,
+				y: rect.y,
+				width: rect.width,
+				height: rect.height,
+				metaOffset: (meta?.getBoundingClientRect().y ?? rect.y) - rect.y,
+				titleWhiteSpace: titleStyle?.whiteSpace,
+				titleOverflow: titleStyle?.overflow,
+				titleTextOverflow: titleStyle?.textOverflow,
+				titleClipped: (title?.scrollWidth ?? 0) > (title?.clientWidth ?? 0),
+			};
 		}),
 	);
 	expect(
 		Math.max(...sessionBoxes.map((box) => box.height)) -
 			Math.min(...sessionBoxes.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
+	expect(Math.min(...sessionBoxes.map((box) => box.height))).toBeGreaterThanOrEqual(64);
+	expect(Math.max(...sessionBoxes.map((box) => box.height))).toBeLessThanOrEqual(72);
+	expect(sessionBoxes[2]?.titleWhiteSpace).toBe("nowrap");
+	expect(sessionBoxes[2]?.titleOverflow).toBe("hidden");
+	expect(sessionBoxes[2]?.titleTextOverflow).toBe("ellipsis");
+	expect(sessionBoxes[2]?.titleClipped).toBe(true);
+	expect(
+		Math.max(...sessionBoxes.map((box) => box.metaOffset)) -
+			Math.min(...sessionBoxes.map((box) => box.metaOffset)),
+	).toBeLessThanOrEqual(1);
 	for (let index = 1; index < sessionBoxes.length; index += 1) {
 		expect(Math.abs(sessionBoxes[index].x - sessionBoxes[0].x)).toBeLessThanOrEqual(1);
 		expect(Math.abs(sessionBoxes[index].width - sessionBoxes[0].width)).toBeLessThanOrEqual(1);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2641,20 +2641,23 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	);
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
-	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
-	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveClass(/md:col-span-2/);
-	await expect(overview.locator('[data-overview-module="projects"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+	await expect(overview.locator('[data-overview-module="projects"]')).not.toHaveClass(
+		/md:col-span-2/,
+	);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Hosted Agent Project",
 	);
-	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText("Ready");
-	await expect(overview.locator('[data-overview-module="agent-interface"]')).toContainText(
-		"Hermes",
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Open Agent Interface" })).toHaveAttribute(
+		"href",
+		/console/,
 	);
-	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Running");
-	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Basic");
+	const compute = page.locator('[data-overview-status="compute"]');
+	await expect(compute).toContainText("Running");
+	await expect(compute).toContainText("Basic");
 	await expect(page.getByText("Your agent is running", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Daily briefing");
 	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
@@ -2665,11 +2668,11 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		"Managed by Clawdi",
 	);
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText("Model");
-	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("CPU");
-	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Memory");
-	await expect(overview.locator('[data-overview-module="compute"]')).toContainText("Storage");
+	await expect(compute).toContainText("CPU");
+	await expect(compute).toContainText("Memory");
+	await expect(compute).toContainText("Storage");
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
-		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toHaveCount(0);
+		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
@@ -2698,7 +2701,7 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
-	await expect(overview.getByTestId("overview-module-skeleton")).toHaveCount(4);
+	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
 	await expect(overview.getByText("Details pending", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Loading…", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1600 });
@@ -2762,7 +2765,7 @@ test("hosted overview keeps project count when names fail", async ({ page }) => 
 	await expect(projectsCard).toContainText("Can’t load project names");
 	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
 	await expect(projectsCard).not.toContainText("No projects added");
-	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="vaults"]')).toBeVisible();
 });
 
 test("hosted overview keeps project count while names load", async ({ page }) => {
@@ -2779,7 +2782,7 @@ test("hosted overview keeps project count while names load", async ({ page }) =>
 	const projectsCard = page.locator('[data-overview-module="projects"]');
 	await expect(projectsCard).toContainText("1 project");
 	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
-	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="vaults"]')).toBeVisible();
 });
 
 test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) => {
@@ -2792,46 +2795,16 @@ test("hosted provisioning stays focused on Compute", async ({ page }, testInfo) 
 	await page.goto(`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${startingDeployment.id}`);
 
 	const main = page.locator("main");
-	const agentInterface = main.locator('[data-overview-module="agent-interface"]');
-	const compute = main.locator('[data-overview-module="compute"]');
-	await expect(agentInterface).toHaveClass(/md:col-span-2/);
-	await expect(compute).toHaveClass(/md:col-span-2/);
-	await expect(compute).toContainText("Starting");
-	await expect(compute).toContainText("Plan");
-	await expect(compute).toContainText("CPU");
-	await expect(compute).toContainText("Memory");
-	await expect(compute).toContainText("Storage");
-	await expect(compute).toContainText("Startup is still in progress.");
-	await expect(compute.getByRole("link", { name: "Compute", exact: true })).toBeVisible();
-	await expect(main.getByText("Starting your agent…", { exact: true })).toHaveCount(0);
-	await expect(
-		compute.getByText("Startup is still in progress.", { exact: false }),
-	).toHaveAttribute("role", "status");
-	const placeholder = main.getByTestId("hosted-overview-provisioning-placeholder");
-	await expect(placeholder).toContainText("More details will appear here");
-	await expect(placeholder).toContainText(
-		"This page will fill in automatically when your agent is ready.",
-	);
-	for (const removedModule of ["memories", "vaults", "connectors"]) {
-		await expect(placeholder).not.toContainText(removedModule);
-	}
+	const panel = main.getByTestId("hosted-initial-deployment-panel");
+	await expect(panel).toContainText("Setting up your agent");
+	for (const detail of ["Starting", "Plan", "CPU", "Memory", "Storage"])
+		await expect(panel).toContainText(detail);
+	await expect(main.locator('[data-agent-overview="hosted"]')).toHaveCount(0);
+	await expect(main.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Resources", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Operate", exact: true })).toHaveCount(0);
 	await expect(main.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1000 });
-	const [gridBox, interfaceBox, computeBox] = await Promise.all([
-		agentInterface.locator("..").boundingBox(),
-		agentInterface.boundingBox(),
-		compute.boundingBox(),
-	]);
-	expect(gridBox).not.toBeNull();
-	expect(interfaceBox).not.toBeNull();
-	expect(computeBox).not.toBeNull();
-	if (gridBox && interfaceBox && computeBox) {
-		expect(Math.abs(interfaceBox.width - computeBox.width)).toBeLessThan(2);
-		expect(interfaceBox.x).toBeCloseTo(gridBox.x, 0);
-		expect(computeBox.x + computeBox.width).toBeCloseTo(gridBox.x + gridBox.width, 0);
-	}
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-provisioning.png"),
 		fullPage: true,
@@ -2855,8 +2828,7 @@ test("hosted unavailable status stays inside Compute", async ({ page }, testInfo
 
 	const main = page.locator("main");
 	const overview = main.locator('[data-agent-overview="hosted"]');
-	const compute = overview.locator('[data-overview-module="compute"]');
-	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
+	const compute = main.locator('[data-overview-status="compute"]');
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.getByRole("heading", { name: "Operate", exact: true })).toBeVisible();
 	await expect(compute).toContainText("Status unavailable");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -19,7 +19,7 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	const [gridBox, cards] = await Promise.all([
 		grid.boundingBox(),
 		grid
-			.locator("article")
+			.locator("[data-overview-module]")
 			.evaluateAll((elements) =>
 				elements.map((element) => element.getBoundingClientRect().toJSON()),
 			),
@@ -42,11 +42,13 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 		expect(card.x + card.width).toBeLessThanOrEqual((gridBox?.x ?? 0) + (gridBox?.width ?? 0) + 1);
 	}
 	const finalRow = rows.at(-1) ?? [];
-	const finalLeft = Math.min(...finalRow.map((card) => card.x));
-	const finalRight = Math.max(...finalRow.map((card) => card.x + card.width));
-	expect(
-		Math.abs((finalLeft + finalRight) / 2 - ((gridBox?.x ?? 0) + (gridBox?.width ?? 0) / 2)),
-	).toBeLessThanOrEqual(2);
+	expect(finalRow).not.toHaveLength(0);
+	expect(Math.abs((finalRow[0]?.x ?? 0) - (gridBox?.x ?? 0))).toBeLessThanOrEqual(2);
+	const overflow = await grid.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
 // HOSTED (Clawdi Cloud) smoke against the vite dev server with dev-auth-bypass
@@ -2867,9 +2869,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(overview.getByText("Managed", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveCount(0);
-	const resourceGrid = overview.locator('[data-overview-layout="balanced-five"]');
+	const resourceGrid = overview.locator('[data-overview-layout="three-column"]');
 	const resourceGeometry = await resourceGrid
-		.locator("article")
+		.locator("[data-overview-module]")
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
 	expect(resourceGeometry).toHaveLength(5);
 	expect(
@@ -2884,7 +2886,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	}
 	expect(
 		await resourceGrid
-			.locator("article")
+			.locator("[data-overview-module]")
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -459,7 +459,10 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText(
 		"smoke-machine.local",
 	);
+	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Machine");
+	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Last seen");
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
+	await expect(overview.locator('[data-overview-module="memories"]')).toContainText("Scope");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1400 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -588,12 +588,11 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	);
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Machine");
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Last seen");
-	await expect(
-		page.locator("#connected-recent-sessions").locator("..").getByRole("button", {
-			name: "View all",
-			exact: true,
-		}),
-	).toHaveAttribute("href", "/agents/agent-smoke-1/sessions");
+	const viewAllSessions = page
+		.locator("#connected-recent-sessions")
+		.locator("..")
+		.getByRole("button", { name: "View all", exact: true });
+	await expect(viewAllSessions).toHaveAttribute("href", "/agents/agent-smoke-1/sessions");
 	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
 	await expect(recentSessions.locator("article")).toHaveCount(3);
 	await expect(recentSessions).not.toContainText("Draft update");
@@ -637,10 +636,18 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 			sessionBoxes[index - 1].y + sessionBoxes[index - 1].height,
 		);
 	}
-	const [recentSessionsBox, liveSyncBox] = await Promise.all([
+	const [recentSessionsBox, liveSyncBox, viewAllBox] = await Promise.all([
 		recentSessions.boundingBox(),
 		page.locator('[data-overview-status="live-sync"]').boundingBox(),
+		viewAllSessions.boundingBox(),
 	]);
+	expect(
+		Math.abs(
+			(viewAllBox?.x ?? 0) +
+				(viewAllBox?.width ?? 0) -
+				((recentSessionsBox?.x ?? 0) + (recentSessionsBox?.width ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	expect(Math.abs((liveSyncBox?.y ?? 0) - (recentSessionsBox?.y ?? 0))).toBeLessThanOrEqual(2);
 	expect(
 		Math.abs(
@@ -706,6 +713,20 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 			mobileSessionBoxes[index - 1].y + mobileSessionBoxes[index - 1].height,
 		);
 	}
+	const [mobileSessionsBox, mobileViewAllBox] = await Promise.all([
+		recentSessions.boundingBox(),
+		viewAllSessions.boundingBox(),
+	]);
+	expect((mobileViewAllBox?.y ?? 0) + (mobileViewAllBox?.height ?? 0)).toBeLessThanOrEqual(
+		(mobileSessionsBox?.y ?? 0) + 1,
+	);
+	expect(
+		Math.abs(
+			(mobileViewAllBox?.x ?? 0) +
+				(mobileViewAllBox?.width ?? 0) -
+				((mobileSessionsBox?.x ?? 0) + (mobileSessionsBox?.width ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 1280, height: 1400 });
 	await page.screenshot({
 		path: testInfo.outputPath("connected-agent-overview.png"),

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -420,7 +420,29 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 
 test("connected agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
 	await stubDashboardApi(page, [], {
-		skillsByProjectId: { "project-smoke": [] },
+		skillsByProjectId: {
+			"project-smoke": [
+				{
+					id: "skill-smoke-research",
+					skill_key: "research",
+					name: "Research",
+					description: "Research workflow",
+					version: 1,
+					source: "cloud",
+					authority: "cloud",
+					source_repo: null,
+					agent_types: ["codex"],
+					file_count: 1,
+					content_hash: "a".repeat(64),
+					is_active: true,
+					created_at: now.toISOString(),
+					updated_at: now.toISOString(),
+					project_id: "project-smoke",
+					project_name: "Smoke Project",
+					project_kind: "environment",
+				},
+			],
+		},
 	});
 	await page.goto("/agents/agent-smoke-1");
 
@@ -432,9 +454,10 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Smoke Project",
 	);
-	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveClass(
-		/bg-identity-7-bg\/20/,
+	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText(
+		"smoke-machine.local",
 	);
+	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1400 });
 	await page.screenshot({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -636,9 +636,17 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		Math.max(...resourceGeometry.map((box) => box.width)) -
 			Math.min(...resourceGeometry.map((box) => box.width)),
 	).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[0].y - resourceGeometry[1].y)).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[1].y - resourceGeometry[2].y)).toBeLessThanOrEqual(2);
-	expect(Math.abs(resourceGeometry[3].y - resourceGeometry[4].y)).toBeLessThanOrEqual(2);
+	for (const rowY of new Set(resourceGeometry.map((box) => Math.round(box.y)))) {
+		const row = resourceGeometry.filter((box) => Math.abs(box.y - rowY) <= 2);
+		expect(
+			Math.max(...row.map((box) => box.height)) - Math.min(...row.map((box) => box.height)),
+		).toBeLessThanOrEqual(2);
+	}
+	expect(
+		await resourceGrid
+			.locator("article")
+			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
+	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	const resourceGridBox = await resourceGrid.boundingBox();
 	expect(
 		Math.abs(

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -216,6 +216,7 @@ const overviewSessions = {
 		last_activity_at: new Date(now.getTime() - index * 60 * 60 * 1000).toISOString(),
 	})),
 	total: 5,
+	page_size: 3,
 };
 
 const memories = {
@@ -587,9 +588,15 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	);
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Machine");
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Last seen");
+	await expect(
+		page.locator("#connected-recent-sessions").locator("..").getByRole("button", {
+			name: "View all",
+			exact: true,
+		}),
+	).toHaveAttribute("href", "/agents/agent-smoke-1/sessions");
 	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
-	await expect(recentSessions.locator("article")).toHaveCount(4);
-	await expect(recentSessions).not.toContainText("Fifth hidden session");
+	await expect(recentSessions.locator("article")).toHaveCount(3);
+	await expect(recentSessions).not.toContainText("Draft update");
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
@@ -692,7 +699,7 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	const mobileSessionBoxes = await recentSessions
 		.locator("article")
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
-	expect(mobileSessionBoxes).toHaveLength(4);
+	expect(mobileSessionBoxes).toHaveLength(3);
 	for (let index = 1; index < mobileSessionBoxes.length; index += 1) {
 		expect(Math.abs(mobileSessionBoxes[index].x - mobileSessionBoxes[0].x)).toBeLessThanOrEqual(1);
 		expect(mobileSessionBoxes[index].y).toBeGreaterThanOrEqual(
@@ -735,13 +742,14 @@ test("connected detail only requests overview data on Overview", async ({ page }
 	expect(skillRequests).toEqual([]);
 });
 
-test("connected Overview requests four recent sessions", async ({ page }) => {
+test("connected Overview requests and renders three recent sessions", async ({ page }) => {
 	const sessionRequests: string[] = [];
-	await stubDashboardApi(page, [], { sessionRequests });
+	await stubDashboardApi(page, [], { sessionRequests, sessionsPage: overviewSessions });
 	await page.goto("/agents/agent-smoke-1");
 	await expect(page.getByRole("heading", { name: "Recent sessions", exact: true })).toBeVisible();
 	await expect.poll(() => sessionRequests.length).toBe(1);
-	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("4");
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("3");
+	await expect(page.getByTestId("overview-session-grid").locator("article")).toHaveCount(3);
 });
 
 test("connected Overview resolves connector metadata from catalog before fan-out", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -454,23 +454,25 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await page.goto("/agents/agent-smoke-1");
 
 	const overview = page.locator('[data-agent-overview="connected"]');
-	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible({
+	await expect(page.getByRole("heading", { name: "Recent sessions", exact: true })).toBeVisible({
 		timeout: 12_000,
 	});
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
-	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveClass(/md:col-span-2/);
-	await expect(overview.locator('[data-overview-module="projects"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
+	await expect(overview.locator('[data-overview-module="projects"]')).not.toHaveClass(
+		/md:col-span-2/,
+	);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Smoke Project",
 	);
-	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText(
+	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText(
 		"smoke-machine.local",
 	);
-	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Machine");
-	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Last seen");
+	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Machine");
+	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Last seen");
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
-		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toHaveCount(0);
+		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
@@ -496,7 +498,7 @@ test("connected overview keeps project count when names fail", async ({ page }) 
 	await expect(projectsCard).toContainText("Can’t load project names");
 	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
 	await expect(projectsCard).not.toContainText("No projects added");
-	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="vaults"]')).toBeVisible();
 });
 
 test("connected overview keeps project count while names load", async ({ page }) => {
@@ -506,7 +508,7 @@ test("connected overview keeps project count while names load", async ({ page })
 	const projectsCard = page.locator('[data-overview-module="projects"]');
 	await expect(projectsCard).toContainText("1 project");
 	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
-	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="vaults"]')).toBeVisible();
 });
 
 test("connected agent Memories stays account-wide with canonical detail links", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1,4 +1,37 @@
-import { expect, type Page, type Route, test } from "@playwright/test";
+import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
+
+async function expectOverviewResourceGeometry(grid: Locator, expectedRows: readonly number[]) {
+	const [gridBox, cards] = await Promise.all([
+		grid.boundingBox(),
+		grid
+			.locator("article")
+			.evaluateAll((elements) =>
+				elements.map((element) => element.getBoundingClientRect().toJSON()),
+			),
+	]);
+	expect(gridBox).not.toBeNull();
+	const rowYs = [...new Set(cards.map((card) => Math.round(card.y)))];
+	const rows = rowYs.map((rowY) => cards.filter((card) => Math.abs(card.y - rowY) <= 2));
+	expect(rows.map((row) => row.length)).toEqual(expectedRows);
+	expect(
+		Math.max(...cards.map((card) => card.width)) - Math.min(...cards.map((card) => card.width)),
+	).toBeLessThanOrEqual(2);
+	for (const row of rows) {
+		expect(
+			Math.max(...row.map((card) => card.height)) - Math.min(...row.map((card) => card.height)),
+		).toBeLessThanOrEqual(2);
+	}
+	for (const card of cards) {
+		expect(card.x).toBeGreaterThanOrEqual((gridBox?.x ?? 0) - 1);
+		expect(card.x + card.width).toBeLessThanOrEqual((gridBox?.x ?? 0) + (gridBox?.width ?? 0) + 1);
+	}
+	const finalRow = rows.at(-1) ?? [];
+	const finalLeft = Math.min(...finalRow.map((card) => card.x));
+	const finalRight = Math.max(...finalRow.map((card) => card.x + card.width));
+	expect(
+		Math.abs((finalLeft + finalRight) / 2 - ((gridBox?.x ?? 0) + (gridBox?.width ?? 0) / 2)),
+	).toBeLessThanOrEqual(2);
+}
 
 const now = new Date("2026-07-04T12:00:00.000Z");
 
@@ -647,17 +680,13 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 			.locator("article")
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
-	const resourceGridBox = await resourceGrid.boundingBox();
-	expect(
-		Math.abs(
-			resourceGeometry[3].x -
-				(resourceGridBox?.x ?? 0) -
-				((resourceGridBox?.x ?? 0) +
-					(resourceGridBox?.width ?? 0) -
-					(resourceGeometry[4].x + resourceGeometry[4].width)),
-		),
-	).toBeLessThanOrEqual(2);
+	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);
+	await page.setViewportSize({ width: 1024, height: 1200 });
+	await expectOverviewResourceGeometry(resourceGrid, [2, 2, 1]);
+	await page.setViewportSize({ width: 768, height: 1200 });
+	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
 	await page.setViewportSize({ width: 390, height: 844 });
+	await expectOverviewResourceGeometry(resourceGrid, [1, 1, 1, 1, 1]);
 	const mobileSessionBoxes = await recentSessions
 		.locator("article")
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -447,7 +447,9 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await page.goto("/agents/agent-smoke-1");
 
 	const overview = page.locator('[data-agent-overview="connected"]');
-	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible({
+		timeout: 12_000,
+	});
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveClass(/md:col-span-2/);
 	await expect(overview.locator('[data-overview-module="projects"]')).toHaveClass(/md:col-span-2/);
@@ -459,6 +461,7 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
+	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1400 });
 	await page.screenshot({
 		path: testInfo.outputPath("connected-agent-overview.png"),

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -536,9 +536,6 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	});
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
-	await expect(overview.locator('[data-overview-module="projects"]')).not.toHaveClass(
-		/md:col-span-2/,
-	);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
 		"Smoke Project",
 	);
@@ -607,7 +604,6 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const connectors = overview.locator('[data-overview-module="connectors"]');
-	await expect(connectors).not.toHaveClass(/md:col-span-2/);
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
 	await expect(connectorLinks).toHaveCount(5);
@@ -616,11 +612,35 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
 	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
+	await expect(sidebar.getByText("Paused", { exact: true })).toBeVisible();
+	await expect(sidebar.getByText(/last seen/i)).toBeVisible();
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
 	}
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
+	const resourceGrid = overview.locator('[data-overview-layout="balanced-five"]');
+	const resourceGeometry = await resourceGrid
+		.locator("article")
+		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
+	expect(resourceGeometry).toHaveLength(5);
+	expect(
+		Math.max(...resourceGeometry.map((box) => box.width)) -
+			Math.min(...resourceGeometry.map((box) => box.width)),
+	).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[0].y - resourceGeometry[1].y)).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[1].y - resourceGeometry[2].y)).toBeLessThanOrEqual(2);
+	expect(Math.abs(resourceGeometry[3].y - resourceGeometry[4].y)).toBeLessThanOrEqual(2);
+	const resourceGridBox = await resourceGrid.boundingBox();
+	expect(
+		Math.abs(
+			resourceGeometry[3].x -
+				(resourceGridBox?.x ?? 0) -
+				((resourceGridBox?.x ?? 0) +
+					(resourceGridBox?.width ?? 0) -
+					(resourceGeometry[4].x + resourceGeometry[4].width)),
+		),
+	).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 390, height: 844 });
 	const mobileSessionBoxes = await recentSessions
 		.locator("article")

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -162,6 +162,26 @@ const sessions = {
 	page: 1,
 	page_size: 25,
 };
+const overviewSessions = {
+	...sessions,
+	items: Array.from({ length: 5 }, (_, index) => ({
+		...sessions.items[0],
+		id: `session-overview-${index + 1}`,
+		local_session_id: `local-overview-${index + 1}`,
+		summary: [
+			"Plan release",
+			"Review customer notes",
+			"Fix sync health",
+			"Draft weekly update",
+			"Fifth hidden session",
+		][index],
+		message_count: index + 2,
+		input_tokens: 100 * (index + 1),
+		output_tokens: 50 * (index + 1),
+		last_activity_at: new Date(now.getTime() - index * 60 * 60 * 1000).toISOString(),
+	})),
+	total: 5,
+};
 
 const memories = {
 	items: [
@@ -191,6 +211,21 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
 }
 
 type DashboardApiStubOptions = {
+	sessionsPage?: unknown;
+	connectorConnections?: readonly unknown[];
+	connectorConnectionsGate?: Promise<void>;
+	connectorConnectionsResponse?: { body: unknown; status: number };
+	connectorCatalog?: readonly {
+		name: string;
+		display_name: string;
+		logo: string;
+		description: string;
+		auth_type: string;
+		connect_disabled: boolean;
+		connect_disabled_reason: null;
+	}[];
+	connectorCatalogGate?: Promise<void>;
+	connectorCatalogResponse?: { body: unknown; status: number };
 	projectBindings?: readonly unknown[];
 	projectBindingsError?: { status: number; detail: string };
 	projectBindingsGate?: Promise<void>;
@@ -289,12 +324,38 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/connectors") {
-			await fulfillJson(route, []);
+			await options.connectorConnectionsGate;
+			if (options.connectorConnectionsResponse) {
+				await fulfillJson(
+					route,
+					options.connectorConnectionsResponse.body,
+					options.connectorConnectionsResponse.status,
+				);
+				return;
+			}
+			await fulfillJson(route, options.connectorConnections ?? []);
+			return;
+		}
+		const connectorAppMatch = url.pathname.match(/^\/v1\/connectors\/available\/([^/]+)$/);
+		if (connectorAppMatch) {
+			const app = options.connectorCatalog?.find(
+				(item) => item.name === decodeURIComponent(connectorAppMatch[1]),
+			);
+			await fulfillJson(route, app ?? { detail: "App not found" }, app ? 200 : 404);
 			return;
 		}
 		if (url.pathname === "/v1/connectors/available") {
+			await options.connectorCatalogGate;
+			if (options.connectorCatalogResponse) {
+				await fulfillJson(
+					route,
+					options.connectorCatalogResponse.body,
+					options.connectorCatalogResponse.status,
+				);
+				return;
+			}
 			await fulfillJson(route, {
-				items: [
+				items: options.connectorCatalog ?? [
 					{
 						name: "gmail",
 						display_name: "Gmail",
@@ -312,7 +373,7 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/sessions") {
-			await fulfillJson(route, sessions);
+			await fulfillJson(route, options.sessionsPage ?? sessions);
 			return;
 		}
 		if (url.pathname === "/v1/memories") {
@@ -419,14 +480,30 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 
 	await page.goto("/agents/agent-smoke-1");
 	await expectSidebarNavigationGroups(page, [
-		{ label: null, items: ["Overview", "Sessions", "Memories"] },
-		{ label: "Resources", items: ["Connectors", "Projects", "Skills", "Vaults"] },
+		{ label: null, items: ["Overview", "Sessions"] },
+		{ label: "Resources", items: ["Projects", "Skills", "Memories", "Vaults", "Connectors"] },
 		{ label: null, items: ["Settings"] },
 	]);
 });
 
 test("connected agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
 	await stubDashboardApi(page, [], {
+		sessionsPage: overviewSessions,
+		connectorConnections: [
+			{ id: "conn-github", app_name: "github", status: "ACTIVE" },
+			{ id: "conn-slack", app_name: "slack", status: "ACTIVE" },
+		],
+		connectorCatalog: ["github", "slack", "gmail", "notion", "linear", "dropbox", "calendar"].map(
+			(name) => ({
+				name,
+				display_name: name[0]?.toUpperCase() + name.slice(1),
+				logo: "",
+				description: `${name} connector`,
+				auth_type: "oauth",
+				connect_disabled: false,
+				connect_disabled_reason: null,
+			}),
+		),
 		skillsByProjectId: {
 			"project-smoke": [
 				{
@@ -470,10 +547,19 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	);
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Machine");
 	await expect(page.locator('[data-overview-status="live-sync"]')).toContainText("Last seen");
+	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
+	await expect(recentSessions.locator("article")).toHaveCount(4);
+	await expect(recentSessions).not.toContainText("Fifth hidden session");
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
+	const connectors = overview.locator('[data-overview-module="connectors"]');
+	await expect(connectors).toContainText("2 connected apps");
+	await expect(connectors.getByRole("link", { name: "Connected: Github" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Connected: Slack" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
+	await expect(connectors.getByRole("link", { name: "Popular: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
@@ -485,6 +571,64 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		path: testInfo.outputPath("connected-agent-overview.png"),
 		fullPage: true,
 	});
+});
+
+test("connected overview keeps connector and catalog states independent", async ({ page }) => {
+	await stubDashboardApi(page, [], {
+		connectorConnectionsGate: new Promise<void>(() => {}),
+		connectorCatalog: [
+			{
+				name: "gmail",
+				display_name: "Gmail",
+				logo: "",
+				description: "Email",
+				auth_type: "oauth",
+				connect_disabled: false,
+				connect_disabled_reason: null,
+			},
+		],
+	});
+	await page.goto("/agents/agent-smoke-1");
+	const card = page.locator('[data-overview-module="connectors"]');
+	await expect(card.getByLabel("Loading connected apps")).toBeVisible();
+	await expect(card.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
+	await expect(card).not.toContainText("No apps connected");
+});
+
+test("connected overview reports connector errors without a false empty state", async ({
+	page,
+}) => {
+	await stubDashboardApi(page, [], {
+		connectorConnectionsResponse: { body: { detail: "failed" }, status: 500 },
+		connectorCatalogResponse: { body: { detail: "failed" }, status: 500 },
+	});
+	await page.goto("/agents/agent-smoke-1");
+	const card = page.locator('[data-overview-module="connectors"]');
+	await expect(card).toContainText("Can’t load connected apps", { timeout: 12_000 });
+	await expect(card).toContainText("Can’t load popular apps");
+	await expect(card).not.toContainText("No apps connected");
+});
+
+test("connected overview preserves active count while popular apps load", async ({ page }) => {
+	await stubDashboardApi(page, [], {
+		connectorConnections: [{ id: "conn-github", app_name: "github", status: "ACTIVE" }],
+		connectorCatalogGate: new Promise<void>(() => {}),
+		connectorCatalog: [
+			{
+				name: "github",
+				display_name: "Github",
+				logo: "",
+				description: "Source",
+				auth_type: "oauth",
+				connect_disabled: false,
+				connect_disabled_reason: null,
+			},
+		],
+	});
+	await page.goto("/agents/agent-smoke-1");
+	const card = page.locator('[data-overview-module="connectors"]');
+	await expect(card).toContainText("1 connected app");
+	await expect(card.getByLabel("Loading popular apps")).toBeVisible();
 });
 
 test("connected overview keeps project count when names fail", async ({ page }) => {

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -4,7 +4,7 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	const [gridBox, cards] = await Promise.all([
 		grid.boundingBox(),
 		grid
-			.locator("article")
+			.locator("[data-overview-module]")
 			.evaluateAll((elements) =>
 				elements.map((element) => element.getBoundingClientRect().toJSON()),
 			),
@@ -26,11 +26,13 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 		expect(card.x + card.width).toBeLessThanOrEqual((gridBox?.x ?? 0) + (gridBox?.width ?? 0) + 1);
 	}
 	const finalRow = rows.at(-1) ?? [];
-	const finalLeft = Math.min(...finalRow.map((card) => card.x));
-	const finalRight = Math.max(...finalRow.map((card) => card.x + card.width));
-	expect(
-		Math.abs((finalLeft + finalRight) / 2 - ((gridBox?.x ?? 0) + (gridBox?.width ?? 0) / 2)),
-	).toBeLessThanOrEqual(2);
+	expect(finalRow).not.toHaveLength(0);
+	expect(Math.abs((finalRow[0]?.x ?? 0) - (gridBox?.x ?? 0))).toBeLessThanOrEqual(2);
+	const overflow = await grid.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
 const now = new Date("2026-07-04T12:00:00.000Z");
@@ -660,9 +662,9 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	}
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
-	const resourceGrid = overview.locator('[data-overview-layout="balanced-five"]');
+	const resourceGrid = overview.locator('[data-overview-layout="three-column"]');
 	const resourceGeometry = await resourceGrid
-		.locator("article")
+		.locator("[data-overview-module]")
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
 	expect(resourceGeometry).toHaveLength(5);
 	expect(
@@ -677,7 +679,7 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	}
 	expect(
 		await resourceGrid
-			.locator("article")
+			.locator("[data-overview-module]")
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -418,6 +418,31 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 	]);
 });
 
+test("connected agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
+	await stubDashboardApi(page, [], {
+		skillsByProjectId: { "project-smoke": [] },
+	});
+	await page.goto("/agents/agent-smoke-1");
+
+	const overview = page.locator('[data-agent-overview="connected"]');
+	await expect(overview.getByRole("heading", { name: "Now", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
+	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="projects"]')).toHaveClass(/md:col-span-2/);
+	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
+		"Smoke Project",
+	);
+	await expect(overview.locator('[data-overview-module="live-sync"]')).toHaveClass(
+		/bg-identity-7-bg\/20/,
+	);
+	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1400 });
+	await page.screenshot({
+		path: testInfo.outputPath("connected-agent-overview.png"),
+		fullPage: true,
+	});
+});
+
 test("connected agent Memories stays account-wide with canonical detail links", async ({
 	page,
 }) => {

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -469,9 +469,13 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Machine");
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Last seen");
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
-	await expect(overview.locator('[data-overview-module="memories"]')).toContainText(
-		"Shared with all your agents",
-	);
+	for (const moduleId of ["memories", "vaults", "connectors"]) {
+		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toHaveCount(0);
+	}
+	const sidebar = page.getByTestId("app-sidebar");
+	for (const section of ["Memories", "Vaults", "Connectors"]) {
+		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
+	}
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1400 });
@@ -492,9 +496,7 @@ test("connected overview keeps project count when names fail", async ({ page }) 
 	await expect(projectsCard).toContainText("Can’t load project names");
 	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
 	await expect(projectsCard).not.toContainText("No projects added");
-	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
-		"Available through 1 project",
-	);
+	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
 });
 
 test("connected overview keeps project count while names load", async ({ page }) => {
@@ -504,9 +506,7 @@ test("connected overview keeps project count while names load", async ({ page })
 	const projectsCard = page.locator('[data-overview-module="projects"]');
 	await expect(projectsCard).toContainText("1 project");
 	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
-	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
-		"Available through 1 project",
-	);
+	await expect(page.locator('[data-overview-module="vaults"]')).toHaveCount(0);
 });
 
 test("connected agent Memories stays account-wide with canonical detail links", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -170,14 +170,14 @@ const overviewSessions = {
 		local_session_id: `local-overview-${index + 1}`,
 		summary: [
 			"Plan release",
-			"Review customer notes",
-			"Fix sync health",
-			"Draft weekly update",
+			"Review customer notes before the quarterly planning meeting",
+			"Investigate a very long synchronization issue affecting several workspaces and prepare a clear remediation plan for the team",
+			"Draft update",
 			"Fifth hidden session",
 		][index],
 		message_count: index + 2,
-		input_tokens: 100 * (index + 1),
-		output_tokens: 50 * (index + 1),
+		input_tokens: [8, 1200, 18_500, 420][index],
+		output_tokens: [4, 340, 9200, 80][index],
 		last_activity_at: new Date(now.getTime() - index * 60 * 60 * 1000).toISOString(),
 	})),
 	total: 5,
@@ -550,22 +550,65 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	const recentSessions = page.getByRole("region", { name: "Recent sessions" });
 	await expect(recentSessions.locator("article")).toHaveCount(4);
 	await expect(recentSessions).not.toContainText("Fifth hidden session");
+	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
+		cards.map((card) => {
+			const rect = card.getBoundingClientRect();
+			return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+		}),
+	);
+	expect(
+		Math.max(...sessionBoxes.map((box) => box.height)) -
+			Math.min(...sessionBoxes.map((box) => box.height)),
+	).toBeLessThanOrEqual(2);
+	for (let index = 1; index < sessionBoxes.length; index += 1) {
+		expect(Math.abs(sessionBoxes[index].x - sessionBoxes[0].x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(sessionBoxes[index].width - sessionBoxes[0].width)).toBeLessThanOrEqual(1);
+		expect(sessionBoxes[index].y).toBeGreaterThanOrEqual(
+			sessionBoxes[index - 1].y + sessionBoxes[index - 1].height,
+		);
+	}
+	const [recentSessionsBox, liveSyncBox] = await Promise.all([
+		recentSessions.boundingBox(),
+		page.locator('[data-overview-status="live-sync"]').boundingBox(),
+	]);
+	expect(Math.abs((liveSyncBox?.y ?? 0) - (recentSessionsBox?.y ?? 0))).toBeLessThanOrEqual(2);
+	expect(
+		Math.abs(
+			(liveSyncBox?.y ?? 0) +
+				(liveSyncBox?.height ?? 0) -
+				((recentSessionsBox?.y ?? 0) + (recentSessionsBox?.height ?? 0)),
+		),
+	).toBeLessThanOrEqual(2);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
 	const connectors = overview.locator('[data-overview-module="connectors"]');
-	await expect(connectors).toContainText("2 connected apps");
-	await expect(connectors.getByRole("link", { name: "Connected: Github" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Connected: Slack" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
-	await expect(connectors.getByRole("link", { name: "Popular: Github" })).toHaveCount(0);
+	await expect(connectors).not.toHaveClass(/md:col-span-2/);
+	await expect(connectors).toContainText("2 connected");
+	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
+	await expect(connectorLinks).toHaveCount(5);
+	await expect(connectorLinks.nth(0)).toHaveAccessibleName("Connected app: Github");
+	await expect(connectorLinks.nth(1)).toHaveAccessibleName("Connected app: Slack");
+	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
+	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
 	const sidebar = page.getByTestId("app-sidebar");
 	for (const section of ["Memories", "Vaults", "Connectors"]) {
 		await expect(sidebar.getByRole("link", { name: section, exact: true })).toBeVisible();
 	}
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
+	await page.setViewportSize({ width: 390, height: 844 });
+	const mobileSessionBoxes = await recentSessions
+		.locator("article")
+		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
+	expect(mobileSessionBoxes).toHaveLength(4);
+	for (let index = 1; index < mobileSessionBoxes.length; index += 1) {
+		expect(Math.abs(mobileSessionBoxes[index].x - mobileSessionBoxes[0].x)).toBeLessThanOrEqual(1);
+		expect(mobileSessionBoxes[index].y).toBeGreaterThanOrEqual(
+			mobileSessionBoxes[index - 1].y + mobileSessionBoxes[index - 1].height,
+		);
+	}
 	await page.setViewportSize({ width: 1280, height: 1400 });
 	await page.screenshot({
 		path: testInfo.outputPath("connected-agent-overview.png"),
@@ -591,7 +634,7 @@ test("connected overview keeps connector and catalog states independent", async 
 	await page.goto("/agents/agent-smoke-1");
 	const card = page.locator('[data-overview-module="connectors"]');
 	await expect(card.getByLabel("Loading connected apps")).toBeVisible();
-	await expect(card.getByRole("link", { name: "Popular: Gmail" })).toBeVisible();
+	await expect(card.getByRole("link", { name: "Available app: Gmail" })).toBeVisible();
 	await expect(card).not.toContainText("No apps connected");
 });
 
@@ -604,8 +647,7 @@ test("connected overview reports connector errors without a false empty state", 
 	});
 	await page.goto("/agents/agent-smoke-1");
 	const card = page.locator('[data-overview-module="connectors"]');
-	await expect(card).toContainText("Can’t load connected apps", { timeout: 12_000 });
-	await expect(card).toContainText("Can’t load popular apps");
+	await expect(card).toContainText("Can’t load apps", { timeout: 12_000 });
 	await expect(card).not.toContainText("No apps connected");
 });
 
@@ -627,8 +669,8 @@ test("connected overview preserves active count while popular apps load", async 
 	});
 	await page.goto("/agents/agent-smoke-1");
 	const card = page.locator('[data-overview-module="connectors"]');
-	await expect(card).toContainText("1 connected app");
-	await expect(card.getByLabel("Loading popular apps")).toBeVisible();
+	await expect(card).toContainText("1 connected");
+	await expect(card.getByLabel("Loading app").first()).toBeVisible();
 });
 
 test("connected overview keeps project count when names fail", async ({ page }) => {

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -171,7 +171,7 @@ const overviewSessions = {
 		summary: [
 			"Plan release",
 			"Review customer notes before the quarterly planning meeting",
-			"Investigate a very long synchronization issue affecting several workspaces and prepare a clear remediation plan for the team",
+			"Investigate a very long synchronization issue affecting several workspaces and prepare a clear remediation plan for the team before the next release review with every regional owner",
 			"Draft update",
 			"Fifth hidden session",
 		][index],
@@ -553,13 +553,36 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
-			return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+			const title = card.querySelector<HTMLElement>('[data-testid="overview-session-title"]');
+			const meta = card.querySelector<HTMLElement>('[data-testid="overview-session-meta"]');
+			const titleStyle = title ? getComputedStyle(title) : null;
+			return {
+				x: rect.x,
+				y: rect.y,
+				width: rect.width,
+				height: rect.height,
+				metaOffset: (meta?.getBoundingClientRect().y ?? rect.y) - rect.y,
+				titleWhiteSpace: titleStyle?.whiteSpace,
+				titleOverflow: titleStyle?.overflow,
+				titleTextOverflow: titleStyle?.textOverflow,
+				titleClipped: (title?.scrollWidth ?? 0) > (title?.clientWidth ?? 0),
+			};
 		}),
 	);
 	expect(
 		Math.max(...sessionBoxes.map((box) => box.height)) -
 			Math.min(...sessionBoxes.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
+	expect(Math.min(...sessionBoxes.map((box) => box.height))).toBeGreaterThanOrEqual(64);
+	expect(Math.max(...sessionBoxes.map((box) => box.height))).toBeLessThanOrEqual(72);
+	expect(sessionBoxes[2]?.titleWhiteSpace).toBe("nowrap");
+	expect(sessionBoxes[2]?.titleOverflow).toBe("hidden");
+	expect(sessionBoxes[2]?.titleTextOverflow).toBe("ellipsis");
+	expect(sessionBoxes[2]?.titleClipped).toBe(true);
+	expect(
+		Math.max(...sessionBoxes.map((box) => box.metaOffset)) -
+			Math.min(...sessionBoxes.map((box) => box.metaOffset)),
+	).toBeLessThanOrEqual(1);
 	for (let index = 1; index < sessionBoxes.length; index += 1) {
 		expect(Math.abs(sessionBoxes[index].x - sessionBoxes[0].x)).toBeLessThanOrEqual(1);
 		expect(Math.abs(sessionBoxes[index].width - sessionBoxes[0].width)).toBeLessThanOrEqual(1);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -195,6 +195,8 @@ type DashboardApiStubOptions = {
 	projectBindingsError?: { status: number; detail: string };
 	projectBindingsGate?: Promise<void>;
 	projects?: readonly unknown[];
+	projectsGate?: Promise<void>;
+	projectsResponse?: { body: unknown; status: number };
 	skillRequests?: string[];
 	skillsByProjectId?: Readonly<Record<string, readonly unknown[]>>;
 	vaultRequests?: string[];
@@ -248,6 +250,11 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/projects") {
+			await options.projectsGate;
+			if (options.projectsResponse) {
+				await fulfillJson(route, options.projectsResponse.body, options.projectsResponse.status);
+				return;
+			}
 			await fulfillJson(route, options.projects ?? projects);
 			return;
 		}
@@ -462,7 +469,9 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Machine");
 	await expect(overview.locator('[data-overview-module="live-sync"]')).toContainText("Last seen");
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
-	await expect(overview.locator('[data-overview-module="memories"]')).toContainText("Scope");
+	await expect(overview.locator('[data-overview-module="memories"]')).toContainText(
+		"Shared with all your agents",
+	);
 	await expect(overview.locator('[data-overview-module="agent-interface"]')).toHaveCount(0);
 	await expect(overview.getByText("Activity and current state", { exact: true })).toHaveCount(0);
 	await page.setViewportSize({ width: 1280, height: 1400 });
@@ -470,6 +479,34 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		path: testInfo.outputPath("connected-agent-overview.png"),
 		fullPage: true,
 	});
+});
+
+test("connected overview keeps project count when names fail", async ({ page }) => {
+	await stubDashboardApi(page, [], {
+		projectsResponse: { status: 500, body: { detail: "project list failed" } },
+	});
+	await page.goto("/agents/agent-smoke-1");
+
+	const projectsCard = page.locator('[data-overview-module="projects"]');
+	await expect(projectsCard).toContainText("1 project");
+	await expect(projectsCard).toContainText("Can’t load project names");
+	await expect(projectsCard.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
+	await expect(projectsCard).not.toContainText("No projects added");
+	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
+		"Available through 1 project",
+	);
+});
+
+test("connected overview keeps project count while names load", async ({ page }) => {
+	await stubDashboardApi(page, [], { projectsGate: new Promise<void>(() => {}) });
+	await page.goto("/agents/agent-smoke-1");
+
+	const projectsCard = page.locator('[data-overview-module="projects"]');
+	await expect(projectsCard).toContainText("1 project");
+	await expect(projectsCard.getByLabel("Loading project names summary")).toBeVisible();
+	await expect(page.locator('[data-overview-module="vaults"]')).toContainText(
+		"Available through 1 project",
+	);
 });
 
 test("connected agent Memories stays account-wide with canonical detail links", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -212,6 +212,7 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
 
 type DashboardApiStubOptions = {
 	sessionsPage?: unknown;
+	sessionRequests?: string[];
 	connectorConnections?: readonly unknown[];
 	connectorConnectionsGate?: Promise<void>;
 	connectorConnectionsResponse?: { body: unknown; status: number };
@@ -226,6 +227,9 @@ type DashboardApiStubOptions = {
 	}[];
 	connectorCatalogGate?: Promise<void>;
 	connectorCatalogResponse?: { body: unknown; status: number };
+	connectorMetadataRequests?: string[];
+	projectBindingRequests?: string[];
+	projectRequests?: string[];
 	projectBindings?: readonly unknown[];
 	projectBindingsError?: { status: number; detail: string };
 	projectBindingsGate?: Promise<void>;
@@ -268,6 +272,7 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/agents/agent-smoke-1/project-bindings") {
+			options.projectBindingRequests?.push(route.request().url());
 			await options.projectBindingsGate;
 			if (options.projectBindingsError) {
 				await fulfillJson(
@@ -285,6 +290,7 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/projects") {
+			options.projectRequests?.push(route.request().url());
 			await options.projectsGate;
 			if (options.projectsResponse) {
 				await fulfillJson(route, options.projectsResponse.body, options.projectsResponse.status);
@@ -338,6 +344,7 @@ async function stubDashboardApi(
 		}
 		const connectorAppMatch = url.pathname.match(/^\/v1\/connectors\/available\/([^/]+)$/);
 		if (connectorAppMatch) {
+			options.connectorMetadataRequests?.push(route.request().url());
 			const app = options.connectorCatalog?.find(
 				(item) => item.name === decodeURIComponent(connectorAppMatch[1]),
 			);
@@ -373,6 +380,7 @@ async function stubDashboardApi(
 			return;
 		}
 		if (url.pathname === "/v1/sessions") {
+			options.sessionRequests?.push(route.request().url());
 			await fulfillJson(route, options.sessionsPage ?? sessions);
 			return;
 		}
@@ -657,6 +665,74 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		path: testInfo.outputPath("connected-agent-overview.png"),
 		fullPage: true,
 	});
+});
+
+test("connected detail only requests overview data on Overview", async ({ page }) => {
+	const sessionRequests: string[] = [];
+	const projectBindingRequests: string[] = [];
+	const projectRequests: string[] = [];
+	const skillRequests: string[] = [];
+	await stubDashboardApi(page, [], {
+		sessionRequests,
+		projectBindingRequests,
+		projectRequests,
+		skillRequests,
+	});
+
+	await page.goto("/agents/agent-smoke-1/settings");
+	await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
+	await page.waitForTimeout(100);
+	expect(sessionRequests).toEqual([]);
+	expect(projectBindingRequests).toEqual([]);
+	expect(projectRequests).toEqual([]);
+	expect(skillRequests).toEqual([]);
+
+	await page.goto("/agents/agent-smoke-1/sessions");
+	await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
+	await expect.poll(() => sessionRequests.length).toBe(1);
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("50");
+	expect(projectBindingRequests).toEqual([]);
+	expect(projectRequests).toEqual([]);
+	expect(skillRequests).toEqual([]);
+});
+
+test("connected Overview requests four recent sessions", async ({ page }) => {
+	const sessionRequests: string[] = [];
+	await stubDashboardApi(page, [], { sessionRequests });
+	await page.goto("/agents/agent-smoke-1");
+	await expect(page.getByRole("heading", { name: "Recent sessions", exact: true })).toBeVisible();
+	await expect.poll(() => sessionRequests.length).toBe(1);
+	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("4");
+});
+
+test("connected Overview resolves connector metadata from catalog before fan-out", async ({
+	page,
+}) => {
+	const connectorMetadataRequests: string[] = [];
+	const catalogApp = (name: string) => ({
+		name,
+		display_name: name,
+		logo: "",
+		description: `${name} connector`,
+		auth_type: "oauth",
+		connect_disabled: false,
+		connect_disabled_reason: null,
+	});
+	await stubDashboardApi(page, [], {
+		connectorMetadataRequests,
+		connectorConnections: [
+			{ id: "conn-github", app_name: "github", status: "ACTIVE" },
+			{ id: "conn-slack", app_name: "slack", status: "ACTIVE" },
+		],
+		connectorCatalog: [catalogApp("github"), catalogApp("gmail")],
+	});
+
+	await page.goto("/agents/agent-smoke-1");
+	await expect(page.locator('[data-overview-module="connectors"]')).toContainText("2 connected");
+	await expect.poll(() => connectorMetadataRequests.length).toBe(1);
+	expect(new URL(connectorMetadataRequests[0] ?? "http://invalid").pathname).toBe(
+		"/v1/connectors/available/slack",
+	);
 });
 
 test("connected overview keeps connector and catalog states independent", async ({ page }) => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -51,6 +51,7 @@ import {
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
 import {
+	type AgentCardStatusProjection,
 	type AgentTile,
 	agentTileMatchesRouteId,
 	compareAgentTiles,
@@ -1006,7 +1007,15 @@ export function focusHeaderSyncSource(
 	hasEnvironment: boolean,
 ): DaemonStatusSource | null {
 	if (!hasEnvironment || kind === "unresolved") return null;
+	if (kind === "cloud") return null;
 	return kind === "connected" ? "self-managed" : "on-clawdi";
+}
+
+export function focusHeaderComputeStatus(
+	kind: AgentChromeKind,
+	tile: AgentTile | null,
+): AgentCardStatusProjection["visual"] | null {
+	return kind === "cloud" ? (tile?.cardStatus?.visual ?? null) : null;
 }
 
 function FocusHeader({
@@ -1056,13 +1065,15 @@ function FocusHeader({
 		activeAgentTile?.name ?? (activeAgent ? agentDisplayName(activeAgent) : "Clawdi Cloud agent");
 	const displayName = displayMachineName(name);
 	const meta = activeAgent ? agentHeaderMeta(activeAgent, activeAgentKind) : null;
-	const activityLabel = meta?.activityLabel ?? "Agent details unavailable";
+	const activityLabel =
+		activeAgentKind === "cloud" ? null : (meta?.activityLabel ?? "Agent details unavailable");
 	const visibleLabel = meta?.visibleLabel;
 	const detailLabel = meta?.detailLabel;
 	const title = [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
 	const manageHref =
 		activeAgentKind === "legacy" ? (legacyHostedDashboardUrl() ?? undefined) : undefined;
 	const syncSource = focusHeaderSyncSource(activeAgentKind, Boolean(activeAgent));
+	const computeStatus = focusHeaderComputeStatus(activeAgentKind, activeAgentTile);
 	return (
 		<div className="min-w-0 text-left">
 			<div className="flex min-w-0 items-center gap-2" title={title}>
@@ -1086,7 +1097,15 @@ function FocusHeader({
 					{visibleLabel}
 				</div>
 			) : null}
-			{activeAgent && syncSource ? (
+			{computeStatus ? (
+				<div
+					className="mt-2 flex min-w-0 items-center gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4"
+					title={computeStatus.tooltip}
+				>
+					<StatusDot className={computeStatus.dotClass} />
+					<span className="truncate font-medium">{computeStatus.label}</span>
+				</div>
+			) : activeAgent && syncSource ? (
 				<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
 					{/* Cloud and legacy agents use supervised-runtime copy. Legacy
 					 * remediation stays in v1 when that dashboard is configured. */}
@@ -1097,7 +1116,10 @@ function FocusHeader({
 						compact
 						tooltipDetail={detailLabel}
 					/>
-					<span className="min-w-0 truncate text-muted-foreground" title={activityLabel}>
+					<span
+						className="min-w-0 truncate text-muted-foreground"
+						title={activityLabel ?? undefined}
+					>
 						{activityLabel}
 					</span>
 				</div>

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OverviewSummaryRows } from "@/components/dashboard/agent-overview-capabilities";
+
+describe("overview summary rows", () => {
+	test("renders resource names as a compact flat list", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewSummaryRows, {
+				items: ["Hosted Agent Project", "Shared Vault", "Telegram: Research"],
+				empty: "No resources",
+			}),
+		);
+
+		expect(markup).toContain('data-testid="overview-summary-list"');
+		for (const item of ["Hosted Agent Project", "Shared Vault", "Telegram: Research"])
+			expect(markup).toContain(item);
+		expect(markup).not.toContain("rounded");
+		expect(markup).not.toContain("border");
+		expect(markup).not.toContain("divide-y");
+		expect(markup).not.toContain("bg-");
+	});
+
+	test("keeps the existing empty state and three-row limit", () => {
+		const populated = renderToStaticMarkup(
+			createElement(OverviewSummaryRows, {
+				items: ["One", "Two", "Three", "Four"],
+				empty: "No resources",
+			}),
+		);
+		const empty = renderToStaticMarkup(
+			createElement(OverviewSummaryRows, { items: [], empty: "No resources" }),
+		);
+
+		expect(populated).toContain("One");
+		expect(populated).toContain("Three");
+		expect(populated).not.toContain("Four");
+		expect(empty).toContain("No resources");
+		expect(empty).not.toContain('data-testid="overview-summary-list"');
+	});
+});

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -140,9 +140,6 @@ const MODULE_PRESENTATION: Record<
 	},
 	projects: {},
 	skills: {},
-	memories: {},
-	vaults: {},
-	connectors: {},
 	"model-provider": { label: "Model & Provider" },
 	channels: {},
 	compute: {

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -63,11 +63,10 @@ export function AgentOverviewCapabilities({
 		<div className="flex flex-col gap-8" data-agent-overview={variant}>
 			{agentOverviewGroups(variant).map((group) => (
 				<section key={group.id} aria-labelledby={`agent-overview-${group.id}`}>
-					<div className="mb-3 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+					<div className="mb-3">
 						<h2 id={`agent-overview-${group.id}`} className="text-sm font-semibold">
 							{group.label}
 						</h2>
-						<p className="text-xs text-muted-foreground">{group.description}</p>
 					</div>
 					<div
 						className={cn("grid gap-3", group.columns === 4 ? "md:grid-cols-4" : "md:grid-cols-3")}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Cloud, Laptop, type LucideIcon, RefreshCw, Settings2 } from "lucide-react";
+import { ArrowRight, type LucideIcon, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,43 @@ import { cn } from "@/lib/utils";
 export type AgentOverviewModuleContent = {
 	body: ReactNode;
 };
+
+export function AgentOverviewStatusCard({
+	agentId,
+	section,
+	routeSearch,
+	title,
+	icon: Icon,
+	tint,
+	children,
+}: {
+	agentId: string;
+	section: "settings";
+	routeSearch: AgentRouteSearch;
+	title: string;
+	icon: LucideIcon;
+	tint: string;
+	children: ReactNode;
+}) {
+	return (
+		<article
+			data-overview-status={title.toLowerCase().replaceAll(" ", "-")}
+			className="rounded-lg border bg-muted/20"
+		>
+			<Link
+				{...agentSectionLink(agentId, section, routeSearch)}
+				className="group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+			>
+				<IconChip size="sm" tint={tint}>
+					<Icon />
+				</IconChip>
+				<h2 className="min-w-0 flex-1 text-sm font-semibold">{title}</h2>
+				<ArrowRight className="size-4 text-muted-foreground" />
+			</Link>
+			<div className="px-4 pb-4">{children}</div>
+		</article>
+	);
+}
 
 export function OverviewModuleSkeleton({
 	label,
@@ -125,28 +162,13 @@ const MODULE_PRESENTATION: Record<
 	AgentOverviewModuleId,
 	{ label?: string; icon?: LucideIcon; tint?: string; source?: boolean }
 > = {
-	sessions: {},
-	"live-sync": {
-		label: "Live Sync",
-		icon: Laptop,
-		tint: "bg-identity-7-bg text-identity-7-fg",
-		source: true,
-	},
-	"agent-interface": {
-		label: "Agent Interface",
-		icon: Cloud,
-		tint: "bg-identity-6-bg text-identity-6-fg",
-		source: true,
-	},
 	projects: {},
 	skills: {},
+	memories: {},
+	vaults: {},
+	connectors: {},
 	"model-provider": { label: "Model & Provider" },
 	channels: {},
-	compute: {
-		label: "Compute",
-		icon: Settings2,
-		tint: "bg-identity-4-bg text-identity-4-fg",
-	},
 };
 
 export function AgentOverviewCapabilities({
@@ -154,25 +176,13 @@ export function AgentOverviewCapabilities({
 	variant,
 	routeSearch,
 	content,
-	visibleModuleIds,
-	moduleSizeOverrides,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
 	routeSearch: AgentRouteSearch;
 	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
-	visibleModuleIds?: readonly AgentOverviewModuleId[];
-	moduleSizeOverrides?: Partial<Record<AgentOverviewModuleId, "standard" | "wide">>;
 }) {
-	const visibleModules = visibleModuleIds ? new Set(visibleModuleIds) : null;
-	const groups = agentOverviewGroups(variant)
-		.map((group) => ({
-			...group,
-			modules: visibleModules
-				? group.modules.filter((module) => visibleModules.has(module.id))
-				: group.modules,
-		}))
-		.filter((group) => group.modules.length > 0);
+	const groups = agentOverviewGroups(variant);
 	return (
 		<div className="flex flex-col gap-8" data-agent-overview={variant}>
 			{groups.map((group) => (
@@ -183,10 +193,9 @@ export function AgentOverviewCapabilities({
 						</h2>
 					</div>
 					<div
-						className={cn("grid gap-3", group.columns === 4 ? "md:grid-cols-4" : "md:grid-cols-3")}
+						className={cn("grid gap-3", group.columns === 3 ? "md:grid-cols-3" : "md:grid-cols-2")}
 					>
 						{group.modules.map((module) => {
-							const moduleSize = moduleSizeOverrides?.[module.id] ?? module.size;
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const presentation = MODULE_PRESENTATION[module.id];
 							const moduleContent = content[module.id];
@@ -199,7 +208,7 @@ export function AgentOverviewCapabilities({
 									className={cn(
 										"min-w-0 overflow-hidden rounded-lg border bg-card",
 										presentation.source && "bg-muted/20",
-										moduleSize === "wide" && "md:col-span-2",
+										module.size === "wide" && "md:col-span-2",
 									)}
 								>
 									<Link

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -138,9 +138,9 @@ export function OverviewMetrics({
 
 export function OverviewSummaryRows({ items, empty }: { items: readonly string[]; empty: string }) {
 	return items.length ? (
-		<ul className="divide-y rounded-md border text-sm">
+		<ul className="space-y-1 text-sm" data-testid="overview-summary-list">
 			{items.slice(0, 3).map((item) => (
-				<li key={item} className="truncate px-3 py-2 font-medium">
+				<li key={item} className="truncate font-medium leading-5">
 					{item}
 				</li>
 			))}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,7 +1,9 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Cloud, Laptop, type LucideIcon, Settings2 } from "lucide-react";
+import { ArrowRight, Cloud, Laptop, type LucideIcon, RefreshCw, Settings2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { type AgentOverviewModuleId, agentOverviewGroups } from "@/lib/agent-capabilities";
 import { type AgentRouteSearch, agentSectionLink } from "@/lib/agent-routes";
 import {
@@ -11,11 +13,105 @@ import {
 import { cn } from "@/lib/utils";
 
 export type AgentOverviewModuleContent = {
-	value: ReactNode;
-	detail: ReactNode;
-	content?: ReactNode;
-	items?: readonly string[];
+	body: ReactNode;
 };
+
+export function OverviewModuleSkeleton({ label, rows = 2 }: { label: string; rows?: 1 | 2 | 3 }) {
+	return (
+		<div
+			data-testid="overview-module-skeleton"
+			aria-label={`Loading ${label} summary`}
+			role="status"
+		>
+			<Skeleton className="h-5 w-24" />
+			<div className="mt-3 space-y-2">
+				{Array.from({ length: rows }).map((_, index) => (
+					<Skeleton key={`${label}-${index}`} className={cn("h-3", index ? "w-2/3" : "w-full")} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+export function OverviewModuleError({ label, onRetry }: { label: string; onRetry?: () => void }) {
+	return (
+		<div className="space-y-3 text-sm" role="status">
+			<p className="font-medium">{label} unavailable</p>
+			{onRetry ? (
+				<Button type="button" variant="outline" size="sm" onClick={onRetry}>
+					<RefreshCw /> Retry
+				</Button>
+			) : null}
+		</div>
+	);
+}
+
+export function OverviewMetadata({
+	items,
+}: {
+	items: readonly { label: string; value: ReactNode }[];
+}) {
+	return (
+		<dl className="space-y-2 text-sm">
+			{items.map((item) => (
+				<div key={item.label} className="flex min-w-0 items-baseline justify-between gap-3">
+					<dt className="text-xs text-muted-foreground">{item.label}</dt>
+					<dd className="min-w-0 break-words text-right font-medium">{item.value}</dd>
+				</div>
+			))}
+		</dl>
+	);
+}
+
+export function OverviewMetrics({
+	items,
+	columns = 3,
+}: {
+	items: readonly { label: string; value: ReactNode }[];
+	columns?: 2 | 3;
+}) {
+	return (
+		<dl className={cn("grid gap-2", columns === 2 ? "grid-cols-2" : "grid-cols-3")}>
+			{items.map((item) => (
+				<div key={item.label} className="rounded-md bg-muted/60 px-2.5 py-2">
+					<dt className="text-[11px] text-muted-foreground">{item.label}</dt>
+					<dd className="mt-0.5 truncate text-sm font-medium">{item.value}</dd>
+				</div>
+			))}
+		</dl>
+	);
+}
+
+export function OverviewSummaryRows({ items, empty }: { items: readonly string[]; empty: string }) {
+	return items.length ? (
+		<ul className="divide-y rounded-md border text-sm">
+			{items.slice(0, 3).map((item) => (
+				<li key={item} className="truncate px-3 py-2 font-medium">
+					{item}
+				</li>
+			))}
+		</ul>
+	) : (
+		<p className="text-sm text-muted-foreground">{empty}</p>
+	);
+}
+
+export function OverviewChips({ items, empty }: { items: readonly string[]; empty: string }) {
+	return items.length ? (
+		<ul className="flex flex-wrap gap-1.5">
+			{items.slice(0, 3).map((item) => (
+				<li
+					key={item}
+					className="max-w-full truncate rounded-full bg-muted px-2.5 py-1 text-xs font-medium"
+				>
+					{item}
+				</li>
+			))}
+		</ul>
+	) : (
+		<p className="text-sm text-muted-foreground">{empty}</p>
+	);
+}
 
 const MODULE_PRESENTATION: Record<
 	AgentOverviewModuleId,
@@ -97,29 +193,7 @@ export function AgentOverviewCapabilities({
 										<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
 										<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 									</Link>
-									<div className="px-4 pb-4">
-										<div className="text-lg font-semibold tracking-tight">
-											{moduleContent?.value ?? "Available"}
-										</div>
-										<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-											{moduleContent?.detail ?? item.description}
-										</p>
-										{moduleContent?.items?.length ? (
-											<ul className="mt-4 flex flex-wrap gap-1.5" aria-label={`${title} summary`}>
-												{moduleContent.items.slice(0, 3).map((summaryItem) => (
-													<li
-														key={summaryItem}
-														className="max-w-full truncate rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground"
-													>
-														{summaryItem}
-													</li>
-												))}
-											</ul>
-										) : null}
-										{moduleContent?.content ? (
-											<div className="mt-4 border-t pt-3">{moduleContent.content}</div>
-										) : null}
-									</div>
+									<div className="px-4 pb-4">{moduleContent?.body ?? null}</div>
 								</article>
 							);
 						})}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,54 +1,146 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Cloud, Laptop } from "lucide-react";
-import { DetailPanel } from "@/components/detail/layout";
-import { agentCapabilities } from "@/lib/agent-capabilities";
+import { ArrowRight, Cloud, Laptop, type LucideIcon, Settings2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { IconChip } from "@/components/icon-chip";
+import { type AgentOverviewModuleId, agentOverviewGroups } from "@/lib/agent-capabilities";
 import { type AgentRouteSearch, agentSectionLink } from "@/lib/agent-routes";
-import type { AgentNavigationVariant } from "@/lib/navigation-model";
+import {
+	AGENT_SECTION_NAVIGATION_ITEMS,
+	type AgentNavigationVariant,
+} from "@/lib/navigation-model";
+import { cn } from "@/lib/utils";
+
+export type AgentOverviewModuleContent = {
+	value: ReactNode;
+	detail: ReactNode;
+	content?: ReactNode;
+	items?: readonly string[];
+};
+
+const MODULE_PRESENTATION: Record<
+	AgentOverviewModuleId,
+	{
+		label?: string;
+		icon?: LucideIcon;
+		tint?: string;
+		accent: string;
+		emphasis?: string;
+		header?: string;
+	}
+> = {
+	sessions: { accent: "border-t-identity-3-fg/45" },
+	"live-sync": {
+		label: "Live Sync",
+		icon: Laptop,
+		tint: "bg-identity-7-bg text-identity-7-fg",
+		accent: "border-t-identity-7-fg/60",
+		emphasis: "border-identity-7-fg/25 bg-identity-7-bg/20",
+		header: "bg-identity-7-bg/30",
+	},
+	"agent-interface": {
+		label: "Agent Interface",
+		icon: Cloud,
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		accent: "border-t-identity-6-fg/60",
+		emphasis: "border-identity-6-fg/25 bg-identity-6-bg/20",
+		header: "bg-identity-6-bg/30",
+	},
+	projects: { accent: "border-t-identity-1-fg/45" },
+	skills: { accent: "border-t-identity-2-fg/45" },
+	memories: { accent: "border-t-identity-6-fg/45" },
+	vaults: { accent: "border-t-identity-4-fg/45" },
+	connectors: { accent: "border-t-identity-7-fg/45" },
+	"model-provider": { label: "Model & Provider", accent: "border-t-identity-2-fg/45" },
+	channels: { accent: "border-t-identity-5-fg/45" },
+	compute: {
+		label: "Compute",
+		icon: Settings2,
+		tint: "bg-identity-4-bg text-identity-4-fg",
+		accent: "border-t-identity-4-fg/45",
+	},
+};
 
 export function AgentOverviewCapabilities({
 	agentId,
 	variant,
 	routeSearch,
+	content,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
 	routeSearch: AgentRouteSearch;
+	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
 }) {
-	const capabilities = agentCapabilities(variant);
-	const SourceIcon = variant === "hosted" ? Cloud : Laptop;
 	return (
-		<DetailPanel className="overflow-hidden p-0">
-			<div className="flex flex-col gap-3 border-b bg-muted/20 p-4 sm:flex-row sm:items-start sm:justify-between">
-				<div className="flex min-w-0 gap-3">
-					<div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-background">
-						<SourceIcon className="size-4 text-muted-foreground" />
+		<div className="flex flex-col gap-8" data-agent-overview={variant}>
+			{agentOverviewGroups(variant).map((group) => (
+				<section key={group.id} aria-labelledby={`agent-overview-${group.id}`}>
+					<div className="mb-3 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+						<h2 id={`agent-overview-${group.id}`} className="text-sm font-semibold">
+							{group.label}
+						</h2>
+						<p className="text-xs text-muted-foreground">{group.description}</p>
 					</div>
-					<div className="min-w-0">
-						<h2 className="text-sm font-semibold">{capabilities.label}</h2>
-						<p className="mt-0.5 text-sm text-muted-foreground">{capabilities.description}</p>
+					<div className="grid gap-3 md:grid-cols-3">
+						{group.modules.map((module) => {
+							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
+							const presentation = MODULE_PRESENTATION[module.id];
+							const moduleContent = content[module.id];
+							const Icon = presentation.icon ?? item.icon;
+							const title = presentation.label ?? item.label;
+							return (
+								<article
+									key={module.id}
+									data-overview-module={module.id}
+									className={cn(
+										"min-w-0 overflow-hidden rounded-xl border border-t-2 bg-card shadow-xs",
+										presentation.accent,
+										presentation.emphasis,
+										module.size === "wide" && "md:col-span-2",
+									)}
+								>
+									<Link
+										{...agentSectionLink(agentId, module.section, routeSearch)}
+										className={cn(
+											"group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+											presentation.header,
+										)}
+									>
+										<IconChip size="sm" tint={presentation.tint ?? item.tint}>
+											<Icon />
+										</IconChip>
+										<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
+										<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+									</Link>
+									<div className="px-4 pb-4">
+										<div className="text-lg font-semibold tracking-tight">
+											{moduleContent?.value ?? "Available"}
+										</div>
+										<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+											{moduleContent?.detail ?? item.description}
+										</p>
+										{moduleContent?.items?.length ? (
+											<ul className="mt-4 flex flex-wrap gap-1.5" aria-label={`${title} summary`}>
+												{moduleContent.items.slice(0, 3).map((summaryItem) => (
+													<li
+														key={summaryItem}
+														className="max-w-full truncate rounded-full bg-identity-1-bg/60 px-2.5 py-1 text-xs font-medium text-identity-1-fg"
+													>
+														{summaryItem}
+													</li>
+												))}
+											</ul>
+										) : null}
+										{moduleContent?.content ? (
+											<div className="mt-4 border-t pt-3">{moduleContent.content}</div>
+										) : null}
+									</div>
+								</article>
+							);
+						})}
 					</div>
-				</div>
-				<p className="max-w-sm text-xs text-muted-foreground sm:text-right">
-					{capabilities.management}
-				</p>
-			</div>
-			<div className="grid divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-				{capabilities.overviewCapabilities.map((capability) => (
-					<Link
-						key={capability.section}
-						{...agentSectionLink(agentId, capability.section, routeSearch)}
-						className="group flex min-w-0 items-start justify-between gap-3 p-4 transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-					>
-						<div className="min-w-0">
-							<div className="text-sm font-medium">{capability.label}</div>
-							<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-								{capability.description}
-							</p>
-						</div>
-						<ArrowRight className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-					</Link>
-				))}
-			</div>
-		</DetailPanel>
+				</section>
+			))}
+		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -19,44 +19,32 @@ export type AgentOverviewModuleContent = {
 
 const MODULE_PRESENTATION: Record<
 	AgentOverviewModuleId,
-	{
-		label?: string;
-		icon?: LucideIcon;
-		tint?: string;
-		accent: string;
-		emphasis?: string;
-		header?: string;
-	}
+	{ label?: string; icon?: LucideIcon; tint?: string; source?: boolean }
 > = {
-	sessions: { accent: "border-t-identity-3-fg/45" },
+	sessions: {},
 	"live-sync": {
 		label: "Live Sync",
 		icon: Laptop,
 		tint: "bg-identity-7-bg text-identity-7-fg",
-		accent: "border-t-identity-7-fg/60",
-		emphasis: "border-identity-7-fg/25 bg-identity-7-bg/20",
-		header: "bg-identity-7-bg/30",
+		source: true,
 	},
 	"agent-interface": {
 		label: "Agent Interface",
 		icon: Cloud,
 		tint: "bg-identity-6-bg text-identity-6-fg",
-		accent: "border-t-identity-6-fg/60",
-		emphasis: "border-identity-6-fg/25 bg-identity-6-bg/20",
-		header: "bg-identity-6-bg/30",
+		source: true,
 	},
-	projects: { accent: "border-t-identity-1-fg/45" },
-	skills: { accent: "border-t-identity-2-fg/45" },
-	memories: { accent: "border-t-identity-6-fg/45" },
-	vaults: { accent: "border-t-identity-4-fg/45" },
-	connectors: { accent: "border-t-identity-7-fg/45" },
-	"model-provider": { label: "Model & Provider", accent: "border-t-identity-2-fg/45" },
-	channels: { accent: "border-t-identity-5-fg/45" },
+	projects: {},
+	skills: {},
+	memories: {},
+	vaults: {},
+	connectors: {},
+	"model-provider": { label: "Model & Provider" },
+	channels: {},
 	compute: {
 		label: "Compute",
 		icon: Settings2,
 		tint: "bg-identity-4-bg text-identity-4-fg",
-		accent: "border-t-identity-4-fg/45",
 	},
 };
 
@@ -81,7 +69,9 @@ export function AgentOverviewCapabilities({
 						</h2>
 						<p className="text-xs text-muted-foreground">{group.description}</p>
 					</div>
-					<div className="grid gap-3 md:grid-cols-3">
+					<div
+						className={cn("grid gap-3", group.columns === 4 ? "md:grid-cols-4" : "md:grid-cols-3")}
+					>
 						{group.modules.map((module) => {
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const presentation = MODULE_PRESENTATION[module.id];
@@ -93,18 +83,14 @@ export function AgentOverviewCapabilities({
 									key={module.id}
 									data-overview-module={module.id}
 									className={cn(
-										"min-w-0 overflow-hidden rounded-xl border border-t-2 bg-card shadow-xs",
-										presentation.accent,
-										presentation.emphasis,
+										"min-w-0 overflow-hidden rounded-lg border bg-card",
+										presentation.source && "bg-muted/20",
 										module.size === "wide" && "md:col-span-2",
 									)}
 								>
 									<Link
 										{...agentSectionLink(agentId, module.section, routeSearch)}
-										className={cn(
-											"group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
-											presentation.header,
-										)}
+										className="group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 									>
 										<IconChip size="sm" tint={presentation.tint ?? item.tint}>
 											<Icon />
@@ -124,7 +110,7 @@ export function AgentOverviewCapabilities({
 												{moduleContent.items.slice(0, 3).map((summaryItem) => (
 													<li
 														key={summaryItem}
-														className="max-w-full truncate rounded-full bg-identity-1-bg/60 px-2.5 py-1 text-xs font-medium text-identity-1-fg"
+														className="max-w-full truncate rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground"
 													>
 														{summaryItem}
 													</li>

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -158,19 +158,6 @@ export function OverviewChips({ items, empty }: { items: readonly string[]; empt
 	);
 }
 
-const MODULE_PRESENTATION: Record<
-	AgentOverviewModuleId,
-	{ label?: string; icon?: LucideIcon; tint?: string; source?: boolean }
-> = {
-	projects: {},
-	skills: {},
-	memories: {},
-	vaults: {},
-	connectors: {},
-	"model-provider": { label: "Model & Provider" },
-	channels: {},
-};
-
 export function AgentOverviewCapabilities({
 	agentId,
 	variant,
@@ -196,38 +183,42 @@ export function AgentOverviewCapabilities({
 						data-overview-layout={group.layout}
 						className={cn(
 							"grid items-start gap-3",
-							group.layout === "balanced-five" ? "md:grid-cols-6" : "md:grid-cols-2",
+							group.layout === "balanced-five"
+								? "@2xl/main:grid-cols-2 @5xl/main:grid-cols-6"
+								: "@2xl/main:grid-cols-2",
 						)}
 					>
 						{group.modules.map((module, moduleIndex) => {
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
-							const presentation = MODULE_PRESENTATION[module.id];
 							const moduleContent = content[module.id];
-							const Icon = presentation.icon ?? item.icon;
-							const title = presentation.label ?? item.label;
+							if (!moduleContent) {
+								throw new Error(`Missing overview content for ${module.id}`);
+							}
+							const Icon = item.icon;
+							const title = module.id === "model-provider" ? "Model & Provider" : item.label;
 							return (
 								<article
 									key={module.id}
 									data-overview-module={module.id}
 									className={cn(
-										"min-w-0 overflow-hidden rounded-lg border bg-card",
-										group.layout === "balanced-five" && "md:col-span-2",
-										group.layout === "balanced-five" && moduleIndex === 3 && "md:col-start-2",
-										presentation.source && "bg-muted/20",
-										module.size === "wide" && "md:col-span-2",
+										"flex min-h-48 min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
+										group.layout === "balanced-five" && "@5xl/main:col-span-2",
+										group.layout === "balanced-five" &&
+											moduleIndex === 3 &&
+											"@5xl/main:col-start-2",
 									)}
 								>
 									<Link
 										{...agentSectionLink(agentId, module.section, routeSearch)}
-										className="group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+										className="group flex h-16 shrink-0 items-center gap-3 px-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 									>
-										<IconChip size="sm" tint={presentation.tint ?? item.tint}>
+										<IconChip size="sm" tint={item.tint}>
 											<Icon />
 										</IconChip>
 										<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
 										<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 									</Link>
-									<div className="px-4 pb-4">{moduleContent?.body ?? null}</div>
+									<div className="flex flex-1 flex-col px-4 pb-4">{moduleContent.body}</div>
 								</article>
 							);
 						})}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, type LucideIcon, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type AgentOverviewModuleId, agentOverviewGroups } from "@/lib/agent-capabilities";
 import { type AgentRouteSearch, agentSectionLink } from "@/lib/agent-routes";
@@ -34,22 +35,26 @@ export function AgentOverviewStatusCard({
 	children: ReactNode;
 }) {
 	return (
-		<article
+		<Card
+			size="sm"
+			role="article"
 			data-overview-status={title.toLowerCase().replaceAll(" ", "-")}
-			className="flex h-full flex-col rounded-lg border bg-muted/20"
+			className="h-full gap-0 bg-muted/20 py-0"
 		>
-			<Link
-				{...agentSectionLink(agentId, section, routeSearch)}
-				className="group flex items-center gap-3 p-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-			>
-				<IconChip size="sm" tint={tint}>
-					<Icon />
-				</IconChip>
-				<h2 className="min-w-0 flex-1 text-sm font-semibold">{title}</h2>
-				<ArrowRight className="size-4 text-muted-foreground" />
-			</Link>
-			<div className="flex flex-1 flex-col px-4 pb-4">{children}</div>
-		</article>
+			<CardHeader className="p-0">
+				<Link
+					{...agentSectionLink(agentId, section, routeSearch)}
+					className="group flex items-center gap-3 px-4 pt-4 pb-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+				>
+					<IconChip size="sm" tint={tint}>
+						<Icon />
+					</IconChip>
+					<h2 className="min-w-0 flex-1 text-sm font-semibold">{title}</h2>
+					<ArrowRight className="size-4 text-muted-foreground" />
+				</Link>
+			</CardHeader>
+			<CardContent className="flex flex-1 flex-col px-4 pb-4">{children}</CardContent>
+		</Card>
 	);
 }
 
@@ -187,44 +192,41 @@ export function AgentOverviewCapabilities({
 						data-overview-layout={group.layout}
 						className={cn(
 							"grid gap-3",
-							group.layout === "balanced-five"
-								? "@2xl/main:grid-cols-4 @4xl/main:grid-cols-6"
+							group.layout === "three-column"
+								? "@2xl/main:grid-cols-2 @4xl/main:grid-cols-3"
 								: "@2xl/main:grid-cols-2",
 						)}
 					>
-						{group.modules.map((module, moduleIndex) => {
+						{group.modules.map((module) => {
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const moduleContent = content[module.id];
 							if (!moduleContent) return null;
 							const Icon = item.icon;
 							const title = module.id === "model-provider" ? "Model & Provider" : item.label;
 							return (
-								<article
+								<Card
+									size="sm"
+									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className={cn(
-										"flex min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
-										group.layout === "balanced-five" && "@2xl/main:col-span-2",
-										group.layout === "balanced-five" &&
-											moduleIndex === 4 &&
-											"@2xl/main:col-start-2 @4xl/main:col-start-auto",
-										group.layout === "balanced-five" &&
-											moduleIndex === 3 &&
-											"@4xl/main:col-start-2",
-									)}
+									className="min-w-0 gap-0 py-0"
 								>
-									<Link
-										{...agentSectionLink(agentId, module.section, routeSearch)}
-										className="group flex shrink-0 items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-									>
-										<IconChip size="sm" tint={item.tint}>
-											<Icon />
-										</IconChip>
-										<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
-										<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-									</Link>
-									<div className="flex flex-1 flex-col px-4 pb-4">{moduleContent.body}</div>
-								</article>
+									<CardHeader className="p-0">
+										<Link
+											{...agentSectionLink(agentId, module.section, routeSearch)}
+											className="group flex items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+										>
+											<IconChip size="sm" tint={item.tint}>
+												<Icon />
+											</IconChip>
+											<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
+											<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+										</Link>
+									</CardHeader>
+									<CardContent className="flex flex-1 flex-col px-4 pb-4">
+										{moduleContent.body}
+									</CardContent>
+								</Card>
 							);
 						})}
 					</div>

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,0 +1,54 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Cloud, Laptop } from "lucide-react";
+import { DetailPanel } from "@/components/detail/layout";
+import { agentCapabilities } from "@/lib/agent-capabilities";
+import { type AgentRouteSearch, agentSectionLink } from "@/lib/agent-routes";
+import type { AgentNavigationVariant } from "@/lib/navigation-model";
+
+export function AgentOverviewCapabilities({
+	agentId,
+	variant,
+	routeSearch,
+}: {
+	agentId: string;
+	variant: AgentNavigationVariant;
+	routeSearch: AgentRouteSearch;
+}) {
+	const capabilities = agentCapabilities(variant);
+	const SourceIcon = variant === "hosted" ? Cloud : Laptop;
+	return (
+		<DetailPanel className="overflow-hidden p-0">
+			<div className="flex flex-col gap-3 border-b bg-muted/20 p-4 sm:flex-row sm:items-start sm:justify-between">
+				<div className="flex min-w-0 gap-3">
+					<div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-background">
+						<SourceIcon className="size-4 text-muted-foreground" />
+					</div>
+					<div className="min-w-0">
+						<h2 className="text-sm font-semibold">{capabilities.label}</h2>
+						<p className="mt-0.5 text-sm text-muted-foreground">{capabilities.description}</p>
+					</div>
+				</div>
+				<p className="max-w-sm text-xs text-muted-foreground sm:text-right">
+					{capabilities.management}
+				</p>
+			</div>
+			<div className="grid divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+				{capabilities.overviewCapabilities.map((capability) => (
+					<Link
+						key={capability.section}
+						{...agentSectionLink(agentId, capability.section, routeSearch)}
+						className="group flex min-w-0 items-start justify-between gap-3 p-4 transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+					>
+						<div className="min-w-0">
+							<div className="text-sm font-medium">{capability.label}</div>
+							<p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+								{capability.description}
+							</p>
+						</div>
+						<ArrowRight className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+					</Link>
+				))}
+			</div>
+		</DetailPanel>
+	);
+}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -155,12 +155,14 @@ export function AgentOverviewCapabilities({
 	routeSearch,
 	content,
 	visibleModuleIds,
+	moduleSizeOverrides,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
 	routeSearch: AgentRouteSearch;
 	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
 	visibleModuleIds?: readonly AgentOverviewModuleId[];
+	moduleSizeOverrides?: Partial<Record<AgentOverviewModuleId, "standard" | "wide">>;
 }) {
 	const visibleModules = visibleModuleIds ? new Set(visibleModuleIds) : null;
 	const groups = agentOverviewGroups(variant)
@@ -184,6 +186,7 @@ export function AgentOverviewCapabilities({
 						className={cn("grid gap-3", group.columns === 4 ? "md:grid-cols-4" : "md:grid-cols-3")}
 					>
 						{group.modules.map((module) => {
+							const moduleSize = moduleSizeOverrides?.[module.id] ?? module.size;
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const presentation = MODULE_PRESENTATION[module.id];
 							const moduleContent = content[module.id];
@@ -196,7 +199,7 @@ export function AgentOverviewCapabilities({
 									className={cn(
 										"min-w-0 overflow-hidden rounded-lg border bg-card",
 										presentation.source && "bg-muted/20",
-										module.size === "wide" && "md:col-span-2",
+										moduleSize === "wide" && "md:col-span-2",
 									)}
 								>
 									<Link

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -36,7 +36,7 @@ export function AgentOverviewStatusCard({
 	return (
 		<article
 			data-overview-status={title.toLowerCase().replaceAll(" ", "-")}
-			className="rounded-lg border bg-muted/20"
+			className="flex h-full flex-col rounded-lg border bg-muted/20"
 		>
 			<Link
 				{...agentSectionLink(agentId, section, routeSearch)}
@@ -48,7 +48,7 @@ export function AgentOverviewStatusCard({
 				<h2 className="min-w-0 flex-1 text-sm font-semibold">{title}</h2>
 				<ArrowRight className="size-4 text-muted-foreground" />
 			</Link>
-			<div className="px-4 pb-4">{children}</div>
+			<div className="flex flex-1 flex-col px-4 pb-4">{children}</div>
 		</article>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -91,6 +91,10 @@ export function OverviewModuleError({ label, onRetry }: { label: string; onRetry
 	);
 }
 
+export function OverviewModuleUnavailable() {
+	return <p className="text-sm text-muted-foreground">Unavailable right now</p>;
+}
+
 export function OverviewMetadata({
 	items,
 }: {
@@ -182,18 +186,16 @@ export function AgentOverviewCapabilities({
 					<div
 						data-overview-layout={group.layout}
 						className={cn(
-							"grid items-start gap-3",
+							"grid gap-3",
 							group.layout === "balanced-five"
-								? "@2xl/main:grid-cols-2 @5xl/main:grid-cols-6"
+								? "@2xl/main:grid-cols-4 @4xl/main:grid-cols-6"
 								: "@2xl/main:grid-cols-2",
 						)}
 					>
 						{group.modules.map((module, moduleIndex) => {
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const moduleContent = content[module.id];
-							if (!moduleContent) {
-								throw new Error(`Missing overview content for ${module.id}`);
-							}
+							if (!moduleContent) return null;
 							const Icon = item.icon;
 							const title = module.id === "model-provider" ? "Model & Provider" : item.label;
 							return (
@@ -201,16 +203,19 @@ export function AgentOverviewCapabilities({
 									key={module.id}
 									data-overview-module={module.id}
 									className={cn(
-										"flex min-h-48 min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
-										group.layout === "balanced-five" && "@5xl/main:col-span-2",
+										"flex min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
+										group.layout === "balanced-five" && "@2xl/main:col-span-2",
+										group.layout === "balanced-five" &&
+											moduleIndex === 4 &&
+											"@2xl/main:col-start-2 @4xl/main:col-start-auto",
 										group.layout === "balanced-five" &&
 											moduleIndex === 3 &&
-											"@5xl/main:col-start-2",
+											"@4xl/main:col-start-2",
 									)}
 								>
 									<Link
 										{...agentSectionLink(agentId, module.section, routeSearch)}
-										className="group flex h-16 shrink-0 items-center gap-3 px-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+										className="group flex shrink-0 items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 									>
 										<IconChip size="sm" tint={item.tint}>
 											<Icon />

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -16,15 +16,23 @@ export type AgentOverviewModuleContent = {
 	body: ReactNode;
 };
 
-export function OverviewModuleSkeleton({ label, rows = 2 }: { label: string; rows?: 1 | 2 | 3 }) {
+export function OverviewModuleSkeleton({
+	label,
+	rows = 2,
+	showHeading = true,
+}: {
+	label: string;
+	rows?: 1 | 2 | 3;
+	showHeading?: boolean;
+}) {
 	return (
 		<div
 			data-testid="overview-module-skeleton"
 			aria-label={`Loading ${label} summary`}
 			role="status"
 		>
-			<Skeleton className="h-5 w-24" />
-			<div className="mt-3 space-y-2">
+			{showHeading ? <Skeleton className="h-5 w-24" /> : null}
+			<div className={cn("space-y-2", showHeading && "mt-3")}>
 				{Array.from({ length: rows }).map((_, index) => (
 					<Skeleton key={`${label}-${index}`} className={cn("h-3", index ? "w-2/3" : "w-full")} />
 				))}
@@ -36,7 +44,7 @@ export function OverviewModuleSkeleton({ label, rows = 2 }: { label: string; row
 export function OverviewModuleError({ label, onRetry }: { label: string; onRetry?: () => void }) {
 	return (
 		<div className="space-y-3 text-sm" role="status">
-			<p className="font-medium">{label} unavailable</p>
+			<p className="font-medium">Can’t load {label.toLowerCase()}</p>
 			{onRetry ? (
 				<Button type="button" variant="outline" size="sm" onClick={onRetry}>
 					<RefreshCw /> Retry
@@ -149,15 +157,26 @@ export function AgentOverviewCapabilities({
 	variant,
 	routeSearch,
 	content,
+	visibleModuleIds,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
 	routeSearch: AgentRouteSearch;
 	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
+	visibleModuleIds?: readonly AgentOverviewModuleId[];
 }) {
+	const visibleModules = visibleModuleIds ? new Set(visibleModuleIds) : null;
+	const groups = agentOverviewGroups(variant)
+		.map((group) => ({
+			...group,
+			modules: visibleModules
+				? group.modules.filter((module) => visibleModules.has(module.id))
+				: group.modules,
+		}))
+		.filter((group) => group.modules.length > 0);
 	return (
 		<div className="flex flex-col gap-8" data-agent-overview={variant}>
-			{agentOverviewGroups(variant).map((group) => (
+			{groups.map((group) => (
 				<section key={group.id} aria-labelledby={`agent-overview-${group.id}`}>
 					<div className="mb-3">
 						<h2 id={`agent-overview-${group.id}`} className="text-sm font-semibold">

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -193,9 +193,13 @@ export function AgentOverviewCapabilities({
 						</h2>
 					</div>
 					<div
-						className={cn("grid gap-3", group.columns === 3 ? "md:grid-cols-3" : "md:grid-cols-2")}
+						data-overview-layout={group.layout}
+						className={cn(
+							"grid items-start gap-3",
+							group.layout === "balanced-five" ? "md:grid-cols-6" : "md:grid-cols-2",
+						)}
 					>
-						{group.modules.map((module) => {
+						{group.modules.map((module, moduleIndex) => {
 							const item = AGENT_SECTION_NAVIGATION_ITEMS[module.section];
 							const presentation = MODULE_PRESENTATION[module.id];
 							const moduleContent = content[module.id];
@@ -207,6 +211,8 @@ export function AgentOverviewCapabilities({
 									data-overview-module={module.id}
 									className={cn(
 										"min-w-0 overflow-hidden rounded-lg border bg-card",
+										group.layout === "balanced-five" && "md:col-span-2",
+										group.layout === "balanced-five" && moduleIndex === 3 && "md:col-start-2",
 										presentation.source && "bg-muted/20",
 										module.size === "wide" && "md:col-span-2",
 									)}

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -80,8 +80,12 @@ export function OverviewVaultsBody({
 }
 
 export function OverviewConnectorsBody() {
-	const connected = useConnectedAppCards();
 	const catalog = useAvailableApps({ page: 1, pageSize: 8 });
+	const connected = useConnectedAppCards({
+		apps: catalog.data?.items,
+		isLoading: catalog.isLoading,
+		error: catalog.error,
+	});
 	const connectedNames = new Set(
 		connected.activeConnections.flatMap((connection) =>
 			connection.app_name ? [connection.app_name] : [],

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ConnectorIcon } from "@/components/connectors/connector-icon";
+import {
+	OverviewModuleError,
+	OverviewModuleSkeleton,
+	OverviewSummaryRows,
+} from "@/components/dashboard/agent-overview-capabilities";
+import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
+import { unwrap, useApi } from "@/lib/api";
+import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
+
+export function OverviewMemoriesBody() {
+	const api = useApi();
+	const query = useQuery({
+		queryKey: ["memories", "", "", 0, 1],
+		queryFn: async () =>
+			unwrap(await api.GET("/v1/memories", { params: { query: { page: 1, page_size: 1 } } })),
+	});
+	if (query.isLoading) return <OverviewModuleSkeleton label="memories" rows={1} />;
+	if (query.error)
+		return <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />;
+	const total = query.data?.total ?? 0;
+	return (
+		<p className="text-lg font-semibold">
+			{total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet"}
+		</p>
+	);
+}
+
+export function OverviewVaultsBody({
+	projectIds,
+	isLoading,
+	error,
+	onRetry,
+}: {
+	projectIds: readonly string[];
+	isLoading: boolean;
+	error: unknown;
+	onRetry: () => void;
+}) {
+	const api = useApi();
+	const query = useQuery({
+		queryKey: ["vaults", "agent-projects", ...projectIds],
+		queryFn: async () =>
+			fetchAgentProjectVaults(projectIds, async (projectId, page, pageSize) =>
+				unwrap(
+					await api.GET("/v1/vault", {
+						params: { query: { project_id: projectId, page, page_size: pageSize } },
+					}),
+				),
+			),
+		enabled: !isLoading && !error && projectIds.length > 0,
+	});
+	if (isLoading || query.isLoading) return <OverviewModuleSkeleton label="vaults" rows={2} />;
+	if (error) return <OverviewModuleError label="Vaults" onRetry={onRetry} />;
+	if (query.error)
+		return <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />;
+	const vaults = query.data ?? [];
+	return (
+		<div className="space-y-3">
+			<p className="text-lg font-semibold">
+				{vaults.length
+					? `${vaults.length} ${vaults.length === 1 ? "vault" : "vaults"}`
+					: "No vaults available"}
+			</p>
+			{vaults.length ? (
+				<OverviewSummaryRows
+					items={vaults.map((vault) => vault.name)}
+					empty="No vaults available"
+				/>
+			) : null}
+		</div>
+	);
+}
+
+export function OverviewConnectorsBody() {
+	const connected = useConnectedAppCards();
+	const catalog = useAvailableApps({ page: 1, pageSize: 8 });
+	if (connected.isLoading && catalog.isLoading)
+		return <OverviewModuleSkeleton label="connectors" rows={2} />;
+	const connectedNames = new Set(connected.data.map((app) => app.name));
+	const connectedAppCount = new Set(
+		connected.activeConnections.map((connection) => connection.app_name),
+	).size;
+	const popular = (catalog.data?.items ?? [])
+		.filter((app) => !connectedNames.has(app.name))
+		.slice(0, 5);
+	return (
+		<div className="space-y-3">
+			<p className="text-lg font-semibold">
+				{connectedAppCount
+					? `${connectedAppCount} connected ${connectedAppCount === 1 ? "app" : "apps"}`
+					: "No apps connected"}
+			</p>
+			{connected.error ? (
+				<OverviewModuleError label="Connected apps" onRetry={connected.refetch} />
+			) : connected.data.length ? (
+				<ConnectorRail label="Connected" apps={connected.data.slice(0, 6)} />
+			) : null}
+			{catalog.error ? (
+				<OverviewModuleError label="Popular apps" onRetry={() => void catalog.refetch()} />
+			) : popular.length ? (
+				<ConnectorRail label="Popular" apps={popular} />
+			) : null}
+		</div>
+	);
+}
+
+function ConnectorRail({
+	label,
+	apps,
+}: {
+	label: string;
+	apps: readonly { name: string; display_name: string; logo: string }[];
+}) {
+	return (
+		<div>
+			<p className="mb-2 text-xs text-muted-foreground">{label}</p>
+			<div className="flex flex-wrap gap-2">
+				{apps.map((app) => (
+					<Link
+						key={app.name}
+						to="/connectors/$name"
+						params={{ name: app.name }}
+						aria-label={`${label}: ${app.display_name}`}
+						title={app.display_name}
+					>
+						<ConnectorIcon name={app.display_name} logo={app.logo} size="sm" />
+					</Link>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -8,6 +8,7 @@ import {
 	OverviewChips,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
+	OverviewModuleUnavailable,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Button } from "@/components/ui/button";
@@ -18,6 +19,7 @@ import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
 
 type SummaryState = {
 	isLoading: boolean;
+	isUnavailable?: boolean;
 	error: unknown;
 	onRetry: () => void;
 };
@@ -30,6 +32,7 @@ export function OverviewProjectsBody({
 	names: SummaryState & { items: readonly string[]; unresolvedCount: number };
 }) {
 	if (bindings.isLoading) return <OverviewModuleSkeleton label="projects" rows={3} />;
+	if (bindings.isUnavailable) return <OverviewModuleUnavailable />;
 	if (bindings.error) return <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />;
 	const count = bindings.count ?? 0;
 	return (
@@ -61,6 +64,7 @@ export function OverviewSkillsBody({
 	...state
 }: SummaryState & { items: readonly string[] }) {
 	if (state.isLoading) return <OverviewModuleSkeleton label="skills" rows={2} />;
+	if (state.isUnavailable) return <OverviewModuleUnavailable />;
 	if (state.error) return <OverviewModuleError label="Skills" onRetry={state.onRetry} />;
 	return (
 		<div className="space-y-3">
@@ -95,16 +99,14 @@ export function OverviewMemoriesBody() {
 export function OverviewVaultsBody({
 	projectIds,
 	resolution,
-	onRetry,
 }: {
 	projectIds: readonly string[];
 	resolution: "loading" | "unavailable" | "ready";
-	onRetry: () => void;
 }) {
 	const query = useAgentProjectVaults(projectIds, { enabled: resolution === "ready" });
 	if (resolution === "loading" || query.isLoading)
 		return <OverviewModuleSkeleton label="vaults" rows={2} />;
-	if (resolution === "unavailable") return <OverviewModuleError label="Vaults" onRetry={onRetry} />;
+	if (resolution === "unavailable") return <OverviewModuleUnavailable />;
 	if (query.error)
 		return <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />;
 	const vaults = query.data ?? [];

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -2,12 +2,14 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { CircleCheck, RefreshCw } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import {
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
 import { unwrap, useApi } from "@/lib/api";
@@ -86,77 +88,106 @@ export function OverviewConnectorsBody() {
 		),
 	);
 	const connectedAppCount = connectedNames.size;
-	const popular = (catalog.data?.items ?? [])
+	const connectedApps = connected.data.slice(0, 5).map((app) => ({ app, connected: true }));
+	const connectionsResolved = !connected.connectionsLoading && !connected.connectionsError;
+	const popularApps = (catalog.data?.items ?? [])
 		.filter((app) => !connectedNames.has(app.name))
-		.slice(0, 5);
+		.slice(0, Math.max(0, 5 - connectedApps.length))
+		.map((app) => ({ app, state: connectionsResolved ? "suggested" : "available" }) as const);
+	const apps = [
+		...connectedApps.map(({ app }) => ({ app, state: "connected" }) as const),
+		...popularApps,
+	];
+	const connectionsUnavailable = Boolean(connected.connectionsError);
+	const catalogUnavailable = Boolean(catalog.error);
+	const allUnavailable = connectionsUnavailable && catalogUnavailable && apps.length === 0;
+	const loadingSlots = Math.max(
+		0,
+		Math.min(
+			5 - apps.length,
+			connected.connectionsLoading || connected.metadataLoading || catalog.isLoading ? 3 : 0,
+		),
+	);
 	return (
 		<div className="space-y-3">
-			{connected.isLoading ? (
-				<ConnectorRailSkeleton label="Connected" />
-			) : connected.connectionsError ? (
-				<OverviewModuleError label="Connected apps" onRetry={connected.refetch} />
-			) : (
-				<div className="space-y-3">
-					<p className="text-lg font-semibold">
-						{connectedAppCount
-							? `${connectedAppCount} connected ${connectedAppCount === 1 ? "app" : "apps"}`
-							: "No apps connected"}
-					</p>
-					{connected.data.length ? (
-						<ConnectorRail label="Connected" apps={connected.data.slice(0, 6)} />
-					) : null}
-					{connected.metadataError ? (
-						<p className="text-xs text-muted-foreground">Some app icons can’t be shown.</p>
-					) : null}
-				</div>
-			)}
-			{catalog.isLoading ? (
-				<ConnectorRailSkeleton label="Popular" />
-			) : catalog.error ? (
-				<OverviewModuleError label="Popular apps" onRetry={() => void catalog.refetch()} />
-			) : popular.length ? (
-				<ConnectorRail label="Popular" apps={popular} />
+			{!connected.connectionsLoading && !connectionsUnavailable ? (
+				<p className="text-lg font-semibold">
+					{connectedAppCount ? `${connectedAppCount} connected` : "No apps connected"}
+				</p>
+			) : null}
+			{allUnavailable ? (
+				<OverviewModuleError
+					label="Apps"
+					onRetry={() => {
+						connected.refetch();
+						void catalog.refetch();
+					}}
+				/>
+			) : apps.length || loadingSlots ? (
+				<ConnectorRail apps={apps} loadingSlots={loadingSlots} />
+			) : null}
+			{allUnavailable ? null : connected.connectionsLoading ? (
+				<span className="sr-only" aria-label="Loading connected apps" role="status" />
+			) : connectionsUnavailable ? (
+				<ConnectorRetry label="Can’t load connected apps" onRetry={connected.refetch} />
+			) : connected.metadataError ? (
+				<ConnectorRetry
+					label="Some connected app icons can’t be shown"
+					onRetry={connected.refetch}
+				/>
+			) : null}
+			{!allUnavailable && catalogUnavailable ? (
+				<ConnectorRetry label="Can’t load suggested apps" onRetry={() => void catalog.refetch()} />
 			) : null}
 		</div>
 	);
 }
 
-function ConnectorRailSkeleton({ label }: { label: string }) {
+function ConnectorRetry({ label, onRetry }: { label: string; onRetry: () => void }) {
 	return (
-		<div aria-label={`Loading ${label.toLowerCase()} apps`} role="status">
-			<p className="mb-2 text-xs text-muted-foreground">{label}</p>
-			<div className="flex gap-2">
-				{Array.from({ length: 5 }).map((_, index) => (
-					<Skeleton key={index} className="size-9 rounded-lg" />
-				))}
-			</div>
+		<div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+			<span>{label}.</span>
+			<Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={onRetry}>
+				<RefreshCw className="size-3" />
+				Retry
+			</Button>
 		</div>
 	);
 }
 
 function ConnectorRail({
-	label,
 	apps,
+	loadingSlots,
 }: {
-	label: string;
-	apps: readonly { name: string; display_name: string; logo: string }[];
+	apps: readonly {
+		app: { name: string; display_name: string; logo: string };
+		state: "connected" | "suggested" | "available";
+	}[];
+	loadingSlots: number;
 }) {
 	return (
-		<div>
-			<p className="mb-2 text-xs text-muted-foreground">{label}</p>
-			<div className="flex flex-wrap gap-2">
-				{apps.map((app) => (
+		<div className="flex flex-wrap gap-2" data-testid="overview-connector-rail">
+			{apps.map(({ app, state }) => (
+				<div key={app.name} className="relative">
 					<Link
-						key={app.name}
 						to="/connectors/$name"
 						params={{ name: app.name }}
-						aria-label={`${label}: ${app.display_name}`}
-						title={app.display_name}
+						aria-label={`${state[0]?.toUpperCase()}${state.slice(1)} app: ${app.display_name}`}
+						title={`${app.display_name}${state === "connected" ? " (connected)" : ""}`}
+						className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<ConnectorIcon name={app.display_name} logo={app.logo} size="sm" />
 					</Link>
-				))}
-			</div>
+					{state === "connected" ? (
+						<span className="absolute -right-1 -bottom-1 rounded-full bg-background text-primary">
+							<CircleCheck className="size-4 fill-background" aria-hidden="true" />
+						</span>
+					) : null}
+				</div>
+			))}
+			{Array.from({ length: loadingSlots }).map((_, index) => (
+				<Skeleton key={index} className="size-9 rounded-lg" aria-label="Loading app" />
+			))}
 		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -5,15 +5,74 @@ import { Link } from "@tanstack/react-router";
 import { CircleCheck, RefreshCw } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import {
+	OverviewChips,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
+import { useAgentProjectVaults } from "@/components/vault/agent-vaults-query";
 import { unwrap, useApi } from "@/lib/api";
 import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
+
+type SummaryState = {
+	isLoading: boolean;
+	error: unknown;
+	onRetry: () => void;
+};
+
+export function OverviewProjectsBody({
+	bindings,
+	names,
+}: {
+	bindings: SummaryState & { count: number | null };
+	names: SummaryState & { items: readonly string[]; unresolvedCount: number };
+}) {
+	if (bindings.isLoading) return <OverviewModuleSkeleton label="projects" rows={3} />;
+	if (bindings.error) return <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />;
+	const count = bindings.count ?? 0;
+	return (
+		<div className="space-y-3">
+			<p className="text-lg font-semibold">
+				{count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added"}
+			</p>
+			{count === 0 ? null : names.isLoading ? (
+				<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
+			) : names.error ? (
+				<OverviewModuleError label="Project names" onRetry={names.onRetry} />
+			) : (
+				<>
+					<OverviewSummaryRows items={names.items} empty="Project names can’t be shown" />
+					{names.unresolvedCount > 0 ? (
+						<p className="text-xs text-muted-foreground">
+							{names.unresolvedCount} project{" "}
+							{names.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown
+						</p>
+					) : null}
+				</>
+			)}
+		</div>
+	);
+}
+
+export function OverviewSkillsBody({
+	items,
+	...state
+}: SummaryState & { items: readonly string[] }) {
+	if (state.isLoading) return <OverviewModuleSkeleton label="skills" rows={2} />;
+	if (state.error) return <OverviewModuleError label="Skills" onRetry={state.onRetry} />;
+	return (
+		<div className="space-y-3">
+			<p className="text-lg font-semibold">
+				{items.length
+					? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
+					: "No skills available"}
+			</p>
+			{items.length ? <OverviewChips items={items} empty="No skills available" /> : null}
+		</div>
+	);
+}
 
 export function OverviewMemoriesBody() {
 	const api = useApi();
@@ -35,30 +94,17 @@ export function OverviewMemoriesBody() {
 
 export function OverviewVaultsBody({
 	projectIds,
-	isLoading,
-	error,
+	resolution,
 	onRetry,
 }: {
 	projectIds: readonly string[];
-	isLoading: boolean;
-	error: unknown;
+	resolution: "loading" | "unavailable" | "ready";
 	onRetry: () => void;
 }) {
-	const api = useApi();
-	const query = useQuery({
-		queryKey: ["vaults", "agent-projects", ...projectIds],
-		queryFn: async () =>
-			fetchAgentProjectVaults(projectIds, async (projectId, page, pageSize) =>
-				unwrap(
-					await api.GET("/v1/vault", {
-						params: { query: { project_id: projectId, page, page_size: pageSize } },
-					}),
-				),
-			),
-		enabled: !isLoading && !error && projectIds.length > 0,
-	});
-	if (isLoading || query.isLoading) return <OverviewModuleSkeleton label="vaults" rows={2} />;
-	if (error) return <OverviewModuleError label="Vaults" onRetry={onRetry} />;
+	const query = useAgentProjectVaults(projectIds, { enabled: resolution === "ready" });
+	if (resolution === "loading" || query.isLoading)
+		return <OverviewModuleSkeleton label="vaults" rows={2} />;
+	if (resolution === "unavailable") return <OverviewModuleError label="Vaults" onRetry={onRetry} />;
 	if (query.error)
 		return <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />;
 	const vaults = query.data ?? [];

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -8,6 +8,7 @@ import {
 	OverviewModuleSkeleton,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
+import { Skeleton } from "@/components/ui/skeleton";
 import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
 import { unwrap, useApi } from "@/lib/api";
 import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
@@ -79,32 +80,56 @@ export function OverviewVaultsBody({
 export function OverviewConnectorsBody() {
 	const connected = useConnectedAppCards();
 	const catalog = useAvailableApps({ page: 1, pageSize: 8 });
-	if (connected.isLoading && catalog.isLoading)
-		return <OverviewModuleSkeleton label="connectors" rows={2} />;
-	const connectedNames = new Set(connected.data.map((app) => app.name));
-	const connectedAppCount = new Set(
-		connected.activeConnections.map((connection) => connection.app_name),
-	).size;
+	const connectedNames = new Set(
+		connected.activeConnections.flatMap((connection) =>
+			connection.app_name ? [connection.app_name] : [],
+		),
+	);
+	const connectedAppCount = connectedNames.size;
 	const popular = (catalog.data?.items ?? [])
 		.filter((app) => !connectedNames.has(app.name))
 		.slice(0, 5);
 	return (
 		<div className="space-y-3">
-			<p className="text-lg font-semibold">
-				{connectedAppCount
-					? `${connectedAppCount} connected ${connectedAppCount === 1 ? "app" : "apps"}`
-					: "No apps connected"}
-			</p>
-			{connected.error ? (
+			{connected.isLoading ? (
+				<ConnectorRailSkeleton label="Connected" />
+			) : connected.connectionsError ? (
 				<OverviewModuleError label="Connected apps" onRetry={connected.refetch} />
-			) : connected.data.length ? (
-				<ConnectorRail label="Connected" apps={connected.data.slice(0, 6)} />
-			) : null}
-			{catalog.error ? (
+			) : (
+				<div className="space-y-3">
+					<p className="text-lg font-semibold">
+						{connectedAppCount
+							? `${connectedAppCount} connected ${connectedAppCount === 1 ? "app" : "apps"}`
+							: "No apps connected"}
+					</p>
+					{connected.data.length ? (
+						<ConnectorRail label="Connected" apps={connected.data.slice(0, 6)} />
+					) : null}
+					{connected.metadataError ? (
+						<p className="text-xs text-muted-foreground">Some app icons can’t be shown.</p>
+					) : null}
+				</div>
+			)}
+			{catalog.isLoading ? (
+				<ConnectorRailSkeleton label="Popular" />
+			) : catalog.error ? (
 				<OverviewModuleError label="Popular apps" onRetry={() => void catalog.refetch()} />
 			) : popular.length ? (
 				<ConnectorRail label="Popular" apps={popular} />
 			) : null}
+		</div>
+	);
+}
+
+function ConnectorRailSkeleton({ label }: { label: string }) {
+	return (
+		<div aria-label={`Loading ${label.toLowerCase()} apps`} role="status">
+			<p className="mb-2 text-xs text-muted-foreground">{label}</p>
+			<div className="flex gap-2">
+				{Array.from({ length: 5 }).map((_, index) => (
+					<Skeleton key={index} className="size-9 rounded-lg" />
+				))}
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agent-project-bindings-query.test.ts
+++ b/apps/web/src/components/dashboard/agent-project-bindings-query.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAgentOverviewProjectNames } from "@/components/dashboard/agent-project-bindings-query";
+
+const bindings = [
+	{
+		id: "binding-primary",
+		agent_id: "agent-1",
+		project_id: "project-1",
+		binding_type: "primary" as const,
+		priority: 0,
+		default_write_enabled: true,
+		created_at: "2026-08-02T00:00:00Z",
+	},
+	{
+		id: "binding-context",
+		agent_id: "agent-1",
+		project_id: "project-2",
+		binding_type: "context" as const,
+		priority: 1,
+		default_write_enabled: false,
+		created_at: "2026-08-02T00:01:00Z",
+	},
+];
+
+describe("resolveAgentOverviewProjectNames", () => {
+	test("preserves binding order and reports unresolved names", () => {
+		const result = resolveAgentOverviewProjectNames(bindings, [
+			{
+				id: "project-1",
+				name: "Primary Project",
+				slug: "primary-project",
+				kind: "environment",
+				origin_environment_id: "agent-1",
+				archived_at: null,
+				created_at: "2026-08-02T00:00:00Z",
+				is_owner: true,
+				owner_display: "Owner",
+				owner_handle: "owner",
+			},
+		]);
+
+		expect(result).toEqual({ names: ["Primary Project"], unresolvedCount: 1 });
+	});
+
+	test("keeps true zero bindings distinct from missing names", () => {
+		expect(resolveAgentOverviewProjectNames([], [])).toEqual({ names: [], unresolvedCount: 0 });
+		expect(resolveAgentOverviewProjectNames(bindings, [])).toEqual({
+			names: [],
+			unresolvedCount: 2,
+		});
+	});
+});

--- a/apps/web/src/components/dashboard/agent-project-bindings-query.ts
+++ b/apps/web/src/components/dashboard/agent-project-bindings-query.ts
@@ -1,8 +1,26 @@
 "use client";
 
 import { useMemo } from "react";
-import { orderedAgentProjectBindings } from "@/components/dashboard/agent-project-scope";
+import {
+	type AgentProjectBinding,
+	orderedAgentProjectBindings,
+} from "@/components/dashboard/agent-project-scope";
 import { useOpenApi } from "@/lib/api";
+import type { components } from "@/lib/api-schemas";
+
+type ProjectRow = components["schemas"]["ProjectResponse"];
+
+export function resolveAgentOverviewProjectNames(
+	bindings: readonly AgentProjectBinding[],
+	projects: readonly ProjectRow[],
+) {
+	const projectsById = new Map(projects.map((project) => [project.id, project.name]));
+	const names = orderedAgentProjectBindings(bindings).flatMap((binding) => {
+		const name = projectsById.get(binding.project_id)?.trim();
+		return name ? [name] : [];
+	});
+	return { names, unresolvedCount: Math.max(0, bindings.length - names.length) };
+}
 
 export function agentProjectBindingsQueryKey(agentId: string | null | undefined) {
 	return [
@@ -35,22 +53,19 @@ export function useAgentOverviewProjects(
 		"get",
 		"/v1/projects",
 		{},
-		{ enabled: enabled && bindings.isSuccess },
+		{ enabled: enabled && bindings.isSuccess && (bindings.data?.length ?? 0) > 0 },
 	);
-	const names = useMemo(() => {
-		const projectsById = new Map(
-			(projects.data ?? []).map((project) => [project.id, project.name]),
-		);
-		return orderedAgentProjectBindings(bindings.data ?? []).flatMap((binding) => {
-			const name = projectsById.get(binding.project_id)?.trim();
-			return name ? [name] : [];
-		});
+	const resolvedNames = useMemo(() => {
+		return resolveAgentOverviewProjectNames(bindings.data ?? [], projects.data ?? []);
 	}, [bindings.data, projects.data]);
 
 	return {
 		bindings,
-		names,
-		isLoading: bindings.isLoading || (bindings.isSuccess && projects.isLoading),
-		projectsError: projects.error,
+		nameResolution: {
+			...resolvedNames,
+			isLoading: (bindings.data?.length ?? 0) > 0 && projects.isLoading,
+			error: projects.error,
+			refetch: projects.refetch,
+		},
 	};
 }

--- a/apps/web/src/components/dashboard/agent-project-bindings-query.ts
+++ b/apps/web/src/components/dashboard/agent-project-bindings-query.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+import { orderedAgentProjectBindings } from "@/components/dashboard/agent-project-scope";
 import { useOpenApi } from "@/lib/api";
 
 export function agentProjectBindingsQueryKey(agentId: string | null | undefined) {
@@ -20,4 +22,35 @@ export function useAgentProjectBindings(
 		{ params: { path: { agent_id: agentId ?? "" } } },
 		{ enabled: enabled && Boolean(agentId) },
 	);
+}
+
+/** Resolves bound Project ids to user-visible names without changing binding authority. */
+export function useAgentOverviewProjects(
+	agentId: string | null | undefined,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	const api = useOpenApi();
+	const bindings = useAgentProjectBindings(agentId, { enabled });
+	const projects = api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{ enabled: enabled && bindings.isSuccess },
+	);
+	const names = useMemo(() => {
+		const projectsById = new Map(
+			(projects.data ?? []).map((project) => [project.id, project.name]),
+		);
+		return orderedAgentProjectBindings(bindings.data ?? []).flatMap((binding) => {
+			const name = projectsById.get(binding.project_id)?.trim();
+			return name ? [name] : [];
+		});
+	}, [bindings.data, projects.data]);
+
+	return {
+		bindings,
+		names,
+		isLoading: bindings.isLoading || (bindings.isSuccess && projects.isLoading),
+		projectsError: projects.error,
+	};
 }

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -9,16 +9,19 @@ import {
 } from "@/components/dashboard/agents-card";
 
 type FocusHeaderSyncSource = typeof import("@/components/app-sidebar").focusHeaderSyncSource;
+type FocusHeaderComputeStatus = typeof import("@/components/app-sidebar").focusHeaderComputeStatus;
 
 type Env = components["schemas"]["AgentResponse"];
 
 let getFocusHeaderSyncSource: FocusHeaderSyncSource | null = null;
+let getFocusHeaderComputeStatus: FocusHeaderComputeStatus | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const sidebar = await import("@/components/app-sidebar");
 	getFocusHeaderSyncSource = sidebar.focusHeaderSyncSource;
+	getFocusHeaderComputeStatus = sidebar.focusHeaderComputeStatus;
 });
 
 function env(overrides: Partial<Env> = {}): Env {
@@ -149,12 +152,27 @@ describe("agentTileCardProjection", () => {
 	});
 });
 
-describe("focused sidebar sync projection", () => {
-	it("shows Cloud sync only after the environment projection exists", () => {
+describe("focused sidebar status projection", () => {
+	it("uses compute status for hosted agents and never reclassifies it from sync", () => {
 		if (!getFocusHeaderSyncSource) throw new Error("focusHeaderSyncSource was not loaded");
+		if (!getFocusHeaderComputeStatus) throw new Error("focusHeaderComputeStatus was not loaded");
+		const hosted: AgentTile = {
+			id: "hosted",
+			source: "on-clawdi",
+			name: "Hosted agent",
+			agentType: "hermes",
+			href: "/agents/hosted",
+			env: env({ sync_enabled: true, last_sync_at: "2020-01-01T00:00:00Z" }),
+			cardStatus: {
+				visual: { label: "Running", tooltip: "Compute status: Running.", dotClass: "dot" },
+				labels: ["Running"],
+			},
+		};
 
-		expect(getFocusHeaderSyncSource("cloud", true)).toBe("on-clawdi");
+		expect(getFocusHeaderSyncSource("cloud", true)).toBeNull();
 		expect(getFocusHeaderSyncSource("cloud", false)).toBeNull();
+		expect(getFocusHeaderComputeStatus("cloud", hosted)?.label).toBe("Running");
+		expect(getFocusHeaderComputeStatus("cloud", { ...hosted, cardStatus: undefined })).toBeNull();
 	});
 
 	it("preserves connected and legacy status copy", () => {
@@ -162,6 +180,8 @@ describe("focused sidebar sync projection", () => {
 
 		expect(getFocusHeaderSyncSource("connected", true)).toBe("self-managed");
 		expect(getFocusHeaderSyncSource("legacy", true)).toBe("on-clawdi");
+		if (!getFocusHeaderComputeStatus) throw new Error("focusHeaderComputeStatus was not loaded");
+		expect(getFocusHeaderComputeStatus("connected", null)).toBeNull();
 	});
 });
 

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -191,23 +191,23 @@ export function ConnectedAgentDetail({
 
 					{activeTab === "overview" ? (
 						<div className="flex flex-col gap-8">
-							<div>
-								<div className="mb-3 flex items-center justify-between">
-									<h2 id="connected-recent-sessions" className="text-sm font-semibold">
-										Recent sessions
-									</h2>
-									<Button
-										render={<Link {...agentSectionLink(id, "sessions", routeSearch)} />}
-										nativeButton={false}
-										variant="ghost"
-										size="sm"
-										className="text-muted-foreground"
-									>
-										View all
-										<ArrowRight />
-									</Button>
-								</div>
-								<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+							<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)] @3xl/main:gap-y-3">
+								<div className="grid min-w-0 gap-3 @3xl/main:row-span-2 @3xl/main:row-start-1 @3xl/main:grid-rows-subgrid">
+									<div className="flex items-center justify-between">
+										<h2 id="connected-recent-sessions" className="text-sm font-semibold">
+											Recent sessions
+										</h2>
+										<Button
+											render={<Link {...agentSectionLink(id, "sessions", routeSearch)} />}
+											nativeButton={false}
+											variant="ghost"
+											size="sm"
+											className="text-muted-foreground"
+										>
+											View all
+											<ArrowRight />
+										</Button>
+									</div>
 									<section
 										aria-labelledby="connected-recent-sessions"
 										className="min-h-40 min-w-0 @3xl/main:min-h-52"
@@ -226,6 +226,8 @@ export function ConnectedAgentDetail({
 											/>
 										)}
 									</section>
+								</div>
+								<div className="@3xl/main:row-start-2">
 									<AgentOverviewStatusCard
 										agentId={id}
 										section="settings"

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -166,7 +166,7 @@ export function ConnectedAgentDetail({
 				<section className="flex flex-col gap-4">
 					<PageHeader
 						title={activeTabLabel}
-						description={activeTabMeta.description}
+						description={activeTab === "overview" ? undefined : activeTabMeta.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
 						status={headerStatus}
 					/>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -7,12 +7,16 @@ import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
+	agentTypeLabel,
+	cleanMachineName,
 } from "@/components/dashboard/agent-label";
+import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { AgentVaultsTab } from "@/components/dashboard/agent-vaults-tab";
+import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
 import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { MemoriesSurface } from "@/components/memories/memories-surface";
@@ -20,6 +24,7 @@ import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Skeleton } from "@/components/ui/skeleton";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
 import {
 	type AgentRouteSearch,
@@ -105,6 +110,15 @@ export function ConnectedAgentDetail({
 		? sessionsError
 		: null;
 	const sessionTotal = blockingSessionsError ? "—" : (sessionsPage?.total ?? 0);
+	const syncStatus = daemonStatusVisual(agent);
+	const syncTone =
+		syncStatus.kind === "live"
+			? "success"
+			: syncStatus.kind === "errored"
+				? "destructive"
+				: syncStatus.kind === "paused"
+					? "warning"
+					: "neutral";
 	const activeTabMeta = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
@@ -144,7 +158,24 @@ export function ConnectedAgentDetail({
 					/>
 
 					{activeTab === "overview" ? (
-						<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-5">
+							<DetailPanel className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
+								<div className="min-w-0">
+									<div className="flex flex-wrap items-center gap-2">
+										<h2 className="truncate text-lg font-semibold tracking-tight">{agentTitle}</h2>
+										<StatusBadge status={syncTone} withDot>
+											{syncStatus.label}
+										</StatusBadge>
+									</div>
+									<p className="mt-1 text-sm text-muted-foreground">
+										{agentTypeLabel(agent.agent_type)} on {cleanMachineName(agent.machine_name)}
+									</p>
+								</div>
+								<div className="text-xs text-muted-foreground sm:text-right">
+									<p>{syncStatus.tooltip}</p>
+									<p className="mt-1">Runtime managed outside Clawdi</p>
+								</div>
+							</DetailPanel>
 							<div className="grid gap-3 sm:grid-cols-3">
 								<AgentStatPanel label="Sessions" value={sessionTotal} />
 								<AgentStatPanel
@@ -158,6 +189,11 @@ export function ConnectedAgentDetail({
 									value={blockingProjectBindingsError ? "—" : (projectBindings?.length ?? "—")}
 								/>
 							</div>
+							<AgentOverviewCapabilities
+								agentId={id}
+								variant="connected"
+								routeSearch={routeSearch}
+							/>
 							{blockingSkillsError ? (
 								<ApiErrorPanel
 									error={blockingSkillsError}
@@ -176,6 +212,10 @@ export function ConnectedAgentDetail({
 									title="Couldn't load agent Projects"
 								/>
 							) : null}
+							<div className="flex items-center justify-between gap-3">
+								<h2 className="text-sm font-medium">Recent sessions</h2>
+								<span className="text-xs text-muted-foreground">Latest synced activity</span>
+							</div>
 							{blockingSessionsError ? (
 								<ApiErrorPanel
 									error={blockingSessionsError}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -12,15 +12,14 @@ import {
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
-	OverviewChips,
 	OverviewMetadata,
 	OverviewModuleError,
-	OverviewModuleSkeleton,
-	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
 import {
 	OverviewConnectorsBody,
 	OverviewMemoriesBody,
+	OverviewProjectsBody,
+	OverviewSkillsBody,
 	OverviewVaultsBody,
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
@@ -30,8 +29,7 @@ import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel"
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { AgentVaultsTab } from "@/components/dashboard/agent-vaults-tab";
 import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
-import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
-import { ENTITY_CARD_BASE } from "@/components/entity-card";
+import { DetailNotFound } from "@/components/detail/layout";
 import { MemoriesSurface } from "@/components/memories/memories-surface";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -194,10 +192,10 @@ export function ConnectedAgentDetail({
 								<h2 id="connected-recent-sessions" className="mb-3 text-sm font-semibold">
 									Recent sessions
 								</h2>
-								<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+								<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 									<section
 										aria-labelledby="connected-recent-sessions"
-										className="min-h-40 min-w-0 lg:min-h-52"
+										className="min-h-40 min-w-0 @3xl/main:min-h-52"
 									>
 										{blockingOverviewSessionsError ? (
 											<OverviewModuleError
@@ -241,68 +239,32 @@ export function ConnectedAgentDetail({
 								routeSearch={routeSearch}
 								content={{
 									projects: {
-										body: projectBindingsLoading ? (
-											<OverviewModuleSkeleton label="projects" rows={3} />
-										) : blockingProjectBindingsError ? (
-											<OverviewModuleError
-												label="Projects"
-												onRetry={() => void refetchProjectBindings()}
+										body: (
+											<OverviewProjectsBody
+												bindings={{
+													count: projectBindings?.length ?? null,
+													isLoading: projectBindingsLoading,
+													error: blockingProjectBindingsError,
+													onRetry: () => void refetchProjectBindings(),
+												}}
+												names={{
+													items: projectNames.names,
+													unresolvedCount: projectNames.unresolvedCount,
+													isLoading: projectNames.isLoading,
+													error: projectNames.error,
+													onRetry: () => void projectNames.refetch(),
+												}}
 											/>
-										) : (
-											<div className="space-y-3">
-												<p className="text-lg font-semibold">
-													{(projectBindings?.length ?? 0) > 0
-														? `${projectBindings?.length} ${projectBindings?.length === 1 ? "project" : "projects"}`
-														: "No projects added"}
-												</p>
-												{(projectBindings?.length ?? 0) === 0 ? null : projectNames.isLoading ? (
-													<OverviewModuleSkeleton
-														label="project names"
-														rows={3}
-														showHeading={false}
-													/>
-												) : projectNames.error ? (
-													<OverviewModuleError
-														label="Project names"
-														onRetry={() => void projectNames.refetch()}
-													/>
-												) : (
-													<>
-														<OverviewSummaryRows
-															items={projectNames.names}
-															empty="Project names can’t be shown"
-														/>
-														{projectNames.unresolvedCount > 0 ? (
-															<p className="text-xs text-muted-foreground">
-																{projectNames.unresolvedCount} project{" "}
-																{projectNames.unresolvedCount === 1 ? "name can’t" : "names can’t"}{" "}
-																be shown
-															</p>
-														) : null}
-													</>
-												)}
-											</div>
 										),
 									},
 									skills: {
-										body: skillsLoading ? (
-											<OverviewModuleSkeleton label="skills" rows={2} />
-										) : blockingSkillsError ? (
-											<OverviewModuleError label="Skills" onRetry={() => void refetchSkills()} />
-										) : (
-											<div className="space-y-3">
-												<p className="text-lg font-semibold">
-													{(skillsForThisEnv?.length ?? 0) > 0
-														? `${skillsForThisEnv?.length} ${skillsForThisEnv?.length === 1 ? "skill" : "skills"}`
-														: "No skills available"}
-												</p>
-												{(skillsForThisEnv?.length ?? 0) > 0 ? (
-													<OverviewChips
-														items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
-														empty="No skills available"
-													/>
-												) : null}
-											</div>
+										body: (
+											<OverviewSkillsBody
+												items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
+												isLoading={skillsLoading}
+												error={blockingSkillsError}
+												onRetry={() => void refetchSkills()}
+											/>
 										),
 									},
 									memories: { body: <OverviewMemoriesBody /> },
@@ -310,8 +272,13 @@ export function ConnectedAgentDetail({
 										body: (
 											<OverviewVaultsBody
 												projectIds={effectiveAgentProjectIds(projectBindings ?? [])}
-												isLoading={projectBindingsLoading}
-											error={blockingProjectBindingsError}
+												resolution={
+													projectBindingsLoading
+														? "loading"
+														: blockingProjectBindingsError
+															? "unavailable"
+															: "ready"
+												}
 												onRetry={() => void refetchProjectBindings()}
 											/>
 										),
@@ -379,32 +346,37 @@ export function ConnectedAgentDetailSkeleton({ hosted = false }: { hosted?: bool
 
 function AgentDetailContentSkeleton() {
 	return (
-		<section className="flex flex-col gap-4">
+		<section className="flex flex-col gap-8">
 			<div className="flex flex-col gap-2">
 				<div className="flex items-center gap-2">
 					<Skeleton className="size-4 rounded-sm" />
 					<Skeleton className="h-5 w-28" />
 				</div>
-				<Skeleton className="h-4 w-80 max-w-full" />
 			</div>
-			<div className="grid gap-3 sm:grid-cols-3">
-				{Array.from({ length: 3 }).map((_, index) => (
-					<DetailPanel key={index} className="p-3">
-						<Skeleton className="h-7 w-12" />
-						<Skeleton className="mt-1.5 h-3 w-16" />
-					</DetailPanel>
-				))}
-			</div>
-			<div className="flex flex-col gap-2">
-				{Array.from({ length: 3 }).map((_, index) => (
-					<div key={index} className={cn(ENTITY_CARD_BASE, "flex items-start gap-3")}>
-						<Skeleton className="size-8 shrink-0 rounded-md" />
-						<div className="min-w-0 flex-1">
-							<Skeleton className="h-4 w-4/5" />
-							<Skeleton className="mt-3 h-3 w-1/2" />
-						</div>
+			<div>
+				<Skeleton className="mb-3 h-4 w-28" />
+				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+					<div className="grid min-h-52 gap-2">
+						{Array.from({ length: 4 }).map((_, index) => (
+							<Skeleton key={index} className="h-11 rounded-lg" />
+						))}
 					</div>
-				))}
+					<Skeleton className="min-h-52 rounded-lg" />
+				</div>
+			</div>
+			<div>
+				<Skeleton className="mb-3 h-4 w-20" />
+				<div className="grid gap-3 @2xl/main:grid-cols-2 @5xl/main:grid-cols-6">
+					{Array.from({ length: 5 }).map((_, index) => (
+						<Skeleton
+							key={index}
+							className={cn(
+								"min-h-48 rounded-lg @5xl/main:col-span-2",
+								index === 3 && "@5xl/main:col-start-2",
+							)}
+						/>
+					))}
+				</div>
 			</div>
 		</section>
 	);

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -11,7 +11,7 @@ import {
 	cleanMachineName,
 } from "@/components/dashboard/agent-label";
 import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
-import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
@@ -75,11 +75,11 @@ export function ConnectedAgentDetail({
 		params: { path: { agent_id: id } },
 	});
 
-	const {
-		data: projectBindings,
-		error: projectBindingsError,
-		refetch: refetchProjectBindings,
-	} = useAgentProjectBindings(id, { enabled: !!agent });
+	const overviewProjects = useAgentOverviewProjects(id, { enabled: !!agent });
+	const projectBindings = overviewProjects.bindings.data;
+	const projectBindingsLoading = overviewProjects.isLoading;
+	const projectBindingsError = overviewProjects.bindings.error;
+	const refetchProjectBindings = overviewProjects.bindings.refetch;
 
 	const {
 		data: sessionsPage,
@@ -94,6 +94,7 @@ export function ConnectedAgentDetail({
 	const agentProjectId = agent?.default_project_id;
 	const {
 		skills: skillsForThisEnv,
+		isLoading: skillsLoading,
 		error: skillsError,
 		refetch: refetchSkills,
 	} = useAgentProjectSkills(id, agentProjectId, id, false, Boolean(agent));
@@ -176,23 +177,58 @@ export function ConnectedAgentDetail({
 									<p className="mt-1">Runtime managed outside Clawdi</p>
 								</div>
 							</DetailPanel>
-							<div className="grid gap-3 sm:grid-cols-3">
-								<AgentStatPanel label="Sessions" value={sessionTotal} />
-								<AgentStatPanel
-									label="Skills"
-									value={
-										blockingSkillsError ? "—" : skillsForThisEnv ? skillsForThisEnv.length : "—"
-									}
-								/>
-								<AgentStatPanel
-									label="Projects"
-									value={blockingProjectBindingsError ? "—" : (projectBindings?.length ?? "—")}
-								/>
-							</div>
 							<AgentOverviewCapabilities
 								agentId={id}
 								variant="connected"
 								routeSearch={routeSearch}
+								content={{
+									sessions: {
+										value: sessionsLoading
+											? "Loading…"
+											: `${sessionTotal} ${sessionTotal === 1 ? "session" : "sessions"}`,
+										detail: "Recent work synced from this agent.",
+										content: blockingSessionsError ? null : (
+											<SessionFeed
+												sessions={(sessionsPage?.items ?? []).slice(0, 3)}
+												isLoading={sessionsLoading}
+												emptyMessage="No sessions synced from this agent yet."
+												emptyVariant="inset"
+												showAgent={false}
+												sessionLink={(session) => scopedSessionLink(session.id)}
+											/>
+										),
+									},
+									"live-sync": { value: syncStatus.label, detail: syncStatus.tooltip },
+									projects: {
+										value: projectBindingsLoading
+											? "Loading…"
+											: projectBindingsError
+												? "Unavailable"
+												: `${projectBindings?.length ?? 0} ${projectBindings?.length === 1 ? "Project" : "Projects"}`,
+										detail: "Projects this agent reads for context and resources.",
+										items: overviewProjects.names,
+									},
+									skills: {
+										value: skillsLoading
+											? "Loading…"
+											: skillsError
+												? "Unavailable"
+												: `${skillsForThisEnv?.length ?? 0} available`,
+										detail: "Skills available through this agent's Projects.",
+									},
+									memories: {
+										value: "Shared context",
+										detail: "Account-wide memory available across agents.",
+									},
+									vaults: {
+										value: "Project access",
+										detail: "Vaults supplied safely through this agent's Projects.",
+									},
+									connectors: {
+										value: "Account connections",
+										detail: "External apps available across agents.",
+									},
+								}}
 							/>
 							{blockingSkillsError ? (
 								<ApiErrorPanel
@@ -212,10 +248,6 @@ export function ConnectedAgentDetail({
 									title="Couldn't load agent Projects"
 								/>
 							) : null}
-							<div className="flex items-center justify-between gap-3">
-								<h2 className="text-sm font-medium">Recent sessions</h2>
-								<span className="text-xs text-muted-foreground">Latest synced activity</span>
-							</div>
 							{blockingSessionsError ? (
 								<ApiErrorPanel
 									error={blockingSessionsError}
@@ -224,16 +256,7 @@ export function ConnectedAgentDetail({
 									}}
 									title="Couldn't load agent sessions"
 								/>
-							) : (
-								<SessionFeed
-									sessions={(sessionsPage?.items ?? []).slice(0, 5)}
-									isLoading={sessionsLoading}
-									emptyMessage="No sessions synced from this agent yet."
-									emptyVariant="inset"
-									showAgent={false}
-									sessionLink={(session) => scopedSessionLink(session.id)}
-								/>
-							)}
+							) : null}
 						</div>
 					) : null}
 
@@ -329,13 +352,4 @@ function parseAgentTab(value: AgentSectionId | string | null): AgentTab | null {
 	if (value === "overview") return "overview";
 	if (CONNECTED_AGENT_SECTION_IDS.includes(value as AgentTab)) return value as AgentTab;
 	return null;
-}
-
-function AgentStatPanel({ label, value }: { label: string; value: React.ReactNode }) {
-	return (
-		<DetailPanel className="p-3">
-			<div className="text-xl font-semibold tabular-nums">{value}</div>
-			<div className="text-xs text-muted-foreground">{label}</div>
-		</DetailPanel>
-	);
 }

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -173,42 +173,50 @@ export function ConnectedAgentDetail({
 
 					{activeTab === "overview" ? (
 						<div className="flex flex-col gap-8">
-							<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-								<section aria-labelledby="connected-recent-sessions">
-									<h2 id="connected-recent-sessions" className="mb-3 text-sm font-semibold">
-										Recent sessions
-									</h2>
+							<div>
+								<h2 id="connected-recent-sessions" className="mb-3 text-sm font-semibold">
+									Recent sessions
+								</h2>
+								<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+									<section
+										aria-labelledby="connected-recent-sessions"
+										className="min-h-40 lg:min-h-52"
+									>
 									{blockingSessionsError ? (
-										<OverviewModuleError label="Sessions" onRetry={() => void refetchSessions()} />
-									) : (
-										<OverviewSessionList
-											sessions={sessionsPage?.items ?? []}
-											isLoading={sessionsLoading}
-											emptyMessage="No recent sessions"
-											sessionLink={(session) => scopedSessionLink(session.id)}
-										/>
-									)}
-								</section>
-								<AgentOverviewStatusCard
-									agentId={id}
-									section="settings"
-									routeSearch={routeSearch}
-									title="Live Sync"
-									icon={Laptop}
-									tint="bg-identity-7-bg text-identity-7-fg"
-								>
-									<div className="space-y-3">
-										<p className="inline-flex items-center gap-2 text-lg font-semibold">
-											<StatusDot status={syncTone} /> {syncStatus.label}
-										</p>
-										<OverviewMetadata
-											items={[
-												{ label: "Machine", value: agent.machine_name },
-												{ label: "Last seen", value: relativeTime(agent.last_seen_at) },
-											]}
-										/>
-									</div>
-								</AgentOverviewStatusCard>
+											<OverviewModuleError
+												label="Sessions"
+												onRetry={() => void refetchSessions()}
+											/>
+										) : (
+											<OverviewSessionList
+												sessions={sessionsPage?.items ?? []}
+												isLoading={sessionsLoading}
+												emptyMessage="No recent sessions"
+												sessionLink={(session) => scopedSessionLink(session.id)}
+											/>
+										)}
+									</section>
+									<AgentOverviewStatusCard
+										agentId={id}
+										section="settings"
+										routeSearch={routeSearch}
+										title="Live Sync"
+										icon={Laptop}
+										tint="bg-identity-7-bg text-identity-7-fg"
+									>
+										<div className="flex h-full flex-col justify-between gap-4">
+											<p className="inline-flex items-center gap-2 text-lg font-semibold">
+												<StatusDot status={syncTone} /> {syncStatus.label}
+											</p>
+											<OverviewMetadata
+												items={[
+													{ label: "Machine", value: agent.machine_name },
+													{ label: "Last seen", value: relativeTime(agent.last_seen_at) },
+												]}
+											/>
+										</div>
+									</AgentOverviewStatusCard>
+								</div>
 							</div>
 							<AgentOverviewCapabilities
 								agentId={id}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -7,8 +7,6 @@ import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
-	agentTypeLabel,
-	cleanMachineName,
 } from "@/components/dashboard/agent-label";
 import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
@@ -24,7 +22,7 @@ import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Skeleton } from "@/components/ui/skeleton";
-import { StatusBadge } from "@/components/ui/status-badge";
+import { StatusDot } from "@/components/ui/status-badge";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
 import {
 	type AgentRouteSearch,
@@ -38,7 +36,7 @@ import { isApiNotFoundError } from "@/lib/api-errors";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { sessionListQueryOptions } from "@/lib/session-queries";
-import { cn, errorMessage } from "@/lib/utils";
+import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 type AgentTab =
 	| "overview"
@@ -160,23 +158,6 @@ export function ConnectedAgentDetail({
 
 					{activeTab === "overview" ? (
 						<div className="flex flex-col gap-5">
-							<DetailPanel className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
-								<div className="min-w-0">
-									<div className="flex flex-wrap items-center gap-2">
-										<h2 className="truncate text-lg font-semibold tracking-tight">{agentTitle}</h2>
-										<StatusBadge status={syncTone} withDot>
-											{syncStatus.label}
-										</StatusBadge>
-									</div>
-									<p className="mt-1 text-sm text-muted-foreground">
-										{agentTypeLabel(agent.agent_type)} on {cleanMachineName(agent.machine_name)}
-									</p>
-								</div>
-								<div className="text-xs text-muted-foreground sm:text-right">
-									<p>{syncStatus.tooltip}</p>
-									<p className="mt-1">Runtime managed outside Clawdi</p>
-								</div>
-							</DetailPanel>
 							<AgentOverviewCapabilities
 								agentId={id}
 								variant="connected"
@@ -198,7 +179,15 @@ export function ConnectedAgentDetail({
 											/>
 										),
 									},
-									"live-sync": { value: syncStatus.label, detail: syncStatus.tooltip },
+									"live-sync": {
+										value: (
+											<span className="inline-flex items-center gap-2">
+												<StatusDot status={syncTone} />
+												{syncStatus.label}
+											</span>
+										),
+										detail: `${agent.machine_name} · last seen ${relativeTime(agent.last_seen_at)}`,
+									},
 									projects: {
 										value: projectBindingsLoading
 											? "Loading…"
@@ -215,18 +204,21 @@ export function ConnectedAgentDetail({
 												? "Unavailable"
 												: `${skillsForThisEnv?.length ?? 0} available`,
 										detail: "Skills available through this agent's Projects.",
+										items: (skillsForThisEnv ?? []).map((skill) => skill.name),
 									},
 									memories: {
-										value: "Shared context",
-										detail: "Account-wide memory available across agents.",
+										value: "Account-wide",
+										detail: "Shared with every agent in this account.",
 									},
 									vaults: {
-										value: "Project access",
-										detail: "Vaults supplied safely through this agent's Projects.",
+										value: projectBindingsLoading
+											? "Loading…"
+											: `From ${projectBindings?.length ?? 0} ${projectBindings?.length === 1 ? "Project" : "Projects"}`,
+										detail: "Secrets are supplied through bound Projects.",
 									},
 									connectors: {
-										value: "Account connections",
-										detail: "External apps available across agents.",
+										value: "Account-wide",
+										detail: "Connected apps are available to every agent.",
 									},
 								}}
 							/>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -284,28 +284,6 @@ export function ConnectedAgentDetail({
 											</div>
 										),
 									},
-									memories: {
-										body: <p className="text-sm font-medium">Shared with all your agents</p>,
-									},
-									vaults: {
-										body: projectBindingsLoading ? (
-											<OverviewModuleSkeleton label="vault sources" rows={2} />
-										) : blockingProjectBindingsError ? (
-											<OverviewModuleError
-												label="Vault sources"
-												onRetry={() => void refetchProjectBindings()}
-											/>
-										) : (
-											<p className="text-sm font-medium">
-												{projectBindings?.length
-													? `Available through ${projectBindings.length} ${projectBindings.length === 1 ? "project" : "projects"}`
-													: "Add a project to use vaults"}
-											</p>
-										),
-									},
-									connectors: {
-										body: <p className="text-sm font-medium">Shared with all your agents</p>,
-									},
 								}}
 							/>
 						</div>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -88,12 +88,23 @@ export function ConnectedAgentDetail({
 		params: { path: { agent_id: id } },
 	});
 
-	const overviewProjects = useAgentOverviewProjects(id, { enabled: !!agent });
+	const overviewEnabled = activeTab === "overview" && Boolean(agent);
+	const overviewProjects = useAgentOverviewProjects(id, { enabled: overviewEnabled });
 	const projectBindings = overviewProjects.bindings.data;
 	const projectBindingsLoading = overviewProjects.bindings.isLoading;
 	const projectBindingsError = overviewProjects.bindings.error;
 	const refetchProjectBindings = overviewProjects.bindings.refetch;
 	const projectNames = overviewProjects.nameResolution;
+
+	const {
+		data: overviewSessionsPage,
+		isLoading: overviewSessionsLoading,
+		error: overviewSessionsError,
+		refetch: refetchOverviewSessions,
+	} = useQuery({
+		...sessionListQueryOptions($api, { environment_id: id, page_size: 4 }),
+		enabled: overviewEnabled,
+	});
 
 	const {
 		data: sessionsPage,
@@ -102,7 +113,7 @@ export function ConnectedAgentDetail({
 		refetch: refetchSessions,
 	} = useQuery({
 		...sessionListQueryOptions($api, { environment_id: id, page_size: 50 }),
-		enabled: !!agent,
+		enabled: activeTab === "sessions" && Boolean(agent),
 	});
 
 	const agentProjectId = agent?.default_project_id;
@@ -111,7 +122,7 @@ export function ConnectedAgentDetail({
 		isLoading: skillsLoading,
 		error: skillsError,
 		refetch: refetchSkills,
-	} = useAgentProjectSkills(id, agentProjectId, id, false, Boolean(agent));
+	} = useAgentProjectSkills(id, agentProjectId, id, false, overviewEnabled);
 
 	const blockingAgentError =
 		isApiNotFoundError(error) || shouldBlockQueryError(error, agent) ? error : null;
@@ -120,6 +131,12 @@ export function ConnectedAgentDetail({
 		: null;
 	const blockingProjectBindingsError = shouldBlockQueryError(projectBindingsError, projectBindings)
 		? projectBindingsError
+		: null;
+	const blockingOverviewSessionsError = shouldBlockQueryError(
+		overviewSessionsError,
+		overviewSessionsPage,
+	)
+		? overviewSessionsError
 		: null;
 	const blockingSessionsError = shouldBlockQueryError(sessionsError, sessionsPage)
 		? sessionsError
@@ -182,15 +199,15 @@ export function ConnectedAgentDetail({
 										aria-labelledby="connected-recent-sessions"
 										className="min-h-40 min-w-0 lg:min-h-52"
 									>
-									{blockingSessionsError ? (
+										{blockingOverviewSessionsError ? (
 											<OverviewModuleError
 												label="Sessions"
-												onRetry={() => void refetchSessions()}
+												onRetry={() => void refetchOverviewSessions()}
 											/>
 										) : (
 											<OverviewSessionList
-												sessions={sessionsPage?.items ?? []}
-												isLoading={sessionsLoading}
+												sessions={overviewSessionsPage?.items ?? []}
+												isLoading={overviewSessionsLoading}
 												emptyMessage="No recent sessions"
 												sessionLink={(session) => scopedSessionLink(session.id)}
 											/>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -8,7 +8,14 @@ import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
 } from "@/components/dashboard/agent-label";
-import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	AgentOverviewCapabilities,
+	OverviewChips,
+	OverviewMetadata,
+	OverviewModuleError,
+	OverviewModuleSkeleton,
+	OverviewSummaryRows,
+} from "@/components/dashboard/agent-overview-capabilities";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
@@ -164,91 +171,132 @@ export function ConnectedAgentDetail({
 								routeSearch={routeSearch}
 								content={{
 									sessions: {
-										value: sessionsLoading
-											? "Loading…"
-											: `${sessionTotal} ${sessionTotal === 1 ? "session" : "sessions"}`,
-										detail: "Recent work synced from this agent.",
-										content: blockingSessionsError ? null : (
-											<SessionFeed
-												sessions={(sessionsPage?.items ?? []).slice(0, 3)}
-												isLoading={sessionsLoading}
-												emptyMessage="No sessions synced from this agent yet."
-												emptyVariant="inset"
-												showAgent={false}
-												sessionLink={(session) => scopedSessionLink(session.id)}
+										body: sessionsLoading ? (
+											<OverviewModuleSkeleton label="sessions" rows={3} />
+										) : blockingSessionsError ? (
+											<OverviewModuleError
+												label="Sessions"
+												onRetry={() => void refetchSessions()}
 											/>
+										) : (
+											<div className="space-y-3">
+												<div>
+													<p className="text-lg font-semibold tracking-tight">
+														{sessionTotal} {sessionTotal === 1 ? "session" : "sessions"}
+													</p>
+													<p className="mt-1 text-xs text-muted-foreground">
+														Recent synced activity
+													</p>
+												</div>
+												<div className="border-t pt-3">
+													<SessionFeed
+														sessions={(sessionsPage?.items ?? []).slice(0, 3)}
+														isLoading={false}
+														emptyMessage="No sessions synced from this agent yet."
+														emptyVariant="inset"
+														showAgent={false}
+														sessionLink={(session) => scopedSessionLink(session.id)}
+													/>
+												</div>
+											</div>
 										),
 									},
 									"live-sync": {
-										value: (
-											<span className="inline-flex items-center gap-2">
-												<StatusDot status={syncTone} />
-												{syncStatus.label}
-											</span>
+										body: (
+											<div className="space-y-3">
+												<p className="inline-flex items-center gap-2 text-lg font-semibold">
+													<StatusDot status={syncTone} /> {syncStatus.label}
+												</p>
+												<OverviewMetadata
+													items={[
+														{ label: "Machine", value: agent.machine_name },
+														{ label: "Last seen", value: relativeTime(agent.last_seen_at) },
+													]}
+												/>
+											</div>
 										),
-										detail: `${agent.machine_name} · last seen ${relativeTime(agent.last_seen_at)}`,
 									},
 									projects: {
-										value: projectBindingsLoading
-											? "Loading…"
-											: projectBindingsError
-												? "Unavailable"
-												: `${projectBindings?.length ?? 0} ${projectBindings?.length === 1 ? "Project" : "Projects"}`,
-										detail: "Projects this agent reads for context and resources.",
-										items: overviewProjects.names,
+										body: projectBindingsLoading ? (
+											<OverviewModuleSkeleton label="projects" rows={3} />
+										) : blockingProjectBindingsError ? (
+											<OverviewModuleError
+												label="Projects"
+												onRetry={() => void refetchProjectBindings()}
+											/>
+										) : (
+											<div className="space-y-3">
+												<p className="text-lg font-semibold">
+													{projectBindings?.length ?? 0} bound
+												</p>
+												<OverviewSummaryRows
+													items={overviewProjects.names}
+													empty="No projects bound"
+												/>
+											</div>
+										),
 									},
 									skills: {
-										value: skillsLoading
-											? "Loading…"
-											: skillsError
-												? "Unavailable"
-												: `${skillsForThisEnv?.length ?? 0} available`,
-										detail: "Skills available through this agent's Projects.",
-										items: (skillsForThisEnv ?? []).map((skill) => skill.name),
+										body: skillsLoading ? (
+											<OverviewModuleSkeleton label="skills" rows={2} />
+										) : blockingSkillsError ? (
+											<OverviewModuleError label="Skills" onRetry={() => void refetchSkills()} />
+										) : (
+											<div className="space-y-3">
+												<p className="text-lg font-semibold">
+													{skillsForThisEnv?.length ?? 0} available
+												</p>
+												<OverviewChips
+													items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
+													empty="No skills available"
+												/>
+											</div>
+										),
 									},
 									memories: {
-										value: "Account-wide",
-										detail: "Shared with every agent in this account.",
+										body: (
+											<OverviewMetadata
+												items={[
+													{ label: "Scope", value: "Account-wide" },
+													{ label: "Access", value: "All agents" },
+												]}
+											/>
+										),
 									},
 									vaults: {
-										value: projectBindingsLoading
-											? "Loading…"
-											: `From ${projectBindings?.length ?? 0} ${projectBindings?.length === 1 ? "Project" : "Projects"}`,
-										detail: "Secrets are supplied through bound Projects.",
+										body: projectBindingsLoading ? (
+											<OverviewModuleSkeleton label="vault sources" rows={2} />
+										) : blockingProjectBindingsError ? (
+											<OverviewModuleError
+												label="Vault sources"
+												onRetry={() => void refetchProjectBindings()}
+											/>
+										) : (
+											<OverviewMetadata
+												items={[
+													{
+														label: "Sources",
+														value: projectBindings?.length
+															? `${projectBindings.length} bound Projects`
+															: "No bound Projects",
+													},
+													{ label: "Delivery", value: "Through Projects" },
+												]}
+											/>
+										),
 									},
 									connectors: {
-										value: "Account-wide",
-										detail: "Connected apps are available to every agent.",
+										body: (
+											<OverviewMetadata
+												items={[
+													{ label: "Scope", value: "Account-wide" },
+													{ label: "Managed", value: "Account settings" },
+												]}
+											/>
+										),
 									},
 								}}
 							/>
-							{blockingSkillsError ? (
-								<ApiErrorPanel
-									error={blockingSkillsError}
-									onRetry={() => {
-										void refetchSkills();
-									}}
-									title="Couldn't load agent skills"
-								/>
-							) : null}
-							{blockingProjectBindingsError ? (
-								<ApiErrorPanel
-									error={blockingProjectBindingsError}
-									onRetry={() => {
-										void refetchProjectBindings();
-									}}
-									title="Couldn't load agent Projects"
-								/>
-							) : null}
-							{blockingSessionsError ? (
-								<ApiErrorPanel
-									error={blockingSessionsError}
-									onRetry={() => {
-										void refetchSessions();
-									}}
-									title="Couldn't load agent sessions"
-								/>
-							) : null}
 						</div>
 					) : null}
 

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { Laptop } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
@@ -10,13 +11,20 @@ import {
 } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
+	AgentOverviewStatusCard,
 	OverviewChips,
 	OverviewMetadata,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	OverviewConnectorsBody,
+	OverviewMemoriesBody,
+	OverviewVaultsBody,
+} from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
+import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
@@ -27,7 +35,7 @@ import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { MemoriesSurface } from "@/components/memories/memories-surface";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { SessionFeed } from "@/components/sessions/session-feed";
+import { OverviewSessionList, SessionFeed } from "@/components/sessions/session-feed";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusDot } from "@/components/ui/status-badge";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
@@ -116,11 +124,6 @@ export function ConnectedAgentDetail({
 	const blockingSessionsError = shouldBlockQueryError(sessionsError, sessionsPage)
 		? sessionsError
 		: null;
-	const sessionTotal = blockingSessionsError ? "—" : (sessionsPage?.total ?? 0);
-	const sessionSummary =
-		typeof sessionTotal === "number" && sessionTotal > 0
-			? `${sessionTotal} recent ${sessionTotal === 1 ? "session" : "sessions"}`
-			: "No recent sessions";
 	const syncStatus = daemonStatusVisual(agent);
 	const syncTone =
 		syncStatus.kind === "live"
@@ -169,56 +172,49 @@ export function ConnectedAgentDetail({
 					/>
 
 					{activeTab === "overview" ? (
-						<div className="flex flex-col gap-5">
+						<div className="flex flex-col gap-8">
+							<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+								<section aria-labelledby="connected-recent-sessions">
+									<h2 id="connected-recent-sessions" className="mb-3 text-sm font-semibold">
+										Recent sessions
+									</h2>
+									{blockingSessionsError ? (
+										<OverviewModuleError label="Sessions" onRetry={() => void refetchSessions()} />
+									) : (
+										<OverviewSessionList
+											sessions={sessionsPage?.items ?? []}
+											isLoading={sessionsLoading}
+											emptyMessage="No recent sessions"
+											sessionLink={(session) => scopedSessionLink(session.id)}
+										/>
+									)}
+								</section>
+								<AgentOverviewStatusCard
+									agentId={id}
+									section="settings"
+									routeSearch={routeSearch}
+									title="Live Sync"
+									icon={Laptop}
+									tint="bg-identity-7-bg text-identity-7-fg"
+								>
+									<div className="space-y-3">
+										<p className="inline-flex items-center gap-2 text-lg font-semibold">
+											<StatusDot status={syncTone} /> {syncStatus.label}
+										</p>
+										<OverviewMetadata
+											items={[
+												{ label: "Machine", value: agent.machine_name },
+												{ label: "Last seen", value: relativeTime(agent.last_seen_at) },
+											]}
+										/>
+									</div>
+								</AgentOverviewStatusCard>
+							</div>
 							<AgentOverviewCapabilities
 								agentId={id}
 								variant="connected"
 								routeSearch={routeSearch}
 								content={{
-									sessions: {
-										body: sessionsLoading ? (
-											<OverviewModuleSkeleton label="sessions" rows={3} />
-										) : blockingSessionsError ? (
-											<OverviewModuleError
-												label="Sessions"
-												onRetry={() => void refetchSessions()}
-											/>
-										) : (
-											<div className="space-y-3">
-												<div>
-													<p className="text-lg font-semibold tracking-tight">{sessionSummary}</p>
-													<p className="mt-1 text-xs text-muted-foreground">
-														Recent synced activity
-													</p>
-												</div>
-												<div className="border-t pt-3">
-													<SessionFeed
-														sessions={(sessionsPage?.items ?? []).slice(0, 3)}
-														isLoading={false}
-														emptyMessage="No sessions synced from this agent yet."
-														emptyVariant="inset"
-														showAgent={false}
-														sessionLink={(session) => scopedSessionLink(session.id)}
-													/>
-												</div>
-											</div>
-										),
-									},
-									"live-sync": {
-										body: (
-											<div className="space-y-3">
-												<p className="inline-flex items-center gap-2 text-lg font-semibold">
-													<StatusDot status={syncTone} /> {syncStatus.label}
-												</p>
-												<OverviewMetadata
-													items={[
-														{ label: "Machine", value: agent.machine_name },
-														{ label: "Last seen", value: relativeTime(agent.last_seen_at) },
-													]}
-												/>
-											</div>
-										),
-									},
 									projects: {
 										body: projectBindingsLoading ? (
 											<OverviewModuleSkeleton label="projects" rows={3} />
@@ -284,6 +280,18 @@ export function ConnectedAgentDetail({
 											</div>
 										),
 									},
+									memories: { body: <OverviewMemoriesBody /> },
+									vaults: {
+										body: (
+											<OverviewVaultsBody
+												projectIds={effectiveAgentProjectIds(projectBindings ?? [])}
+												isLoading={projectBindingsLoading}
+											error={blockingProjectBindingsError}
+												onRetry={() => void refetchProjectBindings()}
+											/>
+										),
+									},
+									connectors: { body: <OverviewConnectorsBody /> },
 								}}
 							/>
 						</div>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -279,7 +279,6 @@ export function ConnectedAgentDetail({
 															? "unavailable"
 															: "ready"
 												}
-												onRetry={() => void refetchProjectBindings()}
 											/>
 										),
 									},
@@ -366,13 +365,14 @@ function AgentDetailContentSkeleton() {
 			</div>
 			<div>
 				<Skeleton className="mb-3 h-4 w-20" />
-				<div className="grid gap-3 @2xl/main:grid-cols-2 @5xl/main:grid-cols-6">
+				<div className="grid gap-3 @2xl/main:grid-cols-4 @4xl/main:grid-cols-6">
 					{Array.from({ length: 5 }).map((_, index) => (
 						<Skeleton
 							key={index}
 							className={cn(
-								"min-h-48 rounded-lg @5xl/main:col-span-2",
-								index === 3 && "@5xl/main:col-start-2",
+								"h-40 rounded-lg @2xl/main:col-span-2",
+								index === 4 && "@2xl/main:col-start-2 @4xl/main:col-start-auto",
+								index === 3 && "@4xl/main:col-start-2",
 							)}
 						/>
 					))}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Laptop } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Laptop } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
@@ -34,6 +35,7 @@ import { MemoriesSurface } from "@/components/memories/memories-surface";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { OverviewSessionList, SessionFeed } from "@/components/sessions/session-feed";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusDot } from "@/components/ui/status-badge";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
@@ -41,6 +43,7 @@ import {
 	type AgentRouteSearch,
 	type AgentSectionId,
 	agentSectionLabel,
+	agentSectionLink,
 	agentSessionDetailLink,
 	CONNECTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
@@ -100,7 +103,7 @@ export function ConnectedAgentDetail({
 		error: overviewSessionsError,
 		refetch: refetchOverviewSessions,
 	} = useQuery({
-		...sessionListQueryOptions($api, { environment_id: id, page_size: 4 }),
+		...sessionListQueryOptions($api, { environment_id: id, page_size: 3 }),
 		enabled: overviewEnabled,
 	});
 
@@ -189,9 +192,21 @@ export function ConnectedAgentDetail({
 					{activeTab === "overview" ? (
 						<div className="flex flex-col gap-8">
 							<div>
-								<h2 id="connected-recent-sessions" className="mb-3 text-sm font-semibold">
-									Recent sessions
-								</h2>
+								<div className="mb-3 flex items-center justify-between">
+									<h2 id="connected-recent-sessions" className="text-sm font-semibold">
+										Recent sessions
+									</h2>
+									<Button
+										render={<Link {...agentSectionLink(id, "sessions", routeSearch)} />}
+										nativeButton={false}
+										variant="ghost"
+										size="sm"
+										className="text-muted-foreground"
+									>
+										View all
+										<ArrowRight />
+									</Button>
+								</div>
 								<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 									<section
 										aria-labelledby="connected-recent-sessions"
@@ -356,7 +371,7 @@ function AgentDetailContentSkeleton() {
 				<Skeleton className="mb-3 h-4 w-28" />
 				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 					<div className="grid min-h-52 gap-2">
-						{Array.from({ length: 4 }).map((_, index) => (
+						{Array.from({ length: 3 }).map((_, index) => (
 							<Skeleton key={index} className="h-11 rounded-lg" />
 						))}
 					</div>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -180,7 +180,7 @@ export function ConnectedAgentDetail({
 								<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 									<section
 										aria-labelledby="connected-recent-sessions"
-										className="min-h-40 lg:min-h-52"
+										className="min-h-40 min-w-0 lg:min-h-52"
 									>
 									{blockingSessionsError ? (
 											<OverviewModuleError

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -82,9 +82,10 @@ export function ConnectedAgentDetail({
 
 	const overviewProjects = useAgentOverviewProjects(id, { enabled: !!agent });
 	const projectBindings = overviewProjects.bindings.data;
-	const projectBindingsLoading = overviewProjects.isLoading;
+	const projectBindingsLoading = overviewProjects.bindings.isLoading;
 	const projectBindingsError = overviewProjects.bindings.error;
 	const refetchProjectBindings = overviewProjects.bindings.refetch;
+	const projectNames = overviewProjects.nameResolution;
 
 	const {
 		data: sessionsPage,
@@ -116,6 +117,10 @@ export function ConnectedAgentDetail({
 		? sessionsError
 		: null;
 	const sessionTotal = blockingSessionsError ? "—" : (sessionsPage?.total ?? 0);
+	const sessionSummary =
+		typeof sessionTotal === "number" && sessionTotal > 0
+			? `${sessionTotal} recent ${sessionTotal === 1 ? "session" : "sessions"}`
+			: "No recent sessions";
 	const syncStatus = daemonStatusVisual(agent);
 	const syncTone =
 		syncStatus.kind === "live"
@@ -181,9 +186,7 @@ export function ConnectedAgentDetail({
 										) : (
 											<div className="space-y-3">
 												<div>
-													<p className="text-lg font-semibold tracking-tight">
-														{sessionTotal} {sessionTotal === 1 ? "session" : "sessions"}
-													</p>
+													<p className="text-lg font-semibold tracking-tight">{sessionSummary}</p>
 													<p className="mt-1 text-xs text-muted-foreground">
 														Recent synced activity
 													</p>
@@ -227,12 +230,36 @@ export function ConnectedAgentDetail({
 										) : (
 											<div className="space-y-3">
 												<p className="text-lg font-semibold">
-													{projectBindings?.length ?? 0} bound
+													{(projectBindings?.length ?? 0) > 0
+														? `${projectBindings?.length} ${projectBindings?.length === 1 ? "project" : "projects"}`
+														: "No projects added"}
 												</p>
-												<OverviewSummaryRows
-													items={overviewProjects.names}
-													empty="No projects bound"
-												/>
+												{(projectBindings?.length ?? 0) === 0 ? null : projectNames.isLoading ? (
+													<OverviewModuleSkeleton
+														label="project names"
+														rows={3}
+														showHeading={false}
+													/>
+												) : projectNames.error ? (
+													<OverviewModuleError
+														label="Project names"
+														onRetry={() => void projectNames.refetch()}
+													/>
+												) : (
+													<>
+														<OverviewSummaryRows
+															items={projectNames.names}
+															empty="Project names can’t be shown"
+														/>
+														{projectNames.unresolvedCount > 0 ? (
+															<p className="text-xs text-muted-foreground">
+																{projectNames.unresolvedCount} project{" "}
+																{projectNames.unresolvedCount === 1 ? "name can’t" : "names can’t"}{" "}
+																be shown
+															</p>
+														) : null}
+													</>
+												)}
 											</div>
 										),
 									},
@@ -244,24 +271,21 @@ export function ConnectedAgentDetail({
 										) : (
 											<div className="space-y-3">
 												<p className="text-lg font-semibold">
-													{skillsForThisEnv?.length ?? 0} available
+													{(skillsForThisEnv?.length ?? 0) > 0
+														? `${skillsForThisEnv?.length} ${skillsForThisEnv?.length === 1 ? "skill" : "skills"}`
+														: "No skills available"}
 												</p>
-												<OverviewChips
-													items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
-													empty="No skills available"
-												/>
+												{(skillsForThisEnv?.length ?? 0) > 0 ? (
+													<OverviewChips
+														items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
+														empty="No skills available"
+													/>
+												) : null}
 											</div>
 										),
 									},
 									memories: {
-										body: (
-											<OverviewMetadata
-												items={[
-													{ label: "Scope", value: "Account-wide" },
-													{ label: "Access", value: "All agents" },
-												]}
-											/>
-										),
+										body: <p className="text-sm font-medium">Shared with all your agents</p>,
 									},
 									vaults: {
 										body: projectBindingsLoading ? (
@@ -272,28 +296,15 @@ export function ConnectedAgentDetail({
 												onRetry={() => void refetchProjectBindings()}
 											/>
 										) : (
-											<OverviewMetadata
-												items={[
-													{
-														label: "Sources",
-														value: projectBindings?.length
-															? `${projectBindings.length} bound Projects`
-															: "No bound Projects",
-													},
-													{ label: "Delivery", value: "Through Projects" },
-												]}
-											/>
+											<p className="text-sm font-medium">
+												{projectBindings?.length
+													? `Available through ${projectBindings.length} ${projectBindings.length === 1 ? "project" : "projects"}`
+													: "Add a project to use vaults"}
+											</p>
 										),
 									},
 									connectors: {
-										body: (
-											<OverviewMetadata
-												items={[
-													{ label: "Scope", value: "Account-wide" },
-													{ label: "Managed", value: "Account settings" },
-												]}
-											/>
-										),
+										body: <p className="text-sm font-medium">Shared with all your agents</p>,
 									},
 								}}
 							/>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -365,16 +365,9 @@ function AgentDetailContentSkeleton() {
 			</div>
 			<div>
 				<Skeleton className="mb-3 h-4 w-20" />
-				<div className="grid gap-3 @2xl/main:grid-cols-4 @4xl/main:grid-cols-6">
+				<div className="grid gap-3 @2xl/main:grid-cols-2 @4xl/main:grid-cols-3">
 					{Array.from({ length: 5 }).map((_, index) => (
-						<Skeleton
-							key={index}
-							className={cn(
-								"h-40 rounded-lg @2xl/main:col-span-2",
-								index === 4 && "@2xl/main:col-start-2 @4xl/main:col-start-auto",
-								index === 3 && "@4xl/main:col-start-2",
-							)}
-						/>
+						<Skeleton key={index} className="h-40 rounded-xl" />
 					))}
 				</div>
 			</div>

--- a/apps/web/src/components/sessions/session-feed.test.tsx
+++ b/apps/web/src/components/sessions/session-feed.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OverviewSessionList } from "@/components/sessions/session-feed";
+
+describe("OverviewSessionList", () => {
+	test("renders three loading rows", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewSessionList, {
+				sessions: [],
+				isLoading: true,
+				emptyMessage: "No recent sessions",
+				sessionLink: () => ({}),
+			}),
+		);
+
+		expect(markup.match(/data-testid="overview-session-skeleton-row"/g)).toHaveLength(3);
+	});
+});

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -21,6 +21,47 @@ import {
 
 type SessionLinkOptions = Pick<LinkProps, "to" | "params" | "search" | "hash">;
 
+export function OverviewSessionList({
+	sessions,
+	isLoading,
+	emptyMessage,
+	sessionLink,
+}: {
+	sessions: SessionListItem[];
+	isLoading: boolean;
+	emptyMessage: string;
+	sessionLink: (session: SessionListItem) => SessionLinkOptions;
+}) {
+	if (isLoading) {
+		return (
+			<div className="grid gap-2 sm:grid-cols-2" aria-label="Loading recent sessions" role="status">
+				{Array.from({ length: 4 }).map((_, index) => (
+					<div key={index} className={ENTITY_CARD_BASE}>
+						<Skeleton className="h-4 w-4/5" />
+						<Skeleton className="mt-3 h-3 w-1/2" />
+					</div>
+				))}
+			</div>
+		);
+	}
+	if (sessions.length === 0) {
+		return <EmptyState variant="inset" icon={MessageSquare} description={emptyMessage} />;
+	}
+	return (
+		<div className="grid gap-2 sm:grid-cols-2">
+			{sessions.slice(0, 4).map((session) => (
+				<SessionFeedCard
+					key={session.id}
+					session={session}
+					showAgent={false}
+					quietAutomated={true}
+					link={sessionLink(session)}
+				/>
+			))}
+		</div>
+	);
+}
+
 /* Human feed for sessions (journey J1): day-grouped cards with the summary
  * as the headline. The data table remains available behind the view toggle
  * for power users. */

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -34,9 +34,9 @@ export function OverviewSessionList({
 }) {
 	if (isLoading) {
 		return (
-			<div className="grid gap-2 sm:grid-cols-2" aria-label="Loading recent sessions" role="status">
+			<div className="grid gap-2" aria-label="Loading recent sessions" role="status">
 				{Array.from({ length: 4 }).map((_, index) => (
-					<div key={index} className={ENTITY_CARD_BASE}>
+					<div key={index} className={cn(ENTITY_CARD_BASE, "h-full min-h-28")}>
 						<Skeleton className="h-4 w-4/5" />
 						<Skeleton className="mt-3 h-3 w-1/2" />
 					</div>
@@ -48,7 +48,7 @@ export function OverviewSessionList({
 		return <EmptyState variant="inset" icon={MessageSquare} description={emptyMessage} />;
 	}
 	return (
-		<div className="grid gap-2 sm:grid-cols-2">
+		<div data-testid="overview-session-grid" className="grid gap-2">
 			{sessions.slice(0, 4).map((session) => (
 				<SessionFeedCard
 					key={session.id}
@@ -184,20 +184,24 @@ function SessionFeedCard({
 				className={cn(
 					ENTITY_CARD_BASE,
 					"transition-colors group-hover:bg-muted/50",
+					compact && "min-h-28",
 					isAutomated && "bg-muted/30",
 				)}
 			>
 				{compact ? (
-					<div className="flex min-w-0 gap-3">
+					<div className="flex min-w-0 items-start gap-3">
 						<AgentIcon agent={session.agent_type} size="lg" />
-						<div className="min-w-0 flex-1">
-							<p className="truncate text-sm font-semibold">{title}</p>
-							<div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+						<div className="grid min-w-0 flex-1 grid-rows-[2.5rem_auto]">
+							<p className="line-clamp-2 text-sm leading-5 font-semibold">{title}</p>
+							<div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground sm:grid-cols-[auto_auto_1fr]">
 								<span>
 									{session.message_count} {session.message_count === 1 ? "message" : "messages"}
 								</span>
 								<span>{formatNumber(totalTokens)} tokens</span>
-								<span title={formatAbsoluteTooltip(session.last_activity_at)}>
+								<span
+									className="col-span-2 sm:col-span-1 sm:text-right"
+									title={formatAbsoluteTooltip(session.last_activity_at)}
+								>
 									{relativeTime(session.last_activity_at)}
 								</span>
 							</div>

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -56,6 +56,7 @@ export function OverviewSessionList({
 					showAgent={false}
 					quietAutomated={true}
 					link={sessionLink(session)}
+					compact
 				/>
 			))}
 		</div>
@@ -162,11 +163,13 @@ function SessionFeedCard({
 	showAgent = true,
 	quietAutomated = true,
 	link,
+	compact = false,
 }: {
 	session: SessionListItem;
 	showAgent?: boolean;
 	quietAutomated?: boolean;
 	link: SessionLinkOptions;
+	compact?: boolean;
 }) {
 	const title = formatSessionSummary(session.summary) || session.local_session_id.slice(0, 8);
 	const projectFolder = session.project_path?.split("/").pop();
@@ -184,24 +187,42 @@ function SessionFeedCard({
 					isAutomated && "bg-muted/30",
 				)}
 			>
-				<EntityHeader
-					align="start"
-					icon={<AgentIcon agent={session.agent_type} size="lg" />}
-					title={title}
-					meta={[
-						showAgent ? agent : null,
-						projectFolder ? (
-							<span key="folder" className="font-mono" title={session.project_path ?? undefined}>
-								{projectFolder}
-							</span>
-						) : null,
-						`${session.message_count} ${session.message_count === 1 ? "message" : "messages"}`,
-						`${formatNumber(totalTokens)} tokens`,
-						<span key="time" title={formatAbsoluteTooltip(session.last_activity_at)}>
-							{relativeTime(session.last_activity_at)}
-						</span>,
-					]}
-				/>
+				{compact ? (
+					<div className="flex min-w-0 gap-3">
+						<AgentIcon agent={session.agent_type} size="lg" />
+						<div className="min-w-0 flex-1">
+							<p className="truncate text-sm font-semibold">{title}</p>
+							<div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+								<span>
+									{session.message_count} {session.message_count === 1 ? "message" : "messages"}
+								</span>
+								<span>{formatNumber(totalTokens)} tokens</span>
+								<span title={formatAbsoluteTooltip(session.last_activity_at)}>
+									{relativeTime(session.last_activity_at)}
+								</span>
+							</div>
+						</div>
+					</div>
+				) : (
+					<EntityHeader
+						align="start"
+						icon={<AgentIcon agent={session.agent_type} size="lg" />}
+						title={title}
+						meta={[
+							showAgent ? agent : null,
+							projectFolder ? (
+								<span key="folder" className="font-mono" title={session.project_path ?? undefined}>
+									{projectFolder}
+								</span>
+							) : null,
+							`${session.message_count} ${session.message_count === 1 ? "message" : "messages"}`,
+							`${formatNumber(totalTokens)} tokens`,
+							<span key="time" title={formatAbsoluteTooltip(session.last_activity_at)}>
+								{relativeTime(session.last_activity_at)}
+							</span>,
+						]}
+					/>
+				)}
 			</div>
 			<Link
 				{...link}

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -35,8 +35,12 @@ export function OverviewSessionList({
 	if (isLoading) {
 		return (
 			<div className="grid gap-2" aria-label="Loading recent sessions" role="status">
-				{Array.from({ length: 4 }).map((_, index) => (
-					<div key={index} className={cn(ENTITY_CARD_BASE, "px-4 py-3")}>
+				{Array.from({ length: 3 }).map((_, index) => (
+					<div
+						key={index}
+						data-testid="overview-session-skeleton-row"
+						className={cn(ENTITY_CARD_BASE, "px-4 py-3")}
+					>
 						<Skeleton className="h-4 w-4/5" />
 						<Skeleton className="mt-1.5 h-3 w-1/2" />
 					</div>
@@ -49,7 +53,7 @@ export function OverviewSessionList({
 	}
 	return (
 		<div data-testid="overview-session-grid" className="grid gap-2">
-			{sessions.slice(0, 4).map((session) => (
+			{sessions.slice(0, 3).map((session) => (
 				<SessionFeedCard
 					key={session.id}
 					session={session}

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -36,9 +36,9 @@ export function OverviewSessionList({
 		return (
 			<div className="grid gap-2" aria-label="Loading recent sessions" role="status">
 				{Array.from({ length: 4 }).map((_, index) => (
-					<div key={index} className={cn(ENTITY_CARD_BASE, "h-full min-h-28")}>
+					<div key={index} className={cn(ENTITY_CARD_BASE, "px-4 py-3")}>
 						<Skeleton className="h-4 w-4/5" />
-						<Skeleton className="mt-3 h-3 w-1/2" />
+						<Skeleton className="mt-1.5 h-3 w-1/2" />
 					</div>
 				))}
 			</div>
@@ -184,24 +184,28 @@ function SessionFeedCard({
 				className={cn(
 					ENTITY_CARD_BASE,
 					"transition-colors group-hover:bg-muted/50",
-					compact && "min-h-28",
+					compact && "px-4 py-3",
 					isAutomated && "bg-muted/30",
 				)}
 			>
 				{compact ? (
 					<div className="flex min-w-0 items-start gap-3">
 						<AgentIcon agent={session.agent_type} size="lg" />
-						<div className="grid min-w-0 flex-1 grid-rows-[2.5rem_auto]">
-							<p className="line-clamp-2 text-sm leading-5 font-semibold">{title}</p>
-							<div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground sm:grid-cols-[auto_auto_1fr]">
+						<div className="w-0 min-w-0 flex-1 overflow-hidden">
+							<p data-testid="overview-session-title" className="truncate text-sm font-semibold">
+								{title}
+							</p>
+							<div
+								data-testid="overview-session-meta"
+								className="mt-1 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground"
+							>
 								<span>
 									{session.message_count} {session.message_count === 1 ? "message" : "messages"}
 								</span>
+								<span aria-hidden="true">·</span>
 								<span>{formatNumber(totalTokens)} tokens</span>
-								<span
-									className="col-span-2 sm:col-span-1 sm:text-right"
-									title={formatAbsoluteTooltip(session.last_activity_at)}
-								>
+								<span aria-hidden="true">·</span>
+								<span title={formatAbsoluteTooltip(session.last_activity_at)}>
 									{relativeTime(session.last_activity_at)}
 								</span>
 							</div>

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { AppBreadcrumb } from "@/components/app-breadcrumb";
 import { NotificationCenter } from "@/components/notification-center";
 import { Separator } from "@/components/ui/separator";
@@ -10,7 +11,7 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
  * Keeps shadcn dashboard-01's trigger/separator/content/action shape,
  * with Clawdi-specific breadcrumbs and notifications.
  */
-export function SiteHeader() {
+export function SiteHeader({ actions }: { actions?: ReactNode }) {
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
 			<div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -22,6 +23,7 @@ export function SiteHeader() {
 				<div className="min-w-0 flex-1">
 					<AppBreadcrumb />
 				</div>
+				{actions}
 				<NotificationCenter />
 			</div>
 		</header>

--- a/apps/web/src/components/vault/agent-vaults-query.ts
+++ b/apps/web/src/components/vault/agent-vaults-query.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
+import { unwrap, useApi } from "@/lib/api";
+
+export function useAgentProjectVaults(
+	projectIds: readonly string[],
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	const api = useApi();
+	return useQuery({
+		queryKey: ["vaults", "agent-projects", ...projectIds],
+		queryFn: async () =>
+			fetchAgentProjectVaults(projectIds, async (projectId, page, pageSize) =>
+				unwrap(
+					await api.GET("/v1/vault", {
+						params: { query: { project_id: projectId, page, page_size: pageSize } },
+					}),
+				),
+			),
+		enabled: enabled && projectIds.length > 0,
+	});
+}

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -30,8 +30,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
+import { useAgentProjectVaults } from "@/components/vault/agent-vaults-query";
 import { vaultDetailSearch } from "@/components/vault/vault-detail-identity";
-import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
@@ -54,7 +54,6 @@ export function VaultsSurface({
 	embedded?: boolean;
 	agentProjectIds?: readonly string[];
 }) {
-	const api = useApi();
 	const $api = useOpenApi();
 	const [search, setSearch] = useState("");
 	const [projectFilter, setProjectFilter] = useState<string>("all");
@@ -70,17 +69,8 @@ export function VaultsSurface({
 			enabled: agentProjectIds === undefined,
 		},
 	);
-	const agentVaults = useQuery({
-		queryKey: ["vaults", "agent-projects", ...(agentProjectIds ?? [])],
-		queryFn: async () =>
-			fetchAgentProjectVaults(agentProjectIds ?? [], async (projectId, page, pageSize) =>
-				unwrap(
-					await api.GET("/v1/vault", {
-						params: { query: { project_id: projectId, page, page_size: pageSize } },
-					}),
-				),
-			),
-		enabled: agentProjectIds !== undefined && agentProjectIds.length > 0,
+	const agentVaults = useAgentProjectVaults(agentProjectIds ?? [], {
+		enabled: agentProjectIds !== undefined,
 	});
 	const vaultsQuery = agentProjectIds === undefined ? accountVaults : agentVaults;
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,8 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import type {
 	DeploymentOperation,
 	HostedDeployment,
@@ -21,9 +19,6 @@ type InvalidateDeploymentSnapshots =
 	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
 type ProjectAcceptedDeploymentTransition =
 	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
-type OverviewReadinessPanel =
-	typeof import("@/hosted/agents/hosted-agent-detail").OverviewReadinessPanel;
-type OverviewFailedPanel = typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailedPanel;
 type ShouldShowHostedProjectionNotice =
 	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowHostedProjectionNotice;
 type RunManualDeploymentRefetch =
@@ -31,8 +26,6 @@ type RunManualDeploymentRefetch =
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
-let overviewReadinessPanel: OverviewReadinessPanel | null = null;
-let overviewFailedPanel: OverviewFailedPanel | null = null;
 let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 
@@ -55,89 +48,7 @@ beforeAll(async () => {
 	const agentHomeModule = await import("@/hosted/agents/agent-home");
 	runManualDeploymentRefetch = agentHomeModule.runManualDeploymentRefetch;
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
-	overviewReadinessPanel = detailModule.OverviewReadinessPanel;
-	overviewFailedPanel = detailModule.OverviewFailedPanel;
 	shouldShowProjectionNotice = detailModule.shouldShowHostedProjectionNotice;
-});
-
-describe("deployment failure remediation rendering", () => {
-	test("routes a failed plan change through review without startup or bare restart copy", () => {
-		if (!overviewFailedPanel) throw new Error("agent detail was not loaded");
-		const operation: DeploymentOperation = {
-			name: "operations/plan-change-failed",
-			metadata: {
-				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-				deploymentId: "hdep_failed",
-				verb: "plan_change" as DeploymentOperation["metadata"]["verb"],
-				targetGeneration: 2,
-				manifestETag: "manifest-failed",
-				createTime: "2026-07-25T00:00:00Z",
-				updateTime: "2026-07-25T00:01:00Z",
-			},
-			done: false,
-			response: null,
-		};
-		const deployment = hostedDeploymentFixture({
-			id: "hdep_failed",
-			status: "failed",
-			acceptedOperation: operation,
-			failure: {
-				type: "https://api.clawdi.ai/problems/operation_aborted",
-				title: "Deployment operation was aborted",
-				status: 409,
-				detail:
-					"MissingGreenlet prevented synchronous plan confirmation for operations/plan-change-failed.",
-				instance: "hdep_failed",
-				code: "operation_aborted",
-				phase: "plan_change",
-				retryable: false,
-				conditionReason: "OperationAborted",
-				conditionMessage: "Deployment operation was aborted",
-				observedGeneration: 2,
-			},
-		});
-
-		const markup = renderToStaticMarkup(
-			createElement(overviewFailedPanel, {
-				deployment,
-				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
-				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
-				onDeleteAccepted: () => undefined,
-			}),
-		);
-
-		expect(markup).toContain("Plan change failed");
-		expect(markup).toContain("The Clawdi service could not confirm the plan change.");
-		expect(markup).toContain("Your plan was not changed and you were not charged.");
-		expect(markup).toContain("Get a fresh quote and confirm the price before trying again.");
-		expect(markup).toContain("Get fresh quote");
-		expect(markup).not.toContain("MissingGreenlet");
-		expect(markup).not.toContain("operations/plan-change-failed");
-		expect(markup).not.toContain("provisioning");
-		expect(markup).not.toContain("synchronous plan confirmation");
-		expect(markup).not.toContain("Agent setup failed");
-		expect(markup).not.toContain("retry startup");
-		expect(markup).not.toContain("Restart compute");
-	});
-
-	test("gives an unexplained failure customer language and a working next step", () => {
-		if (!overviewFailedPanel) throw new Error("agent detail was not loaded");
-		const markup = renderToStaticMarkup(
-			createElement(overviewFailedPanel, {
-				deployment: hostedDeploymentFixture({ status: "failed" }),
-				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
-				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
-				onDeleteAccepted: () => undefined,
-			}),
-		);
-
-		expect(markup).toContain("Agent change failed");
-		expect(markup).toContain("Clawdi couldn’t complete the last change to this agent");
-		expect(markup).toContain("It isn’t safe to try again automatically");
-		expect(markup).toContain('href="mailto:support@clawdi.ai"');
-		expect(markup).not.toContain("Deployment operation");
-		expect(markup).not.toContain("failure reason and operation");
-	});
 });
 
 describe("deployment transition timeout rendering", () => {
@@ -163,62 +74,6 @@ describe("deployment transition timeout rendering", () => {
 		);
 		expect(detailSource).toContain("!isStartingStatus(deploymentStatus)");
 		expect(detailSource).not.toContain('projection.status === "resolved" &&');
-	});
-
-	test("keeps delayed startup copy truthful with automatic and manual checks", () => {
-		if (!overviewReadinessPanel) throw new Error("agent detail was not loaded");
-		const deployment = hostedDeploymentFixture({ status: "creating" });
-		const commonProps = {
-			deployment,
-			isCheckingDeployment: false,
-			onCheckDeploymentAgain: () => undefined,
-		};
-
-		const converging = renderToStaticMarkup(
-			createElement(overviewReadinessPanel, {
-				...commonProps,
-				deploymentTransitionTimedOut: false,
-			}),
-		);
-		const timedOut = renderToStaticMarkup(
-			createElement(overviewReadinessPanel, {
-				...commonProps,
-				deploymentTransitionTimedOut: true,
-			}),
-		);
-
-		expect(converging).toContain("Starting your agent…");
-		expect(converging).toContain("This step should finish within five minutes.");
-		expect(converging).toContain("Startup continues if you leave this page");
-		expect(converging).not.toContain("Provisioning");
-		expect(converging).not.toContain("Booting");
-		expect(converging).not.toContain("Current status");
-		expect(converging).not.toContain("Deployment progress");
-		expect(timedOut).toContain("Your agent is taking longer than expected");
-		expect(timedOut).toContain("latest status still shows your agent starting");
-		expect(timedOut).toContain("Startup may still be continuing");
-		expect(timedOut).toContain("keep checking automatically once a minute");
-		expect(timedOut).toContain("Check again");
-		expect(timedOut).not.toContain("Automatic checks have stopped");
-		expect(timedOut).not.toContain("Startup continues if you leave this page");
-	});
-
-	test("makes the authoritative running state unambiguously Running", () => {
-		if (!overviewReadinessPanel) throw new Error("agent detail was not loaded");
-		const ready = renderToStaticMarkup(
-			createElement(overviewReadinessPanel, {
-				deployment: hostedDeploymentFixture({ status: "running" }),
-				deploymentTransitionTimedOut: false,
-				isCheckingDeployment: false,
-				onCheckDeploymentAgain: () => undefined,
-			}),
-		);
-
-		expect(ready).toContain("Your agent is running");
-		expect(ready).toContain("It is ready to use");
-		expect(ready).not.toContain("automatically");
-		expect(ready).not.toContain("Provisioning");
-		expect(ready).not.toContain("Booting");
 	});
 
 	test("wires the timed-out inventory state and real refetch action into the detail", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -32,6 +32,8 @@ type OverviewFailureAction =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailureAction;
 type OverviewComputeStatus =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewComputeStatus;
+type InitialDeploymentPage =
+	typeof import("@/hosted/agents/hosted-agent-detail").InitialDeploymentPage;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
@@ -39,6 +41,7 @@ let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 let overviewFailureAction: OverviewFailureAction | null = null;
 let overviewComputeStatus: OverviewComputeStatus | null = null;
+let initialDeploymentPage: InitialDeploymentPage | null = null;
 
 function requiredDeploymentStatus(
 	deployment: HostedDeployment | undefined,
@@ -62,6 +65,7 @@ beforeAll(async () => {
 	shouldShowProjectionNotice = detailModule.shouldShowHostedProjectionNotice;
 	overviewFailureAction = detailModule.OverviewFailureAction;
 	overviewComputeStatus = detailModule.OverviewComputeStatus;
+	initialDeploymentPage = detailModule.InitialDeploymentPage;
 });
 
 describe("deployment failure remediation rendering", () => {
@@ -128,6 +132,44 @@ describe("deployment failure remediation rendering", () => {
 });
 
 describe("deployment transition timeout rendering", () => {
+	test("shows only real lifecycle progress during initial startup", () => {
+		if (!initialDeploymentPage) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(initialDeploymentPage, {
+				deployment: hostedDeploymentFixture({ status: "starting" }),
+				deploymentTransitionTimedOut: false,
+				isCheckingDeployment: false,
+				onCheckDeploymentAgain: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("Starting your agent…");
+		expect(markup).toContain("Current status");
+		expect(markup).toContain("Starting");
+		expect(markup).toContain("updates automatically");
+		expect(markup).toContain('data-slot="spinner"');
+		for (const configurationLabel of ["Plan", "CPU", "Memory", "Storage"])
+			expect(markup).not.toContain(`>${configurationLabel}<`);
+	});
+
+	test("keeps the delayed-start retry accessible", () => {
+		if (!initialDeploymentPage) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(initialDeploymentPage, {
+				deployment: hostedDeploymentFixture({ status: "starting" }),
+				deploymentTransitionTimedOut: true,
+				isCheckingDeployment: false,
+				onCheckDeploymentAgain: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain('role="alert"');
+		expect(markup).toContain("Setup is taking longer than expected");
+		expect(markup).toContain("Check again");
+		expect(markup).toContain("Current status");
+		expect(markup).toContain("Starting");
+	});
+
 	test("keeps projection availability notices off the deployment-backed overview", () => {
 		if (!shouldShowProjectionNotice) throw new Error("agent detail was not loaded");
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -152,7 +152,11 @@ describe("overview Compute hierarchy", () => {
 		expect(markup).toContain("4 GiB memory");
 		expect(markup).toContain("20 GiB storage");
 		expect(markup).toContain('aria-label="Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage"');
+		expect(markup).toContain('data-testid="overview-compute-summary"');
 		expect(markup).not.toContain("grid-cols-2");
+		expect(markup).not.toContain("rounded");
+		expect(markup).not.toContain("border");
+		expect(markup).not.toContain("bg-");
 	});
 });
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -32,6 +32,8 @@ type OverviewFailureAction =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailureAction;
 type OverviewComputeStatus =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewComputeStatus;
+type OverviewComputeSummary =
+	typeof import("@/hosted/agents/hosted-agent-detail").OverviewComputeSummary;
 type InitialDeploymentPage =
 	typeof import("@/hosted/agents/hosted-agent-detail").InitialDeploymentPage;
 
@@ -41,6 +43,7 @@ let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 let overviewFailureAction: OverviewFailureAction | null = null;
 let overviewComputeStatus: OverviewComputeStatus | null = null;
+let overviewComputeSummary: OverviewComputeSummary | null = null;
 let initialDeploymentPage: InitialDeploymentPage | null = null;
 
 function requiredDeploymentStatus(
@@ -65,6 +68,7 @@ beforeAll(async () => {
 	shouldShowProjectionNotice = detailModule.shouldShowHostedProjectionNotice;
 	overviewFailureAction = detailModule.OverviewFailureAction;
 	overviewComputeStatus = detailModule.OverviewComputeStatus;
+	overviewComputeSummary = detailModule.OverviewComputeSummary;
 	initialDeploymentPage = detailModule.InitialDeploymentPage;
 });
 
@@ -128,6 +132,27 @@ describe("deployment failure remediation rendering", () => {
 		expect(markup).toContain('href="mailto:support@clawdi.ai"');
 		expect(markup).not.toContain("Deployment operation");
 		expect(markup).not.toContain("failure reason and operation");
+	});
+});
+
+describe("overview Compute hierarchy", () => {
+	test("keeps plan and configuration in one compact summary instead of metric tiles", () => {
+		if (!overviewComputeSummary) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(overviewComputeSummary, {
+				plan: "Basic",
+				vcpu: 2,
+				memoryMib: 4096,
+				storageGib: 20,
+			}),
+		);
+
+		expect(markup).toContain("Basic plan");
+		expect(markup).toContain("2 vCPU");
+		expect(markup).toContain("4 GiB memory");
+		expect(markup).toContain("20 GiB storage");
+		expect(markup).toContain('aria-label="Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage"');
+		expect(markup).not.toContain("grid-cols-2");
 	});
 });
 
@@ -244,9 +269,10 @@ describe("deployment transition timeout rendering", () => {
 			"utf8",
 		);
 		expect(detailSource).toContain(
-			"showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}",
+			"(!isStartingStatus(deploymentStatus) || hasTerminalDeploymentFailure)",
 		);
 		expect(detailSource).toContain("!isStartingStatus(deploymentStatus)");
+		expect(detailSource).toContain("!hasTerminalDeploymentFailure &&");
 		expect(detailSource).not.toContain('projection.status === "resolved" &&');
 	});
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,13 +1,18 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import type {
 	DeploymentOperation,
 	HostedDeployment,
 	HostedDeploymentStatus,
 } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
-import { deploymentFailureReason } from "@/hosted/deployment-failure";
+import {
+	deploymentFailurePresentation,
+	deploymentFailureReason,
+} from "@/hosted/deployment-failure";
 import {
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 	type DeploymentOperationVerb,
@@ -23,11 +28,17 @@ type ShouldShowHostedProjectionNotice =
 	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowHostedProjectionNotice;
 type RunManualDeploymentRefetch =
 	typeof import("@/hosted/agents/agent-home").runManualDeploymentRefetch;
+type OverviewFailureAction =
+	typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailureAction;
+type OverviewComputeStatus =
+	typeof import("@/hosted/agents/hosted-agent-detail").OverviewComputeStatus;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
 let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
+let overviewFailureAction: OverviewFailureAction | null = null;
+let overviewComputeStatus: OverviewComputeStatus | null = null;
 
 function requiredDeploymentStatus(
 	deployment: HostedDeployment | undefined,
@@ -49,6 +60,71 @@ beforeAll(async () => {
 	runManualDeploymentRefetch = agentHomeModule.runManualDeploymentRefetch;
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
 	shouldShowProjectionNotice = detailModule.shouldShowHostedProjectionNotice;
+	overviewFailureAction = detailModule.OverviewFailureAction;
+	overviewComputeStatus = detailModule.OverviewComputeStatus;
+});
+
+describe("deployment failure remediation rendering", () => {
+	test("renders a safe plan-change review link without internal failure details", () => {
+		if (!overviewFailureAction) throw new Error("agent detail was not loaded");
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_failed",
+			status: "failed",
+			acceptedOperation: acceptedOperation("plan_change"),
+			failure: {
+				type: "https://api.clawdi.ai/problems/operation_aborted",
+				title: "MissingGreenlet during provisioning",
+				status: 409,
+				detail: "MissingGreenlet failed operations/plan-change-failed.",
+				instance: "hdep_failed",
+				code: "operation_aborted",
+				phase: "plan_change",
+				retryable: false,
+				conditionReason: "OperationAborted",
+				conditionMessage: "operations/plan-change-failed",
+				observedGeneration: 2,
+			},
+		});
+		const failure = deploymentFailurePresentation(deployment);
+		if (!failure) throw new Error("Expected failure presentation");
+
+		const markup = renderToStaticMarkup(
+			createElement(overviewFailureAction, {
+				deployment,
+				failure,
+				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
+				onDeleteAccepted: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("Get fresh quote");
+		expect(markup).toContain('href="/agents/env_test/settings?source=on-clawdi"');
+		expect(markup).not.toContain("MissingGreenlet");
+		expect(markup).not.toContain("operations/plan-change-failed");
+	});
+
+	test("renders a support next step when no failure reason is available", () => {
+		if (!overviewComputeStatus) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(overviewComputeStatus, {
+				deployment: hostedDeploymentFixture({ status: "failed" }),
+				failure: null,
+				showActions: false,
+				planChangeHref: "/agents/env_test/settings?source=on-clawdi",
+				providerSettingsHref: "/agents/env_test/model-provider?source=on-clawdi",
+				onDeleteAccepted: () => undefined,
+				deploymentTransitionTimedOut: false,
+				isCheckingDeployment: false,
+				onCheckDeploymentAgain: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("The last compute change failed");
+		expect(markup).toContain('href="mailto:support@clawdi.ai"');
+		expect(markup).not.toContain("Deployment operation");
+		expect(markup).not.toContain("failure reason and operation");
+	});
 });
 
 describe("deployment transition timeout rendering", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -178,7 +178,7 @@ describe("deployment transition timeout rendering", () => {
 			expect(markup).toContain(fixture.title);
 			expect(markup).not.toContain("Deploying your agent");
 			expect(markup).not.toContain("Current status");
-			expect(markup).toContain(`>${fixture.activeLabel}</p>`);
+			expect(markup).toContain(fixture.activeLabel);
 			expect(markup).toContain(fixture.step);
 			expect(markup).toContain('aria-label="Deployment progress"');
 			for (const [stage, state] of Object.entries(fixture.states)) {
@@ -191,7 +191,12 @@ describe("deployment transition timeout rendering", () => {
 			for (const shortLabel of ["Environment", "Install", "Ready"])
 				expect(markup).toContain(`>${shortLabel}</p>`);
 			expect(markup).toContain("updates automatically");
-			expect(markup).not.toContain('data-slot="spinner"');
+			if (fixture.status === "running") {
+				expect(markup).not.toContain('data-slot="spinner"');
+			} else {
+				expect(markup).toContain('data-slot="spinner"');
+				expect(markup).toContain('aria-hidden="true"');
+			}
 			expect(markup).not.toContain("aria-valuenow");
 			expect(markup).not.toContain("RuntimeNotReady");
 			expect(markup).not.toContain("DriverApplying");
@@ -218,6 +223,7 @@ describe("deployment transition timeout rendering", () => {
 		expect(markup).toContain(">Installing OpenClaw</p>");
 		expect(markup).toContain("Step 2 of 3");
 		expect(markup).toContain('data-deployment-stage="starting" data-stage-state="active"');
+		expect(markup).not.toContain('data-slot="spinner"');
 	});
 
 	test("keeps projection availability notices off the deployment-backed overview", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -132,24 +132,72 @@ describe("deployment failure remediation rendering", () => {
 });
 
 describe("deployment transition timeout rendering", () => {
-	test("shows only real lifecycle progress during initial startup", () => {
+	test("maps creating, starting, and running onto three concise semantic stages", () => {
 		if (!initialDeploymentPage) throw new Error("agent detail was not loaded");
-		const markup = renderToStaticMarkup(
-			createElement(initialDeploymentPage, {
-				deployment: hostedDeploymentFixture({ status: "starting" }),
-				deploymentTransitionTimedOut: false,
-				isCheckingDeployment: false,
-				onCheckDeploymentAgain: () => undefined,
-			}),
-		);
+		for (const fixture of [
+			{
+				status: "creating",
+				runtime: "hermes",
+				title: "Setting up Hermes",
+				activeLabel: "Preparing your environment",
+				step: "Step 1 of 3",
+				currentStage: "creating",
+				states: { creating: "active", starting: "pending", running: "pending" },
+			},
+			{
+				status: "starting",
+				runtime: "openclaw",
+				title: "Setting up OpenClaw",
+				activeLabel: "Installing OpenClaw",
+				step: "Step 2 of 3",
+				currentStage: "starting",
+				states: { creating: "completed", starting: "active", running: "pending" },
+			},
+			{
+				status: "running",
+				runtime: "hermes",
+				title: "Setting up Hermes",
+				activeLabel: "Ready",
+				step: "Step 3 of 3",
+				currentStage: "running",
+				states: { creating: "completed", starting: "completed", running: "completed" },
+			},
+		] as const) {
+			const markup = renderToStaticMarkup(
+				createElement(initialDeploymentPage, {
+					deployment: hostedDeploymentFixture({
+						status: fixture.status,
+						runtime: fixture.runtime,
+					}),
+					deploymentTransitionTimedOut: false,
+					isCheckingDeployment: false,
+					onCheckDeploymentAgain: () => undefined,
+				}),
+			);
 
-		expect(markup).toContain("Starting your agent…");
-		expect(markup).toContain("Current status");
-		expect(markup).toContain("Starting");
-		expect(markup).toContain("updates automatically");
-		expect(markup).toContain('data-slot="spinner"');
-		for (const configurationLabel of ["Plan", "CPU", "Memory", "Storage"])
-			expect(markup).not.toContain(`>${configurationLabel}<`);
+			expect(markup).toContain(fixture.title);
+			expect(markup).not.toContain("Deploying your agent");
+			expect(markup).not.toContain("Current status");
+			expect(markup).toContain(`>${fixture.activeLabel}</p>`);
+			expect(markup).toContain(fixture.step);
+			expect(markup).toContain('aria-label="Deployment progress"');
+			for (const [stage, state] of Object.entries(fixture.states)) {
+				expect(markup).toMatch(
+					new RegExp(
+						`data-deployment-stage="${stage}" data-stage-state="${state}"${stage === fixture.currentStage ? ' aria-current="step"' : ""}`,
+					),
+				);
+			}
+			for (const shortLabel of ["Environment", "Install", "Ready"])
+				expect(markup).toContain(`>${shortLabel}</p>`);
+			expect(markup).toContain("updates automatically");
+			expect(markup).not.toContain('data-slot="spinner"');
+			expect(markup).not.toContain("aria-valuenow");
+			expect(markup).not.toContain("RuntimeNotReady");
+			expect(markup).not.toContain("DriverApplying");
+			for (const configurationLabel of ["Plan", "CPU", "Memory", "Storage"])
+				expect(markup).not.toContain(`>${configurationLabel}<`);
+		}
 	});
 
 	test("keeps the delayed-start retry accessible", () => {
@@ -166,8 +214,10 @@ describe("deployment transition timeout rendering", () => {
 		expect(markup).toContain('role="alert"');
 		expect(markup).toContain("Setup is taking longer than expected");
 		expect(markup).toContain("Check again");
-		expect(markup).toContain("Current status");
-		expect(markup).toContain("Starting");
+		expect(markup).not.toContain("Current status");
+		expect(markup).toContain(">Installing OpenClaw</p>");
+		expect(markup).toContain("Step 2 of 3");
+		expect(markup).toContain('data-deployment-stage="starting" data-stage-state="active"');
 	});
 
 	test("keeps projection availability notices off the deployment-backed overview", () => {
@@ -272,7 +322,7 @@ describe("deployment transition timeout rendering", () => {
 });
 
 describe("hosted agent customer language", () => {
-	test("uses Starting and Running as lifecycle state vocabulary across surfaces", () => {
+	test("uses grounded deployment language across hosted surfaces", () => {
 		const detailSource = readFileSync(
 			new URL("./hosted-agent-detail.tsx", import.meta.url),
 			"utf8",
@@ -298,7 +348,7 @@ describe("hosted agent customer language", () => {
 		]) {
 			expect(customerCopy).not.toContain(staleLifecycleCopy);
 		}
-		expect(detailSource).toContain("Starting your agent…");
+		expect(detailSource).toMatch(/Setting up \$\{runtimeLabel\}/);
 		expect(detailSource).toContain("Your agent is running");
 		expect(wizardSource).not.toContain("After your agent is running");
 	});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1254,6 +1254,9 @@ function OverviewTab({
 				variant="hosted"
 				routeSearch={routeSearch}
 				visibleModuleIds={provisioning ? ["agent-interface", "compute"] : undefined}
+				moduleSizeOverrides={
+					provisioning ? { "agent-interface": "wide", compute: "wide" } : undefined
+				}
 				content={{
 					sessions: {
 						body: !projectionAvailable ? (
@@ -1444,10 +1447,9 @@ function OverviewTab({
 					data-testid="hosted-overview-provisioning-placeholder"
 					className="rounded-lg border border-dashed bg-muted/20 px-6 py-10 text-center"
 				>
-					<p className="text-sm font-medium">Your agent’s workspace is getting ready</p>
+					<p className="text-sm font-medium">More details will appear here</p>
 					<p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
-						Recent activity, projects, skills, memories, vaults, connectors, models, and channels
-						will appear here automatically when your agent is ready.
+						This page will fill in automatically when your agent is ready.
 					</p>
 				</div>
 			) : null}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1061,7 +1061,7 @@ export function OverviewComputeSummary({
 		`${storageGib} GiB storage`,
 	];
 	return (
-		<div className="space-y-1.5 rounded-md border bg-background/60 px-3 py-2.5">
+		<div className="space-y-1.5" data-testid="overview-compute-summary">
 			<p className="text-sm font-semibold">{plan} plan</p>
 			<ul
 				aria-label={`Configuration: ${configuration.join(", ")}`}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -35,9 +35,10 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
+import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
-import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
+import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { AgentVaultsTab } from "@/components/dashboard/agent-vaults-tab";
 import { EmptyState } from "@/components/empty-state";
 import {
@@ -200,7 +201,6 @@ import {
 	runtimeConsoleUrl,
 	runtimeDisplayName,
 } from "@/hosted/runtimes";
-import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
 import {
 	aiBindingBuildErrorCopy,
 	buildAiBindingFields,
@@ -839,49 +839,6 @@ function HostedAgentSessionsTab({
 
 // ── Overview ─────────────────────────────────────────────────────────────────
 
-function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
-	return (
-		<div className="rounded-lg border p-3">
-			<div className="text-sm font-medium">{value}</div>
-			<div className="text-xs text-muted-foreground">{label}</div>
-		</div>
-	);
-}
-
-function RuntimeStatusValue({
-	deployment,
-	agent,
-}: {
-	deployment: HostedDeployment;
-	agent: components["schemas"]["AgentResponse"] | null | undefined;
-}) {
-	const failure = deploymentFailurePresentation(deployment);
-	const status = hostedRuntimeStatusView(
-		deployment.resource.status,
-		agent,
-		failure?.failedVerb ? failure : null,
-	);
-	return (
-		<div className="flex min-w-0 flex-col gap-1">
-			<span
-				className={cn("inline-flex min-w-0 items-center gap-1.5", status.primary.textClass)}
-				title={`Agent status: ${status.primary.label}`}
-			>
-				<StatusDot status={status.primary.tone} />
-				<span className="truncate">{status.primary.label}</span>
-			</span>
-			{status.secondary ? (
-				<span
-					className={cn("truncate text-xs", status.secondary.textClass)}
-					title={status.secondary.tooltip}
-				>
-					{status.secondary.label}
-				</span>
-			) : null}
-		</div>
-	);
-}
-
 export function OverviewReadinessPanel({
 	deployment,
 	deploymentTransitionTimedOut,
@@ -1160,6 +1117,15 @@ function OverviewTab({
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
+	const overviewProjects = useAgentOverviewProjects(agentId, { enabled: Boolean(agent) });
+	const projectBindings = overviewProjects.bindings;
+	const skills = useAgentProjectSkills(
+		agentId,
+		agent?.default_project_id,
+		agentId,
+		false,
+		Boolean(agent),
+	);
 	return (
 		<div className="flex flex-col gap-5">
 			{showReadinessPanel ? (
@@ -1181,45 +1147,86 @@ function OverviewTab({
 			{deploymentStatus.kind === "stopped" ? (
 				<StoppedAgentState deployment={deployment} variant="inset" />
 			) : null}
-			<div
-				className={cn(
-					"grid gap-2 sm:grid-cols-2",
-					showReadinessPanel ? "lg:grid-cols-4" : "lg:grid-cols-5",
-				)}
-			>
-				{showReadinessPanel ? null : (
-					<StatCard
-						label="Status"
-						value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
-					/>
-				)}
-				<StatCard label="Compute" value={isPerformance ? "Performance" : "Basic"} />
-				<StatCard label="Model" value={model} />
-				<StatCard
-					label="Resources"
-					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)} · ${spec.resources.disk_gib} GiB storage`}
-				/>
-			</div>
-			<AgentOverviewCapabilities agentId={agentId} variant="hosted" routeSearch={routeSearch} />
-			{projectionAvailable ? (
+			<AgentOverviewCapabilities
+				agentId={agentId}
+				variant="hosted"
+				routeSearch={routeSearch}
+				content={{
+					sessions: {
+						value: projectionAvailable
+							? `${sessions.length} recent ${sessions.length === 1 ? "session" : "sessions"}`
+							: "Available when running",
+						detail: "Recent work from this managed agent.",
+						content:
+							projectionAvailable && !sessionsError ? (
+								<SessionFeed
+									sessions={sessions.slice(0, 3)}
+									isLoading={sessionsLoading}
+									emptyMessage={sessionsEmptyMessage}
+									emptyVariant="inset"
+									showAgent={false}
+									sessionLink={sessionLink}
+								/>
+							) : null,
+					},
+					"agent-interface": {
+						value: deploymentRunning ? "Ready to use" : deploymentStatusLabel(deploymentStatus),
+						detail: "Open the managed browser interface for this agent.",
+					},
+					projects: {
+						value: !agent
+							? "Details pending"
+							: projectBindings.isLoading
+								? "Loading…"
+								: projectBindings.error
+									? "Unavailable"
+									: `${projectBindings.data?.length ?? 0} ${projectBindings.data?.length === 1 ? "Project" : "Projects"}`,
+						detail: "Projects this agent reads for context and resources.",
+						items: overviewProjects.names,
+					},
+					skills: {
+						value: !agent
+							? "Details pending"
+							: skills.isLoading
+								? "Loading…"
+								: skills.error
+									? "Unavailable"
+									: `${skills.skills?.length ?? 0} available`,
+						detail: "Skills available through this agent's Projects.",
+					},
+					memories: {
+						value: "Shared context",
+						detail: "Account-wide memory available across agents.",
+					},
+					vaults: {
+						value: "Project access",
+						detail: "Vaults supplied safely through this agent's Projects.",
+					},
+					connectors: {
+						value: "Account connections",
+						detail: "External apps available across agents.",
+					},
+					"model-provider": {
+						value: model,
+						detail: "Primary model and credential source used by this agent.",
+					},
+					channels: {
+						value: "Messaging links",
+						detail: "Manage the channels linked to this agent.",
+					},
+					compute: {
+						value: isPerformance ? "Performance" : "Basic",
+						detail: `${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)} · ${spec.resources.disk_gib} GiB storage`,
+					},
+				}}
+			/>
+			{projectionAvailable && sessionsError ? (
 				<div>
-					<div className="mb-2 text-sm font-medium">Recent sessions</div>
-					{sessionsError ? (
-						<ApiErrorPanel
-							error={sessionsError}
-							onRetry={onRetrySessions}
-							title="Couldn't load sessions"
-						/>
-					) : (
-						<SessionFeed
-							sessions={sessions}
-							isLoading={sessionsLoading}
-							emptyMessage={sessionsEmptyMessage}
-							emptyVariant="inset"
-							showAgent={false}
-							sessionLink={sessionLink}
-						/>
-					)}
+					<ApiErrorPanel
+						error={sessionsError}
+						onRetry={onRetrySessions}
+						title="Couldn't load sessions"
+					/>
 				</div>
 			) : null}
 			{showDeploymentActions ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -187,6 +187,7 @@ import {
 	type DeploymentStatus,
 	deploymentStatusFromResource,
 	deploymentStatusLabel,
+	deploymentStatusTone,
 	isRunningStatus,
 } from "@/hosted/deployment-status";
 import { DeploymentStatusUnavailableState } from "@/hosted/deployment-status-unavailable";
@@ -1047,6 +1048,106 @@ export function OverviewFailedPanel({
 	);
 }
 
+function runtimeConsoleLocation(url: string | null): string | null {
+	if (!url) return null;
+	try {
+		return new URL(url).host;
+	} catch {
+		return null;
+	}
+}
+
+function OverviewComputeStatus({
+	deployment,
+	failure,
+	showActions,
+	planChangeHref,
+	providerSettingsHref,
+	onDeleteAccepted,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
+}: {
+	deployment: HostedDeployment;
+	failure: DeploymentFailurePresentation | null;
+	showActions: boolean;
+	planChangeHref: string;
+	providerSettingsHref: string;
+	onDeleteAccepted: (deploymentId: string) => void;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
+}) {
+	const status = deploymentStatusFromResource(deployment.resource.status);
+	const failed = failure || status.kind === "failed";
+	const retryStatus = status.kind === "unknown" || deploymentTransitionTimedOut;
+	return (
+		<div className="space-y-3 text-xs">
+			{failure ? (
+				<div className="space-y-1 text-destructive-muted-foreground" role="status">
+					<p className="font-medium">{failure.title}</p>
+					<p className="line-clamp-2">{failure.reason}</p>
+				</div>
+			) : status.kind === "failed" ? (
+				<p className="text-destructive-muted-foreground" role="status">
+					The last compute change failed. Contact support before trying again.
+				</p>
+			) : deploymentTransitionTimedOut ? (
+				<p className="text-warning-muted-foreground" role="status">
+					Startup is taking longer than expected.
+				</p>
+			) : isStartingStatus(status) ? (
+				<p className="inline-flex items-center gap-2 text-muted-foreground" role="status">
+					<Spinner className="size-3.5" /> Startup is still in progress.
+				</p>
+			) : status.kind === "stopped" ? (
+				<p className="text-muted-foreground" role="status">
+					Start compute to use sessions, channels, and the agent interface.
+				</p>
+			) : status.kind === "unknown" ? (
+				<p className="text-warning-muted-foreground" role="status">
+					Clawdi cannot confirm the current compute status.
+				</p>
+			) : null}
+			{showActions ? (
+				<div className="flex flex-wrap gap-2">
+					{failure ? (
+						<OverviewFailureAction
+							deployment={deployment}
+							failure={failure}
+							planChangeHref={planChangeHref}
+							providerSettingsHref={providerSettingsHref}
+							onDeleteAccepted={onDeleteAccepted}
+						/>
+					) : status.kind === "stopped" ? (
+						<StartComputeAction deployment={deployment} label="Start" />
+					) : retryStatus ? (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={isCheckingDeployment}
+							onClick={onCheckDeploymentAgain}
+						>
+							{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}
+							Check again
+						</Button>
+					) : canRestartDeployment(status) && !failed ? (
+						<RestartComputeAction deployment={deployment} label="Restart" />
+					) : null}
+					{failure?.remediation.kind === "retry_delete" ? null : (
+						<DeleteComputeAction
+							deployment={deployment}
+							onDeleteAccepted={onDeleteAccepted}
+							variant="outline"
+						/>
+					)}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 function OverviewTab({
 	agentId,
 	routeSearch,
@@ -1109,11 +1210,6 @@ function OverviewTab({
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentFailure = deploymentFailurePresentation(deployment);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
-	const showReadinessPanel =
-		!deploymentFailure &&
-		(deploymentTransitionTimedOut ||
-			isStartingStatus(deploymentStatus) ||
-			deploymentStatus.kind === "running");
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
@@ -1126,27 +1222,12 @@ function OverviewTab({
 		false,
 		Boolean(agent),
 	);
+	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
+	const consoleUrl = runtimeConsoleUrl(deployment, spec.runtime);
+	const consoleLocation = runtimeConsoleLocation(consoleUrl);
+	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
 	return (
 		<div className="flex flex-col gap-5">
-			{showReadinessPanel ? (
-				<OverviewReadinessPanel
-					deployment={deployment}
-					deploymentTransitionTimedOut={deploymentTransitionTimedOut}
-					isCheckingDeployment={isCheckingDeployment}
-					onCheckDeploymentAgain={onCheckDeploymentAgain}
-				/>
-			) : null}
-			{deploymentFailure || deploymentStatus.kind === "failed" ? (
-				<OverviewFailedPanel
-					deployment={deployment}
-					planChangeHref={planChangeHref}
-					providerSettingsHref={providerSettingsHref}
-					onDeleteAccepted={onDeleteAccepted}
-				/>
-			) : null}
-			{deploymentStatus.kind === "stopped" ? (
-				<StoppedAgentState deployment={deployment} variant="inset" />
-			) : null}
 			<AgentOverviewCapabilities
 				agentId={agentId}
 				variant="hosted"
@@ -1170,8 +1251,10 @@ function OverviewTab({
 							) : null,
 					},
 					"agent-interface": {
-						value: deploymentRunning ? "Ready to use" : deploymentStatusLabel(deploymentStatus),
-						detail: "Open the managed browser interface for this agent.",
+						value: deploymentRunning
+							? `${runtimeDisplayName(spec.runtime)} UI ready`
+							: "Unavailable",
+						detail: consoleLocation ?? "Available after compute is running.",
 					},
 					projects: {
 						value: !agent
@@ -1193,30 +1276,58 @@ function OverviewTab({
 									? "Unavailable"
 									: `${skills.skills?.length ?? 0} available`,
 						detail: "Skills available through this agent's Projects.",
+						items: (skills.skills ?? []).map((skill) => skill.name),
 					},
 					memories: {
-						value: "Shared context",
-						detail: "Account-wide memory available across agents.",
+						value: "Account-wide",
+						detail: "Shared with every agent in this account.",
 					},
 					vaults: {
-						value: "Project access",
-						detail: "Vaults supplied safely through this agent's Projects.",
+						value: projectBindings.isLoading
+							? "Loading…"
+							: `From ${projectBindings.data?.length ?? 0} ${projectBindings.data?.length === 1 ? "Project" : "Projects"}`,
+						detail: "Secrets are supplied through bound Projects.",
 					},
 					connectors: {
-						value: "Account connections",
-						detail: "External apps available across agents.",
+						value: "Account-wide",
+						detail: "Connected apps are available to every agent.",
 					},
 					"model-provider": {
 						value: model,
-						detail: "Primary model and credential source used by this agent.",
+						detail: providerId ? `Provider: ${providerId}` : "Provider configuration pending.",
 					},
 					channels: {
-						value: "Messaging links",
-						detail: "Manage the channels linked to this agent.",
+						value: channelLinks.isLoading
+							? "Loading…"
+							: channelLinks.error
+								? "Unavailable"
+								: `${channelLinks.data?.length ?? 0} linked`,
+						detail: "Telegram, Discord, WhatsApp, and iMessage links.",
+						items: (channelLinks.data ?? []).flatMap((link) =>
+							link.account?.name ? [link.account.name] : [],
+						),
 					},
 					compute: {
-						value: isPerformance ? "Performance" : "Basic",
-						detail: `${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)} · ${spec.resources.disk_gib} GiB storage`,
+						value: (
+							<span className="inline-flex items-center gap-2">
+								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
+								{deploymentStatusLabel(deploymentStatus)}
+							</span>
+						),
+						detail: `${isPerformance ? "Performance" : "Basic"} · ${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)}`,
+						content: (
+							<OverviewComputeStatus
+								deployment={deployment}
+								failure={deploymentFailure}
+								showActions={showDeploymentActions}
+								planChangeHref={planChangeHref}
+								providerSettingsHref={providerSettingsHref}
+								onDeleteAccepted={onDeleteAccepted}
+								deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+								isCheckingDeployment={isCheckingDeployment}
+								onCheckDeploymentAgain={onCheckDeploymentAgain}
+							/>
+						),
 					},
 				}}
 			/>
@@ -1229,37 +1340,7 @@ function OverviewTab({
 					/>
 				</div>
 			) : null}
-			{showDeploymentActions ? (
-				<OverviewDeploymentActions deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
-			) : null}
 		</div>
-	);
-}
-
-function OverviewDeploymentActions({
-	deployment,
-	onDeleteAccepted,
-}: {
-	deployment: HostedDeployment;
-	onDeleteAccepted: (deploymentId: string) => void;
-}) {
-	const status = deploymentStatusFromResource(deployment.resource.status);
-	const failed = status.kind === "failed";
-	return (
-		<SettingsSection
-			title="Agent actions"
-			description="These actions remain available while other agent details load."
-		>
-			<div className="flex flex-wrap gap-2.5">
-				{canRestartDeployment(status) && !failed ? (
-					<RestartComputeAction deployment={deployment} />
-				) : null}
-				{canStartDeployment(status) && !failed && status.kind !== "stopped" ? (
-					<StartComputeAction deployment={deployment} />
-				) : null}
-				<DeleteComputeAction deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
-			</div>
-		</SettingsSection>
 	);
 }
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -249,6 +249,7 @@ import {
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
+import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
@@ -552,7 +553,7 @@ export function HostedAgentDetail({
 					/>
 				)}
 				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
-				{!deploymentStatus.known ? (
+				{!deploymentStatus.known && activeTab !== "overview" ? (
 					<DeploymentStatusUnavailableState
 						deployment={deployment}
 						isRetrying={isCheckingDeployment}
@@ -571,7 +572,7 @@ export function HostedAgentDetail({
 					/>
 				) : null}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
-					{deploymentStatus.known && activeTab === "overview" ? (
+					{activeTab === "overview" ? (
 						<OverviewTab
 							agentId={environmentId}
 							routeSearch={routeSearch}
@@ -1223,6 +1224,13 @@ function OverviewTab({
 		Boolean(agent),
 	);
 	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
+	const linkedChannelProviders = Array.from(
+		new Set(
+			(channelLinks.data ?? []).flatMap((link) =>
+				link.account?.provider ? [providerMeta(link.account.provider).label] : [],
+			),
+		),
+	);
 	const consoleUrl = runtimeConsoleUrl(deployment, spec.runtime);
 	const consoleLocation = runtimeConsoleLocation(consoleUrl);
 	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
@@ -1254,7 +1262,9 @@ function OverviewTab({
 						value: deploymentRunning
 							? `${runtimeDisplayName(spec.runtime)} UI ready`
 							: "Unavailable",
-						detail: consoleLocation ?? "Available after compute is running.",
+						detail: deploymentRunning
+							? (consoleLocation ?? "Managed interface available")
+							: "Available after compute is running.",
 					},
 					projects: {
 						value: !agent
@@ -1294,7 +1304,7 @@ function OverviewTab({
 					},
 					"model-provider": {
 						value: model,
-						detail: providerId ? `Provider: ${providerId}` : "Provider configuration pending.",
+						detail: providerId ? `Provider: ${providerId}` : "Managed by Clawdi",
 					},
 					channels: {
 						value: channelLinks.isLoading
@@ -1302,7 +1312,10 @@ function OverviewTab({
 							: channelLinks.error
 								? "Unavailable"
 								: `${channelLinks.data?.length ?? 0} linked`,
-						detail: "Telegram, Discord, WhatsApp, and iMessage links.",
+						detail:
+							(channelLinks.data?.length ?? 0) === 0
+								? "No channels linked"
+								: linkedChannelProviders.join(" · ") || "Linked account details available",
 						items: (channelLinks.data ?? []).flatMap((link) =>
 							link.account?.name ? [link.account.name] : [],
 						),

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1344,7 +1344,10 @@ function OverviewTab({
 					Recent sessions
 				</h2>
 				<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-					<section aria-labelledby="hosted-recent-sessions" className="min-h-40 lg:min-h-52">
+					<section
+						aria-labelledby="hosted-recent-sessions"
+						className="min-h-40 min-w-0 lg:min-h-52"
+					>
 						{sessionsError ? (
 							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
 						) : (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -34,7 +34,15 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
-import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	AgentOverviewCapabilities,
+	OverviewChips,
+	OverviewMetadata,
+	OverviewMetrics,
+	OverviewModuleError,
+	OverviewModuleSkeleton,
+	OverviewSummaryRows,
+} from "@/components/dashboard/agent-overview-capabilities";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
@@ -1224,16 +1232,15 @@ function OverviewTab({
 		Boolean(agent),
 	);
 	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
-	const linkedChannelProviders = Array.from(
-		new Set(
-			(channelLinks.data ?? []).flatMap((link) =>
-				link.account?.provider ? [providerMeta(link.account.provider).label] : [],
-			),
-		),
-	);
+	const linkedChannelRows = (channelLinks.data ?? []).flatMap((link) => {
+		if (!link.account) return [];
+		const provider = providerMeta(link.account.provider).label;
+		return [`${provider}: ${link.account.name}`];
+	});
 	const consoleUrl = runtimeConsoleUrl(deployment, spec.runtime);
 	const consoleLocation = runtimeConsoleLocation(consoleUrl);
 	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
+	const projectionUnavailable = !deploymentStatus.known;
 	return (
 		<div className="flex flex-col gap-5">
 			<AgentOverviewCapabilities
@@ -1242,117 +1249,208 @@ function OverviewTab({
 				routeSearch={routeSearch}
 				content={{
 					sessions: {
-						value: projectionAvailable
-							? `${sessions.length} recent ${sessions.length === 1 ? "session" : "sessions"}`
-							: "Available when running",
-						detail: "Recent work from this managed agent.",
-						content:
-							projectionAvailable && !sessionsError ? (
-								<SessionFeed
-									sessions={sessions.slice(0, 3)}
-									isLoading={sessionsLoading}
-									emptyMessage={sessionsEmptyMessage}
-									emptyVariant="inset"
-									showAgent={false}
-									sessionLink={sessionLink}
-								/>
-							) : null,
+						body: !projectionAvailable ? (
+							projectionUnavailable ? (
+								<OverviewModuleError label="Sessions" />
+							) : (
+								<OverviewModuleSkeleton label="sessions" rows={3} />
+							)
+						) : sessionsLoading ? (
+							<OverviewModuleSkeleton label="sessions" rows={3} />
+						) : sessionsError ? (
+							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
+						) : (
+							<div className="space-y-3">
+								<div>
+									<p className="text-lg font-semibold">{sessions.length} recent</p>
+									<p className="mt-1 text-xs text-muted-foreground">Managed agent activity</p>
+								</div>
+								<div className="border-t pt-3">
+									<SessionFeed
+										sessions={sessions.slice(0, 3)}
+										isLoading={false}
+										emptyMessage={sessionsEmptyMessage}
+										emptyVariant="inset"
+										showAgent={false}
+										sessionLink={sessionLink}
+									/>
+								</div>
+							</div>
+						),
 					},
 					"agent-interface": {
-						value: deploymentRunning
-							? `${runtimeDisplayName(spec.runtime)} UI ready`
-							: "Unavailable",
-						detail: deploymentRunning
-							? (consoleLocation ?? "Managed interface available")
-							: "Available after compute is running.",
+						body: (
+							<div className="space-y-3">
+								<p className="text-lg font-semibold">
+									{deploymentRunning ? "Ready" : "Unavailable"}
+								</p>
+								<OverviewMetadata
+									items={[
+										{ label: "Interface", value: runtimeDisplayName(spec.runtime) },
+										{
+											label: "Endpoint",
+											value: deploymentRunning
+												? (consoleLocation ?? "Managed interface")
+												: "Requires running compute",
+										},
+									]}
+								/>
+							</div>
+						),
 					},
 					projects: {
-						value: !agent
-							? "Details pending"
-							: projectBindings.isLoading
-								? "Loading…"
-								: projectBindings.error
-									? "Unavailable"
-									: `${projectBindings.data?.length ?? 0} ${projectBindings.data?.length === 1 ? "Project" : "Projects"}`,
-						detail: "Projects this agent reads for context and resources.",
-						items: overviewProjects.names,
+						body: !agent ? (
+							projectionUnavailable ? (
+								<OverviewModuleError label="Projects" />
+							) : (
+								<OverviewModuleSkeleton label="projects" rows={3} />
+							)
+						) : projectBindings.isLoading ? (
+							<OverviewModuleSkeleton label="projects" rows={3} />
+						) : projectBindings.error ? (
+							<OverviewModuleError
+								label="Projects"
+								onRetry={() => void projectBindings.refetch()}
+							/>
+						) : (
+							<div className="space-y-3">
+								<p className="text-lg font-semibold">{projectBindings.data?.length ?? 0} bound</p>
+								<OverviewSummaryRows items={overviewProjects.names} empty="No projects bound" />
+							</div>
+						),
 					},
 					skills: {
-						value: !agent
-							? "Details pending"
-							: skills.isLoading
-								? "Loading…"
-								: skills.error
-									? "Unavailable"
-									: `${skills.skills?.length ?? 0} available`,
-						detail: "Skills available through this agent's Projects.",
-						items: (skills.skills ?? []).map((skill) => skill.name),
+						body: !agent ? (
+							projectionUnavailable ? (
+								<OverviewModuleError label="Skills" />
+							) : (
+								<OverviewModuleSkeleton label="skills" rows={2} />
+							)
+						) : skills.isLoading ? (
+							<OverviewModuleSkeleton label="skills" rows={2} />
+						) : skills.error ? (
+							<OverviewModuleError label="Skills" onRetry={() => void skills.refetch()} />
+						) : (
+							<div className="space-y-3">
+								<p className="text-lg font-semibold">{skills.skills?.length ?? 0} available</p>
+								<OverviewChips
+									items={(skills.skills ?? []).map((skill) => skill.name)}
+									empty="No skills available"
+								/>
+							</div>
+						),
 					},
 					memories: {
-						value: "Account-wide",
-						detail: "Shared with every agent in this account.",
+						body: (
+							<OverviewMetadata
+								items={[
+									{ label: "Scope", value: "Account-wide" },
+									{ label: "Access", value: "All agents" },
+								]}
+							/>
+						),
 					},
 					vaults: {
-						value: projectBindings.isLoading
-							? "Loading…"
-							: `From ${projectBindings.data?.length ?? 0} ${projectBindings.data?.length === 1 ? "Project" : "Projects"}`,
-						detail: "Secrets are supplied through bound Projects.",
+						body: !agent ? (
+							projectionUnavailable ? (
+								<OverviewModuleError label="Vault sources" />
+							) : (
+								<OverviewModuleSkeleton label="vault sources" rows={2} />
+							)
+						) : projectBindings.isLoading ? (
+							<OverviewModuleSkeleton label="vault sources" rows={2} />
+						) : projectBindings.error ? (
+							<OverviewModuleError
+								label="Vault sources"
+								onRetry={() => void projectBindings.refetch()}
+							/>
+						) : (
+							<OverviewMetadata
+								items={[
+									{
+										label: "Sources",
+										value: projectBindings.data?.length
+											? `${projectBindings.data.length} bound Projects`
+											: "No bound Projects",
+									},
+									{ label: "Delivery", value: "Through Projects" },
+								]}
+							/>
+						),
 					},
 					connectors: {
-						value: "Account-wide",
-						detail: "Connected apps are available to every agent.",
+						body: (
+							<OverviewMetadata
+								items={[
+									{ label: "Scope", value: "Account-wide" },
+									{ label: "Managed", value: "Account settings" },
+								]}
+							/>
+						),
 					},
 					"model-provider": {
-						value: model,
-						detail: providerId ? `Provider: ${providerId}` : "Managed by Clawdi",
+						body: (
+							<OverviewMetadata
+								items={[
+									{ label: "Model", value: model },
+									{ label: "Provider", value: providerId ?? "Managed by Clawdi" },
+								]}
+							/>
+						),
 					},
 					channels: {
-						value: channelLinks.isLoading
-							? "Loading…"
-							: channelLinks.error
-								? "Unavailable"
-								: `${channelLinks.data?.length ?? 0} linked`,
-						detail:
-							(channelLinks.data?.length ?? 0) === 0
-								? "No channels linked"
-								: linkedChannelProviders.join(" · ") || "Linked account details available",
-						items: (channelLinks.data ?? []).flatMap((link) =>
-							link.account?.name ? [link.account.name] : [],
+						body: !agent ? (
+							projectionUnavailable ? (
+								<OverviewModuleError label="Channels" />
+							) : (
+								<OverviewModuleSkeleton label="channels" rows={2} />
+							)
+						) : channelLinks.isLoading ? (
+							<OverviewModuleSkeleton label="channels" rows={2} />
+						) : channelLinks.error ? (
+							<OverviewModuleError label="Channels" onRetry={() => void channelLinks.refetch()} />
+						) : (
+							<div className="space-y-3">
+								<p className="text-lg font-semibold">{channelLinks.data?.length ?? 0} linked</p>
+								<OverviewSummaryRows items={linkedChannelRows} empty="No channels linked" />
+							</div>
 						),
 					},
 					compute: {
-						value: (
-							<span className="inline-flex items-center gap-2">
-								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
-								{deploymentStatusLabel(deploymentStatus)}
-							</span>
-						),
-						detail: `${isPerformance ? "Performance" : "Basic"} · ${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)}`,
-						content: (
-							<OverviewComputeStatus
-								deployment={deployment}
-								failure={deploymentFailure}
-								showActions={showDeploymentActions}
-								planChangeHref={planChangeHref}
-								providerSettingsHref={providerSettingsHref}
-								onDeleteAccepted={onDeleteAccepted}
-								deploymentTransitionTimedOut={deploymentTransitionTimedOut}
-								isCheckingDeployment={isCheckingDeployment}
-								onCheckDeploymentAgain={onCheckDeploymentAgain}
-							/>
+						body: (
+							<div className="space-y-3">
+								<p className="inline-flex items-center gap-2 text-lg font-semibold">
+									<StatusDot status={deploymentStatusTone(deploymentStatus)} />
+									{deploymentStatusLabel(deploymentStatus)}
+								</p>
+								<OverviewMetrics
+									columns={2}
+									items={[
+										{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
+										{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
+										{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
+									]}
+								/>
+								{deploymentRunning ? null : (
+									<div className="border-t pt-3">
+										<OverviewComputeStatus
+											deployment={deployment}
+											failure={deploymentFailure}
+											showActions={showDeploymentActions}
+											planChangeHref={planChangeHref}
+											providerSettingsHref={providerSettingsHref}
+											onDeleteAccepted={onDeleteAccepted}
+											deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+											isCheckingDeployment={isCheckingDeployment}
+											onCheckDeploymentAgain={onCheckDeploymentAgain}
+										/>
+									</div>
+								)}
+							</div>
 						),
 					},
 				}}
 			/>
-			{projectionAvailable && sessionsError ? (
-				<div>
-					<ApiErrorPanel
-						error={sessionsError}
-						onRetry={onRetrySessions}
-						title="Couldn't load sessions"
-					/>
-				</div>
-			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -37,7 +37,6 @@ import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
 	OverviewMetadata,
-	OverviewMetrics,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewModuleUnavailable,
@@ -486,6 +485,7 @@ export function HostedAgentDetail({
 	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
+	const hasTerminalDeploymentFailure = deploymentFailurePresentation(deployment) !== null;
 	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
 	const cloudEnvironmentId = isCloudEnvId(environmentId);
 	const agentQuery = $api.useQuery(
@@ -553,6 +553,7 @@ export function HostedAgentDetail({
 	const showInitialStartingPage =
 		activeTab === "overview" &&
 		isStartingStatus(deploymentStatus) &&
+		!hasTerminalDeploymentFailure &&
 		projection.status !== "resolved";
 	const interfaceAvailable =
 		activeTab === "overview" && !showInitialStartingPage && isRunningStatus(deploymentStatus);
@@ -626,7 +627,10 @@ export function HostedAgentDetail({
 							canRetryProjection={deploymentProjectionQueryable}
 							onRetryProjection={() => void agentQuery.refetch()}
 							isPerformance={isPerformance}
-							showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}
+							showDeploymentActions={
+								!deploymentRunning &&
+								(!isStartingStatus(deploymentStatus) || hasTerminalDeploymentFailure)
+							}
 							onDeleteAccepted={onDeleteAccepted}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
@@ -1040,6 +1044,37 @@ export function OverviewComputeStatus({
 	);
 }
 
+export function OverviewComputeSummary({
+	plan,
+	vcpu,
+	memoryMib,
+	storageGib,
+}: {
+	plan: string;
+	vcpu: number;
+	memoryMib: number;
+	storageGib: number;
+}) {
+	const configuration = [
+		`${vcpu} vCPU`,
+		`${formatMemoryMib(memoryMib)} memory`,
+		`${storageGib} GiB storage`,
+	];
+	return (
+		<div className="space-y-1.5 rounded-md border bg-background/60 px-3 py-2.5">
+			<p className="text-sm font-semibold">{plan} plan</p>
+			<ul
+				aria-label={`Configuration: ${configuration.join(", ")}`}
+				className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
+			>
+				{configuration.map((item) => (
+					<li key={item}>{item}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
 export function InitialDeploymentPage({
 	deployment,
 	deploymentTransitionTimedOut,
@@ -1325,7 +1360,7 @@ function OverviewTab({
 						icon={Cpu}
 						tint="bg-identity-4-bg text-identity-4-fg"
 					>
-						<div className="flex h-full flex-col justify-between gap-4">
+						<div className="flex h-full flex-col gap-4">
 							<p
 								className="inline-flex items-center gap-2 text-lg font-semibold"
 								title={`Agent status: ${deploymentStatusLabel(deploymentStatus)}`}
@@ -1333,17 +1368,14 @@ function OverviewTab({
 								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
 								{deploymentStatusLabel(deploymentStatus)}
 							</p>
-							<OverviewMetrics
-								columns={2}
-								items={[
-									{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
-									{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
-									{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
-									{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
-								]}
+							<OverviewComputeSummary
+								plan={isPerformance ? "Performance" : "Basic"}
+								vcpu={spec.resources.vcpu}
+								memoryMib={spec.resources.memory_mib}
+								storageGib={spec.resources.disk_gib}
 							/>
 							{deploymentRunning ? null : (
-								<div className="border-t pt-3">
+								<div className="mt-auto border-t pt-3">
 									<OverviewComputeStatus
 										deployment={deployment}
 										failure={deploymentFailure}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -549,12 +549,12 @@ export function HostedAgentDetail({
 	const activeNavItem = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
-	const initialProvisioning =
+	const showInitialStartingPage =
 		activeTab === "overview" &&
 		isStartingStatus(deploymentStatus) &&
 		projection.status !== "resolved";
 	const interfaceAvailable =
-		activeTab === "overview" && !initialProvisioning && isRunningStatus(deploymentStatus);
+		activeTab === "overview" && !showInitialStartingPage && isRunningStatus(deploymentStatus);
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
 	return (
 		<div
@@ -608,7 +608,7 @@ export function HostedAgentDetail({
 					/>
 				) : null}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
-					{initialProvisioning ? (
+					{showInitialStartingPage ? (
 						<InitialDeploymentPage
 							deployment={deployment}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
@@ -1217,7 +1217,7 @@ function InitialDeploymentPage({
 						<h2 className="mt-1 text-xl font-semibold">
 							{deploymentTransitionTimedOut
 								? "Setup is taking longer than expected"
-								: "Setting up your agent"}
+								: "Starting your agent…"}
 						</h2>
 						<p className="mt-2 text-sm text-muted-foreground">
 							{deploymentTransitionTimedOut
@@ -1368,7 +1368,10 @@ function OverviewTab({
 						tint="bg-identity-4-bg text-identity-4-fg"
 					>
 						<div className="flex h-full flex-col justify-between gap-4">
-							<p className="inline-flex items-center gap-2 text-lg font-semibold">
+							<p
+								className="inline-flex items-center gap-2 text-lg font-semibold"
+								title={`Agent status: ${deploymentStatusLabel(deploymentStatus)}`}
+							>
 								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
 								{deploymentStatusLabel(deploymentStatus)}
 							</p>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -571,7 +571,7 @@ export function HostedAgentDetail({
 				{isLiveToolTab ? null : (
 					<PageHeader
 						title={activeTabLabel}
-						description={activeNavItem.description}
+						description={activeTab === "overview" ? undefined : activeNavItem.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
 						actions={
 							interfaceAvailable ? (
@@ -1213,8 +1213,7 @@ function InitialDeploymentPage({
 						)}
 					</div>
 					<div>
-						<p className="text-sm font-medium">Starting</p>
-						<h2 className="mt-1 text-xl font-semibold">
+						<h2 className="text-xl font-semibold">
 							{deploymentTransitionTimedOut
 								? "Setup is taking longer than expected"
 								: "Starting your agent…"}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1052,60 +1052,112 @@ export function InitialDeploymentPage({
 	onCheckDeploymentAgain: () => void;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
+	const runtimeLabel = runtimeDisplayName(deployment.resource.spec.runtime);
+	const stages = [
+		{ status: "creating", label: "Environment" },
+		{ status: "starting", label: "Install" },
+		{ status: "running", label: "Ready" },
+	] as const;
+	const activeStageIndex = status.kind === "starting" ? 1 : status.kind === "running" ? 2 : 0;
+	const activeStageLabel =
+		activeStageIndex === 0
+			? "Preparing your environment"
+			: activeStageIndex === 1
+				? `Installing ${runtimeLabel}`
+				: "Ready";
 	return (
 		<DetailPanel
 			className={cn(
 				"p-6 md:p-8",
-				deploymentTransitionTimedOut
-					? "border-warning/30 bg-warning-muted"
-					: "border-info-muted bg-info-muted",
+				deploymentTransitionTimedOut && "border-warning/30 bg-warning-muted",
 			)}
 		>
 			<div
 				data-testid="hosted-initial-deployment-panel"
 				role={deploymentTransitionTimedOut ? "alert" : undefined}
-				className="space-y-5"
+				className="space-y-6"
 			>
-				<div className="flex gap-4">
-					<div className="flex size-12 shrink-0 items-center justify-center rounded-lg border bg-background">
-						{deploymentTransitionTimedOut ? (
-							<AlertCircle className="size-6" />
-						) : (
-							<Spinner className="size-6" />
-						)}
-					</div>
-					<div className="min-w-0">
-						<h2 className="text-xl font-semibold">
-							{deploymentTransitionTimedOut
-								? "Setup is taking longer than expected"
-								: "Starting your agent…"}
-						</h2>
-						<p className="mt-2 text-sm text-muted-foreground">
-							{deploymentTransitionTimedOut
-								? "Your agent may still be starting. We’ll keep checking automatically, or you can check again now."
-								: "This usually takes a few minutes. This page updates automatically while your agent starts."}
-						</p>
-						<dl className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-							<dt className="text-muted-foreground">Current status</dt>
-							<dd className="inline-flex items-center gap-2 font-medium">
-								<StatusDot status={deploymentStatusTone(status)} />
-								{deploymentStatusLabel(status)}
-							</dd>
-						</dl>
-						{deploymentTransitionTimedOut ? (
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								className="mt-4"
-								disabled={isCheckingDeployment}
-								onClick={onCheckDeploymentAgain}
-							>
-								{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}Check again
-							</Button>
-						) : null}
-					</div>
+				<div>
+					<h2 className="flex items-center gap-2 text-lg font-semibold">
+						{deploymentTransitionTimedOut ? <AlertCircle className="size-5" /> : null}
+						{deploymentTransitionTimedOut
+							? "Setup is taking longer than expected"
+							: `Setting up ${runtimeLabel}`}
+					</h2>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{deploymentTransitionTimedOut
+							? "Your agent may still be starting. We’ll keep checking automatically."
+							: "This page updates automatically as setup progresses."}
+					</p>
 				</div>
+				<div>
+					<div className="flex items-baseline justify-between gap-4">
+						<p
+							className="text-base font-semibold"
+							role="status"
+							aria-live="polite"
+							aria-atomic="true"
+						>
+							{activeStageLabel}
+						</p>
+						<p className="shrink-0 text-xs font-medium text-muted-foreground">
+							Step {activeStageIndex + 1} of {stages.length}
+						</p>
+					</div>
+					<ol aria-label="Deployment progress" className="mt-4 grid w-full grid-cols-3 gap-2">
+						{stages.map((stage, index) => {
+							const stageState =
+								status.kind === "running" || index < activeStageIndex
+									? "completed"
+									: index === activeStageIndex
+										? "active"
+										: "pending";
+							return (
+								<li
+									key={stage.status}
+									data-deployment-stage={stage.status}
+									data-stage-state={stageState}
+									aria-current={index === activeStageIndex ? "step" : undefined}
+									aria-label={`${stage.label}, ${stageState}`}
+								>
+									<div
+										aria-hidden="true"
+										className={cn(
+											"h-2 rounded-full",
+											stageState === "active"
+												? "bg-primary"
+												: stageState === "completed"
+													? "bg-primary/50"
+													: "bg-muted",
+										)}
+									/>
+									<p
+										aria-hidden="true"
+										className={cn(
+											"mt-2 text-xs",
+											stageState === "pending"
+												? "text-muted-foreground"
+												: "font-medium text-foreground",
+										)}
+									>
+										{stage.label}
+									</p>
+								</li>
+							);
+						})}
+					</ol>
+				</div>
+				{deploymentTransitionTimedOut ? (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={isCheckingDeployment}
+						onClick={onCheckDeploymentAgain}
+					>
+						{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}Check again
+					</Button>
+				) : null}
 			</div>
 		</DetailPanel>
 	);
@@ -1221,23 +1273,23 @@ function OverviewTab({
 	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
 	return (
 		<div className="flex flex-col gap-8">
-			<div>
-				<div className="mb-3 flex items-center justify-between">
-					<h2 id="hosted-recent-sessions" className="text-sm font-semibold">
-						Recent sessions
-					</h2>
-					<Button
-						render={<Link {...agentSectionLink(agentId, "sessions", routeSearch)} />}
-						nativeButton={false}
-						variant="ghost"
-						size="sm"
-						className="text-muted-foreground"
-					>
-						View all
-						<ArrowRight />
-					</Button>
-				</div>
-				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+			<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)] @3xl/main:gap-y-3">
+				<div className="grid min-w-0 gap-3 @3xl/main:row-span-2 @3xl/main:row-start-1 @3xl/main:grid-rows-subgrid">
+					<div className="flex items-center justify-between">
+						<h2 id="hosted-recent-sessions" className="text-sm font-semibold">
+							Recent sessions
+						</h2>
+						<Button
+							render={<Link {...agentSectionLink(agentId, "sessions", routeSearch)} />}
+							nativeButton={false}
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground"
+						>
+							View all
+							<ArrowRight />
+						</Button>
+					</div>
 					<section
 						aria-labelledby="hosted-recent-sessions"
 						className="min-h-40 min-w-0 @3xl/main:min-h-52"
@@ -1258,6 +1310,8 @@ function OverviewTab({
 							/>
 						)}
 					</section>
+				</div>
+				<div className="@3xl/main:row-start-2">
 					<AgentOverviewStatusCard
 						agentId={agentId}
 						section="settings"

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1371,34 +1371,6 @@ function OverviewTab({
 							</div>
 						),
 					},
-					memories: {
-						body: <p className="text-sm font-medium">Shared with all your agents</p>,
-					},
-					vaults: {
-						body: !agent ? (
-							projectionUnavailable ? (
-								<OverviewModuleError label="Vault sources" />
-							) : (
-								<OverviewModuleSkeleton label="vault sources" rows={2} />
-							)
-						) : projectBindings.isLoading ? (
-							<OverviewModuleSkeleton label="vault sources" rows={2} />
-						) : projectBindings.error ? (
-							<OverviewModuleError
-								label="Vault sources"
-								onRetry={() => void projectBindings.refetch()}
-							/>
-						) : (
-							<p className="text-sm font-medium">
-								{projectBindings.data?.length
-									? `Available through ${projectBindings.data.length} ${projectBindings.data.length === 1 ? "project" : "projects"}`
-									: "Add a project to use vaults"}
-							</p>
-						),
-					},
-					connectors: {
-						body: <p className="text-sm font-medium">Shared with all your agents</p>,
-					},
 					"model-provider": {
 						body: (
 							<OverviewMetadata

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -570,6 +570,7 @@ export function HostedAgentDetail({
 				) : null}
 				{deploymentStatus.known &&
 				deploymentProjectionQueryable &&
+				!(activeTab === "overview" && isStartingStatus(deploymentStatus)) &&
 				shouldShowHostedProjectionNotice(activeTab) ? (
 					<HostedProjectionNotice
 						projection={projection}
@@ -1222,8 +1223,12 @@ function OverviewTab({
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
+	const sessionSummary = sessions.length
+		? `${sessions.length} recent ${sessions.length === 1 ? "session" : "sessions"}`
+		: "No recent sessions";
 	const overviewProjects = useAgentOverviewProjects(agentId, { enabled: Boolean(agent) });
 	const projectBindings = overviewProjects.bindings;
+	const projectNames = overviewProjects.nameResolution;
 	const skills = useAgentProjectSkills(
 		agentId,
 		agent?.default_project_id,
@@ -1241,12 +1246,14 @@ function OverviewTab({
 	const consoleLocation = runtimeConsoleLocation(consoleUrl);
 	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
 	const projectionUnavailable = !deploymentStatus.known;
+	const provisioning = isStartingStatus(deploymentStatus) && !projectionAvailable;
 	return (
 		<div className="flex flex-col gap-5">
 			<AgentOverviewCapabilities
 				agentId={agentId}
 				variant="hosted"
 				routeSearch={routeSearch}
+				visibleModuleIds={provisioning ? ["agent-interface", "compute"] : undefined}
 				content={{
 					sessions: {
 						body: !projectionAvailable ? (
@@ -1262,7 +1269,7 @@ function OverviewTab({
 						) : (
 							<div className="space-y-3">
 								<div>
-									<p className="text-lg font-semibold">{sessions.length} recent</p>
+									<p className="text-lg font-semibold">{sessionSummary}</p>
 									<p className="mt-1 text-xs text-muted-foreground">Managed agent activity</p>
 								</div>
 								<div className="border-t pt-3">
@@ -1282,19 +1289,13 @@ function OverviewTab({
 						body: (
 							<div className="space-y-3">
 								<p className="text-lg font-semibold">
-									{deploymentRunning ? "Ready" : "Unavailable"}
+									{deploymentRunning ? "Ready to open" : "Not available"}
 								</p>
-								<OverviewMetadata
-									items={[
-										{ label: "Interface", value: runtimeDisplayName(spec.runtime) },
-										{
-											label: "Endpoint",
-											value: deploymentRunning
-												? (consoleLocation ?? "Managed interface")
-												: "Requires running compute",
-										},
-									]}
-								/>
+								<p className="text-sm text-muted-foreground">
+									{deploymentRunning
+										? (consoleLocation ?? runtimeDisplayName(spec.runtime))
+										: "Available when compute is running"}
+								</p>
 							</div>
 						),
 					},
@@ -1314,8 +1315,32 @@ function OverviewTab({
 							/>
 						) : (
 							<div className="space-y-3">
-								<p className="text-lg font-semibold">{projectBindings.data?.length ?? 0} bound</p>
-								<OverviewSummaryRows items={overviewProjects.names} empty="No projects bound" />
+								<p className="text-lg font-semibold">
+									{(projectBindings.data?.length ?? 0) > 0
+										? `${projectBindings.data?.length} ${projectBindings.data?.length === 1 ? "project" : "projects"}`
+										: "No projects added"}
+								</p>
+								{(projectBindings.data?.length ?? 0) === 0 ? null : projectNames.isLoading ? (
+									<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
+								) : projectNames.error ? (
+									<OverviewModuleError
+										label="Project names"
+										onRetry={() => void projectNames.refetch()}
+									/>
+								) : (
+									<>
+										<OverviewSummaryRows
+											items={projectNames.names}
+											empty="Project names can’t be shown"
+										/>
+										{projectNames.unresolvedCount > 0 ? (
+											<p className="text-xs text-muted-foreground">
+												{projectNames.unresolvedCount} project{" "}
+												{projectNames.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown
+											</p>
+										) : null}
+									</>
+								)}
 							</div>
 						),
 					},
@@ -1332,23 +1357,22 @@ function OverviewTab({
 							<OverviewModuleError label="Skills" onRetry={() => void skills.refetch()} />
 						) : (
 							<div className="space-y-3">
-								<p className="text-lg font-semibold">{skills.skills?.length ?? 0} available</p>
-								<OverviewChips
-									items={(skills.skills ?? []).map((skill) => skill.name)}
-									empty="No skills available"
-								/>
+								<p className="text-lg font-semibold">
+									{(skills.skills?.length ?? 0) > 0
+										? `${skills.skills?.length} ${skills.skills?.length === 1 ? "skill" : "skills"}`
+										: "No skills available"}
+								</p>
+								{(skills.skills?.length ?? 0) > 0 ? (
+									<OverviewChips
+										items={(skills.skills ?? []).map((skill) => skill.name)}
+										empty="No skills available"
+									/>
+								) : null}
 							</div>
 						),
 					},
 					memories: {
-						body: (
-							<OverviewMetadata
-								items={[
-									{ label: "Scope", value: "Account-wide" },
-									{ label: "Access", value: "All agents" },
-								]}
-							/>
-						),
+						body: <p className="text-sm font-medium">Shared with all your agents</p>,
 					},
 					vaults: {
 						body: !agent ? (
@@ -1365,28 +1389,15 @@ function OverviewTab({
 								onRetry={() => void projectBindings.refetch()}
 							/>
 						) : (
-							<OverviewMetadata
-								items={[
-									{
-										label: "Sources",
-										value: projectBindings.data?.length
-											? `${projectBindings.data.length} bound Projects`
-											: "No bound Projects",
-									},
-									{ label: "Delivery", value: "Through Projects" },
-								]}
-							/>
+							<p className="text-sm font-medium">
+								{projectBindings.data?.length
+									? `Available through ${projectBindings.data.length} ${projectBindings.data.length === 1 ? "project" : "projects"}`
+									: "Add a project to use vaults"}
+							</p>
 						),
 					},
 					connectors: {
-						body: (
-							<OverviewMetadata
-								items={[
-									{ label: "Scope", value: "Account-wide" },
-									{ label: "Managed", value: "Account settings" },
-								]}
-							/>
-						),
+						body: <p className="text-sm font-medium">Shared with all your agents</p>,
 					},
 					"model-provider": {
 						body: (
@@ -1411,8 +1422,12 @@ function OverviewTab({
 							<OverviewModuleError label="Channels" onRetry={() => void channelLinks.refetch()} />
 						) : (
 							<div className="space-y-3">
-								<p className="text-lg font-semibold">{channelLinks.data?.length ?? 0} linked</p>
-								<OverviewSummaryRows items={linkedChannelRows} empty="No channels linked" />
+								<p className="text-lg font-semibold">
+									{(channelLinks.data?.length ?? 0) > 0
+										? `${channelLinks.data?.length} connected ${channelLinks.data?.length === 1 ? "channel" : "channels"}`
+										: "No channels connected"}
+								</p>
+								<OverviewSummaryRows items={linkedChannelRows} empty="No channels connected" />
 							</div>
 						),
 					},
@@ -1429,6 +1444,7 @@ function OverviewTab({
 										{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
 										{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
 										{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
+										{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
 									]}
 								/>
 								{deploymentRunning ? null : (
@@ -1451,6 +1467,18 @@ function OverviewTab({
 					},
 				}}
 			/>
+			{provisioning ? (
+				<div
+					data-testid="hosted-overview-provisioning-placeholder"
+					className="rounded-lg border border-dashed bg-muted/20 px-6 py-10 text-center"
+				>
+					<p className="text-sm font-medium">Your agent’s workspace is getting ready</p>
+					<p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
+						Recent activity, projects, skills, memories, vaults, connectors, models, and channels
+						will appear here automatically when your agent is ready.
+					</p>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -264,8 +264,8 @@ import {
 	agentProviderHasSingleLinkLimit,
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/channel-linking.logic";
-import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
+import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
@@ -542,8 +542,8 @@ export function HostedAgentDetail({
 	});
 
 	const sessions = useQuery({
-		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 20 }),
-		enabled: deploymentRunning && projection.status === "resolved",
+		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 4 }),
+		enabled: activeTab === "overview" && deploymentRunning && projection.status === "resolved",
 	});
 
 	const activeNavItem = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -6,14 +6,12 @@ import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
 	Check,
-	CircleCheck,
 	Copy,
 	Cpu,
 	ExternalLink,
 	Eye,
 	EyeOff,
 	Info,
-	LifeBuoy,
 	Link2,
 	Link2Off,
 	type LucideIcon,
@@ -37,7 +35,6 @@ import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
-	OverviewChips,
 	OverviewMetadata,
 	OverviewMetrics,
 	OverviewModuleError,
@@ -47,6 +44,8 @@ import {
 import {
 	OverviewConnectorsBody,
 	OverviewMemoriesBody,
+	OverviewProjectsBody,
+	OverviewSkillsBody,
 	OverviewVaultsBody,
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
@@ -621,6 +620,7 @@ export function HostedAgentDetail({
 							routeSearch={routeSearch}
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
+							projectionStatus={projection.status}
 							isPerformance={isPerformance}
 							showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}
 							onDeleteAccepted={onDeleteAccepted}
@@ -883,90 +883,6 @@ function HostedAgentSessionsTab({
 
 // ── Overview ─────────────────────────────────────────────────────────────────
 
-export function OverviewReadinessPanel({
-	deployment,
-	deploymentTransitionTimedOut,
-	isCheckingDeployment,
-	onCheckDeploymentAgain,
-}: {
-	deployment: HostedDeployment;
-	deploymentTransitionTimedOut: boolean;
-	isCheckingDeployment: boolean;
-	onCheckDeploymentAgain: () => void;
-}) {
-	const status = deployment.resource.status;
-	if (status === null) {
-		return (
-			<DeploymentStatusUnavailableState
-				deployment={deployment}
-				isRetrying={isCheckingDeployment}
-				onRetry={onCheckDeploymentAgain}
-			/>
-		);
-	}
-	const ready = status.summary_state === "running";
-	const title = deploymentTransitionTimedOut
-		? "Your agent is taking longer than expected"
-		: ready
-			? "Your agent is running"
-			: startingTitle();
-	const description = deploymentTransitionTimedOut
-		? "The latest status still shows your agent starting after five minutes. Startup may still be continuing. We’ll keep checking automatically once a minute while you’re here, or you can check again now."
-		: ready
-			? "It is ready to use."
-			: "This step should finish within five minutes. Startup continues if you leave this page.";
-	return (
-		<div
-			className={cn(
-				"rounded-xl border p-5",
-				deploymentTransitionTimedOut
-					? "border-warning/30 bg-warning-muted text-warning-muted-foreground"
-					: ready
-						? "border-success/30 bg-success-muted text-success-muted-foreground"
-						: "border-info-muted bg-info-muted text-info-muted-foreground",
-			)}
-		>
-			<div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-				<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-background">
-					{deploymentTransitionTimedOut ? (
-						<AlertCircle className="size-5" />
-					) : ready ? (
-						<CircleCheck className="size-5" />
-					) : (
-						<Spinner className="size-5" />
-					)}
-				</div>
-				<div className="min-w-0 flex-1">
-					<h2 className="text-sm font-semibold text-foreground">{title}</h2>
-					<p className="mt-1 text-sm">{description}</p>
-					{deploymentTransitionTimedOut ? (
-						<div className="mt-3 flex flex-wrap gap-2">
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								disabled={isCheckingDeployment}
-								onClick={onCheckDeploymentAgain}
-							>
-								{isCheckingDeployment ? (
-									<Spinner className="size-3.5" />
-								) : (
-									<RefreshCw className="size-3.5" />
-								)}
-								Check again
-							</Button>
-						</div>
-					) : null}
-				</div>
-			</div>
-		</div>
-	);
-}
-
-function DeploymentFailureReasonText({ reason }: { reason: string }) {
-	return <p className="mt-2 whitespace-pre-wrap break-words text-sm">{reason}</p>;
-}
-
 function OverviewFailureAction({
 	deployment,
 	failure,
@@ -1021,72 +937,6 @@ function OverviewFailureAction({
 					label={remediation.label}
 				/>
 			) : null}
-		</div>
-	);
-}
-
-export function OverviewFailedPanel({
-	deployment,
-	planChangeHref,
-	providerSettingsHref,
-	onDeleteAccepted,
-}: {
-	deployment: HostedDeployment;
-	planChangeHref: string;
-	providerSettingsHref: string;
-	onDeleteAccepted: (deploymentId: string) => void;
-}) {
-	const status = deploymentStatusFromResource(deployment.resource.status);
-	const failure = deploymentFailurePresentation(deployment);
-	if (failure) {
-		return (
-			<Alert data-hosted="true" variant="destructive">
-				<AlertCircle className="size-4" />
-				<AlertTitle>{failure.title}</AlertTitle>
-				<AlertDescription className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-					<div className="min-w-0">
-						<p>
-							{failure.description} Current status: {deploymentStatusLabel(status)}.
-						</p>
-						<DeploymentFailureReasonText reason={failure.reason} />
-					</div>
-					<OverviewFailureAction
-						deployment={deployment}
-						failure={failure}
-						planChangeHref={planChangeHref}
-						providerSettingsHref={providerSettingsHref}
-						onDeleteAccepted={onDeleteAccepted}
-					/>
-				</AlertDescription>
-			</Alert>
-		);
-	}
-	return (
-		<div className="rounded-xl border border-destructive-muted bg-destructive-muted p-5 text-destructive-muted-foreground">
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-				<div className="flex min-w-0 gap-3">
-					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-destructive-muted bg-background">
-						<AlertCircle className="size-5" />
-					</div>
-					<div className="min-w-0">
-						<h2 className="text-sm font-semibold text-foreground">Agent change failed</h2>
-						<p className="mt-1 text-sm">
-							Clawdi couldn’t complete the last change to this agent or determine why. It isn’t safe
-							to try again automatically. Contact support before trying again. Current status:{" "}
-							{deploymentStatusLabel(status)}.
-						</p>
-					</div>
-				</div>
-				<Button
-					render={<a href="mailto:support@clawdi.ai" />}
-					nativeButton={false}
-					variant="outline"
-					size="sm"
-					className="shrink-0"
-				>
-					<LifeBuoy data-icon="inline-start" /> Contact support
-				</Button>
-			</div>
 		</div>
 	);
 }
@@ -1260,6 +1110,7 @@ function OverviewTab({
 	routeSearch,
 	deployment,
 	agent,
+	projectionStatus,
 	isPerformance,
 	showDeploymentActions,
 	onDeleteAccepted,
@@ -1278,6 +1129,7 @@ function OverviewTab({
 	routeSearch: AgentRouteSearch;
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
+	projectionStatus: HostedProjectionResolution<unknown>["status"];
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
 	onDeleteAccepted: (deploymentId: string) => void;
@@ -1296,13 +1148,15 @@ function OverviewTab({
 	onCheckDeploymentAgain: () => void;
 }) {
 	const spec = deployment.resource.spec;
-	const providers = useUserAiProviders();
-	const managedModelCatalog = useManagedModelCatalog();
 	const primaryModel = spec.runtime_configuration.primary_model;
 	const bindingProvider =
 		spec.runtime_configuration.providers.find(
 			(provider) => provider.provider_id === primaryModelProviderId(primaryModel),
 		) ?? spec.runtime_configuration.providers[0];
+	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
+	const managedProvider = !providerId || isManagedProviderId(providerId);
+	const providers = useUserAiProviders({ enabled: !managedProvider });
+	const managedModelCatalog = useManagedModelCatalog({ enabled: managedProvider });
 	const model = modelBindingDisplayName(
 		primaryModel,
 		runtimeAiProviderAuthKind(deployment) ?? bindingProvider?.auth_kind,
@@ -1334,18 +1188,18 @@ function OverviewTab({
 		const provider = providerMeta(link.account.provider).label;
 		return [`${provider}: ${link.account.name}`];
 	});
-	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
-	const projectionUnavailable = !deploymentStatus.known;
+	const projectionLoading = projectionStatus === "loading";
+	const projectionUnavailable = projectionStatus === "unavailable" || !deploymentStatus.known;
 	return (
 		<div className="flex flex-col gap-8">
 			<div>
 				<h2 id="hosted-recent-sessions" className="mb-3 text-sm font-semibold">
 					Recent sessions
 				</h2>
-				<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 					<section
 						aria-labelledby="hosted-recent-sessions"
-						className="min-h-40 min-w-0 lg:min-h-52"
+						className="min-h-40 min-w-0 @3xl/main:min-h-52"
 					>
 						{sessionsError ? (
 							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
@@ -1408,75 +1262,34 @@ function OverviewTab({
 				routeSearch={routeSearch}
 				content={{
 					projects: {
-						body: !agent ? (
-							projectionUnavailable ? (
-								<OverviewModuleError label="Projects" />
-							) : (
-								<OverviewModuleSkeleton label="projects" rows={3} />
-							)
-						) : projectBindings.isLoading ? (
-							<OverviewModuleSkeleton label="projects" rows={3} />
-						) : projectBindings.error ? (
-							<OverviewModuleError
-								label="Projects"
-								onRetry={() => void projectBindings.refetch()}
+						body: (
+							<OverviewProjectsBody
+								bindings={{
+									count: agent ? (projectBindings.data?.length ?? null) : null,
+									isLoading: projectionLoading || projectBindings.isLoading,
+									error: projectionUnavailable
+										? new Error("Projection unavailable")
+										: projectBindings.error,
+									onRetry: () => void projectBindings.refetch(),
+								}}
+								names={{
+									items: projectNames.names,
+									unresolvedCount: projectNames.unresolvedCount,
+									isLoading: projectNames.isLoading,
+									error: projectNames.error,
+									onRetry: () => void projectNames.refetch(),
+								}}
 							/>
-						) : (
-							<div className="space-y-3">
-								<p className="text-lg font-semibold">
-									{(projectBindings.data?.length ?? 0) > 0
-										? `${projectBindings.data?.length} ${projectBindings.data?.length === 1 ? "project" : "projects"}`
-										: "No projects added"}
-								</p>
-								{(projectBindings.data?.length ?? 0) === 0 ? null : projectNames.isLoading ? (
-									<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
-								) : projectNames.error ? (
-									<OverviewModuleError
-										label="Project names"
-										onRetry={() => void projectNames.refetch()}
-									/>
-								) : (
-									<>
-										<OverviewSummaryRows
-											items={projectNames.names}
-											empty="Project names can’t be shown"
-										/>
-										{projectNames.unresolvedCount > 0 ? (
-											<p className="text-xs text-muted-foreground">
-												{projectNames.unresolvedCount} project{" "}
-												{projectNames.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown
-											</p>
-										) : null}
-									</>
-								)}
-							</div>
 						),
 					},
 					skills: {
-						body: !agent ? (
-							projectionUnavailable ? (
-								<OverviewModuleError label="Skills" />
-							) : (
-								<OverviewModuleSkeleton label="skills" rows={2} />
-							)
-						) : skills.isLoading ? (
-							<OverviewModuleSkeleton label="skills" rows={2} />
-						) : skills.error ? (
-							<OverviewModuleError label="Skills" onRetry={() => void skills.refetch()} />
-						) : (
-							<div className="space-y-3">
-								<p className="text-lg font-semibold">
-									{(skills.skills?.length ?? 0) > 0
-										? `${skills.skills?.length} ${skills.skills?.length === 1 ? "skill" : "skills"}`
-										: "No skills available"}
-								</p>
-								{(skills.skills?.length ?? 0) > 0 ? (
-									<OverviewChips
-										items={(skills.skills ?? []).map((skill) => skill.name)}
-										empty="No skills available"
-									/>
-								) : null}
-							</div>
+						body: (
+							<OverviewSkillsBody
+								items={(skills.skills ?? []).map((skill) => skill.name)}
+								isLoading={projectionLoading || skills.isLoading}
+								error={projectionUnavailable ? new Error("Projection unavailable") : skills.error}
+								onRetry={() => void skills.refetch()}
+							/>
 						),
 					},
 					memories: { body: <OverviewMemoriesBody /> },
@@ -1484,22 +1297,42 @@ function OverviewTab({
 						body: (
 							<OverviewVaultsBody
 								projectIds={effectiveAgentProjectIds(projectBindings.data ?? [])}
-								isLoading={projectBindings.isLoading}
-								error={projectBindings.error}
+								resolution={
+									projectionLoading || projectBindings.isLoading
+										? "loading"
+										: projectionUnavailable || projectBindings.error
+											? "unavailable"
+											: "ready"
+								}
 								onRetry={() => void projectBindings.refetch()}
 							/>
 						),
 					},
 					connectors: { body: <OverviewConnectorsBody /> },
 					"model-provider": {
-						body: (
-							<OverviewMetadata
-								items={[
-									{ label: "Model", value: model },
-									{ label: "Provider", value: providerId ?? "Managed by Clawdi" },
-								]}
-							/>
-						),
+						body:
+							providers.isLoading || managedModelCatalog.isLoading ? (
+								<OverviewModuleSkeleton label="model and provider" rows={2} showHeading={false} />
+							) : providers.error || managedModelCatalog.error ? (
+								<OverviewModuleError
+									label="Model & Provider"
+									onRetry={() =>
+										void (managedProvider ? managedModelCatalog.refetch() : providers.refetch())
+									}
+								/>
+							) : (
+								<OverviewMetadata
+									items={[
+										{ label: "Model", value: model },
+										{
+											label: "Provider",
+											value: managedProvider
+												? "Managed by Clawdi"
+												: providerDisplayLabel(providerId ?? "", providers.data ?? []),
+										},
+									]}
+								/>
+							),
 					},
 					channels: {
 						body: !agent ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1093,11 +1093,16 @@ export function InitialDeploymentPage({
 				<div>
 					<div className="flex items-baseline justify-between gap-4">
 						<p
-							className="text-base font-semibold"
+							className="inline-flex items-center gap-2 text-base font-semibold"
 							role="status"
 							aria-live="polite"
 							aria-atomic="true"
 						>
+							{!deploymentTransitionTimedOut && status.kind !== "running" ? (
+								<span className="inline-flex" aria-hidden="true">
+									<Spinner className="size-3.5 shrink-0 text-primary" />
+								</span>
+							) : null}
 							{activeStageLabel}
 						</p>
 						<p className="shrink-0 text-xs font-medium text-muted-foreground">

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1339,61 +1339,63 @@ function OverviewTab({
 	const projectionUnavailable = !deploymentStatus.known;
 	return (
 		<div className="flex flex-col gap-8">
-			<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-				<section aria-labelledby="hosted-recent-sessions">
-					<h2 id="hosted-recent-sessions" className="mb-3 text-sm font-semibold">
-						Recent sessions
-					</h2>
-					{sessionsError ? (
-						<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
-					) : (
-						<OverviewSessionList
-							sessions={sessions}
-							isLoading={sessionsLoading}
-							emptyMessage={sessionsEmptyMessage}
-							sessionLink={sessionLink}
-						/>
-					)}
-				</section>
-				<AgentOverviewStatusCard
-					agentId={agentId}
-					section="settings"
-					routeSearch={routeSearch}
-					title="Compute"
-					icon={Cpu}
-					tint="bg-identity-4-bg text-identity-4-fg"
-				>
-					<div className="space-y-3">
-						<p className="inline-flex items-center gap-2 text-lg font-semibold">
-							<StatusDot status={deploymentStatusTone(deploymentStatus)} />
-							{deploymentStatusLabel(deploymentStatus)}
-						</p>
-						<OverviewMetrics
-							columns={2}
-							items={[
-								{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
-								{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
-								{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
-								{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
-							]}
-						/>
-						{deploymentRunning ? null : (
-							<div className="border-t pt-3">
-								<OverviewComputeStatus
-									deployment={deployment}
-									failure={deploymentFailure}
-									showActions={showDeploymentActions}
-									planChangeHref={planChangeHref}
-									providerSettingsHref={providerSettingsHref}
-									onDeleteAccepted={onDeleteAccepted}
-									deploymentTransitionTimedOut={deploymentTransitionTimedOut}
-									isCheckingDeployment={isCheckingDeployment}
-									onCheckDeploymentAgain={onCheckDeploymentAgain}
-								/>
-							</div>
+			<div>
+				<h2 id="hosted-recent-sessions" className="mb-3 text-sm font-semibold">
+					Recent sessions
+				</h2>
+				<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+					<section aria-labelledby="hosted-recent-sessions" className="min-h-40 lg:min-h-52">
+						{sessionsError ? (
+							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
+						) : (
+							<OverviewSessionList
+								sessions={sessions}
+								isLoading={sessionsLoading}
+								emptyMessage={sessionsEmptyMessage}
+								sessionLink={sessionLink}
+							/>
 						)}
-					</div>
-				</AgentOverviewStatusCard>
+					</section>
+					<AgentOverviewStatusCard
+						agentId={agentId}
+						section="settings"
+						routeSearch={routeSearch}
+						title="Compute"
+						icon={Cpu}
+						tint="bg-identity-4-bg text-identity-4-fg"
+					>
+						<div className="flex h-full flex-col justify-between gap-4">
+							<p className="inline-flex items-center gap-2 text-lg font-semibold">
+								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
+								{deploymentStatusLabel(deploymentStatus)}
+							</p>
+							<OverviewMetrics
+								columns={2}
+								items={[
+									{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
+									{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
+									{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
+									{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
+								]}
+							/>
+							{deploymentRunning ? null : (
+								<div className="border-t pt-3">
+									<OverviewComputeStatus
+										deployment={deployment}
+										failure={deploymentFailure}
+										showActions={showDeploymentActions}
+										planChangeHref={planChangeHref}
+										providerSettingsHref={providerSettingsHref}
+										onDeleteAccepted={onDeleteAccepted}
+										deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+										isCheckingDeployment={isCheckingDeployment}
+										onCheckDeploymentAgain={onCheckDeploymentAgain}
+									/>
+								</div>
+							)}
+						</div>
+					</AgentOverviewStatusCard>
+				</div>
 			</div>
 			<AgentOverviewCapabilities
 				agentId={agentId}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -34,6 +34,7 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
+import { AgentOverviewCapabilities } from "@/components/dashboard/agent-overview-capabilities";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
@@ -571,6 +572,8 @@ export function HostedAgentDetail({
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{deploymentStatus.known && activeTab === "overview" ? (
 						<OverviewTab
+							agentId={environmentId}
+							routeSearch={routeSearch}
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
@@ -1088,6 +1091,8 @@ export function OverviewFailedPanel({
 }
 
 function OverviewTab({
+	agentId,
+	routeSearch,
 	deployment,
 	agent,
 	isPerformance,
@@ -1105,6 +1110,8 @@ function OverviewTab({
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
+	agentId: string;
+	routeSearch: AgentRouteSearch;
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	isPerformance: boolean;
@@ -1193,6 +1200,7 @@ function OverviewTab({
 					value={`${spec.resources.vcpu} vCPU · ${formatMemoryMib(spec.resources.memory_mib)} · ${spec.resources.disk_gib} GiB storage`}
 				/>
 			</div>
+			<AgentOverviewCapabilities agentId={agentId} variant="hosted" routeSearch={routeSearch} />
 			{projectionAvailable ? (
 				<div>
 					<div className="mb-2 text-sm font-medium">Recent sessions</div>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-quer
 import { Link, useRouter } from "@tanstack/react-router";
 import {
 	AlertCircle,
+	ArrowRight,
 	Check,
 	Copy,
 	Cpu,
@@ -542,7 +543,7 @@ export function HostedAgentDetail({
 	});
 
 	const sessions = useQuery({
-		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 4 }),
+		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 3 }),
 		enabled: activeTab === "overview" && deploymentRunning && projection.status === "resolved",
 	});
 
@@ -1039,7 +1040,7 @@ export function OverviewComputeStatus({
 	);
 }
 
-function InitialDeploymentPage({
+export function InitialDeploymentPage({
 	deployment,
 	deploymentTransitionTimedOut,
 	isCheckingDeployment,
@@ -1050,7 +1051,7 @@ function InitialDeploymentPage({
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
-	const spec = deployment.resource.spec;
+	const status = deploymentStatusFromResource(deployment.resource.status);
 	return (
 		<DetailPanel
 			className={cn(
@@ -1060,7 +1061,11 @@ function InitialDeploymentPage({
 					: "border-info-muted bg-info-muted",
 			)}
 		>
-			<div data-testid="hosted-initial-deployment-panel" className="space-y-6">
+			<div
+				data-testid="hosted-initial-deployment-panel"
+				role={deploymentTransitionTimedOut ? "alert" : undefined}
+				className="space-y-5"
+			>
 				<div className="flex gap-4">
 					<div className="flex size-12 shrink-0 items-center justify-center rounded-lg border bg-background">
 						{deploymentTransitionTimedOut ? (
@@ -1069,7 +1074,7 @@ function InitialDeploymentPage({
 							<Spinner className="size-6" />
 						)}
 					</div>
-					<div>
+					<div className="min-w-0">
 						<h2 className="text-xl font-semibold">
 							{deploymentTransitionTimedOut
 								? "Setup is taking longer than expected"
@@ -1077,9 +1082,16 @@ function InitialDeploymentPage({
 						</h2>
 						<p className="mt-2 text-sm text-muted-foreground">
 							{deploymentTransitionTimedOut
-								? "Your agent may still be starting. Check again now, or come back later."
-								: "This usually takes a few minutes. You can leave this page and come back later."}
+								? "Your agent may still be starting. We’ll keep checking automatically, or you can check again now."
+								: "This usually takes a few minutes. This page updates automatically while your agent starts."}
 						</p>
+						<dl className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+							<dt className="text-muted-foreground">Current status</dt>
+							<dd className="inline-flex items-center gap-2 font-medium">
+								<StatusDot status={deploymentStatusTone(status)} />
+								{deploymentStatusLabel(status)}
+							</dd>
+						</dl>
 						{deploymentTransitionTimedOut ? (
 							<Button
 								type="button"
@@ -1094,19 +1106,6 @@ function InitialDeploymentPage({
 						) : null}
 					</div>
 				</div>
-				<OverviewMetrics
-					columns={2}
-					items={[
-						{
-							label: "Plan",
-							value:
-								deployment.current_plan_slug === COMPUTE_PERFORMANCE_SLUG ? "Performance" : "Basic",
-						},
-						{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
-						{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
-						{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
-					]}
-				/>
 			</div>
 		</DetailPanel>
 	);
@@ -1223,9 +1222,21 @@ function OverviewTab({
 	return (
 		<div className="flex flex-col gap-8">
 			<div>
-				<h2 id="hosted-recent-sessions" className="mb-3 text-sm font-semibold">
-					Recent sessions
-				</h2>
+				<div className="mb-3 flex items-center justify-between">
+					<h2 id="hosted-recent-sessions" className="text-sm font-semibold">
+						Recent sessions
+					</h2>
+					<Button
+						render={<Link {...agentSectionLink(agentId, "sessions", routeSearch)} />}
+						nativeButton={false}
+						variant="ghost"
+						size="sm"
+						className="text-muted-foreground"
+					>
+						View all
+						<ArrowRight />
+					</Button>
+				</div>
 				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
 					<section
 						aria-labelledby="hosted-recent-sessions"

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -39,6 +39,7 @@ import {
 	OverviewMetrics,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
+	OverviewModuleUnavailable,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
 import {
@@ -621,6 +622,8 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							projectionStatus={projection.status}
+							canRetryProjection={deploymentProjectionQueryable}
+							onRetryProjection={() => void agentQuery.refetch()}
 							isPerformance={isPerformance}
 							showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}
 							onDeleteAccepted={onDeleteAccepted}
@@ -1105,12 +1108,33 @@ function InitialDeploymentPage({
 	);
 }
 
+function OverviewProjectionUnavailableState({
+	canRetry,
+	onRetry,
+}: {
+	canRetry: boolean;
+	onRetry: () => void;
+}) {
+	return (
+		<div className="flex h-full min-h-40 flex-col items-start justify-center gap-3 rounded-lg border bg-muted/20 p-4">
+			<p className="text-sm text-muted-foreground">Agent details are unavailable right now.</p>
+			{canRetry ? (
+				<Button type="button" variant="outline" size="sm" onClick={onRetry}>
+					<RefreshCw /> Check again
+				</Button>
+			) : null}
+		</div>
+	);
+}
+
 function OverviewTab({
 	agentId,
 	routeSearch,
 	deployment,
 	agent,
 	projectionStatus,
+	canRetryProjection,
+	onRetryProjection,
 	isPerformance,
 	showDeploymentActions,
 	onDeleteAccepted,
@@ -1130,6 +1154,8 @@ function OverviewTab({
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	projectionStatus: HostedProjectionResolution<unknown>["status"];
+	canRetryProjection: boolean;
+	onRetryProjection: () => void;
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
 	onDeleteAccepted: (deploymentId: string) => void;
@@ -1189,7 +1215,7 @@ function OverviewTab({
 		return [`${provider}: ${link.account.name}`];
 	});
 	const projectionLoading = projectionStatus === "loading";
-	const projectionUnavailable = projectionStatus === "unavailable" || !deploymentStatus.known;
+	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
 	return (
 		<div className="flex flex-col gap-8">
 			<div>
@@ -1201,12 +1227,17 @@ function OverviewTab({
 						aria-labelledby="hosted-recent-sessions"
 						className="min-h-40 min-w-0 @3xl/main:min-h-52"
 					>
-						{sessionsError ? (
+						{projectionUnavailable ? (
+							<OverviewProjectionUnavailableState
+								canRetry={canRetryProjection}
+								onRetry={onRetryProjection}
+							/>
+						) : sessionsError ? (
 							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
 						) : (
 							<OverviewSessionList
 								sessions={sessions}
-								isLoading={sessionsLoading}
+								isLoading={projectionLoading || sessionsLoading}
 								emptyMessage={sessionsEmptyMessage}
 								sessionLink={sessionLink}
 							/>
@@ -1267,9 +1298,8 @@ function OverviewTab({
 								bindings={{
 									count: agent ? (projectBindings.data?.length ?? null) : null,
 									isLoading: projectionLoading || projectBindings.isLoading,
-									error: projectionUnavailable
-										? new Error("Projection unavailable")
-										: projectBindings.error,
+									isUnavailable: projectionUnavailable,
+									error: projectBindings.error,
 									onRetry: () => void projectBindings.refetch(),
 								}}
 								names={{
@@ -1287,7 +1317,8 @@ function OverviewTab({
 							<OverviewSkillsBody
 								items={(skills.skills ?? []).map((skill) => skill.name)}
 								isLoading={projectionLoading || skills.isLoading}
-								error={projectionUnavailable ? new Error("Projection unavailable") : skills.error}
+								isUnavailable={projectionUnavailable}
+								error={skills.error}
 								onRetry={() => void skills.refetch()}
 							/>
 						),
@@ -1304,7 +1335,6 @@ function OverviewTab({
 											? "unavailable"
 											: "ready"
 								}
-								onRetry={() => void projectBindings.refetch()}
 							/>
 						),
 					},
@@ -1335,12 +1365,10 @@ function OverviewTab({
 							),
 					},
 					channels: {
-						body: !agent ? (
-							projectionUnavailable ? (
-								<OverviewModuleError label="Channels" />
-							) : (
-								<OverviewModuleSkeleton label="channels" rows={2} />
-							)
+						body: projectionLoading ? (
+							<OverviewModuleSkeleton label="channels" rows={2} />
+						) : projectionUnavailable ? (
+							<OverviewModuleUnavailable />
 						) : channelLinks.isLoading ? (
 							<OverviewModuleSkeleton label="channels" rows={2} />
 						) : channelLinks.error ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -36,6 +36,7 @@ import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
+	AgentOverviewStatusCard,
 	OverviewChips,
 	OverviewMetadata,
 	OverviewMetrics,
@@ -43,11 +44,18 @@ import {
 	OverviewModuleSkeleton,
 	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	OverviewConnectorsBody,
+	OverviewMemoriesBody,
+	OverviewVaultsBody,
+} from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
+import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
 import { AgentProjectsTab } from "@/components/dashboard/agent-projects-tab";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { AgentVaultsTab } from "@/components/dashboard/agent-vaults-tab";
+import { DetailPanel } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CHOICE_GRID_CLASS,
@@ -60,7 +68,7 @@ import { MemoriesSurface } from "@/components/memories/memories-surface";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
-import { SessionFeed } from "@/components/sessions/session-feed";
+import { OverviewSessionList, SessionFeed } from "@/components/sessions/session-feed";
 import { SettingsSection } from "@/components/settings-section";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -282,6 +290,7 @@ import {
 	type AgentSectionId,
 	agentSectionHref,
 	agentSectionLabel,
+	agentSectionLink,
 	agentSessionDetailLink,
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
@@ -540,6 +549,12 @@ export function HostedAgentDetail({
 	const activeNavItem = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
+	const initialProvisioning =
+		activeTab === "overview" &&
+		isStartingStatus(deploymentStatus) &&
+		projection.status !== "resolved";
+	const interfaceAvailable =
+		activeTab === "overview" && !initialProvisioning && isRunningStatus(deploymentStatus);
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
 	return (
 		<div
@@ -558,6 +573,18 @@ export function HostedAgentDetail({
 						title={activeTabLabel}
 						description={activeNavItem.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
+						actions={
+							interfaceAvailable ? (
+								<Button
+									render={<Link {...agentSectionLink(environmentId, "console", routeSearch)} />}
+									nativeButton={false}
+									variant="outline"
+								>
+									<MonitorPlay />
+									Open Agent Interface
+								</Button>
+							) : null
+						}
 					/>
 				)}
 				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
@@ -581,7 +608,14 @@ export function HostedAgentDetail({
 					/>
 				) : null}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
-					{activeTab === "overview" ? (
+					{initialProvisioning ? (
+						<InitialDeploymentPage
+							deployment={deployment}
+							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							isCheckingDeployment={isCheckingDeployment}
+							onCheckDeploymentAgain={onCheckDeploymentAgain}
+						/>
+					) : activeTab === "overview" ? (
 						<OverviewTab
 							agentId={environmentId}
 							routeSearch={routeSearch}
@@ -590,7 +624,6 @@ export function HostedAgentDetail({
 							isPerformance={isPerformance}
 							showDeploymentActions={!deploymentRunning && !isStartingStatus(deploymentStatus)}
 							onDeleteAccepted={onDeleteAccepted}
-							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
 							sessionsError={
@@ -1058,15 +1091,6 @@ export function OverviewFailedPanel({
 	);
 }
 
-function runtimeConsoleLocation(url: string | null): string | null {
-	if (!url) return null;
-	try {
-		return new URL(url).host;
-	} catch {
-		return null;
-	}
-}
-
 function OverviewComputeStatus({
 	deployment,
 	failure,
@@ -1158,6 +1182,80 @@ function OverviewComputeStatus({
 	);
 }
 
+function InitialDeploymentPage({
+	deployment,
+	deploymentTransitionTimedOut,
+	isCheckingDeployment,
+	onCheckDeploymentAgain,
+}: {
+	deployment: HostedDeployment;
+	deploymentTransitionTimedOut: boolean;
+	isCheckingDeployment: boolean;
+	onCheckDeploymentAgain: () => void;
+}) {
+	const spec = deployment.resource.spec;
+	return (
+		<DetailPanel
+			className={cn(
+				"p-6 md:p-8",
+				deploymentTransitionTimedOut
+					? "border-warning/30 bg-warning-muted"
+					: "border-info-muted bg-info-muted",
+			)}
+		>
+			<div data-testid="hosted-initial-deployment-panel" className="space-y-6">
+				<div className="flex gap-4">
+					<div className="flex size-12 shrink-0 items-center justify-center rounded-lg border bg-background">
+						{deploymentTransitionTimedOut ? (
+							<AlertCircle className="size-6" />
+						) : (
+							<Spinner className="size-6" />
+						)}
+					</div>
+					<div>
+						<p className="text-sm font-medium">Starting</p>
+						<h2 className="mt-1 text-xl font-semibold">
+							{deploymentTransitionTimedOut
+								? "Setup is taking longer than expected"
+								: "Setting up your agent"}
+						</h2>
+						<p className="mt-2 text-sm text-muted-foreground">
+							{deploymentTransitionTimedOut
+								? "Your agent may still be starting. Check again now, or come back later."
+								: "This usually takes a few minutes. You can leave this page and come back later."}
+						</p>
+						{deploymentTransitionTimedOut ? (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								className="mt-4"
+								disabled={isCheckingDeployment}
+								onClick={onCheckDeploymentAgain}
+							>
+								{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}Check again
+							</Button>
+						) : null}
+					</div>
+				</div>
+				<OverviewMetrics
+					columns={2}
+					items={[
+						{
+							label: "Plan",
+							value:
+								deployment.current_plan_slug === COMPUTE_PERFORMANCE_SLUG ? "Performance" : "Basic",
+						},
+						{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
+						{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
+						{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
+					]}
+				/>
+			</div>
+		</DetailPanel>
+	);
+}
+
 function OverviewTab({
 	agentId,
 	routeSearch,
@@ -1166,7 +1264,6 @@ function OverviewTab({
 	isPerformance,
 	showDeploymentActions,
 	onDeleteAccepted,
-	projectionAvailable,
 	sessions,
 	sessionsLoading,
 	sessionsError,
@@ -1185,7 +1282,6 @@ function OverviewTab({
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
 	onDeleteAccepted: (deploymentId: string) => void;
-	projectionAvailable: boolean;
 	sessions: SessionListItem[];
 	sessionsLoading: boolean;
 	sessionsError: unknown;
@@ -1223,9 +1319,6 @@ function OverviewTab({
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
-	const sessionSummary = sessions.length
-		? `${sessions.length} recent ${sessions.length === 1 ? "session" : "sessions"}`
-		: "No recent sessions";
 	const overviewProjects = useAgentOverviewProjects(agentId, { enabled: Boolean(agent) });
 	const projectBindings = overviewProjects.bindings;
 	const projectNames = overviewProjects.nameResolution;
@@ -1242,66 +1335,71 @@ function OverviewTab({
 		const provider = providerMeta(link.account.provider).label;
 		return [`${provider}: ${link.account.name}`];
 	});
-	const consoleUrl = runtimeConsoleUrl(deployment, spec.runtime);
-	const consoleLocation = runtimeConsoleLocation(consoleUrl);
 	const providerId = primaryModelProviderId(primaryModel) ?? bindingProvider?.provider_id;
 	const projectionUnavailable = !deploymentStatus.known;
-	const provisioning = isStartingStatus(deploymentStatus) && !projectionAvailable;
 	return (
-		<div className="flex flex-col gap-5">
+		<div className="flex flex-col gap-8">
+			<div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
+				<section aria-labelledby="hosted-recent-sessions">
+					<h2 id="hosted-recent-sessions" className="mb-3 text-sm font-semibold">
+						Recent sessions
+					</h2>
+					{sessionsError ? (
+						<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
+					) : (
+						<OverviewSessionList
+							sessions={sessions}
+							isLoading={sessionsLoading}
+							emptyMessage={sessionsEmptyMessage}
+							sessionLink={sessionLink}
+						/>
+					)}
+				</section>
+				<AgentOverviewStatusCard
+					agentId={agentId}
+					section="settings"
+					routeSearch={routeSearch}
+					title="Compute"
+					icon={Cpu}
+					tint="bg-identity-4-bg text-identity-4-fg"
+				>
+					<div className="space-y-3">
+						<p className="inline-flex items-center gap-2 text-lg font-semibold">
+							<StatusDot status={deploymentStatusTone(deploymentStatus)} />
+							{deploymentStatusLabel(deploymentStatus)}
+						</p>
+						<OverviewMetrics
+							columns={2}
+							items={[
+								{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
+								{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
+								{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
+								{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
+							]}
+						/>
+						{deploymentRunning ? null : (
+							<div className="border-t pt-3">
+								<OverviewComputeStatus
+									deployment={deployment}
+									failure={deploymentFailure}
+									showActions={showDeploymentActions}
+									planChangeHref={planChangeHref}
+									providerSettingsHref={providerSettingsHref}
+									onDeleteAccepted={onDeleteAccepted}
+									deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+									isCheckingDeployment={isCheckingDeployment}
+									onCheckDeploymentAgain={onCheckDeploymentAgain}
+								/>
+							</div>
+						)}
+					</div>
+				</AgentOverviewStatusCard>
+			</div>
 			<AgentOverviewCapabilities
 				agentId={agentId}
 				variant="hosted"
 				routeSearch={routeSearch}
-				visibleModuleIds={provisioning ? ["agent-interface", "compute"] : undefined}
-				moduleSizeOverrides={
-					provisioning ? { "agent-interface": "wide", compute: "wide" } : undefined
-				}
 				content={{
-					sessions: {
-						body: !projectionAvailable ? (
-							projectionUnavailable ? (
-								<OverviewModuleError label="Sessions" />
-							) : (
-								<OverviewModuleSkeleton label="sessions" rows={3} />
-							)
-						) : sessionsLoading ? (
-							<OverviewModuleSkeleton label="sessions" rows={3} />
-						) : sessionsError ? (
-							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
-						) : (
-							<div className="space-y-3">
-								<div>
-									<p className="text-lg font-semibold">{sessionSummary}</p>
-									<p className="mt-1 text-xs text-muted-foreground">Managed agent activity</p>
-								</div>
-								<div className="border-t pt-3">
-									<SessionFeed
-										sessions={sessions.slice(0, 3)}
-										isLoading={false}
-										emptyMessage={sessionsEmptyMessage}
-										emptyVariant="inset"
-										showAgent={false}
-										sessionLink={sessionLink}
-									/>
-								</div>
-							</div>
-						),
-					},
-					"agent-interface": {
-						body: (
-							<div className="space-y-3">
-								<p className="text-lg font-semibold">
-									{deploymentRunning ? "Ready to open" : "Not available"}
-								</p>
-								<p className="text-sm text-muted-foreground">
-									{deploymentRunning
-										? (consoleLocation ?? runtimeDisplayName(spec.runtime))
-										: "Available when compute is running"}
-								</p>
-							</div>
-						),
-					},
 					projects: {
 						body: !agent ? (
 							projectionUnavailable ? (
@@ -1374,6 +1472,18 @@ function OverviewTab({
 							</div>
 						),
 					},
+					memories: { body: <OverviewMemoriesBody /> },
+					vaults: {
+						body: (
+							<OverviewVaultsBody
+								projectIds={effectiveAgentProjectIds(projectBindings.data ?? [])}
+								isLoading={projectBindings.isLoading}
+								error={projectBindings.error}
+								onRetry={() => void projectBindings.refetch()}
+							/>
+						),
+					},
+					connectors: { body: <OverviewConnectorsBody /> },
 					"model-provider": {
 						body: (
 							<OverviewMetadata
@@ -1406,53 +1516,8 @@ function OverviewTab({
 							</div>
 						),
 					},
-					compute: {
-						body: (
-							<div className="space-y-3">
-								<p className="inline-flex items-center gap-2 text-lg font-semibold">
-									<StatusDot status={deploymentStatusTone(deploymentStatus)} />
-									{deploymentStatusLabel(deploymentStatus)}
-								</p>
-								<OverviewMetrics
-									columns={2}
-									items={[
-										{ label: "Plan", value: isPerformance ? "Performance" : "Basic" },
-										{ label: "CPU", value: `${spec.resources.vcpu} vCPU` },
-										{ label: "Memory", value: formatMemoryMib(spec.resources.memory_mib) },
-										{ label: "Storage", value: `${spec.resources.disk_gib} GiB` },
-									]}
-								/>
-								{deploymentRunning ? null : (
-									<div className="border-t pt-3">
-										<OverviewComputeStatus
-											deployment={deployment}
-											failure={deploymentFailure}
-											showActions={showDeploymentActions}
-											planChangeHref={planChangeHref}
-											providerSettingsHref={providerSettingsHref}
-											onDeleteAccepted={onDeleteAccepted}
-											deploymentTransitionTimedOut={deploymentTransitionTimedOut}
-											isCheckingDeployment={isCheckingDeployment}
-											onCheckDeploymentAgain={onCheckDeploymentAgain}
-										/>
-									</div>
-								)}
-							</div>
-						),
-					},
 				}}
 			/>
-			{provisioning ? (
-				<div
-					data-testid="hosted-overview-provisioning-placeholder"
-					className="rounded-lg border border-dashed bg-muted/20 px-6 py-10 text-center"
-				>
-					<p className="text-sm font-medium">More details will appear here</p>
-					<p className="mx-auto mt-2 max-w-xl text-sm text-muted-foreground">
-						This page will fill in automatically when your agent is ready.
-					</p>
-				</div>
-			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -886,7 +886,7 @@ function HostedAgentSessionsTab({
 
 // ── Overview ─────────────────────────────────────────────────────────────────
 
-function OverviewFailureAction({
+export function OverviewFailureAction({
 	deployment,
 	failure,
 	planChangeHref,
@@ -944,7 +944,7 @@ function OverviewFailureAction({
 	);
 }
 
-function OverviewComputeStatus({
+export function OverviewComputeStatus({
 	deployment,
 	failure,
 	showActions,
@@ -977,7 +977,11 @@ function OverviewComputeStatus({
 				</div>
 			) : status.kind === "failed" ? (
 				<p className="text-destructive-muted-foreground" role="status">
-					The last compute change failed. Contact support before trying again.
+					The last compute change failed. Contact{" "}
+					<a className="underline underline-offset-2" href="mailto:support@clawdi.ai">
+						support
+					</a>{" "}
+					before trying again.
 				</p>
 			) : deploymentTransitionTimedOut ? (
 				<p className="text-warning-muted-foreground" role="status">

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -123,7 +123,11 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource).toContain("Basic plan unavailable");
 		expect(wizardSource).not.toContain("basicPlan?.vcpu ?? 2");
 		expect(wizardSource).not.toContain("basicPlan?.ram_gb ?? 4");
-		expect(agentDetailSource).toContain("disk_gib} GiB storage");
+		expect(
+			agentDetailSource.match(
+				/\{ label: "Storage", value: `\$\{spec\.resources\.disk_gib\} GiB` \}/g,
+			),
+		).toHaveLength(2);
 		expect(wizardSource).toContain('className="whitespace-nowrap" data-testid={testId}');
 		expect(wizardSource).toMatch(/data-testid=\{`\$\{testId\}-savings`\}/);
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -127,7 +127,7 @@ describe("deploy wizard responsive layout", () => {
 			agentDetailSource.match(
 				/\{ label: "Storage", value: `\$\{spec\.resources\.disk_gib\} GiB` \}/g,
 			),
-		).toHaveLength(2);
+		).toHaveLength(1);
 		expect(wizardSource).toContain('className="whitespace-nowrap" data-testid={testId}');
 		expect(wizardSource).toMatch(/data-testid=\{`\$\{testId\}-savings`\}/);
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -123,11 +123,7 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource).toContain("Basic plan unavailable");
 		expect(wizardSource).not.toContain("basicPlan?.vcpu ?? 2");
 		expect(wizardSource).not.toContain("basicPlan?.ram_gb ?? 4");
-		expect(
-			agentDetailSource.match(
-				/\{ label: "Storage", value: `\$\{spec\.resources\.disk_gib\} GiB` \}/g,
-			),
-		).toHaveLength(1);
+		expect(agentDetailSource.match(/storageGib=\{spec\.resources\.disk_gib\}/g)).toHaveLength(1);
 		expect(wizardSource).toContain('className="whitespace-nowrap" data-testid={testId}');
 		expect(wizardSource).toMatch(/data-testid=\{`\$\{testId\}-savings`\}/);
 	});

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -124,12 +124,13 @@ export function useHostedUser() {
 	});
 }
 
-export function useManagedModelCatalog() {
+export function useManagedModelCatalog({ enabled = true }: { enabled?: boolean } = {}) {
 	const client = useBillingClient();
 	return useBillingQuery({
 		queryKey: billingKeys.managedModelCatalog,
 		queryFn: () => client.getManagedModelCatalog(),
 		staleTime: 5 * 60_000,
+		enabled,
 	});
 }
 

--- a/apps/web/src/hosted/billing/wallet/wallet-query.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-query.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import type { WalletState } from "@/hosted/billing/contracts";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
+
+type WalletSnapshotQueryOptions =
+	typeof import("@/hosted/billing/wallet/wallet-query").walletSnapshotQueryOptions;
+
+let walletSnapshotQueryOptions: WalletSnapshotQueryOptions | null = null;
+let refreshIntervalMs = 0;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const module = await import("@/hosted/billing/wallet/wallet-query");
+	walletSnapshotQueryOptions = module.walletSnapshotQueryOptions;
+	refreshIntervalMs = module.WALLET_SNAPSHOT_REFRESH_INTERVAL_MS;
+});
+
+describe("walletSnapshotQueryOptions", () => {
+	test("shares the canonical cache key and does not refetch for a second fresh observer", async () => {
+		if (!walletSnapshotQueryOptions) throw new Error("Wallet query options were not loaded");
+		let calls = 0;
+		const wallet: WalletState = {
+			balance_usd: "25.00",
+			x402_enabled: false,
+			auto_reload_enabled: false,
+			auto_reload_threshold_usd: "5.00",
+			auto_reload_amount_cents: 2_500,
+			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_action: {
+				attempt_id: 7,
+				payment_intent_id: "pi_test",
+				client_secret: "must-not-enter-cache",
+				error_code: null,
+			},
+		};
+		const options = walletSnapshotQueryOptions({
+			getWallet: async () => {
+				calls += 1;
+				return wallet;
+			},
+		});
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+		await queryClient.fetchQuery(options);
+		const first = new QueryObserver(queryClient, options);
+		const second = new QueryObserver(queryClient, options);
+		const unsubscribeFirst = first.subscribe(() => undefined);
+		const unsubscribeSecond = second.subscribe(() => undefined);
+		await Promise.resolve();
+
+		expect(options.queryKey).toBe(billingKeys.wallet);
+		expect(options.staleTime).toBe(refreshIntervalMs);
+		expect(options.refetchInterval).toBe(refreshIntervalMs);
+		expect(calls).toBe(1);
+		expect(queryClient.getQueryData<WalletCacheSnapshot>(billingKeys.wallet)).toEqual({
+			balance_usd: "25.00",
+			x402_enabled: false,
+			auto_reload_enabled: false,
+			auto_reload_threshold_usd: "5.00",
+			auto_reload_amount_cents: 2_500,
+			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_action: {
+				attempt_id: 7,
+				payment_intent_id: "pi_test",
+				error_code: null,
+			},
+		});
+
+		unsubscribeFirst();
+		unsubscribeSecond();
+		queryClient.clear();
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/wallet-query.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-query.ts
@@ -6,15 +6,29 @@ import { billingQueryRetry } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { walletSnapshotForCache } from "@/hosted/billing/wallet/wallet-cache";
 
-/** Wallet polling whose query function projects out secrets before caching. */
-export function useWalletSnapshot({ enabled = true }: { enabled?: boolean } = {}) {
-	const client = useBillingClient();
-	return useQuery({
+export const WALLET_SNAPSHOT_REFRESH_INTERVAL_MS = 30_000;
+
+type WalletSnapshotClient = Pick<ReturnType<typeof useBillingClient>, "getWallet">;
+
+export function walletSnapshotQueryOptions(
+	client: WalletSnapshotClient,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	return {
 		queryKey: billingKeys.wallet,
 		queryFn: async () => walletSnapshotForCache(await client.getWallet()),
 		enabled: isDeployApiConfigured() && enabled,
 		retry: billingQueryRetry,
-		refetchInterval: 30_000,
+		// A second observer (for example Settings → Wallet) should reuse the
+		// global header snapshot instead of paying for an immediate mount refetch.
+		staleTime: WALLET_SNAPSHOT_REFRESH_INTERVAL_MS,
+		refetchInterval: WALLET_SNAPSHOT_REFRESH_INTERVAL_MS,
 		refetchIntervalInBackground: false,
-	});
+	};
+}
+
+/** Wallet polling whose query function projects out secrets before caching. */
+export function useWalletSnapshot({ enabled = true }: { enabled?: boolean } = {}) {
+	const client = useBillingClient();
+	return useQuery(walletSnapshotQueryOptions(client, { enabled }));
 }

--- a/apps/web/src/hosted/global-wallet-balance.test.ts
+++ b/apps/web/src/hosted/global-wallet-balance.test.ts
@@ -45,6 +45,8 @@ describe("global Wallet balance presentation", () => {
 		expect(markup).toContain("$1,250.50");
 		expect(markup).toContain("Wallet balance $1,250.50. Open Wallet settings");
 		expect(markup).toContain('data-testid="global-wallet-balance"');
+		expect(markup).toContain("lucide-wallet-cards");
+		expect(markup).not.toMatch(/>\s*Wallet\s*</);
 	});
 
 	test("uses a compact skeleton while loading and never invents a zero balance", () => {
@@ -59,6 +61,10 @@ describe("global Wallet balance presentation", () => {
 		expect(loading).toContain('data-slot="skeleton"');
 		expect(loading).toContain("Wallet balance loading");
 		expect(unavailable).toContain("Wallet balance unavailable");
+		expect(loading).toContain("lucide-wallet-cards");
+		expect(unavailable).toContain("lucide-wallet-cards");
+		expect(unavailable).not.toContain('data-slot="skeleton"');
 		expect(`${loading}${unavailable}`).not.toContain("$0");
+		expect(`${loading}${unavailable}`).not.toMatch(/>\s*Wallet\s*</);
 	});
 });

--- a/apps/web/src/hosted/global-wallet-balance.test.ts
+++ b/apps/web/src/hosted/global-wallet-balance.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+type GlobalWalletBalanceView =
+	typeof import("@/hosted/global-wallet-balance").GlobalWalletBalanceView;
+type HostedWalletBalanceApplicable =
+	typeof import("@/hosted/global-wallet-balance").hostedWalletBalanceApplicable;
+
+let globalWalletBalanceView: GlobalWalletBalanceView | null = null;
+let walletBalanceApplicable: HostedWalletBalanceApplicable | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const module = await import("@/hosted/global-wallet-balance");
+	globalWalletBalanceView = module.GlobalWalletBalanceView;
+	walletBalanceApplicable = module.hostedWalletBalanceApplicable;
+});
+
+describe("global Wallet balance applicability", () => {
+	test("shows only for accounts with Cloud billing access or existing Cloud deployments", () => {
+		if (!walletBalanceApplicable) throw new Error("global Wallet balance was not loaded");
+
+		expect(
+			walletBalanceApplicable({ canCreateCloudAgents: true, existingCloudDeploymentCount: 0 }),
+		).toBe(true);
+		expect(
+			walletBalanceApplicable({ canCreateCloudAgents: false, existingCloudDeploymentCount: 2 }),
+		).toBe(true);
+		expect(
+			walletBalanceApplicable({ canCreateCloudAgents: false, existingCloudDeploymentCount: 0 }),
+		).toBe(false);
+	});
+});
+
+describe("global Wallet balance presentation", () => {
+	test("renders a real balance as the compact global action", () => {
+		if (!globalWalletBalanceView) throw new Error("global Wallet balance was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(globalWalletBalanceView, { state: "ready", balanceUsd: "1250.5" }),
+		);
+
+		expect(markup).toContain("$1,250.50");
+		expect(markup).toContain("Wallet balance $1,250.50. Open Wallet settings");
+		expect(markup).toContain('data-testid="global-wallet-balance"');
+	});
+
+	test("uses a compact skeleton while loading and never invents a zero balance", () => {
+		if (!globalWalletBalanceView) throw new Error("global Wallet balance was not loaded");
+		const loading = renderToStaticMarkup(
+			createElement(globalWalletBalanceView, { state: "loading" }),
+		);
+		const unavailable = renderToStaticMarkup(
+			createElement(globalWalletBalanceView, { state: "unavailable" }),
+		);
+
+		expect(loading).toContain('data-slot="skeleton"');
+		expect(loading).toContain("Wallet balance loading");
+		expect(unavailable).toContain("Wallet balance unavailable");
+		expect(`${loading}${unavailable}`).not.toContain("$0");
+	});
+});

--- a/apps/web/src/hosted/global-wallet-balance.tsx
+++ b/apps/web/src/hosted/global-wallet-balance.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useRouter } from "@tanstack/react-router";
+import { WalletCards } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatUsdExact } from "@/hosted/billing/format";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
+import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
+import { useHostedProductAccess } from "@/lib/hosted-product-access";
+
+export function hostedWalletBalanceApplicable({
+	canCreateCloudAgents,
+	existingCloudDeploymentCount,
+}: {
+	canCreateCloudAgents: boolean;
+	existingCloudDeploymentCount: number;
+}): boolean {
+	return canCreateCloudAgents || existingCloudDeploymentCount > 0;
+}
+
+function WalletBalanceEntry({
+	label,
+	children,
+	onOpenWallet,
+}: {
+	label: string;
+	children?: React.ReactNode;
+	onOpenWallet?: () => void;
+}) {
+	return (
+		<Button
+			type="button"
+			data-hosted="true"
+			aria-label={label}
+			onClick={onOpenWallet}
+			variant="ghost"
+			size="sm"
+			data-testid="global-wallet-balance"
+			className="max-w-40 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+		>
+			<WalletCards className="size-4" />
+			<span className="hidden sm:inline">Wallet</span>
+			{children}
+		</Button>
+	);
+}
+
+export function GlobalWalletBalanceView({
+	state,
+	balanceUsd,
+	onOpenWallet,
+}: {
+	state: "loading" | "ready" | "unavailable";
+	balanceUsd?: string;
+	onOpenWallet?: () => void;
+}) {
+	if (state === "loading") {
+		return (
+			<WalletBalanceEntry
+				label="Wallet balance loading. Open Wallet settings"
+				onOpenWallet={onOpenWallet}
+			>
+				<Skeleton aria-hidden="true" className="h-3.5 w-12" />
+			</WalletBalanceEntry>
+		);
+	}
+
+	const formattedBalance = state === "ready" && balanceUsd ? formatUsdExact(balanceUsd) : null;
+	if (!formattedBalance || formattedBalance === "—") {
+		return (
+			<WalletBalanceEntry
+				label="Wallet balance unavailable. Open Wallet settings"
+				onOpenWallet={onOpenWallet}
+			/>
+		);
+	}
+
+	return (
+		<WalletBalanceEntry
+			label={`Wallet balance ${formattedBalance}. Open Wallet settings`}
+			onOpenWallet={onOpenWallet}
+		>
+			<span className="font-medium text-foreground tabular-nums">{formattedBalance}</span>
+		</WalletBalanceEntry>
+	);
+}
+
+export function GlobalWalletBalance() {
+	const router = useRouter();
+	const hostedAccess = useHostedProductAccess();
+	const cloudInventory = useHostedDeploymentInventory();
+	const billingApplies = hostedWalletBalanceApplicable({
+		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+		existingCloudDeploymentCount: cloudInventory.deployments?.length ?? 0,
+	});
+	const wallet = useWalletSnapshot({ enabled: billingApplies });
+
+	if (!billingApplies) return null;
+	const openWallet = () => {
+		void router.navigate({
+			to: ".",
+			search: (current) => ({ ...current, settings: "billing-wallet" }),
+			hash: true,
+			replace: true,
+			resetScroll: false,
+		});
+	};
+
+	if (wallet.isLoading) {
+		return <GlobalWalletBalanceView state="loading" onOpenWallet={openWallet} />;
+	}
+	if (!wallet.data) {
+		return <GlobalWalletBalanceView state="unavailable" onOpenWallet={openWallet} />;
+	}
+	return (
+		<GlobalWalletBalanceView
+			state="ready"
+			balanceUsd={wallet.data.balance_usd}
+			onOpenWallet={openWallet}
+		/>
+	);
+}
+
+export default GlobalWalletBalance;

--- a/apps/web/src/hosted/global-wallet-balance.tsx
+++ b/apps/web/src/hosted/global-wallet-balance.tsx
@@ -40,7 +40,6 @@ function WalletBalanceEntry({
 			className="max-w-40 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
 		>
 			<WalletCards className="size-4" />
-			<span className="hidden sm:inline">Wallet</span>
 			{children}
 		</Button>
 	);

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -207,6 +207,7 @@ describe("structural secret boundaries without the denylist", () => {
 		).toHaveLength(7);
 
 		const walletConsumers = [
+			"hosted/global-wallet-balance.tsx",
 			"hosted/billing/deploy/deploy-wizard.tsx",
 			"hosted/billing/wallet/wallet-page.tsx",
 			"hosted/billing/subscription/welcome-wallet-card.tsx",

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -25,13 +25,14 @@ export function useAiProviders() {
 	return useOpenApi().useQuery("get", "/v1/ai-providers", {});
 }
 
-export function useUserAiProviders() {
+export function useUserAiProviders({ enabled = true }: { enabled?: boolean } = {}) {
 	return useOpenApi().useQuery(
 		"get",
 		"/v1/ai-providers",
 		{},
 		{
 			select: selectUserAiProviders,
+			enabled,
 		},
 	);
 }

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -24,8 +24,9 @@ describe("agent overview registry", () => {
 			"connectors",
 		]);
 		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
+		expect(hosted[0]?.layout).toBe(connected[0]?.layout);
 		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
-		expect(connected[0]?.layout).toBe("balanced-five");
+		expect(connected[0]?.layout).toBe("three-column");
 		expect(hosted[1]?.layout).toBe("two-column");
 		expect(connected[0]?.modules.every((module) => !("size" in module))).toBe(true);
 	});

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -27,7 +27,7 @@ describe("agent overview registry", () => {
 		expect(hosted[0]?.layout).toBe(connected[0]?.layout);
 		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
 		expect(connected[0]?.layout).toBe("three-column");
-		expect(hosted[1]?.layout).toBe("two-column");
+		expect(hosted[1]?.layout).toBe("three-column");
 		expect(connected[0]?.modules.every((module) => !("size" in module))).toBe(true);
 	});
 

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -24,7 +24,9 @@ describe("agent overview registry", () => {
 		]);
 		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
 		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
-		expect(connected[0]?.modules.find((module) => module.id === "connectors")?.size).toBe("wide");
+		expect(connected[0]?.modules.find((module) => module.id === "connectors")?.size).toBe(
+			"standard",
+		);
 		expect(connected[0]?.modules.find((module) => module.id === "projects")?.size).toBe("standard");
 	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { agentOverviewGroups } from "@/lib/agent-capabilities";
 import { agentNavigationSectionIds } from "@/lib/navigation-model";
 
@@ -27,5 +28,14 @@ describe("agent overview registry", () => {
 		expect(connected[0]?.layout).toBe("balanced-five");
 		expect(hosted[1]?.layout).toBe("two-column");
 		expect(connected[0]?.modules.every((module) => !("size" in module))).toBe(true);
+	});
+
+	test("skips a missing summary without rendering an empty card or crashing the overview", () => {
+		const source = readFileSync(
+			new URL("../components/dashboard/agent-overview-capabilities.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(source).toContain("if (!moduleContent) return null;");
+		expect(source).not.toContain("Missing overview content");
 	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,23 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { agentCapabilities } from "@/lib/agent-capabilities";
+import { agentOverviewGroups } from "@/lib/agent-capabilities";
 import { agentNavigationSectionIds } from "@/lib/navigation-model";
 
 describe("agent capabilities", () => {
 	for (const variant of ["connected", "hosted"] as const) {
-		test(`${variant} overview links only advertise supported sections`, () => {
+		test(`${variant} overview modules only link to supported sections`, () => {
 			const supported = new Set(agentNavigationSectionIds(variant));
-			for (const capability of agentCapabilities(variant).overviewCapabilities) {
-				expect(supported.has(capability.section)).toBe(true);
+			for (const module of agentOverviewGroups(variant).flatMap((group) => group.modules)) {
+				expect(supported.has(module.section)).toBe(true);
 			}
 		});
 	}
 
-	test("keeps runtime management exclusive to hosted agents", () => {
-		expect(agentCapabilities("hosted").overviewCapabilities.map((item) => item.section)).toContain(
-			"console",
-		);
-		expect(
-			agentCapabilities("connected").overviewCapabilities.map((item) => item.section),
-		).not.toContain("console");
+	test("keeps the shared hierarchy stable while varying runtime modules", () => {
+		const connected = agentOverviewGroups("connected");
+		const hosted = agentOverviewGroups("hosted");
+		expect(connected.map((group) => group.id)).toEqual(["now", "resources"]);
+		expect(hosted.map((group) => group.id)).toEqual(["now", "resources", "operate"]);
+		expect(connected[0]?.modules.map((module) => module.id)).toEqual(["sessions", "live-sync"]);
+		expect(hosted[0]?.modules.map((module) => module.id)).toEqual(["sessions", "agent-interface"]);
+		expect(connected[1]?.modules).toEqual(hosted[1]?.modules);
+	});
+
+	test("gives Sessions and Projects the dominant module width", () => {
+		for (const variant of ["connected", "hosted"] as const) {
+			const modules = agentOverviewGroups(variant).flatMap((group) => group.modules);
+			expect(modules.find((module) => module.id === "sessions")?.size).toBe("wide");
+			expect(modules.find((module) => module.id === "projects")?.size).toBe("wide");
+		}
 	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -34,4 +34,12 @@ describe("agent capabilities", () => {
 			expect(modules.find((module) => module.id === "projects")?.size).toBe("wide");
 		}
 	});
+
+	test("keeps desktop columns explicit without presentation copy in the registry", () => {
+		expect(agentOverviewGroups("connected").map((group) => group.columns)).toEqual([3, 3]);
+		expect(agentOverviewGroups("hosted").map((group) => group.columns)).toEqual([4, 3, 3]);
+		for (const group of [...agentOverviewGroups("connected"), ...agentOverviewGroups("hosted")]) {
+			expect(Object.hasOwn(group, "description")).toBe(false);
+		}
+	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -2,58 +2,29 @@ import { describe, expect, test } from "bun:test";
 import { agentOverviewGroups } from "@/lib/agent-capabilities";
 import { agentNavigationSectionIds } from "@/lib/navigation-model";
 
-describe("agent capabilities", () => {
-	for (const variant of ["connected", "hosted"] as const) {
-		test(`${variant} overview modules only link to supported sections`, () => {
+describe("agent overview registry", () => {
+	test("only registers supported sections with real summaries", () => {
+		for (const variant of ["connected", "hosted"] as const) {
 			const supported = new Set(agentNavigationSectionIds(variant));
-			for (const module of agentOverviewGroups(variant).flatMap((group) => group.modules)) {
+			for (const module of agentOverviewGroups(variant).flatMap((group) => group.modules))
 				expect(supported.has(module.section)).toBe(true);
-			}
-		});
-	}
-
-	test("keeps the shared hierarchy stable while varying runtime modules", () => {
+		}
+	});
+	test("shares resource summaries and keeps hosted operations separate", () => {
 		const connected = agentOverviewGroups("connected");
 		const hosted = agentOverviewGroups("hosted");
-		expect(connected.map((group) => group.id)).toEqual(["now", "resources"]);
-		expect(hosted.map((group) => group.id)).toEqual(["now", "resources", "operate"]);
-		expect(connected[0]?.modules.map((module) => module.id)).toEqual(["sessions", "live-sync"]);
-		expect(hosted[0]?.modules.map((module) => module.id)).toEqual([
-			"sessions",
-			"agent-interface",
-			"compute",
+		expect(connected.map((group) => group.id)).toEqual(["resources"]);
+		expect(hosted.map((group) => group.id)).toEqual(["resources", "operate"]);
+		expect(connected[0]?.modules.map((module) => module.id)).toEqual([
+			"projects",
+			"skills",
+			"memories",
+			"connectors",
+			"vaults",
 		]);
-		expect(connected[1]?.modules).toEqual(hosted[1]?.modules);
-		expect(connected[1]?.modules.map((module) => module.id)).toEqual(["projects", "skills"]);
-		expect(hosted[2]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
-	});
-
-	test("keeps navigation capabilities independent from overview summaries", () => {
-		for (const variant of ["connected", "hosted"] as const) {
-			const navigation = agentNavigationSectionIds(variant);
-			const overview = agentOverviewGroups(variant).flatMap((group) =>
-				group.modules.map((module) => module.section),
-			);
-			for (const section of ["memories", "vaults", "connectors"] as const) {
-				expect(navigation).toContain(section);
-				expect(overview).not.toContain(section);
-			}
-		}
-	});
-
-	test("gives Sessions and Projects the dominant module width", () => {
-		for (const variant of ["connected", "hosted"] as const) {
-			const modules = agentOverviewGroups(variant).flatMap((group) => group.modules);
-			expect(modules.find((module) => module.id === "sessions")?.size).toBe("wide");
-			expect(modules.find((module) => module.id === "projects")?.size).toBe("wide");
-		}
-	});
-
-	test("keeps desktop columns explicit without presentation copy in the registry", () => {
-		expect(agentOverviewGroups("connected").map((group) => group.columns)).toEqual([3, 3]);
-		expect(agentOverviewGroups("hosted").map((group) => group.columns)).toEqual([4, 3, 3]);
-		for (const group of [...agentOverviewGroups("connected"), ...agentOverviewGroups("hosted")]) {
-			expect(Object.hasOwn(group, "description")).toBe(false);
-		}
+		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
+		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
+		expect(connected[0]?.modules.find((module) => module.id === "connectors")?.size).toBe("wide");
+		expect(connected[0]?.modules.find((module) => module.id === "projects")?.size).toBe("standard");
 	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { agentCapabilities } from "@/lib/agent-capabilities";
+import { agentNavigationSectionIds } from "@/lib/navigation-model";
+
+describe("agent capabilities", () => {
+	for (const variant of ["connected", "hosted"] as const) {
+		test(`${variant} overview links only advertise supported sections`, () => {
+			const supported = new Set(agentNavigationSectionIds(variant));
+			for (const capability of agentCapabilities(variant).overviewCapabilities) {
+				expect(supported.has(capability.section)).toBe(true);
+			}
+		});
+	}
+
+	test("keeps runtime management exclusive to hosted agents", () => {
+		expect(agentCapabilities("hosted").overviewCapabilities.map((item) => item.section)).toContain(
+			"console",
+		);
+		expect(
+			agentCapabilities("connected").overviewCapabilities.map((item) => item.section),
+		).not.toContain("console");
+	});
+});

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -19,16 +19,13 @@ describe("agent overview registry", () => {
 			"projects",
 			"skills",
 			"memories",
-			"connectors",
 			"vaults",
+			"connectors",
 		]);
 		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
 		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
 		expect(connected[0]?.layout).toBe("balanced-five");
 		expect(hosted[1]?.layout).toBe("two-column");
-		expect(connected[0]?.modules.find((module) => module.id === "connectors")?.size).toBe(
-			"standard",
-		);
-		expect(connected[0]?.modules.find((module) => module.id === "projects")?.size).toBe("standard");
+		expect(connected[0]?.modules.every((module) => !("size" in module))).toBe(true);
 	});
 });

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -24,7 +24,21 @@ describe("agent capabilities", () => {
 			"compute",
 		]);
 		expect(connected[1]?.modules).toEqual(hosted[1]?.modules);
+		expect(connected[1]?.modules.map((module) => module.id)).toEqual(["projects", "skills"]);
 		expect(hosted[2]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
+	});
+
+	test("keeps navigation capabilities independent from overview summaries", () => {
+		for (const variant of ["connected", "hosted"] as const) {
+			const navigation = agentNavigationSectionIds(variant);
+			const overview = agentOverviewGroups(variant).flatMap((group) =>
+				group.modules.map((module) => module.section),
+			);
+			for (const section of ["memories", "vaults", "connectors"] as const) {
+				expect(navigation).toContain(section);
+				expect(overview).not.toContain(section);
+			}
+		}
 	});
 
 	test("gives Sessions and Projects the dominant module width", () => {

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -24,6 +24,8 @@ describe("agent overview registry", () => {
 		]);
 		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
 		expect(hosted[1]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
+		expect(connected[0]?.layout).toBe("balanced-five");
+		expect(hosted[1]?.layout).toBe("two-column");
 		expect(connected[0]?.modules.find((module) => module.id === "connectors")?.size).toBe(
 			"standard",
 		);

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -18,8 +18,13 @@ describe("agent capabilities", () => {
 		expect(connected.map((group) => group.id)).toEqual(["now", "resources"]);
 		expect(hosted.map((group) => group.id)).toEqual(["now", "resources", "operate"]);
 		expect(connected[0]?.modules.map((module) => module.id)).toEqual(["sessions", "live-sync"]);
-		expect(hosted[0]?.modules.map((module) => module.id)).toEqual(["sessions", "agent-interface"]);
+		expect(hosted[0]?.modules.map((module) => module.id)).toEqual([
+			"sessions",
+			"agent-interface",
+			"compute",
+		]);
 		expect(connected[1]?.modules).toEqual(hosted[1]?.modules);
+		expect(hosted[2]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);
 	});
 
 	test("gives Sessions and Projects the dominant module width", () => {

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -6,9 +6,6 @@ export type AgentOverviewModuleId =
 	| "agent-interface"
 	| "projects"
 	| "skills"
-	| "memories"
-	| "vaults"
-	| "connectors"
 	| "model-provider"
 	| "channels"
 	| "compute";
@@ -31,9 +28,6 @@ export type AgentOverviewGroup = {
 const SHARED_RESOURCES = [
 	{ id: "projects", section: "projects", size: "wide" },
 	{ id: "skills", section: "skills", size: "standard" },
-	{ id: "memories", section: "memories", size: "standard" },
-	{ id: "vaults", section: "vaults", size: "standard" },
-	{ id: "connectors", section: "connectors", size: "standard" },
 ] as const satisfies readonly AgentOverviewModule[];
 
 const AGENT_OVERVIEW_GROUPS = {

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -50,7 +50,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		},
 		{
 			id: "operate",
-			label: "Operate",
+			label: "Tools",
 			columns: 2,
 			modules: [
 				{ id: "model-provider", section: "ai", size: "standard" },

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -25,6 +25,7 @@ export type AgentOverviewGroup = {
 	id: AgentOverviewGroupId;
 	label: string;
 	description: string;
+	columns: 3 | 4;
 	modules: readonly AgentOverviewModule[];
 };
 
@@ -42,6 +43,7 @@ const AGENT_OVERVIEW_GROUPS = {
 			id: "now",
 			label: "Now",
 			description: "Activity and current state",
+			columns: 3,
 			modules: [
 				{ id: "sessions", section: "sessions", size: "wide" },
 				{ id: "live-sync", section: "settings", size: "standard" },
@@ -51,6 +53,7 @@ const AGENT_OVERVIEW_GROUPS = {
 			id: "resources",
 			label: "Resources",
 			description: "Context and tools available to this agent",
+			columns: 3,
 			modules: SHARED_RESOURCES,
 		},
 	],
@@ -59,25 +62,28 @@ const AGENT_OVERVIEW_GROUPS = {
 			id: "now",
 			label: "Now",
 			description: "Activity and current state",
+			columns: 4,
 			modules: [
 				{ id: "sessions", section: "sessions", size: "wide" },
 				{ id: "agent-interface", section: "console", size: "standard" },
+				{ id: "compute", section: "settings", size: "standard" },
 			],
 		},
 		{
 			id: "resources",
 			label: "Resources",
 			description: "Context and tools available to this agent",
+			columns: 3,
 			modules: SHARED_RESOURCES,
 		},
 		{
 			id: "operate",
 			label: "Operate",
 			description: "Managed runtime and integrations",
+			columns: 3,
 			modules: [
 				{ id: "model-provider", section: "ai", size: "standard" },
 				{ id: "channels", section: "channels", size: "standard" },
-				{ id: "compute", section: "settings", size: "standard" },
 			],
 		},
 	],

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -20,7 +20,7 @@ export type AgentOverviewModule = {
 export type AgentOverviewGroup = {
 	id: AgentOverviewGroupId;
 	label: string;
-	columns: 2 | 3;
+	layout: "balanced-five" | "two-column";
 	modules: readonly AgentOverviewModule[];
 };
 
@@ -37,7 +37,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			columns: 3,
+			layout: "balanced-five",
 			modules: SHARED_RESOURCES,
 		},
 	],
@@ -45,13 +45,13 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			columns: 3,
+			layout: "balanced-five",
 			modules: SHARED_RESOURCES,
 		},
 		{
 			id: "operate",
 			label: "Tools",
-			columns: 2,
+			layout: "two-column",
 			modules: [
 				{ id: "model-provider", section: "ai", size: "standard" },
 				{ id: "channels", section: "channels", size: "standard" },

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,4 +1,8 @@
-import type { AgentNavigationVariant, AgentSectionId } from "@/lib/navigation-model";
+import {
+	AGENT_RESOURCE_SECTION_IDS,
+	type AgentNavigationVariant,
+	type AgentSectionId,
+} from "@/lib/navigation-model";
 
 export type AgentOverviewModuleId =
 	| "projects"
@@ -14,7 +18,6 @@ export type AgentOverviewGroupId = "resources" | "operate";
 export type AgentOverviewModule = {
 	id: AgentOverviewModuleId;
 	section: AgentSectionId;
-	size: "standard" | "wide";
 };
 
 export type AgentOverviewGroup = {
@@ -24,13 +27,7 @@ export type AgentOverviewGroup = {
 	modules: readonly AgentOverviewModule[];
 };
 
-const SHARED_RESOURCES = [
-	{ id: "projects", section: "projects", size: "standard" },
-	{ id: "skills", section: "skills", size: "standard" },
-	{ id: "memories", section: "memories", size: "standard" },
-	{ id: "connectors", section: "connectors", size: "standard" },
-	{ id: "vaults", section: "vaults", size: "standard" },
-] as const satisfies readonly AgentOverviewModule[];
+const SHARED_RESOURCES = AGENT_RESOURCE_SECTION_IDS.map((section) => ({ id: section, section }));
 
 const AGENT_OVERVIEW_GROUPS = {
 	connected: [
@@ -53,8 +50,8 @@ const AGENT_OVERVIEW_GROUPS = {
 			label: "Tools",
 			layout: "two-column",
 			modules: [
-				{ id: "model-provider", section: "ai", size: "standard" },
-				{ id: "channels", section: "channels", size: "standard" },
+				{ id: "model-provider", section: "ai" },
+				{ id: "channels", section: "channels" },
 			],
 		},
 	],

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,0 +1,68 @@
+import type { AgentNavigationVariant, AgentSectionId } from "@/lib/navigation-model";
+
+export type AgentOverviewCapability = {
+	section: AgentSectionId;
+	label: string;
+	description: string;
+};
+
+export type AgentCapabilities = {
+	variant: AgentNavigationVariant;
+	label: string;
+	description: string;
+	management: string;
+	overviewCapabilities: readonly AgentOverviewCapability[];
+};
+
+const AGENT_CAPABILITIES = {
+	connected: {
+		variant: "connected",
+		label: "Connected agent",
+		description: "Runs on your machine or server and syncs its work to Clawdi.",
+		management: "Runtime controls stay on the machine where this agent runs.",
+		overviewCapabilities: [
+			{
+				section: "sessions",
+				label: "Synced activity",
+				description: "Review sessions reported by this agent.",
+			},
+			{
+				section: "projects",
+				label: "Project access",
+				description: "Control the Projects and resources this agent can use.",
+			},
+			{
+				section: "settings",
+				label: "Agent identity",
+				description: "Rename or disconnect this agent from Clawdi.",
+			},
+		],
+	},
+	hosted: {
+		variant: "hosted",
+		label: "Hosted agent",
+		description: "Runs in Clawdi Cloud with managed compute and runtime access.",
+		management: "Start, stop, configure, and open this agent directly from Clawdi.",
+		overviewCapabilities: [
+			{
+				section: "console",
+				label: "Agent interface",
+				description: "Open the agent's managed browser interface.",
+			},
+			{
+				section: "channels",
+				label: "Channel links",
+				description: "Connect messaging channels directly to this agent.",
+			},
+			{
+				section: "ai",
+				label: "Model & provider",
+				description: "Choose the AI provider and primary model it uses.",
+			},
+		],
+	},
+} as const satisfies Record<AgentNavigationVariant, AgentCapabilities>;
+
+export function agentCapabilities(variant: AgentNavigationVariant): AgentCapabilities {
+	return AGENT_CAPABILITIES[variant];
+}

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,68 +1,90 @@
 import type { AgentNavigationVariant, AgentSectionId } from "@/lib/navigation-model";
 
-export type AgentOverviewCapability = {
+export type AgentOverviewModuleId =
+	| "sessions"
+	| "live-sync"
+	| "agent-interface"
+	| "projects"
+	| "skills"
+	| "memories"
+	| "vaults"
+	| "connectors"
+	| "model-provider"
+	| "channels"
+	| "compute";
+
+export type AgentOverviewGroupId = "now" | "resources" | "operate";
+
+export type AgentOverviewModule = {
+	id: AgentOverviewModuleId;
 	section: AgentSectionId;
-	label: string;
-	description: string;
+	size: "standard" | "wide";
 };
 
-export type AgentCapabilities = {
-	variant: AgentNavigationVariant;
+export type AgentOverviewGroup = {
+	id: AgentOverviewGroupId;
 	label: string;
 	description: string;
-	management: string;
-	overviewCapabilities: readonly AgentOverviewCapability[];
+	modules: readonly AgentOverviewModule[];
 };
 
-const AGENT_CAPABILITIES = {
-	connected: {
-		variant: "connected",
-		label: "Connected agent",
-		description: "Runs on your machine or server and syncs its work to Clawdi.",
-		management: "Runtime controls stay on the machine where this agent runs.",
-		overviewCapabilities: [
-			{
-				section: "sessions",
-				label: "Synced activity",
-				description: "Review sessions reported by this agent.",
-			},
-			{
-				section: "projects",
-				label: "Project access",
-				description: "Control the Projects and resources this agent can use.",
-			},
-			{
-				section: "settings",
-				label: "Agent identity",
-				description: "Rename or disconnect this agent from Clawdi.",
-			},
-		],
-	},
-	hosted: {
-		variant: "hosted",
-		label: "Hosted agent",
-		description: "Runs in Clawdi Cloud with managed compute and runtime access.",
-		management: "Start, stop, configure, and open this agent directly from Clawdi.",
-		overviewCapabilities: [
-			{
-				section: "console",
-				label: "Agent interface",
-				description: "Open the agent's managed browser interface.",
-			},
-			{
-				section: "channels",
-				label: "Channel links",
-				description: "Connect messaging channels directly to this agent.",
-			},
-			{
-				section: "ai",
-				label: "Model & provider",
-				description: "Choose the AI provider and primary model it uses.",
-			},
-		],
-	},
-} as const satisfies Record<AgentNavigationVariant, AgentCapabilities>;
+const SHARED_RESOURCES = [
+	{ id: "projects", section: "projects", size: "wide" },
+	{ id: "skills", section: "skills", size: "standard" },
+	{ id: "memories", section: "memories", size: "standard" },
+	{ id: "vaults", section: "vaults", size: "standard" },
+	{ id: "connectors", section: "connectors", size: "standard" },
+] as const satisfies readonly AgentOverviewModule[];
 
-export function agentCapabilities(variant: AgentNavigationVariant): AgentCapabilities {
-	return AGENT_CAPABILITIES[variant];
+const AGENT_OVERVIEW_GROUPS = {
+	connected: [
+		{
+			id: "now",
+			label: "Now",
+			description: "Activity and current state",
+			modules: [
+				{ id: "sessions", section: "sessions", size: "wide" },
+				{ id: "live-sync", section: "settings", size: "standard" },
+			],
+		},
+		{
+			id: "resources",
+			label: "Resources",
+			description: "Context and tools available to this agent",
+			modules: SHARED_RESOURCES,
+		},
+	],
+	hosted: [
+		{
+			id: "now",
+			label: "Now",
+			description: "Activity and current state",
+			modules: [
+				{ id: "sessions", section: "sessions", size: "wide" },
+				{ id: "agent-interface", section: "console", size: "standard" },
+			],
+		},
+		{
+			id: "resources",
+			label: "Resources",
+			description: "Context and tools available to this agent",
+			modules: SHARED_RESOURCES,
+		},
+		{
+			id: "operate",
+			label: "Operate",
+			description: "Managed runtime and integrations",
+			modules: [
+				{ id: "model-provider", section: "ai", size: "standard" },
+				{ id: "channels", section: "channels", size: "standard" },
+				{ id: "compute", section: "settings", size: "standard" },
+			],
+		},
+	],
+} as const satisfies Record<AgentNavigationVariant, readonly AgentOverviewGroup[]>;
+
+export function agentOverviewGroups(
+	variant: AgentNavigationVariant,
+): readonly AgentOverviewGroup[] {
+	return AGENT_OVERVIEW_GROUPS[variant];
 }

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -48,7 +48,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "operate",
 			label: "Tools",
-			layout: "two-column",
+			layout: "three-column",
 			modules: [
 				{ id: "model-provider", section: "ai" },
 				{ id: "channels", section: "channels" },

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -23,7 +23,7 @@ export type AgentOverviewModule = {
 export type AgentOverviewGroup = {
 	id: AgentOverviewGroupId;
 	label: string;
-	layout: "balanced-five" | "two-column";
+	layout: "three-column" | "two-column";
 	modules: readonly AgentOverviewModule[];
 };
 
@@ -34,7 +34,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			layout: "balanced-five",
+			layout: "three-column",
 			modules: SHARED_RESOURCES,
 		},
 	],
@@ -42,7 +42,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			layout: "balanced-five",
+			layout: "three-column",
 			modules: SHARED_RESOURCES,
 		},
 		{

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -24,7 +24,6 @@ export type AgentOverviewModule = {
 export type AgentOverviewGroup = {
 	id: AgentOverviewGroupId;
 	label: string;
-	description: string;
 	columns: 3 | 4;
 	modules: readonly AgentOverviewModule[];
 };
@@ -42,7 +41,6 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "now",
 			label: "Now",
-			description: "Activity and current state",
 			columns: 3,
 			modules: [
 				{ id: "sessions", section: "sessions", size: "wide" },
@@ -52,7 +50,6 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			description: "Context and tools available to this agent",
 			columns: 3,
 			modules: SHARED_RESOURCES,
 		},
@@ -61,7 +58,6 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "now",
 			label: "Now",
-			description: "Activity and current state",
 			columns: 4,
 			modules: [
 				{ id: "sessions", section: "sessions", size: "wide" },
@@ -72,14 +68,12 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "resources",
 			label: "Resources",
-			description: "Context and tools available to this agent",
 			columns: 3,
 			modules: SHARED_RESOURCES,
 		},
 		{
 			id: "operate",
 			label: "Operate",
-			description: "Managed runtime and integrations",
 			columns: 3,
 			modules: [
 				{ id: "model-provider", section: "ai", size: "standard" },

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -28,7 +28,7 @@ const SHARED_RESOURCES = [
 	{ id: "projects", section: "projects", size: "standard" },
 	{ id: "skills", section: "skills", size: "standard" },
 	{ id: "memories", section: "memories", size: "standard" },
-	{ id: "connectors", section: "connectors", size: "wide" },
+	{ id: "connectors", section: "connectors", size: "standard" },
 	{ id: "vaults", section: "vaults", size: "standard" },
 ] as const satisfies readonly AgentOverviewModule[];
 

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -1,16 +1,15 @@
 import type { AgentNavigationVariant, AgentSectionId } from "@/lib/navigation-model";
 
 export type AgentOverviewModuleId =
-	| "sessions"
-	| "live-sync"
-	| "agent-interface"
 	| "projects"
 	| "skills"
+	| "memories"
+	| "vaults"
+	| "connectors"
 	| "model-provider"
-	| "channels"
-	| "compute";
+	| "channels";
 
-export type AgentOverviewGroupId = "now" | "resources" | "operate";
+export type AgentOverviewGroupId = "resources" | "operate";
 
 export type AgentOverviewModule = {
 	id: AgentOverviewModuleId;
@@ -21,26 +20,20 @@ export type AgentOverviewModule = {
 export type AgentOverviewGroup = {
 	id: AgentOverviewGroupId;
 	label: string;
-	columns: 3 | 4;
+	columns: 2 | 3;
 	modules: readonly AgentOverviewModule[];
 };
 
 const SHARED_RESOURCES = [
-	{ id: "projects", section: "projects", size: "wide" },
+	{ id: "projects", section: "projects", size: "standard" },
 	{ id: "skills", section: "skills", size: "standard" },
+	{ id: "memories", section: "memories", size: "standard" },
+	{ id: "connectors", section: "connectors", size: "wide" },
+	{ id: "vaults", section: "vaults", size: "standard" },
 ] as const satisfies readonly AgentOverviewModule[];
 
 const AGENT_OVERVIEW_GROUPS = {
 	connected: [
-		{
-			id: "now",
-			label: "Now",
-			columns: 3,
-			modules: [
-				{ id: "sessions", section: "sessions", size: "wide" },
-				{ id: "live-sync", section: "settings", size: "standard" },
-			],
-		},
 		{
 			id: "resources",
 			label: "Resources",
@@ -50,16 +43,6 @@ const AGENT_OVERVIEW_GROUPS = {
 	],
 	hosted: [
 		{
-			id: "now",
-			label: "Now",
-			columns: 4,
-			modules: [
-				{ id: "sessions", section: "sessions", size: "wide" },
-				{ id: "agent-interface", section: "console", size: "standard" },
-				{ id: "compute", section: "settings", size: "standard" },
-			],
-		},
-		{
 			id: "resources",
 			label: "Resources",
 			columns: 3,
@@ -68,7 +51,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "operate",
 			label: "Operate",
-			columns: 3,
+			columns: 2,
 			modules: [
 				{ id: "model-provider", section: "ai", size: "standard" },
 				{ id: "channels", section: "channels", size: "standard" },

--- a/apps/web/src/lib/connectors-data.test.ts
+++ b/apps/web/src/lib/connectors-data.test.ts
@@ -46,6 +46,17 @@ describe("connected app metadata planning", () => {
 		).toEqual({ catalogApps: [], missingNames: ["github", "slack"] });
 	});
 
+	it("keeps using stale catalog data when a background refresh fails", () => {
+		const github = catalogApp("github");
+		expect(
+			resolveConnectedAppMetadataPlan(["github", "slack"], {
+				apps: [github],
+				isLoading: false,
+				error: new Error("catalog refresh failed"),
+			}),
+		).toEqual({ catalogApps: [github], missingNames: ["slack"] });
+	});
+
 	it("preserves existing no-catalog behavior for other callers", () => {
 		expect(resolveConnectedAppMetadataPlan(["slack", "github"])).toEqual({
 			catalogApps: [],

--- a/apps/web/src/lib/connectors-data.test.ts
+++ b/apps/web/src/lib/connectors-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { type ConnectorAvailableApp, resolveConnectedAppMetadataPlan } from "./connectors-data";
+
+function catalogApp(name: string): ConnectorAvailableApp {
+	return {
+		name,
+		display_name: name,
+		logo: "",
+		description: `${name} connector`,
+		auth_type: "oauth",
+		connect_disabled: false,
+		connect_disabled_reason: null,
+	};
+}
+
+describe("connected app metadata planning", () => {
+	it("uses catalog metadata and only requests active apps missing from the catalog", () => {
+		const github = catalogApp("github");
+		const plan = resolveConnectedAppMetadataPlan(["github", "slack"], {
+			apps: [github, catalogApp("gmail")],
+			isLoading: false,
+			error: null,
+		});
+
+		expect(plan.catalogApps).toEqual([github]);
+		expect(plan.missingNames).toEqual(["slack"]);
+	});
+
+	it("does not start metadata requests while the first catalog page is loading", () => {
+		expect(
+			resolveConnectedAppMetadataPlan(["github", "slack"], {
+				apps: undefined,
+				isLoading: true,
+				error: null,
+			}),
+		).toEqual({ catalogApps: [], missingNames: [] });
+	});
+
+	it("falls back to detail requests when catalog loading fails", () => {
+		expect(
+			resolveConnectedAppMetadataPlan(["github", "slack"], {
+				apps: undefined,
+				isLoading: false,
+				error: new Error("catalog failed"),
+			}),
+		).toEqual({ catalogApps: [], missingNames: ["github", "slack"] });
+	});
+
+	it("preserves existing no-catalog behavior for other callers", () => {
+		expect(resolveConnectedAppMetadataPlan(["slack", "github"])).toEqual({
+			catalogApps: [],
+			missingNames: ["slack", "github"],
+		});
+	});
+});

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -207,6 +207,8 @@ export function useConnectedAppCards() {
 
 	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);
 	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
+	const connectionsLoading = connectionsQ.isLoading;
+	const metadataLoading = lookup.some((q) => q.isLoading);
 	const connectionsError = connectionsQ.error;
 	const metadataError = lookup.find((q) => q.error)?.error ?? null;
 	const error = connectionsError ?? metadataError;
@@ -222,6 +224,8 @@ export function useConnectedAppCards() {
 		data,
 		hasData,
 		isLoading,
+		connectionsLoading,
+		metadataLoading,
 		error,
 		connectionsError,
 		metadataError,

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -44,7 +44,6 @@ export function resolveConnectedAppMetadataPlan(
 ): ConnectedAppMetadataPlan {
 	if (!catalog) return { catalogApps: [], missingNames: [...names] };
 	if (catalog.isLoading && !catalog.apps) return { catalogApps: [], missingNames: [] };
-	if (catalog.error) return { catalogApps: [], missingNames: [...names] };
 	const byName = new Map((catalog.apps ?? []).map((app) => [app.name, app]));
 	return {
 		catalogApps: names.flatMap((name) => {

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -25,7 +25,35 @@ export const CONNECTOR_CATALOG_PAGE_SIZE = 24;
 export const CONNECTOR_CATALOG_STALE_TIME_MS = 10 * 60 * 1000;
 export const CONNECTOR_CATALOG_GC_TIME_MS = CONNECTOR_CATALOG_STALE_TIME_MS;
 
-type ConnectorAvailableApp = components["schemas"]["ConnectorAvailableAppResponse"];
+export type ConnectorAvailableApp = components["schemas"]["ConnectorAvailableAppResponse"];
+
+export type ConnectedAppCatalogSnapshot = {
+	apps: readonly ConnectorAvailableApp[] | undefined;
+	isLoading: boolean;
+	error: unknown;
+};
+
+type ConnectedAppMetadataPlan = {
+	catalogApps: ConnectorAvailableApp[];
+	missingNames: string[];
+};
+
+export function resolveConnectedAppMetadataPlan(
+	names: readonly string[],
+	catalog?: ConnectedAppCatalogSnapshot,
+): ConnectedAppMetadataPlan {
+	if (!catalog) return { catalogApps: [], missingNames: [...names] };
+	if (catalog.isLoading && !catalog.apps) return { catalogApps: [], missingNames: [] };
+	if (catalog.error) return { catalogApps: [], missingNames: [...names] };
+	const byName = new Map((catalog.apps ?? []).map((app) => [app.name, app]));
+	return {
+		catalogApps: names.flatMap((name) => {
+			const app = byName.get(name);
+			return app ? [app] : [];
+		}),
+		missingNames: names.filter((name) => !byName.has(name)),
+	};
+}
 
 export type AvailableAppsQueryArgs = {
 	page: number;
@@ -175,12 +203,11 @@ export function useDisconnect() {
  * without this rail, they'd never find their connections without
  * searching.
  *
- * Fan-out: one `/available/{name}` query per unique active app.
- * Active connection count is small in practice (single-digit per
- * user), and React Query dedupes against the catalog cache so a
- * page that already loaded the connector also has its metadata.
+ * Fan-out: one `/available/{name}` query per unique active app not
+ * covered by a supplied catalog snapshot. Other callers keep the
+ * existing detail-query behavior when no snapshot is supplied.
  */
-export function useConnectedAppCards() {
+export function useConnectedAppCards(catalog?: ConnectedAppCatalogSnapshot) {
 	const connectionsQ = useConnections();
 	const api = useOpenApi();
 
@@ -200,15 +227,29 @@ export function useConnectedAppCards() {
 		() => Array.from(new Set(activeConnections.flatMap((c) => (c.app_name ? [c.app_name] : [])))),
 		[activeConnections],
 	);
+	const metadataPlan = useMemo(
+		() => resolveConnectedAppMetadataPlan(names, catalog),
+		[names, catalog?.apps, catalog?.error, catalog?.isLoading],
+	);
 
 	const lookup = useQueries({
-		queries: names.map((name) => availableAppQueryOptions(api, name)),
+		queries: metadataPlan.missingNames.map((name) => availableAppQueryOptions(api, name)),
 	});
 
-	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);
-	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
+	const data = useMemo(() => {
+		const byName = new Map(metadataPlan.catalogApps.map((app) => [app.name, app]));
+		for (const query of lookup) {
+			if (query.data) byName.set(query.data.name, query.data);
+		}
+		return names.flatMap((name) => {
+			const app = byName.get(name);
+			return app ? [app] : [];
+		});
+	}, [lookup, metadataPlan.catalogApps, names]);
+	const waitingForCatalog = Boolean(catalog?.isLoading && !catalog.apps && names.length > 0);
+	const isLoading = connectionsQ.isLoading || waitingForCatalog || lookup.some((q) => q.isLoading);
 	const connectionsLoading = connectionsQ.isLoading;
-	const metadataLoading = lookup.some((q) => q.isLoading);
+	const metadataLoading = waitingForCatalog || lookup.some((q) => q.isLoading);
 	const connectionsError = connectionsQ.error;
 	const metadataError = lookup.find((q) => q.error)?.error ?? null;
 	const error = connectionsError ?? metadataError;

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -207,7 +207,9 @@ export function useConnectedAppCards() {
 
 	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);
 	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
-	const error = connectionsQ.error ?? lookup.find((q) => q.error)?.error ?? null;
+	const connectionsError = connectionsQ.error;
+	const metadataError = lookup.find((q) => q.error)?.error ?? null;
+	const error = connectionsError ?? metadataError;
 	const hasData =
 		connectionsQ.data !== undefined && lookup.every((query) => query.data !== undefined);
 	const refetch = () => {
@@ -215,7 +217,16 @@ export function useConnectedAppCards() {
 		for (const q of lookup) void q.refetch();
 	};
 
-	return { activeConnections, data, hasData, isLoading, error, refetch };
+	return {
+		activeConnections,
+		data,
+		hasData,
+		isLoading,
+		error,
+		connectionsError,
+		metadataError,
+		refetch,
+	};
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -29,10 +29,11 @@ function groupShape(
 
 function expectSingleResourcesHeading(
 	groups: ReadonlyArray<{ label: string | null; items: readonly unknown[] }>,
+	expected = ["Resources"],
 ) {
-	expect(groups.filter((group) => group.label !== null).map((group) => group.label)).toEqual([
-		"Resources",
-	]);
+	expect(groups.filter((group) => group.label !== null).map((group) => group.label)).toEqual(
+		expected,
+	);
 	expect(groups.every((group) => group.items.length > 0)).toBe(true);
 }
 
@@ -110,7 +111,6 @@ describe("sidebar navigation model", () => {
 				items: [
 					{ id: "overview", label: "Overview" },
 					{ id: "sessions", label: "Sessions" },
-					{ id: "memories", label: "Memories" },
 				],
 			},
 			{
@@ -118,10 +118,11 @@ describe("sidebar navigation model", () => {
 				label: "Resources",
 				separated: false,
 				items: [
-					{ id: "connectors", label: "Connectors" },
 					{ id: "projects", label: "Projects" },
 					{ id: "skills", label: "Skills" },
+					{ id: "memories", label: "Memories" },
 					{ id: "vaults", label: "Vaults" },
+					{ id: "connectors", label: "Connectors" },
 				],
 			},
 			{
@@ -142,9 +143,6 @@ describe("sidebar navigation model", () => {
 				items: [
 					{ id: "overview", label: "Overview" },
 					{ id: "sessions", label: "Sessions" },
-					{ id: "memories", label: "Memories" },
-					{ id: "console", label: "Agent Interface" },
-					{ id: "terminal", label: "Terminal" },
 				],
 			},
 			{
@@ -152,12 +150,22 @@ describe("sidebar navigation model", () => {
 				label: "Resources",
 				separated: false,
 				items: [
-					{ id: "channels", label: "Channels" },
-					{ id: "ai", label: "AI Providers" },
-					{ id: "connectors", label: "Connectors" },
 					{ id: "projects", label: "Projects" },
 					{ id: "skills", label: "Skills" },
+					{ id: "memories", label: "Memories" },
 					{ id: "vaults", label: "Vaults" },
+					{ id: "connectors", label: "Connectors" },
+				],
+			},
+			{
+				id: "operate",
+				label: "Operate",
+				separated: false,
+				items: [
+					{ id: "console", label: "Agent Interface" },
+					{ id: "terminal", label: "Terminal" },
+					{ id: "channels", label: "Channels" },
+					{ id: "ai", label: "AI Providers" },
 				],
 			},
 			{
@@ -167,30 +175,30 @@ describe("sidebar navigation model", () => {
 				items: [{ id: "settings", label: "Settings" }],
 			},
 		]);
-		expectSingleResourcesHeading(hostedGroups);
+		expectSingleResourcesHeading(hostedGroups, ["Resources", "Operate"]);
 
 		expect(CONNECTED_AGENT_SECTION_IDS).toEqual([
 			"overview",
 			"sessions",
-			"memories",
-			"connectors",
 			"projects",
 			"skills",
+			"memories",
 			"vaults",
+			"connectors",
 			"settings",
 		]);
 		expect(HOSTED_AGENT_SECTION_IDS).toEqual([
 			"overview",
 			"sessions",
+			"projects",
+			"skills",
 			"memories",
+			"vaults",
+			"connectors",
 			"console",
 			"terminal",
 			"channels",
 			"ai",
-			"connectors",
-			"projects",
-			"skills",
-			"vaults",
 			"settings",
 		]);
 

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -159,7 +159,7 @@ describe("sidebar navigation model", () => {
 			},
 			{
 				id: "operate",
-				label: "Operate",
+				label: "Tools",
 				separated: false,
 				items: [
 					{ id: "console", label: "Agent Interface" },
@@ -175,7 +175,7 @@ describe("sidebar navigation model", () => {
 				items: [{ id: "settings", label: "Settings" }],
 			},
 		]);
-		expectSingleResourcesHeading(hostedGroups, ["Resources", "Operate"]);
+		expectSingleResourcesHeading(hostedGroups, ["Resources", "Tools"]);
 
 		expect(CONNECTED_AGENT_SECTION_IDS).toEqual([
 			"overview",

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -255,7 +255,7 @@ export function consoleCommandPaletteItems(
 		);
 }
 
-type AgentNavigationGroupId = "primary" | "resources" | "settings";
+type AgentNavigationGroupId = "primary" | "resources" | "operate" | "settings";
 
 export type AgentNavigationItemMetadata = Omit<NavigationItemMetadata<AgentSectionId>, "href"> & {
 	variants: readonly AgentNavigationVariant[];
@@ -374,13 +374,19 @@ const AGENT_NAVIGATION_GROUPS = [
 	{
 		id: "primary",
 		label: null,
-		itemIds: ["overview", "sessions", "memories", "console", "terminal"],
+		itemIds: ["overview", "sessions"],
 		separated: false,
 	},
 	{
 		id: "resources",
 		label: "Resources",
-		itemIds: ["channels", "ai", "connectors", "projects", "skills", "vaults"],
+		itemIds: ["projects", "skills", "memories", "vaults", "connectors"],
+		separated: false,
+	},
+	{
+		id: "operate",
+		label: "Operate",
+		itemIds: ["console", "terminal", "channels", "ai"],
 		separated: false,
 	},
 	{ id: "settings", label: null, itemIds: ["settings"], separated: true },

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -370,6 +370,14 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 	},
 };
 
+export const AGENT_RESOURCE_SECTION_IDS = [
+	"projects",
+	"skills",
+	"memories",
+	"vaults",
+	"connectors",
+] as const satisfies readonly AgentSectionId[];
+
 const AGENT_NAVIGATION_GROUPS = [
 	{
 		id: "primary",
@@ -380,7 +388,7 @@ const AGENT_NAVIGATION_GROUPS = [
 	{
 		id: "resources",
 		label: "Resources",
-		itemIds: ["projects", "skills", "memories", "vaults", "connectors"],
+		itemIds: AGENT_RESOURCE_SECTION_IDS,
 		separated: false,
 	},
 	{

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -385,7 +385,7 @@ const AGENT_NAVIGATION_GROUPS = [
 	},
 	{
 		id: "operate",
-		label: "Operate",
+		label: "Tools",
 		itemIds: ["console", "terminal", "channels", "ai"],
 		separated: false,
 	},

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -33,6 +33,14 @@ const HostedAgentOwnershipSensor = IS_HOSTED_BUILD
 		)
 	: null;
 
+const GlobalWalletBalance = IS_HOSTED_BUILD
+	? lazy(() =>
+			import("@/hosted/global-wallet-balance").then((m) => ({
+				default: m.GlobalWalletBalance,
+			})),
+		)
+	: null;
+
 export default function DashboardLayout({ children }: { children: ReactNode }) {
 	const hydrated = useHydrated();
 	const [ownership, setOwnership] = useState<AgentOwnership | null>(null);
@@ -74,7 +82,15 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 							data-scroll-restoration-id="dashboard-scroll-container"
 							className="md:h-[calc(100svh-1rem)] md:overflow-y-auto"
 						>
-							<SiteHeader />
+							<SiteHeader
+								actions={
+									GlobalWalletBalance ? (
+										<Suspense fallback={null}>
+											<GlobalWalletBalance />
+										</Suspense>
+									) : null
+								}
+							/>
 							<div className="flex flex-1 flex-col">
 								<div className="@container/main flex flex-1 flex-col gap-2">
 									<div


### PR DESCRIPTION
## Summary

- redesign Connected and Hosted agent Overview pages around recent activity, current status, and useful resource summaries
- share one capability registry for variant-specific navigation and Overview composition while keeping Connected and Hosted capabilities explicit
- use the existing SessionFeedCard in a compact two-line Overview variant: four single-column rows aligned to the Live Sync or Compute card
- show Projects, Skills, Memories, Vaults, and compact Connector icons as real summaries; add Hosted model/provider and channel summaries under Tools
- move Hosted Agent Interface to the header, keep every runtime lifecycle state inside Compute, and use a dedicated starting page before the agent projection is ready
- regroup agent navigation into primary pages, Resources, Hosted-only Tools, and Settings

## Product behavior

Connected Overview shows recent sessions plus Live Sync. Hosted Overview shows recent sessions plus Compute, with an Open Agent Interface action while running. Compute includes plan, CPU, memory, storage, and Running, Starting, Stopped, Failed, or unavailable state handling. The initial Hosted start flow is intentionally a separate large status panel rather than a partial Overview.

Resource cards use query-backed counts and short previews. Loading uses skeletons, successful empty states are explicit, and failures do not masquerade as zero. Connector icons prefer connected apps and fill remaining slots from a small suggested catalog without duplicates.

## Validation

- rebased onto current origin/main; final two-dot diff is limited to Agent Overview, navigation, and focused tests
- isolated Docker Web suite: 864 passed, 0 failed
- isolated Web TypeScript check passed
- isolated OSS production build passed
- focused capability, navigation, project resolution, Hosted language, and deploy layout tests: 52 passed
- mocked Chromium coverage for Connected and Hosted normal layouts, resource loading/empty/error states, Hosted starting, and unavailable Compute states
- final normal Connected, normal Hosted, and Hosted starting screenshots regenerated after copy cleanup
- Biome pre-commit checks and git diff --check passed

## Notes

- no production or tenant data was accessed
- browser fixtures use mocked APIs and stable local connector icons
- one Hosted browser batch hit the existing Vite cold-start dynamic-import transient; the affected normal Overview test passed when rerun against a warmed local server