### PR TITLE
fix(web): unify session and overview card presentation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -91,10 +91,10 @@ async function expectOverviewSessionSlot({
 	await expect(placeholders).toHaveCount(3 - realCount);
 	await expect(grid.getByRole("link")).toHaveCount(realCount);
 	await expect(placeholders.locator("a, button, article")).toHaveCount(0);
-	const compactAlignment = await grid.locator(":scope > article").evaluateAll((articles) =>
+	const cardAlignment = await grid.locator(":scope > article").evaluateAll((articles) =>
 		articles.map((article) => {
-			const avatar = article.querySelector<HTMLElement>('[data-testid="overview-session-avatar"]');
-			const textBlock = article.querySelector<HTMLElement>('[data-testid="overview-session-text"]');
+			const avatar = article.querySelector<HTMLElement>('[data-testid="session-card-avatar"]');
+			const textBlock = article.querySelector<HTMLElement>('[data-testid="session-card-text"]');
 			const avatarBox = avatar?.getBoundingClientRect();
 			const textBox = textBlock?.getBoundingClientRect();
 			return {
@@ -103,7 +103,7 @@ async function expectOverviewSessionSlot({
 			};
 		}),
 	);
-	for (const alignment of compactAlignment)
+	for (const alignment of cardAlignment)
 		expect(Math.abs(alignment.avatarCenter - alignment.textCenter)).toBeLessThanOrEqual(2);
 	const placeholderSemantics = await placeholders.evaluateAll((elements) =>
 		elements.map((element) => ({
@@ -205,19 +205,21 @@ async function expectAgentOverviewTypography(page: Page) {
 	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
 	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
 
-	const detailMetrics = await main.getByTestId("overview-summary-list").evaluateAll((elements) =>
-		elements.map((element) => {
-			const style = getComputedStyle(element);
-			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
-		}),
-	);
+	const detailMetrics = await main
+		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
 	expect(detailMetrics.length).toBeGreaterThan(0);
-	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
+	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
+	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const metadataMetrics = await main
 		.locator(
-			'[data-testid="overview-session-meta"], [data-overview-status] dl, [data-testid="overview-compute-summary"] ul',
+			'[data-testid="session-card-meta"], [data-overview-status] dl, [data-testid="overview-compute-summary"] ul',
 		)
 		.evaluateAll((elements) =>
 			elements.map((element) => {
@@ -244,24 +246,19 @@ async function expectAgentOverviewTypography(page: Page) {
 	expect(new Set(toolPrimaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
 
 	const toolSecondaryMetrics = await main
-		.locator(
-			'[data-overview-tool-secondary], [data-overview-module="channels"] [data-testid="overview-summary-list"]',
-		)
+		.locator("[data-overview-tool-secondary]")
 		.evaluateAll((elements) =>
 			elements.map((element) => {
 				const style = getComputedStyle(element);
 				return { fontSize: style.fontSize, fontWeight: style.fontWeight, color: style.color };
 			}),
 		);
-	expect(toolSecondaryMetrics).toHaveLength(2);
+	expect(toolSecondaryMetrics).toHaveLength(1);
 	expect(new Set(toolSecondaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
 	expect(new Set(toolSecondaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(
 		new Set(["400"]),
 	);
-	expect(new Set(toolSecondaryMetrics.map(({ color }) => color))).toEqual(
-		new Set(toolPrimaryMetrics.map(({ color }) => color)),
-	);
-	expect(toolSecondaryMetrics[0]?.color).not.toBe(metadataMetrics[0]?.color);
+	expect(toolSecondaryMetrics[0]?.color).toBe(metadataMetrics[0]?.color);
 }
 
 // HOSTED (Clawdi Cloud) smoke against the vite dev server with dev-auth-bypass
@@ -3063,8 +3060,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
-			const title = card.querySelector<HTMLElement>('[data-testid="overview-session-title"]');
-			const meta = card.querySelector<HTMLElement>('[data-testid="overview-session-meta"]');
+			const title = card.querySelector<HTMLElement>('[data-testid="session-card-title"]');
+			const meta = card.querySelector<HTMLElement>('[data-testid="session-card-meta"]');
 			const titleStyle = title ? getComputedStyle(title) : null;
 			return {
 				x: rect.x,
@@ -3150,11 +3147,25 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		}),
 	).toBeVisible();
 	await expect(page.getByText("Your agent is running", { exact: true })).toHaveCount(0);
-	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Daily briefing");
-	await expect(overview.locator('[data-overview-module="channels"]')).toContainText(
-		"Research Telegram",
-	);
-	await expect(overview.locator('[data-overview-module="channels"]')).toContainText("Telegram");
+	const resourceBadges = overview.getByTestId("overview-resource-badges");
+	await expect(resourceBadges).toHaveCount(3);
+	await expect(
+		overview.locator('[data-overview-module="projects"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Hosted Agent Project");
+	await expect(
+		overview.locator('[data-overview-module="skills"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Daily briefing");
+	await expect(
+		overview.locator('[data-overview-module="vaults"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Hosted Scoped Vault");
+	const channelRail = overview.getByTestId("overview-channel-rail");
+	await expect(channelRail.getByRole("link")).toHaveCount(1);
+	await expect(
+		channelRail.getByRole("link", {
+			name: "Connected channel: Telegram, Research Telegram",
+		}),
+	).toBeVisible();
+	await expect(channelRail.locator("img")).toHaveAttribute("alt", "Telegram");
 	await expect(overview.locator('[data-overview-module="model-provider"]')).toContainText(
 		"Managed by Clawdi",
 	);
@@ -3170,10 +3181,6 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
-	const flatResourceSummaries = overview.getByTestId("overview-summary-list");
-	await expect(flatResourceSummaries).toHaveCount(3);
-	for (const summary of await flatResourceSummaries.all())
-		await expect(summary).not.toHaveClass(/rounded|border|divide-y|bg-/);
 	const connectors = overview.locator('[data-overview-module="connectors"]');
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
@@ -3261,6 +3268,10 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 				((mobileSessionsBox?.x ?? 0) + (mobileSessionsBox?.width ?? 0)),
 		),
 	).toBeLessThanOrEqual(2);
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-mobile.png"),
+		fullPage: true,
+	});
 	await page.getByRole("button", { name: "Toggle Sidebar", exact: true }).click();
 	const mobileSidebar = page.getByRole("dialog");
 	await expectInlineSidebarStatus(mobileSidebar, "hosted");
@@ -3382,6 +3393,19 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
 	await expect(overview.getByTestId("overview-module-skeleton").first()).toBeVisible();
+	const sessionSkeletons = page
+		.getByRole("status", { name: "Loading recent sessions" })
+		.getByTestId("overview-session-skeleton-row");
+	await expect(sessionSkeletons).toHaveCount(3);
+	const skeletonBoxes = await sessionSkeletons.evaluateAll((rows) =>
+		rows.map((row) => row.getBoundingClientRect().toJSON()),
+	);
+	expect(
+		Math.max(...skeletonBoxes.map((box) => box.height)) -
+			Math.min(...skeletonBoxes.map((box) => box.height)),
+	).toBeLessThanOrEqual(1);
+	expect(skeletonBoxes[0]?.height).toBeGreaterThanOrEqual(64);
+	expect(skeletonBoxes[0]?.height).toBeLessThanOrEqual(72);
 	await expect(overview.locator('[data-overview-module="vaults"]')).not.toContainText(
 		"No vaults available",
 	);
@@ -3535,13 +3559,20 @@ test("hosted Tools channels preserve zero, singular, plural, error, and loading 
 	await page.goto(overviewUrl);
 	await expect(channels.getByText("0 connected channels", { exact: true })).toHaveCount(0);
 	await expect(channels.getByText("No channels connected", { exact: true })).toHaveCount(1);
-	await expect(channels.getByTestId("overview-summary-list")).toHaveCount(0);
+	await expect(channels.getByTestId("overview-channel-rail")).toHaveCount(0);
 
 	options.channelAgentLinksResponse = { body: [channelLink(1, "telegram")], status: 200 };
 	await page.reload();
 	await expect(channels.getByText("1 connected channel", { exact: true })).toBeVisible();
-	await expect(channels.getByTestId("overview-summary-list")).toContainText(
-		"Telegram: Research Telegram",
+	await expect(
+		channels.getByRole("link", {
+			name: "Connected channel: Telegram, Research Telegram",
+		}),
+	).toHaveAttribute("title", "Telegram: Research Telegram (connected)");
+	await expect(channels.getByTestId("overview-channel-rail").getByRole("link")).toHaveCount(1);
+	await expect(channels.getByTestId("overview-channel-rail").locator("img")).toHaveAttribute(
+		"alt",
+		"Telegram",
 	);
 
 	options.channelAgentLinksResponse = {
@@ -3550,7 +3581,14 @@ test("hosted Tools channels preserve zero, singular, plural, error, and loading 
 	};
 	await page.reload();
 	await expect(channels.getByText("2 connected channels", { exact: true })).toBeVisible();
-	await expect(channels.getByTestId("overview-summary-list").locator("li")).toHaveCount(2);
+	const channelLinks = channels.getByTestId("overview-channel-rail").getByRole("link");
+	await expect(channelLinks).toHaveCount(2);
+	await expect(channelLinks.nth(0)).toHaveAccessibleName(
+		"Connected channel: Telegram, Research Telegram",
+	);
+	await expect(channelLinks.nth(1)).toHaveAccessibleName(
+		"Connected channel: Discord, Team Discord",
+	);
 
 	options.channelAgentLinksResponse = {
 		body: { detail: "channel service unavailable" },

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -75,10 +75,10 @@ async function expectOverviewSessionSlot({
 	await expect(placeholders).toHaveCount(3 - realCount);
 	await expect(grid.getByRole("link")).toHaveCount(realCount);
 	await expect(placeholders.locator("a, button, article")).toHaveCount(0);
-	const compactAlignment = await grid.locator(":scope > article").evaluateAll((articles) =>
+	const cardAlignment = await grid.locator(":scope > article").evaluateAll((articles) =>
 		articles.map((article) => {
-			const avatar = article.querySelector<HTMLElement>('[data-testid="overview-session-avatar"]');
-			const textBlock = article.querySelector<HTMLElement>('[data-testid="overview-session-text"]');
+			const avatar = article.querySelector<HTMLElement>('[data-testid="session-card-avatar"]');
+			const textBlock = article.querySelector<HTMLElement>('[data-testid="session-card-text"]');
 			const avatarBox = avatar?.getBoundingClientRect();
 			const textBox = textBlock?.getBoundingClientRect();
 			return {
@@ -87,7 +87,7 @@ async function expectOverviewSessionSlot({
 			};
 		}),
 	);
-	for (const alignment of compactAlignment)
+	for (const alignment of cardAlignment)
 		expect(Math.abs(alignment.avatarCenter - alignment.textCenter)).toBeLessThanOrEqual(2);
 	const placeholderSemantics = await placeholders.evaluateAll((elements) =>
 		elements.map((element) => ({
@@ -129,6 +129,56 @@ async function expectOverviewSessionSlot({
 		),
 	).toBeLessThanOrEqual(2);
 	return regionBox?.height ?? 0;
+}
+
+async function sessionCardVisualContract(card: Locator) {
+	await expect(card).toHaveCount(1);
+	await expect(card.locator(":scope > a")).toHaveCount(1);
+	await expect(card.locator("a a, a button, button a")).toHaveCount(0);
+	return card.evaluate((article) => {
+		const link = article.querySelector<HTMLElement>(":scope > a");
+		const avatar = article.querySelector<HTMLElement>('[data-testid="session-card-avatar"]');
+		const text = article.querySelector<HTMLElement>('[data-testid="session-card-text"]');
+		const title = article.querySelector<HTMLElement>('[data-testid="session-card-title"]');
+		const meta = article.querySelector<HTMLElement>('[data-testid="session-card-meta"]');
+		if (!link || !avatar || !text || !title || !meta) throw new Error("Incomplete SessionCard");
+		const cardBox = article.getBoundingClientRect();
+		const avatarBox = avatar.getBoundingClientRect();
+		const textBox = text.getBoundingClientRect();
+		const linkStyle = getComputedStyle(link);
+		const titleStyle = getComputedStyle(title);
+		const metaStyle = getComputedStyle(meta);
+		return {
+			height: cardBox.height,
+			avatarSize: [avatarBox.width, avatarBox.height],
+			centerDelta: Math.abs(avatarBox.y + avatarBox.height / 2 - (textBox.y + textBox.height / 2)),
+			padding: [
+				linkStyle.paddingTop,
+				linkStyle.paddingRight,
+				linkStyle.paddingBottom,
+				linkStyle.paddingLeft,
+			],
+			gap: linkStyle.gap,
+			title: [
+				titleStyle.fontSize,
+				titleStyle.fontWeight,
+				titleStyle.lineHeight,
+				titleStyle.whiteSpace,
+				titleStyle.overflow,
+				titleStyle.textOverflow,
+			],
+			meta: [metaStyle.fontSize, metaStyle.fontWeight, metaStyle.lineHeight, metaStyle.color],
+			directChildren: Array.from(link.children).map((child) => child.getAttribute("data-testid")),
+		};
+	});
+}
+
+async function expectNoHorizontalOverflow(locator: Locator) {
+	const overflow = await locator.evaluate((element) => ({
+		clientWidth: element.clientWidth,
+		scrollWidth: element.scrollWidth,
+	}));
+	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
 async function expectInlineSidebarStatus(sidebar: Locator, source: "hosted" | "connected") {
@@ -181,18 +231,20 @@ async function expectAgentOverviewTypography(page: Page) {
 	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
 	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
 
-	const detailMetrics = await main.getByTestId("overview-summary-list").evaluateAll((elements) =>
-		elements.map((element) => {
-			const style = getComputedStyle(element);
-			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
-		}),
-	);
+	const detailMetrics = await main
+		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
 	expect(detailMetrics.length).toBeGreaterThan(0);
-	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
+	expect(new Set(detailMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
+	expect(new Set(detailMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const metadataMetrics = await main
-		.locator('[data-testid="overview-session-meta"], [data-overview-status] dl')
+		.locator('[data-testid="session-card-meta"], [data-overview-status] dl')
 		.evaluateAll((elements) =>
 			elements.map((element) => {
 				const style = getComputedStyle(element);
@@ -380,8 +432,8 @@ const overviewSessions = {
 			"Fifth hidden session",
 		][index],
 		message_count: index + 2,
-		input_tokens: [8, 1200, 18_500, 420][index],
-		output_tokens: [4, 340, 9200, 80][index],
+		input_tokens: [8, 1200, 18_500, 420, 60][index],
+		output_tokens: [4, 340, 9200, 80, 20][index],
 		last_activity_at: new Date(now.getTime() - index * 60 * 60 * 1000).toISOString(),
 	})),
 	total: 5,
@@ -776,8 +828,8 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	const sessionBoxes = await recentSessions.locator("article").evaluateAll((cards) =>
 		cards.map((card) => {
 			const rect = card.getBoundingClientRect();
-			const title = card.querySelector<HTMLElement>('[data-testid="overview-session-title"]');
-			const meta = card.querySelector<HTMLElement>('[data-testid="overview-session-meta"]');
+			const title = card.querySelector<HTMLElement>('[data-testid="session-card-title"]');
+			const meta = card.querySelector<HTMLElement>('[data-testid="session-card-meta"]');
 			const titleStyle = title ? getComputedStyle(title) : null;
 			return {
 				x: rect.x,
@@ -834,6 +886,20 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		),
 	).toBeLessThanOrEqual(2);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText("Research");
+	const resourceBadges = overview.getByTestId("overview-resource-badges");
+	await expect(resourceBadges).toHaveCount(3);
+	await expect(
+		overview.locator('[data-overview-module="projects"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Smoke Project");
+	await expect(
+		overview.locator('[data-overview-module="skills"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Research");
+	await expect(
+		overview.locator('[data-overview-module="vaults"] [data-slot="badge"]'),
+	).toHaveAccessibleName("Scoped Vault");
+	await expect(
+		overview.locator('[data-overview-module="memories"] [data-slot="badge"]'),
+	).toHaveCount(0);
 	for (const moduleId of ["memories", "vaults", "connectors"]) {
 		await expect(overview.locator(`[data-overview-module="${moduleId}"]`)).toBeVisible();
 	}
@@ -906,6 +972,10 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 				((mobileSessionsBox?.x ?? 0) + (mobileSessionsBox?.width ?? 0)),
 		),
 	).toBeLessThanOrEqual(2);
+	await page.screenshot({
+		path: testInfo.outputPath("connected-agent-overview-mobile.png"),
+		fullPage: true,
+	});
 	await page.getByRole("button", { name: "Toggle Sidebar", exact: true }).click();
 	const mobileSidebar = page.getByRole("dialog");
 	await expectInlineSidebarStatus(mobileSidebar, "connected");
@@ -956,6 +1026,73 @@ test("connected detail only requests overview data on Overview", async ({ page }
 	expect(projectBindingRequests).toEqual([]);
 	expect(projectRequests).toEqual([]);
 	expect(skillRequests).toEqual([]);
+});
+
+test("SessionCard stays identical across Overview, Agent Sessions, and global Sessions", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 1280, height: 1000 });
+	await stubDashboardApi(page, [], { sessionsPage: overviewSessions });
+
+	await page.goto("/agents/agent-smoke-1");
+	const overviewCard = page
+		.getByRole("region", { name: "Recent sessions" })
+		.getByTestId("session-card")
+		.first();
+	const overviewContract = await sessionCardVisualContract(overviewCard);
+
+	await page.goto("/agents/agent-smoke-1/sessions");
+	await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
+	const agentCard = page.getByTestId("session-card").first();
+	const agentContract = await sessionCardVisualContract(agentCard);
+	expect(agentContract).toEqual(overviewContract);
+	await page.screenshot({
+		path: testInfo.outputPath("connected-agent-sessions-light.png"),
+		fullPage: true,
+	});
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await page.waitForTimeout(250);
+	await page.screenshot({
+		path: testInfo.outputPath("connected-agent-sessions-dark.png"),
+		fullPage: true,
+	});
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+
+	await page.goto("/sessions?view=feed");
+	await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
+	const globalCard = page.getByTestId("session-card").first();
+	const globalContract = await sessionCardVisualContract(globalCard);
+	expect(globalContract).toEqual(overviewContract);
+	await page.screenshot({ path: testInfo.outputPath("global-sessions-light.png"), fullPage: true });
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await page.waitForTimeout(250);
+	await page.screenshot({ path: testInfo.outputPath("global-sessions-dark.png"), fullPage: true });
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expectNoHorizontalOverflow(page.locator("main"));
+	for (const card of await page.getByTestId("session-card").all())
+		await expectNoHorizontalOverflow(card);
+	const longTitle = page.getByTestId("session-card-title").nth(2);
+	await expect(longTitle).toHaveCSS("white-space", "nowrap");
+	await expect(longTitle).toHaveCSS("text-overflow", "ellipsis");
+	expect(await longTitle.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(
+		true,
+	);
+	await page.screenshot({
+		path: testInfo.outputPath("global-sessions-mobile.png"),
+		fullPage: true,
+	});
+
+	await page.goto("/agents/agent-smoke-1/sessions");
+	await expect(page.getByTestId("session-card")).toHaveCount(5);
+	await expectNoHorizontalOverflow(page.locator("main"));
+	for (const card of await page.getByTestId("session-card").all())
+		await expectNoHorizontalOverflow(card);
+	await page.screenshot({
+		path: testInfo.outputPath("connected-agent-sessions-mobile.png"),
+		fullPage: true,
+	});
 });
 
 test("connected Overview keeps a three-row accessible session slot for zero through 3+ sessions", async ({

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -3,44 +3,49 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
 	OverviewMetadata,
-	OverviewSummaryRows,
+	OverviewResourceSummary,
 } from "@/components/dashboard/agent-overview-capabilities";
 
-describe("overview summary rows", () => {
-	test("renders resource names as a compact flat list", () => {
+describe("overview resource summary", () => {
+	test("renders up to three resource names with the existing Badge primitive", () => {
 		const markup = renderToStaticMarkup(
-			createElement(OverviewSummaryRows, {
-				items: ["Hosted Agent Project", "Shared Vault", "Telegram: Research"],
-				empty: "No resources",
+			createElement(OverviewResourceSummary, {
+				primary: "4 projects",
+				items: [
+					"Hosted Agent Project with a deliberately long accessible name",
+					"Shared Vault",
+					"Research Skills",
+					"Hidden fourth resource",
+				],
 			}),
 		);
 
-		expect(markup).toContain('data-testid="overview-summary-list"');
-		for (const item of ["Hosted Agent Project", "Shared Vault", "Telegram: Research"])
+		expect(markup).toContain('data-testid="overview-resource-summary"');
+		expect(markup).toContain('data-testid="overview-resource-badges"');
+		expect(markup).toContain('data-slot="badge"');
+		for (const item of [
+			"Hosted Agent Project with a deliberately long accessible name",
+			"Shared Vault",
+			"Research Skills",
+		])
 			expect(markup).toContain(item);
-		expect(markup).not.toContain("rounded");
-		expect(markup).not.toContain("border");
-		expect(markup).not.toContain("divide-y");
-		expect(markup).not.toContain("bg-");
-		expect(markup).not.toContain("font-medium");
+		expect(markup).not.toContain("Hidden fourth resource");
+		expect(markup).toContain(
+			'title="Hosted Agent Project with a deliberately long accessible name"',
+		);
+		expect(markup).toContain(
+			'aria-label="Hosted Agent Project with a deliberately long accessible name"',
+		);
+		expect(markup).toContain("truncate");
 	});
 
-	test("keeps the existing empty state and three-row limit", () => {
-		const populated = renderToStaticMarkup(
-			createElement(OverviewSummaryRows, {
-				items: ["One", "Two", "Three", "Four"],
-				empty: "No resources",
-			}),
-		);
+	test("does not duplicate an empty primary value with an empty badge list", () => {
 		const empty = renderToStaticMarkup(
-			createElement(OverviewSummaryRows, { items: [], empty: "No resources" }),
+			createElement(OverviewResourceSummary, { primary: "No projects added", items: [] }),
 		);
 
-		expect(populated).toContain("One");
-		expect(populated).toContain("Three");
-		expect(populated).not.toContain("Four");
-		expect(empty).toContain("No resources");
-		expect(empty).not.toContain('data-testid="overview-summary-list"');
+		expect(empty.match(/No projects added/g)).toHaveLength(1);
+		expect(empty).not.toContain('data-testid="overview-resource-badges"');
 	});
 });
 

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,7 +1,8 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, type LucideIcon, RefreshCw } from "lucide-react";
+import { ArrowRight, CircleCheck, type LucideIcon, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -117,34 +118,73 @@ export function OverviewMetadata({
 	);
 }
 
-export function OverviewSummaryRows({ items, empty }: { items: readonly string[]; empty: string }) {
-	return items.length ? (
-		<ul className="space-y-1 text-sm" data-testid="overview-summary-list">
-			{items.slice(0, 3).map((item) => (
-				<li key={item} className="truncate leading-5">
-					{item}
-				</li>
-			))}
-		</ul>
-	) : (
-		<p className="text-sm text-muted-foreground">{empty}</p>
+export function OverviewResourceSummary({
+	primary,
+	items,
+	children,
+}: {
+	primary: ReactNode;
+	items?: readonly string[];
+	children?: ReactNode;
+}) {
+	return (
+		<div className="space-y-3" data-testid="overview-resource-summary">
+			<p data-overview-primary-value className="text-base font-semibold">
+				{primary}
+			</p>
+			{items?.length ? (
+				<ul className="flex min-w-0 flex-wrap gap-1.5" data-testid="overview-resource-badges">
+					{items.slice(0, 3).map((item, index) => (
+						<li key={`${item}-${index}`} className="min-w-0 max-w-full">
+							<Badge
+								variant="secondary"
+								className="max-w-full min-w-0"
+								aria-label={item}
+								title={item}
+							>
+								<span className="truncate">{item}</span>
+							</Badge>
+						</li>
+					))}
+				</ul>
+			) : null}
+			{children}
+		</div>
 	);
 }
 
-export function OverviewChips({ items, empty }: { items: readonly string[]; empty: string }) {
-	return items.length ? (
-		<ul className="flex flex-wrap gap-1.5">
-			{items.slice(0, 3).map((item) => (
-				<li
-					key={item}
-					className="max-w-full truncate rounded-full bg-muted px-2.5 py-1 text-xs font-medium"
-				>
-					{item}
-				</li>
-			))}
+export function OverviewIdentityIconRail({
+	label,
+	testId,
+	children,
+}: {
+	label: string;
+	testId: string;
+	children: ReactNode;
+}) {
+	return (
+		<ul aria-label={label} className="flex flex-wrap gap-2" data-testid={testId}>
+			{children}
 		</ul>
-	) : (
-		<p className="text-sm text-muted-foreground">{empty}</p>
+	);
+}
+
+export function OverviewIdentityIconItem({
+	connected = false,
+	children,
+}: {
+	connected?: boolean;
+	children: ReactNode;
+}) {
+	return (
+		<li className="relative w-fit">
+			{children}
+			{connected ? (
+				<span className="pointer-events-none absolute -right-1 -bottom-1 rounded-full bg-background text-primary">
+					<CircleCheck className="size-4 fill-background" aria-hidden="true" />
+				</span>
+			) : null}
+		</li>
 	);
 }
 

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -2,14 +2,15 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { CircleCheck, RefreshCw } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import {
-	OverviewChips,
+	OverviewIdentityIconItem,
+	OverviewIdentityIconRail,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewModuleUnavailable,
-	OverviewSummaryRows,
+	OverviewResourceSummary,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -35,27 +36,29 @@ export function OverviewProjectsBody({
 	if (bindings.isUnavailable) return <OverviewModuleUnavailable />;
 	if (bindings.error) return <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />;
 	const count = bindings.count ?? 0;
-	return (
-		<div className="space-y-3">
-			<p data-overview-primary-value className="text-base font-semibold">
-				{count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added"}
-			</p>
-			{count === 0 ? null : names.isLoading ? (
+	const primary = count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added";
+	if (count === 0) return <OverviewResourceSummary primary={primary} />;
+	if (names.isLoading)
+		return (
+			<OverviewResourceSummary primary={primary}>
 				<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
-			) : names.error ? (
+			</OverviewResourceSummary>
+		);
+	if (names.error)
+		return (
+			<OverviewResourceSummary primary={primary}>
 				<OverviewModuleError label="Project names" onRetry={names.onRetry} />
-			) : (
-				<>
-					<OverviewSummaryRows items={names.items} empty="Project names can’t be shown" />
-					{names.unresolvedCount > 0 ? (
-						<p className="text-xs text-muted-foreground">
-							{names.unresolvedCount} project{" "}
-							{names.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown
-						</p>
-					) : null}
-				</>
-			)}
-		</div>
+			</OverviewResourceSummary>
+		);
+	const unresolvedCopy = names.unresolvedCount
+		? `${names.unresolvedCount} project ${names.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown`
+		: "Project names can’t be shown";
+	return (
+		<OverviewResourceSummary primary={primary} items={names.items}>
+			{names.unresolvedCount > 0 || names.items.length === 0 ? (
+				<p className="text-sm text-muted-foreground">{unresolvedCopy}</p>
+			) : null}
+		</OverviewResourceSummary>
 	);
 }
 
@@ -67,14 +70,14 @@ export function OverviewSkillsBody({
 	if (state.isUnavailable) return <OverviewModuleUnavailable />;
 	if (state.error) return <OverviewModuleError label="Skills" onRetry={state.onRetry} />;
 	return (
-		<div className="space-y-3">
-			<p data-overview-primary-value className="text-base font-semibold">
-				{items.length
+		<OverviewResourceSummary
+			primary={
+				items.length
 					? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
-					: "No skills available"}
-			</p>
-			{items.length ? <OverviewChips items={items} empty="No skills available" /> : null}
-		</div>
+					: "No skills available"
+			}
+			items={items}
+		/>
 	);
 }
 
@@ -90,9 +93,9 @@ export function OverviewMemoriesBody() {
 		return <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />;
 	const total = query.data?.total ?? 0;
 	return (
-		<p data-overview-primary-value className="text-base font-semibold">
-			{total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet"}
-		</p>
+		<OverviewResourceSummary
+			primary={total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet"}
+		/>
 	);
 }
 
@@ -111,19 +114,14 @@ export function OverviewVaultsBody({
 		return <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />;
 	const vaults = query.data ?? [];
 	return (
-		<div className="space-y-3">
-			<p data-overview-primary-value className="text-base font-semibold">
-				{vaults.length
+		<OverviewResourceSummary
+			primary={
+				vaults.length
 					? `${vaults.length} ${vaults.length === 1 ? "vault" : "vaults"}`
-					: "No vaults available"}
-			</p>
-			{vaults.length ? (
-				<OverviewSummaryRows
-					items={vaults.map((vault) => vault.name)}
-					empty="No vaults available"
-				/>
-			) : null}
-		</div>
+					: "No vaults available"
+			}
+			items={vaults.map((vault) => vault.name)}
+		/>
 	);
 }
 
@@ -218,9 +216,9 @@ function ConnectorRail({
 	loadingSlots: number;
 }) {
 	return (
-		<div className="flex flex-wrap gap-2" data-testid="overview-connector-rail">
+		<OverviewIdentityIconRail label="Connector apps" testId="overview-connector-rail">
 			{apps.map(({ app, state }) => (
-				<div key={app.name} className="relative">
+				<OverviewIdentityIconItem key={app.name} connected={state === "connected"}>
 					<Link
 						to="/connectors/$name"
 						params={{ name: app.name }}
@@ -230,16 +228,13 @@ function ConnectorRail({
 					>
 						<ConnectorIcon name={app.display_name} logo={app.logo} size="sm" />
 					</Link>
-					{state === "connected" ? (
-						<span className="absolute -right-1 -bottom-1 rounded-full bg-background text-primary">
-							<CircleCheck className="size-4 fill-background" aria-hidden="true" />
-						</span>
-					) : null}
-				</div>
+				</OverviewIdentityIconItem>
 			))}
 			{Array.from({ length: loadingSlots }).map((_, index) => (
-				<Skeleton key={index} className="size-9 rounded-lg" aria-label="Loading app" />
+				<li key={index}>
+					<Skeleton className="size-9 rounded-lg" aria-label="Loading app" />
+				</li>
 			))}
-		</div>
+		</OverviewIdentityIconRail>
 	);
 }

--- a/apps/web/src/components/sessions/session-feed.test.tsx
+++ b/apps/web/src/components/sessions/session-feed.test.tsx
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { OverviewSessionList } from "@/components/sessions/session-feed";
 
 describe("OverviewSessionList", () => {
+	test("reuses the single SessionCard structure without a compact visual prop", () => {
+		const source = readFileSync(new URL("./session-feed.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("export function SessionCard(");
+		expect(source.match(/<SessionCard\b/g)).toHaveLength(3);
+		expect(source.match(/<SessionCardSkeleton\b/g)).toHaveLength(2);
+		expect(source).not.toContain("SessionFeedCard");
+		expect(source).not.toMatch(/\bcompact\b/);
+		expect(source).not.toContain("EntityHeader");
+		expect(source.match(/data-testid="session-card-title"/g)).toHaveLength(1);
+		expect(source.match(/data-testid="session-card-meta"/g)).toHaveLength(1);
+	});
+
 	test("renders three loading rows without session links", () => {
 		const markup = renderToStaticMarkup(
 			createElement(OverviewSessionList, {

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -5,7 +5,7 @@ import { MessageSquare } from "lucide-react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentIdentity } from "@/components/dashboard/agent-label";
 import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
-import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { SectionLabel } from "@/components/section-label";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -20,6 +20,31 @@ import {
 } from "@/lib/utils";
 
 type SessionLinkOptions = Pick<LinkProps, "to" | "params" | "search" | "hash">;
+
+type SessionMetadataItem = {
+	key: string;
+	value: string;
+	title?: string;
+	className?: string;
+};
+
+const SESSION_CARD_CLASS = "flex min-h-16.5 min-w-0 items-center gap-3 px-4 py-3 transition-colors";
+
+function SessionCardSkeleton({ testId }: { testId?: string }) {
+	return (
+		<div
+			data-testid={testId}
+			aria-hidden="true"
+			className={cn(ENTITY_CARD_BASE, SESSION_CARD_CLASS)}
+		>
+			<Skeleton className="size-8 shrink-0 rounded-md" />
+			<div className="min-w-0 flex-1">
+				<Skeleton className="h-4 w-4/5" />
+				<Skeleton className="mt-1.5 h-3 w-1/2" />
+			</div>
+		</div>
+	);
+}
 
 export function OverviewSessionList({
 	sessions,
@@ -41,17 +66,7 @@ export function OverviewSessionList({
 				role="status"
 			>
 				{Array.from({ length: 3 }).map((_, index) => (
-					<div
-						key={index}
-						data-testid="overview-session-skeleton-row"
-						aria-hidden="true"
-						className={cn(ENTITY_CARD_BASE, "px-4 py-3")}
-					>
-						<div className="flex h-10 flex-col justify-center">
-							<Skeleton className="h-4 w-4/5" />
-							<Skeleton className="mt-1.5 h-3 w-1/2" />
-						</div>
-					</div>
+					<SessionCardSkeleton key={index} testId="overview-session-skeleton-row" />
 				))}
 			</div>
 		);
@@ -61,13 +76,12 @@ export function OverviewSessionList({
 	return (
 		<div data-testid="overview-session-grid" className="grid gap-2">
 			{visibleSessions.map((session) => (
-				<SessionFeedCard
+				<SessionCard
 					key={session.id}
 					session={session}
 					showAgent={false}
 					quietAutomated={true}
 					link={sessionLink(session)}
-					compact
 				/>
 			))}
 			{Array.from({ length: placeholderCount }).map((_, index) => (
@@ -77,7 +91,8 @@ export function OverviewSessionList({
 					aria-hidden="true"
 					className={cn(
 						ENTITY_CARD_BASE,
-						"pointer-events-none flex h-16.5 items-center border-border/60 bg-muted/10 px-4 py-3 text-xs text-muted-foreground select-none",
+						SESSION_CARD_CLASS,
+						"pointer-events-none border-border/60 bg-muted/10 text-xs text-muted-foreground select-none",
 					)}
 				>
 					{visibleSessions.length === 0 && index === 0 ? emptyMessage : null}
@@ -126,10 +141,7 @@ export function SessionFeed({
 		return (
 			<div className="flex flex-col gap-2">
 				{Array.from({ length: 5 }).map((_, index) => (
-					<div key={index} className={ENTITY_CARD_BASE}>
-						<Skeleton className="h-4 w-4/5" />
-						<Skeleton className="mt-3 h-3 w-1/2" />
-					</div>
+					<SessionCardSkeleton key={index} />
 				))}
 			</div>
 		);
@@ -143,7 +155,7 @@ export function SessionFeed({
 		return (
 			<div className="flex flex-col gap-2">
 				{sessions.map((session) => (
-					<SessionFeedCard
+					<SessionCard
 						key={session.id}
 						session={session}
 						showAgent={showAgent}
@@ -172,7 +184,7 @@ export function SessionFeed({
 					<SectionLabel>{group.label}</SectionLabel>
 					<div className="flex flex-col gap-2">
 						{group.items.map((session) => (
-							<SessionFeedCard
+							<SessionCard
 								key={session.id}
 								session={session}
 								showAgent={showAgent}
@@ -187,18 +199,16 @@ export function SessionFeed({
 	);
 }
 
-function SessionFeedCard({
+export function SessionCard({
 	session,
 	showAgent = true,
 	quietAutomated = true,
 	link,
-	compact = false,
 }: {
 	session: SessionListItem;
 	showAgent?: boolean;
 	quietAutomated?: boolean;
 	link: SessionLinkOptions;
-	compact?: boolean;
 }) {
 	const title = formatSessionSummary(session.summary) || session.local_session_id.slice(0, 8);
 	const projectFolder = session.project_path?.split("/").pop();
@@ -207,67 +217,68 @@ function SessionFeedCard({
 	// Cron jobs and bracketed heartbeats are routine noise — keep them in the
 	// timeline but visually quieter than human work (taste audit round 2).
 	const isAutomated = quietAutomated && /^(Cron:|\[)/.test(title);
+	const metadata: SessionMetadataItem[] = [
+		showAgent ? { key: "agent", value: agent } : null,
+		projectFolder
+			? {
+					key: "project",
+					value: projectFolder,
+					title: session.project_path ?? undefined,
+					className: "font-mono",
+				}
+			: null,
+		{
+			key: "messages",
+			value: `${session.message_count} ${session.message_count === 1 ? "message" : "messages"}`,
+		},
+		{ key: "tokens", value: `${formatNumber(totalTokens)} tokens` },
+		{
+			key: "time",
+			value: relativeTime(session.last_activity_at),
+			title: formatAbsoluteTooltip(session.last_activity_at),
+		},
+	].filter((item): item is SessionMetadataItem => item !== null);
 	return (
-		<article className="group relative z-0">
-			<div
+		<article data-testid="session-card" className="min-w-0">
+			<Link
+				{...link}
+				aria-label={`Open session ${title}`}
 				className={cn(
 					ENTITY_CARD_BASE,
-					"transition-colors group-hover:bg-muted/50",
-					compact && "h-16.5 px-4 py-3",
+					SESSION_CARD_CLASS,
+					"group hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
 					isAutomated && "bg-muted/30",
 				)}
 			>
-				{compact ? (
-					<div className="flex min-w-0 items-center gap-3">
-						<span data-testid="overview-session-avatar" className="flex shrink-0">
-							<AgentIcon agent={session.agent_type} size="lg" />
-						</span>
-						<div data-testid="overview-session-text" className="w-0 min-w-0 flex-1 overflow-hidden">
-							<p data-testid="overview-session-title" className="truncate text-sm font-semibold">
-								{title}
-							</p>
-							<div
-								data-testid="overview-session-meta"
-								className="mt-1 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground"
-							>
-								<span>
-									{session.message_count} {session.message_count === 1 ? "message" : "messages"}
-								</span>
-								<span aria-hidden="true">·</span>
-								<span>{formatNumber(totalTokens)} tokens</span>
-								<span aria-hidden="true">·</span>
-								<span title={formatAbsoluteTooltip(session.last_activity_at)}>
-									{relativeTime(session.last_activity_at)}
-								</span>
-							</div>
-						</div>
-					</div>
-				) : (
-					<EntityHeader
-						align="start"
-						icon={<AgentIcon agent={session.agent_type} size="lg" />}
+				<span data-testid="session-card-avatar" className="flex shrink-0">
+					<AgentIcon agent={session.agent_type} size="lg" />
+				</span>
+				<span data-testid="session-card-text" className="w-0 min-w-0 flex-1">
+					<span
+						data-testid="session-card-title"
+						className="block truncate text-sm leading-5 font-semibold"
 						title={title}
-						meta={[
-							showAgent ? agent : null,
-							projectFolder ? (
-								<span key="folder" className="font-mono" title={session.project_path ?? undefined}>
-									{projectFolder}
+					>
+						{title}
+					</span>
+					<span
+						data-testid="session-card-meta"
+						className="mt-0.5 flex min-w-0 flex-wrap items-center gap-y-0 text-xs leading-4 text-muted-foreground"
+					>
+						{metadata.map((item, index) => (
+							<span key={item.key} className="inline-flex min-w-0 max-w-full items-center">
+								{index > 0 ? (
+									<span className="mx-1.5 shrink-0 text-muted-foreground/40" aria-hidden="true">
+										·
+									</span>
+								) : null}
+								<span className={cn("min-w-0 truncate", item.className)} title={item.title}>
+									{item.value}
 								</span>
-							) : null,
-							`${session.message_count} ${session.message_count === 1 ? "message" : "messages"}`,
-							`${formatNumber(totalTokens)} tokens`,
-							<span key="time" title={formatAbsoluteTooltip(session.last_activity_at)}>
-								{relativeTime(session.last_activity_at)}
-							</span>,
-						]}
-					/>
-				)}
-			</div>
-			<Link
-				{...link}
-				className="absolute inset-0 z-10 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-			>
-				<span className="sr-only">Open session {session.local_session_id}</span>
+							</span>
+						))}
+					</span>
+				</span>
 			</Link>
 		</article>
 	);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -35,10 +35,11 @@ import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
+	OverviewIdentityIconItem,
+	OverviewIdentityIconRail,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
 	OverviewModuleUnavailable,
-	OverviewSummaryRows,
 } from "@/components/dashboard/agent-overview-capabilities";
 import {
 	OverviewConnectorsBody,
@@ -270,6 +271,7 @@ import {
 	ChannelStatusBadge,
 	CopyInline,
 	isNormalChannelStatus,
+	ProviderChip,
 } from "@/hosted/v2/channels/channel-ui";
 import {
 	useAgentChannelLinks,
@@ -1163,11 +1165,9 @@ function OverviewTab({
 	);
 	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
 	const linkedChannelCount = channelLinks.data?.length ?? 0;
-	const linkedChannelRows = (channelLinks.data ?? []).flatMap((link) => {
-		if (!link.account) return [];
-		const provider = providerMeta(link.account.provider).label;
-		return [`${provider}: ${link.account.name}`];
-	});
+	const linkedChannels = (channelLinks.data ?? []).flatMap((link) =>
+		link.account ? [link.account] : [],
+	);
 	const projectionLoading = projectionStatus === "loading";
 	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
 	return (
@@ -1317,7 +1317,7 @@ function OverviewTab({
 									>
 										{model}
 									</p>
-									<p data-overview-tool-secondary className="text-sm">
+									<p data-overview-tool-secondary className="text-sm text-muted-foreground">
 										{managedProvider
 											? "Managed by Clawdi"
 											: providerDisplayLabel(providerId ?? "", providers.data ?? [])}
@@ -1345,11 +1345,34 @@ function OverviewTab({
 										? "No channels connected"
 										: `${linkedChannelCount} connected ${linkedChannelCount === 1 ? "channel" : "channels"}`}
 								</p>
-								{linkedChannelCount > 0 ? (
-									<OverviewSummaryRows
-										items={linkedChannelRows}
-										empty="Channel details unavailable"
-									/>
+								{linkedChannels.length > 0 ? (
+									<OverviewIdentityIconRail
+										label="Connected channels"
+										testId="overview-channel-rail"
+									>
+										{linkedChannels.slice(0, 5).map((channel) => {
+											const provider = providerMeta(channel.provider).label;
+											return (
+												<OverviewIdentityIconItem key={channel.id} connected>
+													<Link
+														to="/channels/$id"
+														params={{ id: channel.id }}
+														aria-label={`Connected channel: ${provider}, ${channel.name}`}
+														title={`${provider}: ${channel.name} (connected)`}
+														className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+													>
+														<ProviderChip
+															provider={channel.provider}
+															size="md"
+															className="size-9"
+														/>
+													</Link>
+												</OverviewIdentityIconItem>
+											);
+										})}
+									</OverviewIdentityIconRail>
+								) : linkedChannelCount > 0 ? (
+									<p className="text-sm text-muted-foreground">Channel details unavailable</p>
 								) : null}
 							</div>
 						),


### PR DESCRIPTION
## Summary
- use one shared `SessionCard` structure across overview, agent, dashboard, and global session feeds
- align session avatar size, typography, height, link semantics, skeletons, and overview placeholders
- show project, skill, and vault names with the existing shadcn Badge primitive
- share a compact accessible icon rail between Connectors and Channels
- keep Model & Provider as primary model plus muted provider text

## Validation
- focused unit tests
- isolated full Web test suite
- Web typecheck
- OSS production build
- Biome
- mocked Playwright across hosted/connected overview, agent/global sessions, desktop/mobile, light/dark, loading/error/empty states
- `git diff --check origin/main..HEAD`

## Safety
- no production or tenant access
- Web-only change; no backend or protocol changes
