### PR TITLE
fix(discord): project authoritative thread topology

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -6,9 +6,11 @@ import logging
 import secrets
 import zlib
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from email import policy
 from email.message import Message
 from email.parser import BytesParser
+from time import monotonic
 from typing import Any
 from urllib.parse import quote
 from uuid import UUID
@@ -26,7 +28,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,10 +41,12 @@ from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_STATUS_ACTIVE,
     ChannelAccount,
     ChannelBinding,
     ChannelBindingAlias,
     ChannelBotAgentLink,
+    ChannelMessage,
 )
 from app.routes.channel_routers.shared import (
     _clear_discord_guild_commands,
@@ -50,6 +54,7 @@ from app.routes.channel_routers.shared import (
     _discord_bot_user,
     _discord_gateway_dispatch,
     _discord_interaction_content,
+    _discord_retry_after_seconds,
     _DiscordProviderResult,
     _fan_out_discord_global_commands,
     _handle_discord_application_commands,
@@ -67,7 +72,6 @@ from app.services.channels import (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
     ChannelAgentContext,
-    ack_channel_inbox_events,
     channel_runtime_account_key,
     channel_runtime_placeholder_token,
     dequeue_discord_gateway_events,
@@ -82,6 +86,7 @@ from app.services.channels import (
     discord_user_display_name_from_payload,
     get_active_channel_account,
     get_channel_agent_reference,
+    lock_active_discord_binding_lease,
     pairing_command_event_was_handled,
     record_discord_interaction_references,
     record_discord_outbound_message,
@@ -101,6 +106,7 @@ router = APIRouter(prefix="/channels/discord", tags=["channels"])
 log = logging.getLogger(__name__)
 
 _DISCORD_GATEWAY_RESUME_BUFFER_SIZE = 100
+_DISCORD_GATEWAY_MAX_CHANNELS = 256
 _DISCORD_GATEWAY_SESSIONS: dict[str, dict[str, Any]] = {}
 _DISCORD_GATEWAY_CAPABILITY_SUBJECT = "clawdi_discord_gateway"
 _DISCORD_GATEWAY_CAPABILITY_AUDIENCE = "clawdi_discord_gateway"
@@ -427,6 +433,23 @@ async def _authorize_discord_channel_request(
         path=path,
         query_params=request.query_params if original_is_channel_get else None,
     )
+    if preflight.status_code != status.HTTP_200_OK:
+        if preflight.status_code in {status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND}:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="channel is not paired",
+            )
+        retry_after = _discord_retry_after_seconds(preflight)
+        raise HTTPException(
+            status_code=preflight.status_code,
+            detail=(
+                "discord api temporarily unavailable"
+                if preflight.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+                or preflight.status_code >= 500
+                else "discord channel lookup failed"
+            ),
+            headers={"Retry-After": str(retry_after)} if retry_after is not None else None,
+        )
     payload = preflight.json_object() if preflight.status_code == status.HTTP_200_OK else None
     if payload is None or _optional_str(payload.get("id")) != channel_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="channel is not paired")
@@ -688,79 +711,59 @@ async def discord_agent_gateway(
     compressor = zlib.compressobj(wbits=zlib.MAX_WBITS) if compress == "zlib-stream" else None
     account: ChannelAccount | None = None
     bot_agent_link_id: UUID | None = None
-    last_sequence = 0
     last_inbox_sequence = 0
-    gateway_sequence = 1
+    gateway_sequence = 0
     session_id = secrets.token_urlsafe(18)
     session_state: dict[str, Any] | None = None
-
-    def inbox_sequence_for_gateway_sequence(sequence: int) -> int | None:
-        if session_state is None:
-            return None
-        inbox_by_gateway = session_state.get("inbox_by_gateway_sequence")
-        if not isinstance(inbox_by_gateway, dict):
-            return None
-        inbox_sequence = inbox_by_gateway.get(sequence)
-        return inbox_sequence if isinstance(inbox_sequence, int) else None
-
-    def max_ackable_inbox_sequence(through_sequence: int) -> int:
-        if session_state is None:
-            return 0
-        inbox_by_gateway = session_state.get("inbox_by_gateway_sequence")
-        if not isinstance(inbox_by_gateway, dict):
-            return 0
-        return max(
-            (
-                inbox_sequence
-                for gateway_sequence_key, inbox_sequence in inbox_by_gateway.items()
-                if isinstance(gateway_sequence_key, int)
-                and isinstance(inbox_sequence, int)
-                and gateway_sequence_key <= through_sequence
-            ),
-            default=0,
-        )
-
-    def remember_dispatched_inbox_sequence(
-        *,
-        gateway_sequence_value: int,
-        inbox_sequence: int,
-    ) -> None:
-        if session_state is None:
-            return
-        inbox_by_gateway = session_state.setdefault("inbox_by_gateway_sequence", {})
-        if isinstance(inbox_by_gateway, dict):
-            inbox_by_gateway[gateway_sequence_value] = inbox_sequence
-
-    async def ack_gateway_sequence(through_sequence: int) -> None:
-        if account is None or bot_agent_link_id is None:
-            return
-        inbox_sequence = max_ackable_inbox_sequence(through_sequence)
-        if inbox_sequence <= 0:
-            return
-        await _ack_discord_gateway_sequence(
-            account=account,
-            bot_agent_link_id=bot_agent_link_id,
-            through_sequence=inbox_sequence,
-        )
+    projected_guilds: set[str] = set()
+    projected_channels: dict[str, dict[str, Any]] = {}
+    deferred_channels: dict[str, float] = {}
 
     async def send_gateway_frame(payload: dict[str, Any], *, record: bool = True) -> None:
-        if record and session_state is not None and payload.get("op") == 0 and payload.get("s"):
+        if compressor is None:
+            await websocket.send_json(payload)
+        else:
+            raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            await websocket.send_bytes(
+                compressor.compress(raw) + compressor.flush(zlib.Z_SYNC_FLUSH)
+            )
+        if record and session_state is not None and payload.get("op") == 0:
             frames = session_state.setdefault("frames", [])
             frames.append(payload)
             if len(frames) > _DISCORD_GATEWAY_RESUME_BUFFER_SIZE:
                 del frames[:-_DISCORD_GATEWAY_RESUME_BUFFER_SIZE]
-                if frames and isinstance(frames[0].get("s"), int):
-                    session_state["dropped_before_sequence"] = frames[0]["s"]
-                    inbox_by_gateway = session_state.get("inbox_by_gateway_sequence")
-                    if isinstance(inbox_by_gateway, dict):
-                        for sequence in list(inbox_by_gateway):
-                            if isinstance(sequence, int) and sequence < frames[0]["s"]:
-                                inbox_by_gateway.pop(sequence, None)
-        if compressor is None:
-            await websocket.send_json(payload)
-            return
-        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        await websocket.send_bytes(compressor.compress(raw) + compressor.flush(zlib.Z_SYNC_FLUSH))
+                session_state["dropped_before_sequence"] = frames[0]["s"]
+
+    async def send_dispatch(
+        event_type: str,
+        data: dict[str, Any],
+        *,
+        record: bool = True,
+    ) -> None:
+        nonlocal gateway_sequence
+        gateway_sequence += 1
+        await send_gateway_frame(
+            {"op": 0, "t": event_type, "s": gateway_sequence, "d": data},
+            record=record,
+        )
+        if session_state is not None:
+            session_state["last_sequence"] = gateway_sequence
+
+    async def send_guild(guild_id: str, guild_name: str) -> None:
+        payload = _discord_guild_create_payload(
+            guild_id=guild_id,
+            guild_name=guild_name,
+            sequence=0,
+        )
+        await send_dispatch("GUILD_CREATE", payload["d"])
+        projected_guilds.add(guild_id)
+
+    async def send_channel(payload: dict[str, Any]) -> None:
+        event_type = _discord_gateway_channel_event(payload)
+        data = dict(payload)
+        if event_type == "THREAD_CREATE":
+            data["newly_created"] = False
+        await send_dispatch(event_type, data)
 
     await send_gateway_frame({"op": 10, "d": {"heartbeat_interval": 45_000}}, record=False)
     try:
@@ -839,33 +842,13 @@ async def discord_agent_gateway(
                     return
                 resolved_account = resolved_agent.account
                 resolved_link_id = resolved_agent.link.id
-                bound_guilds = await _discord_bound_guilds(
-                    db,
-                    account=resolved_account,
-                    bot_agent_link_id=resolved_link_id,
-                )
-                bound_guild_channels = await _discord_bound_guild_channels(
-                    db,
-                    account=resolved_account,
-                    bot_agent_link_id=resolved_link_id,
-                )
             if op == 6:
                 resume_session_id = _optional_str(data.get("session_id"))
                 if resume_session_id is None:
                     await send_gateway_frame({"op": 9, "d": False}, record=False)
                     continue
                 resume_state = _DISCORD_GATEWAY_SESSIONS.get(resume_session_id)
-                if resume_state is None:
-                    if _DISCORD_GATEWAY_SESSIONS:
-                        await send_gateway_frame({"op": 9, "d": False}, record=False)
-                        continue
-                    resume_state = {
-                        "account_id": resolved_account.id,
-                        "bot_agent_link_id": resolved_link_id,
-                        "frames": [],
-                    }
-                    _DISCORD_GATEWAY_SESSIONS[resume_session_id] = resume_state
-                elif (
+                if resume_state is None or (
                     resume_state.get("account_id") != resolved_account.id
                     or resume_state.get("bot_agent_link_id") != resolved_link_id
                 ):
@@ -875,35 +858,81 @@ async def discord_agent_gateway(
                 bot_agent_link_id = resolved_link_id
                 session_id = resume_session_id
                 session_state = resume_state
-                last_sequence = _optional_int_param(data.get("seq")) or 0
-                gateway_sequence = max(gateway_sequence, last_sequence)
-                last_inbox_sequence = max_ackable_inbox_sequence(last_sequence)
-                await ack_gateway_sequence(last_sequence)
+                resume_sequence = _optional_int_param(data.get("seq"))
+                frames = [
+                    retained
+                    for retained in session_state.get("frames", [])
+                    if isinstance(retained, dict) and isinstance(retained.get("s"), int)
+                ]
+                latest_sequence = max(
+                    max((retained["s"] for retained in frames), default=0),
+                    session_state.get("last_sequence", 0),
+                )
                 dropped_before_sequence = session_state.get("dropped_before_sequence")
                 if (
-                    isinstance(dropped_before_sequence, int)
-                    and last_sequence < dropped_before_sequence
+                    resume_sequence is None
+                    or resume_sequence < 0
+                    or resume_sequence > latest_sequence
+                    or not any(retained.get("t") == "READY" for retained in frames)
+                    or (
+                        isinstance(dropped_before_sequence, int)
+                        and resume_sequence < dropped_before_sequence
+                    )
                 ):
                     await send_gateway_frame({"op": 9, "d": False}, record=False)
                     account = None
                     bot_agent_link_id = None
                     session_state = None
                     continue
-                for replayed in [
-                    frame
-                    for frame in session_state.get("frames", [])
-                    if isinstance(frame.get("s"), int) and frame["s"] > last_sequence
-                ]:
+                gateway_sequence = latest_sequence
+                async with async_session_factory() as db:
+                    resume_guilds, resume_channels = await _discord_gateway_authority(
+                        db,
+                        account=account,
+                        bot_agent_link_id=bot_agent_link_id,
+                    )
+                for retained in frames:
+                    event_type = retained.get("t")
+                    event_data = retained.get("d")
+                    if not isinstance(event_data, dict):
+                        continue
+                    if event_type == "READY":
+                        for private in event_data.get("private_channels", []):
+                            if not isinstance(private, dict):
+                                continue
+                            private_id = _optional_str(private.get("id"))
+                            if private_id in resume_channels:
+                                projected_channels[private_id] = private
+                    elif event_type == "GUILD_CREATE":
+                        retained_guild_id = _optional_str(event_data.get("id"))
+                        if retained_guild_id in resume_guilds:
+                            projected_guilds.add(retained_guild_id)
+                    elif event_type == "GUILD_DELETE":
+                        projected_guilds.discard(_optional_str(event_data.get("id")) or "")
+                    elif event_type in {
+                        "CHANNEL_CREATE",
+                        "CHANNEL_UPDATE",
+                        "THREAD_CREATE",
+                        "THREAD_UPDATE",
+                    }:
+                        retained_channel_id = _optional_str(event_data.get("id"))
+                        if retained_channel_id in resume_channels:
+                            thread_metadata = event_data.get("thread_metadata")
+                            if (
+                                event_type == "THREAD_UPDATE"
+                                and isinstance(thread_metadata, dict)
+                                and thread_metadata.get("archived") is True
+                            ):
+                                projected_channels.pop(retained_channel_id, None)
+                            else:
+                                projected_channels[retained_channel_id] = event_data
+                    elif event_type in {"CHANNEL_DELETE", "THREAD_DELETE"}:
+                        projected_channels.pop(_optional_str(event_data.get("id")) or "", None)
+                for replayed in frames:
+                    if replayed["s"] <= resume_sequence:
+                        continue
                     await send_gateway_frame(replayed, record=False)
-                    last_sequence = max(last_sequence, replayed["s"])
-                    gateway_sequence = max(gateway_sequence, replayed["s"])
-                    replayed_inbox_sequence = inbox_sequence_for_gateway_sequence(replayed["s"])
-                    if replayed_inbox_sequence is not None:
-                        last_inbox_sequence = max(last_inbox_sequence, replayed_inbox_sequence)
-                await send_gateway_frame(
-                    {"op": 0, "t": "RESUMED", "s": last_sequence, "d": {}},
-                    record=False,
-                )
+                await send_dispatch("RESUMED", {}, record=False)
             else:
                 account = resolved_account
                 bot_agent_link_id = resolved_link_id
@@ -913,42 +942,57 @@ async def discord_agent_gateway(
                     "frames": [],
                 }
                 _DISCORD_GATEWAY_SESSIONS[session_id] = session_state
-                await send_gateway_frame(
-                    {
-                        "op": 0,
-                        "t": "READY",
-                        "s": 1,
-                        "d": {
-                            "v": 10,
-                            "session_id": session_id,
-                            "resume_gateway_url": (
-                                _discord_gateway_url(resolved_agent)
-                                if capability is not None
-                                else (
-                                    settings.channel_discord_gateway_url.strip().rstrip("/")
-                                    if link_token is not None
-                                    else _public_ws_url("/v1/channels/discord/gateway")
-                                )
-                            ),
-                            "user": _discord_bot_user(account),
-                            "application": {"id": _discord_application_id(account)},
-                            "guilds": [
-                                {"id": guild_id, "unavailable": False} for guild_id in bound_guilds
-                            ],
-                        },
-                    }
-                )
-                last_sequence = 1
-                for guild_id in bound_guilds:
-                    gateway_sequence += 1
-                    await send_gateway_frame(
-                        _discord_guild_create_payload(
-                            guild_id=guild_id,
-                            channel_ids=bound_guild_channels.get(guild_id, []),
-                            sequence=gateway_sequence,
-                        )
+                async with async_session_factory() as db:
+                    guilds, channels = await _discord_gateway_authority(
+                        db,
+                        account=account,
+                        bot_agent_link_id=bot_agent_link_id,
                     )
-                    last_sequence = gateway_sequence
+                for channel_id, guild_id in channels.items():
+                    try:
+                        result = await _request_discord_provider(
+                            account=account,
+                            method="GET",
+                            path=f"channels/{channel_id}",
+                        )
+                    except HTTPException:
+                        continue
+                    channel = _discord_gateway_channel(
+                        result,
+                        channel_id=channel_id,
+                        guild_id=guild_id,
+                    )
+                    if channel is not None:
+                        projected_channels[channel_id] = channel
+                await send_dispatch(
+                    "READY",
+                    {
+                        "v": 10,
+                        "session_id": session_id,
+                        "resume_gateway_url": (
+                            _discord_gateway_url(resolved_agent)
+                            if capability is not None
+                            else (
+                                settings.channel_discord_gateway_url.strip().rstrip("/")
+                                if link_token is not None
+                                else _public_ws_url("/v1/channels/discord/gateway")
+                            )
+                        ),
+                        "user": _discord_bot_user(account),
+                        "application": {"id": _discord_application_id(account)},
+                        "guilds": [{"id": guild_id, "unavailable": False} for guild_id in guilds],
+                        "private_channels": [
+                            payload
+                            for channel_id, payload in projected_channels.items()
+                            if channels.get(channel_id) is None
+                        ],
+                    },
+                )
+                for guild_id, guild_name in guilds.items():
+                    await send_guild(guild_id, guild_name)
+                for channel_id, channel in projected_channels.items():
+                    if channels.get(channel_id) is not None:
+                        await send_channel(channel)
 
         while True:
             async with async_session_factory() as db:
@@ -961,18 +1005,131 @@ async def discord_agent_gateway(
                 )
             if events:
                 for message in events:
-                    inbox_sequence = int(message.inbox_sequence)
-                    gateway_sequence += 1
-                    last_sequence = gateway_sequence
-                    last_inbox_sequence = inbox_sequence
                     payload = _discord_gateway_dispatch(message)
-                    payload["s"] = gateway_sequence
-                    remember_dispatched_inbox_sequence(
-                        gateway_sequence_value=gateway_sequence,
-                        inbox_sequence=inbox_sequence,
+                    guild_id, channel_id = _discord_gateway_scope(payload)
+                    async with async_session_factory() as db:
+                        guilds, channels = await _discord_gateway_authority(
+                            db,
+                            account=account,
+                            bot_agent_link_id=bot_agent_link_id,
+                            priority_channel_id=channel_id,
+                        )
+                    for removed_guild_id in projected_guilds - set(guilds):
+                        await send_dispatch(
+                            "GUILD_DELETE",
+                            {"id": removed_guild_id, "unavailable": False},
+                        )
+                        projected_guilds.discard(removed_guild_id)
+                        for projected_id, projected in list(projected_channels.items()):
+                            if _optional_str(projected.get("guild_id")) == removed_guild_id:
+                                projected_channels.pop(projected_id, None)
+                    for removed_channel_id in set(projected_channels) - set(channels):
+                        projected_channels.pop(removed_channel_id, None)
+                    for removed_channel_id in set(deferred_channels) - set(channels):
+                        deferred_channels.pop(removed_channel_id, None)
+                    event_type = _optional_str(payload.get("t"))
+                    lifecycle = bool(
+                        event_type and event_type.startswith(("GUILD_", "CHANNEL_", "THREAD_"))
                     )
-                    await send_gateway_frame(payload)
-                continue
+                    authorized = (
+                        guild_id in guilds
+                        if lifecycle and guild_id is not None
+                        else channel_id in channels and channels[channel_id] == guild_id
+                    )
+                    projected = (
+                        projected_channels.get(channel_id) if channel_id is not None else None
+                    )
+                    if authorized and not lifecycle and channel_id is not None:
+                        if projected is None:
+                            retry_at = deferred_channels.get(channel_id, 0.0)
+                            if monotonic() < retry_at:
+                                break
+                            result: _DiscordProviderResult | None = None
+                            try:
+                                result = await _request_discord_provider(
+                                    account=account,
+                                    method="GET",
+                                    path=f"channels/{channel_id}",
+                                )
+                            except HTTPException as exc:
+                                if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+                                    retry_after = _discord_retry_after_seconds(
+                                        _DiscordProviderResult(
+                                            content=b"",
+                                            status_code=exc.status_code,
+                                            media_type="application/json",
+                                            headers=dict(exc.headers or {}),
+                                        )
+                                    )
+                                    deferred_channels[channel_id] = monotonic() + (
+                                        retry_after if retry_after is not None else 1.0
+                                    )
+                                    break
+                                if exc.status_code >= 500:
+                                    deferred_channels[channel_id] = monotonic() + 1.0
+                                    break
+                            if (
+                                result is not None
+                                and result.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+                            ):
+                                retry_after = _discord_retry_after_seconds(result)
+                                deferred_channels[channel_id] = monotonic() + (
+                                    retry_after if retry_after is not None else 1.0
+                                )
+                                break
+                            if result is not None and result.status_code >= 500:
+                                deferred_channels[channel_id] = monotonic() + 1.0
+                                break
+                            projected = (
+                                _discord_gateway_channel(
+                                    result,
+                                    channel_id=channel_id,
+                                    guild_id=guild_id,
+                                )
+                                if result is not None
+                                else None
+                            )
+                            if projected is not None:
+                                deferred_channels.pop(channel_id, None)
+
+                    async def send_message() -> None:
+                        if guild_id is not None and guild_id not in projected_guilds:
+                            await send_guild(guild_id, guilds[guild_id])
+                        if channel_id is not None and projected is not None:
+                            if channel_id not in projected_channels:
+                                await send_channel(projected)
+                            projected_channels[channel_id] = projected
+                        data = payload.get("d")
+                        if event_type is not None and isinstance(data, dict):
+                            await send_dispatch(event_type, data)
+
+                    sent = await _send_discord_gateway_message(
+                        account_id=account.id,
+                        bot_agent_link_id=bot_agent_link_id,
+                        message=message,
+                        send=(
+                            send_message
+                            if authorized and (lifecycle or projected is not None)
+                            else None
+                        ),
+                    )
+                    last_inbox_sequence = int(message.inbox_sequence)
+                    if sent == "sent" and lifecycle and channel_id is not None:
+                        data = payload.get("d")
+                        if event_type in {"CHANNEL_DELETE", "THREAD_DELETE"}:
+                            projected_channels.pop(channel_id, None)
+                        elif isinstance(data, dict) and channels.get(channel_id) == guild_id:
+                            thread_metadata = data.get("thread_metadata")
+                            if (
+                                event_type == "THREAD_UPDATE"
+                                and isinstance(thread_metadata, dict)
+                                and thread_metadata.get("archived") is True
+                            ):
+                                projected_channels.pop(channel_id, None)
+                            else:
+                                projected_channels[channel_id] = dict(data)
+                else:
+                    continue
 
             try:
                 frame = await asyncio.wait_for(
@@ -980,9 +1137,6 @@ async def discord_agent_gateway(
                     timeout=max(0.001, settings.discord_gateway_poll_interval_seconds),
                 )
                 if isinstance(frame, dict) and frame.get("op") == 1:
-                    ack_sequence = _optional_int_param(frame.get("d"))
-                    if ack_sequence is not None:
-                        await ack_gateway_sequence(ack_sequence)
                     await send_gateway_frame({"op": 11, "d": None}, record=False)
             except TimeoutError:
                 pass
@@ -1283,24 +1437,6 @@ async def cleanup_discord_guild_commands_after_authority_revoked(
         return False
 
 
-async def _ack_discord_gateway_sequence(
-    *,
-    account: ChannelAccount,
-    bot_agent_link_id: UUID | None,
-    through_sequence: int,
-) -> None:
-    if through_sequence <= 0 or bot_agent_link_id is None:
-        return
-    async with async_session_factory() as db:
-        await ack_channel_inbox_events(
-            db,
-            account=account,
-            bot_agent_link_id=bot_agent_link_id,
-            through_sequence=through_sequence,
-        )
-        await db.commit()
-
-
 async def _handle_discord_interaction_callback(
     db: AsyncSession,
     *,
@@ -1446,22 +1582,94 @@ def _discord_binding_guild_id(binding: ChannelBinding) -> str | None:
     return None
 
 
-def _discord_gateway_channel_payload(*, guild_id: str, channel_id: str) -> dict[str, Any]:
-    return {
-        "id": channel_id,
-        "guild_id": guild_id,
-        "name": channel_id,
-        "type": 0,
-        "position": 0,
-        "permission_overwrites": [],
-        "parent_id": None,
-    }
+async def _discord_gateway_authority(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+    priority_channel_id: str | None = None,
+) -> tuple[dict[str, str], dict[str, str | None]]:
+    priority = (ChannelBindingAlias.alias_external_chat_id == priority_channel_id) | (
+        ChannelBinding.external_chat_id == priority_channel_id
+    )
+    rows = (
+        await db.execute(
+            select(ChannelBinding, ChannelBindingAlias)
+            .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+            .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
+            .outerjoin(
+                ChannelBindingAlias,
+                and_(
+                    ChannelBindingAlias.binding_id == ChannelBinding.id,
+                    ChannelBindingAlias.account_id == account.id,
+                    ChannelBindingAlias.bot_agent_link_id == bot_agent_link_id,
+                    ChannelBindingAlias.alias_kind == "discord_channel",
+                ),
+            )
+            .where(
+                ChannelBinding.account_id == account.id,
+                ChannelBinding.bot_agent_link_id == bot_agent_link_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+                ChannelBotAgentLink.account_id == account.id,
+                ChannelBotAgentLink.user_id == ChannelBinding.user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            )
+            .order_by(priority.desc(), ChannelBindingAlias.updated_at.desc())
+            .limit(_DISCORD_GATEWAY_MAX_CHANNELS)
+        )
+    ).all()
+    guilds: dict[str, str] = {}
+    channels: dict[str, str | None] = {}
+    for binding, alias in rows:
+        guild_id = _discord_binding_guild_id(binding)
+        if guild_id is not None:
+            guilds[guild_id] = binding.external_chat_name or guild_id
+            if alias is not None:
+                channels[alias.alias_external_chat_id] = guild_id
+        elif (binding.external_chat_type or "").lower() in {
+            "dm",
+            "direct_messages",
+            "group_dm",
+            "private",
+        }:
+            channels[binding.external_chat_id] = None
+    return guilds, channels
+
+
+def _discord_gateway_channel(
+    result: _DiscordProviderResult,
+    *,
+    channel_id: str,
+    guild_id: str | None,
+) -> dict[str, Any] | None:
+    payload = result.json_object() if result.status_code == status.HTTP_200_OK else None
+    channel_type = payload.get("type") if payload is not None else None
+    if (
+        payload is None
+        or _optional_str(payload.get("id")) != channel_id
+        or isinstance(channel_type, bool)
+        or not isinstance(channel_type, int)
+    ):
+        return None
+    payload_guild_id = _optional_str(payload.get("guild_id"))
+    if (guild_id is None and (payload_guild_id is not None or channel_type not in {1, 3})) or (
+        guild_id is not None and (payload_guild_id != guild_id or channel_type in {1, 3})
+    ):
+        return None
+    return dict(payload)
+
+
+def _discord_gateway_channel_event(payload: dict[str, Any]) -> str:
+    return "THREAD_CREATE" if payload.get("type") in {10, 11, 12} else "CHANNEL_CREATE"
 
 
 def _discord_guild_create_payload(
     *,
     guild_id: str,
-    channel_ids: list[str],
+    guild_name: str,
     sequence: int,
 ) -> dict[str, Any]:
     return {
@@ -1470,13 +1678,61 @@ def _discord_guild_create_payload(
         "s": sequence,
         "d": {
             "id": guild_id,
-            "name": guild_id,
+            "name": guild_name,
             "unavailable": False,
-            "channels": [
-                _discord_gateway_channel_payload(guild_id=guild_id, channel_id=channel_id)
-                for channel_id in channel_ids
-            ],
+            "channels": [],
             "threads": [],
             "members": [],
         },
     }
+
+
+def _discord_gateway_scope(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    data = payload.get("d")
+    if not isinstance(data, dict):
+        return None, None
+    event_type = _optional_str(payload.get("t"))
+    guild_id = _optional_str(data.get("guild_id"))
+    channel_id = _optional_str(data.get("channel_id"))
+    if event_type and event_type.startswith("GUILD_"):
+        guild_id = _optional_str(data.get("id")) or guild_id
+    elif event_type and event_type.startswith(("CHANNEL_", "THREAD_")):
+        channel_id = _optional_str(data.get("id")) or channel_id
+    return guild_id, channel_id
+
+
+async def _send_discord_gateway_message(
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+    message: ChannelMessage,
+    send: Any | None,
+) -> str:
+    if message.binding_id is None:
+        return "dropped"
+    async with async_session_factory() as db:
+        binding = await lock_active_discord_binding_lease(
+            db,
+            account_id=account_id,
+            bot_agent_link_id=bot_agent_link_id,
+            binding_id=message.binding_id,
+            external_chat_id=message.external_chat_id,
+        )
+        current = (
+            await db.execute(
+                select(ChannelMessage)
+                .where(
+                    ChannelMessage.id == message.id,
+                    ChannelMessage.account_id == account_id,
+                    ChannelMessage.bot_agent_link_id == bot_agent_link_id,
+                )
+                .with_for_update(of=ChannelMessage)
+            )
+        ).scalar_one_or_none()
+        if current is None or current.delivered_at is not None:
+            return "consumed"
+        if binding is not None and send is not None:
+            await send()
+        current.delivered_at = datetime.now(UTC)
+        await db.commit()
+        return "sent" if binding is not None and send is not None else "dropped"

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -994,12 +994,17 @@ async def discord_agent_gateway(
                     if channels.get(channel_id) is not None:
                         await send_channel(channel)
 
+        if bot_agent_link_id is None:
+            await websocket.close(code=4004)
+            return
+        active_link_id = bot_agent_link_id
+
         while True:
             async with async_session_factory() as db:
                 events = await dequeue_discord_gateway_events(
                     db,
                     account=account,
-                    bot_agent_link_id=bot_agent_link_id,
+                    bot_agent_link_id=active_link_id,
                     after_sequence=last_inbox_sequence,
                     limit=100,
                 )
@@ -1011,7 +1016,7 @@ async def discord_agent_gateway(
                         guilds, channels = await _discord_gateway_authority(
                             db,
                             account=account,
-                            bot_agent_link_id=bot_agent_link_id,
+                            bot_agent_link_id=active_link_id,
                             priority_channel_id=channel_id,
                         )
                     for removed_guild_id in projected_guilds - set(guilds):
@@ -1105,7 +1110,7 @@ async def discord_agent_gateway(
 
                     sent = await _send_discord_gateway_message(
                         account_id=account.id,
-                        bot_agent_link_id=bot_agent_link_id,
+                        bot_agent_link_id=active_link_id,
                         message=message,
                         send=(
                             send_message

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -98,6 +98,9 @@ DISCORD_RESERVED_COMMAND_NAMES = frozenset(
     }
 )
 DISCORD_LEGACY_RESERVED_COMMAND_NAMES = frozenset({"bot_pair", "bot_unpair"})
+_DISCORD_UNPAIRED_TUTORIAL_KIND = "discord_unpaired_tutorial"
+_DISCORD_UNPAIRED_TUTORIAL_SUCCESS_COOLDOWN = timedelta(minutes=10)
+_DISCORD_UNPAIRED_TUTORIAL_FAILURE_BACKOFF = timedelta(seconds=30)
 PAIR_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 PAIR_CODE_LENGTH = 10
 PAIR_CODE_GENERATION_ATTEMPTS = 5
@@ -1519,6 +1522,45 @@ async def lock_channel_binding_identity(
     await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
 
 
+async def lock_active_discord_binding_lease(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+    binding_id: UUID,
+    external_chat_id: str,
+) -> ChannelBinding | None:
+    """Hold active Discord authority through the caller's transaction."""
+    lock_name = f"channel-binding:{account_id}:{external_chat_id}"
+    await db.execute(select(func.pg_advisory_xact_lock_shared(func.hashtextextended(lock_name, 0))))
+    return (
+        await db.execute(
+            select(ChannelBinding)
+            .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+            .join(ChannelBotAgentLink, ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id)
+            .where(
+                ChannelBinding.id == binding_id,
+                ChannelBinding.account_id == account_id,
+                ChannelBinding.bot_agent_link_id == bot_agent_link_id,
+                ChannelBinding.external_chat_id == external_chat_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+                ChannelBotAgentLink.account_id == ChannelBinding.account_id,
+                ChannelBotAgentLink.user_id == ChannelBinding.user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            )
+            .with_for_update(
+                read=True,
+                of=(ChannelAccount, ChannelBotAgentLink, ChannelBinding),
+            )
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one_or_none()
+
+
 def binding_is_controlled_by_actor(
     binding: ChannelBinding,
     *,
@@ -1691,7 +1733,8 @@ async def resolve_inbound_binding(
     command_actor_required: bool = False,
 ) -> InboundBindingResult:
     parsed = command if command is not None else parse_pair_command(text)
-    if parsed is not None and parsed.kind in {"pair", "unpair"}:
+    pairing_mutation = parsed is not None and parsed.kind in {"pair", "unpair"}
+    if pairing_mutation:
         await lock_channel_binding_identity(
             db,
             account_id=account.id,
@@ -1707,6 +1750,25 @@ async def resolve_inbound_binding(
                 external_chat_type=external_chat_type,
             )
         ]
+        if not pairing_mutation:
+            leased_bindings: list[ChannelBinding] = []
+            for candidate in sorted(bindings, key=lambda value: value.id):
+                leased = await lock_active_discord_binding_lease(
+                    db,
+                    account_id=account.id,
+                    bot_agent_link_id=candidate.bot_agent_link_id,
+                    binding_id=candidate.id,
+                    external_chat_id=external_chat_id,
+                )
+                if leased is None:
+                    await record_inactive_bot_agent_link_event(
+                        db,
+                        account=account,
+                        binding=candidate,
+                    )
+                else:
+                    leased_bindings.append(leased)
+            bindings = leased_bindings
     binding = bindings[0] if bindings else None
     if parsed is None:
         authorized_bindings: list[ChannelBinding] = []
@@ -5261,7 +5323,15 @@ async def record_discord_dispatch(
                 external_user_id=external_user_id,
             )
     if binding_result.binding is None and not binding_result.command_handled:
-        return False
+        return await _record_discord_unpaired_message_and_maybe_instruct(
+            db,
+            account=account,
+            frame=frame,
+            authority_chat_id=external_chat_id,
+            channel_id=key.channel_id if key is not None else None,
+            guild_id=guild_id,
+            provider_event_id=provider_event_id,
+        )
     data = frame.get("d")
     payload = frame if isinstance(data, dict) else {"d": data}
     messages = await record_inbound_messages_for_bindings(
@@ -5307,6 +5377,130 @@ async def record_discord_dispatch(
             binding_result=binding_result,
             reply=reply,
         )
+    return True
+
+
+async def _record_discord_unpaired_message_and_maybe_instruct(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    frame: dict[str, Any],
+    authority_chat_id: str,
+    channel_id: str | None,
+    guild_id: str | None,
+    provider_event_id: str | None,
+) -> bool:
+    data = frame.get("d")
+    if frame.get("t") != "MESSAGE_CREATE" or not isinstance(data, dict) or channel_id is None:
+        return False
+    message_type = data.get("type", 0)
+    author = data.get("author")
+    if (
+        message_type != 0
+        or not isinstance(author, dict)
+        or author.get("bot") is True
+        or data.get("webhook_id") is not None
+    ):
+        return False
+    if guild_id is not None:
+        application_id = discord_application_id_from_config(account.config)
+        mentions = data.get("mentions")
+        if (
+            application_id is None
+            or not isinstance(mentions, list)
+            or not any(
+                isinstance(mention, dict)
+                and _read_optional_str(mention.get("id")) == application_id
+                for mention in mentions
+            )
+        ):
+            return False
+
+    await lock_channel_binding_identity(
+        db,
+        account_id=account.id,
+        external_chat_id=authority_chat_id,
+    )
+    if await find_binding(db, account=account, external_chat_id=authority_chat_id) is not None:
+        return False
+
+    now = datetime.now(UTC)
+    marker_result = InboundBindingResult(binding=None, bindings=())
+    messages = await record_inbound_messages_for_bindings(
+        db,
+        account=account,
+        binding_result=marker_result,
+        external_chat_id=channel_id,
+        provider_message_id=provider_event_id,
+        text=None,
+        payload={"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "pending"},
+        suppress_duplicate_event=True,
+    )
+    if not messages:
+        return True
+    marker = messages[0][0]
+    marker.delivered_at = now
+    previous = (
+        await db.execute(
+            select(ChannelMessage)
+            .where(
+                ChannelMessage.account_id == account.id,
+                ChannelMessage.external_chat_id == channel_id,
+                ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                ChannelMessage.id != marker.id,
+                func.jsonb_extract_path_text(ChannelMessage.payload, "kind")
+                == _DISCORD_UNPAIRED_TUTORIAL_KIND,
+                func.jsonb_extract_path_text(ChannelMessage.payload, "outcome").in_(
+                    ("sent", "failed")
+                ),
+            )
+            .order_by(ChannelMessage.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if previous is not None:
+        previous_payload = previous.payload if isinstance(previous.payload, dict) else {}
+        cooldown = (
+            _DISCORD_UNPAIRED_TUTORIAL_SUCCESS_COOLDOWN
+            if previous_payload.get("outcome") == "sent"
+            else _DISCORD_UNPAIRED_TUTORIAL_FAILURE_BACKOFF
+        )
+        if previous.created_at + cooldown > now:
+            marker.payload = {"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "suppressed"}
+            return True
+
+    tutorial = (
+        "This Discord server is not paired. Create a Discord pairing code in Clawdi, "
+        "then run /clawdi_pair <code>."
+        if guild_id is not None
+        else "This Discord chat is not paired. Create a Discord pairing code in Clawdi, "
+        "then run /clawdi_pair <code>."
+    )
+    try:
+        await send_discord_message(
+            db,
+            account=account,
+            external_chat_id=channel_id,
+            text=tutorial,
+            bind_to_existing=False,
+        )
+    except HTTPException as exc:
+        marker.payload = {"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "failed"}
+        log.warning(
+            "discord_unpaired_tutorial_failed account_id=%s channel_id=%s status=%s",
+            account.id,
+            channel_id,
+            exc.status_code,
+        )
+    except Exception:
+        marker.payload = {"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "failed"}
+        log.exception(
+            "discord_unpaired_tutorial_failed account_id=%s channel_id=%s",
+            account.id,
+            channel_id,
+        )
+    else:
+        marker.payload = {"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "sent"}
     return True
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import re
 import socket
+import threading
 import zlib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -65,8 +66,8 @@ from app.routes.channel_routers import shared as shared_router
 from app.routes.channel_routers import telegram as telegram_router
 from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
-    _discord_bound_guild_channels,
     _discord_bound_guilds,
+    _discord_gateway_authority,
     _discord_gateway_url,
     _discord_guild_create_payload,
     cleanup_discord_guild_commands_after_authority_revoked,
@@ -8515,6 +8516,7 @@ def test_discord_gateway_link_authorization_accepts_runtime_placeholder(monkeypa
             ready = websocket.receive_json()
             session_id = ready["d"]["session_id"]
             guild = websocket.receive_json()
+            channel = websocket.receive_json()
 
     assert ready["t"] == "READY"
     assert guild["t"] == "GUILD_CREATE"
@@ -8531,7 +8533,7 @@ def test_discord_gateway_link_authorization_accepts_runtime_placeholder(monkeypa
             websocket.send_json(
                 {
                     "op": 6,
-                    "d": {"token": placeholder, "session_id": session_id, "seq": guild["s"]},
+                    "d": {"token": placeholder, "session_id": session_id, "seq": channel["s"]},
                 }
             )
             assert websocket.receive_json()["t"] == "RESUMED"
@@ -8630,7 +8632,25 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
         channel_runtime_account_key(account.id),
     )
 
-    def identify(bearer: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    async def fake_provider_request(*, account, method: str, path: str, **kwargs):
+        channel_id = path.rpartition("/")[2]
+        suffix = channel_id.rpartition("-")[2]
+        return shared_router._DiscordProviderResult(
+            content=json.dumps(
+                {
+                    "id": channel_id,
+                    "guild_id": f"shared-gateway-guild-{suffix}",
+                    "type": 0,
+                    "name": channel_id,
+                }
+            ).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(discord_router, "_request_discord_provider", fake_provider_request)
+
+    def identify(bearer: str) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
         with TestClient(app) as sync_client:
             with sync_client.websocket_connect(
                 "/v1/channels/discord/gateway?v=10&encoding=json",
@@ -8638,17 +8658,23 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
             ) as websocket:
                 assert websocket.receive_json()["op"] == 10
                 websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
-                return websocket.receive_json(), websocket.receive_json()
+                return (
+                    websocket.receive_json(),
+                    websocket.receive_json(),
+                    websocket.receive_json(),
+                )
 
-    ready_a, guild_a = identify(created["agent_token"])
-    ready_b, guild_b = identify(second["agent_token"])
+    ready_a, guild_a, channel_a = identify(created["agent_token"])
+    ready_b, guild_b, channel_b = identify(second["agent_token"])
 
     assert ready_a["d"]["resume_gateway_url"] == settings.channel_discord_gateway_url
     assert ready_b["d"]["resume_gateway_url"] == settings.channel_discord_gateway_url
     assert ready_a["d"]["guilds"] == [{"id": "shared-gateway-guild-a", "unavailable": False}]
     assert ready_b["d"]["guilds"] == [{"id": "shared-gateway-guild-b", "unavailable": False}]
-    assert [channel["id"] for channel in guild_a["d"]["channels"]] == ["shared-gateway-channel-a"]
-    assert [channel["id"] for channel in guild_b["d"]["channels"]] == ["shared-gateway-channel-b"]
+    assert guild_a["d"]["channels"] == guild_b["d"]["channels"] == []
+    assert channel_a["t"] == channel_b["t"] == "CHANNEL_CREATE"
+    assert channel_a["d"]["id"] == "shared-gateway-channel-a"
+    assert channel_b["d"]["id"] == "shared-gateway-channel-b"
     assert "/v1/channels/discord/gateway" not in ready_a["d"]["resume_gateway_url"]
 
     # Simulate discord.py reconnecting to the external resume URL: egress rewrites
@@ -8666,7 +8692,7 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
                     "d": {
                         "token": placeholder,
                         "session_id": ready_a["d"]["session_id"],
-                        "seq": guild_a["s"],
+                        "seq": channel_a["s"],
                     },
                 }
             )
@@ -9606,6 +9632,16 @@ async def test_discord_guild_rest_requires_bound_guild_scope(
         headers=headers,
         json={"content": "hello guild channel"},
     )
+    with_message = await client.post(
+        "/v1/channels/discord/v10/channels/discord-chan-1/messages/source-message/threads",
+        headers=headers,
+        json={"name": "hi", "auto_archive_duration": 1440, "rate_limit_per_user": 0},
+    )
+    without_message = await client.post(
+        "/v1/channels/discord/v10/channels/discord-chan-1/threads",
+        headers=headers,
+        json={"name": "hi", "type": 11, "auto_archive_duration": 1440, "invitable": True},
+    )
     blocked = await client.post(
         "/v1/channels/discord/v10/guilds/discord-guild-2/channels",
         headers=headers,
@@ -9614,6 +9650,7 @@ async def test_discord_guild_rest_requires_bound_guild_scope(
 
     assert allowed.status_code == 200
     assert channel_send.status_code == 200
+    assert with_message.status_code == without_message.status_code == 200
     assert channel_send.json()["id"] == "guild-channel"
     assert blocked.status_code == 403
     assert blocked.json() == {"code": 50001, "message": "Missing Access"}
@@ -9622,6 +9659,12 @@ async def test_discord_guild_rest_requires_bound_guild_scope(
         "Bot discord-provider-token"
     )
     assert _FakeProviderClient.calls[1]["url"].endswith("/channels/discord-chan-1/messages")
+    assert _FakeProviderClient.calls[2]["url"].endswith(
+        "/channels/discord-chan-1/messages/source-message/threads"
+    )
+    assert _FakeProviderClient.calls[3]["url"].endswith("/channels/discord-chan-1/threads")
+    assert json.loads(_FakeProviderClient.calls[2]["content"])["auto_archive_duration"] == 1440
+    assert json.loads(_FakeProviderClient.calls[3]["content"])["type"] == 11
 
 
 @pytest.mark.asyncio
@@ -10527,13 +10570,14 @@ async def test_discord_channel_rest_resolves_caches_and_reuses_unobserved_guild_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("provider_payload", "provider_status", "provider_content"),
+    ("provider_payload", "provider_status", "provider_content", "expected_status"),
     [
-        ({"id": "unknown-channel", "guild_id": "wrong-guild"}, 200, None),
-        ({"id": "unknown-channel", "type": 1}, 200, None),
-        ({"id": "different-channel", "guild_id": "bound-guild"}, 200, None),
-        ({}, 200, b"not-json"),
-        ({"message": "upstream error"}, 500, None),
+        ({"id": "unknown-channel", "guild_id": "wrong-guild"}, 200, None, 403),
+        ({"id": "unknown-channel", "type": 1}, 200, None, 403),
+        ({"id": "different-channel", "guild_id": "bound-guild"}, 200, None, 403),
+        ({}, 200, b"not-json", 403),
+        ({"message": "private upstream error"}, 500, None, 500),
+        ({"retry_after": 7200.5}, 429, None, 429),
     ],
 )
 async def test_discord_unobserved_channel_lookup_failures_do_not_authorize(
@@ -10542,7 +10586,9 @@ async def test_discord_unobserved_channel_lookup_failures_do_not_authorize(
     provider_payload: dict[str, Any],
     provider_status: int,
     provider_content: bytes | None,
+    expected_status: int,
 ):
+    monkeypatch.setattr(shared_router, "discord_rate_limiter", DiscordRateLimiter())
     created = await _create_paired_discord_channel(
         client,
         name=f"discord-unobserved-denied-{uuid4().hex}",
@@ -10564,8 +10610,14 @@ async def test_discord_unobserved_channel_lookup_failures_do_not_authorize(
         headers={"Authorization": f"Bot {created['agent_token']}"},
     )
 
-    assert response.status_code == 403
-    assert response.json() == {"code": 50001, "message": "Missing Access"}
+    assert response.status_code == expected_status
+    if expected_status == 403:
+        assert response.json() == {"code": 50001, "message": "Missing Access"}
+    else:
+        assert response.json() == {"detail": "discord api temporarily unavailable"}
+        assert "private upstream error" not in response.text
+    if expected_status == 429:
+        assert float(response.headers["retry-after"]) == 7200.5
     assert len(_FakeProviderClient.calls) == 1
 
 
@@ -14353,7 +14405,7 @@ async def test_discord_gateway_worker_resumes_and_falls_back_after_invalid_sessi
 
 
 @pytest.mark.asyncio
-async def test_discord_gateway_ready_guilds_come_from_active_bindings(
+async def test_discord_gateway_projection_uses_active_aliases_and_minimal_guild(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
 ):
@@ -14369,14 +14421,22 @@ async def test_discord_gateway_ready_guilds_come_from_active_bindings(
         )
     ).scalar_one()
 
-    guilds = await _discord_bound_guilds(db_session, account=account)
-    guild_channels = await _discord_bound_guild_channels(db_session, account=account)
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account.id)
+        )
+    ).scalar_one()
+    guilds, channels = await _discord_gateway_authority(
+        db_session,
+        account=account,
+        bot_agent_link_id=binding.bot_agent_link_id,
+    )
 
-    assert guilds == ["ready-guild-1"]
-    assert guild_channels == {"ready-guild-1": ["ready-channel-1"]}
+    assert guilds == {"ready-guild-1": "ready-guild-1"}
+    assert channels == {"ready-channel-1": "ready-guild-1"}
     assert _discord_guild_create_payload(
         guild_id="ready-guild-1",
-        channel_ids=guild_channels["ready-guild-1"],
+        guild_name="ready-guild-1",
         sequence=2,
     ) == {
         "op": 0,
@@ -14386,17 +14446,7 @@ async def test_discord_gateway_ready_guilds_come_from_active_bindings(
             "id": "ready-guild-1",
             "name": "ready-guild-1",
             "unavailable": False,
-            "channels": [
-                {
-                    "id": "ready-channel-1",
-                    "guild_id": "ready-guild-1",
-                    "name": "ready-channel-1",
-                    "type": 0,
-                    "position": 0,
-                    "permission_overwrites": [],
-                    "parent_id": None,
-                }
-            ],
+            "channels": [],
             "threads": [],
             "members": [],
         },
@@ -14426,8 +14476,29 @@ def _install_discord_gateway_protocol_fakes(
     monkeypatch,
     *,
     events: list[ChannelMessage] | None = None,
-) -> None:
+    guilds: dict[str, str] | None = None,
+    channels: dict[str, str | None] | None = None,
+    provider_channels: dict[str, dict[str, Any]] | None = None,
+) -> list[str]:
     _DISCORD_GATEWAY_SESSIONS.clear()
+    event_queue = events if events is not None else []
+    guild_authority = guilds if guilds is not None else {"guild-protocol-1": "Protocol Guild"}
+    channel_authority = (
+        channels if channels is not None else {"chan-protocol-1": "guild-protocol-1"}
+    )
+    provider_payloads = (
+        provider_channels
+        if provider_channels is not None
+        else {
+            "chan-protocol-1": {
+                "id": "chan-protocol-1",
+                "guild_id": "guild-protocol-1",
+                "type": 0,
+                "name": "general",
+            }
+        }
+    )
+    provider_paths: list[str] = []
 
     async def fake_resolve_agent(db, *, provider: str, token: str) -> ChannelAgentContext:
         if provider == "discord" and token == "valid-discord-token":
@@ -14452,21 +14523,23 @@ def _install_discord_gateway_protocol_fakes(
             return agent
         raise HTTPException(status_code=401, detail="invalid bot identity")
 
-    async def fake_bound_guilds(
+    async def fake_authority(
         db,
         *,
         account: ChannelAccount,
-        bot_agent_link_id: UUID | None = None,
-    ) -> list[str]:
-        return ["guild-protocol-1"]
+        bot_agent_link_id: UUID,
+        priority_channel_id: str | None = None,
+    ) -> tuple[dict[str, str], dict[str, str | None]]:
+        return dict(guild_authority), dict(channel_authority)
 
-    async def fake_bound_guild_channels(
-        db,
-        *,
-        account: ChannelAccount,
-        bot_agent_link_id: UUID | None = None,
-    ) -> dict[str, list[str]]:
-        return {"guild-protocol-1": ["chan-protocol-1"]}
+    async def fake_provider_request(*, account, method: str, path: str, **kwargs):
+        provider_paths.append(path)
+        payload = provider_payloads[path.rpartition("/")[2]]
+        return shared_router._DiscordProviderResult(
+            content=json.dumps(payload).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
 
     async def fake_dequeue_events(
         db,
@@ -14476,15 +14549,20 @@ def _install_discord_gateway_protocol_fakes(
         after_sequence: int,
         limit: int,
     ):
-        return [event for event in events or [] if event.inbox_sequence > after_sequence][:limit]
+        return [event for event in event_queue if event.inbox_sequence > after_sequence][:limit]
 
-    async def fake_ack_sequence(
+    async def fake_send_message(
         *,
-        account: ChannelAccount,
-        bot_agent_link_id: UUID | None,
-        through_sequence: int,
-    ) -> None:
-        return None
+        account_id: UUID,
+        bot_agent_link_id: UUID,
+        message: ChannelMessage,
+        send,
+    ) -> str:
+        event_queue.remove(message)
+        if send is None:
+            return "dropped"
+        await send()
+        return "sent"
 
     monkeypatch.setattr(
         "app.routes.channel_routers.discord.resolve_channel_agent_by_token",
@@ -14495,21 +14573,22 @@ def _install_discord_gateway_protocol_fakes(
         fake_resolve_identity,
     )
     monkeypatch.setattr(
-        "app.routes.channel_routers.discord._discord_bound_guilds",
-        fake_bound_guilds,
+        "app.routes.channel_routers.discord._discord_gateway_authority",
+        fake_authority,
     )
     monkeypatch.setattr(
-        "app.routes.channel_routers.discord._discord_bound_guild_channels",
-        fake_bound_guild_channels,
+        "app.routes.channel_routers.discord._request_discord_provider",
+        fake_provider_request,
     )
     monkeypatch.setattr(
         "app.routes.channel_routers.discord.dequeue_discord_gateway_events",
         fake_dequeue_events,
     )
     monkeypatch.setattr(
-        "app.routes.channel_routers.discord._ack_discord_gateway_sequence",
-        fake_ack_sequence,
+        "app.routes.channel_routers.discord._send_discord_gateway_message",
+        fake_send_message,
     )
+    return provider_paths
 
 
 def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -14568,6 +14647,8 @@ def test_discord_gateway_resume_validates_session_id_and_token(monkeypatch):
             ready = websocket.receive_json()
             session_id = ready["d"]["session_id"]
             assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            channel = websocket.receive_json()
+            assert channel["t"] == "CHANNEL_CREATE"
 
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
             assert websocket.receive_json()["op"] == 10
@@ -14577,12 +14658,13 @@ def test_discord_gateway_resume_validates_session_id_and_token(monkeypatch):
                     "d": {
                         "token": "valid-discord-token",
                         "session_id": session_id,
-                        "seq": 2,
+                        "seq": channel["s"],
                     },
                 }
             )
             assert websocket.receive_json()["t"] == "RESUMED"
 
+        _DISCORD_GATEWAY_SESSIONS.clear()
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
             assert websocket.receive_json()["op"] == 10
             websocket.send_json(
@@ -14623,7 +14705,11 @@ def test_discord_gateway_resume_replays_buffered_dispatches(monkeypatch):
                 text="missed dispatch",
                 payload={
                     "t": "MESSAGE_CREATE",
-                    "d": {"channel_id": "chan-protocol-1", "content": "missed dispatch"},
+                    "d": {
+                        "channel_id": "chan-protocol-1",
+                        "guild_id": "guild-protocol-1",
+                        "content": "missed dispatch",
+                    },
                 },
             )
         ],
@@ -14636,6 +14722,8 @@ def test_discord_gateway_resume_replays_buffered_dispatches(monkeypatch):
             ready = websocket.receive_json()
             session_id = ready["d"]["session_id"]
             assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            channel = websocket.receive_json()
+            assert channel["t"] == "CHANNEL_CREATE"
             assert websocket.receive_json()["d"]["content"] == "missed dispatch"
 
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
@@ -14646,109 +14734,330 @@ def test_discord_gateway_resume_replays_buffered_dispatches(monkeypatch):
                     "d": {
                         "token": "valid-discord-token",
                         "session_id": session_id,
-                        "seq": 2,
+                        "seq": channel["s"],
                     },
                 }
             )
             replayed = websocket.receive_json()
             resumed = websocket.receive_json()
 
-    assert replayed["t"] == "MESSAGE_CREATE"
-    assert replayed["d"]["content"] == "missed dispatch"
-    assert resumed["t"] == "RESUMED"
-
-
-@pytest.mark.asyncio
-async def test_discord_gateway_stateless_resume_replays_unacked_db_events(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    _install_discord_gateway_test_session_factory(monkeypatch)
-    _DISCORD_GATEWAY_SESSIONS.clear()
-    created = await _create_paired_discord_channel(
-        client,
-        name="discord-stateless-resume",
-        channel_id="stateless-resume-channel",
-        guild_id="stateless-resume-guild",
-    )
-    account = (
-        await db_session.execute(
-            select(ChannelAccount).where(ChannelAccount.id == UUID(created["id"]))
-        )
-    ).scalar_one()
-    binding = (
-        await db_session.execute(
-            select(ChannelBinding).where(
-                ChannelBinding.account_id == account.id,
-                ChannelBinding.external_chat_id == "stateless-resume-guild",
-            )
-        )
-    ).scalar_one()
-    message = ChannelMessage(
-        account_id=account.id,
-        bot_agent_link_id=binding.bot_agent_link_id,
-        binding_id=binding.id,
-        user_id=binding.user_id,
-        direction=MESSAGE_DIRECTION_INBOUND,
-        external_chat_id="stateless-resume-channel",
-        provider_message_id="msg-stateless-resume",
-        text="from db after worker hop",
-        payload={
-            "t": "MESSAGE_CREATE",
-            "d": {
-                "id": "msg-stateless-resume",
-                "channel_id": "stateless-resume-channel",
-                "guild_id": "stateless-resume-guild",
-                "content": "from db after worker hop",
-            },
-        },
-    )
-    db_session.add(message)
-    await db_session.flush()
-    await db_session.refresh(message)
-    await db_session.commit()
-
-    with TestClient(app) as sync_client:
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
             assert websocket.receive_json()["op"] == 10
             websocket.send_json(
                 {
                     "op": 6,
                     "d": {
-                        "token": created["agent_token"],
-                        "session_id": "lost-worker-session",
-                        "seq": 0,
+                        "token": "valid-discord-token",
+                        "session_id": session_id,
+                        "seq": replayed["s"],
                     },
                 }
             )
-            resumed = websocket.receive_json()
-            dispatch = websocket.receive_json()
-            websocket.send_json({"op": 1, "d": dispatch["s"]})
-            heartbeat_ack = websocket.receive_json()
+            resumed_again = websocket.receive_json()
 
+    assert replayed["t"] == "MESSAGE_CREATE"
+    assert replayed["d"]["content"] == "missed dispatch"
     assert resumed["t"] == "RESUMED"
-    assert dispatch["t"] == "MESSAGE_CREATE"
-    assert isinstance(dispatch["s"], int)
-    assert dispatch["d"]["content"] == "from db after worker hop"
-    assert heartbeat_ack == {"op": 11, "d": None}
-    await db_session.refresh(message)
-    assert message.delivered_at is not None
+    assert resumed_again["t"] == "RESUMED"
+    assert resumed_again["s"] > resumed["s"]
+
+
+def test_discord_gateway_thread_only_alias_is_hydrated_before_message(monkeypatch):
+    events = [
+        ChannelMessage(
+            inbox_sequence=10,
+            external_chat_id="guild-protocol-1",
+            provider_message_id="thread-update-1",
+            payload={
+                "t": "THREAD_UPDATE",
+                "d": {
+                    "id": "thread-only-1",
+                    "guild_id": "guild-protocol-1",
+                    "parent_id": "unbound-forum-parent",
+                    "type": 11,
+                    "thread_metadata": {"archived": True},
+                },
+            },
+        ),
+        ChannelMessage(
+            inbox_sequence=11,
+            external_chat_id="guild-protocol-1",
+            provider_message_id="thread-message-1",
+            payload={
+                "t": "MESSAGE_CREATE",
+                "d": {
+                    "id": "thread-message-1",
+                    "channel_id": "thread-only-1",
+                    "guild_id": "guild-protocol-1",
+                    "content": "inside an existing forum post",
+                },
+            },
+        ),
+    ]
+    provider_paths = _install_discord_gateway_protocol_fakes(
+        monkeypatch,
+        events=events,
+        channels={"thread-only-1": "guild-protocol-1"},
+        provider_channels={
+            "thread-only-1": {
+                "id": "thread-only-1",
+                "guild_id": "guild-protocol-1",
+                "parent_id": "unbound-forum-parent",
+                "type": 11,
+                "name": "forum post",
+                "thread_metadata": {"archived": False, "auto_archive_duration": 1440},
+            }
+        },
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            frames = [websocket.receive_json() for _ in range(6)]
+
+    assert [frame["t"] for frame in frames] == [
+        "READY",
+        "GUILD_CREATE",
+        "THREAD_CREATE",
+        "THREAD_UPDATE",
+        "THREAD_CREATE",
+        "MESSAGE_CREATE",
+    ]
+    assert frames[1]["d"]["channels"] == frames[1]["d"]["threads"] == []
+    assert frames[2]["d"]["parent_id"] == frames[4]["d"]["parent_id"] == ("unbound-forum-parent")
+    assert frames[3]["d"]["thread_metadata"]["archived"] is True
+    assert "THREAD_DELETE" not in {frame["t"] for frame in frames}
+    assert provider_paths == ["channels/thread-only-1", "channels/thread-only-1"]
+
+
+@pytest.mark.parametrize("channel_type", [1, 3])
+def test_discord_gateway_ready_projects_exact_private_channel(monkeypatch, channel_type: int):
+    private = {
+        "id": f"private-{channel_type}",
+        "type": channel_type,
+        "name": "Pairing DM" if channel_type == 3 else None,
+        "recipients": [{"id": "user-1", "username": "Ada"}],
+        "last_message_id": "message-1",
+    }
+    provider_paths = _install_discord_gateway_protocol_fakes(
+        monkeypatch,
+        guilds={},
+        channels={private["id"]: None},
+        provider_channels={private["id"]: private},
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            ready = websocket.receive_json()
+
+    assert ready["d"]["private_channels"] == [private]
+    assert provider_paths == [f"channels/{private['id']}"]
+
+
+@pytest.mark.parametrize("channel_type", [15, 16])
+def test_discord_gateway_preserves_forum_and_media_channel_types(monkeypatch, channel_type: int):
+    provider_paths = _install_discord_gateway_protocol_fakes(
+        monkeypatch,
+        channels={"special-channel": "guild-protocol-1"},
+        provider_channels={
+            "special-channel": {
+                "id": "special-channel",
+                "guild_id": "guild-protocol-1",
+                "type": channel_type,
+                "name": "special",
+                "available_tags": [],
+            }
+        },
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            websocket.receive_json()
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            ready, guild, channel = [websocket.receive_json() for _ in range(3)]
+
+    assert [ready["t"], guild["t"], channel["t"]] == [
+        "READY",
+        "GUILD_CREATE",
+        "CHANNEL_CREATE",
+    ]
+    assert channel["d"]["type"] == channel_type
+    assert provider_paths == ["channels/special-channel"]
+
+
+def test_discord_gateway_new_alias_converges_before_queued_message(monkeypatch):
+    guilds: dict[str, str] = {}
+    channels: dict[str, str | None] = {}
+    provider_channels: dict[str, dict[str, Any]] = {}
+    events: list[ChannelMessage] = []
+    provider_paths = _install_discord_gateway_protocol_fakes(
+        monkeypatch,
+        events=events,
+        guilds=guilds,
+        channels=channels,
+        provider_channels=provider_channels,
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            websocket.receive_json()
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            assert websocket.receive_json()["t"] == "READY"
+
+            guilds["new-guild"] = "New Guild"
+            channels["new-thread"] = "new-guild"
+            provider_channels["new-thread"] = {
+                "id": "new-thread",
+                "guild_id": "new-guild",
+                "parent_id": "unbound-parent",
+                "type": 12,
+                "name": "new private thread",
+                "thread_metadata": {"archived": False},
+            }
+            events.append(
+                ChannelMessage(
+                    inbox_sequence=12,
+                    external_chat_id="new-guild",
+                    provider_message_id="new-message",
+                    payload={
+                        "t": "MESSAGE_CREATE",
+                        "d": {
+                            "id": "new-message",
+                            "guild_id": "new-guild",
+                            "channel_id": "new-thread",
+                            "content": "paired after identify",
+                        },
+                    },
+                )
+            )
+            frames = [websocket.receive_json() for _ in range(3)]
+
+    assert [frame["t"] for frame in frames] == [
+        "GUILD_CREATE",
+        "THREAD_CREATE",
+        "MESSAGE_CREATE",
+    ]
+    assert provider_paths == ["channels/new-thread"]
+
+
+def test_discord_gateway_terminal_alias_failure_does_not_block_later_event(monkeypatch):
+    events = [
+        ChannelMessage(
+            inbox_sequence=11,
+            external_chat_id="guild-protocol-1",
+            provider_message_id=f"message-{channel_id}",
+            payload={
+                "t": "MESSAGE_CREATE",
+                "d": {
+                    "id": f"message-{channel_id}",
+                    "guild_id": "guild-protocol-1",
+                    "channel_id": channel_id,
+                    "content": channel_id,
+                },
+            },
+        )
+        for channel_id in ("missing-channel", "valid-channel")
+    ]
+    channels = {
+        "missing-channel": "guild-protocol-1",
+        "valid-channel": "guild-protocol-1",
+    }
+    _install_discord_gateway_protocol_fakes(
+        monkeypatch,
+        events=events,
+        channels=channels,
+        provider_channels={"missing-channel": {}, "valid-channel": {}},
+    )
+    calls: list[str] = []
+    missing_calls = 0
+    rate_limited = threading.Event()
+    now = 0.0
+
+    async def provider_request(*, account, method: str, path: str, **kwargs):
+        nonlocal missing_calls
+        channel_id = path.rpartition("/")[2]
+        calls.append(channel_id)
+        if channel_id == "missing-channel":
+            missing_calls += 1
+            if missing_calls == 2:
+                rate_limited.set()
+                raise HTTPException(
+                    status_code=429,
+                    detail="provider detail must stay private",
+                    headers={"retry-after": "7200.5"},
+                )
+            if missing_calls > 2:
+                raise HTTPException(status_code=400, detail="permanent provider request failure")
+            return _discord_provider_result(404, {"message": "Unknown Channel"})
+        return _discord_provider_result(
+            200,
+            {
+                "id": channel_id,
+                "guild_id": "guild-protocol-1",
+                "type": 0,
+                "name": "valid",
+            },
+        )
+
+    monkeypatch.setattr(discord_router, "_request_discord_provider", provider_request)
+    monkeypatch.setattr(discord_router, "monotonic", lambda: now)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            websocket.receive_json()
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            frames = [websocket.receive_json() for _ in range(3)]
+            assert rate_limited.wait(1)
+            now = 7200.4
+            websocket.send_json({"op": 1, "d": frames[-1]["s"]})
+            assert websocket.receive_json() == {"op": 11, "d": None}
+            now = 7200.6
+            websocket.send_json({"op": 1, "d": frames[-1]["s"]})
+            tail = [websocket.receive_json() for _ in range(2)]
+            assert {"op": 11, "d": None} in tail
+            frames.append(next(frame for frame in tail if frame.get("op") == 0))
+
+    assert [frame["t"] for frame in frames] == [
+        "READY",
+        "GUILD_CREATE",
+        "CHANNEL_CREATE",
+        "MESSAGE_CREATE",
+    ]
+    assert calls == ["missing-channel", "valid-channel", "missing-channel", "missing-channel"]
+
+
+async def _archive_discord_binding_with_identity_lock(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    account_id: UUID,
+    binding_id: UUID,
+    external_chat_id: str,
+) -> None:
+    async with sessionmaker() as db:
+        await channel_service.lock_channel_binding_identity(
+            db,
+            account_id=account_id,
+            external_chat_id=external_chat_id,
+        )
+        binding = await db.get(ChannelBinding, binding_id)
+        assert binding is not None
+        binding.status = BINDING_STATUS_ARCHIVED
+        await db.commit()
 
 
 @pytest.mark.asyncio
-async def test_discord_gateway_early_heartbeat_does_not_ack_undispatched_low_inbox(
+async def test_discord_gateway_send_and_unpair_are_linearized(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    _install_discord_gateway_test_session_factory(monkeypatch)
-    _DISCORD_GATEWAY_SESSIONS.clear()
     created = await _create_paired_discord_channel(
         client,
-        name="discord-gateway-heartbeat-low-inbox",
-        channel_id="ack-race-channel-1",
-        guild_id="ack-race-guild-1",
+        name="discord-send-lease",
+        channel_id="send-lease-channel",
+        guild_id="send-lease-guild",
     )
     account_id = UUID(created["id"])
     link_id = UUID(created["agent_link_id"])
@@ -14756,92 +15065,372 @@ async def test_discord_gateway_early_heartbeat_does_not_ack_undispatched_low_inb
         await db_session.execute(
             select(ChannelBinding).where(
                 ChannelBinding.account_id == account_id,
-                ChannelBinding.bot_agent_link_id == link_id,
-                ChannelBinding.external_chat_id == "ack-race-guild-1",
+                ChannelBinding.external_chat_id == "send-lease-guild",
             )
         )
     ).scalar_one()
-    for guild_id in ("ack-race-guild-2", "ack-race-guild-3"):
-        db_session.add(
-            ChannelBinding(
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction=MESSAGE_DIRECTION_INBOUND,
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="send-lease-message",
+        payload={"t": "MESSAGE_CREATE", "d": {"channel_id": "send-lease-channel"}},
+    )
+    db_session.add(message)
+    await db_session.commit()
+    await db_session.refresh(message)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    send_started = asyncio.Event()
+    allow_send = asyncio.Event()
+    frames: list[str] = []
+
+    async def send() -> None:
+        frames.append("frame")
+        send_started.set()
+        await allow_send.wait()
+
+    send_task = asyncio.create_task(
+        discord_router._send_discord_gateway_message(
+            account_id=account_id,
+            bot_agent_link_id=link_id,
+            message=message,
+            send=send,
+        )
+    )
+    await send_started.wait()
+    unpair_task = asyncio.create_task(
+        _archive_discord_binding_with_identity_lock(
+            sessionmaker,
+            account_id=account_id,
+            binding_id=binding.id,
+            external_chat_id=binding.external_chat_id,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert not unpair_task.done()
+    allow_send.set()
+
+    assert await send_task == "sent"
+    await unpair_task
+    assert frames == ["frame"]
+
+    second = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction=MESSAGE_DIRECTION_INBOUND,
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="after-unpair",
+        payload={"t": "MESSAGE_CREATE", "d": {"channel_id": "send-lease-channel"}},
+    )
+    db_session.add(second)
+    await db_session.commit()
+    await db_session.refresh(second)
+    assert (
+        await discord_router._send_discord_gateway_message(
+            account_id=account_id,
+            bot_agent_link_id=link_id,
+            message=second,
+            send=lambda: frames.append("leaked"),
+        )
+        == "dropped"
+    )
+    assert frames == ["frame"]
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_multiple_connections_send_each_event_once(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-send-once",
+        channel_id="send-once-channel",
+        guild_id="send-once-guild",
+    )
+    account_id = UUID(created["id"])
+    link_id = UUID(created["agent_link_id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction=MESSAGE_DIRECTION_INBOUND,
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="send-once-message",
+        payload={"t": "MESSAGE_CREATE", "d": {"channel_id": "send-once-channel"}},
+    )
+    db_session.add(message)
+    await db_session.commit()
+    await db_session.refresh(message)
+    sends = 0
+
+    async def send() -> None:
+        nonlocal sends
+        sends += 1
+        await asyncio.sleep(0.05)
+
+    results = await asyncio.gather(
+        *(
+            discord_router._send_discord_gateway_message(
                 account_id=account_id,
                 bot_agent_link_id=link_id,
-                user_id=binding.user_id,
-                external_chat_id=guild_id,
-                external_chat_type="guild",
-                external_chat_name=guild_id,
+                message=message,
+                send=send,
             )
+            for _ in range(2)
         )
+    )
+
+    assert sorted(results) == ["consumed", "sent"]
+    assert sends == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_inbound_record_and_unpair_are_linearized(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-producer-lease",
+        channel_id="producer-lease-channel",
+        guild_id="producer-lease-guild",
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    producer_started = asyncio.Event()
+    allow_record = asyncio.Event()
+    original_record = channel_service.record_inbound_messages_for_bindings
+
+    async def paused_record(*args, **kwargs):
+        producer_started.set()
+        await allow_record.wait()
+        return await original_record(*args, **kwargs)
+
+    monkeypatch.setattr(channel_service, "record_inbound_messages_for_bindings", paused_record)
+
+    async def produce(provider_message_id: str) -> bool:
+        async with sessionmaker() as db:
+            account = await db.get(ChannelAccount, account_id)
+            assert account is not None
+            recorded = await record_discord_dispatch(
+                db,
+                account=account,
+                frame={
+                    "t": "MESSAGE_CREATE",
+                    "d": {
+                        "id": provider_message_id,
+                        "guild_id": binding.external_chat_id,
+                        "channel_id": "producer-lease-channel",
+                        "content": "hello",
+                        "author": {"id": "user-1", "bot": False},
+                    },
+                },
+            )
+            await db.commit()
+            return recorded
+
+    producer_task = asyncio.create_task(produce("producer-first"))
+    await producer_started.wait()
+    unpair_task = asyncio.create_task(
+        _archive_discord_binding_with_identity_lock(
+            sessionmaker,
+            account_id=account_id,
+            binding_id=binding.id,
+            external_chat_id=binding.external_chat_id,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert not unpair_task.done()
+    allow_record.set()
+    assert await producer_task is True
+    await unpair_task
+
+    monkeypatch.setattr(channel_service, "record_inbound_messages_for_bindings", original_record)
+    assert await produce("unpair-first") is False
+    rows = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == account_id,
+                    ChannelMessage.provider_message_id.in_(["producer-first", "unpair-first"]),
+                )
+            )
+        ).scalars()
+    )
+    assert [row.provider_message_id for row in rows] == ["producer-first"]
+
+
+@pytest.mark.asyncio
+async def test_discord_unpaired_tutorial_failure_has_short_retry_then_success_cooldown(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-unpaired-tutorial",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    attempts = 0
+
+    async def send_tutorial(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise HTTPException(status_code=502, detail="private provider failure")
+        return "tutorial-message", {"id": "tutorial-message", "channel_id": "dm-channel"}
+
+    monkeypatch.setattr(channel_service, "_send_discord_provider_payload", send_tutorial)
+
+    def frame(message_id: str) -> dict[str, Any]:
+        return {
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": message_id,
+                "channel_id": "dm-channel",
+                "content": "hello",
+                "author": {"id": "discord-user", "bot": False},
+            },
+        }
+
+    for message_id in ("tutorial-failed", "tutorial-backoff"):
+        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
+        await db_session.commit()
+    assert attempts == 1
+
+    markers = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                    func.jsonb_extract_path_text(ChannelMessage.payload, "kind")
+                    == "discord_unpaired_tutorial",
+                )
+            )
+        ).scalars()
+    )
+    for marker in markers:
+        marker.created_at = datetime.now(UTC) - timedelta(seconds=31)
     await db_session.commit()
 
-    previous_poll_interval = settings.discord_gateway_poll_interval_seconds
-    settings.discord_gateway_poll_interval_seconds = 1.0
-    try:
-        with TestClient(app) as sync_client:
-            with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
-                assert websocket.receive_json()["op"] == 10
-                websocket.send_json({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
-                ready = websocket.receive_json()
-                guild_creates = [websocket.receive_json() for _ in range(3)]
-                highest_guild_sequence = max(frame["s"] for frame in guild_creates)
+    for message_id in ("tutorial-retry", "tutorial-success-cooldown"):
+        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
+        await db_session.commit()
+    assert attempts == 2
 
-                assert ready["t"] == "READY"
-                assert {frame["t"] for frame in guild_creates} == {"GUILD_CREATE"}
-                assert highest_guild_sequence > 2
 
-                await asyncio.sleep(0.05)
-                message = ChannelMessage(
+@pytest.mark.asyncio
+async def test_discord_pair_winning_identity_lock_suppresses_unpaired_tutorial(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-pair-tutorial-race",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    link_id = UUID(created["agent_link_id"])
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    pair_locked = asyncio.Event()
+    finish_pair = asyncio.Event()
+    sends = 0
+
+    async def unexpected_send(**kwargs):
+        nonlocal sends
+        sends += 1
+        return None, {}
+
+    monkeypatch.setattr(channel_service, "_send_discord_provider_payload", unexpected_send)
+
+    async def pair() -> None:
+        async with sessionmaker() as db:
+            await channel_service.lock_channel_binding_identity(
+                db,
+                account_id=account_id,
+                external_chat_id="pair-race-guild",
+            )
+            pair_locked.set()
+            await finish_pair.wait()
+            db.add(
+                ChannelBinding(
                     account_id=account_id,
                     bot_agent_link_id=link_id,
-                    binding_id=binding.id,
-                    user_id=binding.user_id,
-                    direction=MESSAGE_DIRECTION_INBOUND,
-                    inbox_sequence=2,
-                    external_chat_id="ack-race-guild-1",
-                    provider_message_id="ack-race-message",
-                    text="low inbox after guild create",
-                    payload={
-                        "t": "MESSAGE_CREATE",
-                        "d": {
-                            "id": "ack-race-message",
-                            "channel_id": "ack-race-channel-1",
-                            "guild_id": "ack-race-guild-1",
-                            "content": "low inbox after guild create",
-                        },
-                    },
+                    user_id=link.user_id,
+                    external_chat_id="pair-race-guild",
+                    external_chat_type="guild",
                 )
-                db_session.add(message)
-                await db_session.flush()
-                await db_session.refresh(message)
-                assert message.inbox_sequence < highest_guild_sequence
-                await db_session.commit()
+            )
+            await db.commit()
 
-                websocket.send_json({"op": 1, "d": highest_guild_sequence})
-                first_frame = websocket.receive_json()
-                if first_frame == {"op": 11, "d": None}:
-                    dispatch = websocket.receive_json()
-                else:
-                    # The gateway poll may observe the newly committed inbox row
-                    # before it processes the heartbeat. Frame ordering is not
-                    # the invariant under test: the stale heartbeat still must
-                    # not acknowledge this later dispatch sequence.
-                    dispatch = first_frame
-                    assert websocket.receive_json() == {"op": 11, "d": None}
-                await db_session.refresh(message)
-                assert message.delivered_at is None
+    async def instruct() -> bool:
+        async with sessionmaker() as db:
+            account = await db.get(ChannelAccount, account_id)
+            assert account is not None
+            recorded = await record_discord_dispatch(
+                db,
+                account=account,
+                frame={
+                    "t": "MESSAGE_CREATE",
+                    "d": {
+                        "id": "pair-race-message",
+                        "guild_id": "pair-race-guild",
+                        "channel_id": "pair-race-channel",
+                        "content": "<@123456789012345678> hi",
+                        "mentions": [{"id": DISCORD_TEST_APPLICATION_ID}],
+                        "author": {"id": "discord-user", "bot": False},
+                    },
+                },
+            )
+            await db.commit()
+            return recorded
 
-                assert dispatch["t"] == "MESSAGE_CREATE"
-                assert dispatch["s"] > highest_guild_sequence
-                assert dispatch["d"]["content"] == "low inbox after guild create"
+    pair_task = asyncio.create_task(pair())
+    await pair_locked.wait()
+    tutorial_task = asyncio.create_task(instruct())
+    await asyncio.sleep(0.05)
+    assert not tutorial_task.done()
+    finish_pair.set()
+    await pair_task
 
-                websocket.send_json({"op": 1, "d": dispatch["s"]})
-                assert websocket.receive_json() == {"op": 11, "d": None}
-
-        await db_session.refresh(message)
-        assert message.delivered_at is not None
-    finally:
-        settings.discord_gateway_poll_interval_seconds = previous_poll_interval
-        _DISCORD_GATEWAY_SESSIONS.clear()
+    assert await tutorial_task is False
+    assert sends == 0
 
 
 def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
@@ -14856,7 +15445,11 @@ def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
                 text="event one",
                 payload={
                     "t": "MESSAGE_CREATE",
-                    "d": {"channel_id": "chan-protocol-1", "content": "event one"},
+                    "d": {
+                        "channel_id": "chan-protocol-1",
+                        "guild_id": "guild-protocol-1",
+                        "content": "event one",
+                    },
                 },
             ),
             ChannelMessage(
@@ -14866,7 +15459,11 @@ def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
                 text="event two",
                 payload={
                     "t": "MESSAGE_CREATE",
-                    "d": {"channel_id": "chan-protocol-1", "content": "event two"},
+                    "d": {
+                        "channel_id": "chan-protocol-1",
+                        "guild_id": "guild-protocol-1",
+                        "content": "event two",
+                    },
                 },
             ),
         ],
@@ -14879,6 +15476,7 @@ def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
             ready = websocket.receive_json()
             session_id = ready["d"]["session_id"]
             assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            assert websocket.receive_json()["t"] == "CHANNEL_CREATE"
             assert websocket.receive_json()["d"]["content"] == "event one"
             assert websocket.receive_json()["d"]["content"] == "event two"
 
@@ -16364,7 +16962,7 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
         },
     }
     assert await record_discord_dispatch(db_session, account=account, frame=dm_frame)
-    assert not await record_discord_dispatch(
+    assert await record_discord_dispatch(
         db_session,
         account=account,
         frame={
@@ -18406,6 +19004,7 @@ async def test_discord_send_uses_provider_rest_api(
     db_session: AsyncSession,
     monkeypatch,
 ):
+    monkeypatch.setattr(channel_service, "discord_rate_limiter", DiscordRateLimiter())
     _FakeProviderClient.calls = []
     _FakeProviderClient.response_payload = {"id": "discord-msg-1"}
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)


### PR DESCRIPTION
## Summary

- project exact Discord channel/thread types into each managed Gateway websocket from existing active Binding/Alias authority
- hydrate missing topology with a scoped Discord GET before delivering MESSAGE_CREATE, then emit minimal GUILD_CREATE and CHANNEL_CREATE/THREAD_CREATE in protocol order
- linearize inbound recording, websocket delivery, and unpair through the existing Binding advisory lock
- preserve provider lifecycle events, bounded resume state, terminal 403/404 behavior, Retry-After handling, and unpaired-chat guidance

## Root cause

Clawdi previously projected every aliased Discord channel as type 0 and omitted real guild/parent/thread topology. discord.py cached a TextChannel (or lacked guild context), so Hermes failed before the create-thread REST request with: This message does not have guild info attached.

This fixes the projection at the Clawdi boundary. It does not modify Hermes, clawdi-hosted, schemas, migrations, dependencies, or lockfiles.

## Verification

- isolated Docker + throwaway pgvector PostgreSQL: 183 Discord tests passed
- Ruff check and format check passed
- compileall passed
- git diff --check passed