### PR TITLE
refactor(backend): extend strict typing boundaries

### DIFF
--- a/backend/app/services/channel_webhooks.py
+++ b/backend/app/services/channel_webhooks.py
@@ -5,14 +5,17 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 from fastapi import HTTPException, status
+from pydantic import TypeAdapter, ValidationError
 
 from app.models.channel import ChannelAccount, ChannelBotAgentLink
 from app.services.metrics import webhook_deliveries
 from app.services.url_security import UnsafeOutboundUrlError, validate_outbound_url
 from app.services.vault_crypto import decrypt_field, encrypt_field
 
+_CONFIG_OBJECT_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
 
-def _optional_str(value: Any) -> str | None:
+
+def _optional_str(value: object) -> str | None:
     if value is None:
         return None
     if isinstance(value, str):
@@ -21,13 +24,21 @@ def _optional_str(value: Any) -> str | None:
     return str(value)
 
 
-def _account_config(account: ChannelAccount) -> dict[str, Any]:
-    return account.config if isinstance(account.config, dict) else {}
+def _config_object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    try:
+        return _CONFIG_OBJECT_ADAPTER.validate_python(value, strict=True)
+    except ValidationError:
+        return {}
 
 
-def bluebubbles_webhook_config(account: ChannelAccount) -> dict[str, Any]:
-    webhook = _account_config(account).get("bluebubbles_webhook")
-    return webhook if isinstance(webhook, dict) else {}
+def _account_config(account: ChannelAccount) -> dict[str, object]:
+    return _config_object(account.config)
+
+
+def bluebubbles_webhook_config(account: ChannelAccount) -> dict[str, object]:
+    return _config_object(_account_config(account).get("bluebubbles_webhook"))
 
 
 def bluebubbles_webhook_password(account: ChannelAccount) -> str | None:
@@ -42,7 +53,7 @@ def bluebubbles_webhook_update(
     url: str,
     events: list[object],
     password: str,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     return {
         "url": url,
         "events": events,
@@ -50,10 +61,9 @@ def bluebubbles_webhook_update(
     }
 
 
-def telegram_link_webhook_config(link: ChannelBotAgentLink) -> dict[str, Any]:
-    config = link.config if isinstance(link.config, dict) else {}
-    webhook = config.get("telegram_webhook")
-    return webhook if isinstance(webhook, dict) else {}
+def telegram_link_webhook_config(link: ChannelBotAgentLink) -> dict[str, object]:
+    config = _config_object(link.config)
+    return _config_object(config.get("telegram_webhook"))
 
 
 def telegram_link_webhook_url(link: ChannelBotAgentLink) -> str | None:

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -50,7 +50,7 @@ _SESSION_RESET_CLOSE_CODES = {4007, 4009}
 
 type GatewayFrame = dict[str, JsonValue]
 
-_GATEWAY_JSON_ADAPTER = TypeAdapter(JsonValue)
+_GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 
 class _GatewayConnection(Protocol):
@@ -228,8 +228,7 @@ class DiscordGatewayWorker:
         try:
             token = decrypt_provider_token(account)
         except HTTPException as exc:
-            detail = exc.detail if isinstance(exc.detail, str) else "provider token unavailable"
-            raise RuntimeError(detail) from exc
+            raise RuntimeError(_provider_token_error_detail(exc.detail)) from exc
 
         can_resume = state.can_resume()
         gateway_url = state.resume_gateway_url
@@ -591,6 +590,10 @@ def discord_gateway_enabled(account: ChannelAccount) -> bool:
 def parse_gateway_frame(raw_frame: str | bytes) -> GatewayFrame | None:
     payload = _GATEWAY_JSON_ADAPTER.validate_json(raw_frame)
     return payload if isinstance(payload, dict) else None
+
+
+def _provider_token_error_detail(detail: object) -> str:
+    return detail if isinstance(detail, str) else "provider token unavailable"
 
 
 def _update_gateway_session_state(state: _GatewayState, frame: GatewayFrame) -> None:

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,6 +35,7 @@ from app.services.audit import record_control_plane_audit
 
 _CURSOR_PREFIX = "clawdi-ro-v1"
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
+_CURSOR_CLAIMS_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
 
 
 @dataclass
@@ -140,9 +142,7 @@ def decode_runtime_observation_cursor(value: str) -> DecodedRuntimeObservationCu
             protected[12:],
             _CURSOR_PREFIX.encode("ascii"),
         )
-        claims = json.loads(claims_raw)
-        if not isinstance(claims, dict):
-            raise ValueError("cursor claims are invalid")
+        claims = _CURSOR_CLAIMS_ADAPTER.validate_json(claims_raw)
         stream_position = claims["streamPosition"]
         if (
             isinstance(stream_position, bool)
@@ -154,15 +154,19 @@ def decode_runtime_observation_cursor(value: str) -> DecodedRuntimeObservationCu
         consumer_id = claims["consumerId"]
         if not isinstance(consumer_id, str) or not consumer_id:
             raise ValueError("cursor consumer is invalid")
+        environment_id = claims["environmentId"]
+        cursor_epoch = claims["cursorEpoch"]
+        if not isinstance(environment_id, str) or not isinstance(cursor_epoch, str):
+            raise ValueError("cursor identity is invalid")
         return DecodedRuntimeObservationCursor(
-            environment_id=uuid.UUID(claims["environmentId"]),
+            environment_id=uuid.UUID(environment_id),
             consumer_id=consumer_id,
-            cursor_epoch=uuid.UUID(claims["cursorEpoch"]),
+            cursor_epoch=uuid.UUID(cursor_epoch),
             stream_position=stream_position,
         )
     except RuntimeObservationProtocolError:
         raise
-    except (InvalidTag, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+    except (InvalidTag, KeyError, TypeError, ValueError, ValidationError) as exc:
         raise RuntimeObservationProtocolError(
             410,
             "observation_cursor_expired",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -107,9 +107,13 @@ strict = [
     "app/routes/sharing.py",
     "app/routes/sync.py",
     "app/services/agent_bindings.py",
+    "app/services/channel_webhooks.py",
+    "app/services/discord_gateway_worker.py",
     "app/services/embedding.py",
     "app/services/imessage_routing.py",
     "app/services/memory_extraction.py",
+    "app/services/private_ip.py",
+    "app/services/runtime_observation.py",
     "app/services/tar_utils.py",
 ]
 

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -59,9 +59,13 @@ EXPECTED_CONFIG = {
         "app/routes/sharing.py",
         "app/routes/sync.py",
         "app/services/agent_bindings.py",
+        "app/services/channel_webhooks.py",
+        "app/services/discord_gateway_worker.py",
         "app/services/embedding.py",
         "app/services/imessage_routing.py",
         "app/services/memory_extraction.py",
+        "app/services/private_ip.py",
+        "app/services/runtime_observation.py",
         "app/services/tar_utils.py",
     ],
 }


### PR DESCRIPTION
## Summary

- promote channel webhook, Discord Gateway, private-IP, and runtime observation services to the exact BasedPyright strict inventory
- replace unknown JSON boundaries with typed Pydantic adapters and explicit runtime claim narrowing
- preserve existing runtime behavior without ignores, casts, suppressions, or new Any annotations

## Verification

- `uv run python scripts/type_governance.py strict` (15 files, zero diagnostics)
- `uv run python scripts/type_governance.py owned` (32 files, zero diagnostics)
- `uv run ruff check .`
- `uv run ruff format --check .`
- focused isolated Docker backend tests: 72 passed
- full isolated Docker backend suite: 1953 passed, 6 skipped

No production, tenant, provider, or deployment operations were performed. This PR is intentionally left unmerged for review.