### PR TITLE
refine(web): align overview cards and agent badges

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -25,8 +25,10 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 			),
 		grid.locator("[data-overview-module]").evaluateAll((elements) =>
 			elements.map((element) => {
+				const cardBox = element.getBoundingClientRect();
 				const header = element.querySelector<HTMLElement>('[data-slot="card-header"]');
 				const headerLink = header?.querySelector<HTMLElement>("a");
+				const linkBox = headerLink?.getBoundingClientRect();
 				const headerStyle = header ? getComputedStyle(header) : null;
 				const linkStyle = headerLink ? getComputedStyle(headerLink) : null;
 				return {
@@ -41,6 +43,9 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 						linkStyle?.paddingBottom,
 						linkStyle?.paddingLeft,
 					],
+					verticalInsetDelta: linkBox
+						? Math.abs(linkBox.top - cardBox.top - (cardBox.bottom - linkBox.bottom))
+						: Number.POSITIVE_INFINITY,
 				};
 			}),
 		),
@@ -80,6 +85,7 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	expect(new Set(shellMetrics.map((metric) => JSON.stringify(metric.linkPadding)))).toEqual(
 		new Set([JSON.stringify(["0px", "0px", "0px", "0px"])]),
 	);
+	for (const metric of shellMetrics) expect(metric.verticalInsetDelta).toBeLessThanOrEqual(1);
 }
 
 async function expectOverviewSessionSlot({
@@ -3027,6 +3033,10 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("3");
 
 	const overview = page.locator('[data-agent-overview="hosted"]');
+	const overviewHeading = page.getByRole("heading", { name: "Overview", exact: true });
+	const overviewTitleRow = overviewHeading.locator("..");
+	await expect(overviewTitleRow.getByText("Cloud", { exact: true })).toHaveCount(1);
+	await expect(overviewTitleRow.getByText("Legacy", { exact: true })).toHaveCount(0);
 	await expect(overview.getByRole("heading", { name: "Resources", exact: true })).toBeVisible({
 		timeout: 12_000,
 	});
@@ -3231,8 +3241,8 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	}
 	const moduleHeights = [...resourceGeometry, ...toolGeometry].map((box) => box.height);
 	expect(Math.max(...moduleHeights) - Math.min(...moduleHeights)).toBeLessThanOrEqual(2);
-	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([80]));
-	expect(Math.max(...moduleHeights)).toBeLessThan(128);
+	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([73]));
+	expect(Math.max(...moduleHeights)).toBeLessThan(80);
 	expect((toolGeometry[1]?.x ?? 0) + (toolGeometry[1]?.width ?? 0)).toBeLessThan(
 		(resourceGeometry[2]?.x ?? 0) + 1,
 	);
@@ -3282,6 +3292,13 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 		fullPage: true,
 	});
 	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}/sessions?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+	const sessionsHeading = page.getByRole("heading", { name: "Sessions", exact: true });
+	await expect(sessionsHeading).toBeVisible();
+	await expect(sessionsHeading.locator("..").getByText("Cloud", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Open Agent Interface" })).toHaveCount(0);
 });
 
 test("hosted overview keeps a three-row accessible session slot for zero through 3+ sessions", async ({
@@ -3953,7 +3970,9 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	await stubHostedApi(page, {
 		agentOrderRequests,
 		deployments: [railHostedDeployment],
-		cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent],
+		cloudAgents: [railHostedCloudAgent, railConnectedCloudAgent, sharedLegacyCloudAgent],
+		legacyAgentEnvironmentIds: [sharedLegacyEnvironmentId],
+		canUseLegacyHostedDashboard: true,
 	});
 
 	await page.goto("/agents");
@@ -3969,6 +3988,25 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	await expectPointerCursor(connectedButton, "connected tile");
 	await expect(rail.getByRole("button", { name: /^Reorder / })).toHaveCount(0);
 	await expect(rail.getByTitle(/^Reorder /)).toHaveCount(0);
+	const cloudMarker = rail.locator('[data-agent-rail-corner-marker="cloud"]');
+	const legacyMarker = rail.locator('[data-agent-rail-corner-marker="legacy"]');
+	await expect(cloudMarker).toHaveCount(1);
+	await expect(legacyMarker).toHaveCount(1);
+	const [cloudMarkerBox, legacyMarkerBox, cloudIconBox, legacyIconBox] = await Promise.all([
+		cloudMarker.boundingBox(),
+		legacyMarker.boundingBox(),
+		cloudMarker.locator("svg").boundingBox(),
+		legacyMarker.locator("svg").boundingBox(),
+	]);
+	if (!cloudMarkerBox || !legacyMarkerBox || !cloudIconBox || !legacyIconBox) {
+		throw new Error("Cloud and Legacy rail corner markers should render.");
+	}
+	expect(cloudMarkerBox.width).toBe(legacyMarkerBox.width);
+	expect(cloudMarkerBox.height).toBe(legacyMarkerBox.height);
+	expect(cloudIconBox.width).toBe(legacyIconBox.width);
+	expect(cloudIconBox.height).toBe(legacyIconBox.height);
+	expect(cloudMarkerBox.width).toBe(16);
+	expect(cloudIconBox.width).toBe(12);
 
 	const connectedTileBox = await rail
 		.getByTestId("app-sidebar-agent-tile")
@@ -4024,6 +4062,30 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	}
 	expect(agentOrderRequests).toEqual([]);
 	expect(touchOrderRequests).toEqual([]);
+});
+
+test("legacy Overview owns its title chip and dashboard action", async ({ page }) => {
+	await stubHostedApi(page, {
+		canUseLegacyHostedDashboard: true,
+		cloudAgents: [sharedLegacyCloudAgent],
+		legacyAgentEnvironmentIds: [sharedLegacyEnvironmentId],
+	});
+	await page.goto(`/agents/${sharedLegacyEnvironmentId}`);
+
+	const main = page.locator("main");
+	const heading = main.getByRole("heading", { name: "Overview", exact: true });
+	await expect(heading).toBeVisible();
+	const titleRow = heading.locator("..");
+	await expect(titleRow.getByText("Legacy", { exact: true })).toBeVisible();
+	const legacyAction = main.getByRole("button", { name: "Open legacy dashboard" });
+	await expect(legacyAction).toHaveAttribute("href", "https://legacy.example/dashboard");
+	await expect(legacyAction).toHaveAttribute("target", "_blank");
+	await expect(main.getByText("Legacy", { exact: true })).toHaveCount(1);
+	await expect(main.getByText("Cloud", { exact: true })).toHaveCount(0);
+
+	await page.goto(`/agents/${sharedLegacyEnvironmentId}/sessions`);
+	await expect(main.getByText("Legacy", { exact: true })).toHaveCount(0);
+	await expect(main.getByRole("link", { name: "Open legacy dashboard" })).toHaveCount(0);
 });
 
 test("hosted agent sidebar renders one Resources heading in canonical order", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -10,8 +10,10 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 			),
 		grid.locator("[data-overview-module]").evaluateAll((elements) =>
 			elements.map((element) => {
+				const cardBox = element.getBoundingClientRect();
 				const header = element.querySelector<HTMLElement>('[data-slot="card-header"]');
 				const headerLink = header?.querySelector<HTMLElement>("a");
+				const linkBox = headerLink?.getBoundingClientRect();
 				const headerStyle = header ? getComputedStyle(header) : null;
 				const linkStyle = headerLink ? getComputedStyle(headerLink) : null;
 				return {
@@ -26,6 +28,9 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 						linkStyle?.paddingBottom,
 						linkStyle?.paddingLeft,
 					],
+					verticalInsetDelta: linkBox
+						? Math.abs(linkBox.top - cardBox.top - (cardBox.bottom - linkBox.bottom))
+						: Number.POSITIVE_INFINITY,
 				};
 			}),
 		),
@@ -64,6 +69,7 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 	expect(new Set(shellMetrics.map((metric) => JSON.stringify(metric.linkPadding)))).toEqual(
 		new Set([JSON.stringify(["0px", "0px", "0px", "0px"])]),
 	);
+	for (const metric of shellMetrics) expect(metric.verticalInsetDelta).toBeLessThanOrEqual(1);
 }
 
 async function expectOverviewSessionSlot({
@@ -956,8 +962,8 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		Math.max(...resourceGeometry.map((box) => box.height)) -
 			Math.min(...resourceGeometry.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
-	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([80]));
-	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(128);
+	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([73]));
+	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(80);
 	expect(
 		await resourceGrid
 			.locator("[data-overview-module]")
@@ -1218,8 +1224,9 @@ test("connected overview reports connector errors without a false empty state", 
 	});
 	await page.goto("/agents/agent-smoke-1");
 	const card = page.locator('[data-overview-module="connectors"]');
-	await expect(card).toContainText("Can’t load apps", { timeout: 12_000 });
-	await expect(card.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
+	await expect(card).toContainText("Unavailable right now", { timeout: 12_000 });
+	await expect(card.getByRole("button", { name: "Retry", exact: true })).toHaveCount(0);
+	await expect(card.locator("a, button")).toHaveCount(1);
 	await expect(card.locator("a button, button a")).toHaveCount(0);
 	await expect(card).not.toContainText("No apps connected");
 });

--- a/apps/web/playwright.hosted.config.ts
+++ b/apps/web/playwright.hosted.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
 			VITE_CLAWDI_API_URL: "http://127.0.0.1:8000",
 			VITE_CLAWDI_HOSTED: "true",
 			VITE_CLAWDI_DEPLOY_API_URL: "http://127.0.0.1:8001",
+			VITE_CLAWDI_LEGACY_DASHBOARD_URL: "https://legacy.example/dashboard",
 			VITE_DEV_AUTH_BYPASS: "true",
 			VITE_DEV_AUTH_TOKEN: "dev-bypass",
 			VITE_STRIPE_PUBLISHABLE_KEY: stripePublishableKey,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -27,7 +27,6 @@ import { Link, useLocation, useRouter, useSearch } from "@tanstack/react-router"
 import {
 	BookOpen,
 	CircleHelp,
-	Cloud,
 	ExternalLink,
 	History,
 	LayoutDashboard,
@@ -755,17 +754,17 @@ function SortableAgentRailItem({
 					<AgentIcon agent={agent.agentType} size="rail" avatarUrl={agent.avatarUrl} />
 					{kind === "cloud" ? (
 						<span
-							title="Clawdi Cloud agent"
-							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-info text-info-foreground ring-2 ring-sidebar"
+							data-agent-rail-corner-marker="cloud"
+							className="-top-1 -right-1 pointer-events-none absolute z-10"
 						>
-							<Cloud aria-hidden="true" className="size-2.5" />
+							<AgentSourceBadge source="hosted" iconOnly />
 						</span>
 					) : kind === "legacy" ? (
 						<span
-							title="Legacy agent"
-							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-warning text-warning-foreground ring-2 ring-sidebar"
+							data-agent-rail-corner-marker="legacy"
+							className="-top-1 -right-1 pointer-events-none absolute z-10"
 						>
-							<History aria-hidden="true" className="size-2.5" />
+							<LegacyAgentBadge iconOnly />
 						</span>
 					) : null}
 				</span>

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { OverviewMetadata } from "@/components/dashboard/agent-overview-capabilities";
+import {
+	OverviewMetadata,
+	OverviewModuleError,
+} from "@/components/dashboard/agent-overview-capabilities";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
 
 describe("overview card typography", () => {
@@ -38,5 +42,26 @@ describe("overview metadata", () => {
 		expect(markup).toContain("space-y-2 text-xs text-muted-foreground");
 		expect(markup).not.toContain("text-sm");
 		expect(markup).not.toContain("font-medium");
+	});
+});
+
+describe("overview modules", () => {
+	test("represents module errors only as the unavailable description", () => {
+		const source = readFileSync(
+			new URL("./agent-overview-resource-bodies.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(source).not.toContain("error: <");
+		expect(source).not.toContain("OverviewModuleError");
+		expect(source).toContain('return { description: "Unavailable right now" }');
+	});
+
+	test("keeps retry support on the shared non-module error surface", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewModuleError, { label: "Sessions", onRetry: () => undefined }),
+		);
+
+		expect(markup).toContain("Retry");
 	});
 });

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -15,7 +15,6 @@ import { cn } from "@/lib/utils";
 
 export type AgentOverviewModuleContent = {
 	description: ReactNode;
-	error?: ReactNode;
 };
 
 export function AgentOverviewStatusCard({
@@ -147,9 +146,9 @@ export function AgentOverviewCapabilities({
 									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className="h-full min-h-20 min-w-0"
+									className="h-full min-w-0"
 								>
-									<CardHeader className="h-full">
+									<CardHeader className="h-full grid-rows-1 content-center gap-0">
 										<Link
 											{...agentSectionLink(agentId, module.section, routeSearch)}
 											aria-label={title}
@@ -166,11 +165,6 @@ export function AgentOverviewCapabilities({
 											</div>
 											<ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 										</Link>
-										{moduleContent.error ? (
-											<div className="min-w-0 pl-11" data-overview-module-error>
-												{moduleContent.error}
-											</div>
-										) : null}
 									</CardHeader>
 								</Card>
 							);

--- a/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-resource-bodies.tsx
@@ -5,7 +5,6 @@ import { useMemo } from "react";
 import {
 	type AgentOverviewModuleContent,
 	OverviewDescriptionSkeleton,
-	OverviewModuleError,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { useAgentProjectVaults } from "@/components/vault/agent-vaults-query";
 import { unwrap, useApi } from "@/lib/api";
@@ -15,7 +14,6 @@ type SummaryState = {
 	isLoading: boolean;
 	isUnavailable?: boolean;
 	error: unknown;
-	onRetry: () => void;
 };
 
 export function overviewProjectsModule({
@@ -25,11 +23,7 @@ export function overviewProjectsModule({
 }): AgentOverviewModuleContent {
 	if (bindings.isLoading) return { description: <OverviewDescriptionSkeleton label="projects" /> };
 	if (bindings.isUnavailable) return { description: "Unavailable right now" };
-	if (bindings.error)
-		return {
-			description: "Unavailable right now",
-			error: <OverviewModuleError label="Projects" onRetry={bindings.onRetry} />,
-		};
+	if (bindings.error) return { description: "Unavailable right now" };
 	const count = bindings.count ?? 0;
 	const primary = count ? `${count} ${count === 1 ? "project" : "projects"}` : "No projects added";
 	return { description: primary };
@@ -41,11 +35,7 @@ export function overviewSkillsModule({
 }: SummaryState & { items: readonly string[] }): AgentOverviewModuleContent {
 	if (state.isLoading) return { description: <OverviewDescriptionSkeleton label="skills" /> };
 	if (state.isUnavailable) return { description: "Unavailable right now" };
-	if (state.error)
-		return {
-			description: "Unavailable right now",
-			error: <OverviewModuleError label="Skills" onRetry={state.onRetry} />,
-		};
+	if (state.error) return { description: "Unavailable right now" };
 	return {
 		description: items.length
 			? `${items.length} ${items.length === 1 ? "skill" : "skills"}`
@@ -66,11 +56,7 @@ export function useOverviewMemoriesModule({
 		enabled,
 	});
 	if (query.isLoading) return { description: <OverviewDescriptionSkeleton label="memories" /> };
-	if (query.error)
-		return {
-			description: "Unavailable right now",
-			error: <OverviewModuleError label="Memories" onRetry={() => void query.refetch()} />,
-		};
+	if (query.error) return { description: "Unavailable right now" };
 	const total = query.data?.total ?? 0;
 	return {
 		description: total ? `${total} ${total === 1 ? "memory" : "memories"}` : "No memories yet",
@@ -90,11 +76,7 @@ export function useOverviewVaultsModule({
 	if (resolution === "loading" || query.isLoading)
 		return { description: <OverviewDescriptionSkeleton label="vaults" /> };
 	if (resolution === "unavailable") return { description: "Unavailable right now" };
-	if (query.error)
-		return {
-			description: "Unavailable right now",
-			error: <OverviewModuleError label="Vaults" onRetry={() => void query.refetch()} />,
-		};
+	if (query.error) return { description: "Unavailable right now" };
 	const vaults = query.data ?? [];
 	return {
 		description: vaults.length
@@ -127,10 +109,5 @@ export function useOverviewConnectorsModule({
 	) : (
 		"No apps connected"
 	);
-	return {
-		description,
-		error: connections.error ? (
-			<OverviewModuleError label="Apps" onRetry={() => void connections.refetch()} />
-		) : undefined,
-	};
+	return { description };
 }

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Laptop } from "lucide-react";
+import { ArrowRight, ExternalLink, Laptop } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
@@ -49,6 +49,7 @@ import {
 } from "@/lib/agent-routes";
 import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
+import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -94,7 +95,6 @@ export function ConnectedAgentDetail({
 	const projectBindings = overviewProjects.data;
 	const projectBindingsLoading = overviewProjects.isLoading;
 	const projectBindingsError = overviewProjects.error;
-	const refetchProjectBindings = overviewProjects.refetch;
 
 	const {
 		data: overviewSessionsPage,
@@ -121,7 +121,6 @@ export function ConnectedAgentDetail({
 		skills: skillsForThisEnv,
 		isLoading: skillsLoading,
 		error: skillsError,
-		refetch: refetchSkills,
 	} = useAgentProjectSkills(id, agentProjectId, id, false, overviewEnabled);
 
 	const blockingAgentError =
@@ -157,9 +156,10 @@ export function ConnectedAgentDetail({
 	const agentTitle = agent ? agentDisplayName(agent) : null;
 	useSetAgentBreadcrumbTitle({ agentId: id, agentTitle, section: activeTab });
 	const headerStatus =
-		agent && showSourceBadge ? (
+		activeTab === "overview" && agent && showSourceBadge ? (
 			<AgentSourceBadgeForEnvironment env={agent} ownershipKind={ownershipKind} compact />
 		) : null;
+	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;
 	const scopedSessionLink = (sessionId: string) => ({
 		...agentSessionDetailLink(id, sessionId, routeSearch),
 	});
@@ -194,9 +194,28 @@ export function ConnectedAgentDetail({
 				<section className="flex flex-col gap-4">
 					<PageHeader
 						title={activeTabLabel}
+						titleAdornment={headerStatus}
 						description={activeTab === "overview" ? undefined : activeTabMeta.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
-						status={headerStatus}
+						actions={
+							activeTab === "overview" && legacyDashboardUrl ? (
+								<Button
+									variant="outline"
+									render={
+										<a
+											href={legacyDashboardUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											aria-label="Open legacy dashboard"
+										/>
+									}
+									nativeButton={false}
+								>
+									<ExternalLink />
+									Legacy dashboard
+								</Button>
+							) : null
+						}
 					/>
 
 					{activeTab === "overview" ? (
@@ -269,14 +288,12 @@ export function ConnectedAgentDetail({
 											count: projectBindings?.length ?? null,
 											isLoading: projectBindingsLoading,
 											error: blockingProjectBindingsError,
-											onRetry: () => void refetchProjectBindings(),
 										},
 									}),
 									skills: overviewSkillsModule({
 										items: (skillsForThisEnv ?? []).map((skill) => skill.name),
 										isLoading: skillsLoading,
 										error: blockingSkillsError,
-										onRetry: () => void refetchSkills(),
 									}),
 									memories: memoriesModule,
 									vaults: vaultsModule,

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
 	title: string;
+	titleAdornment?: ReactNode;
 	description?: string;
 	actions?: ReactNode;
 	/** Left-of-title slot — e.g. a channel or runtime icon. */
@@ -21,6 +22,7 @@ interface PageHeaderProps {
  */
 export function PageHeader({
 	title,
+	titleAdornment,
 	description,
 	actions,
 	icon,
@@ -34,7 +36,12 @@ export function PageHeader({
 			<div className="flex min-w-0 items-center gap-3">
 				{icon ? <div className="shrink-0">{icon}</div> : null}
 				<div className="min-w-0 max-w-full">
-					<h1 className="text-xl font-semibold tracking-tight text-pretty break-words">{title}</h1>
+					<div className="flex min-w-0 flex-wrap items-center gap-2">
+						<h1 className="text-xl font-semibold tracking-tight text-pretty break-words">
+							{title}
+						</h1>
+						{titleAdornment}
+					</div>
 					{description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
 					{status ? <div className="mt-1">{status}</div> : null}
 				</div>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 describe("hosted agent detail header", () => {
-	test("keeps the agent source badge out of tab page headers", () => {
+	test("shows the compact Cloud badge only beside the Overview title", () => {
 		const detailSource = readFileSync(
 			new URL("./hosted-agent-detail.tsx", import.meta.url),
 			"utf8",
@@ -12,7 +12,8 @@ describe("hosted agent detail header", () => {
 			"utf8",
 		);
 
-		expect(detailSource).not.toContain("AgentSourceBadge");
+		expect(detailSource).toContain('<AgentSourceBadge source="hosted" compact />');
+		expect(detailSource).toContain('activeTab === "overview" ? <AgentSourceBadge');
 		expect(sidebarSource).toContain("AgentSourceBadge");
 	});
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -31,7 +31,7 @@ import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { ConnectorsSurface } from "@/components/connectors/connectors-surface";
-import { agentDisplayName } from "@/components/dashboard/agent-label";
+import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
 	AgentOverviewStatusCard,
@@ -530,6 +530,9 @@ export function HostedAgentDetail({
 				{isLiveToolTab ? null : (
 					<PageHeader
 						title={activeTabLabel}
+						titleAdornment={
+							activeTab === "overview" ? <AgentSourceBadge source="hosted" compact /> : null
+						}
 						description={activeTab === "overview" ? undefined : activeNavItem.description}
 						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
 						actions={
@@ -1259,7 +1262,6 @@ function OverviewTab({
 							isLoading: projectionLoading || projectBindings.isLoading,
 							isUnavailable: projectionUnavailable,
 							error: projectBindings.error,
-							onRetry: () => void projectBindings.refetch(),
 						},
 					}),
 					skills: overviewSkillsModule({
@@ -1267,7 +1269,6 @@ function OverviewTab({
 						isLoading: projectionLoading || skills.isLoading,
 						isUnavailable: projectionUnavailable,
 						error: skills.error,
-						onRetry: () => void skills.refetch(),
 					}),
 					memories: memoriesModule,
 					vaults: vaultsModule,
@@ -1281,15 +1282,6 @@ function OverviewTab({
 							) : (
 								model
 							),
-						error:
-							providers.error || managedModelCatalog.error ? (
-								<OverviewModuleError
-									label="Model & Provider"
-									onRetry={() =>
-										void (managedProvider ? managedModelCatalog.refetch() : providers.refetch())
-									}
-								/>
-							) : undefined,
 					},
 					channels: {
 						description:
@@ -1302,9 +1294,6 @@ function OverviewTab({
 							) : (
 								`${linkedChannelCount} connected ${linkedChannelCount === 1 ? "channel" : "channels"}`
 							),
-						error: channelLinks.error ? (
-							<OverviewModuleError label="Channels" onRetry={() => void channelLinks.refetch()} />
-						) : undefined,
 					},
 				}}
 			/>


### PR DESCRIPTION
## Summary
- vertically center overview module headers and reduce cards to their natural compact height
- remove retry actions from summary modules while preserving loading and unavailable states
- place Cloud/Legacy identity chips beside the Overview title and add the configured Legacy dashboard action
- standardize Cloud/Legacy avatar corner markers through the existing shared badge primitives

## Verification
- Web typecheck
- focused unit tests (8 passed)
- Hosted mocked Playwright: modular overview and Legacy overview action (2 passed)
- Connected mocked Playwright: modular overview (passed on clean rerun; first run hit a Vite dynamic-import startup flake)
- full isolated Web tests/build and browser matrix completed before final rebase
- Biome and git diff --check