### PR TITLE
fix(runtime): anchor hosted state to runtime home

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.30",
+      "version": "0.13.31",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.30",
+	"version": "0.13.31",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/paths.test.ts
+++ b/packages/cli/src/runtime/paths.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { getRuntimePaths } from "./paths";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+});
+
+describe("runtime paths", () => {
+	test("anchors hosted user state to the default runtime home", () => {
+		delete process.env.HOME;
+		delete process.env.CLAWDI_RUNTIME_HOME;
+		delete process.env.CLAWDI_HOME;
+
+		const paths = getRuntimePaths({ mode: "hosted" });
+
+		expect(paths.userHome).toBe("/home/clawdi");
+		expect(paths.clawdiHome).toBe("/home/clawdi/.clawdi");
+		expect(paths.systemdUserRoot).toBe("/home/clawdi/.config/systemd/user");
+	});
+
+	test("derives hosted user state from an explicit runtime home", () => {
+		process.env.HOME = "/root";
+		process.env.CLAWDI_RUNTIME_HOME = "/srv/clawdi";
+		delete process.env.CLAWDI_HOME;
+
+		const paths = getRuntimePaths({ mode: "hosted" });
+
+		expect(paths.userHome).toBe("/srv/clawdi");
+		expect(paths.clawdiHome).toBe("/srv/clawdi/.clawdi");
+	});
+
+	test("preserves the explicit Clawdi state override in hosted mode", () => {
+		process.env.HOME = "/root";
+		process.env.CLAWDI_RUNTIME_HOME = "/srv/clawdi";
+		process.env.CLAWDI_HOME = "/var/lib/example-clawdi";
+
+		const paths = getRuntimePaths({ mode: "hosted" });
+
+		expect(paths.userHome).toBe("/srv/clawdi");
+		expect(paths.clawdiHome).toBe("/var/lib/example-clawdi");
+	});
+
+	test("keeps local CLI paths based on HOME", () => {
+		process.env.HOME = "/tmp/local-user";
+		process.env.CLAWDI_RUNTIME_HOME = "/srv/ignored-hosted-home";
+		delete process.env.CLAWDI_HOME;
+
+		const paths = getRuntimePaths({ mode: "local" });
+
+		expect(paths.userHome).toBe("/tmp/local-user");
+		expect(paths.clawdiHome).toBe(join("/tmp/local-user", ".clawdi"));
+	});
+});

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -74,6 +74,14 @@ function defaultHome(mode: RuntimeMode): string {
 	return process.env.HOME || homedir();
 }
 
+function defaultClawdiHome(mode: RuntimeMode, userHome: string): string {
+	if (mode === "hosted") {
+		// Keep the hosted user-state tree anchored to the resolved runtime home.
+		return process.env.CLAWDI_HOME || join(userHome, ".clawdi");
+	}
+	return getClawdiDir();
+}
+
 function runningAsRoot(): boolean {
 	return typeof process.getuid === "function" && process.getuid() === 0;
 }
@@ -97,7 +105,7 @@ export function detectRuntimeMode(): RuntimeMode {
 export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths {
 	const mode = opts.mode ?? detectRuntimeMode();
 	const userHome = defaultHome(mode);
-	const clawdiHome = getClawdiDir();
+	const clawdiHome = defaultClawdiHome(mode, userHome);
 	const serviceStateRoot = envPath("CLAWDI_SERVICE_STATE_DIR") ?? "/var/lib/clawdi";
 	const runRoot = envPath("CLAWDI_RUN_DIR") ?? "/run/clawdi";
 	const shareRoot = envPath("CLAWDI_SHARE_DIR") ?? "/usr/share/clawdi";


### PR DESCRIPTION
## Summary

- derive hosted `clawdiHome` from the already-resolved runtime user home
- preserve explicit `CLAWDI_HOME`, custom hosted HOME, and local CLI behavior
- prepare CLI 0.13.31 for the Incus live gate

## Why

A root hosted orchestrator with no ambient `HOME` correctly resolved `userHome=/home/clawdi`, but generic local CLI state resolution independently selected the root passwd home and produced `clawdiHome=/root/.clawdi`. This keeps both hosted paths under one existing authority without adding environment variables or substrate-specific behavior.

## Verification

- `bun test packages/cli/src/runtime/paths.test.ts packages/cli/tests/runtime.test.ts`
- `bun run --cwd packages/cli typecheck`
- focused runtime bundle and manifest reconciliation tests
- hermetic `bash scripts/test.sh cli`
- Biome
- publish manifest contract
- `git diff --check`