### PR TITLE
fix(channels): harden queue retention

### DIFF
--- a/backend/alembic/versions/b5d8e2a7c4f1_add_channel_retention_indexes.py
+++ b/backend/alembic/versions/b5d8e2a7c4f1_add_channel_retention_indexes.py
@@ -1,0 +1,146 @@
+"""add channel retention indexes
+
+Revision ID: b5d8e2a7c4f1
+Revises: f3b7c1d9e5a2
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b5d8e2a7c4f1"
+down_revision: str | Sequence[str] | None = "f3b7c1d9e5a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # These tables are written by live channel ingress and delivery paths.
+    # Build the demonstrated retention indexes without blocking those writes.
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_channel_bot_agent_links_retention_inactive",
+            "channel_bot_agent_links",
+            ["id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("status <> 'active' OR archived_at IS NOT NULL"),
+        )
+        op.create_index(
+            "ix_channel_debug_events_retention_created",
+            "channel_debug_events",
+            ["created_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("provider IN ('telegram', 'discord')"),
+        )
+        op.create_index(
+            "ix_channel_pair_codes_retention_terminal",
+            "channel_pair_codes",
+            ["updated_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_include=["account_id"],
+            postgresql_where=sa.text("status IN ('claimed', 'revoked')"),
+        )
+        op.create_index(
+            "ix_channel_pair_codes_retention_expired",
+            "channel_pair_codes",
+            ["expires_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_include=["account_id"],
+            postgresql_where=sa.text("status = 'pending'"),
+        )
+        op.create_index(
+            "ix_channel_agent_references_retention_orphaned",
+            "channel_agent_references",
+            ["updated_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(
+                "provider IN ('telegram', 'discord') AND bot_agent_link_id IS NULL"
+            ),
+        )
+        op.create_index(
+            "ix_channel_agent_references_link_retention",
+            "channel_agent_references",
+            ["bot_agent_link_id", "updated_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(
+                "provider IN ('telegram', 'discord') AND bot_agent_link_id IS NOT NULL"
+            ),
+        )
+        op.create_index(
+            "ix_channel_agent_references_discord_interaction",
+            "channel_agent_references",
+            ["created_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(
+                "provider = 'discord' AND ref_kind IN "
+                "('discord_interaction_id_token', 'discord_interaction_token')"
+            ),
+        )
+        op.create_index(
+            "ix_channel_messages_retention_delivered",
+            "channel_messages",
+            ["delivered_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("delivered_at IS NOT NULL"),
+        )
+        op.create_index(
+            "ix_channel_messages_retention_unbound",
+            "channel_messages",
+            ["created_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("direction = 'inbound' AND binding_id IS NULL"),
+        )
+        op.create_index(
+            "ix_channel_messages_discord_interaction_token",
+            "channel_messages",
+            ["created_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(
+                "(payload ? 'token' AND payload ? 'application_id') OR "
+                "(payload ->> 't' = 'INTERACTION_CREATE' AND (payload -> 'd') ? 'token')"
+            ),
+        )
+        op.create_index(
+            "ix_channel_deliveries_retention_terminal",
+            "channel_deliveries",
+            ["updated_at", "id"],
+            postgresql_concurrently=True,
+            postgresql_include=["message_id", "account_id"],
+            postgresql_where=sa.text("status IN ('succeeded', 'failed')"),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for table_name, index_name in (
+            ("channel_deliveries", "ix_channel_deliveries_retention_terminal"),
+            ("channel_messages", "ix_channel_messages_discord_interaction_token"),
+            ("channel_messages", "ix_channel_messages_retention_unbound"),
+            ("channel_messages", "ix_channel_messages_retention_delivered"),
+            (
+                "channel_agent_references",
+                "ix_channel_agent_references_discord_interaction",
+            ),
+            (
+                "channel_agent_references",
+                "ix_channel_agent_references_link_retention",
+            ),
+            (
+                "channel_agent_references",
+                "ix_channel_agent_references_retention_orphaned",
+            ),
+            ("channel_pair_codes", "ix_channel_pair_codes_retention_expired"),
+            ("channel_pair_codes", "ix_channel_pair_codes_retention_terminal"),
+            ("channel_debug_events", "ix_channel_debug_events_retention_created"),
+            (
+                "channel_bot_agent_links",
+                "ix_channel_bot_agent_links_retention_inactive",
+            ),
+        ):
+            op.drop_index(
+                index_name,
+                table_name=table_name,
+                postgresql_concurrently=True,
+            )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -305,9 +305,11 @@ class Settings(BaseSettings):
     channel_long_poll_max_seconds: float = 30.0
     channel_long_poll_interval_seconds: float = 0.1
     discord_gateway_poll_interval_seconds: float = 1.0
-    channel_message_retention_days: int = 30
-    channel_unbound_message_retention_hours: int = 24
-    channel_message_cleanup_batch_size: int = 500
+    channel_message_retention_days: Annotated[int, Field(gt=0, le=3_650)] = 30
+    channel_unbound_message_retention_hours: Annotated[int, Field(gt=0, le=87_600)] = 24
+    channel_message_cleanup_batch_size: Annotated[int, Field(gt=0, le=10_000)] = 500
+    channel_message_cleanup_max_batches: Annotated[int, Field(gt=0, le=1_000)] = 20
+    channel_message_stuck_pending_hours: Annotated[int, Field(gt=0, le=8_760)] = 24
 
     # Shared LLM credentials for any feature that needs chat completions
     # (memory extraction today; session summarization, auto-tagging, etc.

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -146,6 +146,11 @@ class ChannelBotAgentLink(Base, TimestampMixin):
             unique=True,
             postgresql_where=sql_text("archived_at IS NULL"),
         ),
+        Index(
+            "ix_channel_bot_agent_links_retention_inactive",
+            "id",
+            postgresql_where=sql_text("status <> 'active' OR archived_at IS NOT NULL"),
+        ),
     )
 
 
@@ -301,6 +306,23 @@ class ChannelPairCode(Base, TimestampMixin):
     claimed_external_chat_id: Mapped[str | None] = mapped_column(String(300))
     claimed_external_user_id: Mapped[str | None] = mapped_column(String(300))
 
+    __table_args__ = (
+        Index(
+            "ix_channel_pair_codes_retention_terminal",
+            "updated_at",
+            "id",
+            postgresql_include=("account_id",),
+            postgresql_where=sql_text("status IN ('claimed', 'revoked')"),
+        ),
+        Index(
+            "ix_channel_pair_codes_retention_expired",
+            "expires_at",
+            "id",
+            postgresql_include=("account_id",),
+            postgresql_where=sql_text("status = 'pending'"),
+        ),
+    )
+
 
 class ChannelMessage(Base, TimestampMixin):
     __tablename__ = "channel_messages"
@@ -357,6 +379,27 @@ class ChannelMessage(Base, TimestampMixin):
             "inbox_sequence",
         ),
         Index(
+            "ix_channel_messages_retention_delivered",
+            "delivered_at",
+            "id",
+            postgresql_where=sql_text("delivered_at IS NOT NULL"),
+        ),
+        Index(
+            "ix_channel_messages_retention_unbound",
+            "created_at",
+            "id",
+            postgresql_where=sql_text("direction = 'inbound' AND binding_id IS NULL"),
+        ),
+        Index(
+            "ix_channel_messages_discord_interaction_token",
+            "created_at",
+            "id",
+            postgresql_where=sql_text(
+                "(payload ? 'token' AND payload ? 'application_id') OR "
+                "(payload ->> 't' = 'INTERACTION_CREATE' AND (payload -> 'd') ? 'token')"
+            ),
+        ),
+        Index(
             "ux_channel_messages_inbound_provider_event_account",
             "account_id",
             "provider_event_id",
@@ -404,6 +447,15 @@ class ChannelDebugEvent(Base, TimestampMixin):
     status_code: Mapped[int | None] = mapped_column(Integer)
     error: Mapped[str | None] = mapped_column(String(500))
     details: Mapped[dict[str, Any] | None] = mapped_column(JSONB(none_as_null=True))
+
+    __table_args__ = (
+        Index(
+            "ix_channel_debug_events_retention_created",
+            "created_at",
+            "id",
+            postgresql_where=sql_text("provider IN ('telegram', 'discord')"),
+        ),
+    )
 
 
 class ChannelAttachmentUpload(Base, TimestampMixin):
@@ -525,6 +577,32 @@ class ChannelAgentReference(Base, TimestampMixin):
             "ref_value",
             name="uq_channel_agent_references_account_link_kind_value",
         ),
+        Index(
+            "ix_channel_agent_references_retention_orphaned",
+            "updated_at",
+            "id",
+            postgresql_where=sql_text(
+                "provider IN ('telegram', 'discord') AND bot_agent_link_id IS NULL"
+            ),
+        ),
+        Index(
+            "ix_channel_agent_references_link_retention",
+            "bot_agent_link_id",
+            "updated_at",
+            "id",
+            postgresql_where=sql_text(
+                "provider IN ('telegram', 'discord') AND bot_agent_link_id IS NOT NULL"
+            ),
+        ),
+        Index(
+            "ix_channel_agent_references_discord_interaction",
+            "created_at",
+            "id",
+            postgresql_where=sql_text(
+                "provider = 'discord' AND ref_kind IN "
+                "('discord_interaction_id_token', 'discord_interaction_token')"
+            ),
+        ),
     )
 
 
@@ -581,6 +659,13 @@ class ChannelDelivery(Base, TimestampMixin):
             "status",
             "next_attempt_at",
             "created_at",
+        ),
+        Index(
+            "ix_channel_deliveries_retention_terminal",
+            "updated_at",
+            "id",
+            postgresql_include=("message_id", "account_id"),
+            postgresql_where=sql_text("status IN ('succeeded', 'failed')"),
         ),
     )
 

--- a/backend/app/services/channel_message_retention_worker.py
+++ b/backend/app/services/channel_message_retention_worker.py
@@ -14,6 +14,7 @@ from app.services.metrics import (
     channel_queue_stuck_pending,
     channel_retention_budget_exhaustions,
     channel_retention_deletions,
+    channel_retention_secret_scrubs,
 )
 
 log = logging.getLogger(__name__)
@@ -52,7 +53,7 @@ class ChannelMessageRetentionWorker:
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
         stop_event = stop or asyncio.Event()
         current_time = datetime.now(UTC)
-        deleted_total = 0
+        processed_total = 0
         last_saturated: tuple[str, ...] = ()
         batches = 0
         while batches < self._max_batches and not stop_event.is_set():
@@ -64,7 +65,7 @@ class ChannelMessageRetentionWorker:
                 )
                 await db.commit()
             batches += 1
-            deleted_total += batch.total
+            processed_total += batch.total
             for record_kind, deleted in (
                 ("messages", batch.messages),
                 ("debug_events", batch.debug_events),
@@ -73,6 +74,11 @@ class ChannelMessageRetentionWorker:
             ):
                 if deleted:
                     channel_retention_deletions.labels(record_kind=record_kind).inc(deleted)
+            if batch.discord_interaction_payloads:
+                channel_retention_secret_scrubs.labels(
+                    provider="discord",
+                    secret_kind="interaction_token",
+                ).inc(batch.discord_interaction_payloads)
             last_saturated = batch.saturated_kinds(self._batch_size)
             if not last_saturated:
                 break
@@ -83,21 +89,21 @@ class ChannelMessageRetentionWorker:
                 channel_retention_budget_exhaustions.labels(record_kind=record_kind).inc()
             log.warning(
                 "channel retention batch budget exhausted: record_kinds=%s batches=%s "
-                "batch_size=%s deleted=%s",
+                "batch_size=%s processed=%s",
                 ",".join(last_saturated),
                 batches,
                 self._batch_size,
-                deleted_total,
+                processed_total,
             )
         if not stop_event.is_set():
             await self._observe_queues(now=datetime.now(UTC))
-        if deleted_total:
+        if processed_total:
             log.info(
-                "channel retention completed: deleted=%s batches=%s",
-                deleted_total,
+                "channel retention completed: processed=%s batches=%s",
+                processed_total,
                 batches,
             )
-        return deleted_total
+        return processed_total
 
     async def _observe_queues(self, *, now: datetime) -> None:
         async with self._sessionmaker() as db:

--- a/backend/app/services/channel_message_retention_worker.py
+++ b/backend/app/services/channel_message_retention_worker.py
@@ -2,10 +2,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.services.channels import prune_channel_messages
+from app.core.config import settings
+from app.services.channels import channel_queue_snapshots, prune_channel_retention_batch
+from app.services.metrics import (
+    channel_queue_oldest_pending_age,
+    channel_queue_pending,
+    channel_queue_stuck_pending,
+    channel_retention_budget_exhaustions,
+    channel_retention_deletions,
+)
 
 log = logging.getLogger(__name__)
 
@@ -16,15 +25,109 @@ class ChannelMessageRetentionWorker:
         sessionmaker: async_sessionmaker[AsyncSession],
         *,
         poll_interval_seconds: float = 60 * 60,
+        batch_size: int | None = None,
+        max_batches: int | None = None,
+        stuck_pending_hours: int | None = None,
     ) -> None:
         self._sessionmaker = sessionmaker
         self._poll_interval_seconds = poll_interval_seconds
+        self._batch_size = (
+            settings.channel_message_cleanup_batch_size if batch_size is None else batch_size
+        )
+        self._max_batches = (
+            settings.channel_message_cleanup_max_batches if max_batches is None else max_batches
+        )
+        self._stuck_pending_hours = (
+            settings.channel_message_stuck_pending_hours
+            if stuck_pending_hours is None
+            else stuck_pending_hours
+        )
+        if self._batch_size <= 0:
+            raise ValueError("channel retention batch_size must be positive")
+        if self._max_batches <= 0:
+            raise ValueError("channel retention max_batches must be positive")
+        if self._stuck_pending_hours <= 0:
+            raise ValueError("channel retention stuck_pending_hours must be positive")
 
-    async def run_once(self) -> int:
+    async def run_once(self, stop: asyncio.Event | None = None) -> int:
+        stop_event = stop or asyncio.Event()
+        current_time = datetime.now(UTC)
+        deleted_total = 0
+        last_saturated: tuple[str, ...] = ()
+        batches = 0
+        while batches < self._max_batches and not stop_event.is_set():
+            async with self._sessionmaker() as db:
+                batch = await prune_channel_retention_batch(
+                    db,
+                    now=current_time,
+                    limit=self._batch_size,
+                )
+                await db.commit()
+            batches += 1
+            deleted_total += batch.total
+            for record_kind, deleted in (
+                ("messages", batch.messages),
+                ("debug_events", batch.debug_events),
+                ("pair_codes", batch.pair_codes),
+                ("agent_references", batch.agent_references),
+            ):
+                if deleted:
+                    channel_retention_deletions.labels(record_kind=record_kind).inc(deleted)
+            last_saturated = batch.saturated_kinds(self._batch_size)
+            if not last_saturated:
+                break
+            await asyncio.sleep(0)
+
+        if batches == self._max_batches and last_saturated:
+            for record_kind in last_saturated:
+                channel_retention_budget_exhaustions.labels(record_kind=record_kind).inc()
+            log.warning(
+                "channel retention batch budget exhausted: record_kinds=%s batches=%s "
+                "batch_size=%s deleted=%s",
+                ",".join(last_saturated),
+                batches,
+                self._batch_size,
+                deleted_total,
+            )
+        if not stop_event.is_set():
+            await self._observe_queues(now=datetime.now(UTC))
+        if deleted_total:
+            log.info(
+                "channel retention completed: deleted=%s batches=%s",
+                deleted_total,
+                batches,
+            )
+        return deleted_total
+
+    async def _observe_queues(self, *, now: datetime) -> None:
         async with self._sessionmaker() as db:
-            deleted = await prune_channel_messages(db)
-            await db.commit()
-            return deleted
+            snapshots = await channel_queue_snapshots(
+                db,
+                now=now,
+                stuck_after=timedelta(hours=self._stuck_pending_hours),
+            )
+            await db.rollback()
+        for snapshot in snapshots:
+            labels = {"provider": snapshot.provider, "queue": snapshot.queue}
+            oldest_age_seconds = (
+                max(0.0, (now - snapshot.oldest_pending_at).total_seconds())
+                if snapshot.oldest_pending_at is not None
+                else 0.0
+            )
+            channel_queue_pending.labels(**labels).set(snapshot.pending_count)
+            channel_queue_stuck_pending.labels(**labels).set(snapshot.stuck_count)
+            channel_queue_oldest_pending_age.labels(**labels).set(oldest_age_seconds)
+            if snapshot.stuck_count:
+                log.warning(
+                    "channel queue has stuck pending rows: provider=%s queue=%s pending=%s "
+                    "stuck=%s oldest_age_seconds=%.0f threshold_hours=%s",
+                    snapshot.provider,
+                    snapshot.queue,
+                    snapshot.pending_count,
+                    snapshot.stuck_count,
+                    oldest_age_seconds,
+                    self._stuck_pending_hours,
+                )
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
@@ -35,7 +138,7 @@ class ChannelMessageRetentionWorker:
             pass
         while not stop_event.is_set():
             try:
-                await self.run_once()
+                await self.run_once(stop_event)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001 - cleanup must not stop channel workers.

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -17,7 +17,8 @@ import httpx
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import HTTPException, status
-from sqlalchemy import and_, delete, exists, func, or_, select
+from sqlalchemy import and_, delete, exists, func, or_, select, union_all
+from sqlalchemy import text as sql_text
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -200,6 +201,11 @@ DISCORD_EPHEMERAL_REFERENCE_KINDS = (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
 )
+# Discord interaction tokens are valid for 15 minutes. Keep a five-minute
+# grace period for clock skew and in-flight follow-ups, then remove the exact
+# credential fields independently of the message retention horizon.
+DISCORD_INTERACTION_SECRET_RETENTION = timedelta(minutes=20)
+CHANNEL_RETENTION_CANDIDATE_MULTIPLIER = 2
 
 
 @dataclass(frozen=True)
@@ -217,10 +223,17 @@ class ChannelRetentionBatch:
     debug_events: int = 0
     pair_codes: int = 0
     agent_references: int = 0
+    discord_interaction_payloads: int = 0
 
     @property
     def total(self) -> int:
-        return self.messages + self.debug_events + self.pair_codes + self.agent_references
+        return (
+            self.messages
+            + self.debug_events
+            + self.pair_codes
+            + self.agent_references
+            + self.discord_interaction_payloads
+        )
 
     def saturated_kinds(self, limit: int) -> tuple[str, ...]:
         return tuple(
@@ -230,6 +243,7 @@ class ChannelRetentionBatch:
                 ("debug_events", self.debug_events),
                 ("pair_codes", self.pair_codes),
                 ("agent_references", self.agent_references),
+                ("discord_interaction_payloads", self.discord_interaction_payloads),
             )
             if count == limit
         )
@@ -3429,40 +3443,70 @@ async def prune_channel_messages(
         if unbound_retention is not None
         else timedelta(hours=settings.channel_unbound_message_retention_hours)
     )
-    enabled_account = exists(
-        select(ChannelAccount.id).where(
-            ChannelAccount.id == ChannelMessage.account_id,
-            ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+    candidate_limit = batch_limit * CHANNEL_RETENTION_CANDIDATE_MULTIPLIER
+    unbound_candidates = (
+        select(
+            ChannelMessage.id.label("message_id"),
+            ChannelMessage.created_at.label("retained_at"),
         )
+        .where(
+            sql_text("direction = 'inbound' AND binding_id IS NULL"),
+            ChannelMessage.created_at < unbound_cutoff,
+        )
+        .order_by(ChannelMessage.created_at, ChannelMessage.id)
+        .limit(candidate_limit)
     )
-    terminal_delivery = exists(
-        select(ChannelDelivery.id).where(
-            ChannelDelivery.message_id == ChannelMessage.id,
-            ChannelDelivery.status.in_((DELIVERY_STATUS_SUCCEEDED, DELIVERY_STATUS_FAILED)),
+    delivered_candidates = (
+        select(
+            ChannelMessage.id.label("message_id"),
+            ChannelMessage.delivered_at.label("retained_at"),
+        )
+        .where(
+            ChannelMessage.delivered_at.is_not(None),
+            ChannelMessage.delivered_at < delivered_cutoff,
+            ~and_(
+                ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                ChannelMessage.binding_id.is_(None),
+            ),
+        )
+        .order_by(ChannelMessage.delivered_at, ChannelMessage.id)
+        .limit(candidate_limit)
+    )
+    terminal_outbound_candidates = (
+        select(
+            ChannelMessage.id.label("message_id"),
+            ChannelDelivery.updated_at.label("retained_at"),
+        )
+        .select_from(ChannelDelivery)
+        .join(ChannelAccount, ChannelAccount.id == ChannelDelivery.account_id)
+        .join(ChannelMessage, ChannelMessage.id == ChannelDelivery.message_id)
+        .where(
+            ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+            ChannelMessage.delivered_at.is_(None),
+            ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            sql_text("channel_deliveries.status IN ('succeeded', 'failed')"),
             ChannelDelivery.updated_at < delivered_cutoff,
         )
+        .order_by(ChannelDelivery.updated_at, ChannelDelivery.id)
+        .limit(candidate_limit)
+    )
+    candidate_rows = union_all(
+        unbound_candidates,
+        delivered_candidates,
+        terminal_outbound_candidates,
+    ).subquery()
+    candidates = (
+        select(
+            candidate_rows.c.message_id,
+            func.min(candidate_rows.c.retained_at).label("retained_at"),
+        )
+        .group_by(candidate_rows.c.message_id)
+        .subquery()
     )
     result = await db.execute(
         select(ChannelMessage)
-        .where(
-            or_(
-                and_(
-                    ChannelMessage.delivered_at.is_not(None),
-                    ChannelMessage.delivered_at < delivered_cutoff,
-                ),
-                and_(
-                    ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-                    ChannelMessage.binding_id.is_(None),
-                    ChannelMessage.created_at < unbound_cutoff,
-                ),
-                and_(
-                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
-                    enabled_account,
-                    terminal_delivery,
-                ),
-            )
-        )
-        .order_by(ChannelMessage.created_at, ChannelMessage.id)
+        .join(candidates, candidates.c.message_id == ChannelMessage.id)
+        .order_by(candidates.c.retained_at, ChannelMessage.id)
         .limit(batch_limit)
         .with_for_update(skip_locked=True, of=ChannelMessage)
     )
@@ -3495,7 +3539,7 @@ async def prune_channel_debug_events(
     result = await db.execute(
         select(ChannelDebugEvent)
         .where(
-            ChannelDebugEvent.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            sql_text("channel_debug_events.provider IN ('telegram', 'discord')"),
             ChannelDebugEvent.created_at < cutoff,
         )
         .order_by(ChannelDebugEvent.created_at, ChannelDebugEvent.id)
@@ -3526,27 +3570,52 @@ async def prune_channel_pair_codes(
     cutoff = current_time - (
         retention
         if retention is not None
-        else timedelta(days=settings.channel_message_retention_days)
+        else timedelta(hours=settings.channel_unbound_message_retention_hours)
     )
-    result = await db.execute(
-        select(ChannelPairCode)
+    candidate_limit = batch_limit * CHANNEL_RETENTION_CANDIDATE_MULTIPLIER
+    terminal_candidates = (
+        select(
+            ChannelPairCode.id.label("pair_code_id"),
+            ChannelPairCode.updated_at.label("retained_at"),
+        )
+        .select_from(ChannelPairCode)
         .join(ChannelAccount, ChannelAccount.id == ChannelPairCode.account_id)
         .where(
             ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
-            or_(
-                and_(
-                    ChannelPairCode.status.in_(
-                        (PAIR_CODE_STATUS_CLAIMED, PAIR_CODE_STATUS_REVOKED)
-                    ),
-                    ChannelPairCode.updated_at < cutoff,
-                ),
-                and_(
-                    ChannelPairCode.status == PAIR_CODE_STATUS_PENDING,
-                    ChannelPairCode.expires_at < cutoff,
-                ),
-            ),
+            sql_text("channel_pair_codes.status IN ('claimed', 'revoked')"),
+            ChannelPairCode.updated_at < cutoff,
         )
-        .order_by(ChannelPairCode.created_at, ChannelPairCode.id)
+        .order_by(ChannelPairCode.updated_at, ChannelPairCode.id)
+        .limit(candidate_limit)
+    )
+    expired_candidates = (
+        select(
+            ChannelPairCode.id.label("pair_code_id"),
+            ChannelPairCode.expires_at.label("retained_at"),
+        )
+        .select_from(ChannelPairCode)
+        .join(ChannelAccount, ChannelAccount.id == ChannelPairCode.account_id)
+        .where(
+            ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            sql_text("channel_pair_codes.status = 'pending'"),
+            ChannelPairCode.expires_at < cutoff,
+        )
+        .order_by(ChannelPairCode.expires_at, ChannelPairCode.id)
+        .limit(candidate_limit)
+    )
+    candidate_rows = union_all(terminal_candidates, expired_candidates).subquery()
+    candidates = (
+        select(
+            candidate_rows.c.pair_code_id,
+            func.min(candidate_rows.c.retained_at).label("retained_at"),
+        )
+        .group_by(candidate_rows.c.pair_code_id)
+        .subquery()
+    )
+    result = await db.execute(
+        select(ChannelPairCode)
+        .join(candidates, candidates.c.pair_code_id == ChannelPairCode.id)
+        .order_by(candidates.c.retained_at, ChannelPairCode.id)
         .limit(batch_limit)
         .with_for_update(skip_locked=True, of=ChannelPairCode)
     )
@@ -3571,32 +3640,97 @@ async def prune_channel_agent_references(
     if batch_limit == 0:
         return 0
     current_time = now or datetime.now(UTC)
-    cutoff = current_time - (
+    inactive_cutoff = current_time - (
         retention
         if retention is not None
         else timedelta(days=settings.channel_message_retention_days)
     )
-    active_link = exists(
-        select(ChannelBotAgentLink.id).where(
-            ChannelBotAgentLink.id == ChannelAgentReference.bot_agent_link_id,
-            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-            ChannelBotAgentLink.archived_at.is_(None),
+    secret_cutoff = current_time - DISCORD_INTERACTION_SECRET_RETENTION
+    candidate_limit = batch_limit * CHANNEL_RETENTION_CANDIDATE_MULTIPLIER
+    inactive_link_has_expired_reference = exists(
+        select(ChannelAgentReference.id).where(
+            ChannelAgentReference.bot_agent_link_id == ChannelBotAgentLink.id,
+            sql_text("channel_agent_references.provider IN ('telegram', 'discord')"),
+            ChannelAgentReference.updated_at < inactive_cutoff,
         )
+    )
+    inactive_link_ids = tuple(
+        (
+            await db.scalars(
+                select(ChannelBotAgentLink.id)
+                .where(
+                    sql_text("status <> 'active' OR archived_at IS NOT NULL"),
+                    inactive_link_has_expired_reference,
+                )
+                .order_by(ChannelBotAgentLink.id)
+                .limit(candidate_limit)
+            )
+        ).all()
+    )
+    secret_candidates = (
+        select(
+            ChannelAgentReference.id.label("reference_id"),
+            ChannelAgentReference.created_at.label("retained_at"),
+        )
+        .where(
+            sql_text(
+                "channel_agent_references.provider = 'discord' AND "
+                "channel_agent_references.ref_kind IN "
+                "('discord_interaction_id_token', 'discord_interaction_token')"
+            ),
+            ChannelAgentReference.created_at < secret_cutoff,
+        )
+        .order_by(ChannelAgentReference.created_at, ChannelAgentReference.id)
+        .limit(candidate_limit)
+    )
+    orphaned_candidates = (
+        select(
+            ChannelAgentReference.id.label("reference_id"),
+            ChannelAgentReference.updated_at.label("retained_at"),
+        )
+        .where(
+            sql_text(
+                "channel_agent_references.provider IN ('telegram', 'discord') AND "
+                "channel_agent_references.bot_agent_link_id IS NULL"
+            ),
+            ChannelAgentReference.updated_at < inactive_cutoff,
+        )
+        .order_by(ChannelAgentReference.updated_at, ChannelAgentReference.id)
+        .limit(candidate_limit)
+    )
+    inactive_link_candidates = (
+        select(
+            ChannelAgentReference.id.label("reference_id"),
+            ChannelAgentReference.updated_at.label("retained_at"),
+        )
+        .where(
+            sql_text(
+                "channel_agent_references.provider IN ('telegram', 'discord') AND "
+                "channel_agent_references.bot_agent_link_id IS NOT NULL"
+            ),
+            ChannelAgentReference.bot_agent_link_id.in_(inactive_link_ids),
+            ChannelAgentReference.updated_at < inactive_cutoff,
+        )
+        .order_by(ChannelAgentReference.updated_at, ChannelAgentReference.id)
+        .limit(candidate_limit)
+    )
+    candidate_rows = union_all(
+        secret_candidates,
+        orphaned_candidates,
+        inactive_link_candidates,
+    ).subquery()
+    candidates = (
+        select(
+            candidate_rows.c.reference_id,
+            func.min(candidate_rows.c.retained_at).label("retained_at"),
+        )
+        .group_by(candidate_rows.c.reference_id)
+        .subquery()
     )
     result = await db.execute(
         select(ChannelAgentReference)
-        .where(
-            ChannelAgentReference.provider.in_(CHANNEL_RETENTION_PROVIDERS),
-            ChannelAgentReference.updated_at < cutoff,
-            or_(
-                ~active_link,
-                and_(
-                    ChannelAgentReference.provider == CHANNEL_PROVIDER_DISCORD,
-                    ChannelAgentReference.ref_kind.in_(DISCORD_EPHEMERAL_REFERENCE_KINDS),
-                ),
-            ),
-        )
-        .order_by(ChannelAgentReference.updated_at, ChannelAgentReference.id)
+        .join(candidates, candidates.c.reference_id == ChannelAgentReference.id)
+        .order_by(candidates.c.retained_at, ChannelAgentReference.id)
         .limit(batch_limit)
         .with_for_update(skip_locked=True, of=ChannelAgentReference)
     )
@@ -3605,6 +3739,69 @@ async def prune_channel_agent_references(
         await db.delete(reference)
     await db.flush()
     return len(references)
+
+
+async def scrub_discord_interaction_payload_tokens(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    retention: timedelta | None = None,
+    limit: int | None = None,
+) -> int:
+    batch_limit = max(
+        0,
+        settings.channel_message_cleanup_batch_size if limit is None else limit,
+    )
+    if batch_limit == 0:
+        return 0
+    current_time = now or datetime.now(UTC)
+    cutoff = current_time - (
+        retention if retention is not None else DISCORD_INTERACTION_SECRET_RETENTION
+    )
+    result = await db.execute(
+        select(ChannelMessage)
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+        .where(
+            ChannelAccount.provider == CHANNEL_PROVIDER_DISCORD,
+            ChannelMessage.created_at < cutoff,
+            sql_text(
+                "((payload ? 'token' AND payload ? 'application_id') OR "
+                "(payload ->> 't' = 'INTERACTION_CREATE' AND (payload -> 'd') ? 'token'))"
+            ),
+        )
+        .order_by(ChannelMessage.created_at, ChannelMessage.id)
+        .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelMessage)
+    )
+    messages = list(result.scalars().all())
+    scrubbed = 0
+    for message in messages:
+        payload = message.payload
+        if not isinstance(payload, dict):
+            continue
+        scrubbed_payload = _without_discord_interaction_token(payload)
+        if scrubbed_payload is payload:
+            continue
+        message.payload = scrubbed_payload
+        scrubbed += 1
+    await db.flush()
+    return scrubbed
+
+
+def _without_discord_interaction_token(payload: dict[str, Any]) -> dict[str, Any]:
+    scrubbed_payload: dict[str, Any] | None = None
+    if "token" in payload and "application_id" in payload:
+        scrubbed_payload = dict(payload)
+        scrubbed_payload.pop("token", None)
+
+    data = payload.get("d")
+    if payload.get("t") == "INTERACTION_CREATE" and isinstance(data, dict) and "token" in data:
+        if scrubbed_payload is None:
+            scrubbed_payload = dict(payload)
+        scrubbed_data = dict(data)
+        scrubbed_data.pop("token", None)
+        scrubbed_payload["d"] = scrubbed_data
+    return payload if scrubbed_payload is None else scrubbed_payload
 
 
 async def prune_channel_retention_batch(
@@ -3618,6 +3815,9 @@ async def prune_channel_retention_batch(
         messages=await prune_channel_messages(db, now=current_time, limit=limit),
         debug_events=await prune_channel_debug_events(db, now=current_time, limit=limit),
         pair_codes=await prune_channel_pair_codes(db, now=current_time, limit=limit),
+        discord_interaction_payloads=await scrub_discord_interaction_payload_tokens(
+            db, now=current_time, limit=limit
+        ),
         agent_references=await prune_channel_agent_references(db, now=current_time, limit=limit),
     )
 
@@ -3643,9 +3843,32 @@ async def channel_queue_snapshots(
                     func.count(ChannelMessage.id).filter(ChannelMessage.created_at < stuck_cutoff),
                     func.min(ChannelMessage.created_at),
                 )
+                .join(
+                    ChannelBinding,
+                    and_(
+                        ChannelBinding.id == ChannelMessage.binding_id,
+                        ChannelBinding.account_id == ChannelMessage.account_id,
+                        ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                        ChannelBinding.user_id == ChannelMessage.user_id,
+                        ChannelBinding.external_chat_id == ChannelMessage.external_chat_id,
+                    ),
+                )
+                .join(
+                    ChannelBotAgentLink,
+                    and_(
+                        ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
+                        ChannelBotAgentLink.account_id == ChannelMessage.account_id,
+                        ChannelBotAgentLink.user_id == ChannelMessage.user_id,
+                    ),
+                )
                 .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
                 .where(
                     ChannelAccount.provider == provider,
+                    ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                    ChannelAccount.archived_at.is_(None),
+                    ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                    ChannelBotAgentLink.archived_at.is_(None),
                     ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
                     ChannelMessage.binding_id.is_not(None),
                     ChannelMessage.delivered_at.is_(None),
@@ -3670,10 +3893,54 @@ async def channel_queue_snapshots(
                     ),
                     func.min(ChannelDelivery.created_at),
                 )
+                .join(
+                    ChannelMessage,
+                    and_(
+                        ChannelMessage.id == ChannelDelivery.message_id,
+                        ChannelMessage.account_id == ChannelDelivery.account_id,
+                        ChannelMessage.user_id == ChannelDelivery.user_id,
+                    ),
+                )
                 .join(ChannelAccount, ChannelAccount.id == ChannelDelivery.account_id)
+                .outerjoin(
+                    ChannelBotAgentLink,
+                    and_(
+                        ChannelBotAgentLink.id == ChannelDelivery.bot_agent_link_id,
+                        ChannelBotAgentLink.account_id == ChannelDelivery.account_id,
+                        ChannelBotAgentLink.user_id == ChannelDelivery.user_id,
+                    ),
+                )
+                .outerjoin(
+                    ChannelBinding,
+                    and_(
+                        ChannelBinding.id == ChannelMessage.binding_id,
+                        ChannelBinding.account_id == ChannelDelivery.account_id,
+                        ChannelBinding.bot_agent_link_id == ChannelDelivery.bot_agent_link_id,
+                        ChannelBinding.user_id == ChannelDelivery.user_id,
+                        ChannelBinding.external_chat_id == ChannelMessage.external_chat_id,
+                    ),
+                )
                 .where(
                     ChannelAccount.provider == provider,
+                    ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                    ChannelAccount.archived_at.is_(None),
                     ChannelDelivery.status == DELIVERY_STATUS_PENDING,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                    or_(
+                        and_(
+                            ChannelDelivery.bot_agent_link_id.is_(None),
+                            ChannelMessage.bot_agent_link_id.is_(None),
+                            ChannelMessage.binding_id.is_(None),
+                        ),
+                        and_(
+                            ChannelDelivery.bot_agent_link_id.is_not(None),
+                            ChannelMessage.bot_agent_link_id == ChannelDelivery.bot_agent_link_id,
+                            ChannelMessage.binding_id.is_not(None),
+                            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                            ChannelBotAgentLink.archived_at.is_(None),
+                            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                        ),
+                    ),
                 )
             )
         ).one()

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -17,7 +17,7 @@ import httpx
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import HTTPException, status
-from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy import and_, delete, exists, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -53,6 +53,7 @@ from app.models.channel import (
     ChannelBinding,
     ChannelBindingAlias,
     ChannelBotAgentLink,
+    ChannelDebugEvent,
     ChannelDelivery,
     ChannelMessage,
     ChannelPairCode,
@@ -194,6 +195,44 @@ TELEGRAM_REF_FILE_PATH = "telegram_file_path"
 TELEGRAM_REF_MESSAGE_ID = "telegram_message_id"
 DISCORD_REF_INTERACTION_ID_TOKEN = "discord_interaction_id_token"
 DISCORD_REF_INTERACTION_TOKEN = "discord_interaction_token"
+CHANNEL_RETENTION_PROVIDERS = (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD)
+DISCORD_EPHEMERAL_REFERENCE_KINDS = (
+    DISCORD_REF_INTERACTION_ID_TOKEN,
+    DISCORD_REF_INTERACTION_TOKEN,
+)
+
+
+@dataclass(frozen=True)
+class ChannelQueueSnapshot:
+    provider: str
+    queue: str
+    pending_count: int
+    stuck_count: int
+    oldest_pending_at: datetime | None
+
+
+@dataclass(frozen=True)
+class ChannelRetentionBatch:
+    messages: int = 0
+    debug_events: int = 0
+    pair_codes: int = 0
+    agent_references: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.messages + self.debug_events + self.pair_codes + self.agent_references
+
+    def saturated_kinds(self, limit: int) -> tuple[str, ...]:
+        return tuple(
+            kind
+            for kind, count in (
+                ("messages", self.messages),
+                ("debug_events", self.debug_events),
+                ("pair_codes", self.pair_codes),
+                ("agent_references", self.agent_references),
+            )
+            if count == limit
+        )
 
 
 @dataclass(frozen=True)
@@ -3381,10 +3420,27 @@ async def prune_channel_messages(
         return 0
     current_time = now or datetime.now(UTC)
     delivered_cutoff = current_time - (
-        delivered_retention or timedelta(days=settings.channel_message_retention_days)
+        delivered_retention
+        if delivered_retention is not None
+        else timedelta(days=settings.channel_message_retention_days)
     )
     unbound_cutoff = current_time - (
-        unbound_retention or timedelta(hours=settings.channel_unbound_message_retention_hours)
+        unbound_retention
+        if unbound_retention is not None
+        else timedelta(hours=settings.channel_unbound_message_retention_hours)
+    )
+    enabled_account = exists(
+        select(ChannelAccount.id).where(
+            ChannelAccount.id == ChannelMessage.account_id,
+            ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+        )
+    )
+    terminal_delivery = exists(
+        select(ChannelDelivery.id).where(
+            ChannelDelivery.message_id == ChannelMessage.id,
+            ChannelDelivery.status.in_((DELIVERY_STATUS_SUCCEEDED, DELIVERY_STATUS_FAILED)),
+            ChannelDelivery.updated_at < delivered_cutoff,
+        )
     )
     result = await db.execute(
         select(ChannelMessage)
@@ -3399,16 +3455,238 @@ async def prune_channel_messages(
                     ChannelMessage.binding_id.is_(None),
                     ChannelMessage.created_at < unbound_cutoff,
                 ),
+                and_(
+                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                    enabled_account,
+                    terminal_delivery,
+                ),
             )
         )
         .order_by(ChannelMessage.created_at, ChannelMessage.id)
         .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelMessage)
     )
     messages = list(result.scalars().all())
     for message in messages:
         await db.delete(message)
     await db.flush()
     return len(messages)
+
+
+async def prune_channel_debug_events(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    retention: timedelta | None = None,
+    limit: int | None = None,
+) -> int:
+    batch_limit = max(
+        0,
+        settings.channel_message_cleanup_batch_size if limit is None else limit,
+    )
+    if batch_limit == 0:
+        return 0
+    current_time = now or datetime.now(UTC)
+    cutoff = current_time - (
+        retention
+        if retention is not None
+        else timedelta(days=settings.channel_message_retention_days)
+    )
+    result = await db.execute(
+        select(ChannelDebugEvent)
+        .where(
+            ChannelDebugEvent.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            ChannelDebugEvent.created_at < cutoff,
+        )
+        .order_by(ChannelDebugEvent.created_at, ChannelDebugEvent.id)
+        .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelDebugEvent)
+    )
+    events = list(result.scalars().all())
+    for event in events:
+        await db.delete(event)
+    await db.flush()
+    return len(events)
+
+
+async def prune_channel_pair_codes(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    retention: timedelta | None = None,
+    limit: int | None = None,
+) -> int:
+    batch_limit = max(
+        0,
+        settings.channel_message_cleanup_batch_size if limit is None else limit,
+    )
+    if batch_limit == 0:
+        return 0
+    current_time = now or datetime.now(UTC)
+    cutoff = current_time - (
+        retention
+        if retention is not None
+        else timedelta(days=settings.channel_message_retention_days)
+    )
+    result = await db.execute(
+        select(ChannelPairCode)
+        .join(ChannelAccount, ChannelAccount.id == ChannelPairCode.account_id)
+        .where(
+            ChannelAccount.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            or_(
+                and_(
+                    ChannelPairCode.status.in_(
+                        (PAIR_CODE_STATUS_CLAIMED, PAIR_CODE_STATUS_REVOKED)
+                    ),
+                    ChannelPairCode.updated_at < cutoff,
+                ),
+                and_(
+                    ChannelPairCode.status == PAIR_CODE_STATUS_PENDING,
+                    ChannelPairCode.expires_at < cutoff,
+                ),
+            ),
+        )
+        .order_by(ChannelPairCode.created_at, ChannelPairCode.id)
+        .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelPairCode)
+    )
+    pair_codes = list(result.scalars().all())
+    for pair_code in pair_codes:
+        await db.delete(pair_code)
+    await db.flush()
+    return len(pair_codes)
+
+
+async def prune_channel_agent_references(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    retention: timedelta | None = None,
+    limit: int | None = None,
+) -> int:
+    batch_limit = max(
+        0,
+        settings.channel_message_cleanup_batch_size if limit is None else limit,
+    )
+    if batch_limit == 0:
+        return 0
+    current_time = now or datetime.now(UTC)
+    cutoff = current_time - (
+        retention
+        if retention is not None
+        else timedelta(days=settings.channel_message_retention_days)
+    )
+    active_link = exists(
+        select(ChannelBotAgentLink.id).where(
+            ChannelBotAgentLink.id == ChannelAgentReference.bot_agent_link_id,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+        )
+    )
+    result = await db.execute(
+        select(ChannelAgentReference)
+        .where(
+            ChannelAgentReference.provider.in_(CHANNEL_RETENTION_PROVIDERS),
+            ChannelAgentReference.updated_at < cutoff,
+            or_(
+                ~active_link,
+                and_(
+                    ChannelAgentReference.provider == CHANNEL_PROVIDER_DISCORD,
+                    ChannelAgentReference.ref_kind.in_(DISCORD_EPHEMERAL_REFERENCE_KINDS),
+                ),
+            ),
+        )
+        .order_by(ChannelAgentReference.updated_at, ChannelAgentReference.id)
+        .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelAgentReference)
+    )
+    references = list(result.scalars().all())
+    for reference in references:
+        await db.delete(reference)
+    await db.flush()
+    return len(references)
+
+
+async def prune_channel_retention_batch(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    limit: int | None = None,
+) -> ChannelRetentionBatch:
+    current_time = now or datetime.now(UTC)
+    return ChannelRetentionBatch(
+        messages=await prune_channel_messages(db, now=current_time, limit=limit),
+        debug_events=await prune_channel_debug_events(db, now=current_time, limit=limit),
+        pair_codes=await prune_channel_pair_codes(db, now=current_time, limit=limit),
+        agent_references=await prune_channel_agent_references(db, now=current_time, limit=limit),
+    )
+
+
+async def channel_queue_snapshots(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    stuck_after: timedelta | None = None,
+) -> tuple[ChannelQueueSnapshot, ...]:
+    current_time = now or datetime.now(UTC)
+    stuck_cutoff = current_time - (
+        stuck_after
+        if stuck_after is not None
+        else timedelta(hours=settings.channel_message_stuck_pending_hours)
+    )
+    snapshots: list[ChannelQueueSnapshot] = []
+    for provider in CHANNEL_RETENTION_PROVIDERS:
+        inbox_row = (
+            await db.execute(
+                select(
+                    func.count(ChannelMessage.id),
+                    func.count(ChannelMessage.id).filter(ChannelMessage.created_at < stuck_cutoff),
+                    func.min(ChannelMessage.created_at),
+                )
+                .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+                .where(
+                    ChannelAccount.provider == provider,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                    ChannelMessage.binding_id.is_not(None),
+                    ChannelMessage.delivered_at.is_(None),
+                )
+            )
+        ).one()
+        snapshots.append(
+            ChannelQueueSnapshot(
+                provider=provider,
+                queue="inbox",
+                pending_count=int(inbox_row[0]),
+                stuck_count=int(inbox_row[1]),
+                oldest_pending_at=inbox_row[2],
+            )
+        )
+        outbox_row = (
+            await db.execute(
+                select(
+                    func.count(ChannelDelivery.id),
+                    func.count(ChannelDelivery.id).filter(
+                        ChannelDelivery.created_at < stuck_cutoff
+                    ),
+                    func.min(ChannelDelivery.created_at),
+                )
+                .join(ChannelAccount, ChannelAccount.id == ChannelDelivery.account_id)
+                .where(
+                    ChannelAccount.provider == provider,
+                    ChannelDelivery.status == DELIVERY_STATUS_PENDING,
+                )
+            )
+        ).one()
+        snapshots.append(
+            ChannelQueueSnapshot(
+                provider=provider,
+                queue="outbox",
+                pending_count=int(outbox_row[0]),
+                stuck_count=int(outbox_row[1]),
+                oldest_pending_at=outbox_row[2],
+            )
+        )
+    return tuple(snapshots)
 
 
 async def wait_for_channel_inbox_events(
@@ -3690,6 +3968,8 @@ async def deliver_channel_delivery(
 
     message.provider_message_id = provider_message_id
     message.payload = _delivery_success_payload(message.payload, provider_response)
+    if account.provider in CHANNEL_RETENTION_PROVIDERS:
+        message.delivered_at = datetime.now(UTC)
     delivery.status = DELIVERY_STATUS_SUCCEEDED
     delivery.locked_at = None
     delivery.locked_by = None
@@ -4338,6 +4618,7 @@ async def send_telegram_message(
         provider_message_id=provider_message_id,
         text=text,
         payload=payload if isinstance(payload, dict) else None,
+        delivered_at=datetime.now(UTC),
     )
 
 
@@ -4447,6 +4728,7 @@ async def send_discord_message(
         provider_message_id=provider_message_id,
         text=text,
         payload=response_payload,
+        delivered_at=datetime.now(UTC),
     )
 
 
@@ -4474,6 +4756,7 @@ async def record_discord_outbound_message(
         provider_message_id=provider_message_id,
         text=_read_optional_str(provider_response.get("content")) or "",
         payload=None,
+        delivered_at=datetime.now(UTC),
     )
 
 
@@ -4879,6 +5162,7 @@ async def _record_outbound_channel_message(
     provider_message_id: str | None,
     text: str,
     payload: dict[str, Any] | None,
+    delivered_at: datetime | None = None,
 ) -> ChannelMessage:
     owner_user_id = binding.user_id if binding is not None else account.user_id
     message = ChannelMessage(
@@ -4891,6 +5175,7 @@ async def _record_outbound_channel_message(
         provider_message_id=provider_message_id,
         text=text,
         payload=payload,
+        delivered_at=delivered_at,
     )
     db.add(message)
     await db.flush()

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -92,6 +92,12 @@ channel_retention_deletions = Counter(
     ["record_kind"],
     registry=registry,
 )
+channel_retention_secret_scrubs = Counter(
+    "msg_router_channel_retention_secret_scrubs_total",
+    "Expired provider credential fields removed from retained channel payloads",
+    ["provider", "secret_kind"],
+    registry=registry,
+)
 channel_retention_budget_exhaustions = Counter(
     "msg_router_channel_retention_budget_exhaustions_total",
     "Channel retention runs that exhausted their configured batch budget",

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -68,6 +68,36 @@ webhook_ttl_drops = Counter(
     "Total inbox rows dropped by TTL sweep or expired before delivery",
     registry=registry,
 )
+channel_queue_pending = Gauge(
+    "msg_router_channel_queue_pending",
+    "Pending durable channel queue rows",
+    ["provider", "queue"],
+    registry=registry,
+)
+channel_queue_stuck_pending = Gauge(
+    "msg_router_channel_queue_stuck_pending",
+    "Pending durable channel queue rows older than the configured alert horizon",
+    ["provider", "queue"],
+    registry=registry,
+)
+channel_queue_oldest_pending_age = Gauge(
+    "msg_router_channel_queue_oldest_pending_age_seconds",
+    "Age in seconds of the oldest pending durable channel queue row",
+    ["provider", "queue"],
+    registry=registry,
+)
+channel_retention_deletions = Counter(
+    "msg_router_channel_retention_deletions_total",
+    "Channel retention rows deleted by record kind",
+    ["record_kind"],
+    registry=registry,
+)
+channel_retention_budget_exhaustions = Counter(
+    "msg_router_channel_retention_budget_exhaustions_total",
+    "Channel retention runs that exhausted their configured batch budget",
+    ["record_kind"],
+    registry=registry,
+)
 
 
 def render_metrics() -> bytes:

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -17,6 +17,7 @@ from app.services.discord_command_reconciliation_worker import (
     DiscordCommandReconciliationWorker,
 )
 from app.services.discord_gateway_worker import DiscordGatewayWorker
+from app.services.metrics import metrics_content_type, render_metrics
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 
 configure_application_logging()
@@ -50,21 +51,28 @@ class ChannelWorkerHealth:
         }
 
 
-def _http_response(status_code: int, payload: dict[str, str]) -> bytes:
+def _raw_http_response(status_code: int, body: bytes, *, content_type: str) -> bytes:
     reason = {
         200: "OK",
         404: "Not Found",
         503: "Service Unavailable",
     }.get(status_code, "Error")
-    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = (
         f"HTTP/1.1 {status_code} {reason}\r\n"
-        "Content-Type: application/json\r\n"
+        f"Content-Type: {content_type}\r\n"
         f"Content-Length: {len(body)}\r\n"
         "Connection: close\r\n"
         "\r\n"
     ).encode("ascii")
     return headers + body
+
+
+def _http_response(status_code: int, payload: dict[str, str]) -> bytes:
+    return _raw_http_response(
+        status_code,
+        json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        content_type="application/json",
+    )
 
 
 async def _handle_health_request(
@@ -82,7 +90,15 @@ async def _handle_health_request(
 
         method = parts[0] if parts else ""
         path = parts[1] if len(parts) > 1 else ""
-        if method != "GET" or path != "/health":
+        if method == "GET" and path == "/metrics":
+            writer.write(
+                _raw_http_response(
+                    200,
+                    render_metrics(),
+                    content_type=metrics_content_type(),
+                )
+            )
+        elif method != "GET" or path != "/health":
             writer.write(_http_response(404, {"status": "not_found"}))
         elif health.healthy:
             writer.write(_http_response(200, health.payload()))

--- a/backend/tests/test_channel_retention.py
+++ b/backend/tests/test_channel_retention.py
@@ -6,17 +6,19 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_STATUS_DISABLED,
     DELIVERY_STATUS_FAILED,
     DELIVERY_STATUS_SUCCEEDED,
     MESSAGE_DIRECTION_INBOUND,
     PAIR_CODE_STATUS_CLAIMED,
     PAIR_CODE_STATUS_PENDING,
+    PAIR_CODE_STATUS_REVOKED,
     ChannelAccount,
     ChannelAgentReference,
     ChannelBinding,
@@ -32,6 +34,7 @@ from app.models.user import User
 from app.services import channels as channel_service
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
 from app.services.channels import (
+    DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
     TELEGRAM_REF_FILE_ID,
     ChannelRetentionBatch,
@@ -39,6 +42,7 @@ from app.services.channels import (
     deliver_channel_delivery,
     enqueue_channel_outbound_message,
     prune_channel_messages,
+    prune_channel_pair_codes,
     prune_channel_retention_batch,
     send_discord_message,
     send_telegram_message,
@@ -505,6 +509,254 @@ async def test_operational_retention_preserves_live_authority_and_pending_work(
 
 
 @pytest.mark.asyncio
+async def test_pair_code_retention_uses_short_unbound_horizon_and_preserves_boundary(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    account, link, _binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="pair-retention-horizon",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    cutoff = now - timedelta(hours=24)
+    expired_terminal = ChannelPairCode(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_CLAIMED,
+        expires_at=cutoff,
+        claimed_at=cutoff,
+        created_at=cutoff - timedelta(days=1),
+        updated_at=cutoff - timedelta(microseconds=1),
+    )
+    expired_pending = ChannelPairCode(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_PENDING,
+        expires_at=cutoff - timedelta(microseconds=1),
+        created_at=cutoff - timedelta(days=1),
+        updated_at=cutoff,
+    )
+    boundary_terminal = ChannelPairCode(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_REVOKED,
+        expires_at=cutoff,
+        created_at=cutoff - timedelta(hours=1),
+        updated_at=cutoff,
+    )
+    boundary_pending = ChannelPairCode(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_PENDING,
+        expires_at=cutoff,
+        created_at=cutoff - timedelta(hours=1),
+        updated_at=cutoff,
+    )
+    live_pending = ChannelPairCode(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_PENDING,
+        expires_at=now + timedelta(minutes=5),
+    )
+    db_session.add_all(
+        [
+            expired_terminal,
+            expired_pending,
+            boundary_terminal,
+            boundary_pending,
+            live_pending,
+        ]
+    )
+    await db_session.flush()
+
+    deleted = await prune_channel_pair_codes(db_session, now=now, limit=10)
+
+    assert deleted == 2
+    assert await db_session.get(ChannelPairCode, expired_terminal.id) is None
+    assert await db_session.get(ChannelPairCode, expired_pending.id) is None
+    assert await db_session.get(ChannelPairCode, boundary_terminal.id) is not None
+    assert await db_session.get(ChannelPairCode, boundary_pending.id) is not None
+    assert await db_session.get(ChannelPairCode, live_pending.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_discord_interaction_secrets_expire_without_deleting_pending_content(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    discord, link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="discord-secret-retention",
+    )
+    telegram, _telegram_link, telegram_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-secret-control",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    expired = now - timedelta(minutes=20, microseconds=1)
+    boundary = now - timedelta(minutes=20)
+
+    webhook_message = await _add_message(
+        db_session,
+        account=discord,
+        binding=binding,
+        text="keep webhook content",
+    )
+    webhook_message.created_at = expired
+    webhook_message.payload = {
+        "type": 2,
+        "id": "interaction-webhook",
+        "token": "expired-webhook-secret",
+        "application_id": "discord-application",
+        "context": 0,
+        "data": {"name": "agent_status", "options": [{"name": "detail", "value": 1}]},
+    }
+    gateway_message = await _add_message(
+        db_session,
+        account=discord,
+        binding=binding,
+        text="keep gateway content",
+    )
+    gateway_message.created_at = expired
+    gateway_message.payload = {
+        "op": 0,
+        "t": "INTERACTION_CREATE",
+        "s": 42,
+        "d": {
+            "id": "interaction-gateway",
+            "token": "expired-gateway-secret",
+            "application_id": "discord-application",
+            "content": "keep event content",
+            "context": 1,
+        },
+    }
+    recent_message = await _add_message(
+        db_session,
+        account=discord,
+        binding=binding,
+        text="recent interaction",
+    )
+    recent_message.created_at = boundary
+    recent_message.payload = {
+        "type": 2,
+        "id": "interaction-recent",
+        "token": "recent-secret",
+        "application_id": "discord-application",
+        "context": 0,
+        "data": {"name": "agent_status"},
+    }
+    telegram_control = await _add_message(
+        db_session,
+        account=telegram,
+        binding=telegram_binding,
+        text="telegram token-shaped payload",
+    )
+    telegram_control.created_at = expired
+    telegram_control.payload = {
+        "id": "telegram-control",
+        "token": "telegram-secret-shaped-value",
+        "application_id": "not-discord",
+        "message": {"text": "keep telegram payload"},
+    }
+    expired_references = [
+        ChannelAgentReference(
+            account_id=discord.id,
+            bot_agent_link_id=link.id,
+            binding_id=binding.id,
+            message_id=webhook_message.id,
+            user_id=seed_user.id,
+            provider=CHANNEL_PROVIDER_DISCORD,
+            ref_kind=DISCORD_REF_INTERACTION_ID_TOKEN,
+            ref_value="interaction-webhook:expired-webhook-secret",
+            created_at=expired,
+            updated_at=expired,
+        ),
+        ChannelAgentReference(
+            account_id=discord.id,
+            bot_agent_link_id=link.id,
+            binding_id=binding.id,
+            message_id=gateway_message.id,
+            user_id=seed_user.id,
+            provider=CHANNEL_PROVIDER_DISCORD,
+            ref_kind=DISCORD_REF_INTERACTION_TOKEN,
+            ref_value="expired-gateway-secret",
+            created_at=expired,
+            updated_at=expired,
+        ),
+    ]
+    recent_reference = ChannelAgentReference(
+        account_id=discord.id,
+        bot_agent_link_id=link.id,
+        binding_id=binding.id,
+        message_id=recent_message.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        ref_kind=DISCORD_REF_INTERACTION_TOKEN,
+        ref_value="recent-secret",
+        created_at=boundary,
+        updated_at=boundary,
+    )
+    db_session.add_all([*expired_references, recent_reference])
+    await db_session.flush()
+
+    batch = await prune_channel_retention_batch(db_session, now=now, limit=20)
+
+    assert batch.messages == 0
+    assert batch.discord_interaction_payloads == 2
+    assert batch.agent_references == 2
+    await db_session.refresh(webhook_message)
+    await db_session.refresh(gateway_message)
+    await db_session.refresh(recent_message)
+    await db_session.refresh(telegram_control)
+    assert webhook_message.payload == {
+        "type": 2,
+        "id": "interaction-webhook",
+        "application_id": "discord-application",
+        "context": 0,
+        "data": {"name": "agent_status", "options": [{"name": "detail", "value": 1}]},
+    }
+    assert gateway_message.payload == {
+        "op": 0,
+        "t": "INTERACTION_CREATE",
+        "s": 42,
+        "d": {
+            "id": "interaction-gateway",
+            "application_id": "discord-application",
+            "content": "keep event content",
+            "context": 1,
+        },
+    }
+    assert recent_message.payload is not None
+    assert recent_message.payload["token"] == "recent-secret"
+    assert telegram_control.payload is not None
+    assert telegram_control.payload["token"] == "telegram-secret-shaped-value"
+    for reference in expired_references:
+        assert await db_session.get(ChannelAgentReference, reference.id) is None
+    assert await db_session.get(ChannelAgentReference, recent_reference.id) is not None
+
+
+@pytest.mark.asyncio
 async def test_queue_snapshots_report_provider_specific_stuck_pending(
     engine,
     db_session: AsyncSession,
@@ -580,6 +832,152 @@ async def test_queue_snapshots_report_provider_specific_stuck_pending(
 
 
 @pytest.mark.asyncio
+async def test_queue_snapshots_ignore_historical_inactive_authority_and_identity_mismatches(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    active, _active_link, active_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-active",
+    )
+    (
+        archived_account,
+        _archived_account_link,
+        archived_account_binding,
+    ) = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-archived-account",
+    )
+    (
+        disabled_account,
+        _disabled_account_link,
+        disabled_account_binding,
+    ) = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-disabled-account",
+    )
+    archived_binding_account, _binding_link, archived_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-archived-binding",
+    )
+    archived_link_account, archived_link, archived_link_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-archived-link",
+    )
+    mismatch_account, mismatch_link, mismatch_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="snapshot-mismatch",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    old = now - timedelta(hours=25)
+
+    valid_inbox = await _add_message(
+        db_session,
+        account=active,
+        binding=active_binding,
+        text="valid inbox",
+    )
+    valid_inbox.created_at = old
+    valid_outbox_message, valid_outbox = await enqueue_channel_outbound_message(
+        db_session,
+        account=active,
+        external_chat_id=active_binding.external_chat_id,
+        text="valid linked outbox",
+    )
+    account_outbox_message, account_outbox = await enqueue_channel_outbound_message(
+        db_session,
+        account=active,
+        external_chat_id="snapshot-account-scoped",
+        text="valid account outbox",
+    )
+    for row in (valid_outbox_message, valid_outbox, account_outbox_message, account_outbox):
+        row.created_at = old
+
+    historical_authorities = (
+        (archived_account, archived_account_binding),
+        (disabled_account, disabled_account_binding),
+        (archived_binding_account, archived_binding),
+        (archived_link_account, archived_link_binding),
+    )
+    for account, binding in historical_authorities:
+        inbox = await _add_message(
+            db_session,
+            account=account,
+            binding=binding,
+            text="historical inbox",
+        )
+        inbox.created_at = old
+        outbox_message, outbox = await enqueue_channel_outbound_message(
+            db_session,
+            account=account,
+            external_chat_id=binding.external_chat_id,
+            text="historical outbox",
+        )
+        outbox_message.created_at = old
+        outbox.created_at = old
+
+    mismatch_inbox = await _add_message(
+        db_session,
+        account=mismatch_account,
+        binding=mismatch_binding,
+        text="mismatched inbox identity",
+    )
+    mismatch_inbox.created_at = old
+    mismatch_inbox.bot_agent_link_id = active_binding.bot_agent_link_id
+    mismatch_outbox_message, mismatch_outbox = await enqueue_channel_outbound_message(
+        db_session,
+        account=mismatch_account,
+        external_chat_id=mismatch_binding.external_chat_id,
+        text="mismatched outbox identity",
+    )
+    mismatch_outbox_message.created_at = old
+    mismatch_outbox.created_at = old
+    mismatch_outbox.bot_agent_link_id = active_binding.bot_agent_link_id
+
+    archived_account.archived_at = now
+    disabled_account.status = CHANNEL_STATUS_DISABLED
+    archived_binding.status = "archived"
+    archived_link.archived_at = now
+    await db_session.flush()
+
+    snapshots = await channel_queue_snapshots(
+        db_session,
+        now=now,
+        stuck_after=timedelta(hours=24),
+    )
+    by_key = {(snapshot.provider, snapshot.queue): snapshot for snapshot in snapshots}
+
+    telegram_inbox = by_key[(CHANNEL_PROVIDER_TELEGRAM, "inbox")]
+    telegram_outbox = by_key[(CHANNEL_PROVIDER_TELEGRAM, "outbox")]
+    assert telegram_inbox.pending_count == 1
+    assert telegram_inbox.stuck_count == 1
+    assert telegram_inbox.oldest_pending_at == old
+    assert telegram_outbox.pending_count == 2
+    assert telegram_outbox.stuck_count == 2
+    assert telegram_outbox.oldest_pending_at == old
+    assert mismatch_link.archived_at is None
+
+
+@pytest.mark.asyncio
 async def test_retention_worker_drains_multiple_bounded_batches(
     engine,
     db_session: AsyncSession,
@@ -622,3 +1020,36 @@ async def test_retention_worker_drains_multiple_bounded_batches(
     assert deleted == 4
     assert remaining == 1
     assert "channel retention batch budget exhausted" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_channel_retention_indexes_match_oldest_first_query_contract(engine):
+    expected = {
+        "ix_channel_bot_agent_links_retention_inactive": "(id)",
+        "ix_channel_debug_events_retention_created": "(created_at, id)",
+        "ix_channel_pair_codes_retention_terminal": "(updated_at, id)",
+        "ix_channel_pair_codes_retention_expired": "(expires_at, id)",
+        "ix_channel_agent_references_retention_orphaned": "(updated_at, id)",
+        "ix_channel_agent_references_link_retention": "(bot_agent_link_id, updated_at, id)",
+        "ix_channel_agent_references_discord_interaction": "(created_at, id)",
+        "ix_channel_messages_retention_delivered": "(delivered_at, id)",
+        "ix_channel_messages_retention_unbound": "(created_at, id)",
+        "ix_channel_messages_discord_interaction_token": "(created_at, id)",
+        "ix_channel_deliveries_retention_terminal": "(updated_at, id)",
+    }
+    async with engine.connect() as connection:
+        rows = await connection.execute(
+            text(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE schemaname = current_schema() AND ("
+                "indexname LIKE 'ix_channel_%retention%' OR "
+                "indexname = 'ix_channel_messages_discord_interaction_token' OR "
+                "indexname = 'ix_channel_agent_references_discord_interaction')"
+            )
+        )
+    definitions = {row.indexname: row.indexdef for row in rows}
+
+    assert expected.keys() <= definitions.keys()
+    for index_name, ordered_columns in expected.items():
+        assert ordered_columns in definitions[index_name]
+        assert " WHERE " in definitions[index_name]

--- a/backend/tests/test_channel_retention.py
+++ b/backend/tests/test_channel_retention.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.channel import (
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_TELEGRAM,
+    DELIVERY_STATUS_FAILED,
+    DELIVERY_STATUS_SUCCEEDED,
+    MESSAGE_DIRECTION_INBOUND,
+    PAIR_CODE_STATUS_CLAIMED,
+    PAIR_CODE_STATUS_PENDING,
+    ChannelAccount,
+    ChannelAgentReference,
+    ChannelBinding,
+    ChannelBotAgentLink,
+    ChannelDebugEvent,
+    ChannelDelivery,
+    ChannelMessage,
+    ChannelPairCode,
+    ChannelScheduledMessage,
+)
+from app.models.session import AgentEnvironment
+from app.models.user import User
+from app.services import channels as channel_service
+from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
+from app.services.channels import (
+    DISCORD_REF_INTERACTION_TOKEN,
+    TELEGRAM_REF_FILE_ID,
+    ChannelRetentionBatch,
+    channel_queue_snapshots,
+    deliver_channel_delivery,
+    enqueue_channel_outbound_message,
+    prune_channel_messages,
+    prune_channel_retention_batch,
+    send_discord_message,
+    send_telegram_message,
+)
+from app.services.metrics import render_metrics
+
+pytestmark = pytest.mark.committed_db
+
+
+async def _create_account_and_binding(
+    db: AsyncSession,
+    *,
+    user: User,
+    agent: AgentEnvironment,
+    provider: str,
+    chat_id: str,
+) -> tuple[ChannelAccount, ChannelBotAgentLink, ChannelBinding]:
+    account = ChannelAccount(
+        user_id=user.id,
+        provider=provider,
+        name=f"{provider}-retention-{uuid4().hex[:12]}",
+        webhook_secret_hash=f"secret-{uuid4().hex}",
+    )
+    db.add(account)
+    await db.flush()
+    link = ChannelBotAgentLink(
+        account_id=account.id,
+        user_id=user.id,
+        agent_id=agent.id,
+        agent_token_hash=f"token-{uuid4().hex}",
+    )
+    db.add(link)
+    await db.flush()
+    binding = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=user.id,
+        external_chat_id=chat_id,
+        external_chat_type="private",
+        external_chat_name=f"Chat {chat_id}",
+    )
+    db.add(binding)
+    await db.flush()
+    return account, link, binding
+
+
+async def _add_message(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    binding: ChannelBinding | None,
+    text: str,
+    direction: str = MESSAGE_DIRECTION_INBOUND,
+) -> ChannelMessage:
+    message = ChannelMessage(
+        account_id=account.id,
+        bot_agent_link_id=binding.bot_agent_link_id if binding is not None else None,
+        binding_id=binding.id if binding is not None else None,
+        user_id=account.user_id,
+        direction=direction,
+        external_chat_id=binding.external_chat_id if binding is not None else "unbound",
+        text=text,
+        payload={"text": text},
+    )
+    db.add(message)
+    await db.flush()
+    return message
+
+
+@pytest.mark.asyncio
+async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    telegram, _telegram_link, _telegram_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-sync",
+    )
+    discord, _discord_link, discord_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="discord-sync",
+    )
+
+    async def fake_telegram_send(**_kwargs):
+        return "telegram-provider-message", {"ok": True}
+
+    async def fake_discord_send(**_kwargs):
+        return "discord-provider-message", {"id": "discord-provider-message"}
+
+    monkeypatch.setattr(channel_service, "_send_telegram_provider_payload", fake_telegram_send)
+    monkeypatch.setattr(channel_service, "_send_discord_provider_payload", fake_discord_send)
+
+    telegram_message = await send_telegram_message(
+        db_session,
+        account=telegram,
+        external_chat_id="telegram-sync",
+        text="telegram delivered",
+        bind_to_existing=False,
+    )
+    discord_message = await send_discord_message(
+        db_session,
+        account=discord,
+        external_chat_id="discord-sync",
+        text="discord delivered",
+        bind_to_existing=False,
+    )
+    recorded_discord_message = await channel_service.record_discord_outbound_message(
+        db_session,
+        account=discord,
+        binding=discord_binding,
+        external_chat_id=discord_binding.external_chat_id,
+        provider_response={
+            "id": "discord-gateway-provider-message",
+            "channel_id": discord_binding.external_chat_id,
+            "content": "discord gateway delivered",
+        },
+    )
+
+    assert telegram_message.delivered_at is not None
+    assert discord_message.delivered_at is not None
+    assert recorded_discord_message.delivered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_queued_success_and_terminal_failure_prune_with_delivery_cascade(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, _link, _binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="bound-chat",
+    )
+    succeeded_message, succeeded_delivery = await enqueue_channel_outbound_message(
+        db_session,
+        account=account,
+        external_chat_id="success-unbound-chat",
+        text="success",
+    )
+
+    async def fake_success(**_kwargs):
+        return "provider-success", {"ok": True}
+
+    monkeypatch.setattr(channel_service, "send_provider_outbound_payload", fake_success)
+    await deliver_channel_delivery(db_session, delivery=succeeded_delivery)
+    assert succeeded_delivery.status == DELIVERY_STATUS_SUCCEEDED
+    assert succeeded_message.delivered_at is not None
+
+    failed_message, failed_delivery = await enqueue_channel_outbound_message(
+        db_session,
+        account=account,
+        external_chat_id="failure-unbound-chat",
+        text="failure",
+    )
+
+    async def fake_terminal_failure(**_kwargs):
+        raise HTTPException(status_code=400, detail="provider rejected message")
+
+    monkeypatch.setattr(channel_service, "send_provider_outbound_payload", fake_terminal_failure)
+    await deliver_channel_delivery(db_session, delivery=failed_delivery)
+    assert failed_delivery.status == DELIVERY_STATUS_FAILED
+    assert failed_message.delivered_at is None
+
+    pending_message, pending_delivery = await enqueue_channel_outbound_message(
+        db_session,
+        account=account,
+        external_chat_id="pending-unbound-chat",
+        text="pending",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    old = now - timedelta(days=31)
+    succeeded_message.delivered_at = old
+    succeeded_message.created_at = old
+    succeeded_delivery.updated_at = old
+    failed_message.created_at = old
+    failed_delivery.updated_at = old
+    pending_message.created_at = old
+    pending_delivery.created_at = old
+    pending_delivery.updated_at = old
+    await db_session.flush()
+
+    deleted = await prune_channel_messages(db_session, now=now, limit=10)
+
+    assert deleted == 2
+    assert await db_session.get(ChannelMessage, succeeded_message.id) is None
+    assert await db_session.get(ChannelMessage, failed_message.id) is None
+    terminal_deliveries = await db_session.scalar(
+        select(func.count(ChannelDelivery.id)).where(
+            ChannelDelivery.id.in_((succeeded_delivery.id, failed_delivery.id))
+        )
+    )
+    assert terminal_deliveries == 0
+    assert await db_session.get(ChannelMessage, pending_message.id) is not None
+    assert await db_session.get(ChannelDelivery, pending_delivery.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_retention_horizons_are_strict_and_pending_bound_is_not_deleted(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    account, _link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="retention-horizon",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    delivered_cutoff = now - timedelta(days=30)
+    unbound_cutoff = now - timedelta(hours=24)
+    expired_delivered = await _add_message(
+        db_session, account=account, binding=binding, text="expired-delivered"
+    )
+    expired_delivered.delivered_at = delivered_cutoff - timedelta(microseconds=1)
+    boundary_delivered = await _add_message(
+        db_session, account=account, binding=binding, text="boundary-delivered"
+    )
+    boundary_delivered.delivered_at = delivered_cutoff
+    expired_unbound = await _add_message(
+        db_session, account=account, binding=None, text="expired-unbound"
+    )
+    expired_unbound.created_at = unbound_cutoff - timedelta(microseconds=1)
+    boundary_unbound = await _add_message(
+        db_session, account=account, binding=None, text="boundary-unbound"
+    )
+    boundary_unbound.created_at = unbound_cutoff
+    pending_bound = await _add_message(
+        db_session, account=account, binding=binding, text="pending-bound"
+    )
+    pending_bound.created_at = now - timedelta(days=365)
+    await db_session.flush()
+
+    deleted = await prune_channel_messages(db_session, now=now, limit=10)
+
+    assert deleted == 2
+    assert await db_session.get(ChannelMessage, expired_delivered.id) is None
+    assert await db_session.get(ChannelMessage, expired_unbound.id) is None
+    assert await db_session.get(ChannelMessage, boundary_delivered.id) is not None
+    assert await db_session.get(ChannelMessage, boundary_unbound.id) is not None
+    assert await db_session.get(ChannelMessage, pending_bound.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_message_cleaners_skip_locked_rows(
+    engine,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    account, _link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="concurrent-cleaners",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    old = now - timedelta(days=31)
+    for index in range(5):
+        message = await _add_message(
+            db_session,
+            account=account,
+            binding=binding,
+            text=f"expired-{index}",
+        )
+        message.created_at = old
+        message.delivered_at = old
+    await db_session.commit()
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as first, session_factory() as second:
+        first_deleted = await prune_channel_messages(first, now=now, limit=2)
+        second_deleted = await prune_channel_messages(second, now=now, limit=2)
+        await first.commit()
+        await second.commit()
+
+    remaining = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(ChannelMessage.account_id == account.id)
+    )
+    assert first_deleted == 2
+    assert second_deleted == 2
+    assert remaining == 1
+
+
+@pytest.mark.asyncio
+async def test_operational_retention_preserves_live_authority_and_pending_work(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    telegram, telegram_link, telegram_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-operational",
+    )
+    discord, discord_link, discord_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="discord-operational",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    old = now - timedelta(days=31)
+
+    old_debug = ChannelDebugEvent(
+        account_id=telegram.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        direction="inbound",
+        stage="retention-test",
+        outcome="failure",
+        created_at=old,
+    )
+    recent_debug = ChannelDebugEvent(
+        account_id=telegram.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        direction="inbound",
+        stage="retention-test",
+        outcome="success",
+        created_at=now - timedelta(days=1),
+    )
+    expired_pair = ChannelPairCode(
+        account_id=telegram.id,
+        bot_agent_link_id=telegram_link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_PENDING,
+        expires_at=old - timedelta(days=1),
+        created_at=old,
+        updated_at=old,
+    )
+    claimed_pair = ChannelPairCode(
+        account_id=discord.id,
+        bot_agent_link_id=discord_link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_CLAIMED,
+        expires_at=old,
+        claimed_at=old,
+        created_at=old,
+        updated_at=old,
+    )
+    live_pair = ChannelPairCode(
+        account_id=telegram.id,
+        bot_agent_link_id=telegram_link.id,
+        user_id=seed_user.id,
+        code_hash=uuid4().hex,
+        status=PAIR_CODE_STATUS_PENDING,
+        expires_at=now + timedelta(hours=1),
+    )
+    active_telegram_file = ChannelAgentReference(
+        account_id=telegram.id,
+        bot_agent_link_id=telegram_link.id,
+        binding_id=telegram_binding.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        ref_kind=TELEGRAM_REF_FILE_ID,
+        ref_value="active-file-id",
+        created_at=old,
+        updated_at=old,
+    )
+    expired_discord_token = ChannelAgentReference(
+        account_id=discord.id,
+        bot_agent_link_id=discord_link.id,
+        binding_id=discord_binding.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        ref_kind=DISCORD_REF_INTERACTION_TOKEN,
+        ref_value="expired-interaction-token",
+        created_at=old,
+        updated_at=old,
+    )
+    durable_discord_reference = ChannelAgentReference(
+        account_id=discord.id,
+        bot_agent_link_id=discord_link.id,
+        binding_id=discord_binding.id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        ref_kind="durable-test-reference",
+        ref_value="keep-active-reference",
+        created_at=old,
+        updated_at=old,
+    )
+    orphan_reference = ChannelAgentReference(
+        account_id=telegram.id,
+        bot_agent_link_id=None,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        ref_kind=TELEGRAM_REF_FILE_ID,
+        ref_value="orphan-file-id",
+        created_at=old,
+        updated_at=old,
+    )
+    schedule = ChannelScheduledMessage(
+        account_id=discord.id,
+        bot_agent_link_id=discord_link.id,
+        binding_id=discord_binding.id,
+        user_id=seed_user.id,
+        external_chat_id=discord_binding.external_chat_id,
+        scheduled_for=now + timedelta(days=1),
+        payload={"text": "future work"},
+    )
+    db_session.add_all(
+        [
+            old_debug,
+            recent_debug,
+            expired_pair,
+            claimed_pair,
+            live_pair,
+            active_telegram_file,
+            expired_discord_token,
+            durable_discord_reference,
+            orphan_reference,
+            schedule,
+        ]
+    )
+    pending_message, pending_delivery = await enqueue_channel_outbound_message(
+        db_session,
+        account=telegram,
+        external_chat_id="pending-operational",
+        text="pending work",
+    )
+    pending_message.created_at = old
+    pending_delivery.created_at = old
+    pending_delivery.updated_at = old
+    await db_session.flush()
+
+    batch = await prune_channel_retention_batch(db_session, now=now, limit=100)
+
+    assert batch == ChannelRetentionBatch(
+        messages=0,
+        debug_events=1,
+        pair_codes=2,
+        agent_references=2,
+    )
+    assert await db_session.get(ChannelDebugEvent, old_debug.id) is None
+    assert await db_session.get(ChannelDebugEvent, recent_debug.id) is not None
+    assert await db_session.get(ChannelPairCode, live_pair.id) is not None
+    assert await db_session.get(ChannelAgentReference, active_telegram_file.id) is not None
+    assert await db_session.get(ChannelAgentReference, durable_discord_reference.id) is not None
+    assert await db_session.get(ChannelAgentReference, expired_discord_token.id) is None
+    assert await db_session.get(ChannelAgentReference, orphan_reference.id) is None
+    assert await db_session.get(ChannelScheduledMessage, schedule.id) is not None
+    assert await db_session.get(ChannelMessage, pending_message.id) is not None
+    assert await db_session.get(ChannelDelivery, pending_delivery.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_queue_snapshots_report_provider_specific_stuck_pending(
+    engine,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+    caplog: pytest.LogCaptureFixture,
+):
+    telegram, _telegram_link, telegram_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-stuck",
+    )
+    discord, _discord_link, discord_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="discord-stuck",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    old = now - timedelta(hours=25)
+    old_inbox = await _add_message(
+        db_session, account=telegram, binding=telegram_binding, text="old inbox"
+    )
+    old_inbox.created_at = old
+    await _add_message(db_session, account=telegram, binding=telegram_binding, text="new inbox")
+    old_outbox_message, old_outbox = await enqueue_channel_outbound_message(
+        db_session,
+        account=discord,
+        external_chat_id=discord_binding.external_chat_id,
+        text="old outbox",
+    )
+    old_outbox_message.created_at = old
+    old_outbox.created_at = old
+    await db_session.flush()
+
+    snapshots = await channel_queue_snapshots(
+        db_session,
+        now=now,
+        stuck_after=timedelta(hours=24),
+    )
+    by_key = {(snapshot.provider, snapshot.queue): snapshot for snapshot in snapshots}
+
+    telegram_inbox = by_key[(CHANNEL_PROVIDER_TELEGRAM, "inbox")]
+    discord_outbox = by_key[(CHANNEL_PROVIDER_DISCORD, "outbox")]
+    assert telegram_inbox.pending_count == 2
+    assert telegram_inbox.stuck_count == 1
+    assert telegram_inbox.oldest_pending_at == old
+    assert discord_outbox.pending_count == 1
+    assert discord_outbox.stuck_count == 1
+    assert discord_outbox.oldest_pending_at == old
+    assert by_key[(CHANNEL_PROVIDER_DISCORD, "inbox")].pending_count == 0
+    assert by_key[(CHANNEL_PROVIDER_TELEGRAM, "outbox")].pending_count == 0
+
+    await db_session.commit()
+    worker = ChannelMessageRetentionWorker(
+        async_sessionmaker(engine, expire_on_commit=False),
+        batch_size=10,
+        max_batches=1,
+        stuck_pending_hours=24,
+    )
+    with caplog.at_level(logging.WARNING):
+        await worker.run_once()
+    metrics = render_metrics().decode("utf-8")
+    assert 'msg_router_channel_queue_pending{provider="telegram",queue="inbox"} 2.0' in metrics
+    assert (
+        'msg_router_channel_queue_stuck_pending{provider="telegram",queue="inbox"} 1.0' in metrics
+    )
+    assert "provider=telegram queue=inbox" in caplog.text
+    assert "provider=discord queue=outbox" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_retention_worker_drains_multiple_bounded_batches(
+    engine,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+    caplog: pytest.LogCaptureFixture,
+):
+    account, _link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="bounded-worker",
+    )
+    old = datetime.now(UTC) - timedelta(days=31)
+    for index in range(5):
+        message = await _add_message(
+            db_session,
+            account=account,
+            binding=binding,
+            text=f"bounded-{index}",
+        )
+        message.created_at = old
+        message.delivered_at = old
+    await db_session.commit()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    worker = ChannelMessageRetentionWorker(
+        session_factory,
+        batch_size=2,
+        max_batches=2,
+        stuck_pending_hours=24,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        deleted = await worker.run_once()
+
+    remaining = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(ChannelMessage.account_id == account.id)
+    )
+    assert deleted == 4
+    assert remaining == 1
+    assert "channel retention batch budget exhausted" in caplog.text

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -8,6 +8,7 @@ from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWo
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
+from app.services.channels import ChannelRetentionBatch
 from app.services.discord_command_reconciliation_worker import (
     DiscordCommandReconciliationWorker,
 )
@@ -51,9 +52,61 @@ async def test_channel_message_retention_worker_delays_first_prune(monkeypatch):
     assert calls == []
 
 
-async def _read_health_response(port: int) -> str:
+class _FakeRetentionSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def commit(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_channel_message_retention_worker_stops_between_batches(monkeypatch):
+    stop = asyncio.Event()
+    calls: list[int] = []
+
+    async def fake_prune(_db, *, now, limit):
+        del now
+        calls.append(limit)
+        stop.set()
+        return ChannelRetentionBatch(messages=limit)
+
+    monkeypatch.setattr(
+        "app.services.channel_message_retention_worker.prune_channel_retention_batch",
+        fake_prune,
+    )
+    worker = ChannelMessageRetentionWorker(
+        lambda: _FakeRetentionSession(),
+        batch_size=3,
+        max_batches=10,
+        stuck_pending_hours=24,
+    )
+
+    deleted = await worker.run_once(stop)
+
+    assert deleted == 3
+    assert calls == [3]
+
+
+@pytest.mark.parametrize(
+    ("field", "kwargs"),
+    [
+        ("batch_size", {"batch_size": 0}),
+        ("max_batches", {"max_batches": 0}),
+        ("stuck_pending_hours", {"stuck_pending_hours": 0}),
+    ],
+)
+def test_channel_message_retention_worker_rejects_non_positive_bounds(field, kwargs):
+    with pytest.raises(ValueError, match=field):
+        ChannelMessageRetentionWorker(None, **kwargs)
+
+
+async def _read_health_response(port: int, path: str = "/health") -> str:
     reader, writer = await asyncio.open_connection("127.0.0.1", port)
-    writer.write(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+    writer.write(f"GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".encode("ascii"))
     await writer.drain()
     response = await reader.read()
     writer.close()
@@ -85,3 +138,24 @@ async def test_channel_worker_health_endpoint_reports_readiness():
     assert '"status":"ok"' in ready
     assert "503 Service Unavailable" in stopping
     assert '"status":"stopping"' in stopping
+
+
+@pytest.mark.asyncio
+async def test_channel_worker_exports_process_local_metrics_without_changing_health():
+    health = ChannelWorkerHealth(ready=True)
+    server = await asyncio.start_server(
+        lambda reader, writer: _handle_health_request(reader, writer, health),
+        "127.0.0.1",
+        0,
+    )
+    assert server.sockets
+    port = server.sockets[0].getsockname()[1]
+
+    async with server:
+        metrics = await _read_health_response(port, "/metrics")
+        health_response = await _read_health_response(port)
+
+    assert "200 OK" in metrics
+    assert "msg_router_channel_queue_pending" in metrics
+    assert "200 OK" in health_response
+    assert '"status":"ok"' in health_response

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -146,3 +146,33 @@ def test_runtime_observation_hard_retention_cannot_precede_replay_horizon():
             runtime_observation_replay_horizon_days=8,
             runtime_observation_hard_retention_days=7,
         )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "channel_message_retention_days",
+        "channel_unbound_message_retention_hours",
+        "channel_message_cleanup_batch_size",
+        "channel_message_cleanup_max_batches",
+        "channel_message_stuck_pending_hours",
+    ],
+)
+def test_channel_retention_settings_require_positive_bounds(field: str):
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, **{field: 0})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("channel_message_retention_days", 3_651),
+        ("channel_unbound_message_retention_hours", 87_601),
+        ("channel_message_cleanup_batch_size", 10_001),
+        ("channel_message_cleanup_max_batches", 1_001),
+        ("channel_message_stuck_pending_hours", 8_761),
+    ],
+)
+def test_channel_retention_settings_reject_unbounded_work(field: str, value: int):
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, **{field: value})

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -51,6 +51,7 @@ def test_metrics_exports_all_expected_metrics() -> None:
     assert "msg_router_channel_queue_stuck_pending" in text
     assert "msg_router_channel_queue_oldest_pending_age_seconds" in text
     assert "msg_router_channel_retention_deletions_total" in text
+    assert "msg_router_channel_retention_secret_scrubs_total" in text
     assert "msg_router_channel_retention_budget_exhaustions_total" in text
 
 

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -47,6 +47,11 @@ def test_metrics_exports_all_expected_metrics() -> None:
     assert "msg_router_active_polls" in text
     assert "msg_router_webhook_deliveries_total" in text
     assert "msg_router_webhook_ttl_drops_total" in text
+    assert "msg_router_channel_queue_pending" in text
+    assert "msg_router_channel_queue_stuck_pending" in text
+    assert "msg_router_channel_queue_oldest_pending_age_seconds" in text
+    assert "msg_router_channel_retention_deletions_total" in text
+    assert "msg_router_channel_retention_budget_exhaustions_total" in text
 
 
 def test_metrics_increment_counters() -> None:

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -319,8 +319,8 @@ Retention ownership is deliberately narrow:
 | Accounts, links, secrets, bindings, aliases, credentials | Durable product and authorization state; owner lifecycle controls deletion. |
 | Messages and deliveries | Bound pending inbox and pending outbox rows are durable and are never time-pruned. Delivered inbound, terminal Telegram/Discord outbound, and old unbound inbound rows use the configured message horizons; delivery rows cascade with their message. |
 | Debug events | Telegram/Discord operational history uses the delivered-message horizon. |
-| Pair codes | Claimed/revoked codes and codes expired beyond the message horizon are ephemeral. Live codes are preserved. |
-| Agent references | Active Telegram file/message authorization stays durable. Expired Discord interaction-token references and references without an active link use the message horizon. Discord documents a 15-minute interaction-token lifetime. |
+| Pair codes | Claimed/revoked codes and long-expired pending codes use the short unbound-message horizon (24 hours by default). Live codes are preserved. |
+| Agent references | Active Telegram file/message authorization stays durable. Discord interaction-token references expire after 20 minutes; references without an active link otherwise use the delivered-message horizon. |
 | Scheduled messages | Durable pending product work; the generic retention worker does not delete it. |
 
 Telegram documents that upstream updates are not kept longer than 24 hours,
@@ -334,11 +334,26 @@ age/count metrics and logs a warning after
 existing `/health` readiness contract is unchanged; its process-local `/metrics`
 surface exposes these gauges and counters.
 
-Message text and provider JSON are not scrubbed ahead of row retention. Text is
-active channel activity history, pending Telegram replay needs the provider
-payload, and Telegram/Discord tutorial cooldowns read delivered payload markers.
-Introducing a second compaction horizon would change those consumers and needs
-an explicit product contract; the worker does not guess one.
+Queue gauges include only currently deliverable authority: the Account, Link,
+and Binding must be active, unarchived, and identity-consistent. Historical rows
+under retired authority do not create false stuck alerts. Account-scoped pending
+outbound rows remain visible when they do not require a Link.
+
+Message text and non-secret provider JSON are not scrubbed ahead of row
+retention. Text is active channel activity history, pending Telegram replay
+needs the provider payload, and Telegram/Discord tutorial cooldowns read
+delivered payload markers. The narrow exception is Discord interaction
+credentials: Discord documents a 15-minute token lifetime, so after a five-minute
+safety margin the worker deletes the corresponding Agent references and removes
+only the root interaction `token` or `INTERACTION_CREATE` `d.token` field. The
+remaining message/content/context and dedupe tombstone stay intact, including
+for pending rows. The hourly worker removes eligible secrets on its next sweep;
+`msg_router_channel_retention_secret_scrubs_total` records completed scrubs and
+the retention-budget metric exposes a backlog that outlives the per-run bound.
+
+Retention selects use dedicated partial/composite indexes for their fixed
+provider/state predicates and oldest-first columns. The indexes are created
+concurrently so migration does not block live channel writes.
 
 Protocol references:
 
@@ -347,6 +362,8 @@ Protocol references:
 - [PostgreSQL locking clause](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)
 - [SQLAlchemy `with_for_update`](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update)
 
-Done: with the channels worker running,
+The channels-worker role is non-proxied. Port 8000 is the worker process-local
+health/metrics listener, not an externally routed API endpoint. When running
+that process directly, or from inside its container/network namespace,
 `curl -fsS http://127.0.0.1:8000/metrics | rg 'msg_router_channel_(queue|retention)'`
 prints the queue and retention metric families.

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -303,3 +303,50 @@ uses Python `logging` with `logging.basicConfig(level=logging.INFO)` in
 `RequestTimingMiddleware` adds `X-Process-Time-Ms` to HTTP responses. Requests
 at or above `SLOW_REQUEST_LOG_MS` log as `request_slow`; 5xx responses log as
 `request_error`, and uncaught exceptions log as `request_failed`.
+
+## Channel queue retention
+
+The channels worker drains retention hourly in independently committed batches.
+`CHANNEL_MESSAGE_CLEANUP_BATCH_SIZE` bounds each record kind per transaction and
+`CHANNEL_MESSAGE_CLEANUP_MAX_BATCHES` bounds one run. PostgreSQL row locks with
+`SKIP LOCKED` let overlapping cleaners divide eligible rows without deleting
+pending work or waiting on one another.
+
+Retention ownership is deliberately narrow:
+
+| State | Retention rule |
+| --- | --- |
+| Accounts, links, secrets, bindings, aliases, credentials | Durable product and authorization state; owner lifecycle controls deletion. |
+| Messages and deliveries | Bound pending inbox and pending outbox rows are durable and are never time-pruned. Delivered inbound, terminal Telegram/Discord outbound, and old unbound inbound rows use the configured message horizons; delivery rows cascade with their message. |
+| Debug events | Telegram/Discord operational history uses the delivered-message horizon. |
+| Pair codes | Claimed/revoked codes and codes expired beyond the message horizon are ephemeral. Live codes are preserved. |
+| Agent references | Active Telegram file/message authorization stays durable. Expired Discord interaction-token references and references without an active link use the message horizon. Discord documents a 15-minute interaction-token lifetime. |
+| Scheduled messages | Durable pending product work; the generic retention worker does not delete it. |
+
+Telegram documents that upstream updates are not kept longer than 24 hours,
+but Clawdi does not silently apply that limit to the shared bound inbox. Discord
+does not have the same coordinated drop contract, and the current schema has no
+terminal drop outcome. Instead, the worker exports provider-specific pending
+age/count metrics and logs a warning after
+`CHANNEL_MESSAGE_STUCK_PENDING_HOURS` (24 hours by default). Alert when
+`msg_router_channel_queue_stuck_pending` is non-zero or when
+`msg_router_channel_retention_budget_exhaustions_total` increases. The worker's
+existing `/health` readiness contract is unchanged; its process-local `/metrics`
+surface exposes these gauges and counters.
+
+Message text and provider JSON are not scrubbed ahead of row retention. Text is
+active channel activity history, pending Telegram replay needs the provider
+payload, and Telegram/Discord tutorial cooldowns read delivered payload markers.
+Introducing a second compaction horizon would change those consumers and needs
+an explicit product contract; the worker does not guess one.
+
+Protocol references:
+
+- [Telegram `getUpdates`](https://core.telegram.org/bots/api#getupdates)
+- [Discord interaction responses](https://docs.discord.com/developers/interactions/receiving-and-responding)
+- [PostgreSQL locking clause](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)
+- [SQLAlchemy `with_for_update`](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update)
+
+Done: with the channels worker running,
+`curl -fsS http://127.0.0.1:8000/metrics | rg 'msg_router_channel_(queue|retention)'`
+prints the queue and retention metric families.


### PR DESCRIPTION
## Summary

- mark synchronous Telegram/Discord outbound records and queued provider successes terminal in the same transaction; terminal failures become retention-eligible through their delivery outcome and message deletion cascades deliveries
- replace the hourly one-batch ceiling with bounded multi-batch cleanup using PostgreSQL `FOR UPDATE SKIP LOCKED`, independent commits, shutdown checks, and per-kind budgets
- count pending/stuck work only when Account, Binding, Link, message, and delivery authority is still active and identity-consistent, while preserving valid Account-scoped outbound rows
- retain bound pending work, but expose provider-specific pending count, oldest age, stuck count, deletion, secret-scrub, and budget-exhaustion metrics from the channels-worker process without changing `/health`
- prune Telegram/Discord debug events, short-horizon pair codes, expired Discord interaction references, and orphan/inactive-link references while preserving active Telegram reply/file authorization and scheduled work
- remove Discord interaction credentials after a 20-minute horizon: delete token references and scrub only root `token` / `INTERACTION_CREATE.d.token`, retaining non-secret message/content/context and dedupe tombstones
- add demonstrated partial/composite retention indexes with a concurrent Alembic migration and matching model metadata

## Capacity and retention decisions

The declared deployment shape has one non-proxied channels-worker. Previous message capacity was 500 rows/hour (12,000/day). Defaults now allow 20 batches of 500 rows per hourly run: 10,000 deletions/hour independently for messages, debug events, pair codes, and Agent references (40,000 total), plus up to 10,000 Discord payload scrubs/hour.

This remains bounded. A single record-kind backlog above 10,000 eligible rows/hour can still outpace cleanup; `msg_router_channel_retention_budget_exhaustions_total` reports that condition. Each candidate stream is also bounded to twice the mutation limit so two overlapping cleaners can skip one another's locks without unbounded selection.

Bound pending inbox/outbox work is not silently time-pruned. Telegram documents a 24-hour upstream update limit, but Discord has no coordinated equivalent here and the shared schema has no terminal drop outcome. Pending metrics therefore alert on offline work. Historical rows under disabled/archived or identity-mismatched authority are excluded from those gauges.

Pair codes use the short unbound horizon (24 hours by default); live codes and exact cutoff rows remain. Discord documents 15-minute interaction tokens. A five-minute safety margin preserves valid callbacks/followups, after which the next hourly sweep removes credential references and exact payload token fields. Non-secret Discord payload content and Telegram payloads remain unchanged.

## Migration and query-plan evidence

Revision `b5d8e2a7c4f1` is based on the current main head and creates indexes concurrently. Open #740 must rebase its pending revision onto this new head; the configuration overlap remains narrowly limited to the existing `channel_message_*` block.

Representative PostgreSQL 16 data (120k debug events, 140k pair codes/references, 360k+ messages, and mixed pending/terminal deliveries) showed the pre-index queries doing sequential scans / disk sorts: debug ~93ms, pair codes ~162ms, references ~1.2s, combined messages ~749ms. Final plans use the retention indexes: debug ~4.5ms; Discord payload scrub ~1.3ms; secret/orphan/inactive-link reference candidates ~0.6/~0.3/~2.3ms; terminal-delivery index-only selection ~0.7ms; the full provider/message validation join was ~118ms in the worst-case fixture where all 20k terminal rows shared one timestamp. Pair-code provider filtering scans only the eligible partial-index backlog rather than the growing primary table.

## Verification

All database checks used throwaway `pgvector/pgvector:pg16` PostgreSQL instances migrated to this branch's Alembic head.

- focused retention/worker/metrics: 27 passed
- focused retention/worker/metrics/inbox: 35 passed
- broader channel/Telegram/Discord routes, gateway, fixtures, and rate limiting: 462 passed
- migration from zero and `b5d8e2a7c4f1 -> f3b7c1d9e5a2 -> b5d8e2a7c4f1` downgrade/upgrade
- `uv lock --check`
- `uv run python scripts/check_dependency_authority.py`
- `uv run python scripts/type_governance.py owned` (0 diagnostics, 36 files)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall app scripts tests alembic`
- `git diff --check origin/main..HEAD`

## Upstream contracts

- PostgreSQL queue-like `SKIP LOCKED`: https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE
- SQLAlchemy `Select.with_for_update(skip_locked=True)`: https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update
- Telegram upstream update retention: https://core.telegram.org/bots/api#getupdates
- Discord interaction token lifetime: https://docs.discord.com/developers/interactions/receiving-and-responding

The channels-worker metrics listener is process-local on its non-proxied port 8000; it is not an externally routed main API endpoint. This PR remains intentionally unmerged.

