### PR TITLE
fix(discord): grant public thread creation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -8993,7 +8993,7 @@ test("Telegram and Discord pairing acknowledge one newly active binding at 320px
 					expires_at: validExpiry,
 					pairing_command: "/clawdi_pair 3456789BCD",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9491,7 +9491,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: validExpiry,
 					pairing_command: "/clawdi_pair 56789BCDFG",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9506,7 +9506,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: validExpiry,
 					pairing_command: "/clawdi_pair HJKLMNPQRS",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -9521,7 +9521,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 					expires_at: "2000-01-01T00:00:00Z",
 					pairing_command: "/clawdi_pair TVWXYZ2345",
 					discord_install_url:
-						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands",
 					discord_user_install_url:
 						"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 				},
@@ -10204,7 +10204,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		.poll(() => page.evaluate(() => navigator.clipboard.readText()))
 		.toContain("integration_type=0");
 	await expect(discordServerInstallLink).toHaveAttribute("href", /integration_type=0/);
-	await expect(discordServerInstallLink).toHaveAttribute("href", /permissions=274878024768/);
+	await expect(discordServerInstallLink).toHaveAttribute("href", /permissions=309237763136/);
 	await discordDmTab.click();
 	await expect(discordPairDialog.locator('[data-discord-pair-path="dm"]')).toBeVisible();
 	const discordUserInstallQr = discordPairDialog.getByRole("img", {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -44,15 +44,16 @@ describe("hosted channel instructions and gates", () => {
 
 	test("accepts only the explicit Discord Guild Install bot contract", () => {
 		const supported =
-			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands";
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands";
 		expect(verifiedDiscordServerInstallUrl(supported)).toBe(supported);
 		for (const unsupported of [
 			null,
 			undefined,
-			"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=274878024768&scope=bot%20applications.commands",
-			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&permissions=274878024768&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&permissions=309237763136&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&permissions=309237763136&scope=bot%20applications.commands",
 			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=0&scope=bot%20applications.commands",
-			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+			"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=applications.commands",
 		]) {
 			expect(verifiedDiscordServerInstallUrl(unsupported)).toBeNull();
 		}

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -58,7 +58,7 @@ export function verifiedDiscordServerInstallUrl(value: string | null | undefined
 			url.searchParams.getAll("client_id").length !== 1 ||
 			url.searchParams.get("integration_type") !== "0" ||
 			url.searchParams.getAll("integration_type").length !== 1 ||
-			url.searchParams.get("permissions") !== "274878024768" ||
+			url.searchParams.get("permissions") !== "309237763136" ||
 			url.searchParams.getAll("permissions").length !== 1 ||
 			url.searchParams.getAll("scope").length !== 1 ||
 			scopes.size !== 2 ||

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -132,19 +132,23 @@ DISCORD_GUILD_INTERACTION_CONTEXT = 0
 DISCORD_BOT_DM_INTERACTION_CONTEXT = 1
 DISCORD_RESERVED_COMMAND_VERSION = 3
 DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
-DISCORD_INSTALL_CONFIG_VERSION = 1
+DISCORD_INSTALL_CONFIG_VERSION = 2
 DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
 DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY = "discord_user_install_supported"
 # Discord API docs baseline 07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3.
 # ADD_REACTIONS, VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS, ATTACH_FILES,
-# READ_MESSAGE_HISTORY, and SEND_MESSAGES_IN_THREADS. Never request
+# READ_MESSAGE_HISTORY, CREATE_PUBLIC_THREADS, and SEND_MESSAGES_IN_THREADS.
+# CREATE_PUBLIC_THREADS is required by Hermes' /thread and auto-thread paths
+# (including its create-from-message fallback) and by the transparent Discord
+# transport's pinned thread-create contract. Private-thread creation and thread
+# moderation are not part of the managed surface. Never request
 # ADMINISTRATOR or MANAGE_GUILD for the bot; pair mutation authority is the
 # invoking member's computed permissions. The managed OpenClaw projection
 # disables advanced actions that need excluded role permissions; Gateway
 # intents are a separate capability and never widen the bot role. The default
 # install deliberately excludes CONNECT, SPEAK, MANAGE_MESSAGES, MANAGE_EVENTS,
 # and MANAGE_GUILD_EXPRESSIONS.
-DISCORD_MINIMAL_BOT_PERMISSIONS = 274_878_024_768
+DISCORD_MINIMAL_BOT_PERMISSIONS = 309_237_763_136
 DISCORD_GUILD_PERMISSION_DENIED = "discord_guild_permission_denied"
 DISCORD_GUILD_USE_INTERACTION = "discord_guild_use_interaction"
 DISCORD_GUILD_INSTALL_REQUIRED = "discord_guild_install_required"

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -135,6 +135,8 @@ DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
 DISCORD_INSTALL_CONFIG_VERSION = 2
 DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
 DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY = "discord_user_install_supported"
+DISCORD_GATEWAY_MESSAGE_CONTENT_FLAG = 1 << 18
+DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG = 1 << 19
 # Discord API docs baseline 07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3.
 # ADD_REACTIONS, VIEW_CHANNEL, SEND_MESSAGES, EMBED_LINKS, ATTACH_FILES,
 # READ_MESSAGE_HISTORY, CREATE_PUBLIC_THREADS, and SEND_MESSAGES_IN_THREADS.
@@ -3643,6 +3645,7 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
         provider_token=token,
         config=account.config,
     )
+    _require_discord_message_content_intent(identity)
     raw_integration_config = identity.get("integration_types_config")
     integration_config = (
         {
@@ -4051,6 +4054,19 @@ def _verify_discord_application_identity(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Discord bot token belongs to a different application.",
+        )
+
+
+def _require_discord_message_content_intent(payload: dict[str, Any]) -> None:
+    """Require the privileged intent that the native Gateway always identifies with."""
+    flags = payload.get("flags")
+    approved = DISCORD_GATEWAY_MESSAGE_CONTENT_FLAG
+    limited = DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG
+    enabled_flags = approved | limited
+    if not isinstance(flags, int) or isinstance(flags, bool) or flags & enabled_flags == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=("Enable the Message Content Intent for this Discord application, then retry."),
         )
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -16536,6 +16536,7 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
             (
                 {
                     "id": DISCORD_TEST_APPLICATION_ID,
+                    "flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG,
                     "integration_types_config": {
                         "0": {
                             "oauth2_install_params": {
@@ -16704,6 +16705,48 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
         account.config["discord_reserved_command_version"]
         == channel_service.DISCORD_RESERVED_COMMAND_VERSION
     )
+
+
+@pytest.mark.asyncio
+async def test_discord_pair_preparation_requires_message_content_intent(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _DiscordPreparationProviderClient.reset(
+        [
+            (
+                {
+                    "id": DISCORD_TEST_APPLICATION_ID,
+                    "flags": 0,
+                    "integration_types_config": {"0": {}},
+                },
+                200,
+            )
+        ]
+    )
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", _DiscordPreparationProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-message-content-readiness",
+                "provider_token": "discord-provider-token",
+                "config": {
+                    "application_id": DISCORD_TEST_APPLICATION_ID,
+                    "public_key": DISCORD_TEST_PUBLIC_KEY,
+                },
+            },
+        )
+    ).json()
+
+    pair = await client.post(f"/v1/channels/{created['id']}/pair-codes", json={})
+
+    assert pair.status_code == 400
+    assert pair.json() == {
+        "detail": "Enable the Message Content Intent for this Discord application, then retry."
+    }
+    assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == ["GET"]
 
 
 @pytest.mark.asyncio
@@ -17286,6 +17329,7 @@ async def test_discord_pair_preparation_requires_exact_persisted_install_contrac
             (
                 {
                     "id": DISCORD_TEST_APPLICATION_ID,
+                    "flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG,
                     "integration_types_config": initial_integration_types,
                 },
                 200,
@@ -18736,6 +18780,7 @@ async def test_discord_guild_only_install_capability_stays_guild_only(
             (
                 {
                     "id": DISCORD_TEST_APPLICATION_ID,
+                    "flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG,
                     "integration_types_config": {
                         "0": {
                             "oauth2_install_params": {
@@ -18971,6 +19016,23 @@ def test_discord_minimal_bot_permissions_are_exact_text_and_public_thread_baseli
     excluded_bits = (3, 4, 5, 13, 17, 20, 21, 28, 29, 30, 31, 33, 34, 36, 40, 43, 44, 49)
     for excluded_bit in excluded_bits:
         assert permissions & (1 << excluded_bit) == 0
+
+
+def test_discord_message_content_intent_readiness_accepts_limited_or_approved_flags() -> None:
+    channel_service._require_discord_message_content_intent(
+        {"flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG}
+    )
+    channel_service._require_discord_message_content_intent(
+        {"flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_FLAG}
+    )
+
+    for payload in ({}, {"flags": 0}, {"flags": True}, {"flags": "524288"}):
+        with pytest.raises(HTTPException) as exc_info:
+            channel_service._require_discord_message_content_intent(payload)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == (
+            "Enable the Message Content Intent for this Discord application, then retry."
+        )
 
 
 def _discord_provider_result(

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -17217,7 +17217,13 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
         ([({"id": "223456789012345678"}, 200)], 409),
         (
             [
-                ({"id": DISCORD_TEST_APPLICATION_ID}, 200),
+                (
+                    {
+                        "id": DISCORD_TEST_APPLICATION_ID,
+                        "flags": channel_service.DISCORD_GATEWAY_MESSAGE_CONTENT_LIMITED_FLAG,
+                    },
+                    200,
+                ),
                 ({"message": "invalid interactions endpoint"}, 400),
             ],
             502,

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -13392,6 +13392,7 @@ def test_discord_gateway_helpers_build_protocol_payloads():
         },
     }
     assert discord_gateway_intents(ChannelAccount(config=None)) == DISCORD_DEFAULT_INTENTS
+    assert DISCORD_DEFAULT_INTENTS == sum(1 << bit for bit in (0, 9, 10, 12, 13, 15))
     assert discord_gateway_intents(ChannelAccount(config={"gateway_intents": "513"})) == 513
     lock_key = discord_gateway_advisory_lock_key(UUID("00000000-0000-0000-0000-000000000001"))
     assert 0 <= lock_key <= 0x7FFF_FFFF_FFFF_FFFF
@@ -16678,11 +16679,11 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
         "https://discord.com/oauth2/authorize"
         f"?client_id={DISCORD_TEST_APPLICATION_ID}"
         "&integration_type=0"
-        "&permissions=274878024768"
+        "&permissions=309237763136"
         "&scope=bot%20applications.commands"
     )
     bot_permissions = int(parse_qs(urlparse(install_url).query)["permissions"][0])
-    assert bot_permissions == sum(1 << bit for bit in (6, 10, 11, 14, 15, 16, 38))
+    assert bot_permissions == sum(1 << bit for bit in (6, 10, 11, 14, 15, 16, 35, 38))
     assert bot_permissions & ((1 << 3) | (1 << 5)) == 0
     assert pair.json()["discord_user_install_url"] == (
         "https://discord.com/oauth2/authorize"
@@ -16694,7 +16695,10 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
     assert account.config["discord_interactions_configured"] is True
-    assert account.config["discord_install_config_version"] == 1
+    assert (
+        account.config["discord_install_config_version"]
+        == channel_service.DISCORD_INSTALL_CONFIG_VERSION
+    )
     assert account.config["discord_user_install_supported"] is True
     assert (
         account.config["discord_reserved_command_version"]
@@ -18948,11 +18952,23 @@ async def test_discord_admin_token_change_invalidates_verified_install_capabilit
     assert "discord_user_install_supported" not in account.config
 
 
-def test_discord_minimal_bot_permissions_are_exact_text_baseline() -> None:
+def test_discord_minimal_bot_permissions_are_exact_text_and_public_thread_baseline() -> None:
     permissions = channel_service.DISCORD_MINIMAL_BOT_PERMISSIONS
 
-    assert permissions == sum(1 << bit for bit in (6, 10, 11, 14, 15, 16, 38))
-    excluded_bits = (3, 4, 5, 13, 17, 20, 21, 28, 29, 30, 31, 33, 34, 35, 36, 40, 43, 44, 49)
+    expected_permission_bits = {
+        "ADD_REACTIONS": 6,
+        "VIEW_CHANNEL": 10,
+        "SEND_MESSAGES": 11,
+        "EMBED_LINKS": 14,
+        "ATTACH_FILES": 15,
+        "READ_MESSAGE_HISTORY": 16,
+        "CREATE_PUBLIC_THREADS": 35,
+        "SEND_MESSAGES_IN_THREADS": 38,
+    }
+    assert permissions == sum(1 << bit for bit in expected_permission_bits.values())
+    assert permissions == 309_237_763_136
+
+    excluded_bits = (3, 4, 5, 13, 17, 20, 21, 28, 29, 30, 31, 33, 34, 36, 40, 43, 44, 49)
     for excluded_bit in excluded_bits:
         assert permissions & (1 << excluded_bit) == 0
 

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -310,6 +310,21 @@ no `bot` scope, and carries no bot permission bitfield. The native Gateway
 default (`46593`) separately enables Guilds, Guild Messages, Guild Message
 Reactions, Direct Messages, Direct Message Reactions, and Message Content. It
 does not enable Guild Members, Presences, moderation, or voice intents.
+Discord account preparation verifies that the application flags contain either
+the approved or limited Message Content capability before configuring installs.
+If the owner has not enabled that privileged intent, preparation stops with an
+actionable configuration error; Clawdi does not try to mutate privileged-intent
+Portal settings.
+
+Hermes' upstream Discord client also asks for Voice States, but the managed
+Clawdi Gateway is the event authority and intentionally ignores the downstream
+IDENTIFY intent selection. Managed Discord voice is not enabled: the install
+does not grant Connect, Speak, or Send Voice Messages, and the upstream voice
+message helper can fall back to an ordinary attachment. Likewise, managed
+Hermes uses its allow-everyone mode without the Members intent. Member search
+from its optional admin toolset is therefore not a managed capability; Clawdi
+does not broaden the privileged Guild Members intent merely because the raw
+adapter exposes that tool.
 
 Unpair flow:
 

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -291,14 +291,25 @@ cannot be safely materialized in DMs. User Install DMs support Clawdi's
 account-global reserved pair/unpair commands and routed messages only.
 
 The managed server install requests only Add Reactions, View Channels, Send
-Messages, Embed Links, Attach Files, Read Message History, and Send Messages in
-Threads (`274878024768`). Voice, moderation, event, expression, channel, role,
-pin, poll, sticker, and optional thread-tool actions are not granted by
-default. Managed OpenClaw projections explicitly gate those optional action
-surfaces; ordinary replies in existing threads continue through normal message
-sending. Managed Hermes projections leave user allowlists empty instead of
-writing a `"*"` username, so they do not accidentally request Server Members
-intent while preserving the adapter's documented allow-everyone behavior.
+Messages, Embed Links, Attach Files, Read Message History, Create Public
+Threads, and Send Messages in Threads (`309237763136`). Create Public Threads
+supports Hermes' public `/thread`, auto-thread, and forum-post behavior plus the
+transparent transport's public thread-create contract. Create Private Threads
+and Manage Threads remain excluded: Clawdi does not create private threads or
+archive, lock, rename, or delete threads. Managed OpenClaw projections gate its
+optional thread-management tool surface; ordinary replies in existing threads
+continue through normal message sending. Managed Hermes projections leave user
+allowlists empty instead of writing a `"*"` username, so they do not accidentally
+request Server Members intent while preserving the adapter's documented
+allow-everyone behavior.
+
+OAuth scopes, bot role permissions, and Gateway intents are independent. Guild
+Install uses the `bot` and `applications.commands` OAuth scopes and the exact
+permission bitfield above. User Install uses only `applications.commands`, has
+no `bot` scope, and carries no bot permission bitfield. The native Gateway
+default (`46593`) separately enables Guilds, Guild Messages, Guild Message
+Reactions, Direct Messages, Direct Message Reactions, and Message Content. It
+does not enable Guild Members, Presences, moderation, or voice intents.
 
 Unpair flow:
 

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -296,8 +296,14 @@ Threads, and Send Messages in Threads (`309237763136`). Create Public Threads
 supports Hermes' public `/thread`, auto-thread, and forum-post behavior plus the
 transparent transport's public thread-create contract. Create Private Threads
 and Manage Threads remain excluded: Clawdi does not create private threads or
-archive, lock, rename, or delete threads. Managed OpenClaw projections gate its
-optional thread-management tool surface; ordinary replies in existing threads
+archive, lock, or delete threads. Hermes supplies names in its thread-create
+requests and does not rename existing threads. OpenClaw can asynchronously
+replace an auto-thread's provisional name with a generated title, but it PATCHes
+only the thread ID returned by that same bot create request; Discord permits a
+thread creator to change `name`, `archived`, and `auto_archive_duration` without
+Manage Threads. Managed OpenClaw projections also set `actions.channels` and
+`actions.threads` to false, blocking arbitrary `sendMessage.threadName` renames
+and the optional thread action tool; ordinary replies in existing threads
 continue through normal message sending. Managed Hermes projections leave user
 allowlists empty instead of writing a `"*"` username, so they do not accidentally
 request Server Members intent while preserving the adapter's documented

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -214,10 +214,11 @@ function buildOpenClawChannelsProjection(
 				groupPolicy: "open",
 				allowFrom: ["*"],
 				guilds: { "*": { requireMention: false, users: ["*"] } },
-				// The managed invite grants the text/reaction/attachment baseline only.
-				// OpenClaw groups thread creation/list/reply behind one gate, so disable
-				// that optional tool surface while ordinary replies in existing threads
-				// continue through the normal message send path.
+				// The managed invite also grants public-thread creation for runtime
+				// workflows such as forum posts and thread-bound sessions. OpenClaw's
+				// broader thread action tool also exposes listing/reply operations, so
+				// keep that optional tool surface disabled; ordinary thread delivery and
+				// supported runtime-managed creation continue through their own paths.
 				actions: {
 					stickers: false,
 					polls: false,

--- a/packages/cli/tests/commands/channel.test.ts
+++ b/packages/cli/tests/commands/channel.test.ts
@@ -397,7 +397,7 @@ describe("channel commands", () => {
 							expires_at: new Date().toISOString(),
 							pairing_command: "/clawdi_pair NPQRSTVWXY",
 							discord_install_url:
-								"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=274878024768&scope=bot%20applications.commands",
+								"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=0&permissions=309237763136&scope=bot%20applications.commands",
 							discord_user_install_url:
 								"https://discord.com/oauth2/authorize?client_id=123456789012345678&integration_type=1&scope=applications.commands",
 						},


### PR DESCRIPTION
## Summary

- add `CREATE_PUBLIC_THREADS` to the deterministic Guild Install bitfield (`309237763136`)
- keep private-thread, thread-management, voice, member-search, and server-management privileges excluded
- validate that a user-supplied Discord application has either the approved or limited Message Content application flag before install configuration
- keep User Install as `applications.commands` only, without bot scope or bot permissions

## Control-plane boundaries

| Control | Default | Meaning |
|---|---|---|
| Guild Install OAuth | `bot applications.commands`, `integration_type=0` | Adds bot + commands to a guild |
| User Install OAuth | `applications.commands`, `integration_type=1` | User-context commands/DM routing; no bot and no permissions parameter |
| Bot role permissions | `309237763136` | Initial guild role; channel/category overwrites still apply |
| Upstream Gateway intents | `46593` | Clawdi worker's Discord event subscription, independent of role permissions |
| Downstream synthetic Gateway | binding-scoped replay | Ignores a managed adapter's requested intents; clients cannot widen upstream collection |

Application preparation writes and verifies identical Guild/User values in top-level `install_params` and `integration_types_config`. Web URL verification, CLI/E2E fixtures, docs, and backend generation use the same values.

## Exact bot permission decomposition

| Flag | Bit | Reachable evidence |
|---|---:|---|
| ADD_REACTIONS | 6 | capture 08 PUTs the bot's Unicode reaction |
| VIEW_CHANNEL | 10 | guild visibility and GET-channel authorization preflight |
| SEND_MESSAGES | 11 | message/component/edit/delete/file/thread captures |
| EMBED_LINKS | 14 | rich JSON and attachment-embed proxy tests |
| ATTACH_FILES | 15 | multipart image/data/voice fallback paths |
| READ_MESSAGE_HISTORY | 16 | replies/references, reaction creation, history reads |
| CREATE_PUBLIC_THREADS | 35 | capture 28 creates a public thread; Hermes /thread and auto-thread |
| SEND_MESSAGES_IN_THREADS | 38 | capture 28 and unobserved-thread send test |

`309237763136 = Σ(1 << [6,10,11,14,15,16,35,38])`.

Not granted: Administrator, Create Instant Invite, Manage Guild/Channels/Roles/Webhooks/Messages/Threads, Send TTS, Mention Everyone, external emoji/sticker usage, Create Private Threads, Send Polls, Send Voice Messages, Connect, Speak, or other server/voice/moderation permissions.

## Exact Gateway intent decomposition

`46593 = Σ(1 << [0,9,10,12,13,15])`.

| Intent | Why |
|---|---|
| GUILDS | guild lifecycle plus THREAD_CREATE/UPDATE/DELETE/MEMBER_UPDATE |
| GUILD_MESSAGES | guild MESSAGE_CREATE/UPDATE/DELETE |
| GUILD_MESSAGE_REACTIONS | guild reaction ingress |
| DIRECT_MESSAGES | User Install/bot DM message ingress |
| DIRECT_MESSAGE_REACTIONS | the same channel-id routing handles DM reaction events |
| MESSAGE_CONTENT | text, embeds, attachments, components, polls and text pairing |

Only Message Content is privileged. Guild Members, Presences and Guild Voice States are absent. Interaction Create is not intent-gated.

Clawdi now validates `Application.flags` before PATCH/install setup and accepts either `GATEWAY_MESSAGE_CONTENT (1<<18)` or `GATEWAY_MESSAGE_CONTENT_LIMITED (1<<19)`. If neither is present it returns: “Enable the Message Content Intent for this Discord application, then retry.” It does not mutate Portal intent settings.

## Capability → endpoint → authorization matrix

“Raw” means the binding-scoped proxy forwards the request, after which Discord is the final permission authority. Raw reachability is not an install-default promise.

| Capability / endpoint | Managed Hermes | Managed OpenClaw | Raw proxy | Default authorization |
|---|---|---|---|---|
| Guild/DM create/read message | yes | yes | yes | View/Send/History in guild; no guild flags in DM |
| Embed/component send | yes | yes | yes | Embed Links for embeds; components no extra role flag |
| Image/file/audio attachment | yes | yes | yes | Attach Files |
| Reply/reference | yes | yes | yes | Send Messages + Read Message History |
| Edit/delete own message | yes | reachable | yes | no Manage Messages |
| Edit/delete others or bulk delete | no managed behavior | moderation disabled | syntactically reachable | Manage Messages absent → Discord 403 |
| Add own Unicode reaction | default reactions enabled | reachable | yes | Add Reactions + Read Message History |
| Remove own reaction | reachable | reachable | yes | no Manage Messages |
| Remove others/all reactions | no managed behavior | moderation disabled | syntactically reachable | Manage Messages absent |
| Public text/announcement thread | /thread + auto-thread | action tool disabled; forum and thread-bound runtime paths remain | yes | Create Public Threads |
| Reply in thread | yes | normal reply remains | yes | Send Messages in Threads |
| Forum/media post | yes | outbound send auto-creates a post thread | yes | Discord requires Send Messages; Create Public Threads is ignored |
| Private thread | no | disabled | syntactically reachable | Create Private Threads absent |
| Rename existing thread | no PATCH behavior | `sendMessage.threadName` is blocked by managed `actions.channels=false`; optional generated auto-thread title PATCH targets only the ID returned by the same bot create | syntactically reachable | Creator may change `name` without Manage Threads; arbitrary/non-creator rename reaches Discord 403 |
| Archive/lock/delete thread | no | optional management surfaces disabled | syntactically reachable | Manage Threads absent |
| Slash command registration | guild shadows + reserved commands | same transport | virtualized/fanned out | applications.commands scope; USE_APPLICATION_COMMANDS is an invoking-member permission, not needed on bot role |
| Interaction callback | yes | yes | reference-bound | interaction token; no Manage Webhooks |
| Deferred followup/original response | yes | yes | reference-bound webhook route | interaction token; no webhook.incoming scope or Manage Webhooks |
| Poll/sticker/TTS/mass mention | no install-default promise | polls/stickers disabled | fields may be preserved | corresponding optional flags absent; Discord denies/degrades |
| Permission overwrite/channel/admin endpoint | no managed default | channels/roles disabled | bound channel/guild wildcard forwards | management flags absent; provider 403 is the deliberate final boundary |

The raw proxy permits `channels/{bound-or-same-guild}/...` and `guilds/{bound-guild}/...`; Clawdi first enforces link/binding scope and same-guild channel preflight. Tests deliberately preserve future fields and permission-overwrite routes. This protocol compatibility does not justify granting Manage Channels or any other management flag.

## Hermes-specific boundaries (pinned 736fc4d86)

- Hermes requests Message Content and Voice States in its own client, but managed Clawdi uses the upstream worker and synthetic downstream Gateway. The downstream IDENTIFY selection cannot widen upstream `46593`; Guild Voice States remains unavailable by design.
- Voice channels are not a managed product surface. Connect, Speak and Guild Voice States remain excluded.
- `send_voice` first attempts a native voice message (`SEND_VOICE_MESSAGES`, bit 46) and falls back to an ordinary attachment. The native form is optional degradation, not a required install capability, so bit 46 remains excluded.
- `DISCORD_ALLOW_ALL_USERS=true` keeps Hermes members intent false. Although its default core `discord` toolset includes `search_members`, Search/List Guild Members needs privileged Guild Members access. That tool action is intentionally unavailable in managed mode; this is documented rather than silently broadening a privileged intent.
- Default reactions are enabled and are covered by Add Reactions + Read Message History.
- `/thread`, message auto-thread, handoff, and forum-post paths put the title in the create request. This commit has no `PATCH /channels/{thread.id}` rename behavior.

## Thread rename boundary (OpenClaw + Discord)

- [Discord's pinned thread rules](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/topics/threads.mdx#editing--deleting-threads) say the thread creator may change `name`, `archived`, and `auto_archive_duration` without Manage Threads. Changing `locked` or `rate_limit_per_user`, and deleting a thread, require Manage Threads.
- Clawdi documents OpenClaw main evidence at `ba467fbd3efa9ab109e620c4e42cfe92388171c5` and stable v2026.7.1 at `2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4`; the official installer currently selects the npm `latest` tag unless a version is supplied. The audited current upstream retains the same relevant paths.
- Explicit `threadCreate` is gated by `actions.threads`; managed Clawdi sets it false. `sendMessage.threadName` can PATCH any existing thread but is gated by `actions.channels`; managed Clawdi also sets it false.
- Channel `autoThread` is opt-in channel configuration. In generated-title mode, OpenClaw first creates the thread and then asynchronously PATCHes the exact `created.id` captured in that same call. Reuse/failure paths return an existing thread before scheduling rename. The rename job is not persisted or replayed at startup, so a restart can lose the cosmetic rename but cannot retarget a non-bot-owned thread.
- Thread-bound session creation is enabled by upstream default, but it supplies the final name in `POST /channels/{channel.id}/threads`; startup reconciliation probes/removes stored bindings and does not rename them. Forum/media outbound likewise names the post during creation.
- Therefore managed default behavior does not require Manage Threads bit 34. Raw proxy compatibility does not change that install-default conclusion.

Pinned upstream code: [OpenClaw auto-thread create/generated rename](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/extensions/discord/src/monitor/threading.auto-thread.ts), [OpenClaw `sendMessage.threadName` channel gate](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/extensions/discord/src/actions/runtime.messaging.send.ts), and [Hermes Discord adapter](https://github.com/NousResearch/hermes-agent/blob/736fc4d86a1acd8c96473aeb55f9c783e2170dca/plugins/platforms/discord/adapter.py).

## Inbound and fixture coverage

Captured inbound events: READY, GUILD_CREATE, MESSAGE_CREATE/UPDATE/DELETE, MESSAGE_REACTION_ADD, INTERACTION_CREATE, THREAD_CREATE and THREAD_MEMBER_UPDATE. The worker also handles GUILD_DELETE cleanup. Clawdi records/replays dispatches having an authorized channel/guild/thread routing key.

Captured outbound endpoints include:

- message POST/PATCH/DELETE
- own reaction PUT
- create thread from message + send inside thread
- global and guild command PUT
- interaction callbacks
- interaction webhook followups
- multipart images/data files

Behavior tests additionally cover rich embeds/components/future fields, multipart references, unobserved same-guild threads, permission-overwrite forwarding, interaction-token binding and guild/link isolation.

## Pinned official Discord sources

Commit: `07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3`.

- [Permissions](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/topics/permissions.mdx)
- [OAuth2 scopes/integration_type](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/topics/oauth2.mdx)
- [Application flags/install config](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/resources/application.mdx)
- [Messages/reactions/attachments](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/resources/message.mdx)
- [Thread/forum/channel endpoints](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/resources/channel.mdx)
- [Thread semantics](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/topics/threads.mdx)
- [Gateway intents](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/events/gateway.mdx)
- [Interactions](https://github.com/discord/discord-api-docs/blob/07c83a8f1c54accd8e8d13072a5e08d1b1be7ac3/developers/interactions/receiving-and-responding.mdx)

## Verification

- Docker-backed capability-focused backend tests: 8 passed
- Docker-backed install/readiness/permission tests: 9 passed
- Web channel-linking tests: 8 passed; OSS build passed
- CLI channel tests: 15 passed
- Web/CLI typechecks, Ruff, Ruff format, Biome and diff checks passed

PR only. No deployment or Discord Portal operation performed.