### PR TITLE
fix: reject invalid skill text and redact bot paths

### DIFF
--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -9,6 +9,7 @@ of application logs.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import cast
 
@@ -16,6 +17,10 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 _PROCESS_TIME_HEADER = b"x-process-time-ms"
+_TELEGRAM_BOT_API_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
 
 
 class RequestTimingMiddleware:
@@ -30,7 +35,8 @@ class RequestTimingMiddleware:
 
         started = time.perf_counter()
         method = cast(str, scope.get("method", "GET"))
-        path = cast(str, scope.get("path", ""))
+        raw_path = cast(str, scope.get("path", ""))
+        path = _log_safe_path(raw_path)
         status_code = 500
 
         async def timed_send(message: Message) -> None:
@@ -67,7 +73,10 @@ class RequestTimingMiddleware:
                 duration_ms,
                 _request_id(scope),
             )
-        elif _is_slow(duration_ms=duration_ms, slow_ms=self.slow_ms):
+        elif not _is_expected_long_poll(raw_path) and _is_slow(
+            duration_ms=duration_ms,
+            slow_ms=self.slow_ms,
+        ):
             logger.warning(
                 "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
                 method,
@@ -84,6 +93,20 @@ def _elapsed_ms(started: float) -> float:
 
 def _is_slow(*, duration_ms: float, slow_ms: float) -> bool:
     return slow_ms > 0 and duration_ms >= slow_ms
+
+
+def _log_safe_path(path: str) -> str:
+    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
+    if match is None:
+        return path
+    return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
+
+
+def _is_expected_long_poll(path: str) -> bool:
+    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
+    if match is None or "/file/" in match.group("prefix").lower():
+        return False
+    return (match.group("suffix") or "").lower() == "/getupdates"
 
 
 def _request_id(scope: Scope) -> str:

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -77,6 +77,7 @@ from app.services.sync_events import (
     get_skills_revision,
 )
 from app.services.tar_utils import (
+    SkillTextValidationError,
     TarValidationError,
     extract_skill_md,
     parse_frontmatter,
@@ -1225,7 +1226,16 @@ async def _do_upload_skill(
     if not skill_md:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Archive must contain a SKILL.md")
 
-    fm = parse_frontmatter(skill_md)
+    try:
+        fm = parse_frontmatter(skill_md)
+    except SkillTextValidationError:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_skill_text",
+                "message": "SKILL.md must not contain NUL characters.",
+            },
+        ) from None
     name = fm.get("name", skill_key)
     description = fm.get("description", "")
 

--- a/backend/app/services/tar_utils.py
+++ b/backend/app/services/tar_utils.py
@@ -34,6 +34,10 @@ class TarValidationError(ValueError):
     """Raised when a tar archive fails validation."""
 
 
+class SkillTextValidationError(ValueError):
+    """Raised when SKILL.md text cannot be stored safely."""
+
+
 def validate_tar(data: bytes) -> int:
     """Validate a tar.gz archive. Returns file count.
 
@@ -157,6 +161,14 @@ def parse_frontmatter(content: str) -> dict[str, str]:
     """
     import yaml
 
+    # PostgreSQL text values cannot contain NUL. Check the full document as
+    # well as decoded YAML values below: a literal NUL can live in the body,
+    # while a quoted YAML escape (for example ``"bad\0name"``) materializes
+    # only after ``safe_load``. Rejecting at the document boundary keeps an
+    # invalid Skill from reaching an ORM autoflush as an opaque 500.
+    if "\x00" in content:
+        raise SkillTextValidationError("SKILL.md must not contain NUL characters")
+
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
     if not match:
         return {}
@@ -195,12 +207,17 @@ def parse_frontmatter(content: str) -> dict[str, str]:
             continue
         cap = _per_key_caps.get(key, _default_cap)
         if isinstance(value, str):
-            fm[key] = value.strip()[:cap]
+            normalized = value.strip()[:cap]
         elif isinstance(value, bool):
             # Match YAML wire form ("true"/"false") not Python's "True"/"False".
             # Callers comparing against literal "true" wouldn't expect Python
             # capitalization to leak through.
-            fm[key] = "true" if value else "false"
+            normalized = "true" if value else "false"
         elif isinstance(value, (int, float)):
-            fm[key] = str(value)[:cap]
+            normalized = str(value)[:cap]
+        else:
+            continue
+        if "\x00" in key or "\x00" in normalized:
+            raise SkillTextValidationError("Skill frontmatter must not contain NUL characters")
+        fm[key] = normalized
     return fm

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -77,3 +77,54 @@ async def test_request_timing_logs_errors_without_query_string(caplog: pytest.Lo
     assert "request_error method=GET path=/v1/sessions status=500" in caplog.text
     assert "request_id=req_test" in caplog.text
     assert "token=secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "expected_path"),
+    [
+        (
+            "/v1/channels/telegram/bot123456:secret/getUpdates",
+            "/v1/channels/telegram/bot[redacted]/getUpdates",
+        ),
+        (
+            "/api/channels/telegram/bot/123456:secret/sendMessage",
+            "/api/channels/telegram/bot/[redacted]/sendMessage",
+        ),
+        (
+            "/v1/channels/telegram/file/bot123456:secret/documents/file.txt",
+            "/v1/channels/telegram/file/bot[redacted]/documents/file.txt",
+        ),
+    ],
+)
+async def test_request_timing_redacts_telegram_routing_credentials(
+    caplog: pytest.LogCaptureFixture,
+    path: str,
+    expected_path: str,
+):
+    async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b"error"})
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    await _collect(RequestTimingMiddleware(inner, slow_ms=750), _scope(path=path))
+
+    assert f"path={expected_path}" in caplog.text
+    assert "123456:secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_request_timing_does_not_warn_for_successful_telegram_long_poll(
+    caplog: pytest.LogCaptureFixture,
+):
+    async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    await _collect(
+        RequestTimingMiddleware(inner, slow_ms=0.000_001),
+        _scope(path="/v1/channels/telegram/bot123456:secret/getUpdates"),
+    )
+
+    assert caplog.text == ""

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -60,6 +60,37 @@ async def test_skill_upload_happy_path(client: httpx.AsyncClient, project_id: st
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    [
+        "---\nname: invalid\ndescription: metadata\n---\n# Body\x00\n",
+        '---\nname: "invalid\\0name"\ndescription: metadata\n---\n# Body\n',
+        '---\nname: invalid\ndescription: "invalid\\0description"\n---\n# Body\n',
+    ],
+)
+async def test_skill_upload_rejects_nul_text_before_persistence(
+    client: httpx.AsyncClient,
+    project_id: str,
+    content: str,
+):
+    tar_bytes, _ = tar_from_content("invalid-nul", content)
+
+    response = await client.post(
+        f"/v1/projects/{project_id}/skills/upload",
+        data={"skill_key": "invalid-nul"},
+        files={"file": ("invalid-nul.tar.gz", tar_bytes, "application/gzip")},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == {
+        "code": "invalid_skill_text",
+        "message": "SKILL.md must not contain NUL characters.",
+    }
+    missing = await client.get(f"/v1/projects/{project_id}/skills/invalid-nul")
+    assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_dashboard_edit_with_stale_content_hash_returns_412(
     client: httpx.AsyncClient, project_id: str
 ):


### PR DESCRIPTION
## Summary
- reject literal and YAML-decoded NUL characters in SKILL.md before persistence
- redact Telegram routing credentials from request timing logs
- suppress expected slow warnings for successful Telegram getUpdates long polls while preserving errors

## Verification
- `bash scripts/test.sh backend tests/test_skills.py tests/test_request_timing.py` (38 passed)
- `bash scripts/test.sh backend` (1943 passed before logging-only follow-up; final run 1946 passed with one unrelated 1s WhatsApp timeout, isolated rerun passed)
- isolated Ruff check and format check passed
- `git diff --check` passed