### PR TITLE
fix(channels): harden Telegram and Discord protocol delivery

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2522,6 +2522,7 @@ function ChannelsTab({
 				agent_id: data.agent_id,
 				status: data.status,
 				created_at: data.created_at,
+				binding_count: 0,
 			});
 			return true;
 		} catch (error) {
@@ -2670,6 +2671,7 @@ function ChannelsTab({
 							agent_id: environmentId,
 							status: "active",
 							created_at: new Date().toISOString(),
+							binding_count: 0,
 						}),
 					);
 					if (bot.provider === "telegram") {

--- a/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-bindings.logic.test.ts
@@ -18,6 +18,7 @@ function link(id: string, status = "active"): AgentChannelLink {
 		agent_id: "55555555-5555-4555-8555-555555555555",
 		status,
 		created_at: "2026-07-31T00:00:00Z",
+		binding_count: 0,
 	};
 }
 

--- a/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
@@ -52,6 +52,7 @@ function link(
 		status: "active",
 		created_at: createdAt,
 		...overrides,
+		binding_count: overrides.binding_count ?? 0,
 	};
 }
 

--- a/apps/web/src/hosted/v2/channels/channel-edit-client.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-edit-client.logic.ts
@@ -1,0 +1,16 @@
+import type { components } from "@clawdi/shared/api";
+
+type GeneratedAgentChannelLink = components["schemas"]["ChannelAgentLinkWithAccountResponse"];
+type AgentChannelLinkPayload = Omit<GeneratedAgentChannelLink, "binding_count"> & {
+	binding_count?: number;
+};
+
+export type AgentChannelLink = Omit<GeneratedAgentChannelLink, "account"> & {
+	account?: components["schemas"]["ChannelAccountResponse"] | null;
+};
+
+export function normalizeAgentChannelLinks(
+	links: readonly AgentChannelLinkPayload[],
+): AgentChannelLink[] {
+	return links.map((link) => ({ ...link, binding_count: link.binding_count ?? 0 }));
+}

--- a/apps/web/src/hosted/v2/channels/channel-edit-client.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-edit-client.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeAgentChannelLinks } from "./channel-edit-client.logic";
+
+const account = {
+	id: "11111111-1111-4111-8111-111111111111",
+	provider: "telegram",
+	name: "Telegram bot",
+	status: "active",
+	visibility: "private" as const,
+	has_provider_token: true,
+	webhook_url: "https://example.test/telegram",
+	created_at: "2026-08-01T00:00:00Z",
+};
+
+function link(bindingCount?: number) {
+	return {
+		id: "22222222-2222-4222-8222-222222222222",
+		account_id: account.id,
+		agent_id: "33333333-3333-4333-8333-333333333333",
+		status: "active",
+		created_at: "2026-08-01T00:00:00Z",
+		account,
+		...(bindingCount === undefined ? {} : { binding_count: bindingCount }),
+	};
+}
+
+describe("agent channel link response normalization", () => {
+	test("defaults a missing binding count during an independent backend rollout", () => {
+		expect(normalizeAgentChannelLinks([link()])[0]?.binding_count).toBe(0);
+	});
+
+	test("preserves the backend aggregate when present", () => {
+		expect(normalizeAgentChannelLinks([link(3)])[0]?.binding_count).toBe(3);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-edit-client.ts
+++ b/apps/web/src/hosted/v2/channels/channel-edit-client.ts
@@ -1,14 +1,10 @@
 "use client";
 
-import type { components } from "@clawdi/shared/api";
 import { useMemo } from "react";
 import { unwrap, useApi } from "@/lib/api";
+import { normalizeAgentChannelLinks } from "./channel-edit-client.logic";
 
-type GeneratedAgentChannelLink = components["schemas"]["ChannelAgentLinkWithAccountResponse"];
-
-export type AgentChannelLink = Omit<GeneratedAgentChannelLink, "account"> & {
-	account?: components["schemas"]["ChannelAccountResponse"] | null;
-};
+export type { AgentChannelLink } from "./channel-edit-client.logic";
 
 /**
  * Small facade over the generated cloud-api client for agent-link edit routes.
@@ -21,10 +17,12 @@ export function useChannelEditApi() {
 		return {
 			/** GET /api/channels/agent-links?agent_id={id} — links for one agent. */
 			listAgentLinks: async (agentId: string) =>
-				unwrap(
-					await api.GET("/v1/channels/agent-links", {
-						params: { query: { agent_id: agentId } },
-					}),
+				normalizeAgentChannelLinks(
+					unwrap(
+						await api.GET("/v1/channels/agent-links", {
+							params: { query: { agent_id: agentId } },
+						}),
+					),
 				),
 			/** DELETE /api/channels/{accountId}/agent-links/{linkId} — unlink. */
 			unlinkAgent: async (accountId: string, linkId: string) =>

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -4,7 +4,11 @@ import asyncio
 import json
 import logging
 import secrets
+import threading
 import zlib
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email import policy
@@ -28,7 +32,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -72,6 +76,7 @@ from app.services.channels import (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
     ChannelAgentContext,
+    ack_discord_gateway_messages,
     channel_runtime_account_key,
     channel_runtime_placeholder_token,
     dequeue_discord_gateway_events,
@@ -107,7 +112,8 @@ log = logging.getLogger(__name__)
 
 _DISCORD_GATEWAY_RESUME_BUFFER_SIZE = 100
 _DISCORD_GATEWAY_MAX_CHANNELS = 256
-_DISCORD_GATEWAY_SESSIONS: dict[str, dict[str, Any]] = {}
+_DISCORD_GATEWAY_MAX_SESSIONS = 256
+_DISCORD_GATEWAY_SESSION_TTL_SECONDS = 5 * 60.0
 _DISCORD_GATEWAY_CAPABILITY_SUBJECT = "clawdi_discord_gateway"
 _DISCORD_GATEWAY_CAPABILITY_AUDIENCE = "clawdi_discord_gateway"
 
@@ -129,6 +135,139 @@ class _DiscordChannelAuthorization:
 class _DiscordMessageReferenceIdentity:
     guild_id: str | None
     channel_id: str | None
+
+
+@dataclass
+class _DiscordGatewaySessionEntry:
+    state: dict[str, Any]
+    touched_at: float
+    connection_count: int
+
+
+class _DiscordGatewaySessionStore:
+    """Process-local Resume optimization with a bounded disconnected cache."""
+
+    def __init__(
+        self,
+        *,
+        max_sessions: int,
+        ttl_seconds: float,
+        now: Callable[[], float] = monotonic,
+    ) -> None:
+        if max_sessions <= 0 or ttl_seconds <= 0:
+            raise ValueError("discord gateway session bounds must be positive")
+        self._max_sessions = max_sessions
+        self._ttl_seconds = ttl_seconds
+        self._now = now
+        self._entries: OrderedDict[str, _DiscordGatewaySessionEntry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def put(self, session_id: str, state: dict[str, Any]) -> None:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            self._entries[session_id] = _DiscordGatewaySessionEntry(
+                state=state,
+                touched_at=now,
+                connection_count=1,
+            )
+            self._entries.move_to_end(session_id)
+
+    def connect(self, session_id: str) -> dict[str, Any] | None:
+        """Claim a disconnected Resume session for one live connection."""
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            entry = self._entries.get(session_id)
+            if entry is None:
+                return None
+            entry.connection_count += 1
+            entry.touched_at = now
+            self._entries.move_to_end(session_id)
+            return entry.state
+
+    def disconnect(self, session_id: str) -> None:
+        now = self._now()
+        with self._lock:
+            entry = self._entries.get(session_id)
+            if entry is None:
+                return
+            entry.connection_count = max(0, entry.connection_count - 1)
+            if entry.connection_count:
+                return
+            entry.touched_at = now
+            self._entries.move_to_end(session_id)
+            self._prune(now)
+            self._enforce_bound()
+
+    def get(self, session_id: str) -> dict[str, Any] | None:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            entry = self._entries.get(session_id)
+            if entry is None:
+                return None
+            entry.touched_at = now
+            self._entries.move_to_end(session_id)
+            return entry.state
+
+    def touch(self, session_id: str) -> bool:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            entry = self._entries.get(session_id)
+            if entry is None:
+                return False
+            entry.touched_at = now
+            self._entries.move_to_end(session_id)
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def discard(self, session_id: str) -> None:
+        with self._lock:
+            self._entries.pop(session_id, None)
+
+    def __len__(self) -> int:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            return len(self._entries)
+
+    def session_ids(self) -> tuple[str, ...]:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            return tuple(self._entries)
+
+    def _prune(self, now: float) -> None:
+        expired = [
+            session_id
+            for session_id, entry in self._entries.items()
+            if entry.connection_count == 0 and entry.touched_at + self._ttl_seconds <= now
+        ]
+        for session_id in expired:
+            self._entries.pop(session_id, None)
+
+    def _enforce_bound(self) -> None:
+        disconnected = sum(entry.connection_count == 0 for entry in self._entries.values())
+        if disconnected <= self._max_sessions:
+            return
+        for session_id, entry in tuple(self._entries.items()):
+            if entry.connection_count:
+                continue
+            self._entries.pop(session_id, None)
+            disconnected -= 1
+            if disconnected <= self._max_sessions:
+                break
+
+
+_DISCORD_GATEWAY_SESSIONS = _DiscordGatewaySessionStore(
+    max_sessions=_DISCORD_GATEWAY_MAX_SESSIONS,
+    ttl_seconds=_DISCORD_GATEWAY_SESSION_TTL_SECONDS,
+)
 
 
 class _DiscordCreateMessageParseError(ValueError):
@@ -718,8 +857,29 @@ async def discord_agent_gateway(
     projected_guilds: set[str] = set()
     projected_channels: dict[str, dict[str, Any]] = {}
     deferred_channels: dict[str, float] = {}
+    consumer_lease: AbstractAsyncContextManager[bool] | None = None
+    consumer_lease_entered = False
+    owns_session_entry = False
 
-    async def send_gateway_frame(payload: dict[str, Any], *, record: bool = True) -> None:
+    async def send_gateway_frame(
+        payload: dict[str, Any],
+        *,
+        record: bool = True,
+        message_checkpoint: tuple[UUID, int] | None = None,
+    ) -> None:
+        if session_state is not None and payload.get("op") == 0:
+            session_state["last_sequence"] = payload["s"]
+            if record:
+                frames = session_state.setdefault("frames", [])
+                frames.append(payload)
+                if message_checkpoint is not None:
+                    checkpoints = session_state.get("message_checkpoints")
+                    if isinstance(checkpoints, OrderedDict):
+                        checkpoints[payload["s"]] = message_checkpoint
+                if len(frames) > _DISCORD_GATEWAY_RESUME_BUFFER_SIZE:
+                    dropped = frames[:-_DISCORD_GATEWAY_RESUME_BUFFER_SIZE]
+                    del frames[:-_DISCORD_GATEWAY_RESUME_BUFFER_SIZE]
+                    session_state["dropped_through_sequence"] = dropped[-1]["s"]
         if compressor is None:
             await websocket.send_json(payload)
         else:
@@ -727,27 +887,63 @@ async def discord_agent_gateway(
             await websocket.send_bytes(
                 compressor.compress(raw) + compressor.flush(zlib.Z_SYNC_FLUSH)
             )
-        if record and session_state is not None and payload.get("op") == 0:
-            frames = session_state.setdefault("frames", [])
-            frames.append(payload)
-            if len(frames) > _DISCORD_GATEWAY_RESUME_BUFFER_SIZE:
-                del frames[:-_DISCORD_GATEWAY_RESUME_BUFFER_SIZE]
-                session_state["dropped_before_sequence"] = frames[0]["s"]
+        if session_state is not None:
+            _DISCORD_GATEWAY_SESSIONS.touch(session_id)
 
     async def send_dispatch(
         event_type: str,
         data: dict[str, Any],
         *,
         record: bool = True,
-    ) -> None:
+        message_checkpoint: tuple[UUID, int] | None = None,
+    ) -> int:
         nonlocal gateway_sequence
         gateway_sequence += 1
         await send_gateway_frame(
             {"op": 0, "t": event_type, "s": gateway_sequence, "d": data},
             record=record,
+            message_checkpoint=message_checkpoint,
         )
-        if session_state is not None:
-            session_state["last_sequence"] = gateway_sequence
+        return gateway_sequence
+
+    async def acknowledge_gateway_sequence(sequence: int | None) -> None:
+        if (
+            sequence is None
+            or sequence < 0
+            or session_state is None
+            or account is None
+            or bot_agent_link_id is None
+        ):
+            return
+        last_sequence = session_state.get("last_sequence", 0)
+        if not isinstance(last_sequence, int) or sequence > last_sequence:
+            return
+        checkpoints = session_state.get("message_checkpoints")
+        if not isinstance(checkpoints, OrderedDict):
+            return
+        acknowledged_sequences = [
+            gateway_sequence for gateway_sequence in checkpoints if gateway_sequence <= sequence
+        ]
+        message_ids = [
+            checkpoint[0]
+            for gateway_sequence in acknowledged_sequences
+            if (
+                isinstance((checkpoint := checkpoints.get(gateway_sequence)), tuple)
+                and len(checkpoint) == 2
+                and isinstance(checkpoint[0], UUID)
+            )
+        ]
+        if message_ids:
+            async with async_session_factory() as db:
+                await ack_discord_gateway_messages(
+                    db,
+                    account_id=account.id,
+                    bot_agent_link_id=bot_agent_link_id,
+                    message_ids=message_ids,
+                )
+                await db.commit()
+        for gateway_sequence in acknowledged_sequences:
+            checkpoints.pop(gateway_sequence, None)
 
     async def send_guild(guild_id: str, guild_name: str) -> None:
         payload = _discord_guild_create_payload(
@@ -847,13 +1043,32 @@ async def discord_agent_gateway(
                 if resume_session_id is None:
                     await send_gateway_frame({"op": 9, "d": False}, record=False)
                     continue
-                resume_state = _DISCORD_GATEWAY_SESSIONS.get(resume_session_id)
-                if resume_state is None or (
+                resume_state = _DISCORD_GATEWAY_SESSIONS.connect(resume_session_id)
+                if resume_state is None:
+                    await send_gateway_frame({"op": 9, "d": False}, record=False)
+                    continue
+                if (
                     resume_state.get("account_id") != resolved_account.id
                     or resume_state.get("bot_agent_link_id") != resolved_link_id
                 ):
+                    _DISCORD_GATEWAY_SESSIONS.disconnect(resume_session_id)
                     await send_gateway_frame({"op": 9, "d": False}, record=False)
                     continue
+                owns_session_entry = True
+                consumer_lease = _discord_gateway_consumer_lease(
+                    account_id=resolved_account.id,
+                    bot_agent_link_id=resolved_link_id,
+                )
+                lease_acquired = await consumer_lease.__aenter__()
+                consumer_lease_entered = True
+                if not lease_acquired:
+                    await consumer_lease.__aexit__(None, None, None)
+                    consumer_lease = None
+                    consumer_lease_entered = False
+                    _DISCORD_GATEWAY_SESSIONS.disconnect(resume_session_id)
+                    owns_session_entry = False
+                    await websocket.close(code=4008)
+                    return
                 account = resolved_account
                 bot_agent_link_id = resolved_link_id
                 session_id = resume_session_id
@@ -868,29 +1083,73 @@ async def discord_agent_gateway(
                     max((retained["s"] for retained in frames), default=0),
                     session_state.get("last_sequence", 0),
                 )
-                dropped_before_sequence = session_state.get("dropped_before_sequence")
+                dropped_through_sequence = session_state.get("dropped_through_sequence")
                 if (
                     resume_sequence is None
                     or resume_sequence < 0
                     or resume_sequence > latest_sequence
-                    or not any(retained.get("t") == "READY" for retained in frames)
+                    or session_state.get("identified") is not True
                     or (
-                        isinstance(dropped_before_sequence, int)
-                        and resume_sequence < dropped_before_sequence
+                        isinstance(dropped_through_sequence, int)
+                        and resume_sequence < dropped_through_sequence
                     )
                 ):
                     await send_gateway_frame({"op": 9, "d": False}, record=False)
+                    _DISCORD_GATEWAY_SESSIONS.discard(session_id)
+                    await consumer_lease.__aexit__(None, None, None)
+                    consumer_lease = None
+                    consumer_lease_entered = False
                     account = None
                     bot_agent_link_id = None
                     session_state = None
+                    owns_session_entry = False
+                    session_id = secrets.token_urlsafe(18)
                     continue
+                await acknowledge_gateway_sequence(resume_sequence)
                 gateway_sequence = latest_sequence
+                stored_inbox_sequence = session_state.get("last_inbox_sequence", 0)
+                last_inbox_sequence = (
+                    stored_inbox_sequence if isinstance(stored_inbox_sequence, int) else 0
+                )
+                remaining_checkpoints = session_state.get("message_checkpoints")
+                if isinstance(remaining_checkpoints, OrderedDict):
+                    last_inbox_sequence = max(
+                        (
+                            last_inbox_sequence,
+                            *(
+                                checkpoint[1]
+                                for checkpoint in remaining_checkpoints.values()
+                                if (
+                                    isinstance(checkpoint, tuple)
+                                    and len(checkpoint) == 2
+                                    and isinstance(checkpoint[1], int)
+                                )
+                            ),
+                        )
+                    )
+                stored_guilds = session_state.get("projected_guilds")
+                if isinstance(stored_guilds, set):
+                    projected_guilds.update(
+                        guild_id for guild_id in stored_guilds if isinstance(guild_id, str)
+                    )
+                stored_channels = session_state.get("projected_channels")
+                if isinstance(stored_channels, dict):
+                    projected_channels.update(
+                        {
+                            channel_id: dict(channel)
+                            for channel_id, channel in stored_channels.items()
+                            if isinstance(channel_id, str) and isinstance(channel, dict)
+                        }
+                    )
                 async with async_session_factory() as db:
                     resume_guilds, resume_channels = await _discord_gateway_authority(
                         db,
                         account=account,
                         bot_agent_link_id=bot_agent_link_id,
                     )
+                projected_guilds.intersection_update(resume_guilds)
+                for projected_channel_id in set(projected_channels) - set(resume_channels):
+                    projected_channels.pop(projected_channel_id, None)
                 for retained in frames:
                     event_type = retained.get("t")
                     event_data = retained.get("d")
@@ -932,16 +1191,37 @@ async def discord_agent_gateway(
                     if replayed["s"] <= resume_sequence:
                         continue
                     await send_gateway_frame(replayed, record=False)
+                session_state["projected_guilds"] = projected_guilds
+                session_state["projected_channels"] = projected_channels
                 await send_dispatch("RESUMED", {}, record=False)
             else:
+                consumer_lease = _discord_gateway_consumer_lease(
+                    account_id=resolved_account.id,
+                    bot_agent_link_id=resolved_link_id,
+                )
+                lease_acquired = await consumer_lease.__aenter__()
+                consumer_lease_entered = True
+                if not lease_acquired:
+                    await consumer_lease.__aexit__(None, None, None)
+                    consumer_lease = None
+                    consumer_lease_entered = False
+                    await websocket.close(code=4008)
+                    return
                 account = resolved_account
                 bot_agent_link_id = resolved_link_id
+                owns_session_entry = True
+                last_inbox_sequence = 0
                 session_state = {
                     "account_id": account.id,
                     "bot_agent_link_id": bot_agent_link_id,
                     "frames": [],
+                    "identified": True,
+                    "projected_guilds": projected_guilds,
+                    "projected_channels": projected_channels,
+                    "message_checkpoints": OrderedDict(),
+                    "last_inbox_sequence": 0,
                 }
-                _DISCORD_GATEWAY_SESSIONS[session_id] = session_state
+                _DISCORD_GATEWAY_SESSIONS.put(session_id, session_state)
                 async with async_session_factory() as db:
                     guilds, channels = await _discord_gateway_authority(
                         db,
@@ -1000,14 +1280,20 @@ async def discord_agent_gateway(
         active_link_id = bot_agent_link_id
 
         while True:
-            async with async_session_factory() as db:
-                events = await dequeue_discord_gateway_events(
-                    db,
-                    account=account,
-                    bot_agent_link_id=active_link_id,
-                    after_sequence=last_inbox_sequence,
-                    limit=100,
-                )
+            checkpoints = (
+                session_state.get("message_checkpoints") if session_state is not None else None
+            )
+            checkpoint_count = len(checkpoints) if isinstance(checkpoints, OrderedDict) else 0
+            events: list[ChannelMessage] = []
+            if checkpoint_count < _DISCORD_GATEWAY_RESUME_BUFFER_SIZE:
+                async with async_session_factory() as db:
+                    events = await dequeue_discord_gateway_events(
+                        db,
+                        account=account,
+                        bot_agent_link_id=active_link_id,
+                        after_sequence=last_inbox_sequence,
+                        limit=_DISCORD_GATEWAY_RESUME_BUFFER_SIZE - checkpoint_count,
+                    )
             if events:
                 for message in events:
                     payload = _discord_gateway_dispatch(message)
@@ -1097,7 +1383,7 @@ async def discord_agent_gateway(
                             if projected is not None:
                                 deferred_channels.pop(channel_id, None)
 
-                    async def send_message() -> None:
+                    async def send_message() -> int:
                         if guild_id is not None and guild_id not in projected_guilds:
                             await send_guild(guild_id, guilds[guild_id])
                         if channel_id is not None and projected is not None:
@@ -1106,9 +1392,17 @@ async def discord_agent_gateway(
                             projected_channels[channel_id] = projected
                         data = payload.get("d")
                         if event_type is not None and isinstance(data, dict):
-                            await send_dispatch(event_type, data)
+                            return await send_dispatch(
+                                event_type,
+                                data,
+                                message_checkpoint=(
+                                    message.id,
+                                    int(message.inbox_sequence),
+                                ),
+                            )
+                        raise RuntimeError("discord gateway message has no dispatch payload")
 
-                    sent = await _send_discord_gateway_message(
+                    sent, _dispatched_sequence = await _send_discord_gateway_message(
                         account_id=account.id,
                         bot_agent_link_id=active_link_id,
                         message=message,
@@ -1119,6 +1413,8 @@ async def discord_agent_gateway(
                         ),
                     )
                     last_inbox_sequence = int(message.inbox_sequence)
+                    if session_state is not None:
+                        session_state["last_inbox_sequence"] = last_inbox_sequence
                     if sent == "sent" and lifecycle and channel_id is not None:
                         data = payload.get("d")
                         if event_type in {"CHANNEL_DELETE", "THREAD_DELETE"}:
@@ -1142,11 +1438,17 @@ async def discord_agent_gateway(
                     timeout=max(0.001, settings.discord_gateway_poll_interval_seconds),
                 )
                 if isinstance(frame, dict) and frame.get("op") == 1:
+                    await acknowledge_gateway_sequence(_optional_int_param(frame.get("d")))
                     await send_gateway_frame({"op": 11, "d": None}, record=False)
             except TimeoutError:
                 pass
     except WebSocketDisconnect:
         return
+    finally:
+        if consumer_lease is not None and consumer_lease_entered:
+            await consumer_lease.__aexit__(None, None, None)
+        if owns_session_entry:
+            _DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
 
 
 @router.post(
@@ -1711,10 +2013,10 @@ async def _send_discord_gateway_message(
     account_id: UUID,
     bot_agent_link_id: UUID,
     message: ChannelMessage,
-    send: Any | None,
-) -> str:
+    send: Callable[[], Awaitable[int]] | None,
+) -> tuple[str, int | None]:
     if message.binding_id is None:
-        return "dropped"
+        return "dropped", None
     async with async_session_factory() as db:
         binding = await lock_active_discord_binding_lease(
             db,
@@ -1731,13 +2033,37 @@ async def _send_discord_gateway_message(
                     ChannelMessage.account_id == account_id,
                     ChannelMessage.bot_agent_link_id == bot_agent_link_id,
                 )
-                .with_for_update(of=ChannelMessage)
+                .with_for_update(of=ChannelMessage, skip_locked=True)
             )
         ).scalar_one_or_none()
         if current is None or current.delivered_at is not None:
-            return "consumed"
+            return "consumed", None
         if binding is not None and send is not None:
-            await send()
+            dispatched_sequence = await send()
+            # The downstream heartbeat/Resume sequence, not socket.send(), is
+            # the durable receipt acknowledgement for synthetic Gateway data.
+            await db.commit()
+            return "sent", dispatched_sequence
         current.delivered_at = datetime.now(UTC)
         await db.commit()
-        return "sent" if binding is not None and send is not None else "dropped"
+        return "dropped", None
+
+
+@asynccontextmanager
+async def _discord_gateway_consumer_lease(
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+):
+    """Allow one synthetic shard consumer per AgentLink across processes."""
+    lock_name = f"discord-agent-gateway:{account_id}:{bot_agent_link_id}"
+    async with async_session_factory() as db:
+        acquired = bool(
+            await db.scalar(
+                select(func.pg_try_advisory_xact_lock(func.hashtextextended(lock_name, 0)))
+            )
+        )
+        try:
+            yield acquired
+        finally:
+            await db.rollback()

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -91,7 +91,7 @@ from app.services.channel_config import (
     validate_required_discord_interactions_config,
 )
 from app.services.channel_debug_events import (
-    public_channel_debug_details,
+    public_channel_debug_details_response,
     public_channel_delivery_error,
     public_channel_operation_error,
 )
@@ -346,7 +346,7 @@ def _activity_debug_event_response(
         outcome=event.outcome,
         status_code=event.status_code,
         error=public_channel_operation_error(event.error),
-        details=public_channel_debug_details(event.details),
+        details=public_channel_debug_details_response(event.details),
         created_at=event.created_at,
         updated_at=event.updated_at,
     )
@@ -1711,7 +1711,9 @@ async def _channel_health_items(
         )
         .group_by(ChannelMessage.account_id)
     )
-    last_message_by_account = dict(message_rows.all())
+    last_message_by_account: dict[UUID, datetime] = {
+        account_id: timestamp for account_id, timestamp in message_rows.tuples().all()
+    }
 
     event_rows = await db.execute(
         select(ChannelDebugEvent.account_id, func.max(ChannelDebugEvent.created_at))
@@ -1721,7 +1723,11 @@ async def _channel_health_items(
         )
         .group_by(ChannelDebugEvent.account_id)
     )
-    last_event_by_account = dict(event_rows.all())
+    last_event_by_account: dict[UUID, datetime] = {
+        account_id: timestamp
+        for account_id, timestamp in event_rows.tuples().all()
+        if account_id is not None
+    }
 
     debug_error_ranked = (
         select(

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 from uuid import UUID
@@ -89,6 +90,11 @@ from app.services.channel_config import (
     validate_channel_account_config_urls,
     validate_required_discord_interactions_config,
 )
+from app.services.channel_debug_events import (
+    public_channel_debug_details,
+    public_channel_delivery_error,
+    public_channel_operation_error,
+)
 from app.services.channels import (
     PAIR_COMMAND,
     archive_bot_agent_link,
@@ -126,7 +132,6 @@ from app.services.channels import (
     lock_channel_binding_identity,
     mark_discord_reserved_commands_current,
     normalize_telegram_bot_username,
-    pending_channel_inbox_count,
     rearm_discord_command_reconciliation,
     rotate_bot_agent_link_token,
     store_channel_secrets,
@@ -152,19 +157,6 @@ RUNTIME_CHANNEL_PROVIDERS = (
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_WHATSAPP,
-)
-
-SECRETISH_ACTIVITY_DETAIL_KEYS = (
-    "secret",
-    "token",
-    "password",
-    "authorization",
-    "auth",
-    "api_key",
-    "apikey",
-    "key",
-    "credential",
-    "cookie",
 )
 
 
@@ -301,10 +293,13 @@ async def _runtime_credentials_response(
 def _agent_link_with_account_response(
     link: ChannelBotAgentLink,
     account: ChannelAccount,
+    *,
+    binding_count: int = 0,
 ) -> ChannelAgentLinkWithAccountResponse:
     return ChannelAgentLinkWithAccountResponse(
         **_agent_link_response(link).model_dump(),
         account=_account_response(account),
+        binding_count=binding_count,
     )
 
 
@@ -326,7 +321,9 @@ def _activity_message_response(
         delivery_attempts=delivery.attempts if delivery is not None else None,
         delivery_max_attempts=delivery.max_attempts if delivery is not None else None,
         delivery_next_attempt_at=delivery.next_attempt_at if delivery is not None else None,
-        delivery_last_error=delivery.last_error if delivery is not None else None,
+        delivery_last_error=(
+            public_channel_delivery_error(delivery.last_error) if delivery is not None else None
+        ),
         provider_message_id=message.provider_message_id,
         text=message.text,
         created_at=message.created_at,
@@ -348,8 +345,8 @@ def _activity_debug_event_response(
         stage=event.stage,
         outcome=event.outcome,
         status_code=event.status_code,
-        error=event.error,
-        details=_sanitize_activity_details(event.details),
+        error=public_channel_operation_error(event.error),
+        details=public_channel_debug_details(event.details),
         created_at=event.created_at,
         updated_at=event.updated_at,
     )
@@ -592,10 +589,11 @@ async def list_channel_health(
 ) -> ChannelHealthListResponse:
     accounts = await _health_accounts(db, user_id=auth.user_id)
     return ChannelHealthListResponse(
-        items=[
-            await _channel_health_item(db, account=account, user_id=auth.user_id)
-            for account in accounts
-        ],
+        items=await _channel_health_items(
+            db,
+            accounts=accounts,
+            user_id=auth.user_id,
+        ),
     )
 
 
@@ -732,7 +730,14 @@ async def list_agent_channel_links(
         user_id=auth.user_id,
         agent_id=agent_id,
     )
-    return [_agent_link_with_account_response(link, account) for link, account in rows]
+    return [
+        _agent_link_with_account_response(
+            link,
+            account,
+            binding_count=binding_count,
+        )
+        for link, account, binding_count in rows
+    ]
 
 
 @router.get("/{account_id}/activity")
@@ -1080,7 +1085,7 @@ async def delete_channel_agent_link(
             account_id=account.id,
             external_chat_id=binding.external_chat_id,
         )
-    await archive_bot_agent_link(db, link=link)
+    await archive_bot_agent_link(db, link=link, account=account)
     await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,
@@ -1622,54 +1627,207 @@ async def _health_accounts(
     return accounts
 
 
-async def _channel_health_item(
+async def _channel_health_items(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
+    accounts: list[ChannelAccount],
     user_id: UUID,
+) -> list[ChannelHealthItemResponse]:
+    if not accounts:
+        return []
+    account_ids = [account.id for account in accounts]
+
+    pending_inbox_rows = await db.execute(
+        select(
+            ChannelMessage.account_id,
+            func.count(ChannelMessage.id),
+            func.min(ChannelMessage.created_at),
+        )
+        .join(
+            ChannelBinding,
+            and_(
+                ChannelBinding.id == ChannelMessage.binding_id,
+                ChannelBinding.account_id == ChannelMessage.account_id,
+                ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                ChannelBinding.user_id == ChannelMessage.user_id,
+            ),
+        )
+        .join(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
+                ChannelBotAgentLink.account_id == ChannelMessage.account_id,
+            ),
+        )
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+        .where(
+            ChannelMessage.account_id.in_(account_ids),
+            ChannelMessage.user_id == user_id,
+            ChannelMessage.direction == "inbound",
+            ChannelMessage.binding_id.is_not(None),
+            ChannelMessage.delivered_at.is_(None),
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+        )
+        .group_by(ChannelMessage.account_id)
+    )
+    pending_inbox_by_account = {
+        account_id: (int(count), oldest_pending_at)
+        for account_id, count, oldest_pending_at in pending_inbox_rows.all()
+    }
+
+    delivery_rows = await db.execute(
+        select(
+            ChannelDelivery.account_id,
+            func.count(ChannelDelivery.id)
+            .filter(ChannelDelivery.status == DELIVERY_STATUS_PENDING)
+            .label("pending_count"),
+            func.count(ChannelDelivery.id)
+            .filter(ChannelDelivery.status == DELIVERY_STATUS_IN_PROGRESS)
+            .label("in_progress_count"),
+            func.count(ChannelDelivery.id)
+            .filter(ChannelDelivery.status == DELIVERY_STATUS_FAILED)
+            .label("failed_count"),
+        )
+        .where(
+            ChannelDelivery.account_id.in_(account_ids),
+            ChannelDelivery.user_id == user_id,
+        )
+        .group_by(ChannelDelivery.account_id)
+    )
+    delivery_counts_by_account = {
+        account_id: (int(pending), int(in_progress), int(failed))
+        for account_id, pending, in_progress, failed in delivery_rows.all()
+    }
+
+    message_rows = await db.execute(
+        select(ChannelMessage.account_id, func.max(ChannelMessage.created_at))
+        .where(
+            ChannelMessage.account_id.in_(account_ids),
+            ChannelMessage.user_id == user_id,
+        )
+        .group_by(ChannelMessage.account_id)
+    )
+    last_message_by_account = dict(message_rows.all())
+
+    event_rows = await db.execute(
+        select(ChannelDebugEvent.account_id, func.max(ChannelDebugEvent.created_at))
+        .where(
+            ChannelDebugEvent.account_id.in_(account_ids),
+            ChannelDebugEvent.user_id == user_id,
+        )
+        .group_by(ChannelDebugEvent.account_id)
+    )
+    last_event_by_account = dict(event_rows.all())
+
+    debug_error_ranked = (
+        select(
+            ChannelDebugEvent.account_id,
+            ChannelDebugEvent.created_at,
+            ChannelDebugEvent.stage,
+            ChannelDebugEvent.outcome,
+            ChannelDebugEvent.error,
+            func.row_number()
+            .over(
+                partition_by=ChannelDebugEvent.account_id,
+                order_by=(ChannelDebugEvent.created_at.desc(), ChannelDebugEvent.id.desc()),
+            )
+            .label("row_number"),
+        )
+        .where(
+            ChannelDebugEvent.account_id.in_(account_ids),
+            ChannelDebugEvent.user_id == user_id,
+            or_(
+                ChannelDebugEvent.outcome == "failure",
+                ChannelDebugEvent.error.is_not(None),
+            ),
+        )
+        .subquery()
+    )
+    debug_error_rows = await db.execute(
+        select(
+            debug_error_ranked.c.account_id,
+            debug_error_ranked.c.created_at,
+            debug_error_ranked.c.stage,
+            debug_error_ranked.c.outcome,
+            debug_error_ranked.c.error,
+        ).where(debug_error_ranked.c.row_number == 1)
+    )
+    debug_error_by_account = {
+        account_id: (created_at, stage, outcome, error)
+        for account_id, created_at, stage, outcome, error in debug_error_rows.all()
+    }
+
+    delivery_error_ranked = (
+        select(
+            ChannelDelivery.account_id,
+            ChannelDelivery.updated_at,
+            ChannelDelivery.last_error,
+            func.row_number()
+            .over(
+                partition_by=ChannelDelivery.account_id,
+                order_by=(ChannelDelivery.updated_at.desc(), ChannelDelivery.id.desc()),
+            )
+            .label("row_number"),
+        )
+        .where(
+            ChannelDelivery.account_id.in_(account_ids),
+            ChannelDelivery.user_id == user_id,
+            ChannelDelivery.last_error.is_not(None),
+        )
+        .subquery()
+    )
+    delivery_error_rows = await db.execute(
+        select(
+            delivery_error_ranked.c.account_id,
+            delivery_error_ranked.c.updated_at,
+            delivery_error_ranked.c.last_error,
+        ).where(delivery_error_ranked.c.row_number == 1)
+    )
+    delivery_error_by_account = {
+        account_id: (updated_at, last_error)
+        for account_id, updated_at, last_error in delivery_error_rows.all()
+    }
+
+    return [
+        _channel_health_item(
+            account=account,
+            pending_inbox_stats=pending_inbox_by_account.get(account.id, (0, None)),
+            delivery_counts=delivery_counts_by_account.get(account.id, (0, 0, 0)),
+            last_message_at=last_message_by_account.get(account.id),
+            last_event_at=last_event_by_account.get(account.id),
+            debug_error=debug_error_by_account.get(account.id),
+            delivery_error=delivery_error_by_account.get(account.id),
+        )
+        for account in accounts
+    ]
+
+
+def _channel_health_item(
+    *,
+    account: ChannelAccount,
+    pending_inbox_stats: tuple[int, datetime | None],
+    delivery_counts: tuple[int, int, int],
+    last_message_at: datetime | None,
+    last_event_at: datetime | None,
+    debug_error: tuple[datetime, str, str, str | None] | None,
+    delivery_error: tuple[datetime, str] | None,
 ) -> ChannelHealthItemResponse:
-    pending_inbox = await _count_pending_inbox(db, account=account, user_id=user_id)
-    pending_deliveries = await _count_deliveries(
-        db,
-        account=account,
-        user_id=user_id,
-        status_value=DELIVERY_STATUS_PENDING,
-    )
-    in_progress_deliveries = await _count_deliveries(
-        db,
-        account=account,
-        user_id=user_id,
-        status_value=DELIVERY_STATUS_IN_PROGRESS,
-    )
-    failed_deliveries = await _count_deliveries(
-        db,
-        account=account,
-        user_id=user_id,
-        status_value=DELIVERY_STATUS_FAILED,
-    )
-    last_message_at = await _last_message_at(db, account=account, user_id=user_id)
-    last_event = await _last_debug_event(db, account=account, user_id=user_id, error_only=False)
-    last_debug_error = await _last_debug_event(
-        db,
-        account=account,
-        user_id=user_id,
-        error_only=True,
-    )
-    last_delivery_error = await _last_delivery_error(db, account=account, user_id=user_id)
+    pending_inbox, oldest_pending_inbox_at = pending_inbox_stats
+    pending_deliveries, in_progress_deliveries, failed_deliveries = delivery_counts
     last_error_at = None
     last_error = None
     last_error_stage = None
     last_error_outcome = None
-    if last_debug_error is not None:
-        last_error_at = last_debug_error.created_at
-        last_error = last_debug_error.error
-        last_error_stage = last_debug_error.stage
-        last_error_outcome = last_debug_error.outcome
-    if last_delivery_error is not None and (
-        last_error_at is None or last_delivery_error.updated_at > last_error_at
-    ):
-        last_error_at = last_delivery_error.updated_at
-        last_error = last_delivery_error.last_error
+    if debug_error is not None:
+        last_error_at, last_error_stage, last_error_outcome, raw_error = debug_error
+        last_error = public_channel_operation_error(raw_error)
+    if delivery_error is not None and (last_error_at is None or delivery_error[0] > last_error_at):
+        last_error_at = delivery_error[0]
+        last_error = public_channel_delivery_error(delivery_error[1])
         last_error_stage = "delivery"
         last_error_outcome = "failure"
 
@@ -1703,107 +1861,18 @@ async def _channel_health_item(
         health_status=health_status,
         reasons=reasons,
         pending_inbox=pending_inbox,
+        oldest_pending_inbox_at=oldest_pending_inbox_at,
         pending_deliveries=pending_deliveries,
         in_progress_deliveries=in_progress_deliveries,
         failed_deliveries=failed_deliveries,
         last_message_at=last_message_at,
-        last_event_at=last_event.created_at if last_event is not None else None,
+        last_event_at=last_event_at,
         last_error_at=last_error_at,
         last_error=last_error,
         last_error_stage=last_error_stage,
         last_error_outcome=last_error_outcome,
         native_transport=_native_transport_health(account),
     )
-
-
-async def _count_pending_inbox(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    user_id: UUID,
-) -> int:
-    return await pending_channel_inbox_count(
-        db,
-        account=account,
-        user_id=user_id,
-    )
-
-
-async def _count_deliveries(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    user_id: UUID,
-    status_value: str,
-) -> int:
-    result = await db.execute(
-        select(func.count())
-        .select_from(ChannelDelivery)
-        .where(
-            ChannelDelivery.account_id == account.id,
-            ChannelDelivery.user_id == user_id,
-            ChannelDelivery.status == status_value,
-        )
-    )
-    return int(result.scalar_one())
-
-
-async def _last_message_at(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    user_id: UUID,
-):
-    result = await db.execute(
-        select(ChannelMessage.created_at)
-        .where(
-            ChannelMessage.account_id == account.id,
-            ChannelMessage.user_id == user_id,
-        )
-        .order_by(ChannelMessage.created_at.desc(), ChannelMessage.id.desc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
-
-
-async def _last_debug_event(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    user_id: UUID,
-    error_only: bool,
-) -> ChannelDebugEvent | None:
-    query = select(ChannelDebugEvent).where(
-        ChannelDebugEvent.account_id == account.id,
-        ChannelDebugEvent.user_id == user_id,
-    )
-    if error_only:
-        query = query.where(
-            (ChannelDebugEvent.outcome == "failure") | ChannelDebugEvent.error.is_not(None)
-        )
-    result = await db.execute(
-        query.order_by(ChannelDebugEvent.created_at.desc(), ChannelDebugEvent.id.desc()).limit(1)
-    )
-    return result.scalar_one_or_none()
-
-
-async def _last_delivery_error(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    user_id: UUID,
-) -> ChannelDelivery | None:
-    result = await db.execute(
-        select(ChannelDelivery)
-        .where(
-            ChannelDelivery.account_id == account.id,
-            ChannelDelivery.user_id == user_id,
-            ChannelDelivery.last_error.is_not(None),
-        )
-        .order_by(ChannelDelivery.updated_at.desc(), ChannelDelivery.id.desc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
 
 
 def _native_transport_health(account: ChannelAccount) -> dict[str, Any] | None:
@@ -1821,29 +1890,3 @@ def _telegram_bot_username(account: ChannelAccount) -> str | None:
     if not isinstance(value, str):
         return None
     return normalize_telegram_bot_username(value)
-
-
-def _sanitize_activity_details(value: Any, *, depth: int = 0) -> Any:
-    if depth > 4:
-        return "[truncated]"
-    if value is None or isinstance(value, (bool, int, float)):
-        return value
-    if isinstance(value, str):
-        return value[:500]
-    if isinstance(value, list):
-        return [_sanitize_activity_details(item, depth=depth + 1) for item in value[:20]]
-    if isinstance(value, dict):
-        result: dict[str, Any] = {}
-        for key, item in list(value.items())[:40]:
-            safe_key = str(key)
-            if _is_secretish_activity_key(safe_key):
-                result[safe_key] = "[redacted]"
-            else:
-                result[safe_key] = _sanitize_activity_details(item, depth=depth + 1)
-        return result
-    return str(value)[:500]
-
-
-def _is_secretish_activity_key(key: str) -> bool:
-    normalized = key.lower().replace("-", "_")
-    return any(part in normalized for part in SECRETISH_ACTIVITY_DETAIL_KEYS)

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -1613,7 +1613,8 @@ async def _request_discord_provider(
         "Content-Type": content_type,
     }
     headers.update(_discord_request_headers(request_headers))
-    decision = discord_rate_limiter.check(method, normalized_path)
+    account_scope = str(account.id)
+    decision = discord_rate_limiter.check(account_scope, method, normalized_path)
     if not decision.allowed:
         rate_limit_rejects.labels(
             channel="discord",
@@ -1634,7 +1635,7 @@ async def _request_discord_provider(
     try:
         with track_proxy_latency("discord", method):
             async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(method, normalized_path)
+                discord_rate_limiter.consume(account_scope, method, normalized_path)
                 response = await client.request(
                     method,
                     url,
@@ -1643,6 +1644,7 @@ async def _request_discord_provider(
                     params=query_params,
                 )
                 discord_rate_limiter.observe(
+                    account_scope,
                     method,
                     normalized_path,
                     _discord_rate_limit_response_headers(response),
@@ -1724,7 +1726,7 @@ async def _validate_discord_provider_base_url(base_url: str) -> None:
         outbound_errors.labels(channel="discord", method="provider_url").inc()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="discord api base url must be a public https URL",
         ) from exc
 
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -2576,7 +2576,7 @@ async def _validate_telegram_provider_base_url(base_url: str) -> None:
         outbound_errors.labels(channel="telegram", method="provider_url").inc()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="telegram api base url must be a public https URL",
         ) from exc
 
 

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -177,6 +177,7 @@ class ChannelAgentLinkResponse(BaseModel):
 
 class ChannelAgentLinkWithAccountResponse(ChannelAgentLinkResponse):
     account: ChannelAccountResponse
+    binding_count: int = 0
 
 
 class ChannelPairCodeCreate(BaseModel):
@@ -317,6 +318,7 @@ class ChannelHealthItemResponse(BaseModel):
     health_status: ChannelHealthStatus
     reasons: list[str] = Field(default_factory=list)
     pending_inbox: int = 0
+    oldest_pending_inbox_at: datetime | None = None
     pending_deliveries: int = 0
     in_progress_deliveries: int = 0
     failed_deliveries: int = 0

--- a/backend/app/services/channel_config.py
+++ b/backend/app/services/channel_config.py
@@ -65,8 +65,18 @@ async def validate_channel_account_config_urls(
     if not isinstance(config, dict):
         return
     if provider == CHANNEL_PROVIDER_DISCORD:
-        await _validate_optional_http_config(config, "api_base_url", "discord api_base_url")
-        await _validate_optional_websocket_config(config, "gateway_url", "discord gateway_url")
+        await _validate_optional_http_config(
+            config,
+            "api_base_url",
+            "discord api_base_url",
+            unsafe_detail="discord api_base_url must be a public https URL",
+        )
+        await _validate_optional_websocket_config(
+            config,
+            "gateway_url",
+            "discord gateway_url",
+            unsafe_detail="discord gateway_url must be a public wss URL",
+        )
     if provider == CHANNEL_PROVIDER_IMESSAGE:
         await _validate_optional_http_config(config, "server_url", "imessage server_url")
 
@@ -75,6 +85,8 @@ async def _validate_optional_http_config(
     config: dict[str, Any],
     key: str,
     label: str,
+    *,
+    unsafe_detail: str | None = None,
 ) -> None:
     value = _optional_url_config(config, key, label)
     if value is None:
@@ -84,7 +96,7 @@ async def _validate_optional_http_config(
     except UnsafeOutboundUrlError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=unsafe_detail or str(exc),
         ) from exc
 
 
@@ -92,6 +104,8 @@ async def _validate_optional_websocket_config(
     config: dict[str, Any],
     key: str,
     label: str,
+    *,
+    unsafe_detail: str | None = None,
 ) -> None:
     value = _optional_url_config(config, key, label)
     if value is None:
@@ -101,7 +115,7 @@ async def _validate_optional_websocket_config(
     except UnsafeOutboundUrlError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=unsafe_detail or str(exc),
         ) from exc
 
 

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -8,21 +8,66 @@ from typing import TypeGuard
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
+    BINDING_STATUS_ACTIVE,
+    BOT_AGENT_LINK_STATUS_ACTIVE,
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_STATUS_ACTIVE,
+    MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
+    ChannelBinding,
+    ChannelBotAgentLink,
     ChannelDebugEvent,
+    ChannelMessage,
 )
 
 DEFAULT_DEBUG_EVENT_LIMIT = 100
 MAX_DEBUG_EVENT_LIMIT = 1000
 MAX_DEBUG_STRING = 500
+PUBLIC_CHANNEL_DELIVERY_ERROR = "channel_delivery_failed"
+PUBLIC_CHANNEL_OPERATION_ERROR = "channel_operation_failed"
+PUBLIC_CHANNEL_DELIVERY_ERROR_CODES = frozenset(
+    {
+        "channel_account_inactive",
+        "channel_agent_link_archived",
+        "channel_agent_link_authority_missing",
+        "channel_agent_link_update_contended",
+        "channel_binding_inactive",
+        "channel_delivery_failed",
+        "channel_message_missing",
+        "channel_provider_credential_unavailable",
+        "channel_provider_rate_limited",
+        "channel_provider_rejected",
+        "channel_provider_unreachable",
+    }
+)
 SECRET_KEY_RE = re.compile(
     r"(token|secret|password|authorization|auth|key|credential|cookie)",
     re.I,
+)
+_PUBLIC_SAFE_CODE_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,119}$", re.I)
+_PUBLIC_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.:@/-]{1,300}$")
+_PUBLIC_SAFE_DETAIL_STRING_KEYS = frozenset(
+    {
+        "direction",
+        "event_type",
+        "method",
+        "operation",
+        "outcome",
+        "provider",
+        "reason",
+        "stage",
+        "state",
+        "status",
+        "binding_status",
+        "bot_agent_link_status",
+        "link_status",
+    }
 )
 
 
@@ -55,19 +100,34 @@ async def record_channel_debug_event(
 ) -> ChannelDebugEvent | None:
     try:
         now = datetime.now(UTC)
+        normalized_provider = _normalize(provider)
+        minimize_stored_diagnostics = normalized_provider in {
+            CHANNEL_PROVIDER_TELEGRAM,
+            CHANNEL_PROVIDER_DISCORD,
+        }
         async with db.begin_nested():
             event = ChannelDebugEvent(
                 account_id=account.id if account is not None else None,
                 user_id=user_id,
-                provider=_normalize(provider),
+                provider=normalized_provider,
                 external_chat_id=_truncate(external_chat_id, 300),
                 direction=direction,
                 stage=_truncate(stage, 80) or "unknown",
                 outcome=outcome,
                 request_id=_truncate(request_id, 120),
                 status_code=status_code,
-                error=_truncate(error, MAX_DEBUG_STRING),
-                details=_sanitize_details(details) if details is not None else None,
+                error=(
+                    public_channel_operation_error(error)
+                    if minimize_stored_diagnostics
+                    else _truncate(error, MAX_DEBUG_STRING)
+                ),
+                details=(
+                    public_channel_debug_details(details)
+                    if minimize_stored_diagnostics
+                    else _sanitize_details(details)
+                    if details is not None
+                    else None
+                ),
                 created_at=now,
                 updated_at=now,
             )
@@ -121,19 +181,40 @@ async def channel_debug_health(
         .scalars()
         .all()
     )
+    account_ids = [account.id for account in accounts]
+    pending_inbox_by_account = await _pending_inbox_stats_by_account(
+        db,
+        account_ids=account_ids,
+        user_id=user_id,
+    )
+    last_event_by_account = await _last_events_by_account(
+        db,
+        account_ids=account_ids,
+        user_id=user_id,
+        error_only=False,
+    )
+    last_error_by_account = await _last_events_by_account(
+        db,
+        account_ids=account_ids,
+        user_id=user_id,
+        error_only=True,
+    )
     health: list[dict[str, JsonValue]] = []
     for account in accounts:
+        pending_inbox, oldest_pending_inbox_at = pending_inbox_by_account.get(
+            account.id,
+            (0, None),
+        )
         item: dict[str, JsonValue] = {
             "accountId": str(account.id),
             "provider": account.provider,
             "name": account.name,
-            "pendingInbox": await _pending_inbox_count(db, account=account),
-            "lastEvent": _debug_event_response(
-                await _last_event(db, account=account, error_only=False)
+            "pendingInbox": pending_inbox,
+            "oldestPendingInboxAt": (
+                oldest_pending_inbox_at.isoformat() if oldest_pending_inbox_at is not None else None
             ),
-            "lastError": _debug_event_response(
-                await _last_event(db, account=account, error_only=True)
-            ),
+            "lastEvent": _debug_event_response(last_event_by_account.get(account.id)),
+            "lastError": _debug_event_response(last_error_by_account.get(account.id)),
         }
         if account.provider == CHANNEL_PROVIDER_WHATSAPP:
             from app.services.whatsapp_provider_bridge import (
@@ -163,34 +244,160 @@ def _debug_event_response(event: ChannelDebugEvent | None) -> dict[str, JsonValu
         "outcome": event.outcome,
         "requestId": event.request_id,
         "status": event.status_code,
-        "error": event.error,
-        "details": _sanitize_details(event.details),
+        "error": public_channel_operation_error(event.error),
+        "details": public_channel_debug_details(event.details),
     }
 
 
-async def _pending_inbox_count(db: AsyncSession, *, account: ChannelAccount) -> int:
-    # Local import avoids the channels -> debug-events module cycle.
-    from app.services.channels import pending_channel_inbox_count
-
-    return await pending_channel_inbox_count(db, account=account)
+def public_channel_operation_error(error: str | None) -> str | None:
+    return PUBLIC_CHANNEL_OPERATION_ERROR if error is not None else None
 
 
-async def _last_event(
+def public_channel_delivery_error(error: str | None) -> str | None:
+    if error is None:
+        return None
+    return error if error in PUBLIC_CHANNEL_DELIVERY_ERROR_CODES else PUBLIC_CHANNEL_DELIVERY_ERROR
+
+
+def public_channel_debug_details(
+    value: object,
+    *,
+    key: str | None = None,
+    depth: int = 0,
+) -> JsonValue:
+    """Return user-safe debug structure without provider or exception strings."""
+    if depth > 4:
+        return "[truncated]"
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, str):
+        if key is None:
+            return "[redacted]"
+        normalized_key = key.lower().replace("-", "_")
+        if SECRET_KEY_RE.search(normalized_key):
+            return "[redacted]"
+        if normalized_key == "id" or normalized_key.endswith("_id"):
+            return value if _PUBLIC_SAFE_ID_RE.fullmatch(value) else "[redacted]"
+        if normalized_key in _PUBLIC_SAFE_DETAIL_STRING_KEYS and _PUBLIC_SAFE_CODE_RE.fullmatch(
+            value
+        ):
+            return value
+        return "[redacted]"
+    if _is_object_list(value):
+        return [public_channel_debug_details(item, key=key, depth=depth + 1) for item in value[:20]]
+    if _is_object_mapping(value):
+        out: dict[str, JsonValue] = {}
+        for child_key, child in list(value.items())[:40]:
+            key_str = str(child_key)
+            out[key_str] = (
+                "[redacted]"
+                if SECRET_KEY_RE.search(key_str)
+                else public_channel_debug_details(
+                    child,
+                    key=key_str,
+                    depth=depth + 1,
+                )
+            )
+        return out
+    return "[redacted]"
+
+
+async def _pending_inbox_stats_by_account(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
-    error_only: bool,
-) -> ChannelDebugEvent | None:
-    query = select(ChannelDebugEvent).where(ChannelDebugEvent.account_id == account.id)
-    if error_only:
-        query = query.where(
-            (ChannelDebugEvent.outcome == "failure") | ChannelDebugEvent.error.is_not(None)
+    account_ids: list[UUID],
+    user_id: UUID,
+) -> dict[UUID, tuple[int, datetime | None]]:
+    if not account_ids:
+        return {}
+    rows = await db.execute(
+        select(
+            ChannelMessage.account_id,
+            func.count(ChannelMessage.id),
+            func.min(ChannelMessage.created_at),
         )
-    query = query.order_by(ChannelDebugEvent.created_at.desc(), ChannelDebugEvent.id.desc()).limit(
-        1
+        .join(
+            ChannelBinding,
+            and_(
+                ChannelBinding.id == ChannelMessage.binding_id,
+                ChannelBinding.account_id == ChannelMessage.account_id,
+                ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
+                ChannelBinding.user_id == ChannelMessage.user_id,
+            ),
+        )
+        .join(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.id == ChannelMessage.bot_agent_link_id,
+                ChannelBotAgentLink.account_id == ChannelMessage.account_id,
+            ),
+        )
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+        .where(
+            ChannelMessage.account_id.in_(account_ids),
+            ChannelMessage.user_id == user_id,
+            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+            ChannelMessage.binding_id.is_not(None),
+            ChannelMessage.delivered_at.is_(None),
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+        )
+        .group_by(ChannelMessage.account_id)
     )
-    result = await db.execute(query)
-    return result.scalar_one_or_none()
+    return {
+        account_id: (int(count), oldest_pending_at)
+        for account_id, count, oldest_pending_at in rows.all()
+    }
+
+
+async def _last_events_by_account(
+    db: AsyncSession,
+    *,
+    account_ids: list[UUID],
+    user_id: UUID,
+    error_only: bool,
+) -> dict[UUID, ChannelDebugEvent]:
+    if not account_ids:
+        return {}
+    filters = [
+        ChannelDebugEvent.account_id.in_(account_ids),
+        ChannelDebugEvent.user_id == user_id,
+    ]
+    if error_only:
+        filters.append(
+            or_(
+                ChannelDebugEvent.outcome == "failure",
+                ChannelDebugEvent.error.is_not(None),
+            )
+        )
+    ranked = (
+        select(
+            ChannelDebugEvent.id.label("event_id"),
+            func.row_number()
+            .over(
+                partition_by=ChannelDebugEvent.account_id,
+                order_by=(ChannelDebugEvent.created_at.desc(), ChannelDebugEvent.id.desc()),
+            )
+            .label("row_number"),
+        )
+        .where(*filters)
+        .subquery()
+    )
+    events = (
+        (
+            await db.execute(
+                select(ChannelDebugEvent)
+                .join(ranked, ranked.c.event_id == ChannelDebugEvent.id)
+                .where(ranked.c.row_number == 1)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {event.account_id: event for event in events if event.account_id is not None}
 
 
 def _sanitize_details(value: object, *, depth: int = 0) -> JsonValue:

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -302,6 +302,23 @@ def public_channel_debug_details(
     return "[redacted]"
 
 
+def public_channel_debug_details_response(
+    value: Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    """Return user-safe object details for typed public response schemas."""
+    if value is None:
+        return None
+    details: dict[str, object] = {}
+    for child_key, child in list(value.items())[:40]:
+        key = str(child_key)
+        details[key] = (
+            "[redacted]"
+            if SECRET_KEY_RE.search(key)
+            else public_channel_debug_details(child, key=key, depth=1)
+        )
+    return details
+
+
 async def _pending_inbox_stats_by_account(
     db: AsyncSession,
     *,

--- a/backend/app/services/channel_message_retention_worker.py
+++ b/backend/app/services/channel_message_retention_worker.py
@@ -14,6 +14,7 @@ from app.services.metrics import (
     channel_queue_stuck_pending,
     channel_retention_budget_exhaustions,
     channel_retention_deletions,
+    channel_retention_delivery_expirations,
     channel_retention_secret_scrubs,
 )
 
@@ -66,6 +67,10 @@ class ChannelMessageRetentionWorker:
                 await db.commit()
             batches += 1
             processed_total += batch.total
+            if batch.telegram_delivery_expirations:
+                channel_retention_delivery_expirations.labels(provider="telegram").inc(
+                    batch.telegram_delivery_expirations
+                )
             for record_kind, deleted in (
                 ("messages", batch.messages),
                 ("debug_events", batch.debug_events),

--- a/backend/app/services/channel_webhook_delivery_worker.py
+++ b/backend/app/services/channel_webhook_delivery_worker.py
@@ -22,6 +22,7 @@ from app.models.channel import (
 )
 from app.services.channel_webhooks import deliver_telegram_agent_webhook
 from app.services.channels import (
+    TELEGRAM_UPDATE_RETENTION,
     bot_agent_link_has_provider_cardinality_capability,
     bot_agent_link_has_strict_v2_authority,
     telegram_update_payload,
@@ -46,7 +47,7 @@ class ChannelWebhookDeliveryWorker:
         poll_interval_seconds: float = 1.0,
         backoff_base_seconds: float = 1.0,
         backoff_cap_seconds: float = 60.0,
-        ttl_seconds: int = 24 * 60 * 60,
+        ttl_seconds: int = int(TELEGRAM_UPDATE_RETENTION.total_seconds()),
     ) -> None:
         self._sessionmaker = sessionmaker
         self._poll_interval_seconds = poll_interval_seconds

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import json
@@ -17,7 +18,7 @@ import httpx
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import HTTPException, status
-from sqlalchemy import and_, delete, exists, func, or_, select, union_all
+from sqlalchemy import and_, delete, exists, func, or_, select, union_all, update
 from sqlalchemy import text as sql_text
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
@@ -165,6 +166,17 @@ DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE = "discord_bot_guild_membership_unavail
 DISCORD_DM_CHAT_TYPES = frozenset({"dm", "direct_messages", "group_dm", "private"})
 DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
 DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
+DELIVERY_ERROR_ACCOUNT_INACTIVE = "channel_account_inactive"
+DELIVERY_ERROR_BINDING_INACTIVE = "channel_binding_inactive"
+DELIVERY_ERROR_FAILED = "channel_delivery_failed"
+DELIVERY_ERROR_LINK_ARCHIVED = "channel_agent_link_archived"
+DELIVERY_ERROR_LINK_AUTHORITY = "channel_agent_link_authority_missing"
+DELIVERY_ERROR_LINK_CONTENTION = "channel_agent_link_update_contended"
+DELIVERY_ERROR_MESSAGE_MISSING = "channel_message_missing"
+DELIVERY_ERROR_PROVIDER_CREDENTIAL = "channel_provider_credential_unavailable"
+DELIVERY_ERROR_PROVIDER_RATE_LIMITED = "channel_provider_rate_limited"
+DELIVERY_ERROR_PROVIDER_REJECTED = "channel_provider_rejected"
+DELIVERY_ERROR_PROVIDER_UNREACHABLE = "channel_provider_unreachable"
 HERMES_AGENT_TYPE = "hermes"
 OPENCLAW_AGENT_TYPE = "openclaw"
 HOSTED_RUNTIME_AGENT_TYPES = frozenset({HERMES_AGENT_TYPE, OPENCLAW_AGENT_TYPE})
@@ -175,6 +187,7 @@ STRICT_V2_AGENT_LINK_DETAIL = "Only Cloud Agents can be linked or paired with ch
 WHATSAPP_COMING_SOON_DETAIL = (
     "WhatsApp channels are coming soon for hosted agents. Telegram and Discord are available now."
 )
+TELEGRAM_UPDATE_RETENTION = timedelta(hours=24)
 
 
 def hosted_agent_provider_link_limit_detail(provider: str, *, duplicate: bool = False) -> str:
@@ -219,6 +232,7 @@ class ChannelQueueSnapshot:
 
 @dataclass(frozen=True)
 class ChannelRetentionBatch:
+    telegram_delivery_expirations: int = 0
     messages: int = 0
     debug_events: int = 0
     pair_codes: int = 0
@@ -228,7 +242,8 @@ class ChannelRetentionBatch:
     @property
     def total(self) -> int:
         return (
-            self.messages
+            self.telegram_delivery_expirations
+            + self.messages
             + self.debug_events
             + self.pair_codes
             + self.agent_references
@@ -239,6 +254,7 @@ class ChannelRetentionBatch:
         return tuple(
             kind
             for kind, count in (
+                ("telegram_delivery_expirations", self.telegram_delivery_expirations),
                 ("messages", self.messages),
                 ("debug_events", self.debug_events),
                 ("pair_codes", self.pair_codes),
@@ -597,7 +613,7 @@ async def get_or_create_bot_agent_link(
             # Older rows can carry an archived status without archived_at even
             # though the partial unique index keys only on archived_at. Finish
             # that interrupted archive before inserting its replacement.
-            await archive_bot_agent_link(db, link=link)
+            await archive_bot_agent_link(db, link=link, account=account)
         else:
             if not await bot_agent_link_has_strict_v2_authority(db, link=link):
                 raise HTTPException(
@@ -1069,10 +1085,40 @@ async def list_owned_active_bot_agent_links_for_agent(
     *,
     user_id: UUID,
     agent_id: UUID,
-) -> list[tuple[ChannelBotAgentLink, ChannelAccount]]:
+) -> list[tuple[ChannelBotAgentLink, ChannelAccount, int]]:
+    active_binding_counts = (
+        select(
+            ChannelBinding.account_id.label("account_id"),
+            ChannelBinding.bot_agent_link_id.label("bot_agent_link_id"),
+            ChannelBinding.user_id.label("user_id"),
+            func.count(ChannelBinding.id).label("binding_count"),
+        )
+        .where(
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            ChannelBinding.user_id == user_id,
+        )
+        .group_by(
+            ChannelBinding.account_id,
+            ChannelBinding.bot_agent_link_id,
+            ChannelBinding.user_id,
+        )
+        .subquery()
+    )
     result = await db.execute(
-        select(ChannelBotAgentLink, ChannelAccount)
+        select(
+            ChannelBotAgentLink,
+            ChannelAccount,
+            func.coalesce(active_binding_counts.c.binding_count, 0),
+        )
         .join(ChannelAccount, ChannelAccount.id == ChannelBotAgentLink.account_id)
+        .outerjoin(
+            active_binding_counts,
+            and_(
+                active_binding_counts.c.account_id == ChannelBotAgentLink.account_id,
+                active_binding_counts.c.bot_agent_link_id == ChannelBotAgentLink.id,
+                active_binding_counts.c.user_id == ChannelBotAgentLink.user_id,
+            ),
+        )
         .where(
             ChannelBotAgentLink.user_id == user_id,
             ChannelBotAgentLink.agent_id == agent_id,
@@ -1089,7 +1135,7 @@ async def list_owned_active_bot_agent_links_for_agent(
             ChannelBotAgentLink.created_at,
         )
     )
-    return [(link, account) for link, account in result.all()]
+    return [(link, account, int(binding_count)) for link, account, binding_count in result.all()]
 
 
 async def rotate_bot_agent_link_token(
@@ -1121,6 +1167,7 @@ async def archive_bot_agent_link(
     db: AsyncSession,
     *,
     link: ChannelBotAgentLink,
+    account: ChannelAccount | None = None,
 ) -> None:
     now = datetime.now(UTC)
     link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
@@ -1168,7 +1215,14 @@ async def archive_bot_agent_link(
         )
     )
     for delivery in deliveries_result.scalars().all():
-        _fail_delivery(delivery, "channel agent link archived")
+        _fail_delivery(
+            delivery,
+            "channel agent link archived",
+            use_safe_diagnostics=(
+                account is not None
+                and account.provider in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}
+            ),
+        )
 
     await db.flush()
 
@@ -1328,7 +1382,12 @@ async def archive_channel_account(db: AsyncSession, *, account: ChannelAccount) 
         )
     )
     for delivery in deliveries_result.scalars().all():
-        _fail_delivery(delivery, "channel account archived")
+        _fail_delivery(
+            delivery,
+            "channel account archived",
+            use_safe_diagnostics=account.provider
+            in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD},
+        )
 
     await db.flush()
 
@@ -2159,18 +2218,20 @@ async def discord_bot_guild_membership_check(
         label="discord api base url",
     )
     path = f"/guilds/{guild_id}"
-    decision = discord_rate_limiter.check("GET", path)
+    account_scope = str(account.id)
+    decision = discord_rate_limiter.check(account_scope, "GET", path)
     if not decision.allowed:
         return DiscordGuildMembershipCheck(denied_reason=DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE)
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, "GET"):
             async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume("GET", path)
+                discord_rate_limiter.consume(account_scope, "GET", path)
                 response = await client.get(
                     f"{base_url.rstrip('/')}{path}",
                     headers={"Authorization": f"Bot {token}"},
                 )
                 discord_rate_limiter.observe(
+                    account_scope,
                     "GET",
                     path,
                     _discord_rate_limit_response_headers(response),
@@ -3258,6 +3319,7 @@ async def dequeue_telegram_updates(
     limit: int,
     allowed_updates: set[str] | None = None,
 ) -> list[dict[str, Any]]:
+    now = datetime.now(UTC)
     filters = [
         ChannelMessage.account_id == account.id,
         ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
@@ -3266,6 +3328,18 @@ async def dequeue_telegram_updates(
     ]
     if bot_agent_link_id is not None:
         filters.append(ChannelMessage.bot_agent_link_id == bot_agent_link_id)
+    # Telegram's hosted Bot API retains incoming updates for no longer than
+    # 24 hours. A managed polling client must not see a more durable history
+    # merely because Clawdi stores its inbox in PostgreSQL.
+    await db.execute(
+        update(ChannelMessage)
+        .where(
+            *filters,
+            ChannelMessage.created_at < now - TELEGRAM_UPDATE_RETENTION,
+        )
+        .values(delivered_at=now)
+        .execution_options(synchronize_session=False)
+    )
     result = await db.execute(
         select(ChannelMessage)
         .join(
@@ -3301,17 +3375,19 @@ async def dequeue_telegram_updates(
         )
     )
     updates: list[dict[str, Any]] = []
-    now = datetime.now(UTC)
     for message in result.scalars().all():
-        update = telegram_update_payload(message)
+        update_payload = telegram_update_payload(message)
         update_id = telegram_update_id(message)
         if offset is not None and update_id < offset:
             message.delivered_at = now
             continue
-        if allowed_updates and not _telegram_update_allowed(update, allowed_updates):
+        if allowed_updates and not _telegram_update_allowed(
+            update_payload,
+            allowed_updates,
+        ):
             message.delivered_at = now
             continue
-        updates.append(update)
+        updates.append(update_payload)
         if len(updates) >= limit:
             break
     await db.flush()
@@ -3393,6 +3469,35 @@ async def ack_channel_inbox_events(
     now = datetime.now(UTC)
     for message in messages:
         message.delivered_at = now
+    await db.flush()
+    return len(messages)
+
+
+async def ack_discord_gateway_messages(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+    bot_agent_link_id: UUID,
+    message_ids: list[UUID],
+) -> int:
+    """Acknowledge only durable messages dispatched by one Gateway session."""
+    if not message_ids:
+        return 0
+    result = await db.execute(
+        select(ChannelMessage)
+        .where(
+            ChannelMessage.id.in_(message_ids),
+            ChannelMessage.account_id == account_id,
+            ChannelMessage.bot_agent_link_id == bot_agent_link_id,
+            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+            ChannelMessage.delivered_at.is_(None),
+        )
+        .with_for_update(of=ChannelMessage)
+    )
+    messages = list(result.scalars().all())
+    delivered_at = datetime.now(UTC)
+    for message in messages:
+        message.delivered_at = delivered_at
     await db.flush()
     return len(messages)
 
@@ -3513,6 +3618,49 @@ async def prune_channel_messages(
     messages = list(result.scalars().all())
     for message in messages:
         await db.delete(message)
+    await db.flush()
+    return len(messages)
+
+
+async def expire_stale_telegram_inbox_messages(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    retention: timedelta | None = None,
+    limit: int | None = None,
+) -> int:
+    """Terminally consume Telegram updates outside the provider replay horizon.
+
+    This is delivery expiry, not physical retention deletion. Rows remain
+    available for the ordinary delivered-message retention horizon.
+    """
+    batch_limit = max(
+        0,
+        settings.channel_message_cleanup_batch_size if limit is None else limit,
+    )
+    if batch_limit == 0:
+        return 0
+    current_time = now or datetime.now(UTC)
+    cutoff = current_time - (retention or TELEGRAM_UPDATE_RETENTION)
+    result = await db.execute(
+        select(ChannelMessage)
+        .join(ChannelAccount, ChannelAccount.id == ChannelMessage.account_id)
+        .where(
+            ChannelAccount.provider == CHANNEL_PROVIDER_TELEGRAM,
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            ChannelAccount.archived_at.is_(None),
+            ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+            ChannelMessage.binding_id.is_not(None),
+            ChannelMessage.delivered_at.is_(None),
+            ChannelMessage.created_at < cutoff,
+        )
+        .order_by(ChannelMessage.created_at, ChannelMessage.id)
+        .limit(batch_limit)
+        .with_for_update(skip_locked=True, of=ChannelMessage)
+    )
+    messages = list(result.scalars().all())
+    for message in messages:
+        message.delivered_at = current_time
     await db.flush()
     return len(messages)
 
@@ -3812,6 +3960,11 @@ async def prune_channel_retention_batch(
 ) -> ChannelRetentionBatch:
     current_time = now or datetime.now(UTC)
     return ChannelRetentionBatch(
+        telegram_delivery_expirations=await expire_stale_telegram_inbox_messages(
+            db,
+            now=current_time,
+            limit=limit,
+        ),
         messages=await prune_channel_messages(db, now=current_time, limit=limit),
         debug_events=await prune_channel_debug_events(db, now=current_time, limit=limit),
         pair_codes=await prune_channel_pair_codes(db, now=current_time, limit=limit),
@@ -3994,6 +4147,22 @@ async def pending_channel_inbox_count(
     bot_agent_link_id: UUID | None = None,
     user_id: UUID | None = None,
 ) -> int:
+    count, _oldest_pending_at = await pending_channel_inbox_stats(
+        db,
+        account=account,
+        bot_agent_link_id=bot_agent_link_id,
+        user_id=user_id,
+    )
+    return count
+
+
+async def pending_channel_inbox_stats(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID | None = None,
+    user_id: UUID | None = None,
+) -> tuple[int, datetime | None]:
     filters = [
         ChannelMessage.account_id == account.id,
         ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
@@ -4005,7 +4174,7 @@ async def pending_channel_inbox_count(
     if user_id is not None:
         filters.append(ChannelMessage.user_id == user_id)
     result = await db.execute(
-        select(ChannelMessage.id)
+        select(func.count(ChannelMessage.id), func.min(ChannelMessage.created_at))
         .join(
             ChannelBinding,
             and_(
@@ -4032,7 +4201,8 @@ async def pending_channel_inbox_count(
             ChannelAccount.archived_at.is_(None),
         )
     )
-    return len(result.scalars().all())
+    count, oldest_pending_at = result.one()
+    return int(count), oldest_pending_at
 
 
 async def drop_pending_telegram_updates(
@@ -4193,6 +4363,7 @@ async def deliver_channel_delivery(
     *,
     delivery: ChannelDelivery,
 ) -> ChannelDelivery:
+    account: ChannelAccount | None = None
     try:
         account = await _delivery_account(db, delivery)
         link = await _lock_active_delivery_link(db, delivery)
@@ -4216,32 +4387,75 @@ async def deliver_channel_delivery(
                 )
         message = await _delivery_message(db, delivery)
         await _lock_active_delivery_binding(db, delivery=delivery, message=message)
-        provider_message_id, provider_response = await send_provider_outbound_payload(
+        provider_message_id, _provider_response = await send_provider_outbound_payload(
             account=account,
             external_chat_id=message.external_chat_id,
             text=message.text or "",
             provider_payload=_channel_message_provider_payload(message),
+            discord_nonce=(
+                _discord_delivery_nonce(message.id)
+                if account.provider == CHANNEL_PROVIDER_DISCORD
+                else None
+            ),
         )
     except HTTPException as exc:
         error = _http_exception_detail(exc)
-        if _is_delivery_link_lock_contention(exc, error=error):
-            _schedule_delivery_link_contention_retry(delivery, error)
+        delivery_provider = (
+            account.provider
+            if account is not None
+            else await db.scalar(
+                select(ChannelAccount.provider).where(ChannelAccount.id == delivery.account_id)
+            )
+        )
+        use_safe_diagnostics = delivery_provider in {
+            CHANNEL_PROVIDER_TELEGRAM,
+            CHANNEL_PROVIDER_DISCORD,
+        }
+        if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+            _schedule_delivery_retry(
+                delivery,
+                error,
+                use_safe_diagnostics=use_safe_diagnostics,
+                retry_after_seconds=_http_retry_after_seconds(exc),
+            )
+        elif _is_delivery_link_lock_contention(exc, error=error):
+            _schedule_delivery_link_contention_retry(
+                delivery,
+                error,
+                use_safe_diagnostics=use_safe_diagnostics,
+            )
         elif exc.status_code < status.HTTP_500_INTERNAL_SERVER_ERROR:
-            _fail_delivery(delivery, error)
+            _fail_delivery(
+                delivery,
+                error,
+                use_safe_diagnostics=use_safe_diagnostics,
+            )
         else:
-            _schedule_delivery_retry(delivery, error)
+            _schedule_delivery_retry(
+                delivery,
+                error,
+                use_safe_diagnostics=use_safe_diagnostics,
+            )
         await db.flush()
         return delivery
 
+    stored_provider_response = (
+        _safe_delivery_provider_response(
+            provider=account.provider,
+            provider_message_id=provider_message_id,
+        )
+        if account.provider in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}
+        else _provider_response
+    )
     message.provider_message_id = provider_message_id
-    message.payload = _delivery_success_payload(message.payload, provider_response)
+    message.payload = _delivery_success_payload(message.payload, stored_provider_response)
     if account.provider in CHANNEL_RETENTION_PROVIDERS:
         message.delivered_at = datetime.now(UTC)
     delivery.status = DELIVERY_STATUS_SUCCEEDED
     delivery.locked_at = None
     delivery.locked_by = None
     delivery.last_error = None
-    delivery.provider_response = provider_response
+    delivery.provider_response = stored_provider_response
     await db.flush()
     return delivery
 
@@ -4276,6 +4490,7 @@ async def send_provider_outbound_payload(
     external_chat_id: str,
     text: str,
     provider_payload: dict[str, Any] | None = None,
+    discord_nonce: str | None = None,
 ) -> tuple[str | None, dict[str, Any]]:
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
         return await _send_telegram_provider_payload(
@@ -4288,6 +4503,7 @@ async def send_provider_outbound_payload(
             account=account,
             external_chat_id=external_chat_id,
             text=text,
+            nonce=discord_nonce,
         )
     if account.provider == CHANNEL_PROVIDER_WHATSAPP:
         return await _send_whatsapp_provider_payload(
@@ -4422,6 +4638,7 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
         application_id=application_id,
         provider_token=token,
         config=account.config,
+        rate_limit_scope=str(account.id),
     )
     _require_discord_message_content_intent(identity)
     raw_integration_config = identity.get("integration_types_config")
@@ -4465,6 +4682,7 @@ async def configure_discord_application(account: ChannelAccount) -> dict[str, An
         "Content-Type": "application/json",
     }
     configured = await _discord_application_request(
+        account_scope=str(account.id),
         method="PATCH",
         url=url,
         headers=headers,
@@ -4542,6 +4760,7 @@ async def verify_discord_application_token_identity(
     application_id: str,
     provider_token: str,
     config: dict[str, Any] | None,
+    rate_limit_scope: str | None = None,
 ) -> dict[str, Any]:
     """Verify a Discord credential without mutating the Developer Portal."""
     raw_base_url = config.get("api_base_url") if isinstance(config, dict) else None
@@ -4557,6 +4776,7 @@ async def verify_discord_application_token_identity(
         label="discord api base url",
     )
     identity = await _discord_application_request(
+        account_scope=rate_limit_scope or f"application:{application_id}",
         method="GET",
         url=f"{base_url.rstrip('/')}/applications/@me",
         headers={
@@ -4747,13 +4967,14 @@ def mark_discord_reserved_commands_current(account: ChannelAccount) -> None:
 
 async def _discord_application_request(
     *,
+    account_scope: str,
     method: str,
     url: str,
     headers: dict[str, str],
     json_payload: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     path = "/applications/@me"
-    decision = discord_rate_limiter.check(method, path)
+    decision = discord_rate_limiter.check(account_scope, method, path)
     if not decision.allowed:
         rate_limit_rejects.labels(
             channel=CHANNEL_PROVIDER_DISCORD,
@@ -4771,7 +4992,7 @@ async def _discord_application_request(
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, method):
             async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(method, path)
+                discord_rate_limiter.consume(account_scope, method, path)
                 response = await client.request(
                     method,
                     url,
@@ -4779,6 +5000,7 @@ async def _discord_application_request(
                     json=json_payload,
                 )
                 discord_rate_limiter.observe(
+                    account_scope,
                     method,
                     path,
                     _discord_rate_limit_response_headers(response),
@@ -4860,7 +5082,7 @@ async def send_telegram_message(
     direct_messages_topic_id: int | None = None,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_TELEGRAM)
-    provider_message_id, payload = await _send_telegram_provider_payload(
+    provider_message_id, _provider_payload = await _send_telegram_provider_payload(
         account=account,
         external_chat_id=external_chat_id,
         text=text,
@@ -4884,7 +5106,10 @@ async def send_telegram_message(
         external_chat_id=external_chat_id,
         provider_message_id=provider_message_id,
         text=text,
-        payload=payload if isinstance(payload, dict) else None,
+        payload=_safe_delivery_provider_response(
+            provider=account.provider,
+            provider_message_id=provider_message_id,
+        ),
         delivered_at=datetime.now(UTC),
     )
 
@@ -4972,7 +5197,7 @@ async def send_discord_message(
     bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_DISCORD)
-    provider_message_id, response_payload = await _send_discord_provider_payload(
+    provider_message_id, _response_payload = await _send_discord_provider_payload(
         account=account,
         external_chat_id=external_chat_id,
         text=text,
@@ -4994,7 +5219,10 @@ async def send_discord_message(
         external_chat_id=external_chat_id,
         provider_message_id=provider_message_id,
         text=text,
-        payload=response_payload,
+        payload=_safe_delivery_provider_response(
+            provider=account.provider,
+            provider_message_id=provider_message_id,
+        ),
         delivered_at=datetime.now(UTC),
     )
 
@@ -5032,6 +5260,7 @@ async def _send_discord_provider_payload(
     account: ChannelAccount,
     external_chat_id: str,
     text: str,
+    nonce: str | None = None,
 ) -> tuple[str | None, dict[str, Any]]:
     token = decrypt_provider_token(account)
     base_url = (
@@ -5050,7 +5279,11 @@ async def _send_discord_provider_payload(
         "content": text,
         "allowed_mentions": {"parse": []},
     }
-    decision = discord_rate_limiter.check("POST", path)
+    if nonce is not None:
+        payload["nonce"] = nonce
+        payload["enforce_nonce"] = True
+    account_scope = str(account.id)
+    decision = discord_rate_limiter.check(account_scope, "POST", path)
     if not decision.allowed:
         rate_limit_rejects.labels(
             channel=CHANNEL_PROVIDER_DISCORD,
@@ -5058,22 +5291,29 @@ async def _send_discord_provider_payload(
         ).inc()
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail={
-                "message": "discord route is rate limited",
-                "retry_after": decision.retry_after_seconds,
-                "global": decision.global_limit,
-            },
+            detail="discord api rate limited",
+            headers={
+                "Retry-After": str(decision.retry_after_seconds),
+            }
+            if decision.retry_after_seconds is not None
+            else None,
         )
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, "POST"):
             async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume("POST", path)
+                discord_rate_limiter.consume(account_scope, "POST", path)
                 response = await client.post(
                     url,
                     headers={"Authorization": f"Bot {token}"},
                     json=payload,
                 )
-                discord_rate_limiter.observe("POST", path, response.headers, response.status_code)
+                discord_rate_limiter.observe(
+                    account_scope,
+                    "POST",
+                    path,
+                    response.headers,
+                    response.status_code,
+                )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
         raise HTTPException(
@@ -5081,6 +5321,14 @@ async def _send_discord_provider_payload(
             detail="discord api unreachable",
         ) from exc
     outbound_messages.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
+    if response.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
+        retry_after = _discord_rate_limit_response_headers(response).get("retry-after")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="discord api rate limited",
+            headers={"Retry-After": retry_after} if retry_after is not None else None,
+        )
     if response.status_code >= 400:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
         raise HTTPException(
@@ -5156,6 +5404,7 @@ async def sync_discord_commands(
                 }
                 response = await _discord_command_request(
                     client,
+                    account_scope=str(account.id),
                     method="GET",
                     url=url,
                     path=f"{path}/commands",
@@ -5193,6 +5442,7 @@ async def sync_discord_commands(
                 for command_payload in command_payloads:
                     response = await _discord_command_request(
                         client,
+                        account_scope=str(account.id),
                         method="POST",
                         url=url,
                         path=f"{path}/commands",
@@ -5216,6 +5466,7 @@ async def sync_discord_commands(
                 for command_id in legacy_command_ids:
                     response = await _discord_command_request(
                         client,
+                        account_scope=str(account.id),
                         method="DELETE",
                         url=f"{url}/{command_id}",
                         path=f"{path}/commands/{command_id}",
@@ -5232,6 +5483,7 @@ async def sync_discord_commands(
             for command_payload in command_payloads:
                 response = await _discord_command_request(
                     client,
+                    account_scope=str(account.id),
                     method="POST",
                     url=url,
                     path=f"{path}/commands",
@@ -5254,13 +5506,14 @@ async def sync_discord_commands(
 async def _discord_command_request(
     client: httpx.AsyncClient,
     *,
+    account_scope: str,
     method: str,
     url: str,
     path: str,
     headers: dict[str, str],
     json_payload: dict[str, Any] | None = None,
 ) -> httpx.Response:
-    decision = discord_rate_limiter.check(method, path)
+    decision = discord_rate_limiter.check(account_scope, method, path)
     if not decision.allowed:
         retry_after = decision.retry_after_seconds
         raise HTTPException(
@@ -5268,12 +5521,13 @@ async def _discord_command_request(
             detail="discord command sync is rate limited",
             headers={"Retry-After": str(retry_after)} if retry_after is not None else None,
         )
-    discord_rate_limiter.consume(method, path)
+    discord_rate_limiter.consume(account_scope, method, path)
     if json_payload is None:
         response = await client.request(method, url, headers=headers)
     else:
         response = await client.request(method, url, headers=headers, json=json_payload)
     discord_rate_limiter.observe(
+        account_scope,
         method,
         path,
         _discord_rate_limit_response_headers(response),
@@ -5532,13 +5786,42 @@ async def _post_provider_json(
             detail=unreachable_detail,
         ) from exc
     outbound_messages.labels(channel=channel, method=method).inc()
+    response_payload = _response_json_or_text(response)
+    if (
+        channel == CHANNEL_PROVIDER_TELEGRAM
+        and response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    ):
+        outbound_errors.labels(channel=channel, method=method).inc()
+        retry_after = _telegram_retry_after_seconds(response, response_payload)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="telegram api rate limited",
+            headers={"Retry-After": str(retry_after)} if retry_after is not None else None,
+        )
     if response.status_code >= 400:
         outbound_errors.labels(channel=channel, method=method).inc()
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=rejected_detail,
         )
-    return _response_json_or_text(response)
+    return response_payload
+
+
+def _telegram_retry_after_seconds(
+    response: httpx.Response,
+    payload: dict[str, Any],
+) -> float | None:
+    raw_header = response.headers.get("retry-after")
+    parameters = payload.get("parameters")
+    raw_parameter = parameters.get("retry_after") if isinstance(parameters, dict) else None
+    for value in (raw_header, raw_parameter):
+        try:
+            seconds = float(value)
+        except (TypeError, ValueError):
+            continue
+        if seconds >= 0:
+            return seconds
+    return None
 
 
 async def _validate_provider_endpoint_url(
@@ -5552,9 +5835,14 @@ async def _validate_provider_endpoint_url(
         await validate_channel_http_url(url, label=label)
     except UnsafeOutboundUrlError as exc:
         outbound_errors.labels(channel=channel, method=method).inc()
+        if channel in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}:
+            detail = f"{channel} provider url must be a public https URL"
+        else:
+            # Paused provider behavior is intentionally unchanged.
+            detail = str(exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=detail,
         ) from exc
 
 
@@ -6290,19 +6578,34 @@ async def _lock_active_delivery_binding(
     return binding
 
 
-def _schedule_delivery_retry(delivery: ChannelDelivery, error: str) -> None:
+def _schedule_delivery_retry(
+    delivery: ChannelDelivery,
+    error: str,
+    *,
+    use_safe_diagnostics: bool = False,
+    retry_after_seconds: float | None = None,
+) -> None:
     delivery.locked_at = None
     delivery.locked_by = None
-    delivery.last_error = error[:1000]
+    delivery.last_error = _delivery_error_code(error) if use_safe_diagnostics else error[:1000]
     if delivery.attempts >= delivery.max_attempts:
         delivery.status = DELIVERY_STATUS_FAILED
         return
-    delay_seconds = min(2 ** max(delivery.attempts - 1, 0), 300)
+    delay_seconds = (
+        min(max(retry_after_seconds, 0.1), 3600)
+        if retry_after_seconds is not None
+        else min(2 ** max(delivery.attempts - 1, 0), 300)
+    )
     delivery.status = DELIVERY_STATUS_PENDING
     delivery.next_attempt_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
 
 
-def _schedule_delivery_link_contention_retry(delivery: ChannelDelivery, error: str) -> None:
+def _schedule_delivery_link_contention_retry(
+    delivery: ChannelDelivery,
+    error: str,
+    *,
+    use_safe_diagnostics: bool = False,
+) -> None:
     refunded_attempts = max(delivery.attempts - 1, 0)
     delay_seconds = min(
         2 ** max(refunded_attempts, 0),
@@ -6311,15 +6614,20 @@ def _schedule_delivery_link_contention_retry(delivery: ChannelDelivery, error: s
     delivery.attempts = refunded_attempts
     delivery.locked_at = None
     delivery.locked_by = None
-    delivery.last_error = error[:1000]
+    delivery.last_error = _delivery_error_code(error) if use_safe_diagnostics else error[:1000]
     delivery.status = DELIVERY_STATUS_PENDING
     delivery.next_attempt_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
 
 
-def _fail_delivery(delivery: ChannelDelivery, error: str) -> None:
+def _fail_delivery(
+    delivery: ChannelDelivery,
+    error: str,
+    *,
+    use_safe_diagnostics: bool = False,
+) -> None:
     delivery.locked_at = None
     delivery.locked_by = None
-    delivery.last_error = error[:1000]
+    delivery.last_error = _delivery_error_code(error) if use_safe_diagnostics else error[:1000]
     delivery.status = DELIVERY_STATUS_FAILED
 
 
@@ -6332,6 +6640,62 @@ def _is_delivery_link_lock_contention(exc: HTTPException, *, error: str) -> bool
 
 def _http_exception_detail(exc: HTTPException) -> str:
     return exc.detail if isinstance(exc.detail, str) else "channel delivery failed"
+
+
+def _http_retry_after_seconds(exc: HTTPException) -> float | None:
+    raw = (exc.headers or {}).get("Retry-After")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def _delivery_error_code(error: str) -> str:
+    codes = {
+        "channel account archived": DELIVERY_ERROR_ACCOUNT_INACTIVE,
+        "channel account is not active": DELIVERY_ERROR_ACCOUNT_INACTIVE,
+        "channel agent link archived": DELIVERY_ERROR_LINK_ARCHIVED,
+        "channel agent link has no managed runtime authority": DELIVERY_ERROR_LINK_AUTHORITY,
+        DELIVERY_LINK_LOCK_CONTENTION_ERROR: DELIVERY_ERROR_LINK_CONTENTION,
+        "channel binding archived": DELIVERY_ERROR_BINDING_INACTIVE,
+        "channel delivery has no active binding": DELIVERY_ERROR_BINDING_INACTIVE,
+        "channel message not found": DELIVERY_ERROR_MESSAGE_MISSING,
+        "channel account has no provider token configured": DELIVERY_ERROR_PROVIDER_CREDENTIAL,
+        "telegram api unreachable": DELIVERY_ERROR_PROVIDER_UNREACHABLE,
+        "discord api unreachable": DELIVERY_ERROR_PROVIDER_UNREACHABLE,
+        "telegram api rate limited": DELIVERY_ERROR_PROVIDER_RATE_LIMITED,
+        "discord api rate limited": DELIVERY_ERROR_PROVIDER_RATE_LIMITED,
+        "telegram api rejected message": DELIVERY_ERROR_PROVIDER_REJECTED,
+        "discord api rejected message": DELIVERY_ERROR_PROVIDER_REJECTED,
+        "channel delivery failed": DELIVERY_ERROR_FAILED,
+        hosted_agent_provider_link_limit_detail(
+            CHANNEL_PROVIDER_TELEGRAM,
+            duplicate=True,
+        ): DELIVERY_ERROR_LINK_AUTHORITY,
+        hosted_agent_provider_link_limit_detail(
+            CHANNEL_PROVIDER_DISCORD,
+            duplicate=True,
+        ): DELIVERY_ERROR_LINK_AUTHORITY,
+    }
+    return codes.get(error, DELIVERY_ERROR_FAILED)
+
+
+def _safe_delivery_provider_response(
+    *,
+    provider: str,
+    provider_message_id: str | None,
+) -> dict[str, Any]:
+    response: dict[str, Any] = {"provider": provider, "accepted": True}
+    if provider_message_id is not None:
+        response["provider_message_id"] = provider_message_id[:300]
+    return response
+
+
+def _discord_delivery_nonce(message_id: UUID) -> str:
+    # Discord accepts at most 25 characters. A UUID is non-secret durable
+    # identity; base64url preserves all 128 bits in 22 characters.
+    return base64.urlsafe_b64encode(message_id.bytes).rstrip(b"=").decode("ascii")
 
 
 def _command_name(command: dict[str, Any]) -> str:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -5815,6 +5815,8 @@ def _telegram_retry_after_seconds(
     parameters = payload.get("parameters")
     raw_parameter = parameters.get("retry_after") if isinstance(parameters, dict) else None
     for value in (raw_header, raw_parameter):
+        if value is None:
+            continue
         try:
             seconds = float(value)
         except (TypeError, ValueError):
@@ -6644,6 +6646,8 @@ def _http_exception_detail(exc: HTTPException) -> str:
 
 def _http_retry_after_seconds(exc: HTTPException) -> float | None:
     raw = (exc.headers or {}).get("Retry-After")
+    if raw is None:
+        return None
     try:
         value = float(raw)
     except (TypeError, ValueError):

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -316,8 +316,6 @@ class DiscordGatewayWorker:
         if frame is None:
             return
         sequence = frame.get("s")
-        if isinstance(sequence, int):
-            state.sequence = sequence
         op = frame.get("op")
         if op == 0:
             _update_gateway_session_state(state, frame)
@@ -327,6 +325,11 @@ class DiscordGatewayWorker:
                 frame,
                 gateway_session_id=state.session_id,
             )
+            # A RESUME sequence acknowledges every Dispatch through this value.
+            # Advance it only after the event's durable admission succeeds, or
+            # a reconnect could skip the failed event permanently.
+            if isinstance(sequence, int) and not isinstance(sequence, bool):
+                state.sequence = sequence
         elif op == 1:
             await _send_heartbeat(websocket, state)
         elif op == 7:

--- a/backend/app/services/discord_rate_limiter.py
+++ b/backend/app/services/discord_rate_limiter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import threading
 import time
+from collections import OrderedDict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
@@ -20,67 +22,115 @@ class DiscordBucketState:
     bucket_id: str | None = None
 
 
+@dataclass
+class _DiscordGlobalState:
+    window_started_at: float
+    count: int = 0
+    blocked_until: float = 0.0
+    updated_at: float = 0.0
+
+
 class DiscordRateLimiter:
+    """Process-local Discord REST limiter scoped to one authentication identity.
+
+    Discord applies per-route and global limits to the authenticated bot or
+    user. ``account_scope`` must therefore be a stable, non-secret account or
+    application identifier, never a provider token.
+    """
+
     def __init__(
         self,
         *,
         global_per_second: int = 50,
+        max_buckets: int = 4096,
+        max_scopes: int = 2048,
+        scope_idle_ttl_seconds: float = 10 * 60,
         now: Callable[[], float] | None = None,
     ) -> None:
+        if global_per_second <= 0:
+            raise ValueError("global_per_second must be positive")
+        if max_buckets <= 0 or max_scopes <= 0:
+            raise ValueError("rate limiter bounds must be positive")
+        if scope_idle_ttl_seconds <= 0:
+            raise ValueError("scope_idle_ttl_seconds must be positive")
         self._global_per_second = global_per_second
-        self._global_window_started_at = 0.0
-        self._global_count = 0
-        self._global_blocked_until = 0.0
-        self._buckets: dict[str, DiscordBucketState] = {}
+        self._max_buckets = max_buckets
+        self._max_scopes = max_scopes
+        self._scope_idle_ttl_seconds = scope_idle_ttl_seconds
+        self._global_states: OrderedDict[str, _DiscordGlobalState] = OrderedDict()
+        self._buckets: OrderedDict[str, DiscordBucketState] = OrderedDict()
         self._now = now or time.monotonic
+        self._lock = threading.Lock()
 
-    def check(self, method: str, path: str) -> DiscordRateLimitDecision:
+    def check(
+        self,
+        account_scope: str,
+        method: str,
+        path: str,
+    ) -> DiscordRateLimitDecision:
         now = self._now()
-        if self._global_blocked_until > now:
+        with self._lock:
+            self._prune(now)
+            global_state = self._global_states.get(account_scope)
+            if global_state is not None:
+                self._touch_global(account_scope, global_state, now)
+                if global_state.blocked_until > now:
+                    return DiscordRateLimitDecision(
+                        allowed=False,
+                        retry_after_seconds=global_state.blocked_until - now,
+                        global_limit=True,
+                    )
+                global_state.blocked_until = 0.0
+                if now - global_state.window_started_at >= 1:
+                    global_state.window_started_at = now
+                    global_state.count = 0
+                if global_state.count >= self._global_per_second:
+                    retry_after = max(0.1, global_state.window_started_at + 1 - now)
+                    return DiscordRateLimitDecision(
+                        allowed=False,
+                        retry_after_seconds=retry_after,
+                        global_limit=True,
+                    )
+
+            key = self.route_key(account_scope, method, path)
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                return DiscordRateLimitDecision(allowed=True)
+            self._buckets.move_to_end(key)
+            if bucket.remaining > 0:
+                return DiscordRateLimitDecision(allowed=True)
             return DiscordRateLimitDecision(
                 allowed=False,
-                retry_after_seconds=self._global_blocked_until - now,
-                global_limit=True,
-            )
-        self._global_blocked_until = 0.0
-        if now - self._global_window_started_at >= 1:
-            self._global_window_started_at = now
-            self._global_count = 0
-        if self._global_count >= self._global_per_second:
-            retry_after = max(0.1, self._global_window_started_at + 1 - now)
-            return DiscordRateLimitDecision(
-                allowed=False,
-                retry_after_seconds=retry_after,
-                global_limit=True,
+                retry_after_seconds=max(0.1, bucket.reset_at - now),
             )
 
-        key = self.route_key(method, path)
-        bucket = self._buckets.get(key)
-        if bucket is None:
-            return DiscordRateLimitDecision(allowed=True)
-        if bucket.reset_at <= now:
-            self._buckets.pop(key, None)
-            return DiscordRateLimitDecision(allowed=True)
-        if bucket.remaining > 0:
-            return DiscordRateLimitDecision(allowed=True)
-        return DiscordRateLimitDecision(
-            allowed=False,
-            retry_after_seconds=max(0.1, bucket.reset_at - now),
-        )
-
-    def consume(self, method: str, path: str) -> None:
+    def consume(self, account_scope: str, method: str, path: str) -> None:
         now = self._now()
-        if now - self._global_window_started_at >= 1:
-            self._global_window_started_at = now
-            self._global_count = 0
-        self._global_count += 1
+        with self._lock:
+            self._prune(now)
+            global_state = self._global_states.get(account_scope)
+            if global_state is None:
+                global_state = _DiscordGlobalState(
+                    window_started_at=now,
+                    updated_at=now,
+                )
+                self._global_states[account_scope] = global_state
+            elif now - global_state.window_started_at >= 1:
+                global_state.window_started_at = now
+                global_state.count = 0
+            global_state.count += 1
+            self._touch_global(account_scope, global_state, now)
+            self._enforce_scope_bound()
 
-        bucket = self._buckets.get(self.route_key(method, path))
-        if bucket and bucket.reset_at > now and bucket.remaining > 0:
-            bucket.remaining -= 1
+            key = self.route_key(account_scope, method, path)
+            bucket = self._buckets.get(key)
+            if bucket is not None and bucket.remaining > 0:
+                bucket.remaining -= 1
+                self._buckets.move_to_end(key)
 
     def observe(
         self,
+        account_scope: str,
         method: str,
         path: str,
         headers: Mapping[str, str],
@@ -94,37 +144,55 @@ class DiscordRateLimiter:
         bucket_id = headers.get("x-ratelimit-bucket")
         global_header = (headers.get("x-ratelimit-global") or "").lower() == "true"
 
-        if status_code == 429 and global_header:
-            delay = retry_after if retry_after is not None else reset_after
-            if delay is not None:
-                self._global_blocked_until = max(
-                    self._global_blocked_until,
-                    now + max(0.0, delay),
-                )
-            return
-
-        if status_code == 429:
-            delay = retry_after if retry_after is not None else reset_after
-            if delay is None:
+        with self._lock:
+            self._prune(now)
+            if status_code == 429 and global_header:
+                delay = retry_after if retry_after is not None else reset_after
+                if delay is not None:
+                    global_state = self._global_states.get(account_scope)
+                    if global_state is None:
+                        global_state = _DiscordGlobalState(
+                            window_started_at=now,
+                            updated_at=now,
+                        )
+                        self._global_states[account_scope] = global_state
+                    global_state.blocked_until = max(
+                        global_state.blocked_until,
+                        now + max(0.0, delay),
+                    )
+                    self._touch_global(account_scope, global_state, now)
+                    self._enforce_scope_bound()
                 return
-            self._buckets[self.route_key(method, path)] = DiscordBucketState(
-                remaining=0,
-                reset_at=now + max(0.0, delay),
-                limit=limit,
-                bucket_id=bucket_id,
+
+            key = self.route_key(account_scope, method, path)
+            if status_code == 429:
+                delay = retry_after if retry_after is not None else reset_after
+                if delay is None:
+                    return
+                self._store_bucket(
+                    key,
+                    DiscordBucketState(
+                        remaining=0,
+                        reset_at=now + max(0.0, delay),
+                        limit=limit,
+                        bucket_id=bucket_id,
+                    ),
+                )
+                return
+
+            if remaining is None or reset_after is None:
+                return
+            self._store_bucket(
+                key,
+                DiscordBucketState(
+                    remaining=remaining,
+                    reset_at=now + max(0.0, reset_after),
+                    limit=limit,
+                    bucket_id=bucket_id,
+                ),
             )
-            return
 
-        if remaining is None or reset_after is None:
-            return
-        self._buckets[self.route_key(method, path)] = DiscordBucketState(
-            remaining=remaining,
-            reset_at=now + reset_after,
-            limit=limit,
-            bucket_id=bucket_id,
-        )
-
-    def route_key(self, method: str, path: str) -> str:
+    def route_key(self, account_scope: str, method: str, path: str) -> str:
         normalized = path.split("?", 1)[0]
         normalized = normalized.removeprefix("/v1/channels/discord/v10")
         normalized = normalized.removeprefix("/api/channels/discord/v10")
@@ -143,10 +211,66 @@ class DiscordRateLimiter:
                 parts.append(":token")
             else:
                 parts.append(segment)
-        return f"{method.upper()} /{'/'.join(parts)}|{major}"
+        return f"{account_scope}|{method.upper()} /{'/'.join(parts)}|{major}"
 
-    def inspect(self, method: str, path: str) -> DiscordBucketState | None:
-        return self._buckets.get(self.route_key(method, path))
+    def inspect(
+        self,
+        account_scope: str,
+        method: str,
+        path: str,
+    ) -> DiscordBucketState | None:
+        now = self._now()
+        with self._lock:
+            self._prune(now)
+            key = self.route_key(account_scope, method, path)
+            bucket = self._buckets.get(key)
+            if bucket is not None:
+                self._buckets.move_to_end(key)
+            return bucket
+
+    def reset(self) -> None:
+        with self._lock:
+            self._global_states.clear()
+            self._buckets.clear()
+
+    def _store_bucket(self, key: str, bucket: DiscordBucketState) -> None:
+        if bucket.reset_at <= self._now():
+            self._buckets.pop(key, None)
+            return
+        self._buckets[key] = bucket
+        self._buckets.move_to_end(key)
+        while len(self._buckets) > self._max_buckets:
+            self._buckets.popitem(last=False)
+
+    def _touch_global(
+        self,
+        account_scope: str,
+        state: _DiscordGlobalState,
+        now: float,
+    ) -> None:
+        state.updated_at = now
+        self._global_states.move_to_end(account_scope)
+
+    def _enforce_scope_bound(self) -> None:
+        while len(self._global_states) > self._max_scopes:
+            self._global_states.popitem(last=False)
+
+    def _prune(self, now: float) -> None:
+        expired_bucket_keys = [
+            key for key, bucket in self._buckets.items() if bucket.reset_at <= now
+        ]
+        for key in expired_bucket_keys:
+            self._buckets.pop(key, None)
+
+        expired_scope_keys = [
+            key
+            for key, state in self._global_states.items()
+            if state.blocked_until <= now
+            and state.window_started_at + 1 <= now
+            and state.updated_at + self._scope_idle_ttl_seconds <= now
+        ]
+        for key in expired_scope_keys:
+            self._global_states.pop(key, None)
 
 
 def _float_header(headers: Mapping[str, str], key: str) -> float | None:

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -92,6 +92,12 @@ channel_retention_deletions = Counter(
     ["record_kind"],
     registry=registry,
 )
+channel_retention_delivery_expirations = Counter(
+    "msg_router_channel_retention_delivery_expirations_total",
+    "Pending channel deliveries terminally consumed at a provider retention horizon",
+    ["provider"],
+    registry=registry,
+)
 channel_retention_secret_scrubs = Counter(
     "msg_router_channel_retention_secret_scrubs_total",
     "Expired provider credential fields removed from retained channel payloads",

--- a/backend/app/services/telegram_rate_limiter.py
+++ b/backend/app/services/telegram_rate_limiter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass
 
 
@@ -26,12 +28,29 @@ class TelegramRateLimiter:
         bot_refill_per_second: float = 30.0,
         chat_capacity: int = 5,
         chat_refill_per_second: float = 1.0,
+        max_buckets: int = 4096,
+        idle_ttl_seconds: float = 10 * 60,
+        now: Callable[[], float] | None = None,
     ) -> None:
+        if bot_capacity <= 0 or chat_capacity <= 0:
+            raise ValueError("capacities must be positive")
+        if bot_refill_per_second <= 0 or chat_refill_per_second <= 0:
+            raise ValueError("refill rates must be positive")
+        if max_buckets < 2 or idle_ttl_seconds <= 0:
+            raise ValueError("rate limiter bounds must be positive")
         self.bot_capacity = float(bot_capacity)
         self.bot_refill_per_second = bot_refill_per_second
         self.chat_capacity = float(chat_capacity)
         self.chat_refill_per_second = chat_refill_per_second
-        self._buckets: dict[tuple[str, str, str | None], _Bucket] = {}
+        self._max_buckets = max_buckets
+        # Never expire a bucket before it has naturally refilled to capacity.
+        self._idle_ttl_seconds = max(
+            idle_ttl_seconds,
+            self.bot_capacity / self.bot_refill_per_second,
+            self.chat_capacity / self.chat_refill_per_second,
+        )
+        self._now = now or time.monotonic
+        self._buckets: OrderedDict[tuple[str, str, str | None], _Bucket] = OrderedDict()
         self._lock = threading.Lock()
 
     def check_and_consume(
@@ -45,11 +64,14 @@ class TelegramRateLimiter:
             return TelegramRateLimitDecision(allowed=True)
 
         with self._lock:
+            now = self._now()
+            self._prune(now)
             bot_decision = self._consume(
                 ("bot", account_id, None),
                 capacity=self.bot_capacity,
                 refill_per_second=self.bot_refill_per_second,
                 scope="bot",
+                now=now,
             )
             if not bot_decision.allowed:
                 return bot_decision
@@ -58,6 +80,7 @@ class TelegramRateLimiter:
                 capacity=self.chat_capacity,
                 refill_per_second=self.chat_refill_per_second,
                 scope="chat",
+                now=now,
             )
             if not chat_decision.allowed:
                 self._refund(("bot", account_id, None), capacity=self.bot_capacity)
@@ -74,8 +97,8 @@ class TelegramRateLimiter:
         capacity: float,
         refill_per_second: float,
         scope: str,
+        now: float,
     ) -> TelegramRateLimitDecision:
-        now = time.monotonic()
         bucket = self._buckets.get(key)
         if bucket is None:
             bucket = _Bucket(tokens=capacity, updated_at=now)
@@ -83,6 +106,9 @@ class TelegramRateLimiter:
         elapsed = max(0.0, now - bucket.updated_at)
         bucket.tokens = min(capacity, bucket.tokens + elapsed * refill_per_second)
         bucket.updated_at = now
+        self._buckets.move_to_end(key)
+        while len(self._buckets) > self._max_buckets:
+            self._buckets.popitem(last=False)
         if bucket.tokens >= 1.0:
             bucket.tokens -= 1.0
             return TelegramRateLimitDecision(allowed=True)
@@ -97,6 +123,16 @@ class TelegramRateLimiter:
         bucket = self._buckets.get(key)
         if bucket is not None:
             bucket.tokens = min(capacity, bucket.tokens + 1.0)
+            self._buckets.move_to_end(key)
+
+    def _prune(self, now: float) -> None:
+        expired = [
+            key
+            for key, bucket in self._buckets.items()
+            if bucket.updated_at + self._idle_ttl_seconds <= now
+        ]
+        for key in expired:
+            self._buckets.pop(key, None)
 
 
 def _telegram_send_method_is_limited(method: str) -> bool:

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -223,6 +223,14 @@ def analyze(paths: Sequence[str], *, gating: bool) -> Analysis:
         text=True,
     )
     analysis = parse_analysis(completed.stdout, len(paths))
+    if gating and completed.returncode == 1:
+        diagnostic_report = {
+            "generalDiagnostics": analysis["generalDiagnostics"],
+            "summary": analysis["summary"],
+        }
+        raise ValueError(
+            f"analyzer exited 1 with diagnostics: {json.dumps(diagnostic_report, sort_keys=True)}"
+        )
     if completed.returncode not in ({0} if gating else {0, 1}):
         raise ValueError(
             f"analyzer exited {completed.returncode}: {completed.stderr.strip() or 'no stderr'}"

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from sqlalchemy import event as sqlalchemy_event
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
@@ -11,6 +13,8 @@ from app.models.channel import (
     MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
     ChannelBinding,
+    ChannelBotAgentLink,
+    ChannelDebugEvent,
     ChannelMessage,
 )
 from app.models.user import User
@@ -49,13 +53,15 @@ async def test_channel_debug_events_are_sanitized_and_filterable(
         external_chat_id="chat-1",
         request_id="req-1",
         status_code=503,
-        error="upstream " + ("x" * 700),
+        error="upstream Authorization: Bot debug-secret-marker " + ("x" * 700),
         details={
-            "providerToken": "telegram-secret",
+            "providerToken": "debug-secret-marker",
             "nested": {
-                "authorization": "Bearer secret",
-                "message": "m" * 700,
+                "authorization": "Bearer debug-secret-marker",
+                "message": "postgresql://user:debug-secret-marker@db.example/app",
             },
+            "provider_body": "https://cdn.example/file?signature=debug-secret-marker",
+            "reason": "provider_failure",
             "items": list(range(25)),
             "opaque": object(),
         },
@@ -77,11 +83,21 @@ async def test_channel_debug_events_are_sanitized_and_filterable(
     assert event["status"] == 503
     assert event["details"]["providerToken"] == "[redacted]"
     assert event["details"]["nested"]["authorization"] == "[redacted]"
-    assert "telegram-secret" not in response.text
-    assert len(event["details"]["nested"]["message"]) <= 503
+    assert event["details"]["nested"]["message"] == "[redacted]"
+    assert event["details"]["provider_body"] == "[redacted]"
+    assert event["details"]["reason"] == "provider_failure"
     assert len(event["details"]["items"]) == 20
     assert isinstance(event["details"]["opaque"], str)
-    assert len(event["error"]) <= 503
+    assert event["error"] == "channel_operation_failed"
+    assert "debug-secret-marker" not in response.text
+
+    stored = (
+        await db_session.execute(
+            select(ChannelDebugEvent).where(ChannelDebugEvent.id == UUID(event["id"]))
+        )
+    ).scalar_one()
+    assert stored.error == "channel_operation_failed"
+    assert "debug-secret-marker" not in str(stored.details)
 
 
 @pytest.mark.asyncio
@@ -180,8 +196,129 @@ async def test_channel_debug_health_reports_pending_inbox_and_last_error(
     health = next(channel for channel in channels if channel["accountId"] == created["id"])
     assert health["provider"] == "discord"
     assert health["pendingInbox"] == 1
+    assert health["oldestPendingInboxAt"] is not None
     assert health["lastEvent"]["stage"] == "rest"
-    assert health["lastError"]["error"] == "rate limited"
+    assert health["lastError"]["error"] == "channel_operation_failed"
+
+
+@pytest.mark.asyncio
+async def test_channel_debug_health_select_count_is_constant_across_accounts(
+    client: httpx.AsyncClient,
+    engine,
+):
+    async def create_account(index: int) -> None:
+        response = await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": f"debug-health-query-count-{index}-{uuid4().hex}",
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    async def health_select_count() -> int:
+        select_count = 0
+
+        def count_selects(_conn, _cursor, statement, _parameters, _context, _executemany):
+            nonlocal select_count
+            if statement.lstrip().upper().startswith("SELECT"):
+                select_count += 1
+
+        sqlalchemy_event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+        try:
+            response = await client.get("/v1/channels/debug/health")
+        finally:
+            sqlalchemy_event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+        assert response.status_code == 200, response.text
+        return select_count
+
+    await create_account(0)
+    one_account_count = await health_select_count()
+    for index in range(1, 5):
+        await create_account(index)
+    five_account_count = await health_select_count()
+
+    assert one_account_count == 4
+    assert five_account_count == one_account_count
+
+
+@pytest.mark.asyncio
+async def test_channel_debug_health_isolates_cross_user_accounts_and_aggregates(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent,
+):
+    owned = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": f"owned-debug-health-{uuid4().hex}"},
+        )
+    ).json()
+    owned_account = await db_session.get(ChannelAccount, UUID(owned["id"]))
+    assert owned_account is not None
+
+    other_user = User(
+        clerk_id=f"debug-health-other-{uuid4().hex}",
+        email=f"debug-health-other-{uuid4().hex}@clawdi.local",
+        name="Debug Health Other",
+    )
+    db_session.add(other_user)
+    await db_session.flush()
+    other_account = ChannelAccount(
+        user_id=other_user.id,
+        provider="telegram",
+        name=f"other-debug-health-{uuid4().hex}",
+        webhook_secret_hash=uuid4().hex,
+    )
+    db_session.add(other_account)
+    await db_session.flush()
+    other_link = ChannelBotAgentLink(
+        account_id=other_account.id,
+        user_id=other_user.id,
+        agent_id=channel_agent.id,
+        agent_token_hash=uuid4().hex,
+    )
+    db_session.add(other_link)
+    await db_session.flush()
+    other_binding = ChannelBinding(
+        account_id=other_account.id,
+        bot_agent_link_id=other_link.id,
+        user_id=other_user.id,
+        external_chat_id="other-user-debug-health",
+    )
+    db_session.add(other_binding)
+    await db_session.flush()
+    db_session.add(
+        ChannelMessage(
+            account_id=other_account.id,
+            bot_agent_link_id=other_link.id,
+            binding_id=other_binding.id,
+            user_id=other_user.id,
+            direction=MESSAGE_DIRECTION_INBOUND,
+            external_chat_id=other_binding.external_chat_id,
+            text="other user pending",
+        )
+    )
+    await record_channel_debug_event(
+        db_session,
+        account=other_account,
+        user_id=other_user.id,
+        provider="telegram",
+        direction="inbound",
+        stage="other_user_secret_stage",
+        outcome="failure",
+        error="must remain isolated",
+    )
+    await db_session.commit()
+
+    response = await client.get("/v1/channels/debug/health")
+
+    assert response.status_code == 200, response.text
+    by_account = {item["accountId"]: item for item in response.json()["channels"]}
+    assert owned["id"] in by_account
+    assert str(other_account.id) not in by_account
+    assert "other_user_secret_stage" not in response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channel_inbox.py
+++ b/backend/tests/test_channel_inbox.py
@@ -570,6 +570,52 @@ async def test_telegram_inbox_uses_update_id_offset_and_drains_filtered_updates(
 
 
 @pytest.mark.asyncio
+async def test_telegram_inbox_terminally_consumes_updates_older_than_official_retention(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    # https://core.telegram.org/bots/api#getting-updates: incoming updates
+    # are not kept longer than 24 hours by Telegram's hosted Bot API.
+    account, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-retention-chat",
+    )
+    expired = await _add_message(
+        db_session,
+        account=account,
+        binding=binding,
+        text="expired",
+        payload={"update_id": 201, "message": {"text": "expired"}},
+    )
+    current = await _add_message(
+        db_session,
+        account=account,
+        binding=binding,
+        text="current",
+        payload={"update_id": 202, "message": {"text": "current"}},
+    )
+    expired.created_at = datetime.now(UTC) - timedelta(hours=24, seconds=1)
+    await db_session.commit()
+
+    updates = await dequeue_telegram_updates(
+        db_session,
+        account=account,
+        offset=None,
+        limit=100,
+    )
+    await db_session.refresh(expired)
+    await db_session.refresh(current)
+
+    assert [update["update_id"] for update in updates] == [202]
+    assert expired.delivered_at is not None
+    assert current.delivered_at is None
+
+
+@pytest.mark.asyncio
 async def test_channel_inbox_wait_polls_until_new_committed_event(
     db_session: AsyncSession,
     seed_user: User,

--- a/backend/tests/test_channel_retention.py
+++ b/backend/tests/test_channel_retention.py
@@ -41,6 +41,7 @@ from app.services.channels import (
     channel_queue_snapshots,
     deliver_channel_delivery,
     enqueue_channel_outbound_message,
+    expire_stale_telegram_inbox_messages,
     prune_channel_messages,
     prune_channel_pair_codes,
     prune_channel_retention_batch,
@@ -297,6 +298,177 @@ async def test_retention_horizons_are_strict_and_pending_bound_is_not_deleted(
     assert await db_session.get(ChannelMessage, boundary_delivered.id) is not None
     assert await db_session.get(ChannelMessage, boundary_unbound.id) is not None
     assert await db_session.get(ChannelMessage, pending_bound.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_stale_telegram_delivery_expiry_handles_offline_links_and_strict_cutoff(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    telegram, telegram_link, telegram_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="offline-polling-no-webhook",
+    )
+    assert telegram_link.config is None
+    discord, _discord_link, discord_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        chat_id="discord-no-silent-expiry",
+    )
+    disabled, _disabled_link, disabled_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="disabled-telegram",
+    )
+    disabled.status = CHANNEL_STATUS_DISABLED
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    cutoff = now - timedelta(hours=24)
+    expired = await _add_message(
+        db_session,
+        account=telegram,
+        binding=telegram_binding,
+        text="expired offline update",
+    )
+    expired.created_at = cutoff - timedelta(microseconds=1)
+    boundary = await _add_message(
+        db_session,
+        account=telegram,
+        binding=telegram_binding,
+        text="strict boundary",
+    )
+    boundary.created_at = cutoff
+    active = await _add_message(
+        db_session,
+        account=telegram,
+        binding=telegram_binding,
+        text="still within provider horizon",
+    )
+    active.created_at = cutoff + timedelta(microseconds=1)
+    old_discord = await _add_message(
+        db_session,
+        account=discord,
+        binding=discord_binding,
+        text="discord remains pending",
+    )
+    old_discord.created_at = cutoff - timedelta(days=30)
+    old_disabled = await _add_message(
+        db_session,
+        account=disabled,
+        binding=disabled_binding,
+        text="disabled telegram remains pending",
+    )
+    old_disabled.created_at = cutoff - timedelta(days=30)
+    await db_session.flush()
+
+    expired_count = await expire_stale_telegram_inbox_messages(
+        db_session,
+        now=now,
+        limit=10,
+    )
+
+    assert expired_count == 1
+    assert expired.delivered_at == now
+    assert boundary.delivered_at is None
+    assert active.delivered_at is None
+    assert old_discord.delivered_at is None
+    assert old_disabled.delivered_at is None
+    assert await db_session.get(ChannelMessage, expired.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_telegram_delivery_expiry_cleaners_skip_locked_rows(
+    engine,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    account, _link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="concurrent-telegram-expiry",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    for index in range(5):
+        message = await _add_message(
+            db_session,
+            account=account,
+            binding=binding,
+            text=f"stale-pending-{index}",
+        )
+        message.created_at = now - timedelta(hours=25)
+    await db_session.commit()
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as first, session_factory() as second:
+        first_expired = await expire_stale_telegram_inbox_messages(first, now=now, limit=2)
+        second_expired = await expire_stale_telegram_inbox_messages(second, now=now, limit=2)
+        await first.commit()
+        await second.commit()
+
+    delivered = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(
+            ChannelMessage.account_id == account.id,
+            ChannelMessage.delivered_at.is_not(None),
+        )
+    )
+    total = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(ChannelMessage.account_id == account.id)
+    )
+    assert first_expired == 2
+    assert second_expired == 2
+    assert delivered == 4
+    assert total == 5
+
+
+@pytest.mark.asyncio
+async def test_expired_telegram_delivery_becomes_ordinary_retention_eligible(
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+):
+    account, _link, binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="eventual-physical-retention",
+    )
+    now = datetime(2026, 8, 2, tzinfo=UTC)
+    message = await _add_message(
+        db_session,
+        account=account,
+        binding=binding,
+        text="expire then retain",
+    )
+    message.created_at = now - timedelta(hours=25)
+    await db_session.flush()
+
+    assert await expire_stale_telegram_inbox_messages(db_session, now=now, limit=1) == 1
+    assert message.delivered_at == now
+    await prune_channel_messages(
+        db_session,
+        now=now + timedelta(days=30),
+        delivered_retention=timedelta(days=30),
+        limit=10_000,
+    )
+    assert await db_session.get(ChannelMessage, message.id) is not None
+    await prune_channel_messages(
+        db_session,
+        now=now + timedelta(days=30, microseconds=1),
+        delivered_retention=timedelta(days=30),
+        limit=10_000,
+    )
+    assert await db_session.get(ChannelMessage, message.id) is None
 
 
 @pytest.mark.asyncio
@@ -823,11 +995,12 @@ async def test_queue_snapshots_report_provider_specific_stuck_pending(
     with caplog.at_level(logging.WARNING):
         await worker.run_once()
     metrics = render_metrics().decode("utf-8")
-    assert 'msg_router_channel_queue_pending{provider="telegram",queue="inbox"} 2.0' in metrics
+    assert 'msg_router_channel_queue_pending{provider="telegram",queue="inbox"} 1.0' in metrics
     assert (
-        'msg_router_channel_queue_stuck_pending{provider="telegram",queue="inbox"} 1.0' in metrics
+        'msg_router_channel_queue_stuck_pending{provider="telegram",queue="inbox"} 0.0' in metrics
     )
-    assert "provider=telegram queue=inbox" in caplog.text
+    assert 'msg_router_channel_retention_delivery_expirations_total{provider="telegram"}' in metrics
+    assert "provider=telegram queue=inbox" not in caplog.text
     assert "provider=discord queue=outbox" in caplog.text
 
 
@@ -1001,7 +1174,6 @@ async def test_retention_worker_drains_multiple_bounded_batches(
             text=f"bounded-{index}",
         )
         message.created_at = old
-        message.delivered_at = old
     await db_session.commit()
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     worker = ChannelMessageRetentionWorker(
@@ -1012,14 +1184,24 @@ async def test_retention_worker_drains_multiple_bounded_batches(
     )
 
     with caplog.at_level(logging.WARNING):
-        deleted = await worker.run_once()
+        processed = await worker.run_once()
 
-    remaining = await db_session.scalar(
-        select(func.count(ChannelMessage.id)).where(ChannelMessage.account_id == account.id)
+    remaining_pending = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(
+            ChannelMessage.account_id == account.id,
+            ChannelMessage.delivered_at.is_(None),
+        )
     )
-    assert deleted == 4
-    assert remaining == 1
+    retained_rows = await db_session.scalar(
+        select(func.count(ChannelMessage.id)).where(
+            ChannelMessage.account_id == account.id,
+        )
+    )
+    assert processed == 4
+    assert remaining_pending == 1
+    assert retained_rows == 5
     assert "channel retention batch budget exhausted" in caplog.text
+    assert "telegram_delivery_expirations" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -17,6 +17,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -73,6 +74,7 @@ from app.routes.channel_routers.discord import (
     cleanup_discord_guild_commands_after_authority_revoked,
 )
 from app.routes.channel_routers.shared import _discord_gateway_dispatch
+from app.services import channel_config as channel_config_service
 from app.services import channels as channel_service
 from app.services.bluebubbles_socket import BlueBubblesSocketManager
 from app.services.channel_debug_events import record_channel_debug_event
@@ -106,6 +108,7 @@ from app.services.discord_gateway_worker import (
     DISCORD_DEFAULT_INTENTS,
     DiscordGatewayWorker,
     _GatewayState,
+    _send_heartbeat,
     discord_gateway_advisory_lock_key,
     discord_gateway_intents,
     discord_gateway_uri,
@@ -116,6 +119,7 @@ from app.services.discord_gateway_worker import (
 from app.services.discord_rate_limiter import DiscordRateLimiter
 from app.services.runtime_observation import retire_runtime_environment
 from app.services.telegram_rate_limiter import telegram_rate_limiter
+from app.services.url_security import UnsafeOutboundUrlError
 from app.services.whatsapp_baileys import (
     load_or_create_whatsapp_auth_cert,
     mint_whatsapp_agent_credential,
@@ -580,6 +584,20 @@ class _SequencedProviderClient(_FakeProviderClient):
         self.calls.append({"url": url, **kwargs})
         status_code = self.status_codes.pop(0) if self.status_codes else 200
         return _FakeProviderResponse({}, status_code=status_code)
+
+
+class _AmbiguousDiscordCreateMessageClient(_FakeProviderClient):
+    attempts = 0
+
+    async def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        self.__class__.attempts += 1
+        if self.attempts == 1:
+            raise httpx.ReadTimeout(
+                "response was lost after provider acceptance",
+                request=httpx.Request("POST", str(url)),
+            )
+        return _FakeProviderResponse({"id": "123456789012345679"})
 
 
 class _DiscordPreparationProviderClient(_FakeProviderClient):
@@ -1414,7 +1432,7 @@ async def test_channel_activity_lists_messages_deliveries_and_debug_events_safel
     assert outbound_item["delivery_id"] == outbound["delivery_id"]
     assert outbound_item["delivery_status"] == DELIVERY_STATUS_FAILED
     assert outbound_item["delivery_attempts"] == 2
-    assert outbound_item["delivery_last_error"] == "provider timed out"
+    assert outbound_item["delivery_last_error"] == "channel_delivery_failed"
     inbound_item = next(item for item in items if item["text"] == "activity inbound")
     assert inbound_item["direction"] == MESSAGE_DIRECTION_INBOUND
     assert inbound_item["provider_message_id"] == "provider-message-1"
@@ -1422,6 +1440,7 @@ async def test_channel_activity_lists_messages_deliveries_and_debug_events_safel
     assert debug_item["stage"] == "delivery"
     assert debug_item["outcome"] == "failure"
     assert debug_item["status_code"] == 503
+    assert debug_item["error"] == "channel_operation_failed"
     assert debug_item["details"]["providerToken"] == "[redacted]"
     assert debug_item["details"]["nested"]["authorization"] == "[redacted]"
     assert provider_token not in response.text
@@ -1576,12 +1595,57 @@ async def test_channel_health_summarizes_delivery_and_debug_state(
     assert "pending_inbox" in health["reasons"]
     assert "recent_error" in health["reasons"]
     assert health["pending_inbox"] == 1
+    assert health["oldest_pending_inbox_at"] is not None
     assert health["pending_deliveries"] == 1
     assert health["failed_deliveries"] == 1
-    assert health["last_error"] in {"rate limited", "provider rejected request"}
+    assert health["last_error"] in {
+        "channel_operation_failed",
+        "channel_delivery_failed",
+    }
     assert health["last_error_stage"] in {"delivery", None}
     assert health["last_message_at"] is not None
     assert health["last_event_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_channel_health_select_count_is_constant_across_accounts(
+    client: httpx.AsyncClient,
+    engine,
+):
+    async def create_account(index: int) -> None:
+        response = await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": f"health-query-count-{index}-{uuid4().hex}",
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    async def health_select_count() -> int:
+        select_count = 0
+
+        def count_selects(_conn, _cursor, statement, _parameters, _context, _executemany):
+            nonlocal select_count
+            if statement.lstrip().upper().startswith("SELECT"):
+                select_count += 1
+
+        sqlalchemy_event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+        try:
+            response = await client.get("/v1/channels/health")
+        finally:
+            sqlalchemy_event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
+        assert response.status_code == 200, response.text
+        return select_count
+
+    await create_account(0)
+    one_account_count = await health_select_count()
+    for index in range(1, 5):
+        await create_account(index)
+    five_account_count = await health_select_count()
+
+    assert one_account_count == 7
+    assert five_account_count == one_account_count
 
 
 @pytest.mark.asyncio
@@ -3352,11 +3416,11 @@ async def test_delete_channel_agent_link_cleans_only_link_scoped_runtime_state(
     assert target_binding.status == BINDING_STATUS_ARCHIVED
     assert sibling_binding.status == BINDING_STATUS_ACTIVE
     assert target_pending_delivery.status == DELIVERY_STATUS_FAILED
-    assert target_pending_delivery.last_error == "channel agent link archived"
+    assert target_pending_delivery.last_error == "channel_agent_link_archived"
     assert target_in_progress_delivery.status == DELIVERY_STATUS_FAILED
     assert target_in_progress_delivery.locked_at is None
     assert target_in_progress_delivery.locked_by is None
-    assert target_in_progress_delivery.last_error == "channel agent link archived"
+    assert target_in_progress_delivery.last_error == "channel_agent_link_archived"
     assert sibling_delivery.status == DELIVERY_STATUS_PENDING
     assert sibling_delivery.last_error is None
 
@@ -3365,6 +3429,7 @@ async def test_delete_channel_agent_link_cleans_only_link_scoped_runtime_state(
 async def test_list_channel_agent_links_by_agent_returns_linked_channel_summaries(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    engine,
     seed_user,
     channel_agent,
     second_channel_agent,
@@ -3422,10 +3487,55 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
         )
     assert other_user_link.status_code == 201, other_user_link.text
 
-    listed = await client.get(
-        "/v1/channels/agent-links",
-        params={"agent_id": str(channel_agent.id)},
+    db_session.add_all(
+        [
+            ChannelBinding(
+                account_id=UUID(private["id"]),
+                bot_agent_link_id=UUID(private["agent_link_id"]),
+                user_id=seed_user.id,
+                external_chat_id="agent-links-private-active",
+                status=BINDING_STATUS_ACTIVE,
+            ),
+            ChannelBinding(
+                account_id=UUID(public_body["id"]),
+                bot_agent_link_id=UUID(public_link.json()["id"]),
+                user_id=seed_user.id,
+                external_chat_id="agent-links-public-active",
+                status=BINDING_STATUS_ACTIVE,
+            ),
+            ChannelBinding(
+                account_id=UUID(public_body["id"]),
+                bot_agent_link_id=UUID(public_link.json()["id"]),
+                user_id=seed_user.id,
+                external_chat_id="agent-links-public-archived",
+                status=BINDING_STATUS_ARCHIVED,
+            ),
+            ChannelBinding(
+                account_id=UUID(public_body["id"]),
+                bot_agent_link_id=UUID(other_user_link.json()["id"]),
+                user_id=other_user.id,
+                external_chat_id="agent-links-other-user-active",
+                status=BINDING_STATUS_ACTIVE,
+            ),
+        ]
     )
+    await db_session.commit()
+
+    select_count = 0
+
+    def count_selects(_conn, _cursor, statement, _parameters, _context, _executemany):
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    sqlalchemy_event.listen(engine.sync_engine, "before_cursor_execute", count_selects)
+    try:
+        listed = await client.get(
+            "/v1/channels/agent-links",
+            params={"agent_id": str(channel_agent.id)},
+        )
+    finally:
+        sqlalchemy_event.remove(engine.sync_engine, "before_cursor_execute", count_selects)
 
     assert listed.status_code == 200, listed.text
     body = listed.json()
@@ -3440,11 +3550,14 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
     assert private_item["account"]["id"] == private["id"]
     assert private_item["account"]["name"] == private["name"]
     assert private_item["account"]["visibility"] == "private"
+    assert private_item["binding_count"] == 1
     assert public_item["id"] == public_link.json()["id"]
     assert public_item["account"]["id"] == public_body["id"]
     assert public_item["account"]["visibility"] == "public"
+    assert public_item["binding_count"] == 1
     assert other_private["id"] not in by_account_id
     assert other_user_listing.status_code == 404
+    assert select_count == 2
 
 
 @pytest.mark.asyncio
@@ -5350,7 +5463,42 @@ async def test_user_channel_config_rejects_insecure_discord_gateway_url(
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "discord gateway_url must use wss"
+    assert response.json()["detail"] == "discord gateway_url must be a public wss URL"
+
+
+@pytest.mark.asyncio
+async def test_discord_account_config_url_error_does_not_leak_validator_detail(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    marker = "internal-host.invalid Authorization: Bot validator-secret"
+
+    async def reject_sensitive_url(_url: str, *, label: str) -> None:
+        assert label == "discord api_base_url"
+        raise UnsafeOutboundUrlError(marker)
+
+    monkeypatch.setattr(
+        channel_config_service,
+        "validate_channel_http_url",
+        reject_sensitive_url,
+    )
+
+    response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "discord",
+            "name": "discord-sensitive-config-error",
+            "provider_token": "discord-token",
+            "config": {
+                **_discord_ready_config(),
+                "api_base_url": "https://discord-provider.example/api/v10",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "discord api_base_url must be a public https URL"}
+    assert marker not in response.text
 
 
 @pytest.mark.asyncio
@@ -5376,7 +5524,7 @@ async def test_provider_send_rejects_existing_private_config_url(monkeypatch):
         )
 
     assert exc.value.status_code == 400
-    assert "private host" in str(exc.value.detail)
+    assert exc.value.detail == "discord provider url must be a public https URL"
     assert _FakeProviderClient.calls == []
 
 
@@ -5399,8 +5547,107 @@ async def test_telegram_command_sync_rejects_private_provider_base_url(monkeypat
         await channel_service.sync_telegram_commands(account=account, commands=[])
 
     assert exc.value.status_code == 400
-    assert "private host" in str(exc.value.detail)
+    assert exc.value.detail == "telegram provider url must be a public https URL"
     assert _FakeProviderClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_channel_command_sync_url_error_does_not_leak_validator_detail(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": "telegram-sensitive-service-url-error"},
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    ciphertext, nonce = encrypt_optional_token("telegram-provider-token")
+    account.encrypted_provider_token = ciphertext
+    account.provider_token_nonce = nonce
+    await db_session.commit()
+    marker = "10.0.0.9 postgresql://user:password@db.internal/app"
+
+    async def reject_sensitive_url(_url: str, *, label: str) -> None:
+        assert label == "telegram api base url"
+        raise UnsafeOutboundUrlError(marker)
+
+    monkeypatch.setattr(channel_service, "validate_channel_http_url", reject_sensitive_url)
+
+    response = await client.post(f"/v1/channels/{created['id']}/commands/sync", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "telegram provider url must be a public https URL"}
+    assert marker not in response.text
+
+
+@pytest.mark.asyncio
+async def test_telegram_proxy_url_error_does_not_leak_validator_detail(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "telegram", "name": "telegram-sensitive-proxy-url-error"},
+        )
+    ).json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    ciphertext, nonce = encrypt_optional_token("telegram-provider-token")
+    account.encrypted_provider_token = ciphertext
+    account.provider_token_nonce = nonce
+    await db_session.commit()
+    marker = "169.254.169.254 Authorization: Bot proxy-secret"
+
+    async def reject_sensitive_url(_url: str, *, label: str) -> None:
+        assert label == "telegram api base url"
+        raise UnsafeOutboundUrlError(marker)
+
+    monkeypatch.setattr(telegram_router, "validate_channel_http_url", reject_sensitive_url)
+
+    response = await client.post(
+        _telegram_bot_path(created, "getMe"),
+        headers=_telegram_agent_headers(created),
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "telegram api base url must be a public https URL"}
+    assert marker not in response.text
+
+
+@pytest.mark.asyncio
+async def test_discord_proxy_url_error_does_not_leak_validator_detail(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-sensitive-proxy-url-error",
+        channel_id="discord-sensitive-channel",
+        guild_id="discord-sensitive-guild",
+    )
+    marker = "127.0.0.1 signed_url=https://internal.invalid/?signature=secret"
+
+    async def reject_sensitive_url(_url: str, *, label: str) -> None:
+        assert label == "discord api base url"
+        raise UnsafeOutboundUrlError(marker)
+
+    monkeypatch.setattr(shared_router, "validate_channel_http_url", reject_sensitive_url)
+
+    response = await client.get(
+        "/v1/channels/discord/v10/guilds/discord-sensitive-guild",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "discord api base url must be a public https URL"}
+    assert marker not in response.text
 
 
 @pytest.mark.asyncio
@@ -7658,7 +7905,7 @@ async def test_telegram_agent_webhook_inactive_link_records_debug_health(
     assert "pending_inbox" not in health["reasons"]
     assert "recent_error" in health["reasons"]
     assert health["pending_inbox"] == 0
-    assert health["last_error"] == "bot agent link inactive"
+    assert health["last_error"] == "channel_operation_failed"
     assert health["last_error_stage"] == "agent_webhook"
     assert health["last_error_outcome"] == "failure"
     assert activity_response.status_code == 200, activity_response.text
@@ -7667,7 +7914,7 @@ async def test_telegram_agent_webhook_inactive_link_records_debug_health(
     )
     assert debug_item["stage"] == "agent_webhook"
     assert debug_item["outcome"] == "failure"
-    assert debug_item["error"] == "bot agent link inactive"
+    assert debug_item["error"] == "channel_operation_failed"
     assert debug_item["details"]["reason"] == "link_archived"
     assert debug_item["details"]["bot_agent_link_id"] == created["agent_link_id"]
     assert debug_item["details"]["bot_agent_link_status"] == "archived"
@@ -11634,9 +11881,23 @@ def test_discord_rate_limiter_blocks_exhausted_route_bucket():
         "x-ratelimit-bucket": "bucket-1",
     }
 
-    limiter.observe("POST", "/channels/123456789012345678/messages", headers, 200)
-    decision = limiter.check("POST", "/channels/123456789012345678/messages")
-    other = limiter.check("POST", "/channels/987654321098765432/messages")
+    limiter.observe(
+        "account-a",
+        "POST",
+        "/channels/123456789012345678/messages",
+        headers,
+        200,
+    )
+    decision = limiter.check(
+        "account-a",
+        "POST",
+        "/channels/123456789012345678/messages",
+    )
+    other = limiter.check(
+        "account-a",
+        "POST",
+        "/channels/987654321098765432/messages",
+    )
 
     assert decision.allowed is False
     assert decision.retry_after_seconds is not None
@@ -14406,6 +14667,130 @@ async def test_discord_gateway_worker_resumes_and_falls_back_after_invalid_sessi
 
 
 @pytest.mark.asyncio
+async def test_discord_gateway_worker_resumes_from_last_durably_committed_dispatch(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-worker-durable-sequence-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    persist_started = asyncio.Event()
+    allow_failure = asyncio.Event()
+    failed_once = False
+    committed_event_ids: set[str] = set()
+    observed_sequences: list[int] = []
+
+    async def record_with_one_failure(
+        _sessionmaker,
+        _account_id: UUID,
+        frame: dict[str, Any],
+        *,
+        gateway_session_id: str | None = None,
+    ) -> bool:
+        nonlocal failed_once
+        sequence = frame.get("s")
+        assert isinstance(sequence, int)
+        observed_sequences.append(sequence)
+        event_id = str(frame.get("d", {}).get("id", frame.get("t")))
+        if sequence == 12 and not failed_once:
+            failed_once = True
+            persist_started.set()
+            await allow_failure.wait()
+            raise SQLAlchemyError("simulated durable admission failure")
+        if event_id in committed_event_ids:
+            return False
+        committed_event_ids.add(event_id)
+        return True
+
+    monkeypatch.setattr(
+        "app.services.discord_gateway_worker.record_discord_gateway_dispatch",
+        record_with_one_failure,
+    )
+    first_stop = asyncio.Event()
+    resume_stop = asyncio.Event()
+    first_socket = _FakeDiscordGatewaySocket(
+        [
+            {"op": 10, "d": {"heartbeat_interval": 60_000}},
+            {
+                "op": 0,
+                "t": "READY",
+                "s": 11,
+                "d": {
+                    "session_id": "durable-sequence-session",
+                    "resume_gateway_url": "wss://gateway.discord.gg/resume",
+                },
+            },
+            {
+                "op": 0,
+                "t": "MESSAGE_CREATE",
+                "s": 12,
+                "d": {"id": "durable-message-12", "channel_id": "channel-1"},
+            },
+        ],
+        first_stop,
+    )
+    resume_socket = _FakeDiscordGatewaySocket(
+        [
+            {"op": 10, "d": {"heartbeat_interval": 60_000}},
+            {
+                "op": 0,
+                "t": "MESSAGE_CREATE",
+                "s": 12,
+                "d": {"id": "durable-message-12", "channel_id": "channel-1"},
+            },
+            {
+                "op": 0,
+                "t": "MESSAGE_CREATE",
+                "s": 12,
+                "d": {"id": "durable-message-12", "channel_id": "channel-1"},
+            },
+        ],
+        resume_stop,
+    )
+    worker = DiscordGatewayWorker(
+        async_sessionmaker(db_session.bind, expire_on_commit=False),
+        connect_factory=_FakeDiscordGatewayConnect([first_socket, resume_socket]),
+    )
+    state = _GatewayState()
+
+    first_connection = asyncio.create_task(
+        worker._connect_and_record(account_id, first_stop, state)
+    )
+    await persist_started.wait()
+    assert state.sequence == 11
+    await _send_heartbeat(first_socket, state)
+    assert first_socket.sent[-1] == {"op": 1, "d": 11}
+    allow_failure.set()
+    with pytest.raises(SQLAlchemyError, match="durable admission failure"):
+        await first_connection
+
+    assert state.sequence == 11
+    await worker._connect_and_record(account_id, resume_stop, state)
+
+    assert resume_socket.sent[0] == {
+        "op": 6,
+        "d": {
+            "token": "discord-provider-token",
+            "session_id": "durable-sequence-session",
+            "seq": 11,
+        },
+    }
+    assert state.sequence == 12
+    assert observed_sequences == [11, 12, 12, 12]
+    assert committed_event_ids == {"READY", "durable-message-12"}
+
+
+@pytest.mark.asyncio
 async def test_discord_gateway_projection_uses_active_aliases_and_minimal_guild(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -14558,12 +14943,27 @@ def _install_discord_gateway_protocol_fakes(
         bot_agent_link_id: UUID,
         message: ChannelMessage,
         send,
-    ) -> str:
-        event_queue.remove(message)
+    ) -> tuple[str, int | None]:
         if send is None:
-            return "dropped"
-        await send()
-        return "sent"
+            event_queue.remove(message)
+            return "dropped", None
+        dispatched_sequence = await send()
+        return "sent", dispatched_sequence
+
+    async def fake_ack_messages(
+        db,
+        *,
+        account_id: UUID,
+        bot_agent_link_id: UUID,
+        message_ids: list[UUID],
+    ) -> int:
+        before = len(event_queue)
+        event_queue[:] = [event for event in event_queue if event.id not in message_ids]
+        return before - len(event_queue)
+
+    @asynccontextmanager
+    async def fake_consumer_lease(**_kwargs):
+        yield True
 
     monkeypatch.setattr(
         "app.routes.channel_routers.discord.resolve_channel_agent_by_token",
@@ -14588,6 +14988,14 @@ def _install_discord_gateway_protocol_fakes(
     monkeypatch.setattr(
         "app.routes.channel_routers.discord._send_discord_gateway_message",
         fake_send_message,
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord._discord_gateway_consumer_lease",
+        fake_consumer_lease,
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord.ack_discord_gateway_messages",
+        fake_ack_messages,
     )
     return provider_paths
 
@@ -14761,6 +15169,219 @@ def test_discord_gateway_resume_replays_buffered_dispatches(monkeypatch):
     assert resumed["t"] == "RESUMED"
     assert resumed_again["t"] == "RESUMED"
     assert resumed_again["s"] > resumed["s"]
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_new_identify_replays_unacknowledged_db_message_after_restart(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _DISCORD_GATEWAY_SESSIONS.clear()
+    channel_id = "restart-replay-channel"
+    guild_id = "restart-replay-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name=f"discord-restart-replay-{uuid4().hex}",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction=MESSAGE_DIRECTION_INBOUND,
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="restart-replay-message",
+        text="replay after restart",
+        payload={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "restart-replay-message",
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "content": "replay after restart",
+                "author": {"id": "restart-user"},
+            },
+        },
+    )
+    db_session.add(message)
+    await db_session.commit()
+
+    async def fake_provider_request(*, account, method: str, path: str, **_kwargs):
+        assert path == f"channels/{channel_id}"
+        return shared_router._DiscordProviderResult(
+            content=json.dumps(
+                {"id": channel_id, "guild_id": guild_id, "type": 0, "name": "restart"}
+            ).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(discord_router, "_request_discord_provider", fake_provider_request)
+    _install_discord_gateway_test_session_factory(monkeypatch)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+            ready = websocket.receive_json()
+            assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            assert websocket.receive_json()["t"] == "CHANNEL_CREATE"
+            first_dispatch = websocket.receive_json()
+            assert first_dispatch["d"]["id"] == "restart-replay-message"
+
+    await db_session.refresh(message)
+    assert message.delivered_at is None
+
+    # Process-local Resume state is gone, but the durable pending row remains.
+    _DISCORD_GATEWAY_SESSIONS.clear()
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {
+                        "token": created["agent_token"],
+                        "session_id": ready["d"]["session_id"],
+                        "seq": first_dispatch["s"],
+                    },
+                }
+            )
+            assert websocket.receive_json() == {"op": 9, "d": False}
+            websocket.send_json({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+            assert websocket.receive_json()["t"] == "READY"
+            assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            assert websocket.receive_json()["t"] == "CHANNEL_CREATE"
+            replayed = websocket.receive_json()
+            assert replayed["d"]["id"] == "restart-replay-message"
+            websocket.send_json({"op": 1, "d": replayed["s"]})
+            assert websocket.receive_json() == {"op": 11, "d": None}
+
+    await db_session.refresh(message)
+    assert message.delivered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_resume_sequence_acks_and_replays_exact_db_message(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _DISCORD_GATEWAY_SESSIONS.clear()
+    channel_id = "resume-ack-channel"
+    guild_id = "resume-ack-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name=f"discord-resume-ack-{uuid4().hex}",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction=MESSAGE_DIRECTION_INBOUND,
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="resume-ack-message",
+        payload={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "resume-ack-message",
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "content": "resume me",
+                "author": {"id": "resume-user"},
+            },
+        },
+    )
+    db_session.add(message)
+    await db_session.commit()
+
+    async def fake_provider_request(*, account, method: str, path: str, **_kwargs):
+        return shared_router._DiscordProviderResult(
+            content=json.dumps(
+                {"id": channel_id, "guild_id": guild_id, "type": 0, "name": "resume"}
+            ).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(discord_router, "_request_discord_provider", fake_provider_request)
+    _install_discord_gateway_test_session_factory(monkeypatch)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+            ready = websocket.receive_json()
+            assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            channel = websocket.receive_json()
+            dispatch = websocket.receive_json()
+
+    # Model cancellation after the frame/checkpoint was registered and sent but
+    # before the connection-local durable inbox cursor was advanced.
+    session_state = _DISCORD_GATEWAY_SESSIONS.get(ready["d"]["session_id"])
+    assert session_state is not None
+    session_state["last_inbox_sequence"] = 0
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {
+                        "token": created["agent_token"],
+                        "session_id": ready["d"]["session_id"],
+                        "seq": channel["s"],
+                    },
+                }
+            )
+            replayed = websocket.receive_json()
+            assert replayed == dispatch
+            resumed = websocket.receive_json()
+            assert resumed["t"] == "RESUMED"
+            websocket.send_json({"op": 1, "d": channel["s"]})
+            # The pending DB row is already represented by the replayed
+            # checkpoint, so it must not be dequeued a second time here.
+            assert websocket.receive_json() == {"op": 11, "d": None}
+
+    await db_session.refresh(message)
+    assert message.delivered_at is None
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {
+                        "token": created["agent_token"],
+                        "session_id": ready["d"]["session_id"],
+                        "seq": replayed["s"],
+                    },
+                }
+            )
+            assert websocket.receive_json()["t"] == "RESUMED"
+
+    await db_session.refresh(message)
+    assert message.delivered_at is not None
 
 
 def test_discord_gateway_thread_only_alias_is_hydrated_before_message(monkeypatch):
@@ -15088,10 +15709,11 @@ async def test_discord_gateway_send_and_unpair_are_linearized(
     allow_send = asyncio.Event()
     frames: list[str] = []
 
-    async def send() -> None:
+    async def send() -> int:
         frames.append("frame")
         send_started.set()
         await allow_send.wait()
+        return 42
 
     send_task = asyncio.create_task(
         discord_router._send_discord_gateway_message(
@@ -15114,9 +15736,25 @@ async def test_discord_gateway_send_and_unpair_are_linearized(
     assert not unpair_task.done()
     allow_send.set()
 
-    assert await send_task == "sent"
+    assert await send_task == ("sent", 42)
     await unpair_task
     assert frames == ["frame"]
+    await db_session.refresh(message)
+    assert message.delivered_at is None
+
+    async with sessionmaker() as ack_db:
+        assert (
+            await channel_service.ack_discord_gateway_messages(
+                ack_db,
+                account_id=account_id,
+                bot_agent_link_id=link_id,
+                message_ids=[message.id],
+            )
+            == 1
+        )
+        await ack_db.commit()
+    await db_session.refresh(message)
+    assert message.delivered_at is not None
 
     second = ChannelMessage(
         account_id=account_id,
@@ -15131,15 +15769,12 @@ async def test_discord_gateway_send_and_unpair_are_linearized(
     db_session.add(second)
     await db_session.commit()
     await db_session.refresh(second)
-    assert (
-        await discord_router._send_discord_gateway_message(
-            account_id=account_id,
-            bot_agent_link_id=link_id,
-            message=second,
-            send=lambda: frames.append("leaked"),
-        )
-        == "dropped"
-    )
+    assert await discord_router._send_discord_gateway_message(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        message=second,
+        send=lambda: frames.append("leaked"),
+    ) == ("dropped", None)
     assert frames == ["frame"]
 
 
@@ -15176,10 +15811,11 @@ async def test_discord_gateway_multiple_connections_send_each_event_once(
     await db_session.refresh(message)
     sends = 0
 
-    async def send() -> None:
+    async def send() -> int:
         nonlocal sends
         sends += 1
         await asyncio.sleep(0.05)
+        return 42
 
     results = await asyncio.gather(
         *(
@@ -15193,7 +15829,7 @@ async def test_discord_gateway_multiple_connections_send_each_event_once(
         )
     )
 
-    assert sorted(results) == ["consumed", "sent"]
+    assert sorted(results) == [("consumed", None), ("sent", 42)]
     assert sends == 1
 
 
@@ -15479,6 +16115,8 @@ def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
             assert websocket.receive_json()["t"] == "GUILD_CREATE"
             assert websocket.receive_json()["t"] == "CHANNEL_CREATE"
             assert websocket.receive_json()["d"]["content"] == "event one"
+            websocket.send_json({"op": 1, "d": 4})
+            assert websocket.receive_json() == {"op": 11, "d": None}
             assert websocket.receive_json()["d"]["content"] == "event two"
 
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
@@ -15494,6 +16132,35 @@ def test_discord_gateway_resume_rejects_sequence_older_than_buffer(monkeypatch):
                 }
             )
             assert websocket.receive_json() == {"op": 9, "d": False}
+
+
+def test_discord_gateway_resume_accepts_latest_sequence_after_ready_eviction(monkeypatch):
+    monkeypatch.setattr("app.routes.channel_routers.discord._DISCORD_GATEWAY_RESUME_BUFFER_SIZE", 1)
+    _install_discord_gateway_protocol_fakes(monkeypatch)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+            ready = websocket.receive_json()
+            assert ready["t"] == "READY"
+            assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            latest = websocket.receive_json()
+            assert latest["t"] == "CHANNEL_CREATE"
+
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json(
+                {
+                    "op": 6,
+                    "d": {
+                        "token": "valid-discord-token",
+                        "session_id": ready["d"]["session_id"],
+                        "seq": latest["s"],
+                    },
+                }
+            )
+            assert websocket.receive_json()["t"] == "RESUMED"
 
 
 @pytest.mark.asyncio
@@ -15895,7 +16562,7 @@ async def test_discord_webhook_inactive_link_records_debug_health(
     assert "pending_inbox" not in health["reasons"]
     assert "recent_error" in health["reasons"]
     assert health["pending_inbox"] == 0
-    assert health["last_error"] == "bot agent link inactive"
+    assert health["last_error"] == "channel_operation_failed"
     assert health["last_error_stage"] == "agent_webhook"
     assert health["last_error_outcome"] == "failure"
     assert activity_response.status_code == 200, activity_response.text
@@ -15904,7 +16571,7 @@ async def test_discord_webhook_inactive_link_records_debug_health(
     )
     assert debug_item["stage"] == "agent_webhook"
     assert debug_item["outcome"] == "failure"
-    assert debug_item["error"] == "bot agent link inactive"
+    assert debug_item["error"] == "channel_operation_failed"
     assert debug_item["details"]["reason"] == "link_archived"
     assert debug_item["details"]["bot_agent_link_id"] == created["agent_link_id"]
     assert debug_item["details"]["bot_agent_link_status"] == "archived"
@@ -17589,7 +18256,7 @@ async def test_delete_channel_fails_pending_outbound_deliveries(
     assert delivery.status == DELIVERY_STATUS_FAILED
     assert delivery.locked_at is None
     assert delivery.locked_by is None
-    assert delivery.last_error == "channel account archived"
+    assert delivery.last_error == "channel_account_inactive"
     account = await db_session.get(ChannelAccount, UUID(created["id"]), populate_existing=True)
     assert account is not None
     assert account.encrypted_provider_token is None
@@ -17638,7 +18305,295 @@ async def test_channel_delivery_worker_retries_provider_failures(
     ).scalar_one()
     assert delivery.status == "pending"
     assert delivery.attempts == 1
-    assert delivery.last_error == "telegram api unreachable"
+    assert delivery.last_error == "channel_provider_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_does_not_persist_provider_response_secrets(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    marker = "delivery-provider-secret-marker"
+
+    async def provider_response_with_secrets(**_kwargs):
+        return "702", {
+            "ok": True,
+            "result": {
+                "message_id": 702,
+                "authorization": f"Bot {marker}",
+                "document": {
+                    "file_url": f"https://cdn.example/file?signature={marker}",
+                },
+                "text": marker,
+            },
+        }
+
+    monkeypatch.setattr(
+        channel_service,
+        "send_provider_outbound_payload",
+        provider_response_with_secrets,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": f"telegram-safe-provider-response-{uuid4().hex}",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    sent = await client.post(
+        f"/v1/channels/{created['id']}/messages",
+        json={"external_chat_id": "111", "text": "persist safe metadata only"},
+    )
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    delivered_id = await ChannelDeliveryWorker(sessionmaker).run_once()
+
+    assert delivered_id == UUID(sent.json()["delivery_id"])
+    delivery = (
+        await db_session.execute(
+            select(ChannelDelivery)
+            .where(ChannelDelivery.id == delivered_id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    message = await db_session.get(
+        ChannelMessage,
+        UUID(sent.json()["id"]),
+        populate_existing=True,
+    )
+    assert message is not None
+    assert delivery.provider_response == {
+        "provider": "telegram",
+        "accepted": True,
+        "provider_message_id": "702",
+    }
+    assert marker not in str(delivery.provider_response)
+    assert marker not in str(message.payload)
+
+
+@pytest.mark.asyncio
+async def test_discord_delivery_retry_reuses_official_enforced_nonce(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # https://discord.com/developers/docs/resources/message#create-message
+    # documents a <=25 character nonce plus enforce_nonce duplicate return.
+    _AmbiguousDiscordCreateMessageClient.calls = []
+    _AmbiguousDiscordCreateMessageClient.attempts = 0
+    monkeypatch.setattr(
+        channel_service.httpx,
+        "AsyncClient",
+        _AmbiguousDiscordCreateMessageClient,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-durable-nonce-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    sent = await client.post(
+        f"/v1/channels/{created['id']}/messages",
+        json={"external_chat_id": "123456789012345678", "text": "send once"},
+    )
+    delivery_id = UUID(sent.json()["delivery_id"])
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = ChannelDeliveryWorker(sessionmaker)
+
+    assert await worker.run_once() == delivery_id
+    delivery = await db_session.get(ChannelDelivery, delivery_id, populate_existing=True)
+    assert delivery is not None
+    assert delivery.status == DELIVERY_STATUS_PENDING
+    assert delivery.last_error == "channel_provider_unreachable"
+    delivery.next_attempt_at = datetime(2000, 1, 1, tzinfo=UTC)
+    await db_session.commit()
+
+    assert await worker.run_once() == delivery_id
+    await db_session.refresh(delivery)
+
+    assert delivery.status == "succeeded"
+    assert len(_AmbiguousDiscordCreateMessageClient.calls) == 2
+    first_payload = _AmbiguousDiscordCreateMessageClient.calls[0]["json"]
+    second_payload = _AmbiguousDiscordCreateMessageClient.calls[1]["json"]
+    assert first_payload == second_payload
+    assert first_payload["content"] == "send once"
+    assert first_payload["allowed_mentions"] == {"parse": []}
+    assert first_payload["enforce_nonce"] is True
+    assert len(first_payload["nonce"]) == 22
+
+
+@pytest.mark.asyncio
+async def test_discord_delivery_429_remains_pending_until_retry_after(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def rate_limited_provider(**_kwargs):
+        raise HTTPException(
+            status_code=429,
+            detail="discord api rate limited",
+            headers={"Retry-After": "7.5"},
+        )
+
+    monkeypatch.setattr(
+        channel_service,
+        "send_provider_outbound_payload",
+        rate_limited_provider,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-delivery-429-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    sent = await client.post(
+        f"/v1/channels/{created['id']}/messages",
+        json={"external_chat_id": "123456789012345678", "text": "retry after"},
+    )
+    delivery_id = UUID(sent.json()["delivery_id"])
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    started_at = datetime.now(UTC)
+
+    assert await ChannelDeliveryWorker(sessionmaker).run_once() == delivery_id
+
+    delivery = await db_session.get(ChannelDelivery, delivery_id, populate_existing=True)
+    assert delivery is not None
+    assert delivery.status == DELIVERY_STATUS_PENDING
+    assert delivery.last_error == "channel_provider_rate_limited"
+    assert delivery.next_attempt_at >= started_at + timedelta(seconds=7)
+    activity = await client.get(f"/v1/channels/{created['id']}/activity")
+    health = await client.get("/v1/channels/health")
+    activity_delivery = next(
+        item for item in activity.json()["items"] if item["delivery_id"] == str(delivery_id)
+    )
+    health_item = next(
+        item for item in health.json()["items"] if item["account_id"] == created["id"]
+    )
+    assert activity_delivery["delivery_last_error"] == "channel_provider_rate_limited"
+    assert health_item["last_error"] == "channel_provider_rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_429_preserves_official_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class RateLimitedTelegramClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            return httpx.Response(
+                429,
+                json={
+                    "ok": False,
+                    "error_code": 429,
+                    "parameters": {"retry_after": 12},
+                },
+            )
+
+    async def allow_test_url(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(channel_service.httpx, "AsyncClient", RateLimitedTelegramClient)
+    monkeypatch.setattr(channel_service, "validate_channel_http_url", allow_test_url)
+
+    with pytest.raises(HTTPException) as caught:
+        await channel_service._post_provider_json(
+            channel=CHANNEL_PROVIDER_TELEGRAM,
+            method="sendMessage",
+            url="https://api.telegram.org/bot-placeholder/sendMessage",
+            json_payload={"chat_id": "1", "text": "rate limit"},
+            timeout_seconds=20,
+            unreachable_detail="telegram api unreachable",
+            rejected_detail="telegram api rejected message",
+        )
+
+    assert caught.value.status_code == 429
+    assert caught.value.detail == "telegram api rate limited"
+    assert caught.value.headers == {"Retry-After": "12.0"}
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_unknown_exception_detail_is_stored_and_returned_as_code(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    marker = "delivery-error-secret-marker"
+
+    async def provider_failure_with_secret(**_kwargs):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Authorization: Bot {marker} postgresql://user:pass@db.example/app",
+        )
+
+    monkeypatch.setattr(
+        channel_service,
+        "send_provider_outbound_payload",
+        provider_failure_with_secret,
+    )
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "discord",
+                "name": f"discord-safe-delivery-error-{uuid4().hex}",
+                "provider_token": "discord-provider-token",
+                "config": _discord_ready_config(),
+            },
+        )
+    ).json()
+    sent_response = await client.post(
+        f"/v1/channels/{created['id']}/messages",
+        json={"external_chat_id": "123456789012345678", "text": "fail safely"},
+    )
+    assert sent_response.status_code == 201, sent_response.text
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    delivered_id = await ChannelDeliveryWorker(sessionmaker).run_once()
+    activity = await client.get(f"/v1/channels/{created['id']}/activity")
+    health = await client.get("/v1/channels/health")
+
+    delivery = (
+        await db_session.execute(
+            select(ChannelDelivery)
+            .where(ChannelDelivery.id == delivered_id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    assert delivery.last_error == "channel_delivery_failed"
+    assert marker not in str(delivery.last_error)
+    assert activity.status_code == 200
+    activity_item = next(
+        item for item in activity.json()["items"] if item["delivery_id"] == str(delivered_id)
+    )
+    assert activity_item["delivery_last_error"] == "channel_delivery_failed"
+    health_item = next(
+        item for item in health.json()["items"] if item["account_id"] == created["id"]
+    )
+    assert health_item["last_error"] == "channel_delivery_failed"
+    assert marker not in activity.text
+    assert marker not in health.text
 
 
 @pytest.mark.asyncio
@@ -17713,7 +18668,7 @@ async def test_channel_delivery_does_not_send_after_claimed_link_is_archived(
     assert delivery.status == DELIVERY_STATUS_FAILED
     assert delivery.locked_at is None
     assert delivery.locked_by is None
-    assert delivery.last_error == "channel agent link archived"
+    assert delivery.last_error == "channel_agent_link_archived"
 
 
 @pytest.mark.asyncio
@@ -17779,7 +18734,7 @@ async def test_channel_delivery_does_not_send_after_runtime_is_retired(
         )
     ).scalar_one()
     assert delivery.status == DELIVERY_STATUS_FAILED
-    assert delivery.last_error == "channel agent link has no managed runtime authority"
+    assert delivery.last_error == "channel_agent_link_authority_missing"
 
 
 @pytest.mark.asyncio
@@ -17838,7 +18793,7 @@ async def test_channel_delivery_does_not_send_after_binding_is_unpaired(
         )
     ).scalar_one()
     assert delivery.status == DELIVERY_STATUS_FAILED
-    assert delivery.last_error == "channel binding archived"
+    assert delivery.last_error == "channel_binding_inactive"
 
 
 @pytest.mark.asyncio
@@ -17982,7 +18937,7 @@ async def test_channel_delivery_link_lock_contention_does_not_exhaust_attempts(
     assert contended_delivery.attempts == 1
     assert contended_delivery.locked_at is None
     assert contended_delivery.locked_by is None
-    assert contended_delivery.last_error == channel_service.DELIVERY_LINK_LOCK_CONTENTION_ERROR
+    assert contended_delivery.last_error == "channel_agent_link_update_contended"
     assert _FakeProviderClient.calls == []
 
     contended_delivery.next_attempt_at = datetime(2000, 1, 1, tzinfo=UTC)
@@ -19816,7 +20771,11 @@ async def test_discord_membership_helper_classifies_real_provider_responses(
     assert result.guild_name == (expected_guild_name or None)
     assert len(MembershipClient.calls) == 1
     if status_code == 429:
-        decision = limiter.check("GET", "/guilds/membership-real-guild")
+        decision = limiter.check(
+            str(account.id),
+            "GET",
+            "/guilds/membership-real-guild",
+        )
         assert decision.allowed is False
         assert decision.retry_after_seconds == pytest.approx(17.0)
 

--- a/backend/tests/test_discord_gateway_session_store.py
+++ b/backend/tests/test_discord_gateway_session_store.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from app.routes.channel_routers.discord import _DiscordGatewaySessionStore
+
+
+def test_discord_gateway_session_store_expires_idle_sessions():
+    now = 0.0
+    store = _DiscordGatewaySessionStore(
+        max_sessions=2,
+        ttl_seconds=5,
+        now=lambda: now,
+    )
+    state = {"last_sequence": 3}
+    store.put("session-a", state)
+
+    now = 10.0
+    assert store.get("session-a") is state
+    store.disconnect("session-a")
+    now = 14.9
+    assert store.get("session-a") is state
+    now = 20.0
+
+    assert store.get("session-a") is None
+    assert len(store) == 0
+
+
+def test_discord_gateway_session_store_uses_deterministic_lru_eviction():
+    store = _DiscordGatewaySessionStore(
+        max_sessions=2,
+        ttl_seconds=60,
+        now=lambda: 0.0,
+    )
+    store.put("session-a", {})
+    store.disconnect("session-a")
+    store.put("session-b", {})
+    store.disconnect("session-b")
+    assert store.touch("session-a") is True
+
+    store.put("session-c", {})
+    store.disconnect("session-c")
+
+    assert store.session_ids() == ("session-a", "session-c")
+    assert store.get("session-b") is None
+
+
+def test_discord_gateway_session_store_stays_bounded_under_churn():
+    store = _DiscordGatewaySessionStore(
+        max_sessions=3,
+        ttl_seconds=60,
+        now=lambda: 0.0,
+    )
+
+    for index in range(100):
+        store.put(f"session-{index}", {"last_sequence": index})
+        store.disconnect(f"session-{index}")
+
+    assert len(store) == 3
+    assert store.session_ids() == ("session-97", "session-98", "session-99")
+
+
+def test_discord_gateway_session_store_never_evicts_connected_sessions():
+    now = 0.0
+    store = _DiscordGatewaySessionStore(
+        max_sessions=1,
+        ttl_seconds=5,
+        now=lambda: now,
+    )
+    active = {"last_sequence": 1}
+    store.put("active", active)
+    for index in range(3):
+        store.put(f"idle-{index}", {})
+        store.disconnect(f"idle-{index}")
+    now = 100.0
+
+    assert store.get("active") is active
+    assert store.session_ids() == ("active",)

--- a/backend/tests/test_discord_rate_limiter.py
+++ b/backend/tests/test_discord_rate_limiter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from app.services.discord_rate_limiter import DiscordRateLimiter
 
+_ACCOUNT_SCOPE = "account-a"
+
 
 class _Headers(dict[str, str]):
     def get(self, key: str, default: str | None = None) -> str | None:
@@ -17,10 +19,11 @@ def test_discord_route_key_collapses_snowflakes_and_keeps_major_parameter():
 
     assert (
         limiter.route_key(
+            _ACCOUNT_SCOPE,
             "PATCH",
             "/api/v10/channels/1494815997981491361/messages/1494831575131492536",
         )
-        == "PATCH /channels/:major/messages/:id|1494815997981491361"
+        == "account-a|PATCH /channels/:major/messages/:id|1494815997981491361"
     )
 
 
@@ -28,6 +31,7 @@ def test_discord_route_key_templates_webhook_tokens():
     limiter = DiscordRateLimiter()
 
     key = limiter.route_key(
+        _ACCOUNT_SCOPE,
         "POST",
         "/api/v10/webhooks/1469647169291026595/aW50ZXJhY3Rpb246MTQ5NDgzNDk3ODY2MjUxODkzNA__",
     )
@@ -38,8 +42,16 @@ def test_discord_route_key_templates_webhook_tokens():
 def test_discord_route_key_keeps_different_channel_buckets_distinct():
     limiter = DiscordRateLimiter()
 
-    a = limiter.route_key("POST", "/api/v10/channels/111111111111111111/messages")
-    b = limiter.route_key("POST", "/api/v10/channels/222222222222222222/messages")
+    a = limiter.route_key(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/api/v10/channels/111111111111111111/messages",
+    )
+    b = limiter.route_key(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/api/v10/channels/222222222222222222/messages",
+    )
 
     assert a != b
 
@@ -47,11 +59,24 @@ def test_discord_route_key_keeps_different_channel_buckets_distinct():
 def test_discord_route_key_strips_api_prefixes():
     limiter = DiscordRateLimiter()
 
-    assert limiter.route_key("POST", "/channels/111111111111111111/messages") == (
-        limiter.route_key("POST", "/api/v10/channels/111111111111111111/messages")
-    )
-    assert limiter.route_key("POST", "/channels/111111111111111111/messages") == (
+    assert limiter.route_key(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/channels/111111111111111111/messages",
+    ) == (
         limiter.route_key(
+            _ACCOUNT_SCOPE,
+            "POST",
+            "/api/v10/channels/111111111111111111/messages",
+        )
+    )
+    assert limiter.route_key(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/channels/111111111111111111/messages",
+    ) == (
+        limiter.route_key(
+            _ACCOUNT_SCOPE,
             "POST",
             "/v1/channels/discord/v10/channels/111111111111111111/messages",
         )
@@ -63,8 +88,9 @@ def test_discord_limiter_allows_by_default_and_observes_headers():
     limiter = DiscordRateLimiter(now=lambda: now)
     path = "/channels/111111111111111111/messages"
 
-    assert limiter.check("POST", path).allowed is True
+    assert limiter.check(_ACCOUNT_SCOPE, "POST", path).allowed is True
     limiter.observe(
+        _ACCOUNT_SCOPE,
         "POST",
         path,
         _headers(
@@ -76,7 +102,7 @@ def test_discord_limiter_allows_by_default_and_observes_headers():
         ),
         200,
     )
-    state = limiter.inspect("POST", path)
+    state = limiter.inspect(_ACCOUNT_SCOPE, "POST", path)
 
     assert state is not None
     assert state.remaining == 4
@@ -88,15 +114,16 @@ def test_discord_limiter_blocks_until_bucket_reset_then_clears():
     limiter = DiscordRateLimiter(now=lambda: now)
     path = "/channels/111111111111111111/messages"
     limiter.observe(
+        _ACCOUNT_SCOPE,
         "POST",
         path,
         _headers({"x-ratelimit-remaining": "0", "x-ratelimit-reset-after": "1"}),
         200,
     )
 
-    blocked = limiter.check("POST", path)
+    blocked = limiter.check(_ACCOUNT_SCOPE, "POST", path)
     now = 1.5
-    after = limiter.check("POST", path)
+    after = limiter.check(_ACCOUNT_SCOPE, "POST", path)
 
     assert blocked.allowed is False
     assert blocked.retry_after_seconds == 1.0
@@ -108,8 +135,8 @@ def test_discord_limiter_honors_retry_after_on_429():
     limiter = DiscordRateLimiter(now=lambda: now)
     path = "/channels/111111111111111111/messages"
 
-    limiter.observe("POST", path, _headers({"retry-after": "5"}), 429)
-    blocked = limiter.check("POST", path)
+    limiter.observe(_ACCOUNT_SCOPE, "POST", path, _headers({"retry-after": "5"}), 429)
+    blocked = limiter.check(_ACCOUNT_SCOPE, "POST", path)
 
     assert blocked.allowed is False
     assert blocked.retry_after_seconds == 5.0
@@ -120,9 +147,9 @@ def test_discord_limiter_treats_zero_retry_after_as_immediately_due():
     limiter = DiscordRateLimiter(now=lambda: now)
     path = "/channels/111111111111111111/messages"
 
-    limiter.observe("POST", path, _headers({"retry-after": "0"}), 429)
+    limiter.observe(_ACCOUNT_SCOPE, "POST", path, _headers({"retry-after": "0"}), 429)
 
-    assert limiter.check("POST", path).allowed is True
+    assert limiter.check(_ACCOUNT_SCOPE, "POST", path).allowed is True
 
 
 def test_discord_limiter_consume_decrements_remaining_for_in_flight_requests():
@@ -130,29 +157,32 @@ def test_discord_limiter_consume_decrements_remaining_for_in_flight_requests():
     limiter = DiscordRateLimiter(now=lambda: now)
     path = "/channels/111111111111111111/messages"
     limiter.observe(
+        _ACCOUNT_SCOPE,
         "POST",
         path,
         _headers({"x-ratelimit-remaining": "2", "x-ratelimit-reset-after": "2"}),
         200,
     )
 
-    limiter.consume("POST", path)
-    limiter.consume("POST", path)
+    limiter.consume(_ACCOUNT_SCOPE, "POST", path)
+    limiter.consume(_ACCOUNT_SCOPE, "POST", path)
 
-    assert limiter.inspect("POST", path).remaining == 0
-    assert limiter.check("POST", path).allowed is False
+    state = limiter.inspect(_ACCOUNT_SCOPE, "POST", path)
+    assert state is not None
+    assert state.remaining == 0
+    assert limiter.check(_ACCOUNT_SCOPE, "POST", path).allowed is False
 
 
 def test_discord_limiter_blocks_past_global_budget_and_resets_after_one_second():
     now = 0.0
     limiter = DiscordRateLimiter(global_per_second=3, now=lambda: now)
-    limiter.consume("GET", "/users/@me")
-    limiter.consume("GET", "/users/@me")
-    limiter.consume("GET", "/users/@me")
+    limiter.consume(_ACCOUNT_SCOPE, "GET", "/users/@me")
+    limiter.consume(_ACCOUNT_SCOPE, "GET", "/users/@me")
+    limiter.consume(_ACCOUNT_SCOPE, "GET", "/users/@me")
 
-    blocked = limiter.check("GET", "/users/@me")
+    blocked = limiter.check(_ACCOUNT_SCOPE, "GET", "/users/@me")
     now = 1.001
-    after = limiter.check("GET", "/users/@me")
+    after = limiter.check(_ACCOUNT_SCOPE, "GET", "/users/@me")
 
     assert blocked.allowed is False
     assert blocked.global_limit is True
@@ -164,16 +194,29 @@ def test_discord_limiter_upstream_global_429_clamps_window():
     limiter = DiscordRateLimiter(global_per_second=100, now=lambda: now)
 
     limiter.observe(
+        _ACCOUNT_SCOPE,
         "POST",
         "/channels/111111111111111111/messages",
         _headers({"retry-after": "2", "x-ratelimit-global": "true"}),
         429,
     )
-    blocked = limiter.check("POST", "/channels/111111111111111111/messages")
+    blocked = limiter.check(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/channels/111111111111111111/messages",
+    )
     now = 1.001
-    still_blocked = limiter.check("GET", "/applications/222222222222222222/commands")
+    still_blocked = limiter.check(
+        _ACCOUNT_SCOPE,
+        "GET",
+        "/applications/222222222222222222/commands",
+    )
     now = 2.001
-    after = limiter.check("GET", "/applications/222222222222222222/commands")
+    after = limiter.check(
+        _ACCOUNT_SCOPE,
+        "GET",
+        "/applications/222222222222222222/commands",
+    )
 
     assert blocked.allowed is False
     assert blocked.global_limit is True
@@ -183,3 +226,85 @@ def test_discord_limiter_upstream_global_429_clamps_window():
     assert still_blocked.retry_after_seconds is not None
     assert 0.99 < still_blocked.retry_after_seconds < 1.0
     assert after.allowed is True
+
+
+def test_discord_limiter_isolates_route_and_global_state_by_account_scope():
+    # https://discord.com/developers/docs/topics/rate-limits: individual bots
+    # are identified for rate limiting through request authentication.
+    now = 0.0
+    limiter = DiscordRateLimiter(global_per_second=1, now=lambda: now)
+    path = "/channels/111111111111111111/messages"
+
+    limiter.observe(
+        "account-a",
+        "POST",
+        path,
+        _headers({"retry-after": "5"}),
+        429,
+    )
+    limiter.consume("account-a", "GET", "/users/@me")
+
+    assert limiter.check("account-a", "POST", path).allowed is False
+    assert limiter.check("account-a", "GET", "/users/@me").global_limit is True
+    assert limiter.check("account-b", "POST", path).allowed is True
+    assert limiter.check("account-b", "GET", "/users/@me").allowed is True
+
+
+def test_discord_limiter_prunes_expired_buckets_during_unrelated_checks():
+    now = 0.0
+    limiter = DiscordRateLimiter(now=lambda: now)
+    limiter.observe(
+        _ACCOUNT_SCOPE,
+        "POST",
+        "/channels/111111111111111111/messages",
+        _headers({"x-ratelimit-remaining": "0", "x-ratelimit-reset-after": "1"}),
+        200,
+    )
+
+    now = 2.0
+    assert limiter.check("account-b", "GET", "/users/@me").allowed is True
+    assert (
+        limiter.inspect(
+            _ACCOUNT_SCOPE,
+            "POST",
+            "/channels/111111111111111111/messages",
+        )
+        is None
+    )
+
+
+def test_discord_limiter_bounds_buckets_and_scopes_with_lru_eviction():
+    now = 0.0
+    limiter = DiscordRateLimiter(
+        global_per_second=100,
+        max_buckets=2,
+        max_scopes=2,
+        now=lambda: now,
+    )
+    paths = [f"/channels/{value}/messages" for value in (111, 222, 333)]
+    for index, path in enumerate(paths):
+        scope = f"account-{index}"
+        limiter.observe(
+            scope,
+            "POST",
+            path,
+            _headers({"x-ratelimit-remaining": "0", "x-ratelimit-reset-after": "60"}),
+            200,
+        )
+        limiter.consume(scope, "GET", "/users/@me")
+
+    assert limiter.inspect("account-0", "POST", paths[0]) is None
+    assert limiter.inspect("account-1", "POST", paths[1]) is not None
+    assert limiter.inspect("account-2", "POST", paths[2]) is not None
+    assert "account-0" not in limiter._global_states
+    assert tuple(limiter._global_states) == ("account-1", "account-2")
+
+
+def test_discord_limiter_prunes_idle_account_scopes():
+    now = 0.0
+    limiter = DiscordRateLimiter(scope_idle_ttl_seconds=2, now=lambda: now)
+    limiter.consume(_ACCOUNT_SCOPE, "GET", "/users/@me")
+
+    now = 2.1
+    assert limiter.check("account-b", "GET", "/users/@me").allowed is True
+    assert _ACCOUNT_SCOPE not in limiter._global_states

--- a/backend/tests/test_telegram_rate_limiter.py
+++ b/backend/tests/test_telegram_rate_limiter.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from app.services.telegram_rate_limiter import TelegramRateLimiter
+
+
+def _consume(
+    limiter: TelegramRateLimiter,
+    *,
+    account_id: str = "account-a",
+    chat_id: str = "chat-a",
+):
+    return limiter.check_and_consume(
+        account_id=account_id,
+        method="sendMessage",
+        chat_id=chat_id,
+    )
+
+
+def test_telegram_limiter_preserves_bot_and_chat_budgets():
+    limiter = TelegramRateLimiter(
+        bot_capacity=2,
+        bot_refill_per_second=1,
+        chat_capacity=2,
+        chat_refill_per_second=1,
+        now=lambda: 0.0,
+    )
+
+    assert _consume(limiter).allowed is True
+    assert _consume(limiter).allowed is True
+    blocked = _consume(limiter)
+
+    assert blocked.allowed is False
+    assert blocked.scope == "bot"
+
+
+def test_telegram_limiter_refunds_bot_budget_when_chat_is_limited():
+    limiter = TelegramRateLimiter(
+        bot_capacity=2,
+        bot_refill_per_second=1,
+        chat_capacity=1,
+        chat_refill_per_second=1,
+        now=lambda: 0.0,
+    )
+
+    assert _consume(limiter, chat_id="chat-a").allowed is True
+    blocked = _consume(limiter, chat_id="chat-a")
+    other_chat = _consume(limiter, chat_id="chat-b")
+
+    assert blocked.allowed is False
+    assert blocked.scope == "chat"
+    assert other_chat.allowed is True
+
+
+def test_telegram_limiter_prunes_idle_buckets_during_unrelated_requests():
+    now = 0.0
+    limiter = TelegramRateLimiter(
+        bot_capacity=1,
+        bot_refill_per_second=1,
+        chat_capacity=1,
+        chat_refill_per_second=1,
+        idle_ttl_seconds=2,
+        now=lambda: now,
+    )
+    assert _consume(limiter).allowed is True
+    assert len(limiter._buckets) == 2
+
+    now = 2.1
+    assert _consume(limiter, account_id="account-b", chat_id="chat-b").allowed is True
+
+    assert tuple(limiter._buckets) == (
+        ("bot", "account-b", None),
+        ("chat", "account-b", "chat-b"),
+    )
+
+
+def test_telegram_limiter_bounds_buckets_with_deterministic_lru_eviction():
+    limiter = TelegramRateLimiter(max_buckets=4, now=lambda: 0.0)
+
+    for index in range(3):
+        assert (
+            _consume(
+                limiter,
+                account_id=f"account-{index}",
+                chat_id=f"chat-{index}",
+            ).allowed
+            is True
+        )
+
+    assert tuple(limiter._buckets) == (
+        ("bot", "account-1", None),
+        ("chat", "account-1", "chat-1"),
+        ("bot", "account-2", None),
+        ("chat", "account-2", "chat-2"),
+    )
+
+
+def test_telegram_limiter_is_thread_safe_under_concurrent_consumers():
+    limiter = TelegramRateLimiter(
+        bot_capacity=100,
+        bot_refill_per_second=1,
+        chat_capacity=100,
+        chat_refill_per_second=1,
+        now=lambda: 0.0,
+    )
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        decisions = list(executor.map(lambda _index: _consume(limiter), range(100)))
+
+    assert all(decision.allowed for decision in decisions)
+    assert limiter._buckets[("bot", "account-a", None)].tokens == 0
+    assert limiter._buckets[("chat", "account-a", "chat-a")].tokens == 0

--- a/backend/tests/test_type_governance.py
+++ b/backend/tests/test_type_governance.py
@@ -168,6 +168,26 @@ def test_gate_rejects_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         type_governance.analyze(["app/core/query_utils.py"], gating=True)
 
 
+def test_gate_reports_stdout_diagnostics_for_exit_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = analysis(
+        files=1,
+        errors=1,
+        diagnostics=[{"severity": "error", "message": "typed failure"}],
+    )
+    install_analyzer(tmp_path, monkeypatch, payload=payload, exit_code=1)
+
+    with pytest.raises(ValueError) as exc_info:
+        type_governance.analyze(["app/core/query_utils.py"], gating=True)
+
+    message = str(exc_info.value)
+    assert "analyzer exited 1 with diagnostics" in message
+    assert "typed failure" in message
+    assert '"errorCount": 1' in message
+    assert "no stderr" not in message
+
+
 def test_gate_rejects_nonzero_exit_without_diagnostics(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -430,6 +430,57 @@ Provider-wide state stays account-scoped:
 - Admin-managed command sync.
 - Provider-side credentials and extra encrypted secrets.
 
+## Delivery, Replay, And Diagnostic Boundaries
+
+Telegram polling follows the Bot API's upstream retention contract. The
+official Bot API says updates [are not kept longer than 24
+hours](https://core.telegram.org/bots/api#getting-updates). A bounded retention
+worker phase terminally consumes enabled Telegram bound inbox rows older than
+that horizon even when a polling runtime is offline and no Link webhook is
+configured. This sets the delivery acknowledgement timestamp; it does not
+physically delete the message. The row remains until the normal delivered-row
+retention horizon. Pending rows inside 24 hours are durable, but they are not
+count-bounded: a safe capacity bound still needs atomic database admission that
+can backpressure webhook and polling ingress without silently deleting
+authenticated updates.
+
+The synthetic Discord Gateway treats PostgreSQL, not its process-local Resume
+buffer, as delivery authority. A socket send leaves the exact
+`channel_messages` row pending. The client's next opcode 1 heartbeat sequence
+or opcode 6 Resume sequence acknowledges only message rows mapped at or below
+that received dispatch sequence, matching Discord's [Gateway sequence and
+Resume contract](https://discord.com/developers/docs/events/gateway#resuming).
+Disconnected Resume sessions use a bounded, expiring in-memory replay cache;
+active sessions are never evicted. An unknown or expired session receives
+opcode 9 with `d=false`, and the following Identify replays still-pending DB
+messages. The per-connection unacknowledged window backpressures one live
+socket, but durable Discord pending rows are also not globally count-bounded.
+
+Queued Discord Create Message retries use one stable UUID-derived `nonce` with
+`enforce_nonce=true`, following Discord's [Create Message
+contract](https://discord.com/developers/docs/resources/message#create-message-jsonform-params).
+Telegram exposes no equivalent idempotency primitive, so an HTTP timeout after
+provider acceptance can still duplicate a retried Telegram send.
+
+Discord REST limiter state is scoped by a stable, non-secret Clawdi account or
+Discord application identifier. It never uses the provider token as a key and
+never shares route or global 429 state across unrelated bot authentication
+identities, matching Discord's [authentication-scoped rate-limit
+contract](https://discord.com/developers/docs/topics/rate-limits).
+
+User-authenticated activity, health, and debug APIs never return raw provider
+or exception strings. `delivery_last_error` and health `last_error` preserve an
+allowlisted `channel_*` delivery code or fall back to
+`channel_delivery_failed`; debug event `error` uses
+`channel_operation_failed`, and debug `details` retains only bounded structural
+values. Telegram and Discord debug/delivery write paths persist the same stable
+codes and safe provider-message metadata. Full exception context belongs only
+in already-redacted internal logs.
+
+Done: with a migrated throwaway PostgreSQL configured as `DATABASE_URL`,
+`cd backend && uv run pytest -q tests/test_channel_inbox.py tests/test_channel_debug_events.py`
+exits 0.
+
 ## Outbound URL Security
 
 Channel accounts can carry public provider endpoint overrides, such as

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4127,6 +4127,11 @@ export interface components {
             /** Agent Token */
             agent_token?: string | null;
             account: components["schemas"]["ChannelAccountResponse"];
+            /**
+             * Binding Count
+             * @default 0
+             */
+            binding_count: number;
         };
         /** ChannelBindingDeleteResponse */
         ChannelBindingDeleteResponse: {
@@ -4304,6 +4309,8 @@ export interface components {
              * @default 0
              */
             pending_inbox: number;
+            /** Oldest Pending Inbox At */
+            oldest_pending_inbox_at?: string | null;
             /**
              * Pending Deliveries
              * @default 0


### PR DESCRIPTION
## Summary

- Make PostgreSQL the synthetic Discord Gateway delivery authority: dispatches remain pending until a downstream heartbeat or valid Resume sequence acknowledges exact message rows. Resume cache state is bounded and expiring for disconnected sessions, while Identify after restart replays pending DB events.
- Advance upstream Discord Gateway Resume sequence only after durable dispatch admission. Scope Discord REST rate limits by stable non-secret account or application identity, bound provider limiter caches, preserve 429 Retry-After, and add a stable enforced nonce to queued Create Message retries.
- Enforce the official Telegram 24-hour update delivery horizon both at getUpdates and in a bounded retention-worker phase, including offline polling Links with no webhook. Bound Telegram limiter state and preserve Bot API retry_after semantics.
- Redact user-authenticated activity, health, debug, and enabled-provider URL validation errors; minimize persisted enabled-provider diagnostics; replace public health and debug-health per-account query fan-out with fixed set-based queries; add oldest_pending_inbox_at and set-based binding_count.
- Normalize a missing Web agent-link binding_count to 0 at the single client boundary for independent backend/Web rollout; locally constructed new links start at 0.
- Regenerate shared API types. No migration is added; current origin/main includes #760 retention indexes, cleanup worker, and queue metrics.

## Demonstrated P1 findings fixed

- Synthetic Gateway websocket send previously marked a DB message delivered before downstream receipt, so a process restart could lose it permanently.
- Gateway dispatch sequence advanced before durable admission, allowing Resume to skip the failed dispatch.
- Process-global Gateway Resume sessions, Telegram limiter buckets, and Discord limiter buckets/scopes could grow without bound.
- Discord global and route limiter state crossed bot-token boundaries because keys omitted authentication scope.
- Ambiguous queued Discord Create Message retry could duplicate an accepted message without nonce enforcement.
- Enabled-provider exception/provider response strings were persisted and returned through user-authenticated activity, health, and debug APIs.
- Public channel health performed about eight queries per account per poll; debug health retained a separate three-query per-account fan-out; Agent detail separately polled bindings per account.
- Telegram DB polling could replay updates older than the upstream protocol horizon, while an offline polling runtime or Link without a webhook could leave stale pending rows forever.

## Public response behavior

- Existing delivery_last_error and health last_error fields return an allowlisted stable channel_* code or channel_delivery_failed.
- Debug error returns channel_operation_failed; debug details retains only bounded structural values.
- Enabled Telegram/Discord provider URL failures return stable public-HTTPS validation text without raw exception, address, host, or credential details.
- GET /v1/channels/health adds nullable oldest_pending_inbox_at.
- GET /v1/channels/agent-links?agent_id=... adds integer binding_count.

## Delivery expiry versus physical retention

Telegram updates older than the official 24-hour provider horizon are terminally consumed by setting delivered_at. The retention worker uses bounded oldest-first batches and SKIP LOCKED, and it runs even when no polling runtime or Link webhook can consume the update. This is delivery expiry, not physical deletion: the message row remains until the ordinary delivered-message retention horizon and is then eligible for #760 cleanup. The strict cutoff preserves exactly-24-hour and newer pending updates. Discord pending rows are never silently expired by this phase.

This does not claim durable ingress is globally count-bounded. Telegram pending delivery is age-bounded but can still grow without a count bound inside the 24-hour window. Discord pending rows remain count-unbounded globally; one active synthetic socket backpressures at its unacknowledged Resume window. A safe global capacity limit still needs atomic database admission plus authenticated webhook/poll or Gateway disconnect/backpressure semantics, not silent deletion or a per-process counter. Telegram also has no Create Message idempotency primitive, so provider acceptance followed by an ambiguous HTTP timeout can still duplicate a retry.

## Audited clean

- Ingress admission, provider-event dedupe, pair/unpair replay, Binding/Link/Account authority, command replies, unpaired tutorials, forum/thread/DM topology, and Telegram offset commit ordering.
- Webhook/long-poll/Gateway route shapes, reconnect behavior, lock ordering, and multi-consumer serialization after the changes above.
- CLI/runtime Telegram path-token projection, Discord REST and Gateway rewrites, bearer projection, query preservation, and route-shape drift tests. No CLI contract bug was demonstrated and no CLI change is present in the two-dot diff.
- WhatsApp and iMessage behavior remain outside this protocol change; WhatsApp nativeTransport debug-health projection is unchanged.

## Official contracts checked

- Telegram update retention: https://core.telegram.org/bots/api#getting-updates
- Discord authentication-scoped rate limits: https://discord.com/developers/docs/topics/rate-limits
- Discord Gateway Resume and heartbeat sequence: https://discord.com/developers/docs/events/gateway#resuming
- Discord Create Message nonce and enforce_nonce: https://discord.com/developers/docs/resources/message#create-message-jsonform-params
- Pinned discord.py 2.7.1 source: https://github.com/Rapptz/discord.py/tree/v2.7.1
- Pinned Hermes source inventory only: https://github.com/NousResearch/hermes-agent/tree/8208fc52701332f213e6c51ebc0b610be00300de

No Hermes/OpenClaw upstream code or hosted/live system was modified.

## Verification

- Fresh throwaway PostgreSQL migrated to current head: 500 passed, 1 skipped across every test_channel*.py, test_discord*.py, test_telegram*.py, plus the opt-in channel blackbox file.
- Focused latest blocker regressions: 26 passed.
- Backend: Ruff, Ruff format check, compileall, type governance, and generated API consistency passed.
- CLI: typecheck plus Docker clean runner: 1566 passed, 4 skipped; Python egress addon: 21 passed and 3 subtests passed.
- Shared: typecheck plus Docker clean runner: 72 passed.
- Web: typecheck passed; focused agent-link normalization/card/binding tests: 9 passed.