### PR TITLE
fix(web): redesign agent projects as cards

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2689,9 +2689,92 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	expect(touchOrderRequests).toEqual([]);
 });
 
-test("hosted agent sidebar renders one Resources heading in canonical order", async ({ page }) => {
+test("hosted agent sidebar renders one Resources heading in canonical order", async ({
+	page,
+}, testInfo) => {
+	const hostedProjectBindings = [
+		{
+			id: "binding-hosted-context-later",
+			agent_id: railHostedEnvironmentId,
+			project_id: "project-hosted-context-later",
+			binding_type: "context",
+			priority: 2,
+			default_write_enabled: false,
+			created_at: "2026-07-15T00:02:00Z",
+		},
+		{
+			id: "binding-hosted-primary",
+			agent_id: railHostedEnvironmentId,
+			project_id: "project-hosted",
+			binding_type: "primary",
+			priority: 0,
+			default_write_enabled: true,
+			created_at: "2026-07-15T00:00:00Z",
+		},
+		{
+			id: "binding-hosted-context-first",
+			agent_id: railHostedEnvironmentId,
+			project_id: "project-hosted-context-first",
+			binding_type: "context",
+			priority: 1,
+			default_write_enabled: false,
+			created_at: "2026-07-15T00:01:00Z",
+		},
+	];
+	const hostedAgentProjects = [
+		{
+			id: "project-hosted",
+			name: "Hosted Agent Project",
+			slug: "hosted-agent-project",
+			kind: "environment",
+			origin_environment_id: railHostedEnvironmentId,
+			archived_at: null,
+			created_at: "2026-07-15T00:00:00Z",
+			is_owner: true,
+			owner_display: "Hosted User",
+			owner_handle: "hosted-user",
+		},
+		{
+			id: "project-hosted-context-first",
+			name: "Hosted Shared Knowledge",
+			slug: "hosted-shared-knowledge",
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: "2026-07-15T00:01:00Z",
+			is_owner: false,
+			owner_display: "Platform Team",
+			owner_handle: "platform-team",
+		},
+		{
+			id: "project-hosted-context-later",
+			name: "Hosted Automation",
+			slug: "hosted-automation",
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: "2026-07-15T00:02:00Z",
+			is_owner: true,
+			owner_display: "Hosted User",
+			owner_handle: "hosted-user",
+		},
+		{
+			id: "project-hosted-choice",
+			name: "Hosted Project Choice",
+			slug: "hosted-project-choice",
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: "2026-07-15T00:03:00Z",
+			is_owner: true,
+			owner_display: "Hosted User",
+			owner_handle: "hosted-user",
+		},
+	];
 	await stubHostedApi(page, {
 		agentResourceFixtures: true,
+		agentProjectBindings: hostedProjectBindings,
+		agentProjects: hostedAgentProjects,
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 	});
@@ -2777,7 +2860,82 @@ test("hosted agent sidebar renders one Resources heading in canonical order", as
 
 	await page.goto(`/agents/${railHostedEnvironmentId}/project-access${query}`);
 	await expect(main.getByRole("heading", { name: "Projects", level: 1 })).toBeVisible();
-	await expect(main.getByText("Hosted Agent Project", { exact: true })).toBeVisible();
+	const projectStack = main.getByTestId("agent-project-stack");
+	const projectGrid = projectStack.getByTestId("agent-project-grid");
+	const projectCards = projectGrid.getByTestId("agent-project-card");
+	await expect(projectCards).toHaveCount(3);
+	expect(
+		await projectGrid.evaluate(
+			(element) => getComputedStyle(element).gridTemplateColumns.split(" ").length,
+		),
+	).toBe(3);
+	await expect(projectCards.nth(0)).toContainText("Hosted Agent Project");
+	await expect(projectCards.nth(0)).toContainText("Read order 1");
+	await expect(projectCards.nth(0)).toContainText("Default write destination");
+	await expect(projectCards.nth(0)).not.toContainText("Owner");
+	await expect(projectCards.nth(1)).toContainText("Hosted Shared Knowledge");
+	await expect(projectCards.nth(1)).toContainText("Read order 2");
+	await expect(projectCards.nth(1)).toContainText("Viewer");
+	await expect(projectCards.nth(2)).toContainText("Hosted Automation");
+	await expect(projectCards.nth(2)).toContainText("Read order 3");
+	for (const card of await projectCards.all()) {
+		await expect(card.locator(":scope > div")).toHaveCSS("border-top-width", "1px");
+	}
+	await projectCards.nth(1).hover();
+	await expect(
+		projectCards.nth(1).getByRole("button", { name: "Move Hosted Shared Knowledge up" }),
+	).toBeDisabled();
+	await expect(
+		projectCards.nth(1).getByRole("button", { name: "Remove Hosted Shared Knowledge" }),
+	).toBeVisible();
+	await projectCards.nth(1).getByRole("button", { name: "Remove Hosted Shared Knowledge" }).click();
+	const removeProjectDialog = page.getByRole("alertdialog", { name: "Remove this Project?" });
+	await expect(removeProjectDialog).toContainText(
+		"Hosted Shared Knowledge will no longer be available to this agent.",
+	);
+	await removeProjectDialog.getByRole("button", { name: "Cancel" }).click();
+	await expect(projectStack.getByLabel("Project to add")).toHaveCount(0);
+	await projectStack.getByRole("button", { name: "Add Project", exact: true }).click();
+	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
+	await expect(addProjectDialog).toBeVisible();
+	const compactProjectPicker = addProjectDialog.getByLabel("Project to add");
+	await compactProjectPicker.click();
+	await page.getByRole("option", { name: /Hosted Project Choice/ }).click();
+	await expect(
+		addProjectDialog.getByRole("button", { name: "Add Project", exact: true }),
+	).toBeEnabled();
+	await addProjectDialog.getByRole("button", { name: "Cancel" }).click();
+	await projectStack.screenshot({ path: testInfo.outputPath("hosted-agent-projects-desktop.png") });
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await projectStack.screenshot({ path: testInfo.outputPath("hosted-agent-projects-dark.png") });
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	const centeredProjectsSurface = projectStack.locator(
+		"xpath=ancestor::div[@data-hosted='true'][1]",
+	);
+	expect(
+		await centeredProjectsSurface.evaluate((element) => element.getBoundingClientRect().width),
+	).toBeLessThanOrEqual(1280);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	expect(
+		await projectGrid.evaluate(
+			(element) => getComputedStyle(element).gridTemplateColumns.split(" ").length,
+		),
+	).toBe(1);
+	await expect
+		.poll(() =>
+			projectCards
+				.nth(1)
+				.getByRole("button", { name: "Remove Hosted Shared Knowledge" })
+				.evaluate((element) => getComputedStyle(element.parentElement ?? element).opacity),
+		)
+		.toBe("1");
+	expect(
+		await page
+			.locator("html")
+			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
+	await projectStack.screenshot({ path: testInfo.outputPath("hosted-agent-projects-mobile.png") });
 
 	await page.goto(`/agents/${railHostedEnvironmentId}/vaults${query}`);
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -64,7 +64,7 @@ const projects = [
 		id: "project-unrelated",
 		name: "Unrelated Project",
 		slug: "unrelated-project",
-		kind: "custom",
+		kind: "workspace",
 		origin_environment_id: null,
 		archived_at: null,
 		created_at: now.toISOString(),
@@ -445,8 +445,12 @@ test("connected agent Memories stays account-wide with canonical detail links", 
 
 test("connected agent resource tabs reuse scoped Projects, account Connectors, and effective Vaults", async ({
 	page,
-}) => {
+}, testInfo) => {
 	const vaultRequests: string[] = [];
+	const longContextProjectName =
+		"Automation Library for exceptionally long production workflow names across several teams";
+	const longContextProjectSlug =
+		"automation-library-for-exceptionally-long-production-workflow-names-across-several-teams";
 	const projectAccessBindings = [
 		{
 			...projectBindings[0],
@@ -486,8 +490,8 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 		},
 		{
 			id: "project-context-later",
-			name: "Automation Library",
-			slug: "automation-library",
+			name: longContextProjectName,
+			slug: longContextProjectSlug,
 			kind: "workspace",
 			origin_environment_id: null,
 			archived_at: null,
@@ -503,6 +507,7 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 		vaultRequests,
 	});
 
+	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/agents/agent-smoke-1/connectors?q=gmail&page=2");
 	const main = page.locator("main");
 	await expect(main.getByRole("heading", { name: "Connectors", level: 1 })).toBeVisible();
@@ -518,35 +523,120 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 		timeout: 15_000,
 	});
 	const projectStack = main.getByTestId("agent-project-stack");
-	const projectRows = projectStack.locator('ol[aria-label="Effective Project read order"] > li');
-	await expect(projectRows).toHaveCount(3);
-	await expect(projectRows.nth(0)).toContainText("Smoke Project");
-	await expect(projectRows.nth(0)).toContainText("Writes here by default");
-	await expect(projectRows.nth(0)).not.toContainText("Fixed");
-	await expect(projectRows.nth(0)).not.toContainText("Default writes");
-	await expect(projectRows.nth(0).locator('[data-slot="badge"]')).toHaveCount(2);
-	await expect(projectRows.nth(0).getByRole("button")).toHaveCount(0);
-	await expect(projectRows.nth(1)).toContainText("Team Knowledge");
-	await expect(projectRows.nth(1)).toContainText("Viewer");
-	await expect(projectRows.nth(1)).not.toContainText("Read access");
-	await expect(projectRows.nth(1)).not.toContainText("Skills and Vaults");
-	await expect(projectRows.nth(1).locator('[data-slot="badge"]')).toHaveCount(2);
-	await expect(projectRows.nth(2)).toContainText("Automation Library");
-	await expect(projectRows.nth(2).locator('[data-slot="badge"]')).toHaveCount(1);
+	const projectGrid = projectStack.getByTestId("agent-project-grid");
+	const projectCards = projectGrid.getByTestId("agent-project-card");
+	await expect(projectCards).toHaveCount(3);
+	expect(
+		await projectGrid.evaluate(
+			(element) => getComputedStyle(element).gridTemplateColumns.split(" ").length,
+		),
+	).toBe(3);
+	for (const card of await projectCards.all()) {
+		await expect(card.locator(":scope > div")).toHaveCSS("border-top-width", "1px");
+	}
+	await expect(projectCards.nth(0)).toContainText("Smoke Project");
+	await expect(projectCards.nth(0)).toContainText("Read order 1");
+	await expect(projectCards.nth(0)).toContainText("Default write destination");
+	await expect(projectCards.nth(0)).not.toContainText("Fixed");
+	await expect(projectCards.nth(0)).not.toContainText("Owner");
+	await expect(projectCards.nth(0).locator('[data-slot="badge"]')).toHaveCount(1);
+	await expect(projectCards.nth(0).getByRole("button")).toHaveCount(0);
+	await expect(projectCards.nth(1)).toContainText("Team Knowledge");
+	await expect(projectCards.nth(1)).toContainText("Read order 2");
+	await expect(projectCards.nth(1)).toContainText("Viewer");
+	await expect(projectCards.nth(1)).not.toContainText("Read access");
+	await expect(projectCards.nth(1)).not.toContainText("Skills and Vaults");
+	await expect(projectCards.nth(1).locator('[data-slot="badge"]')).toHaveCount(2);
+	await expect(projectCards.nth(2)).toContainText(longContextProjectName);
+	await expect(projectCards.nth(2)).toContainText("Read order 3");
+	await expect(projectCards.nth(2).locator('[data-slot="badge"]')).toHaveCount(1);
+	await projectCards.nth(1).hover();
 	await expect(
-		projectRows.nth(1).getByRole("button", { name: "Move Team Knowledge up" }),
+		projectCards.nth(1).getByRole("button", { name: "Move Team Knowledge up" }),
 	).toBeDisabled();
 	await expect(
-		projectRows.nth(1).getByRole("button", { name: "Remove Team Knowledge" }),
+		projectCards.nth(1).getByRole("button", { name: "Remove Team Knowledge" }),
 	).toBeVisible();
-	await expect(projectStack.getByTestId("agent-project-add")).toBeVisible();
-	await expect(projectStack.getByLabel("Add a Project")).toBeVisible();
+	await expect
+		.poll(() =>
+			projectCards
+				.nth(1)
+				.getByRole("button", { name: "Remove Team Knowledge" })
+				.evaluate((element) => getComputedStyle(element.parentElement ?? element).opacity),
+		)
+		.toBe("1");
+	await projectCards.nth(1).getByRole("button", { name: "Remove Team Knowledge" }).click();
+	const removeProjectDialog = page.getByRole("alertdialog", { name: "Remove this Project?" });
+	await expect(removeProjectDialog).toContainText(
+		"Team Knowledge will no longer be available to this agent.",
+	);
+	await removeProjectDialog.getByRole("button", { name: "Cancel" }).click();
+	await expect(projectStack.getByLabel("Project to add")).toHaveCount(0);
+	const addProjectTrigger = projectStack.getByRole("button", { name: "Add Project", exact: true });
+	await expect(addProjectTrigger).toBeVisible();
+	await addProjectTrigger.click();
+	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
+	await expect(addProjectDialog).toBeVisible();
+	await expect(addProjectDialog.getByRole("heading", { name: "Add Project" })).toBeVisible();
+	const compactProjectPicker = addProjectDialog.getByLabel("Project to add");
+	await expect(compactProjectPicker).toBeVisible();
+	await compactProjectPicker.click();
+	await page.getByRole("option", { name: /Unrelated Project/ }).click();
+	await expect(
+		addProjectDialog.getByRole("button", { name: "Add Project", exact: true }),
+	).toBeEnabled();
+	await addProjectDialog.getByRole("button", { name: "Cancel" }).click();
+	await expect(addProjectDialog).toHaveCount(0);
+
+	await projectStack.screenshot({
+		path: testInfo.outputPath("connected-agent-projects-desktop.png"),
+	});
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await projectStack.screenshot({ path: testInfo.outputPath("connected-agent-projects-dark.png") });
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+
+	await page.setViewportSize({ width: 2000, height: 1000 });
+	const centeredAgentSurface = projectStack.locator(
+		"xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' max-w-7xl ')][1]",
+	);
+	expect(
+		await centeredAgentSurface.evaluate((element) => element.getBoundingClientRect().width),
+	).toBeLessThanOrEqual(1280);
 
 	await page.setViewportSize({ width: 390, height: 844 });
-	await expect(projectRows.nth(2)).toBeVisible();
+	await expect(projectCards.nth(2)).toBeVisible();
+	expect(
+		await projectGrid.evaluate(
+			(element) => getComputedStyle(element).gridTemplateColumns.split(" ").length,
+		),
+	).toBe(1);
+	await expect
+		.poll(() =>
+			projectCards
+				.nth(1)
+				.getByRole("button", { name: "Remove Team Knowledge" })
+				.evaluate((element) => getComputedStyle(element.parentElement ?? element).opacity),
+		)
+		.toBe("1");
+	const longTitle = projectCards.nth(2).getByRole("heading", { name: longContextProjectName });
+	const longSlug = projectCards.nth(2).getByText(longContextProjectSlug, { exact: true });
+	expect(await longTitle.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(
+		true,
+	);
+	expect(await longSlug.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(
+		true,
+	);
 	expect(
 		await projectStack.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
 	).toBe(true);
+	expect(
+		await page
+			.locator("html")
+			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
+	await projectStack.screenshot({
+		path: testInfo.outputPath("connected-agent-projects-mobile.png"),
+	});
 
 	await page.goto("/agents/agent-smoke-1/vaults");
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();

--- a/apps/web/src/components/dashboard/agent-projects-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-projects-tab.test.ts
@@ -2,18 +2,52 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 describe("agent Projects presentation", () => {
-	test("keeps one ordered stack with concise role and access signals", () => {
+	test("uses the shared resource-card grid with concise order and access signals", () => {
 		const source = readFileSync(new URL("./agent-projects-tab.tsx", import.meta.url), "utf8");
 
 		expect(source).toContain('aria-label="Effective Project read order"');
-		expect(source).toContain("Writes here by default");
-		expect(source).toContain("showAccess={!isProjectOwner(project)}");
+		expect(source).toContain('data-testid="agent-project-grid"');
+		expect(source).toContain('data-testid="agent-project-card"');
+		expect(source).toContain("className={HERO_GRID_CLASS}");
+		expect(source).toContain("<HeroCard");
+		expect(source).toContain("<IconChip");
+		expect(source).toContain("<ProjectKindBadge");
+		expect(source).toContain("Default write destination");
+		expect(source).toMatch(/Read order \$\{position \+ 1\}/);
+		expect(source).toContain('<Badge variant="outline">Viewer</Badge>');
 		expect(source).toMatch(/aria-label=\{`Move \$\{projectName\} up`\}/);
 		expect(source).toMatch(/aria-label=\{`Move \$\{projectName\} down`\}/);
 		expect(source).toMatch(/aria-label=\{`Remove \$\{projectName\}`\}/);
+		expect(source).toContain("sm:group-focus-within:opacity-100");
+		expect(source).toContain("sm:group-hover:opacity-100");
 		expect(source).not.toContain(">Fixed<");
 		expect(source).not.toContain("Default writes");
 		expect(source).not.toContain("Read access");
 		expect(source).not.toContain("Reads Skills and Vaults");
+	});
+
+	test("keeps Project selection behind the compact toolbar dialog", () => {
+		const source = readFileSync(new URL("./agent-projects-tab.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("<ListToolbar");
+		expect(source).toContain("<DialogTitle>Add Project</DialogTitle>");
+		expect(source).toContain('data-testid="agent-project-add-dialog"');
+		expect(source).toContain("<ProjectCompactPicker");
+		expect(source).toContain('ariaLabel="Project to add"');
+		expect(source).toContain("No Custom or shared Projects are available to add.");
+		expect(source).not.toContain("<ProjectScopePicker");
+		expect(source).not.toContain('data-testid="agent-project-add"');
+	});
+
+	test("preserves binding mutations, confirmation, and query invalidation", () => {
+		const source = readFileSync(new URL("./agent-projects-tab.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain('api.POST("/v1/agents/{agent_id}/project-bindings/context"');
+		expect(source).toContain('api.PATCH("/v1/agents/{agent_id}/project-bindings/context/reorder"');
+		expect(source).toContain('api.DELETE("/v1/agents/{agent_id}/project-bindings/{binding_id}"');
+		expect(source).toContain("<ConfirmAction");
+		expect(source).toContain('title="Remove this Project?"');
+		expect(source).toContain("agentProjectBindingsQueryKey(agentId)");
+		expect(source).toContain('invalidateQueries({ queryKey: ["projects"] })');
 	});
 });

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, FolderKanban, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -14,19 +14,33 @@ import {
 	orderedAgentProjectBindings,
 } from "@/components/dashboard/agent-project-scope";
 import { EmptyState } from "@/components/empty-state";
+import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
+import { IconChip } from "@/components/icon-chip";
+import { ListToolbar } from "@/components/list-toolbar";
 import {
+	displayProjectName,
 	isCustomProject,
 	isProjectOwner,
-	ProjectIdentity,
-	ProjectScopePicker,
+	ProjectCompactPicker,
+	ProjectKindBadge,
+	projectAlias,
 } from "@/components/projects/project-metadata";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
+import { identityFor } from "@/lib/identity";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 
@@ -91,6 +105,7 @@ function AgentProjectsPanel({
 }) {
 	const api = useApi();
 	const [contextProjectId, setContextProjectId] = useState("");
+	const [addOpen, setAddOpen] = useState(false);
 	const orderedBindings = orderedAgentProjectBindings(bindings);
 	const primary = orderedBindings.find((binding) => binding.binding_type === "primary") ?? null;
 	const contexts = orderedBindings.filter((binding) => binding.binding_type === "context");
@@ -115,6 +130,7 @@ function AgentProjectsPanel({
 		},
 		onSuccess: () => {
 			setContextProjectId("");
+			setAddOpen(false);
 			onChanged();
 			toast.success("Project added");
 		},
@@ -165,9 +181,20 @@ function AgentProjectsPanel({
 
 	if (isLoading) {
 		return (
-			<div className="space-y-3" data-testid="agent-projects-loading">
-				<Skeleton className="h-4 w-96 max-w-full" />
-				<Skeleton className="h-52 w-full rounded-lg" />
+			<div className="space-y-4" data-testid="agent-projects-loading">
+				<div className="flex justify-end">
+					<Skeleton className="h-8 w-28 rounded-md" />
+				</div>
+				<div className={HERO_GRID_CLASS}>
+					{Array.from({ length: 3 }).map((_, index) => (
+						<div key={index} className={`${HERO_CARD_BASE} flex min-h-36 flex-col gap-3`}>
+							<Skeleton className="size-10 rounded-lg" />
+							<Skeleton className="h-4 w-36 max-w-full" />
+							<Skeleton className="h-3 w-28 max-w-full" />
+							<Skeleton className="mt-auto h-3 w-40 max-w-full" />
+						</div>
+					))}
+				</div>
 			</div>
 		);
 	}
@@ -194,157 +221,211 @@ function AgentProjectsPanel({
 
 	return (
 		<div className="space-y-4" data-testid="agent-project-stack">
-			<section className="overflow-hidden rounded-lg border bg-card/60">
-				{effectiveBindings.length === 0 ? (
-					<EmptyState
-						variant="inset"
-						className="rounded-none border-0"
-						description="The Agent Project is not available yet."
-					/>
-				) : (
-					<ol className="divide-y" aria-label="Effective Project read order">
-						{effectiveBindings.map((binding, position) => {
-							const project = projectsById.get(binding.project_id);
-							const projectName = project?.name || binding.project_id;
-							const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
-							const contextIndex = binding.binding_type === "context" ? position - 1 : -1;
-							return (
-								<li
-									key={binding.id}
-									className="grid gap-3 px-3 py-3 sm:px-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
-									data-binding-type={binding.binding_type}
-								>
-									<div className="flex min-w-0 items-start gap-3">
-										<div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-background text-xs font-semibold tabular-nums">
-											<span className="sr-only">Position </span>
-											{position + 1}
-										</div>
-										<ProjectUseLine binding={binding} project={project} />
-									</div>
-									{binding.binding_type === "context" ? (
-										<div className="flex items-center justify-end gap-1">
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												disabled={contextIndex === 0 || reorder.isPending}
-												onClick={() => moveContext(binding.id, -1)}
-												title="Move up"
-												aria-label={`Move ${projectName} up`}
-											>
-												<ArrowUp className="size-3.5" />
-											</Button>
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												disabled={contextIndex === contexts.length - 1 || reorder.isPending}
-												onClick={() => moveContext(binding.id, 1)}
-												title="Move down"
-												aria-label={`Move ${projectName} down`}
-											>
-												<ArrowDown className="size-3.5" />
-											</Button>
-											<ConfirmAction
-												title="Remove this Project?"
-												description={
-													<>
-														<p>{projectName} will no longer be available to this agent.</p>
-														<p>The Project and its resources are not deleted.</p>
-													</>
-												}
-												confirmLabel="Remove Project"
-												destructive
-												onConfirm={() => removeBinding.mutate(binding.id)}
-											>
+			<ListToolbar
+				actions={
+					<Button
+						size="sm"
+						disabled={!primary}
+						onClick={() => {
+							setContextProjectId("");
+							setAddOpen(true);
+						}}
+					>
+						<Plus className="size-3.5" />
+						Add Project
+					</Button>
+				}
+			/>
+
+			{effectiveBindings.length === 0 ? (
+				<EmptyState variant="inset" description="The Agent Project is not available yet." />
+			) : (
+				<ol
+					className={HERO_GRID_CLASS}
+					aria-label="Effective Project read order"
+					data-testid="agent-project-grid"
+				>
+					{effectiveBindings.map((binding, position) => {
+						const project = projectsById.get(binding.project_id);
+						const projectName = project ? displayProjectName(project) : binding.project_id;
+						const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
+						const contextIndex = binding.binding_type === "context" ? position - 1 : -1;
+						return (
+							<li
+								key={binding.id}
+								className="min-w-0"
+								data-binding-type={binding.binding_type}
+								data-testid="agent-project-card"
+							>
+								<AgentProjectCard
+									binding={binding}
+									project={project}
+									position={position}
+									actions={
+										binding.binding_type === "context" ? (
+											<div className="flex items-center gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-focus-within:opacity-100 sm:group-hover:opacity-100">
 												<Button
 													variant="ghost"
 													size="icon-sm"
-													disabled={isRemoving}
-													title="Remove"
-													aria-label={`Remove ${projectName}`}
+													disabled={contextIndex === 0 || reorder.isPending}
+													onClick={() => moveContext(binding.id, -1)}
+													title="Move up"
+													aria-label={`Move ${projectName} up`}
 												>
-													{isRemoving ? (
-														<Spinner className="size-3.5" />
-													) : (
-														<Trash2 className="size-3.5 text-destructive" />
-													)}
+													<ArrowUp className="size-3.5" />
 												</Button>
-											</ConfirmAction>
-										</div>
-									) : null}
-								</li>
-							);
-						})}
-					</ol>
-				)}
+												<Button
+													variant="ghost"
+													size="icon-sm"
+													disabled={contextIndex === contexts.length - 1 || reorder.isPending}
+													onClick={() => moveContext(binding.id, 1)}
+													title="Move down"
+													aria-label={`Move ${projectName} down`}
+												>
+													<ArrowDown className="size-3.5" />
+												</Button>
+												<ConfirmAction
+													title="Remove this Project?"
+													description={
+														<>
+															<p>{projectName} will no longer be available to this agent.</p>
+															<p>The Project and its resources are not deleted.</p>
+														</>
+													}
+													confirmLabel="Remove Project"
+													destructive
+													onConfirm={() => removeBinding.mutate(binding.id)}
+												>
+													<Button
+														variant="ghost"
+														size="icon-sm"
+														disabled={isRemoving}
+														title="Remove"
+														aria-label={`Remove ${projectName}`}
+													>
+														{isRemoving ? (
+															<Spinner className="size-3.5" />
+														) : (
+															<Trash2 className="size-3.5 text-destructive" />
+														)}
+													</Button>
+												</ConfirmAction>
+											</div>
+										) : null
+									}
+								/>
+							</li>
+						);
+					})}
+				</ol>
+			)}
 
-				<div
-					className="grid gap-3 border-t bg-background/40 p-3 sm:p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end"
-					data-testid="agent-project-add"
-				>
-					<div className="space-y-2">
-						<ProjectScopePicker
-							projects={contextChoices}
-							value={contextProjectId}
-							onValueChange={setContextProjectId}
-							label="Add a Project"
-							placeholder="Choose a Custom or shared Project…"
-							layout="stacked"
-							disabled={!primary || contextChoices.length === 0}
-						/>
-						{contextChoices.length === 0 ? (
-							<p className="text-xs text-muted-foreground">
+			<Dialog
+				open={addOpen}
+				onOpenChange={(open) => {
+					setAddOpen(open);
+					if (!open) setContextProjectId("");
+				}}
+			>
+				<DialogContent className="sm:max-w-md" data-testid="agent-project-add-dialog">
+					<DialogHeader>
+						<DialogTitle>Add Project</DialogTitle>
+						<DialogDescription>
+							Add a Custom or shared Project to this agent's read order.
+						</DialogDescription>
+					</DialogHeader>
+					<form
+						className="space-y-4"
+						onSubmit={(event) => {
+							event.preventDefault();
+							if (!contextProjectId || addContext.isPending) return;
+							addContext.mutate();
+						}}
+					>
+						{contextChoices.length > 0 ? (
+							<ProjectCompactPicker
+								projects={contextChoices}
+								value={contextProjectId}
+								onValueChange={setContextProjectId}
+								placeholder="Choose a Project…"
+								ariaLabel="Project to add"
+								disabled={addContext.isPending}
+							/>
+						) : (
+							<p className="text-sm text-muted-foreground">
 								No Custom or shared Projects are available to add.
 							</p>
-						) : null}
-					</div>
-					<Button
-						size="sm"
-						disabled={!primary || !contextProjectId || addContext.isPending}
-						variant={contextProjectId ? "default" : "outline"}
-						onClick={() => addContext.mutate()}
-					>
-						{addContext.isPending ? (
-							<Spinner className="size-3.5" />
-						) : (
-							<Plus className="size-3.5" />
 						)}
-						Add Project
-					</Button>
-				</div>
-			</section>
+						<DialogFooter>
+							<Button type="button" variant="ghost" onClick={() => setAddOpen(false)}>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={!contextProjectId || addContext.isPending}>
+								{addContext.isPending ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<Plus className="size-3.5" />
+								)}
+								Add Project
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }
 
-function ProjectUseLine({
+function AgentProjectCard({
 	binding,
 	project,
+	position,
+	actions,
 }: {
 	binding: AgentProjectBinding;
 	project: ProjectRow | undefined;
+	position: number;
+	actions?: React.ReactNode;
 }) {
-	const defaultWriteBadge =
-		binding.binding_type === "primary" ? (
-			<Badge variant="secondary">Writes here by default</Badge>
-		) : null;
+	const footer = [
+		`Read order ${position + 1}`,
+		binding.binding_type === "primary" ? "Default write destination" : null,
+	];
 	if (!project) {
 		return (
-			<div className="min-w-0">
-				<div className="flex flex-wrap items-center gap-2">
-					<span className="truncate text-sm font-medium">{binding.project_id}</span>
-					{defaultWriteBadge}
-					<Badge variant="outline">Access unavailable</Badge>
-				</div>
-			</div>
+			<HeroCard
+				icon={
+					<IconChip tint="bg-muted text-muted-foreground">
+						<FolderKanban />
+					</IconChip>
+				}
+				title={binding.project_id}
+				badges={<Badge variant="outline">Access unavailable</Badge>}
+				footer={footer}
+				actions={actions}
+			/>
 		);
 	}
+	const projectName = displayProjectName(project);
+	const identity = identityFor(projectName);
 	return (
-		<div className="min-w-0">
-			<ProjectIdentity
-				project={project}
-				badges={defaultWriteBadge}
-				showAccess={!isProjectOwner(project)}
-			/>
-		</div>
+		<HeroCard
+			icon={
+				<IconChip tint={identity.colorClasses} className="text-xl">
+					{identity.emoji}
+				</IconChip>
+			}
+			title={projectName}
+			badges={
+				<>
+					<ProjectKindBadge kind={project.kind ?? "workspace"} />
+					{isProjectOwner(project) ? null : <Badge variant="outline">Viewer</Badge>}
+				</>
+			}
+			description={projectAlias(project)}
+			descriptionClassName="truncate font-mono"
+			footer={footer}
+			actions={actions}
+		/>
 	);
 }


### PR DESCRIPTION
## Summary

- replace the oversized Agent Projects stack with the shared HeroCard resource grid while preserving effective DOM read order
- move Project selection into a compact Add Project dialog and keep context reorder/remove controls accessible on keyboard, hover, and mobile
- retain Connected/Hosted sharing, projection gates, binding mutations, confirmation, and query invalidation
- add focused contract coverage plus Connected and Hosted browser assertions for card count, ordering, dialogs, actions, centered width, truncation, and mobile overflow

## Verification

- bun run --cwd apps/web test
- bun run --cwd apps/web typecheck
- bunx biome check apps/web/src apps/web/e2e/sidebar-runtime-smoke.pw.ts apps/web/e2e/hosted-smoke.pw.ts
- bunx playwright test e2e/sidebar-runtime-smoke.pw.ts --project=chromium -g "connected agent resource tabs reuse scoped Projects"
- bunx playwright test --config=playwright.hosted.config.ts e2e/hosted-smoke.pw.ts --project=chromium -g "hosted agent sidebar renders one Resources heading"
- git diff --check

## UX tradeoff

Desktop context actions stay visually quiet until the card is hovered or focused; they remain keyboard-focusable and are always visible at mobile widths. Reordering remains explicit up/down controls rather than drag and drop, preserving the existing mutation semantics.