### PR TITLE
fix: await SSE stream child tasks on cancellation

### DIFF
--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -38,7 +38,6 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
-from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -129,16 +128,24 @@ async def _stream(
             return
         event_task = asyncio.create_task(queue.get())
         revoked_task = asyncio.create_task(revoked.wait())
-        done, pending = await asyncio.wait(
-            {event_task, revoked_task},
-            timeout=HEARTBEAT_INTERVAL_S,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for task in pending:
-            task.cancel()
-        for task in pending:
-            with suppress(asyncio.CancelledError):
-                await task
+        child_tasks = (event_task, revoked_task)
+        try:
+            done, _pending = await asyncio.wait(
+                child_tasks,
+                timeout=HEARTBEAT_INTERVAL_S,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            # A client disconnect cancels the async generator while it may be
+            # parked inside ``asyncio.wait``. Cleanup after a normal wait is
+            # therefore insufficient: Queue.get/Event.wait tasks survive and
+            # asyncio later reports "Task was destroyed but it is pending".
+            # Own both child tasks on every exit, including generator
+            # cancellation and server shutdown.
+            for task in child_tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*child_tasks, return_exceptions=True)
         if revoked_task in done or revoked.is_set():
             return
         if event_task not in done:

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -276,6 +276,50 @@ async def test_stream_returns_when_revoked_event_set():
 
 
 @pytest.mark.asyncio
+async def test_stream_cancellation_awaits_internal_wait_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Disconnect cancellation must not orphan Queue/Event wait tasks."""
+    from unittest.mock import Mock
+
+    from app.routes import sync as sync_route
+
+    queue: asyncio.Queue = asyncio.Queue()
+    revoked = asyncio.Event()
+    request = Mock()
+
+    async def _not_disconnected():
+        return False
+
+    request.is_disconnected = _not_disconnected
+    gen = sync_route._stream(queue, request, revoked)
+    assert await gen.__anext__() == b": connected\n\n"
+
+    original_create_task = asyncio.create_task
+    internal_tasks: list[asyncio.Task] = []
+
+    def _track_create_task(coro):
+        task = original_create_task(coro)
+        internal_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(sync_route.asyncio, "create_task", _track_create_task)
+    next_chunk = original_create_task(gen.__anext__())
+    for _ in range(10):
+        if len(internal_tasks) == 2:
+            break
+        await asyncio.sleep(0)
+    assert len(internal_tasks) == 2
+
+    next_chunk.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await next_chunk
+
+    assert all(task.done() for task in internal_tasks)
+    assert all(task.cancelled() for task in internal_tasks)
+
+
+@pytest.mark.asyncio
 async def test_stream_drops_event_queued_before_revoke():
     """Race: event lands in the queue right before / during the
     25s `wait_for(queue.get())`. The refresher fires `revoked`


### PR DESCRIPTION
## Summary

- cancel and await SSE Queue/Event child tasks on every stream exit
- cover client-disconnect cancellation so asyncio tasks cannot be orphaned

## Verification

- `bash scripts/test.sh backend tests/test_sync_events.py tests/test_request_timing.py` — 34 passed
- `bash scripts/test.sh backend` — 1948 passed, 6 skipped
- isolated Ruff check and format check — passed

No schema, dependency, workflow, or production configuration changes.