### PR TITLE
fix(web): unify project resource surfaces

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2872,7 +2872,7 @@ test("hosted agent sidebar renders one Resources heading in canonical order", as
 	await expect(projectCards.nth(0)).toContainText("Hosted Agent Project");
 	await expect(projectCards.nth(0)).toContainText("Read order 1");
 	await expect(projectCards.nth(0)).toContainText("Default write destination");
-	await expect(projectCards.nth(0)).toContainText("Owner");
+	await expect(projectCards.nth(0)).not.toContainText("Owner");
 	await expect(
 		projectCards.nth(0).getByRole("link", { name: "Open Hosted Agent Project" }),
 	).toHaveAttribute("href", "/projects/project-hosted");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2872,7 +2872,10 @@ test("hosted agent sidebar renders one Resources heading in canonical order", as
 	await expect(projectCards.nth(0)).toContainText("Hosted Agent Project");
 	await expect(projectCards.nth(0)).toContainText("Read order 1");
 	await expect(projectCards.nth(0)).toContainText("Default write destination");
-	await expect(projectCards.nth(0)).not.toContainText("Owner");
+	await expect(projectCards.nth(0)).toContainText("Owner");
+	await expect(
+		projectCards.nth(0).getByRole("link", { name: "Open Hosted Agent Project" }),
+	).toHaveAttribute("href", "/projects/project-hosted");
 	await expect(projectCards.nth(1)).toContainText("Hosted Shared Knowledge");
 	await expect(projectCards.nth(1)).toContainText("Read order 2");
 	await expect(projectCards.nth(1)).toContainText("Viewer");
@@ -2889,6 +2892,11 @@ test("hosted agent sidebar renders one Resources heading in canonical order", as
 		projectCards.nth(1).getByRole("button", { name: "Remove Hosted Shared Knowledge" }),
 	).toBeVisible();
 	await projectCards.nth(1).getByRole("button", { name: "Remove Hosted Shared Knowledge" }).click();
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === `/agents/${railHostedEnvironmentId}/project-access` && url.search === query
+		);
+	});
 	const removeProjectDialog = page.getByRole("alertdialog", { name: "Remove this Project?" });
 	await expect(removeProjectDialog).toContainText(
 		"Hosted Shared Knowledge will no longer be available to this agent.",
@@ -2936,6 +2944,8 @@ test("hosted agent sidebar renders one Resources heading in canonical order", as
 			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
 	).toBe(true);
 	await projectStack.screenshot({ path: testInfo.outputPath("hosted-agent-projects-mobile.png") });
+	await projectCards.nth(0).getByRole("link", { name: "Open Hosted Agent Project" }).click();
+	await expect(page).toHaveURL(/\/projects\/project-hosted$/);
 
 	await page.goto(`/agents/${railHostedEnvironmentId}/vaults${query}`);
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -510,7 +510,9 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/agents/agent-smoke-1/connectors?q=gmail&page=2");
 	const main = page.locator("main");
-	await expect(main.getByRole("heading", { name: "Connectors", level: 1 })).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Connectors", level: 1 })).toBeVisible({
+		timeout: 15_000,
+	});
 	await expect(page).toHaveTitle("Connectors · Clawdi");
 	await expect(
 		main.getByText("Account-wide connectors available across all agents."),
@@ -538,9 +540,12 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await expect(projectCards.nth(0)).toContainText("Read order 1");
 	await expect(projectCards.nth(0)).toContainText("Default write destination");
 	await expect(projectCards.nth(0)).not.toContainText("Fixed");
-	await expect(projectCards.nth(0)).not.toContainText("Owner");
-	await expect(projectCards.nth(0).locator('[data-slot="badge"]')).toHaveCount(1);
+	await expect(projectCards.nth(0)).toContainText("Owner");
+	await expect(projectCards.nth(0).locator('[data-slot="badge"]')).toHaveCount(2);
 	await expect(projectCards.nth(0).getByRole("button")).toHaveCount(0);
+	await expect(
+		projectCards.nth(0).getByRole("link", { name: "Open Smoke Project" }),
+	).toHaveAttribute("href", "/projects/project-smoke");
 	await expect(projectCards.nth(1)).toContainText("Team Knowledge");
 	await expect(projectCards.nth(1)).toContainText("Read order 2");
 	await expect(projectCards.nth(1)).toContainText("Viewer");
@@ -549,7 +554,7 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await expect(projectCards.nth(1).locator('[data-slot="badge"]')).toHaveCount(2);
 	await expect(projectCards.nth(2)).toContainText(longContextProjectName);
 	await expect(projectCards.nth(2)).toContainText("Read order 3");
-	await expect(projectCards.nth(2).locator('[data-slot="badge"]')).toHaveCount(1);
+	await expect(projectCards.nth(2).locator('[data-slot="badge"]')).toHaveCount(2);
 	await projectCards.nth(1).hover();
 	await expect(
 		projectCards.nth(1).getByRole("button", { name: "Move Team Knowledge up" }),
@@ -566,6 +571,7 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 		)
 		.toBe("1");
 	await projectCards.nth(1).getByRole("button", { name: "Remove Team Knowledge" }).click();
+	await expect(page).toHaveURL(/\/agents\/agent-smoke-1\/project-access$/);
 	const removeProjectDialog = page.getByRole("alertdialog", { name: "Remove this Project?" });
 	await expect(removeProjectDialog).toContainText(
 		"Team Knowledge will no longer be available to this agent.",
@@ -637,6 +643,34 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await projectStack.screenshot({
 		path: testInfo.outputPath("connected-agent-projects-mobile.png"),
 	});
+	const primaryProjectLink = projectCards.nth(0).getByRole("link", { name: "Open Smoke Project" });
+	await primaryProjectLink.focus();
+	await expect(primaryProjectLink).toBeFocused();
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/projects\/project-smoke$/);
+
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.goto("/projects");
+	await expect(main.getByRole("heading", { name: "Projects", level: 1 })).toBeVisible();
+	const consoleProjectGrid = main.getByTestId("project-grid");
+	const consoleSharedProject = consoleProjectGrid.getByRole("link", {
+		name: "Open Team Knowledge",
+	});
+	await expect(consoleSharedProject).toHaveAttribute("href", "/projects/project-context-first");
+	await expect(consoleSharedProject.locator("xpath=..")).toContainText("Custom Project");
+	await expect(consoleSharedProject.locator("xpath=..")).toContainText("Viewer");
+	await main.screenshot({ path: testInfo.outputPath("console-projects-desktop.png") });
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await main.screenshot({ path: testInfo.outputPath("console-projects-dark.png") });
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(consoleSharedProject).toBeVisible();
+	expect(
+		await page
+			.locator("html")
+			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
+	await main.screenshot({ path: testInfo.outputPath("console-projects-mobile.png") });
 
 	await page.goto("/agents/agent-smoke-1/vaults");
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -540,8 +540,8 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await expect(projectCards.nth(0)).toContainText("Read order 1");
 	await expect(projectCards.nth(0)).toContainText("Default write destination");
 	await expect(projectCards.nth(0)).not.toContainText("Fixed");
-	await expect(projectCards.nth(0)).toContainText("Owner");
-	await expect(projectCards.nth(0).locator('[data-slot="badge"]')).toHaveCount(2);
+	await expect(projectCards.nth(0)).not.toContainText("Owner");
+	await expect(projectCards.nth(0).locator('[data-slot="badge"]')).toHaveCount(1);
 	await expect(projectCards.nth(0).getByRole("button")).toHaveCount(0);
 	await expect(
 		projectCards.nth(0).getByRole("link", { name: "Open Smoke Project" }),
@@ -554,7 +554,7 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 	await expect(projectCards.nth(1).locator('[data-slot="badge"]')).toHaveCount(2);
 	await expect(projectCards.nth(2)).toContainText(longContextProjectName);
 	await expect(projectCards.nth(2)).toContainText("Read order 3");
-	await expect(projectCards.nth(2).locator('[data-slot="badge"]')).toHaveCount(2);
+	await expect(projectCards.nth(2).locator('[data-slot="badge"]')).toHaveCount(1);
 	await projectCards.nth(1).hover();
 	await expect(
 		projectCards.nth(1).getByRole("button", { name: "Move Team Knowledge up" }),
@@ -657,8 +657,16 @@ test("connected agent resource tabs reuse scoped Projects, account Connectors, a
 		name: "Open Team Knowledge",
 	});
 	await expect(consoleSharedProject).toHaveAttribute("href", "/projects/project-context-first");
-	await expect(consoleSharedProject.locator("xpath=..")).toContainText("Custom Project");
 	await expect(consoleSharedProject.locator("xpath=..")).toContainText("Viewer");
+	await expect(consoleProjectGrid.getByText("Custom Project", { exact: true })).toHaveCount(0);
+	await expect(consoleProjectGrid.getByText("Owner", { exact: true })).toHaveCount(0);
+	await main.getByRole("button", { name: /System projects/i }).click();
+	const systemProjectCard = main
+		.getByRole("link", { name: "Open Smoke Project" })
+		.locator("xpath=..");
+	await expect(systemProjectCard).toContainText("Agent Project");
+	await expect(systemProjectCard).toContainText("Agent: Smoke Codex");
+	await expect(systemProjectCard).not.toContainText("Owner");
 	await main.screenshot({ path: testInfo.outputPath("console-projects-desktop.png") });
 	await page.locator("html").evaluate((element) => element.classList.add("dark"));
 	await main.screenshot({ path: testInfo.outputPath("console-projects-dark.png") });

--- a/apps/web/src/components/dashboard/agent-projects-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-projects-tab.test.ts
@@ -34,7 +34,9 @@ describe("agent Projects presentation", () => {
 		);
 
 		expect(source).toContain("<ProjectKindBadge");
-		expect(source).toContain('isProjectOwner(project) ? "Owner" : "Viewer"');
+		expect(source).toContain("const showViewer = !isProjectOwner(project)");
+		expect(source).toContain('showViewer ? <Badge variant="outline">Viewer</Badge> : null');
+		expect(source).toContain("showKind ? <ProjectKindBadge");
 		expect(source).toContain("description={projectAlias(project)}");
 		expect(source).toContain('to: "/projects/$id"');
 		expect(source).toContain("ariaLabel={");

--- a/apps/web/src/components/dashboard/agent-projects-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-projects-tab.test.ts
@@ -9,12 +9,13 @@ describe("agent Projects presentation", () => {
 		expect(source).toContain('data-testid="agent-project-grid"');
 		expect(source).toContain('data-testid="agent-project-card"');
 		expect(source).toContain("className={HERO_GRID_CLASS}");
-		expect(source).toContain("<HeroCard");
-		expect(source).toContain("<IconChip");
-		expect(source).toContain("<ProjectKindBadge");
+		expect(source).toContain("<ProjectResourceCard");
+		expect(source).toContain("<ProjectResourceCardSkeleton");
+		expect(source).toContain("<UnavailableProjectResourceCard");
 		expect(source).toContain("Default write destination");
 		expect(source).toMatch(/Read order \$\{position \+ 1\}/);
-		expect(source).toContain('<Badge variant="outline">Viewer</Badge>');
+		expect(source).not.toContain("ProjectKindBadge");
+		expect(source).not.toContain('variant="outline">Viewer');
 		expect(source).toMatch(/aria-label=\{`Move \$\{projectName\} up`\}/);
 		expect(source).toMatch(/aria-label=\{`Move \$\{projectName\} down`\}/);
 		expect(source).toMatch(/aria-label=\{`Remove \$\{projectName\}`\}/);
@@ -24,6 +25,20 @@ describe("agent Projects presentation", () => {
 		expect(source).not.toContain("Default writes");
 		expect(source).not.toContain("Read access");
 		expect(source).not.toContain("Reads Skills and Vaults");
+	});
+
+	test("delegates canonical identity, access language, and navigation to the shared Project card", () => {
+		const source = readFileSync(
+			new URL("../projects/project-resource-card.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(source).toContain("<ProjectKindBadge");
+		expect(source).toContain('isProjectOwner(project) ? "Owner" : "Viewer"');
+		expect(source).toContain("description={projectAlias(project)}");
+		expect(source).toContain('to: "/projects/$id"');
+		expect(source).toContain("ariaLabel={");
+		expect(source).toContain("Open ");
 	});
 
 	test("keeps Project selection behind the compact toolbar dialog", () => {

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, FolderKanban, Plus, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -14,18 +14,18 @@ import {
 	orderedAgentProjectBindings,
 } from "@/components/dashboard/agent-project-scope";
 import { EmptyState } from "@/components/empty-state";
-import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
-import { IconChip } from "@/components/icon-chip";
+import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { ListToolbar } from "@/components/list-toolbar";
 import {
 	displayProjectName,
 	isCustomProject,
-	isProjectOwner,
 	ProjectCompactPicker,
-	ProjectKindBadge,
-	projectAlias,
 } from "@/components/projects/project-metadata";
-import { Badge } from "@/components/ui/badge";
+import {
+	ProjectResourceCard,
+	ProjectResourceCardSkeleton,
+	UnavailableProjectResourceCard,
+} from "@/components/projects/project-resource-card";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import {
@@ -40,7 +40,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
-import { identityFor } from "@/lib/identity";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 
@@ -187,12 +186,7 @@ function AgentProjectsPanel({
 				</div>
 				<div className={HERO_GRID_CLASS}>
 					{Array.from({ length: 3 }).map((_, index) => (
-						<div key={index} className={`${HERO_CARD_BASE} flex min-h-36 flex-col gap-3`}>
-							<Skeleton className="size-10 rounded-lg" />
-							<Skeleton className="h-4 w-36 max-w-full" />
-							<Skeleton className="h-3 w-28 max-w-full" />
-							<Skeleton className="mt-auto h-3 w-40 max-w-full" />
-						</div>
+						<ProjectResourceCardSkeleton key={index} />
 					))}
 				</div>
 			</div>
@@ -393,39 +387,12 @@ function AgentProjectCard({
 	];
 	if (!project) {
 		return (
-			<HeroCard
-				icon={
-					<IconChip tint="bg-muted text-muted-foreground">
-						<FolderKanban />
-					</IconChip>
-				}
-				title={binding.project_id}
-				badges={<Badge variant="outline">Access unavailable</Badge>}
+			<UnavailableProjectResourceCard
+				projectId={binding.project_id}
 				footer={footer}
 				actions={actions}
 			/>
 		);
 	}
-	const projectName = displayProjectName(project);
-	const identity = identityFor(projectName);
-	return (
-		<HeroCard
-			icon={
-				<IconChip tint={identity.colorClasses} className="text-xl">
-					{identity.emoji}
-				</IconChip>
-			}
-			title={projectName}
-			badges={
-				<>
-					<ProjectKindBadge kind={project.kind ?? "workspace"} />
-					{isProjectOwner(project) ? null : <Badge variant="outline">Viewer</Badge>}
-				</>
-			}
-			description={projectAlias(project)}
-			descriptionClassName="truncate font-mono"
-			footer={footer}
-			actions={actions}
-		/>
-	);
+	return <ProjectResourceCard project={project} footer={footer} actions={actions} />;
 }

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -394,5 +394,5 @@ function AgentProjectCard({
 			/>
 		);
 	}
-	return <ProjectResourceCard project={project} footer={footer} actions={actions} />;
+	return <ProjectResourceCard project={project} footer={footer} actions={actions} showKind />;
 }

--- a/apps/web/src/components/projects/project-resource-card.tsx
+++ b/apps/web/src/components/projects/project-resource-card.tsx
@@ -23,15 +23,18 @@ export function ProjectResourceCard({
 	project,
 	footer,
 	actions,
+	showKind = false,
 	className,
 }: {
 	project: ProjectMetadata;
 	footer?: ReactNode | ReactNode[];
 	actions?: ReactNode;
+	showKind?: boolean;
 	className?: string;
 }) {
 	const projectName = displayProjectName(project);
 	const identity = identityFor(projectName);
+	const showViewer = !isProjectOwner(project);
 	return (
 		<HeroCard
 			icon={
@@ -41,10 +44,12 @@ export function ProjectResourceCard({
 			}
 			title={projectName}
 			badges={
-				<>
-					<ProjectKindBadge kind={project.kind ?? "workspace"} />
-					<Badge variant="outline">{isProjectOwner(project) ? "Owner" : "Viewer"}</Badge>
-				</>
+				showKind || showViewer ? (
+					<>
+						{showKind ? <ProjectKindBadge kind={project.kind ?? "workspace"} /> : null}
+						{showViewer ? <Badge variant="outline">Viewer</Badge> : null}
+					</>
+				) : undefined
 			}
 			description={projectAlias(project)}
 			descriptionClassName="truncate font-mono"

--- a/apps/web/src/components/projects/project-resource-card.tsx
+++ b/apps/web/src/components/projects/project-resource-card.tsx
@@ -1,0 +1,99 @@
+import { FolderKanban } from "lucide-react";
+import type { ReactNode } from "react";
+import { HERO_CARD_BASE, HeroCard } from "@/components/entity-card";
+import { IconChip } from "@/components/icon-chip";
+import {
+	displayProjectName,
+	isProjectOwner,
+	ProjectKindBadge,
+	type ProjectMetadata,
+	projectAlias,
+} from "@/components/projects/project-metadata";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { identityFor } from "@/lib/identity";
+import { cn } from "@/lib/utils";
+
+/**
+ * Canonical Project card. Collection surfaces supply only their contextual
+ * metadata and actions; Project identity, access language, and navigation stay
+ * identical everywhere.
+ */
+export function ProjectResourceCard({
+	project,
+	footer,
+	actions,
+	className,
+}: {
+	project: ProjectMetadata;
+	footer?: ReactNode | ReactNode[];
+	actions?: ReactNode;
+	className?: string;
+}) {
+	const projectName = displayProjectName(project);
+	const identity = identityFor(projectName);
+	return (
+		<HeroCard
+			icon={
+				<IconChip tint={identity.colorClasses} className="text-xl">
+					{identity.emoji}
+				</IconChip>
+			}
+			title={projectName}
+			badges={
+				<>
+					<ProjectKindBadge kind={project.kind ?? "workspace"} />
+					<Badge variant="outline">{isProjectOwner(project) ? "Owner" : "Viewer"}</Badge>
+				</>
+			}
+			description={projectAlias(project)}
+			descriptionClassName="truncate font-mono"
+			footer={footer}
+			actions={actions}
+			link={project.id ? { to: "/projects/$id", params: { id: project.id } } : undefined}
+			ariaLabel={`Open ${projectName}`}
+			className={className}
+		/>
+	);
+}
+
+export function UnavailableProjectResourceCard({
+	projectId,
+	footer,
+	actions,
+}: {
+	projectId: string;
+	footer?: ReactNode | ReactNode[];
+	actions?: ReactNode;
+}) {
+	return (
+		<HeroCard
+			icon={
+				<IconChip tint="bg-muted text-muted-foreground">
+					<FolderKanban />
+				</IconChip>
+			}
+			title={projectId}
+			badges={<Badge variant="outline">Access unavailable</Badge>}
+			footer={footer}
+			actions={actions}
+			interactive={false}
+		/>
+	);
+}
+
+export function ProjectResourceCardSkeleton() {
+	return (
+		<div className={cn(HERO_CARD_BASE, "flex min-h-36 flex-col gap-3")}>
+			<Skeleton className="size-10 rounded-lg" />
+			<div className="min-w-0 space-y-2">
+				<Skeleton className="h-5 w-44 max-w-full" />
+				<Skeleton className="h-3 w-32" />
+			</div>
+			<div className="mt-auto flex items-center gap-3">
+				<Skeleton className="h-3 w-16" />
+				<Skeleton className="h-3 w-16" />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -1,24 +1,24 @@
 "use client";
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { ChevronDown, Plus, Share2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
-import { IconChip } from "@/components/icon-chip";
+import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	displayProjectName,
 	isCustomProject,
-	type ProjectAgentMetadata,
-	ProjectIdentity,
-	projectAgentFor,
 	projectKindSortRank,
 } from "@/components/projects/project-metadata";
+import {
+	ProjectResourceCard,
+	ProjectResourceCardSkeleton,
+} from "@/components/projects/project-resource-card";
 import { SectionLabel } from "@/components/section-label";
 import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
 import { Button } from "@/components/ui/button";
@@ -32,16 +32,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchInput } from "@/components/ui/search-input";
-import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
-import { identityFor } from "@/lib/identity";
 import { getProjectResourceDefinition, projectDetailHref } from "@/lib/project-resource-model";
 import { cn, errorMessage } from "@/lib/utils";
 
-type Env = components["schemas"]["AgentResponse"];
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
@@ -66,15 +63,6 @@ export default function ProjectsPage() {
 	});
 
 	const rows = projects.data ?? [];
-	const environments = useQuery({
-		queryKey: ["agents"],
-		queryFn: async (): Promise<Env[]> => unwrap(await api.GET("/v1/agents")),
-		enabled: rows.some((project) => project.kind === "environment"),
-	});
-	const agentsById = useMemo(
-		() => new Map((environments.data ?? []).map((agent) => [agent.id, agent])),
-		[environments.data],
-	);
 
 	// Per-project resource counts for the cards. Shares the skills cache with
 	// the Skills page (same queryKey); vault list carries project_ids.
@@ -181,7 +169,7 @@ export default function ProjectsPage() {
 				<PageHeader title="Projects" description={PROJECTS_RESOURCE.managementDescription} />
 				<div className={HERO_GRID_CLASS}>
 					{Array.from({ length: 6 }).map((_, i) => (
-						<ProjectCardSkeleton key={i} />
+						<ProjectResourceCardSkeleton key={i} />
 					))}
 				</div>
 			</div>
@@ -293,14 +281,28 @@ export default function ProjectsPage() {
 						"transition-opacity",
 						projects.isFetching && !projects.isLoading ? "opacity-60" : "opacity-100",
 					)}
+					data-testid="project-grid"
 				>
 					{gridProjects.map(({ project, shared }) => (
-						<ProjectCard
+						<ProjectResourceCard
 							key={project.id}
 							project={project}
-							shared={shared}
-							skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
-							vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
+							footer={[
+								formatCountLabel(
+									skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0),
+									"skill",
+								),
+								formatCountLabel(
+									vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0),
+									"vault",
+								),
+								shared && project.owner_display ? `by ${project.owner_display}` : null,
+							]}
+							actions={
+								!shared && isCustomProject(project) ? (
+									<ProjectShareAction project={project} />
+								) : null
+							}
 						/>
 					))}
 				</div>
@@ -311,31 +313,40 @@ export default function ProjectsPage() {
 					<button
 						type="button"
 						onClick={() => setSystemOpen((v) => !v)}
-						className="flex flex-wrap items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
+						className="flex w-full items-start gap-1.5 text-left text-muted-foreground transition-colors hover:text-foreground"
 						aria-expanded={systemOpen}
 					>
 						<ChevronDown
 							className={cn(
-								"size-4 transition-transform duration-150",
+								"mt-0.5 size-4 shrink-0 transition-transform duration-150",
 								!systemOpen && "-rotate-90",
 							)}
 						/>
-						<SectionLabel className="px-0" count={systemProjects.length}>
-							System projects
-						</SectionLabel>
-						<span className="ml-1 text-xs">
-							account default and one per connected agent — managed automatically
+						<span className="min-w-0">
+							<SectionLabel className="px-0" count={systemProjects.length}>
+								System projects
+							</SectionLabel>
+							<span className="block text-xs">
+								Account default and one per connected agent — managed automatically
+							</span>
 						</span>
 					</button>
 					{systemOpen ? (
-						<div className="divide-y overflow-hidden rounded-lg border bg-card">
+						<div className={HERO_GRID_CLASS}>
 							{systemProjects.map((project) => (
-								<SystemProjectRow
+								<ProjectResourceCard
 									key={project.id}
 									project={project}
-									agent={projectAgentFor(project, agentsById)}
-									skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
-									vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
+									footer={[
+										formatCountLabel(
+											skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0),
+											"skill",
+										),
+										formatCountLabel(
+											vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0),
+											"vault",
+										),
+									]}
 								/>
 							))}
 						</div>
@@ -346,119 +357,19 @@ export default function ProjectsPage() {
 	);
 }
 
-function ProjectCard({
-	project,
-	shared,
-	skillCount,
-	vaultCount,
-}: {
-	project: ProjectRow;
-	shared: boolean;
-	skillCount: CountValue;
-	vaultCount: CountValue;
-}) {
+function ProjectShareAction({ project }: { project: ProjectRow }) {
 	const projectName = displayProjectName(project);
 	return (
-		<HeroCard
-			icon={
-				<IconChip tint={identityFor(projectName).colorClasses} className="text-xl">
-					{identityFor(projectName).emoji}
-				</IconChip>
-			}
-			title={projectName}
-			badges={shared ? <StatusChip>Shared with you</StatusChip> : null}
-			description={<span className="font-mono">{project.slug}</span>}
-			footer={[
-				formatCountLabel(skillCount, "skill"),
-				formatCountLabel(vaultCount, "vault"),
-				shared && project.owner_display ? `by ${project.owner_display}` : null,
-			]}
-			actions={
-				!shared && isCustomProject(project) ? (
-					<div className="opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
-						<ShareProjectDialog
-							projectId={project.id}
-							projectName={projectName}
-							projectKind={project.kind}
-						>
-							<Button variant="ghost" size="icon-sm" aria-label={`Share ${projectName}`}>
-								<Share2 className="size-3.5" />
-							</Button>
-						</ShareProjectDialog>
-					</div>
-				) : null
-			}
-			link={{ to: "/projects/$id", params: { id: project.id } }}
-			ariaLabel={`Open ${projectName}`}
-		/>
-	);
-}
-
-function ProjectCardSkeleton() {
-	return (
-		<div className={cn(HERO_CARD_BASE, "flex min-h-36 flex-col gap-3")}>
-			<Skeleton className="size-10 rounded-lg" />
-			<div className="min-w-0 space-y-2">
-				<Skeleton className="h-5 w-44 max-w-full" />
-				<Skeleton className="h-3 w-32" />
-			</div>
-			<div className="mt-auto flex items-center gap-3">
-				<Skeleton className="h-3 w-16" />
-				<Skeleton className="h-3 w-16" />
-			</div>
-		</div>
-	);
-}
-
-function StatusChip({ children }: { children: React.ReactNode }) {
-	return (
-		<span className="shrink-0 rounded-sm bg-info-muted px-1.5 py-0.5 text-2xs font-medium text-info-muted-foreground">
-			{children}
-		</span>
-	);
-}
-
-function SystemProjectRow({
-	project,
-	agent,
-	skillCount,
-	vaultCount,
-}: {
-	project: ProjectRow;
-	agent?: ProjectAgentMetadata | null;
-	skillCount: CountValue;
-	vaultCount: CountValue;
-}) {
-	const isGlobal = project.kind === "personal";
-	return (
-		<div className="group relative flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50">
-			<span
-				className={cn(
-					"flex size-7 shrink-0 select-none items-center justify-center rounded-md text-sm leading-none",
-					identityFor(displayProjectName(project)).colorClasses,
-				)}
+		<div className="opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+			<ShareProjectDialog
+				projectId={project.id}
+				projectName={projectName}
+				projectKind={project.kind}
 			>
-				{isGlobal ? "🌐" : identityFor(displayProjectName(project)).emoji}
-			</span>
-			<div className="min-w-0 flex-1">
-				<ProjectIdentity
-					project={project}
-					agent={agent}
-					showOwner={false}
-					showAccess={false}
-					showIcon={false}
-				/>
-			</div>
-			<span className="hidden shrink-0 text-xs text-muted-foreground tabular-nums sm:inline">
-				{formatCountLabel(skillCount, "skill")} · {formatCountLabel(vaultCount, "vault")}
-			</span>
-			<Link
-				to="/projects/$id"
-				params={{ id: project.id }}
-				className="absolute inset-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-			>
-				<span className="sr-only">Open {displayProjectName(project)}</span>
-			</Link>
+				<Button variant="ghost" size="icon-sm" aria-label={`Share ${projectName}`}>
+					<Share2 className="size-3.5" />
+				</Button>
+			</ShareProjectDialog>
 		</div>
 	);
 }

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -13,6 +13,9 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	displayProjectName,
 	isCustomProject,
+	type ProjectAgentMetadata,
+	projectAgentFor,
+	projectAgentLabel,
 	projectKindSortRank,
 } from "@/components/projects/project-metadata";
 import {
@@ -40,6 +43,7 @@ import { getProjectResourceDefinition, projectDetailHref } from "@/lib/project-r
 import { cn, errorMessage } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
+type Env = components["schemas"]["AgentResponse"];
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type CountValue = number | "unavailable";
@@ -63,6 +67,15 @@ export default function ProjectsPage() {
 	});
 
 	const rows = projects.data ?? [];
+	const environments = useQuery({
+		queryKey: ["agents"],
+		queryFn: async (): Promise<Env[]> => unwrap(await api.GET("/v1/agents")),
+		enabled: rows.some((project) => project.kind === "environment"),
+	});
+	const agentsById = useMemo(
+		() => new Map((environments.data ?? []).map((agent) => [agent.id, agent])),
+		[environments.data],
+	);
 
 	// Per-project resource counts for the cards. Shares the skills cache with
 	// the Skills page (same queryKey); vault list carries project_ids.
@@ -334,19 +347,12 @@ export default function ProjectsPage() {
 					{systemOpen ? (
 						<div className={HERO_GRID_CLASS}>
 							{systemProjects.map((project) => (
-								<ProjectResourceCard
+								<SystemProjectCard
 									key={project.id}
 									project={project}
-									footer={[
-										formatCountLabel(
-											skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0),
-											"skill",
-										),
-										formatCountLabel(
-											vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0),
-											"vault",
-										),
-									]}
+									agent={projectAgentFor(project, agentsById)}
+									skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
+									vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
 								/>
 							))}
 						</div>
@@ -354,6 +360,30 @@ export default function ProjectsPage() {
 				</section>
 			) : null}
 		</div>
+	);
+}
+
+function SystemProjectCard({
+	project,
+	agent,
+	skillCount,
+	vaultCount,
+}: {
+	project: ProjectRow;
+	agent: ProjectAgentMetadata | null;
+	skillCount: CountValue;
+	vaultCount: CountValue;
+}) {
+	return (
+		<ProjectResourceCard
+			project={project}
+			showKind
+			footer={[
+				formatCountLabel(skillCount, "skill"),
+				formatCountLabel(vaultCount, "vault"),
+				project.kind === "environment" && agent ? `Agent: ${projectAgentLabel(agent)}` : null,
+			]}
+		/>
 	);
 }
 


### PR DESCRIPTION
## Summary
- introduce one canonical Project resource card for Console and Agent surfaces, including identity, kind, access, alias, loading state, and `/projects/$id` navigation
- keep Agent-only relationship metadata and controls composable above the stretched link so reorder/remove remain independent and mobile-accessible
- render managed Console Projects with the same card grid and clean up the mobile system-project disclosure
- add focused contracts plus Connected and Hosted Playwright coverage for canonical links, keyboard navigation, nested actions, long names, responsive layout, and light/dark/mobile screenshots

## UX reasoning
A Project should retain the same identity and destination wherever users encounter it. Console answers “what Projects can I access?” while the Agent page answers “in what order can this agent read them, and where does it write?” The shared card owns the first question; Agent-only footer metadata and controls answer the second without repeating resource explanations or creating a second Project concept.

## Verification
- `bun run --cwd apps/web test` (Docker clean runner: 850 tests; typecheck and OSS build included)
- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src`
- `bun run --cwd apps/web build:oss`
- Connected Playwright: `sidebar-runtime-smoke.pw.ts` / `connected agent resource tabs...`
- Hosted Playwright: `hosted-smoke.pw.ts` / `hosted agent sidebar renders one Resources heading...`
- inspected Connected Agent, Hosted Agent, and Console screenshots at desktop light/dark and 390px mobile

No production, deployment, cluster, tenant, or hosted-repository operations were performed.