### PR TITLE
refine(web): compact agent overview identity rails

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2972,6 +2972,11 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const sessionRequests: string[] = [];
 	const aiProviderRequests: string[] = [];
 	const managedModelRequests: string[] = [];
+	const overviewConnectorRequests: string[] = [];
+	page.on("request", (request) => {
+		const path = new URL(request.url()).pathname;
+		if (path.startsWith("/v1/connectors/available")) overviewConnectorRequests.push(path);
+	});
 	const telegramAccount = {
 		id: "channel-overview-telegram",
 		provider: "telegram",
@@ -3201,11 +3206,28 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const connectors = overview.locator('[data-overview-module="connectors"]');
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
-	await expect(connectorLinks).toHaveCount(5);
+	await expect(connectorLinks).toHaveCount(2);
 	await expect(connectorLinks.nth(0)).toHaveAccessibleName("Connected app: Github");
 	await expect(connectorLinks.nth(1)).toHaveAccessibleName("Connected app: Slack");
-	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
-	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
+	await expect(connectors.getByRole("link", { name: /Gmail/ })).toHaveCount(0);
+	await expect(connectorLinks.locator("svg")).toHaveCount(0);
+	expect(overviewConnectorRequests).toEqual([
+		"/v1/connectors/available/github",
+		"/v1/connectors/available/slack",
+	]);
+	const connectorIconBoxes = await connectorLinks
+		.locator("div")
+		.evaluateAll((icons) => icons.map((icon) => icon.getBoundingClientRect().toJSON()));
+	const channelIconBoxes = await channelRail
+		.locator("img")
+		.evaluateAll((icons) => icons.map((icon) => icon.getBoundingClientRect().toJSON()));
+	expect(
+		[...connectorIconBoxes, ...channelIconBoxes].map((box) => [box.width, box.height]),
+	).toEqual([
+		[24, 24],
+		[24, 24],
+		[24, 24],
+	]);
 	const sidebar = page.getByTestId("app-sidebar");
 	await expect(sidebar.getByText("Running", { exact: true })).toBeVisible();
 	await expectInlineSidebarStatus(sidebar, "hosted");
@@ -3260,8 +3282,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	}
 	const moduleHeights = [...resourceGeometry, ...toolGeometry].map((box) => box.height);
 	expect(Math.max(...moduleHeights) - Math.min(...moduleHeights)).toBeLessThanOrEqual(2);
-	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([128]));
-	expect(Math.max(...moduleHeights)).toBeLessThan(144);
+	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([112]));
+	expect(Math.max(...moduleHeights)).toBeLessThan(128);
 	expect((toolGeometry[1]?.x ?? 0) + (toolGeometry[1]?.width ?? 0)).toBeLessThan(
 		(resourceGeometry[2]?.x ?? 0) + 1,
 	);
@@ -3683,6 +3705,21 @@ test("hosted Tools channels preserve zero, singular, plural, error, and loading 
 	await expect(channelLinks.nth(1)).toHaveAccessibleName(
 		"Connected channel: Discord, Team Discord",
 	);
+
+	options.channelAgentLinksResponse = {
+		body: [
+			channelLink(1, "telegram"),
+			channelLink(2, "discord"),
+			channelLink(3, "telegram"),
+			channelLink(4, "discord"),
+			channelLink(5, "telegram"),
+			channelLink(1, "telegram"),
+		],
+		status: 200,
+	};
+	await page.reload();
+	await expect(channels.getByText("6 connected channels", { exact: true })).toBeVisible();
+	await expect(channels.getByTestId("overview-channel-rail").getByRole("link")).toHaveCount(4);
 
 	options.channelAgentLinksResponse = {
 		body: { detail: "channel service unavailable" },

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -511,6 +511,7 @@ type DashboardApiStubOptions = {
 	connectorCatalogGate?: Promise<void>;
 	connectorCatalogResponse?: { body: unknown; status: number };
 	connectorMetadataRequests?: string[];
+	connectorMetadataGate?: Promise<void>;
 	projectBindingRequests?: string[];
 	projectRequests?: string[];
 	projectBindings?: readonly unknown[];
@@ -628,6 +629,7 @@ async function stubDashboardApi(
 		const connectorAppMatch = url.pathname.match(/^\/v1\/connectors\/available\/([^/]+)$/);
 		if (connectorAppMatch) {
 			options.connectorMetadataRequests?.push(route.request().url());
+			await options.connectorMetadataGate;
 			const app = options.connectorCatalog?.find(
 				(item) => item.name === decodeURIComponent(connectorAppMatch[1]),
 			);
@@ -935,11 +937,16 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 	const connectors = overview.locator('[data-overview-module="connectors"]');
 	await expect(connectors).toContainText("2 connected");
 	const connectorLinks = connectors.getByTestId("overview-connector-rail").getByRole("link");
-	await expect(connectorLinks).toHaveCount(5);
+	await expect(connectorLinks).toHaveCount(2);
 	await expect(connectorLinks.nth(0)).toHaveAccessibleName("Connected app: Github");
 	await expect(connectorLinks.nth(1)).toHaveAccessibleName("Connected app: Slack");
-	await expect(connectorLinks.nth(2)).toHaveAccessibleName("Suggested app: Gmail");
-	await expect(connectors.getByRole("link", { name: "Suggested app: Github" })).toHaveCount(0);
+	await expect(connectors.getByRole("link", { name: /Gmail/ })).toHaveCount(0);
+	await expect(connectorLinks.locator("svg")).toHaveCount(0);
+	for (const link of await connectorLinks.all()) {
+		const box = await link.locator("div").boundingBox();
+		expect(box?.width).toBe(24);
+		expect(box?.height).toBe(24);
+	}
 	const sidebar = page.getByTestId("app-sidebar");
 	await expect(sidebar.getByText("Paused", { exact: true })).toBeVisible();
 	await expect(sidebar.getByText(/last seen/i)).toBeVisible();
@@ -968,8 +975,8 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		Math.max(...resourceGeometry.map((box) => box.height)) -
 			Math.min(...resourceGeometry.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
-	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([128]));
-	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(144);
+	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([112]));
+	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(128);
 	expect(
 		await resourceGrid
 			.locator("[data-overview-module]")
@@ -1169,10 +1176,15 @@ test("connected Overview keeps a three-row accessible session slot for zero thro
 	expect(Math.max(...measurements) - Math.min(...measurements)).toBeLessThanOrEqual(2);
 });
 
-test("connected Overview resolves connector metadata from catalog before fan-out", async ({
+test("connected Overview limits detail metadata without requesting the popular catalog", async ({
 	page,
 }) => {
 	const connectorMetadataRequests: string[] = [];
+	const catalogRequests: string[] = [];
+	page.on("request", (request) => {
+		if (new URL(request.url()).pathname === "/v1/connectors/available")
+			catalogRequests.push(request.url());
+	});
 	const catalogApp = (name: string) => ({
 		name,
 		display_name: name,
@@ -1187,19 +1199,31 @@ test("connected Overview resolves connector metadata from catalog before fan-out
 		connectorConnections: [
 			{ id: "conn-github", app_name: "github", status: "ACTIVE" },
 			{ id: "conn-slack", app_name: "slack", status: "ACTIVE" },
+			{ id: "conn-gmail", app_name: "gmail", status: "ACTIVE" },
+			{ id: "conn-notion", app_name: "notion", status: "ACTIVE" },
+			{ id: "conn-linear", app_name: "linear", status: "ACTIVE" },
+			{ id: "conn-github-duplicate", app_name: "github", status: "ACTIVE" },
 		],
-		connectorCatalog: [catalogApp("github"), catalogApp("gmail")],
+		connectorCatalog: ["github", "slack", "gmail", "notion", "linear"].map(catalogApp),
 	});
 
 	await page.goto("/agents/agent-smoke-1");
-	await expect(page.locator('[data-overview-module="connectors"]')).toContainText("2 connected");
-	await expect.poll(() => connectorMetadataRequests.length).toBe(1);
-	expect(new URL(connectorMetadataRequests[0] ?? "http://invalid").pathname).toBe(
+	const card = page.locator('[data-overview-module="connectors"]');
+	await expect(card).toContainText("5 connected");
+	await expect(card.getByTestId("overview-connector-rail").getByRole("link")).toHaveCount(4);
+	await expect.poll(() => connectorMetadataRequests.length).toBe(4);
+	expect(connectorMetadataRequests.map((request) => new URL(request).pathname)).toEqual([
+		"/v1/connectors/available/github",
 		"/v1/connectors/available/slack",
-	);
+		"/v1/connectors/available/gmail",
+		"/v1/connectors/available/notion",
+	]);
+	expect(catalogRequests).toEqual([]);
 });
 
-test("connected overview keeps connector and catalog states independent", async ({ page }) => {
+test("connected overview does not render an empty rail while connections load", async ({
+	page,
+}) => {
 	await stubDashboardApi(page, [], {
 		connectorConnectionsGate: new Promise<void>(() => {}),
 		connectorCatalog: [
@@ -1217,7 +1241,8 @@ test("connected overview keeps connector and catalog states independent", async 
 	await page.goto("/agents/agent-smoke-1");
 	const card = page.locator('[data-overview-module="connectors"]');
 	await expect(card.getByLabel("Loading connected apps")).toBeVisible();
-	await expect(card.getByRole("link", { name: "Available app: Gmail" })).toBeVisible();
+	await expect(card.getByRole("link")).toHaveCount(1);
+	await expect(card.getByTestId("overview-connector-rail").getByRole("link")).toHaveCount(0);
 	await expect(card).not.toContainText("No apps connected");
 });
 
@@ -1234,10 +1259,10 @@ test("connected overview reports connector errors without a false empty state", 
 	await expect(card).not.toContainText("No apps connected");
 });
 
-test("connected overview preserves active count while popular apps load", async ({ page }) => {
+test("connected overview preserves active count while icon metadata loads", async ({ page }) => {
 	await stubDashboardApi(page, [], {
 		connectorConnections: [{ id: "conn-github", app_name: "github", status: "ACTIVE" }],
-		connectorCatalogGate: new Promise<void>(() => {}),
+		connectorMetadataGate: new Promise<void>(() => {}),
 		connectorCatalog: [
 			{
 				name: "github",

--- a/apps/web/src/components/connectors/connector-icon.tsx
+++ b/apps/web/src/components/connectors/connector-icon.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 const SIZES = {
-	sm: { box: "size-9", pad: "p-1", text: "text-sm", radius: "rounded-lg" },
+	sm: { box: "size-6", pad: "p-0.5", text: "text-xs", radius: "rounded-md" },
 	md: { box: "size-10", pad: "p-1.5", text: "text-base", radius: "rounded-lg" },
 	lg: { box: "size-14", pad: "p-2", text: "text-2xl", radius: "rounded-xl" },
 } as const;

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
+	OverviewIdentityIconItem,
 	OverviewMetadata,
 	OverviewResourceDetails,
 } from "@/components/dashboard/agent-overview-capabilities";
@@ -44,6 +45,17 @@ describe("overview resource details", () => {
 		const empty = renderToStaticMarkup(createElement(OverviewResourceDetails, { items: [] }));
 
 		expect(empty).not.toContain('data-testid="overview-resource-badges"');
+	});
+});
+
+describe("overview identity rail item", () => {
+	test("renders content without a connected adornment", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewIdentityIconItem, null, createElement("span", null, "GitHub")),
+		);
+
+		expect(markup).toBe('<li class="w-fit"><span>GitHub</span></li>');
+		expect(markup).not.toContain("circle-check");
 	});
 });
 

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, CircleCheck, type LucideIcon, RefreshCw } from "lucide-react";
+import { ArrowRight, type LucideIcon, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
 import { IconChip } from "@/components/icon-chip";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +18,8 @@ export type AgentOverviewModuleContent = {
 	description: ReactNode;
 	body?: ReactNode;
 };
+
+export const OVERVIEW_IDENTITY_RAIL_LIMIT = 4;
 
 export function AgentOverviewStatusCard({
 	agentId,
@@ -177,23 +179,8 @@ export function OverviewIdentityIconRail({
 	);
 }
 
-export function OverviewIdentityIconItem({
-	connected = false,
-	children,
-}: {
-	connected?: boolean;
-	children: ReactNode;
-}) {
-	return (
-		<li className="relative w-fit">
-			{children}
-			{connected ? (
-				<span className="pointer-events-none absolute -right-1 -bottom-1 rounded-full bg-background text-primary">
-					<CircleCheck className="size-4 fill-background" aria-hidden="true" />
-				</span>
-			) : null}
-		</li>
-	);
+export function OverviewIdentityIconItem({ children }: { children: ReactNode }) {
+	return <li className="w-fit">{children}</li>;
 }
 
 export function AgentOverviewCapabilities({
@@ -238,7 +225,7 @@ export function AgentOverviewCapabilities({
 									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className="h-full min-h-32 min-w-0 gap-0 py-0"
+									className="h-full min-h-28 min-w-0 gap-0 py-0"
 								>
 									<CardHeader className="p-0">
 										<Link

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -6,6 +6,7 @@ import { RefreshCw } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import {
 	type AgentOverviewModuleContent,
+	OVERVIEW_IDENTITY_RAIL_LIMIT,
 	OverviewDescriptionSkeleton,
 	OverviewIdentityIconItem,
 	OverviewIdentityIconRail,
@@ -17,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAgentProjectVaults } from "@/components/vault/agent-vaults-query";
 import { unwrap, useApi } from "@/lib/api";
-import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
+import { useConnectedAppCards } from "@/lib/connectors-data";
 
 type SummaryState = {
 	isLoading: boolean;
@@ -157,39 +158,24 @@ export function useOverviewConnectorsModule({
 }: {
 	enabled?: boolean;
 } = {}): AgentOverviewModuleContent {
-	const catalog = useAvailableApps({ page: 1, pageSize: 8, enabled });
-	const connected = useConnectedAppCards(
-		{
-			apps: catalog.data?.items,
-			isLoading: catalog.isLoading,
-			error: catalog.error,
-		},
-		{ enabled },
-	);
+	const connected = useConnectedAppCards(undefined, {
+		enabled,
+		limit: OVERVIEW_IDENTITY_RAIL_LIMIT,
+	});
 	const connectedNames = new Set(
 		connected.activeConnections.flatMap((connection) =>
 			connection.app_name ? [connection.app_name] : [],
 		),
 	);
 	const connectedAppCount = connectedNames.size;
-	const connectedApps = connected.data.slice(0, 5).map((app) => ({ app, connected: true }));
-	const connectionsResolved = !connected.connectionsLoading && !connected.connectionsError;
-	const popularApps = (catalog.data?.items ?? [])
-		.filter((app) => !connectedNames.has(app.name))
-		.slice(0, Math.max(0, 5 - connectedApps.length))
-		.map((app) => ({ app, state: connectionsResolved ? "suggested" : "available" }) as const);
-	const apps = [
-		...connectedApps.map(({ app }) => ({ app, state: "connected" }) as const),
-		...popularApps,
-	];
+	const apps = connected.data;
 	const connectionsUnavailable = Boolean(connected.connectionsError);
-	const catalogUnavailable = Boolean(catalog.error);
-	const allUnavailable = connectionsUnavailable && catalogUnavailable && apps.length === 0;
+	const allUnavailable = connectionsUnavailable && apps.length === 0;
 	const loadingSlots = Math.max(
 		0,
 		Math.min(
-			5 - apps.length,
-			connected.connectionsLoading || connected.metadataLoading || catalog.isLoading ? 3 : 0,
+			OVERVIEW_IDENTITY_RAIL_LIMIT - apps.length,
+			connected.connectionsLoading || connected.metadataLoading ? 3 : 0,
 		),
 	);
 	const description = connected.connectionsLoading ? (
@@ -201,16 +187,17 @@ export function useOverviewConnectorsModule({
 	) : (
 		"No apps connected"
 	);
+	const hasBody =
+		allUnavailable || apps.length > 0 || loadingSlots > 0 || Boolean(connected.metadataError);
 	return {
 		description,
-		body: (
+		body: hasBody ? (
 			<div className="space-y-3">
 				{allUnavailable ? (
 					<OverviewModuleError
 						label="Apps"
 						onRetry={() => {
 							connected.refetch();
-							void catalog.refetch();
 						}}
 					/>
 				) : apps.length || loadingSlots ? (
@@ -226,14 +213,8 @@ export function useOverviewConnectorsModule({
 						onRetry={connected.refetch}
 					/>
 				) : null}
-				{!allUnavailable && catalogUnavailable ? (
-					<ConnectorRetry
-						label="Can’t load suggested apps"
-						onRetry={() => void catalog.refetch()}
-					/>
-				) : null}
 			</div>
-		),
+		) : undefined,
 	};
 }
 
@@ -253,21 +234,18 @@ function ConnectorRail({
 	apps,
 	loadingSlots,
 }: {
-	apps: readonly {
-		app: { name: string; display_name: string; logo: string };
-		state: "connected" | "suggested" | "available";
-	}[];
+	apps: readonly { name: string; display_name: string; logo: string }[];
 	loadingSlots: number;
 }) {
 	return (
 		<OverviewIdentityIconRail label="Connector apps" testId="overview-connector-rail">
-			{apps.map(({ app, state }) => (
-				<OverviewIdentityIconItem key={app.name} connected={state === "connected"}>
+			{apps.map((app) => (
+				<OverviewIdentityIconItem key={app.name}>
 					<Link
 						to="/connectors/$name"
 						params={{ name: app.name }}
-						aria-label={`${state[0]?.toUpperCase()}${state.slice(1)} app: ${app.display_name}`}
-						title={`${app.display_name}${state === "connected" ? " (connected)" : ""}`}
+						aria-label={`Connected app: ${app.display_name}`}
+						title={`${app.display_name} (connected)`}
 						className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 					>
 						<ConnectorIcon name={app.display_name} logo={app.logo} size="sm" />
@@ -276,7 +254,7 @@ function ConnectorRail({
 			))}
 			{Array.from({ length: loadingSlots }).map((_, index) => (
 				<li key={index}>
-					<Skeleton className="size-9 rounded-lg" aria-label="Loading app" />
+					<Skeleton className="size-6 rounded-md" aria-label="Loading app" />
 				</li>
 			))}
 		</OverviewIdentityIconRail>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -35,6 +35,7 @@ import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
+	OVERVIEW_IDENTITY_RAIL_LIMIT,
 	OverviewDescriptionSkeleton,
 	OverviewIdentityIconItem,
 	OverviewIdentityIconRail,
@@ -1165,8 +1166,12 @@ function OverviewTab({
 	);
 	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
 	const linkedChannelCount = channelLinks.data?.length ?? 0;
-	const linkedChannels = (channelLinks.data ?? []).flatMap((link) =>
-		link.account ? [link.account] : [],
+	const linkedChannels = Array.from(
+		new Map(
+			(channelLinks.data ?? []).flatMap((link) =>
+				link.account ? [[link.account.id, link.account] as const] : [],
+			),
+		).values(),
 	);
 	const projectionLoading = projectionStatus === "loading";
 	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
@@ -1331,10 +1336,10 @@ function OverviewTab({
 						) : linkedChannels.length > 0 ? (
 							<div data-overview-tool-summary="channels">
 								<OverviewIdentityIconRail label="Connected channels" testId="overview-channel-rail">
-									{linkedChannels.slice(0, 5).map((channel) => {
+									{linkedChannels.slice(0, OVERVIEW_IDENTITY_RAIL_LIMIT).map((channel) => {
 										const provider = providerMeta(channel.provider).label;
 										return (
-											<OverviewIdentityIconItem key={channel.id} connected>
+											<OverviewIdentityIconItem key={channel.id}>
 												<Link
 													to="/channels/$id"
 													params={{ id: channel.id }}
@@ -1342,7 +1347,7 @@ function OverviewTab({
 													title={`${provider}: ${channel.name} (connected)`}
 													className="block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 												>
-													<ProviderChip provider={channel.provider} size="md" className="size-9" />
+													<ProviderChip provider={channel.provider} size="sm" />
 												</Link>
 											</OverviewIdentityIconItem>
 										);

--- a/apps/web/src/lib/connectors-data.test.ts
+++ b/apps/web/src/lib/connectors-data.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { type ConnectorAvailableApp, resolveConnectedAppMetadataPlan } from "./connectors-data";
+import {
+	type ConnectorAvailableApp,
+	limitConnectedAppMetadataNames,
+	resolveConnectedAppMetadataPlan,
+} from "./connectors-data";
 
 function catalogApp(name: string): ConnectorAvailableApp {
 	return {
@@ -14,6 +18,19 @@ function catalogApp(name: string): ConnectorAvailableApp {
 }
 
 describe("connected app metadata planning", () => {
+	it("limits Overview metadata lookups without changing the full stable app order", () => {
+		const names = ["github", "slack", "gmail", "notion", "linear"];
+
+		expect(limitConnectedAppMetadataNames(names, 4)).toEqual([
+			"github",
+			"slack",
+			"gmail",
+			"notion",
+		]);
+		expect(limitConnectedAppMetadataNames(names)).toBe(names);
+		expect(limitConnectedAppMetadataNames(names, 0)).toEqual([]);
+	});
+
 	it("uses catalog metadata and only requests active apps missing from the catalog", () => {
 		const github = catalogApp("github");
 		const plan = resolveConnectedAppMetadataPlan(["github", "slack"], {

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -38,6 +38,13 @@ type ConnectedAppMetadataPlan = {
 	missingNames: string[];
 };
 
+export function limitConnectedAppMetadataNames(
+	names: readonly string[],
+	limit?: number,
+): readonly string[] {
+	return limit === undefined ? names : names.slice(0, Math.max(0, limit));
+}
+
 export function resolveConnectedAppMetadataPlan(
 	names: readonly string[],
 	catalog?: ConnectedAppCatalogSnapshot,
@@ -209,12 +216,13 @@ export function useDisconnect() {
  * searching.
  *
  * Fan-out: one `/available/{name}` query per unique active app not
- * covered by a supplied catalog snapshot. Other callers keep the
- * existing detail-query behavior when no snapshot is supplied.
+ * covered by a supplied catalog snapshot. Callers can cap metadata
+ * resolution for compact previews without changing the full connection
+ * count; the default preserves the existing unbounded behavior.
  */
 export function useConnectedAppCards(
 	catalog?: ConnectedAppCatalogSnapshot,
-	{ enabled = true }: { enabled?: boolean } = {},
+	{ enabled = true, limit }: { enabled?: boolean; limit?: number } = {},
 ) {
 	const connectionsQ = useConnections({ enabled });
 	const api = useOpenApi();
@@ -235,9 +243,10 @@ export function useConnectedAppCards(
 		() => Array.from(new Set(activeConnections.flatMap((c) => (c.app_name ? [c.app_name] : [])))),
 		[activeConnections],
 	);
+	const metadataNames = useMemo(() => limitConnectedAppMetadataNames(names, limit), [names, limit]);
 	const metadataPlan = useMemo(
-		() => resolveConnectedAppMetadataPlan(names, catalog),
-		[names, catalog?.apps, catalog?.error, catalog?.isLoading],
+		() => resolveConnectedAppMetadataPlan(metadataNames, catalog),
+		[metadataNames, catalog?.apps, catalog?.error, catalog?.isLoading],
 	);
 
 	const lookup = useQueries({
@@ -252,12 +261,14 @@ export function useConnectedAppCards(
 		for (const query of lookup) {
 			if (query.data) byName.set(query.data.name, query.data);
 		}
-		return names.flatMap((name) => {
+		return metadataNames.flatMap((name) => {
 			const app = byName.get(name);
 			return app ? [app] : [];
 		});
-	}, [lookup, metadataPlan.catalogApps, names]);
-	const waitingForCatalog = Boolean(catalog?.isLoading && !catalog.apps && names.length > 0);
+	}, [lookup, metadataPlan.catalogApps, metadataNames]);
+	const waitingForCatalog = Boolean(
+		catalog?.isLoading && !catalog.apps && metadataNames.length > 0,
+	);
 	const isLoading = connectionsQ.isLoading || waitingForCatalog || lookup.some((q) => q.isLoading);
 	const connectionsLoading = connectionsQ.isLoading;
 	const metadataLoading = waitingForCatalog || lookup.some((q) => q.isLoading);


### PR DESCRIPTION
## Summary
- reduce Agent Overview Resources and Tools cards from 128px to a shared 112px standard height
- show only the first four connected connectors and channels, with no suggested catalog fillers or connected adornments
- align both identity rails on the existing 24px small icon geometry
- remove the Overview connector catalog request and cap detail metadata lookup to the four visible apps

## Verification
- Docker full Web tests, typecheck, and OSS production build
- focused unit tests: 11 passed
- Connected mocked Playwright: 4 passed
- Hosted Overview and Channels state/limit Playwright
- desktop/dark/mobile visual review
- Biome and git diff --check