### PR TITLE
fix(runtime): make install receipts authoritative

### DIFF
--- a/packages/cli/src/runtime/install-receipts.ts
+++ b/packages/cli/src/runtime/install-receipts.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -38,18 +38,32 @@ export function runtimeInstallReceiptsPath(paths: RuntimePaths): string {
 
 export function readRuntimeInstallReceipts(paths: RuntimePaths): RuntimeInstallReceipts | null {
 	const path = runtimeInstallReceiptsPath(paths);
-	if (!existsSync(path)) return null;
+	let stat: ReturnType<typeof lstatSync>;
 	try {
-		const stat = lstatSync(path);
-		if (!stat.isFile() || (stat.mode & 0o777) !== 0o600) return null;
-		if (typeof process.getuid === "function" && stat.uid !== process.getuid()) return null;
-		if (typeof process.getgid === "function" && stat.gid !== process.getgid()) return null;
-		const value: unknown = JSON.parse(readFileSync(path, "utf8"));
-		const parsed = runtimeInstallReceiptsSchema.safeParse(value);
-		return parsed.success ? parsed.data : null;
-	} catch {
-		return null;
+		stat = lstatSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw runtimeInstallReceiptError("could not be inspected", error);
 	}
+	if (!stat.isFile()) {
+		throw new Error("runtime install receipts are not a trusted regular file");
+	}
+	if ((stat.mode & 0o777) !== 0o600) {
+		throw new Error("runtime install receipts do not have private file permissions");
+	}
+	if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+		throw new Error("runtime install receipts do not have the expected file owner");
+	}
+
+	let value: unknown;
+	try {
+		value = JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		throw runtimeInstallReceiptError("could not be decoded", error);
+	}
+	const parsed = runtimeInstallReceiptsSchema.safeParse(value);
+	if (!parsed.success) throw new Error("runtime install receipts do not match the expected schema");
+	return parsed.data;
 }
 
 export function writeRuntimeInstallReceipts(
@@ -57,12 +71,28 @@ export function writeRuntimeInstallReceipts(
 	paths: RuntimePaths,
 ): void {
 	const parsed = runtimeInstallReceiptsSchema.parse(receipts);
-	writePrivateFileAtomic(
-		runtimeInstallReceiptsPath(paths),
-		`${JSON.stringify(parsed, null, 2)}\n`,
-		{
-			mode: 0o600,
-			dirMode: 0o755,
-		},
-	);
+	try {
+		writePrivateFileAtomic(
+			runtimeInstallReceiptsPath(paths),
+			`${JSON.stringify(parsed, null, 2)}\n`,
+			{
+				mode: 0o600,
+				dirMode: 0o755,
+			},
+		);
+	} catch (error) {
+		throw runtimeInstallReceiptError("could not be persisted", error);
+	}
+	const persisted = readRuntimeInstallReceipts(paths);
+	if (!persisted || JSON.stringify(persisted) !== JSON.stringify(parsed)) {
+		throw new Error("runtime install receipts did not pass post-write verification");
+	}
+}
+
+function runtimeInstallReceiptError(message: string, error: unknown): Error {
+	const code =
+		typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+			? ` (${error.code})`
+			: "";
+	return new Error(`runtime install receipts ${message}${code}`);
 }

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -275,9 +275,11 @@ function egressRuntimeManifest(
 ): RuntimeManifest {
 	process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
 	const commandPath = join(paths.userHome, ".openclaw", "bin", "openclaw");
-	mkdirSync(dirname(commandPath), { recursive: true });
-	writeFileSync(commandPath, "#!/usr/bin/env sh\nexit 0\n");
-	chmodSync(commandPath, 0o700);
+	writeFakeGatewayCli({
+		path: commandPath,
+		runtime: "openclaw",
+		unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+	});
 	return baseManifest(
 		paths,
 		{
@@ -500,6 +502,7 @@ function writeFakeGatewayCli(input: {
 	path: string;
 	runtime: "openclaw" | "hermes";
 	unitPath: string;
+	configPatchPath?: string;
 	failInstall?: boolean;
 }): void {
 	mkdirSync(dirname(input.path), { recursive: true });
@@ -508,6 +511,12 @@ function writeFakeGatewayCli(input: {
 		`#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
+	"--version")
+		printf '%s\\n' '${input.runtime === "openclaw" ? "OpenClaw test-version" : "Hermes test-version"}'
+		;;
+  "config patch --stdin")
+    ${input.configPatchPath ? `cat > '${input.configPatchPath}'` : "cat >/dev/null"}
+    ;;
   "gateway install --force --json"|"gateway install --force"|"gateway install")
     ${
 			input.failInstall
@@ -519,8 +528,12 @@ Description=Official gateway
 
 [Service]
 ExecStart=official gateway run
-EOF`
+EOF
+    printf '%s\\n' '{"ok":true}'`
 		}
+    ;;
+  "gateway uninstall")
+    rm -f '${input.unitPath}'
     ;;
   *)
     printf 'unexpected ${input.runtime} command: %s\\n' "$*" >&2
@@ -2919,9 +2932,11 @@ describe("runtime manifest reconciliation invariants", () => {
 			egressEngine.sha256,
 			"mitmdump",
 		);
-		mkdirSync(dirname(commandPath), { recursive: true });
-		writeFileSync(commandPath, "#!/usr/bin/env sh\nexit 0\n");
-		chmodSync(commandPath, 0o700);
+		writeFakeGatewayCli({
+			path: commandPath,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		mkdirSync(dirname(engineBinary), { recursive: true });
 		writeFileSync(engineBinary, "#!/usr/bin/env sh\nexit 0\n");
 		chmodSync(engineBinary, 0o700);
@@ -3096,9 +3111,11 @@ describe("runtime manifest reconciliation invariants", () => {
 			egressEngine.sha256,
 			"mitmdump",
 		);
-		mkdirSync(dirname(commandPath), { recursive: true });
-		writeFileSync(commandPath, "#!/usr/bin/env sh\nexit 0\n");
-		chmodSync(commandPath, 0o700);
+		writeFakeGatewayCli({
+			path: commandPath,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		mkdirSync(dirname(engineBinary), { recursive: true });
 		writeFileSync(engineBinary, "#!/usr/bin/env sh\nexit 0\n");
 		chmodSync(engineBinary, 0o700);
@@ -3943,17 +3960,12 @@ describe("runtime manifest reconciliation invariants", () => {
 		chmodSync(paths.runConfigRoot, 0o755);
 		chmodSync(paths.systemdEnvRoot, 0o755);
 		chmodSync(paths.managedSecretRoot, 0o711);
-		writeFileSync(
-			commandPath,
-			[
-				"#!/usr/bin/env bash",
-				"set -euo pipefail",
-				"cat >/dev/null || true",
-				`printf '%s\\n' '{"forward-converged":true}' > '${targetConfig}'`,
-				"",
-			].join("\n"),
-		);
-		chmodSync(commandPath, 0o700);
+		writeFakeGatewayCli({
+			path: commandPath,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+			configPatchPath: targetConfig,
+		});
 		mkdirSync(dropInRoot, { recursive: true });
 		writeFileSync(
 			managedUserDropIn,
@@ -4452,6 +4464,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			`#!/usr/bin/env bash
 set -euo pipefail
 test "$(id -u)" = "10001"
+if [ "$*" = "--version" ]; then
+  printf '%s\\n' 'OpenClaw test-version'
+  exit 0
+fi
 test "$*" = "gateway install --force --json"
 unit="$HOME/.config/systemd/user/\${OPENCLAW_SYSTEMD_UNIT:-openclaw-gateway.service}"
 cp "$unit" "$unit.bak"

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -12,7 +12,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { readRuntimeInstallReceipts } from "./install-receipts";
+import {
+	readRuntimeInstallReceipts,
+	runtimeInstallReceiptsPath,
+	writeRuntimeInstallReceipts,
+} from "./install-receipts";
 import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	type RuntimeManifest,
@@ -98,6 +102,8 @@ function writeFakeGatewayCli(input: {
 		snapshotPrefix: string;
 	};
 }): void {
+	const version =
+		input.version ?? (input.runtime === "hermes" ? "Hermes Agent v0.18.0" : "OpenClaw 2026.7.29");
 	const stateCheck = input.requiredSystemdState
 		? `test -f '${input.requiredSystemdState.envPath}'
     test -f '${input.requiredSystemdState.dropInPath}'
@@ -110,15 +116,11 @@ function writeFakeGatewayCli(input: {
 	writeFileSync(
 		input.path,
 		`#!/usr/bin/env bash
-set -euo pipefail
-case "$*" in
-	${
-		input.version
-			? `"--version")
-	printf '%s\\n' '${input.version}'
-	;;`
-			: ""
-	}
+	set -euo pipefail
+	case "$*" in
+	  "--version")
+		printf '%s\\n' '${version}'
+		;;
   "gateway install --force --json"|"gateway install --force"|"gateway install")
 	${stateCheck}
 	printf '%s %s\\n' '${input.runtime}' "$*" >> '${input.logPath}'
@@ -212,6 +214,7 @@ function writeFakePluginCli(input: {
 	inspectStatePath: string;
 	pluginSourcePath: string;
 	failInstallMarker: string;
+	version?: string;
 }): void {
 	mkdirSync(dirname(input.path), { recursive: true });
 	writeFileSync(
@@ -219,7 +222,7 @@ function writeFakePluginCli(input: {
 		`#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  "--version") printf '%s\\n' 'OpenClaw 2026.7.29' ;;
+	  "--version") printf '%s\\n' '${input.version ?? "OpenClaw 2026.7.29"}' ;;
   "plugins inspect discord --json") cat '${input.inspectStatePath}' ;;
   "plugins install @openclaw/discord")
 	mkdir -p '${dirname(input.inspectStatePath)}'
@@ -241,32 +244,38 @@ esac
 interface InstallGateHarness {
 	converge: (commitAuthority?: () => void) => ReturnType<typeof convergeRuntimeManifest>;
 	drift: () => void;
+	revise: () => void;
 	failNextInstall: () => void;
 	restoreInstaller: () => void;
 	installCount: () => number;
 	receipt: () => unknown;
 }
 
-function officialServiceHarness(): InstallGateHarness {
+function officialServiceHarness(runtime: "openclaw" | "hermes" = "hermes"): InstallGateHarness {
 	const paths = tempRuntimePaths();
 	const logPath = join(paths.runRoot, "official-service-receipt.log");
-	const command = join(paths.userHome, ".local", "bin", "hermes");
-	const unitPath = join(paths.systemdUserRoot, "hermes-gateway.service");
+	const command =
+		runtime === "openclaw"
+			? join(paths.userHome, ".openclaw", "bin", "openclaw")
+			: join(paths.userHome, ".local", "bin", "hermes");
+	const unitPath = join(paths.systemdUserRoot, `${runtime}-gateway.service`);
 	const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
 	process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
 	writeFakeSystemctl({ path: systemctlCommand, logPath });
-	const writeCli = (failInstall = false) =>
+	const writeCli = (failInstall = false, version?: string) =>
 		writeFakeGatewayCli({
 			path: command,
 			logPath,
-			runtime: "hermes",
+			runtime,
 			unitPath,
-			version: "Hermes Agent v0.18.0",
+			version: version ?? (runtime === "hermes" ? "Hermes Agent v0.18.0" : "OpenClaw 2026.7.29"),
 			failInstall,
 		});
 	writeCli();
+	const manifest = installGateManifest(paths, runtime, command);
+	if (runtime === "openclaw") delete manifest.projection;
 	const load: RuntimeManifestLoad = {
-		manifest: installGateManifest(paths, "hermes", command),
+		manifest,
 		source: "remote-datasource",
 		sourcePath: "inline-service-receipt",
 		offline: false,
@@ -278,10 +287,15 @@ function officialServiceHarness(): InstallGateHarness {
 				executeOfficialServiceInstallers: true,
 			}),
 		drift: () => chmodSync(unitPath, 0o600),
+		revise: () =>
+			writeCli(false, runtime === "hermes" ? "Hermes Agent v0.18.1" : "OpenClaw 2026.7.30"),
 		failNextInstall: () => writeCli(true),
 		restoreInstaller: () => writeCli(),
-		installCount: () => readFileSync(logPath, "utf8").match(/hermes gateway install/g)?.length ?? 0,
-		receipt: () => readRuntimeInstallReceipts(paths)?.officialServices["hermes-gateway.service"],
+		installCount: () =>
+			readFileSync(logPath, "utf8").match(new RegExp(`${runtime} gateway install`, "g"))?.length ??
+			0,
+		receipt: () =>
+			readRuntimeInstallReceipts(paths)?.officialServices[`${runtime}-gateway.service`],
 	};
 }
 
@@ -311,6 +325,15 @@ function channelPluginHarness(): InstallGateHarness {
 		converge: (commitAuthority) =>
 			convergeRuntimeManifest(load, paths, commitAuthority ? { commitAuthority } : {}),
 		drift: () => writeFileSync(pluginSourcePath, "export const discordPlugin = false;\n"),
+		revise: () =>
+			writeFakePluginCli({
+				path: command,
+				installLogPath,
+				inspectStatePath,
+				pluginSourcePath,
+				failInstallMarker,
+				version: "OpenClaw 2026.7.30",
+			}),
 		failNextInstall: () => writeFileSync(failInstallMarker, "fail\n"),
 		restoreInstaller: () => rmSync(failInstallMarker, { force: true }),
 		installCount: () =>
@@ -320,7 +343,8 @@ function channelPluginHarness(): InstallGateHarness {
 }
 
 const installGateHarnesses = [
-	["official service", officialServiceHarness],
+	["Hermes official service", () => officialServiceHarness("hermes")],
+	["OpenClaw official service", () => officialServiceHarness("openclaw")],
 	["channel plugin", channelPluginHarness],
 ] as const;
 
@@ -1177,7 +1201,7 @@ describe("runtime manifest services", () => {
 		}
 	});
 
-	test("prepares the Hermes dashboard artifact before activation and keeps ExecStart build-free", () => {
+	test("reuses the Hermes dashboard artifact across full refreshes and rebuilds real drift", () => {
 		const paths = tempRuntimePaths();
 		const logPath = join(paths.runRoot, "hermes-dashboard-prerequisite.log");
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
@@ -1246,17 +1270,29 @@ describe("runtime manifest services", () => {
 		);
 		expect(converge().installErrors).toEqual([]);
 		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
+		expect(converge().installErrors).toEqual([]);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
 		expect(
 			readRuntimeInstallReceipts(paths)?.officialServices["hermes-dashboard:artifact"],
 		).toBeDefined();
 
-		writeFileSync(join(dirname(distIndex), "app.js"), "drifted asset\n");
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.1",
+		});
 		expect(converge().installErrors).toEqual([]);
 		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(6);
 
-		rmSync(join(dirname(distIndex), "app.js"));
+		writeFileSync(join(dirname(distIndex), "app.js"), "drifted asset\n");
 		expect(converge().installErrors).toEqual([]);
 		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(9);
+
+		rmSync(join(dirname(distIndex), "app.js"));
+		expect(converge().installErrors).toEqual([]);
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(12);
 	});
 
 	test("passes the transparent-egress system CA to every Hermes dashboard npm command", () => {
@@ -1303,7 +1339,7 @@ describe("runtime manifest services", () => {
 		]);
 	});
 
-	test("binds a cold Hermes dashboard receipt after the installer creates the command", () => {
+	test("reuses a persisted Hermes dashboard receipt after process planning restarts", () => {
 		const paths = tempRuntimePaths();
 		const logPath = join(paths.runRoot, "hermes-dashboard-cold-receipt.log");
 		const npmCommand = join(paths.runRoot, "bin", "npm");
@@ -1348,9 +1384,7 @@ describe("runtime manifest services", () => {
 		const currentRevision = coldPlan.target?.expectedCurrentRevision;
 		expect(currentRevision).toMatch(/^[a-f0-9]{64}$/);
 
-		const receiptPlan = planHermesDashboardArtifact(
-			[program],
-			paths,
+		writeRuntimeInstallReceipts(
 			{
 				schemaVersion: "clawdi.runtimeInstallReceipts.v1",
 				officialServices: {
@@ -1361,6 +1395,12 @@ describe("runtime manifest services", () => {
 				},
 				channelPlugins: {},
 			},
+			paths,
+		);
+		const receiptPlan = planHermesDashboardArtifact(
+			[program],
+			paths,
+			readRuntimeInstallReceipts(paths),
 			true,
 		);
 		expect(prepareHermesDashboardArtifact(receiptPlan, paths)).toBeNull();
@@ -1450,6 +1490,176 @@ describe("runtime manifest services", () => {
 		expect(existsSync(join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"))).toBe(false);
 		expect(existsSync(join(paths.systemdUserRoot, "hermes-gateway.service"))).toBe(false);
 		expect(existsSync(join(paths.userHome, ".hermes", "config.yaml"))).toBe(false);
+
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const retry = convergeRuntimeManifest(
+			{
+				manifest,
+				source: "remote-datasource",
+				sourcePath: "inline-dashboard-retry",
+				offline: false,
+			},
+			paths,
+			{
+				systemdApply: {
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
+					rollback: () => {},
+				},
+			},
+		);
+		expect(retry.installErrors).toEqual([]);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>Hermes dashboard</html>\n");
+		expect(
+			readRuntimeInstallReceipts(paths)?.officialServices["hermes-dashboard:artifact"],
+		).toBeDefined();
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(6);
+	});
+
+	test("blocks Hermes dashboard preparation when an existing receipt cannot be read", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-receipt-read.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(dirname(distIndex), { recursive: true });
+		writeFileSync(distIndex, "<html>trusted dashboard</html>\n");
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const receiptPath = runtimeInstallReceiptsPath(paths);
+		mkdirSync(dirname(receiptPath), { recursive: true });
+		writeFileSync(receiptPath, "{not-json}\n", { mode: 0o600 });
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, ["dashboard"]);
+		let authorityCommits = 0;
+
+		const result = convergeRuntimeManifest(
+			{
+				manifest,
+				source: "remote-datasource",
+				sourcePath: "inline-dashboard-receipt-read-failure",
+				offline: false,
+			},
+			paths,
+			{
+				commitAuthority: () => {
+					authorityCommits += 1;
+				},
+				executeOfficialServiceInstallers: true,
+			},
+		);
+
+		expect(result.installErrors).toEqual([
+			expect.stringContaining("runtime install receipts could not be decoded"),
+		]);
+		expect(authorityCommits).toBe(0);
+		expect(existsSync(logPath)).toBe(false);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>trusted dashboard</html>\n");
+	});
+
+	test("rolls back a built Hermes artifact when receipt persistence fails, then retries", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "hermes-dashboard-receipt-write.log");
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const npmCommand = join(paths.runRoot, "bin", "npm");
+		const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
+		const distIndex = join(
+			paths.userHome,
+			".hermes",
+			"hermes-agent",
+			"hermes_cli",
+			"web_dist",
+			"index.html",
+		);
+		mkdirSync(dirname(distIndex), { recursive: true });
+		writeFileSync(distIndex, "<html>previous dashboard</html>\n");
+		process.env.PATH = `${dirname(npmCommand)}:${process.env.PATH ?? ""}`;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
+		writeFakeSystemctl({ path: systemctlCommand, logPath });
+		writeFakeGatewayCli({
+			path: hermesCommand,
+			logPath,
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+			version: "Hermes Agent v0.18.0",
+		});
+		writeFakeNpm({ path: npmCommand, logPath, distIndex });
+		const manifest = installGateManifest(paths, "hermes", hermesCommand);
+		manifest.runtimes.hermes!.services.dashboard = runSettings(hermesCommand, ["dashboard"]);
+		const receiptPath = runtimeInstallReceiptsPath(paths);
+		let authorityCommits = 0;
+		let rollbacks = 0;
+		const load: RuntimeManifestLoad = {
+			manifest,
+			source: "remote-datasource",
+			sourcePath: "inline-dashboard-receipt-write-failure",
+			offline: false,
+		};
+
+		const failed = convergeRuntimeManifest(load, paths, {
+			commitAuthority: () => {
+				authorityCommits += 1;
+			},
+			systemdApply: {
+				activateEgressPrerequisite: () => ({
+					applied: true,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				}),
+				activate: () => {
+					mkdirSync(receiptPath, { recursive: true });
+					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+				},
+				rollback: () => {
+					rollbacks += 1;
+				},
+			},
+		});
+
+		expect(failed.installErrors).toEqual([
+			expect.stringContaining("runtime install receipts could not be persisted"),
+		]);
+		expect(authorityCommits).toBe(0);
+		expect(rollbacks).toBe(1);
+		expect(existsSync(receiptPath)).toBe(false);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>previous dashboard</html>\n");
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(3);
+
+		const retried = convergeRuntimeManifest(load, paths, {
+			systemdApply: {
+				activateEgressPrerequisite: () => ({
+					applied: true,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				}),
+				activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
+				rollback: () => {},
+			},
+		});
+		expect(retried.installErrors).toEqual([]);
+		expect(readFileSync(distIndex, "utf8")).toBe("<html>Hermes dashboard</html>\n");
+		expect(
+			readRuntimeInstallReceipts(paths)?.officialServices["hermes-dashboard:artifact"],
+		).toBeDefined();
+		expect(readFileSync(logPath, "utf8").match(/^npm /gm)).toHaveLength(6);
 	});
 
 	test("rejects an upstream-incompatible npm before dashboard mutation", () => {
@@ -1606,11 +1816,23 @@ describe("runtime manifest services", () => {
 
 	test.each(
 		installGateHarnesses,
-	)("does not bless post-install %s drift during authority commit", (_name, createHarness) => {
+	)("reconciles a real %s command revision change exactly once", (_name, createHarness) => {
+		const harness = createHarness();
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(1);
+
+		harness.revise();
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(2);
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(2);
+	});
+
+	test.each(installGateHarnesses)("does not bless post-commit %s drift", (_name, createHarness) => {
 		const harness = createHarness();
 		expect(harness.converge(harness.drift).installErrors).toEqual([]);
 		expect(harness.installCount()).toBe(1);
-		expect(harness.receipt()).toBeUndefined();
+		expect(harness.receipt()).toBeDefined();
 
 		expect(harness.converge().installErrors).toEqual([]);
 		expect(harness.installCount()).toBe(2);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1828,6 +1828,23 @@ describe("runtime manifest services", () => {
 		expect(harness.installCount()).toBe(2);
 	});
 
+	test.each(
+		installGateHarnesses,
+	)("rolls back the %s receipt when authority commit fails", (_name, createHarness) => {
+		const harness = createHarness();
+		const failed = harness.converge(() => {
+			throw new Error("authority commit rejected");
+		});
+
+		expect(failed.installErrors.join("\n")).toContain("authority commit rejected");
+		expect(harness.installCount()).toBe(1);
+		expect(harness.receipt()).toBeUndefined();
+
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(2);
+		expect(harness.receipt()).toBeDefined();
+	});
+
 	test.each(installGateHarnesses)("does not bless post-commit %s drift", (_name, createHarness) => {
 		const harness = createHarness();
 		expect(harness.converge(harness.drift).installErrors).toEqual([]);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1845,6 +1845,30 @@ describe("runtime manifest services", () => {
 		expect(harness.receipt()).toBeDefined();
 	});
 
+	test.each(
+		installGateHarnesses,
+	)("restores the prior %s receipt when replacement authority fails", (_name, createHarness) => {
+		const harness = createHarness();
+		expect(harness.converge().installErrors).toEqual([]);
+		const previousReceipt = harness.receipt();
+		expect(previousReceipt).toBeDefined();
+
+		harness.revise();
+		const failed = harness.converge(() => {
+			throw new Error("replacement authority rejected");
+		});
+
+		expect(failed.installErrors.join("\n")).toContain("replacement authority rejected");
+		expect(harness.installCount()).toBe(2);
+		expect(harness.receipt()).toEqual(previousReceipt);
+
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(3);
+		expect(harness.receipt()).not.toEqual(previousReceipt);
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(3);
+	});
+
 	test.each(installGateHarnesses)("does not bless post-commit %s drift", (_name, createHarness) => {
 		const harness = createHarness();
 		expect(harness.converge(harness.drift).installErrors).toEqual([]);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -97,6 +97,7 @@ import {
 	type RuntimeInstallReceiptEntry,
 	type RuntimeInstallReceipts,
 	readRuntimeInstallReceipts,
+	runtimeInstallReceiptsPath,
 	writeRuntimeInstallReceipts,
 } from "./install-receipts";
 import {
@@ -5022,6 +5023,7 @@ function runtimeManagedMutationPlan(input: {
 	systemdUserUnits: string[];
 } {
 	const rootTargets = new Set(runtimeRootLiveMutationTargets(input.manifest, input.paths));
+	rootTargets.add(runtimeInstallReceiptsPath(input.paths));
 	const rootMetadataTargets = new Set<string>();
 	if (
 		hostedCodexManagedProvider(input.manifest) ||

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3467,7 +3467,11 @@ function installOpenClawChannelPlugins(input: {
 		input.receiptTargets.channelPlugins.set(key, target);
 		if (verifiedCurrentRevision !== null) continue;
 		runPluginInstallWithFallback(input.commandPath, specs, input.home, input.workspaceRoot);
-		target.expectedCurrentRevision = currentRevision();
+		const installedRevision = currentRevision();
+		if (!installedRevision) {
+			throw new Error(`OpenClaw ${channel} channel plugin install could not be verified`);
+		}
+		target.expectedCurrentRevision = installedRevision;
 	}
 }
 
@@ -4130,12 +4134,7 @@ function commitRuntimeInstallReceipts(
 	const receipts = emptyRuntimeInstallReceipts();
 	commitRuntimeInstallReceiptGroup(receipts.officialServices, targets.officialServices);
 	commitRuntimeInstallReceiptGroup(receipts.channelPlugins, targets.channelPlugins);
-	try {
-		writeRuntimeInstallReceipts(receipts, paths);
-	} catch {
-		// Receipt persistence is an optimization. Failing closed means the next
-		// convergence executes the unchanged official install commands again.
-	}
+	writeRuntimeInstallReceipts(receipts, paths);
 }
 
 function commitRuntimeInstallReceiptGroup(
@@ -4143,9 +4142,13 @@ function commitRuntimeInstallReceiptGroup(
 	targets: Map<string, RuntimeInstallReceiptTarget>,
 ): void {
 	for (const [key, target] of [...targets].sort(([left], [right]) => left.localeCompare(right))) {
-		if (!target.expectedCurrentRevision) continue;
+		if (!target.expectedCurrentRevision) {
+			throw new Error(`runtime install receipt target ${key} was not verified`);
+		}
 		const currentRevision = target.currentRevision();
-		if (currentRevision !== target.expectedCurrentRevision) continue;
+		if (currentRevision !== target.expectedCurrentRevision) {
+			throw new Error(`runtime install receipt target ${key} changed before commit`);
+		}
 		receipts[key] = { desiredRevision: target.desiredRevision, currentRevision };
 	}
 }
@@ -5179,7 +5182,7 @@ export function convergeRuntimeManifest(
 	const runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[] = [];
 	const installErrors: string[] = [];
 	const appliedState = readRuntimeAppliedState(paths);
-	const previousInstallReceipts = readRuntimeInstallReceipts(paths);
+	let previousInstallReceipts: RuntimeInstallReceipts | null = null;
 	const installReceiptTargets: RuntimeInstallReceiptTargets = {
 		officialServices: new Map(),
 		channelPlugins: new Map(),
@@ -5204,6 +5207,24 @@ export function convergeRuntimeManifest(
 		previousProjectedProviderIds,
 	});
 	if (installErrors.length > 0) {
+		return runtimeConvergenceWithoutApply({
+			load,
+			paths,
+			workspaceRoot,
+			enabledRuntimes,
+			installErrors,
+			projectedProviderIds: Object.fromEntries(
+				Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
+					runtime,
+					[...providerIds],
+				]),
+			),
+		});
+	}
+	try {
+		previousInstallReceipts = readRuntimeInstallReceipts(paths);
+	} catch (error) {
+		installErrors.push(error instanceof Error ? error.message : String(error));
 		return runtimeConvergenceWithoutApply({
 			load,
 			paths,
@@ -5923,6 +5944,7 @@ export function convergeRuntimeManifest(
 			const egressRevisionPreviouslyCommitted =
 				desiredEgressSidecarSecretRevision !== undefined &&
 				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
+			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			opts.commitAuthority?.(convergence, {
 				...(desiredDaemonAuthTokenRevision !== undefined &&
 				(systemdActivationApplied || daemonRevisionPreviouslyCommitted)
@@ -5933,7 +5955,6 @@ export function convergeRuntimeManifest(
 					? { egressSidecarSecretRevision: desiredEgressSidecarSecretRevision }
 					: {}),
 			});
-			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			try {
 				for (const cleanupError of removeStaleRuntimeSystemdFiles(paths, systemdUnits.staleFiles)) {
 					console.warn(`post-commit systemd file cleanup deferred: ${cleanupError}`);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1021,8 +1021,13 @@ export function installOfficialRuntimeService(
 ): string | null {
 	reloadRuntimeUserManager(paths, paths.userHome);
 	const error = installOfficialRuntimeUserService({ ...item.program, cwd: paths.userHome }, paths);
-	if (!error) item.target.expectedCurrentRevision = item.target.currentRevision();
-	return error;
+	if (error) return error;
+	const currentRevision = item.target.currentRevision();
+	if (!currentRevision) {
+		return `official ${runtimeSystemdProgramName(item.program)} service install could not be verified`;
+	}
+	item.target.expectedCurrentRevision = currentRevision;
+	return null;
 }
 
 function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: string): void {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1004,9 +1004,49 @@ function cachedHostedCliDesiredState(home: string, packageSpec: string): Runtime
 
 function seedOpenClawBinary(home: string): void {
 	const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 	mkdirSync(dirname(openclawBin), { recursive: true });
-	writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
+	writeFileSync(
+		openclawBin,
+		`#!/bin/sh
+if [ "\${1:-}" = "--version" ]; then
+  printf 'openclaw test-version\n'
+  exit 0
+fi
+if [ "$*" = "gateway install --force --json" ]; then
+  mkdir -p '${dirname(unitPath)}'
+  printf '%s\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${unitPath}'
+  printf '{"ok":true}\n'
+  exit 0
+fi
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  cat >/dev/null
+fi
+exit 0
+`,
+	);
 	chmodSync(openclawBin, 0o700);
+}
+
+function openClawDiscordPluginInspectFixture(pluginSource: string): Record<string, unknown> {
+	return {
+		plugin: {
+			id: "discord",
+			source: pluginSource,
+			origin: "global",
+			status: "loaded",
+			version: "1.2.3",
+			enabled: true,
+		},
+		install: {
+			source: "npm",
+			spec: "@openclaw/discord",
+			installPath: dirname(pluginSource),
+			resolvedName: "@openclaw/discord",
+			resolvedVersion: "1.2.3",
+			integrity: "sha512-test",
+		},
+	};
 }
 
 function seedOfficialOpenClawServiceInstaller(home: string): void {
@@ -4481,6 +4521,7 @@ exit 0
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawCommand = join(root, "openclaw-command.log");
 		const patchCount = join(root, "openclaw-patch-count");
+		const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -4490,6 +4531,7 @@ exit 0
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1" = "--version" ]; then printf "OpenClaw test-version\\n"; exit 0; fi',
 				`printf '%s\\n' "$*" >> '${openclawCommand}'`,
 				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
 				`  count=$(cat '${patchCount}' 2>/dev/null || printf '0')`,
@@ -4499,6 +4541,8 @@ exit 0
 				"  exit 0",
 				"fi",
 				'if [ "$1 $2 $3 $4" = "gateway install --force --json" ]; then',
+				`  mkdir -p '${dirname(unitPath)}'`,
+				`  printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${unitPath}'`,
 				"  printf '{\"ok\":true}\\n'",
 				"  exit 0",
 				"fi",
@@ -6119,8 +6163,7 @@ exit 64
 		const bootstrapToken = "bootstrap-transport-token";
 		const runtimeAuthToken = "runtime-business-token";
 		mkdirSync(dirname(openclawBin), { recursive: true });
-		writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
-		chmodSync(openclawBin, 0o700);
+		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -9470,7 +9513,10 @@ fi
 			const rejectedEvent = JSON.parse(logs.at(-1) ?? "{}");
 			const rejectedEventText = JSON.stringify(rejectedEvent);
 			expect(rejectedEvent.status).toBe("error");
-			expect(rejectedEvent.error).toContain("transparent-egress prerequisite activation failed");
+			// The verified OpenClaw service receipt keeps the official installer out
+			// of this steady-state apply, so sidecar activation belongs to the final
+			// systemd transaction instead of the installer prerequisite phase.
+			expect(rejectedEvent.error).toContain("systemd apply failed");
 			expect(rejectedEvent.systemdUnitsChanged).toBe(false);
 			expect(rejectedEvent.systemdApply).toEqual({
 				applied: false,
@@ -9489,6 +9535,7 @@ fi
 			expect(readFileSync(paths.manifestLastGood, "utf-8")).toBe(committedLastGood);
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const rollbackSystemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
+			expect(rollbackSystemctlCalls).not.toContain("official openclaw installer");
 			expect(
 				rollbackSystemctlCalls.filter((call) => call === "restart clawdi-runtime-sidecar.service"),
 			).toHaveLength(2);
@@ -11854,6 +11901,7 @@ chmod +x "$prefix/bin/clawdi"
 		const openclawPatch = join(root, "openclaw-channel-patch.json");
 		const openclawPatchArgs = join(root, "openclaw-channel-patch-args.txt");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
+		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
@@ -11876,6 +11924,12 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
 fi
 if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
   printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+  mkdir -p '${dirname(openclawPluginSource)}'
+  printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
+  exit 0
+fi
+if [ "$*" = "plugins inspect discord --json" ]; then
+  printf '%s\\n' '${JSON.stringify(openClawDiscordPluginInspectFixture(openclawPluginSource))}'
   exit 0
 fi
 if [ "$*" = "gateway install --force --json" ]; then
@@ -13224,12 +13278,17 @@ exit 64
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-channel-remove-patch.jsonl");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
+		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		mkdirSync(join(home, ".openclaw", "bin"), { recursive: true });
 		mkdirSync(workspace, { recursive: true });
 		writeFileSync(
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf 'openclaw test-version\\n'
+  exit 0
+fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   cat >> '${openclawPatch}'
   printf '\\n---\\n' >> '${openclawPatch}'
@@ -13237,6 +13296,12 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
 fi
 if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
   printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+  mkdir -p '${dirname(openclawPluginSource)}'
+  printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
+  exit 0
+fi
+if [ "$*" = "plugins inspect discord --json" ]; then
+  printf '%s\\n' '${JSON.stringify(openClawDiscordPluginInspectFixture(openclawPluginSource))}'
   exit 0
 fi
 printf 'unexpected openclaw command: %s\\n' "$*" >&2
@@ -13332,11 +13397,18 @@ exit 64
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-channel-patch.json");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
+		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(dirname(openclawPluginSource), { recursive: true });
+		writeFileSync(openclawPluginSource, "export const discordPlugin = true;\n");
 		writeFileSync(
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf 'openclaw test-version\\n'
+  exit 0
+fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   cat > '${openclawPatch}'
   exit 0
@@ -13346,6 +13418,10 @@ if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
   printf 'plugin already exists: %s\\n' "$HOME/.openclaw/npm/projects/openclaw-discord/node_modules/\${3:-}" >&2
   printf 'Use openclaw plugins update to upgrade the tracked plugin.\\n' >&2
   exit 1
+fi
+if [ "$*" = "plugins inspect discord --json" ]; then
+  printf '%s\\n' '${JSON.stringify(openClawDiscordPluginInspectFixture(openclawPluginSource))}'
+  exit 0
 fi
 printf 'unexpected openclaw command: %s\\n' "$*" >&2
 exit 64


### PR DESCRIPTION
## Summary
- treat install receipts as durable authority instead of a best-effort cache
- fail closed on malformed, untrusted, unreadable, or unpersistable receipts
- verify receipt targets again before committing applied authority
- require verifiable current revisions after official service and OpenClaw plugin installs
- preserve Hermes-specific dashboard artifact hashing/build behavior while sharing receipt persistence semantics

## Why
A successful Hermes dashboard build could previously lose or silently skip its receipt while still committing applied authority. The next full runtime refresh then treated the artifact as absent and repeated the expensive npm build. The same persistence gap affected OpenClaw official service and plugin installer receipts.

## Transaction semantics
- only `ENOENT` means no prior receipt
- receipt writes are atomic and read back immediately
- receipt commit occurs before external applied-authority commit
- existing live-state snapshot rollback restores receipt, artifact, and service state if any later commit step fails
- real command, unit, plugin, or dashboard artifact drift still triggers reconciliation

## Validation
- Docker focused: 202 passed, 0 failed across manifest reconciliation and service tests
- Docker full CLI: 1520 passed, 4 declared skips, 0 failed across 114 files
- CLI typecheck
- repository Biome check (892 files)
- `git diff --check origin/main..HEAD`

## Rollout / risk
This changes hosted runtime convergence failure semantics. Corrupt or untrusted receipt state now blocks apply and surfaces a sanitized error instead of silently re-running installers. Please keep rollout deliberate and monitor runtime observation errors after release.

No production or tenant access was used during implementation or verification.