### PR TITLE
fix: suppress HTTP client request URL logs

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import logging
+
+_HTTP_CLIENT_LOGGERS = ("httpx", "httpcore", "httpx2", "httpcore2")
+
+
+def configure_application_logging() -> None:
+    logging.basicConfig(level=logging.INFO)
+    # HTTP client INFO records include complete request URLs. Provider URLs can
+    # carry routing credentials, so application code logs sanitized failures
+    # explicitly instead of emitting the clients' request-level diagnostics.
+    for logger_name in _HTTP_CLIENT_LOGGERS:
+        logging.getLogger(logger_name).setLevel(logging.WARNING)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.core.auth import warm_clerk_jwks
 from app.core.config import settings
 from app.core.database import get_session
+from app.core.logging_config import configure_application_logging
 from app.core.sentry import init_sentry
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.request_id import RequestIDMiddleware
@@ -67,9 +68,7 @@ from app.services.embedding import LocalEmbedder
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
-logging.basicConfig(level=logging.INFO)
-logging.getLogger("httpx").setLevel(logging.WARNING)
-logging.getLogger("httpcore").setLevel(logging.WARNING)
+configure_application_logging()
 log = logging.getLogger(__name__)
 init_sentry()
 

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from app.core.database import async_session_factory, engine
+from app.core.logging_config import configure_application_logging
 from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWorker
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
@@ -18,7 +19,7 @@ from app.services.discord_command_reconciliation_worker import (
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 
-logging.basicConfig(level=logging.INFO)
+configure_application_logging()
 log = logging.getLogger(__name__)
 
 CHANNEL_WORKER_HEALTH_HOST = "0.0.0.0"

--- a/backend/app/workers/discord_gateway.py
+++ b/backend/app/workers/discord_gateway.py
@@ -5,9 +5,10 @@ import logging
 import signal
 
 from app.core.database import async_session_factory, engine
+from app.core.logging_config import configure_application_logging
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 
-logging.basicConfig(level=logging.INFO)
+configure_application_logging()
 log = logging.getLogger(__name__)
 
 

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import logging
+
+from app.core.logging_config import configure_application_logging
+
+
+def test_application_logging_suppresses_http_client_request_urls():
+    logger_names = ("httpx", "httpcore", "httpx2", "httpcore2")
+    previous_levels = {
+        logger_name: logging.getLogger(logger_name).level for logger_name in logger_names
+    }
+    try:
+        for logger_name in logger_names:
+            logging.getLogger(logger_name).setLevel(logging.INFO)
+
+        configure_application_logging()
+
+        assert all(
+            logging.getLogger(logger_name).level == logging.WARNING for logger_name in logger_names
+        )
+    finally:
+        for logger_name, level in previous_levels.items():
+            logging.getLogger(logger_name).setLevel(level)


### PR DESCRIPTION
## Summary

- centralize application logging setup for web and channel worker entrypoints
- suppress request-level INFO logs from both generations of httpx/httpcore
- retain application-owned sanitized error logging

## Production evidence

The deployed web process emitted a complete Composio tool-router URL through the `httpx2` INFO logger. Provider URLs can contain routing credentials, so third-party request URL logging should be disabled at the process boundary.

## Verification

- Docker focused backend: 10 passed
- isolated Ruff check and format check: passed
- `git diff --check`: passed