### PR TITLE
fix(telegram): fence live pairing lifecycle delivery

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -77,12 +77,12 @@ from app.services.channels import (
     discord_message_id_from_payload,
     discord_pair_command_from_payload,
     discord_pairing_command_admission,
-    discord_pairing_command_event_was_handled,
     discord_pairing_reply_for_command,
     discord_text_from_payload,
     discord_user_display_name_from_payload,
     get_active_channel_account,
     get_channel_agent_reference,
+    pairing_command_event_was_handled,
     record_discord_interaction_references,
     record_discord_outbound_message,
     record_inactive_bot_agent_link_event,
@@ -1032,7 +1032,7 @@ async def discord_webhook(
     command = discord_pair_command_from_payload(payload)
     channel_id, guild_id = discord_channel_scope_from_payload(payload)
     provider_event_id = discord_message_id_from_payload(payload)
-    if await discord_pairing_command_event_was_handled(
+    if await pairing_command_event_was_handled(
         db,
         account=account,
         external_chat_id=external_chat_id,

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -98,6 +98,7 @@ from app.services.channels import (
     channel_webhook_url,
     configure_discord_application,
     configure_telegram_provider_webhook,
+    consume_pending_inbound_messages_for_bindings,
     create_pair_code,
     decrypt_agent_link_token,
     discord_bot_install_url,
@@ -1236,6 +1237,7 @@ async def delete_channel_binding(
         )
 
     binding.status = BINDING_STATUS_ARCHIVED
+    await consume_pending_inbound_messages_for_bindings(db, bindings=[binding])
     record_control_plane_audit(
         db,
         actor_type="user",

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -126,6 +126,7 @@ from app.services.channels import (
     lock_channel_binding_identity,
     mark_discord_reserved_commands_current,
     normalize_telegram_bot_username,
+    pending_channel_inbox_count,
     rearm_discord_command_reconciliation,
     rotate_bot_agent_link_token,
     store_channel_secrets,
@@ -1714,18 +1715,11 @@ async def _count_pending_inbox(
     account: ChannelAccount,
     user_id: UUID,
 ) -> int:
-    result = await db.execute(
-        select(func.count())
-        .select_from(ChannelMessage)
-        .where(
-            ChannelMessage.account_id == account.id,
-            ChannelMessage.user_id == user_id,
-            ChannelMessage.direction == "inbound",
-            ChannelMessage.binding_id.is_not(None),
-            ChannelMessage.delivered_at.is_(None),
-        )
+    return await pending_channel_inbox_count(
+        db,
+        account=account,
+        user_id=user_id,
     )
-    return int(result.scalar_one())
 
 
 async def _count_deliveries(

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -759,6 +759,7 @@ async def telegram_webhook(
         text=text,
         payload=payload,
         suppress_duplicate_event=True,
+        require_active_authority=not binding_result.command_handled,
     )
     if not messages:
         existing = await find_existing_inbound_provider_event(

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -974,31 +974,31 @@ async def _deliver_telegram_agent_webhook_for_binding(
     ).one_or_none()
     if authority is None:
         return False
-    binding, account, link = authority
+    current_binding, current_account, current_link = authority
     if (
-        binding.status != BINDING_STATUS_ACTIVE
-        or account.status != CHANNEL_STATUS_ACTIVE
-        or account.archived_at is not None
+        current_binding.status != BINDING_STATUS_ACTIVE
+        or current_account.status != CHANNEL_STATUS_ACTIVE
+        or current_account.archived_at is not None
     ):
         return False
-    if link is None or link.status != BOT_AGENT_LINK_STATUS_ACTIVE or link.archived_at is not None:
+    if current_link.status != BOT_AGENT_LINK_STATUS_ACTIVE or current_link.archived_at is not None:
         await record_inactive_bot_agent_link_event(
             db,
-            account=account,
-            binding=binding,
-            link=link,
+            account=current_account,
+            binding=current_binding,
+            link=current_link,
         )
         return False
     if not await bot_agent_link_has_strict_v2_authority(
         db,
-        link=link,
+        link=current_link,
     ) or not await bot_agent_link_has_provider_cardinality_capability(
         db,
-        account=account,
-        link=link,
+        account=current_account,
+        link=current_link,
     ):
         return False
-    return await _deliver_telegram_agent_webhook(account, link, payload)
+    return await _deliver_telegram_agent_webhook(current_account, current_link, payload)
 
 
 async def _validate_telegram_webhook_url(account: Any, url: str) -> JSONResponse | None:

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -110,8 +110,8 @@ router = APIRouter(prefix="/channels/telegram", tags=["channels"])
 log = logging.getLogger(__name__)
 
 TELEGRAM_UNPAIRED_TUTORIAL = (
-    "This chat isn't paired yet. In Clawdi, open your agent, choose Pair Telegram, "
-    "then use the generated link or send /clawdi_pair <code> here."
+    "This chat isn't paired yet. In Clawdi, open your agent's Telegram channel, "
+    "choose Pair, then use the link or send /clawdi_pair <code> here."
 )
 TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN = timedelta(minutes=10)
 _TELEGRAM_UNPAIRED_TUTORIAL_KIND = "telegram_unpaired_tutorial"

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import unquote_plus
 from uuid import UUID
@@ -32,9 +32,12 @@ from app.models.channel import (
     BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_STATUS_ACTIVE,
+    MESSAGE_DIRECTION_OUTBOUND,
     ChannelAccount,
     ChannelBinding,
     ChannelBotAgentLink,
+    ChannelMessage,
 )
 from app.routes.channel_routers.shared import (
     _allowed_updates,
@@ -56,6 +59,9 @@ from app.services.channels import (
     TELEGRAM_REF_FILE_PATH,
     TELEGRAM_REF_MESSAGE_ID,
     ChannelAgentContext,
+    ChannelPairCommand,
+    InboundBindingResult,
+    binding_is_controlled_by_actor,
     bot_agent_link_has_provider_cardinality_capability,
     bot_agent_link_has_strict_v2_authority,
     channel_agent_reference_exists,
@@ -67,6 +73,7 @@ from app.services.channels import (
     find_existing_inbound_provider_event,
     get_active_channel_account,
     lock_channel_binding_identity,
+    pairing_command_event_was_handled,
     parse_pair_command,
     pending_channel_inbox_count,
     record_channel_agent_reference,
@@ -76,6 +83,7 @@ from app.services.channels import (
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
     send_pairing_command_reply,
+    send_telegram_message,
     telegram_chat_from_update,
     telegram_direct_messages_topic_id_from_update,
     telegram_event_id_from_update,
@@ -100,6 +108,13 @@ from app.services.url_security import UnsafeOutboundUrlError, validate_channel_h
 
 router = APIRouter(prefix="/channels/telegram", tags=["channels"])
 log = logging.getLogger(__name__)
+
+TELEGRAM_UNPAIRED_TUTORIAL = (
+    "This chat isn't paired yet. In Clawdi, open your agent, choose Pair Telegram, "
+    "then use the generated link or send /clawdi_pair <code> here."
+)
+TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN = timedelta(minutes=10)
+_TELEGRAM_UNPAIRED_TUTORIAL_KIND = "telegram_unpaired_tutorial"
 
 
 # Keep this list explicit. Telegram ignores parameters it doesn't use, so the
@@ -685,6 +700,26 @@ async def telegram_webhook(
     command = parse_pair_command(text)
     provider_event_id = telegram_event_id_from_update(payload)
     provider_event_scope = telegram_event_scope_from_update(payload)
+    external_user_id = telegram_external_user_id_from_update(payload)
+    if await pairing_command_event_was_handled(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        provider_event_id=provider_event_id,
+        provider_event_scope=provider_event_scope,
+        command=command,
+    ):
+        existing = await find_existing_inbound_provider_event(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            provider_event_id=provider_event_id,
+            provider_event_scope=provider_event_scope,
+        )
+        return TelegramWebhookResponse(
+            ok=True,
+            binding_id=existing.binding_id if existing is not None else None,
+        )
     previous_link_id: UUID | None = None
     if command is not None and command.kind in {"pair", "unpair"}:
         previous_binding = (
@@ -703,37 +738,16 @@ async def telegram_webhook(
         ).scalar_one_or_none()
         if previous_binding is not None:
             previous_link_id = previous_binding.bot_agent_link_id
-    if command is not None:
-        existing = await find_existing_inbound_provider_event(
-            db,
-            account=account,
-            external_chat_id=external_chat_id,
-            provider_event_id=provider_event_id,
-            provider_event_scope=provider_event_scope,
-        )
-        if existing is not None:
-            return TelegramWebhookResponse(ok=True, binding_id=existing.binding_id)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
         external_chat_id=external_chat_id,
         external_chat_type=external_chat_type,
         external_chat_name=external_chat_name,
-        external_user_id=telegram_external_user_id_from_update(payload),
+        external_user_id=external_user_id,
         text=text,
         command=command,
     )
-    if command is not None:
-        existing = await find_existing_inbound_provider_event(
-            db,
-            account=account,
-            external_chat_id=external_chat_id,
-            provider_event_id=provider_event_id,
-            provider_event_scope=provider_event_scope,
-        )
-        if existing is not None:
-            return TelegramWebhookResponse(ok=True, binding_id=existing.binding_id)
-
     messages = await record_inbound_messages_for_bindings(
         db,
         account=account,
@@ -777,6 +791,17 @@ async def telegram_webhook(
         command=command,
         binding_result=binding_result,
     )
+    if reply is None:
+        reply = await _send_telegram_unpaired_tutorial(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            external_chat_type=external_chat_type,
+            external_user_id=external_user_id,
+            payload=payload,
+            command=command,
+            binding_result=binding_result,
+        )
     if reply is not None:
         await db.commit()
     if binding_result.paired or binding_result.unpaired:
@@ -809,6 +834,105 @@ async def telegram_webhook(
     )
 
 
+async def _send_telegram_unpaired_tutorial(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    external_chat_id: str,
+    external_chat_type: str | None,
+    external_user_id: str | None,
+    payload: dict[str, Any],
+    command: ChannelPairCommand | None,
+    binding_result: InboundBindingResult,
+) -> ChannelMessage | None:
+    message = payload.get("message")
+    if (
+        not isinstance(message, dict)
+        or command is not None
+        or binding_result.binding is not None
+        or binding_result.bindings
+    ):
+        return None
+    sender = message.get("from")
+    if isinstance(sender, dict) and sender.get("is_bot") is True:
+        return None
+
+    direct_messages_topic_id = telegram_direct_messages_topic_id_from_update(payload)
+    if external_chat_type == "private":
+        cooldown_scope = f"private:{external_chat_id}"
+    elif external_chat_type == "direct_messages" and direct_messages_topic_id is not None:
+        cooldown_scope = f"direct_messages:{external_chat_id}:{direct_messages_topic_id}"
+    else:
+        return None
+
+    marker = {
+        "kind": _TELEGRAM_UNPAIRED_TUTORIAL_KIND,
+        "scope": cooldown_scope,
+    }
+    try:
+        async with db.begin_nested():
+            await lock_channel_binding_identity(
+                db,
+                account_id=account.id,
+                external_chat_id=external_chat_id,
+            )
+            active_binding = await find_binding(
+                db,
+                account=account,
+                external_chat_id=external_chat_id,
+            )
+            if active_binding is not None and (
+                external_chat_type != "direct_messages"
+                or binding_is_controlled_by_actor(
+                    active_binding,
+                    external_user_id=external_user_id,
+                )
+            ):
+                return None
+            recent_tutorial = await db.scalar(
+                select(ChannelMessage.id)
+                .where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                    ChannelMessage.external_chat_id == external_chat_id,
+                    ChannelMessage.created_at
+                    >= datetime.now(UTC) - TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN,
+                    ChannelMessage.payload.contains({"clawdi_system": marker}),
+                )
+                .limit(1)
+            )
+            if recent_tutorial is not None:
+                return None
+            tutorial = await send_telegram_message(
+                db,
+                account=account,
+                external_chat_id=external_chat_id,
+                text=TELEGRAM_UNPAIRED_TUTORIAL,
+                bind_to_existing=False,
+                message_thread_id=telegram_message_thread_id_from_update(payload),
+                direct_messages_topic_id=direct_messages_topic_id,
+            )
+            tutorial_payload = dict(tutorial.payload) if isinstance(tutorial.payload, dict) else {}
+            tutorial_payload["clawdi_system"] = marker
+            tutorial.payload = tutorial_payload
+            await db.flush()
+            return tutorial
+    except HTTPException as exc:
+        log.warning(
+            "telegram_unpaired_tutorial_failed account_id=%s chat_id=%s status=%s",
+            account.id,
+            external_chat_id,
+            exc.status_code,
+        )
+    except Exception:
+        log.exception(
+            "telegram_unpaired_tutorial_failed account_id=%s chat_id=%s",
+            account.id,
+            external_chat_id,
+        )
+    return None
+
+
 def _telegram_error_response(description: str, error_code: int) -> JSONResponse:
     return JSONResponse(
         status_code=error_code,
@@ -819,13 +943,44 @@ def _telegram_error_response(description: str, error_code: int) -> JSONResponse:
 async def _deliver_telegram_agent_webhook_for_binding(
     db: AsyncSession,
     *,
-    account: Any,
+    account: ChannelAccount,
     binding: ChannelBinding | None,
     payload: dict[str, Any],
 ) -> bool:
     if binding is None or binding.bot_agent_link_id is None:
         return False
-    link = await db.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    authority = (
+        await db.execute(
+            select(ChannelBinding, ChannelAccount, ChannelBotAgentLink)
+            .join(
+                ChannelAccount,
+                ChannelAccount.id == ChannelBinding.account_id,
+            )
+            .join(
+                ChannelBotAgentLink,
+                ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
+            )
+            .where(
+                ChannelBinding.id == binding.id,
+                ChannelBinding.account_id == account.id,
+                ChannelBotAgentLink.account_id == account.id,
+            )
+            .execution_options(populate_existing=True)
+            # The binding row is the data-plane fence. Account and Link
+            # retirement archive this row in the same transaction, while
+            # locking either parent here would invert the retirement order.
+            .with_for_update(of=ChannelBinding)
+        )
+    ).one_or_none()
+    if authority is None:
+        return False
+    binding, account, link = authority
+    if (
+        binding.status != BINDING_STATUS_ACTIVE
+        or account.status != CHANNEL_STATUS_ACTIVE
+        or account.archived_at is not None
+    ):
+        return False
     if link is None or link.status != BOT_AGENT_LINK_STATUS_ACTIVE or link.archived_at is not None:
         await record_inactive_bot_agent_link_event(
             db,

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -11,10 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
-    MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
     ChannelDebugEvent,
-    ChannelMessage,
 )
 
 DEFAULT_DEBUG_EVENT_LIMIT = 100
@@ -169,15 +167,10 @@ def _debug_event_response(event: ChannelDebugEvent | None) -> dict[str, Any] | N
 
 
 async def _pending_inbox_count(db: AsyncSession, *, account: ChannelAccount) -> int:
-    result = await db.execute(
-        select(ChannelMessage.id).where(
-            ChannelMessage.account_id == account.id,
-            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-            ChannelMessage.binding_id.is_not(None),
-            ChannelMessage.delivered_at.is_(None),
-        )
-    )
-    return len(result.scalars().all())
+    # Local import avoids the channels -> debug-events module cycle.
+    from app.services.channels import pending_channel_inbox_count
+
+    return await pending_channel_inbox_count(db, account=account)
 
 
 async def _last_event(

--- a/backend/app/services/channel_webhook_delivery_worker.py
+++ b/backend/app/services/channel_webhook_delivery_worker.py
@@ -10,11 +10,13 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
+    BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_STATUS_ACTIVE,
     MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
+    ChannelBinding,
     ChannelBotAgentLink,
     ChannelMessage,
 )
@@ -90,7 +92,14 @@ class ChannelWebhookDeliveryWorker:
     ) -> tuple[ChannelMessage, ChannelAccount, ChannelBotAgentLink] | None:
         result = await db.execute(
             select(ChannelMessage, ChannelAccount, ChannelBotAgentLink)
-            .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+            .join(
+                ChannelBinding,
+                ChannelBinding.id == ChannelMessage.binding_id,
+            )
+            .join(
+                ChannelAccount,
+                ChannelAccount.id == ChannelMessage.account_id,
+            )
             .join(
                 ChannelBotAgentLink,
                 ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
@@ -99,6 +108,9 @@ class ChannelWebhookDeliveryWorker:
                 ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
                 ChannelMessage.binding_id.is_not(None),
                 ChannelMessage.delivered_at.is_(None),
+                ChannelBinding.account_id == ChannelMessage.account_id,
+                ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
                 ChannelAccount.provider == CHANNEL_PROVIDER_TELEGRAM,
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
@@ -120,7 +132,10 @@ class ChannelWebhookDeliveryWorker:
             )
             .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
             .limit(1)
-            .with_for_update(skip_locked=True)
+            .with_for_update(
+                skip_locked=True,
+                of=ChannelBinding,
+            )
         )
         row = result.first()
         if row is None:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1077,8 +1077,10 @@ async def archive_bot_agent_link(
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
         )
     )
-    for binding in bindings_result.scalars().all():
+    archived_bindings = list(bindings_result.scalars().all())
+    for binding in archived_bindings:
         binding.status = BINDING_STATUS_ARCHIVED
+    await consume_pending_inbound_messages_for_bindings(db, bindings=archived_bindings)
 
     pair_codes_result = await db.execute(
         select(ChannelPairCode).where(
@@ -1235,8 +1237,10 @@ async def archive_channel_account(db: AsyncSession, *, account: ChannelAccount) 
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
         )
     )
-    for binding in bindings_result.scalars().all():
+    archived_bindings = list(bindings_result.scalars().all())
+    for binding in archived_bindings:
         binding.status = BINDING_STATUS_ARCHIVED
+    await consume_pending_inbound_messages_for_bindings(db, bindings=archived_bindings)
 
     pair_codes_result = await db.execute(
         select(ChannelPairCode).where(
@@ -1797,6 +1801,10 @@ async def resolve_inbound_binding(
             )
         for active_binding in authorized_bindings:
             active_binding.status = BINDING_STATUS_ARCHIVED
+        await consume_pending_inbound_messages_for_bindings(
+            db,
+            bindings=authorized_bindings,
+        )
         return InboundBindingResult(
             binding=binding,
             bindings=tuple(authorized_bindings),
@@ -2274,6 +2282,11 @@ def telegram_message_thread_id_from_update(payload: dict[str, Any]) -> int | Non
     if chat_type == "private":
         return message_thread_id
     if chat_type in {"group", "supergroup"} and chat.get("is_forum") is True:
+        # Telegram's General forum topic uses thread id 1, but normal sends to
+        # that topic omit message_thread_id. Preserve the original update for
+        # runtimes; this helper only selects the target for core replies.
+        if message_thread_id == 1:
+            return None
         return message_thread_id
     return None
 
@@ -2544,15 +2557,16 @@ async def find_existing_inbound_provider_event(
     return result.scalar_one_or_none()
 
 
-async def discord_pairing_command_event_was_handled(
+async def pairing_command_event_was_handled(
     db: AsyncSession,
     *,
     account: ChannelAccount,
     external_chat_id: str,
     provider_event_id: str | None,
+    provider_event_scope: str = PROVIDER_EVENT_SCOPE_CHAT,
     command: ChannelPairCommand | None,
 ) -> bool:
-    """Serialize pairing mutations and reject a previously handled Discord event."""
+    """Serialize pairing mutations and reject a previously handled provider event."""
     if provider_event_id is None or command is None or command.kind not in {"pair", "unpair"}:
         return False
     # The same transaction-level scope lock is acquired again by
@@ -2569,8 +2583,35 @@ async def discord_pairing_command_event_was_handled(
         account=account,
         external_chat_id=external_chat_id,
         provider_event_id=provider_event_id,
+        provider_event_scope=provider_event_scope,
     )
     return existing is not None
+
+
+async def consume_pending_inbound_messages_for_bindings(
+    db: AsyncSession,
+    *,
+    bindings: list[ChannelBinding],
+) -> int:
+    """Revoke queued adapter delivery when binding authority is archived."""
+    binding_ids = {binding.id for binding in bindings}
+    if not binding_ids:
+        return 0
+    result = await db.execute(
+        select(ChannelMessage)
+        .where(
+            ChannelMessage.binding_id.in_(binding_ids),
+            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+            ChannelMessage.delivered_at.is_(None),
+        )
+        .with_for_update()
+    )
+    messages = list(result.scalars().all())
+    delivered_at = datetime.now(UTC)
+    for message in messages:
+        message.delivered_at = delivered_at
+    await db.flush()
+    return len(messages)
 
 
 async def record_inbound_messages_for_bindings(
@@ -3042,9 +3083,36 @@ async def dequeue_telegram_updates(
         filters.append(ChannelMessage.bot_agent_link_id == bot_agent_link_id)
     result = await db.execute(
         select(ChannelMessage)
+        .join(
+            ChannelBinding,
+            and_(
+                ChannelBinding.id == ChannelMessage.binding_id,
+                ChannelBinding.account_id == ChannelMessage.account_id,
+                ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+            ),
+        )
+        .join(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
+                ChannelBotAgentLink.account_id == ChannelMessage.account_id,
+            ),
+        )
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
         .where(*filters)
+        .where(
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+        )
         .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
         .limit(max(limit * 4, limit))
+        .with_for_update(
+            read=True,
+            of=ChannelBinding,
+        )
     )
     updates: list[dict[str, Any]] = []
     now = datetime.now(UTC)
@@ -3255,7 +3323,33 @@ async def pending_channel_inbox_count(
     ]
     if bot_agent_link_id is not None:
         filters.append(ChannelMessage.bot_agent_link_id == bot_agent_link_id)
-    result = await db.execute(select(ChannelMessage.id).where(*filters))
+    result = await db.execute(
+        select(ChannelMessage.id)
+        .join(
+            ChannelBinding,
+            and_(
+                ChannelBinding.id == ChannelMessage.binding_id,
+                ChannelBinding.account_id == ChannelMessage.account_id,
+                ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+            ),
+        )
+        .join(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
+                ChannelBotAgentLink.account_id == ChannelMessage.account_id,
+            ),
+        )
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+        .where(*filters)
+        .where(
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+        )
+    )
     return len(result.scalars().all())
 
 
@@ -5041,7 +5135,7 @@ async def record_discord_dispatch(
         return False
     command = discord_pair_command_from_payload(frame)
     provider_event_id = discord_message_id_from_payload(frame)
-    if await discord_pairing_command_event_was_handled(
+    if await pairing_command_event_was_handled(
         db,
         account=account,
         external_chat_id=external_chat_id,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -2701,7 +2701,6 @@ async def _lock_active_inbound_bindings(
             and_(
                 ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
                 ChannelBotAgentLink.account_id == ChannelBinding.account_id,
-                ChannelBotAgentLink.user_id == ChannelBinding.user_id,
             ),
         )
         .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
@@ -3160,6 +3159,7 @@ async def dequeue_telegram_updates(
                 ChannelBinding.id == ChannelMessage.binding_id,
                 ChannelBinding.account_id == ChannelMessage.account_id,
                 ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                ChannelBinding.user_id == ChannelMessage.user_id,
             ),
         )
         .join(
@@ -3405,6 +3405,7 @@ async def pending_channel_inbox_count(
                 ChannelBinding.id == ChannelMessage.binding_id,
                 ChannelBinding.account_id == ChannelMessage.account_id,
                 ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                ChannelBinding.user_id == ChannelMessage.user_id,
             ),
         )
         .join(

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -2626,6 +2626,7 @@ async def record_inbound_messages_for_bindings(
     provider_event_id: str | None = None,
     provider_event_scope: str = PROVIDER_EVENT_SCOPE_CHAT,
     suppress_duplicate_event: bool = False,
+    require_active_authority: bool = False,
 ) -> list[tuple[ChannelMessage, ChannelBinding | None]]:
     target_bindings: tuple[ChannelBinding | None, ...]
     if binding_result.bindings:
@@ -2634,6 +2635,28 @@ async def record_inbound_messages_for_bindings(
         target_bindings = (binding_result.binding,)
     else:
         target_bindings = (None,)
+
+    if require_active_authority:
+        bound_targets = tuple(binding for binding in target_bindings if binding is not None)
+        if bound_targets:
+            active_bindings = await _lock_active_inbound_bindings(
+                db,
+                account=account,
+                bindings=bound_targets,
+            )
+            # Preserve the provider event as unbound idempotency evidence when
+            # authority retired after resolution. Never leave late pending work
+            # attached to an archived Binding.
+            if active_bindings is None:
+                for binding in bound_targets:
+                    await record_inactive_bot_agent_link_event(
+                        db,
+                        account=account,
+                        binding=binding,
+                    )
+                target_bindings = (None,)
+            else:
+                target_bindings = active_bindings
 
     messages: list[tuple[ChannelMessage, ChannelBinding | None]] = []
     for binding in target_bindings:
@@ -2654,6 +2677,54 @@ async def record_inbound_messages_for_bindings(
     if binding_result.command_handled:
         _mark_inbound_messages_delivered(messages)
     return messages
+
+
+async def _lock_active_inbound_bindings(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bindings: tuple[ChannelBinding, ...],
+) -> tuple[ChannelBinding, ...] | None:
+    expected = {binding.id: (binding.bot_agent_link_id, binding.user_id) for binding in bindings}
+    authority_filters = [
+        and_(
+            ChannelBinding.id == binding_id,
+            ChannelBinding.bot_agent_link_id == bot_agent_link_id,
+            ChannelBinding.user_id == user_id,
+        )
+        for binding_id, (bot_agent_link_id, user_id) in expected.items()
+    ]
+    result = await db.execute(
+        select(ChannelBinding)
+        .join(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
+                ChannelBotAgentLink.account_id == ChannelBinding.account_id,
+                ChannelBotAgentLink.user_id == ChannelBinding.user_id,
+            ),
+        )
+        .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+        .where(
+            or_(*authority_filters),
+            ChannelBinding.account_id == account.id,
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+        )
+        .order_by(ChannelBinding.id)
+        .execution_options(populate_existing=True)
+        # Account and Link retirement archive their Bindings in the same
+        # transaction. A shared Binding lease therefore linearizes every
+        # authority retirement without inverting the parent lock order.
+        .with_for_update(read=True, of=ChannelBinding)
+    )
+    active_bindings = tuple(result.scalars().all())
+    if len(active_bindings) != len(expected):
+        return None
+    return active_bindings
 
 
 async def record_inactive_bot_agent_link_event(
@@ -3314,6 +3385,7 @@ async def pending_channel_inbox_count(
     *,
     account: ChannelAccount,
     bot_agent_link_id: UUID | None = None,
+    user_id: UUID | None = None,
 ) -> int:
     filters = [
         ChannelMessage.account_id == account.id,
@@ -3323,6 +3395,8 @@ async def pending_channel_inbox_count(
     ]
     if bot_agent_link_id is not None:
         filters.append(ChannelMessage.bot_agent_link_id == bot_agent_link_id)
+    if user_id is not None:
+        filters.append(ChannelMessage.user_id == user_id)
     result = await db.execute(
         select(ChannelMessage.id)
         .join(

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
+    BINDING_STATUS_ARCHIVED,
     MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
     ChannelBinding,
@@ -111,20 +112,42 @@ async def test_channel_debug_health_reports_pending_inbox_and_last_error(
         external_chat_type="guild_text",
         external_chat_name="debug",
     )
-    db_session.add(binding)
+    historical_binding = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        user_id=seed_user.id,
+        external_chat_id="discord-channel-debug-historical",
+        external_chat_type="guild_text",
+        external_chat_name="debug historical",
+        status=BINDING_STATUS_ARCHIVED,
+    )
+    db_session.add_all([binding, historical_binding])
     await db_session.flush()
-    db_session.add(
-        ChannelMessage(
-            account_id=account.id,
-            bot_agent_link_id=UUID(created["agent_link_id"]),
-            binding_id=binding.id,
-            user_id=seed_user.id,
-            direction=MESSAGE_DIRECTION_INBOUND,
-            external_chat_id=binding.external_chat_id,
-            provider_message_id="debug-message-1",
-            text="debug payload",
-            payload={"t": "MESSAGE_CREATE"},
-        )
+    db_session.add_all(
+        [
+            ChannelMessage(
+                account_id=account.id,
+                bot_agent_link_id=UUID(created["agent_link_id"]),
+                binding_id=binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=binding.external_chat_id,
+                provider_message_id="debug-message-1",
+                text="debug payload",
+                payload={"t": "MESSAGE_CREATE"},
+            ),
+            ChannelMessage(
+                account_id=account.id,
+                bot_agent_link_id=UUID(created["agent_link_id"]),
+                binding_id=historical_binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=historical_binding.external_chat_id,
+                provider_message_id="debug-message-historical",
+                text="must not affect debug health",
+                payload={"t": "MESSAGE_CREATE"},
+            ),
+        ]
     )
     await record_channel_debug_event(
         db_session,

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -62,6 +62,7 @@ from app.routes import admin as admin_router
 from app.routes.channel_routers import discord as discord_router
 from app.routes.channel_routers import public as public_router
 from app.routes.channel_routers import shared as shared_router
+from app.routes.channel_routers import telegram as telegram_router
 from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
     _discord_bound_guild_channels,
@@ -7818,6 +7819,93 @@ async def test_telegram_webhook_worker_retries_failed_agent_delivery(
 
 
 @pytest.mark.asyncio
+async def test_telegram_webhook_worker_does_not_retry_after_unpair(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_sequenced_provider_client([503])
+    monkeypatch.setattr(
+        "app.services.channel_webhooks.httpx.AsyncClient",
+        _SequencedProviderClient,
+    )
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-agent-webhook-unpair-revokes-retry",
+        provider_token=None,
+    )
+    assert (
+        await client.post(
+            _telegram_bot_path(created, "setWebhook"),
+            headers=_telegram_agent_headers(created),
+            json={"url": "https://agent.example/agent-hook"},
+        )
+    ).status_code == 200
+    inbound = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 9_021,
+            "message": {
+                "message_id": 9_021,
+                "text": "must not retry after unpair",
+                "chat": {"id": 42, "type": "private"},
+                "from": {"id": 4242, "is_bot": False},
+            },
+        },
+    )
+    message = (
+        await db_session.execute(
+            select(ChannelMessage).where(ChannelMessage.provider_event_id == "update:9021")
+        )
+    ).scalar_one()
+    assert inbound.status_code == 200
+    assert message.delivered_at is None
+    assert len(_SequencedProviderClient.calls) == 1
+
+    unpaired = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 9_022,
+            "message": {
+                "message_id": 9_022,
+                "text": "/clawdi_unpair",
+                "chat": {"id": 42, "type": "private"},
+                "from": {"id": 4242, "is_bot": False},
+            },
+        },
+    )
+    assert unpaired.status_code == 200
+    assert unpaired.json()["unpaired"] is True
+    await db_session.refresh(message)
+    assert message.delivered_at is not None
+
+    # Historical rows can predate revocation consumption. Even if one remains
+    # pending, the worker must treat current binding authority as the fence.
+    message.delivered_at = None
+    await db_session.commit()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    assert await channel_service.pending_channel_inbox_count(db_session, account=account) == 0
+    binding = await db_session.get(ChannelBinding, message.binding_id)
+    assert binding is not None
+    assert (
+        await telegram_router._deliver_telegram_agent_webhook_for_binding(
+            db_session,
+            account=account,
+            binding=binding,
+            payload={"update_id": 9_021},
+        )
+        is False
+    )
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    assert await ChannelWebhookDeliveryWorker(sessionmaker).run_once() is None
+    assert len(_SequencedProviderClient.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_telegram_webhook_worker_skips_non_webhook_queue_head(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -11928,6 +12016,62 @@ async def test_telegram_webhook_pair_code_sends_user_reply(
 
 
 @pytest.mark.asyncio
+async def test_telegram_general_forum_pairing_reply_omits_thread_id(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 109}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-general-forum-pair-reply",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    _clear_fake_provider_calls()
+
+    paired = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 7_601,
+            "message": {
+                "message_id": 7_601,
+                "message_thread_id": 1,
+                "is_topic_message": True,
+                "text": f"/clawdi_pair {pair['code']}",
+                "chat": {
+                    "id": -1007601,
+                    "type": "supergroup",
+                    "is_forum": True,
+                },
+                "from": {"id": 7601, "is_bot": False},
+            },
+        },
+    )
+
+    assert paired.status_code == 200
+    assert paired.json()["paired"] is True
+    pairing_reply = next(
+        call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
+    )
+    assert pairing_reply["json"] == {
+        "chat_id": "-1007601",
+        "text": "Paired! This chat is now connected to your agent.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_telegram_webhook_pair_command_sends_failure_replies(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -12318,6 +12462,11 @@ async def test_telegram_channel_direct_message_pairing_replies_stay_in_originati
         },
         {
             "chat_id": "-100987654326",
+            "direct_messages_topic_id": 9999,
+            "text": telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+        },
+        {
+            "chat_id": "-100987654326",
             "direct_messages_topic_id": 4242,
             "text": "Unpaired. This chat is no longer connected to an agent.",
         },
@@ -12423,6 +12572,361 @@ async def test_telegram_webhook_unpair_redelivery_does_not_duplicate_reply(
     replies = [call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")]
     assert [call["json"]["text"] for call in replies] == [
         "Unpaired. This chat is no longer connected to an agent."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_concurrent_replayed_unpair_cannot_archive_replacement_binding(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 105}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    chat_id = "987654399"
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-concurrent-replayed-unpair",
+        chat_id=chat_id,
+    )
+    replacement_pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    original_unpair = {
+        "update_id": 7_603,
+        "message": {
+            "message_id": 7_603,
+            "text": "/clawdi_unpair",
+            "chat": {"id": int(chat_id), "type": "private"},
+            "from": {"id": 4242, "is_bot": False},
+        },
+    }
+    replacement_pair_update = {
+        "update_id": 7_604,
+        "message": {
+            "message_id": 7_604,
+            "text": f"/clawdi_pair {replacement_pair['code']}",
+            "chat": {"id": int(chat_id), "type": "private"},
+            "from": {"id": 4242, "is_bot": False},
+        },
+    }
+    original_record = telegram_router.record_inbound_messages_for_bindings
+    unpair_before_event_commit = asyncio.Event()
+    release_unpair_commit = asyncio.Event()
+    paused = False
+
+    async def pause_first_unpair_before_event_commit(*args: Any, **kwargs: Any):
+        nonlocal paused
+        binding_result = kwargs["binding_result"]
+        if binding_result.unpaired and not paused:
+            paused = True
+            unpair_before_event_commit.set()
+            await release_unpair_commit.wait()
+        return await original_record(*args, **kwargs)
+
+    monkeypatch.setattr(
+        telegram_router,
+        "record_inbound_messages_for_bindings",
+        pause_first_unpair_before_event_commit,
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    previous_session_override = app.dependency_overrides[get_session]
+
+    async def independent_request_session() -> AsyncIterator[AsyncSession]:
+        async with sessionmaker() as request_db:
+            yield request_db
+
+    await db_session.rollback()
+    app.dependency_overrides[get_session] = independent_request_session
+
+    async def post_update(payload: dict[str, Any]) -> httpx.Response:
+        return await client.post(
+            f"/v1/channels/telegram/{created['id']}/webhook",
+            headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+            json=payload,
+        )
+
+    try:
+        first_unpair_task = asyncio.create_task(post_update(original_unpair))
+        await asyncio.wait_for(unpair_before_event_commit.wait(), timeout=2)
+        replacement_pair_task = asyncio.create_task(post_update(replacement_pair_update))
+        await asyncio.sleep(0.05)
+        replay_task = asyncio.create_task(post_update(original_unpair))
+        await asyncio.sleep(0.05)
+        release_unpair_commit.set()
+        first_unpair, repaired, replay = await asyncio.gather(
+            first_unpair_task,
+            replacement_pair_task,
+            replay_task,
+        )
+    finally:
+        app.dependency_overrides[get_session] = previous_session_override
+
+    assert first_unpair.json()["unpaired"] is True
+    assert repaired.json()["paired"] is True
+    assert replay.json()["unpaired"] is False
+    async with sessionmaker() as verification_db:
+        active_bindings = list(
+            (
+                await verification_db.execute(
+                    select(ChannelBinding).where(
+                        ChannelBinding.account_id == UUID(created["id"]),
+                        ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    )
+                )
+            ).scalars()
+        )
+    assert len(active_bindings) == 1
+    assert active_bindings[0].external_chat_id == chat_id
+    replies = [call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")]
+    assert [call["json"]["text"] for call in replies].count(
+        "Unpaired. This chat is no longer connected to an agent."
+    ) == 1
+
+
+@pytest.mark.asyncio
+async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_non_authoritative(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 106}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-unpaired-private-tutorial",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    _clear_fake_provider_calls()
+    webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+    first_update = {
+        "update_id": 7_610,
+        "message": {
+            "message_id": 7_610,
+            "text": "/start",
+            "chat": {"id": 987654410, "type": "private"},
+            "from": {"id": 987654410, "is_bot": False},
+        },
+    }
+
+    first = await client.post(webhook_url, headers=headers, json=first_update)
+    replay = await client.post(webhook_url, headers=headers, json=first_update)
+    cooled_down = await client.post(
+        webhook_url,
+        headers=headers,
+        json={
+            "update_id": 7_611,
+            "message": {
+                "message_id": 7_611,
+                "text": "hello?",
+                "chat": {"id": 987654410, "type": "private"},
+                "from": {"id": 987654410, "is_bot": False},
+            },
+        },
+    )
+
+    assert first.status_code == 200
+    assert replay.status_code == 200
+    assert cooled_down.status_code == 200
+    tutorial_calls = [
+        call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
+    ]
+    assert [call["json"] for call in tutorial_calls] == [
+        {
+            "chat_id": "987654410",
+            "text": telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+        }
+    ]
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    pair_row = await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    assert pair_row is not None
+    assert pair_row.status == PAIR_CODE_STATUS_PENDING
+    tutorial_message = (
+        await db_session.execute(
+            select(ChannelMessage).where(
+                ChannelMessage.account_id == UUID(created["id"]),
+                ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                ChannelMessage.text == telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+            )
+        )
+    ).scalar_one()
+    tutorial_message.created_at = (
+        datetime.now(UTC)
+        - telegram_router.TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN
+        - timedelta(seconds=1)
+    )
+    await db_session.commit()
+
+    after_cooldown = await client.post(
+        webhook_url,
+        headers=headers,
+        json={
+            "update_id": 7_612,
+            "message": {
+                "message_id": 7_612,
+                "text": "still there?",
+                "chat": {"id": 987654410, "type": "private"},
+                "from": {"id": 987654410, "is_bot": False},
+            },
+        },
+    )
+    assert after_cooldown.status_code == 200
+    assert (
+        len([call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")])
+        == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_unpaired_tutorial_failure_does_not_expose_internal_error(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 110}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-unpaired-tutorial-provider-failure",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FailingProviderClient)
+
+    response = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 7_613,
+            "message": {
+                "message_id": 7_613,
+                "text": "help me pair",
+                "chat": {"id": 987654413, "type": "private"},
+                "from": {"id": 987654413, "is_bot": False},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "paired": False,
+        "unpaired": False,
+        "binding_id": None,
+    }
+    assert len(_FailingProviderClient.calls) == 1
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(
+                ChannelMessage.account_id == UUID(created["id"]),
+                ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+            )
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_unpaired_tutorial_avoids_groups_and_scopes_channel_dm_cooldown(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 107}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-unpaired-tutorial-scopes",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    _clear_fake_provider_calls()
+    webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+
+    for update_id, chat in (
+        (7_620, {"id": -1007620, "type": "group"}),
+        (7_621, {"id": -1007621, "type": "supergroup", "is_forum": True}),
+    ):
+        response = await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "update_id": update_id,
+                "message": {
+                    "message_id": update_id,
+                    "message_thread_id": 77,
+                    "is_topic_message": True,
+                    "text": "ordinary group message",
+                    "chat": chat,
+                    "from": {"id": 77, "is_bot": False},
+                },
+            },
+        )
+        assert response.status_code == 200
+
+    direct_chat = {
+        "id": -1007622,
+        "type": "supergroup",
+        "is_direct_messages": True,
+    }
+    for update_id, topic_id in ((7_622, 81), (7_623, 81), (7_624, 82)):
+        response = await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "update_id": update_id,
+                "message": {
+                    "message_id": update_id,
+                    "direct_messages_topic": {"topic_id": topic_id},
+                    "is_topic_message": True,
+                    "text": "ordinary channel DM",
+                    "chat": direct_chat,
+                    "from": {"id": topic_id, "is_bot": False},
+                },
+            },
+        )
+        assert response.status_code == 200
+
+    tutorial_calls = [
+        call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
+    ]
+    assert [call["json"] for call in tutorial_calls] == [
+        {
+            "chat_id": "-1007622",
+            "direct_messages_topic_id": 81,
+            "text": telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+        },
+        {
+            "chat_id": "-1007622",
+            "direct_messages_topic_id": 82,
+            "text": telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+        },
     ]
 
 
@@ -12642,6 +13146,104 @@ async def test_delete_binding_unpairs_exactly_one_chat_and_cleans_telegram_proje
 
 
 @pytest.mark.asyncio
+async def test_telegram_ui_unpair_revokes_pending_polling_update_across_repair(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 108}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-ui-unpair-revokes-polling",
+        chat_id="441",
+        chat_type="private",
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == account.id,
+                ChannelBinding.external_chat_id == "441",
+            )
+        )
+    ).scalar_one()
+    inbound = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 7_641,
+            "message": {
+                "message_id": 7_641,
+                "text": "queued before unpair",
+                "chat": {"id": 441, "type": "private"},
+                "from": {"id": 4242, "is_bot": False},
+            },
+        },
+    )
+    assert inbound.status_code == 200
+    queued = (
+        await db_session.execute(
+            select(ChannelMessage).where(ChannelMessage.provider_event_id == "update:7641")
+        )
+    ).scalar_one()
+    assert queued.delivered_at is None
+    assert await channel_service.pending_channel_inbox_count(db_session, account=account) == 1
+
+    deleted = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+    assert deleted.status_code == 200
+    assert deleted.json()["unpaired"] is True
+    await db_session.refresh(queued)
+    assert queued.delivered_at is not None
+    assert await channel_service.pending_channel_inbox_count(db_session, account=account) == 0
+
+    replacement_pair = (
+        await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    repaired = await client.post(
+        f"/v1/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 7_642,
+            "message": {
+                "message_id": 7_642,
+                "text": f"/clawdi_pair {replacement_pair['code']}",
+                "chat": {"id": 441, "type": "private"},
+                "from": {"id": 4242, "is_bot": False},
+            },
+        },
+    )
+    assert repaired.status_code == 200
+    assert repaired.json()["paired"] is True
+    active_binding = (
+        await db_session.execute(
+            select(ChannelBinding)
+            .where(
+                ChannelBinding.account_id == account.id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    assert active_binding.id == binding.id
+    updates = await client.post(
+        _telegram_bot_path(created, "getUpdates"),
+        headers=_telegram_agent_headers(created),
+        json={},
+    )
+    assert updates.status_code == 200
+    assert updates.json()["result"] == []
+
+
+@pytest.mark.asyncio
 async def test_delete_binding_keeps_unpair_durable_when_telegram_notification_fails(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -12832,26 +13434,6 @@ async def test_telegram_start_claims_explicit_agent_link_and_redelivery_is_idemp
     }
     webhook_url = f"/v1/channels/telegram/{created['id']}/webhook"
     headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
-    from app.routes.channel_routers import telegram as telegram_router
-
-    original_find = telegram_router.find_existing_inbound_provider_event
-    precheck_count = 0
-    both_prechecks_started = asyncio.Event()
-
-    async def synchronized_find(*args, **kwargs):
-        nonlocal precheck_count
-        precheck_count += 1
-        if precheck_count <= 2:
-            if precheck_count == 2:
-                both_prechecks_started.set()
-            await both_prechecks_started.wait()
-        return await original_find(*args, **kwargs)
-
-    monkeypatch.setattr(
-        telegram_router,
-        "find_existing_inbound_provider_event",
-        synchronized_find,
-    )
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
 
     async def independent_session():
@@ -13291,6 +13873,9 @@ def test_telegram_reply_thread_requires_a_true_private_or_forum_topic():
         )
         == 77
     )
+    general_topic = update(chat_type="supergroup", is_topic=True, is_forum=True)
+    general_topic["message"]["message_thread_id"] = 1
+    assert telegram_message_thread_id_from_update(general_topic) is None
     assert (
         telegram_message_thread_id_from_update(update(chat_type="private", is_topic=False)) is None
     )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -12530,6 +12530,7 @@ async def test_telegram_channel_direct_message_pairing_replies_stay_in_originati
 @pytest.mark.asyncio
 async def test_telegram_webhook_unpair_redelivery_does_not_duplicate_reply(
     client: httpx.AsyncClient,
+    db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ):
     _reset_fake_provider_client({"ok": True, "result": {"message_id": 103}})
@@ -12573,6 +12574,15 @@ async def test_telegram_webhook_unpair_redelivery_does_not_duplicate_reply(
     assert [call["json"]["text"] for call in replies] == [
         "Unpaired. This chat is no longer connected to an agent."
     ]
+    command_message = (
+        await db_session.execute(
+            select(ChannelMessage).where(
+                ChannelMessage.account_id == UUID(created["id"]),
+                ChannelMessage.provider_event_id == "update:7003",
+            )
+        )
+    ).scalar_one()
+    assert command_message.delivered_at is not None
 
 
 @pytest.mark.asyncio
@@ -12693,6 +12703,11 @@ async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    expected_tutorial = (
+        "This chat isn't paired yet. In Clawdi, open your agent's Telegram channel, "
+        "choose Pair, then use the link or send /clawdi_pair <code> here."
+    )
+    assert telegram_router.TELEGRAM_UNPAIRED_TUTORIAL == expected_tutorial
     _reset_fake_provider_client({"ok": True, "result": {"message_id": 106}})
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = (
@@ -12749,7 +12764,7 @@ async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_
     assert [call["json"] for call in tutorial_calls] == [
         {
             "chat_id": "987654410",
-            "text": telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+            "text": expected_tutorial,
         }
     ]
     assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
@@ -12761,7 +12776,7 @@ async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_
             select(ChannelMessage).where(
                 ChannelMessage.account_id == UUID(created["id"]),
                 ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
-                ChannelMessage.text == telegram_router.TELEGRAM_UNPAIRED_TUTORIAL,
+                ChannelMessage.text == expected_tutorial,
             )
         )
     ).scalar_one()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1492,20 +1492,42 @@ async def test_channel_health_summarizes_delivery_and_debug_state(
         external_chat_type="private",
         external_chat_name="Health Chat",
     )
-    db_session.add(binding)
+    archived_binding = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        user_id=seed_user.id,
+        external_chat_id="historical-health-chat",
+        external_chat_type="private",
+        external_chat_name="Historical Health Chat",
+        status=BINDING_STATUS_ARCHIVED,
+    )
+    db_session.add_all([binding, archived_binding])
     await db_session.flush()
-    db_session.add(
-        ChannelMessage(
-            account_id=account.id,
-            bot_agent_link_id=UUID(created["agent_link_id"]),
-            binding_id=binding.id,
-            user_id=seed_user.id,
-            direction=MESSAGE_DIRECTION_INBOUND,
-            external_chat_id=binding.external_chat_id,
-            provider_message_id="health-inbound-1",
-            text="needs delivery",
-            payload={},
-        )
+    db_session.add_all(
+        [
+            ChannelMessage(
+                account_id=account.id,
+                bot_agent_link_id=UUID(created["agent_link_id"]),
+                binding_id=binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=binding.external_chat_id,
+                provider_message_id="health-inbound-1",
+                text="needs delivery",
+                payload={},
+            ),
+            ChannelMessage(
+                account_id=account.id,
+                bot_agent_link_id=UUID(created["agent_link_id"]),
+                binding_id=archived_binding.id,
+                user_id=seed_user.id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id=archived_binding.external_chat_id,
+                provider_message_id="historical-health-inbound",
+                text="must not affect health",
+                payload={},
+            ),
+        ]
     )
     await db_session.commit()
 
@@ -7557,6 +7579,10 @@ async def test_telegram_update_redelivery_retries_failed_agent_webhook(
     assert messages[0].delivered_at is None
     assert len(_SequencedProviderClient.calls) == 1
 
+    # Production webhook requests close their scoped session after the
+    # redelivery response. Mirror that boundary before the independent worker
+    # tries to acquire the Binding delivery fence.
+    await db_session.rollback()
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     result = await ChannelWebhookDeliveryWorker(sessionmaker).run_once()
     await db_session.refresh(messages[0])
@@ -7627,9 +7653,9 @@ async def test_telegram_agent_webhook_inactive_link_records_debug_health(
         item for item in health_response.json()["items"] if item["account_id"] == created["id"]
     )
     assert health["health_status"] == "error"
-    assert "pending_inbox" in health["reasons"]
+    assert "pending_inbox" not in health["reasons"]
     assert "recent_error" in health["reasons"]
-    assert health["pending_inbox"] >= 1
+    assert health["pending_inbox"] == 0
     assert health["last_error"] == "bot agent link inactive"
     assert health["last_error_stage"] == "agent_webhook"
     assert health["last_error_outcome"] == "failure"
@@ -13259,6 +13285,250 @@ async def test_telegram_ui_unpair_revokes_pending_polling_update_across_repair(
 
 
 @pytest.mark.asyncio
+async def test_telegram_ui_unpair_winning_before_inbound_lease_records_only_unbound_evidence(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 109}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    chat_id = "442"
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-unpair-wins-before-inbound-lease",
+        chat_id=chat_id,
+        chat_type="private",
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.external_chat_id == chat_id,
+            )
+        )
+    ).scalar_one()
+    binding_id = binding.id
+    original_record = telegram_router.record_inbound_messages_for_bindings
+    resolved_before_lease = asyncio.Event()
+    release_inbound = asyncio.Event()
+
+    async def pause_before_ordinary_inbound_lease(*args: Any, **kwargs: Any):
+        if kwargs["text"] == "ordinary update paused before lease":
+            assert kwargs["require_active_authority"] is True
+            resolved_before_lease.set()
+            await release_inbound.wait()
+        return await original_record(*args, **kwargs)
+
+    monkeypatch.setattr(
+        telegram_router,
+        "record_inbound_messages_for_bindings",
+        pause_before_ordinary_inbound_lease,
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    previous_session_override = app.dependency_overrides[get_session]
+
+    async def independent_request_session() -> AsyncIterator[AsyncSession]:
+        async with sessionmaker() as request_db:
+            yield request_db
+
+    await db_session.rollback()
+    await db_session.refresh(seed_user)
+    app.dependency_overrides[get_session] = independent_request_session
+    inbound_task: asyncio.Task[httpx.Response] | None = None
+    try:
+        inbound_task = asyncio.create_task(
+            client.post(
+                f"/v1/channels/telegram/{created['id']}/webhook",
+                headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+                json={
+                    "update_id": 7_643,
+                    "message": {
+                        "message_id": 7_643,
+                        "text": "ordinary update paused before lease",
+                        "chat": {"id": int(chat_id), "type": "private"},
+                        "from": {"id": 4242, "is_bot": False},
+                    },
+                },
+            )
+        )
+        await asyncio.wait_for(resolved_before_lease.wait(), timeout=2)
+        deleted = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding_id}")
+        assert deleted.status_code == 200, deleted.text
+        assert deleted.json()["unpaired"] is True
+        release_inbound.set()
+        inbound = await asyncio.wait_for(inbound_task, timeout=2)
+    finally:
+        release_inbound.set()
+        if inbound_task is not None and not inbound_task.done():
+            await asyncio.gather(inbound_task, return_exceptions=True)
+        app.dependency_overrides[get_session] = previous_session_override
+
+    assert inbound.status_code == 200, inbound.text
+    assert inbound.json()["binding_id"] is None
+    async with sessionmaker() as verification_db:
+        message = (
+            await verification_db.execute(
+                select(ChannelMessage).where(ChannelMessage.provider_event_id == "update:7643")
+            )
+        ).scalar_one()
+        account = await verification_db.get(ChannelAccount, UUID(created["id"]))
+        assert account is not None
+        assert message.binding_id is None
+        assert (
+            await channel_service.pending_channel_inbox_count(
+                verification_db,
+                account=account,
+            )
+            == 0
+        )
+    updates = await client.post(
+        _telegram_bot_path(created, "getUpdates"),
+        headers=_telegram_agent_headers(created),
+        json={},
+    )
+    assert updates.status_code == 200
+    assert updates.json()["result"] == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_inbound_lease_makes_ui_unpair_wait_and_consume_inserted_row(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 110}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    chat_id = "443"
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-inbound-lease-makes-unpair-wait",
+        chat_id=chat_id,
+        chat_type="private",
+    )
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(
+                ChannelBinding.account_id == UUID(created["id"]),
+                ChannelBinding.external_chat_id == chat_id,
+            )
+        )
+    ).scalar_one()
+    binding_id = binding.id
+    original_record = telegram_router.record_inbound_messages_for_bindings
+    lease_acquired = asyncio.Event()
+    release_inbound_commit = asyncio.Event()
+
+    async def pause_after_ordinary_inbound_lease(*args: Any, **kwargs: Any):
+        messages = await original_record(*args, **kwargs)
+        if kwargs["text"] == "ordinary update holding lease":
+            assert kwargs["require_active_authority"] is True
+            lease_acquired.set()
+            await release_inbound_commit.wait()
+        return messages
+
+    monkeypatch.setattr(
+        telegram_router,
+        "record_inbound_messages_for_bindings",
+        pause_after_ordinary_inbound_lease,
+    )
+    original_identity_lock = public_router.lock_channel_binding_identity
+    unpair_started = asyncio.Event()
+
+    async def observe_unpair_start(*args: Any, **kwargs: Any):
+        unpair_started.set()
+        return await original_identity_lock(*args, **kwargs)
+
+    monkeypatch.setattr(public_router, "lock_channel_binding_identity", observe_unpair_start)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    previous_session_override = app.dependency_overrides[get_session]
+
+    async def independent_request_session() -> AsyncIterator[AsyncSession]:
+        async with sessionmaker() as request_db:
+            yield request_db
+
+    await db_session.rollback()
+    await db_session.refresh(seed_user)
+    app.dependency_overrides[get_session] = independent_request_session
+    inbound_task: asyncio.Task[httpx.Response] | None = None
+    unpair_task: asyncio.Task[httpx.Response] | None = None
+    try:
+        inbound_task = asyncio.create_task(
+            client.post(
+                f"/v1/channels/telegram/{created['id']}/webhook",
+                headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+                json={
+                    "update_id": 7_644,
+                    "message": {
+                        "message_id": 7_644,
+                        "text": "ordinary update holding lease",
+                        "chat": {"id": int(chat_id), "type": "private"},
+                        "from": {"id": 4242, "is_bot": False},
+                    },
+                },
+            )
+        )
+        await asyncio.wait_for(lease_acquired.wait(), timeout=2)
+        unpair_task = asyncio.create_task(
+            client.delete(f"/v1/channels/{created['id']}/bindings/{binding_id}")
+        )
+        await asyncio.wait_for(unpair_started.wait(), timeout=2)
+        await asyncio.sleep(0.05)
+        assert not unpair_task.done()
+        release_inbound_commit.set()
+        inbound, deleted = await asyncio.wait_for(
+            asyncio.gather(inbound_task, unpair_task),
+            timeout=3,
+        )
+    finally:
+        release_inbound_commit.set()
+        pending_tasks = [
+            task for task in (inbound_task, unpair_task) if task is not None and not task.done()
+        ]
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+        app.dependency_overrides[get_session] = previous_session_override
+
+    assert inbound.status_code == 200, inbound.text
+    assert inbound.json()["binding_id"] == str(binding_id)
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json()["unpaired"] is True
+    async with sessionmaker() as verification_db:
+        message = (
+            await verification_db.execute(
+                select(ChannelMessage).where(ChannelMessage.provider_event_id == "update:7644")
+            )
+        ).scalar_one()
+        account = await verification_db.get(ChannelAccount, UUID(created["id"]))
+        assert account is not None
+        assert message.binding_id == binding_id
+        assert message.delivered_at is not None
+        assert (
+            await channel_service.pending_channel_inbox_count(
+                verification_db,
+                account=account,
+            )
+            == 0
+        )
+    updates = await client.post(
+        _telegram_bot_path(created, "getUpdates"),
+        headers=_telegram_agent_headers(created),
+        json={},
+    )
+    assert updates.status_code == 200
+    assert updates.json()["result"] == []
+
+
+@pytest.mark.asyncio
 async def test_delete_binding_keeps_unpair_durable_when_telegram_notification_fails(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -15023,8 +15293,9 @@ async def test_discord_webhook_inactive_link_records_debug_health(
         item for item in health_response.json()["items"] if item["account_id"] == created["id"]
     )
     assert health["health_status"] == "error"
-    assert "pending_inbox" in health["reasons"]
+    assert "pending_inbox" not in health["reasons"]
     assert "recent_error" in health["reasons"]
+    assert health["pending_inbox"] == 0
     assert health["last_error"] == "bot agent link inactive"
     assert health["last_error_stage"] == "agent_webhook"
     assert health["last_error_outcome"] == "failure"


### PR DESCRIPTION
## Summary

- serialize Telegram pair/unpair replay checks under the same chat advisory lock as binding mutation, so an old unpair retry cannot archive a replacement pairing
- make the active ChannelBinding row the live data-plane fence for Telegram polling, inline agent webhooks, and webhook retries; consume pending inbound work on command/UI unpair, Link retirement, and account archive; exclude archived authority from pending counts
- preserve runtime update topics while omitting message_thread_id=1 only for core replies to a forum General topic
- send a concise pairing tutorial for authenticated, ordinary unpaired private messages and channel-DM topics, with provider-event idempotency and a durable 10-minute chat/topic cooldown; groups and forums stay silent, and the flow never claims a code or creates binding authority

## Lifecycle boundary

The managed runtime bundle projects AgentLink/account credentials as channelBindings. It does not project per-chat ChannelBinding rows. The repository already documents ChannelBinding as provider routing state outside sourceRevision in docs/managed-runtime.md. Therefore a Telegram runtime starting before any chat is paired is expected; pairing/unpairing must converge through live backend authority, not restarts, wildcard allowlists, or manifest snapshots.

No hosted or production repository was changed.

## Protocol and upstream references

- Telegram Bot API Update.update_id is the replay identity, getUpdates confirms updates via offset, and webhook/getUpdates are mutually exclusive: https://core.telegram.org/bots/api#update and https://core.telegram.org/bots/api#getupdates
- Telegram Bot API distinguishes forum/private message_thread_id from direct_messages_topic_id: https://core.telegram.org/bots/api#sendmessage
- Official Bot API server source parses the two topic identities separately: https://github.com/tdlib/telegram-bot-api/blob/adfd7f6a8e990272851777eeb3ae0def4216f161/telegram-bot-api/Client.cpp
- OpenClaw preserves topic-scoped sessions and omits thread 1 for General-topic sends: https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/docs/channels/telegram.md
- Hermes applies the same General-topic send rule while retaining thread metadata: https://github.com/NousResearch/hermes-agent/blob/8208fc52701332f213e6c51ebc0b610be00300de/plugins/platforms/telegram/adapter.py#L1171-L1183

## Tests

- uv run ruff check .
- uv run ruff format --check .
- uv run python -m compileall -q app scripts tests alembic
- against a fresh migrated pgvector PostgreSQL: uv run pytest -q tests/test_channels.py tests/test_channel_inbox.py
  - 384 passed

Focused coverage includes concurrent replayed unpair plus replacement pair, stale polling across UI unpair and same-row repair, stale inline/worker webhook work, pending-count authority filtering, private tutorial replay/cooldown/provider failure, group/forum silence, channel-DM topic isolation, pair-code non-consumption, and General-topic reply targeting.
