### PR TITLE
refine(web): align overview skeleton geometry

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3241,8 +3241,9 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	}
 	const moduleHeights = [...resourceGeometry, ...toolGeometry].map((box) => box.height);
 	expect(Math.max(...moduleHeights) - Math.min(...moduleHeights)).toBeLessThanOrEqual(2);
-	expect(new Set(moduleHeights.map((height) => Math.round(height)))).toEqual(new Set([73]));
-	expect(Math.max(...moduleHeights)).toBeLessThan(80);
+	for (const height of moduleHeights) {
+		expect(Math.abs(height - (sessionBoxes[0]?.height ?? 0))).toBeLessThanOrEqual(2);
+	}
 	expect((toolGeometry[1]?.x ?? 0) + (toolGeometry[1]?.width ?? 0)).toBeLessThan(
 		(resourceGeometry[2]?.x ?? 0) + 1,
 	);
@@ -3497,6 +3498,47 @@ test("hosted projection loading uses module skeletons", async ({ page }, testInf
 	await page.setViewportSize({ width: 1280, height: 1600 });
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-agent-overview-loading.png"),
+		fullPage: true,
+	});
+});
+
+test("hosted inventory loading skeleton matches the compact overview geometry", async ({
+	page,
+}, testInfo) => {
+	await stubHostedApi(page, {
+		deploymentsResponse: {
+			body: [railHostedDeployment],
+			status: 200,
+			delayMs: 5_000,
+		},
+	});
+	await page.goto(
+		`/agents/${railHostedEnvironmentId}?source=on-clawdi&d=${railHostedDeployment.id}`,
+	);
+
+	const skeleton = page.locator("[data-agent-detail-skeleton]");
+	await expect(skeleton).toBeVisible();
+	await expect(skeleton.locator("[data-overview-module-skeleton]")).toHaveCount(7);
+	await expect(skeleton.getByTestId("overview-session-skeleton-row")).toHaveCount(3);
+	const moduleBoxes = await skeleton
+		.locator("[data-overview-module-skeleton]")
+		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
+	expect(
+		Math.max(...moduleBoxes.map((box) => box.height)) -
+			Math.min(...moduleBoxes.map((box) => box.height)),
+	).toBeLessThanOrEqual(2);
+	const sessionsBox = await skeleton.getByTestId("overview-session-grid").boundingBox();
+	const statusBox = await skeleton.getByTestId("overview-status-card-skeleton").boundingBox();
+	const sessionRowBox = await skeleton
+		.getByTestId("overview-session-skeleton-row")
+		.first()
+		.boundingBox();
+	for (const box of moduleBoxes) {
+		expect(Math.abs(box.height - (sessionRowBox?.height ?? 0))).toBeLessThanOrEqual(2);
+	}
+	expect(Math.abs((sessionsBox?.height ?? 0) - (statusBox?.height ?? 0))).toBeLessThanOrEqual(2);
+	await page.screenshot({
+		path: testInfo.outputPath("hosted-agent-overview-initial-skeleton.png"),
 		fullPage: true,
 	});
 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -962,8 +962,9 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 		Math.max(...resourceGeometry.map((box) => box.height)) -
 			Math.min(...resourceGeometry.map((box) => box.height)),
 	).toBeLessThanOrEqual(2);
-	expect(new Set(resourceGeometry.map((box) => Math.round(box.height)))).toEqual(new Set([73]));
-	expect(Math.max(...resourceGeometry.map((box) => box.height))).toBeLessThan(80);
+	for (const box of resourceGeometry) {
+		expect(Math.abs(box.height - (sessionBoxes[0]?.height ?? 0))).toBeLessThanOrEqual(2);
+	}
 	expect(
 		await resourceGrid
 			.locator("[data-overview-module]")

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
+	AgentOverviewCapabilitiesSkeleton,
+	OverviewDescriptionSkeleton,
 	OverviewMetadata,
 	OverviewModuleError,
 } from "@/components/dashboard/agent-overview-capabilities";
@@ -46,6 +48,30 @@ describe("overview metadata", () => {
 });
 
 describe("overview modules", () => {
+	test("keeps loading summaries on the standard description line height", () => {
+		const markup = renderToStaticMarkup(
+			createElement(OverviewDescriptionSkeleton, { label: "projects" }),
+		);
+
+		expect(markup).toContain("h-5 w-20");
+		expect(markup).not.toContain("h-4 w-20");
+	});
+
+	test("uses the same compact Card grid for initial overview skeletons", () => {
+		const connected = renderToStaticMarkup(
+			createElement(AgentOverviewCapabilitiesSkeleton, { variant: "connected" }),
+		);
+		const hosted = renderToStaticMarkup(
+			createElement(AgentOverviewCapabilitiesSkeleton, { variant: "hosted" }),
+		);
+
+		expect(connected.match(/data-overview-module-skeleton=/g)).toHaveLength(5);
+		expect(hosted.match(/data-overview-module-skeleton=/g)).toHaveLength(7);
+		expect(hosted).toContain("h-full min-w-0 py-3");
+		expect(hosted).toContain("grid-rows-1 content-center gap-0");
+		expect(hosted).not.toContain("h-40");
+	});
+
 	test("represents module errors only as the unavailable description", () => {
 		const source = readFileSync(
 			new URL("./agent-overview-resource-bodies.tsx", import.meta.url),

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -80,7 +80,7 @@ export function OverviewModuleError({ label, onRetry }: { label: string; onRetry
 }
 
 export function OverviewDescriptionSkeleton({ label }: { label: string }) {
-	return <Skeleton className="h-4 w-20" aria-label={`Loading ${label} summary`} role="status" />;
+	return <Skeleton className="h-5 w-20" aria-label={`Loading ${label} summary`} role="status" />;
 }
 
 export function OverviewModuleUnavailable() {
@@ -146,7 +146,7 @@ export function AgentOverviewCapabilities({
 									role="article"
 									key={module.id}
 									data-overview-module={module.id}
-									className="h-full min-w-0"
+									className="h-full min-w-0 py-3"
 								>
 									<CardHeader className="h-full grid-rows-1 content-center gap-0">
 										<Link
@@ -169,6 +169,52 @@ export function AgentOverviewCapabilities({
 								</Card>
 							);
 						})}
+					</div>
+				</section>
+			))}
+		</div>
+	);
+}
+
+export function AgentOverviewCapabilitiesSkeleton({
+	variant,
+}: {
+	variant: AgentNavigationVariant;
+}) {
+	const groups = agentOverviewGroups(variant);
+	return (
+		<div className="flex flex-col gap-8" aria-hidden="true" data-agent-overview-skeleton={variant}>
+			{groups.map((group) => (
+				<section key={group.id}>
+					<Skeleton className="mb-3 h-5 w-20" />
+					<div
+						data-overview-layout={group.layout}
+						className={cn(
+							"grid auto-rows-fr items-stretch gap-3",
+							group.layout === "three-column"
+								? "@2xl/main:grid-cols-2 @4xl/main:grid-cols-3"
+								: "@2xl/main:grid-cols-2",
+						)}
+					>
+						{group.modules.map((module) => (
+							<Card
+								size="sm"
+								key={module.id}
+								data-overview-module-skeleton={module.id}
+								className="h-full min-w-0 py-3"
+							>
+								<CardHeader className="h-full grid-rows-1 content-center gap-0">
+									<div className="flex min-w-0 items-center gap-3">
+										<Skeleton className="size-8 shrink-0 rounded-lg" />
+										<div className="min-w-0 flex-1">
+											<Skeleton className="h-5 w-24" />
+											<Skeleton className="h-5 w-20" />
+										</div>
+										<Skeleton className="size-4 shrink-0" />
+									</div>
+								</CardHeader>
+							</Card>
+						))}
 					</div>
 				</section>
 			))}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/dashboard/agent-label";
 import {
 	AgentOverviewCapabilities,
+	AgentOverviewCapabilitiesSkeleton,
 	AgentOverviewStatusCard,
 	OverviewMetadata,
 	OverviewModuleError,
@@ -34,8 +35,13 @@ import { DetailNotFound } from "@/components/detail/layout";
 import { MemoriesSurface } from "@/components/memories/memories-surface";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { OverviewSessionList, SessionFeed } from "@/components/sessions/session-feed";
+import {
+	OverviewSessionList,
+	OverviewSessionListSkeleton,
+	SessionFeed,
+} from "@/components/sessions/session-feed";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusDot } from "@/components/ui/status-badge";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
@@ -189,7 +195,7 @@ export function ConnectedAgentDetail({
 					/>
 				)
 			) : isLoading ? (
-				<AgentDetailContentSkeleton />
+				<AgentDetailContentSkeleton variant="connected" />
 			) : agent ? (
 				<section className="flex flex-col gap-4">
 					<PageHeader
@@ -353,39 +359,55 @@ export function ConnectedAgentDetailSkeleton({ hosted = false }: { hosted?: bool
 			data-hosted={hosted ? "true" : undefined}
 			className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
 		>
-			<AgentDetailContentSkeleton />
+			<AgentDetailContentSkeleton variant={hosted ? "hosted" : "connected"} />
 		</div>
 	);
 }
 
-function AgentDetailContentSkeleton() {
+function AgentDetailContentSkeleton({ variant }: { variant: "connected" | "hosted" }) {
 	return (
-		<section className="flex flex-col gap-8">
-			<div className="flex flex-col gap-2">
-				<div className="flex items-center gap-2">
+		<section className="flex flex-col gap-8" data-agent-detail-skeleton>
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="flex items-center gap-3">
 					<Skeleton className="size-4 rounded-sm" />
-					<Skeleton className="h-5 w-28" />
+					<Skeleton className="h-7 w-28" />
+					{variant === "hosted" ? <Skeleton className="h-5 w-14 rounded-full" /> : null}
 				</div>
+				{variant === "hosted" ? <Skeleton className="h-9 w-48 rounded-md" /> : null}
 			</div>
-			<div>
-				<Skeleton className="mb-3 h-4 w-28" />
-				<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)]">
-					<div className="grid min-h-52 gap-2">
-						{Array.from({ length: 3 }).map((_, index) => (
-							<Skeleton key={index} className="h-11 rounded-lg" />
-						))}
+			<div className="grid items-stretch gap-4 @3xl/main:grid-cols-[minmax(0,2fr)_minmax(16rem,1fr)] @3xl/main:gap-y-3">
+				<div className="grid min-w-0 gap-3 @3xl/main:row-span-2 @3xl/main:row-start-1 @3xl/main:grid-rows-subgrid">
+					<div className="flex items-center justify-between">
+						<Skeleton className="h-5 w-28" />
+						<Skeleton className="h-8 w-20" />
 					</div>
-					<Skeleton className="min-h-52 rounded-lg" />
+					<OverviewSessionListSkeleton />
+				</div>
+				<div className="@3xl/main:row-start-2">
+					<Card
+						size="sm"
+						className="h-full gap-0 bg-muted/20 py-0"
+						aria-hidden="true"
+						data-testid="overview-status-card-skeleton"
+					>
+						<CardHeader className="p-0">
+							<div className="flex items-center gap-3 px-4 py-3">
+								<Skeleton className="size-8 shrink-0 rounded-lg" />
+								<div className="min-w-0 flex-1">
+									<Skeleton className="h-5 w-20" />
+									<Skeleton className="h-5 w-16" />
+								</div>
+								<Skeleton className="size-4 shrink-0" />
+							</div>
+						</CardHeader>
+						<CardContent className="flex flex-1 flex-col justify-end gap-2 px-4 pb-4">
+							<Skeleton className="h-4 w-full" />
+							<Skeleton className="h-4 w-3/4" />
+						</CardContent>
+					</Card>
 				</div>
 			</div>
-			<div>
-				<Skeleton className="mb-3 h-4 w-20" />
-				<div className="grid gap-3 @2xl/main:grid-cols-2 @4xl/main:grid-cols-3">
-					{Array.from({ length: 5 }).map((_, index) => (
-						<Skeleton key={index} className="h-40 rounded-xl" />
-					))}
-				</div>
-			</div>
+			<AgentOverviewCapabilitiesSkeleton variant={variant} />
 		</section>
 	);
 }

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -46,6 +46,21 @@ function SessionCardSkeleton({ testId }: { testId?: string }) {
 	);
 }
 
+export function OverviewSessionListSkeleton() {
+	return (
+		<div
+			data-testid="overview-session-grid"
+			className="grid gap-2"
+			aria-label="Loading recent sessions"
+			role="status"
+		>
+			{Array.from({ length: 3 }).map((_, index) => (
+				<SessionCardSkeleton key={index} testId="overview-session-skeleton-row" />
+			))}
+		</div>
+	);
+}
+
 export function OverviewSessionList({
 	sessions,
 	isLoading,
@@ -58,18 +73,7 @@ export function OverviewSessionList({
 	sessionLink: (session: SessionListItem) => SessionLinkOptions;
 }) {
 	if (isLoading) {
-		return (
-			<div
-				data-testid="overview-session-grid"
-				className="grid gap-2"
-				aria-label="Loading recent sessions"
-				role="status"
-			>
-				{Array.from({ length: 3 }).map((_, index) => (
-					<SessionCardSkeleton key={index} testId="overview-session-skeleton-row" />
-				))}
-			</div>
-		);
+		return <OverviewSessionListSkeleton />;
 	}
 	const visibleSessions = sessions.slice(0, 3);
 	const placeholderCount = 3 - visibleSessions.length;


### PR DESCRIPTION
## Summary
- make overview module cards use the same compact 66px rhythm as Session cards
- rebuild initial Connected/Hosted overview loading states from the existing Card and Session skeleton primitives
- keep loading descriptions on the standard CardDescription line height to prevent layout shift
- match Hosted header, three-session column, status card, Resources, and Tools geometry while loading

## Verification
- Web typecheck
- focused unit tests: 9 passed
- Hosted mocked Playwright: normal overview, projection loading, and initial inventory loading: 3 passed
- Connected mocked Playwright modular overview: 1 passed
- Biome and git diff --check
- browser screenshot reviewed