### PR TITLE
Archive disconnected Agents and Projects in place

### DIFF
--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -137,7 +137,7 @@ export function AgentSettingsPanel({
 			),
 		onSuccess: () => {
 			toast.success("Agent disconnected", {
-				description: "Sessions and skills stay in your account.",
+				description: "Sessions, Skills, and Projects are retained until it reconnects.",
 			});
 			queryClient.invalidateQueries({
 				predicate: (q) => {
@@ -378,13 +378,10 @@ export function AgentSettingsPanel({
 						<ConfirmAction
 							title="Disconnect this agent?"
 							description={
-								<>
-									<p>Sessions and skills stay in your account.</p>
-									<p>
-										This agent will stop syncing and sessions will no longer be tagged with it.
-										Reconnect from that agent to resume.
-									</p>
-								</>
+								<p>
+									Sync stops and the Agent leaves active views. Sessions, Skills, and Projects are
+									retained and return when it reconnects.
+								</p>
 							}
 							confirmLabel="Disconnect agent"
 							destructive

--- a/backend/alembic/versions/f3b7c1d9e5a2_archive_agent_lifecycle.py
+++ b/backend/alembic/versions/f3b7c1d9e5a2_archive_agent_lifecycle.py
@@ -1,0 +1,27 @@
+"""archive agent lifecycle
+
+Revision ID: f3b7c1d9e5a2
+Revises: e8f4a1c9d2b7
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "f3b7c1d9e5a2"
+down_revision = "e8f4a1c9d2b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_environments",
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_agent_environments_archived_at", "agent_environments", ["archived_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_environments_archived_at", table_name="agent_environments")
+    op.drop_column("agent_environments", "archived_at")

--- a/backend/alembic/versions/f3b7c1d9e5a2_archive_agent_lifecycle.py
+++ b/backend/alembic/versions/f3b7c1d9e5a2_archive_agent_lifecycle.py
@@ -1,7 +1,7 @@
 """archive agent lifecycle
 
 Revision ID: f3b7c1d9e5a2
-Revises: e8f4a1c9d2b7
+Revises: 6a9d2c4e8f10
 """
 
 import sqlalchemy as sa
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "f3b7c1d9e5a2"
-down_revision = "e8f4a1c9d2b7"
+down_revision = "6a9d2c4e8f10"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -219,6 +219,29 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     key_hash = hashlib.sha256(token.encode()).hexdigest()
     cached = _get_cached_api_key_auth(key_hash)
     if cached is not None:
+        # Bound Agent keys are an operational authority boundary. Revalidate
+        # their durable key + Agent lifecycle on every cache hit so a request
+        # racing archive commit cannot re-cache authority after the caller's
+        # post-commit invalidation, and so other worker-local caches fail
+        # closed immediately after they observe the committed archive.
+        if cached.api_key is not None and cached.api_key.environment_id is not None:
+            from app.models.session import AgentEnvironment
+
+            active_key_id = await db.scalar(
+                select(ApiKey.id)
+                .join(
+                    AgentEnvironment,
+                    AgentEnvironment.id == ApiKey.environment_id,
+                )
+                .where(
+                    ApiKey.id == cached.api_key.id,
+                    ApiKey.revoked_at.is_(None),
+                    AgentEnvironment.archived_at.is_(None),
+                )
+            )
+            if active_key_id is None:
+                _api_key_auth_cache.pop(key_hash, None)
+                raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
         return cached
 
     result = await db.execute(select(ApiKey).where(ApiKey.key_hash == key_hash))
@@ -259,13 +282,18 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
         if api_key_project_id is None:
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Agent is archived")
 
-    _cache_api_key_auth(
-        key_hash=key_hash,
-        api_key=api_key,
-        user=user,
-        api_key_project_id=api_key_project_id,
-        now=now,
-    )
+    # Agent-bound keys are lifecycle authority and must never be installed in
+    # a process-local cache. A cache fill racing archive commit could otherwise
+    # happen after the archive caller's post-commit invalidation. Unbound keys
+    # retain the existing cache behavior.
+    if api_key.environment_id is None:
+        _cache_api_key_auth(
+            key_hash=key_hash,
+            api_key=api_key,
+            user=user,
+            api_key_project_id=api_key_project_id,
+            now=now,
+        )
     return AuthContext(user=user, api_key=api_key, api_key_project_id=api_key_project_id)
 
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -252,9 +252,12 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
                 select(AgentEnvironment.default_project_id).where(
                     AgentEnvironment.id == api_key.environment_id,
                     AgentEnvironment.user_id == api_key.user_id,
+                    AgentEnvironment.archived_at.is_(None),
                 )
             )
         ).scalar_one_or_none()
+        if api_key_project_id is None:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Agent is archived")
 
     _cache_api_key_auth(
         key_hash=key_hash,

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -104,6 +104,7 @@ async def resolve_default_write_project(
             select(AgentEnvironment.default_project_id).where(
                 AgentEnvironment.id == bound_env_id,
                 AgentEnvironment.user_id == auth.user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
         project_id = result.scalar_one_or_none()
@@ -123,7 +124,10 @@ async def resolve_default_write_project(
     # data.
     result = await db.execute(
         select(AgentEnvironment.default_project_id)
-        .where(AgentEnvironment.user_id == auth.user_id)
+        .where(
+            AgentEnvironment.user_id == auth.user_id,
+            AgentEnvironment.archived_at.is_(None),
+        )
         .order_by(
             AgentEnvironment.last_seen_at.desc().nulls_last(),
             AgentEnvironment.id.desc(),
@@ -174,6 +178,7 @@ async def validate_project_for_caller(
         select(Project.id).where(
             Project.user_id == auth.user_id,
             Project.id == project_id,
+            Project.archived_at.is_(None),
         )
     )
     if project_owner.scalar_one_or_none() is None:
@@ -188,6 +193,7 @@ async def validate_project_for_caller(
             select(AgentEnvironment.default_project_id).where(
                 AgentEnvironment.id == bound_env_id,
                 AgentEnvironment.user_id == auth.user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
         bound_project = bound_project_result.scalar_one_or_none()
@@ -260,7 +266,12 @@ async def project_ids_owned_by_user(
     materialization. Runtime Vault plaintext reads use the broader readable
     set because viewer membership is a read grant for Vault values too.
     """
-    rows = await db.execute(select(Project.id).where(Project.user_id == user_id))
+    rows = await db.execute(
+        select(Project.id).where(
+            Project.user_id == user_id,
+            Project.archived_at.is_(None),
+        )
+    )
     return list(rows.scalars().all())
 
 
@@ -280,8 +291,11 @@ async def project_ids_readable_by_user(
     shared_ids = list(
         (
             await db.execute(
-                select(ProjectMembership.project_id).where(
-                    ProjectMembership.member_user_id == user_id
+                select(ProjectMembership.project_id)
+                .join(Project, Project.id == ProjectMembership.project_id)
+                .where(
+                    ProjectMembership.member_user_id == user_id,
+                    Project.archived_at.is_(None),
                 )
             )
         )

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -45,6 +45,10 @@ class AgentEnvironment(Base, TimestampMixin):
     agent_version: Mapped[str | None] = mapped_column(String(50))
     os: Mapped[str] = mapped_column(String(50), nullable=False)
     registration_key: Mapped[str | None] = mapped_column(String(300))
+    # Archived agents retain their stable identity and every relationship.
+    # Operational/query boundaries treat only NULL as active; registration
+    # may reactivate the row in place.
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # Agent identity labels. `default_name` is assigned by Cloud API for
     # explicit hosted identities; `display_name` is the user's dashboard override.

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -88,7 +88,11 @@ from app.services.agent_environments import (
     local_machine_registration_key,
     register_agent_environment,
 )
-from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
+from app.services.agent_lifecycle import (
+    AgentLifecycleBoundaryError,
+    active_agent_filter,
+    archive_agent_and_project,
+)
 from app.services.ai_provider_credentials import (
     OAuthCredentialClaimConflict,
     lock_ai_provider_owner,
@@ -1545,8 +1549,17 @@ async def _admin_delete_environment(
         },
     )
     await queue_environment_runtime_manifest_changed(db, env.user_id, environment_id)
-    await archive_agent_and_project(db, agent=env)
+    try:
+        revoked_key_ids = await archive_agent_and_project(db, agent=env)
+    except AgentLifecycleBoundaryError:
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Agent Project ownership could not be proven; no resources were archived.",
+        ) from None
     await db.commit()
+    for key_id in revoked_key_ids:
+        invalidate_api_key_auth_cache(key_id)
     logger.info(
         "admin_environment_deleted target_clerk_id=%s env_id=%s",
         target_clerk_id,

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -88,11 +88,7 @@ from app.services.agent_environments import (
     local_machine_registration_key,
     register_agent_environment,
 )
-from app.services.agent_skill_projection import (
-    AgentSkillProjectionBoundaryError,
-    delete_agent_project_skill_rows,
-    delete_agent_skill_files_best_effort,
-)
+from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
 from app.services.ai_provider_credentials import (
     OAuthCredentialClaimConflict,
     lock_ai_provider_owner,
@@ -1525,6 +1521,7 @@ async def _admin_delete_environment(
             .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == target_user_id,
+                active_agent_filter(),
             )
             .with_for_update()
             .execution_options(populate_existing=True)
@@ -1547,22 +1544,9 @@ async def _admin_delete_environment(
             "explicit_identity": env.registration_key is None,
         },
     )
-    try:
-        skill_file_keys = await delete_agent_project_skill_rows(db, agent=env)
-    except AgentSkillProjectionBoundaryError:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            "Agent Project ownership could not be proven; no resources were deleted.",
-        ) from None
-    await release_runtime_oauth_claims(
-        db,
-        owner_user_id=env.user_id,
-        environment_id=environment_id,
-    )
     await queue_environment_runtime_manifest_changed(db, env.user_id, environment_id)
-    await db.delete(env)
+    await archive_agent_and_project(db, agent=env)
     await db.commit()
-    await delete_agent_skill_files_best_effort(skill_file_keys, agent_id=environment_id)
     logger.info(
         "admin_environment_deleted target_clerk_id=%s env_id=%s",
         target_clerk_id,
@@ -1633,6 +1617,7 @@ async def _admin_upsert_runtime_state(
             .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == target_user_id,
+                active_agent_filter(),
             )
             .with_for_update()
             .execution_options(populate_existing=True)
@@ -1843,6 +1828,7 @@ async def _admin_delete_runtime_state(
             .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == target_user_id,
+                active_agent_filter(),
             )
             .with_for_update()
             .execution_options(populate_existing=True)

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -512,6 +512,7 @@ async def _runtime_channels_environment_id(
             select(AgentEnvironment.id).where(
                 AgentEnvironment.id == requested_environment_id,
                 AgentEnvironment.user_id == auth.user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
     ).scalar_one_or_none()

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -749,6 +749,7 @@ def _user_sessions_stmt(auth: AuthContext):
 
     Strict Hosted runtimes intentionally receive cross-Agent history. Legacy
     environment keys predate that contract and retain their local boundary.
+    Session-history reads intentionally retain archived Agent type/name.
     """
     stmt = (
         select(Session, AgentEnvironment.agent_type)

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -81,6 +81,8 @@ async def _attach_source_machines(
         }
     rows = []
     if sids:
+        # Historical Session enrichment retains archived Agent identity; this
+        # outer join grants no runtime or mutation authority.
         rows = (
             await db.execute(
                 select(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -35,11 +35,7 @@ from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
     register_agent_environment,
 )
-from app.services.agent_skill_projection import (
-    AgentSkillProjectionBoundaryError,
-    delete_agent_project_skill_rows,
-    delete_agent_skill_files_best_effort,
-)
+from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
 from app.services.ai_provider_credentials import (
     OAuthCredentialClaimConflict,
     lock_ai_provider_owner,
@@ -448,6 +444,7 @@ async def _load_owned_agent(
             .where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == owner_user_id,
+                active_agent_filter(),
             )
             .with_for_update()
         )
@@ -659,25 +656,8 @@ async def platform_delete_agent(
         "machine_id": agent.machine_id,
         "explicit_identity": agent.registration_key is None,
     }
-    try:
-        skill_file_keys = await delete_agent_project_skill_rows(db, agent=agent)
-    except AgentSkillProjectionBoundaryError:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "code": "agent_project_ownership_unproven",
-                "message": (
-                    "Agent Project ownership could not be proven; no resources were deleted."
-                ),
-            },
-        ) from None
-    await release_runtime_oauth_claims(
-        db,
-        owner_user_id=owner.id,
-        environment_id=agent_id,
-    )
     await queue_environment_runtime_manifest_changed(db, owner.id, agent_id)
-    await db.delete(agent)
+    await archive_agent_and_project(db, agent=agent)
     await _complete_mutation(
         db,
         operation="agents.delete",
@@ -694,7 +674,6 @@ async def platform_delete_agent(
         environment_id=agent_id,
         audit_details=audit_details,
     )
-    await delete_agent_skill_files_best_effort(skill_file_keys, agent_id=agent_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -35,7 +35,11 @@ from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
     register_agent_environment,
 )
-from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
+from app.services.agent_lifecycle import (
+    AgentLifecycleBoundaryError,
+    active_agent_filter,
+    archive_agent_and_project,
+)
 from app.services.ai_provider_credentials import (
     OAuthCredentialClaimConflict,
     lock_ai_provider_owner,
@@ -657,7 +661,18 @@ async def platform_delete_agent(
         "explicit_identity": agent.registration_key is None,
     }
     await queue_environment_runtime_manifest_changed(db, owner.id, agent_id)
-    await archive_agent_and_project(db, agent=agent)
+    try:
+        revoked_key_ids = await archive_agent_and_project(db, agent=agent)
+    except AgentLifecycleBoundaryError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "agent_project_ownership_unproven",
+                "message": (
+                    "Agent Project ownership could not be proven; no resources were archived."
+                ),
+            },
+        ) from None
     await _complete_mutation(
         db,
         operation="agents.delete",
@@ -674,6 +689,8 @@ async def platform_delete_agent(
         environment_id=agent_id,
         audit_details=audit_details,
     )
+    for key_id in revoked_key_ids:
+        invalidate_api_key_auth_cache(key_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -20,6 +20,7 @@ from app.core.project import project_ids_visible_to, resolve_default_write_proje
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_membership import ProjectMembership
 from app.models.user import User
+from app.services.agent_lifecycle import active_project_filter
 from app.services.sharing import safe_owner_display, safe_owner_handle
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -203,6 +204,7 @@ async def list_projects(
         select(Project, User, ProjectMembership)
         .outerjoin(User, User.id == Project.user_id)
         .outerjoin(ProjectMembership, membership_join)
+        .where(active_project_filter())
         .order_by(Project.created_at.desc())
     )
     if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
@@ -246,7 +248,7 @@ async def get_project(
     if project_uuid not in visible_project_ids:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
     project = (
-        await db.execute(select(Project).where(Project.id == project_uuid))
+        await db.execute(select(Project).where(Project.id == project_uuid, active_project_filter()))
     ).scalar_one_or_none()
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -80,6 +80,8 @@ async def _resolve_session_for_view(
         sign-in CTA).
       - 403 if authed but no matching grant exists.
     """
+    # Public Session history retains archived Agent type. Visibility comes
+    # solely from Session ownership/share grants, never Agent authority.
     stmt = (
         select(Session, AgentEnvironment.agent_type, User)
         .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -63,6 +63,8 @@ TYPE_LIMIT = 5
 
 async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
     needle = like_needle(query)
+    # Historical search retains archived Agent labels; this join grants no
+    # operational Agent authority.
     stmt = (
         select(Session, AgentEnvironment.agent_type)
         .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -4,7 +4,7 @@ import logging
 import mimetypes
 import re
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal, cast, overload
 from uuid import UUID, uuid4
 
 from fastapi import (
@@ -279,6 +279,28 @@ async def register_environment(
     return await _register_agent_identity(body, auth, db)
 
 
+@overload
+async def _list_agent_identities(
+    request: Request,
+    response: Response,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[True],
+) -> list[AgentResponse] | Response: ...
+
+
+@overload
+async def _list_agent_identities(
+    request: Request,
+    response: Response,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[False],
+) -> list[EnvironmentResponse] | Response: ...
+
+
 async def _list_agent_identities(
     request: Request,
     response: Response,
@@ -367,6 +389,30 @@ async def list_environments(
     return await _list_agent_identities(request, response, auth, db, agent_response=False)
 
 
+@overload
+async def _get_agent_identity(
+    agent_id: UUID,
+    request: Request,
+    response: Response,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[True],
+) -> AgentResponse | Response: ...
+
+
+@overload
+async def _get_agent_identity(
+    agent_id: UUID,
+    request: Request,
+    response: Response,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[False],
+) -> EnvironmentResponse | Response: ...
+
+
 async def _get_agent_identity(
     agent_id: UUID,
     request: Request,
@@ -450,7 +496,9 @@ async def list_environment_runtime_observed(
                 owner_user_id=auth.user_id,
             )
             states_by_env = {
-                environment_id: row.state for environment_id, row in source_batch.rows.items()
+                environment_id: row.state
+                for environment_id, row in source_batch.rows.items()
+                if row.state is not None
             }
             key_identity = vault_key_identity(settings.vault_encryption_key)
             for environment_id in source_batch.rows:
@@ -512,6 +560,22 @@ async def list_environment_runtime_observed(
             )
         )
     return RuntimeObservedSummaryResponse(counts=counts, items=items)
+
+
+@overload
+async def _reorder_agent_identities(
+    requested_ids: list[UUID], auth: AuthContext, db: AsyncSession, *, agent_response: Literal[True]
+) -> list[AgentResponse]: ...
+
+
+@overload
+async def _reorder_agent_identities(
+    requested_ids: list[UUID],
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[False],
+) -> list[EnvironmentResponse]: ...
 
 
 async def _reorder_agent_identities(
@@ -639,6 +703,28 @@ async def get_environment(
     )
 
 
+@overload
+async def _update_agent_identity(
+    agent_id: UUID,
+    body: EnvironmentUpdate,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[True],
+) -> AgentResponse: ...
+
+
+@overload
+async def _update_agent_identity(
+    agent_id: UUID,
+    body: EnvironmentUpdate,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[False],
+) -> EnvironmentResponse: ...
+
+
 async def _update_agent_identity(
     agent_id: UUID,
     body: EnvironmentUpdate,
@@ -696,6 +782,18 @@ async def update_environment(
     return await _update_agent_identity(environment_id, body, auth, db, agent_response=False)
 
 
+@overload
+async def _clear_agent_avatar(
+    agent_id: UUID, auth: AuthContext, db: AsyncSession, *, agent_response: Literal[True]
+) -> AgentResponse: ...
+
+
+@overload
+async def _clear_agent_avatar(
+    agent_id: UUID, auth: AuthContext, db: AsyncSession, *, agent_response: Literal[False]
+) -> EnvironmentResponse: ...
+
+
 async def _clear_agent_avatar(
     agent_id: UUID,
     auth: AuthContext,
@@ -749,6 +847,28 @@ async def clear_environment_avatar(
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentResponse:
     return await _clear_agent_avatar(environment_id, auth, db, agent_response=False)
+
+
+@overload
+async def _upload_agent_avatar(
+    agent_id: UUID,
+    file: UploadFile,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[True],
+) -> AgentResponse: ...
+
+
+@overload
+async def _upload_agent_avatar(
+    agent_id: UUID,
+    file: UploadFile,
+    auth: AuthContext,
+    db: AsyncSession,
+    *,
+    agent_response: Literal[False],
+) -> EnvironmentResponse: ...
 
 
 async def _upload_agent_avatar(
@@ -1089,6 +1209,21 @@ def _agent_to_response(env: AgentEnvironment) -> AgentResponse:
     )
 
 
+@overload
+def _identity_response(
+    env: AgentEnvironment, hosted_state: HostedRuntimeState | None, *, agent_response: Literal[True]
+) -> AgentResponse: ...
+
+
+@overload
+def _identity_response(
+    env: AgentEnvironment,
+    hosted_state: HostedRuntimeState | None,
+    *,
+    agent_response: Literal[False],
+) -> EnvironmentResponse: ...
+
+
 def _identity_response(
     env: AgentEnvironment,
     hosted_state: HostedRuntimeState | None,
@@ -1427,7 +1562,7 @@ def _runtime_desired_provider_binding(
 
 def _runtime_observed_provider_status(
     observed: HostedRuntimeObservedProviderPayload | None,
-) -> str:
+) -> Literal["ok", "error", "unknown", "not_configured"]:
     if observed is None:
         return "unknown"
     payload = observed.root
@@ -2331,13 +2466,14 @@ async def list_sessions(
     # ANY of summary / project / id wins, and the strongest match
     # drives the rank. NULL-safe via COALESCE — sessions with NULL
     # summary still match if their project_path or id does.
+    relevance_expr: Any | None
     if q:
         sim_summary = func.similarity(func.coalesce(Session.summary, ""), q)
         sim_project = func.similarity(func.coalesce(Session.project_path, ""), q)
         sim_local = func.similarity(Session.local_session_id, q)
         relevance_expr = func.greatest(sim_summary, sim_project, sim_local)
     else:
-        relevance_expr = None  # type: ignore[assignment]
+        relevance_expr = None
 
     base = select(
         Session,
@@ -2347,7 +2483,7 @@ async def list_sessions(
         AgentEnvironment.machine_name,
         is_shared_subq,
     ).outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
-    session_filters = [Session.user_id == auth.user_id]
+    session_filters: list[Any] = [Session.user_id == auth.user_id]
     agent_filter = AgentEnvironment.agent_type == agent if agent else None
     if bound_env is not None:
         session_filters.append(Session.environment_id == bound_env)
@@ -2414,6 +2550,7 @@ async def list_sessions(
         # for the typical few-thousand-rows-per-user. If a power user
         # ever hits real latency here, swap to `WHERE summary % :q`
         # plus a GIN index. Threshold tuned for "type to filter" UX.
+        assert relevance_expr is not None
         session_filters.append(relevance_expr >= _TRGM_THRESHOLD)
 
     base = base.where(*session_filters)
@@ -3138,10 +3275,10 @@ def _link_is_shared_subq():
 def _permission_to_response(p: SessionPermission) -> SessionPermissionResponse:
     return SessionPermissionResponse(
         id=str(p.id),
-        kind=p.kind,
+        kind=cast(Literal["link", "user", "email"], p.kind),
         user_id=str(p.user_id) if p.user_id else None,
         email=p.email,
-        role=p.role,
+        role=cast(Literal["viewer"], p.role),
         invited_by=str(p.invited_by) if p.invited_by else None,
         accepted_at=p.accepted_at,
         expires_at=p.expires_at,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -25,7 +25,13 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import AuthContext, get_auth, require_scope, require_web_auth
+from app.core.auth import (
+    AuthContext,
+    get_auth,
+    invalidate_api_key_auth_cache,
+    require_scope,
+    require_web_auth,
+)
 from app.core.config import settings
 from app.core.database import get_session, runtime_snapshot_session
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
@@ -84,7 +90,11 @@ from app.services.agent_environments import (
     local_machine_registration_key,
     register_agent_environment,
 )
-from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
+from app.services.agent_lifecycle import (
+    AgentLifecycleBoundaryError,
+    active_agent_filter,
+    archive_agent_and_project,
+)
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_extraction import extract_memories_from_session
@@ -698,6 +708,7 @@ async def _clear_agent_avatar(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -753,6 +764,7 @@ async def _upload_agent_avatar(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -1532,8 +1544,17 @@ async def _delete_agent_identity(
             "This agent uses an explicit identity and cannot be disconnected here",
         )
     await queue_environment_runtime_manifest_changed(db, auth.user_id, agent_id)
-    await archive_agent_and_project(db, agent=env)
+    try:
+        revoked_key_ids = await archive_agent_and_project(db, agent=env)
+    except AgentLifecycleBoundaryError:
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Agent Project ownership could not be proven; no resources were archived.",
+        ) from None
     await db.commit()
+    for key_id in revoked_key_ids:
+        invalidate_api_key_auth_cache(key_id)
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -84,12 +84,7 @@ from app.services.agent_environments import (
     local_machine_registration_key,
     register_agent_environment,
 )
-from app.services.agent_skill_projection import (
-    AgentSkillProjectionBoundaryError,
-    delete_agent_project_skill_rows,
-    delete_agent_skill_files_best_effort,
-)
-from app.services.ai_provider_credentials import release_runtime_oauth_claims
+from app.services.agent_lifecycle import active_agent_filter, archive_agent_and_project
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_extraction import extract_memories_from_session
@@ -291,7 +286,7 @@ async def _list_agent_identities(
     bound_env = _bound_env_id(auth)
     stmt = (
         select(AgentEnvironment)
-        .where(AgentEnvironment.user_id == auth.user_id)
+        .where(AgentEnvironment.user_id == auth.user_id, active_agent_filter())
         .order_by(
             AgentEnvironment.sort_order.asc(),
             AgentEnvironment.created_at.asc(),
@@ -384,6 +379,7 @@ async def _get_agent_identity(
             .where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).first()
@@ -410,7 +406,7 @@ async def list_environment_runtime_observed(
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedSummaryResponse:
     bound_env = _bound_env_id(auth)
-    filters = [AgentEnvironment.user_id == auth.user_id]
+    filters = [AgentEnvironment.user_id == auth.user_id, active_agent_filter()]
     if bound_env is not None:
         filters.append(AgentEnvironment.id == bound_env)
 
@@ -524,6 +520,7 @@ async def _reorder_agent_identities(
             await db.execute(
                 select(AgentEnvironment)
                 .where(AgentEnvironment.user_id == auth.user_id)
+                .where(active_agent_filter())
                 .order_by(
                     AgentEnvironment.sort_order.asc(),
                     AgentEnvironment.created_at.asc(),
@@ -645,6 +642,7 @@ async def _update_agent_identity(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -835,6 +833,7 @@ async def get_environment_runtime_observed(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -958,6 +957,7 @@ async def get_agent_mcp_inventory(
             .where(
                 HostedRuntimeState.environment_id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -1515,13 +1515,12 @@ async def _delete_agent_identity(
     auth: AuthContext,
     db: AsyncSession,
 ) -> None:
-    """Delete an agent environment. Existing sessions remain (orphaned)
-    so users don't lose history when removing a machine. The session
-    list query uses an outer-join so orphaned rows still render."""
+    """Archive an Agent and its exclusive Project without breaking identity."""
     result = await db.execute(
         select(AgentEnvironment).where(
             AgentEnvironment.id == agent_id,
             AgentEnvironment.user_id == auth.user_id,
+            active_agent_filter(),
         )
     )
     env = result.scalar_one_or_none()
@@ -1532,22 +1531,9 @@ async def _delete_agent_identity(
             status.HTTP_409_CONFLICT,
             "This agent uses an explicit identity and cannot be disconnected here",
         )
-    try:
-        skill_file_keys = await delete_agent_project_skill_rows(db, agent=env)
-    except AgentSkillProjectionBoundaryError:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            "Agent Project ownership could not be proven; no resources were deleted.",
-        ) from None
-    await release_runtime_oauth_claims(
-        db,
-        owner_user_id=auth.user_id,
-        environment_id=agent_id,
-    )
     await queue_environment_runtime_manifest_changed(db, auth.user_id, agent_id)
-    await db.delete(env)
+    await archive_agent_and_project(db, agent=env)
     await db.commit()
-    await delete_agent_skill_files_best_effort(skill_file_keys, agent_id=agent_id)
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -1696,6 +1682,7 @@ async def sync_heartbeat(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -1887,6 +1874,7 @@ async def batch_create_sessions(
                 select(AgentEnvironment.id).where(
                     AgentEnvironment.id.in_(requested_env_ids),
                     AgentEnvironment.user_id == auth.user_id,
+                    active_agent_filter(),
                 )
             )
         )

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -918,6 +918,7 @@ async def _agent_sync_project(
         .where(
             AgentEnvironment.id == agent_id,
             AgentEnvironment.user_id == auth.user_id,
+            AgentEnvironment.archived_at.is_(None),
             Project.user_id == auth.user_id,
             Project.kind == PROJECT_KIND_ENVIRONMENT,
             Project.origin_environment_id == agent_id,

--- a/backend/app/services/agent_bindings.py
+++ b/backend/app/services/agent_bindings.py
@@ -13,6 +13,7 @@ from app.models.agent_project_binding import AgentProjectBinding
 from app.models.project import Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
+from app.services.agent_lifecycle import active_agent_filter, active_project_filter
 
 
 async def get_owned_agent_or_404(
@@ -26,6 +27,7 @@ async def get_owned_agent_or_404(
             select(AgentEnvironment).where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == user_id,
+                active_agent_filter(),
             )
         )
     ).scalar_one_or_none()
@@ -41,7 +43,7 @@ async def assert_project_visible_to_user(
     project_id: UUID,
 ) -> Project:
     project = (
-        await db.execute(select(Project).where(Project.id == project_id))
+        await db.execute(select(Project).where(Project.id == project_id, active_project_filter()))
     ).scalar_one_or_none()
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
@@ -68,7 +70,7 @@ async def assert_project_writable_by_user(
     project_id: UUID,
 ) -> Project:
     project = (
-        await db.execute(select(Project).where(Project.id == project_id))
+        await db.execute(select(Project).where(Project.id == project_id, active_project_filter()))
     ).scalar_one_or_none()
     if project is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
+from app.services.agent_lifecycle import reactivate_agent_and_project
 
 _AGENT_TYPE_LABELS = {
     "openclaw": "OpenClaw",
@@ -83,6 +84,8 @@ async def register_agent_environment(
             )
         ).scalar_one_or_none()
         if existing is not None:
+            if existing.archived_at is not None:
+                await reactivate_agent_and_project(db, agent=existing)
             await _refresh_agent_environment(
                 db,
                 existing,
@@ -118,6 +121,8 @@ async def register_agent_environment(
             )
         ).scalar_one_or_none()
         if existing is not None:
+            if existing.archived_at is not None:
+                await reactivate_agent_and_project(db, agent=existing)
             await _refresh_agent_environment(
                 db,
                 existing,
@@ -205,6 +210,8 @@ async def register_agent_environment(
                 os_name=os_name,
                 registration_key=registration_key,
             )
+            if winner.archived_at is not None:
+                await reactivate_agent_and_project(db, agent=winner)
             if commit:
                 await db.commit()
             else:
@@ -222,6 +229,23 @@ async def register_agent_environment(
         ).scalar_one_or_none()
         if winner is None:
             raise
+        if winner.archived_at is not None:
+            await reactivate_agent_and_project(db, agent=winner)
+            await _refresh_agent_environment(
+                db,
+                winner,
+                user_id=user_id,
+                machine_id=machine_id,
+                machine_name=machine_name,
+                agent_type=agent_type,
+                agent_version=agent_version,
+                os_name=os_name,
+                registration_key=registration_key,
+            )
+            if commit:
+                await db.commit()
+            else:
+                await db.flush()
         return AgentEnvironmentRegistration(env=winner, created=False)
 
 

--- a/backend/app/services/agent_lifecycle.py
+++ b/backend/app/services/agent_lifecycle.py
@@ -1,0 +1,86 @@
+"""Authoritative active/archive lifecycle predicates and mutations."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import invalidate_api_key_auth_cache
+from app.models.api_key import ApiKey
+from app.models.project import Project
+from app.models.session import AgentEnvironment
+
+
+def active_agent_filter():
+    return AgentEnvironment.archived_at.is_(None)
+
+
+def active_project_filter():
+    return Project.archived_at.is_(None)
+
+
+async def archive_agent_and_project(
+    db: AsyncSession, *, agent: AgentEnvironment, now: datetime | None = None
+) -> None:
+    """Archive identity and its exclusive Agent Project in one transaction.
+
+    Relationships and resource rows are intentionally untouched. Bound keys
+    are revoked in the same transaction so an archived identity has no cached
+    or persistent operational authority.
+    """
+    archived_at = now or datetime.now(UTC)
+    agent.archived_at = archived_at
+    project = await db.scalar(
+        select(Project)
+        .where(
+            Project.id == agent.default_project_id,
+            Project.user_id == agent.user_id,
+        )
+        .with_for_update()
+    )
+    if project is None:
+        raise RuntimeError("Agent Project is missing")
+    project.archived_at = archived_at
+    key_ids = list(
+        (
+            await db.scalars(
+                select(ApiKey.id).where(
+                    ApiKey.environment_id == agent.id,
+                    ApiKey.revoked_at.is_(None),
+                )
+            )
+        ).all()
+    )
+    await db.execute(update(ApiKey).where(ApiKey.id.in_(key_ids)).values(revoked_at=archived_at))
+    for key_id in key_ids:
+        invalidate_api_key_auth_cache(key_id)
+
+
+async def reactivate_agent_and_project(db: AsyncSession, *, agent: AgentEnvironment) -> None:
+    """Reactivate the existing identity and exclusive Project atomically."""
+    agent.archived_at = None
+    project = await db.scalar(
+        select(Project)
+        .where(
+            Project.id == agent.default_project_id,
+            Project.user_id == agent.user_id,
+        )
+        .with_for_update()
+    )
+    if project is None:
+        raise RuntimeError("Agent Project is missing")
+    project.archived_at = None
+
+
+async def active_owned_agent(
+    db: AsyncSession, *, user_id: UUID, agent_id: UUID, for_update: bool = False
+) -> AgentEnvironment | None:
+    stmt = select(AgentEnvironment).where(
+        AgentEnvironment.id == agent_id,
+        AgentEnvironment.user_id == user_id,
+        active_agent_filter(),
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    return await db.scalar(stmt)

--- a/backend/app/services/agent_lifecycle.py
+++ b/backend/app/services/agent_lifecycle.py
@@ -6,10 +6,13 @@ from uuid import UUID
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import invalidate_api_key_auth_cache
 from app.models.api_key import ApiKey
-from app.models.project import Project
+from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
+
+
+class AgentLifecycleBoundaryError(RuntimeError):
+    """The exclusive Agent/Project lifecycle relationship is not provable."""
 
 
 def active_agent_filter():
@@ -22,54 +25,105 @@ def active_project_filter():
 
 async def archive_agent_and_project(
     db: AsyncSession, *, agent: AgentEnvironment, now: datetime | None = None
-) -> None:
+) -> tuple[UUID, ...]:
     """Archive identity and its exclusive Agent Project in one transaction.
 
     Relationships and resource rows are intentionally untouched. Bound keys
     are revoked in the same transaction so an archived identity has no cached
     or persistent operational authority.
     """
-    archived_at = now or datetime.now(UTC)
-    agent.archived_at = archived_at
+    locked_agent = await db.scalar(
+        select(AgentEnvironment)
+        .where(
+            AgentEnvironment.id == agent.id,
+            AgentEnvironment.user_id == agent.user_id,
+            active_agent_filter(),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if locked_agent is None:
+        raise AgentLifecycleBoundaryError("active Agent identity is not available")
+
     project = await db.scalar(
         select(Project)
         .where(
-            Project.id == agent.default_project_id,
-            Project.user_id == agent.user_id,
+            Project.id == locked_agent.default_project_id,
+            Project.user_id == locked_agent.user_id,
+            Project.kind == PROJECT_KIND_ENVIRONMENT,
+            Project.origin_environment_id == locked_agent.id,
         )
         .with_for_update()
     )
     if project is None:
-        raise RuntimeError("Agent Project is missing")
+        raise AgentLifecycleBoundaryError("exclusive Agent Project is not provable")
+
+    sibling_ids = tuple(
+        (
+            await db.scalars(
+                select(AgentEnvironment.id)
+                .where(AgentEnvironment.default_project_id == project.id)
+                .with_for_update()
+            )
+        ).all()
+    )
+    if sibling_ids != (locked_agent.id,):
+        raise AgentLifecycleBoundaryError("Agent Project is shared by another Agent")
+
+    archived_at = now or datetime.now(UTC)
+    locked_agent.archived_at = archived_at
     project.archived_at = archived_at
     key_ids = list(
         (
             await db.scalars(
                 select(ApiKey.id).where(
-                    ApiKey.environment_id == agent.id,
+                    ApiKey.environment_id == locked_agent.id,
                     ApiKey.revoked_at.is_(None),
                 )
             )
         ).all()
     )
     await db.execute(update(ApiKey).where(ApiKey.id.in_(key_ids)).values(revoked_at=archived_at))
-    for key_id in key_ids:
-        invalidate_api_key_auth_cache(key_id)
+    return tuple(key_ids)
 
 
 async def reactivate_agent_and_project(db: AsyncSession, *, agent: AgentEnvironment) -> None:
     """Reactivate the existing identity and exclusive Project atomically."""
-    agent.archived_at = None
+    locked_agent = await db.scalar(
+        select(AgentEnvironment)
+        .where(
+            AgentEnvironment.id == agent.id,
+            AgentEnvironment.user_id == agent.user_id,
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if locked_agent is None:
+        raise AgentLifecycleBoundaryError("Agent identity is not available")
     project = await db.scalar(
         select(Project)
         .where(
-            Project.id == agent.default_project_id,
-            Project.user_id == agent.user_id,
+            Project.id == locked_agent.default_project_id,
+            Project.user_id == locked_agent.user_id,
+            Project.kind == PROJECT_KIND_ENVIRONMENT,
+            Project.origin_environment_id == locked_agent.id,
         )
         .with_for_update()
     )
     if project is None:
-        raise RuntimeError("Agent Project is missing")
+        raise AgentLifecycleBoundaryError("exclusive Agent Project is not provable")
+    sibling_ids = tuple(
+        (
+            await db.scalars(
+                select(AgentEnvironment.id)
+                .where(AgentEnvironment.default_project_id == project.id)
+                .with_for_update()
+            )
+        ).all()
+    )
+    if sibling_ids != (locked_agent.id,):
+        raise AgentLifecycleBoundaryError("Agent Project is shared by another Agent")
+    locked_agent.archived_at = None
     project.archived_at = None
 
 

--- a/backend/app/services/ai_provider_credentials.py
+++ b/backend/app/services/ai_provider_credentials.py
@@ -67,6 +67,7 @@ async def environment_binds_provider(
             .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
     ).one_or_none()
@@ -92,6 +93,7 @@ async def environment_matches_runtime(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == owner_user_id,
                 AgentEnvironment.agent_type == runtime,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
     ) is not None
@@ -152,7 +154,10 @@ async def validate_prospective_bound_runtime_auth(
                 HostedRuntimeState,
                 HostedRuntimeState.environment_id == AgentEnvironment.id,
             )
-            .where(AgentEnvironment.user_id == owner_user_id)
+            .where(
+                AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
             .order_by(AgentEnvironment.id)
         )
     ).all()
@@ -182,7 +187,10 @@ async def provider_has_hosted_runtime_consumer(
                 AgentEnvironment,
                 AgentEnvironment.id == HostedRuntimeState.environment_id,
             )
-            .where(AgentEnvironment.user_id == owner_user_id)
+            .where(
+                AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
             .order_by(HostedRuntimeState.environment_id)
         )
     ).scalars()

--- a/backend/app/services/api_key.py
+++ b/backend/app/services/api_key.py
@@ -90,6 +90,7 @@ async def mint_api_key(
             select(AgentEnvironment.id).where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
         )
         if owner_check.scalar_one_or_none() is None:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -488,6 +488,7 @@ async def get_or_create_bot_agent_link(
             .where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == link_user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
             .execution_options(populate_existing=True)
             .with_for_update(of=(AgentEnvironment, V2RuntimeEnvironmentFence))
@@ -592,6 +593,7 @@ async def get_strict_v2_hosted_channel_agent_or_409(
         .where(
             AgentEnvironment.id == agent_id,
             AgentEnvironment.user_id == user_id,
+            AgentEnvironment.archived_at.is_(None),
         )
         .execution_options(populate_existing=True)
     )
@@ -645,6 +647,7 @@ async def bot_agent_link_allows_new_pairing(
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
                 AgentEnvironment.user_id == user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
             .execution_options(populate_existing=True)
             .with_for_update(of=(ChannelBotAgentLink, V2RuntimeEnvironmentFence))
@@ -781,7 +784,10 @@ async def list_strict_v2_hosted_channel_agent_ids(
                 V2RuntimeEnvironmentFence,
                 V2RuntimeEnvironmentFence.environment_id == AgentEnvironment.id,
             )
-            .where(AgentEnvironment.user_id == user_id)
+            .where(
+                AgentEnvironment.user_id == user_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
             .order_by(AgentEnvironment.created_at, AgentEnvironment.id)
         )
     ).all()
@@ -817,6 +823,7 @@ async def ensure_hosted_agent_provider_link_available(
             .where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == user_id,
+                AgentEnvironment.archived_at.is_(None),
             )
             .with_for_update()
         )
@@ -1261,6 +1268,7 @@ async def resolve_channel_agent_by_token(
             ChannelAccount.archived_at.is_(None),
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             AgentEnvironment.user_id == ChannelBotAgentLink.user_id,
+            AgentEnvironment.archived_at.is_(None),
         )
         .execution_options(populate_existing=True)
     )
@@ -1307,6 +1315,7 @@ async def resolve_channel_agent_by_identity(
             ChannelAccount.archived_at.is_(None),
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             AgentEnvironment.user_id == ChannelBotAgentLink.user_id,
+            AgentEnvironment.archived_at.is_(None),
         )
         .execution_options(populate_existing=True)
     )

--- a/backend/app/services/runtime_manifest_resources.py
+++ b/backend/app/services/runtime_manifest_resources.py
@@ -28,6 +28,7 @@ async def runtime_manifest_reserved_skill_ids(
         .where(
             AgentEnvironment.user_id == user_id,
             AgentEnvironment.default_project_id == project_id,
+            AgentEnvironment.archived_at.is_(None),
         )
     )
     reserved: set[str] = set()

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -185,6 +185,7 @@ async def provision_runtime_environment_fence(
             .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == owner_id,
+                AgentEnvironment.archived_at.is_(None),
             )
             .with_for_update()
         )

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -126,7 +126,10 @@ async def load_runtime_source_batch(
 ) -> RuntimeSourceBatch:
     if not environment_ids:
         return RuntimeSourceBatch({}, {}, {}, {}, {})
-    env_filters: list[ColumnElement[bool]] = [AgentEnvironment.id.in_(environment_ids)]
+    env_filters: list[ColumnElement[bool]] = [
+        AgentEnvironment.id.in_(environment_ids),
+        AgentEnvironment.archived_at.is_(None),
+    ]
     if owner_user_id is not None:
         env_filters.append(AgentEnvironment.user_id == owner_user_id)
     env_rows = (

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -18,12 +18,12 @@
         "_runtime_observed_health": "ae05a09ea1093bddf0b12c8d16d19938f1b2bd9289335e010f297fb280ef54bc",
         "_runtime_observed_provider_health": "09163dc80fb3ad1262888b26bb1112de122e88e0a30e21fc502679ffbee79660",
         "_runtime_observed_provider_reasons": "3ec8cbf00837a6c33f7d2fe8bfe2415c0cba80faddf46b85f62e948d700b61ba",
-        "_runtime_observed_provider_status": "f83854879fa63585f1734b814f8e3230269f53d9fec69faf3c3036bc4fa97935",
+        "_runtime_observed_provider_status": "16301469fdcb18d246328a0f61eabf27b1f681be907e51a443af81ff2755bc03",
         "_runtime_observed_response": "8ef8aae004cb5bef49162dc40ffbf195d5bb9d621d963cdefbbf7441cd5bae27",
         "_runtime_observed_summary": "a81dcb71c60b6c15e8ac850d1ed1cea0dac338923c01da1afa6616d049b9c68a",
         "_validated_runtime_observed_diagnostics": "4e6bf338bbc8657b7a76e39abf4a32c63852069f966c2414a5c9f16d3231aa75",
         "get_environment_runtime_observed": "dd4f3c99370ebec312aed74d64bbc3c77dc223f5b5998c943a7012d573deea1c",
-        "list_environment_runtime_observed": "2470b8d002fa58baf70d847cbcc833b83dbac872f6eb74323ba8447d175b0812",
+        "list_environment_runtime_observed": "831a7dbf1009763e7c0581cfbba143b2ba03d7ae404f7edb5c2440a655a2daa4",
         "sync_heartbeat": "1b64282f6b3d0fdb519fa29d8915cd8f1f1ecb6533f11ee7756a4a6afa801317"
       }
     },

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -22,9 +22,9 @@
         "_runtime_observed_response": "8ef8aae004cb5bef49162dc40ffbf195d5bb9d621d963cdefbbf7441cd5bae27",
         "_runtime_observed_summary": "a81dcb71c60b6c15e8ac850d1ed1cea0dac338923c01da1afa6616d049b9c68a",
         "_validated_runtime_observed_diagnostics": "4e6bf338bbc8657b7a76e39abf4a32c63852069f966c2414a5c9f16d3231aa75",
-        "get_environment_runtime_observed": "8e5ce544ba94b70dc05fa1f6cae638b8b0cb851d62dbbf025e21aec94bafd010",
-        "list_environment_runtime_observed": "1c07db398c99892163b6c9415d9155378f7191c01a7920a0e2804b55f09027a4",
-        "sync_heartbeat": "52471a426362351eb96b5f5b213513336feaa878510f949f1ba396ac7e5fbaae"
+        "get_environment_runtime_observed": "dd4f3c99370ebec312aed74d64bbc3c77dc223f5b5998c943a7012d573deea1c",
+        "list_environment_runtime_observed": "2470b8d002fa58baf70d847cbcc833b83dbac872f6eb74323ba8447d175b0812",
+        "sync_heartbeat": "1b64282f6b3d0fdb519fa29d8915cd8f1f1ecb6533f11ee7756a4a6afa801317"
       }
     },
     "backend/app/routes/platform.py": {

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2555,10 +2555,14 @@ async def test_admin_delete_env_archives_identity_and_preserves_relationships(
     assert env is not None
     assert env.archived_at is not None
     retained_skills = (
-        await db_session.execute(
-            select(Skill).where(Skill.project_id == environment.default_project_id)
+        (
+            await db_session.execute(
+                select(Skill).where(Skill.project_id == environment.default_project_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(retained_skills) == 2
     await db_session.refresh(seed_user)
     assert seed_user.skills_revision == revision_before

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2211,7 +2211,8 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     env = (
         await db_session.execute(select(AgentEnvironment).where(AgentEnvironment.id == agent_id))
     ).scalar_one_or_none()
-    assert env is None
+    assert env is not None
+    assert env.archived_at is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2464,7 +2464,7 @@ async def test_admin_register_env_idempotent(admin_client, db_session, seed_user
 
 
 @pytest.mark.asyncio
-async def test_admin_delete_env_removes_environment_and_orphans_sessions(
+async def test_admin_delete_env_archives_identity_and_preserves_relationships(
     admin_client, db_session, seed_user
 ):
     """Hosted compute delete needs an admin path to remove the
@@ -2552,19 +2552,21 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
     env = (
         await db_session.execute(select(AgentEnvironment).where(AgentEnvironment.id == env_id))
     ).scalar_one_or_none()
-    assert env is None
-    assert (
+    assert env is not None
+    assert env.archived_at is not None
+    retained_skills = (
         await db_session.execute(
             select(Skill).where(Skill.project_id == environment.default_project_id)
         )
-    ).scalars().all() == []
+    ).scalars().all()
+    assert len(retained_skills) == 2
     await db_session.refresh(seed_user)
-    assert seed_user.skills_revision == revision_before + 2
+    assert seed_user.skills_revision == revision_before
     await db_session.refresh(session_row)
-    assert session_row.environment_id is None
+    assert session_row.environment_id == env_id
     await db_session.refresh(claimed_payload)
-    assert claimed_payload.consumer_environment_id is None
-    assert claimed_payload.consumer_runtime is None
+    assert claimed_payload.consumer_environment_id == env_id
+    assert claimed_payload.consumer_runtime == "codex"
     event = (
         await db_session.execute(
             select(ControlPlaneAuditEvent).where(
@@ -2615,7 +2617,9 @@ async def test_admin_delete_environment_accepts_matching_optional_owner(
     )
 
     assert response.status_code == 204, response.text
-    assert await db_session.get(AgentEnvironment, env.id) is None
+    archived = await db_session.get(AgentEnvironment, env.id)
+    assert archived is not None
+    assert archived.archived_at is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_agent_archival_migration.py
+++ b/backend/tests/test_agent_archival_migration.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+@pytest.mark.asyncio
+async def test_agent_archival_migration_upgrade_downgrade_preserves_rows(engine: AsyncEngine):
+    path = (
+        Path(__file__).parents[1]
+        / "alembic"
+        / "versions"
+        / "f3b7c1d9e5a2_archive_agent_lifecycle.py"
+    )
+    spec = importlib.util.spec_from_file_location("agent_archival_migration", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    schema = f"agent_archival_{uuid.uuid4().hex}"
+    row_id = uuid.uuid4()
+
+    def run(sync_conn):
+        old_op = migration.op
+        sync_conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        sync_conn.execute(sa.text(f'SET search_path TO "{schema}"'))
+        try:
+            sync_conn.execute(sa.text("CREATE TABLE agent_environments (id uuid PRIMARY KEY)"))
+            sync_conn.execute(
+                sa.text("INSERT INTO agent_environments (id) VALUES (:id)"),
+                {"id": row_id},
+            )
+            migration.op = Operations(MigrationContext.configure(sync_conn))
+            migration.upgrade()
+            assert (
+                sync_conn.execute(
+                    sa.text("SELECT archived_at FROM agent_environments WHERE id = :id"),
+                    {"id": row_id},
+                ).scalar_one()
+                is None
+            )
+            migration.downgrade()
+            assert (
+                sync_conn.execute(
+                    sa.text("SELECT count(*) FROM agent_environments WHERE id = :id"),
+                    {"id": row_id},
+                ).scalar_one()
+                == 1
+            )
+        finally:
+            migration.op = old_op
+            sync_conn.execute(sa.text("SET search_path TO public"))
+            sync_conn.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+    async with engine.begin() as conn:
+        await conn.run_sync(run)

--- a/backend/tests/test_auth_keys.py
+++ b/backend/tests/test_auth_keys.py
@@ -113,6 +113,53 @@ async def test_revoked_api_key_is_rejected(db_session, seed_user):
 
 
 @pytest.mark.asyncio
+async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
+    client: httpx.AsyncClient, db_session, seed_user
+):
+    import hashlib
+    import uuid
+
+    from fastapi import HTTPException
+
+    from app.core.auth import _api_key_auth_cache, _auth_via_api_key
+    from app.services.agent_environments import (
+        local_machine_registration_key,
+        register_agent_environment,
+    )
+    from app.services.api_key import mint_api_key
+
+    machine_id = f"cached-key-{uuid.uuid4().hex}"
+    registered = await register_agent_environment(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=machine_id,
+        machine_name="Cached key Agent",
+        agent_type="codex",
+        agent_version="1.0.0",
+        os_name="linux",
+        sort_order=0,
+        registration_key=local_machine_registration_key(machine_id, "codex"),
+    )
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="cached Agent key",
+        environment_id=registered.env.id,
+    )
+    assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    key_hash = hashlib.sha256(minted.raw_key.encode()).hexdigest()
+    assert key_hash not in _api_key_auth_cache
+
+    disconnected = await client.delete(f"/v1/agents/{registered.env.id}")
+    assert disconnected.status_code == 204, disconnected.text
+    with pytest.raises(HTTPException) as exc_info:
+        await _auth_via_api_key(minted.raw_key, db_session)
+    assert exc_info.value.status_code == 401
+    assert "revoked" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
 async def test_me_reflects_clerk_auth(client: httpx.AsyncClient):
     body = (await client.get("/v1/auth/me")).json()
     assert body["auth_type"] == "clerk"

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -20195,3 +20195,35 @@ async def test_discord_gateway_guild_delete_archives_cleans_and_is_replay_safe(
     assert len(bindings) == 1
     assert bindings[0]["external_chat_id"] == guild_id
     assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_archived_agent_cannot_route_channels_and_reactivation_restores_authority(
+    db_session, seed_user, channel_agent
+):
+    from fastapi import HTTPException
+
+    from app.services.agent_lifecycle import (
+        archive_agent_and_project,
+        reactivate_agent_and_project,
+    )
+    from app.services.channels import get_strict_v2_hosted_channel_agent_or_409
+
+    await archive_agent_and_project(db_session, agent=channel_agent)
+    await db_session.commit()
+    with pytest.raises(HTTPException) as exc_info:
+        await get_strict_v2_hosted_channel_agent_or_409(
+            db_session,
+            agent_id=channel_agent.id,
+            user_id=seed_user.id,
+        )
+    assert exc_info.value.status_code == 409
+
+    await reactivate_agent_and_project(db_session, agent=channel_agent)
+    await db_session.commit()
+    restored = await get_strict_v2_hosted_channel_agent_or_409(
+        db_session,
+        agent_id=channel_agent.id,
+        user_id=seed_user.id,
+    )
+    assert restored.id == channel_agent.id

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -1181,12 +1181,9 @@ async def test_platform_idempotency_replays_every_mutation_without_second_side_e
     await db_session.refresh(seed_user)
     assert seed_user.skills_revision == revision_before_agent_delete
 
-    assert (
-        await db_session.scalar(
-            select(func.count()).select_from(ApiKey).where(ApiKey.id == uuid.UUID(key_id))
-        )
-        == 0
-    )
+    retained_key = await db_session.get(ApiKey, uuid.UUID(key_id))
+    assert retained_key is not None
+    assert retained_key.revoked_at is not None
     idempotency_count = await db_session.scalar(
         select(func.count())
         .select_from(PlatformMutationIdempotency)

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -388,7 +388,9 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
         json={"owner": owner},
     )
     assert deleted_agent.status_code == 204, deleted_agent.text
-    assert await db_session.get(AgentEnvironment, agent_id) is None
+    archived_agent = await db_session.get(AgentEnvironment, agent_id)
+    assert archived_agent is not None
+    assert archived_agent.archived_at is not None
 
     events = (
         (
@@ -1174,10 +1176,10 @@ async def test_platform_idempotency_replays_every_mutation_without_second_side_e
         await db_session.scalar(
             select(func.count()).select_from(Skill).where(Skill.project_id == agent_project_id)
         )
-        == 0
+        == 2
     )
     await db_session.refresh(seed_user)
-    assert seed_user.skills_revision == revision_before_agent_delete + 2
+    assert seed_user.skills_revision == revision_before_agent_delete
 
     assert (
         await db_session.scalar(

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -1103,7 +1103,7 @@ async def test_workload_owner_is_still_mandatory_and_mismatch_is_forbidden(
 
 
 @pytest.mark.asyncio
-async def test_platform_agent_delete_releases_runtime_oauth_claim_in_same_transaction(
+async def test_platform_agent_archive_preserves_runtime_oauth_claim(
     workload_harness,
     seed_user,
     db_session,
@@ -1142,10 +1142,11 @@ async def test_platform_agent_delete_releases_runtime_oauth_claim_in_same_transa
     )
 
     assert deleted.status_code == 204, deleted.text
-    assert await db_session.get(AgentEnvironment, agent_id) is None
+    agent = await db_session.get(AgentEnvironment, agent_id)
+    assert agent is not None and agent.archived_at is not None
     await db_session.refresh(payload)
-    assert payload.consumer_environment_id is None
-    assert payload.consumer_runtime is None
+    assert payload.consumer_environment_id == agent_id
+    assert payload.consumer_runtime == "openclaw"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1511,6 +1511,8 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     env_id = await _register_env_named(client, machine_id, agent_type="codex")
 
     from app.models.ai_provider import AiProviderAuthPayload
+    from app.services.ai_provider_credentials import environment_matches_runtime
+    from app.services.runtime_source import load_runtime_source_batch
     from app.services.vault_crypto import encrypt
 
     encrypted, nonce = encrypt('{"kind":"oauth-test"}')
@@ -1527,6 +1529,12 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     )
     db_session.add(claimed_payload)
     await db_session.commit()
+    assert await environment_matches_runtime(
+        db_session,
+        owner_user_id=seed_user.id,
+        environment_id=uuid.UUID(env_id),
+        runtime="codex",
+    )
     started = datetime.now(UTC).isoformat()
     await client.post(
         "/v1/sessions/batch",
@@ -1576,6 +1584,18 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     await db_session.refresh(claimed_payload)
     assert str(claimed_payload.consumer_environment_id) == env_id
     assert claimed_payload.consumer_runtime == "codex"
+    assert not await environment_matches_runtime(
+        db_session,
+        owner_user_id=seed_user.id,
+        environment_id=uuid.UUID(env_id),
+        runtime="codex",
+    )
+    archived_source = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[uuid.UUID(env_id)],
+        owner_user_id=seed_user.id,
+    )
+    assert uuid.UUID(env_id) not in archived_source.rows
 
     assert (await client.get("/v1/agents")).json() == []
     assert (await client.get(f"/v1/agents/{env_id}")).status_code == 404
@@ -1589,6 +1609,20 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     # registration above already used the same generated value.
     assert reconnected == env_id
     assert (await client.get(f"/v1/agents/{env_id}")).status_code == 200
+    assert await environment_matches_runtime(
+        db_session,
+        owner_user_id=seed_user.id,
+        environment_id=uuid.UUID(env_id),
+        runtime="codex",
+    )
+    restored_source = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[uuid.UUID(env_id)],
+        owner_user_id=seed_user.id,
+    )
+    assert uuid.UUID(env_id) in restored_source.rows
+    await db_session.refresh(claimed_payload)
+    assert claimed_payload.consumer_environment_id == uuid.UUID(env_id)
 
 
 @pytest.mark.asyncio
@@ -1636,6 +1670,42 @@ async def test_delete_environment_rejects_explicit_agent_identity(
 async def test_delete_environment_404_for_unknown(client: httpx.AsyncClient):
     r = await client.delete(f"/v1/environments/{uuid.uuid4()}")
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fails_atomically_when_agent_project_is_shared(
+    client: httpx.AsyncClient, db_session: AsyncSession, seed_user
+):
+    from sqlalchemy import select
+
+    from app.models.project import Project
+    from app.models.session import AgentEnvironment
+
+    env_id = uuid.UUID(await _register_env(client, f"shared-project-{uuid.uuid4().hex}"))
+    agent = await db_session.scalar(select(AgentEnvironment).where(AgentEnvironment.id == env_id))
+    assert agent is not None
+    project = await db_session.get(Project, agent.default_project_id)
+    assert project is not None
+    sibling = AgentEnvironment(
+        id=uuid.uuid4(),
+        user_id=seed_user.id,
+        machine_id=f"corrupt-sibling-{uuid.uuid4().hex}",
+        machine_name="Corrupt sibling",
+        agent_type="codex",
+        os="linux",
+        registration_key=f"machine:corrupt-{uuid.uuid4().hex}:agent:codex",
+        default_project_id=project.id,
+    )
+    db_session.add(sibling)
+    await db_session.commit()
+
+    response = await client.delete(f"/v1/agents/{env_id}")
+    assert response.status_code == 409, response.text
+    assert "could not be proven" in response.text
+    await db_session.refresh(agent)
+    await db_session.refresh(project)
+    assert agent.archived_at is None
+    assert project.archived_at is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1503,26 +1503,12 @@ async def test_session_batch_rejects_malformed_uuid_with_422_not_500(client: htt
 
 
 @pytest.mark.asyncio
-async def test_delete_environment_orphans_sessions_via_fk(
+async def test_disconnect_archives_identity_and_preserves_session_link(
     client: httpx.AsyncClient, db_session: AsyncSession, seed_user
 ):
-    """Deleting an environment must keep historical sessions but null out
-    the FK so the list query renders them as unlabeled — never 500.
-    The FK + ON DELETE SET NULL is what makes this safe under concurrent
-    deletion (the previous SELECT-then-INSERT race could create orphans
-    that violated invariants the codebase implicitly relied on).
-
-    This test asserts at *both* layers:
-      1. HTTP — the dashboard list endpoint returns the row with null
-         agent label (could pass without an FK, just via outerjoin).
-      2. Raw SQL — `sessions.environment_id IS NULL` after delete. This
-         is what proves `ON DELETE SET NULL` actually fired; without the
-         FK the column would still hold the deleted UUID."""
-    env_id = await _register_env_named(
-        client,
-        f"delete-oauth-claim-{uuid.uuid4().hex}",
-        agent_type="codex",
-    )
+    """Disconnect keeps the stable Agent identity attached to history."""
+    machine_id = f"delete-oauth-claim-{uuid.uuid4().hex}"
+    env_id = await _register_env_named(client, machine_id, agent_type="codex")
 
     from app.models.ai_provider import AiProviderAuthPayload
     from app.services.vault_crypto import encrypt
@@ -1564,11 +1550,11 @@ async def test_delete_environment_orphans_sessions_via_fk(
     assert listing["total"] == 1
     item = listing["items"][0]
     assert item["local_session_id"] == "keep-me"
-    assert item["agent_name"] is None
+    assert item["agent_name"] == f"mac-{machine_id}"
     assert item["agent_display_name"] is None
     assert item["agent_default_name"] is None
-    assert item["agent_type"] is None
-    assert item["machine_name"] is None
+    assert item["agent_type"] == "codex"
+    assert item["machine_name"] == f"mac-{machine_id}"
 
     # The decisive check: after the DELETE, the session's environment_id
     # column is NULL (not the deleted UUID). This only happens because the
@@ -1586,10 +1572,23 @@ async def test_delete_environment_orphans_sessions_via_fk(
             {"sid": "keep-me"},
         )
     ).one()
-    assert row.environment_id is None
+    assert str(row.environment_id) == env_id
     await db_session.refresh(claimed_payload)
-    assert claimed_payload.consumer_environment_id is None
-    assert claimed_payload.consumer_runtime is None
+    assert str(claimed_payload.consumer_environment_id) == env_id
+    assert claimed_payload.consumer_runtime == "codex"
+
+    assert (await client.get("/v1/agents")).json() == []
+    assert (await client.get(f"/v1/agents/{env_id}")).status_code == 404
+
+    reconnected = await _register_env_named(
+        client,
+        machine_id,
+        agent_type="codex",
+    )
+    # This helper uses the machine id as registration identity; the original
+    # registration above already used the same generated value.
+    assert reconnected == env_id
+    assert (await client.get(f"/v1/agents/{env_id}")).status_code == 200
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skill_authority.py
+++ b/backend/tests/test_skill_authority.py
@@ -907,7 +907,7 @@ async def test_old_project_fence_cannot_delete_unclaimed_cloud_row(
 
 
 @pytest.mark.asyncio
-async def test_dashboard_agent_delete_cleans_all_agent_project_rows_files_and_revision(
+async def test_dashboard_agent_disconnect_preserves_agent_project_rows_and_files(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
@@ -984,7 +984,6 @@ async def test_dashboard_agent_delete_cleans_all_agent_project_rows_files_and_re
     await db_session.commit()
     before = await client.get("/v1/skills", params={"project_id": str(environment_project.id)})
     assert before.status_code == 200, before.text
-    old_etag = before.headers["etag"]
     await db_session.refresh(seed_user)
     revision_before = seed_user.skills_revision
     events = subscribe(
@@ -994,48 +993,20 @@ async def test_dashboard_agent_delete_cleans_all_agent_project_rows_files_and_re
     try:
         deleted = await client.delete(f"/v1/agents/{agent_id}")
         assert deleted.status_code == 204, deleted.text
-        deletion_events = [await asyncio.wait_for(events.get(), timeout=1) for _ in range(3)]
     finally:
         unsubscribe(seed_user.id, events)
-    await db_session.refresh(seed_user)
-    assert seed_user.skills_revision == revision_before + 3
-    assert sorted(event["skills_revision"] for event in deletion_events) == [
-        revision_before + 1,
-        revision_before + 2,
-        revision_before + 3,
-    ]
-    assert [event["project_id"] for event in deletion_events].count(
-        str(environment_project.id)
-    ) == 2
-    assert [event["project_id"] for event in deletion_events].count(str(old_project.id)) == 1
-
-    conditional = await client.get(
-        "/v1/skills",
-        params={"project_id": str(environment_project.id)},
-        headers={"If-None-Match": old_etag},
+    await db_session.refresh(environment_project)
+    assert environment_project.archived_at is not None
+    preserved = (
+        (await db_session.execute(select(Skill).where(Skill.project_id == environment_project.id)))
+        .scalars()
+        .all()
     )
-    assert conditional.status_code == 200, conditional.text
-    assert conditional.headers["etag"] != old_etag
-    assert conditional.json()["items"] == []
-    assert (
-        await db_session.execute(select(Skill).where(Skill.project_id == environment_project.id))
-    ).scalars().all() == []
-    assert (
-        await db_session.execute(select(Skill).where(Skill.project_id == old_project.id))
-    ).scalars().all() == []
-    kept = (
-        await db_session.execute(
-            select(Skill).where(
-                Skill.project_id == workspace_project.id,
-                Skill.skill_key == "keep-workspace",
-                Skill.is_active,
-            )
-        )
-    ).scalar_one()
-    assert kept.authority == SKILL_AUTHORITY_CLOUD
-    assert await file_store.exists(workspace_file_key) is True
+    assert {row.skill_key for row in preserved} == {"delete-legacy", "delete-claimed"}
     for file_key in agent_file_keys:
-        assert await file_store.exists(file_key) is False
+        assert await file_store.exists(file_key) is True
+    await db_session.refresh(seed_user)
+    assert seed_user.skills_revision == revision_before
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a single `AgentEnvironment.archived_at` lifecycle state and migration
- archive Agent + exclusive Agent Project atomically while preserving Sessions, Skills, files, bindings, runtime state, and provider relationships
- prove the exclusive Agent/Project boundary under row locks and return safe 409 errors on corrupt ownership
- revoke bound credentials commit-safely; Agent-bound keys are never process-cached
- exclude archived identities from active Agent/Project, runtime, Channel, provider, avatar, and mutation boundaries
- reactivate the same Agent and Project IDs on canonical re-registration
- update Connected disconnect copy

Hosted companion: Clawdi-AI/clawdi-hosted#1311

## Verification
- `bun run test`: CLI/web/shared 1486 passed, 4 skipped; backend 1923 passed, 7 skipped
- focused Docker lifecycle/migration/auth/channel/admin/platform tests passed
- `bun run typecheck` and `bun run check` passed
- focused Connected UI test: 3 passed
- OSS web build passed
- v1 runtime-observation byte-freeze contract passed with only the three intentional archived-authority gate hashes updated

No production, cluster, provider, or tenant operations were performed.