### PR TITLE
fix(web): keep query refreshes visually stable

### DIFF
--- a/apps/web/e2e/query-refresh-hosted.pw.ts
+++ b/apps/web/e2e/query-refresh-hosted.pw.ts
@@ -1,0 +1,114 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+const CLOUD_API = "http://127.0.0.1:8000";
+const DEPLOY_API = "http://127.0.0.1:8001";
+const account = {
+	id: "33333333-3333-4333-8333-333333333333",
+	provider: "telegram",
+	name: "Stable Telegram",
+	status: "active",
+	visibility: "private",
+	has_provider_token: true,
+	webhook_url: "https://example.test/channels/stable",
+	created_at: "2026-08-02T12:00:00.000Z",
+};
+const health = {
+	account_id: account.id,
+	provider: account.provider,
+	name: account.name,
+	visibility: account.visibility,
+	channel_status: account.status,
+	health_status: "ok",
+	reasons: [],
+	pending_inbox: 0,
+	pending_deliveries: 0,
+	in_progress_deliveries: 0,
+	failed_deliveries: 0,
+	last_message_at: null,
+	last_event_at: null,
+	last_error_at: null,
+	last_error: null,
+	last_error_stage: null,
+	last_error_outcome: null,
+	native_transport: null,
+};
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+}
+
+async function stubChannels(page: Page) {
+	const refreshStarted = deferred();
+	const releaseRefresh = deferred();
+	let healthRequests = 0;
+	await page.route(`${DEPLOY_API}/**`, async (route) => {
+		const path = new URL(route.request().url()).pathname;
+		if (path === "/me" || path === "/v1/me") {
+			return fulfillJson(route, {
+				capabilities: { can_use_v1: false, can_use_v2: true },
+			});
+		}
+		if (path === "/v1/agent-environments") {
+			return fulfillJson(route, { environment_ids: [] });
+		}
+		if (path === "/v2/deployments") return fulfillJson(route, []);
+		return fulfillJson(route, {});
+	});
+	await page.route(`${CLOUD_API}/v1/**`, async (route) => {
+		const path = new URL(route.request().url()).pathname;
+		if (path === "/v1/channels") return fulfillJson(route, [account]);
+		if (path === "/v1/channels/bot-pool") return fulfillJson(route, { providers: {} });
+		if (path === "/v1/channels/health") {
+			healthRequests += 1;
+			if (healthRequests > 1) {
+				refreshStarted.resolve();
+				await releaseRefresh.promise;
+			}
+			return fulfillJson(route, { items: [health] });
+		}
+		if (path === "/v1/agents" || path === "/v1/projects") return fulfillJson(route, []);
+		return fulfillJson(route, {});
+	});
+	return { refreshStarted, releaseRefresh, healthRequests: () => healthRequests };
+}
+
+for (const viewport of [
+	{ label: "desktop", width: 1440, height: 1000 },
+	{ label: "320px", width: 320, height: 800 },
+]) {
+	test(`Channels content stays stable during health polling at ${viewport.label}`, async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: viewport.width, height: viewport.height });
+		const refresh = await stubChannels(page);
+		await page.goto("/channels");
+
+		const card = page.locator(`[data-channel-account-id="${account.id}"]`);
+		await expect(card).toContainText(account.name);
+		await expect(page.getByRole("button", { name: /All\s+1/ })).toBeVisible();
+		const before = await card.boundingBox();
+		if (!before) throw new Error("Expected the Channel card to have layout bounds");
+
+		await expect.poll(refresh.healthRequests, { timeout: 25_000 }).toBeGreaterThan(1);
+		await refresh.refreshStarted.promise;
+		try {
+			await expect(card).toContainText(account.name);
+			await expect(page.getByRole("button", { name: /All\s+1/ })).toBeVisible();
+			expect(await card.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
+			expect(await card.locator(".animate-pulse").count()).toBe(0);
+			const during = await card.boundingBox();
+			if (!during) throw new Error("Expected the Channel card to remain mounted during refresh");
+			expect(during).toEqual(before);
+		} finally {
+			refresh.releaseRefresh.resolve();
+		}
+	});
+}

--- a/apps/web/e2e/query-refresh-no-flicker.pw.ts
+++ b/apps/web/e2e/query-refresh-no-flicker.pw.ts
@@ -1,0 +1,122 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+const now = "2026-08-02T12:00:00.000Z";
+const agent = {
+	id: "11111111-1111-4111-8111-111111111111",
+	name: "stable-agent",
+	default_name: "Stable Agent",
+	machine_name: "stable-agent.local",
+	display_name: "Stable Agent",
+	avatar_url: null,
+	sort_order: 0,
+	agent_type: "codex",
+	agent_version: "1.0.0",
+	os: "linux",
+	last_seen_at: now,
+	last_sync_at: now,
+	last_sync_error: null,
+	last_revision_seen: 1,
+	queue_depth_high_water: 0,
+	dropped_count: 0,
+	sync_enabled: true,
+	explicit_identity: true,
+	default_project_id: "22222222-2222-4222-8222-222222222222",
+};
+const project = {
+	id: agent.default_project_id,
+	name: "Stable Project",
+	slug: "stable-project",
+	kind: "environment",
+	origin_environment_id: agent.id,
+	archived_at: null,
+	created_at: now,
+	is_owner: true,
+	owner_display: "Browser User",
+	owner_handle: "browser-user",
+};
+const stats = {
+	total_sessions: 1,
+	total_messages: 1,
+	total_tokens: 1,
+	active_days: 1,
+	current_streak: 1,
+	longest_streak: 1,
+	peak_hour: 12,
+	favorite_model: "gpt-5",
+	skills_count: 0,
+	memories_count: 0,
+	vault_count: 0,
+	vault_keys_count: 0,
+	connectors_count: 0,
+	manual_sessions_last_7_days: 1,
+	contribution: [{ date: "2026-08-02", count: 1, level: 1 }],
+};
+const emptyPage = { items: [], total: 0, page: 1, page_size: 25 };
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+}
+
+async function stubDashboard(page: Page) {
+	const refreshStarted = deferred();
+	const releaseRefresh = deferred();
+	let agentRequests = 0;
+	await page.route("**/v1/**", async (route) => {
+		const path = new URL(route.request().url()).pathname;
+		if (path === "/v1/agents") {
+			agentRequests += 1;
+			if (agentRequests > 1) {
+				refreshStarted.resolve();
+				await releaseRefresh.promise;
+			}
+			return fulfillJson(route, [agent]);
+		}
+		if (path === "/v1/dashboard/stats") return fulfillJson(route, stats);
+		if (path === "/v1/projects") return fulfillJson(route, [project]);
+		if (path === "/v1/sessions") return fulfillJson(route, emptyPage);
+		return fulfillJson(route, {});
+	});
+	return { refreshStarted, releaseRefresh, agentRequests: () => agentRequests };
+}
+
+for (const viewport of [
+	{ label: "desktop", width: 1440, height: 1000 },
+	{ label: "320px", width: 320, height: 800 },
+]) {
+	test(`dashboard Agent content stays stable during polling at ${viewport.label}`, async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: viewport.width, height: viewport.height });
+		const refresh = await stubDashboard(page);
+		await page.goto("/");
+
+		const link = page.getByRole("link", { name: /Open Stable Agent/ }).first();
+		await expect(link).toBeVisible();
+		await expect(page.getByText("1 agent", { exact: true })).toBeVisible();
+		const card = link.locator("..");
+		const before = await card.boundingBox();
+		if (!before) throw new Error("Expected the Agent card to have layout bounds");
+
+		await expect.poll(refresh.agentRequests, { timeout: 15_000 }).toBeGreaterThan(1);
+		await refresh.refreshStarted.promise;
+		try {
+			await expect(link).toBeVisible();
+			await expect(page.getByText("1 agent", { exact: true })).toBeVisible();
+			expect(await card.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
+			expect(await card.locator(".animate-pulse").count()).toBe(0);
+			const during = await card.boundingBox();
+			if (!during) throw new Error("Expected the Agent card to remain mounted during refresh");
+			expect(during).toEqual(before);
+		} finally {
+			refresh.releaseRefresh.resolve();
+		}
+	});
+}

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,7 +6,7 @@ const serverPort = new URL(baseURL).port || "3200";
 export default defineConfig({
 	testDir: "./e2e",
 	testMatch: "**/*.pw.ts",
-	testIgnore: "**/hosted-smoke.pw.ts",
+	testIgnore: ["**/hosted-smoke.pw.ts", "**/query-refresh-hosted.pw.ts"],
 	timeout: 30_000,
 	expect: {
 		timeout: 5_000,

--- a/apps/web/playwright.hosted.config.ts
+++ b/apps/web/playwright.hosted.config.ts
@@ -11,7 +11,7 @@ const stripePublishableKey = process.env.E2E_STRIPE_PUBLISHABLE_KEY ?? "pk_test_
 
 export default defineConfig({
 	testDir: "./e2e",
-	testMatch: "**/hosted-smoke.pw.ts",
+	testMatch: ["**/hosted-smoke.pw.ts", "**/query-refresh-hosted.pw.ts"],
 	timeout: 60_000,
 	expect: { timeout: 12_000 },
 	fullyParallel: false,

--- a/apps/web/src/components/connectors/connectors-surface.tsx
+++ b/apps/web/src/components/connectors/connectors-surface.tsx
@@ -24,6 +24,7 @@ import {
 	useConnectedAppCards,
 } from "@/lib/connectors-data";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn } from "@/lib/utils";
 
@@ -128,8 +129,13 @@ function ConnectorsList({ embedded }: { embedded: boolean }) {
 	});
 	const pageData = catalogQ.data;
 	const isCatalogLoading = catalogQ.isLoading;
-	const isCatalogFetching = catalogQ.isFetching;
-	const catalogError = catalogQ.error;
+	const catalogError = shouldBlockQueryError(catalogQ.error, pageData) ? catalogQ.error : null;
+	const connectedError = shouldBlockQueryError(
+		connected.error,
+		connected.hasData ? connected.data : undefined,
+	)
+		? connected.error
+		: null;
 
 	const connectedNames = useMemo(
 		() => new Set(connected.activeConnections.map((c) => c.app_name)),
@@ -158,7 +164,7 @@ function ConnectorsList({ embedded }: { embedded: boolean }) {
 	// disappear and the user has no signal anything went wrong.
 	const showConnectedRail =
 		!debouncedQuery &&
-		(connected.isLoading || connected.activeConnections.length > 0 || !!connected.error);
+		(connected.isLoading || connected.activeConnections.length > 0 || !!connectedError);
 	const headerStatus =
 		total > 0 || connected.activeConnections.length > 0 ? (
 			<div className="flex flex-wrap items-center gap-2">
@@ -194,7 +200,7 @@ function ConnectorsList({ embedded }: { embedded: boolean }) {
 					apps={connected.data}
 					activeCount={connected.activeConnections.length}
 					isLoading={connected.isLoading}
-					error={connected.error}
+					error={connectedError}
 					onRetry={connected.refetch}
 				/>
 			) : null}
@@ -206,7 +212,6 @@ function ConnectorsList({ embedded }: { embedded: boolean }) {
 				totalPages={totalPages}
 				connectedNames={connectedNames}
 				isLoading={isCatalogLoading}
-				isFetching={isCatalogFetching}
 				error={catalogError}
 				query={query}
 				onRetry={() => {
@@ -271,7 +276,6 @@ function CatalogSection({
 	totalPages,
 	connectedNames,
 	isLoading,
-	isFetching,
 	error,
 	query,
 	onRetry,
@@ -284,7 +288,6 @@ function CatalogSection({
 	totalPages: number;
 	connectedNames: Set<string>;
 	isLoading: boolean;
-	isFetching: boolean;
 	error: Error | null;
 	query: string;
 	onRetry: () => void;
@@ -318,7 +321,7 @@ function CatalogSection({
 	} else {
 		content = (
 			<>
-				<div className={cn(CONNECTOR_GRID_CLASS, isFetching && "opacity-60 transition-opacity")}>
+				<div className={CONNECTOR_GRID_CLASS}>
 					{items.map((app) => (
 						<ConnectorCard key={app.name} app={app} isConnected={connectedNames.has(app.name)} />
 					))}

--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -18,6 +18,7 @@ import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { unwrap, useApi } from "@/lib/api";
 import { useAuthFields } from "@/lib/connectors-data";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { buildCredentialPayload, getVisibleCredentialFields } from "./credentials-dialog.logic";
 
@@ -139,7 +140,7 @@ export function ConnectorCredentialsDialog({
 						<div className="flex items-center justify-center py-6">
 							<Spinner className="size-5 text-muted-foreground" />
 						</div>
-					) : fields.error ? (
+					) : shouldBlockQueryError(fields.error, fields.data) ? (
 						<ApiErrorPanel
 							error={fields.error}
 							onRetry={() => {

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -89,19 +89,24 @@ export function AddAgentSetup() {
 	const api = useOpenApi();
 	const origin = useOrigin();
 	const prompt = `Set up Clawdi on this machine. Fetch ${origin}/skill.md, and follow the skills to set it up. Finally, confirm the installation with \`clawdi doctor\`.`;
+	const baseline = useRef<Set<string> | null>(null);
 
 	// Live success detection: snapshot the env ids on first load, then poll
-	// while mounted. Anything new is "your agent just connected".
+	// while mounted until a new Agent appears. Anything new is "your agent
+	// just connected"; once that terminal state is reached, polling stops.
 	const envs = api.useQuery(
 		"get",
 		"/v1/agents",
 		{},
 		{
-			refetchInterval: 5_000,
+			refetchInterval: (query) => {
+				const current = query.state.data;
+				if (!current || !baseline.current) return 5_000;
+				return current.some((agent) => !baseline.current?.has(agent.id)) ? false : 5_000;
+			},
 			refetchIntervalInBackground: false,
 		},
 	);
-	const baseline = useRef<Set<string> | null>(null);
 	useEffect(() => {
 		if (envs.data && baseline.current === null) {
 			baseline.current = new Set(envs.data.map((e) => e.id));

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -40,6 +40,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 
@@ -68,11 +69,11 @@ export function AgentProjectsTab({
 			bindings={bindings.data ?? []}
 			projects={projects.data ?? []}
 			isLoading={bindings.isLoading || projects.isLoading}
-			bindingsError={bindings.error}
+			bindingsError={shouldBlockQueryError(bindings.error, bindings.data) ? bindings.error : null}
 			onRetryBindings={() => {
 				void bindings.refetch();
 			}}
-			projectsError={projects.error}
+			projectsError={shouldBlockQueryError(projects.error, projects.data) ? projects.error : null}
 			onRetryProjects={() => {
 				void projects.refetch();
 			}}

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/agent-ownership";
 import { toastApiError, unwrap, useAgentAvatarUploader, useApi, useOpenApi } from "@/lib/api";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage } from "@/lib/utils";
 
 type Environment = components["schemas"]["AgentResponse"];
@@ -175,7 +176,7 @@ export function AgentSettingsPanel({
 		);
 	}
 
-	if (error || !agent) {
+	if (shouldBlockQueryError(error, agent) || !agent) {
 		return (
 			<div className={cn("flex flex-col gap-1 rounded-md border p-4", className)}>
 				<div className="text-sm font-semibold">Settings unavailable</div>

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -16,6 +16,7 @@ import { SkillCardGrid } from "@/components/skills/skill-card";
 import { type AgentRouteSearch, agentSkillDetailLink } from "@/lib/agent-routes";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { skillCapabilities } from "@/lib/skill-authority";
 
 export function useAgentProjectSkills(
@@ -38,8 +39,9 @@ export function useAgentProjectSkills(
 			return { projectIds: [], error };
 		}
 	}, [agentProjectId, bindings.data]);
+	const bindingsResolved = bindings.data !== undefined;
 	const queryEnabled =
-		enabled && agentProjectSkillsQueryEnabled(bindings.isSuccess, scope.projectIds) && !scope.error;
+		enabled && agentProjectSkillsQueryEnabled(bindingsResolved, scope.projectIds) && !scope.error;
 
 	// Bindings are resolved before any Skill request. Each effective Project is
 	// server-filtered and fully paginated, then rows remain in Project read order.
@@ -69,13 +71,16 @@ export function useAgentProjectSkills(
 	});
 
 	const skills = query.data;
-	const error = bindings.error ?? scope.error ?? query.error;
+	const blockingBindingsError = shouldBlockQueryError(bindings.error, bindings.data)
+		? bindings.error
+		: null;
+	const error = blockingBindingsError ?? scope.error ?? query.error;
 	const isLoading =
 		enabled &&
 		(bindings.isLoading ||
-			(bindings.isSuccess && !scope.error && scope.projectIds.length > 0 && query.isLoading));
+			(bindingsResolved && !scope.error && scope.projectIds.length > 0 && query.isLoading));
 	const refetch = async () => {
-		if (!bindings.data || bindings.error || scope.error) {
+		if (!bindings.data || blockingBindingsError || scope.error) {
 			await bindings.refetch();
 			return;
 		}
@@ -123,7 +128,7 @@ export function AgentSkillsTab({
 		[projects.data],
 	);
 
-	if (skillsError) {
+	if (shouldBlockQueryError(skillsError, skills)) {
 		return (
 			<div>
 				<ApiErrorPanel
@@ -139,7 +144,7 @@ export function AgentSkillsTab({
 
 	return (
 		<div className="space-y-4" data-testid="agent-skills-inventory">
-			{projects.error ? (
+			{shouldBlockQueryError(projects.error, projects.data) ? (
 				<ApiErrorPanel
 					error={projects.error}
 					onRetry={() => {

--- a/apps/web/src/components/dashboard/agent-vaults-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-vaults-tab.tsx
@@ -5,6 +5,7 @@ import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bi
 import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
 import { Skeleton } from "@/components/ui/skeleton";
 import { VaultsSurface } from "@/components/vault/vaults-surface";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 export function AgentVaultsTab({ agentId }: { agentId: string }) {
 	const bindings = useAgentProjectBindings(agentId);
@@ -23,7 +24,7 @@ export function AgentVaultsTab({ agentId }: { agentId: string }) {
 		);
 	}
 
-	if (bindings.error) {
+	if (shouldBlockQueryError(bindings.error, bindings.data)) {
 		return (
 			<ApiErrorPanel
 				error={bindings.error}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -31,6 +31,7 @@ import {
 import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -92,7 +93,18 @@ export function ConnectedAgentDetail({
 		refetch: refetchSkills,
 	} = useAgentProjectSkills(id, agentProjectId, id, false, Boolean(agent));
 
-	const sessionTotal = sessionsError ? "—" : (sessionsPage?.total ?? 0);
+	const blockingAgentError =
+		isApiNotFoundError(error) || shouldBlockQueryError(error, agent) ? error : null;
+	const blockingSkillsError = shouldBlockQueryError(skillsError, skillsForThisEnv)
+		? skillsError
+		: null;
+	const blockingProjectBindingsError = shouldBlockQueryError(projectBindingsError, projectBindings)
+		? projectBindingsError
+		: null;
+	const blockingSessionsError = shouldBlockQueryError(sessionsError, sessionsPage)
+		? sessionsError
+		: null;
+	const sessionTotal = blockingSessionsError ? "—" : (sessionsPage?.total ?? 0);
 	const activeTabMeta = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
@@ -108,12 +120,12 @@ export function ConnectedAgentDetail({
 	});
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
-			{error ? (
-				isApiNotFoundError(error) ? (
-					<DetailNotFound title="Agent not found" message={errorMessage(error)} />
+			{blockingAgentError ? (
+				isApiNotFoundError(blockingAgentError) ? (
+					<DetailNotFound title="Agent not found" message={errorMessage(blockingAgentError)} />
 				) : (
 					<ApiErrorPanel
-						error={error}
+						error={blockingAgentError}
 						onRetry={() => {
 							void refetchAgent();
 						}}
@@ -137,34 +149,36 @@ export function ConnectedAgentDetail({
 								<AgentStatPanel label="Sessions" value={sessionTotal} />
 								<AgentStatPanel
 									label="Skills"
-									value={skillsError ? "—" : skillsForThisEnv ? skillsForThisEnv.length : "—"}
+									value={
+										blockingSkillsError ? "—" : skillsForThisEnv ? skillsForThisEnv.length : "—"
+									}
 								/>
 								<AgentStatPanel
 									label="Projects"
-									value={projectBindingsError ? "—" : (projectBindings?.length ?? "—")}
+									value={blockingProjectBindingsError ? "—" : (projectBindings?.length ?? "—")}
 								/>
 							</div>
-							{skillsError ? (
+							{blockingSkillsError ? (
 								<ApiErrorPanel
-									error={skillsError}
+									error={blockingSkillsError}
 									onRetry={() => {
 										void refetchSkills();
 									}}
 									title="Couldn't load agent skills"
 								/>
 							) : null}
-							{projectBindingsError ? (
+							{blockingProjectBindingsError ? (
 								<ApiErrorPanel
-									error={projectBindingsError}
+									error={blockingProjectBindingsError}
 									onRetry={() => {
 										void refetchProjectBindings();
 									}}
 									title="Couldn't load agent Projects"
 								/>
 							) : null}
-							{sessionsError ? (
+							{blockingSessionsError ? (
 								<ApiErrorPanel
-									error={sessionsError}
+									error={blockingSessionsError}
 									onRetry={() => {
 										void refetchSessions();
 									}}
@@ -184,9 +198,9 @@ export function ConnectedAgentDetail({
 					) : null}
 
 					{activeTab === "sessions" ? (
-						sessionsError ? (
+						blockingSessionsError ? (
 							<ApiErrorPanel
-								error={sessionsError}
+								error={blockingSessionsError}
 								onRetry={() => {
 									void refetchSessions();
 								}}

--- a/apps/web/src/components/memories/memories-surface.test.ts
+++ b/apps/web/src/components/memories/memories-surface.test.ts
@@ -5,10 +5,10 @@ describe("shared Memories surface", () => {
 	test("keeps account-wide behavior in one reusable component", () => {
 		const source = readFileSync(new URL("./memories-surface.tsx", import.meta.url), "utf8");
 
-		expect(source).toContain('api.GET("/v1/memories"');
+		expect(source).toContain('$api.useQuery(\n\t\t"get",\n\t\t"/v1/memories"');
 		expect(source).toContain('api.PATCH("/v1/settings"');
-		expect(source).toContain('api.POST("/v1/memories"');
-		expect(source).toContain('api.DELETE("/v1/memories/{memory_id}"');
+		expect(source).toContain('api.useMutation("post", "/v1/memories"');
+		expect(source).toContain('$api.useMutation("delete", "/v1/memories/{memory_id}"');
 		expect(source).toContain('to="/memories/$id"');
 		expect(source).toContain("DataTablePagination");
 		expect(source).toContain("Search memories…");

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -40,9 +40,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { unwrap, useApi } from "@/lib/api";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { Memory } from "@/lib/api-schemas";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
@@ -64,6 +65,7 @@ const ADD_CATEGORY_ITEMS = CATEGORIES.filter((category) => category.value !== AL
 
 export function MemoriesSurface() {
 	const api = useApi();
+	const $api = useOpenApi();
 	const queryClient = useQueryClient();
 	const [search, setSearch] = useState("");
 	const [category, setCategory] = useState<string>(ALL);
@@ -89,7 +91,7 @@ export function MemoriesSurface() {
 			),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["settings"] });
-			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/memories"] });
 		},
 		onError: (e) => toast.error("Couldn't update settings", { description: errorMessage(e) }),
 	});
@@ -99,7 +101,7 @@ export function MemoriesSurface() {
 				await api.PATCH("/v1/settings", { body: { settings: { mem0_api_key: key } } }),
 			);
 			queryClient.invalidateQueries({ queryKey: ["settings"] });
-			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/memories"] });
 			return result;
 		} catch (error) {
 			toast.error("Couldn't update settings", { description: errorMessage(error) });
@@ -107,39 +109,34 @@ export function MemoriesSurface() {
 		}
 	});
 
-	const { data, isLoading, isFetching, error, refetch } = useQuery({
-		queryKey: ["memories", debouncedSearch, apiCategory, pagination.pageIndex, pagination.pageSize],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/memories", {
-					params: {
-						query: {
-							page: pagination.pageIndex + 1,
-							page_size: pagination.pageSize,
-							q: debouncedSearch || undefined,
-							category: apiCategory || undefined,
-						},
-					},
-				}),
-			),
-		placeholderData: keepPreviousData,
-	});
+	const { data, isLoading, error, refetch } = $api.useQuery(
+		"get",
+		"/v1/memories",
+		{
+			params: {
+				query: {
+					page: pagination.pageIndex + 1,
+					page_size: pagination.pageSize,
+					q: debouncedSearch || undefined,
+					category: apiCategory || undefined,
+				},
+			},
+		},
+		{ placeholderData: keepPreviousData },
+	);
 
 	const memories = data?.items;
 	const total = data?.total ?? 0;
 
-	const deleteMemory = useMutation({
-		mutationFn: async (id: string) =>
-			unwrap(
-				await api.DELETE("/v1/memories/{memory_id}", {
-					params: { path: { memory_id: id } },
-				}),
-			),
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["memories"] }),
+	const deleteMemory = $api.useMutation("delete", "/v1/memories/{memory_id}", {
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["get", "/v1/memories"] }),
 		onError: (e) => toast.error("Couldn't delete memory", { description: errorMessage(e) }),
 	});
 
-	const requestDeleteMemory = useCallback((id: string) => deleteMemory.mutate(id), [deleteMemory]);
+	const requestDeleteMemory = useCallback(
+		(id: string) => deleteMemory.mutate({ params: { path: { memory_id: id } } }),
+		[deleteMemory],
+	);
 
 	const emptyMessage =
 		debouncedSearch || apiCategory
@@ -220,7 +217,7 @@ export function MemoriesSurface() {
 				}
 			/>
 
-			{error ? (
+			{shouldBlockQueryError(error, data) ? (
 				<ApiErrorPanel
 					error={error}
 					onRetry={() => {
@@ -229,12 +226,7 @@ export function MemoriesSurface() {
 					title="Couldn't load memories"
 				/>
 			) : (
-				<div
-					className={cn(
-						"space-y-6 transition-opacity",
-						isFetching && !isLoading ? "opacity-60" : "opacity-100",
-					)}
-				>
+				<div className="space-y-6">
 					<MemoryNotesGrid
 						memories={memories ?? []}
 						isLoading={isLoading}
@@ -416,23 +408,17 @@ function Mem0KeyForm({
 }
 
 function AddMemoryForm() {
-	const api = useApi();
+	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [content, setContent] = useState("");
 	const [addCategory, setAddCategory] = useState("fact");
 	const secretFinding = findLikelySecret(content);
 
-	const createMemory = useMutation({
-		mutationFn: async () =>
-			unwrap(
-				await api.POST("/v1/memories", {
-					body: { content, category: addCategory, source: "web" },
-				}),
-			),
+	const createMemory = api.useMutation("post", "/v1/memories", {
 		onSuccess: () => {
 			setOpen(false);
-			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/memories"] });
 		},
 		onError: (e) => toast.error("Couldn't add memory", { description: errorMessage(e) }),
 	});
@@ -503,7 +489,12 @@ function AddMemoryForm() {
 							</Select>
 						</div>
 						<Button
-							onClick={() => content.trim() && createMemory.mutate()}
+							onClick={() =>
+								content.trim() &&
+								createMemory.mutate({
+									body: { content, category: addCategory, source: "web" },
+								})
+							}
 							disabled={!content.trim() || !!secretFinding || createMemory.isPending}
 						>
 							{createMemory.isPending ? <Spinner /> : <Plus />}

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -21,6 +21,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { projectDetailHref } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage } from "@/lib/utils";
 import {
 	type AcceptInvitationResponse,
@@ -147,7 +148,9 @@ export function NotificationCenter() {
 				<NotificationCenterContent
 					invitations={items}
 					isLoading={invitations.isLoading}
-					error={invitations.error}
+					error={
+						shouldBlockQueryError(invitations.error, invitations.data) ? invitations.error : null
+					}
 					onRetry={() => invitations.refetch()}
 					acceptInvitation={(invitation) =>
 						accept.mutate({ id: invitation.id, projectName: invitation.project_name })

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -168,8 +168,7 @@ export function SettingsDialog({
 		IS_HOSTED_BUILD &&
 		(hostedAccess.canCreateCloudAgents ||
 			hasExistingCloudAgents ||
-			(requestedBillingSection &&
-				(!mounted || hostedAccess.isLoading || Boolean(hostedAccess.error))));
+			(requestedBillingSection && (!mounted || hostedAccess.isLoading || hostedAccess.isError)));
 	const items = SETTINGS_NAV.filter((item) => !item.cloudOnly || showBilling);
 	const activeSection = items.some((item) => item.id === section)
 		? section
@@ -180,7 +179,7 @@ export function SettingsDialog({
 		requestedBillingSection &&
 		IS_HOSTED_BUILD &&
 		mounted &&
-		Boolean(hostedAccess.error) &&
+		hostedAccess.isError &&
 		!hostedAccess.canCreateCloudAgents &&
 		!hasExistingCloudAgents;
 

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -53,6 +53,7 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
 import { formatShortDate } from "@/lib/format";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
 const API_KEY_LABEL_MAX_LENGTH = 200;
@@ -201,7 +202,7 @@ export function ApiKeysPanel() {
 				</p>
 			</div>
 
-			{error ? (
+			{shouldBlockQueryError(error, listedKeys) ? (
 				<ApiErrorPanel error={error} onRetry={() => refetch()} title="Couldn’t load API keys" />
 			) : isLoading ? (
 				<>

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -46,6 +46,7 @@ import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycl
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
 
@@ -296,7 +297,7 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 
 			{links.isLoading ? (
 				<Skeleton className="h-16 w-full" />
-			) : links.error ? (
+			) : shouldBlockQueryError(links.error, links.data) ? (
 				<EmptyHint
 					variant="destructive"
 					message={
@@ -634,7 +635,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			<Separator />
 			{invites.isLoading ? (
 				<Skeleton className="h-16 w-full" />
-			) : invites.error ? (
+			) : shouldBlockQueryError(invites.error, invites.data) ? (
 				<EmptyHint
 					variant="destructive"
 					message={
@@ -857,7 +858,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 			<Separator />
 			{members.isLoading ? (
 				<Skeleton className="h-16 w-full" />
-			) : members.error ? (
+			) : shouldBlockQueryError(members.error, members.data) ? (
 				<EmptyHint
 					variant="destructive"
 					message={

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -28,6 +28,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ensureBlob, unwrap, useApi, useOpenApi, useSkillArchiveUploader } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { skillCapabilities } from "@/lib/skill-authority";
 import { errorMessage } from "@/lib/utils";
 
@@ -68,7 +69,9 @@ export function SendSkillDialog({
 		},
 	);
 	const projects = projectsQuery.data;
-	const destinationLoadError = projectsQuery.error;
+	const destinationLoadError = shouldBlockQueryError(projectsQuery.error, projectsQuery.data)
+		? projectsQuery.error
+		: null;
 
 	// Target value encodes a Cloud-owned destination Project id. Environment
 	// Projects are filesystem projections and are deliberately excluded.

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -32,6 +32,7 @@ import { buildKeyImportPreview } from "@/components/vault/key-import-logic";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { errorMessage } from "@/lib/utils";
 
@@ -113,13 +114,19 @@ export function AddKeysDialog({
 		effectiveChoice === NEW_VAULT &&
 		!vaultSlug &&
 		(vaultsQuery.isLoading || projectsQuery.isLoading);
+	const blockingVaultsError = shouldBlockQueryError(vaultsQuery.error, vaultsQuery.data)
+		? vaultsQuery.error
+		: null;
+	const blockingProjectsError = shouldBlockQueryError(projectsQuery.error, projectsQuery.data)
+		? projectsQuery.error
+		: null;
 	const newVaultUnavailable =
 		effectiveChoice === NEW_VAULT &&
 		!vaultSlug &&
 		!vaultsQuery.isLoading &&
 		!projectsQuery.isLoading &&
-		!vaultsQuery.error &&
-		!projectsQuery.error &&
+		!blockingVaultsError &&
+		!blockingProjectsError &&
 		writableProject === undefined;
 	const existingItems = useQuery({
 		queryKey: ["vault-items", selectedVaultId, effectiveSlug, selectedVaultProjectId],
@@ -149,7 +156,10 @@ export function AddKeysDialog({
 		effectiveChoice !== NEW_VAULT &&
 		(vaultsQuery.isLoading || selectedVaultId === undefined || existingItems.isLoading);
 	const destinationLoadError =
-		vaultsQuery.error ?? (effectiveChoice === NEW_VAULT ? projectsQuery.error : null);
+		blockingVaultsError ?? (effectiveChoice === NEW_VAULT ? blockingProjectsError : null);
+	const existingItemsError = shouldBlockQueryError(existingItems.error, existingItems.data)
+		? existingItems.error
+		: null;
 	const canSave =
 		importPlan.parsed.errors.length === 0 &&
 		importableCount > 0 &&
@@ -159,7 +169,7 @@ export function AddKeysDialog({
 		!newVaultUnavailable &&
 		!destinationPending &&
 		!destinationLoadError &&
-		!existingItems.error;
+		!existingItemsError;
 
 	const save = useSensitiveAction(async () => {
 		try {
@@ -343,9 +353,9 @@ export function AddKeysDialog({
 							</AlertDescription>
 						</Alert>
 					) : null}
-					{existingItems.error ? (
+					{existingItemsError ? (
 						<ApiErrorPanel
-							error={existingItems.error}
+							error={existingItemsError}
 							onRetry={() => {
 								void existingItems.refetch();
 							}}

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -28,6 +28,7 @@ import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -114,14 +115,21 @@ export function CopyKeysDialog({
 		[projectsQuery.data],
 	);
 	const newVaultPending = creatingNewVault && (vaultsQuery.isLoading || projectsQuery.isLoading);
+	const blockingVaultsError = shouldBlockQueryError(vaultsQuery.error, vaultsQuery.data)
+		? vaultsQuery.error
+		: null;
+	const blockingProjectsError = shouldBlockQueryError(projectsQuery.error, projectsQuery.data)
+		? projectsQuery.error
+		: null;
 	const newVaultUnavailable =
 		creatingNewVault &&
 		!projectsQuery.isLoading &&
 		!vaultsQuery.isLoading &&
-		!projectsQuery.error &&
-		!vaultsQuery.error &&
+		!blockingProjectsError &&
+		!blockingVaultsError &&
 		writableProject === undefined;
-	const destinationLoadError = vaultsQuery.error ?? (creatingNewVault ? projectsQuery.error : null);
+	const destinationLoadError =
+		blockingVaultsError ?? (creatingNewVault ? blockingProjectsError : null);
 	const canRun =
 		keys.length > 0 &&
 		!destinationLoadError &&

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -21,6 +21,7 @@ import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycl
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -273,7 +274,7 @@ export function SplitVaultDialog({
 							them. Add the new vaults to those Projects afterwards.
 						</p>
 					) : null}
-					{projectsQuery.error ? (
+					{shouldBlockQueryError(projectsQuery.error, projectsQuery.data) ? (
 						<ApiErrorPanel
 							error={projectsQuery.error}
 							onRetry={() => {
@@ -288,7 +289,7 @@ export function SplitVaultDialog({
 							selected.length === 0 ||
 							run.isPending ||
 							projectsQuery.isLoading ||
-							!!projectsQuery.error
+							shouldBlockQueryError(projectsQuery.error, projectsQuery.data)
 						}
 						onClick={() => run.mutate()}
 					>

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -37,6 +37,7 @@ import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -95,6 +96,7 @@ export function VaultsSurface({
 		() => new Map((projects.data ?? []).map((p) => [p.id, p.name])),
 		[projects.data],
 	);
+	const projectNamesUnavailable = shouldBlockQueryError(projects.error, projects.data);
 
 	const items =
 		agentProjectIds === undefined ? (accountVaults.data?.items ?? []) : (agentVaults.data ?? []);
@@ -191,7 +193,7 @@ export function VaultsSurface({
 				}
 			/>
 
-			{vaultsQuery.error ? (
+			{shouldBlockQueryError(vaultsQuery.error, vaultsQuery.data) ? (
 				<ApiErrorPanel
 					error={vaultsQuery.error}
 					onRetry={() => {
@@ -230,7 +232,7 @@ export function VaultsSurface({
 				/>
 			) : (
 				<>
-					{projects.error ? (
+					{projectNamesUnavailable ? (
 						<ApiErrorPanel
 							error={projects.error}
 							onRetry={() => {
@@ -239,19 +241,13 @@ export function VaultsSurface({
 							title="Couldn't load Project names"
 						/>
 					) : null}
-					<div
-						className={cn(
-							HERO_GRID_CLASS,
-							"transition-opacity",
-							vaultsQuery.isFetching && !vaultsQuery.isLoading ? "opacity-60" : "opacity-100",
-						)}
-					>
+					<div className={HERO_GRID_CLASS}>
 						{mine.map((vault) => (
 							<VaultCard
 								key={vault.id}
 								vault={vault}
 								projectNameById={projectNameById}
-								projectNamesUnavailable={!!projects.error}
+								projectNamesUnavailable={projectNamesUnavailable}
 								visibleProjectIds={visibleProjectIds}
 							/>
 						))}
@@ -268,7 +264,7 @@ export function VaultsSurface({
 										key={vault.id}
 										vault={vault}
 										projectNameById={projectNameById}
-										projectNamesUnavailable={!!projects.error}
+										projectNamesUnavailable={projectNamesUnavailable}
 										visibleProjectIds={visibleProjectIds}
 										shared
 									/>

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -44,6 +44,18 @@ import { cn } from "@/lib/utils";
 const UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS = 5_000;
 const UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS = 24;
 
+export async function runManualDeploymentRefetch(
+	refetch: () => Promise<unknown>,
+	setManualChecking: (checking: boolean) => void,
+): Promise<void> {
+	setManualChecking(true);
+	try {
+		await refetch();
+	} finally {
+		setManualChecking(false);
+	}
+}
+
 /**
  * Agent home for hosted builds. An agent backed by a hosted deployment renders
  * the hosted agent detail (`HostedAgentDetail`); a connected agent — or one
@@ -84,6 +96,7 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
+	const manualCheckInFlightRef = useRef(false);
 	const [manualChecking, setManualChecking] = useState(false);
 	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
 	const hostedSection = HOSTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
@@ -172,12 +185,12 @@ export function AgentHome({
 	}, [refetch, shouldAutoRefetchUnresolvedHostedAgent]);
 
 	const handleCheckAgain = async () => {
-		if (isFetchingRef.current || manualChecking) return;
-		setManualChecking(true);
+		if (manualCheckInFlightRef.current) return;
+		manualCheckInFlightRef.current = true;
 		try {
-			await refetch();
+			await runManualDeploymentRefetch(refetch, setManualChecking);
 		} finally {
-			setManualChecking(false);
+			manualCheckInFlightRef.current = false;
 		}
 	};
 
@@ -236,7 +249,7 @@ export function AgentHome({
 				section={section}
 				routeSearch={routeSearch}
 				matches={ambiguousMatches}
-				isFetching={manualChecking}
+				isChecking={manualChecking}
 				onRetry={() => void handleCheckAgain()}
 			/>
 		);
@@ -304,14 +317,14 @@ function DeploymentChooser({
 	section,
 	routeSearch,
 	matches,
-	isFetching,
+	isChecking,
 	onRetry,
 }: {
 	environmentId: string;
 	section: AgentSectionId;
 	routeSearch: AgentRouteSearch;
 	matches: readonly AgentDeploymentMatch[];
-	isFetching: boolean;
+	isChecking: boolean;
 	onRetry: () => void;
 }) {
 	const hasUnknownStatus = matches.some(
@@ -336,10 +349,10 @@ function DeploymentChooser({
 							type="button"
 							variant="outline"
 							size="sm"
-							disabled={isFetching}
+							disabled={isChecking}
 							onClick={onRetry}
 						>
-							{isFetching ? <Spinner className="size-3.5" /> : <RefreshCw />}
+							{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw />}
 							Check again
 						</Button>
 					</AlertDescription>

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { focusManager } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { AlertCircle, ChevronRight, RefreshCw } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -83,6 +84,7 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
+	const [manualChecking, setManualChecking] = useState(false);
 	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
 	const hostedSection = HOSTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
 	const connectedSection = CONNECTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
@@ -154,7 +156,7 @@ export function AgentHome({
 
 		let attempts = 0;
 		const intervalId = window.setInterval(() => {
-			if (isFetchingRef.current) return;
+			if (!focusManager.isFocused() || isFetchingRef.current) return;
 
 			attempts += 1;
 			void refetch();
@@ -169,9 +171,14 @@ export function AgentHome({
 		};
 	}, [refetch, shouldAutoRefetchUnresolvedHostedAgent]);
 
-	const handleCheckAgain = () => {
-		if (isFetchingRef.current) return;
-		void refetch();
+	const handleCheckAgain = async () => {
+		if (isFetchingRef.current || manualChecking) return;
+		setManualChecking(true);
+		try {
+			await refetch();
+		} finally {
+			setManualChecking(false);
+		}
 	};
 
 	// No route may be classified as connected until deployment membership has
@@ -200,7 +207,7 @@ export function AgentHome({
 
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
-	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
+	if (isLoading) {
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
@@ -229,8 +236,8 @@ export function AgentHome({
 				section={section}
 				routeSearch={routeSearch}
 				matches={ambiguousMatches}
-				isFetching={isFetching}
-				onRetry={handleCheckAgain}
+				isFetching={manualChecking}
+				onRetry={() => void handleCheckAgain()}
 			/>
 		);
 	}
@@ -252,8 +259,8 @@ export function AgentHome({
 				routeSearch={deploymentRouteSearch}
 				onDeleteAccepted={() => router.navigate({ href: "/", replace: true })}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
-				isCheckingDeployment={isFetching}
-				onCheckDeploymentAgain={handleCheckAgain}
+				isCheckingDeployment={manualChecking}
+				onCheckDeploymentAgain={() => void handleCheckAgain()}
 			/>
 		);
 	}
@@ -268,8 +275,14 @@ export function AgentHome({
 					title="Clawdi Cloud agent not found"
 					description="This Clawdi Cloud agent may still be starting or may have been removed."
 					action={
-						<Button type="button" variant="outline" size="sm" onClick={handleCheckAgain}>
-							<RefreshCw /> Check again
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={manualChecking}
+							onClick={() => void handleCheckAgain()}
+						>
+							{manualChecking ? <Spinner className="size-3.5" /> : <RefreshCw />} Check again
 						</Button>
 					}
 				/>

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -221,8 +221,10 @@ describe("deployment transition timeout rendering", () => {
 
 		expect(source).toContain("deploymentTransitionTimedOut,");
 		expect(source).toContain("deploymentTransitionTimedOut={deploymentTransitionTimedOut}");
-		expect(source).toContain("onCheckDeploymentAgain={handleCheckAgain}");
-		expect(source).toContain("void refetch();");
+		expect(source).toContain("const [manualChecking, setManualChecking] = useState(false);");
+		expect(source).toContain("await refetch();");
+		expect(source).toContain("isCheckingDeployment={manualChecking}");
+		expect(source).toContain("onCheckDeploymentAgain={() => void handleCheckAgain()}");
 	});
 });
 

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type {
@@ -26,12 +26,15 @@ type OverviewReadinessPanel =
 type OverviewFailedPanel = typeof import("@/hosted/agents/hosted-agent-detail").OverviewFailedPanel;
 type ShouldShowHostedProjectionNotice =
 	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowHostedProjectionNotice;
+type RunManualDeploymentRefetch =
+	typeof import("@/hosted/agents/agent-home").runManualDeploymentRefetch;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
 let overviewReadinessPanel: OverviewReadinessPanel | null = null;
 let overviewFailedPanel: OverviewFailedPanel | null = null;
 let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
+let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 
 function requiredDeploymentStatus(
 	deployment: HostedDeployment | undefined,
@@ -49,6 +52,8 @@ beforeAll(async () => {
 	const module = await import("@/hosted/agents/deployment-hooks");
 	invalidateSnapshots = module.invalidateDeploymentSnapshots;
 	projectAcceptedTransition = module.projectAcceptedDeploymentTransition;
+	const agentHomeModule = await import("@/hosted/agents/agent-home");
+	runManualDeploymentRefetch = agentHomeModule.runManualDeploymentRefetch;
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
 	overviewReadinessPanel = detailModule.OverviewReadinessPanel;
 	overviewFailedPanel = detailModule.OverviewFailedPanel;
@@ -218,13 +223,78 @@ describe("deployment transition timeout rendering", () => {
 
 	test("wires the timed-out inventory state and real refetch action into the detail", () => {
 		const source = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
+		const manualHandler = source.slice(
+			source.indexOf("const handleCheckAgain"),
+			source.indexOf("// No route may be classified as connected"),
+		);
 
 		expect(source).toContain("deploymentTransitionTimedOut,");
 		expect(source).toContain("deploymentTransitionTimedOut={deploymentTransitionTimedOut}");
 		expect(source).toContain("const [manualChecking, setManualChecking] = useState(false);");
-		expect(source).toContain("await refetch();");
+		expect(manualHandler).toContain("manualCheckInFlightRef.current");
+		expect(manualHandler).toContain(
+			"await runManualDeploymentRefetch(refetch, setManualChecking);",
+		);
+		expect(manualHandler).not.toContain("isFetchingRef");
+		expect(source).toContain("isChecking={manualChecking}");
 		expect(source).toContain("isCheckingDeployment={manualChecking}");
 		expect(source).toContain("onCheckDeploymentAgain={() => void handleCheckAgain()}");
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(detailSource).toContain("isChecking={isCheckingProjection}");
+		expect(detailSource).not.toContain("isFetching={isCheckingProjection}");
+	});
+
+	test("gives a manual check local feedback while an ambient refetch is active", async () => {
+		if (!runManualDeploymentRefetch) throw new Error("agent home was not loaded");
+		let requestCount = 0;
+		let ambientRequestAborted = false;
+		let resolveManualRequest: ((value: string) => void) | undefined;
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const observer = new QueryObserver(client, {
+			queryKey: ["test", "manual-check-during-ambient-refetch"],
+			queryFn: ({ signal }) => {
+				requestCount += 1;
+				if (requestCount === 1) {
+					return new Promise<string>((_resolve, reject) => {
+						signal.addEventListener(
+							"abort",
+							() => {
+								ambientRequestAborted = true;
+								reject(new Error("ambient request aborted"));
+							},
+							{ once: true },
+						);
+					});
+				}
+				return new Promise<string>((resolve) => {
+					resolveManualRequest = resolve;
+				});
+			},
+			initialData: "cached deployment",
+		});
+		const unsubscribe = observer.subscribe(() => undefined);
+		const ambientRefetch = observer.refetch({ cancelRefetch: false });
+		const checkingStates: boolean[] = [];
+
+		const manualRefetch = runManualDeploymentRefetch(
+			() => observer.refetch(),
+			(checking) => checkingStates.push(checking),
+		);
+
+		expect(checkingStates).toEqual([true]);
+		expect(requestCount).toBe(2);
+		expect(ambientRequestAborted).toBe(true);
+		if (!resolveManualRequest) throw new Error("manual request did not start");
+		resolveManualRequest("fresh deployment");
+		await Promise.all([ambientRefetch, manualRefetch]);
+
+		expect(checkingStates).toEqual([true, false]);
+		expect(observer.getCurrentResult().data).toBe("fresh deployment");
+		unsubscribe();
+		client.clear();
 	});
 });
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -562,7 +562,7 @@ export function HostedAgentDetail({
 				shouldShowHostedProjectionNotice(activeTab) ? (
 					<HostedProjectionNotice
 						projection={projection}
-						isFetching={isCheckingProjection}
+						isChecking={isCheckingProjection}
 						onRetry={() => {
 							void checkProjectionAgain();
 						}}
@@ -684,11 +684,11 @@ export function HostedAgentDetail({
 
 function HostedProjectionNotice({
 	projection,
-	isFetching,
+	isChecking,
 	onRetry,
 }: {
 	projection: HostedProjectionResolution<components["schemas"]["AgentResponse"]>;
-	isFetching: boolean;
+	isChecking: boolean;
 	onRetry: () => void;
 }) {
 	if (projection.status === "resolved") return null;
@@ -711,8 +711,8 @@ function HostedProjectionNotice({
 						Sessions, Projects, Skills, Vaults, and Channels will appear when this agent is ready.
 						Available actions and tools still work.
 					</span>
-					<Button type="button" variant="outline" size="sm" disabled={isFetching} onClick={onRetry}>
-						{isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
+					<Button type="button" variant="outline" size="sm" disabled={isChecking} onClick={onRetry}>
+						{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
 						Check again
 					</Button>
 				</AlertDescription>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -92,10 +92,7 @@ import {
 	useResetRuntimeUiAccess,
 	useUpdateDeployment,
 } from "@/hosted/agents/deployment-hooks";
-import {
-	HOSTED_AGENT_SESSIONS_REFRESH_POLICY,
-	shouldBlockHostedSessionsError,
-} from "@/hosted/agents/hosted-agent-session-query";
+import { HOSTED_AGENT_SESSIONS_REFRESH_POLICY } from "@/hosted/agents/hosted-agent-session-query";
 import {
 	HostedTerminalPanel,
 	type HostedTerminalStatus,
@@ -282,6 +279,7 @@ import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -464,6 +462,7 @@ export function HostedAgentDetail({
 	onCheckDeploymentAgain: () => void;
 }) {
 	const $api = useOpenApi();
+	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
@@ -491,6 +490,15 @@ export function HostedAgentDetail({
 		error: agentQuery.error,
 		isPending: agentQuery.isPending,
 	});
+	const checkProjectionAgain = async () => {
+		if (isCheckingProjection) return;
+		setIsCheckingProjection(true);
+		try {
+			await agentQuery.refetch();
+		} finally {
+			setIsCheckingProjection(false);
+		}
+	};
 	const agent = projection.status === "resolved" ? projection.data : null;
 	const name = agent
 		? deploymentDisplayName(agentDisplayName(agent), runtime)
@@ -554,9 +562,9 @@ export function HostedAgentDetail({
 				shouldShowHostedProjectionNotice(activeTab) ? (
 					<HostedProjectionNotice
 						projection={projection}
-						isFetching={agentQuery.isFetching}
+						isFetching={isCheckingProjection}
 						onRetry={() => {
-							void agentQuery.refetch();
+							void checkProjectionAgain();
 						}}
 					/>
 				) : null}
@@ -571,7 +579,9 @@ export function HostedAgentDetail({
 							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
-							sessionsError={sessions.error}
+							sessionsError={
+								shouldBlockQueryError(sessions.error, sessions.data) ? sessions.error : null
+							}
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
 							planChangeHref={planChangeHref}
@@ -649,10 +659,10 @@ export function HostedAgentDetail({
 							<ChannelsTab environmentId={environmentId} agentType={runtime} agentName={name} />
 						) : (
 							<ChannelsSyncState
-								isChecking={isCheckingDeployment || agentQuery.isFetching}
+								isChecking={isCheckingDeployment || isCheckingProjection}
 								onCheckAgain={() => {
 									onCheckDeploymentAgain();
-									if (cloudEnvironmentId) void agentQuery.refetch();
+									if (cloudEnvironmentId) void checkProjectionAgain();
 								}}
 							/>
 						)
@@ -788,7 +798,7 @@ function HostedAgentSessionsTab({
 		if (sessions.data && page > pageCount) setPage(pageCount);
 	}, [page, pageCount, sessions.data]);
 
-	if (shouldBlockHostedSessionsError(sessions.error, sessions.data !== undefined)) {
+	if (shouldBlockQueryError(sessions.error, sessions.data)) {
 		return (
 			<ApiErrorPanel
 				error={sessions.error}
@@ -799,12 +809,7 @@ function HostedAgentSessionsTab({
 	}
 
 	return (
-		<div
-			className={cn(
-				"space-y-4 transition-opacity",
-				sessions.isFetching && !sessions.isLoading ? "opacity-60" : "opacity-100",
-			)}
-		>
+		<div className="space-y-4">
 			<SessionFeed
 				sessions={sessions.data?.items ?? []}
 				isLoading={sessions.isLoading && !sessions.data}
@@ -2075,7 +2080,7 @@ function AiProviderTab({
 			primaryProviderChoice: initialPrimaryChoice,
 			primaryModel: currentModel,
 		},
-		managedCatalogReady: managedModelCatalog.isSuccess,
+		managedCatalogReady: managedModelCatalog.data !== undefined,
 		managedModels,
 		operationMode: "update",
 		providers: list,
@@ -2130,7 +2135,7 @@ function AiProviderTab({
 					badge={bindingMode === "unmanaged" ? <Badge variant="secondary">Current</Badge> : null}
 				/>
 				{providers.isLoading ? <EntityCardSkeleton titleBadge trailingBadge /> : null}
-				{providers.error ? (
+				{shouldBlockQueryError(providers.error, providers.data) ? (
 					<div className="@2xl/main:col-span-2">
 						<ApiErrorPanel
 							normalizer={billingErrorNormalizer}
@@ -2554,7 +2559,7 @@ function ChannelsTab({
 				description="Clawdi-managed bots available to your account."
 				bots={cardGroups.clawdiBots}
 				isLoading={botPool.isLoading}
-				error={botPool.error}
+				error={shouldBlockQueryError(botPool.error, botPool.data) ? botPool.error : null}
 				onRetry={() => void botPool.refetch()}
 				emptyTitle="No Clawdi bots available"
 				renderBot={renderBot}
@@ -2566,7 +2571,7 @@ function ChannelsTab({
 				description="Bots whose provider credentials you manage."
 				bots={cardGroups.customBots}
 				isLoading={channels.isLoading}
-				error={channels.error}
+				error={shouldBlockQueryError(channels.error, channels.data) ? channels.error : null}
 				onRetry={() => void channels.refetch()}
 				emptyTitle="No custom bots yet"
 				action={
@@ -2585,7 +2590,7 @@ function ChannelsTab({
 				renderBot={renderBot}
 			/>
 
-			{linked.error ? (
+			{shouldBlockQueryError(linked.error, linked.data) ? (
 				<ApiErrorPanel
 					error={linked.error}
 					onRetry={() => linked.refetch()}
@@ -3223,6 +3228,7 @@ function ComputeSettingsSections({
 	const walletTopUp = useWalletTopUpDialog(PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY);
 	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
+	const blockingPlansError = shouldBlockQueryError(plans.error, plans.data) ? plans.error : null;
 	const currentPaidPlan =
 		computePlanSlug === COMPUTE_BASIC_SLUG
 			? basicPlan
@@ -3515,11 +3521,11 @@ function ComputeSettingsSections({
 						id="compute-plan-controls"
 						className="flex w-full scroll-mt-6 flex-col gap-2 lg:w-auto lg:min-w-64 lg:items-end"
 					>
-						{(hasTerminalFallback || isIncludedBasic) && plans.error ? (
+						{(hasTerminalFallback || isIncludedBasic) && blockingPlansError ? (
 							<div className="w-full lg:w-72">
 								<ApiErrorPanel
 									normalizer={billingErrorNormalizer}
-									error={plans.error}
+									error={blockingPlansError}
 									onRetry={() => void plans.refetch()}
 									title="Couldn’t check paid compute availability"
 								/>

--- a/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
@@ -6,10 +6,10 @@ import {
 	QueryClient,
 	QueryObserver,
 } from "@tanstack/react-query";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import {
 	HOSTED_AGENT_SESSIONS_REFETCH_INTERVAL_MS,
 	HOSTED_AGENT_SESSIONS_REFRESH_POLICY,
-	shouldBlockHostedSessionsError,
 } from "./hosted-agent-session-query";
 
 const detailSource = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
@@ -50,8 +50,8 @@ describe("hosted agent sessions refresh", () => {
 			expect(second.data).toEqual(cachedData);
 			expect(second.error).toBe(error);
 			expect(second.isRefetchError).toBe(true);
-			expect(shouldBlockHostedSessionsError(second.error, second.data !== undefined)).toBe(false);
-			expect(shouldBlockHostedSessionsError(error, false)).toBe(true);
+			expect(shouldBlockQueryError(second.error, second.data)).toBe(false);
+			expect(shouldBlockQueryError(error, undefined)).toBe(true);
 		} finally {
 			unsubscribe();
 			queryClient.clear();

--- a/apps/web/src/hosted/agents/hosted-agent-session-query.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-session-query.ts
@@ -3,7 +3,3 @@ export const HOSTED_AGENT_SESSIONS_REFRESH_POLICY = {
 	refetchInterval: HOSTED_AGENT_SESSIONS_REFETCH_INTERVAL_MS,
 	refetchIntervalInBackground: false,
 } as const;
-
-export function shouldBlockHostedSessionsError(error: unknown, hasData: boolean): boolean {
-	return error !== null && error !== undefined && !hasData;
-}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -347,13 +347,16 @@ describe("AI provider usability gate", () => {
 });
 
 describe("billing-read gates", () => {
-	test("keeps deploy disabled until inventory succeeds and offers retries", () => {
-		expect(wizardSource).toContain("deployments.isSuccess &&");
+	test("keeps deploy disabled until inventory resolves and offers scoped retries", () => {
+		expect(wizardSource).toContain("const deploymentsResolved = deployments.data !== undefined;");
+		expect(wizardSource).toContain("shouldBlockQueryError(deployments.error, deployments.data)");
 		expect(wizardSource).toContain("activeIncludedBasicSlot === null");
 		expect(wizardSource).toContain("Free Basic agent availability is unknown");
 		expect(wizardSource).toContain("No free agent is assumed.");
 		expect(wizardSource).toContain('title="Couldn\'t check existing agents"');
 		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
+		expect(wizardSource).toContain("disabled={checkingDeployments}");
+		expect(wizardSource).toContain("onClick={() => void checkDeploymentsAgain()}");
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
 		expect(wizardSource).toContain("async function retryWalletQuote()");
 		expect(wizardSource).toContain('toast.error("Couldn’t refresh Wallet quote"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -170,6 +170,7 @@ import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picke
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 import { env } from "@/lib/env";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 type Compute = "basic" | "performance";
@@ -392,7 +393,21 @@ export function DeployWizard() {
 		"Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
 	);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
+	const [checkingDeployments, setCheckingDeployments] = useState(false);
 	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
+	const deploymentsResolved = deployments.data !== undefined;
+	const blockingDeploymentsError = shouldBlockQueryError(deployments.error, deployments.data)
+		? deployments.error
+		: null;
+	const checkDeploymentsAgain = async () => {
+		if (checkingDeployments) return;
+		setCheckingDeployments(true);
+		try {
+			await deployments.refetch();
+		} finally {
+			setCheckingDeployments(false);
+		}
+	};
 
 	// Keep the first client render on the same deterministic fallback as SSR,
 	// then adopt runtime IANA data and best-effort browser defaults after mount.
@@ -418,8 +433,8 @@ export function DeployWizard() {
 		[basicPlan, term],
 	);
 	const activeIncludedBasicSlot = useMemo(
-		() => (deployments.isSuccess ? usesActiveIncludedBasicSlot(deployments.data) : null),
-		[deployments.data, deployments.isSuccess],
+		() => (deploymentsResolved ? usesActiveIncludedBasicSlot(deployments.data ?? []) : null),
+		[deployments.data, deploymentsResolved],
 	);
 	const basicSelection = useMemo(
 		() =>
@@ -444,7 +459,7 @@ export function DeployWizard() {
 		? computePricePresentation(basicOffer, basicOffers)
 		: null;
 	const perfPricePresentation = perfOffer ? computePricePresentation(perfOffer, perfOffers) : null;
-	const paidSelection: PaidDeploySelection | null = !deployments.isSuccess
+	const paidSelection: PaidDeploySelection | null = !deploymentsResolved
 		? null
 		: compute === "performance" && perfPlan && perfOfferSelection
 			? {
@@ -500,6 +515,8 @@ export function DeployWizard() {
 	const availabilityContext = { runtime, environmentId: null };
 	const providerList = usableProviders(savedProviderList, availabilityContext);
 	const managedModels = managedModelCatalog.data?.models ?? [];
+	const managedModelCatalogResolved = managedModelCatalog.data !== undefined;
+	const plansResolved = plans.data !== undefined;
 	const {
 		draft: aiBindingDraft,
 		managedPrimaryModelReady,
@@ -513,7 +530,7 @@ export function DeployWizard() {
 			primaryProviderChoice: DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 			primaryModel: DEFAULT_DEPLOY_PRIMARY_MODEL,
 		},
-		managedCatalogReady: managedModelCatalog.isSuccess,
+		managedCatalogReady: managedModelCatalogResolved,
 		managedModels,
 		operationMode: "create",
 		providers: providerList,
@@ -524,7 +541,7 @@ export function DeployWizard() {
 	const managedModelsNeedRetry =
 		managedProviderSelected &&
 		managedModels.length === 0 &&
-		(Boolean(managedModelCatalog.error) || managedModelCatalog.isSuccess);
+		(Boolean(managedModelCatalog.error) || managedModelCatalogResolved);
 	const managedModelsLoading =
 		managedProviderSelected && managedModels.length === 0 && !managedModelsNeedRetry;
 	const computePlanReady =
@@ -549,9 +566,9 @@ export function DeployWizard() {
 	const submitBlockingReason = (() => {
 		if (submitting) return null;
 		if (personaError) return personaError;
-		if (!plans.isSuccess) return "Waiting for compute plans.";
-		if (!deployments.isSuccess) {
-			return deployments.error
+		if (!plansResolved) return "Waiting for compute plans.";
+		if (!deploymentsResolved) {
+			return blockingDeploymentsError
 				? "Retry the agent availability check above."
 				: "Checking your free Basic agent availability.";
 		}
@@ -562,7 +579,7 @@ export function DeployWizard() {
 			return "Choose an available primary model.";
 		}
 		if (paidSelection && paymentMethod === "wallet") {
-			if (!wallet.isSuccess || !wallet.data) {
+			if (!wallet.data) {
 				return wallet.error
 					? "Retry loading your Wallet balance above."
 					: "Loading your Wallet balance.";
@@ -593,9 +610,9 @@ export function DeployWizard() {
 	}
 
 	useEffect(() => {
-		if (compute !== "performance" || !plans.isSuccess || perfPlan) return;
+		if (compute !== "performance" || !plansResolved || perfPlan) return;
 		setCompute("basic");
-	}, [compute, plans.isSuccess, perfPlan]);
+	}, [compute, perfPlan, plansResolved]);
 
 	useEffect(() => {
 		const selectedOffer = compute === "performance" ? perfOfferSelection : basicOfferSelection;
@@ -950,8 +967,8 @@ export function DeployWizard() {
 		.join(" · ");
 
 	const plansLoadError =
-		plans.error ??
-		(plans.isSuccess && !basicPlan && !perfPlan
+		(shouldBlockQueryError(plans.error, plans.data) ? plans.error : null) ??
+		(plansResolved && !basicPlan && !perfPlan
 			? new Error("The billing service returned no compute plans. Try loading plans again.")
 			: null);
 
@@ -1042,7 +1059,7 @@ export function DeployWizard() {
 							/>
 							{aiProviders.isLoading ? (
 								<Skeleton className="h-[74px] w-full rounded-lg" />
-							) : aiProviders.error ? (
+							) : shouldBlockQueryError(aiProviders.error, aiProviders.data) ? (
 								<div className="@2xl/main:col-span-2">
 									<ApiErrorPanel
 										title="Couldn't load providers"
@@ -1104,11 +1121,11 @@ export function DeployWizard() {
 
 				<SettingsSection title="Compute">
 					<div className="flex flex-col gap-3">
-						{!deployments.isSuccess ? (
-							deployments.error ? (
+						{!deploymentsResolved ? (
+							blockingDeploymentsError ? (
 								<ApiErrorPanel
 									normalizer={billingErrorNormalizer}
-									error={deployments.error}
+									error={blockingDeploymentsError}
 									onRetry={() => void deployments.refetch()}
 									title="Couldn't check existing agents"
 								/>
@@ -1118,7 +1135,7 @@ export function DeployWizard() {
 								</p>
 							)
 						) : null}
-						{deployments.isSuccess && activeIncludedBasicSlot === null ? (
+						{deploymentsResolved && activeIncludedBasicSlot === null ? (
 							<Alert data-hosted="true">
 								<TriangleAlert />
 								<AlertTitle>Free Basic agent availability is unknown</AlertTitle>
@@ -1131,10 +1148,10 @@ export function DeployWizard() {
 										type="button"
 										variant="outline"
 										size="sm"
-										disabled={deployments.isFetching}
-										onClick={() => void deployments.refetch()}
+										disabled={checkingDeployments}
+										onClick={() => void checkDeploymentsAgain()}
 									>
-										{deployments.isFetching ? (
+										{checkingDeployments ? (
 											<Spinner className="size-3.5" />
 										) : (
 											<RefreshCw className="size-3.5" />
@@ -1158,7 +1175,7 @@ export function DeployWizard() {
 							<EntityChoiceCard
 								selected={compute === "basic"}
 								onClick={
-									deployments.isSuccess && !basicUnavailable
+									deploymentsResolved && !basicUnavailable
 										? () => setComputeTier("basic")
 										: undefined
 								}
@@ -1169,9 +1186,9 @@ export function DeployWizard() {
 								}
 								title="Basic"
 								description={
-									!deployments.isSuccess ? (
+									!deploymentsResolved ? (
 										<span className="text-xs">
-											{deployments.error
+											{blockingDeploymentsError
 												? "Basic availability couldn't be checked"
 												: "Checking free Basic slot availability"}
 										</span>
@@ -1188,7 +1205,7 @@ export function DeployWizard() {
 								}
 								detailsPlacement="trailing"
 								details={
-									deployments.isSuccess && basicSelection.mode === "included" ? (
+									deploymentsResolved && basicSelection.mode === "included" ? (
 										<ComputePriceBlock
 											testId="basic-compute-price"
 											presentation={{
@@ -1197,7 +1214,7 @@ export function DeployWizard() {
 												savings: null,
 											}}
 										/>
-									) : deployments.isSuccess && basicPricePresentation ? (
+									) : deploymentsResolved && basicPricePresentation ? (
 										<ComputePriceBlock
 											testId="basic-compute-price"
 											presentation={basicPricePresentation}
@@ -1205,21 +1222,21 @@ export function DeployWizard() {
 									) : null
 								}
 								badge={
-									!deployments.isSuccess ? (
+									!deploymentsResolved ? (
 										<Badge variant="secondary">
-											{deployments.error ? "Unavailable" : "Checking…"}
+											{blockingDeploymentsError ? "Unavailable" : "Checking…"}
 										</Badge>
 									) : basicSelection.mode === "unavailable" ? (
 										<Badge variant="secondary">Unavailable</Badge>
 									) : null
 								}
-								disabled={!deployments.isSuccess || basicUnavailable}
+								disabled={!deploymentsResolved || basicUnavailable}
 								className="items-center p-3"
 							/>
 							<EntityChoiceCard
 								selected={compute === "performance"}
 								onClick={
-									deployments.isSuccess && perfPlan && perfOfferSelection
+									deploymentsResolved && perfPlan && perfOfferSelection
 										? () => setComputeTier("performance")
 										: undefined
 								}
@@ -1251,7 +1268,7 @@ export function DeployWizard() {
 									) : null
 								}
 								badge={perfPricePresentation ? null : <Badge>Unavailable</Badge>}
-								disabled={!deployments.isSuccess || !perfPlan || !perfOfferSelection}
+								disabled={!deploymentsResolved || !perfPlan || !perfOfferSelection}
 								className="items-center p-3"
 							/>
 						</div>
@@ -1433,7 +1450,10 @@ export function DeployWizard() {
 												variant="link"
 												size="sm"
 												className="h-auto p-0"
-												disabled={wallet.isFetching || subscriptionCreateQuote.isFetching}
+												disabled={
+													(wallet.isFetching && wallet.data === undefined) ||
+													subscriptionCreateQuote.isFetching
+												}
 												onClick={() => void retryWalletQuote()}
 											>
 												Retry

--- a/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
@@ -22,6 +22,7 @@ import { useComputeBillingHistory } from "@/hosted/billing/hooks";
 import { billingHistoryFundingLabel } from "@/hosted/billing/subscription/billing-history.logic";
 import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
 import { formatShortDate } from "@/lib/format";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 function statusLabel(status: string): string {
 	const known: Record<string, string> = {
@@ -110,7 +111,7 @@ export function BillingHistorySection() {
 						</div>
 					))}
 				</div>
-			) : history.error && rows.length === 0 ? (
+			) : shouldBlockQueryError(history.error, history.data) ? (
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={history.error}

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/hosted/billing/wallet/wallet-funding";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 const PLAN_ITEMS = [
 	{ value: "compute_basic", label: "Basic" },
@@ -129,6 +130,9 @@ export function SubscriptionCreateDialog({
 		enabled: open && hostedAccess.canCreateCloudAgents && fundingSource === "wallet",
 	});
 	const walletDebit = createQuote.data?.walletDebit ?? null;
+	const blockingCreateQuoteError = shouldBlockQueryError(createQuote.error, createQuote.data)
+		? createQuote.error
+		: null;
 	const walletShortfallUsd = walletDebitShortfallUsd(walletDebit);
 	const walletInsufficient = walletShortfallUsd !== null;
 	const isPending = createSubscription.isPending;
@@ -246,7 +250,7 @@ export function SubscriptionCreateDialog({
 		!createSelection ||
 		isPending ||
 		(fundingSource === "wallet" &&
-			(!walletDebit || createQuote.isFetching || !!createQuote.error || walletInsufficient));
+			(!walletDebit || blockingCreateQuoteError !== null || walletInsufficient));
 
 	return (
 		<>
@@ -341,10 +345,10 @@ export function SubscriptionCreateDialog({
 								<p className="text-sm text-muted-foreground" role="status">
 									Getting the exact wallet debit…
 								</p>
-							) : createQuote.error ? (
+							) : blockingCreateQuoteError ? (
 								<ApiErrorPanel
 									normalizer={billingErrorNormalizer}
-									error={createQuote.error}
+									error={blockingCreateQuoteError}
 									onRetry={() => void createQuote.refetch()}
 									title="Couldn’t get subscription quote"
 								/>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -19,6 +19,7 @@ import { PlanComparison } from "@/hosted/billing/subscription/plan-comparison";
 import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION =
@@ -59,7 +60,7 @@ export function SubscriptionPage() {
 		);
 	}
 
-	if (plans.error) {
+	if (shouldBlockQueryError(plans.error, plans.data)) {
 		return (
 			<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
 				<PageHeader title="Compute" description={DESCRIPTION} />

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -14,6 +14,7 @@ import { useHostedDeployments, usePlans, useWalletLedger } from "@/hosted/billin
 import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
 import { welcomeWalletDescription } from "@/hosted/billing/subscription/welcome-wallet-card.logic";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 const WELCOME_GRANT_RECHECK_INTERVAL_MS = 5_000;
 const WELCOME_GRANT_TIMEOUT_MS = 60_000;
@@ -35,9 +36,19 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 	const grantApplied = grant?.status === "applied";
 	const grantPending = grant?.status === "pending";
 	const hasDeployments = (deployments.data?.length ?? 0) > 0;
-	const ledgerHasError = Boolean(ledger.error);
+	const blockingWalletError = shouldBlockQueryError(wallet.error, wallet.data)
+		? wallet.error
+		: null;
+	const blockingLedgerError = shouldBlockQueryError(ledger.error, ledger.data)
+		? ledger.error
+		: null;
+	const blockingDeploymentsError = shouldBlockQueryError(deployments.error, deployments.data)
+		? deployments.error
+		: null;
+	const ledgerHasError = Boolean(blockingLedgerError);
 	const [grantCheckTimedOut, setGrantCheckTimedOut] = useState(false);
 	const [grantCheckGeneration, setGrantCheckGeneration] = useState(0);
+	const [manualRefreshing, setManualRefreshing] = useState(false);
 	const grantRefetchInFlight = useRef(false);
 	const refetchLedger = ledger.refetch;
 
@@ -91,10 +102,16 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 		refetchLedger,
 	]);
 
-	function retryGrantCheck() {
+	async function retryGrantCheck() {
+		if (manualRefreshing) return;
 		setGrantCheckTimedOut(false);
 		setGrantCheckGeneration((generation) => generation + 1);
-		void refetchLedger().catch(() => undefined);
+		setManualRefreshing(true);
+		try {
+			await refetchLedger();
+		} finally {
+			setManualRefreshing(false);
+		}
 	}
 
 	// Past onboarding — they already have at least one agent.
@@ -112,7 +129,7 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 			</Card>
 		);
 	}
-	const loadError = wallet.error ?? ledger.error ?? deployments.error;
+	const loadError = blockingWalletError ?? blockingLedgerError ?? blockingDeploymentsError;
 	if (loadError) {
 		return (
 			<Card data-hosted="true">
@@ -121,9 +138,9 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 						normalizer={billingErrorNormalizer}
 						error={loadError}
 						onRetry={() => {
-							if (wallet.error) void wallet.refetch();
-							if (ledger.error) void ledger.refetch();
-							if (deployments.error) void deployments.refetch();
+							if (blockingWalletError) void wallet.refetch();
+							if (blockingLedgerError) void ledger.refetch();
+							if (blockingDeploymentsError) void deployments.refetch();
 						}}
 						title="Couldn't load welcome balance"
 					/>
@@ -176,10 +193,10 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 							<Button
 								type="button"
 								variant="outline"
-								onClick={retryGrantCheck}
-								disabled={ledger.isFetching}
+								onClick={() => void retryGrantCheck()}
+								disabled={manualRefreshing}
 							>
-								{ledger.isFetching ? <Spinner /> : <RefreshCw />}
+								{manualRefreshing ? <Spinner /> : <RefreshCw />}
 								Refresh balance
 							</Button>
 						) : null}

--- a/apps/web/src/hosted/billing/usage/usage-page.test.ts
+++ b/apps/web/src/hosted/billing/usage/usage-page.test.ts
@@ -38,7 +38,10 @@ describe("usage availability rendering", () => {
 		const source = readFileSync(new URL("./usage-page.tsx", import.meta.url), "utf8");
 
 		expect(source).toContain("<UsageRetryButton");
-		expect(source).toContain("void usage.refetch();");
+		expect(source).toContain("const [manualRetrying, setManualRetrying] = useState(false);");
+		expect(source).toContain("await usage.refetch();");
+		expect(source).toContain("isRetrying={manualRetrying}");
+		expect(source).not.toContain("isRetrying={usage.isFetching}");
 	});
 
 	test("renders a real complete zero as no usage", () => {

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Activity, AlertCircle, RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
@@ -24,6 +25,7 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatShortDate } from "@/lib/format";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Clawdi AI usage in USD for the current reporting window across your agents.";
@@ -62,6 +64,16 @@ export function UsagePage() {
 	const usage = useUsage();
 	const providers = useUserAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
+	const [manualRetrying, setManualRetrying] = useState(false);
+	const retryUsage = async () => {
+		if (manualRetrying) return;
+		setManualRetrying(true);
+		try {
+			await usage.refetch();
+		} finally {
+			setManualRetrying(false);
+		}
+	};
 
 	if (usage.isLoading) {
 		return (
@@ -72,7 +84,7 @@ export function UsagePage() {
 		);
 	}
 
-	if (usage.error || !usage.data) {
+	if (shouldBlockQueryError(usage.error, usage.data) || !usage.data) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
@@ -80,7 +92,7 @@ export function UsagePage() {
 					normalizer={billingErrorNormalizer}
 					error={usage.error}
 					onRetry={() => {
-						void usage.refetch();
+						void retryUsage();
 					}}
 				/>
 			</div>
@@ -92,9 +104,9 @@ export function UsagePage() {
 			usage={usage.data}
 			providers={providers.data ?? []}
 			managedModels={managedModelCatalog.data?.models ?? []}
-			isRetrying={usage.isFetching}
+			isRetrying={manualRetrying}
 			onRetry={() => {
-				void usage.refetch();
+				void retryUsage();
 			}}
 		/>
 	);

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -28,6 +28,7 @@ import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/walle
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { env } from "@/lib/env";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "One balance for Clawdi AI, wallet-funded compute, top-ups, and auto-reload.";
@@ -142,7 +143,7 @@ export function WalletPage() {
 		);
 	}
 
-	if (wallet.error || !wallet.data) {
+	if (shouldBlockQueryError(wallet.error, wallet.data) || !wallet.data) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
 				<PageHeader title="Wallet" description={DESCRIPTION} />
@@ -203,14 +204,14 @@ export function WalletPage() {
 							isLoading={ledger.isLoading}
 							hasMore={ledgerData?.has_more ?? false}
 							atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledgerData?.has_more ?? false)}
-							isFetchingMore={ledger.isFetching}
+							isFetchingMore={ledger.isPlaceholderData && ledger.isFetching}
 							onShowMore={
-								ledger.error
+								ledger.error && ledger.data === undefined
 									? undefined
 									: () => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))
 							}
 						/>
-						{ledger.error ? (
+						{ledger.error && ledger.data === undefined ? (
 							<ApiErrorPanel
 								normalizer={billingErrorNormalizer}
 								error={ledger.error}

--- a/apps/web/src/hosted/billing/wallet/wallet-query.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-query.ts
@@ -15,5 +15,6 @@ export function useWalletSnapshot({ enabled = true }: { enabled?: boolean } = {}
 		enabled: isDeployApiConfigured() && enabled,
 		retry: billingQueryRetry,
 		refetchInterval: 30_000,
+		refetchIntervalInBackground: false,
 	});
 }

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Skeleton } from "@/components/ui/skeleton";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useHostedUser } from "@/hosted/billing/hooks";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 /**
  * x402 self-funding block. Agents can top up their own wallet on-chain via the
@@ -32,7 +33,7 @@ export function X402Card() {
 			<CardContent>
 				{me.isLoading ? (
 					<Skeleton className="h-9 w-full rounded-md" />
-				) : me.error ? (
+				) : shouldBlockQueryError(me.error, me.data) ? (
 					<ApiErrorPanel
 						normalizer={billingErrorNormalizer}
 						error={me.error}

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -116,8 +116,9 @@ describe("hosted inventory resolution matrix", () => {
 			isPending: false,
 		});
 
-		expect(result.status).toBe("error");
+		expect(result.status).toBe("resolved");
 		expect(result.hasSnapshot).toBe(true);
+		expect(result.error).toBeNull();
 		expect(result.deployments?.map((item) => item.resource.id)).toEqual([running.resource.id]);
 		expect(hostedDeploymentMembers([deleted])).toEqual([]);
 	});

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -151,17 +151,20 @@ export function resolveHostedInventory({
 	}
 
 	const deployments = data === undefined ? null : hostedDeploymentMembers(data);
+	// TanStack Query retains the last successful data when a later refetch
+	// fails. That snapshot remains the authoritative membership view; the
+	// refresh error must not turn a resolved list (including an empty list)
+	// back into a blocking inventory state.
+	if (deployments !== null) {
+		return { status: "resolved", deployments, hasSnapshot: true, error: null };
+	}
 	if (error) {
 		return {
 			status: isNetworkError(error) ? "unavailable" : "error",
-			deployments,
-			hasSnapshot: deployments !== null,
+			deployments: null,
+			hasSnapshot: false,
 			error,
 		};
-	}
-
-	if (deployments !== null) {
-		return { status: "resolved", deployments, hasSnapshot: true, error: null };
 	}
 
 	return {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -137,7 +137,7 @@ export function AddProviderDialog({
 	const providerLabel = identity.label ?? (providerId || meta.label);
 	const runtimeEnv = form.runtimeEnv.trim() || meta.defaultRuntimeEnv;
 	const presetCatalog = selectedPreset ? presetCatalogToProviderModels(selectedPreset) : [];
-	const providerListReady = providerListAllowsSubmit(isEdit, providers.isSuccess);
+	const providerListReady = providerListAllowsSubmit(isEdit, providers.data !== undefined);
 	const savedCredentialAvailable = editing != null && editing.auth.type !== "none";
 	const customNameProvided =
 		meta.custom !== true || selectedPreset !== null || Boolean(form.label.trim());

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -45,6 +45,7 @@ import {
 import { providerPresentation } from "@/hosted/v2/ai-providers/model-binding";
 import { ProviderConnectionTest } from "@/hosted/v2/ai-providers/provider-connection-test";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Choose how your agents reach a model.";
@@ -58,6 +59,9 @@ export function AiProvidersPage() {
 	const [editing, setEditing] = useState<AiProvider | null>(null);
 
 	const list = providers.data ?? [];
+	const blockingProvidersError = shouldBlockQueryError(providers.error, providers.data)
+		? providers.error
+		: null;
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
@@ -67,7 +71,7 @@ export function AiProvidersPage() {
 				actions={
 					<Button
 						size="sm"
-						disabled={!providers.isSuccess}
+						disabled={providers.data === undefined}
 						onClick={() => {
 							setEditing(null);
 							setAddOpen(true);
@@ -85,12 +89,14 @@ export function AiProvidersPage() {
 			</div>
 
 			<div className="flex flex-col gap-2">
-				<SectionLabel count={!providers.isLoading && !providers.error ? list.length : undefined}>
+				<SectionLabel
+					count={!providers.isLoading && !blockingProvidersError ? list.length : undefined}
+				>
 					Your providers
 				</SectionLabel>
-				{providers.error ? (
+				{blockingProvidersError ? (
 					<ApiErrorPanel
-						error={providers.error}
+						error={blockingProvidersError}
 						onRetry={() => providers.refetch()}
 						title="Couldn’t load providers"
 					/>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -53,6 +53,8 @@ import {
 	useSyncCommands,
 } from "@/hosted/v2/channels/channels-hooks";
 import { agentSectionLink } from "@/lib/agent-routes";
+import { isApiNotFoundError } from "@/lib/api-errors";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, relativeTime } from "@/lib/utils";
 
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
@@ -205,7 +207,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 		);
 	}
 
-	if (channel.error) {
+	if (isApiNotFoundError(channel.error) || shouldBlockQueryError(channel.error, channel.data)) {
 		return (
 			<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 				<ApiErrorPanel
@@ -323,7 +325,7 @@ function AgentsTab({ accountId }: { accountId: string }) {
 	const envs = useEnvironments();
 
 	if (links.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
-	if (links.error) {
+	if (shouldBlockQueryError(links.error, links.data)) {
 		return (
 			<ApiErrorPanel
 				error={links.error}
@@ -336,7 +338,7 @@ function AgentsTab({ accountId }: { accountId: string }) {
 
 	return (
 		<div className="flex flex-col gap-3">
-			{envs.error ? (
+			{shouldBlockQueryError(envs.error, envs.data) ? (
 				<ApiErrorPanel
 					error={envs.error}
 					onRetry={() => envs.refetch()}
@@ -390,7 +392,7 @@ function AgentsTab({ accountId }: { accountId: string }) {
 function ActivityTab({ accountId }: { accountId: string }) {
 	const activity = useChannelActivity(accountId);
 	if (activity.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
-	if (activity.error) {
+	if (shouldBlockQueryError(activity.error, activity.data)) {
 		return (
 			<ApiErrorPanel
 				error={activity.error}
@@ -462,7 +464,7 @@ function ActivityRow({ item }: { item: ChannelActivityItem }) {
 function HealthTab({ accountId }: { accountId: string }) {
 	const health = useChannelHealth();
 	if (health.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
-	if (health.error) {
+	if (shouldBlockQueryError(health.error, health.data)) {
 		return (
 			<ApiErrorPanel
 				error={health.error}

--- a/apps/web/src/hosted/v2/channels/channel-health-query.ts
+++ b/apps/web/src/hosted/v2/channels/channel-health-query.ts
@@ -7,5 +7,6 @@ export function channelHealthQueryOptions<TData>(queryFn: () => Promise<TData>) 
 		queryKey: channelKeys.health,
 		queryFn,
 		refetchInterval: CHANNEL_HEALTH_REFETCH_INTERVAL_MS,
+		refetchIntervalInBackground: false,
 	};
 }

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -38,6 +38,7 @@ import {
 	sharedBotsFromPool,
 } from "@/hosted/v2/channels/channels-page.logic";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Manage Custom bots and discover Clawdi bots for your Agents.";
@@ -52,14 +53,19 @@ export function ChannelsPage() {
 
 	const channelItems = channels.data ?? [];
 	const sharedItems = sharedBotsFromPool(botPool.data?.providers);
+	const channelsError = shouldBlockQueryError(channels.error, channels.data)
+		? channels.error
+		: null;
+	const botPoolError = shouldBlockQueryError(botPool.error, botPool.data) ? botPool.error : null;
+	const healthError = shouldBlockQueryError(health.error, health.data) ? health.error : null;
 	const counts = providerCounts([...channelItems, ...sharedItems]);
 	const visibleProviders = providersWithBots(counts);
 	const totalCount = channelItems.length + sharedItems.length;
 	const inventoryEmpty =
 		!channels.isLoading &&
 		!botPool.isLoading &&
-		!channels.error &&
-		!botPool.error &&
+		!channelsError &&
+		!botPoolError &&
 		totalCount === 0;
 
 	return (
@@ -104,10 +110,10 @@ export function ChannelsPage() {
 					<OwnedBotsSection
 						channels={channelItems}
 						isLoading={channels.isLoading}
-						error={channels.error}
+						error={channelsError}
 						onRetry={() => channels.refetch()}
 						healthItems={health.data?.items ?? []}
-						healthError={health.error}
+						healthError={healthError}
 						onRetryHealth={() => health.refetch()}
 						filter={filter}
 					/>
@@ -115,7 +121,7 @@ export function ChannelsPage() {
 					<SharedBotsSection
 						bots={sharedItems}
 						isLoading={botPool.isLoading}
-						error={botPool.error}
+						error={botPoolError}
 						onRetry={() => botPool.refetch()}
 						filter={filter}
 					/>

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -208,12 +208,14 @@ export function useConnectedAppCards() {
 	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);
 	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
 	const error = connectionsQ.error ?? lookup.find((q) => q.error)?.error ?? null;
+	const hasData =
+		connectionsQ.data !== undefined && lookup.every((query) => query.data !== undefined);
 	const refetch = () => {
 		void connectionsQ.refetch();
 		for (const q of lookup) void q.refetch();
 	};
 
-	return { activeConnections, data, isLoading, error, refetch };
+	return { activeConnections, data, hasData, isLoading, error, refetch };
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/query-refresh-contract.test.ts
+++ b/apps/web/src/lib/query-refresh-contract.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SOURCE_ROOT = join(import.meta.dir, "..");
+
+function sourceFiles(directory: string, files: string[] = []): string[] {
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) {
+			sourceFiles(path, files);
+		} else if (
+			(entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+			!entry.name.includes(".test.")
+		) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+function source(relativePath: string): string {
+	return readFileSync(join(SOURCE_ROOT, relativePath), "utf8");
+}
+
+describe("query refresh presentation contract", () => {
+	test("does not couple background fetching to content opacity", () => {
+		const opacityCoupling = /isFetching[\s\S]{0,160}opacity-|opacity-[\s\S]{0,160}isFetching/;
+		const violations = sourceFiles(SOURCE_ROOT)
+			.filter((path) => opacityCoupling.test(readFileSync(path, "utf8")))
+			.map((path) => relative(SOURCE_ROOT, path));
+
+		expect(violations).toEqual([]);
+	});
+
+	test("keeps known empty, count, and error surfaces data-aware", () => {
+		const projects = source("pages/dashboard/projects/page.tsx");
+		const billingHistory = source("hosted/billing/subscription/billing-history-section.tsx");
+		const subscriptionDialog = source("hosted/billing/subscription/subscription-create-dialog.tsx");
+		const deployWizard = source("hosted/billing/deploy/deploy-wizard.tsx");
+		const providerDialog = source("hosted/v2/ai-providers/add-provider-dialog.tsx");
+		const hostedInventory = source("hosted/hosted-agent-resolution.ts");
+		const hostedAgentHome = source("hosted/agents/agent-home.tsx");
+		const connectedAgentDetail = source("components/dashboard/connected-agent-detail.tsx");
+		const channelDetail = source("hosted/v2/channels/channel-detail-page.tsx");
+		const memoryDetail = source("pages/dashboard/memories/[id]/page.tsx");
+		const memories = source("components/memories/memories-surface.tsx");
+		const projectsPage = source("pages/dashboard/projects/page.tsx");
+		const vaults = source("components/vault/vaults-surface.tsx");
+		const projectDetail = source("pages/dashboard/projects/[id]/page.tsx");
+
+		expect(projects).toContain(
+			"const skillCountsUnavailable = shouldBlockQueryError(skills.error, skills.data);",
+		);
+		expect(projects).toContain(
+			"const vaultCountsUnavailable = shouldBlockQueryError(vaults.error, vaults.data);",
+		);
+		expect(billingHistory).toContain("shouldBlockQueryError(history.error, history.data)");
+		expect(subscriptionDialog).toContain(
+			"shouldBlockQueryError(createQuote.error, createQuote.data)",
+		);
+		expect(deployWizard).not.toContain(".isSuccess");
+		expect(providerDialog).toContain(
+			"providerListAllowsSubmit(isEdit, providers.data !== undefined)",
+		);
+		expect(hostedInventory).toContain(
+			'return { status: "resolved", deployments, hasSnapshot: true, error: null };',
+		);
+		expect(hostedAgentHome).not.toContain("requestedHostedAgent && !deployment && isFetching");
+		expect(hostedAgentHome).toContain("disabled={manualChecking}");
+		expect(hostedAgentHome).toContain("!focusManager.isFocused() || isFetchingRef.current");
+		expect(connectedAgentDetail).toContain(
+			"isApiNotFoundError(error) || shouldBlockQueryError(error, agent)",
+		);
+		expect(channelDetail).toContain(
+			"isApiNotFoundError(channel.error) || shouldBlockQueryError(channel.error, channel.data)",
+		);
+		expect(memoryDetail).toContain('api.useQuery("get", "/v1/memories/{memory_id}"');
+		expect(memoryDetail).toContain('api.useMutation("delete", "/v1/memories/{memory_id}"');
+		expect(memories).toContain('$api.useQuery(\n\t\t"get",\n\t\t"/v1/memories"');
+		expect(memories).toContain('api.useMutation("post", "/v1/memories"');
+		expect(memories).toContain('$api.useMutation("delete", "/v1/memories/{memory_id}"');
+		expect(projectsPage).toContain('$api.useMutation("post", "/v1/projects"');
+		expect(vaults).not.toContain("projectNamesUnavailable={!!projects.error}");
+		expect(projectDetail).not.toContain("selectedBindings.isError");
+	});
+
+	test("keeps every intended polling surface out of background tabs", () => {
+		const pollingPolicyFiles = [
+			"components/app-sidebar.tsx",
+			"components/dashboard/add-agent-setup.tsx",
+			"components/dashboard/agent-skills-query.ts",
+			"hosted/agents/hosted-agent-detail.tsx",
+			"hosted/agents/hosted-agent-session-query.ts",
+			"hosted/billing/hooks.ts",
+			"hosted/billing/wallet/wallet-query.ts",
+			"hosted/v2/channels/channel-health-query.ts",
+			"hosted/v2/channels/channels-hooks.ts",
+			"pages/dashboard/agents/page.tsx",
+			"pages/dashboard/page.tsx",
+		];
+		const missingForegroundPolicy = pollingPolicyFiles.filter(
+			(path) => !source(path).includes("refetchIntervalInBackground: false"),
+		);
+
+		expect(missingForegroundPolicy).toEqual([]);
+		expect(source("components/dashboard/add-agent-setup.tsx")).toContain(
+			"return current.some((agent)",
+		);
+		expect(source("components/dashboard/add-agent-setup.tsx")).toContain("? false : 5_000");
+	});
+});

--- a/apps/web/src/lib/query-state.test.ts
+++ b/apps/web/src/lib/query-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { shouldBlockQueryError } from "@/lib/query-state";
+
+describe("query refresh presentation", () => {
+	test("keeps successful data usable after a background refetch fails", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let attempt = 0;
+		const observer = new QueryObserver(queryClient, {
+			queryKey: ["refresh-contract"],
+			queryFn: async () => {
+				attempt += 1;
+				if (attempt === 1) return { count: 3 };
+				throw new Error("temporary refresh failure");
+			},
+		});
+		const unsubscribe = observer.subscribe(() => undefined);
+
+		try {
+			await observer.refetch();
+			await observer.refetch();
+			const result = observer.getCurrentResult();
+
+			expect(result.data).toEqual({ count: 3 });
+			expect(result.error).toBeInstanceOf(Error);
+			expect(shouldBlockQueryError(result.error, result.data)).toBe(false);
+			expect(shouldBlockQueryError(result.error, undefined)).toBe(true);
+		} finally {
+			unsubscribe();
+			queryClient.clear();
+		}
+	});
+});

--- a/apps/web/src/lib/query-state.ts
+++ b/apps/web/src/lib/query-state.ts
@@ -1,0 +1,7 @@
+/**
+ * TanStack Query retains successful data when a later refetch fails. Treat the
+ * error as blocking only when there is no usable cache entry to keep rendering.
+ */
+export function shouldBlockQueryError(error: unknown, data: unknown): boolean {
+	return error !== null && error !== undefined && data === undefined;
+}

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { useOpenApi } from "@/lib/api";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 
@@ -48,6 +49,7 @@ export default function AgentsIndexPage() {
 
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
 	const selfManagedCount = selfManagedTiles.length;
+	const blockingEnvsError = shouldBlockQueryError(envsError, environments) ? envsError : null;
 	const hostedAccessLoading = Boolean(HostedAgentsByCompute && hostedAccess.isLoading);
 	const cloudDeploymentManagementEnabled = Boolean(HostedAgentsByCompute);
 	const legacyHostedAgentsEnabled = Boolean(
@@ -64,7 +66,7 @@ export default function AgentsIndexPage() {
 				<Suspense fallback={<AgentsCard agents={selfManagedTiles} isLoading />}>
 					<HostedAgentsByCompute
 						envsLoading={envsLoading}
-						selfManagedError={envsError}
+						selfManagedError={blockingEnvsError}
 						onRetrySelfManaged={() => {
 							void refetchEnvs();
 						}}
@@ -79,7 +81,7 @@ export default function AgentsIndexPage() {
 				<AgentsCard
 					agents={selfManagedTiles}
 					isLoading={envsLoading}
-					error={envsError}
+					error={blockingEnvsError}
 					onRetry={() => {
 						void refetchEnvs();
 					}}

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -30,6 +30,7 @@ import {
 	useConnectorTools,
 	useDisconnect,
 } from "@/lib/connectors-data";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -258,7 +259,7 @@ function ConnectorDetail({ name }: { name: string }) {
 	// thrown 404 from the hosted catalog adapter) and outright network
 	// failures. Surface it so the user sees what's wrong instead of a
 	// silently-broken connect page.
-	if (appQ.error) {
+	if (isApiNotFoundError(appQ.error) || shouldBlockQueryError(appQ.error, appQ.data)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
 				{isApiNotFoundError(appQ.error) ? (
@@ -335,7 +336,7 @@ function ConnectorDetail({ name }: { name: string }) {
 					}
 				/>
 				<div className="p-4">
-					{!usesNoAuth && connectionsQ.error ? (
+					{!usesNoAuth && shouldBlockQueryError(connectionsQ.error, connectionsQ.data) ? (
 						// Without this, a failed connections fetch silently renders
 						// the "No connected accounts yet" empty state — the user
 						// would think they have nothing connected when really we
@@ -437,7 +438,7 @@ function ConnectorDetail({ name }: { name: string }) {
 			<ConnectorToolsList
 				tools={tools ?? []}
 				isLoading={isToolsLoading}
-				error={toolsQ.error}
+				error={shouldBlockQueryError(toolsQ.error, toolsQ.data) ? toolsQ.error : null}
 				onRetry={() => {
 					void toolsQ.refetch();
 				}}

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { Brain, Laptop, Trash2 } from "lucide-react";
 import { toast } from "sonner";
@@ -13,15 +13,16 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
-import { unwrap, useApi } from "@/lib/api";
+import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { projectResourceHref } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 	const router = useRouter();
-	const api = useApi();
+	const api = useOpenApi();
 	const queryClient = useQueryClient();
 
 	const {
@@ -29,14 +30,8 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 		isLoading,
 		error,
 		refetch,
-	} = useQuery({
-		queryKey: ["memory", memoryId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/memories/{memory_id}", {
-					params: { path: { memory_id: memoryId } },
-				}),
-			),
+	} = api.useQuery("get", "/v1/memories/{memory_id}", {
+		params: { path: { memory_id: memoryId } },
 	});
 
 	// First sentence (or 80 chars) — keeps the breadcrumb readable.
@@ -44,33 +39,29 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 		? memory.content.split(/[.\n]/)[0]?.slice(0, 80)?.trim() || null
 		: null;
 	useSetBreadcrumbTitle(memoryTitle);
+	const blockingError =
+		isApiNotFoundError(error) || shouldBlockQueryError(error, memory) ? error : null;
 
-	const deleteMemory = useMutation({
-		mutationFn: async () =>
-			unwrap(
-				await api.DELETE("/v1/memories/{memory_id}", {
-					params: { path: { memory_id: memoryId } },
-				}),
-			),
+	const deleteMemory = api.useMutation("delete", "/v1/memories/{memory_id}", {
 		onSuccess: () => {
 			toast.success("Memory Deleted", {
 				description: "Your agents will no longer recall it.",
 			});
-			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/memories"] });
 			void router.navigate({ href: projectResourceHref("memories") });
 		},
 		onError: (e) => toast.error("Couldn't delete memory", { description: errorMessage(e) }),
 	});
 
-	const onDelete = () => deleteMemory.mutate();
+	const onDelete = () => deleteMemory.mutate({ params: { path: { memory_id: memoryId } } });
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			{error && isApiNotFoundError(error) ? (
-				<DetailNotFound title="Memory not found" message={errorMessage(error)} />
-			) : error ? (
+			{blockingError && isApiNotFoundError(blockingError) ? (
+				<DetailNotFound title="Memory not found" message={errorMessage(blockingError)} />
+			) : blockingError ? (
 				<ApiErrorPanel
-					error={error}
+					error={blockingError}
 					onRetry={() => {
 						void refetch();
 					}}

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -25,6 +25,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useOpenApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn } from "@/lib/utils";
 
@@ -150,6 +151,14 @@ export default function DashboardPage() {
 	);
 	const sessions = sessionsPage?.items.slice(0, RECENT_SESSIONS_LIMIT);
 	const contribution = stats?.contribution;
+	const blockingStatsError = shouldBlockQueryError(statsError, stats) ? statsError : null;
+	const blockingProjectsError = shouldBlockQueryError(projectsError, projects)
+		? projectsError
+		: null;
+	const blockingEnvsError = shouldBlockQueryError(envsError, environments) ? envsError : null;
+	const blockingSessionsError = shouldBlockQueryError(sessionsError, sessionsPage)
+		? sessionsError
+		: null;
 
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
 	const selfManagedFleetSummary = useMemo(
@@ -164,8 +173,8 @@ export default function DashboardPage() {
 	// `<HostedAgentsSection>` so this page doesn't need the hosted
 	// counts at all.
 	const selfManagedCount = selfManagedTiles.length;
-	const hasAgents = !envsLoading && !envsError && selfManagedCount > 0;
-	const ossIsEmptyState = !envsLoading && !envsError && selfManagedCount === 0;
+	const hasAgents = !envsLoading && !blockingEnvsError && selfManagedCount > 0;
+	const ossIsEmptyState = !envsLoading && !blockingEnvsError && selfManagedCount === 0;
 	const projectTypeCounts = useMemo(
 		() => (projects ? countProjectTypes(projects) : undefined),
 		[projects],
@@ -179,7 +188,7 @@ export default function DashboardPage() {
 	const greetingState: AgentGreetingState =
 		hostedAccessLoading || envsLoading
 			? "loading"
-			: envsError || hostedAccess.isError
+			: blockingEnvsError || hostedAccess.isError
 				? "error"
 				: "resolved";
 	const greeting = renderGreeting(selfManagedFleetSummary, { state: greetingState });
@@ -199,7 +208,7 @@ export default function DashboardPage() {
 						{(summary, state) =>
 							renderGreeting(summary, {
 								state:
-									envsError || hostedAccess.isError || state.error
+									blockingEnvsError || hostedAccess.isError || state.error
 										? "error"
 										: envsLoading || state.isLoading || !state.membershipResolved
 											? "loading"
@@ -226,7 +235,7 @@ export default function DashboardPage() {
 						<Suspense fallback={<AgentsCard agents={selfManagedTiles} isLoading />}>
 							<HostedAgentsSection
 								envsLoading={envsLoading}
-								selfManagedError={envsError}
+								selfManagedError={blockingEnvsError}
 								onRetrySelfManaged={() => {
 									void refetchEnvs();
 								}}
@@ -243,7 +252,7 @@ export default function DashboardPage() {
 						<AgentsCard
 							agents={selfManagedTiles}
 							isLoading={envsLoading}
-							error={envsError}
+							error={blockingEnvsError}
 							onRetry={() => {
 								void refetchEnvs();
 							}}
@@ -256,9 +265,9 @@ export default function DashboardPage() {
 							<CardDescription>Sessions per day in the last 12 months</CardDescription>
 						</CardHeader>
 						<CardContent>
-							{statsError ? (
+							{blockingStatsError ? (
 								<ApiErrorPanel
-									error={statsError}
+									error={blockingStatsError}
 									onRetry={() => {
 										void refetchStats();
 									}}
@@ -286,9 +295,9 @@ export default function DashboardPage() {
 								<ArrowRight />
 							</Button>
 						</div>
-						{sessionsError ? (
+						{blockingSessionsError ? (
 							<ApiErrorPanel
-								error={sessionsError}
+								error={blockingSessionsError}
 								onRetry={() => {
 									void refetchSessions();
 								}}
@@ -328,21 +337,21 @@ export default function DashboardPage() {
 					) : null}
 					<ResourcesCard
 						stats={stats}
-						statsError={statsError}
+						statsError={blockingStatsError}
 						onRetryStats={() => {
 							void refetchStats();
 						}}
 						projectCount={projects?.length}
 						projectTypeCounts={projectTypeCounts}
 						projectCountLoading={projectsLoading}
-						projectCountError={projectsError}
+						projectCountError={blockingProjectsError}
 						onRetryProjectCount={() => {
 							void refetchProjects();
 						}}
 					/>
 					<ThisWeekCard
 						stats={stats}
-						error={statsError}
+						error={blockingStatsError}
 						onRetry={() => {
 							void refetchStats();
 						}}

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -84,6 +84,7 @@ import type { components } from "@/lib/api-schemas";
 import { formatShortDate } from "@/lib/format";
 import { identityFor } from "@/lib/identity";
 import { projectDetailHref, projectResourceHref } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { isBrowserWritableSkillProject, skillCapabilities } from "@/lib/skill-authority";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -271,7 +272,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 		);
 	}
 
-	if (projects.error) {
+	if (shouldBlockQueryError(projects.error, projects.data)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Button
@@ -323,19 +324,36 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 		);
 	}
 
-	const skillCount: CountValue | undefined = skills.error
+	const blockingSkillsError = shouldBlockQueryError(skills.error, skills.data)
+		? skills.error
+		: null;
+	const blockingVaultsError = shouldBlockQueryError(vaults.error, vaults.data)
+		? vaults.error
+		: null;
+	const blockingMembersError = shouldBlockQueryError(members.error, members.data)
+		? members.error
+		: null;
+	const blockingEnvironmentsError = shouldBlockQueryError(environments.error, environments.data)
+		? environments.error
+		: null;
+	const blockingBoundAgentsError = shouldBlockQueryError(boundAgents.error, boundAgents.data)
+		? boundAgents.error
+		: null;
+	const skillCount: CountValue | undefined = blockingSkillsError
 		? "unavailable"
 		: skills.data?.items.length;
-	const vaultCount: CountValue | undefined = vaults.error
+	const vaultCount: CountValue | undefined = blockingVaultsError
 		? "unavailable"
 		: vaults.data?.items.length;
-	const peopleCount: CountValue | undefined = members.error
+	const peopleCount: CountValue | undefined = blockingMembersError
 		? "unavailable"
 		: members.data
 			? members.data.length + 1
 			: undefined; // +1 = owner
 	const agentCount: CountValue | undefined =
-		environments.error || boundAgents.error ? "unavailable" : boundAgents.data?.length;
+		blockingEnvironmentsError || blockingBoundAgentsError
+			? "unavailable"
+			: boundAgents.data?.length;
 
 	const addToAgentDialog = (trigger: ReactElement) => (
 		<UseProjectWithAgentDialog
@@ -461,9 +479,9 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 				{canManageSkills && showInstallSkill ? (
 					<InstallSkillInProjectForm projectId={project.id} onChanged={refresh} />
 				) : null}
-				{skills.error ? (
+				{blockingSkillsError ? (
 					<ApiErrorPanel
-						error={skills.error}
+						error={blockingSkillsError}
 						onRetry={() => {
 							void skills.refetch();
 						}}
@@ -508,9 +526,9 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 				) : null}
 				{vaults.isLoading ? (
 					<Skeleton className="h-24 w-full" />
-				) : vaults.error ? (
+				) : blockingVaultsError ? (
 					<ApiErrorPanel
-						error={vaults.error}
+						error={blockingVaultsError}
 						onRetry={() => {
 							void vaults.refetch();
 						}}
@@ -548,9 +566,9 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 				>
 					{members.isLoading ? (
 						<Skeleton className="h-16 w-full" />
-					) : members.error ? (
+					) : blockingMembersError ? (
 						<ApiErrorPanel
-							error={members.error}
+							error={blockingMembersError}
 							onRetry={() => {
 								void members.refetch();
 							}}
@@ -611,17 +629,17 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 			>
 				{boundAgents.isLoading || environments.isLoading ? (
 					<Skeleton className="h-16 w-full" />
-				) : environments.error ? (
+				) : blockingEnvironmentsError ? (
 					<ApiErrorPanel
-						error={environments.error}
+						error={blockingEnvironmentsError}
 						onRetry={() => {
 							void environments.refetch();
 						}}
 						title="Couldn't load agents"
 					/>
-				) : boundAgents.error ? (
+				) : blockingBoundAgentsError ? (
 					<ApiErrorPanel
-						error={boundAgents.error}
+						error={blockingBoundAgentsError}
 						onRetry={() => {
 							void boundAgents.refetch();
 						}}
@@ -883,6 +901,10 @@ function UseProjectWithAgentDialog({
 	const selectedEnv = orderedEnvironments.find((env) => env.id === selectedAgentId) ?? null;
 	const projectIsHome = selectedEnv?.default_project_id === project.id;
 	const selectedBindings = useAgentProjectBindings(selectedAgentId, { enabled: open });
+	const blockingSelectedBindingsError = shouldBlockQueryError(
+		selectedBindings.error,
+		selectedBindings.data,
+	);
 	const existingBinding =
 		selectedBindings.data?.find((binding) => binding.project_id === project.id) ?? null;
 	const projectIsAlreadyAvailable = projectIsHome || !!existingBinding;
@@ -1044,7 +1066,7 @@ function UseProjectWithAgentDialog({
 							)}
 						</div>
 
-						{selectedBindings.error ? (
+						{blockingSelectedBindingsError ? (
 							<ApiErrorPanel
 								error={selectedBindings.error}
 								onRetry={() => {
@@ -1077,7 +1099,7 @@ function UseProjectWithAgentDialog({
 										!selectedAgentId ||
 										addProjectToAgent.isPending ||
 										selectedBindings.isLoading ||
-										selectedBindings.isError ||
+										blockingSelectedBindingsError ||
 										projectIsAlreadyAvailable
 									}
 								>

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { ChevronDown, Plus, Share2 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -40,9 +40,11 @@ import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { getProjectResourceDefinition, projectDetailHref } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
+type ProjectCreate = components["schemas"]["ProjectCreate"];
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type CountValue = number | "unavailable";
 
@@ -118,6 +120,8 @@ export default function ProjectsPage() {
 		}
 		return m;
 	}, [vaults.data]);
+	const skillCountsUnavailable = shouldBlockQueryError(skills.error, skills.data);
+	const vaultCountsUnavailable = shouldBlockQueryError(vaults.error, vaults.data);
 
 	const ownedProjects = useMemo(
 		() => rows.filter((s) => s.is_owner !== false).sort(compareProjectsForProductUse),
@@ -155,13 +159,7 @@ export default function ProjectsPage() {
 		);
 	}, [customProjects, sharedProjects, search]);
 
-	const createProject = useMutation({
-		mutationFn: async (): Promise<ProjectRow> => {
-			const payload: { name: string; slug?: string } = { name: newProjectName.trim() };
-			const slug = normalizeSlugInput(newProjectSlug);
-			if (slug) payload.slug = slug;
-			return unwrap(await api.POST("/v1/projects", { body: payload }));
-		},
+	const createProject = $api.useMutation("post", "/v1/projects", {
 		onSuccess: (project) => {
 			setCreateOpen(false);
 			qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
@@ -210,7 +208,7 @@ export default function ProjectsPage() {
 				}
 			/>
 
-			{projects.error ? (
+			{shouldBlockQueryError(projects.error, projects.data) ? (
 				<ApiErrorPanel
 					error={projects.error}
 					onRetry={() => {
@@ -243,7 +241,10 @@ export default function ProjectsPage() {
 						onSubmit={(event) => {
 							event.preventDefault();
 							if (!newProjectName.trim() || createProject.isPending) return;
-							createProject.mutate();
+							const body: ProjectCreate = { name: newProjectName.trim() };
+							const slug = normalizeSlugInput(newProjectSlug);
+							if (slug) body.slug = slug;
+							createProject.mutate({ body });
 						}}
 					>
 						<div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]">
@@ -295,25 +296,18 @@ export default function ProjectsPage() {
 					No projects match “{search.trim()}”.
 				</p>
 			) : (
-				<div
-					className={cn(
-						HERO_GRID_CLASS,
-						"transition-opacity",
-						projects.isFetching && !projects.isLoading ? "opacity-60" : "opacity-100",
-					)}
-					data-testid="project-grid"
-				>
+				<div className={HERO_GRID_CLASS} data-testid="project-grid">
 					{gridProjects.map(({ project, shared }) => (
 						<ProjectResourceCard
 							key={project.id}
 							project={project}
 							footer={[
 								formatCountLabel(
-									skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0),
+									skillCountsUnavailable ? "unavailable" : (skillCounts.get(project.id) ?? 0),
 									"skill",
 								),
 								formatCountLabel(
-									vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0),
+									vaultCountsUnavailable ? "unavailable" : (vaultCounts.get(project.id) ?? 0),
 									"vault",
 								),
 								shared && project.owner_display ? `by ${project.owner_display}` : null,
@@ -358,8 +352,12 @@ export default function ProjectsPage() {
 									key={project.id}
 									project={project}
 									agent={projectAgentFor(project, agentsById)}
-									skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
-									vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
+									skillCount={
+										skillCountsUnavailable ? "unavailable" : (skillCounts.get(project.id) ?? 0)
+									}
+									vaultCount={
+										vaultCountsUnavailable ? "unavailable" : (vaultCounts.get(project.id) ?? 0)
+									}
 								/>
 							))}
 						</div>

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -38,6 +38,7 @@ import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionMessage } from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import {
 	SESSION_DETAIL_GC_MS,
 	SESSION_DETAIL_STALE_MS,
@@ -261,7 +262,7 @@ export function SessionDetailContent({
 		);
 	}
 
-	if (sessionError) {
+	if (isApiNotFoundError(sessionError) || shouldBlockQueryError(sessionError, session)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				{isApiNotFoundError(sessionError) ? (
@@ -387,7 +388,7 @@ export function SessionDetailContent({
 			{session.has_content ? (
 				isContentLoading ? (
 					<MessagesSkeleton />
-				) : isContentError ? (
+				) : isContentError && shouldBlockQueryError(contentError, pagesData) ? (
 					<ApiErrorPanel
 						error={contentError}
 						onRetry={() => {

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -28,6 +28,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useOpenApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, recencyBucketFor } from "@/lib/utils";
@@ -142,11 +143,10 @@ function SessionsListInner() {
 		],
 	);
 
-	const { data, isLoading, isFetching, error, refetch } = useQuery({
+	const { data, isLoading, error, refetch } = useQuery({
 		...sessionListQueryOptions($api, sessionQuery),
-		// Keep previous results visible during refetch; the
-		// `isFetching && !isLoading` opacity transition below is
-		// the only "loading" signal the user sees.
+		// Keep the previous page visible while search, filters, or pagination
+		// move to a new query key.
 		placeholderData: keepPreviousData,
 	});
 
@@ -340,7 +340,7 @@ function SessionsListInner() {
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<PageHeader title="Sessions" description={SESSIONS_RESOURCE.managementDescription} />
 
-			{error ? (
+			{shouldBlockQueryError(error, data) ? (
 				<ApiErrorPanel
 					error={error}
 					onRetry={() => {
@@ -349,12 +349,7 @@ function SessionsListInner() {
 					title="Couldn't load sessions"
 				/>
 			) : (
-				<div
-					className={cn(
-						"space-y-4 transition-opacity",
-						isFetching && !isLoading ? "opacity-60" : "opacity-100",
-					)}
-				>
+				<div className="space-y-4">
 					{sessionToolbar}
 					{params.view === "table" ? (
 						<div className="hidden md:block">

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -56,6 +56,7 @@ import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { isBrowserWritableSkillProject, skillCapabilities } from "@/lib/skill-authority";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -156,7 +157,6 @@ function SkillsPageInner() {
 	const {
 		data: skillsData,
 		isLoading: skillsLoading,
-		isFetching: skillsFetching,
 		error: skillsError,
 		refetch: refetchSkills,
 	} = useQuery({
@@ -174,6 +174,10 @@ function SkillsPageInner() {
 		enabled: !isResolvingTarget,
 		placeholderData: keepPreviousData,
 	});
+	const blockingProjectsError = shouldBlockQueryError(projectsError, projects)
+		? projectsError
+		: null;
+	const blockingSkillsError = shouldBlockQueryError(skillsError, skillsData) ? skillsError : null;
 	// Tab row shows custom + personal projects; the per-agent long tail
 	// lives behind one overflow menu (a 16-tab row teaches nothing).
 	// Both ranked by installed-skill count, busiest first.
@@ -603,9 +607,9 @@ function SkillsPageInner() {
 				}
 			/>
 
-			{projectsError ? (
+			{blockingProjectsError ? (
 				<ApiErrorPanel
-					error={projectsError}
+					error={blockingProjectsError}
 					onRetry={() => {
 						void refetchProjects();
 					}}
@@ -619,9 +623,9 @@ function SkillsPageInner() {
 			    'No skills installed on this agent yet,' which is
 			    indistinguishable from a real /api/skills outage from
 			    the user's perspective. */}
-			{skillsError ? (
+			{blockingSkillsError ? (
 				<ApiErrorPanel
-					error={skillsError}
+					error={blockingSkillsError}
 					onRetry={() => {
 						void refetchSkills();
 					}}
@@ -645,12 +649,7 @@ function SkillsPageInner() {
 				</Alert>
 			) : null}
 
-			<section
-				className={cn(
-					"space-y-3 transition-opacity",
-					skillsFetching && !skillsLoading ? "opacity-60" : "opacity-100",
-				)}
-			>
+			<section className="space-y-3">
 				<SectionLabel
 					count={
 						skillsForTarget

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -56,6 +56,7 @@ import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
+import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn, errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -130,6 +131,15 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 			names.map((name) => ({ section, name })),
 		);
 	}, [keys.data]);
+	const blockingVaultDetailError =
+		isApiNotFoundError(vaultDetail.error) ||
+		shouldBlockQueryError(vaultDetail.error, vaultDetail.data)
+			? vaultDetail.error
+			: null;
+	const blockingKeysError = shouldBlockQueryError(keys.error, keys.data) ? keys.error : null;
+	const blockingProjectsError = shouldBlockQueryError(projects.error, projects.data)
+		? projects.error
+		: null;
 
 	// Curation toolkit for grab-bag vaults (the default vault holds
 	// hundreds of keys): search by name, batch-select, then copy/move
@@ -283,7 +293,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 		);
 	}
 
-	if (vaultDetail.error) {
+	if (blockingVaultDetailError) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Button
@@ -296,14 +306,14 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					<ArrowLeft className="mr-1.5 size-4" />
 					Vaults
 				</Button>
-				{isApiNotFoundError(vaultDetail.error) ? (
+				{isApiNotFoundError(blockingVaultDetailError) ? (
 					<DetailNotFound
 						title="Vault not found"
 						message="This vault may have been removed, or your account no longer has access."
 					/>
 				) : (
 					<ApiErrorPanel
-						error={vaultDetail.error}
+						error={blockingVaultDetailError}
 						onRetry={() => {
 							void vaultDetail.refetch();
 						}}
@@ -411,7 +421,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					<div className="min-w-0">
 						<div className="flex items-center gap-2">
 							<h2 className="text-sm font-semibold">Keys</h2>
-							{keys.error ? (
+							{blockingKeysError ? (
 								<Badge variant="secondary" className="tabular-nums">
 									—
 								</Badge>
@@ -503,9 +513,9 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 				{keys.isLoading ? (
 					<Skeleton className="h-32 w-full rounded-lg" />
-				) : keys.error ? (
+				) : blockingKeysError ? (
 					<ApiErrorPanel
-						error={keys.error}
+						error={blockingKeysError}
 						onRetry={() => {
 							void keys.refetch();
 						}}
@@ -644,7 +654,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 							<h2 className="text-sm font-semibold">Projects</h2>
 							{projects.isLoading ? null : (
 								<Badge variant="secondary" className="tabular-nums">
-									{projects.error ? "—" : attachedProjects.length}
+									{blockingProjectsError ? "—" : attachedProjects.length}
 								</Badge>
 							)}
 						</div>
@@ -653,7 +663,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 							Projects resolve the keys at runtime.
 						</p>
 					</div>
-					{isOwner && !projects.error ? (
+					{isOwner && !blockingProjectsError ? (
 						<AttachProjectPicker
 							projects={(projects.data ?? []).filter(
 								(p) => p.is_owner !== false && !(vault.project_ids ?? []).includes(p.id),
@@ -665,9 +675,9 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 				</div>
 				{projects.isLoading ? (
 					<Skeleton className="h-16 w-full" />
-				) : projects.error ? (
+				) : blockingProjectsError ? (
 					<ApiErrorPanel
-						error={projects.error}
+						error={blockingProjectsError}
 						onRetry={() => {
 							void projects.refetch();
 						}}

--- a/docs/openapi-react-query.md
+++ b/docs/openapi-react-query.md
@@ -18,21 +18,33 @@ structured error bodies. Only `useOpenApi()` converts non-2xx responses to
 
 ## Loading and refresh contract
 
-- Use `isPending`/`isLoading` only for the first load when no data is present.
-- A background `isFetching` state may add a quiet refresh affordance or opacity
-  treatment, but it must keep the existing count, rows, dimensions, and empty
-  state decision.
-- A refetch error with cached data keeps rendering that data. Reserve blocking
-  error panels for queries without usable data.
+- Use `isPending`/`isLoading` only for the first load while `data` is
+  `undefined`. A stable skeleton may represent that unresolved layout.
+- Treat `isFetching` as network activity, not as permission to restyle the
+  current result. Background refresh must not change primary-content opacity,
+  swap content for a skeleton, hide counts, revisit the empty-state decision,
+  or replace usable content with an error panel.
+- A refetch error with cached data keeps rendering that data. Use
+  `shouldBlockQueryError(error, data)` where a component needs the shared
+  blocking-error distinction. A resource-detail 404 is the intentional
+  exception: deletion makes the cached entity no longer usable, so the not-found
+  boundary is authoritative.
+- User-triggered refresh may show a subtle local progress indicator. Track that
+  action locally instead of presenting ambient polling or focus-refetch
+  `isFetching` as user progress. Mutation-local progress remains appropriate.
 - Polling must be bounded, disabled in background unless explicitly required,
-  and must use stable path/query parameters. Query cancellation is supplied by
+  and must use stable path/query parameters. In this app, a poll is bounded by
+  its mounted foreground surface, a recoverable transient state, or an explicit
+  maximum-attempt/terminal condition. Every intended poll sets
+  `refetchIntervalInBackground: false`. Query cancellation is supplied by
   openapi-react-query's propagated `AbortSignal`.
 - Use `placeholderData: keepPreviousData` when a list identity changes through
   search, filtering, or pagination.
 
-The paired-chat inventory is the reference polling case: its three-second
-bindings refresh passes `isPending`, not `isFetching`, to the dialog. Cached
-chat rows and counts therefore do not flash on every poll.
+The paired-chat inventory is one reference polling case: its three-second
+bindings refresh passes initial pending state, not background fetching state,
+to the dialog. The same contract applies to Agent skills and sessions, channel
+health, dashboard Agents, deployment reconciliation, and Wallet refreshes.
 
 ## Intentional TanStack Query exceptions
 
@@ -65,10 +77,24 @@ key or the matching `[method, path]` prefix.
 
 The integration was checked against official sources matching the lockfile:
 
-- `openapi-react-query` 0.5.4:
-  <https://github.com/openapi-ts/openapi-typescript/tree/openapi-react-query%400.5.4/packages/openapi-react-query>
-- `openapi-fetch` 0.17.0:
-  <https://github.com/openapi-ts/openapi-typescript/tree/openapi-fetch%400.17.0/packages/openapi-fetch>
-- TanStack Query 5.101.4 background fetching and cancellation:
-  <https://tanstack.com/query/v5/docs/framework/react/guides/background-fetching-indicators>
-  and <https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation>
+- `openapi-react-query` 0.5.4 wraps TanStack query options, forwards the query
+  context `AbortSignal`, and constructs the typed `[method, path, init]` key:
+  <https://github.com/openapi-ts/openapi-typescript/blob/openapi-react-query%400.5.4/packages/openapi-react-query/src/index.ts>
+- `openapi-fetch` 0.17.0 typed client and middleware implementation:
+  <https://github.com/openapi-ts/openapi-typescript/tree/openapi-fetch%400.17.0/packages/openapi-fetch/src>
+- TanStack Query 5.101.4 distinguishes initial pending state from background
+  `isFetching`, retains prior pages with `keepPreviousData`, and supplies query
+  cancellation:
+  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/background-fetching-indicators.md>,
+  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/paginated-queries.md>,
+  and
+  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/query-cancellation.md>.
+- React 19.2.7 is the component/runtime contract used by these surfaces:
+  <https://github.com/facebook/react/tree/v19.2.7/packages/react>.
+- Base UI 1.6.0 and shadcn 4.16.1 provide accessible progress and skeleton
+  primitives; they do not redefine query lifecycle state. Their versioned
+  sources reinforce using those primitives as explicit task/placeholder UI,
+  while TanStack remains authoritative for data state:
+  <https://github.com/mui/base-ui/blob/v1.6.0/docs/src/app/%28docs%29/react/components/progress/page.mdx>
+  and
+  <https://github.com/shadcn-ui/ui/blob/shadcn%404.16.1/apps/v4/content/docs/components/base/skeleton.mdx>.

--- a/docs/openapi-react-query.md
+++ b/docs/openapi-react-query.md
@@ -31,7 +31,11 @@ structured error bodies. Only `useOpenApi()` converts non-2xx responses to
   boundary is authoritative.
 - User-triggered refresh may show a subtle local progress indicator. Track that
   action locally instead of presenting ambient polling or focus-refetch
-  `isFetching` as user progress. Mutation-local progress remains appropriate.
+  `isFetching` as user progress. Do not reject the click because an ambient
+  fetch is active: call `refetch()` and let TanStack's default
+  `cancelRefetch: true` coordinate the in-flight request while the local action
+  owns its spinner and disabled state. Mutation-local progress remains
+  appropriate.
 - Polling must be bounded, disabled in background unless explicitly required,
   and must use stable path/query parameters. In this app, a poll is bounded by
   its mounted foreground surface, a recoverable transient state, or an explicit
@@ -84,11 +88,13 @@ The integration was checked against official sources matching the lockfile:
   <https://github.com/openapi-ts/openapi-typescript/tree/openapi-fetch%400.17.0/packages/openapi-fetch/src>
 - TanStack Query 5.101.4 distinguishes initial pending state from background
   `isFetching`, retains prior pages with `keepPreviousData`, and supplies query
-  cancellation:
+  cancellation; its `refetch` contract defaults `cancelRefetch` to `true`:
   <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/background-fetching-indicators.md>,
   <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/paginated-queries.md>,
   and
-  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/query-cancellation.md>.
+  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/guides/query-cancellation.md>,
+  plus
+  <https://github.com/TanStack/query/blob/%40tanstack%2Freact-query%405.101.4/docs/framework/react/reference/useQuery.md>.
 - React 19.2.7 is the component/runtime contract used by these surfaces:
   <https://github.com/facebook/react/tree/v19.2.7/packages/react>.
 - Base UI 1.6.0 and shadcn 4.16.1 provide accessible progress and skeleton


### PR DESCRIPTION
## Summary

- make loading and error rendering data-aware across OSS and hosted query consumers so cached rows, counts, cards, empty states, and layout stay stable during background refreshes
- remove periodic opacity pulses and skeleton/content swaps; scope visible refresh progress to explicit user actions
- keep polling foreground-only and bounded, including terminal conditions for setup/deployment convergence and TanStack focus awareness for the route-level inventory retry loop
- keep manual **Check again** actions responsive during ambient fetches: the local action owns spinner/disabled feedback while TanStack `refetch()` coordinates the in-flight request
- converge standard Memory list/detail CRUD and Project creation onto the generated openapi-react-query operations and keys
- add source-level, QueryObserver, and Playwright regressions for desktop and 320px polling surfaces

## Upstream basis and intentional exceptions

`docs/openapi-react-query.md` records the refresh contract and pinned official sources for openapi-react-query 0.5.4, openapi-fetch 0.17.0, TanStack Query 5.101.4, React 19.2.7, Base UI 1.6.0, and shadcn 4.16.1. It now also cites the TanStack v5 `refetch` contract: `cancelRefetch` defaults to `true`, so an explicit manual action must not be silently rejected because ambient `isFetching` is already true.

Explicit TanStack Query remains for aggregation/projection, upload/download/stream, sensitive-cache, complex optimistic, billing/deployment state-machine, and hosted ownership/access flows. These cache values or protocols do not map one-to-one to a standard OpenAPI operation.

The intentional visual-refresh boundary is an authoritative 404 on a resource detail: the cached entity has been deleted and is no longer usable, so the detail moves to its not-found boundary. Ordinary refetch failures with cached data stay non-blocking.

## Verification

- `bun run --cwd apps/web test` — 867 passed, 0 failed across 141 files in the Docker-backed isolated runner; this runner also passed web typecheck and OSS build
- `bun run --cwd apps/web test src/hosted/agents/deployment-hooks.test.ts` — 18 passed, including the ambient-fetch/manual-action QueryObserver behavior regression; isolated runner also passed typecheck and OSS build
- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src` — 534 files
- `bun run check` — 877 files
- `bun run --cwd apps/web build:oss`
- `bunx playwright test e2e/query-refresh-no-flicker.pw.ts --config=playwright.config.ts` — 2 passed (desktop and 320px, real 10s Agent poll)
- `bunx playwright test e2e/query-refresh-hosted.pw.ts --config=playwright.hosted.config.ts` — 2 passed after the blocker fix (desktop and 320px, real 20s Channel health poll)
- focused refresh/query-state/deployment/usage regressions — 52 passed
- pre-commit Biome hooks passed for both commits

No schema/generated-client changes. No production, tenant, deployment, payment-provider, Discord Portal, or hosted-repository operations were performed. This PR is intentionally unmerged.