### PR TITLE
refactor(web): converge OpenAPI React Query usage

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
 		"nitro": "^3.0.260610-beta",
 		"nuqs": "^2.9.0",
 		"openapi-fetch": "^0.17.0",
+		"openapi-react-query": "^0.5.4",
 		"posthog-js": "^1.396.6",
 		"qrcode.react": "^4.2.0",
 		"react": "catalog:",

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -22,7 +22,7 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter, useSearch } from "@tanstack/react-router";
 import {
 	BookOpen,
@@ -98,7 +98,7 @@ import {
 	agentSectionHref,
 	parseAgentPathname,
 } from "@/lib/agent-routes";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import {
 	availableAppsQueryOptions,
@@ -272,7 +272,7 @@ function SidebarNavSection({
 }
 
 function usePrefetchConnectorsCatalog() {
-	const api = useApi();
+	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	return useCallback(() => {
 		void queryClient.prefetchQuery(
@@ -824,22 +824,22 @@ function FocusRailContent({
 			previousRail: AgentTile[];
 		}) => unwrap(await api.PATCH("/v1/agents/order", { body: { agent_ids: environmentIds } })),
 		onMutate: async ({ environmentIds, previousRail }) => {
-			await queryClient.cancelQueries({ queryKey: ["agents"] });
-			const previous = queryClient.getQueryData<SidebarEnvironment[]>(["agents"]);
-			queryClient.setQueryData<SidebarEnvironment[]>(["agents"], (current) =>
+			await queryClient.cancelQueries({ queryKey: ["get", "/v1/agents"] });
+			const previous = queryClient.getQueryData<SidebarEnvironment[]>(["get", "/v1/agents", {}]);
+			queryClient.setQueryData<SidebarEnvironment[]>(["get", "/v1/agents", {}], (current) =>
 				current ? reorderEnvironmentsForCache(current, environmentIds) : current,
 			);
 			return { previous, previousRail };
 		},
 		onError: (error, _variables, context) => {
 			if (context?.previous) {
-				queryClient.setQueryData(["agents"], context.previous);
+				queryClient.setQueryData(["get", "/v1/agents", {}], context.previous);
 			}
 			if (context?.previousRail) setRailAgentsOrder(context.previousRail);
 			toast.error("Couldn't reorder agents", { description: errorMessage(error) });
 		},
 		onSuccess: (data) => {
-			queryClient.setQueryData(["agents"], data);
+			queryClient.setQueryData(["get", "/v1/agents", {}], data);
 		},
 	});
 	const onDragEnd = (event: DragEndEvent) => {
@@ -1421,7 +1421,7 @@ export function AppSidebar({
 	const { user } = useCurrentUser();
 	const { setOpen: setPaletteOpen } = useCommandPalette();
 	const { isMobile, setOpenMobile, state: sidebarState } = useSidebar();
-	const api = useApi();
+	const $api = useOpenApi();
 	const hostedAccess = useHostedProductAccess();
 	const hydrated = useHydrated();
 	const [hostedAgentTiles, setHostedAgentTiles] = useState<AgentTile[] | null>(null);
@@ -1439,11 +1439,15 @@ export function AppSidebar({
 	const agentRoute = parseAgentPathname(pathname);
 	const activeAgentId = agentRoute?.agentId ?? null;
 	const activeDeploymentSelector = agentRoute ? agentDeploymentSelector(routeSearch) : null;
-	const { data: environments } = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-		refetchInterval: activeAgentId ? 10_000 : false,
-	});
+	const { data: environments } = $api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			refetchInterval: activeAgentId ? 10_000 : false,
+			refetchIntervalInBackground: false,
+		},
+	);
 	const hydratedEnvironments = hydrated ? environments : undefined;
 	const selfManagedTiles = useMemo(
 		() => selfManagedAgentTiles(hydratedEnvironments),

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { Brain, Key, type LucideIcon, MessageSquare, Settings, Sparkles } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
@@ -15,7 +15,7 @@ import {
 	CommandSeparator,
 } from "@/components/ui/command";
 import { Spinner } from "@/components/ui/spinner";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import type { SearchHit } from "@/lib/api-schemas";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
@@ -100,7 +100,7 @@ function CommandPalette({
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }) {
-	const api = useApi();
+	const api = useOpenApi();
 	const router = useRouter();
 	const hostedAccess = useHostedProductAccess();
 	const [query, setQuery] = useState("");
@@ -138,17 +138,19 @@ function CommandPalette({
 		return shortcuts;
 	}, [hostedAccess.canCreateCloudAgents]);
 
-	const { data, isFetching } = useQuery({
-		queryKey: ["command-search", debounced],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/search", { params: { query: { q: debounced } } })),
-		enabled: open && debounced.trim().length > 0,
-		staleTime: 30_000,
-		// Keep the last page of results visible while a new debounced query
-		// flies out — prevents the palette flashing to "empty" on every
-		// keystroke.
-		placeholderData: keepPreviousData,
-	});
+	const { data, isFetching } = api.useQuery(
+		"get",
+		"/v1/search",
+		{ params: { query: { q: debounced } } },
+		{
+			enabled: open && debounced.trim().length > 0,
+			staleTime: 30_000,
+			// Keep the last page of results visible while a new debounced query
+			// flies out — prevents the palette flashing to "empty" on every
+			// keystroke.
+			placeholderData: keepPreviousData,
+		},
+	);
 
 	const jump = useCallback(
 		(href: string) => {

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -12,7 +12,7 @@ import {
 	EntityRow,
 } from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { availableAppQueryOptions, connectorToolsQueryOptions } from "@/lib/connectors-data";
 import { connectorDetailHref } from "@/lib/project-resource-model";
 import { cn } from "@/lib/utils";
@@ -30,7 +30,7 @@ export function ConnectorCard({
 	app: { name: string; display_name: string; description: string; logo: string };
 	isConnected?: boolean;
 }) {
-	const api = useApi();
+	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	const prefetchDetail = useCallback(() => {
 		void queryClient.prefetchQuery(availableAppQueryOptions(api, app.name));

--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -52,7 +52,7 @@ export function ConnectorCredentialsDialog({
 				body: { credentials },
 			}),
 		);
-		queryClient.invalidateQueries({ queryKey: ["connections"] });
+		queryClient.invalidateQueries({ queryKey: ["get", "/v1/connectors"] });
 	});
 	const [values, setValues] = useState<Record<string, string>>({});
 	const [submitError, setSubmitError] = useState<string | null>(null);

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Bot, Check, Copy, Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -9,7 +8,7 @@ import { AgentLabel, AgentSourceBadgeForEnvironment } from "@/components/dashboa
 import { agentRegistrationDescription } from "@/components/dashboard/agent-registration-status";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { cn, errorMessage } from "@/lib/utils";
 
 // Fallback origin used during SSR and on the first client render before the
@@ -87,17 +86,21 @@ function CopyButton({
  * watches for newly registered agents and surfaces an explicit success state.
  */
 export function AddAgentSetup() {
-	const api = useApi();
+	const api = useOpenApi();
 	const origin = useOrigin();
 	const prompt = `Set up Clawdi on this machine. Fetch ${origin}/skill.md, and follow the skills to set it up. Finally, confirm the installation with \`clawdi doctor\`.`;
 
 	// Live success detection: snapshot the env ids on first load, then poll
 	// while mounted. Anything new is "your agent just connected".
-	const envs = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-		refetchInterval: 5_000,
-	});
+	const envs = api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			refetchInterval: 5_000,
+			refetchIntervalInBackground: false,
+		},
+	);
 	const baseline = useRef<Set<string> | null>(null);
 	useEffect(() => {
 		if (envs.data && baseline.current === null) {

--- a/apps/web/src/components/dashboard/agent-project-bindings-query.ts
+++ b/apps/web/src/components/dashboard/agent-project-bindings-query.ts
@@ -1,28 +1,23 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import type { AgentProjectBinding } from "@/components/dashboard/agent-project-scope";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 
 export function agentProjectBindingsQueryKey(agentId: string | null | undefined) {
-	return ["agent-project-bindings", agentId ?? ""] as const;
+	return [
+		"get",
+		"/v1/agents/{agent_id}/project-bindings",
+		{ params: { path: { agent_id: agentId ?? "" } } },
+	] as const;
 }
 
 export function useAgentProjectBindings(
 	agentId: string | null | undefined,
 	{ enabled = true }: { enabled?: boolean } = {},
 ) {
-	const api = useApi();
-	return useQuery({
-		queryKey: agentProjectBindingsQueryKey(agentId),
-		queryFn: async (): Promise<AgentProjectBinding[]> => {
-			if (!agentId) throw new Error("Agent identity is not resolved");
-			return unwrap(
-				await api.GET("/v1/agents/{agent_id}/project-bindings", {
-					params: { path: { agent_id: agentId } },
-				}),
-			);
-		},
-		enabled: enabled && Boolean(agentId),
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/agents/{agent_id}/project-bindings",
+		{ params: { path: { agent_id: agentId ?? "" } } },
+		{ enabled: enabled && Boolean(agentId) },
+	);
 }

--- a/apps/web/src/components/dashboard/agent-projects-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-projects-tab.test.ts
@@ -65,6 +65,6 @@ describe("agent Projects presentation", () => {
 		expect(source).toContain("<ConfirmAction");
 		expect(source).toContain('title="Remove this Project?"');
 		expect(source).toContain("agentProjectBindingsQueryKey(agentId)");
-		expect(source).toContain('invalidateQueries({ queryKey: ["projects"] })');
+		expect(source).toContain('invalidateQueries({ queryKey: ["get", "/v1/projects"] })');
 	});
 });

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowDown, ArrowUp, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -38,7 +38,7 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
@@ -50,13 +50,16 @@ export function AgentProjectsTab({
 	agentId: string;
 	enabled?: boolean;
 }) {
-	const api = useApi();
+	const $api = useOpenApi();
 	const queryClient = useQueryClient();
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-		enabled,
-	});
+	const projects = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled,
+		},
+	);
 	const bindings = useAgentProjectBindings(agentId, { enabled });
 
 	return (
@@ -75,7 +78,7 @@ export function AgentProjectsTab({
 			}}
 			onChanged={() => {
 				void queryClient.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) });
-				void queryClient.invalidateQueries({ queryKey: ["projects"] });
+				void queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
 			}}
 		/>
 	);

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { ExternalLink, RotateCcw, Save, Trash2, Unplug, Upload } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -25,7 +25,7 @@ import {
 	agentOwnershipKindFromId,
 	useAgentOwnership,
 } from "@/lib/agent-ownership";
-import { toastApiError, unwrap, useAgentAvatarUploader, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useAgentAvatarUploader, useApi, useOpenApi } from "@/lib/api";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -36,8 +36,11 @@ const MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024;
 const AGENT_AVATAR_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
 
 function updateEnvironmentCaches(queryClient: QueryClient, environment: Environment) {
-	queryClient.setQueryData(["agents", environment.id], environment);
-	queryClient.setQueryData<Environment[]>(["agents"], (current) =>
+	queryClient.setQueryData(
+		["get", "/v1/agents/{agent_id}", { params: { path: { agent_id: environment.id } } }],
+		environment,
+	);
+	queryClient.setQueryData<Environment[]>(["get", "/v1/agents", {}], (current) =>
 		current?.map((item) => (item.id === environment.id ? environment : item)),
 	);
 }
@@ -52,6 +55,7 @@ export function AgentSettingsPanel({
 	formatName?: (name: string) => string;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const ownership = useAgentOwnership();
@@ -63,14 +67,8 @@ export function AgentSettingsPanel({
 		data: agent,
 		isLoading,
 		error,
-	} = useQuery({
-		queryKey: ["agents", environmentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}", {
-					params: { path: { agent_id: environmentId } },
-				}),
-			),
+	} = $api.useQuery("get", "/v1/agents/{agent_id}", {
+		params: { path: { agent_id: environmentId } },
 	});
 
 	const serverDraftName = agent

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -14,12 +14,9 @@ import {
 } from "@/components/dashboard/agent-skills-query";
 import { SkillCardGrid } from "@/components/skills/skill-card";
 import { type AgentRouteSearch, agentSkillDetailLink } from "@/lib/agent-routes";
-import { unwrap, useApi } from "@/lib/api";
-import type { components } from "@/lib/api-schemas";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
 import { skillCapabilities } from "@/lib/skill-authority";
-
-type ProjectRow = components["schemas"]["ProjectResponse"];
 
 export function useAgentProjectSkills(
 	agentId: string,
@@ -100,7 +97,7 @@ export function AgentSkillsTab({
 	isResolvingAgentProject?: boolean;
 	projectionFence?: string;
 }) {
-	const api = useApi();
+	const $api = useOpenApi();
 	const {
 		skills,
 		isLoading: skillsLoading,
@@ -113,11 +110,14 @@ export function AgentSkillsTab({
 		true,
 		!isResolvingAgentProject,
 	);
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-		enabled: !isResolvingAgentProject,
-	});
+	const projects = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: !isResolvingAgentProject,
+		},
+	);
 	const projectsById = useMemo(
 		() => new Map((projects.data ?? []).map((project) => [project.id, project])),
 		[projects.data],

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -28,7 +28,7 @@ import {
 	agentSessionDetailLink,
 	CONNECTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -56,7 +56,7 @@ export function ConnectedAgentDetail({
 	showSourceBadge?: boolean;
 }) {
 	const id = environmentId;
-	const api = useApi();
+	const $api = useOpenApi();
 	const ownership = useAgentOwnership();
 	const activeTab = parseAgentTab(section) ?? "overview";
 
@@ -65,14 +65,8 @@ export function ConnectedAgentDetail({
 		isLoading,
 		error,
 		refetch: refetchAgent,
-	} = useQuery({
-		queryKey: ["agents", id],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}", {
-					params: { path: { agent_id: id } },
-				}),
-			),
+	} = $api.useQuery("get", "/v1/agents/{agent_id}", {
+		params: { path: { agent_id: id } },
 	});
 
 	const {
@@ -87,7 +81,7 @@ export function ConnectedAgentDetail({
 		error: sessionsError,
 		refetch: refetchSessions,
 	} = useQuery({
-		...sessionListQueryOptions(api, { environment_id: id, page_size: 50 }),
+		...sessionListQueryOptions($api, { environment_id: id, page_size: 50 }),
 		enabled: !!agent,
 	});
 

--- a/apps/web/src/components/notification-center.logic.test.ts
+++ b/apps/web/src/components/notification-center.logic.test.ts
@@ -6,6 +6,7 @@ import {
 	getNotificationCenterTriggerLabel,
 	getPendingNotificationCount,
 	getProjectInvitationAccessCopy,
+	NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS,
 	type ProjectInvitationNotification,
 } from "./notification-center.logic";
 
@@ -57,5 +58,12 @@ describe("notification center logic", () => {
 		expect(accepted.description).toContain("Read-only access");
 		expect(accepted.description).toContain("Open the Project");
 		expect(accepted.description).toContain("add it to an agent");
+	});
+
+	test("refreshes canonical OpenAPI membership caches after accepting an invitation", () => {
+		expect(NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS).toContainEqual(["get", "/v1/projects"]);
+		expect(NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS).toContainEqual(["get", "/v1/agents"]);
+		expect(NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS).not.toContainEqual(["projects"]);
+		expect(NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS).not.toContainEqual(["agents"]);
 	});
 });

--- a/apps/web/src/components/notification-center.logic.ts
+++ b/apps/web/src/components/notification-center.logic.ts
@@ -8,12 +8,12 @@ export type AcceptInvitationResponse = Schemas["InvitationAcceptResponse"];
 // Project invitations are the first notification source. Keep the shell named
 // generically so future notification types (agent health, billing, access
 // changes) can join without replacing the header affordance.
-export const NOTIFICATION_CENTER_QUERY_KEY = ["me-invitations"] as const;
+export const NOTIFICATION_CENTER_QUERY_KEY = ["get", "/v1/me/invitations"] as const;
 export const NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS = [
 	NOTIFICATION_CENTER_QUERY_KEY,
 	["skills"],
-	["projects"],
-	["agents"],
+	["get", "/v1/projects"],
+	["get", "/v1/agents"],
 ] as const;
 
 export function getPendingNotificationCount(

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { CheckCircle2, InboxIcon, MailOpen, XCircle } from "lucide-react";
 import { useState } from "react";
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
-import { ApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { projectDetailHref } from "@/lib/project-resource-model";
 import { cn, errorMessage } from "@/lib/utils";
@@ -31,7 +31,6 @@ import {
 	getPendingNotificationCount,
 	getProjectInvitationAccessCopy,
 	NOTIFICATION_CENTER_MEMBERSHIP_QUERY_KEYS,
-	NOTIFICATION_CENTER_QUERY_KEY,
 	type ProjectInvitationNotification,
 } from "./notification-center.logic";
 
@@ -39,6 +38,7 @@ export function NotificationCenter() {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const api = useApi();
+	const $api = useOpenApi();
 	const [open, setOpen] = useState(false);
 
 	function refetchMembershipDerived() {
@@ -47,12 +47,14 @@ export function NotificationCenter() {
 		}
 	}
 
-	const invitations = useQuery({
-		queryKey: NOTIFICATION_CENTER_QUERY_KEY,
-		queryFn: async (): Promise<ProjectInvitationNotification[]> =>
-			unwrap(await api.GET("/v1/me/invitations")),
-		refetchOnWindowFocus: true,
-	});
+	const invitations = $api.useQuery(
+		"get",
+		"/v1/me/invitations",
+		{},
+		{
+			refetchOnWindowFocus: true,
+		},
+	);
 
 	const accept = useMutation({
 		mutationFn: async ({

--- a/apps/web/src/components/sessions/share-controls.tsx
+++ b/apps/web/src/components/sessions/share-controls.tsx
@@ -11,6 +11,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { ApiError, unwrap, useApi } from "@/lib/api";
+import { sessionDetailQueryKey } from "@/lib/session-queries";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 /**
@@ -73,8 +74,8 @@ function SharePopover({ sessionId, isShared }: { sessionId: string; isShared: bo
 
 	function invalidate() {
 		qc.invalidateQueries({ queryKey: ["session-permissions", sessionId] });
-		qc.invalidateQueries({ queryKey: ["session", sessionId] });
-		qc.invalidateQueries({ queryKey: ["sessions"] });
+		qc.invalidateQueries({ queryKey: sessionDetailQueryKey(sessionId) });
+		qc.invalidateQueries({ queryKey: ["get", "/v1/sessions"] });
 	}
 
 	// Optimistic toggle: flip the cached link permission immediately so the

--- a/apps/web/src/components/settings/api-keys-panel.logic.ts
+++ b/apps/web/src/components/settings/api-keys-panel.logic.ts
@@ -1,6 +1,6 @@
 import type { ApiKey } from "@/lib/api-schemas";
 
-export const API_KEYS_QUERY_KEY = ["api-keys"] as const;
+export const API_KEYS_QUERY_KEY = ["get", "/v1/auth/keys"] as const;
 
 /** Keep revoked keys out of the UI while older backends are still in a rolling deployment. */
 export function activeApiKeys(keys: readonly ApiKey[] | undefined): ApiKey[] {

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Check, Copy, KeyRound, Laptop, Plus, ShieldCheck, Trash2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
@@ -50,7 +50,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
-import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
 import { formatShortDate } from "@/lib/format";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -65,6 +65,7 @@ type RevokeContext = {
 /** API Keys settings — CLI-facing bearer tokens. */
 export function ApiKeysPanel() {
 	const api = useApi();
+	const $api = useOpenApi();
 	const queryClient = useQueryClient();
 	const [createDialogOpen, setCreateDialogOpen] = useState(false);
 	const [newLabel, setNewLabel] = useState("");
@@ -84,15 +85,7 @@ export function ApiKeysPanel() {
 		error: "Couldn’t copy the API key — select and copy it manually.",
 	});
 
-	const {
-		data: listedKeys,
-		error,
-		isLoading,
-		refetch,
-	} = useQuery({
-		queryKey: API_KEYS_QUERY_KEY,
-		queryFn: async () => unwrap(await api.GET("/v1/auth/keys")),
-	});
+	const { data: listedKeys, error, isLoading, refetch } = $api.useQuery("get", "/v1/auth/keys");
 	const keys = useMemo(() => activeApiKeys(listedKeys), [listedKeys]);
 
 	const createKey = useSensitiveAction(async (label: string) => {

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -762,7 +762,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 		qc.invalidateQueries({ queryKey: ["share-links", projectId] });
 		qc.invalidateQueries({ queryKey: ["invitations", projectId] });
 		qc.invalidateQueries({ queryKey: ["skills"] });
-		qc.invalidateQueries({ queryKey: ["projects"] });
+		qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
 	};
 
 	const remove = useMutation({

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Send } from "lucide-react";
 import { type ReactElement, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -25,7 +25,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { ensureBlob, unwrap, useApi, useSkillArchiveUploader } from "@/lib/api";
+import { ensureBlob, unwrap, useApi, useOpenApi, useSkillArchiveUploader } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { skillCapabilities } from "@/lib/skill-authority";
@@ -49,6 +49,7 @@ export function SendSkillDialog({
 	onDone?: () => void;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const uploadSkillArchive = useSkillArchiveUploader();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
@@ -58,11 +59,14 @@ export function SendSkillDialog({
 	const single = skills.length === 1 ? skills[0] : null;
 	const batchLabel = single ? single.name : `${skills.length} skills`;
 
-	const projectsQuery = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-		enabled: open,
-	});
+	const projectsQuery = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: open,
+		},
+	);
 	const projects = projectsQuery.data;
 	const destinationLoadError = projectsQuery.error;
 

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -30,7 +30,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { buildKeyImportPreview } from "@/components/vault/key-import-logic";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
@@ -54,6 +54,7 @@ export function AddKeysDialog({
 	children?: ReactElement;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [text, setText] = useState("");
@@ -61,17 +62,24 @@ export function AddKeysDialog({
 	const [newVaultName, setNewVaultName] = useState("");
 	const [updateExisting, setUpdateExisting] = useState(false);
 
-	const vaultsQuery = useQuery({
-		queryKey: ["vaults", "all"],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
-		enabled: open,
-	});
-	const projectsQuery = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-		enabled: open,
-	});
+	const vaultsQuery = $api.useQuery(
+		"get",
+		"/v1/vault",
+		{
+			params: { query: { page_size: 200 } },
+		},
+		{
+			enabled: open,
+		},
+	);
+	const projectsQuery = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: open,
+		},
+	);
 
 	const ownVaults = useMemo(
 		() => (vaultsQuery.data?.items ?? []).filter((v) => v.is_owner !== false),
@@ -193,7 +201,7 @@ export function AddKeysDialog({
 				);
 			}
 			const summary = importPlan.summary;
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			qc.invalidateQueries({
 				queryKey: targetVaultId ? ["vault-items", targetVaultId] : ["vault-items"],
 			});

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Plus } from "lucide-react";
 import { type ReactElement, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { errorMessage } from "@/lib/utils";
@@ -54,6 +54,7 @@ export function CopyKeysDialog({
 	children: ReactElement;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [targetChoice, setTargetChoice] = useState("");
@@ -63,17 +64,24 @@ export function CopyKeysDialog({
 	const attachedCount = vault.project_ids?.length ?? 0;
 	const verb = mode === "move" ? "Move" : "Copy";
 
-	const vaultsQuery = useQuery({
-		queryKey: ["vaults", "all"],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
-		enabled: open,
-	});
-	const projectsQuery = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-		enabled: open,
-	});
+	const vaultsQuery = $api.useQuery(
+		"get",
+		"/v1/vault",
+		{
+			params: { query: { page_size: 200 } },
+		},
+		{
+			enabled: open,
+		},
+	);
+	const projectsQuery = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: open,
+		},
+	);
 	const ownVaults = useMemo(
 		() => (vaultsQuery.data?.items ?? []).filter((v) => v.is_owner !== false),
 		[vaultsQuery.data],
@@ -213,7 +221,7 @@ export function CopyKeysDialog({
 			return { targetSlug, copied, failed, sourceRemoveFailed };
 		},
 		onSuccess: ({ targetSlug, copied, failed, sourceRemoveFailed }) => {
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			qc.invalidateQueries({ queryKey: ["vault-items"] });
 			const sourceCleanupFailed = sourceRemoveFailed.length > 0;
 			toast.success(

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Scissors } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -18,7 +18,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { errorMessage } from "@/lib/utils";
@@ -72,6 +72,7 @@ export function SplitVaultDialog({
 	onDone?: () => void;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [excluded, setExcluded] = useState<Set<string>>(new Set());
@@ -84,11 +85,14 @@ export function SplitVaultDialog({
 	const selected = useMemo(() => groups.filter((g) => !excluded.has(g.slug)), [groups, excluded]);
 	const selectedKeyCount = selected.reduce((n, g) => n + g.keys.length, 0);
 
-	const projectsQuery = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-		enabled: open,
-	});
+	const projectsQuery = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: open,
+		},
+	);
 	const projects = projectsQuery.data;
 
 	const run = useMutation({
@@ -174,7 +178,7 @@ export function SplitVaultDialog({
 			return { done, failed, affectedKeys };
 		},
 		onSuccess: ({ done, failed, affectedKeys }) => {
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			qc.invalidateQueries({ queryKey: ["vault-items"] });
 			exit.beginClose();
 			toast.success(`Split into ${done} ${done === 1 ? "vault" : "vaults"}`, {

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -33,14 +33,13 @@ import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { vaultDetailSearch } from "@/components/vault/vault-detail-identity";
 import { fetchAgentProjectVaults } from "@/components/vault/vault-scope";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { cn, errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
-type ProjectRow = components["schemas"]["ProjectResponse"];
 
 const VAULTS_RESOURCE = getProjectResourceDefinition("vaults");
 
@@ -55,16 +54,21 @@ export function VaultsSurface({
 	agentProjectIds?: readonly string[];
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const [search, setSearch] = useState("");
 	const [projectFilter, setProjectFilter] = useState<string>("all");
 
-	const accountVaults = useQuery({
-		queryKey: ["vaults", "all"],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
-		placeholderData: keepPreviousData,
-		enabled: agentProjectIds === undefined,
-	});
+	const accountVaults = $api.useQuery(
+		"get",
+		"/v1/vault",
+		{
+			params: { query: { page_size: 200 } },
+		},
+		{
+			placeholderData: keepPreviousData,
+			enabled: agentProjectIds === undefined,
+		},
+	);
 	const agentVaults = useQuery({
 		queryKey: ["vaults", "agent-projects", ...(agentProjectIds ?? [])],
 		queryFn: async () =>
@@ -79,11 +83,14 @@ export function VaultsSurface({
 	});
 	const vaultsQuery = agentProjectIds === undefined ? accountVaults : agentVaults;
 
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-		placeholderData: keepPreviousData,
-	});
+	const projects = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			placeholderData: keepPreviousData,
+		},
+	);
 	const projectNameById = useMemo(
 		() => new Map((projects.data ?? []).map((p) => [p.id, p.name])),
 		[projects.data],
@@ -380,22 +387,30 @@ function VaultCardSkeleton() {
 
 function NewVaultDialog({ trigger }: { trigger?: ReactElement }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
 	const [name, setName] = useState("");
 
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-		enabled: open,
-	});
-	const vaultsQuery = useQuery({
-		queryKey: ["vaults", "all"],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
-		enabled: open,
-	});
+	const projects = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			enabled: open,
+		},
+	);
+	const vaultsQuery = $api.useQuery(
+		"get",
+		"/v1/vault",
+		{
+			params: { query: { page_size: 200 } },
+		},
+		{
+			enabled: open,
+		},
+	);
 	// A vault is created through a project the user can write to; the
 	// personal (Global) project always exists and is the least surprising
 	// default — attachments can be changed afterwards on the vault page.
@@ -431,7 +446,7 @@ function NewVaultDialog({ trigger }: { trigger?: ReactElement }) {
 			);
 		},
 		onSuccess: (created) => {
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			setOpen(false);
 			toast.success("Vault created", { description: "Add keys, then share it through a Project." });
 			void router.navigate({

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -336,13 +336,13 @@ describe("deployment mutation settlement", () => {
 	test("invalidates deployment membership and its additive agent projection together", () => {
 		const queryClient = new QueryClient();
 		queryClient.setQueryData(billingKeys.deployments, []);
-		queryClient.setQueryData(["agents"], []);
+		queryClient.setQueryData(["get", "/v1/agents"], []);
 
 		if (!invalidateSnapshots) throw new Error("deployment hooks were not loaded");
 		invalidateSnapshots(queryClient);
 
 		expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
-		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 	});
 
 	test("uses the shared invalidation on every inventory-changing mutation settlement", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -41,14 +41,14 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 
 export function invalidateDeploymentSnapshots(qc: QueryClient) {
 	void qc.invalidateQueries({ queryKey: billingKeys.deployments });
-	void qc.invalidateQueries({ queryKey: ["agents"] });
+	void qc.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 }
 
 function scheduleDeploymentSettlingRefresh(qc: QueryClient) {
 	for (const delay of SETTLING_REFRESH_DELAYS_MS) {
 		globalThis.setTimeout(() => {
 			void qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			void qc.invalidateQueries({ queryKey: ["agents"] });
+			void qc.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 		}, delay);
 	}
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -249,6 +249,7 @@ import {
 	agentProviderHasSingleLinkLimit,
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/channel-linking.logic";
+import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelBinding } from "@/hosted/v2/channels/channel-types";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
@@ -276,7 +277,7 @@ import {
 	agentSessionDetailLink,
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
-import { ApiError, toastApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
@@ -462,28 +463,28 @@ export function HostedAgentDetail({
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
-	const api = useApi();
+	const $api = useOpenApi();
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
 	const cloudEnvironmentId = isCloudEnvId(environmentId);
-	const agentQuery = useQuery({
-		queryKey: ["agents", environmentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}", {
-					params: { path: { agent_id: environmentId } },
-				}),
-			),
-		enabled: cloudEnvironmentId && deploymentProjectionQueryable,
-		refetchInterval: (query) =>
-			missingProjectionRefetchInterval(
-				query.state.error,
-				deploymentStatus,
-				query.state.fetchFailureCount,
-			),
-		refetchIntervalInBackground: false,
-	});
+	const agentQuery = $api.useQuery(
+		"get",
+		"/v1/agents/{agent_id}",
+		{
+			params: { path: { agent_id: environmentId } },
+		},
+		{
+			enabled: cloudEnvironmentId && deploymentProjectionQueryable,
+			refetchInterval: (query) =>
+				missingProjectionRefetchInterval(
+					query.state.error,
+					deploymentStatus,
+					query.state.fetchFailureCount,
+				),
+			refetchIntervalInBackground: false,
+		},
+	);
 	const projection = resolveHostedAgentProjection({
 		enabled: cloudEnvironmentId && deploymentProjectionQueryable,
 		data: agentQuery.data,
@@ -513,7 +514,7 @@ export function HostedAgentDetail({
 	});
 
 	const sessions = useQuery({
-		...sessionListQueryOptions(api, { environment_id: environmentId, page_size: 20 }),
+		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 20 }),
 		enabled: deploymentRunning && projection.status === "resolved",
 	});
 
@@ -765,7 +766,7 @@ function HostedAgentSessionsTab({
 	enabled: boolean;
 	routeSearch: AgentRouteSearch;
 }) {
-	const api = useApi();
+	const $api = useOpenApi();
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(20);
 
@@ -774,7 +775,7 @@ function HostedAgentSessionsTab({
 	}, [environmentId]);
 
 	const sessions = useQuery({
-		...sessionListQueryOptions(api, { environment_id: environmentId, page, page_size: pageSize }),
+		...sessionListQueryOptions($api, { environment_id: environmentId, page, page_size: pageSize }),
 		enabled: enabled && isCloudEnvId(environmentId),
 		placeholderData: keepPreviousData,
 		// staleTime only controls freshness; this mounted-tab observer owns visibility refreshes.
@@ -2445,9 +2446,9 @@ function ChannelsTab({
 	function acceptLinkedChannel(nextLink: AgentChannelLink) {
 		setRecentLinks((current) => new Map(current).set(nextLink.account_id, nextLink));
 		void qc.invalidateQueries({ queryKey: ["agent-channel-links", environmentId] });
-		void qc.invalidateQueries({ queryKey: ["channel-agent-links", nextLink.account_id] });
-		void qc.invalidateQueries({ queryKey: ["channel-bot-pool"] });
-		void qc.invalidateQueries({ queryKey: ["channels"] });
+		void qc.invalidateQueries({ queryKey: channelKeys.agentLinks(nextLink.account_id) });
+		void qc.invalidateQueries({ queryKey: channelKeys.pool });
+		void qc.invalidateQueries({ queryKey: channelKeys.list });
 		showPairingForLink(nextLink);
 	}
 
@@ -2529,8 +2530,8 @@ function ChannelsTab({
 				bot={bot}
 				pairedChats={linkForBot ? (pairedChatsByLinkId.get(linkForBot.id) ?? []) : []}
 				bindings={bindingQuery?.data}
-				bindingsLoading={Boolean(bindingQuery?.isFetching)}
-				bindingsError={Boolean(bindingQuery?.error)}
+				bindingsLoading={Boolean(bindingQuery?.isPending)}
+				bindingsError={Boolean(bindingQuery?.error && bindingQuery.data === undefined)}
 				onBindingsRetry={() => void bindingQuery?.refetch()}
 				agentName={agentName}
 				agentType={agentType}

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -35,7 +35,7 @@ describe("accepted deployment navigation", () => {
 		});
 		const agentsProjection = [{ id: "agent_before_acceptance" }];
 		queryClient.setQueryData(billingKeys.deployments, [existing, staleCreated]);
-		queryClient.setQueryData(["agents"], agentsProjection);
+		queryClient.setQueryData(["get", "/v1/agents"], agentsProjection);
 		const inFlightStaleList = queryClient
 			.fetchQuery({
 				queryKey: billingKeys.deployments,
@@ -80,9 +80,13 @@ describe("accepted deployment navigation", () => {
 			authoritative,
 		]);
 		expect(navigations).toEqual([{ href: "/agents/hdep_created?source=on-clawdi", replace: true }]);
-		expect(queryClient.getQueryData<typeof agentsProjection>(["agents"])).toBe(agentsProjection);
-		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
-		expect(queryClient.getQueryCache().findAll({ queryKey: ["agents"] })).toHaveLength(1);
+		expect(queryClient.getQueryData<typeof agentsProjection>(["get", "/v1/agents"])).toBe(
+			agentsProjection,
+		);
+		expect(queryClient.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryCache().findAll({ queryKey: ["get", "/v1/agents"] })).toHaveLength(
+			1,
+		);
 
 		queryClient.clear();
 	});

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -52,7 +52,7 @@ export async function navigateToAcceptedDeployment({
 	queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
 		upsertAuthoritativeDeployment(deployments, authoritative),
 	);
-	void queryClient.invalidateQueries({ queryKey: ["agents"] });
+	void queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 
 	await navigate({
 		href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -170,7 +170,7 @@ describe("refreshCheckoutReturnQueries", () => {
 			},
 		});
 		qc.setQueryData(billingKeys.plans, [{ id: "plan_before_checkout" }]);
-		qc.setQueryData(["agents"], [{ id: "agent_before_checkout" }]);
+		qc.setQueryData(["get", "/v1/agents"], [{ id: "agent_before_checkout" }]);
 
 		const result = await refreshCheckoutReturnQueries(qc);
 
@@ -181,7 +181,7 @@ describe("refreshCheckoutReturnQueries", () => {
 			5_000,
 		);
 		expect(qc.getQueryState(billingKeys.plans)?.isInvalidated).toBe(true);
-		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 	});
 
 	test("refreshes ancillary checkout state without invalidating a seeded deployment handoff", async () => {

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -279,7 +279,7 @@ export async function refreshCheckoutReturnQueries(
 	const results = await Promise.allSettled([
 		...requiredRefreshes,
 		qc.invalidateQueries({ queryKey: billingKeys.plans }),
-		qc.invalidateQueries({ queryKey: ["agents"] }),
+		qc.invalidateQueries({ queryKey: ["get", "/v1/agents"] }),
 	]);
 	const requiredRefreshFailures = results
 		.slice(0, requiredRefreshes.length)

--- a/apps/web/src/hosted/billing/sensitive-actions.ts
+++ b/apps/web/src/hosted/billing/sensitive-actions.ts
@@ -22,7 +22,7 @@ function useInvalidateBillingAfterCheckout() {
 		queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
 		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 		queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
-		queryClient.invalidateQueries({ queryKey: ["agents"] });
+		queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 	};
 }
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -29,7 +29,7 @@ function queryClientWithWalletActivity(): QueryClient {
 	});
 	qc.setQueryData(billingKeys.deployments, []);
 	qc.setQueryData(billingKeys.billingHistory(20), { pages: [] });
-	qc.setQueryData(["agents"], []);
+	qc.setQueryData(["get", "/v1/agents"], []);
 	return qc;
 }
 
@@ -75,7 +75,7 @@ describe("handleTopupStartResult", () => {
 		).toBe(true);
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.billingHistory(20))?.isInvalidated).toBe(true);
-		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 		expect(setup.resetAttempt).toHaveBeenCalledTimes(1);
 		expect(setup.closeDialog).toHaveBeenCalledTimes(1);
 		expect(setup.toastInfo).toHaveBeenCalledWith("Payment accepted", {

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -56,7 +56,7 @@ export function invalidateWalletActivity(queryClient: QueryClient): void {
 	queryClient.invalidateQueries({ queryKey: billingKeys.subscriptionCreateQuotes });
 	queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
 	queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
-	queryClient.invalidateQueries({ queryKey: ["agents"] });
+	queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 }
 
 export function completeTopup(

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -383,7 +383,10 @@ export function AddProviderDialog({
 				models: modelsFromText(form.modelsText, editing.models, presetCatalog),
 			} satisfies AiProviderPatch;
 			const saved = await patchProvider
-				.mutateAsync({ providerId: editing.provider_id, body: patch })
+				.mutateAsync({
+					params: { path: { provider_id: editing.provider_id } },
+					body: patch,
+				})
 				.catch(() => null);
 			if (!saved) return;
 			toast.success("Provider settings updated");

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.test.ts
@@ -64,7 +64,7 @@ describe("provider mutation contract", () => {
 
 		expect(hooksSource).toContain('api.POST("/v1/ai-providers/accept"');
 		expect(hooksSource).toContain('api.POST("/v1/ai-providers/test"');
-		expect(hooksSource).toContain('api.POST("/v1/ai-providers/{provider_id}/test"');
+		expect(hooksSource).toContain('useMutation("post", "/v1/ai-providers/{provider_id}/test"');
 		expect(hooksSource).toContain(
 			'api.POST("/v1/ai-providers/{provider_id}/auth/oauth/device/start"',
 		);

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { projectUserSelectableAiProviders } from "@clawdi/shared";
-import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
 	AiProviderAcceptRequest,
@@ -11,33 +11,29 @@ import type {
 	AiProviderList,
 	AiProviderOAuthDevicePollResponse,
 	AiProviderOAuthDeviceStartResponse,
-	AiProviderPatch,
 } from "@/hosted/v2/ai-providers/types";
-import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /** Typed data hooks for the AI Providers surface (cloud-api `/v1/ai-providers`). */
 
-const KEY = ["ai-providers"] as const;
+const KEY = ["get", "/v1/ai-providers"] as const;
 export const selectUserAiProviders = (data: AiProviderList) =>
 	projectUserSelectableAiProviders(data.providers);
 
-function aiProvidersQueryOptions(api: ReturnType<typeof useApi>) {
-	return queryOptions({
-		queryKey: KEY,
-		queryFn: async () => unwrap(await api.GET("/v1/ai-providers")),
-	});
-}
-
 export function useAiProviders() {
-	return useQuery(aiProvidersQueryOptions(useApi()));
+	return useOpenApi().useQuery("get", "/v1/ai-providers", {});
 }
 
 export function useUserAiProviders() {
-	return useQuery({
-		...aiProvidersQueryOptions(useApi()),
-		select: selectUserAiProviders,
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/ai-providers",
+		{},
+		{
+			select: selectUserAiProviders,
+		},
+	);
 }
 
 export function useAcceptProvider() {
@@ -69,31 +65,18 @@ export function useAcceptProvider() {
 }
 
 export function usePatchProvider() {
-	const api = useApi();
+	const api = useOpenApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (vars: { providerId: string; body: AiProviderPatch }) =>
-			unwrap(
-				await api.PATCH("/v1/ai-providers/{provider_id}", {
-					params: { path: { provider_id: vars.providerId } },
-					body: vars.body,
-				}),
-			),
+	return api.useMutation("patch", "/v1/ai-providers/{provider_id}", {
 		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
 		onError: toastApiError("Couldn't update provider"),
 	});
 }
 
 export function useDeleteProvider() {
-	const api = useApi();
+	const api = useOpenApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (providerId: string) =>
-			unwrap(
-				await api.DELETE("/v1/ai-providers/{provider_id}", {
-					params: { path: { provider_id: providerId } },
-				}),
-			),
+	return api.useMutation("delete", "/v1/ai-providers/{provider_id}", {
 		onSuccess: (result) => {
 			qc.invalidateQueries({ queryKey: KEY });
 			toast.success("Provider removed", {
@@ -122,15 +105,7 @@ export function useTestDraftProviderConnection() {
 }
 
 export function useTestProviderConnection() {
-	const api = useApi();
-	return useMutation({
-		mutationFn: async ({ providerId, model }: { providerId: string; model?: string }) =>
-			unwrap(
-				await api.POST("/v1/ai-providers/{provider_id}/test", {
-					params: { path: { provider_id: providerId } },
-					body: model ? { model } : {},
-				}),
-			),
+	return useOpenApi().useMutation("post", "/v1/ai-providers/{provider_id}/test", {
 		onError: toastApiError("Couldn't test connection"),
 	});
 }

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -209,11 +209,14 @@ function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage
 	}
 
 	function removeProvider() {
-		del.mutate(provider.provider_id, {
-			onSuccess: () => {
-				setOpen(false);
+		del.mutate(
+			{ params: { path: { provider_id: provider.provider_id } } },
+			{
+				onSuccess: () => {
+					setOpen(false);
+				},
 			},
-		});
+		);
 	}
 
 	return (

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
@@ -35,8 +35,8 @@ export function ProviderConnectionTest({
 
 	function runTest() {
 		testConnection.mutate({
-			providerId: provider.provider_id,
-			...(testedModel ? { model: testedModel } : {}),
+			params: { path: { provider_id: provider.provider_id } },
+			body: testedModel ? { model: testedModel } : {},
 		});
 	}
 

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -168,7 +168,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 		setRemoving(true);
 		void (async () => {
 			try {
-				await del.mutateAsync(id);
+				await del.mutateAsync({ params: { path: { account_id: id } } });
 				await router.navigate({ href: "/channels" });
 			} catch {
 				// useDeleteChannel already surfaces the API error.

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -77,7 +77,7 @@ describe("channel mutation feedback", () => {
 		const detail = source("./channel-detail-page.tsx");
 
 		for (const [feedback, request] of [
-			["setRemoving(true)", "await del.mutateAsync(id)"],
+			["setRemoving(true)", "await del.mutateAsync({"],
 			["setSyncing(true)", "await sync.mutateAsync"],
 		] as const) {
 			expectFeedbackBeforeRequest(detail, feedback, request);

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -230,13 +230,16 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).toContain("pairedChatsByLinkId.get(linkForBot.id) ?? []");
 		expect(pairedChatRow).toContain("Only this chat will be disconnected");
 		expect(pairedChatRow).toContain("<ConfirmAction");
-		expect(pairedChatRow).toContain("unpair.mutateAsync(binding.id)");
+		expect(pairedChatRow).toContain("binding_id: binding.id");
 		expect(pairedChatRow).toContain("unpair.isPending");
 		expect(confirmAction).toContain("void runConfirm().catch");
 		expect(hooks).toContain("export function useDeleteChannelBinding");
 		expect(hooks).toContain("keys.bindings(accountId)");
 		expect(hooks).toContain('toastApiError("Couldn\'t unpair chat")');
 		expect(hooks).toContain("refetchInterval: 3_000");
+		expect(agentDetail).toContain("bindingsLoading={Boolean(bindingQuery?.isPending)}");
+		expect(agentDetail).not.toContain("bindingsLoading={Boolean(bindingQuery?.isFetching)}");
+		expect(agentDetail).toContain("bindingQuery?.error && bindingQuery.data === undefined");
 		expect(pairedChatRow).toContain("binding.last_message_at");
 		expect(pairedChatRow).toContain("Last activity {relativeTime(binding.last_message_at)}");
 		expect(pairedChatRow).not.toContain("No activity yet");

--- a/apps/web/src/hosted/v2/channels/channel-query-cache.ts
+++ b/apps/web/src/hosted/v2/channels/channel-query-cache.ts
@@ -1,13 +1,29 @@
 import type { QueryClient } from "@tanstack/react-query";
 
 export const channelKeys = {
-	list: ["channels"] as const,
-	pool: ["channel-bot-pool"] as const,
-	health: ["channel-health"] as const,
-	channel: (id: string) => ["channel", id] as const,
-	agentLinks: (id: string) => ["channel-agent-links", id] as const,
-	bindings: (id: string) => ["channel-bindings", id] as const,
-	activity: (id: string) => ["channel-activity", id] as const,
+	list: ["get", "/v1/channels"] as const,
+	pool: ["get", "/v1/channels/bot-pool"] as const,
+	health: ["get", "/v1/channels/health", {}] as const,
+	channel: (id: string) =>
+		["get", "/v1/channels/{account_id}", { params: { path: { account_id: id } } }] as const,
+	agentLinks: (id: string) =>
+		[
+			"get",
+			"/v1/channels/{account_id}/agent-links",
+			{ params: { path: { account_id: id } } },
+		] as const,
+	bindings: (id: string) =>
+		[
+			"get",
+			"/v1/channels/{account_id}/bindings",
+			{ params: { path: { account_id: id } } },
+		] as const,
+	activity: (id: string) =>
+		[
+			"get",
+			"/v1/channels/{account_id}/activity",
+			{ params: { path: { account_id: id }, query: { limit: 50 } } },
+		] as const,
 };
 
 export async function invalidateCreatedChannelQueries(
@@ -33,6 +49,8 @@ export async function removeDeletedChannelQueries(
 	channelId: string,
 ): Promise<void> {
 	qc.removeQueries({ queryKey: channelKeys.channel(channelId) });
+	// Bespoke command projections still use this non-OpenAPI cache namespace.
+	qc.removeQueries({ queryKey: ["channel", channelId] });
 	qc.removeQueries({ queryKey: channelKeys.agentLinks(channelId) });
 	qc.removeQueries({ queryKey: channelKeys.bindings(channelId) });
 	qc.removeQueries({ queryKey: channelKeys.activity(channelId) });

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -1,117 +1,87 @@
 "use client";
 
-import {
-	queryOptions,
-	useMutation,
-	useQueries,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useChannelEditApi } from "@/hosted/v2/channels/channel-edit-client";
-import { channelHealthQueryOptions } from "@/hosted/v2/channels/channel-health-query";
+import { CHANNEL_HEALTH_REFETCH_INTERVAL_MS } from "@/hosted/v2/channels/channel-health-query";
 import {
 	invalidateCreatedChannelQueries,
 	channelKeys as keys,
 	removeDeletedChannelQueries,
 } from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
-import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 /**
  * Typed data hooks for the native channels surface. All reads/writes go
- * through the generated cloud-api client (`useApi`) against
+ * through the generated cloud-api client (`useOpenApi` or `useApi`) against
  * `/v1/channels/*`; mutations invalidate the affected queries and surface
  * recoverable errors as toasts.
  */
 
 export function useChannels() {
-	const api = useApi();
-	return useQuery({
-		queryKey: keys.list,
-		queryFn: async () => unwrap(await api.GET("/v1/channels")),
-	});
+	return useOpenApi().useQuery("get", "/v1/channels");
 }
 
 export function useBotPool() {
-	const api = useApi();
-	return useQuery({
-		queryKey: keys.pool,
-		queryFn: async () => unwrap(await api.GET("/v1/channels/bot-pool")),
-	});
+	return useOpenApi().useQuery("get", "/v1/channels/bot-pool");
 }
 
 export function useChannelHealth() {
-	const api = useApi();
-	return useQuery(
-		channelHealthQueryOptions(async () => unwrap(await api.GET("/v1/channels/health"))),
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/channels/health",
+		{},
+		{
+			refetchInterval: CHANNEL_HEALTH_REFETCH_INTERVAL_MS,
+			refetchIntervalInBackground: false,
+		},
 	);
 }
 
 export function useChannel(id: string) {
-	const api = useApi();
-	return useQuery({
-		queryKey: keys.channel(id),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/channels/{account_id}", {
-					params: { path: { account_id: id } },
-				}),
-			),
-		enabled: Boolean(id),
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/channels/{account_id}",
+		{ params: { path: { account_id: id } } },
+		{ enabled: Boolean(id) },
+	);
 }
 
 export function useChannelAgentLinks(id: string) {
-	const api = useApi();
-	return useQuery({
-		queryKey: keys.agentLinks(id),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/channels/{account_id}/agent-links", {
-					params: { path: { account_id: id } },
-				}),
-			),
-		enabled: Boolean(id),
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/channels/{account_id}/agent-links",
+		{ params: { path: { account_id: id } } },
+		{ enabled: Boolean(id) },
+	);
 }
 
-function channelBindingsQueryOptions(api: ReturnType<typeof useApi>, id: string) {
-	return queryOptions({
-		queryKey: keys.bindings(id),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/channels/{account_id}/bindings", {
-					params: { path: { account_id: id } },
-				}),
-			),
-		enabled: Boolean(id),
-		refetchInterval: 3_000,
-	});
+function channelBindingsQueryOptions(api: ReturnType<typeof useOpenApi>, id: string) {
+	return api.queryOptions(
+		"get",
+		"/v1/channels/{account_id}/bindings",
+		{ params: { path: { account_id: id } } },
+		{ enabled: Boolean(id), refetchInterval: 3_000, refetchIntervalInBackground: false },
+	);
 }
 
 export function useChannelBindings(id: string) {
-	return useQuery(channelBindingsQueryOptions(useApi(), id));
+	return useQuery(channelBindingsQueryOptions(useOpenApi(), id));
 }
 
 export function useChannelBindingsForAccounts(accountIds: readonly string[]) {
-	const api = useApi();
+	const api = useOpenApi();
 	return useQueries({
 		queries: accountIds.map((accountId) => channelBindingsQueryOptions(api, accountId)),
 	});
 }
 
 export function useDeleteChannelBinding(accountId: string) {
-	const api = useApi();
+	const api = useOpenApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (bindingId: string) =>
-			unwrap(
-				await api.DELETE("/v1/channels/{account_id}/bindings/{binding_id}", {
-					params: { path: { account_id: accountId, binding_id: bindingId } },
-				}),
-			),
+	return api.useMutation("delete", "/v1/channels/{account_id}/bindings/{binding_id}", {
 		onSuccess: async (result) => {
 			await Promise.all([
 				qc.invalidateQueries({ queryKey: keys.bindings(accountId) }),
@@ -128,26 +98,17 @@ export function useDeleteChannelBinding(accountId: string) {
 }
 
 export function useChannelActivity(id: string) {
-	const api = useApi();
-	return useQuery({
-		queryKey: keys.activity(id),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/channels/{account_id}/activity", {
-					params: { path: { account_id: id }, query: { limit: 50 } },
-				}),
-			),
-		enabled: Boolean(id),
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/channels/{account_id}/activity",
+		{ params: { path: { account_id: id }, query: { limit: 50 } } },
+		{ enabled: Boolean(id) },
+	);
 }
 
 /** Connected agents available to link / pair. Shares the `environments` key. */
 export function useEnvironments() {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-	});
+	return useOpenApi().useQuery("get", "/v1/agents", {});
 }
 
 export function useCreateChannel() {
@@ -176,16 +137,11 @@ export function useCreateChannel() {
 }
 
 export function useDeleteChannel() {
-	const api = useApi();
+	const api = useOpenApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async (id: string) =>
-			unwrap(
-				await api.DELETE("/v1/channels/{account_id}", {
-					params: { path: { account_id: id } },
-				}),
-			),
-		onSuccess: async (_data, id) => {
+	return api.useMutation("delete", "/v1/channels/{account_id}", {
+		onSuccess: async (_data, variables) => {
+			const id = variables.params.path.account_id;
 			await removeDeletedChannelQueries(qc, id);
 			toast.success("Channel removed");
 		},

--- a/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chat-row.tsx
@@ -88,7 +88,11 @@ export function PairedChatRow({
 					description="Only this chat will be disconnected. Other chats and the connected channel stay active."
 					confirmLabel="Unpair chat"
 					destructive
-					onConfirm={() => unpair.mutateAsync(binding.id)}
+					onConfirm={() =>
+						unpair.mutateAsync({
+							params: { path: { account_id: accountId, binding_id: binding.id } },
+						})
+					}
 				>
 					<Button
 						variant="ghost"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,7 @@
 
 import { type components, extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient from "openapi-fetch";
+import createQueryClient from "openapi-react-query";
 import { useCallback, useMemo } from "react";
 import { ApiError, ApiNetworkError } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
@@ -15,6 +16,21 @@ export { ApiError, toastApiError } from "@/lib/api-errors";
 const API_URL = env.VITE_CLAWDI_API_URL;
 type SkillUploadResponse = components["schemas"]["SkillUploadResponse"];
 type EnvironmentResponse = components["schemas"]["AgentResponse"];
+
+type ApiErrorResponse<Response> = Response extends object
+	? Omit<Response, "content"> & { content: { "application/json": ApiError } }
+	: Response;
+type ApiResponses<Responses> = {
+	[Status in keyof Responses]: `${Status & (string | number)}` extends `2${string}`
+		? Responses[Status]
+		: ApiErrorResponse<Responses[Status]>;
+} & { default: { content: { "application/json": ApiError } } };
+type ApiOperation<Operation> = Operation extends { responses: infer Responses }
+	? Omit<Operation, "responses"> & { responses: ApiResponses<Responses> }
+	: Operation;
+type ApiPaths = {
+	[Path in keyof paths]: { [Method in keyof paths[Path]]: ApiOperation<paths[Path][Method]> };
+};
 
 function apiUrl(path: string): string {
 	const base = API_URL.endsWith("/") ? API_URL : `${API_URL}/`;
@@ -68,10 +84,10 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
  * Use inside a React component/hook — Clerk's `getToken` is only available
  * in the browser tree.
  */
-export function useApi() {
+function useConfiguredApi(throwOnError: boolean) {
 	const { getToken } = useAuthToken();
 	return useMemo(() => {
-		const client = createClient<paths>({ baseUrl: API_URL, fetch: fetchWithTimeout });
+		const client = createClient<ApiPaths>({ baseUrl: API_URL, fetch: fetchWithTimeout });
 		client.use({
 			async onRequest({ request }) {
 				const token = await getToken();
@@ -79,9 +95,31 @@ export function useApi() {
 				return request;
 			},
 		});
+		if (throwOnError) {
+			client.use({
+				async onResponse({ response }) {
+					if (!response.ok) {
+						throw new ApiError(response.status, await apiErrorDetail(response.clone()));
+					}
+					return response;
+				},
+			});
+		}
 		return client;
-	}, [getToken]);
+	}, [getToken, throwOnError]);
 }
+
+/** Generated fetch client for flows that inspect the typed response envelope directly. */
+export function useApi() {
+	return useConfiguredApi(false);
+}
+
+/** Standard OpenAPI-backed TanStack Query client with shared transport policy. */
+export function useOpenApi() {
+	const client = useConfiguredApi(true);
+	return useMemo(() => createQueryClient(client), [client]);
+}
+export type OpenApiClient = ReturnType<typeof useOpenApi>;
 
 /**
  * Unwrap an openapi-fetch result. Throws ApiError on non-2xx so TanStack

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -1,15 +1,9 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import {
-	keepPreviousData,
-	useMutation,
-	useQueries,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
+import { keepPreviousData, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
-import { unwrap, useApi } from "@/lib/api";
+import { type OpenApiClient, useOpenApi } from "@/lib/api";
 
 /**
  * Connector data hooks. Always talk to cloud-api — there is no
@@ -31,7 +25,6 @@ export const CONNECTOR_CATALOG_PAGE_SIZE = 24;
 export const CONNECTOR_CATALOG_STALE_TIME_MS = 10 * 60 * 1000;
 export const CONNECTOR_CATALOG_GC_TIME_MS = CONNECTOR_CATALOG_STALE_TIME_MS;
 
-type ApiClient = ReturnType<typeof useApi>;
 type ConnectorAvailableApp = components["schemas"]["ConnectorAvailableAppResponse"];
 
 export type AvailableAppsQueryArgs = {
@@ -41,82 +34,95 @@ export type AvailableAppsQueryArgs = {
 };
 
 export function availableAppsQueryKey({ page, pageSize, search }: AvailableAppsQueryArgs) {
-	return ["available-apps", { page, pageSize, search }] as const;
+	return [
+		"get",
+		"/v1/connectors/available",
+		{ params: { query: { page, page_size: pageSize, ...(search ? { search } : {}) } } },
+	] as const;
 }
 
-export function availableAppsQueryOptions(api: ApiClient, args: AvailableAppsQueryArgs) {
+export function availableAppsQueryOptions(api: OpenApiClient, args: AvailableAppsQueryArgs) {
 	const { page, pageSize, search } = args;
-	return {
-		queryKey: availableAppsQueryKey(args),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/connectors/available", {
-					params: {
-						query: { page, page_size: pageSize, ...(search ? { search } : {}) },
-					},
-				}),
-			),
-		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
-		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
-	};
+	return api.queryOptions(
+		"get",
+		"/v1/connectors/available",
+		{
+			params: { query: { page, page_size: pageSize, ...(search ? { search } : {}) } },
+		},
+		{
+			staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+			gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+		},
+	);
 }
 
 export function availableAppQueryKey(appName: string) {
-	return ["available-app", appName] as const;
+	return [
+		"get",
+		"/v1/connectors/available/{app_name}",
+		{ params: { path: { app_name: appName } } },
+	] as const;
 }
 
-export function availableAppQueryOptions(api: ApiClient, appName: string) {
-	return {
-		queryKey: availableAppQueryKey(appName),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/connectors/available/{app_name}", {
-					params: { path: { app_name: appName } },
-				}),
-			),
-		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
-		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
-	};
+export function availableAppQueryOptions(api: OpenApiClient, appName: string) {
+	return api.queryOptions(
+		"get",
+		"/v1/connectors/available/{app_name}",
+		{
+			params: { path: { app_name: appName } },
+		},
+		{
+			staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+			gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+		},
+	);
 }
 
-export function connectionsQueryOptions(api: ApiClient) {
-	return {
-		queryKey: ["connections"] as const,
-		queryFn: async () => unwrap(await api.GET("/v1/connectors")),
-		refetchOnWindowFocus: "always" as const,
-	};
+export function connectionsQueryOptions(api: OpenApiClient) {
+	return api.queryOptions(
+		"get",
+		"/v1/connectors",
+		{},
+		{
+			refetchOnWindowFocus: "always" as const,
+		},
+	);
 }
 
 export function connectorToolsQueryKey(appName: string) {
-	return ["connector-tools", appName] as const;
+	return [
+		"get",
+		"/v1/connectors/{app_name}/tools",
+		{ params: { path: { app_name: appName } } },
+	] as const;
 }
 
-export function connectorToolsQueryOptions(api: ApiClient, appName: string) {
-	return {
-		queryKey: connectorToolsQueryKey(appName),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/connectors/{app_name}/tools", {
-					params: { path: { app_name: appName } },
-				}),
-			),
-		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
-		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
-	};
+export function connectorToolsQueryOptions(api: OpenApiClient, appName: string) {
+	return api.queryOptions(
+		"get",
+		"/v1/connectors/{app_name}/tools",
+		{
+			params: { path: { app_name: appName } },
+		},
+		{
+			staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+			gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+		},
+	);
 }
 
 export function useConnections() {
-	const api = useApi();
+	const api = useOpenApi();
 	return useQuery(connectionsQueryOptions(api));
 }
 
 export function useAvailableApp(appName: string) {
-	const api = useApi();
+	const api = useOpenApi();
 	return useQuery(availableAppQueryOptions(api, appName));
 }
 
 export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryArgs) {
-	const api = useApi();
+	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	const query = useQuery({
 		...availableAppsQueryOptions(api, { page, pageSize, search }),
@@ -133,39 +139,27 @@ export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryA
 }
 
 export function useConnectorTools(appName: string) {
-	const api = useApi();
+	const api = useOpenApi();
 	return useQuery(connectorToolsQueryOptions(api, appName));
 }
 
 export function useAuthFields(appName: string, { enabled }: { enabled: boolean }) {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["auth-fields", appName],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/connectors/{app_name}/auth-fields", {
-					params: { path: { app_name: appName } },
-				}),
-			),
-		enabled,
-	});
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/connectors/{app_name}/auth-fields",
+		{ params: { path: { app_name: appName } } },
+		{ enabled },
+	);
 }
 
 // ─────────────────────────────────────────────────────────────────────
 // Mutations
 
 export function useDisconnect() {
-	const api = useApi();
+	const api = useOpenApi();
 	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: async ({ connectionId }: { connectionId: string }): Promise<void> => {
-			unwrap(
-				await api.DELETE("/v1/connectors/{connection_id}", {
-					params: { path: { connection_id: connectionId } },
-				}),
-			);
-		},
-		onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
+	return api.useMutation("delete", "/v1/connectors/{connection_id}", {
+		onSuccess: () => qc.invalidateQueries({ queryKey: ["get", "/v1/connectors"] }),
 	});
 }
 
@@ -188,7 +182,7 @@ export function useDisconnect() {
  */
 export function useConnectedAppCards() {
 	const connectionsQ = useConnections();
-	const api = useApi();
+	const api = useOpenApi();
 
 	const activeConnections = useMemo(
 		() => connectionsQ.data?.filter(isActiveConnection) ?? [],

--- a/apps/web/src/lib/session-queries.test.ts
+++ b/apps/web/src/lib/session-queries.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeSessionListQuery, sessionListQueryKey } from "./session-queries";
+import {
+	normalizeSessionListQuery,
+	sessionDetailQueryKey,
+	sessionListQueryKey,
+} from "./session-queries";
 
 describe("session query cache keys", () => {
 	it("fills backend defaults so equivalent list queries share cache", () => {
@@ -41,5 +45,13 @@ describe("session query cache keys", () => {
 			model: ["a", "z"],
 			tag: ["alpha", "beta"],
 		});
+	});
+
+	it("uses the OpenAPI detail key consumed by session pages", () => {
+		expect(sessionDetailQueryKey("session_1")).toEqual([
+			"get",
+			"/v1/sessions/{session_id}",
+			{ params: { path: { session_id: "session_1" } } },
+		]);
 	});
 });

--- a/apps/web/src/lib/session-queries.ts
+++ b/apps/web/src/lib/session-queries.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import type { paths } from "@clawdi/shared/api";
-import { queryOptions } from "@tanstack/react-query";
-import { unwrap, type useApi } from "@/lib/api";
+import type { OpenApiClient } from "@/lib/api";
 
 export const SESSION_LIST_STALE_MS = 60_000;
 export const SESSION_LIST_GC_MS = 10 * 60_000;
@@ -11,7 +10,6 @@ export const SESSION_DETAIL_GC_MS = 10 * 60_000;
 export const SESSION_MESSAGES_STALE_MS = 5 * 60_000;
 export const SESSION_MESSAGES_GC_MS = 30 * 60_000;
 
-type ApiClient = ReturnType<typeof useApi>;
 export type SessionListQuery = NonNullable<paths["/v1/sessions"]["get"]["parameters"]["query"]>;
 
 const DEFAULT_SESSION_LIST_QUERY = {
@@ -72,20 +70,26 @@ export function normalizeSessionListQuery(query: SessionListQuery = {}): Session
 }
 
 export function sessionListQueryKey(query: SessionListQuery = {}) {
-	return ["sessions", "list", normalizeSessionListQuery(query)] as const;
+	return ["get", "/v1/sessions", { params: { query: normalizeSessionListQuery(query) } }] as const;
 }
 
-export function sessionListQueryOptions(api: ApiClient, query: SessionListQuery = {}) {
+export function sessionDetailQueryKey(sessionId: string) {
+	return [
+		"get",
+		"/v1/sessions/{session_id}",
+		{ params: { path: { session_id: sessionId } } },
+	] as const;
+}
+
+export function sessionListQueryOptions(api: OpenApiClient, query: SessionListQuery = {}) {
 	const normalized = normalizeSessionListQuery(query);
-	return queryOptions({
-		queryKey: sessionListQueryKey(normalized),
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/sessions", {
-					params: { query: normalized },
-				}),
-			),
-		staleTime: SESSION_LIST_STALE_MS,
-		gcTime: SESSION_LIST_GC_MS,
-	});
+	return api.queryOptions(
+		"get",
+		"/v1/sessions",
+		{ params: { query: normalized } },
+		{
+			staleTime: SESSION_LIST_STALE_MS,
+			gcTime: SESSION_LIST_GC_MS,
+		},
+	);
 }

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useMemo } from "react";
 import { AgentsCard, selfManagedAgentTiles } from "@/components/dashboard/agents-card";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
@@ -28,20 +27,24 @@ const HostedAgentsByCompute = IS_HOSTED_BUILD
 	: null;
 
 export default function AgentsIndexPage() {
-	const api = useApi();
+	const api = useOpenApi();
 	const hostedAccess = useHostedProductAccess();
 	const {
 		data: environments,
 		isLoading: envsLoading,
 		error: envsError,
 		refetch: refetchEnvs,
-	} = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-		// Match the Overview/agent-detail 10s cadence so the live status badges
-		// stay live on this list too.
-		refetchInterval: 10_000,
-	});
+	} = api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			// Match the Overview/agent-detail 10s cadence so the live status badges
+			// stay live on this list too.
+			refetchInterval: 10_000,
+			refetchIntervalInBackground: false,
+		},
+	);
 
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
 	const selfManagedCount = selfManagedTiles.length;

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -131,7 +131,7 @@ function ConnectorDetail({ name }: { name: string }) {
 		inflightDisconnectsRef.current.add(connectionId);
 		setDisconnectingIds((s) => new Set(s).add(connectionId));
 		disconnectMutation.mutate(
-			{ connectionId },
+			{ params: { path: { connection_id: connectionId } } },
 			{
 				onSettled: () => {
 					inflightDisconnectsRef.current.delete(connectionId);

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -22,7 +22,7 @@ import { SessionFeed } from "@/components/sessions/session-feed";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -81,7 +81,7 @@ const HostedFleetSummary = IS_HOSTED_BUILD
 	: null;
 
 export default function DashboardPage() {
-	const api = useApi();
+	const $api = useOpenApi();
 	const hostedAccess = useHostedProductAccess();
 
 	const {
@@ -89,40 +89,50 @@ export default function DashboardPage() {
 		isLoading: statsLoading,
 		error: statsError,
 		refetch: refetchStats,
-	} = useQuery({
-		queryKey: ["dashboard-stats"],
-		queryFn: async () => unwrap(await api.GET("/v1/dashboard/stats")),
-		// Overview counts are cheap and reflect recent mutations across many
-		// resources, so keep this query fresher than the global 30s default.
-		staleTime: 0,
-		refetchOnMount: "always",
-	});
+	} = $api.useQuery(
+		"get",
+		"/v1/dashboard/stats",
+		{},
+		{
+			// Overview counts are cheap and reflect recent mutations across many
+			// resources, so keep this query fresher than the global 30s default.
+			staleTime: 0,
+			refetchOnMount: "always",
+		},
+	);
 
 	const {
 		data: projects,
 		isLoading: projectsLoading,
 		error: projectsError,
 		refetch: refetchProjects,
-	} = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-		staleTime: DASHBOARD_STALE_MS,
-	});
+	} = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			staleTime: DASHBOARD_STALE_MS,
+		},
+	);
 
 	const {
 		data: environments,
 		isLoading: envsLoading,
 		error: envsError,
 		refetch: refetchEnvs,
-	} = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-		// Daemon-status badge classification is time-sensitive — a
-		// daemon that paused while the tab was open would otherwise
-		// stay green indefinitely. Match the agent detail page's
-		// 10s cadence so the live indicator is actually live.
-		refetchInterval: 10_000,
-	});
+	} = $api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			// Daemon-status badge classification is time-sensitive — a
+			// daemon that paused while the tab was open would otherwise
+			// stay green indefinitely. Match the agent detail page's
+			// 10s cadence so the live indicator is actually live.
+			refetchInterval: 10_000,
+			refetchIntervalInBackground: false,
+		},
+	);
 
 	// Manual sessions only: on a working fleet ~3/4 of sessions are
 	// cron/heartbeat ticks, and "Recent sessions" buried the user's own
@@ -133,7 +143,7 @@ export default function DashboardPage() {
 		error: sessionsError,
 		refetch: refetchSessions,
 	} = useQuery(
-		sessionListQueryOptions(api, {
+		sessionListQueryOptions($api, {
 			page_size: RECENT_SESSIONS_CACHE_PAGE_SIZE,
 			automated: false,
 		}),

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -23,6 +23,10 @@ import {
 	agentDisplayName,
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
+import {
+	agentProjectBindingsQueryKey,
+	useAgentProjectBindings,
+} from "@/components/dashboard/agent-project-bindings-query";
 import { DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -73,7 +77,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { vaultDetailSearch } from "@/components/vault/vault-detail-identity";
 import { agentSectionHref, agentSectionLabel } from "@/lib/agent-routes";
-import { ApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { formatApiError, isApiNotFoundError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
@@ -96,6 +100,7 @@ const AGENT_PROJECTS_SECTION_LABEL = agentSectionLabel("projects");
 
 export default function ProjectDetailPage({ projectId }: { projectId: string }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const router = useRouter();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
@@ -109,10 +114,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 	const [showCreateVault, setShowCreateVault] = useState(false);
 	const joinedFromShare = searchParams.get("joined") === "share";
 
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-	});
+	const projects = $api.useQuery("get", "/v1/projects", {});
 
 	const rows = projects.data ?? [];
 	const project = rows.find((row) => row.id === projectId) ?? null;
@@ -136,11 +138,14 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 		}
 	};
 
-	const environments = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-		enabled: !!project,
-	});
+	const environments = $api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			enabled: !!project,
+		},
+	);
 	const agentsById = useMemo(
 		() => new Map((environments.data ?? []).map((agent) => [agent.id, agent])),
 		[environments.data],
@@ -214,9 +219,9 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 	});
 
 	const refresh = () => {
-		qc.invalidateQueries({ queryKey: ["projects"] });
+		qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
 		qc.invalidateQueries({ queryKey: ["skills"] });
-		qc.invalidateQueries({ queryKey: ["vaults"] });
+		qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 		qc.invalidateQueries({ queryKey: ["project-bound-agents", projectId] });
 	};
 
@@ -229,7 +234,9 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 			),
 		onSuccess: () => {
 			refresh();
-			qc.invalidateQueries({ queryKey: ["agent-project-bindings"] });
+			qc.invalidateQueries({
+				queryKey: ["get", "/v1/agents/{agent_id}/project-bindings"],
+			});
 			toast.success("Left Shared Project", { description: "Membership removed." });
 			void router.navigate({ href: projectResourceHref("projects") });
 		},
@@ -875,16 +882,7 @@ function UseProjectWithAgentDialog({
 	}));
 	const selectedEnv = orderedEnvironments.find((env) => env.id === selectedAgentId) ?? null;
 	const projectIsHome = selectedEnv?.default_project_id === project.id;
-	const selectedBindings = useQuery({
-		queryKey: ["agent-project-bindings", selectedAgentId],
-		queryFn: async (): Promise<AgentProjectBinding[]> =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}/project-bindings", {
-					params: { path: { agent_id: selectedAgentId } },
-				}),
-			),
-		enabled: open && !!selectedAgentId,
-	});
+	const selectedBindings = useAgentProjectBindings(selectedAgentId, { enabled: open });
 	const existingBinding =
 		selectedBindings.data?.find((binding) => binding.project_id === project.id) ?? null;
 	const projectIsAlreadyAvailable = projectIsHome || !!existingBinding;
@@ -907,9 +905,9 @@ function UseProjectWithAgentDialog({
 		},
 		onSuccess: () => {
 			const agentName = selectedEnv ? displayAgentName(selectedEnv) : "the agent";
-			qc.invalidateQueries({ queryKey: ["agent-project-bindings", selectedAgentId] });
+			qc.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(selectedAgentId) });
 			qc.invalidateQueries({ queryKey: ["skills"] });
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			toast.success("Project Added", {
 				description: `Done. ${agentName} can now use ${projectName}'s skills and Vault keys.`,
 				action: {

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -35,7 +35,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchInput } from "@/components/ui/search-input";
-import { ApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
@@ -43,8 +43,6 @@ import { getProjectResourceDefinition, projectDetailHref } from "@/lib/project-r
 import { cn, errorMessage } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
-type Env = components["schemas"]["AgentResponse"];
-
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type CountValue = number | "unavailable";
 
@@ -52,6 +50,7 @@ const PROJECTS_RESOURCE = getProjectResourceDefinition("projects");
 
 export default function ProjectsPage() {
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const router = useRouter();
 	const [newProjectName, setNewProjectName] = useState("");
@@ -60,18 +59,24 @@ export default function ProjectsPage() {
 	const [search, setSearch] = useState("");
 	const [systemOpen, setSystemOpen] = useState(false);
 
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-		placeholderData: keepPreviousData,
-	});
+	const projects = $api.useQuery(
+		"get",
+		"/v1/projects",
+		{},
+		{
+			placeholderData: keepPreviousData,
+		},
+	);
 
 	const rows = projects.data ?? [];
-	const environments = useQuery({
-		queryKey: ["agents"],
-		queryFn: async (): Promise<Env[]> => unwrap(await api.GET("/v1/agents")),
-		enabled: rows.some((project) => project.kind === "environment"),
-	});
+	const environments = $api.useQuery(
+		"get",
+		"/v1/agents",
+		{},
+		{
+			enabled: rows.some((project) => project.kind === "environment"),
+		},
+	);
 	const agentsById = useMemo(
 		() => new Map((environments.data ?? []).map((agent) => [agent.id, agent])),
 		[environments.data],
@@ -89,12 +94,16 @@ export default function ProjectsPage() {
 			),
 		placeholderData: keepPreviousData,
 	});
-	const vaults = useQuery({
-		queryKey: ["vaults", "all"],
-		queryFn: async () =>
-			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
-		placeholderData: keepPreviousData,
-	});
+	const vaults = $api.useQuery(
+		"get",
+		"/v1/vault",
+		{
+			params: { query: { page_size: 200 } },
+		},
+		{
+			placeholderData: keepPreviousData,
+		},
+	);
 	const skillCounts = useMemo(() => {
 		const m = new Map<string, number>();
 		for (const s of skills.data?.items ?? []) {
@@ -155,7 +164,7 @@ export default function ProjectsPage() {
 		},
 		onSuccess: (project) => {
 			setCreateOpen(false);
-			qc.invalidateQueries({ queryKey: ["projects"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
 			toast.success("Project created", {
 				description: `${project.name} is ready for skills, vaults, and sharing.`,
 			});

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import {
 	ArrowDown,
 	ArrowDownNarrowWide,
@@ -33,7 +33,7 @@ import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionMessage } from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
@@ -58,6 +58,7 @@ export function SessionDetailContent({
 	agentId?: string | null;
 }) {
 	const api = useApi();
+	const $api = useOpenApi();
 	const { user } = useCurrentUser();
 
 	const {
@@ -65,35 +66,35 @@ export function SessionDetailContent({
 		isLoading: isSessionLoading,
 		error: sessionError,
 		refetch: refetchSession,
-	} = useQuery({
-		queryKey: ["session", sessionId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/sessions/{session_id}", {
-					params: { path: { session_id: sessionId } },
-				}),
-			),
-		// Don't retry 4xx (malformed UUID, not-found, unauthorized) — they won't
-		// recover on retry and the default 3× retry makes the page hang in
-		// "Loading..." for seconds before the user learns the URL is bogus.
-		retry: (failureCount, err) => {
-			const status = err instanceof ApiError ? err.status : 0;
-			if (status >= 400 && status < 500) return false;
-			return failureCount < 2;
+	} = $api.useQuery(
+		"get",
+		"/v1/sessions/{session_id}",
+		{
+			params: { path: { session_id: sessionId } },
 		},
-		staleTime: SESSION_DETAIL_STALE_MS,
-		gcTime: SESSION_DETAIL_GC_MS,
-	});
-	const { data: scopedAgent } = useQuery({
-		queryKey: ["agents", agentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}", {
-					params: { path: { agent_id: agentId ?? "" } },
-				}),
-			),
-		enabled: !!agentId,
-	});
+		{
+			// Don't retry 4xx (malformed UUID, not-found, unauthorized) — they won't
+			// recover on retry and the default 3× retry makes the page hang in
+			// "Loading..." for seconds before the user learns the URL is bogus.
+			retry: (failureCount, err) => {
+				const status = err instanceof ApiError ? err.status : 0;
+				if (status >= 400 && status < 500) return false;
+				return failureCount < 2;
+			},
+			staleTime: SESSION_DETAIL_STALE_MS,
+			gcTime: SESSION_DETAIL_GC_MS,
+		},
+	);
+	const { data: scopedAgent } = $api.useQuery(
+		"get",
+		"/v1/agents/{agent_id}",
+		{
+			params: { path: { agent_id: agentId ?? "" } },
+		},
+		{
+			enabled: !!agentId,
+		},
+	);
 
 	// Direction toggle: "desc" (newest-first, default) is the most
 	// common review case for clawdi — users open a session to see

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -25,7 +25,7 @@ import { DataTableFacetedFilter } from "@/components/ui/data-table-faceted-filte
 import { DataTablePagination } from "@/components/ui/data-table-pagination";
 import { SearchInput } from "@/components/ui/search-input";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
@@ -78,7 +78,7 @@ export default function SessionsPage() {
 }
 
 function SessionsListInner() {
-	const api = useApi();
+	const $api = useOpenApi();
 	const queryClient = useQueryClient();
 
 	// All filter / sort / pagination state lives in the URL via
@@ -143,17 +143,14 @@ function SessionsListInner() {
 	);
 
 	const { data, isLoading, isFetching, error, refetch } = useQuery({
-		...sessionListQueryOptions(api, sessionQuery),
+		...sessionListQueryOptions($api, sessionQuery),
 		// Keep previous results visible during refetch; the
 		// `isFetching && !isLoading` opacity transition below is
 		// the only "loading" signal the user sees.
 		placeholderData: keepPreviousData,
 	});
 
-	const { data: envs } = useQuery({
-		queryKey: ["agents", "filter"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-	});
+	const { data: envs } = $api.useQuery("get", "/v1/agents", {});
 	const agentOptions = useMemo(() => {
 		const set = new Set<string>();
 		for (const e of envs ?? []) {
@@ -197,9 +194,9 @@ function SessionsListInner() {
 	useEffect(() => {
 		if (!data || params.page >= pageCount) return;
 		void queryClient.prefetchQuery(
-			sessionListQueryOptions(api, { ...sessionQuery, page: params.page + 1 }),
+			sessionListQueryOptions($api, { ...sessionQuery, page: params.page + 1 }),
 		);
-	}, [api, data, pageCount, params.page, queryClient, sessionQuery]);
+	}, [$api, data, pageCount, params.page, queryClient, sessionQuery]);
 
 	const groupable = params.sort === "last_activity_at" || params.sort === "started_at";
 

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -48,7 +48,7 @@ import {
 	agentDeploymentRouteQuery,
 	agentSectionHref,
 } from "@/lib/agent-routes";
-import { ApiError, unwrap, useApi } from "@/lib/api";
+import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { decodeResourceRouteParam, projectResourceHref } from "@/lib/project-resource-model";
 import { skillCapabilities } from "@/lib/skill-authority";
@@ -95,6 +95,7 @@ export function SkillDetailContent({
 }) {
 	const router = useRouter();
 	const api = useApi();
+	const $api = useOpenApi();
 	const queryClient = useQueryClient();
 
 	// `?project=<project_id>` is set by the skills list page when the
@@ -148,16 +149,16 @@ export function SkillDetailContent({
 	});
 
 	const agentEnvironmentId = agentId ?? skill?.environment_id ?? null;
-	const { data: skillAgent } = useQuery({
-		queryKey: ["agents", agentEnvironmentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/agents/{agent_id}", {
-					params: { path: { agent_id: agentEnvironmentId ?? "" } },
-				}),
-			),
-		enabled: !!agentEnvironmentId,
-	});
+	const { data: skillAgent } = $api.useQuery(
+		"get",
+		"/v1/agents/{agent_id}",
+		{
+			params: { path: { agent_id: agentEnvironmentId ?? "" } },
+		},
+		{
+			enabled: !!agentEnvironmentId,
+		},
+	);
 	const skillAgentLabel = skillAgent
 		? agentDisplayName(skillAgent)
 		: skill?.machine_name
@@ -167,10 +168,10 @@ export function SkillDetailContent({
 	useSetBreadcrumbSegmentTitle(agentId ? agentSectionHref(agentId) : null, skillAgentLabel);
 	useSetBreadcrumbTitle(breadcrumbTitle);
 
-	const { data: defaultProject, error: projectError } = useQuery({
-		queryKey: ["projects", "default"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects/default")),
-	});
+	const { data: defaultProject, error: projectError } = $api.useQuery(
+		"get",
+		"/v1/projects/default",
+	);
 	// Edits land in the skill's own project when the detail response
 	// carries one (multi-machine accounts), falling back to the
 	// caller's default project (single-machine accounts and legacy
@@ -182,10 +183,7 @@ export function SkillDetailContent({
 	// Persisted authority and durable Project kind jointly control every
 	// browser mutation. In particular, environment-kind Projects stay
 	// read-only even after Agent deletion clears origin_environment_id.
-	const { data: projects } = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-	});
+	const { data: projects } = $api.useQuery("get", "/v1/projects", {});
 	const skillProject = useMemo(
 		() =>
 			skill?.project_id

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -51,7 +51,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { SearchInput } from "@/components/ui/search-input";
 import { Spinner } from "@/components/ui/spinner";
-import { ensureBlob, unwrap, useApi, useSkillArchiveUploader } from "@/lib/api";
+import { ensureBlob, unwrap, useApi, useOpenApi, useSkillArchiveUploader } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -80,6 +80,7 @@ export default function SkillsPage() {
 
 function SkillsPageInner() {
 	const api = useApi();
+	const $api = useOpenApi();
 	const uploadSkillArchive = useSkillArchiveUploader();
 	const queryClient = useQueryClient();
 	// `?project=<project_id>` is the canonical scope. `?target=<env_id>`
@@ -103,10 +104,7 @@ function SkillsPageInner() {
 		data: projects,
 		error: projectsError,
 		refetch: refetchProjects,
-	} = useQuery({
-		queryKey: ["projects"],
-		queryFn: async () => unwrap(await api.GET("/v1/projects")),
-	});
+	} = $api.useQuery("get", "/v1/projects", {});
 	const orderedProjects = useMemo(
 		() => [...(projects ?? [])].filter((project) => project.id).sort(compareProjectsForUse),
 		[projects],
@@ -118,10 +116,7 @@ function SkillsPageInner() {
 	const capabilitiesForSkill = (skill: SkillSummary) =>
 		skillCapabilities(skill, skill.project_id ? projectsById.get(skill.project_id) : undefined);
 
-	const { data: envs } = useQuery({
-		queryKey: ["agents"],
-		queryFn: async () => unwrap(await api.GET("/v1/agents")),
-	});
+	const { data: envs } = $api.useQuery("get", "/v1/agents", {});
 
 	// Resolution order:
 	//   - URL has ?project=X and projects loaded:

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -52,7 +52,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { CopyKeysDialog } from "@/components/vault/copy-keys-dialog";
 import { prefixGroupsFor, SplitVaultDialog } from "@/components/vault/split-vault-dialog";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -80,6 +80,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 	const slug = decodeURIComponent(rawSlug);
 	const [vaultId] = useQueryState("vault", parseAsString);
 	const api = useApi();
+	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const router = useRouter();
 
@@ -104,10 +105,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 	const isOwner = vault?.is_owner !== false;
 	const anyProjectId = vault?.project_ids?.[0];
 
-	const projects = useQuery({
-		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
-	});
+	const projects = $api.useQuery("get", "/v1/projects", {});
 	const projectById = useMemo(
 		() => new Map((projects.data ?? []).map((p) => [p.id, p])),
 		[projects.data],
@@ -159,7 +157,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 		filteredKeyNames.length > 0 && filteredKeyNames.every((k) => selectedKeys.has(keyId(k)));
 
 	const refresh = () => {
-		qc.invalidateQueries({ queryKey: ["vaults"] });
+		qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 		qc.invalidateQueries({ queryKey: ["vault-items", vault?.id, slug] });
 		qc.invalidateQueries({ queryKey: ["vault-detail", slug, vault?.id] });
 	};
@@ -255,7 +253,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 				}),
 			),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			qc.removeQueries({ queryKey: ["vault-items", vault?.id, slug] });
 			toast.success("Vault deleted", {
 				description: `${vault?.name ?? slug} and its keys were removed.`,

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "nitro": "^3.0.260610-beta",
         "nuqs": "^2.9.0",
         "openapi-fetch": "^0.17.0",
+        "openapi-react-query": "^0.5.4",
         "posthog-js": "^1.396.6",
         "qrcode.react": "^4.2.0",
         "react": "catalog:",
@@ -1791,6 +1792,8 @@
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "openapi-fetch": ["openapi-fetch@0.17.0", "", { "dependencies": { "openapi-typescript-helpers": "^0.1.0" } }, "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig=="],
+
+    "openapi-react-query": ["openapi-react-query@0.5.4", "", { "dependencies": { "openapi-typescript-helpers": "^0.1.0" }, "peerDependencies": { "@tanstack/react-query": "^5.80.0", "openapi-fetch": "^0.17.0" } }, "sha512-V9lRiozjHot19/BYSgXYoyznDxDJQhEBSdi26+SJ0UqjMANLQhkni4XG+Z7e3Ag7X46ZLMrL9VxYkghU3QvbWg=="],
 
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.1.0", "", {}, "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw=="],
 

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -4,6 +4,9 @@ Guide for contributors working on `apps/web/`. The web app is a TanStack Start
 dashboard built with React 19, TanStack Router, Tailwind v4, shadcn/ui, TanStack
 Query, Zustand, and Clerk.
 
+For typed cloud-api queries, cache keys, refresh semantics, and documented
+TanStack Query exceptions, see [`openapi-react-query.md`](openapi-react-query.md).
+
 ## Local web loop
 
 Use the canonical local-stack runbook in

--- a/docs/openapi-react-query.md
+++ b/docs/openapi-react-query.md
@@ -1,0 +1,74 @@
+# OpenAPI React Query
+
+The web app uses `useOpenApi()` from `apps/web/src/lib/api.ts` for ordinary
+cloud-api reads and writes. It wraps the generated `paths` type with
+`openapi-fetch` and `openapi-react-query`; callers use the generated
+`[method, path, init]` query key rather than maintaining a parallel key.
+
+The shared fetch client owns Clerk authentication, the 20-second request
+ceiling, caller and TanStack abort propagation, transport error mapping, and
+non-2xx conversion to `ApiError`. This keeps the existing QueryClient retry
+policy, error panels, and mutation toasts consistent. Do not create another
+OpenAPI fetch/query client in a feature module.
+
+`useApi()` intentionally retains `openapi-fetch`'s typed `{ data, error,
+response }` envelope for bespoke flows that branch on exact response status or
+structured error bodies. Only `useOpenApi()` converts non-2xx responses to
+`ApiError`; do not add that middleware to the shared raw client.
+
+## Loading and refresh contract
+
+- Use `isPending`/`isLoading` only for the first load when no data is present.
+- A background `isFetching` state may add a quiet refresh affordance or opacity
+  treatment, but it must keep the existing count, rows, dimensions, and empty
+  state decision.
+- A refetch error with cached data keeps rendering that data. Reserve blocking
+  error panels for queries without usable data.
+- Polling must be bounded, disabled in background unless explicitly required,
+  and must use stable path/query parameters. Query cancellation is supplied by
+  openapi-react-query's propagated `AbortSignal`.
+- Use `placeholderData: keepPreviousData` when a list identity changes through
+  search, filtering, or pagination.
+
+The paired-chat inventory is the reference polling case: its three-second
+bindings refresh passes `isPending`, not `isFetching`, to the dialog. Cached
+chat rows and counts therefore do not flash on every poll.
+
+## Intentional TanStack Query exceptions
+
+These cases remain explicit TanStack Query because the cache value or request
+is deliberately different from one standard OpenAPI operation:
+
+- Aggregations and projections: agent skill inventories, project skill/vault
+  inventories, project bound-agent joins, hosted inventory, and session-message
+  pagination combine multiple requests or pages into one cache entry.
+- Uploads, downloads, and streams: skill archives, agent avatars, session
+  artifacts, terminal/session streams, and connector authorization flows use
+  `Blob`, `FormData`, streaming, or browser navigation semantics.
+- Secret/sensitive caches: memory settings, vault items, API-key creation, AI
+  provider credential acceptance/testing/OAuth, and Stripe client secrets
+  remove secret material before QueryCache.
+- Complex optimistic projections: agent/sidebar ordering and identity edits,
+  API-key revoke, project membership/sharing, channel link/pair workflows, and
+  skill/vault moves update or roll back several cache views atomically.
+- Billing and deployment: `apps/web/src/hosted/billing/**` and deployment hooks
+  retain their idempotency keys, reconciliation state machine, cross-service
+  error model, and sensitive cache boundary.
+- Hosted access and ownership sensors call a separately configured hosted API
+  or derive cross-service state; they are not cloud-api OpenAPI operations.
+
+An ordinary single OpenAPI operation with standard response caching is not an
+exception. Add it through `useOpenApi()` and invalidate with its query option's
+key or the matching `[method, path]` prefix.
+
+## Upstream contracts
+
+The integration was checked against official sources matching the lockfile:
+
+- `openapi-react-query` 0.5.4:
+  <https://github.com/openapi-ts/openapi-typescript/tree/openapi-react-query%400.5.4/packages/openapi-react-query>
+- `openapi-fetch` 0.17.0:
+  <https://github.com/openapi-ts/openapi-typescript/tree/openapi-fetch%400.17.0/packages/openapi-fetch>
+- TanStack Query 5.101.4 background fetching and cancellation:
+  <https://tanstack.com/query/v5/docs/framework/react/guides/background-fetching-indicators>
+  and <https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation>


### PR DESCRIPTION
## Summary
- add one typed `openapi-react-query` integration on the shared authenticated `openapi-fetch` client, including timeout, AbortSignal propagation, transport handling, and centralized `ApiError` normalization
- migrate standard cloud-api queries/mutations and queryOptions to generated `[method, path, init]` keys, aligning cache updates and invalidation prefixes across agents, projects, sessions, channels, connectors, vault metadata, search, notifications, API keys, and AI providers
- fix paired-chat three-second polling flashes by reserving loading/error replacement states for initial no-data loads, while retaining cached counts, rows, and layout during background refreshes
- document loading semantics, official pinned upstream contracts, and every category intentionally retaining bespoke TanStack Query behavior

## Verification
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test:internal` (860 passed)
- `bun run --cwd apps/web test` (isolated Docker runner)
- `bunx biome check apps/web/src`
- `bun run --cwd apps/web build:oss`
- hosted Playwright paired-chat loading/error/retry and Telegram/Discord 320px scenarios (2 passed)

No schema or generated-client changes. No deployment or production operations performed.