### PR TITLE
fix(runtime): expose official installer diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.29",
+      "version": "0.13.30",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public runtime contract |
-| Last updated | 2026-07-22 |
+| Last updated | 2026-08-02 |
 | Owner | CLI runtime and cloud-api layers |
 
 This document describes the public Clawdi CLI and dashboard contract for managed
@@ -243,6 +243,16 @@ that boundary convergent in both directions:
   exact plan-derived filesystem pre-images and reconciles systemd to that
   restored set; it never applies a partially rendered generation merely because
   another convergence step reported an error.
+
+An official installer failure reports its exit code, terminating signal or
+spawn error, and bounded stdout/stderr tails. Capture is capped at 64 KiB per
+stream and each reported tail at 4,000 characters. Terminal controls are
+removed and known secret values, credentials, URL parameters, and environment
+assignments are redacted. For an installer with a JSON contract, Clawdi
+allowlists only `error`, `message`, `hints`, and `warnings`; it never projects
+the rest of the installer response, a runtime manifest, or process environment.
+The failure still aborts Apply before authority commits and uses the existing
+filesystem/systemd rollback transaction.
 
 Official service installers/uninstallers run only in the hosted systemd apply
 path. Unit tests select installer execution through an explicit in-process test
@@ -731,13 +741,43 @@ specifically `cli-config.yaml.example`,
 
 ### Official OpenClaw evidence
 
-Research was refreshed on 2026-07-22. The then-current official `main` commit
-was [`ba467fbd3efa9ab109e620c4e42cfe92388171c5`](https://github.com/openclaw/openclaw/commit/ba467fbd3efa9ab109e620c4e42cfe92388171c5).
-The latest stable release was
+Installer research was refreshed on 2026-08-02. The official `main` commit at
+that time was
+[`1e9a620a28d6d8f8a0ba165f2004718a79030460`](https://github.com/openclaw/openclaw/commit/1e9a620a28d6d8f8a0ba165f2004718a79030460).
+The stable release tag
 [`v2026.7.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1),
-whose annotated tag resolves to release commit
+resolves to release commit
 [`2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4`](https://github.com/openclaw/openclaw/commit/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4).
-All behavior evidence below is pinned to the newer exact `main` commit.
+The immutable integration target is `openclaw@2026.7.1-2` with npm integrity
+`sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==`.
+Its npm manifest omits `gitHead`, while its own `openclaw --version` reports
+`OpenClaw 2026.7.1-2 (0790d9f)`, identifying official source commit
+[`0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).
+
+At that published commit, the official installer contract is:
+
+| Stage | Official line evidence | Diagnostic consequence |
+| --- | --- | --- |
+| Gateway install preparation | [`install.ts` lines 141-298](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/install.ts#L141-L298) | Config initialization, service inspection, token resolution, and plan construction all precede the platform service install. |
+| JSON failure response | [`response.ts` lines 49-50](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/response.ts#L49-L50) and [109-177](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/response.ts#L109-L177) | `--json` emits the structured failure through the JSON writer and exits with code 1. Clawdi must inspect stdout as well as stderr. |
+| Systemd staging | [`systemd.ts` lines 831-950](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/daemon/systemd.ts#L831-L950) | User-manager validation and environment/unit writes happen before activation. |
+| Systemd activation | [`systemd.ts` lines 1101-1147](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/daemon/systemd.ts#L1101-L1147) | `daemon-reload`, enable, and restart are separate failure points after staging. |
+
+Consequently, the absence of gateway process journal entries does not identify
+which installer stage failed. The isolated regression test runs the published
+package's real `gateway install --force --json` path under a live systemd user
+manager and UID/GID 10001, forces an immutable pre-activation `EISDIR` failure,
+and proves exit/stdout propagation plus exact transaction rollback without
+inventing a success path:
+
+```bash
+scripts/test-runtime-official-installer-systemd.sh
+```
+
+Done: the command exits 0 and reports `1 pass`.
+
+The Runtime UI behavior evidence below remains pinned to exact official commit
+[`ba467fbd3efa9ab109e620c4e42cfe92388171c5`](https://github.com/openclaw/openclaw/commit/ba467fbd3efa9ab109e620c4e42cfe92388171c5).
 
 | Requirement | Official line evidence | Contract consequence |
 | --- | --- | --- |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.29",
+	"version": "0.13.30",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1882,13 +1882,26 @@ cat > '${logPath}'
 			offline: false,
 		});
 
-		writeFakeGatewayCli({
-			path: openclawCommand,
-			logPath,
-			runtime: "openclaw",
-			unitPath,
-			failInstall: true,
-		});
+		const installerToken = "official-installer-token-must-not-leak";
+		process.env.OFFICIAL_INSTALLER_TEST_TOKEN = installerToken;
+		mkdirSync(dirname(openclawCommand), { recursive: true });
+		writeFileSync(
+			openclawCommand,
+			`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "gateway install --force --json")
+    printf '%s' '{"ok":false,"error":"official stdout marker official-installer-token-must-not-leak","manifest":{"secretValues":{"hidden":"manifest-secret-must-not-leak"}}}'
+    printf 'discarded-stderr-prefix' >&2
+    printf '%5000s' '' | tr ' ' x >&2
+    printf '\\x1b[31mofficial stderr marker\\x1b[0m OFFICIAL_INSTALLER_TEST_TOKEN=%s VISIBLE_ENV=environment-value-must-not-leak Bearer %s https://diagnostic-user:url-password-must-not-leak@example.test/path?token=query-token-must-not-leak\n' "$OFFICIAL_INSTALLER_TEST_TOKEN" "$OFFICIAL_INSTALLER_TEST_TOKEN" >&2
+    exit 41
+    ;;
+  *) exit 64 ;;
+esac
+`,
+		);
+		chmodSync(openclawCommand, 0o700);
 		let authorityCommits = 0;
 		let finalActivations = 0;
 		const failedFirstInstall = convergeRuntimeManifest(load("inline-install-failure", 1), paths, {
@@ -1909,9 +1922,23 @@ cat > '${logPath}'
 				rollback: () => {},
 			},
 		});
-		expect(failedFirstInstall.installErrors.join("\n")).toContain(
-			"official openclaw-gateway service install failed",
-		);
+		const firstInstallError = failedFirstInstall.installErrors.join("\n");
+		expect(firstInstallError).toContain("official openclaw-gateway service install failed");
+		expect(firstInstallError).toContain("exit code 41");
+		expect(firstInstallError).toContain("stdout tail:");
+		expect(firstInstallError).toContain("official stdout marker <redacted>");
+		expect(firstInstallError).toContain("stderr tail:");
+		expect(firstInstallError).toContain("official stderr marker");
+		expect(firstInstallError).toContain("OFFICIAL_INSTALLER_TEST_TOKEN=<redacted>");
+		expect(firstInstallError).toContain("VISIBLE_ENV=<redacted>");
+		expect(firstInstallError).not.toContain(installerToken);
+		expect(firstInstallError).not.toContain("manifest-secret-must-not-leak");
+		expect(firstInstallError).not.toContain("environment-value-must-not-leak");
+		expect(firstInstallError).not.toContain("url-password-must-not-leak");
+		expect(firstInstallError).not.toContain("query-token-must-not-leak");
+		expect(firstInstallError).not.toContain("discarded-stderr-prefix");
+		expect(firstInstallError).not.toContain("\u001b");
+		expect(firstInstallError.length).toBeLessThan(5000);
 		expect(existsSync(paths.managedConfig)).toBe(false);
 		expect(existsSync(manifest.workspaceRoot ?? "")).toBe(false);
 		expect(existsSync(dropInPath)).toBe(false);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -15,6 +15,7 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { stripTerminalEscapes } from "../lib/sanitize";
 import { runtimeContentSha256 } from "./applied-state";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import type { RuntimeInstallReceiptEntry, RuntimeInstallReceipts } from "./install-receipts";
@@ -890,6 +891,100 @@ function officialRuntimeServiceInstallArgs(program: RuntimeSystemdUserProgram): 
 	return officialRuntimeServiceDescriptorForProgram(program)?.installArgs ?? null;
 }
 
+const OFFICIAL_INSTALLER_MAX_BUFFER_BYTES = 64 * 1024;
+const OFFICIAL_INSTALLER_OUTPUT_TAIL_CHARACTERS = 4000;
+const SENSITIVE_ENV_KEY_SEGMENT =
+	/(?:^|_)(?:API_KEY|AUTH|COOKIE|CREDENTIAL|KEY|PASSWORD|PASSWD|PRIVATE_KEY|SECRET|SESSION|TOKEN)(?:$|_)/i;
+const ENV_ASSIGNMENT = /\b([A-Za-z_][A-Za-z0-9_]*)=(?:"(?:\\.|[^"\\])*"|'[^']*'|[^\s]+)/g;
+const BEARER_CREDENTIAL = /\b(Bearer)\s+[^\s,"'}\]]+/gi;
+const URL_USERINFO = /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi;
+const SENSITIVE_URL_VALUE =
+	/([?&#](?:access_token|api_key|auth|authorization|client_secret|credential|key|password|refresh_token|secret|token)=)[^&#\s]+/gi;
+const SENSITIVE_STRUCTURED_VALUE =
+	/((?:["']?(?:access[_-]?token|api[_-]?key|auth(?:orization)?|credential|password|private[_-]?key|secret|token)["']?)\s*:\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,}\]]+)/gi;
+
+function officialInstallerSecretValues(program: RuntimeSystemdUserProgram): string[] {
+	const values = new Set(Object.values(program.resolvedSecretEnv).filter(Boolean));
+	for (const [key, value] of Object.entries(program.env)) {
+		if (value && SENSITIVE_ENV_KEY_SEGMENT.test(key)) values.add(value);
+	}
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value && value.length >= 8 && SENSITIVE_ENV_KEY_SEGMENT.test(key)) values.add(value);
+	}
+	return [...values].sort((left, right) => right.length - left.length);
+}
+
+function officialInstallerJsonDiagnostic(value: string): string | null | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+	const record = parsed as Record<string, unknown>;
+	const diagnostic: Record<string, unknown> = {};
+	for (const key of ["error", "message"] as const) {
+		if (typeof record[key] === "string" && record[key]) diagnostic[key] = record[key];
+	}
+	for (const key of ["hints", "warnings"] as const) {
+		if (!Array.isArray(record[key])) continue;
+		const strings = record[key]
+			.filter((item): item is string => typeof item === "string")
+			.slice(-10);
+		if (strings.length > 0) diagnostic[key] = strings;
+	}
+	return Object.keys(diagnostic).length > 0 ? JSON.stringify(diagnostic) : null;
+}
+
+function redactOfficialInstallerOutput(value: string, secrets: readonly string[]): string {
+	let redacted = stripTerminalEscapes(value);
+	for (const secret of secrets) redacted = redacted.replaceAll(secret, "<redacted>");
+	return redacted
+		.replace(ENV_ASSIGNMENT, "$1=<redacted>")
+		.replace(BEARER_CREDENTIAL, "$1 <redacted>")
+		.replace(URL_USERINFO, "$1<redacted>@")
+		.replace(SENSITIVE_URL_VALUE, "$1<redacted>")
+		.replace(SENSITIVE_STRUCTURED_VALUE, '$1"<redacted>"');
+}
+
+function officialInstallerOutputTail(
+	value: string | Buffer | null | undefined,
+	secrets: readonly string[],
+	options: { requireJson?: boolean } = {},
+): string | null {
+	const raw = String(value ?? "").trim();
+	if (!raw) return null;
+	const jsonDiagnostic = officialInstallerJsonDiagnostic(raw);
+	const diagnostic =
+		jsonDiagnostic === undefined ? (options.requireJson ? null : raw) : jsonDiagnostic;
+	if (!diagnostic) return null;
+	const redacted = redactOfficialInstallerOutput(diagnostic, secrets).trim();
+	return redacted ? redacted.slice(-OFFICIAL_INSTALLER_OUTPUT_TAIL_CHARACTERS) : null;
+}
+
+function officialInstallerFailureDetail(
+	program: RuntimeSystemdUserProgram,
+	result: ReturnType<typeof spawnRuntimeUserCommand>,
+): string {
+	const secrets = officialInstallerSecretValues(program);
+	const spawnError = result.error
+		? officialInstallerOutputTail(result.error.message, secrets)
+		: null;
+	const stdout = officialInstallerOutputTail(result.stdout, secrets, {
+		requireJson: officialRuntimeServiceInstallArgs(program)?.includes("--json") === true,
+	});
+	const stderr = officialInstallerOutputTail(result.stderr, secrets);
+	const details = [
+		`exit code ${result.status ?? "unavailable"}`,
+		result.signal ? `signal ${result.signal}` : null,
+		result.error ? `spawn error: ${spawnError ?? "unknown"}` : null,
+		stdout ? `stdout tail: ${stdout}` : null,
+		stderr ? `stderr tail: ${stderr}` : null,
+	].filter((detail): detail is string => detail !== null);
+	return details.join("; ");
+}
+
 function installOfficialRuntimeUserService(
 	program: RuntimeSystemdUserProgram,
 	paths: RuntimePaths,
@@ -902,11 +997,20 @@ function installOfficialRuntimeUserService(
 	}
 	try {
 		resetFailedRuntimeUserService(runtimeSystemdProgramName(program), paths, program.cwd);
-		runRuntimeUserCommand(program.command, args, "", paths.userHome, program.cwd);
-		return null;
+		const result = spawnRuntimeUserCommand(program.command, args, paths.userHome, program.cwd, {
+			maxBufferBytes: OFFICIAL_INSTALLER_MAX_BUFFER_BYTES,
+		});
+		return result.status === 0 && !result.error
+			? null
+			: `official ${runtimeSystemdProgramName(program)} service install failed: ${officialInstallerFailureDetail(program, result)}`;
 	} catch (error) {
+		const secrets = officialInstallerSecretValues(program);
+		const detail = officialInstallerOutputTail(
+			error instanceof Error ? error.message : String(error),
+			secrets,
+		);
 		return `official ${runtimeSystemdProgramName(program)} service install failed: ${
-			error instanceof Error ? error.message : String(error)
+			detail ?? "unknown error"
 		}`;
 	}
 }

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -140,7 +140,12 @@ export function spawnRuntimeUserCommand(
 	args: string[],
 	home: string,
 	cwd: string,
-	options: { egressSystemCaFile?: string; input?: string; timeoutMs?: number } = {},
+	options: {
+		egressSystemCaFile?: string;
+		input?: string;
+		maxBufferBytes?: number;
+		timeoutMs?: number;
+	} = {},
 ): ReturnType<typeof spawnSync> {
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
@@ -151,6 +156,7 @@ export function spawnRuntimeUserCommand(
 				cwd,
 				encoding: "utf8",
 				input: options.input,
+				maxBuffer: options.maxBufferBytes,
 				timeout: options.timeoutMs,
 			});
 		}
@@ -158,7 +164,14 @@ export function spawnRuntimeUserCommand(
 			return spawnSync(
 				"runuser",
 				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
-				{ env, cwd, encoding: "utf8", input: options.input, timeout: options.timeoutMs },
+				{
+					env,
+					cwd,
+					encoding: "utf8",
+					input: options.input,
+					maxBuffer: options.maxBufferBytes,
+					timeout: options.timeoutMs,
+				},
 			);
 		}
 		throw new Error(
@@ -170,6 +183,7 @@ export function spawnRuntimeUserCommand(
 		cwd,
 		encoding: "utf8",
 		input: options.input,
+		maxBuffer: options.maxBufferBytes,
 		timeout: options.timeoutMs,
 	});
 }

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { convergeRuntimeManifest } from "../../src/runtime/manifest";
+import type { RuntimeManifest } from "../../src/runtime/manifest-contract";
+import type { RuntimeManifestLoad } from "../../src/runtime/manifest-source";
+import { getRuntimePaths } from "../../src/runtime/paths";
+
+const REAL_SYSTEMD_GATE = "CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD";
+
+test("propagates the real official OpenClaw installer failure and rolls back as UID 10001", () => {
+	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
+
+	expect(process.geteuid?.()).toBe(0);
+	const runtimeHome = "/home/clawdi";
+	const runtimeUid = 10_001;
+	const runtimeGid = 10_001;
+	const commandPath = join(runtimeHome, ".openclaw", "bin", "openclaw");
+	const expectedVersion = process.env.CLAWDI_TEST_OPENCLAW_VERSION ?? "";
+	const expectedCommit = process.env.CLAWDI_TEST_OPENCLAW_COMMIT ?? "";
+	const version = spawnSync(commandPath, ["--version"], {
+		encoding: "utf8",
+		env: { ...process.env, HOME: runtimeHome },
+	});
+	expect(version.status).toBe(0);
+	expect(version.stdout).toContain(`OpenClaw ${expectedVersion}`);
+	expect(version.stdout).toContain(`(${expectedCommit.slice(0, 7)})`);
+
+	const userManager = spawnSync("systemctl", ["is-active", `user@${runtimeUid}.service`], {
+		encoding: "utf8",
+	});
+	expect(userManager.status).toBe(0);
+	expect(userManager.stdout.trim()).toBe("active");
+	expect(statSync(`/run/user/${runtimeUid}/bus`).isSocket()).toBe(true);
+	const userSystemd = spawnSync(
+		"runuser",
+		[
+			"-u",
+			"clawdi",
+			"--",
+			"env",
+			`HOME=${runtimeHome}`,
+			`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+			`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+			"systemctl",
+			"--user",
+			"show-environment",
+		],
+		{ encoding: "utf8" },
+	);
+	expect(userSystemd.status).toBe(0);
+
+	const root = mkdtempSync(join(tmpdir(), "clawdi-real-openclaw-systemd-"));
+	chmodSync(root, 0o755);
+	const clawdiHome = join(root, "clawdi-home");
+	mkdirSync(clawdiHome);
+	chownSync(clawdiHome, runtimeUid, runtimeGid);
+	chmodSync(clawdiHome, 0o700);
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = "clawdi";
+	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+	process.env.CLAWDI_RUNTIME_HOME = runtimeHome;
+	process.env.CLAWDI_HOME = clawdiHome;
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
+	process.env.CLAWDI_AUTH_TOKEN = "real-systemd-test-auth-token";
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	const paths = getRuntimePaths({ mode: "hosted" });
+	const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+	const unitSentinel = join(unitPath, "preserved-before-install");
+	const dropInPath = join(
+		paths.systemdUserRoot,
+		"openclaw-gateway.service.d",
+		"10-clawdi-hosted.conf",
+	);
+	const enablementPath = join(
+		paths.systemdUserRoot,
+		"default.target.wants",
+		"openclaw-gateway.service",
+	);
+	const openClawConfig = join(runtimeHome, ".openclaw", "openclaw.json");
+	const gatewayEnvironment = join(runtimeHome, ".openclaw", "gateway.systemd.env");
+	expect(existsSync(unitPath)).toBe(false);
+	expect(existsSync(openClawConfig)).toBe(false);
+	expect(existsSync(gatewayEnvironment)).toBe(false);
+	const previousOpenClawConfig = '{"gateway":{"mode":"local"}}\n';
+	const previousGatewayEnvironment = "PRESERVED_ENV=before\n";
+	writeFileSync(openClawConfig, previousOpenClawConfig, { mode: 0o600 });
+	writeFileSync(gatewayEnvironment, previousGatewayEnvironment, { mode: 0o600 });
+	mkdirSync(dirname(unitPath), { recursive: true });
+	mkdirSync(unitPath, { recursive: false });
+	writeFileSync(unitSentinel, "preserve exact rollback target\n");
+
+	const workspaceRoot = join(runtimeHome, "clawdi-systemd-test-workspace");
+	const manifest: RuntimeManifest = {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "hdep_real_openclaw_systemd",
+		environmentId: "env_real_openclaw_systemd",
+		instanceId: "hri_real_openclaw_systemd",
+		generation: 1,
+		issuedAt: "2026-08-02T00:00:00.000Z",
+		workspaceRoot,
+		controlPlane: { apiUrl: "https://cloud-api.example.test" },
+		runtimes: {
+			openclaw: {
+				enabled: true,
+				run: { command: commandPath, args: ["gateway", "run"], env: {}, prependPath: [] },
+				services: {},
+			},
+		},
+		recovery: {},
+	};
+	const load: RuntimeManifestLoad = {
+		manifest,
+		source: "remote-datasource",
+		sourcePath: "real-openclaw-systemd-fixture",
+		offline: false,
+		applyContext: {
+			kind: "context-file",
+			identity: {
+				generation: manifest.generation,
+				manifestETag: '"real-systemd-test"',
+				applyReceiptId: "real-systemd-test-receipt",
+				bootNonce: "real-systemd-test-boot",
+			},
+			cliPackageSpec: "clawdi@0.13.30",
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_systemd",
+				auth: { type: "bearer", token: "real-systemd-test-auth-token" },
+			},
+		},
+	};
+	let authorityCommits = 0;
+	const result = convergeRuntimeManifest(load, paths, {
+		executeOfficialServiceInstallers: true,
+		cacheLastGood: false,
+		commitAuthority: () => {
+			authorityCommits += 1;
+		},
+	});
+	const detail = result.installErrors.join("\n");
+	expect(detail).toContain("official openclaw-gateway service install failed");
+	expect(detail).toContain("exit code 1");
+	expect(detail).toContain("stdout tail:");
+	expect(detail).toContain("Gateway install failed:");
+	expect(detail).toContain("EISDIR");
+	expect(detail).not.toContain("stderr tail:");
+	expect(detail.length).toBeLessThan(5000);
+	expect(authorityCommits).toBe(0);
+	expect(statSync(unitPath).isDirectory()).toBe(true);
+	expect(readFileSync(unitSentinel, "utf8")).toBe("preserve exact rollback target\n");
+	expect(readFileSync(openClawConfig, "utf8")).toBe(previousOpenClawConfig);
+	expect(readFileSync(gatewayEnvironment, "utf8")).toBe(previousGatewayEnvironment);
+	for (const path of [unitPath, openClawConfig, gatewayEnvironment]) {
+		const stat = statSync(path);
+		expect(stat.uid).toBe(0);
+		expect(stat.gid).toBe(0);
+	}
+	expect(statSync(openClawConfig).mode & 0o777).toBe(0o600);
+	expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
+	for (const path of [
+		`${unitPath}.bak`,
+		dropInPath,
+		enablementPath,
+		paths.managedConfig,
+		paths.manifestLastGood,
+	]) {
+		expect(existsSync(path)).toBe(false);
+	}
+	expect(existsSync(workspaceRoot)).toBe(false);
+});

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -1,0 +1,47 @@
+ARG BUN_VERSION=1.3.14
+ARG NODE_VERSION=24.18.0
+
+FROM oven/bun:${BUN_VERSION} AS bun
+FROM node:${NODE_VERSION}-bookworm
+
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
+
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		ca-certificates \
+		dbus-user-session \
+		systemd \
+		systemd-sysv \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 10001 clawdi \
+	&& useradd --uid 10001 --gid 10001 --create-home --home-dir /home/clawdi --shell /bin/bash clawdi
+
+# `openclaw --version` identifies this published package as official source
+# commit 0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c. npm omits gitHead, so the
+# registry integrity and the CLI's own commit identity are both verified.
+ARG OPENCLAW_VERSION=2026.7.1-2
+ARG OPENCLAW_COMMIT=0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c
+ARG OPENCLAW_INTEGRITY=sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==
+RUN npm pack "openclaw@${OPENCLAW_VERSION}" --pack-destination /tmp --silent >/dev/null \
+	&& OPENCLAW_TARBALL="/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
+		OPENCLAW_EXPECTED_INTEGRITY="${OPENCLAW_INTEGRITY}" \
+		node --input-type=module --eval \
+			'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; const actual = `sha512-${createHash("sha512").update(readFileSync(process.env.OPENCLAW_TARBALL)).digest("base64")}`; if (actual !== process.env.OPENCLAW_EXPECTED_INTEGRITY) { throw new Error(`OpenClaw package integrity mismatch: ${actual}`); }' \
+	&& runuser -u clawdi -- env HOME=/home/clawdi npm install --global \
+		--prefix /home/clawdi/.openclaw \
+		"/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
+		--ignore-scripts --no-audit --no-fund \
+	&& rm "/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
+	&& OPENCLAW_VERSION_OUTPUT="$(runuser -u clawdi -- env HOME=/home/clawdi \
+		/home/clawdi/.openclaw/bin/openclaw --version)" \
+	&& printf '%s\n' "$OPENCLAW_VERSION_OUTPUT" | grep -F "OpenClaw ${OPENCLAW_VERSION}" \
+	&& printf '%s\n' "$OPENCLAW_VERSION_OUTPUT" \
+		| grep -F "$(printf '%s' "$OPENCLAW_COMMIT" | cut -c1-7)"
+
+ENV CLAWDI_TEST_OPENCLAW_VERSION=${OPENCLAW_VERSION} \
+	CLAWDI_TEST_OPENCLAW_COMMIT=${OPENCLAW_COMMIT}
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/scripts/test-runtime-official-installer-systemd.sh
+++ b/scripts/test-runtime-official-installer-systemd.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+fixture="$repo_root/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile"
+image="clawdi-runtime-official-installer-systemd-test:local-$$"
+container="clawdi-runtime-official-installer-systemd-test-$$"
+
+cleanup() {
+	docker rm -f "$container" >/dev/null 2>&1 || true
+	docker image rm "$image" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if [[ ! -d "$repo_root/node_modules" ]]; then
+	echo "node_modules is missing; run bun install --frozen-lockfile first" >&2
+	exit 2
+fi
+
+docker build --quiet --file "$fixture" --tag "$image" "$(dirname -- "$fixture")" >/dev/null
+docker run --detach --privileged \
+	--name "$container" \
+	--tmpfs /run \
+	--tmpfs /run/lock \
+	--tmpfs /tmp:exec \
+	--volume "$repo_root:/repo" \
+	--workdir /repo \
+	"$image" >/dev/null
+
+for _attempt in $(seq 1 100); do
+	if docker exec "$container" systemctl is-system-running >/dev/null 2>&1; then
+		break
+	fi
+	if docker exec "$container" systemctl is-system-running 2>/dev/null | grep -Eq '^(running|degraded)$'; then
+		break
+	fi
+	sleep 0.1
+done
+
+docker exec "$container" loginctl enable-linger clawdi
+docker exec "$container" systemctl start user@10001.service
+for _attempt in $(seq 1 100); do
+	if docker exec "$container" test -S /run/user/10001/bus \
+		&& docker exec "$container" systemctl is-active --quiet user@10001.service; then
+		break
+	fi
+	sleep 0.1
+done
+docker exec "$container" test -S /run/user/10001/bus
+docker exec "$container" systemctl is-active --quiet user@10001.service
+docker exec --env CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD=1 "$container" \
+	bun test --isolate --max-concurrency=1 --timeout 30000 \
+	packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts


### PR DESCRIPTION
## Summary

- capture official runtime service installer results through the existing runtime-user spawn helper
- report exit code, signal/spawn error, and bounded stdout/stderr tails while stripping terminal controls and redacting secrets, credentials, URL parameters, environment assignments, and non-diagnostic JSON fields
- retain the existing fail-closed Apply transaction and exact filesystem/systemd rollback behavior
- add an opt-in real systemd + UID/GID 10001 regression using the immutable official `openclaw@2026.7.1-2` package
- document the upstream contract and prepare `clawdi@0.13.30`

## Diagnosis

Clawdi 0.13.29 invoked the official service installer synchronously, but its catch path surfaced only `Error.message`; Node's captured stdout/stderr never reached runtime diagnostics.

The tested official npm package is `openclaw@2026.7.1-2` with integrity `sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==`. Its npm manifest has no `gitHead`; `openclaw --version` reports `OpenClaw 2026.7.1-2 (0790d9f)`, identifying official source commit [`0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).

At that commit:

- gateway config, service inspection, token resolution, and plan construction precede install: [`install.ts` L141-L298](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/install.ts#L141-L298)
- `--json` failures go through the JSON writer and exit 1: [`response.ts` L49-L50](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/response.ts#L49-L50), [`response.ts` L109-L177](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/daemon-cli/response.ts#L109-L177)
- systemd availability and environment/unit writes occur before activation: [`systemd.ts` L831-L950](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/daemon/systemd.ts#L831-L950)
- daemon-reload, enable, and restart are distinct later failure points: [`systemd.ts` L1101-L1147](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/daemon/systemd.ts#L1101-L1147)

Therefore, missing gateway process journal entries do not identify the failing installer stage.

## Test coverage

The unit regression proves exit 41 propagation, stdout/stderr tails, the 4,000-character tail bound, ANSI/control stripping, JSON allowlisting, credential/environment redaction, and rollback without authority commit.

The privileged Docker regression starts PID 1 systemd, an active `user@10001.service`, and the UID/GID 10001 DBus manager. It installs the integrity-pinned official package and invokes the real `openclaw gateway install --force --json` path through Clawdi. A unit-path directory intentionally produces the official pre-activation `EISDIR` failure. The test proves exit 1 and JSON stdout propagation, empty stderr behavior, no authority commit, and exact restoration of prior root-owned unit/config/env bytes, ownership, modes, drop-in/enablement state, workspace, and last-good/managed state. It does not fake a successful install.

## Verification

- `scripts/test-runtime-official-installer-systemd.sh` — 1 pass, 37 assertions
- focused runtime tests — 23 pass, 0 fail
- `bun run --cwd packages/cli test` — 1506 pass, 4 existing gated native skips, 0 fail
- `bun run --cwd packages/cli typecheck`
- focused `bunx biome check`
- `bash -n scripts/test-runtime-official-installer-systemd.sh` and ShellCheck when available
- `bun run --cwd packages/cli check:publish-manifest`
- `bun test --isolate --max-concurrency=1 packages/cli/tests/cli-publish-workflow.test.ts` — 6 pass, 0 fail

## Release impact

The CLI package and lockfile move from 0.13.29 to 0.13.30. If merged, the normal CLI publish workflow should publish that version. This PR does not publish npm or dispatch a release workflow.

## Limitations and rollout

The isolated real-systemd test reproduces a controlled upstream failure, not the unresolved live failure. It did not reveal a safe generic runtime fix beyond diagnostics, so this PR adds no substrate special case, wrapper, fallback, ownership recursion, permission bypass, or compatibility path. Another live canary release is required to reveal the bounded, redacted official error.

No live or production operation was performed. The live substrate gate has not passed. This PR is intentionally unmerged.

Head: `d678bef578cdd4915c6985e2b3a62157c94d169c`.
