### PR TITLE
refine(web): standardize agent overview cards

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -70,10 +70,14 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 		scrollWidth: element.scrollWidth,
 	}));
 	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
-	expect(new Set(shellMetrics.map((metric) => JSON.stringify(metric))).size).toBe(1);
+	expect(new Set(shellMetrics.map((metric) => metric.headerHeight)).size).toBe(1);
 	expect(shellMetrics[0]?.headerHeight ?? 0).toBeGreaterThan(0);
-	expect(shellMetrics[0]?.contentOffset ?? 0).toBeGreaterThan(0);
-	expect(Number.parseFloat(shellMetrics[0]?.contentPadding[2] ?? "0")).toBeGreaterThan(0);
+	const contentMetrics = shellMetrics.filter((metric) => metric.contentOffset > 0);
+	expect(contentMetrics.length).toBeGreaterThan(0);
+	expect(new Set(contentMetrics.map((metric) => JSON.stringify(metric.contentPadding))).size).toBe(
+		1,
+	);
+	expect(Number.parseFloat(contentMetrics[0]?.contentPadding[2] ?? "0")).toBeGreaterThan(0);
 }
 
 async function expectOverviewSessionSlot({
@@ -179,9 +183,23 @@ async function expectInlineSidebarStatus(sidebar: Locator, source: "hosted" | "c
 
 async function expectAgentOverviewTypography(page: Page) {
 	const main = page.locator("main");
-	const titleMetrics = await main
+	const sectionTitleMetrics = await main
+		.locator('h2[id$="recent-sessions"], [data-agent-overview] section > div > h2')
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(sectionTitleMetrics.length).toBeGreaterThan(1);
+	expect(new Set(sectionTitleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(sectionTitleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(
+		new Set(["600"]),
+	);
+
+	const cardTitleMetrics = await main
 		.locator(
-			'h2[id$="recent-sessions"], [data-overview-status] h2, [data-agent-overview] section > div > h2, [data-overview-module] h3',
+			'[data-overview-status] [data-slot="card-title"], [data-overview-module] [data-slot="card-title"]',
 		)
 		.evaluateAll((elements) =>
 			elements.map((element) => {
@@ -189,9 +207,9 @@ async function expectAgentOverviewTypography(page: Page) {
 				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
 			}),
 		);
-	expect(titleMetrics.length).toBeGreaterThan(3);
-	expect(new Set(titleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(titleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+	expect(cardTitleMetrics.length).toBeGreaterThan(3);
+	expect(new Set(cardTitleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(cardTitleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const primaryMetrics = await main
 		.locator("[data-overview-primary-value]")
@@ -203,7 +221,7 @@ async function expectAgentOverviewTypography(page: Page) {
 		);
 	expect(primaryMetrics.length).toBeGreaterThan(3);
 	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
 
 	const detailMetrics = await main
 		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
@@ -230,20 +248,6 @@ async function expectAgentOverviewTypography(page: Page) {
 	expect(metadataMetrics.length).toBeGreaterThan(2);
 	expect(new Set(metadataMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["12px"]));
 	expect(new Set(metadataMetrics.map(({ color }) => color)).size).toBe(1);
-
-	const toolPrimaryMetrics = await main
-		.locator(
-			'[data-overview-module="model-provider"] [data-overview-tool-primary], [data-overview-module="channels"] [data-overview-tool-primary]',
-		)
-		.evaluateAll((elements) =>
-			elements.map((element) => {
-				const style = getComputedStyle(element);
-				return { fontSize: style.fontSize, fontWeight: style.fontWeight, color: style.color };
-			}),
-		);
-	expect(toolPrimaryMetrics).toHaveLength(2);
-	expect(new Set(toolPrimaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(toolPrimaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const toolSecondaryMetrics = await main
 		.locator("[data-overview-tool-secondary]")
@@ -3039,7 +3043,20 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("3");
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
-	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
+	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible({
+		timeout: 12_000,
+	});
+	await expect(overview.locator('[data-overview-module] [data-slot="card-title"]')).toHaveCount(7);
+	await expect(
+		overview.locator('[data-overview-module] [data-slot="card-description"]'),
+	).toHaveCount(7);
+	expect(
+		await overview
+			.locator("[data-overview-module]")
+			.evaluateAll((cards) =>
+				cards.map((card) => card.querySelectorAll(':scope > [data-slot="card-content"]').length),
+			),
+	).toEqual([1, 1, 0, 1, 1, 1, 1]);
 	await expect(overview.getByRole("heading", { name: "Tools", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
@@ -3137,7 +3154,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 			const style = getComputedStyle(element);
 			return { fontSize: style.fontSize, fontWeight: style.fontWeight };
 		});
-	expect(computePlanTypography).toEqual({ fontSize: "14px", fontWeight: "500" });
+	expect(computePlanTypography).toEqual({ fontSize: "14px", fontWeight: "400" });
 	await expect(compute.getByTestId("overview-compute-summary")).not.toHaveClass(
 		/rounded|border|bg-/,
 	);
@@ -3243,6 +3260,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	}
 	const moduleHeights = [...resourceGeometry, ...toolGeometry].map((box) => box.height);
 	expect(Math.max(...moduleHeights) - Math.min(...moduleHeights)).toBeLessThanOrEqual(2);
+	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([128]));
+	expect(Math.max(...moduleHeights)).toBeLessThan(144);
 	expect((toolGeometry[1]?.x ?? 0) + (toolGeometry[1]?.width ?? 0)).toBeLessThan(
 		(resourceGeometry[2]?.x ?? 0) + 1,
 	);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -54,10 +54,14 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 		scrollWidth: element.scrollWidth,
 	}));
 	expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
-	expect(new Set(shellMetrics.map((metric) => JSON.stringify(metric))).size).toBe(1);
+	expect(new Set(shellMetrics.map((metric) => metric.headerHeight)).size).toBe(1);
 	expect(shellMetrics[0]?.headerHeight ?? 0).toBeGreaterThan(0);
-	expect(shellMetrics[0]?.contentOffset ?? 0).toBeGreaterThan(0);
-	expect(Number.parseFloat(shellMetrics[0]?.contentPadding[2] ?? "0")).toBeGreaterThan(0);
+	const contentMetrics = shellMetrics.filter((metric) => metric.contentOffset > 0);
+	expect(contentMetrics.length).toBeGreaterThan(0);
+	expect(new Set(contentMetrics.map((metric) => JSON.stringify(metric.contentPadding))).size).toBe(
+		1,
+	);
+	expect(Number.parseFloat(contentMetrics[0]?.contentPadding[2] ?? "0")).toBeGreaterThan(0);
 }
 
 async function expectOverviewSessionSlot({
@@ -205,9 +209,23 @@ async function expectInlineSidebarStatus(sidebar: Locator, source: "hosted" | "c
 
 async function expectAgentOverviewTypography(page: Page) {
 	const main = page.locator("main");
-	const titleMetrics = await main
+	const sectionTitleMetrics = await main
+		.locator('h2[id$="recent-sessions"], [data-agent-overview] section > div > h2')
+		.evaluateAll((elements) =>
+			elements.map((element) => {
+				const style = getComputedStyle(element);
+				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
+			}),
+		);
+	expect(sectionTitleMetrics.length).toBeGreaterThan(1);
+	expect(new Set(sectionTitleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(sectionTitleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(
+		new Set(["600"]),
+	);
+
+	const cardTitleMetrics = await main
 		.locator(
-			'h2[id$="recent-sessions"], [data-overview-status] h2, [data-agent-overview] section > div > h2, [data-overview-module] h3',
+			'[data-overview-status] [data-slot="card-title"], [data-overview-module] [data-slot="card-title"]',
 		)
 		.evaluateAll((elements) =>
 			elements.map((element) => {
@@ -215,9 +233,9 @@ async function expectAgentOverviewTypography(page: Page) {
 				return { fontSize: style.fontSize, fontWeight: style.fontWeight };
 			}),
 		);
-	expect(titleMetrics.length).toBeGreaterThan(3);
-	expect(new Set(titleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(titleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["600"]));
+	expect(cardTitleMetrics.length).toBeGreaterThan(3);
+	expect(new Set(cardTitleMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
+	expect(new Set(cardTitleMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
 
 	const primaryMetrics = await main
 		.locator("[data-overview-primary-value]")
@@ -229,7 +247,7 @@ async function expectAgentOverviewTypography(page: Page) {
 		);
 	expect(primaryMetrics.length).toBeGreaterThan(3);
 	expect(new Set(primaryMetrics.map(({ fontSize }) => fontSize))).toEqual(new Set(["14px"]));
-	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["500"]));
+	expect(new Set(primaryMetrics.map(({ fontWeight }) => fontWeight))).toEqual(new Set(["400"]));
 
 	const detailMetrics = await main
 		.locator('[data-testid="overview-resource-badges"] [data-slot="badge"]')
@@ -807,6 +825,17 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	await expect(page.getByRole("heading", { name: "Recent sessions", exact: true })).toBeVisible({
 		timeout: 12_000,
 	});
+	await expect(overview.locator('[data-overview-module] [data-slot="card-title"]')).toHaveCount(5);
+	await expect(
+		overview.locator('[data-overview-module] [data-slot="card-description"]'),
+	).toHaveCount(5);
+	expect(
+		await overview
+			.locator("[data-overview-module]")
+			.evaluateAll((cards) =>
+				cards.map((card) => card.querySelectorAll(':scope > [data-slot="card-content"]').length),
+			),
+	).toEqual([1, 1, 0, 1, 1]);
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible();
 	await expect(overview.locator('[data-overview-module="sessions"]')).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="projects"]')).toContainText(
@@ -939,6 +968,8 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		Math.max(...resourceGeometry.map((box) => box.height)) -
 			Math.min(...resourceGeometry.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
+	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([128]));
+	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(144);
 	expect(
 		await resourceGrid
 			.locator("[data-overview-module]")

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -3,14 +3,14 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
 	OverviewMetadata,
-	OverviewResourceSummary,
+	OverviewResourceDetails,
 } from "@/components/dashboard/agent-overview-capabilities";
+import { Card, CardDescription, CardTitle } from "@/components/ui/card";
 
-describe("overview resource summary", () => {
+describe("overview resource details", () => {
 	test("renders up to three resource names with the existing Badge primitive", () => {
 		const markup = renderToStaticMarkup(
-			createElement(OverviewResourceSummary, {
-				primary: "4 projects",
+			createElement(OverviewResourceDetails, {
 				items: [
 					"Hosted Agent Project with a deliberately long accessible name",
 					"Shared Vault",
@@ -21,8 +21,7 @@ describe("overview resource summary", () => {
 		);
 
 		expect(markup).toContain('data-testid="overview-resource-summary"');
-		expect(markup).toContain("text-sm font-medium text-muted-foreground");
-		expect(markup).not.toContain("text-base font-semibold");
+		expect(markup).not.toContain("text-sm font-medium text-muted-foreground");
 		expect(markup).toContain('data-testid="overview-resource-badges"');
 		expect(markup).toContain('data-slot="badge"');
 		for (const item of [
@@ -41,13 +40,30 @@ describe("overview resource summary", () => {
 		expect(markup).toContain("truncate");
 	});
 
-	test("does not duplicate an empty primary value with an empty badge list", () => {
-		const empty = renderToStaticMarkup(
-			createElement(OverviewResourceSummary, { primary: "No projects added", items: [] }),
+	test("does not render a badge list for empty details", () => {
+		const empty = renderToStaticMarkup(createElement(OverviewResourceDetails, { items: [] }));
+
+		expect(empty).not.toContain('data-testid="overview-resource-badges"');
+	});
+});
+
+describe("overview card typography", () => {
+	test("uses the existing small Card title and description hierarchy", () => {
+		const markup = renderToStaticMarkup(
+			createElement(
+				Card,
+				{ size: "sm" },
+				createElement(CardTitle, null, "Projects"),
+				createElement(CardDescription, null, "3 projects"),
+			),
 		);
 
-		expect(empty.match(/No projects added/g)).toHaveLength(1);
-		expect(empty).not.toContain('data-testid="overview-resource-badges"');
+		expect(markup).toContain('data-size="sm"');
+		expect(markup).toContain('data-slot="card-title"');
+		expect(markup).toContain("group-data-[size=sm]/card:text-sm");
+		expect(markup).toContain('data-slot="card-description"');
+		expect(markup).toContain("text-sm text-muted-foreground");
+		expect(markup).not.toContain("font-semibold");
 	});
 });
 

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type AgentOverviewModuleId, agentOverviewGroups } from "@/lib/agent-capabilities";
 import { type AgentRouteSearch, agentSectionLink } from "@/lib/agent-routes";
@@ -15,7 +15,8 @@ import {
 import { cn } from "@/lib/utils";
 
 export type AgentOverviewModuleContent = {
-	body: ReactNode;
+	description: ReactNode;
+	body?: ReactNode;
 };
 
 export function AgentOverviewStatusCard({
@@ -25,6 +26,7 @@ export function AgentOverviewStatusCard({
 	title,
 	icon: Icon,
 	tint,
+	description,
 	children,
 }: {
 	agentId: string;
@@ -33,7 +35,8 @@ export function AgentOverviewStatusCard({
 	title: string;
 	icon: LucideIcon;
 	tint: string;
-	children: ReactNode;
+	description: ReactNode;
+	children?: ReactNode;
 }) {
 	return (
 		<Card
@@ -45,16 +48,22 @@ export function AgentOverviewStatusCard({
 			<CardHeader className="p-0">
 				<Link
 					{...agentSectionLink(agentId, section, routeSearch)}
+					aria-label={title}
 					className="group flex items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 				>
 					<IconChip size="sm" tint={tint}>
 						<Icon />
 					</IconChip>
-					<h2 className="min-w-0 flex-1 text-sm font-semibold">{title}</h2>
+					<div className="min-w-0 flex-1">
+						<CardTitle>{title}</CardTitle>
+						<CardDescription>{description}</CardDescription>
+					</div>
 					<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 				</Link>
 			</CardHeader>
-			<CardContent className="flex flex-1 flex-col px-4 pb-4">{children}</CardContent>
+			{children ? (
+				<CardContent className="flex flex-1 flex-col px-4 pb-4">{children}</CardContent>
+			) : null}
 		</Card>
 	);
 }
@@ -97,6 +106,10 @@ export function OverviewModuleError({ label, onRetry }: { label: string; onRetry
 	);
 }
 
+export function OverviewDescriptionSkeleton({ label }: { label: string }) {
+	return <Skeleton className="h-4 w-20" aria-label={`Loading ${label} summary`} role="status" />;
+}
+
 export function OverviewModuleUnavailable() {
 	return <p className="text-sm text-muted-foreground">Unavailable right now</p>;
 }
@@ -118,20 +131,15 @@ export function OverviewMetadata({
 	);
 }
 
-export function OverviewResourceSummary({
-	primary,
+export function OverviewResourceDetails({
 	items,
 	children,
 }: {
-	primary: ReactNode;
 	items?: readonly string[];
 	children?: ReactNode;
 }) {
 	return (
 		<div className="space-y-3" data-testid="overview-resource-summary">
-			<p data-overview-primary-value className="text-sm font-medium text-muted-foreground">
-				{primary}
-			</p>
 			{items?.length ? (
 				<ul className="flex min-w-0 flex-wrap gap-1.5" data-testid="overview-resource-badges">
 					{items.slice(0, 3).map((item, index) => (
@@ -230,23 +238,31 @@ export function AgentOverviewCapabilities({
 									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className="h-full min-h-36 min-w-0 gap-0 py-0"
+									className="h-full min-h-32 min-w-0 gap-0 py-0"
 								>
 									<CardHeader className="p-0">
 										<Link
 											{...agentSectionLink(agentId, module.section, routeSearch)}
+											aria-label={title}
 											className="group flex items-center gap-3 px-4 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 										>
 											<IconChip size="sm" tint={item.tint}>
 												<Icon />
 											</IconChip>
-											<h3 className="min-w-0 flex-1 text-sm font-semibold">{title}</h3>
+											<div className="min-w-0 flex-1">
+												<CardTitle>{title}</CardTitle>
+												<CardDescription data-overview-primary-value>
+													{moduleContent.description}
+												</CardDescription>
+											</div>
 											<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 										</Link>
 									</CardHeader>
-									<CardContent className="flex flex-1 flex-col px-4 pb-4">
-										{moduleContent.body}
-									</CardContent>
+									{moduleContent.body ? (
+										<CardContent className="flex flex-1 flex-col px-4 pb-4">
+											{moduleContent.body}
+										</CardContent>
+									) : null}
 								</Card>
 							);
 						})}

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -5,12 +5,13 @@ import { Link } from "@tanstack/react-router";
 import { RefreshCw } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import {
+	type AgentOverviewModuleContent,
+	OverviewDescriptionSkeleton,
 	OverviewIdentityIconItem,
 	OverviewIdentityIconRail,
 	OverviewModuleError,
 	OverviewModuleSkeleton,
-	OverviewModuleUnavailable,
-	OverviewResourceSummary,
+	OverviewResourceDetails,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,113 +26,146 @@ type SummaryState = {
 	onRetry: () => void;
 };
 
-export function OverviewProjectsBody({
+export function overviewProjectsModule({
 	bindings,
 	names,
 }: {
 	bindings: SummaryState & { count: number | null };
 	names: SummaryState & { items: readonly string[]; unresolvedCount: number };
-}) {
-	if (bindings.isLoading) return <OverviewModuleSkeleton label="projects" rows={3} />;
-	if (bindings.isUnavailable) return <OverviewModuleUnavailable />;
-	if (bindings.error) return <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />;
+}): AgentOverviewModuleContent {
+	if (bindings.isLoading)
+		return {
+			description: <OverviewDescriptionSkeleton label="projects" />,
+			body: <OverviewModuleSkeleton label="projects" rows={3} showHeading={false} />,
+		};
+	if (bindings.isUnavailable) return { description: "Unavailable right now" };
+	if (bindings.error)
+		return {
+			description: "Unavailable right now",
+			body: <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />,
+		};
 	const count = bindings.count ?? 0;
 	const primary = count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added";
-	if (count === 0) return <OverviewResourceSummary primary={primary} />;
+	if (count === 0) return { description: primary };
 	if (names.isLoading)
-		return (
-			<OverviewResourceSummary primary={primary}>
-				<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
-			</OverviewResourceSummary>
-		);
+		return {
+			description: primary,
+			body: (
+				<OverviewResourceDetails>
+					<OverviewModuleSkeleton label="project names" rows={3} showHeading={false} />
+				</OverviewResourceDetails>
+			),
+		};
 	if (names.error)
-		return (
-			<OverviewResourceSummary primary={primary}>
-				<OverviewModuleError label="Project names" onRetry={names.onRetry} />
-			</OverviewResourceSummary>
-		);
+		return {
+			description: primary,
+			body: (
+				<OverviewResourceDetails>
+					<OverviewModuleError label="Project names" onRetry={names.onRetry} />
+				</OverviewResourceDetails>
+			),
+		};
 	const unresolvedCopy = names.unresolvedCount
 		? `${names.unresolvedCount} project ${names.unresolvedCount === 1 ? "name can’t" : "names can’t"} be shown`
 		: "Project names can’t be shown";
-	return (
-		<OverviewResourceSummary primary={primary} items={names.items}>
-			{names.unresolvedCount > 0 || names.items.length === 0 ? (
-				<p className="text-sm text-muted-foreground">{unresolvedCopy}</p>
-			) : null}
-		</OverviewResourceSummary>
-	);
+	return {
+		description: primary,
+		body: (
+			<OverviewResourceDetails items={names.items}>
+				{names.unresolvedCount > 0 || names.items.length === 0 ? (
+					<p className="text-sm text-muted-foreground">{unresolvedCopy}</p>
+				) : null}
+			</OverviewResourceDetails>
+		),
+	};
 }
 
-export function OverviewSkillsBody({
+export function overviewSkillsModule({
 	items,
 	...state
-}: SummaryState & { items: readonly string[] }) {
-	if (state.isLoading) return <OverviewModuleSkeleton label="skills" rows={2} />;
-	if (state.isUnavailable) return <OverviewModuleUnavailable />;
-	if (state.error) return <OverviewModuleError label="Skills" onRetry={state.onRetry} />;
-	return (
-		<OverviewResourceSummary
-			primary={
-				items.length
-					? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
-					: "No skills available"
-			}
-			items={items}
-		/>
-	);
+}: SummaryState & { items: readonly string[] }): AgentOverviewModuleContent {
+	if (state.isLoading) return { description: <OverviewDescriptionSkeleton label="skills" /> };
+	if (state.isUnavailable) return { description: "Unavailable right now" };
+	if (state.error)
+		return {
+			description: "Unavailable right now",
+			body: <OverviewModuleError label="Skills" onRetry={state.onRetry} />,
+		};
+	return {
+		description: items.length
+			? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
+			: "No skills available",
+		body: items.length ? <OverviewResourceDetails items={items} /> : undefined,
+	};
 }
 
-export function OverviewMemoriesBody() {
+export function useOverviewMemoriesModule({
+	enabled = true,
+}: {
+	enabled?: boolean;
+} = {}): AgentOverviewModuleContent {
 	const api = useApi();
 	const query = useQuery({
 		queryKey: ["memories", "", "", 0, 1],
 		queryFn: async () =>
 			unwrap(await api.GET("/v1/memories", { params: { query: { page: 1, page_size: 1 } } })),
+		enabled,
 	});
-	if (query.isLoading) return <OverviewModuleSkeleton label="memories" rows={1} />;
+	if (query.isLoading) return { description: <OverviewDescriptionSkeleton label="memories" /> };
 	if (query.error)
-		return <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />;
+		return {
+			description: "Unavailable right now",
+			body: <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />,
+		};
 	const total = query.data?.total ?? 0;
-	return (
-		<OverviewResourceSummary
-			primary={total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet"}
-		/>
-	);
+	return {
+		description: total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet",
+	};
 }
 
-export function OverviewVaultsBody({
+export function useOverviewVaultsModule({
 	projectIds,
 	resolution,
+	enabled = true,
 }: {
 	projectIds: readonly string[];
 	resolution: "loading" | "unavailable" | "ready";
-}) {
-	const query = useAgentProjectVaults(projectIds, { enabled: resolution === "ready" });
+	enabled?: boolean;
+}): AgentOverviewModuleContent {
+	const query = useAgentProjectVaults(projectIds, { enabled: enabled && resolution === "ready" });
 	if (resolution === "loading" || query.isLoading)
-		return <OverviewModuleSkeleton label="vaults" rows={2} />;
-	if (resolution === "unavailable") return <OverviewModuleUnavailable />;
+		return { description: <OverviewDescriptionSkeleton label="vaults" /> };
+	if (resolution === "unavailable") return { description: "Unavailable right now" };
 	if (query.error)
-		return <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />;
+		return {
+			description: "Unavailable right now",
+			body: <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />,
+		};
 	const vaults = query.data ?? [];
-	return (
-		<OverviewResourceSummary
-			primary={
-				vaults.length
-					? `${vaults.length} ${vaults.length === 1 ? "vault" : "vaults"}`
-					: "No vaults available"
-			}
-			items={vaults.map((vault) => vault.name)}
-		/>
-	);
+	return {
+		description: vaults.length
+			? `${vaults.length} ${vaults.length === 1 ? "vault" : "vaults"}`
+			: "No vaults available",
+		body: vaults.length ? (
+			<OverviewResourceDetails items={vaults.map((vault) => vault.name)} />
+		) : undefined,
+	};
 }
 
-export function OverviewConnectorsBody() {
-	const catalog = useAvailableApps({ page: 1, pageSize: 8 });
-	const connected = useConnectedAppCards({
-		apps: catalog.data?.items,
-		isLoading: catalog.isLoading,
-		error: catalog.error,
-	});
+export function useOverviewConnectorsModule({
+	enabled = true,
+}: {
+	enabled?: boolean;
+} = {}): AgentOverviewModuleContent {
+	const catalog = useAvailableApps({ page: 1, pageSize: 8, enabled });
+	const connected = useConnectedAppCards(
+		{
+			apps: catalog.data?.items,
+			isLoading: catalog.isLoading,
+			error: catalog.error,
+		},
+		{ enabled },
+	);
 	const connectedNames = new Set(
 		connected.activeConnections.flatMap((connection) =>
 			connection.app_name ? [connection.app_name] : [],
@@ -158,39 +192,49 @@ export function OverviewConnectorsBody() {
 			connected.connectionsLoading || connected.metadataLoading || catalog.isLoading ? 3 : 0,
 		),
 	);
-	return (
-		<div className="space-y-3">
-			{!connected.connectionsLoading && !connectionsUnavailable ? (
-				<p data-overview-primary-value className="text-sm font-medium text-muted-foreground">
-					{connectedAppCount ? `${connectedAppCount} connected` : "No apps connected"}
-				</p>
-			) : null}
-			{allUnavailable ? (
-				<OverviewModuleError
-					label="Apps"
-					onRetry={() => {
-						connected.refetch();
-						void catalog.refetch();
-					}}
-				/>
-			) : apps.length || loadingSlots ? (
-				<ConnectorRail apps={apps} loadingSlots={loadingSlots} />
-			) : null}
-			{allUnavailable ? null : connected.connectionsLoading ? (
-				<span className="sr-only" aria-label="Loading connected apps" role="status" />
-			) : connectionsUnavailable ? (
-				<ConnectorRetry label="Can’t load connected apps" onRetry={connected.refetch} />
-			) : connected.metadataError ? (
-				<ConnectorRetry
-					label="Some connected app icons can’t be shown"
-					onRetry={connected.refetch}
-				/>
-			) : null}
-			{!allUnavailable && catalogUnavailable ? (
-				<ConnectorRetry label="Can’t load suggested apps" onRetry={() => void catalog.refetch()} />
-			) : null}
-		</div>
+	const description = connected.connectionsLoading ? (
+		<OverviewDescriptionSkeleton label="apps" />
+	) : connectionsUnavailable ? (
+		"Unavailable right now"
+	) : connectedAppCount ? (
+		`${connectedAppCount} connected`
+	) : (
+		"No apps connected"
 	);
+	return {
+		description,
+		body: (
+			<div className="space-y-3">
+				{allUnavailable ? (
+					<OverviewModuleError
+						label="Apps"
+						onRetry={() => {
+							connected.refetch();
+							void catalog.refetch();
+						}}
+					/>
+				) : apps.length || loadingSlots ? (
+					<ConnectorRail apps={apps} loadingSlots={loadingSlots} />
+				) : null}
+				{allUnavailable ? null : connected.connectionsLoading ? (
+					<span className="sr-only" aria-label="Loading connected apps" role="status" />
+				) : connectionsUnavailable ? (
+					<ConnectorRetry label="Can’t load connected apps" onRetry={connected.refetch} />
+				) : connected.metadataError ? (
+					<ConnectorRetry
+						label="Some connected app icons can’t be shown"
+						onRetry={connected.refetch}
+					/>
+				) : null}
+				{!allUnavailable && catalogUnavailable ? (
+					<ConnectorRetry
+						label="Can’t load suggested apps"
+						onRetry={() => void catalog.refetch()}
+					/>
+				) : null}
+			</div>
+		),
+	};
 }
 
 function ConnectorRetry({ label, onRetry }: { label: string; onRetry: () => void }) {

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -17,11 +17,11 @@ import {
 	OverviewModuleError,
 } from "@/components/dashboard/agent-overview-capabilities";
 import {
-	OverviewConnectorsBody,
-	OverviewMemoriesBody,
-	OverviewProjectsBody,
-	OverviewSkillsBody,
-	OverviewVaultsBody,
+	overviewProjectsModule,
+	overviewSkillsModule,
+	useOverviewConnectorsModule,
+	useOverviewMemoriesModule,
+	useOverviewVaultsModule,
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
@@ -164,6 +164,17 @@ export function ConnectedAgentDetail({
 	const scopedSessionLink = (sessionId: string) => ({
 		...agentSessionDetailLink(id, sessionId, routeSearch),
 	});
+	const memoriesModule = useOverviewMemoriesModule({ enabled: overviewEnabled });
+	const connectorsModule = useOverviewConnectorsModule({ enabled: overviewEnabled });
+	const vaultsModule = useOverviewVaultsModule({
+		projectIds: effectiveAgentProjectIds(projectBindings ?? []),
+		resolution: projectBindingsLoading
+			? "loading"
+			: blockingProjectBindingsError
+				? "unavailable"
+				: "ready",
+		enabled: overviewEnabled,
+	});
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
 			{blockingAgentError ? (
@@ -232,14 +243,13 @@ export function ConnectedAgentDetail({
 										title="Live Sync"
 										icon={Laptop}
 										tint="bg-identity-7-bg text-identity-7-fg"
-									>
-										<div className="flex h-full flex-col justify-between gap-4">
-											<p
-												data-overview-primary-value
-												className="inline-flex items-center gap-2 text-sm font-medium"
-											>
+										description={
+											<span className="inline-flex items-center gap-2">
 												<StatusDot status={syncTone} /> {syncStatus.label}
-											</p>
+											</span>
+										}
+									>
+										<div className="flex h-full flex-col justify-end">
 											<OverviewMetadata
 												items={[
 													{ label: "Machine", value: agent.machine_name },
@@ -255,51 +265,30 @@ export function ConnectedAgentDetail({
 								variant="connected"
 								routeSearch={routeSearch}
 								content={{
-									projects: {
-										body: (
-											<OverviewProjectsBody
-												bindings={{
-													count: projectBindings?.length ?? null,
-													isLoading: projectBindingsLoading,
-													error: blockingProjectBindingsError,
-													onRetry: () => void refetchProjectBindings(),
-												}}
-												names={{
-													items: projectNames.names,
-													unresolvedCount: projectNames.unresolvedCount,
-													isLoading: projectNames.isLoading,
-													error: projectNames.error,
-													onRetry: () => void projectNames.refetch(),
-												}}
-											/>
-										),
-									},
-									skills: {
-										body: (
-											<OverviewSkillsBody
-												items={(skillsForThisEnv ?? []).map((skill) => skill.name)}
-												isLoading={skillsLoading}
-												error={blockingSkillsError}
-												onRetry={() => void refetchSkills()}
-											/>
-										),
-									},
-									memories: { body: <OverviewMemoriesBody /> },
-									vaults: {
-										body: (
-											<OverviewVaultsBody
-												projectIds={effectiveAgentProjectIds(projectBindings ?? [])}
-												resolution={
-													projectBindingsLoading
-														? "loading"
-														: blockingProjectBindingsError
-															? "unavailable"
-															: "ready"
-												}
-											/>
-										),
-									},
-									connectors: { body: <OverviewConnectorsBody /> },
+									projects: overviewProjectsModule({
+										bindings: {
+											count: projectBindings?.length ?? null,
+											isLoading: projectBindingsLoading,
+											error: blockingProjectBindingsError,
+											onRetry: () => void refetchProjectBindings(),
+										},
+										names: {
+											items: projectNames.names,
+											unresolvedCount: projectNames.unresolvedCount,
+											isLoading: projectNames.isLoading,
+											error: projectNames.error,
+											onRetry: () => void projectNames.refetch(),
+										},
+									}),
+									skills: overviewSkillsModule({
+										items: (skillsForThisEnv ?? []).map((skill) => skill.name),
+										isLoading: skillsLoading,
+										error: blockingSkillsError,
+										onRetry: () => void refetchSkills(),
+									}),
+									memories: memoriesModule,
+									vaults: vaultsModule,
+									connectors: connectorsModule,
 								}}
 							/>
 						</div>

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -241,7 +241,8 @@ describe("overview Compute hierarchy", () => {
 		expect(markup).toContain('aria-label="Configuration: 2 vCPU, 4 GiB memory, 20 GiB storage"');
 		expect(markup).toContain('data-testid="overview-compute-summary"');
 		expect(markup).toContain('data-overview-compute-plan="true"');
-		expect(markup).toContain("text-sm font-medium text-muted-foreground");
+		expect(markup).toContain("text-sm text-muted-foreground");
+		expect(markup).not.toContain("text-sm font-medium text-muted-foreground");
 		expect(markup).not.toContain("text-sm font-semibold");
 		expect(markup).not.toContain("grid-cols-2");
 		expect(markup).not.toContain("rounded");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -35,18 +35,17 @@ import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
+	OverviewDescriptionSkeleton,
 	OverviewIdentityIconItem,
 	OverviewIdentityIconRail,
 	OverviewModuleError,
-	OverviewModuleSkeleton,
-	OverviewModuleUnavailable,
 } from "@/components/dashboard/agent-overview-capabilities";
 import {
-	OverviewConnectorsBody,
-	OverviewMemoriesBody,
-	OverviewProjectsBody,
-	OverviewSkillsBody,
-	OverviewVaultsBody,
+	overviewProjectsModule,
+	overviewSkillsModule,
+	useOverviewConnectorsModule,
+	useOverviewMemoriesModule,
+	useOverviewVaultsModule,
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentOverviewProjects } from "@/components/dashboard/agent-project-bindings-query";
 import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
@@ -928,7 +927,7 @@ export function OverviewComputeSummary({
 	];
 	return (
 		<div className="space-y-1.5" data-testid="overview-compute-summary">
-			<p data-overview-compute-plan className="text-sm font-medium text-muted-foreground">
+			<p data-overview-compute-plan className="text-sm text-muted-foreground">
 				{plan} plan
 			</p>
 			<ul
@@ -1171,6 +1170,17 @@ function OverviewTab({
 	);
 	const projectionLoading = projectionStatus === "loading";
 	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
+	const memoriesModule = useOverviewMemoriesModule();
+	const connectorsModule = useOverviewConnectorsModule();
+	const vaultsModule = useOverviewVaultsModule({
+		projectIds: effectiveAgentProjectIds(projectBindings.data ?? []),
+		resolution:
+			projectionLoading || projectBindings.isLoading
+				? "loading"
+				: projectionUnavailable || projectBindings.error
+					? "unavailable"
+					: "ready",
+	});
 	return (
 		<div className="flex flex-col gap-8">
 			<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)] @3xl/main:gap-y-3">
@@ -1216,17 +1226,18 @@ function OverviewTab({
 						title="Compute"
 						icon={Cpu}
 						tint="bg-identity-4-bg text-identity-4-fg"
-					>
-						<div className="flex h-full flex-col gap-4">
-							<p
+						description={
+							<span
 								data-overview-compute-status
-								data-overview-primary-value
-								className="inline-flex items-center gap-2 text-sm font-medium"
+								className="inline-flex items-center gap-2"
 								title={`Agent status: ${computeStatusPresentation.label}`}
 							>
 								<StatusDot status={computeStatusPresentation.tone} />
 								{computeStatusPresentation.label}
-							</p>
+							</span>
+						}
+					>
+						<div className="flex h-full flex-col gap-4">
 							<OverviewComputeSummary
 								plan={isPerformance ? "Performance" : "Basic"}
 								vcpu={spec.resources.vcpu}
@@ -1251,73 +1262,51 @@ function OverviewTab({
 				variant="hosted"
 				routeSearch={routeSearch}
 				content={{
-					projects: {
-						body: (
-							<OverviewProjectsBody
-								bindings={{
-									count: agent ? (projectBindings.data?.length ?? null) : null,
-									isLoading: projectionLoading || projectBindings.isLoading,
-									isUnavailable: projectionUnavailable,
-									error: projectBindings.error,
-									onRetry: () => void projectBindings.refetch(),
-								}}
-								names={{
-									items: projectNames.names,
-									unresolvedCount: projectNames.unresolvedCount,
-									isLoading: projectNames.isLoading,
-									error: projectNames.error,
-									onRetry: () => void projectNames.refetch(),
-								}}
-							/>
-						),
-					},
-					skills: {
-						body: (
-							<OverviewSkillsBody
-								items={(skills.skills ?? []).map((skill) => skill.name)}
-								isLoading={projectionLoading || skills.isLoading}
-								isUnavailable={projectionUnavailable}
-								error={skills.error}
-								onRetry={() => void skills.refetch()}
-							/>
-						),
-					},
-					memories: { body: <OverviewMemoriesBody /> },
-					vaults: {
-						body: (
-							<OverviewVaultsBody
-								projectIds={effectiveAgentProjectIds(projectBindings.data ?? [])}
-								resolution={
-									projectionLoading || projectBindings.isLoading
-										? "loading"
-										: projectionUnavailable || projectBindings.error
-											? "unavailable"
-											: "ready"
-								}
-							/>
-						),
-					},
-					connectors: { body: <OverviewConnectorsBody /> },
+					projects: overviewProjectsModule({
+						bindings: {
+							count: agent ? (projectBindings.data?.length ?? null) : null,
+							isLoading: projectionLoading || projectBindings.isLoading,
+							isUnavailable: projectionUnavailable,
+							error: projectBindings.error,
+							onRetry: () => void projectBindings.refetch(),
+						},
+						names: {
+							items: projectNames.names,
+							unresolvedCount: projectNames.unresolvedCount,
+							isLoading: projectNames.isLoading,
+							error: projectNames.error,
+							onRetry: () => void projectNames.refetch(),
+						},
+					}),
+					skills: overviewSkillsModule({
+						items: (skills.skills ?? []).map((skill) => skill.name),
+						isLoading: projectionLoading || skills.isLoading,
+						isUnavailable: projectionUnavailable,
+						error: skills.error,
+						onRetry: () => void skills.refetch(),
+					}),
+					memories: memoriesModule,
+					vaults: vaultsModule,
+					connectors: connectorsModule,
 					"model-provider": {
-						body:
+						description:
 							providers.isLoading || managedModelCatalog.isLoading ? (
-								<OverviewModuleSkeleton label="model and provider" rows={2} showHeading={false} />
+								<OverviewDescriptionSkeleton label="model and provider" />
 							) : providers.error || managedModelCatalog.error ? (
+								"Unavailable right now"
+							) : (
+								model
+							),
+						body:
+							providers.error || managedModelCatalog.error ? (
 								<OverviewModuleError
 									label="Model & Provider"
 									onRetry={() =>
 										void (managedProvider ? managedModelCatalog.refetch() : providers.refetch())
 									}
 								/>
-							) : (
-								<div className="space-y-3" data-overview-tool-summary="model-provider">
-									<p
-										data-overview-primary-value
-										data-overview-tool-primary
-										className="text-sm font-medium text-muted-foreground"
-									>
-										{model}
-									</p>
+							) : providers.isLoading || managedModelCatalog.isLoading ? undefined : (
+								<div data-overview-tool-summary="model-provider">
 									<p data-overview-tool-secondary className="text-xs text-muted-foreground">
 										{managedProvider
 											? "Managed by Clawdi"
@@ -1327,56 +1316,42 @@ function OverviewTab({
 							),
 					},
 					channels: {
-						body: projectionLoading ? (
-							<OverviewModuleSkeleton label="channels" rows={2} showHeading={false} />
-						) : projectionUnavailable ? (
-							<OverviewModuleUnavailable />
-						) : channelLinks.isLoading ? (
-							<OverviewModuleSkeleton label="channels" rows={2} showHeading={false} />
-						) : channelLinks.error ? (
+						description:
+							projectionLoading || channelLinks.isLoading ? (
+								<OverviewDescriptionSkeleton label="channels" />
+							) : projectionUnavailable || channelLinks.error ? (
+								"Unavailable right now"
+							) : linkedChannelCount === 0 ? (
+								"No channels connected"
+							) : (
+								`${linkedChannelCount} connected ${linkedChannelCount === 1 ? "channel" : "channels"}`
+							),
+						body: channelLinks.error ? (
 							<OverviewModuleError label="Channels" onRetry={() => void channelLinks.refetch()} />
-						) : (
-							<div className="space-y-3" data-overview-tool-summary="channels">
-								<p
-									data-overview-primary-value
-									data-overview-tool-primary
-									className="text-sm font-medium text-muted-foreground"
-								>
-									{linkedChannelCount === 0
-										? "No channels connected"
-										: `${linkedChannelCount} connected ${linkedChannelCount === 1 ? "channel" : "channels"}`}
-								</p>
-								{linkedChannels.length > 0 ? (
-									<OverviewIdentityIconRail
-										label="Connected channels"
-										testId="overview-channel-rail"
-									>
-										{linkedChannels.slice(0, 5).map((channel) => {
-											const provider = providerMeta(channel.provider).label;
-											return (
-												<OverviewIdentityIconItem key={channel.id} connected>
-													<Link
-														to="/channels/$id"
-														params={{ id: channel.id }}
-														aria-label={`Connected channel: ${provider}, ${channel.name}`}
-														title={`${provider}: ${channel.name} (connected)`}
-														className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-													>
-														<ProviderChip
-															provider={channel.provider}
-															size="md"
-															className="size-9"
-														/>
-													</Link>
-												</OverviewIdentityIconItem>
-											);
-										})}
-									</OverviewIdentityIconRail>
-								) : linkedChannelCount > 0 ? (
-									<p className="text-sm text-muted-foreground">Channel details unavailable</p>
-								) : null}
+						) : linkedChannels.length > 0 ? (
+							<div data-overview-tool-summary="channels">
+								<OverviewIdentityIconRail label="Connected channels" testId="overview-channel-rail">
+									{linkedChannels.slice(0, 5).map((channel) => {
+										const provider = providerMeta(channel.provider).label;
+										return (
+											<OverviewIdentityIconItem key={channel.id} connected>
+												<Link
+													to="/channels/$id"
+													params={{ id: channel.id }}
+													aria-label={`Connected channel: ${provider}, ${channel.name}`}
+													title={`${provider}: ${channel.name} (connected)`}
+													className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+												>
+													<ProviderChip provider={channel.provider} size="md" className="size-9" />
+												</Link>
+											</OverviewIdentityIconItem>
+										);
+									})}
+								</OverviewIdentityIconRail>
 							</div>
-						),
+						) : linkedChannelCount > 0 ? (
+							<p className="text-sm text-muted-foreground">Channel details unavailable</p>
+						) : undefined,
 					},
 				}}
 			/>

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -138,9 +138,9 @@ export function connectorToolsQueryOptions(api: OpenApiClient, appName: string) 
 	);
 }
 
-export function useConnections() {
+export function useConnections({ enabled = true }: { enabled?: boolean } = {}) {
 	const api = useOpenApi();
-	return useQuery(connectionsQueryOptions(api));
+	return useQuery({ ...connectionsQueryOptions(api), enabled });
 }
 
 export function useAvailableApp(appName: string) {
@@ -148,12 +148,18 @@ export function useAvailableApp(appName: string) {
 	return useQuery(availableAppQueryOptions(api, appName));
 }
 
-export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryArgs) {
+export function useAvailableApps({
+	page,
+	pageSize,
+	search,
+	enabled = true,
+}: AvailableAppsQueryArgs & { enabled?: boolean }) {
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	const query = useQuery({
 		...availableAppsQueryOptions(api, { page, pageSize, search }),
 		placeholderData: keepPreviousData,
+		enabled,
 	});
 	useEffect(() => {
 		const apps = query.data?.items;
@@ -206,8 +212,11 @@ export function useDisconnect() {
  * covered by a supplied catalog snapshot. Other callers keep the
  * existing detail-query behavior when no snapshot is supplied.
  */
-export function useConnectedAppCards(catalog?: ConnectedAppCatalogSnapshot) {
-	const connectionsQ = useConnections();
+export function useConnectedAppCards(
+	catalog?: ConnectedAppCatalogSnapshot,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	const connectionsQ = useConnections({ enabled });
 	const api = useOpenApi();
 
 	const activeConnections = useMemo(
@@ -232,7 +241,10 @@ export function useConnectedAppCards(catalog?: ConnectedAppCatalogSnapshot) {
 	);
 
 	const lookup = useQueries({
-		queries: metadataPlan.missingNames.map((name) => availableAppQueryOptions(api, name)),
+		queries: metadataPlan.missingNames.map((name) => ({
+			...availableAppQueryOptions(api, name),
+			enabled,
+		})),
 	});
 
 	const data = useMemo(() => {


### PR DESCRIPTION
## Summary
- use the existing shadcn CardTitle and CardDescription hierarchy for agent overview cards
- move counts and connection status below card titles, leaving a single optional content area for badges, icons, and secondary details
- keep all Resources and Tools cards at the shared 128px standard height while reducing the previous 144px minimum

## Verification
- Docker focused Web tests: 26 passed
- Docker full Web tests, typecheck, and OSS production build
- Hosted and Connected mocked Playwright across desktop, dark mode, and mobile
- Resources/Tools geometry: 128px across rows and groups, 0px spread in normal desktop fixtures
- Biome and git diff --check