### PR TITLE
fix(cli): stop cleanly after agent disconnect

### DIFF
--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -137,7 +137,7 @@ export function AgentSettingsPanel({
 			),
 		onSuccess: () => {
 			toast.success("Agent disconnected", {
-				description: "Sessions, Skills, and Projects are retained until it reconnects.",
+				description: "Data is retained. Run `clawdi setup` on this installation to reconnect.",
 			});
 			queryClient.invalidateQueries({
 				predicate: (q) => {
@@ -193,8 +193,8 @@ export function AgentSettingsPanel({
 	const nameChanged = normalizedDraftName !== currentCustomName;
 	const hasCustomAvatar = Boolean(agent.avatar_url);
 	const ownershipKind = agentOwnershipKindFromId(agent.id, ownership);
-	// Disconnect deregisters the environment — destructive, so it must wait
-	// for RESOLVED ownership (`ownership !== null`). While the hosted sensor
+	// Disconnect archives the active Agent and Project, so it must wait for
+	// RESOLVED ownership (`ownership !== null`). While the hosted sensor
 	// is still resolving, a live hosted/legacy agent would otherwise briefly
 	// classify as connected and expose a working Disconnect.
 	const disconnectUnavailable = agentDisconnectUnavailable({
@@ -367,20 +367,19 @@ export function AgentSettingsPanel({
 			{!disconnectUnavailable ? (
 				<SettingsSection
 					title="Disconnect"
-					description="Remove this connected agent from your dashboard."
+					description="Stop this installation while keeping its Clawdi data."
 					variant="destructive"
 				>
 					<div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 						<p className="max-w-md text-sm text-muted-foreground">
-							The agent stops syncing here. Existing sessions, skills, and Projects stay in your
-							account.
+							Sync stops and retained Sessions, Skills, files, and Projects stay in your account.
 						</p>
 						<ConfirmAction
 							title="Disconnect this agent?"
 							description={
 								<p>
-									Sync stops and the Agent leaves active views. Sessions, Skills, and Projects are
-									retained and return when it reconnects.
+									Disconnect stops this installation and removes it from active views. Run{" "}
+									<code>clawdi setup</code> on it to reconnect with the same retained data.
 								</p>
 							}
 							confirmLabel="Disconnect agent"

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -137,7 +137,7 @@ export function AgentSettingsPanel({
 			),
 		onSuccess: () => {
 			toast.success("Agent disconnected", {
-				description: "Data is retained. Run `clawdi setup` on this installation to reconnect.",
+				description: "Data is retained. Run clawdi setup on this installation to reconnect.",
 			});
 			queryClient.invalidateQueries({
 				predicate: (q) => {

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -126,6 +126,7 @@ _AGENT_AVATAR_PREFIX = "agent-avatars/"
 _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$")
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
 _HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
+_AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected"
 _RUNTIME_OBSERVED_ADAPTER = TypeAdapter(HostedRuntimeObserved)
 _MANUAL_SESSION_SUMMARY_FILTER = text(
     "(sessions.summary IS NULL OR "
@@ -435,13 +436,24 @@ async def _get_agent_identity(
             .where(
                 AgentEnvironment.id == agent_id,
                 AgentEnvironment.user_id == auth.user_id,
-                active_agent_filter(),
             )
         )
     ).first()
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
     env, state = row
+    if env.archived_at is not None:
+        # The owner may distinguish their retained, disconnected identity from
+        # a random id. The user_id predicate above and bound-id fence before the
+        # query keep nonexistent, cross-owner, and mismatched bound ids at 404.
+        # Released daemons already treat 403 as a no-restart supervisor stop.
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": _AGENT_DISCONNECTED_ERROR_CODE,
+                "message": "Agent is disconnected",
+            },
+        )
     payload = _identity_response(env, state, agent_response=agent_response)
     etag = strong_json_etag(payload.model_dump(mode="json"))
     headers = {"ETag": etag, "Cache-Control": "private, no-cache"}

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -9,7 +9,11 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import AuthContext, get_auth, get_auth_short_session
+from app.main import app
+from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
+from app.models.user import User
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
 
 _DEPRECATED_HOSTED_FIELDS = {"hosted_managed", "hosted_deployment_id"}
@@ -217,8 +221,66 @@ async def test_agent_delete_disconnects_self_managed_agent(client: httpx.AsyncCl
     response = await client.delete(f"/v1/agents/{agent_id}")
     assert response.status_code == 204, response.text
 
-    detail = await client.get(f"/v1/agents/{agent_id}")
-    assert detail.status_code == 404
+    expected_detail = {
+        "detail": {
+            "code": "agent_disconnected",
+            "message": "Agent is disconnected",
+        }
+    }
+    for path in (
+        f"/v1/agents/{agent_id}",
+        f"/v1/environments/{agent_id}",
+        f"/api/agents/{agent_id}",
+        f"/api/environments/{agent_id}",
+    ):
+        detail = await client.get(path)
+        assert detail.status_code == 403, (path, detail.text)
+        assert detail.json() == expected_detail
+
+    assert (await client.get("/v1/agents")).json() == []
+    assert (await client.get("/v1/environments")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_archived_agent_detail_does_not_leak_to_missing_wrong_owner_or_bound_mismatch(
+    client: httpx.AsyncClient,
+    seed_user,
+):
+    agent_id = await _register_agent(client)
+    disconnected = await client.delete(f"/v1/agents/{agent_id}")
+    assert disconnected.status_code == 204, disconnected.text
+
+    missing_id = uuid.uuid4()
+    assert (await client.get(f"/v1/agents/{missing_id}")).status_code == 404
+    assert (await client.get(f"/v1/environments/{missing_id}")).status_code == 404
+
+    other_user = User(
+        id=uuid.uuid4(),
+        clerk_id=f"other_{uuid.uuid4().hex}",
+        email="other@example.test",
+        name="Other",
+    )
+
+    async def wrong_owner_auth() -> AuthContext:
+        return AuthContext(user=other_user)
+
+    app.dependency_overrides[get_auth] = wrong_owner_auth
+    app.dependency_overrides[get_auth_short_session] = wrong_owner_auth
+    assert (await client.get(f"/v1/agents/{agent_id}")).status_code == 404
+    assert (await client.get(f"/v1/environments/{agent_id}")).status_code == 404
+
+    mismatched_key = ApiKey(
+        user_id=seed_user.id,
+        environment_id=uuid.uuid4(),
+    )
+
+    async def mismatched_bound_auth() -> AuthContext:
+        return AuthContext(user=seed_user, api_key=mismatched_key)
+
+    app.dependency_overrides[get_auth] = mismatched_bound_auth
+    app.dependency_overrides[get_auth_short_session] = mismatched_bound_auth
+    assert (await client.get(f"/v1/agents/{agent_id}")).status_code == 404
+    assert (await client.get(f"/v1/environments/{agent_id}")).status_code == 404
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1507,13 +1507,21 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     client: httpx.AsyncClient, db_session: AsyncSession, seed_user
 ):
     """Disconnect keeps the stable Agent identity attached to history."""
-    machine_id = f"delete-oauth-claim-{uuid.uuid4().hex}"
+    machine_id = f"disconnect-oauth-claim-{uuid.uuid4().hex}"
     env_id = await _register_env_named(client, machine_id, agent_type="codex")
 
     from app.models.ai_provider import AiProviderAuthPayload
+    from app.models.project import Project
+    from app.models.session import AgentEnvironment
     from app.services.ai_provider_credentials import environment_matches_runtime
     from app.services.runtime_source import load_runtime_source_batch
     from app.services.vault_crypto import encrypt
+
+    agent = await db_session.get(AgentEnvironment, uuid.UUID(env_id))
+    assert agent is not None
+    project_id = agent.default_project_id
+    project = await db_session.get(Project, project_id)
+    assert project is not None
 
     encrypted, nonce = encrypt('{"kind":"oauth-test"}')
     claimed_payload = AiProviderAuthPayload(
@@ -1545,7 +1553,7 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
                     "local_session_id": "keep-me",
                     "started_at": started,
                     "message_count": 1,
-                    "summary": "should survive deletion",
+                    "summary": "should survive disconnect",
                 }
             ]
         },
@@ -1564,12 +1572,8 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     assert item["agent_type"] == "codex"
     assert item["machine_name"] == f"mac-{machine_id}"
 
-    # The decisive check: after the DELETE, the session's environment_id
-    # column is NULL (not the deleted UUID). This only happens because the
-    # FK has ON DELETE SET NULL — without the constraint, the column would
-    # still hold the now-dangling reference. Filter by the deleted env_id
-    # so prior test runs (the test DB doesn't fully clean between runs)
-    # don't pollute the count.
+    # The decisive check: Disconnect archives in place, so the Session keeps
+    # its stable environment_id. No hard delete or FK cascade runs here.
     row = (
         await db_session.execute(
             text(
@@ -1581,6 +1585,10 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
         )
     ).one()
     assert str(row.environment_id) == env_id
+    await db_session.refresh(agent)
+    await db_session.refresh(project)
+    assert agent.archived_at is not None
+    assert project.archived_at is not None
     await db_session.refresh(claimed_payload)
     assert str(claimed_payload.consumer_environment_id) == env_id
     assert claimed_payload.consumer_runtime == "codex"
@@ -1609,6 +1617,12 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     # registration above already used the same generated value.
     assert reconnected == env_id
     assert (await client.get(f"/v1/agents/{env_id}")).status_code == 200
+    await db_session.refresh(agent)
+    await db_session.refresh(project)
+    assert agent.default_project_id == project_id
+    assert agent.archived_at is None
+    assert project.id == project_id
+    assert project.archived_at is None
     assert await environment_matches_runtime(
         db_session,
         owner_user_id=seed_user.id,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1606,7 +1606,9 @@ async def test_disconnect_archives_identity_and_preserves_session_link(
     assert uuid.UUID(env_id) not in archived_source.rows
 
     assert (await client.get("/v1/agents")).json() == []
-    assert (await client.get(f"/v1/agents/{env_id}")).status_code == 404
+    archived_detail = await client.get(f"/v1/agents/{env_id}")
+    assert archived_detail.status_code == 403
+    assert archived_detail.json()["detail"]["code"] == "agent_disconnected"
 
     reconnected = await _register_env_named(
         client,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -294,10 +294,9 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		}
 	}
 
-	// Preserve any non-zero exitCode the engine set (e.g. auth
-	// failure → 1). A naked `process.exit(0)` would otherwise mask
-	// the failure and supervisors would stop restarting on a
-	// revoked deploy-key.
+	// Preserve any non-zero exitCode the engine set (for example, an
+	// auth/disconnect no-restart stop → 2). A naked `process.exit(0)` would
+	// otherwise mask the outcome and defeat the supervisor contract.
 	const code = process.exitCode ?? 0;
 	log.info("serve.exit", { code });
 	process.exit(code);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -294,9 +294,9 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		}
 	}
 
-	// Preserve any non-zero exitCode the engine set (for example, an
-	// auth/disconnect no-restart stop → 2). A naked `process.exit(0)` would
-	// otherwise mask the outcome and defeat the supervisor contract.
+	// Preserve any supervisor control outcome the engine set (for example,
+	// auth/disconnect no-restart → 2). A naked `process.exit(0)` would mask it
+	// and defeat the supervisor contract; status 2 does not imply a crash.
 	const code = process.exitCode ?? 0;
 	log.info("serve.exit", { code });
 	process.exit(code);

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -277,6 +277,8 @@ describe("installer.install (Linux systemd)", () => {
 			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_HOST=0.0.0.0"');
 			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_PORT=17654"');
 			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1"');
+			expect(content).toContain("Restart=always");
+			expect(content).toContain("RestartPreventExitStatus=2");
 		} finally {
 			process.env.PATH = oldPath;
 		}

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -520,8 +520,8 @@ function installSystemd(opts: InstallOpts): {
 	// silently dies until the user logs in again. macOS launchd
 	// already does the right thing here; align Linux to match.
 	// `RestartPreventExitStatus=2` reserves a one-shot abort code
-	// for genuinely-broken configs (auth revoked, schema older
-	// than this binary expects) so we can opt out of restart
+	// for non-retryable states (auth revoked, Agent disconnected,
+	// schema older than this binary expects) so we can opt out of restart
 	// without flipping the whole policy.
 	// `WantedBy=default.target` is the systemd --user equivalent
 	// of "start at user login"; requires `loginctl enable-linger

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -519,10 +519,10 @@ function installSystemd(opts: InstallOpts): {
 	// 0 as a deliberate stop and won't relaunch — the daemon
 	// silently dies until the user logs in again. macOS launchd
 	// already does the right thing here; align Linux to match.
-	// `RestartPreventExitStatus=2` reserves a one-shot abort code
-	// for non-retryable states (auth revoked, Agent disconnected,
-	// schema older than this binary expects) so we can opt out of restart
-	// without flipping the whole policy.
+	// `RestartPreventExitStatus=2` reserves a supervisor control outcome for
+	// states that require user action (auth revoked, Agent disconnected, or a
+	// schema older than this binary expects). It suppresses restart without
+	// classifying those intentional stops as application crashes.
 	// `WantedBy=default.target` is the systemd --user equivalent
 	// of "start at user login"; requires `loginctl enable-linger
 	// <user>` to fire on boot rather than first login session.

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -899,7 +899,35 @@ describe("daemon startup Agent lookup", () => {
 		}
 	}
 
-	it("maps the persisted canonical Agent 404 to a clean no-restart stop", async () => {
+	it("maps the stable archived-Agent 403 to disconnected guidance and a no-restart stop", async () => {
+		await withStartupCase(
+			async () =>
+				new Response('{"detail":{"code":"agent_disconnected","message":"Agent is disconnected"}}', {
+					status: 403,
+					headers: { "content-type": "application/json" },
+				}),
+			async ({ abortController, requests, logs }) => {
+				await runSyncEngine({
+					environmentId: "agent-disconnected",
+					adapter: adapterRegistry.hermes.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(requests).toHaveLength(1);
+				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-disconnected");
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain('"level":"info","event":"engine.agent_disconnected"');
+				expect(logs.join("")).toContain("This installation is disconnected");
+				expect(logs.join("")).toContain("retained data");
+				expect(logs.join("")).not.toContain('"event":"engine.auth_failed"');
+			},
+		);
+	});
+
+	it("keeps an ambiguous 404 on a safe legacy-compatible stop path", async () => {
 		await withStartupCase(
 			async () => new Response('{"detail":"Agent not found"}', { status: 404 }),
 			async ({ abortController, requests, logs }) => {
@@ -916,7 +944,33 @@ describe("daemon startup Agent lookup", () => {
 				expect(process.exitCode).toBe(2);
 				expect(abortController.signal.aborted).toBe(true);
 				expect(logs.join("")).toContain('"level":"info","event":"engine.agent_disconnected"');
+				expect(logs.join("")).toContain("Agent was not found");
+				expect(logs.join("")).not.toContain("retained data");
 				expect(logs.join("")).not.toContain('"level":"error","event":"engine.agent_disconnected"');
+			},
+		);
+	});
+
+	it("keeps an unrelated 403 on the established auth-failure stop path", async () => {
+		await withStartupCase(
+			async () =>
+				new Response('{"detail":"Forbidden"}', {
+					status: 403,
+					headers: { "content-type": "application/json" },
+				}),
+			async ({ abortController, logs }) => {
+				await runSyncEngine({
+					environmentId: "agent-forbidden",
+					adapter: adapterRegistry.hermes.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain('"level":"error","event":"engine.auth_failed"');
+				expect(logs.join("")).not.toContain('"event":"engine.agent_disconnected"');
 			},
 		);
 	});
@@ -939,6 +993,29 @@ describe("daemon startup Agent lookup", () => {
 				expect(
 					requests.every((request) => new URL(request.url).pathname === "/v1/agents/agent-offline"),
 				).toBe(true);
+				expect(process.exitCode).toBe(0);
+				expect(abortController.signal.aborted).toBe(false);
+			},
+		);
+	});
+
+	it("keeps network failures on the ordinary retry and fatal path", async () => {
+		await withStartupCase(
+			async () => {
+				throw new TypeError("fetch failed");
+			},
+			async ({ abortController, requests }) => {
+				await expect(
+					runSyncEngine({
+						environmentId: "agent-network-offline",
+						adapter: adapterRegistry.hermes.create(),
+						abort: abortController.signal,
+						abortController,
+						forcePollWatcher: true,
+					}),
+				).rejects.toMatchObject({ status: 0, isNetwork: true });
+
+				expect(requests).toHaveLength(3);
 				expect(process.exitCode).toBe(0);
 				expect(abortController.signal.aborted).toBe(false);
 			},

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -847,10 +847,15 @@ describe("isAuthFailure", () => {
 describe("daemon startup Agent lookup", () => {
 	async function withStartupCase(
 		fetchImpl: (request: Request) => Promise<Response>,
-		run: (fixture: { abortController: AbortController; requests: Request[] }) => Promise<void>,
+		run: (fixture: {
+			abortController: AbortController;
+			requests: Request[];
+			logs: string[];
+		}) => Promise<void>,
 	): Promise<void> {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-daemon-startup-"));
 		const originalFetch = globalThis.fetch;
+		const originalStderrWrite = process.stderr.write;
 		const originalHome = process.env.CLAWDI_HOME;
 		const originalState = process.env.CLAWDI_STATE_DIR;
 		const originalApiUrl = process.env.CLAWDI_API_URL;
@@ -858,6 +863,7 @@ describe("daemon startup Agent lookup", () => {
 		const originalAuthOrigin = process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
 		const originalExitCode = process.exitCode;
 		const requests: Request[] = [];
+		const logs: string[] = [];
 		try {
 			process.env.CLAWDI_HOME = join(root, "home");
 			process.env.CLAWDI_STATE_DIR = join(root, "serve");
@@ -870,9 +876,14 @@ describe("daemon startup Agent lookup", () => {
 				requests.push(request);
 				return fetchImpl(request);
 			}) as typeof fetch;
-			await run({ abortController: new AbortController(), requests });
+			process.stderr.write = ((chunk: string | Uint8Array) => {
+				logs.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+				return true;
+			}) as typeof process.stderr.write;
+			await run({ abortController: new AbortController(), requests, logs });
 		} finally {
 			globalThis.fetch = originalFetch;
+			process.stderr.write = originalStderrWrite;
 			if (originalHome === undefined) delete process.env.CLAWDI_HOME;
 			else process.env.CLAWDI_HOME = originalHome;
 			if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
@@ -891,7 +902,7 @@ describe("daemon startup Agent lookup", () => {
 	it("maps the persisted canonical Agent 404 to a clean no-restart stop", async () => {
 		await withStartupCase(
 			async () => new Response('{"detail":"Agent not found"}', { status: 404 }),
-			async ({ abortController, requests }) => {
+			async ({ abortController, requests, logs }) => {
 				await runSyncEngine({
 					environmentId: "agent-disconnected",
 					adapter: adapterRegistry.hermes.create(),
@@ -904,6 +915,8 @@ describe("daemon startup Agent lookup", () => {
 				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-disconnected");
 				expect(process.exitCode).toBe(2);
 				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain('"level":"info","event":"engine.agent_disconnected"');
+				expect(logs.join("")).not.toContain('"level":"error","event":"engine.agent_disconnected"');
 			},
 		);
 	});

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -38,6 +38,7 @@ import {
 	reconcileAgentSkillProjectionListing,
 	reconcileDelayMs,
 	resolveOwningSkillKey,
+	runSyncEngine,
 	SyncHealth,
 	skillInvalidationKey,
 	staleSkillProjectionProjectIds,
@@ -840,6 +841,95 @@ describe("isAuthFailure", () => {
 		expect(isAuthFailure(undefined)).toBe(false);
 		expect(isAuthFailure("401")).toBe(false);
 		expect(isAuthFailure({ status: 401 })).toBe(false);
+	});
+});
+
+describe("daemon startup Agent lookup", () => {
+	async function withStartupCase(
+		fetchImpl: (request: Request) => Promise<Response>,
+		run: (fixture: { abortController: AbortController; requests: Request[] }) => Promise<void>,
+	): Promise<void> {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-daemon-startup-"));
+		const originalFetch = globalThis.fetch;
+		const originalHome = process.env.CLAWDI_HOME;
+		const originalState = process.env.CLAWDI_STATE_DIR;
+		const originalApiUrl = process.env.CLAWDI_API_URL;
+		const originalAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		const originalAuthOrigin = process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+		const originalExitCode = process.exitCode;
+		const requests: Request[] = [];
+		try {
+			process.env.CLAWDI_HOME = join(root, "home");
+			process.env.CLAWDI_STATE_DIR = join(root, "serve");
+			process.env.CLAWDI_API_URL = "https://cloud.example.test";
+			process.env.CLAWDI_AUTH_TOKEN = "clawdi_test_token";
+			process.env.CLAWDI_AUTH_TOKEN_ORIGIN = "https://cloud.example.test";
+			process.exitCode = 0;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = input instanceof Request ? input : new Request(input, init);
+				requests.push(request);
+				return fetchImpl(request);
+			}) as typeof fetch;
+			await run({ abortController: new AbortController(), requests });
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalHome;
+			if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
+			else process.env.CLAWDI_STATE_DIR = originalState;
+			if (originalApiUrl === undefined) delete process.env.CLAWDI_API_URL;
+			else process.env.CLAWDI_API_URL = originalApiUrl;
+			if (originalAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalAuthToken;
+			if (originalAuthOrigin === undefined) delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+			else process.env.CLAWDI_AUTH_TOKEN_ORIGIN = originalAuthOrigin;
+			process.exitCode = originalExitCode ?? 0;
+			rmSync(root, { recursive: true, force: true });
+		}
+	}
+
+	it("maps the persisted canonical Agent 404 to a clean no-restart stop", async () => {
+		await withStartupCase(
+			async () => new Response('{"detail":"Agent not found"}', { status: 404 }),
+			async ({ abortController, requests }) => {
+				await runSyncEngine({
+					environmentId: "agent-disconnected",
+					adapter: adapterRegistry.hermes.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(requests).toHaveLength(1);
+				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-disconnected");
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+			},
+		);
+	});
+
+	it("keeps server failures on the ordinary retry and fatal path", async () => {
+		await withStartupCase(
+			async () => new Response("offline", { status: 503 }),
+			async ({ abortController, requests }) => {
+				await expect(
+					runSyncEngine({
+						environmentId: "agent-offline",
+						adapter: adapterRegistry.hermes.create(),
+						abort: abortController.signal,
+						abortController,
+						forcePollWatcher: true,
+					}),
+				).rejects.toThrow(/503/);
+
+				expect(requests).toHaveLength(3);
+				expect(
+					requests.every((request) => new URL(request.url).pathname === "/v1/agents/agent-offline"),
+				).toBe(true);
+				expect(process.exitCode).toBe(0);
+				expect(abortController.signal.aborted).toBe(false);
+			},
+		);
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -401,13 +401,13 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		// Do not broaden this to other 404s; Skill and unrelated resource
 		// misses retain their existing retry/failure behavior.
 		if (e instanceof ApiError && e.status === 404) {
-			log.error("engine.agent_disconnected", {
+			log.info("engine.agent_disconnected", {
 				environment_id: opts.environmentId,
-				hint: "This installation is disconnected. Run `clawdi setup` to reconnect it with retained data.",
+				hint: "This installation is disconnected. Run clawdi setup to reconnect it with retained data.",
 			});
-			// Reuse the supervisor's established no-restart outcome. On macOS,
-			// KeepAlive requires the same best-effort self-unload used for an
-			// unrecoverable authentication stop.
+			// Exit status 2 is the supervisor's established no-restart control
+			// outcome, not an application-crash classification. On macOS,
+			// KeepAlive requires the same best-effort self-unload used for auth.
 			process.exitCode = 2;
 			removeLaunchdDaemonSupervision(opts.adapter.agentType);
 			opts.abortController.abort();

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -77,6 +77,34 @@ export function isSkillSyncServerEvent(event: ServerEvent): event is SkillServer
 	);
 }
 
+const AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected";
+
+function agentLookupStopHint(error: unknown): string | null {
+	if (!(error instanceof ApiError)) return null;
+	// Older active-only Core versions returned 404 for the owner's archived
+	// Agent. Keep that rolling-upgrade stop only at the exact lookup call, but
+	// do not claim that an ambiguous 404 proves the Agent was disconnected.
+	if (error.status === 404) {
+		return "This installation's Agent was not found. Run clawdi setup to reconnect this installation.";
+	}
+	if (error.status !== 403) return null;
+	try {
+		const payload: unknown = JSON.parse(error.body);
+		if (typeof payload !== "object" || payload === null || !("detail" in payload)) return null;
+		const detail = payload.detail;
+		const disconnected =
+			typeof detail === "object" &&
+			detail !== null &&
+			"code" in detail &&
+			detail.code === AGENT_DISCONNECTED_ERROR_CODE;
+		return disconnected
+			? "This installation is disconnected. Run clawdi setup to reconnect it with retained data."
+			: null;
+	} catch {
+		return null;
+	}
+}
+
 export function skillInvalidationKey(event: ServerEvent, projectId: string): string | null {
 	if (!isSkillSyncServerEvent(event) || event.project_id !== projectId) return null;
 	return event.skill_key;
@@ -349,6 +377,18 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		root_dir: rootDir,
 		state_dir: stateDir,
 	});
+	const stopForDisconnectedAgent = (hint: string): void => {
+		log.info("engine.agent_disconnected", {
+			environment_id: opts.environmentId,
+			hint,
+		});
+		// Exit status 2 is the supervisor's established no-restart control
+		// outcome, not an application-crash classification. On macOS,
+		// KeepAlive requires the same best-effort self-unload used for auth.
+		process.exitCode = 2;
+		removeLaunchdDaemonSupervision(opts.adapter.agentType);
+		opts.abortController.abort();
+	};
 
 	// Fetch this Agent's default_project_id at boot. Projection requests are
 	// Agent-scoped, while the durable claim and absence report are additionally
@@ -384,6 +424,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	try {
 		defaultProjectId = await fetchDefaultProjectId();
 	} catch (e) {
+		const stopHint = agentLookupStopHint(e);
+		if (stopHint !== null) {
+			stopForDisconnectedAgent(stopHint);
+			return;
+		}
 		if (isAuthFailure(e)) {
 			log.error("engine.auth_failed", { origin: "boot_project_fetch" });
 			process.exitCode = 2;
@@ -391,24 +436,6 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			// handler below — boot-time auth failure also needs
 			// supervision removal on macOS or launchd respawns
 			// the daemon every 10s.
-			removeLaunchdDaemonSupervision(opts.adapter.agentType);
-			opts.abortController.abort();
-			return;
-		}
-		// This 404 is meaningful only at this exact startup boundary: the
-		// daemon looked up its persisted Agent id through the canonical Agent
-		// route, whose active-only lookup hides a user-disconnected identity.
-		// Do not broaden this to other 404s; Skill and unrelated resource
-		// misses retain their existing retry/failure behavior.
-		if (e instanceof ApiError && e.status === 404) {
-			log.info("engine.agent_disconnected", {
-				environment_id: opts.environmentId,
-				hint: "This installation is disconnected. Run clawdi setup to reconnect it with retained data.",
-			});
-			// Exit status 2 is the supervisor's established no-restart control
-			// outcome, not an application-crash classification. On macOS,
-			// KeepAlive requires the same best-effort self-unload used for auth.
-			process.exitCode = 2;
 			removeLaunchdDaemonSupervision(opts.adapter.agentType);
 			opts.abortController.abort();
 			return;
@@ -547,6 +574,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				}
 				consecutiveFailures = 0;
 			} catch (e) {
+				const stopHint = agentLookupStopHint(e);
+				if (stopHint !== null) {
+					stopForDisconnectedAgent(stopHint);
+					return;
+				}
 				if (isAuthFailure(e)) {
 					triggerAuthFailureAbort("project_refresh");
 					return;

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -395,6 +395,24 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			opts.abortController.abort();
 			return;
 		}
+		// This 404 is meaningful only at this exact startup boundary: the
+		// daemon looked up its persisted Agent id through the canonical Agent
+		// route, whose active-only lookup hides a user-disconnected identity.
+		// Do not broaden this to other 404s; Skill and unrelated resource
+		// misses retain their existing retry/failure behavior.
+		if (e instanceof ApiError && e.status === 404) {
+			log.error("engine.agent_disconnected", {
+				environment_id: opts.environmentId,
+				hint: "This installation is disconnected. Run `clawdi setup` to reconnect it with retained data.",
+			});
+			// Reuse the supervisor's established no-restart outcome. On macOS,
+			// KeepAlive requires the same best-effort self-unload used for an
+			// unrecoverable authentication stop.
+			process.exitCode = 2;
+			removeLaunchdDaemonSupervision(opts.adapter.agentType);
+			opts.abortController.abort();
+			return;
+		}
 		throw e;
 	}
 	log.info("engine.project_resolved", { default_project_id: defaultProjectId });


### PR DESCRIPTION
## Summary

- treat a 404 only from the daemon startup canonical Agent lookup as an intentional Disconnect and exit through the existing supervisor no-restart status
- log concise `clawdi setup` recovery guidance while leaving auth, server, network, and unrelated 404 behavior unchanged
- clarify Dashboard Disconnect retention/reconnect copy and fix the stale backend session-archive comment
- strengthen coverage that setup-style re-registration restores the same Agent and Project IDs

## Lifecycle review

Disconnect remains synchronous. The route performs one bounded PostgreSQL transaction (runtime invalidation enqueue, Agent/Project archive, and bound-key revocation), followed by in-process cache invalidation. PostgreSQL NOTIFY participates in that transaction and after-commit SSE fan-out is in-memory; no synchronous provider, object-store, cluster, or other external I/O was found. Hosted infrastructure deletion remains on its separate LRO lifecycle.

## Verification

- `bun test packages/cli/src/serve/sync-engine.test.ts packages/cli/src/serve/installer.test.ts`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test` (1487 passed, 4 skipped)
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build:oss`
- focused Biome and Ruff checks
- `uv run pytest tests/test_sessions.py::test_disconnect_archives_identity_and_preserves_session_link -q` against a migrated throwaway PostgreSQL
- `uv run python -m compileall app scripts tests alembic`

Unmerged by design.