### PR TITLE
fix(runtime): repair hosted OpenClaw ownership boundaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.28",
+      "version": "0.13.29",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.28",
+	"version": "0.13.29",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4385,6 +4385,195 @@ describe("runtime manifest reconciliation invariants", () => {
 		).toEqual([join(home, ".openclaw", "bin"), join(home, ".openclaw", "tools")].sort());
 	});
 
+	test("accepts an installed runtime command symlink as an exact transaction target", () => {
+		const paths = tempRuntimePaths();
+		const appRoot = join(paths.userHome, ".openclaw");
+		const commandPath = join(appRoot, "bin", "openclaw");
+		const commandTarget = join(appRoot, "openclaw-entrypoint");
+		mkdirSync(dirname(commandPath), { recursive: true });
+		writeFileSync(commandTarget, "#!/bin/sh\nexit 0\n");
+		chmodSync(commandTarget, 0o755);
+		symlinkSync(commandTarget, commandPath);
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				install: {
+					authority: "official",
+					method: "official-installer",
+					url: OFFICIAL_INSTALL_URLS.openclaw,
+					home: paths.userHome,
+					args: [...OFFICIAL_INSTALL_ARGS.openclaw],
+				},
+				run: runSettings(commandPath, ["gateway", "run"]),
+				services: {},
+			},
+		});
+
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "symlinked-openclaw"), paths);
+		expect(result.installErrors).toEqual([]);
+		expect(readlinkSync(commandPath)).toBe(commandTarget);
+	});
+
+	test("repairs root bootstrap ownership for the UID 10001 official OpenClaw service path", () => {
+		if (process.geteuid?.() !== 0 || !existsSync("/usr/bin/setpriv")) return;
+		const paths = tempRuntimePaths();
+		const fixtureRoot = dirname(paths.serviceStateRoot);
+		const runtimeUid = 10_001;
+		const runtimeGid = 10_001;
+		const appRoot = join(paths.userHome, ".openclaw");
+		const binDir = join(appRoot, "bin");
+		const commandPath = join(binDir, "openclaw");
+		const gatewayEnvironment = join(appRoot, "gateway.systemd.env");
+		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+		const unitBackupPath = `${unitPath}.bak`;
+		const runtimeOwnedPaths = [
+			appRoot,
+			binDir,
+			commandPath,
+			dirname(dirname(paths.systemdUserRoot)),
+			dirname(paths.systemdUserRoot),
+			paths.systemdUserRoot,
+			unitPath,
+			unitBackupPath,
+			gatewayEnvironment,
+		];
+
+		chmodSync(fixtureRoot, 0o755);
+		mkdirSync(paths.userHome, { recursive: true });
+		chownSync(paths.userHome, runtimeUid, runtimeGid);
+		chmodSync(paths.userHome, 0o700);
+		mkdirSync(paths.clawdiHome, { recursive: true });
+		chownSync(paths.clawdiHome, runtimeUid, runtimeGid);
+		chmodSync(paths.clawdiHome, 0o700);
+		mkdirSync(binDir, { recursive: true });
+		mkdirSync(dirname(unitPath), { recursive: true });
+		writeFileSync(
+			commandPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+test "$(id -u)" = "10001"
+test "$*" = "gateway install --force --json"
+unit="$HOME/.config/systemd/user/\${OPENCLAW_SYSTEMD_UNIT:-openclaw-gateway.service}"
+cp "$unit" "$unit.bak"
+printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=openclaw gateway run' > "$unit"
+printf '%s\\n' 'OPENCLAW_OFFICIAL_USER_STATE=1' > "$HOME/.openclaw/gateway.systemd.env"
+chmod 0600 "$HOME/.openclaw/gateway.systemd.env"
+printf '{"ok":true}\\n'
+`,
+		);
+		writeFileSync(unitPath, "[Unit]\nDescription=previous official unit\n");
+		writeFileSync(unitBackupPath, "previous official backup\n");
+		writeFileSync(gatewayEnvironment, "PREVIOUS_OFFICIAL_STATE=1\n");
+		for (const path of [appRoot, binDir]) {
+			chownSync(path, 0, 0);
+			chmodSync(path, 0o700);
+		}
+		for (const path of [commandPath, unitPath, unitBackupPath, gatewayEnvironment]) {
+			chownSync(path, 0, 0);
+			chmodSync(path, 0o700);
+		}
+		chmodSync(unitPath, 0o600);
+		chmodSync(unitBackupPath, 0o600);
+		chmodSync(gatewayEnvironment, 0o600);
+
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				install: {
+					authority: "official",
+					method: "official-installer",
+					url: OFFICIAL_INSTALL_URLS.openclaw,
+					home: paths.userHome,
+					args: [...OFFICIAL_INSTALL_ARGS.openclaw],
+				},
+				run: runSettings(commandPath, ["gateway", "run"]),
+				services: {},
+			},
+		});
+
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "root-openclaw-ownership"),
+			paths,
+			{
+				executeOfficialServiceInstallers: false,
+			},
+		);
+		expect(result.installErrors).toEqual([]);
+		for (const path of runtimeOwnedPaths) {
+			const node = statSync(path);
+			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
+		}
+		expect(statSync(appRoot).mode & 0o777).toBe(0o700);
+		expect(statSync(commandPath).mode & 0o777).toBe(0o700);
+		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
+		expect([statSync(paths.daemonAuthToken).uid, statSync(paths.daemonAuthToken).gid]).toEqual([
+			0, 0,
+		]);
+		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
+
+		const installed = execFileSync(
+			"/usr/bin/setpriv",
+			[
+				`--reuid=${runtimeUid}`,
+				`--regid=${runtimeGid}`,
+				"--clear-groups",
+				"env",
+				`HOME=${paths.userHome}`,
+				"OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service",
+				commandPath,
+				"gateway",
+				"install",
+				"--force",
+				"--json",
+			],
+			{ cwd: paths.userHome, encoding: "utf8" },
+		);
+		expect(JSON.parse(installed)).toEqual({ ok: true });
+		expect(statSync(unitPath).uid).toBe(runtimeUid);
+		expect(statSync(unitBackupPath).uid).toBe(runtimeUid);
+		expect(statSync(gatewayEnvironment).uid).toBe(runtimeUid);
+		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
+
+		for (const path of runtimeOwnedPaths) chownSync(path, 0, 0);
+		const beforeRollback = new Map(
+			runtimeOwnedPaths.map(
+				(path) =>
+					[
+						path,
+						{
+							content: statSync(path).isFile() ? readFileSync(path) : null,
+							mode: statSync(path).mode & 0o777,
+						},
+					] as const,
+			),
+		);
+		const failed = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "root-openclaw-ownership-rollback"),
+			paths,
+			{
+				cacheLastGood: false,
+				commitAuthority: () => {
+					throw new Error("injected ownership commit failure");
+				},
+				executeOfficialServiceInstallers: false,
+			},
+		);
+		expect(failed.installErrors.join("\n")).toContain("injected ownership commit failure");
+		for (const [path, previous] of beforeRollback) {
+			const node = statSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
+			expect(node.mode & 0o777).toBe(previous.mode);
+			if (previous.content) expect(readFileSync(path)).toEqual(previous.content);
+		}
+		expect([statSync(paths.daemonAuthToken).uid, statSync(paths.daemonAuthToken).gid]).toEqual([
+			0, 0,
+		]);
+		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
+	});
+
 	test("restores exact installer targets and reconciles the planned units after installer failure", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -189,6 +189,8 @@ import {
 	runRuntimeUserCommand,
 	runtimeEgressGid,
 	runtimeEgressUid,
+	runtimeUserGid,
+	runtimeUserUid,
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
@@ -4799,6 +4801,26 @@ export function runtimeUserMutationTargets(
 		...installerTargets,
 		...hostedChannelCredentialMutationTargets(manifest, home),
 	]);
+	for (const name of HOSTED_RUNTIME_TARGETS) {
+		if (manifest.runtimes[name]?.enabled !== true) continue;
+		const commandPath = runtimeCommandPath(name, home);
+		if (
+			commandPath &&
+			!installerTargets.some((target) => {
+				const candidate = relative(resolve(target), resolve(commandPath));
+				return candidate === "" || (!candidate.startsWith("..") && !isAbsolute(candidate));
+			})
+		) {
+			// The command itself is an ownership mutation even when no runtime
+			// install is pending. Root bootstrap images can otherwise leave a
+			// private root-owned executable that root observes as present but the
+			// official runtime user cannot execute. OpenClaw's official installer
+			// defaults to ~/.openclaw and writes the CLI under its bin directory:
+			// https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/scripts/install-cli.sh#L64-L66
+			// https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/scripts/install-cli.sh#L1122-L1129
+			targets.add(commandPath);
+		}
+	}
 	if (
 		manifest.runtimes.hermes?.enabled &&
 		manifest.runtimes.hermes.services?.dashboard &&
@@ -4860,6 +4882,7 @@ function runtimeManagedMutationPlan(input: {
 	observations: ReadonlyMap<string, RuntimeInstallObservation>;
 }): {
 	snapshot: RuntimeManagedMutationPlan;
+	runtimeUserOwnershipTargets: string[];
 	staleOfficialUnits: string[];
 	systemdUserUnits: string[];
 } {
@@ -4900,13 +4923,38 @@ function runtimeManagedMutationPlan(input: {
 		]),
 	].sort();
 	const rootTargetsList = [...rootTargets].sort();
+	const projectionHome = hostedRuntimeProjectionHome(input.manifest, input.paths);
+	const runtimeCommandTargets = HOSTED_RUNTIME_TARGETS.flatMap((name) => {
+		if (input.manifest.runtimes[name]?.enabled !== true) return [];
+		const commandPath = runtimeCommandPath(name, projectionHome);
+		return commandPath ? [commandPath] : [];
+	});
+	const runtimeUserMetadataTargets = [
+		...new Set([
+			...systemd.metadataTargets,
+			input.paths.userHome,
+			input.paths.clawdiHome,
+			...mutationAncestorMetadataTargets(runtimeUserTargets, [
+				input.paths.userHome,
+				input.paths.clawdiHome,
+			]),
+		]),
+	].sort();
+	const runtimeUserOwnershipTargets = [
+		...new Set([...runtimeUserTargets, ...runtimeUserMetadataTargets, ...runtimeCommandTargets]),
+	].sort((left, right) => left.length - right.length || left.localeCompare(right));
 	return {
 		snapshot: {
 			rootTargets: rootTargetsList,
 			trustedRootDirectories: runtimeRootLiveMutationDirectories(input.manifest, input.paths),
 			runtimeUserTargets,
 			runtimeUserTrustedRoots: [input.paths.clawdiHome, input.paths.userHome],
-			runtimeUserSymlinkTargets: systemd.symlinkTargets,
+			runtimeUserSymlinkTargets: [
+				...new Set([
+					...systemd.symlinkTargets,
+					...runtimeCommandTargets.filter((target) => runtimeUserTargets.includes(target)),
+				]),
+			].sort(),
 			metadataTargets: [
 				...new Set([
 					...rootMetadataTargets,
@@ -4919,18 +4967,37 @@ function runtimeManagedMutationPlan(input: {
 						input.paths.runRoot,
 						input.paths.systemdSystemRoot,
 					]),
-					input.paths.userHome,
-					input.paths.clawdiHome,
-					...mutationAncestorMetadataTargets(runtimeUserTargets, [
-						input.paths.userHome,
-						input.paths.clawdiHome,
-					]),
+					...runtimeUserMetadataTargets,
 				]),
 			].sort(),
 		},
+		runtimeUserOwnershipTargets,
 		staleOfficialUnits: systemd.staleOfficialUnits,
 		systemdUserUnits: systemd.unitNames,
 	};
+}
+
+function ensureRuntimeUserOwnershipBoundaries(targets: readonly string[]): void {
+	if (!runningAsRoot()) return;
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (!runtimeUser || runtimeUser === "root" || runtimeUser === "0") return;
+	const uid = runtimeUserUid(runtimeUser);
+	const gid = runtimeUserGid(runtimeUser);
+	if (uid === 0 || gid === 0) {
+		throw new Error(`runtime user ${runtimeUser} resolved to a root filesystem identity`);
+	}
+	for (const path of targets) {
+		let node: ReturnType<typeof lstatSync>;
+		try {
+			node = lstatSync(path);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
+		}
+		if (node.uid === uid && node.gid === gid) continue;
+		if (node.isSymbolicLink()) lchownSync(path, uid, gid);
+		else chownSync(path, uid, gid);
+	}
 }
 
 export function convergeRuntimeManifest(
@@ -5054,6 +5121,11 @@ export function convergeRuntimeManifest(
 		userUnits: [],
 	};
 	try {
+		// Runtime-user targets and their ancestor metadata are already in the
+		// exact pre-image snapshot. Establish their positive ownership boundary
+		// before any official installer or CLI command drops privilege. Modes are
+		// intentionally preserved, so private runtime state stays private.
+		ensureRuntimeUserOwnershipBoundaries(mutationPlan.runtimeUserOwnershipTargets);
 		observations.clear();
 		for (const [name, runtime] of runtimeEntries) {
 			const observation = observeRuntimeInstall(name, runtime, projectionHome);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1041,6 +1041,17 @@ export function planRuntimeSystemdUserMutations(
 		targets.add(enablementPath);
 		symlinkTargets.add(enablementPath);
 		if (officialRuntimeServiceInstallArgs(program)) {
+			if (program.runtime === "openclaw") {
+				// OpenClaw's official Linux installer writes the base unit in place and
+				// preserves the previous unit beside it. Both are official-user
+				// transaction mutations:
+				// https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/daemon/systemd.ts#L985-L1004
+				targets.add(`${unitPath}.bak`);
+				// The same installer may write its owner-only environment file under
+				// the OpenClaw state directory:
+				// https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/daemon/systemd.ts#L1099-L1170
+				targets.add(join(paths.userHome, ".openclaw", "gateway.systemd.env"));
+			}
 			const dropInPath = systemdDropInFilePath(paths, name);
 			targets.add(dropInPath);
 			metadataTargets.add(dirname(dropInPath));


### PR DESCRIPTION
## Summary

- Establish runtime-user ownership for exact hosted mutation targets and ancestor metadata after the pre-image snapshot and before any installer or CLI privilege drop.
- Include the installed official command, OpenClaw unit backup, and owner-only gateway environment file in the exact transaction boundary.
- Preserve existing modes, root ownership for Clawdi sensitive files, symlink safety, and exact fail-closed rollback; this uses no recursive chown/chmod or runtime-specific infrastructure logic.
- Prepare the next unpublished CLI release by bumping only `packages/cli/package.json` and `bun.lock` to `0.13.29`.

## Root cause and upstream contract

The live root bootstrap left `~/.openclaw` as root:root 0700. Planning as root observed the official command as present, while the transaction only snapshotted ancestor metadata and never established a positive runtime-user ownership boundary. UID 10001 therefore could not traverse the app path, so the official gateway installer failed and convergence rolled back.

The target list follows the pinned official OpenClaw sources:

- [`install-cli.sh` defaults to `$HOME/.openclaw`](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/scripts/install-cli.sh#L64-L66) and [writes `$PREFIX/bin/openclaw`](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/scripts/install-cli.sh#L1122-L1129).
- The official systemd installer [writes the user unit and adjacent `.bak`](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/daemon/systemd.ts#L985-L1004) and [maintains `gateway.systemd.env` as mode 0600 state](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/daemon/systemd.ts#L1099-L1170).

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun test --isolate packages/cli/src/runtime/manifest-reconciliation.test.ts packages/cli/src/runtime/manifest-services.test.ts packages/cli/src/runtime/manifest-mutation-parity.test.ts` — 193 pass, 0 fail
- Root test-runner container filtered to `repairs root bootstrap ownership for the UID 10001 official OpenClaw service path` — 1 pass, 45 assertions; executes `gateway install --force --json` under UID/GID 10001 and verifies exact rollback plus root-owned daemon token
- `bunx biome check packages/cli/src/runtime/manifest.ts packages/cli/src/runtime/runtime-systemd-reconciliation.ts packages/cli/src/runtime/manifest-reconciliation.test.ts packages/cli/package.json`
- `bun run --cwd packages/cli check:publish-manifest`
- `git diff --check origin/main..HEAD`

No live system or tenant data was modified. No npm package was published, and this PR must remain unmerged for deliberate rollout and live canary proof.