### PR TITLE
fix(web): surface transient runtime health

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -202,8 +202,8 @@ async function expectAgentOverviewTypography(page: Page) {
 			}),
 		);
 	expect(primaryMetrics.length).toBeGreaterThan(3);
-	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
-	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const detailMetrics = await main
 		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
@@ -242,8 +242,8 @@ async function expectAgentOverviewTypography(page: Page) {
 			}),
 		);
 	expect(toolPrimaryMetrics).toHaveLength(2);
-	expect(new Set(toolPrimaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
-	expect(new Set(toolPrimaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+	expect(new Set(toolPrimaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(toolPrimaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const toolSecondaryMetrics = await main
 		.locator("[data-overview-tool-secondary]")
@@ -254,7 +254,7 @@ async function expectAgentOverviewTypography(page: Page) {
 			}),
 		);
 	expect(toolSecondaryMetrics).toHaveLength(1);
-	expect(new Set(toolSecondaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(toolSecondaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
 	expect(new Set(toolSecondaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(
 		new Set(["400"]),
 	);
@@ -3137,7 +3137,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			const style = getComputedStyle(element);
 			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
 		});
-	expect(computePlanTypography).toEqual({ fontSize: "14px", fontWeight: "600" });
+	expect(computePlanTypography).toEqual({ fontSize: "14px", fontWeight: "500" });
 	await expect(compute.getByTestId("overview-compute-summary")).not.toHaveClass(
 		/rounded|border|bg-/,
 	);
@@ -3241,6 +3241,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			Math.abs((toolGeometry[index]?.x ?? 0) - (resourceGeometry[index]?.x ?? 0)),
 		).toBeLessThanOrEqual(2);
 	}
+	const moduleHeights = [...resourceGeometry, ...toolGeometry].map((box) => box.height);
+	expect(Math.max(...moduleHeights) - Math.min(...moduleHeights)).toBeLessThanOrEqual(2);
 	expect((toolGeometry[1]?.x ?? 0) + (toolGeometry[1]?.width ?? 0)).toBeLessThan(
 		(resourceGeometry[2]?.x ?? 0) + 1,
 	);
@@ -3336,6 +3338,79 @@ test("hosted overview keeps a three-row accessible session slot for zero through
 	}
 
 	expect(Math.max(...measurements) - Math.min(...measurements)).toBeLessThanOrEqual(2);
+});
+
+test("post-ready runtime health degradation stays navigable and surfaces consistently", async ({
+	page,
+}, testInfo) => {
+	const degradedDeployment = mutationDeploymentReadFixture(railHostedDeployment);
+	const status = degradedDeployment.resource.status;
+	if (!status) throw new Error("Expected running deployment status");
+	status.conditions = [
+		{
+			type: "Degraded",
+			status: "True",
+			observedGeneration: status.observedGeneration,
+			lastTransitionTime: "2026-08-02T12:00:00Z",
+			reason: "RuntimeHealthDegraded",
+			message: "Fresh runtime health is temporarily unavailable",
+		},
+	];
+	await stubHostedApi(page, {
+		deployments: [degradedDeployment],
+		cloudAgents: [railHostedCloudAgent],
+		sessionsPage: hostedOverviewSessionsPage(1),
+	});
+
+	await page.goto("/agents");
+	const main = page.locator("main");
+	const agentCard = main
+		.getByRole("link", { name: "Open Rail Cloud. Status: Temporarily unavailable", exact: true })
+		.locator("..");
+	await expect(agentCard).toContainText("Temporarily unavailable");
+	await expect(agentCard.getByTitle(/Status: Temporarily unavailable/)).toBeVisible();
+
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+	const compute = main.locator('[data-overview-status="compute"]');
+	const computeStatus = compute.locator("[data-overview-compute-status]");
+	await expect(computeStatus).toHaveText("Temporarily unavailable");
+	await expect(computeStatus.locator('[data-slot="status-dot"]')).toHaveAttribute(
+		"data-status",
+		"warning",
+	);
+	await expect(page.getByTestId("app-sidebar-agent-status")).toContainText(
+		"Temporarily unavailable",
+	);
+	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Agent Interface", exact: true })).toBeVisible();
+	await expect(
+		page.getByRole("region", { name: "Recent sessions" }).locator("article"),
+	).toHaveCount(1);
+	await expect(
+		main.getByText("Agent details are unavailable right now.", { exact: true }),
+	).toHaveCount(0);
+	await expect(
+		main.getByText("Fresh runtime health is temporarily unavailable", { exact: true }),
+	).toHaveCount(0);
+	await page.setViewportSize({ width: 1280, height: 1100 });
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-runtime-degraded.png"),
+		fullPage: true,
+	});
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-runtime-degraded-dark.png"),
+		fullPage: true,
+	});
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(computeStatus).toBeVisible();
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-runtime-degraded-mobile.png"),
+		fullPage: true,
+	});
 });
 
 test("hosted overview shows a custom provider label and gates provider catalogs", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -228,8 +228,8 @@ async function expectAgentOverviewTypography(page: Page) {
 			}),
 		);
 	expect(primaryMetrics.length).toBeGreaterThan(3);
-	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["16px"]));
-	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const detailMetrics = await main
 		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
@@ -935,6 +935,10 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 			Math.max(...row.map((box) => box.height)) - Math.min(...row.map((box) => box.height)),
 		).toBeLessThanOrEqual(2);
 	}
+	expect(
+		Math.max(...resourceGeometry.map((box) => box.height)) -
+			Math.min(...resourceGeometry.map((box) => box.height)),
+	).toBeLessThanOrEqual(2);
 	expect(
 		await resourceGrid
 			.locator("[data-overview-module]")

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -21,6 +21,8 @@ describe("overview resource summary", () => {
 		);
 
 		expect(markup).toContain('data-testid="overview-resource-summary"');
+		expect(markup).toContain("text-sm font-medium text-muted-foreground");
+		expect(markup).not.toContain("text-base font-semibold");
 		expect(markup).toContain('data-testid="overview-resource-badges"');
 		expect(markup).toContain('data-slot="badge"');
 		for (const item of [

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -86,10 +86,10 @@ export function OverviewModuleSkeleton({
 
 export function OverviewModuleError({ label, onRetry }: { label: string; onRetry?: () => void }) {
 	return (
-		<div className="space-y-3 text-sm" role="status">
-			<p className="font-medium">Can’t load {label.toLowerCase()}</p>
+		<div className="space-y-2 text-sm text-muted-foreground" role="status">
+			<p>Can’t load {label.toLowerCase()}</p>
 			{onRetry ? (
-				<Button type="button" variant="outline" size="sm" onClick={onRetry}>
+				<Button type="button" variant="ghost" size="sm" className="h-7 px-2" onClick={onRetry}>
 					<RefreshCw /> Retry
 				</Button>
 			) : null}
@@ -129,7 +129,7 @@ export function OverviewResourceSummary({
 }) {
 	return (
 		<div className="space-y-3" data-testid="overview-resource-summary">
-			<p data-overview-primary-value className="text-base font-semibold">
+			<p data-overview-primary-value className="text-sm font-medium text-muted-foreground">
 				{primary}
 			</p>
 			{items?.length ? (
@@ -212,7 +212,7 @@ export function AgentOverviewCapabilities({
 					<div
 						data-overview-layout={group.layout}
 						className={cn(
-							"grid items-stretch gap-3",
+							"grid auto-rows-fr items-stretch gap-3",
 							group.layout === "three-column"
 								? "@2xl/main:grid-cols-2 @4xl/main:grid-cols-3"
 								: "@2xl/main:grid-cols-2",
@@ -230,7 +230,7 @@ export function AgentOverviewCapabilities({
 									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className="h-full min-w-0 gap-0 py-0"
+									className="h-full min-h-36 min-w-0 gap-0 py-0"
 								>
 									<CardHeader className="p-0">
 										<Link

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -161,7 +161,7 @@ export function OverviewConnectorsBody() {
 	return (
 		<div className="space-y-3">
 			{!connected.connectionsLoading && !connectionsUnavailable ? (
-				<p data-overview-primary-value className="text-base font-semibold">
+				<p data-overview-primary-value className="text-sm font-medium text-muted-foreground">
 					{connectedAppCount ? `${connectedAppCount} connected` : "No apps connected"}
 				</p>
 			) : null}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -236,7 +236,7 @@ export function ConnectedAgentDetail({
 										<div className="flex h-full flex-col justify-between gap-4">
 											<p
 												data-overview-primary-value
-												className="inline-flex items-center gap-2 text-base font-semibold"
+												className="inline-flex items-center gap-2 text-sm font-medium"
 											>
 												<StatusDot status={syncTone} /> {syncStatus.label}
 											</p>

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -25,7 +25,10 @@ import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import { deploymentStatusFromResource, deploymentStatusLabel } from "@/hosted/deployment-status";
+import {
+	deploymentRuntimeStatusPresentation,
+	deploymentStatusFromResource,
+} from "@/hosted/deployment-status";
 import { defaultDeploymentRuntime, isHostedRuntime } from "@/hosted/runtimes";
 import {
 	type AgentRouteSearch,
@@ -384,7 +387,7 @@ function DeploymentChooser({
 								icon={<AgentIcon agent={match.runtime} size="lg" />}
 								title={name}
 								meta={[
-									deploymentStatusLabel(deploymentStatusFromResource(deployment.resource.status)),
+									deploymentRuntimeStatusPresentation(deployment.resource.status).label,
 									`Created ${formatShortDate(deployment.resource.metadata.createdAt)}`,
 								]}
 								titleAdornment={

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -241,7 +241,8 @@ describe("overview Compute hierarchy", () => {
 		expect(markup).toContain('aria-label="Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage"');
 		expect(markup).toContain('data-testid="overview-compute-summary"');
 		expect(markup).toContain('data-overview-compute-plan="true"');
-		expect(markup).toContain("text-sm font-semibold");
+		expect(markup).toContain("text-sm font-medium text-muted-foreground");
+		expect(markup).not.toContain("text-sm font-semibold");
 		expect(markup).not.toContain("grid-cols-2");
 		expect(markup).not.toContain("rounded");
 		expect(markup).not.toContain("border");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -200,9 +200,9 @@ import {
 	canStart as canStartDeployment,
 	canStop as canStopDeployment,
 	type DeploymentStatus,
+	deploymentRuntimeStatusPresentation,
 	deploymentStatusFromResource,
 	deploymentStatusLabel,
-	deploymentStatusTone,
 	isRunningStatus,
 } from "@/hosted/deployment-status";
 import { DeploymentStatusUnavailableState } from "@/hosted/deployment-status-unavailable";
@@ -928,7 +928,7 @@ export function OverviewComputeSummary({
 	];
 	return (
 		<div className="space-y-1.5" data-testid="overview-compute-summary">
-			<p data-overview-compute-plan className="text-sm font-semibold">
+			<p data-overview-compute-plan className="text-sm font-medium text-muted-foreground">
 				{plan} plan
 			</p>
 			<ul
@@ -1143,11 +1143,12 @@ function OverviewTab({
 			managedModelCatalog.data?.models ?? [],
 		),
 	);
-	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
+	const runtimeStatusPresentation = deploymentRuntimeStatusPresentation(deployment.resource.status);
+	const deploymentStatus = runtimeStatusPresentation.status;
 	const deploymentFailure = deploymentFailurePresentation(deployment);
 	const computeStatusPresentation = deploymentFailure?.status ?? {
-		label: deploymentStatusLabel(deploymentStatus),
-		tone: deploymentStatusTone(deploymentStatus),
+		label: runtimeStatusPresentation.label,
+		tone: runtimeStatusPresentation.tone,
 	};
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const sessionsEmptyMessage = deploymentRunning
@@ -1220,7 +1221,7 @@ function OverviewTab({
 							<p
 								data-overview-compute-status
 								data-overview-primary-value
-								className="inline-flex items-center gap-2 text-base font-semibold"
+								className="inline-flex items-center gap-2 text-sm font-medium"
 								title={`Agent status: ${computeStatusPresentation.label}`}
 							>
 								<StatusDot status={computeStatusPresentation.tone} />
@@ -1313,11 +1314,11 @@ function OverviewTab({
 									<p
 										data-overview-primary-value
 										data-overview-tool-primary
-										className="text-base font-semibold"
+										className="text-sm font-medium text-muted-foreground"
 									>
 										{model}
 									</p>
-									<p data-overview-tool-secondary className="text-sm text-muted-foreground">
+									<p data-overview-tool-secondary className="text-xs text-muted-foreground">
 										{managedProvider
 											? "Managed by Clawdi"
 											: providerDisplayLabel(providerId ?? "", providers.data ?? [])}
@@ -1339,7 +1340,7 @@ function OverviewTab({
 								<p
 									data-overview-primary-value
 									data-overview-tool-primary
-									className="text-base font-semibold"
+									className="text-sm font-medium text-muted-foreground"
 								>
 									{linkedChannelCount === 0
 										? "No channels connected"

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -11,6 +11,7 @@ import {
 	type DeploymentOperationVerb,
 	deploymentPollingState,
 	deploymentRefetchInterval,
+	deploymentRuntimeStatusPresentation,
 	deploymentStatusFromResource,
 	deploymentStatusLabel,
 	deploymentStatusTone,
@@ -122,6 +123,39 @@ describe("DeploymentStatus", () => {
 			expect(deploymentStatusLabel(status)).toBe(label);
 			expect(deploymentStatusTone(status)).toBe(tone);
 		}
+	});
+
+	test("surfaces current post-ready runtime health degradation without changing lifecycle", () => {
+		const deployment = hostedDeploymentFixture({ status: "running" });
+		const status = deployment.resource.status;
+		if (!status) throw new Error("Expected fixture status");
+		const degradedStatus = {
+			...status,
+			conditions: [
+				{
+					type: "Degraded" as const,
+					status: "True" as const,
+					observedGeneration: status.observedGeneration,
+					lastTransitionTime: "2026-08-02T12:00:00Z",
+					reason: "RuntimeHealthDegraded",
+					message: "Fresh runtime health is temporarily unavailable",
+				},
+			],
+		};
+
+		expect(deploymentRuntimeStatusPresentation(degradedStatus)).toEqual({
+			status: { kind: "running", raw: "running", known: true },
+			label: "Temporarily unavailable",
+			tone: "warning",
+		});
+		expect(
+			deploymentRuntimeStatusPresentation({
+				...degradedStatus,
+				conditions: [
+					{ ...degradedStatus.conditions[0], observedGeneration: status.observedGeneration - 1 },
+				],
+			}).label,
+		).toBe("Running");
 	});
 
 	test("classifies terminal and transitional states", () => {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -41,6 +41,11 @@ export type UnknownDeploymentStatus =
 	  };
 
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
+export type DeploymentStatusPresentation = {
+	status: DeploymentStatus;
+	label: string;
+	tone: DeploymentStatusTone;
+};
 // `plan_change` is a projected failure phase; `runtime_switch` remains a live
 // legacy wire value while the hosted main rollout converges.
 export type DeploymentOperationVerb =
@@ -158,6 +163,33 @@ export function deploymentStatusTone(status: DeploymentStatus): DeploymentStatus
 		default:
 			return exhaustive(status);
 	}
+}
+
+function hasCurrentRuntimeHealthDegradation(status: HostedDeploymentStatus): boolean {
+	return (
+		status.summary_state === "running" &&
+		status.conditions.some(
+			(condition) =>
+				condition.type === "Degraded" &&
+				condition.status === "True" &&
+				condition.reason === "RuntimeHealthDegraded" &&
+				condition.observedGeneration === status.observedGeneration,
+		)
+	);
+}
+
+export function deploymentRuntimeStatusPresentation(
+	resourceStatus: HostedDeploymentStatus | null,
+): DeploymentStatusPresentation {
+	const status = deploymentStatusFromResource(resourceStatus);
+	if (resourceStatus && hasCurrentRuntimeHealthDegradation(resourceStatus)) {
+		return { status, label: "Temporarily unavailable", tone: "warning" };
+	}
+	return {
+		status,
+		label: deploymentStatusLabel(status),
+		tone: deploymentStatusTone(status),
+	};
 }
 
 export function isRunningStatus(status: DeploymentStatus): boolean {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -466,6 +466,32 @@ describe("hostedRuntimeStatusView", () => {
 		expect(view.secondary?.label).toBe("Sync paused");
 	});
 
+	test("shows current runtime health degradation as a warning while staying active", () => {
+		if (!getRuntimeStatusView) throw new Error("hostedRuntimeStatusView was not loaded");
+		const deployment = hostedDeploymentFixture({ status: "running" });
+		const status = deployment.resource.status;
+		if (!status) throw new Error("Expected fixture status");
+		const view = getRuntimeStatusView(
+			{
+				...status,
+				conditions: [
+					{
+						type: "Degraded",
+						status: "True",
+						observedGeneration: status.observedGeneration,
+						lastTransitionTime: "2026-08-02T12:00:00Z",
+						reason: "RuntimeHealthDegraded",
+						message: "Fresh runtime health is temporarily unavailable",
+					},
+				],
+			},
+			env(),
+		);
+
+		expect(view.primary).toMatchObject({ label: "Temporarily unavailable", tone: "warning" });
+		expect(view.active).toBe(true);
+	});
+
 	test("suppresses reassuring live sync when compute is stopped", () => {
 		const view = hostedRuntimeStatusView("stopped", env());
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -18,9 +18,7 @@ import {
 import {
 	type DeploymentStatus,
 	type DeploymentStatusTone,
-	deploymentStatusFromResource,
-	deploymentStatusLabel,
-	deploymentStatusTone,
+	deploymentRuntimeStatusPresentation,
 	isRunningStatus,
 } from "@/hosted/deployment-status";
 import {
@@ -58,10 +56,11 @@ export function hostedRuntimeStatusView(
 	env: Env | null | undefined,
 	failurePresentation?: DeploymentFailurePresentation | null,
 ): HostedRuntimeStatusView {
-	const compute = deploymentStatusFromResource(deployment);
+	const computePresentation = deploymentRuntimeStatusPresentation(deployment);
+	const compute = computePresentation.status;
 	const failureStatus = compute.kind === "failed" ? failurePresentation?.status : null;
-	const computeLabel = failureStatus?.label ?? deploymentStatusLabel(compute);
-	const computeTone = failureStatus?.tone ?? deploymentStatusTone(compute);
+	const computeLabel = failureStatus?.label ?? computePresentation.label;
+	const computeTone = failureStatus?.tone ?? computePresentation.tone;
 	const sync = env === undefined ? null : daemonStatusVisual(env, "on-clawdi");
 	const computeIsRunning = isRunningStatus(compute);
 	const failureReason =


### PR DESCRIPTION
## Summary
- surface current-generation `RuntimeHealthDegraded` as a warning across agent cards, sidebar, chooser, and Compute without changing the running lifecycle
- keep Sessions and Agent Interface available during the backend grace window
- normalize Overview module cards to equal-height standard grids and reduce body typography to the shared muted hierarchy

## Verification
- Docker isolated Web typecheck, 46 focused tests, and OSS production build
- mocked Hosted Playwright: normal overview and runtime-degraded overview
- mocked Connected Playwright: normal overview
- light, dark, and mobile screenshots reviewed
- Biome and `git diff --check`

## Rollout
This UI recognizes the condition introduced by Clawdi-AI/clawdi-hosted#1345. It is backward compatible when that reason is absent.