### PR TITLE
fix(web): refine agent overview hierarchy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -51,6 +51,59 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
+async function expectAgentOverviewTypography(page: Page) {
+	const main = page.locator("main");
+	const titleMetrics = await main
+		.locator(
+			'h2[id$="recent-sessions"], [data-overview-status] h2, [data-agent-overview] section > div > h2, [data-overview-module] h3',
+		)
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(titleMetrics.length).toBeGreaterThan(3);
+	expect(new Set(titleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(titleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+
+	const primaryMetrics = await main
+		.locator("[data-overview-primary-value]")
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(primaryMetrics.length).toBeGreaterThan(3);
+	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+
+	const detailMetrics = await main.getByTestId("overview-summary-list").evaluateAll((elements) =>
+		elements.map((element) => {
+			const style = getComputedStyle(element);
+			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+		}),
+	);
+	expect(detailMetrics.length).toBeGreaterThan(0);
+	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
+
+	const metadataMetrics = await main
+		.locator(
+			'[data-testid="overview-session-meta"], [data-overview-status] dl, [data-testid="overview-compute-summary"] ul',
+		)
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, color: style.color };
+			}),
+		);
+	expect(metadataMetrics.length).toBeGreaterThan(2);
+	expect(new Set(metadataMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
+	expect(new Set(metadataMetrics.map(({ color }) => color)).size).toBe(1);
+}
+
 // HOSTED (Clawdi Cloud) smoke against the vite dev server with dev-auth-bypass
 // (NO Clerk key needed) + deploy-api enabled so /deploy renders. Exercises the
 // deploy wizard's Base UI Select asserting ZERO browser console/page errors.
@@ -68,6 +121,47 @@ function hostedUser(canUseV2 = true, canUseV1 = false) {
 	};
 }
 const emptyPage = { items: [], total: 0, page: 1, page_size: 25 };
+
+function hostedOverviewSessionsPage(itemCount: number) {
+	const summaries = [
+		"Prepare launch brief",
+		"Research customer feedback before the product planning review",
+		"Investigate a long-running customer issue across several projects and write a detailed plan for the next release review with every regional owner and support lead",
+		"Review risks",
+		"Fifth hosted session",
+	];
+	return {
+		items: Array.from({ length: itemCount }, (_, index) => ({
+			id: `hosted-overview-session-${index + 1}`,
+			local_session_id: `hosted-local-${index + 1}`,
+			project_path: "/hosted",
+			agent_name: "rail-cloud",
+			agent_display_name: "Rail Cloud",
+			agent_default_name: "Rail Cloud",
+			agent_type: "hermes",
+			machine_name: "rail-cloud",
+			started_at: `2026-07-15T0${index}:00:00Z`,
+			ended_at: null,
+			updated_at: `2026-07-15T0${index}:30:00Z`,
+			last_activity_at: `2026-07-15T0${index}:30:00Z`,
+			duration_seconds: 1800,
+			message_count: index + 3,
+			input_tokens: (index + 1) * 200,
+			output_tokens: (index + 1) * 100,
+			cache_read_tokens: 0,
+			model: "gpt-5",
+			models_used: ["gpt-5"],
+			summary: summaries[index],
+			tags: [],
+			status: "active",
+			content_hash: `hosted-hash-${index}`,
+		})),
+		total: itemCount,
+		page: 1,
+		page_size: 3,
+	};
+}
+
 const hostedMemories = {
 	items: [
 		{
@@ -2697,42 +2791,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		deployments: [railHostedDeployment],
 		cloudAgents: [railHostedCloudAgent],
 		agentResourceFixtures: true,
-		sessionsPage: {
-			items: Array.from({ length: 5 }, (_, index) => ({
-				id: `hosted-overview-session-${index + 1}`,
-				local_session_id: `hosted-local-${index + 1}`,
-				project_path: "/hosted",
-				agent_name: "rail-cloud",
-				agent_display_name: "Rail Cloud",
-				agent_default_name: "Rail Cloud",
-				agent_type: "hermes",
-				machine_name: "rail-cloud",
-				started_at: `2026-07-15T0${index}:00:00Z`,
-				ended_at: null,
-				updated_at: `2026-07-15T0${index}:30:00Z`,
-				last_activity_at: `2026-07-15T0${index}:30:00Z`,
-				duration_seconds: 1800,
-				message_count: index + 3,
-				input_tokens: (index + 1) * 200,
-				output_tokens: (index + 1) * 100,
-				cache_read_tokens: 0,
-				model: "gpt-5",
-				models_used: ["gpt-5"],
-				summary: [
-					"Prepare launch brief",
-					"Research customer feedback before the product planning review",
-					"Investigate a long-running customer issue across several projects and write a detailed plan for the next release review with every regional owner and support lead",
-					"Review risks",
-					"Fifth hosted session",
-				][index],
-				tags: [],
-				status: "active",
-				content_hash: `hosted-hash-${index}`,
-			})),
-			total: 5,
-			page: 1,
-			page_size: 3,
-		},
+		sessionsPage: hostedOverviewSessionsPage(5),
 		connectorConnections: [
 			{ id: "hosted-conn-github", app_name: "github", status: "ACTIVE" },
 			{ id: "hosted-conn-slack", app_name: "slack", status: "ACTIVE" },
@@ -2875,6 +2934,13 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const compute = page.locator('[data-overview-status="compute"]');
 	await expect(compute).toContainText("Running");
 	await expect(compute).toContainText("Basic plan");
+	const computePlanTypography = await compute
+		.locator("[data-overview-compute-plan]")
+		.evaluate((element) => {
+			const style = getComputedStyle(element);
+			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+		});
+	expect(computePlanTypography).toEqual({ fontSize: "14px", fontWeight: "600" });
 	await expect(compute.getByTestId("overview-compute-summary")).not.toHaveClass(
 		/rounded|border|bg-/,
 	);
@@ -2955,6 +3021,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);
 	await expectOverviewResourceGeometry(toolsGrid, [2]);
+	await expectAgentOverviewTypography(page);
 	expect(
 		Math.abs(
 			(resourceGeometry[0]?.width ?? 0) -
@@ -2986,6 +3053,83 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	).toBeLessThanOrEqual(2);
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({ path: testInfo.outputPath("hosted-agent-overview.png"), fullPage: true });
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await expect(page.locator("html")).toHaveClass(/dark/);
+	await page.waitForTimeout(250);
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-dark.png"),
+		fullPage: true,
+	});
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+});
+
+test("hosted overview naturally sizes one, two, and three real sessions", async ({ page }) => {
+	await page.setViewportSize({ width: 1280, height: 900 });
+	const options = {
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		sessionsPage: hostedOverviewSessionsPage(1),
+	};
+	await stubHostedApi(page, options);
+	const overviewUrl = `/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`;
+	const measurements: Array<{
+		count: number;
+		sessionsHeight: number;
+		computeHeight: number;
+	}> = [];
+
+	for (const count of [1, 2, 3]) {
+		options.sessionsPage = hostedOverviewSessionsPage(count);
+		if (count === 1) await page.goto(overviewUrl);
+		else await page.reload();
+
+		const recentSessions = page.getByRole("region", { name: "Recent sessions" });
+		const sessionGrid = recentSessions.getByTestId("overview-session-grid");
+		const compute = page.locator('[data-overview-status="compute"]');
+		await expect(recentSessions.locator("article")).toHaveCount(count);
+		await expect(compute).toContainText("Running");
+		const [sessionsBox, sessionGridBox, computeBox, sessionsMinHeight, computeMinHeight] =
+			await Promise.all([
+				recentSessions.boundingBox(),
+				sessionGrid.boundingBox(),
+				compute.boundingBox(),
+				recentSessions.evaluate((element) => getComputedStyle(element).minHeight),
+				compute.evaluate((element) => getComputedStyle(element).minHeight),
+			]);
+		expect(sessionsBox).not.toBeNull();
+		expect(sessionGridBox).not.toBeNull();
+		expect(computeBox).not.toBeNull();
+		expect(sessionsMinHeight).toBe("auto");
+		expect(computeMinHeight).toBe("0px");
+		expect(
+			Math.abs((sessionsBox?.height ?? 0) - (sessionGridBox?.height ?? 0)),
+		).toBeLessThanOrEqual(1);
+		expect(Math.abs((computeBox?.y ?? 0) - (sessionsBox?.y ?? 0))).toBeLessThanOrEqual(2);
+		if (count === 3) {
+			expect(
+				Math.abs(
+					(computeBox?.y ?? 0) +
+						(computeBox?.height ?? 0) -
+						((sessionsBox?.y ?? 0) + (sessionsBox?.height ?? 0)),
+				),
+			).toBeLessThanOrEqual(2);
+		}
+		measurements.push({
+			count,
+			sessionsHeight: sessionsBox?.height ?? 0,
+			computeHeight: computeBox?.height ?? 0,
+		});
+	}
+
+	expect(measurements.map(({ count }) => count)).toEqual([1, 2, 3]);
+	expect(measurements[1]?.sessionsHeight ?? 0).toBeGreaterThan(
+		(measurements[0]?.sessionsHeight ?? 0) + 60,
+	);
+	expect(measurements[2]?.sessionsHeight ?? 0).toBeGreaterThan(
+		(measurements[1]?.sessionsHeight ?? 0) + 60,
+	);
+	expect(measurements[0]?.computeHeight ?? 0).toBeLessThan(measurements[2]?.sessionsHeight ?? 0);
+	expect(measurements[1]?.computeHeight ?? 0).toBeLessThan(measurements[2]?.sessionsHeight ?? 0);
 });
 
 test("hosted overview shows a custom provider label and gates provider catalogs", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -35,6 +35,57 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
+async function expectAgentOverviewTypography(page: Page) {
+	const main = page.locator("main");
+	const titleMetrics = await main
+		.locator(
+			'h2[id$="recent-sessions"], [data-overview-status] h2, [data-agent-overview] section > div > h2, [data-overview-module] h3',
+		)
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(titleMetrics.length).toBeGreaterThan(3);
+	expect(new Set(titleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(titleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+
+	const primaryMetrics = await main
+		.locator("[data-overview-primary-value]")
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(primaryMetrics.length).toBeGreaterThan(3);
+	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+
+	const detailMetrics = await main.getByTestId("overview-summary-list").evaluateAll((elements) =>
+		elements.map((element) => {
+			const style = getComputedStyle(element);
+			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+		}),
+	);
+	expect(detailMetrics.length).toBeGreaterThan(0);
+	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
+
+	const metadataMetrics = await main
+		.locator('[data-testid="overview-session-meta"], [data-overview-status] dl')
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, color: style.color };
+			}),
+		);
+	expect(metadataMetrics.length).toBeGreaterThan(2);
+	expect(new Set(metadataMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
+	expect(new Set(metadataMetrics.map(({ color }) => color)).size).toBe(1);
+}
+
 const now = new Date("2026-07-04T12:00:00.000Z");
 
 const agents = [
@@ -697,6 +748,7 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 			.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-overview-module"))),
 	).toEqual(["projects", "skills", "memories", "vaults", "connectors"]);
 	await expectOverviewResourceGeometry(resourceGrid, [3, 2]);
+	await expectAgentOverviewTypography(page);
 	await page.setViewportSize({ width: 1024, height: 1200 });
 	await expectOverviewResourceGeometry(resourceGrid, [2, 2, 1]);
 	await page.setViewportSize({ width: 768, height: 1200 });

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { OverviewSummaryRows } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	OverviewMetadata,
+	OverviewSummaryRows,
+} from "@/components/dashboard/agent-overview-capabilities";
 
 describe("overview summary rows", () => {
 	test("renders resource names as a compact flat list", () => {
@@ -19,6 +22,7 @@ describe("overview summary rows", () => {
 		expect(markup).not.toContain("border");
 		expect(markup).not.toContain("divide-y");
 		expect(markup).not.toContain("bg-");
+		expect(markup).not.toContain("font-medium");
 	});
 
 	test("keeps the existing empty state and three-row limit", () => {
@@ -37,5 +41,22 @@ describe("overview summary rows", () => {
 		expect(populated).not.toContain("Four");
 		expect(empty).toContain("No resources");
 		expect(empty).not.toContain('data-testid="overview-summary-list"');
+	});
+});
+
+describe("overview metadata", () => {
+	test("uses the shared muted metadata hierarchy for labels and values", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewMetadata, {
+				items: [
+					{ label: "Machine", value: "workstation.local" },
+					{ label: "Last seen", value: "Just now" },
+				],
+			}),
+		);
+
+		expect(markup).toContain("space-y-2 text-xs text-muted-foreground");
+		expect(markup).not.toContain("text-sm");
+		expect(markup).not.toContain("font-medium");
 	});
 });

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -106,30 +106,11 @@ export function OverviewMetadata({
 	items: readonly { label: string; value: ReactNode }[];
 }) {
 	return (
-		<dl className="space-y-2 text-sm">
+		<dl className="space-y-2 text-xs text-muted-foreground">
 			{items.map((item) => (
 				<div key={item.label} className="flex min-w-0 items-baseline justify-between gap-3">
-					<dt className="text-xs text-muted-foreground">{item.label}</dt>
-					<dd className="min-w-0 break-words text-right font-medium">{item.value}</dd>
-				</div>
-			))}
-		</dl>
-	);
-}
-
-export function OverviewMetrics({
-	items,
-	columns = 3,
-}: {
-	items: readonly { label: string; value: ReactNode }[];
-	columns?: 2 | 3;
-}) {
-	return (
-		<dl className={cn("grid gap-2", columns === 2 ? "grid-cols-2" : "grid-cols-3")}>
-			{items.map((item) => (
-				<div key={item.label} className="rounded-md bg-muted/60 px-2.5 py-2">
-					<dt className="text-[11px] text-muted-foreground">{item.label}</dt>
-					<dd className="mt-0.5 truncate text-sm font-medium">{item.value}</dd>
+					<dt>{item.label}</dt>
+					<dd className="min-w-0 break-words text-right">{item.value}</dd>
 				</div>
 			))}
 		</dl>
@@ -140,7 +121,7 @@ export function OverviewSummaryRows({ items, empty }: { items: readonly string[]
 	return items.length ? (
 		<ul className="space-y-1 text-sm" data-testid="overview-summary-list">
 			{items.slice(0, 3).map((item) => (
-				<li key={item} className="truncate font-medium leading-5">
+				<li key={item} className="truncate leading-5">
 					{item}
 				</li>
 			))}

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -37,7 +37,7 @@ export function OverviewProjectsBody({
 	const count = bindings.count ?? 0;
 	return (
 		<div className="space-y-3">
-			<p className="text-lg font-semibold">
+			<p data-overview-primary-value className="text-base font-semibold">
 				{count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added"}
 			</p>
 			{count === 0 ? null : names.isLoading ? (
@@ -68,7 +68,7 @@ export function OverviewSkillsBody({
 	if (state.error) return <OverviewModuleError label="Skills" onRetry={state.onRetry} />;
 	return (
 		<div className="space-y-3">
-			<p className="text-lg font-semibold">
+			<p data-overview-primary-value className="text-base font-semibold">
 				{items.length
 					? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
 					: "No skills available"}
@@ -90,7 +90,7 @@ export function OverviewMemoriesBody() {
 		return <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />;
 	const total = query.data?.total ?? 0;
 	return (
-		<p className="text-lg font-semibold">
+		<p data-overview-primary-value className="text-base font-semibold">
 			{total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet"}
 		</p>
 	);
@@ -112,7 +112,7 @@ export function OverviewVaultsBody({
 	const vaults = query.data ?? [];
 	return (
 		<div className="space-y-3">
-			<p className="text-lg font-semibold">
+			<p data-overview-primary-value className="text-base font-semibold">
 				{vaults.length
 					? `${vaults.length} ${vaults.length === 1 ? "vault" : "vaults"}`
 					: "No vaults available"}
@@ -163,7 +163,7 @@ export function OverviewConnectorsBody() {
 	return (
 		<div className="space-y-3">
 			{!connected.connectionsLoading && !connectionsUnavailable ? (
-				<p className="text-lg font-semibold">
+				<p data-overview-primary-value className="text-base font-semibold">
 					{connectedAppCount ? `${connectedAppCount} connected` : "No apps connected"}
 				</p>
 			) : null}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -210,7 +210,7 @@ export function ConnectedAgentDetail({
 									</div>
 									<section
 										aria-labelledby="connected-recent-sessions"
-										className="min-h-40 min-w-0 @3xl/main:min-h-52"
+										className="min-w-0 self-start"
 									>
 										{blockingOverviewSessionsError ? (
 											<OverviewModuleError
@@ -237,7 +237,10 @@ export function ConnectedAgentDetail({
 										tint="bg-identity-7-bg text-identity-7-fg"
 									>
 										<div className="flex h-full flex-col justify-between gap-4">
-											<p className="inline-flex items-center gap-2 text-lg font-semibold">
+											<p
+												data-overview-primary-value
+												className="inline-flex items-center gap-2 text-base font-semibold"
+											>
 												<StatusDot status={syncTone} /> {syncStatus.label}
 											</p>
 											<OverviewMetadata

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -153,6 +153,8 @@ describe("overview Compute hierarchy", () => {
 		expect(markup).toContain("20 GiB storage");
 		expect(markup).toContain('aria-label="Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage"');
 		expect(markup).toContain('data-testid="overview-compute-summary"');
+		expect(markup).toContain('data-overview-compute-plan="true"');
+		expect(markup).toContain("text-sm font-semibold");
 		expect(markup).not.toContain("grid-cols-2");
 		expect(markup).not.toContain("rounded");
 		expect(markup).not.toContain("border");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1062,7 +1062,9 @@ export function OverviewComputeSummary({
 	];
 	return (
 		<div className="space-y-1.5" data-testid="overview-compute-summary">
-			<p className="text-sm font-semibold">{plan} plan</p>
+			<p data-overview-compute-plan className="text-sm font-semibold">
+				{plan} plan
+			</p>
 			<ul
 				aria-label={`Configuration: ${configuration.join(", ")}`}
 				className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
@@ -1330,10 +1332,7 @@ function OverviewTab({
 							<ArrowRight />
 						</Button>
 					</div>
-					<section
-						aria-labelledby="hosted-recent-sessions"
-						className="min-h-40 min-w-0 @3xl/main:min-h-52"
-					>
+					<section aria-labelledby="hosted-recent-sessions" className="min-w-0 self-start">
 						{projectionUnavailable ? (
 							<OverviewProjectionUnavailableState
 								canRetry={canRetryProjection}
@@ -1362,7 +1361,8 @@ function OverviewTab({
 					>
 						<div className="flex h-full flex-col gap-4">
 							<p
-								className="inline-flex items-center gap-2 text-lg font-semibold"
+								data-overview-primary-value
+								className="inline-flex items-center gap-2 text-base font-semibold"
 								title={`Agent status: ${deploymentStatusLabel(deploymentStatus)}`}
 							>
 								<StatusDot status={deploymentStatusTone(deploymentStatus)} />
@@ -1481,7 +1481,7 @@ function OverviewTab({
 							<OverviewModuleError label="Channels" onRetry={() => void channelLinks.refetch()} />
 						) : (
 							<div className="space-y-3">
-								<p className="text-lg font-semibold">
+								<p data-overview-primary-value className="text-base font-semibold">
 									{(channelLinks.data?.length ?? 0) > 0
 										? `${channelLinks.data?.length} connected ${channelLinks.data?.length === 1 ? "channel" : "channels"}`
 										: "No channels connected"}


### PR DESCRIPTION
## Summary
- normalize Agent Overview typography to the existing shadcn/project scale
- flatten Compute hierarchy and remove fixed session-column minimum heights
- keep Compute aligned with three real recent sessions while allowing one or two sessions to size naturally

## Validation
- Docker Web typecheck
- 22 focused tests
- OSS production build
- mocked Chromium coverage for Hosted and Connected overviews
- Hosted 1/2/3-session geometry contracts
- light and dark visual QA
- Biome and git diff check

No production or tenant data was accessed.