### PR TITLE
fix: exclude SSE streams from slow request warnings

### DIFF
--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -17,6 +17,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 _PROCESS_TIME_HEADER = b"x-process-time-ms"
+_SYNC_EVENTS_PATH = "/api/sync/events"
 _TELEGRAM_BOT_API_PATH_RE = re.compile(
     r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
     re.IGNORECASE,
@@ -73,7 +74,7 @@ class RequestTimingMiddleware:
                 duration_ms,
                 _request_id(scope),
             )
-        elif not _is_expected_long_poll(raw_path) and _is_slow(
+        elif not _is_expected_long_request(raw_path) and _is_slow(
             duration_ms=duration_ms,
             slow_ms=self.slow_ms,
         ):
@@ -102,7 +103,9 @@ def _log_safe_path(path: str) -> str:
     return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
 
 
-def _is_expected_long_poll(path: str) -> bool:
+def _is_expected_long_request(path: str) -> bool:
+    if path == _SYNC_EVENTS_PATH:
+        return True
     match = _TELEGRAM_BOT_API_PATH_RE.match(path)
     if match is None or "/file/" in match.group("prefix").lower():
         return False

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -114,8 +114,16 @@ async def test_request_timing_redacts_telegram_routing_credentials(
 
 
 @pytest.mark.asyncio
-async def test_request_timing_does_not_warn_for_successful_telegram_long_poll(
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/sync/events",
+        "/v1/channels/telegram/bot123456:secret/getUpdates",
+    ],
+)
+async def test_request_timing_does_not_warn_for_successful_long_request(
     caplog: pytest.LogCaptureFixture,
+    path: str,
 ):
     async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": []})
@@ -124,7 +132,7 @@ async def test_request_timing_does_not_warn_for_successful_telegram_long_poll(
     caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
     await _collect(
         RequestTimingMiddleware(inner, slow_ms=0.000_001),
-        _scope(path="/v1/channels/telegram/bot123456:secret/getUpdates"),
+        _scope(path=path),
     )
 
     assert caplog.text == ""


### PR DESCRIPTION
## Summary

- classify the successful sync-events SSE endpoint as an expected long-running request
- keep server errors on that endpoint visible through the existing higher-priority error branch
- share the same explicit timing policy used by Telegram long polling

## Production evidence

The newly deployed SSE cleanup release completed multiple `/api/sync/events` connections without orphaned-task errors, but those successful ~42s streams were still logged as slow warnings.

## Verification

- Docker focused backend: 35 passed
- isolated Ruff check and format check: passed
- `git diff --check`: passed