### PR TITLE
Standardize dialog exit lifecycle across web callers

### DIFF
--- a/apps/web/e2e/api-keys-settings.pw.ts
+++ b/apps/web/e2e/api-keys-settings.pw.ts
@@ -193,7 +193,15 @@ test("API key settings protects secrets and reconciles optimistic revokes", asyn
 	});
 
 	await page.getByRole("button", { name: "Create API key", exact: true }).first().click();
-	const createDialog = page.getByRole("dialog", { name: "Create API key" });
+	let createDialog = page.getByRole("dialog", { name: "Create API key" });
+	await createDialog.getByLabel("Key name").fill("Retained through exit");
+	await page.keyboard.press("Escape");
+	await expect(createDialog.getByLabel("Key name")).toHaveValue("Retained through exit");
+	await expect(createDialog).toHaveCount(0);
+
+	await page.getByRole("button", { name: "Create API key", exact: true }).first().click();
+	createDialog = page.getByRole("dialog", { name: "Create API key" });
+	await expect(createDialog.getByLabel("Key name")).toHaveValue("");
 	await createDialog.getByLabel("Key name").fill("Backup container");
 	await createDialog.getByRole("button", { name: "Create API key", exact: true }).click();
 
@@ -220,18 +228,25 @@ test("API key settings protects secrets and reconciles optimistic revokes", asyn
 	await page.getByRole("button", { name: "Revoke CI runner" }).click();
 	await page.getByRole("button", { name: "Revoke key", exact: true }).click();
 	await expect(page.getByText("CI runner", { exact: true })).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Revoke Backup container" })).toBeEnabled();
+	const retainedRevoke = page.getByRole("alertdialog", { name: "Revoke “CI runner”?" });
+	await expect(retainedRevoke).toBeVisible();
+	await expect(retainedRevoke.getByRole("button", { name: "Revoke key" })).toBeDisabled();
 	await expect.poll(() => api.deleteRequests).toContain("active-short");
 	successfulDelete.resolve();
+	await expect(retainedRevoke).toHaveCount(0);
 	await expect(page.getByText("API key revoked", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Revoke Backup container" })).toBeEnabled();
 
 	const failedDelete = api.setNextDelete(true);
 	await page.getByRole("button", { name: "Revoke Backup container" }).click();
 	await page.getByRole("button", { name: "Revoke key", exact: true }).click();
 	await expect(page.getByText("Backup container", { exact: true })).toHaveCount(0);
 	failedDelete.resolve();
-	await expect(desktopTable.getByText("Backup container", { exact: true })).toBeVisible();
 	await expect(page.getByText("Couldn’t revoke API key", { exact: true })).toBeVisible();
+	const failedRevoke = page.getByRole("alertdialog", { name: "Revoke “Backup container”?" });
+	await expect(failedRevoke).toBeVisible();
+	await failedRevoke.getByRole("button", { name: "Cancel" }).click();
+	await expect(desktopTable.getByText("Backup container", { exact: true })).toBeVisible();
 
 	await page.setViewportSize({ width: 390, height: 844 });
 	await page.reload();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1202,6 +1202,7 @@ type HostedApiStubOptions = {
 	providerDraftTestResponses?: StubResponse[];
 	providerOAuthStartRequests?: string[];
 	providerOAuthStartResponses?: StubResponse[];
+	providerOAuthPollResponses?: StubResponse[];
 	providerPatchRequests?: string[];
 	providerPatchResponses?: StubResponse[];
 	providerTestRequests?: string[];
@@ -1934,6 +1935,16 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			const response = options.providerOAuthStartResponses?.shift() ?? {
 				status: 500,
 				body: { detail: "No provider OAuth response configured" },
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (
+			p.match(/^\/v1\/ai-providers\/[^/]+\/auth\/oauth\/device\/poll$/) &&
+			r.request().method() === "POST"
+		) {
+			const response = options.providerOAuthPollResponses?.shift() ?? {
+				status: 200,
+				body: { status: "pending", retry_after_seconds: 60 },
 			};
 			return fulfillJson(r, response.body, response.status);
 		}
@@ -3783,7 +3794,7 @@ test("AI Provider OAuth and destructive confirmations keep dialog semantics on m
 						verification_url: "https://auth.openai.com/codex/device",
 						user_code: "NEW-CODE",
 						expires_at: "2099-01-01T00:00:00Z",
-						poll_interval_seconds: 60,
+						poll_interval_seconds: 1,
 					},
 				},
 			},
@@ -3801,6 +3812,7 @@ test("AI Provider OAuth and destructive confirmations keep dialog semantics on m
 				},
 			},
 		],
+		providerOAuthPollResponses: [{ status: 200, body: { status: "ready" } }],
 	});
 	await page.goto("/ai-providers");
 
@@ -3873,8 +3885,14 @@ test("AI Provider OAuth and destructive confirmations keep dialog semantics on m
 			process.env.PROVIDER_OAUTH_DESKTOP_SCREENSHOT_PATH ??
 			testInfo.outputPath("provider-oauth-desktop.png"),
 	});
-	await page.keyboard.press("Escape");
+	await expect(oauthDialog).toHaveAttribute("data-ending-style", "");
+	await expect(oauthDialog.getByText("NEW-CODE", { exact: true })).toBeVisible();
 	await expect(oauthDialog).toHaveCount(0);
+	await main.getByRole("button", { name: "Add provider", exact: true }).click();
+	const cleanReopen = page.getByRole("dialog", { name: "Add a provider" });
+	await expect(cleanReopen).toBeVisible();
+	await expect(cleanReopen.getByText("NEW-CODE", { exact: true })).toHaveCount(0);
+	await page.keyboard.press("Escape");
 
 	await page.setViewportSize({ width: 390, height: 844 });
 	await main.getByRole("button", { name: "Remove ChatGPT (Codex)", exact: true }).click();

--- a/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
+++ b/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
@@ -1,0 +1,116 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+const now = "2026-08-02T12:00:00.000Z";
+const project = {
+	id: "project-sharing",
+	name: "Shared workspace",
+	slug: "shared-workspace",
+	kind: "workspace",
+	origin_environment_id: null,
+	archived_at: null,
+	created_at: now,
+	is_owner: true,
+	owner_display: "Dev User",
+	owner_handle: "dev-user",
+};
+
+async function json(route: Route, body: unknown, status = 200) {
+	await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+}
+
+async function stubSharingApi(page: Page) {
+	let links = [
+		{
+			id: "link-one",
+			prefix: "link-prefix",
+			label: "Review link",
+			created_at: now,
+			revoked_at: null,
+			redeem_count: 0,
+			last_redeemed_at: null,
+		},
+	];
+	let invitations = [{ id: "invite-one", invitee_email: "invitee@example.com", created_at: now }];
+	let members = [
+		{
+			id: "member-one",
+			user_id: "user-one",
+			user_email: "member@example.com",
+			user_display: "Member One",
+			role: "viewer",
+			joined_via: "invitation",
+			joined_at: now,
+		},
+	];
+
+	await page.route("**/v1/**", async (route) => {
+		const request = route.request();
+		const path = new URL(request.url()).pathname;
+		if (path === "/v1/projects") return json(route, [project]);
+		if (path === "/v1/agents") return json(route, []);
+		if (path === "/v1/dashboard/stats") return json(route, {});
+		if (path === "/v1/skills") return json(route, { items: [], total: 0, page: 1, page_size: 25 });
+		if (path === "/v1/projects/project-sharing/share-links") return json(route, links);
+		if (path === "/v1/projects/project-sharing/invitations") return json(route, invitations);
+		if (path === "/v1/projects/project-sharing/members") return json(route, members);
+		if (request.method() === "DELETE" && path.endsWith("/share-links/link-one")) {
+			links = [];
+			return json(route, {});
+		}
+		if (request.method() === "DELETE" && path.endsWith("/invitations/invite-one")) {
+			invitations = [];
+			return json(route, {});
+		}
+		if (request.method() === "DELETE" && path.endsWith("/members/user-one")) {
+			members = [];
+			return json(route, {});
+		}
+		return json(route, {});
+	});
+}
+
+test("sharing row mutations retain targets through Base UI exit and reopen cleanly", async ({
+	page,
+}) => {
+	await stubSharingApi(page);
+	await page.setViewportSize({ width: 320, height: 720 });
+	await page.goto("/projects");
+	await page.getByRole("button", { name: "Share Shared workspace" }).click();
+
+	const cases = [
+		{
+			trigger: "Turn off share link link-prefix",
+			action: "Turn Off Link",
+			retained: "Turn off this share link?",
+		},
+		{
+			trigger: "Cancel invitation for invitee@example.com",
+			action: "Cancel invitation",
+			retained: "invitee@example.com",
+		},
+		{
+			trigger: "Remove member member@example.com",
+			action: "Remove Member",
+			retained: "member@example.com",
+		},
+	] as const;
+
+	for (const item of cases) {
+		const trigger = page.getByRole("button", { name: item.trigger });
+		await trigger.click();
+		const alert = page.getByRole("alertdialog");
+		await expect(alert).toContainText(item.retained);
+		await alert.getByRole("button", { name: item.action }).click();
+		await expect(alert).toHaveAttribute("data-ending-style", "");
+		await expect(alert).toContainText(item.retained);
+		await expect(alert).toBeHidden();
+		await expect(trigger).toHaveCount(0);
+	}
+
+	await page.keyboard.press("Escape");
+	await expect(page.getByRole("dialog")).toBeHidden();
+	await page.getByRole("button", { name: "Share Shared workspace" }).click();
+	await expect(
+		page.getByRole("button", { name: /Turn off share link|Cancel invitation|Remove / }),
+	).toHaveCount(0);
+});

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -138,13 +138,6 @@ function CommandPalette({
 		return shortcuts;
 	}, [hostedAccess.canCreateCloudAgents]);
 
-	// Reset the input when the palette closes so reopening is a fresh state
-	// — otherwise stale results from the previous query briefly flash before
-	// a new debounce cycle fires.
-	useEffect(() => {
-		if (!open) setQuery("");
-	}, [open]);
-
 	const { data, isFetching } = useQuery({
 		queryKey: ["command-search", debounced],
 		queryFn: async () =>
@@ -220,6 +213,9 @@ function CommandPalette({
 		<CommandDialog
 			open={open}
 			onOpenChange={onOpenChange}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) setQuery("");
+			}}
 			title="Search"
 			description="Open a page or search sessions, memories, skills, and vaults. Use the Search button in the sidebar or Cmd/Ctrl+K."
 		>

--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -19,7 +19,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { unwrap, useApi } from "@/lib/api";
 import { useAuthFields } from "@/lib/connectors-data";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
-import { errorMessage } from "@/lib/utils";
 import { buildCredentialPayload, getVisibleCredentialFields } from "./credentials-dialog.logic";
 
 /**
@@ -77,6 +76,7 @@ export function ConnectorCredentialsDialog({
 	// pattern as the OAuth/disconnect handlers in the detail page.
 	const inflightSubmitRef = useRef(false);
 	useEffect(() => {
+		if (!open) return;
 		openGenRef.current += 1;
 		setValues({});
 		setSubmitError(null);
@@ -103,16 +103,28 @@ export function ConnectorCredentialsDialog({
 			setValues({});
 			toast.success(`${displayName} connected`);
 			onOpenChange(false);
-		} catch (e) {
+		} catch {
 			if (gen !== openGenRef.current) return;
-			setSubmitError(errorMessage(e));
+			setSubmitError("The credentials couldn’t be saved. Check the values and try again.");
 		} finally {
 			inflightSubmitRef.current = false;
 		}
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) openGenRef.current += 1;
+				onOpenChange(nextOpen);
+			}}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) {
+					setValues({});
+					setSubmitError(null);
+				}
+			}}
+		>
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>
 					<DialogTitle>Connect {displayName}</DialogTitle>

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -316,8 +316,8 @@ function AgentProjectsPanel({
 
 			<Dialog
 				open={addOpen}
-				onOpenChange={(open) => {
-					setAddOpen(open);
+				onOpenChange={setAddOpen}
+				onOpenChangeComplete={(open) => {
 					if (!open) setContextProjectId("");
 				}}
 			>

--- a/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const sourceRoot = resolve(import.meta.dir, "..");
+
+// Stateful callers whose retained payload or target is owned by the shared contract.
+const SHARED_LIFECYCLE = [
+	"components/sharing/share-project-dialog.tsx",
+	"components/settings/api-keys-panel.tsx",
+	"components/vault/split-vault-dialog.tsx",
+	"hosted/agents/hosted-agent-detail.tsx",
+	"hosted/billing/components/stripe-checkout-dialog.tsx",
+	"hosted/billing/subscription/plan-change-dialog.tsx",
+	"hosted/v2/ai-providers/add-provider-dialog.tsx",
+] as const;
+
+// Local form state already remains mounted for Base UI's exit window; these callers only
+// need to reset in onOpenChangeComplete and do not benefit from duplicating a snapshot.
+const COMPLETION_ONLY = [
+	"components/command-palette.tsx",
+	"components/connectors/credentials-dialog.tsx",
+	"components/dashboard/agent-projects-tab.tsx",
+	"components/memories/memories-surface.tsx",
+	"components/skills/send-skill-dialog.tsx",
+	"components/ui/confirm-action.tsx",
+	"components/vault/add-keys-dialog.tsx",
+	"components/vault/vaults-surface.tsx",
+	"hosted/billing/wallet/top-up-dialog.tsx",
+	"hosted/v2/ai-providers/ai-providers-page.tsx",
+	"hosted/v2/ai-providers/provider-connection-test.tsx",
+	"hosted/v2/channels/connect-bot-dialog.tsx",
+	"pages/dashboard/projects/page.tsx",
+	"pages/dashboard/vault/[slug]/page.tsx",
+] as const;
+
+// Intentional exceptions: stateless wrappers/simple confirmations, navigation-owned shells,
+// or responsive presentation switches with no close-time payload reset. Pairing callers are
+// canonical #725 code and deliberately outside this follow-up.
+const STATELESS_OR_CANONICAL = [
+	"components/dashboard/add-agent-dialog.tsx",
+	"components/dashboard/daemon-status.tsx",
+	"components/dashboard/new-agent-button.tsx",
+	"components/settings-dialog.tsx",
+	"components/ui/command.tsx",
+	"components/ui/sidebar.tsx",
+	"components/vault/copy-keys-dialog.tsx",
+	"hosted/agents/deployment-delete-action.tsx",
+	"hosted/billing/subscription/subscription-create-dialog.tsx",
+	"hosted/v2/channels/discord-pair-dialog.tsx",
+	"hosted/v2/channels/paired-chats-dialog.tsx",
+	"hosted/v2/channels/pairing-dialog-ui.tsx",
+	"hosted/v2/channels/telegram-pair-dialog.tsx",
+	"pages/dashboard/projects/[id]/page.tsx",
+] as const;
+
+describe("stateful popup lifecycle inventory", () => {
+	test("classifies every Dialog, AlertDialog, or Sheet caller", async () => {
+		const discovered: string[] = [];
+		for await (const file of new Bun.Glob("**/*.tsx").scan(sourceRoot)) {
+			const contents = readFileSync(resolve(sourceRoot, file), "utf8");
+			if (
+				/from "@\/components\/ui\/(dialog|alert-dialog|sheet)"/.test(contents) ||
+				(contents.includes("<CommandDialog") && contents.includes('from "@/components/ui/command"'))
+			) {
+				discovered.push(relative(sourceRoot, resolve(sourceRoot, file)));
+			}
+		}
+		const classified = [...SHARED_LIFECYCLE, ...COMPLETION_ONLY, ...STATELESS_OR_CANONICAL];
+		expect(discovered.sort()).toEqual([...classified].sort());
+	});
+
+	test("uses the shared snapshot owner only where payload retention is required", () => {
+		for (const path of SHARED_LIFECYCLE) {
+			expect(readFileSync(resolve(sourceRoot, path), "utf8"), path).toContain(
+				"useDialogExitLifecycle",
+			);
+		}
+		for (const path of COMPLETION_ONLY) {
+			expect(readFileSync(resolve(sourceRoot, path), "utf8"), path).toContain(
+				"onOpenChangeComplete",
+			);
+		}
+	});
+});

--- a/apps/web/src/components/dialog-exit-lifecycle.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+	dialogExitRenderedValue,
+	reduceDialogExitState,
+} from "@/components/ui/use-dialog-exit-lifecycle";
+
+const sourceRoot = resolve(import.meta.dir, "..");
+
+function source(path: string) {
+	return readFileSync(resolve(sourceRoot, path), "utf8");
+}
+
+describe("dialog exit lifecycle", () => {
+	test("uses the repository Base UI completion and ending-state contract", () => {
+		const helper = source("components/ui/use-dialog-exit-lifecycle.ts");
+		const dialog = source("components/ui/dialog.tsx");
+		const sheet = source("components/ui/sheet.tsx");
+		expect(helper).toContain("Base UI's exit window");
+		expect(helper).not.toContain("forceRender");
+		expect(helper).not.toContain("keepMounted");
+		expect(dialog).toContain("data-closed:animate-out");
+		expect(sheet).toContain("data-ending-style:opacity-0");
+	});
+
+	test("clears caller form state after Base UI finishes closing", () => {
+		for (const path of [
+			"components/command-palette.tsx",
+			"components/connectors/credentials-dialog.tsx",
+			"components/settings/api-keys-panel.tsx",
+			"components/vault/add-keys-dialog.tsx",
+			"components/vault/vaults-surface.tsx",
+			"components/memories/memories-surface.tsx",
+			"pages/dashboard/projects/page.tsx",
+		]) {
+			expect(source(path), path).toContain("onOpenChangeComplete");
+		}
+	});
+
+	test("retains payment and credential payloads only for the existing exit window", () => {
+		const checkout = source("hosted/billing/components/stripe-checkout-dialog.tsx");
+		expect(checkout).toContain("useDialogExitLifecycle");
+		expect(checkout).toContain("onOpenChangeComplete");
+		expect(checkout).toContain("clientSecret: null");
+
+		const runtime = source("hosted/agents/hosted-agent-detail.tsx");
+		expect(runtime).toContain("renderedCredentials");
+		expect(runtime).toContain("credentialExit.completeClose()");
+	});
+
+	test("retains runtime credentials when an identity refresh programmatically closes the dialog", () => {
+		const credentials = { username: "runtime-user", password: "one-time-secret" };
+		const closing = reduceDialogExitState(
+			{ phase: "open" as const, snapshot: null as typeof credentials | null },
+			{ type: "close", snapshot: credentials },
+		);
+		expect(dialogExitRenderedValue({ open: false, state: closing, value: null })).toEqual(
+			credentials,
+		);
+
+		const runtime = source("hosted/agents/hosted-agent-detail.tsx");
+		const identityClose = runtime.indexOf("if (open) credentialExit.beginClose()");
+		const clearAfterIdentity = runtime.indexOf("clearSensitiveState();", identityClose);
+		expect(identityClose).toBeGreaterThan(-1);
+		expect(clearAfterIdentity).toBeGreaterThan(identityClose);
+	});
+
+	test("invalidates stale async writes independently from visual cleanup", () => {
+		const credentials = source("components/connectors/credentials-dialog.tsx");
+		expect(credentials).toContain("if (!nextOpen) openGenRef.current += 1");
+		expect(credentials).toContain("onOpenChangeComplete");
+
+		const provider = source("hosted/v2/ai-providers/add-provider-dialog.tsx");
+		expect(provider).toContain("dialogSessionRef.current += 1");
+		expect(provider).toContain("dialogSession !== dialogSessionRef.current");
+		expect(provider).toContain("onOpenChangeComplete={completeOpenChange}");
+		expect(provider).toContain("oauthExit.beginClose()");
+		expect(provider).toContain("oauthExit.completeClose()");
+	});
+
+	test("keeps mutation dialogs under stable panel owners until Base UI completes exit", () => {
+		const sharing = source("components/sharing/share-project-dialog.tsx");
+		for (const target of ["renderedRevokeTarget", "renderedCancelTarget", "renderedRemoveTarget"]) {
+			expect(sharing).toContain(target);
+		}
+		expect(sharing.match(/onOpenChangeComplete=/g)?.length).toBeGreaterThanOrEqual(3);
+		expect(sharing).not.toContain(
+			"<LinkRow\n\t\t\t\t\t\t\tkey={link.id}\n\t\t\t\t\t\t\tlink={link}\n\t\t\t\t\t\t\tonRevoke={() => revoke.mutate",
+		);
+	});
+});

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -431,7 +431,6 @@ function AddMemoryForm() {
 				}),
 			),
 		onSuccess: () => {
-			setContent("");
 			setOpen(false);
 			queryClient.invalidateQueries({ queryKey: ["memories"] });
 		},
@@ -441,8 +440,8 @@ function AddMemoryForm() {
 	return (
 		<Dialog
 			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
+			onOpenChange={setOpen}
+			onOpenChangeComplete={(next) => {
 				if (!next) setContent("");
 			}}
 		>

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -15,9 +15,18 @@ import {
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { TimeTooltip } from "@/components/time-tooltip";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ConfirmAction } from "@/components/ui/confirm-action";
 import { DataTable } from "@/components/ui/data-table";
 import {
 	Dialog,
@@ -39,6 +48,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
@@ -60,6 +70,14 @@ export function ApiKeysPanel() {
 	const [newLabel, setNewLabel] = useState("");
 	const [createdKey, setCreatedKey] = useState<string | null>(null);
 	const [secretAcknowledged, setSecretAcknowledged] = useState(false);
+	const [revokeOpen, setRevokeOpen] = useState(false);
+	const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+	const revokeExit = useDialogExitLifecycle({
+		open: revokeOpen,
+		value: revokeTarget,
+		emptyValue: null,
+	});
+	const renderedRevokeTarget = revokeExit.renderedValue;
 	const normalizedNewLabel = newLabel.trim();
 	const { copied, copy } = useCopyToClipboard({
 		success: "API key copied to clipboard",
@@ -110,6 +128,8 @@ export function ApiKeysPanel() {
 			return { removedKey };
 		},
 		onSuccess: () => {
+			revokeExit.beginClose();
+			setRevokeOpen(false);
 			toast.success("API key revoked");
 		},
 		onError: (mutationError, _keyId, context) => {
@@ -130,10 +150,10 @@ export function ApiKeysPanel() {
 		},
 	});
 
-	const handleRevoke = useCallback(
-		(keyId: string) => revokeKey.mutateAsync(keyId),
-		[revokeKey.mutateAsync],
-	);
+	const handleRevoke = useCallback((key: ApiKey) => {
+		setRevokeTarget(key);
+		setRevokeOpen(true);
+	}, []);
 	const showExpiration = keys.some((key) => key.expires_at !== null);
 	const columns = useMemo(
 		() => apiKeyColumns({ showExpiration, onRevoke: handleRevoke }),
@@ -150,19 +170,20 @@ export function ApiKeysPanel() {
 
 	function handleCreateDialogOpenChange(nextOpen: boolean) {
 		if (!nextOpen && (createKey.isPending || createdKey !== null)) return;
-		if (!nextOpen) {
-			createKey.reset();
-			setNewLabel("");
-			setSecretAcknowledged(false);
-		}
 		setCreateDialogOpen(nextOpen);
 	}
 
 	function finishSecretReveal() {
 		if (!secretAcknowledged) return;
-		setCreatedKey(null);
-		setSecretAcknowledged(false);
 		setCreateDialogOpen(false);
+	}
+
+	function handleCreateDialogOpenChangeComplete(nextOpen: boolean) {
+		if (nextOpen) return;
+		createKey.reset();
+		setCreatedKey(null);
+		setNewLabel("");
+		setSecretAcknowledged(false);
 	}
 
 	return (
@@ -210,7 +231,11 @@ export function ApiKeysPanel() {
 				</>
 			)}
 
-			<Dialog open={createDialogOpen} onOpenChange={handleCreateDialogOpenChange}>
+			<Dialog
+				open={createDialogOpen}
+				onOpenChange={handleCreateDialogOpenChange}
+				onOpenChangeComplete={handleCreateDialogOpenChangeComplete}
+			>
 				<DialogContent
 					showCloseButton={!createKey.isPending && createdKey === null}
 					className="sm:max-w-lg"
@@ -327,6 +352,48 @@ export function ApiKeysPanel() {
 					)}
 				</DialogContent>
 			</Dialog>
+			<AlertDialog
+				open={revokeOpen}
+				onOpenChange={(nextOpen) => {
+					if (revokeKey.isPending) return;
+					if (nextOpen) revokeExit.beginOpen();
+					else revokeExit.beginClose();
+					setRevokeOpen(nextOpen);
+				}}
+				onOpenChangeComplete={(nextOpen) => {
+					if (!nextOpen) {
+						revokeExit.completeClose();
+						setRevokeTarget(null);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							Revoke “{renderedRevokeTarget?.label ?? "API key"}”?
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							Requests using this key will stop working. This can’t be undone; create and install a
+							new key to reconnect the client.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={revokeKey.isPending}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							disabled={!renderedRevokeTarget || revokeKey.isPending}
+							onClick={(event) => {
+								event.preventDefault();
+								if (renderedRevokeTarget && !revokeKey.isPending)
+									revokeKey.mutate(renderedRevokeTarget.id);
+							}}
+						>
+							{revokeKey.isPending ? <Spinner /> : null}
+							Revoke key
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }
@@ -336,7 +403,7 @@ function apiKeyColumns({
 	onRevoke,
 }: {
 	showExpiration: boolean;
-	onRevoke: (keyId: string) => Promise<unknown>;
+	onRevoke: (key: ApiKey) => void;
 }): ColumnDef<ApiKey>[] {
 	const columns: ColumnDef<ApiKey>[] = [
 		{
@@ -415,32 +482,20 @@ function RevokeApiKeyAction({
 	onRevoke,
 }: {
 	apiKey: ApiKey;
-	onRevoke: (keyId: string) => Promise<unknown>;
+	onRevoke: (key: ApiKey) => void;
 }) {
 	return (
-		<ConfirmAction
-			title={`Revoke “${apiKey.label}”?`}
-			description={
-				<p>
-					Requests using this key will stop working. This can’t be undone; create and install a new
-					key to reconnect the client.
-				</p>
-			}
-			confirmLabel="Revoke key"
-			destructive
-			onConfirm={() => onRevoke(apiKey.id)}
+		<Button
+			type="button"
+			variant="ghost"
+			size="sm"
+			aria-label={`Revoke ${apiKey.label}`}
+			className="text-muted-foreground hover:text-destructive"
+			onClick={() => onRevoke(apiKey)}
 		>
-			<Button
-				type="button"
-				variant="ghost"
-				size="sm"
-				aria-label={`Revoke ${apiKey.label}`}
-				className="text-muted-foreground hover:text-destructive"
-			>
-				<Trash2 aria-hidden="true" />
-				Revoke
-			</Button>
-		</ConfirmAction>
+			<Trash2 aria-hidden="true" />
+			Revoke
+		</Button>
 	);
 }
 
@@ -489,7 +544,7 @@ function ApiKeysMobileList({
 	onRevoke,
 }: {
 	keys: ApiKey[];
-	onRevoke: (keyId: string) => Promise<unknown>;
+	onRevoke: (key: ApiKey) => void;
 }) {
 	return (
 		<div className="flex flex-col gap-3">

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -14,7 +14,7 @@ import {
 	UserMinus,
 	Users,
 } from "lucide-react";
-import { type ReactElement, useEffect, useState } from "react";
+import { type ReactElement, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { isCustomProject } from "@/components/projects/project-metadata";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -42,6 +42,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
@@ -161,8 +162,17 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 	// The just-created link's full URL is shown once because the server
 	// stores only the prefix going forward.
 	const [freshLink, setFreshLink] = useState<ShareLinkCreated | null>(null);
+	const [revokeOpen, setRevokeOpen] = useState(false);
+	const [revokeTarget, setRevokeTarget] = useState<ShareLinkRow | null>(null);
+	const revokeSucceededRef = useRef(false);
+	const revokeExit = useDialogExitLifecycle({
+		open: revokeOpen,
+		value: revokeTarget,
+		emptyValue: null,
+	});
+	const renderedRevokeTarget = revokeExit.renderedValue;
 	useEffect(() => {
-		if (!open) setFreshLink(null);
+		if (open) setFreshLink(null);
 	}, [open]);
 
 	const links = useQuery({
@@ -218,7 +228,9 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			);
 		},
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["share-links", projectId] });
+			revokeSucceededRef.current = true;
+			revokeExit.beginClose();
+			setRevokeOpen(false);
 			toast.success("Share Link Turned Off");
 		},
 		onError: (e) => {
@@ -301,12 +313,59 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 						<LinkRow
 							key={link.id}
 							link={link}
-							onRevoke={() => revoke.mutate(link.id)}
+							onRevoke={() => {
+								revokeSucceededRef.current = false;
+								setRevokeTarget(link);
+								setRevokeOpen(true);
+							}}
 							revoking={revoke.isPending && revoke.variables === link.id}
 						/>
 					))}
 				</ul>
 			)}
+			<AlertDialog
+				open={revokeOpen}
+				onOpenChange={(nextOpen) => {
+					if (!revoke.isPending) {
+						if (nextOpen) revokeExit.beginOpen();
+						else revokeExit.beginClose();
+						setRevokeOpen(nextOpen);
+					}
+				}}
+				onOpenChangeComplete={(nextOpen) => {
+					if (nextOpen) return;
+					setRevokeTarget(null);
+					revokeExit.completeClose();
+					if (revokeSucceededRef.current) {
+						revokeSucceededRef.current = false;
+						void qc.invalidateQueries({ queryKey: ["share-links", projectId] });
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Turn off this share link?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Anyone who has not already joined through this link will lose access to it. Existing
+							Viewers stay connected until you remove them from People.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={revoke.isPending}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(event) => {
+								event.preventDefault();
+								if (renderedRevokeTarget && !revoke.isPending)
+									revoke.mutate(renderedRevokeTarget.id);
+							}}
+							disabled={!renderedRevokeTarget || revoke.isPending}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{revoke.isPending ? "Turning off…" : "Turn Off Link"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }
@@ -447,39 +506,16 @@ function LinkRow({
 					</div>
 				</div>
 				{!revoked ? (
-					<AlertDialog>
-						<AlertDialogTrigger
-							render={
-								<Button
-									variant="ghost"
-									size="icon"
-									disabled={revoking}
-									title="Turn off link"
-									aria-label={`Turn off share link ${link.prefix}`}
-								/>
-							}
-						>
-							<Trash2 className="size-3.5 text-destructive" />
-						</AlertDialogTrigger>
-						<AlertDialogContent>
-							<AlertDialogHeader>
-								<AlertDialogTitle>Turn off this share link?</AlertDialogTitle>
-								<AlertDialogDescription>
-									Anyone who has not already joined through this link will lose access to it.
-									Existing Viewers stay connected until you remove them from People.
-								</AlertDialogDescription>
-							</AlertDialogHeader>
-							<AlertDialogFooter>
-								<AlertDialogCancel>Cancel</AlertDialogCancel>
-								<AlertDialogAction
-									onClick={onRevoke}
-									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-								>
-									Turn Off Link
-								</AlertDialogAction>
-							</AlertDialogFooter>
-						</AlertDialogContent>
-					</AlertDialog>
+					<Button
+						variant="ghost"
+						size="icon"
+						disabled={revoking}
+						title="Turn off link"
+						aria-label={`Turn off share link ${link.prefix}`}
+						onClick={onRevoke}
+					>
+						<Trash2 className="size-3.5 text-destructive" />
+					</Button>
 				) : null}
 			</div>
 		</li>
@@ -490,6 +526,15 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 	const api = useApi();
 	const qc = useQueryClient();
 	const [email, setEmail] = useState("");
+	const [cancelOpen, setCancelOpen] = useState(false);
+	const [cancelTarget, setCancelTarget] = useState<Invitation | null>(null);
+	const cancelSucceededRef = useRef(false);
+	const cancelExit = useDialogExitLifecycle({
+		open: cancelOpen,
+		value: cancelTarget,
+		emptyValue: null,
+	});
+	const renderedCancelTarget = cancelExit.renderedValue;
 
 	const invites = useQuery({
 		queryKey: ["invitations", projectId],
@@ -533,7 +578,9 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			);
 		},
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
+			cancelSucceededRef.current = true;
+			cancelExit.beginClose();
+			setCancelOpen(false);
 			toast.success("Invitation Cancelled");
 		},
 		onError: (e) => {
@@ -621,42 +668,67 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 									</span>
 								</div>
 							</div>
-							<AlertDialog>
-								<AlertDialogTrigger
-									render={
-										<Button
-											variant="ghost"
-											size="icon"
-											disabled={cancel.isPending && cancel.variables === inv.id}
-											title="Cancel invitation"
-											aria-label={`Cancel invitation for ${inv.invitee_email}`}
-										/>
-									}
-								>
-									<Trash2 className="size-3.5 text-destructive" />
-								</AlertDialogTrigger>
-								<AlertDialogContent>
-									<AlertDialogHeader>
-										<AlertDialogTitle>Cancel this invitation?</AlertDialogTitle>
-										<AlertDialogDescription>
-											{inv.invitee_email} will no longer see this invitation in their dashboard.
-										</AlertDialogDescription>
-									</AlertDialogHeader>
-									<AlertDialogFooter>
-										<AlertDialogCancel>Keep invitation</AlertDialogCancel>
-										<AlertDialogAction
-											onClick={() => cancel.mutate(inv.id)}
-											className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-										>
-											Cancel invitation
-										</AlertDialogAction>
-									</AlertDialogFooter>
-								</AlertDialogContent>
-							</AlertDialog>
+							<Button
+								variant="ghost"
+								size="icon"
+								disabled={cancel.isPending && cancel.variables === inv.id}
+								title="Cancel invitation"
+								aria-label={`Cancel invitation for ${inv.invitee_email}`}
+								onClick={() => {
+									cancelSucceededRef.current = false;
+									setCancelTarget(inv);
+									setCancelOpen(true);
+								}}
+							>
+								<Trash2 className="size-3.5 text-destructive" />
+							</Button>
 						</li>
 					))}
 				</ul>
 			)}
+			<AlertDialog
+				open={cancelOpen}
+				onOpenChange={(nextOpen) => {
+					if (!cancel.isPending) {
+						if (nextOpen) cancelExit.beginOpen();
+						else cancelExit.beginClose();
+						setCancelOpen(nextOpen);
+					}
+				}}
+				onOpenChangeComplete={(nextOpen) => {
+					if (nextOpen) return;
+					setCancelTarget(null);
+					cancelExit.completeClose();
+					if (cancelSucceededRef.current) {
+						cancelSucceededRef.current = false;
+						void qc.invalidateQueries({ queryKey: ["invitations", projectId] });
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Cancel this invitation?</AlertDialogTitle>
+						<AlertDialogDescription>
+							{renderedCancelTarget?.invitee_email ?? "This person"} will no longer see this
+							invitation in their dashboard.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={cancel.isPending}>Keep invitation</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(event) => {
+								event.preventDefault();
+								if (renderedCancelTarget && !cancel.isPending)
+									cancel.mutate(renderedCancelTarget.id);
+							}}
+							disabled={!renderedCancelTarget || cancel.isPending}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{cancel.isPending ? "Cancelling…" : "Cancel invitation"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }
@@ -664,6 +736,16 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 function MembersPanel({ projectId }: { projectId: string }) {
 	const api = useApi();
 	const qc = useQueryClient();
+	const [stopAllOpen, setStopAllOpen] = useState(false);
+	const [removeOpen, setRemoveOpen] = useState(false);
+	const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+	const removeSucceededRef = useRef(false);
+	const removeExit = useDialogExitLifecycle({
+		open: removeOpen,
+		value: removeTarget,
+		emptyValue: null,
+	});
+	const renderedRemoveTarget = removeExit.renderedValue;
 
 	const members = useQuery({
 		queryKey: ["project-members", projectId],
@@ -692,7 +774,9 @@ function MembersPanel({ projectId }: { projectId: string }) {
 			);
 		},
 		onSuccess: () => {
-			refreshSharingState();
+			removeSucceededRef.current = true;
+			removeExit.beginClose();
+			setRemoveOpen(false);
 			toast.success("Member Removed");
 		},
 		onError: (e) =>
@@ -709,6 +793,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 				}),
 			),
 		onSuccess: (body) => {
+			setStopAllOpen(false);
 			refreshSharingState();
 			toast.success("Sharing Stopped", {
 				description: `Turned off ${body.links_revoked} link(s) and removed ${body.members_removed} member(s).`,
@@ -730,7 +815,12 @@ function MembersPanel({ projectId }: { projectId: string }) {
 						People who accepted access. Viewers can read this Project until you remove them.
 					</p>
 				</div>
-				<AlertDialog>
+				<AlertDialog
+					open={stopAllOpen}
+					onOpenChange={(nextOpen) => {
+						if (!unshare.isPending) setStopAllOpen(nextOpen);
+					}}
+				>
 					<AlertDialogTrigger
 						render={
 							<Button
@@ -752,9 +842,10 @@ function MembersPanel({ projectId }: { projectId: string }) {
 							</AlertDialogDescription>
 						</AlertDialogHeader>
 						<AlertDialogFooter>
-							<AlertDialogCancel>Keep Sharing</AlertDialogCancel>
+							<AlertDialogCancel disabled={unshare.isPending}>Keep Sharing</AlertDialogCancel>
 							<AlertDialogAction
 								onClick={() => unshare.mutate()}
+								disabled={unshare.isPending}
 								className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							>
 								Stop all sharing
@@ -797,43 +888,72 @@ function MembersPanel({ projectId }: { projectId: string }) {
 										})}
 									</div>
 								</div>
-								<AlertDialog>
-									<AlertDialogTrigger
-										render={
-											<Button
-												variant="ghost"
-												size="icon"
-												disabled={remove.isPending}
-												title="Remove member"
-												aria-label={`Remove member ${label}`}
-											/>
-										}
-									>
-										<UserMinus className="size-3.5 text-destructive" />
-									</AlertDialogTrigger>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>Remove this member?</AlertDialogTitle>
-											<AlertDialogDescription>
-												{label} will lose access to this Project.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel>Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												onClick={() => remove.mutate(member.user_id)}
-												className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-											>
-												Remove Member
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
+								<Button
+									variant="ghost"
+									size="icon"
+									disabled={remove.isPending}
+									title="Remove member"
+									aria-label={`Remove member ${label}`}
+									onClick={() => {
+										removeSucceededRef.current = false;
+										setRemoveTarget(member);
+										setRemoveOpen(true);
+									}}
+								>
+									<UserMinus className="size-3.5 text-destructive" />
+								</Button>
 							</li>
 						);
 					})}
 				</ul>
 			)}
+			<AlertDialog
+				open={removeOpen}
+				onOpenChange={(nextOpen) => {
+					if (!remove.isPending) {
+						if (nextOpen) removeExit.beginOpen();
+						else removeExit.beginClose();
+						setRemoveOpen(nextOpen);
+					}
+				}}
+				onOpenChangeComplete={(nextOpen) => {
+					if (nextOpen) return;
+					setRemoveTarget(null);
+					removeExit.completeClose();
+					if (removeSucceededRef.current) {
+						removeSucceededRef.current = false;
+						refreshSharingState();
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Remove this member?</AlertDialogTitle>
+						<AlertDialogDescription>
+							{renderedRemoveTarget
+								? (renderedRemoveTarget.user_email ??
+									renderedRemoveTarget.user_display ??
+									renderedRemoveTarget.user_id)
+								: "This member"}{" "}
+							will lose access to this Project.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={remove.isPending}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(event) => {
+								event.preventDefault();
+								if (renderedRemoveTarget && !remove.isPending)
+									remove.mutate(renderedRemoveTarget.user_id);
+							}}
+							disabled={!renderedRemoveTarget || remove.isPending}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{remove.isPending ? "Removing…" : "Remove Member"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -192,7 +192,16 @@ export function SendSkillDialog({
 	);
 
 	return (
-		<Dialog open={open} onOpenChange={setOpen}>
+		<Dialog
+			open={open}
+			onOpenChange={setOpen}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) {
+					setTarget("");
+					setRemoveFromSource(false);
+				}
+			}}
+		>
 			<DialogTrigger render={trigger} />
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>

--- a/apps/web/src/components/ui/confirm-action.tsx
+++ b/apps/web/src/components/ui/confirm-action.tsx
@@ -44,6 +44,7 @@ export function ConfirmAction({
 	// a sub-frame window where a fast double-click (or Enter repeat) could fire
 	// the destructive action twice before React repaints.
 	const locked = useRef(false);
+	const closingAfterSuccess = useRef(false);
 
 	async function runConfirm() {
 		if (locked.current) return;
@@ -51,15 +52,28 @@ export function ConfirmAction({
 		setPending(true);
 		try {
 			await onConfirm();
+			closingAfterSuccess.current = true;
 			setOpen(false);
 		} finally {
-			setPending(false);
-			locked.current = false;
+			if (!closingAfterSuccess.current) {
+				setPending(false);
+				locked.current = false;
+			}
 		}
 	}
 
 	return (
-		<AlertDialog open={open} onOpenChange={(next) => !pending && setOpen(next)}>
+		<AlertDialog
+			open={open}
+			onOpenChange={(next) => !pending && setOpen(next)}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen && closingAfterSuccess.current) {
+					closingAfterSuccess.current = false;
+					setPending(false);
+					locked.current = false;
+				}
+			}}
+		>
 			<AlertDialogTrigger render={children} />
 			<AlertDialogContent>
 				<AlertDialogHeader>

--- a/apps/web/src/components/ui/use-dialog-exit-lifecycle.test.ts
+++ b/apps/web/src/components/ui/use-dialog-exit-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type DialogExitState,
+	dialogExitRenderedValue,
+	reduceDialogExitState,
+} from "./use-dialog-exit-lifecycle";
+
+type SecretSnapshot = { secret: string | null; screen: "form" | "oauth" };
+
+const empty: SecretSnapshot = { secret: null, screen: "form" };
+
+describe("dialog exit lifecycle contract", () => {
+	test("retains the rendered snapshot while closing and clears sensitive state on completion", () => {
+		const open: DialogExitState<SecretSnapshot> = {
+			phase: "open",
+			snapshot: empty,
+		};
+		const closing = reduceDialogExitState(open, {
+			type: "close",
+			snapshot: { secret: "one-time-code", screen: "oauth" },
+		});
+		expect(closing).toEqual({
+			phase: "closing",
+			snapshot: { secret: "one-time-code", screen: "oauth" },
+		});
+
+		expect(reduceDialogExitState(closing, { type: "complete", emptySnapshot: empty })).toEqual({
+			phase: "closed",
+			snapshot: empty,
+		});
+	});
+
+	test("close then reopen leaves the old snapshot out of the clean open phase", () => {
+		const closing = reduceDialogExitState<SecretSnapshot>(
+			{ phase: "open", snapshot: empty },
+			{ type: "close", snapshot: { secret: "old", screen: "oauth" } },
+		);
+		const reopened = reduceDialogExitState(closing, { type: "open" });
+		expect(reopened.phase).toBe("open");
+		expect(dialogExitRenderedValue({ open: false, state: closing, value: empty })).toEqual({
+			secret: "old",
+			screen: "oauth",
+		});
+		expect(dialogExitRenderedValue({ open: true, state: closing, value: empty })).toEqual(empty);
+	});
+});

--- a/apps/web/src/components/ui/use-dialog-exit-lifecycle.ts
+++ b/apps/web/src/components/ui/use-dialog-exit-lifecycle.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useReducer } from "react";
+
+export type DialogExitPhase = "open" | "closing" | "closed";
+
+export interface DialogExitState<T> {
+	phase: DialogExitPhase;
+	snapshot: T;
+}
+
+type DialogExitAction<T> =
+	| { type: "open" }
+	| { type: "close"; snapshot: T }
+	| { type: "complete"; emptySnapshot: T };
+
+export function reduceDialogExitState<T>(
+	state: DialogExitState<T>,
+	action: DialogExitAction<T>,
+): DialogExitState<T> {
+	switch (action.type) {
+		case "open":
+			return { ...state, phase: "open" };
+		case "close":
+			return {
+				phase: "closing",
+				snapshot: action.snapshot,
+			};
+		case "complete":
+			return { ...state, phase: "closed", snapshot: action.emptySnapshot };
+	}
+}
+
+export function dialogExitRenderedValue<T>(input: {
+	open: boolean;
+	state: DialogExitState<T>;
+	value: T;
+}): T {
+	return !input.open && input.state.phase === "closing" ? input.state.snapshot : input.value;
+}
+
+/**
+ * Owns the state boundary between a controlled popup and Base UI's exit window.
+ * `beginClose` only captures the rendered value before the caller closes. The caller
+ * must synchronously invalidate or cancel its async work before or while closing.
+ * `completeClose` clears the snapshot only after Base UI has completed either its
+ * animation or reduced-motion close path.
+ */
+export function useDialogExitLifecycle<T>(input: { open: boolean; value: T; emptyValue: T }) {
+	const { open, value, emptyValue } = input;
+	const [state, dispatch] = useReducer(reduceDialogExitState<T>, {
+		phase: open ? "open" : "closed",
+		snapshot: open ? value : emptyValue,
+	});
+
+	const beginOpen = useCallback(() => {
+		dispatch({ type: "open" });
+	}, []);
+	const beginClose = useCallback(() => {
+		dispatch({ type: "close", snapshot: value });
+	}, [value]);
+	const completeClose = useCallback(() => {
+		dispatch({ type: "complete", emptySnapshot: emptyValue });
+	}, [emptyValue]);
+	return {
+		beginOpen,
+		beginClose,
+		completeClose,
+		phase: state.phase,
+		renderedValue: dialogExitRenderedValue({ open, state, value }),
+	};
+}

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -204,7 +204,6 @@ export function AddKeysDialog({
 						? `${summary.created} new, ${summary.updated} updated, ${summary.skipped} skipped in vault://${slug}.`
 						: `In vault://${slug}. Agents read them through the CLI at runtime.`,
 			});
-			setText("");
 			setOpen(false);
 		} catch (error) {
 			toast.error("Couldn't save keys", { description: errorMessage(error) });
@@ -213,6 +212,7 @@ export function AddKeysDialog({
 	});
 
 	useEffect(() => {
+		if (!open) return;
 		setText("");
 		setNewVaultName("");
 		setVaultChoice(vaultId ?? "");
@@ -227,7 +227,18 @@ export function AddKeysDialog({
 	);
 
 	return (
-		<Dialog open={open} onOpenChange={setOpen}>
+		<Dialog
+			open={open}
+			onOpenChange={setOpen}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) {
+					setText("");
+					setNewVaultName("");
+					setVaultChoice(vaultId ?? "");
+					setUpdateExisting(false);
+				}
+			}}
+		>
 			<DialogTrigger render={trigger} />
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -76,6 +77,8 @@ export function SplitVaultDialog({
 	const [excluded, setExcluded] = useState<Set<string>>(new Set());
 	const [removeOriginals, setRemoveOriginals] = useState(true);
 	const [progress, setProgress] = useState<string | null>(null);
+	const exit = useDialogExitLifecycle({ open, value: progress, emptyValue: null });
+	const renderedProgress = exit.renderedValue;
 
 	const anyProjectId = vault.project_ids?.[0];
 	const selected = useMemo(() => groups.filter((g) => !excluded.has(g.slug)), [groups, excluded]);
@@ -173,7 +176,7 @@ export function SplitVaultDialog({
 		onSuccess: ({ done, failed, affectedKeys }) => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			qc.invalidateQueries({ queryKey: ["vault-items"] });
-			setProgress(null);
+			exit.beginClose();
 			toast.success(`Split into ${done} ${done === 1 ? "vault" : "vaults"}`, {
 				description:
 					`${affectedKeys} keys ${removeOriginals ? "moved" : "copied"} with clean names.` +
@@ -189,7 +192,22 @@ export function SplitVaultDialog({
 	});
 
 	return (
-		<Dialog open={open} onOpenChange={(next) => !run.isPending && setOpen(next)}>
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				if (run.isPending) return;
+				if (next) exit.beginOpen();
+				else exit.beginClose();
+				setOpen(next);
+			}}
+			onOpenChangeComplete={(next) => {
+				if (next) return;
+				exit.completeClose();
+				setProgress(null);
+				setExcluded(new Set());
+				setRemoveOriginals(true);
+			}}
+		>
 			<DialogTrigger render={<Button variant="outline" size="sm" />}>
 				<Scissors className="size-3.5" />
 				Split into vaults…
@@ -271,8 +289,8 @@ export function SplitVaultDialog({
 						onClick={() => run.mutate()}
 					>
 						{run.isPending ? <Spinner /> : <Scissors className="size-3.5" />}
-						{run.isPending && progress
-							? `Splitting ${progress}`
+						{(run.isPending || !open) && renderedProgress
+							? `Splitting ${renderedProgress}`
 							: `Split ${selectedKeyCount} keys into ${selected.length} ${selected.length === 1 ? "vault" : "vaults"}`}
 					</Button>
 				</div>

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -433,7 +433,6 @@ function NewVaultDialog({ trigger }: { trigger?: ReactElement }) {
 		onSuccess: (created) => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			setOpen(false);
-			setName("");
 			toast.success("Vault created", { description: "Add keys, then share it through a Project." });
 			void router.navigate({
 				to: "/vault/$slug",
@@ -453,8 +452,8 @@ function NewVaultDialog({ trigger }: { trigger?: ReactElement }) {
 	return (
 		<Dialog
 			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
+			onOpenChange={setOpen}
+			onOpenChangeComplete={(next) => {
 				if (!next) setName("");
 			}}
 		>

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -305,7 +305,7 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Username"');
 		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Password"');
 		expect(detailSource).toContain(
-			'<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />',
+			'<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />',
 		);
 		expect(detailSource).toContain("Sign in to Hermes");
 		expect(detailSource).toContain("Get your Hermes username and password from Access.");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -83,6 +83,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -1483,6 +1484,8 @@ function RuntimeUiAccessDialog({
 	const loadedIdentityRef = useRef<string | null>(null);
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const [accessHintOpen, setAccessHintOpen] = useState(false);
+	const credentialExit = useDialogExitLifecycle({ open, value: credentials, emptyValue: null });
+	const renderedCredentials = credentialExit.renderedValue;
 	const identity = `${deployment.resource.id}\0${deployment.resource.metadata.resourceVersion}\0${runtime}\0${endpointUrl}`;
 	const accessHintStorageKey = hermesAccessHintStorageKey(deployment.resource.id);
 
@@ -1527,10 +1530,11 @@ function RuntimeUiAccessDialog({
 	useEffect(() => {
 		if (loadedIdentityRef.current === identity) return;
 		loadedIdentityRef.current = identity;
+		if (open) credentialExit.beginClose();
 		clearSensitiveState();
 		setOpen(false);
 		if (runtime === "openclaw") void loadCredentials();
-	}, [clearSensitiveState, identity, loadCredentials, runtime]);
+	}, [clearSensitiveState, credentialExit.beginClose, identity, loadCredentials, open, runtime]);
 
 	useEffect(() => {
 		if (runtime !== "hermes") {
@@ -1546,11 +1550,21 @@ function RuntimeUiAccessDialog({
 
 	const handleOpenChange = useCallback(
 		(nextOpen: boolean) => {
+			if (nextOpen) credentialExit.beginOpen();
+			else credentialExit.beginClose();
 			setOpen(nextOpen);
 			if (nextOpen && runtime === "hermes") dismissAccessHint();
 			if (nextOpen && !credentials && !isLoading) void loadCredentials();
 		},
-		[credentials, dismissAccessHint, isLoading, loadCredentials, runtime],
+		[
+			credentialExit.beginClose,
+			credentialExit.beginOpen,
+			credentials,
+			dismissAccessHint,
+			isLoading,
+			loadCredentials,
+			runtime,
+		],
 	);
 
 	const openRuntime = useCallback(async () => {
@@ -1596,12 +1610,19 @@ function RuntimeUiAccessDialog({
 
 	const acceptReset = useCallback(async () => {
 		await reset.mutateAsync({ id: deployment.resource.id });
+		credentialExit.beginClose();
 		clearSensitiveState();
 		setOpen(false);
-	}, [clearSensitiveState, deployment.resource.id, reset]);
+	}, [clearSensitiveState, credentialExit.beginClose, deployment.resource.id, reset]);
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={handleOpenChange}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) credentialExit.completeClose();
+			}}
+		>
 			<div className="flex items-center gap-1.5">
 				<Popover
 					open={runtime === "hermes" && accessHintOpen}
@@ -1651,7 +1672,7 @@ function RuntimeUiAccessDialog({
 					onClick={() => void openRuntime()}
 					aria-label={`Open ${label} in new window`}
 				>
-					{isLoading && !credentials ? (
+					{isLoading && !renderedCredentials ? (
 						<Spinner className="size-3.5" />
 					) : (
 						<ExternalLink className="size-3.5" />
@@ -1693,17 +1714,17 @@ function RuntimeUiAccessDialog({
 					/>
 				) : null}
 
-				{credentials?.runtime === "hermes" ? (
+				{renderedCredentials?.runtime === "hermes" ? (
 					<div className="overflow-hidden rounded-lg border bg-card/60">
-						<RuntimeUiCredentialRow label="Username" value={credentials.username} />
+						<RuntimeUiCredentialRow label="Username" value={renderedCredentials.username} />
 						<Separator />
-						<RuntimeUiCredentialRow label="Password" value={credentials.password} secret />
+						<RuntimeUiCredentialRow label="Password" value={renderedCredentials.password} secret />
 					</div>
 				) : null}
 
-				{credentials?.runtime === "openclaw" ? (
+				{renderedCredentials?.runtime === "openclaw" ? (
 					<div className="overflow-hidden rounded-lg border bg-card/60">
-						<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />
+						<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />
 					</div>
 				) : null}
 
@@ -3285,16 +3306,12 @@ function ComputeSettingsSections({
 		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
 		setSubscriptionCreateOpen(false);
 		setPlanChangeOpen(false);
-		setPlanChangeQuote(null);
 		setPendingPlanChangeName(null);
 		walletTopUp.reset();
 	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, walletTopUp.reset]);
 
 	function setPlanChangeDialogOpen(open: boolean) {
 		setPlanChangeOpen(open);
-		if (!open && pendingPlanChangeName === null) {
-			setPlanChangeQuote(null);
-		}
 	}
 
 	async function requestPlanChangeQuote(selection: PlanChangeSelection) {
@@ -3346,7 +3363,6 @@ function ComputeSettingsSections({
 				});
 			}
 			setPendingPlanChangeName(null);
-			setPlanChangeQuote(null);
 			setPlanChangeDialogOpen(false);
 		} catch (error) {
 			if (error instanceof PlanChangePendingError) {
@@ -3435,6 +3451,9 @@ function ComputeSettingsSections({
 					onQuote={requestPlanChangeQuote}
 					onConfirm={confirmPlanChange}
 					onTopUp={() => walletTopUp.show()}
+					onExitComplete={() => {
+						if (pendingPlanChangeName === null) setPlanChangeQuote(null);
+					}}
 				/>
 			) : null}
 

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
 import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import { env } from "@/lib/env";
@@ -41,6 +42,10 @@ type StripeCheckoutDialogProps = {
 };
 
 type DialogState = "loading" | "ready" | "error";
+type RetainedCheckout = Pick<
+	StripeCheckoutDialogProps,
+	"clientSecret" | "description" | "summary" | "title"
+>;
 type CheckoutAppearance = NonNullable<
 	NonNullable<StripeCheckoutElementsSdkOptions["elementsOptions"]>["appearance"]
 >;
@@ -291,6 +296,12 @@ export function StripeCheckoutDialog({
 	const [message, setMessage] = useState<string | null>(null);
 	const [attempt, setAttempt] = useState(0);
 	const [checkoutSubmitting, setCheckoutSubmitting] = useState(false);
+	const checkout = { clientSecret, description, summary, title } satisfies RetainedCheckout;
+	const exit = useDialogExitLifecycle({
+		open,
+		value: checkout,
+		emptyValue: { clientSecret: null, description: "", summary: null, title: "" },
+	});
 	const appearance = useCheckoutAppearance(open);
 	const onCompleteRef = useRef(onComplete);
 
@@ -298,9 +309,13 @@ export function StripeCheckoutDialog({
 		onCompleteRef.current = onComplete;
 	}, [onComplete]);
 
+	const renderedCheckout = exit.renderedValue;
+	const renderedClientSecret = renderedCheckout.clientSecret;
+
 	const completeCheckout = useCallback(() => {
+		exit.beginClose();
 		onCompleteRef.current();
-	}, []);
+	}, [exit.beginClose]);
 
 	const handleProviderLoadError = useCallback(() => {
 		setState("error");
@@ -308,7 +323,7 @@ export function StripeCheckoutDialog({
 	}, []);
 
 	useEffect(() => {
-		if (!open || !clientSecret) return;
+		if (!open || !renderedClientSecret) return;
 		let cancelled = false;
 		setCheckoutSubmitting(false);
 		setStripe(null);
@@ -341,12 +356,12 @@ export function StripeCheckoutDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [attempt, clientSecret, key, open]);
+	}, [attempt, key, open, renderedClientSecret]);
 
 	const providerOptions = useMemo<StripeCheckoutElementsSdkOptions | null>(() => {
-		if (!clientSecret) return null;
+		if (!renderedClientSecret) return null;
 		return {
-			clientSecret,
+			clientSecret: renderedClientSecret,
 			elementsOptions: {
 				appearance,
 				loader: "auto",
@@ -356,29 +371,43 @@ export function StripeCheckoutDialog({
 				},
 			},
 		};
-	}, [appearance, clientSecret]);
+	}, [appearance, renderedClientSecret]);
 
 	function requestOpenChange(nextOpen: boolean) {
 		if (!nextOpen && checkoutSubmitting) return;
+		if (nextOpen) exit.beginOpen();
+		else exit.beginClose();
 		onOpenChange(nextOpen);
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={requestOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={requestOpenChange}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) {
+					exit.completeClose();
+					setStripe(null);
+					setMessage(null);
+					setState("loading");
+					setCheckoutSubmitting(false);
+				}
+			}}
+		>
 			<DialogContent
 				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
 				data-hosted="true"
 				showCloseButton={!checkoutSubmitting}
 			>
 				<DialogHeader>
-					<DialogTitle>{title}</DialogTitle>
-					<DialogDescription>{description}</DialogDescription>
+					<DialogTitle>{renderedCheckout.title}</DialogTitle>
+					<DialogDescription>{renderedCheckout.description}</DialogDescription>
 				</DialogHeader>
-				<CheckoutSummaryPanel summary={summary} />
+				<CheckoutSummaryPanel summary={renderedCheckout.summary} />
 				<Separator />
 				{state === "ready" && stripe && providerOptions ? (
 					<CheckoutElementsProvider
-						key={`${clientSecret}:${attempt}`}
+						key={`${renderedClientSecret}:${attempt}`}
 						stripe={stripe}
 						options={providerOptions}
 					>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -181,13 +181,13 @@ describe("deploy wizard product copy and flow", () => {
 describe("hosted agent security and copy", () => {
 	test("shows the Hermes username and masks Hermes and OpenClaw secrets", () => {
 		expect(agentDetailSource).toContain(
-			'<RuntimeUiCredentialRow label="Username" value={credentials.username} />',
+			'<RuntimeUiCredentialRow label="Username" value={renderedCredentials.username} />',
 		);
 		expect(agentDetailSource).toContain(
-			'<RuntimeUiCredentialRow label="Password" value={credentials.password} secret />',
+			'<RuntimeUiCredentialRow label="Password" value={renderedCredentials.password} secret />',
 		);
 		expect(agentDetailSource).toContain(
-			'<RuntimeUiCredentialRow label="Token" value={credentials.token} secret />',
+			'<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />',
 		);
 		expect(agentDetailSource).not.toContain("hermes-password-");
 		expect(agentDetailSource).not.toContain("openclaw-token-");

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import { WalletDebitEquation } from "@/hosted/billing/components/wallet-debit-equation";
 import type {
@@ -72,6 +73,7 @@ export function PlanChangeDialog({
 	onQuote,
 	onConfirm,
 	onTopUp,
+	onExitComplete,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -88,6 +90,7 @@ export function PlanChangeDialog({
 	onQuote: (selection: PlanChangeSelection) => void;
 	onConfirm: (operationId: string) => void;
 	onTopUp?: () => void;
+	onExitComplete?: () => void;
 }) {
 	const initialSelection = useMemo(
 		() =>
@@ -95,6 +98,8 @@ export function PlanChangeDialog({
 		[currentBillingTermMonths, currentPlanSlug, defaultFundingSource],
 	);
 	const [selection, setSelection] = useState(initialSelection);
+	const exit = useDialogExitLifecycle({ open, value: quote, emptyValue: null });
+	const displayedQuote = exit.renderedValue;
 	const selectedPlan =
 		selection.target_plan_slug === "compute_performance"
 			? resolvePerformancePlan(plans)
@@ -108,16 +113,16 @@ export function PlanChangeDialog({
 		(offer) => offer.billing_term_months === selection.target_billing_term_months,
 	);
 	const noChange = isSamePlanChangeSelection(selection, currentPlanSlug, currentBillingTermMonths);
-	const quoteFundingSource = quote?.funding_source ?? selection.funding_source;
+	const quoteFundingSource = displayedQuote?.funding_source ?? selection.funding_source;
 	const walletBalanceAfter =
-		quoteFundingSource === "wallet" && quote?.amount_usd && walletBalanceUsd
-			? walletBalanceAfterDebit(walletBalanceUsd, quote.amount_usd)
+		quoteFundingSource === "wallet" && displayedQuote?.amount_usd && walletBalanceUsd
+			? walletBalanceAfterDebit(walletBalanceUsd, displayedQuote.amount_usd)
 			: null;
 	const walletInsufficient = walletBalanceAfter?.startsWith("-") ?? false;
 	const walletQuoteMissingAmount =
 		quoteFundingSource === "wallet" &&
-		quote?.change_kind === "immediate_upgrade" &&
-		!quote.amount_usd;
+		displayedQuote?.change_kind === "immediate_upgrade" &&
+		!displayedQuote.amount_usd;
 	const walletReady = selection.funding_source !== "wallet" || walletBalanceUsd !== null;
 
 	useEffect(() => {
@@ -151,71 +156,85 @@ export function PlanChangeDialog({
 	}
 
 	const quoteTitle =
-		quote?.change_kind === "immediate_upgrade" ? "Confirm immediate upgrade" : "Schedule downgrade";
+		displayedQuote?.change_kind === "immediate_upgrade"
+			? "Confirm immediate upgrade"
+			: "Schedule downgrade";
 	const confirmLabel =
-		quote?.change_kind === "immediate_upgrade" ? "Confirm upgrade" : "Schedule downgrade";
+		displayedQuote?.change_kind === "immediate_upgrade" ? "Confirm upgrade" : "Schedule downgrade";
 	const busyLabel =
-		quote?.change_kind === "immediate_upgrade"
+		displayedQuote?.change_kind === "immediate_upgrade"
 			? "Confirming plan change…"
 			: "Scheduling downgrade…";
 	const blocksClose = isQuoting || (isConfirming && !hasAcceptedChange);
+	function requestOpenChange(nextOpen: boolean) {
+		if (blocksClose) return;
+		if (nextOpen) exit.beginOpen();
+		else exit.beginClose();
+		onOpenChange(nextOpen);
+	}
 
 	return (
 		<Dialog
 			open={open}
-			onOpenChange={(nextOpen) => {
-				if (!blocksClose) onOpenChange(nextOpen);
+			onOpenChange={requestOpenChange}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) {
+					exit.completeClose();
+					onExitComplete?.();
+				}
 			}}
 		>
 			<DialogContent data-hosted="true" className="sm:max-w-lg" showCloseButton={!blocksClose}>
 				<DialogHeader>
-					<DialogTitle>{quote ? quoteTitle : "Change compute subscription"}</DialogTitle>
+					<DialogTitle>{displayedQuote ? quoteTitle : "Change compute subscription"}</DialogTitle>
 					<DialogDescription>
-						{quote
-							? quote.change_kind === "immediate_upgrade"
+						{displayedQuote
+							? displayedQuote.change_kind === "immediate_upgrade"
 								? "The quoted proration is charged now. Compute changes after payment is confirmed."
-								: `The current plan remains active until ${formatShortDate(quote.effective_at)}.`
+								: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
 							: "Choose a compute plan and monthly or annual billing, then review the exact price and timing."}
 					</DialogDescription>
 				</DialogHeader>
 
-				{quote ? (
+				{displayedQuote ? (
 					<div className="flex flex-col gap-4">
 						<div className="grid gap-3 rounded-lg border bg-muted/20 p-3 sm:grid-cols-2">
 							<dl>
 								<dt className="text-xs text-muted-foreground">New subscription</dt>
 								<dd className="font-medium">
-									{computeTierLabel(planSlug(quote.target_plan_slug))} ·{" "}
-									{billingTermLabel(quote.target_billing_term_months)}
+									{computeTierLabel(planSlug(displayedQuote.target_plan_slug))} ·{" "}
+									{billingTermLabel(displayedQuote.target_billing_term_months)}
 								</dd>
 							</dl>
 							<dl>
 								<dt className="text-xs text-muted-foreground">
-									{quote.change_kind === "immediate_upgrade" ? "Due now" : "Effective date"}
+									{displayedQuote.change_kind === "immediate_upgrade"
+										? "Due now"
+										: "Effective date"}
 								</dt>
 								<dd className="font-medium tabular-nums">
-									{quote.change_kind === "immediate_upgrade"
+									{displayedQuote.change_kind === "immediate_upgrade"
 										? quoteFundingSource === "wallet"
-											? quote.amount_usd
-												? formatUsdExact(quote.amount_usd)
+											? displayedQuote.amount_usd
+												? formatUsdExact(displayedQuote.amount_usd)
 												: "—"
-											: formatCents(quote.amount_cents)
-										: formatShortDate(quote.effective_at)}
+											: formatCents(displayedQuote.amount_cents)
+										: formatShortDate(displayedQuote.effective_at)}
 								</dd>
 							</dl>
 						</div>
 						{quoteFundingSource === "wallet" &&
-						quote.change_kind === "immediate_upgrade" &&
-						quote.amount_usd &&
+						displayedQuote.change_kind === "immediate_upgrade" &&
+						displayedQuote.amount_usd &&
 						walletBalanceUsd &&
 						walletBalanceAfter ? (
 							<WalletDebitEquation
 								balanceBeforeUsd={walletBalanceUsd}
-								debitAmountUsd={quote.amount_usd}
+								debitAmountUsd={displayedQuote.amount_usd}
 								balanceAfterUsd={walletBalanceAfter}
 							/>
 						) : null}
-						{quote.change_kind === "scheduled_downgrade" ? (
+						{displayedQuote.change_kind === "scheduled_downgrade" ? (
 							<Alert>
 								<CalendarClock aria-hidden />
 								<AlertTitle>No charge today</AlertTitle>
@@ -260,11 +279,15 @@ export function PlanChangeDialog({
 							</Alert>
 						) : null}
 						<DialogFooter>
-							<Button variant="ghost" onClick={() => onOpenChange(false)} disabled={blocksClose}>
+							<Button
+								variant="ghost"
+								onClick={() => requestOpenChange(false)}
+								disabled={blocksClose}
+							>
 								{hasAcceptedChange ? "Close" : "Back"}
 							</Button>
 							<Button
-								onClick={() => onConfirm(quote.operation_id)}
+								onClick={() => onConfirm(displayedQuote.operation_id)}
 								disabled={isConfirming || walletInsufficient || walletQuoteMissingAmount}
 							>
 								{isConfirming ? (
@@ -365,7 +388,7 @@ export function PlanChangeDialog({
 							</p>
 						) : null}
 						<DialogFooter>
-							<Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isQuoting}>
+							<Button variant="ghost" onClick={() => requestOpenChange(false)} disabled={isQuoting}>
 								Cancel
 							</Button>
 							<Button

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -137,7 +137,6 @@ export function TopUpDialog({
 
 	function close(next: boolean) {
 		if (!next && (topUp.isPending || paymentSubmitting)) return;
-		if (!next) reset();
 		onOpenChange(next);
 	}
 
@@ -167,7 +166,6 @@ export function TopUpDialog({
 				// Successful completion is not a dismiss attempt. Close directly so the
 				// in-flight guard cannot leave a completed payment flow stranded open.
 				closeDialog: () => {
-					reset();
 					onOpenChange(false);
 				},
 				toastInfo: toast.info,
@@ -191,8 +189,6 @@ export function TopUpDialog({
 	// inline by StripePaymentForm, which keeps the payment flow open until it settles
 	// rather than closing on an unconfirmed payment.
 	function onPaid(status: PaymentOutcome) {
-		setClientSecret(null);
-		setStep("amount");
 		setPaymentSubmitting(false);
 		completeTopup(status === "succeeded" ? "succeeded" : "processing", {
 			queryClient: qc,
@@ -311,7 +307,13 @@ export function TopUpDialog({
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={close}>
+		<Dialog
+			open={open}
+			onOpenChange={close}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) reset();
+			}}
+		>
 			<DialogContent
 				className="sm:max-w-md"
 				data-hosted="true"

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -13,6 +13,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
@@ -94,10 +95,12 @@ export function AddProviderDialog({
 		null,
 	);
 	const acceptAttemptRef = useRef<AcceptAttempt | null>(null);
+	const dialogSessionRef = useRef(0);
 	const {
 		session: oauth,
 		issue: oauthIssue,
-		cancel: cancelOAuth,
+		invalidate: invalidateOAuth,
+		clear: clearOAuth,
 		transition: transitionOAuth,
 	} = useProviderOAuthDeviceFlow({
 		poll: (session) =>
@@ -105,9 +108,16 @@ export function AddProviderDialog({
 		onReady: (session) => {
 			toast.success("Signed in with ChatGPT");
 			if (session.mode === "accept") onCreated?.(session.providerId);
-			onOpenChange(false);
+			requestClose(false);
 		},
 	});
+	const oauthExit = useDialogExitLifecycle({
+		open,
+		value: { session: oauth, issue: oauthIssue },
+		emptyValue: { session: null, issue: null },
+	});
+	const renderedOAuth = oauthExit.renderedValue.session;
+	const renderedOAuthIssue = oauthExit.renderedValue.issue;
 
 	const selectedPreset = providerPresetById(form.presetId);
 	const selectedRegion = selectedPreset
@@ -139,8 +149,10 @@ export function AddProviderDialog({
 		(form.authMethod === "oauth" || savedCredentialAvailable || Boolean(form.apiKey.trim()));
 
 	useEffect(() => {
-		cancelOAuth();
 		if (!open) return;
+		oauthExit.beginOpen();
+		invalidateOAuth();
+		clearOAuth();
 		setDraftTestResult(null);
 		acceptAttemptRef.current = null;
 
@@ -188,7 +200,7 @@ export function AddProviderDialog({
 			regionId: null,
 		});
 		setStep("choose");
-	}, [cancelOAuth, open, editing, resetForm]);
+	}, [clearOAuth, editing, invalidateOAuth, oauthExit.beginOpen, open, resetForm]);
 
 	function selectProvider(choice: ProviderChoice) {
 		acceptAttemptRef.current = null;
@@ -354,9 +366,8 @@ export function AddProviderDialog({
 					})
 					.catch(() => null);
 				if (result?.status !== "ready") return;
-				updateForm({ apiKey: "" });
 				toast.success("Provider updated");
-				onOpenChange(false);
+				requestClose(false);
 				return;
 			}
 			const patch = {
@@ -376,7 +387,7 @@ export function AddProviderDialog({
 				.catch(() => null);
 			if (!saved) return;
 			toast.success("Provider settings updated");
-			onOpenChange(false);
+			requestClose(false);
 			return;
 		}
 
@@ -398,15 +409,15 @@ export function AddProviderDialog({
 			.catch(() => null);
 		if (result?.status !== "ready") return;
 		toast.success("Provider added");
-		updateForm({ apiKey: "" });
 		onCreated?.(result.provider.provider_id);
-		onOpenChange(false);
+		requestClose(false);
 	}
 
 	async function testDraftConnection() {
 		const credential = form.apiKey.trim();
 		if (!credential || form.authMethod !== "api_key") return;
 		setDraftTestResult(null);
+		const dialogSession = dialogSessionRef.current;
 		const result = await testDraft
 			.execute({
 				provider: providerBody(),
@@ -414,17 +425,27 @@ export function AddProviderDialog({
 				model: modelsFromText(form.modelsText, editing?.models, presetCatalog)?.[0]?.id ?? null,
 			})
 			.catch(() => null);
-		if (!result) return;
+		if (!result || dialogSession !== dialogSessionRef.current) return;
 		setDraftTestResult(result);
 		if (result.ok) toast.success("Connection verified");
 	}
 
 	function requestClose(next: boolean) {
 		if (!next) {
-			cancelOAuth();
-			updateForm({ apiKey: "" });
+			oauthExit.beginClose();
+			dialogSessionRef.current += 1;
+			invalidateOAuth();
 		}
 		onOpenChange(next);
+	}
+
+	function completeOpenChange(next: boolean) {
+		if (next) return;
+		clearOAuth();
+		oauthExit.completeClose();
+		updateForm({ apiKey: "" });
+		setDraftTestResult(null);
+		acceptAttemptRef.current = null;
 	}
 
 	async function restartOAuth() {
@@ -442,7 +463,7 @@ export function AddProviderDialog({
 		oauthDevicePoll.isPending;
 
 	return (
-		<Dialog open={open} onOpenChange={requestClose}>
+		<Dialog open={open} onOpenChange={requestClose} onOpenChangeComplete={completeOpenChange}>
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
@@ -450,7 +471,7 @@ export function AddProviderDialog({
 			>
 				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
 					<DialogTitle>
-						{oauth
+						{renderedOAuth
 							? "Sign in with ChatGPT"
 							: isEdit
 								? (editing?.readiness?.deployable ?? editing?.usable) &&
@@ -462,7 +483,7 @@ export function AddProviderDialog({
 									: `Set up ${providerLabel}`}
 					</DialogTitle>
 					<DialogDescription>
-						{oauth
+						{renderedOAuth
 							? "Open ChatGPT, enter the one-time code, and this page will finish automatically."
 							: isOAuthEdit
 								? "Subscription access is ready. Reconnect only to change or repair the account."
@@ -482,11 +503,11 @@ export function AddProviderDialog({
 					data-testid="provider-dialog-body"
 					className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4 sm:px-6"
 				>
-					{oauth ? (
+					{renderedOAuth ? (
 						<ProviderOAuthFlow
-							issue={oauthIssue}
-							verificationUrl={oauth.verificationUrl}
-							userCode={oauth.userCode}
+							issue={renderedOAuthIssue}
+							verificationUrl={renderedOAuth.verificationUrl}
+							userCode={renderedOAuth.userCode}
 							starting={acceptProvider.isPending || oauthDeviceStart.isPending}
 							polling={oauthDevicePoll.isPending}
 							onRestart={() => void runAction(restartOAuth)}
@@ -544,9 +565,9 @@ export function AddProviderDialog({
 					)}
 				</div>
 
-				{step === "choose" && !isEdit && !oauth ? null : (
+				{step === "choose" && !isEdit && !renderedOAuth ? null : (
 					<DialogFooter className="shrink-0 border-t bg-popover px-5 py-3 sm:px-6 sm:py-4">
-						{oauth ? (
+						{renderedOAuth ? (
 							<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
 								Cancel
 							</Button>

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -206,20 +206,24 @@ function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage
 	function changeOpen(next: boolean) {
 		if (del.isPending) return;
 		setOpen(next);
-		if (!next) setAcknowledged(false);
 	}
 
 	function removeProvider() {
 		del.mutate(provider.provider_id, {
 			onSuccess: () => {
 				setOpen(false);
-				setAcknowledged(false);
 			},
 		});
 	}
 
 	return (
-		<AlertDialog open={open} onOpenChange={changeOpen}>
+		<AlertDialog
+			open={open}
+			onOpenChange={changeOpen}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) setAcknowledged(false);
+			}}
+		>
 			<AlertDialogTrigger
 				render={
 					<Button

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
@@ -42,12 +42,17 @@ export function ProviderConnectionTest({
 
 	function changeOpen(next: boolean) {
 		setOpen(next);
-		if (!next) testConnection.reset();
 	}
 
 	const result = testConnection.data;
 	return (
-		<Dialog open={open} onOpenChange={changeOpen}>
+		<Dialog
+			open={open}
+			onOpenChange={changeOpen}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) testConnection.reset();
+			}}
+		>
 			<DialogTrigger
 				render={
 					<Button variant="ghost" size="sm" aria-label={`Test connection for ${providerLabel}`} />

--- a/apps/web/src/hosted/v2/ai-providers/use-provider-oauth-device-flow.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-provider-oauth-device-flow.ts
@@ -68,8 +68,11 @@ export function useProviderOAuthDeviceFlow({
 	pollRef.current = poll;
 	onReadyRef.current = onReady;
 
-	const cancel = useCallback(() => {
+	const invalidate = useCallback(() => {
 		cancelOAuthSessionLifecycle(lifecycleRef.current);
+	}, []);
+
+	const clear = useCallback(() => {
 		setIssue(null);
 		setSession(null);
 	}, []);
@@ -167,5 +170,5 @@ export function useProviderOAuthDeviceFlow({
 		};
 	}, [session]);
 
-	return { session, issue, cancel, transition };
+	return { session, issue, invalidate, clear, transition };
 }

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -162,9 +162,12 @@ export function ConnectBotDialog({
 		if (!nextOpen) {
 			dialogSessionRef.current += 1;
 			setToken("");
-			setCreated(null);
 		}
 		onOpenChange(nextOpen);
+	}
+
+	function handleOpenChangeComplete(nextOpen: boolean) {
+		if (!nextOpen) setCreated(null);
 	}
 
 	const providerChoices = (
@@ -192,7 +195,11 @@ export function ConnectBotDialog({
 	);
 
 	return (
-		<Dialog open={open} onOpenChange={handleOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={handleOpenChange}
+			onOpenChangeComplete={handleOpenChangeComplete}
+		>
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -154,8 +154,6 @@ export default function ProjectsPage() {
 			return unwrap(await api.POST("/v1/projects", { body: payload }));
 		},
 		onSuccess: (project) => {
-			setNewProjectName("");
-			setNewProjectSlug("");
 			setCreateOpen(false);
 			qc.invalidateQueries({ queryKey: ["projects"] });
 			toast.success("Project created", {
@@ -215,8 +213,8 @@ export default function ProjectsPage() {
 
 			<Dialog
 				open={createOpen}
-				onOpenChange={(open) => {
-					setCreateOpen(open);
+				onOpenChange={setCreateOpen}
+				onOpenChangeComplete={(open) => {
 					if (!open) {
 						setNewProjectName("");
 						setNewProjectSlug("");

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -914,6 +914,8 @@ function ShareKeysDialog({
 			open={open}
 			onOpenChange={(next) => {
 				setOpen(next);
+			}}
+			onOpenChangeComplete={(next) => {
 				if (!next) reset();
 			}}
 		>


### PR DESCRIPTION
## Summary

- defer non-sensitive caller state resets to Base UI `onOpenChangeComplete(false)` so Dialog, AlertDialog, and related popup exit animations retain their current visual state
- invalidate stale async writes immediately on close while retaining checkout, quote, result, and runtime credential payloads only for the existing exit window
- keep success/pending visuals stable through auto-close and make Stop all sharing explicitly controlled
- cover Escape/manual close, clean reopen, secret success auto-close, and mutation-driven row removal in the API key Playwright flow

This follow-up is rebased on `165b5d07e` (#725). The merged Telegram/Discord pairing lifecycle files are unchanged.

## Verification

- `bun test apps/web/src/components/dialog-exit-lifecycle.test.ts` (3 passed)
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web e2e api-keys-settings.pw.ts` (2 Chromium tests passed; desktop and narrow-screen screenshot attachments)
- `bun test apps/web/src/hosted/agents/deployment-hooks.test.ts apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts` (43 passed)
- `bun run --cwd apps/web test` (Docker clean runner: 853 passed)
- `bun run --cwd apps/web build:oss`
- `bun run check`

## Boundaries

Code, tests, and this PR only. No merge, deploy, production, tenant, payment-provider, Discord Portal, or other live operations were performed.
