### PR TITLE
feat(backend): add managed WhatsApp admin onboarding

### DIFF
--- a/backend/alembic/versions/b4e8c1d7a2f9_discriminate_whatsapp_onboarding.py
+++ b/backend/alembic/versions/b4e8c1d7a2f9_discriminate_whatsapp_onboarding.py
@@ -22,9 +22,29 @@ def upgrade() -> None:
         "channel_whatsapp_onboarding_sessions",
         "ownership_kind IN ('custom', 'managed')",
     )
+    op.drop_constraint(
+        "uq_channel_whatsapp_onboarding_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_channel_whatsapp_onboarding_kind_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        ["ownership_kind", "user_id", "request_id"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint(
+        "uq_channel_whatsapp_onboarding_kind_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_channel_whatsapp_onboarding_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        ["user_id", "request_id"],
+    )
     op.drop_constraint(
         "ck_channel_whatsapp_onboarding_ownership_kind",
         "channel_whatsapp_onboarding_sessions",

--- a/backend/alembic/versions/b4e8c1d7a2f9_discriminate_whatsapp_onboarding.py
+++ b/backend/alembic/versions/b4e8c1d7a2f9_discriminate_whatsapp_onboarding.py
@@ -1,0 +1,33 @@
+"""Discriminate managed and Custom WhatsApp onboarding reservations."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b4e8c1d7a2f9"
+down_revision: str | Sequence[str] | None = "a9d4e7c2f1b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_whatsapp_onboarding_sessions",
+        sa.Column("ownership_kind", sa.String(length=16), server_default="custom", nullable=False),
+    )
+    op.create_check_constraint(
+        "ck_channel_whatsapp_onboarding_ownership_kind",
+        "channel_whatsapp_onboarding_sessions",
+        "ownership_kind IN ('custom', 'managed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_channel_whatsapp_onboarding_ownership_kind",
+        "channel_whatsapp_onboarding_sessions",
+        type_="check",
+    )
+    op.drop_column("channel_whatsapp_onboarding_sessions", "ownership_kind")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -107,6 +107,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await start_postgres_listener()
     try:
         await whatsapp_sidecars.start()
+        if whatsapp_sidecars.managed_account_ids:
+            await whatsapp_sidecars.reconcile_managed_ownership()
     except Exception:
         await whatsapp_sidecars.stop()
         await stop_postgres_listener()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,6 +67,9 @@ from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_device_onboarding import expire_stale_whatsapp_onboarding_sessions
+from app.services.whatsapp_managed_onboarding import (
+    expire_stale_managed_whatsapp_onboarding_sessions,
+)
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
 configure_application_logging()
@@ -116,31 +119,40 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     await warm_clerk_jwks()
 
-    if whatsapp_sidecars.custom_slot_ids:
+    if whatsapp_sidecars.custom_slot_ids or whatsapp_sidecars.managed_account_ids:
 
         async def _expire_whatsapp_onboarding() -> None:
             while True:
                 await asyncio.sleep(15)
                 try:
-                    await whatsapp_sidecars.reconcile_custom_ownership()
+                    if whatsapp_sidecars.custom_slot_ids:
+                        await whatsapp_sidecars.reconcile_custom_ownership()
+                    if whatsapp_sidecars.managed_account_ids:
+                        await whatsapp_sidecars.reconcile_managed_ownership()
                 except asyncio.CancelledError:
                     raise
                 except Exception:
-                    log.exception("WhatsApp Custom ownership reconciliation failed")
+                    log.exception("WhatsApp sidecar ownership reconciliation failed")
                 try:
                     async with async_session_factory() as db:
-                        await expire_stale_whatsapp_onboarding_sessions(
-                            db,
-                            registry=whatsapp_sidecars,
-                        )
+                        if whatsapp_sidecars.custom_slot_ids:
+                            await expire_stale_whatsapp_onboarding_sessions(
+                                db,
+                                registry=whatsapp_sidecars,
+                            )
+                        if whatsapp_sidecars.managed_account_ids:
+                            await expire_stale_managed_whatsapp_onboarding_sessions(
+                                db,
+                                registry=whatsapp_sidecars,
+                            )
                 except asyncio.CancelledError:
                     raise
                 except Exception:
-                    log.exception("WhatsApp Custom onboarding expiry sweep failed")
+                    log.exception("WhatsApp onboarding expiry sweep failed")
 
         task = asyncio.create_task(
             _expire_whatsapp_onboarding(),
-            name="whatsapp-custom-onboarding-expiry",
+            name="whatsapp-onboarding-expiry",
         )
         background.add(task)
         task.add_done_callback(background.discard)
@@ -432,6 +444,8 @@ def _is_whatsapp_onboarding_request(request: Request) -> bool:
         (
             "/api/channels/whatsapp/onboarding/",
             "/v1/channels/whatsapp/onboarding/",
+            "/api/admin/channels/whatsapp/onboarding",
+            "/v1/admin/channels/whatsapp/onboarding",
         )
     )
 

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -43,6 +43,8 @@ WHATSAPP_ONBOARDING_STATE_CONNECTED = "connected"
 WHATSAPP_ONBOARDING_STATE_EXPIRED = "expired"
 WHATSAPP_ONBOARDING_STATE_CANCELED = "canceled"
 WHATSAPP_ONBOARDING_STATE_ERROR = "error"
+WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM = "custom"
+WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED = "managed"
 WHATSAPP_ONBOARDING_ACTIVE_STATES = (
     WHATSAPP_ONBOARDING_STATE_GENERATING,
     WHATSAPP_ONBOARDING_STATE_READY,
@@ -131,6 +133,12 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
     __tablename__ = "channel_whatsapp_onboarding_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    ownership_kind: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+        server_default=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+    )
     sidecar_account_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -166,9 +166,10 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
 
     __table_args__ = (
         UniqueConstraint(
+            "ownership_kind",
             "user_id",
             "request_id",
-            name="uq_channel_whatsapp_onboarding_user_request",
+            name="uq_channel_whatsapp_onboarding_kind_user_request",
         ),
         Index(
             "uq_channel_whatsapp_onboarding_active_sidecar_account",

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -31,7 +31,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any, Never, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -75,12 +75,17 @@ from app.schemas.admin import (
     AdminEnvironmentCreate,
     AdminManagedAiProviderResponse,
     AdminManagedAiProviderUpsert,
+    AdminManagedWhatsAppOnboardingCreate,
     AdminRuntimeStateResponse,
     AdminRuntimeStateUpsert,
 )
 from app.schemas.ai_provider import AiProviderDeleteResponse, ai_provider_auth_from_persistence
 from app.schemas.api_key import ApiKeyCreated, ApiKeyRevokeResponse
-from app.schemas.channel import ChannelCommandSyncRequest, ChannelCommandSyncResponse
+from app.schemas.channel import (
+    ChannelCommandSyncRequest,
+    ChannelCommandSyncResponse,
+    ChannelWhatsAppOnboardingSessionResponse,
+)
 from app.schemas.platform import PlatformOwner
 from app.schemas.session import EnvironmentCreatedResponse
 from app.services.agent_environments import (
@@ -170,6 +175,12 @@ from app.services.user_provisioning import (
     lazy_create_user_with_personal_project,
 )
 from app.services.whatsapp_device_onboarding import require_whatsapp_custom_logout_for_archive
+from app.services.whatsapp_managed_onboarding import (
+    cancel_managed_whatsapp_onboarding,
+    get_managed_whatsapp_onboarding,
+    require_managed_whatsapp_logout_for_archive,
+    start_managed_whatsapp_onboarding,
+)
 from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
 
 logger = logging.getLogger(__name__)
@@ -181,6 +192,11 @@ logger = logging.getLogger(__name__)
 # tell admin endpoints exist let alone what header they expect. The
 # routes themselves stay live — gating is `require_admin_api_key`.
 router = APIRouter(prefix="/admin", tags=["admin"], include_in_schema=False)
+
+
+def _no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
 
 
 def _admin_app_setting_response(setting: AppSetting) -> AdminAppSettingResponse:
@@ -1168,6 +1184,97 @@ async def admin_create_channel(
     )
 
 
+@router.post(
+    "/channels/whatsapp/onboarding",
+    response_model=ChannelWhatsAppOnboardingSessionResponse,
+)
+async def admin_start_managed_whatsapp_onboarding(
+    body: AdminManagedWhatsAppOnboardingCreate,
+    response: Response,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    _no_store(response)
+    target = await _resolve_or_create_user(db, body.target_clerk_id)
+    result = await start_managed_whatsapp_onboarding(
+        db,
+        account_id=body.account_id,
+        user_id=target.id,
+        request_id=body.request_id,
+        name=body.name,
+        registry=get_active_whatsapp_sidecar_registry(),
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="channel.whatsapp.onboarding.start",
+        resource_type="channel_whatsapp_onboarding",
+        resource_id=str(result.id),
+        channel_account_id=result.channel_account_id,
+        target_user_id=target.id,
+        source="api.admin",
+        details={"account_id": str(body.account_id), "state": result.state},
+    )
+    await db.commit()
+    return result
+
+
+@router.get(
+    "/channels/whatsapp/onboarding/{session_id}",
+    response_model=ChannelWhatsAppOnboardingSessionResponse,
+)
+async def admin_get_managed_whatsapp_onboarding(
+    session_id: UUID,
+    response: Response,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    _no_store(response)
+    result = await get_managed_whatsapp_onboarding(
+        db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="channel.whatsapp.onboarding.status",
+        resource_type="channel_whatsapp_onboarding",
+        resource_id=str(result.id),
+        channel_account_id=result.channel_account_id,
+        source="api.admin",
+        details={"state": result.state},
+    )
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/channels/whatsapp/onboarding/{session_id}",
+    response_model=ChannelWhatsAppOnboardingSessionResponse,
+)
+async def admin_cancel_managed_whatsapp_onboarding(
+    session_id: UUID,
+    response: Response,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    _no_store(response)
+    result = await cancel_managed_whatsapp_onboarding(
+        db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="channel.whatsapp.onboarding.cancel",
+        resource_type="channel_whatsapp_onboarding",
+        resource_id=str(result.id),
+        channel_account_id=result.channel_account_id,
+        source="api.admin",
+        details={"state": result.state},
+    )
+    await db.commit()
+    return result
+
+
 @router.get("/channels/{account_id}", response_model=AdminChannelResponse)
 async def admin_get_channel(
     account_id: UUID,
@@ -1396,6 +1503,10 @@ async def admin_delete_channel(
     )
     await require_whatsapp_custom_logout_for_archive(
         db,
+        account=account,
+        registry=get_active_whatsapp_sidecar_registry(),
+    )
+    await require_managed_whatsapp_logout_for_archive(
         account=account,
         registry=get_active_whatsapp_sidecar_registry(),
     )

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -195,7 +195,7 @@ router = APIRouter(prefix="/admin", tags=["admin"], include_in_schema=False)
 
 
 def _no_store(response: Response) -> None:
-    response.headers["Cache-Control"] = "no-store"
+    response.headers["Cache-Control"] = "no-store, private"
     response.headers["Pragma"] = "no-cache"
 
 
@@ -1233,17 +1233,6 @@ async def admin_get_managed_whatsapp_onboarding(
     result = await get_managed_whatsapp_onboarding(
         db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
     )
-    record_control_plane_audit(
-        db,
-        actor_type="admin",
-        action="channel.whatsapp.onboarding.status",
-        resource_type="channel_whatsapp_onboarding",
-        resource_id=str(result.id),
-        channel_account_id=result.channel_account_id,
-        source="api.admin",
-        details={"state": result.state},
-    )
-    await db.commit()
     return result
 
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -278,6 +278,21 @@ class AdminChannelCreate(BaseModel):
         return _clean_channel_secret_values(value)
 
 
+class AdminManagedWhatsAppOnboardingCreate(BaseModel):
+    account_id: UUID
+    target_clerk_id: str = Field(min_length=1, max_length=255)
+    request_id: UUID
+    name: str = Field(min_length=1, max_length=120)
+
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("name cannot be blank")
+        return stripped
+
+
 class AdminChannelUpdate(BaseModel):
     """Patch provider bot metadata and credentials.
 

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -15,6 +15,7 @@ from app.models.channel import (
     CHANNEL_STATUS_ACTIVE,
     CHANNEL_VISIBILITY_PRIVATE,
     WHATSAPP_ONBOARDING_ACTIVE_STATES,
+    WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
     WHATSAPP_ONBOARDING_STATE_CANCELED,
     WHATSAPP_ONBOARDING_STATE_CONNECTED,
     WHATSAPP_ONBOARDING_STATE_ERROR,
@@ -120,6 +121,7 @@ async def start_whatsapp_onboarding(
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     existing = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.user_id == user_id,
             ChannelWhatsAppOnboardingSession.request_id == request_id,
         )
@@ -140,6 +142,7 @@ async def start_whatsapp_onboarding(
     await _lock_allocation(db)
     existing = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.user_id == user_id,
             ChannelWhatsAppOnboardingSession.request_id == request_id,
         )
@@ -169,6 +172,7 @@ async def start_whatsapp_onboarding(
         )
     unfinished_name = await db.scalar(
         select(ChannelWhatsAppOnboardingSession.id).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.user_id == user_id,
             ChannelWhatsAppOnboardingSession.name == name,
             ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_SESSION_STATES),
@@ -194,6 +198,7 @@ async def start_whatsapp_onboarding(
         )
     now = datetime.now(UTC)
     onboarding = ChannelWhatsAppOnboardingSession(
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
         sidecar_account_id=sidecar_account_id,
         sidecar_config_revision=sidecar_config_revision,
         user_id=user_id,
@@ -528,6 +533,7 @@ async def require_whatsapp_custom_logout_for_archive(
         await registry.unbind_custom_account(slot_id=sidecar_account_id, account_id=account.id)
     onboarding = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.channel_account_id == account.id,
             ChannelWhatsAppOnboardingSession.user_id == account.user_id,
             ChannelWhatsAppOnboardingSession.state == WHATSAPP_ONBOARDING_STATE_CONNECTED,
@@ -557,6 +563,8 @@ async def expire_stale_whatsapp_onboarding_sessions(
         (
             await db.scalars(
                 select(ChannelWhatsAppOnboardingSession.id).where(
+                    ChannelWhatsAppOnboardingSession.ownership_kind
+                    == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
                     ChannelWhatsAppOnboardingSession.state.in_(stale_states),
                     ChannelWhatsAppOnboardingSession.expires_at <= deadline,
                 )
@@ -569,6 +577,8 @@ async def expire_stale_whatsapp_onboarding_sessions(
             select(ChannelWhatsAppOnboardingSession)
             .where(
                 ChannelWhatsAppOnboardingSession.id == session_id,
+                ChannelWhatsAppOnboardingSession.ownership_kind
+                == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
                 ChannelWhatsAppOnboardingSession.state.in_(stale_states),
                 ChannelWhatsAppOnboardingSession.expires_at <= deadline,
             )
@@ -591,6 +601,7 @@ async def _owned_session(
         select(ChannelWhatsAppOnboardingSession)
         .where(
             ChannelWhatsAppOnboardingSession.id == session_id,
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.user_id == user_id,
         )
         .with_for_update()
@@ -622,6 +633,7 @@ async def _free_account_ids(
     if not configured:
         return []
     session_query = select(ChannelWhatsAppOnboardingSession.sidecar_account_id).where(
+        ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
         ChannelWhatsAppOnboardingSession.sidecar_account_id.in_(configured),
         ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_SESSION_STATES),
     )

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -369,7 +369,7 @@ async def cancel_whatsapp_onboarding(
         )
     try:
         await client.health()
-        canceled = await _stop_unfinished_pairing(client)
+        canceled = await stop_whatsapp_pairing(client)
     except WhatsAppSidecarError:
         await _mark_session_error(db, onboarding)
         raise HTTPException(
@@ -518,7 +518,7 @@ async def require_whatsapp_custom_logout_for_archive(
                 config_revision=sidecar_config_revision,
                 registry=registry,
             )
-        disconnected = await _stop_unfinished_pairing(client, current=current)
+        disconnected = await stop_whatsapp_pairing(client, current=current)
     except WhatsAppSidecarError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -882,7 +882,7 @@ async def _expire_session(
                 onboarding,
                 manual_pairing_code_supported=False,
             )
-        canceled = await _stop_unfinished_pairing(client, current=current)
+        canceled = await stop_whatsapp_pairing(client, current=current)
     except WhatsAppSidecarError:
         return await _mark_session_error(db, onboarding)
     if canceled.status != "stopped" or canceled.registered:
@@ -906,7 +906,7 @@ async def _confirm_stopped(
         )
     try:
         await client.health()
-        stopped = await _stop_unfinished_pairing(client)
+        stopped = await stop_whatsapp_pairing(client)
     except WhatsAppSidecarError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -919,7 +919,7 @@ async def _confirm_stopped(
         )
 
 
-async def _stop_unfinished_pairing(
+async def stop_whatsapp_pairing(
     client: WhatsAppSidecarClient,
     *,
     current: WhatsAppSidecarPairingStatus | None = None,
@@ -947,14 +947,14 @@ async def _logout_registered_pairing(
     while True:
         if not observed.registered:
             return observed if observed.status == "stopped" else await client.pairing_cancel()
+        if asyncio.get_running_loop().time() >= deadline:
+            raise WhatsAppSidecarUnavailableError("custom sidecar did not reconnect for logout")
         if observed.status == "connected":
             try:
                 return await client.pairing_logout()
             except WhatsAppSidecarUnavailableError:
                 observed = await client.pairing_status()
                 continue
-        if asyncio.get_running_loop().time() >= deadline:
-            raise WhatsAppSidecarUnavailableError("custom sidecar did not reconnect for logout")
         if observed.status in {"starting", "disconnected", "stopped"}:
             await client.pairing_retry()
         await asyncio.sleep(0.25)

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -941,18 +941,19 @@ async def _logout_registered_pairing(
     current: WhatsAppSidecarPairingStatus,
 ) -> WhatsAppSidecarPairingStatus:
     if not current.registered:
-        raise WhatsAppSidecarProtocolError("custom sidecar lost registered auth")
+        raise WhatsAppSidecarProtocolError("WhatsApp sidecar lost registered auth")
     deadline = asyncio.get_running_loop().time() + _LOGOUT_RECOVERY_TTL_SECONDS
     observed = current
     while True:
         if not observed.registered:
             return observed if observed.status == "stopped" else await client.pairing_cancel()
         if asyncio.get_running_loop().time() >= deadline:
-            raise WhatsAppSidecarUnavailableError("custom sidecar did not reconnect for logout")
+            raise WhatsAppSidecarUnavailableError("WhatsApp sidecar did not reconnect for logout")
         if observed.status == "connected":
             try:
                 return await client.pairing_logout()
             except WhatsAppSidecarUnavailableError:
+                await asyncio.sleep(0.25)
                 observed = await client.pairing_status()
                 continue
         if observed.status in {"starting", "disconnected", "stopped"}:

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -23,7 +24,10 @@ from app.models.channel import (
     ChannelAccount,
     ChannelWhatsAppOnboardingSession,
 )
-from app.schemas.channel import ChannelWhatsAppOnboardingSessionResponse
+from app.schemas.channel import (
+    ChannelWhatsAppOnboardingSessionResponse,
+    WhatsAppOnboardingState,
+)
 from app.services.channels import generate_webhook_secret, hash_token
 from app.services.whatsapp_device_onboarding import (
     WHATSAPP_ONBOARDING_TTL,
@@ -174,7 +178,11 @@ async def require_managed_whatsapp_logout_for_archive(
         or config.get("connection_mode") != "baileys_managed"
     ):
         return
-    client = registry.get_managed_client(account.id) if registry else None
+    if registry is None:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
+        )
+    client = registry.get_managed_client(account.id)
     revision = config.get("sidecar_config_revision")
     if (
         client is None
@@ -229,24 +237,14 @@ async def _refresh(
     registry: ConfiguredWhatsAppSidecarRegistry | None,
     start_qr: bool,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
-    client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
-    if (
-        client is None
-        or registry.managed_account_revision(onboarding.sidecar_account_id)
+    if registry is None:
+        return await _error(db, onboarding)
+    client = registry.get_managed_client(onboarding.sidecar_account_id)
+    if client is None or (
+        registry.managed_account_revision(onboarding.sidecar_account_id)
         != onboarding.sidecar_config_revision
     ):
         return await _error(db, onboarding)
-    if datetime.now(UTC) >= onboarding.expires_at:
-        try:
-            stopped = await stop_whatsapp_pairing(client)
-        except WhatsAppSidecarError:
-            return await _error(db, onboarding)
-        if stopped.status != "stopped" or stopped.registered:
-            return await _error(db, onboarding)
-        onboarding.state = WHATSAPP_ONBOARDING_STATE_EXPIRED
-        onboarding.completed_at = datetime.now(UTC)
-        await db.commit()
-        return _response(onboarding)
     try:
         await client.capabilities()
         health = await client.health()
@@ -257,6 +255,17 @@ async def _refresh(
         return await _error(db, onboarding)
     if health.connected and pairing.status == "connected" and pairing.registered:
         await _promote(db, onboarding=onboarding, registry=registry)
+        return _response(onboarding)
+    if datetime.now(UTC) >= onboarding.expires_at:
+        try:
+            stopped = await stop_whatsapp_pairing(client, current=pairing)
+        except WhatsAppSidecarError:
+            return await _error(db, onboarding)
+        if stopped.status != "stopped" or stopped.registered:
+            return await _error(db, onboarding)
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_EXPIRED
+        onboarding.completed_at = datetime.now(UTC)
+        await db.commit()
         return _response(onboarding)
     if pairing.registered:
         onboarding.state = WHATSAPP_ONBOARDING_STATE_SCANNED
@@ -376,7 +385,7 @@ def _response(
         id=row.id,
         channel_account_id=row.channel_account_id,
         name=row.name,
-        state=row.state,
+        state=cast(WhatsAppOnboardingState, row.state),
         method="qr",
         qr=qr,
         qr_expires_at=qr_expires_at,

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from fastapi import HTTPException, status
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
@@ -15,6 +16,7 @@ from app.models.channel import (
     WHATSAPP_ONBOARDING_STATE_CANCELED,
     WHATSAPP_ONBOARDING_STATE_CONNECTED,
     WHATSAPP_ONBOARDING_STATE_ERROR,
+    WHATSAPP_ONBOARDING_STATE_EXPIRED,
     WHATSAPP_ONBOARDING_STATE_GENERATING,
     WHATSAPP_ONBOARDING_STATE_READY,
     WHATSAPP_ONBOARDING_STATE_SCANNED,
@@ -23,7 +25,10 @@ from app.models.channel import (
 )
 from app.schemas.channel import ChannelWhatsAppOnboardingSessionResponse
 from app.services.channels import generate_webhook_secret, hash_token
-from app.services.whatsapp_device_onboarding import WHATSAPP_ONBOARDING_TTL
+from app.services.whatsapp_device_onboarding import (
+    WHATSAPP_ONBOARDING_TTL,
+    stop_whatsapp_pairing,
+)
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarError,
     WhatsAppSidecarProtocolError,
@@ -32,6 +37,7 @@ from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegi
 
 _LOCK_ID = 8_071_323_913
 _OWNING_STATES = ("generating", "ready", "scanned", "connected", "error")
+_EXPIRABLE_STATES = ("generating", "ready", "scanned", "error")
 
 
 async def start_managed_whatsapp_onboarding(
@@ -83,6 +89,16 @@ async def start_managed_whatsapp_onboarding(
         raise HTTPException(
             status.HTTP_409_CONFLICT, "configured WhatsApp account is already onboarded"
         )
+    duplicate_name = await db.scalar(
+        select(ChannelAccount.id).where(
+            ChannelAccount.user_id == user_id,
+            ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAccount.name == name,
+            ChannelAccount.archived_at.is_(None),
+        )
+    )
+    if duplicate_name is not None:
+        raise HTTPException(status.HTTP_409_CONFLICT, "WhatsApp account name already exists")
     now = datetime.now(UTC)
     onboarding = ChannelWhatsAppOnboardingSession(
         ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
@@ -111,6 +127,7 @@ async def get_managed_whatsapp_onboarding(
     if onboarding.state in {
         WHATSAPP_ONBOARDING_STATE_CONNECTED,
         WHATSAPP_ONBOARDING_STATE_CANCELED,
+        WHATSAPP_ONBOARDING_STATE_EXPIRED,
     }:
         return _response(onboarding)
     return await _refresh(db, onboarding=onboarding, registry=registry, start_qr=False)
@@ -131,7 +148,7 @@ async def cancel_managed_whatsapp_onboarding(
         )
     client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
     try:
-        stopped = await client.pairing_cancel() if client is not None else None
+        stopped = await stop_whatsapp_pairing(client) if client is not None else None
     except WhatsAppSidecarError:
         stopped = None
     if stopped is None or stopped.status != "stopped" or stopped.registered:
@@ -168,7 +185,7 @@ async def require_managed_whatsapp_logout_for_archive(
             status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
         )
     try:
-        result = await client.pairing_logout()
+        result = await stop_whatsapp_pairing(client)
     except WhatsAppSidecarError:
         raise HTTPException(
             status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
@@ -178,6 +195,31 @@ async def require_managed_whatsapp_logout_for_archive(
             status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
         )
     await registry.unbind_managed_account(account.id)
+
+
+async def expire_stale_managed_whatsapp_onboarding_sessions(
+    db: AsyncSession,
+    *,
+    registry: ConfiguredWhatsAppSidecarRegistry,
+) -> int:
+    session_ids = list(
+        (
+            await db.scalars(
+                select(ChannelWhatsAppOnboardingSession.id).where(
+                    ChannelWhatsAppOnboardingSession.ownership_kind
+                    == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+                    ChannelWhatsAppOnboardingSession.state.in_(_EXPIRABLE_STATES),
+                    ChannelWhatsAppOnboardingSession.expires_at <= datetime.now(UTC),
+                )
+            )
+        ).all()
+    )
+    expired = 0
+    for session_id in session_ids:
+        result = await get_managed_whatsapp_onboarding(db, session_id=session_id, registry=registry)
+        if result.state == WHATSAPP_ONBOARDING_STATE_EXPIRED:
+            expired += 1
+    return expired
 
 
 async def _refresh(
@@ -194,6 +236,17 @@ async def _refresh(
         != onboarding.sidecar_config_revision
     ):
         return await _error(db, onboarding)
+    if datetime.now(UTC) >= onboarding.expires_at:
+        try:
+            stopped = await stop_whatsapp_pairing(client)
+        except WhatsAppSidecarError:
+            return await _error(db, onboarding)
+        if stopped.status != "stopped" or stopped.registered:
+            return await _error(db, onboarding)
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_EXPIRED
+        onboarding.completed_at = datetime.now(UTC)
+        await db.commit()
+        return _response(onboarding)
     try:
         await client.capabilities()
         health = await client.health()
@@ -226,34 +279,56 @@ async def _promote(
     onboarding: ChannelWhatsAppOnboardingSession,
     registry: ConfiguredWhatsAppSidecarRegistry,
 ) -> None:
+    account_id = onboarding.sidecar_account_id
+    session_id = onboarding.id
+    newly_bound = False
     account = await db.get(ChannelAccount, onboarding.sidecar_account_id)
-    if account is None:
-        account = ChannelAccount(
-            id=onboarding.sidecar_account_id,
-            user_id=onboarding.user_id,
-            provider=CHANNEL_PROVIDER_WHATSAPP,
-            name=onboarding.name,
-            status=CHANNEL_STATUS_ACTIVE,
-            visibility=CHANNEL_VISIBILITY_PUBLIC,
-            webhook_secret_hash=hash_token(generate_webhook_secret()),
-            config={
-                "connection_mode": "baileys_managed",
-                "sidecar_config_revision": onboarding.sidecar_config_revision,
-            },
+    try:
+        if account is None:
+            account = ChannelAccount(
+                id=account_id,
+                user_id=onboarding.user_id,
+                provider=CHANNEL_PROVIDER_WHATSAPP,
+                name=onboarding.name,
+                status=CHANNEL_STATUS_ACTIVE,
+                visibility=CHANNEL_VISIBILITY_PUBLIC,
+                webhook_secret_hash=hash_token(generate_webhook_secret()),
+                config={
+                    "connection_mode": "baileys_managed",
+                    "sidecar_config_revision": onboarding.sidecar_config_revision,
+                },
+            )
+            db.add(account)
+            await db.flush()
+        elif not _matches(
+            account, user_id=onboarding.user_id, revision=onboarding.sidecar_config_revision
+        ):
+            raise WhatsAppSidecarProtocolError("managed WhatsApp identity conflict")
+        newly_bound = await registry.bind_managed_account(
+            account.id, config_revision=onboarding.sidecar_config_revision
         )
-        db.add(account)
-        await db.flush()
-    elif not _matches(
-        account, user_id=onboarding.user_id, revision=onboarding.sidecar_config_revision
-    ):
-        raise WhatsAppSidecarProtocolError("managed WhatsApp identity conflict")
-    onboarding.channel_account_id = account.id
-    onboarding.state = WHATSAPP_ONBOARDING_STATE_CONNECTED
-    onboarding.completed_at = datetime.now(UTC)
-    await db.commit()
-    await registry.bind_managed_account(
-        account.id, config_revision=onboarding.sidecar_config_revision
-    )
+        onboarding.channel_account_id = account.id
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_CONNECTED
+        onboarding.completed_at = datetime.now(UTC)
+        await db.commit()
+    except BaseException as exc:
+        await db.rollback()
+        if newly_bound:
+            await registry.unbind_managed_account(account_id)
+        failed = await _session(db, session_id)
+        failed.state = WHATSAPP_ONBOARDING_STATE_ERROR
+        await db.commit()
+        if isinstance(exc, IntegrityError):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "WhatsApp account name or identity already exists",
+            ) from exc
+        if isinstance(exc, WhatsAppSidecarError):
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "WhatsApp transport could not be attached",
+            ) from None
+        raise
 
 
 def _matches(account: ChannelAccount, *, user_id: UUID, revision: str) -> bool:

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.channel import (
+    CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PUBLIC,
+    WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+    WHATSAPP_ONBOARDING_STATE_CANCELED,
+    WHATSAPP_ONBOARDING_STATE_CONNECTED,
+    WHATSAPP_ONBOARDING_STATE_ERROR,
+    WHATSAPP_ONBOARDING_STATE_GENERATING,
+    WHATSAPP_ONBOARDING_STATE_READY,
+    WHATSAPP_ONBOARDING_STATE_SCANNED,
+    ChannelAccount,
+    ChannelWhatsAppOnboardingSession,
+)
+from app.schemas.channel import ChannelWhatsAppOnboardingSessionResponse
+from app.services.channels import generate_webhook_secret, hash_token
+from app.services.whatsapp_device_onboarding import WHATSAPP_ONBOARDING_TTL
+from app.services.whatsapp_native_transport import (
+    WhatsAppSidecarError,
+    WhatsAppSidecarProtocolError,
+)
+from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
+
+_LOCK_ID = 8_071_323_913
+_OWNING_STATES = ("generating", "ready", "scanned", "connected", "error")
+
+
+async def start_managed_whatsapp_onboarding(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+    user_id: UUID,
+    request_id: UUID,
+    name: str,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    if registry is None or registry.get_managed_client(account_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "configured WhatsApp account not found")
+    revision = registry.managed_account_revision(account_id)
+    if revision is None:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable")
+    await db.execute(text("SELECT pg_advisory_xact_lock(:id)"), {"id": _LOCK_ID})
+    existing = await db.scalar(
+        select(ChannelWhatsAppOnboardingSession).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind
+            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+            ChannelWhatsAppOnboardingSession.user_id == user_id,
+            ChannelWhatsAppOnboardingSession.request_id == request_id,
+        )
+    )
+    if existing is not None:
+        if existing.sidecar_account_id != account_id:
+            raise HTTPException(status.HTTP_409_CONFLICT, "request already owns another account")
+        await db.commit()
+        return await get_managed_whatsapp_onboarding(db, session_id=existing.id, registry=registry)
+    occupied = await db.scalar(
+        select(ChannelWhatsAppOnboardingSession.id).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind
+            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+            ChannelWhatsAppOnboardingSession.sidecar_account_id == account_id,
+            ChannelWhatsAppOnboardingSession.state.in_(_OWNING_STATES),
+        )
+    )
+    if occupied is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "configured WhatsApp account is already owned"
+        )
+    account = await db.get(ChannelAccount, account_id)
+    if account is not None:
+        if not _matches(account, user_id=user_id, revision=revision):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "configured WhatsApp account identity conflicts"
+            )
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "configured WhatsApp account is already onboarded"
+        )
+    now = datetime.now(UTC)
+    onboarding = ChannelWhatsAppOnboardingSession(
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+        sidecar_account_id=account_id,
+        sidecar_config_revision=revision,
+        user_id=user_id,
+        request_id=request_id,
+        name=name,
+        state=WHATSAPP_ONBOARDING_STATE_GENERATING,
+        method="qr",
+        started_at=now,
+        expires_at=now + WHATSAPP_ONBOARDING_TTL,
+    )
+    db.add(onboarding)
+    await db.commit()
+    return await _refresh(db, onboarding=onboarding, registry=registry, start_qr=True)
+
+
+async def get_managed_whatsapp_onboarding(
+    db: AsyncSession,
+    *,
+    session_id: UUID,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    onboarding = await _session(db, session_id)
+    if onboarding.state in {
+        WHATSAPP_ONBOARDING_STATE_CONNECTED,
+        WHATSAPP_ONBOARDING_STATE_CANCELED,
+    }:
+        return _response(onboarding)
+    return await _refresh(db, onboarding=onboarding, registry=registry, start_qr=False)
+
+
+async def cancel_managed_whatsapp_onboarding(
+    db: AsyncSession,
+    *,
+    session_id: UUID,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    onboarding = await _session(db, session_id)
+    if onboarding.state == WHATSAPP_ONBOARDING_STATE_CANCELED:
+        return _response(onboarding)
+    if onboarding.state == WHATSAPP_ONBOARDING_STATE_CONNECTED:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "archive the connected WhatsApp account instead"
+        )
+    client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
+    try:
+        stopped = await client.pairing_cancel() if client is not None else None
+    except WhatsAppSidecarError:
+        stopped = None
+    if stopped is None or stopped.status != "stopped" or stopped.registered:
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_ERROR
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp cancellation could not be confirmed"
+        )
+    onboarding.state = WHATSAPP_ONBOARDING_STATE_CANCELED
+    onboarding.completed_at = datetime.now(UTC)
+    await db.commit()
+    return _response(onboarding)
+
+
+async def require_managed_whatsapp_logout_for_archive(
+    *,
+    account: ChannelAccount,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> None:
+    config = account.config if isinstance(account.config, dict) else {}
+    if (
+        account.provider != CHANNEL_PROVIDER_WHATSAPP
+        or config.get("connection_mode") != "baileys_managed"
+    ):
+        return
+    client = registry.get_managed_client(account.id) if registry else None
+    revision = config.get("sidecar_config_revision")
+    if (
+        client is None
+        or not isinstance(revision, str)
+        or registry.managed_account_revision(account.id) != revision
+    ):
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
+        )
+    try:
+        result = await client.pairing_logout()
+    except WhatsAppSidecarError:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
+        ) from None
+    if result.status != "stopped" or result.registered:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
+        )
+    await registry.unbind_managed_account(account.id)
+
+
+async def _refresh(
+    db: AsyncSession,
+    *,
+    onboarding: ChannelWhatsAppOnboardingSession,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    start_qr: bool,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
+    if (
+        client is None
+        or registry.managed_account_revision(onboarding.sidecar_account_id)
+        != onboarding.sidecar_config_revision
+    ):
+        return await _error(db, onboarding)
+    try:
+        await client.capabilities()
+        health = await client.health()
+        pairing = await (client.pairing_qr() if start_qr else client.pairing_status())
+    except WhatsAppSidecarError:
+        return await _error(db, onboarding)
+    if health.registered != pairing.registered:
+        return await _error(db, onboarding)
+    if health.connected and pairing.status == "connected" and pairing.registered:
+        await _promote(db, onboarding=onboarding, registry=registry)
+        return _response(onboarding)
+    if pairing.registered:
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_SCANNED
+        await db.commit()
+        return _response(onboarding)
+    if (
+        pairing.status == "pairing_qr"
+        and pairing.qr is not None
+        and pairing.qr_expires_at is not None
+    ):
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_READY
+        await db.commit()
+        return _response(onboarding, qr=pairing.qr, qr_expires_at=pairing.qr_expires_at)
+    return await _error(db, onboarding)
+
+
+async def _promote(
+    db: AsyncSession,
+    *,
+    onboarding: ChannelWhatsAppOnboardingSession,
+    registry: ConfiguredWhatsAppSidecarRegistry,
+) -> None:
+    account = await db.get(ChannelAccount, onboarding.sidecar_account_id)
+    if account is None:
+        account = ChannelAccount(
+            id=onboarding.sidecar_account_id,
+            user_id=onboarding.user_id,
+            provider=CHANNEL_PROVIDER_WHATSAPP,
+            name=onboarding.name,
+            status=CHANNEL_STATUS_ACTIVE,
+            visibility=CHANNEL_VISIBILITY_PUBLIC,
+            webhook_secret_hash=hash_token(generate_webhook_secret()),
+            config={
+                "connection_mode": "baileys_managed",
+                "sidecar_config_revision": onboarding.sidecar_config_revision,
+            },
+        )
+        db.add(account)
+        await db.flush()
+    elif not _matches(
+        account, user_id=onboarding.user_id, revision=onboarding.sidecar_config_revision
+    ):
+        raise WhatsAppSidecarProtocolError("managed WhatsApp identity conflict")
+    onboarding.channel_account_id = account.id
+    onboarding.state = WHATSAPP_ONBOARDING_STATE_CONNECTED
+    onboarding.completed_at = datetime.now(UTC)
+    await db.commit()
+    await registry.bind_managed_account(
+        account.id, config_revision=onboarding.sidecar_config_revision
+    )
+
+
+def _matches(account: ChannelAccount, *, user_id: UUID, revision: str) -> bool:
+    config = account.config if isinstance(account.config, dict) else {}
+    return (
+        account.user_id == user_id
+        and account.provider == CHANNEL_PROVIDER_WHATSAPP
+        and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+        and account.archived_at is None
+        and config.get("connection_mode") == "baileys_managed"
+        and config.get("sidecar_config_revision") == revision
+    )
+
+
+async def _session(db: AsyncSession, session_id: UUID) -> ChannelWhatsAppOnboardingSession:
+    row = await db.scalar(
+        select(ChannelWhatsAppOnboardingSession)
+        .where(
+            ChannelWhatsAppOnboardingSession.id == session_id,
+            ChannelWhatsAppOnboardingSession.ownership_kind
+            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+        )
+        .with_for_update()
+    )
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "onboarding not found")
+    return row
+
+
+async def _error(
+    db: AsyncSession, row: ChannelWhatsAppOnboardingSession
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    row.state = WHATSAPP_ONBOARDING_STATE_ERROR
+    await db.commit()
+    return _response(row)
+
+
+def _response(
+    row: ChannelWhatsAppOnboardingSession,
+    *,
+    qr: str | None = None,
+    qr_expires_at: datetime | None = None,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    return ChannelWhatsAppOnboardingSessionResponse(
+        id=row.id,
+        channel_account_id=row.channel_account_id,
+        name=row.name,
+        state=row.state,
+        method="qr",
+        qr=qr,
+        qr_expires_at=qr_expires_at,
+        manual_pairing_code_supported=False,
+        started_at=row.started_at,
+        expires_at=row.expires_at,
+        completed_at=row.completed_at,
+    )

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -251,6 +251,8 @@ class ConfiguredWhatsAppSidecarRegistry:
                     )
                 await self.bind_managed_account(account_id, config_revision=revision)
             except WhatsAppSidecarError:
+                if account_id in self._bound_managed_accounts:
+                    await self.unbind_managed_account(account_id)
                 log.error("WhatsApp managed account %s is not safe to attach", account_id)
 
     async def _managed_accounts(self, db: AsyncSession) -> list[ChannelAccount]:

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -9,10 +9,13 @@ from uuid import UUID
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_VISIBILITY_PUBLIC,
+    WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
     WHATSAPP_ONBOARDING_STATE_ERROR,
     ChannelAccount,
     ChannelWhatsAppOnboardingSession,
@@ -98,6 +101,7 @@ class ConfiguredWhatsAppSidecarRegistry:
         _validate_disjoint_physical_slots(self._managed, self._custom)
         self._client_factory = client_factory
         self._clients_by_slot: dict[UUID, WhatsAppSidecarClient] = {}
+        self._bound_managed_accounts: set[UUID] = set()
         self._custom_slot_to_account: dict[UUID, UUID] = {}
         self._custom_account_to_slot: dict[UUID, UUID] = {}
         self._blocked_custom_slots: set[UUID] = set()
@@ -116,6 +120,18 @@ class ConfiguredWhatsAppSidecarRegistry:
         if slot_id not in self._custom or slot_id in self._blocked_custom_slots:
             return None
         return self._clients_by_slot.get(slot_id)
+
+    def get_managed_client(self, account_id: UUID) -> WhatsAppSidecarClient | None:
+        if account_id not in self._managed:
+            return None
+        return self._clients_by_slot.get(account_id)
+
+    def managed_account_revision(self, account_id: UUID) -> str | None:
+        config = self._managed.get(account_id)
+        return config.binding_revision if config is not None else None
+
+    def managed_is_bound(self, account_id: UUID) -> bool:
+        return account_id in self._bound_managed_accounts
 
     def custom_slot_is_blocked(self, slot_id: UUID) -> bool:
         return slot_id in self._blocked_custom_slots
@@ -148,7 +164,6 @@ class ConfiguredWhatsAppSidecarRegistry:
                         account_id,
                         type(exc).__name__,
                     )
-                self._register_transport(account_id, client)
 
             if self._custom:
                 await self.reconcile_custom_ownership()
@@ -173,10 +188,84 @@ class ConfiguredWhatsAppSidecarRegistry:
         self._custom_slot_to_account.clear()
         self._custom_account_to_slot.clear()
         self._blocked_custom_slots.clear()
+        self._bound_managed_accounts.clear()
         clients = tuple(self._clients_by_slot.values())
         self._clients_by_slot.clear()
         if clients:
             await asyncio.gather(*(client.aclose() for client in clients), return_exceptions=True)
+
+    async def bind_managed_account(self, account_id: UUID, *, config_revision: str) -> bool:
+        config = self._managed.get(account_id)
+        client = self._clients_by_slot.get(account_id)
+        if config is None or client is None or config.binding_revision != config_revision:
+            raise WhatsAppSidecarProtocolError("managed Baileys account is unavailable")
+        if account_id in self._bound_managed_accounts:
+            return False
+        self._register_transport(account_id, client)
+        self._bound_managed_accounts.add(account_id)
+        return True
+
+    async def unbind_managed_account(self, account_id: UUID) -> bool:
+        if account_id not in self._bound_managed_accounts:
+            return False
+        task = self._ingress_tasks.pop(account_id, None)
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        unregister_whatsapp_provider_transport(account_id)
+        self._bound_managed_accounts.remove(account_id)
+        return True
+
+    async def reconcile_managed_ownership(self, db: AsyncSession | None = None) -> None:
+        """Attach ingress only for promoted public accounts with exact configured identity."""
+        if db is None:
+            async with async_session_factory() as owned_db:
+                accounts = await self._managed_accounts(owned_db)
+        else:
+            accounts = await self._managed_accounts(db)
+        desired: dict[UUID, str] = {}
+        for account in accounts:
+            config = account.config if isinstance(account.config, dict) else {}
+            revision = config.get("sidecar_config_revision")
+            if config.get("connection_mode") != "baileys_managed" or not isinstance(revision, str):
+                log.error("WhatsApp managed account %s has invalid physical identity", account.id)
+                continue
+            desired[account.id] = revision
+        for account_id in tuple(self._bound_managed_accounts - desired.keys()):
+            await self.unbind_managed_account(account_id)
+        for account_id, revision in desired.items():
+            try:
+                client = self._clients_by_slot.get(account_id)
+                if client is None:
+                    raise WhatsAppSidecarProtocolError("managed Baileys account is unavailable")
+                health = await client.health()
+                pairing = await client.pairing_status()
+                if (
+                    not health.connected
+                    or not health.registered
+                    or pairing.status != "connected"
+                    or not pairing.registered
+                ):
+                    raise WhatsAppSidecarProtocolError(
+                        "managed Baileys physical auth is unavailable"
+                    )
+                await self.bind_managed_account(account_id, config_revision=revision)
+            except WhatsAppSidecarError:
+                log.error("WhatsApp managed account %s is not safe to attach", account_id)
+
+    async def _managed_accounts(self, db: AsyncSession) -> list[ChannelAccount]:
+        return list(
+            (
+                await db.scalars(
+                    select(ChannelAccount).where(
+                        ChannelAccount.id.in_(self._managed),
+                        ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+                        ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                        ChannelAccount.archived_at.is_(None),
+                    )
+                )
+            ).all()
+        )
 
     async def bind_custom_account(
         self,
@@ -287,7 +376,9 @@ class ConfiguredWhatsAppSidecarRegistry:
                     (
                         await db.scalars(
                             select(ChannelWhatsAppOnboardingSession).where(
-                                ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_STATES)
+                                ChannelWhatsAppOnboardingSession.ownership_kind
+                                == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+                                ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_STATES),
                             )
                         )
                     ).all()

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -55,6 +55,9 @@ class _ManagedOnboardingSidecar:
         self.registered = False
         self.qr = "sensitive-rotating-qr"
         self.logout_fails = False
+        self.logout_calls = 0
+        self.cancel_calls = 0
+        self.stopped = False
 
     async def refresh_health(self) -> bool:
         return self.connected
@@ -75,9 +78,12 @@ class _ManagedOnboardingSidecar:
         )
 
     async def pairing_qr(self):
+        self.stopped = False
         return await self.pairing_status()
 
     async def pairing_status(self):
+        if self.stopped:
+            return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
         if self.connected:
             return WhatsAppSidecarPairingStatus(status="connected", registered=self.registered)
         return WhatsAppSidecarPairingStatus(
@@ -88,14 +94,25 @@ class _ManagedOnboardingSidecar:
         )
 
     async def pairing_cancel(self):
+        self.cancel_calls += 1
+        if self.registered:
+            raise AssertionError("registered sessions must logout, not cancel")
+        self.connected = False
+        self.stopped = True
         return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
 
     async def pairing_logout(self):
+        self.logout_calls += 1
         if self.logout_fails:
             raise WhatsAppSidecarUnavailableError("unavailable")
         self.connected = False
         self.registered = False
+        self.stopped = True
         return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+
+    async def pairing_retry(self):
+        self.connected = True
+        return await self.pairing_status()
 
     async def provider_events(self, *, limit=100):
         return []
@@ -2890,7 +2907,7 @@ async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logou
             "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
         )
         assert started.status_code == 200, started.text
-        assert started.headers["cache-control"] == "no-store"
+        assert started.headers["cache-control"] == "no-store, private"
         assert started.json()["qr"] == fake.qr
         assert await db_session.get(ChannelAccount, account_id) is None
         fake.qr = "sensitive-rotated-qr"
@@ -2904,6 +2921,7 @@ async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logou
             f"/v1/admin/channels/whatsapp/onboarding/{started.json()['id']}", headers=_AUTH
         )
         assert promoted.status_code == 200, promoted.text
+        assert promoted.headers["cache-control"] == "no-store, private"
         assert promoted.json()["channel_account_id"] == str(account_id)
         account = await db_session.get(ChannelAccount, account_id)
         assert account is not None and account.visibility == "public"
@@ -2940,3 +2958,102 @@ async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logou
         ).status_code == 204
     finally:
         await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_admin_managed_whatsapp_errors_are_authenticated_configured_only_and_no_store(
+    admin_client, seed_user, monkeypatch
+):
+    import app.routes.admin as admin_routes
+
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: None)
+    payload = {
+        "account_id": str(uuid.uuid4()),
+        "target_clerk_id": seed_user.clerk_id,
+        "request_id": str(uuid.uuid4()),
+        "name": "Shared WhatsApp",
+    }
+    responses = [
+        await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json=payload),
+        await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json={}, headers=_AUTH),
+        await admin_client.post(
+            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
+        ),
+        await admin_client.get(
+            f"/v1/admin/channels/whatsapp/onboarding/{uuid.uuid4()}", headers=_AUTH
+        ),
+        await admin_client.delete(
+            f"/v1/admin/channels/whatsapp/onboarding/{uuid.uuid4()}", headers=_AUTH
+        ),
+    ]
+    assert [response.status_code for response in responses] == [401, 422, 404, 404, 404]
+    for response in responses:
+        assert response.headers["cache-control"] == "no-store, private"
+        assert response.headers["pragma"] == "no-cache"
+
+
+@pytest.mark.asyncio
+async def test_admin_managed_whatsapp_cancel_success_is_no_store(
+    admin_client, seed_user, monkeypatch
+):
+    import app.routes.admin as admin_routes
+
+    account_id = uuid.uuid4()
+    fake = _ManagedOnboardingSidecar()
+    registry = ConfiguredWhatsAppSidecarRegistry(
+        json.dumps(
+            {
+                str(account_id): {
+                    "base_url": "http://127.0.0.1:43194",
+                    "api_token": "fake",
+                }
+            }
+        ),
+        client_factory=lambda _config: fake,
+    )
+    await registry.start()
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    try:
+        started = await admin_client.post(
+            "/v1/admin/channels/whatsapp/onboarding",
+            headers=_AUTH,
+            json={
+                "account_id": str(account_id),
+                "target_clerk_id": seed_user.clerk_id,
+                "request_id": str(uuid.uuid4()),
+                "name": "Cancelable Shared WhatsApp",
+            },
+        )
+        canceled = await admin_client.delete(
+            f"/v1/admin/channels/whatsapp/onboarding/{started.json()['id']}", headers=_AUTH
+        )
+        assert canceled.status_code == 200
+        assert canceled.json()["state"] == "canceled"
+        assert canceled.headers["cache-control"] == "no-store, private"
+        assert canceled.headers["pragma"] == "no-cache"
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["telegram", "discord"])
+async def test_admin_delete_non_whatsapp_provider_regression(
+    admin_client, db_session, seed_user, provider
+):
+    from app.models.channel import ChannelAccount
+
+    account = ChannelAccount(
+        user_id=seed_user.id,
+        provider=provider,
+        name=f"delete-{provider}-{uuid.uuid4()}",
+        status="active",
+        visibility="public",
+        webhook_secret_hash="0" * 64,
+        config={},
+    )
+    db_session.add(account)
+    await db_session.commit()
+    response = await admin_client.delete(f"/v1/admin/channels/{account.id}", headers=_AUTH)
+    assert response.status_code == 204
+    await db_session.refresh(account)
+    assert account.archived_at is not None

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -12,6 +12,7 @@ import uuid
 from collections import Counter
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import httpx
@@ -30,6 +31,13 @@ from app.services.managed_ai_provider import (
     V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
 )
+from app.services.whatsapp_native_transport import (
+    WhatsAppSidecarCapabilities,
+    WhatsAppSidecarHealth,
+    WhatsAppSidecarPairingStatus,
+    WhatsAppSidecarUnavailableError,
+)
+from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
 _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # Shared header dict for the bulk of tests that exercise the happy-path
@@ -37,6 +45,72 @@ _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # (auth-gate regression tests) build their own dict inline so the
 # tampering stays visible at the call site.
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
+
+
+class _ManagedOnboardingSidecar:
+    transport_mode = "sidecar"
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.registered = False
+        self.qr = "sensitive-rotating-qr"
+        self.logout_fails = False
+
+    async def refresh_health(self) -> bool:
+        return self.connected
+
+    async def aclose(self) -> None:
+        return None
+
+    async def capabilities(self):
+        return WhatsAppSidecarCapabilities(
+            pairing=frozenset({"qr", "code", "cancel", "logout", "retry"})
+        )
+
+    async def health(self):
+        return WhatsAppSidecarHealth(
+            status="connected" if self.connected else "pairing_qr",
+            connected=self.connected,
+            registered=self.registered,
+        )
+
+    async def pairing_qr(self):
+        return await self.pairing_status()
+
+    async def pairing_status(self):
+        if self.connected:
+            return WhatsAppSidecarPairingStatus(status="connected", registered=self.registered)
+        return WhatsAppSidecarPairingStatus(
+            status="pairing_qr",
+            registered=False,
+            qr=self.qr,
+            qr_expires_at=datetime.now(UTC) + timedelta(seconds=30),
+        )
+
+    async def pairing_cancel(self):
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+
+    async def pairing_logout(self):
+        if self.logout_fails:
+            raise WhatsAppSidecarUnavailableError("unavailable")
+        self.connected = False
+        self.registered = False
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+
+    async def provider_events(self, *, limit=100):
+        return []
+
+    async def acknowledge_provider_events(self, *, through_sequence):
+        return None
+
+    async def relay_message(self, request):
+        return request.message_id
+
+    async def send_node(self, node):
+        return None
+
+    async def query(self, node, timeout_ms):
+        return None
 
 
 @pytest_asyncio.fixture
@@ -2785,3 +2859,84 @@ async def test_admin_endpoints_excluded_from_openapi_schema(admin_client, seed_u
         "include_in_schema=False must hide the route from /openapi.json without "
         "actually disabling it."
     )
+
+
+@pytest.mark.asyncio
+async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logout_is_fail_closed(
+    admin_client, db_session, seed_user, monkeypatch
+):
+    import app.routes.admin as admin_routes
+    from app.models.channel import ChannelAccount, ChannelWhatsAppOnboardingSession
+
+    account_id = uuid.uuid4()
+    fake = _ManagedOnboardingSidecar()
+    registry = ConfiguredWhatsAppSidecarRegistry(
+        json.dumps({str(account_id): {"base_url": "http://127.0.0.1:43192", "api_token": "fake"}}),
+        client_factory=lambda _config: fake,
+    )
+    await registry.start()
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    payload = {
+        "account_id": str(account_id),
+        "target_clerk_id": seed_user.clerk_id,
+        "request_id": str(uuid.uuid4()),
+        "name": "Shared WhatsApp",
+    }
+    try:
+        assert (
+            await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json=payload)
+        ).status_code == 401
+        started = await admin_client.post(
+            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
+        )
+        assert started.status_code == 200, started.text
+        assert started.headers["cache-control"] == "no-store"
+        assert started.json()["qr"] == fake.qr
+        assert await db_session.get(ChannelAccount, account_id) is None
+        fake.qr = "sensitive-rotated-qr"
+        repeated = await admin_client.post(
+            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
+        )
+        assert repeated.json()["id"] == started.json()["id"]
+        assert repeated.json()["qr"] == fake.qr
+        fake.connected = fake.registered = True
+        promoted = await admin_client.get(
+            f"/v1/admin/channels/whatsapp/onboarding/{started.json()['id']}", headers=_AUTH
+        )
+        assert promoted.status_code == 200, promoted.text
+        assert promoted.json()["channel_account_id"] == str(account_id)
+        account = await db_session.get(ChannelAccount, account_id)
+        assert account is not None and account.visibility == "public"
+        assert account.config["connection_mode"] == "baileys_managed"
+        session = await db_session.get(
+            ChannelWhatsAppOnboardingSession, uuid.UUID(started.json()["id"])
+        )
+        assert session.ownership_kind == "managed"
+        await registry.stop()
+        registry = ConfiguredWhatsAppSidecarRegistry(
+            json.dumps(
+                {
+                    str(account_id): {
+                        "base_url": "http://127.0.0.1:43192",
+                        "api_token": "fake",
+                    }
+                }
+            ),
+            client_factory=lambda _config: fake,
+        )
+        await registry.start()
+        await registry.reconcile_managed_ownership(db_session)
+        assert registry.managed_is_bound(account_id)
+        monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+        fake.logout_fails = True
+        assert (
+            await admin_client.delete(f"/v1/admin/channels/{account_id}", headers=_AUTH)
+        ).status_code == 503
+        await db_session.refresh(account)
+        assert account.archived_at is None
+        fake.logout_fails = False
+        assert (
+            await admin_client.delete(f"/v1/admin/channels/{account_id}", headers=_AUTH)
+        ).status_code == 204
+    finally:
+        await registry.stop()

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -17,6 +17,7 @@ from app.models.channel import (
     ChannelWhatsAppOnboardingSession,
 )
 from app.services.channels import archive_channel_account
+from app.services.whatsapp_device_onboarding import stop_whatsapp_pairing
 from app.services.whatsapp_managed_onboarding import (
     cancel_managed_whatsapp_onboarding,
     expire_stale_managed_whatsapp_onboarding_sessions,
@@ -243,6 +244,33 @@ async def test_expired_managed_reservation_confirms_stop(db_session, seed_user):
 
 
 @pytest.mark.asyncio
+async def test_expired_reservation_promotes_connected_registered_sidecar(db_session, seed_user):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
+        session.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        await db_session.commit()
+        fake.connected = fake.registered = True
+
+        assert (
+            await expire_stale_managed_whatsapp_onboarding_sessions(db_session, registry=registry)
+            == 0
+        )
+        account = await db_session.get(ChannelAccount, account_id)
+        assert account is not None
+        await db_session.refresh(session)
+        assert session.state == "connected"
+        assert fake.logout_calls == 0
+        assert fake.cancel_calls == 0
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
 async def test_logout_then_archive_rollback_is_idempotent_on_retry(db_session, seed_user):
     account_id = uuid4()
     fake = FakeManagedSidecar()
@@ -391,5 +419,45 @@ async def test_restart_reconciliation_fails_closed_on_revision_and_physical_drif
         fake.connected = True
         await registry.reconcile_managed_ownership(db_session)
         assert registry.managed_is_bound(account_id)
+
+        fake.connected = fake.registered = False
+        await registry.reconcile_managed_ownership(db_session)
+        assert not registry.managed_is_bound(account_id)
+
+        fake.connected = fake.registered = True
+        await registry.reconcile_managed_ownership(db_session)
+        assert registry.managed_is_bound(account_id)
+        account.config = {
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": "drifted-again",
+        }
+        await db_session.commit()
+        await registry.reconcile_managed_ownership(db_session)
+        assert not registry.managed_is_bound(account_id)
     finally:
         await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_registered_logout_unavailable_retries_with_backoff(monkeypatch):
+    fake = FakeManagedSidecar()
+    fake.connected = fake.registered = True
+    failures = 3
+    sleeps: list[float] = []
+    original_logout = fake.pairing_logout
+
+    async def flaky_logout():
+        nonlocal failures
+        if failures:
+            failures -= 1
+            raise WhatsAppSidecarUnavailableError("injected transient failure")
+        return await original_logout()
+
+    async def record_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(fake, "pairing_logout", flaky_logout)
+    monkeypatch.setattr("app.services.whatsapp_device_onboarding.asyncio.sleep", record_sleep)
+    result = await stop_whatsapp_pairing(fake)
+    assert result.status == "stopped"
+    assert sleeps == [0.25, 0.25, 0.25]

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.channel import (
+    CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PUBLIC,
+    WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+    WHATSAPP_ONBOARDING_STATE_GENERATING,
+    ChannelAccount,
+    ChannelWhatsAppOnboardingSession,
+)
+from app.services.channels import archive_channel_account
+from app.services.whatsapp_managed_onboarding import (
+    cancel_managed_whatsapp_onboarding,
+    expire_stale_managed_whatsapp_onboarding_sessions,
+    get_managed_whatsapp_onboarding,
+    require_managed_whatsapp_logout_for_archive,
+    start_managed_whatsapp_onboarding,
+)
+from app.services.whatsapp_native_transport import (
+    WhatsAppSidecarCapabilities,
+    WhatsAppSidecarHealth,
+    WhatsAppSidecarPairingStatus,
+    WhatsAppSidecarProtocolError,
+    WhatsAppSidecarUnavailableError,
+)
+from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
+
+
+class FakeManagedSidecar:
+    transport_mode = "sidecar"
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.registered = False
+        self.cancel_calls = 0
+        self.logout_calls = 0
+        self.stopped = False
+        self.cancel_fails = False
+
+    async def refresh_health(self) -> bool:
+        return self.connected
+
+    async def aclose(self) -> None:
+        return None
+
+    async def capabilities(self) -> WhatsAppSidecarCapabilities:
+        return WhatsAppSidecarCapabilities(
+            pairing=frozenset({"qr", "code", "cancel", "logout", "retry"})
+        )
+
+    async def health(self) -> WhatsAppSidecarHealth:
+        status = (
+            "connected" if self.connected else ("disconnected" if self.registered else "pairing_qr")
+        )
+        return WhatsAppSidecarHealth(
+            status=status, connected=self.connected, registered=self.registered
+        )
+
+    async def pairing_qr(self) -> WhatsAppSidecarPairingStatus:
+        self.stopped = False
+        return await self.pairing_status()
+
+    async def pairing_status(self) -> WhatsAppSidecarPairingStatus:
+        if self.stopped:
+            return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+        if self.registered:
+            return WhatsAppSidecarPairingStatus(
+                status="connected" if self.connected else "disconnected", registered=True
+            )
+        return WhatsAppSidecarPairingStatus(
+            status="pairing_qr",
+            registered=False,
+            qr="ephemeral-qr",
+            qr_expires_at=datetime.now(UTC) + timedelta(seconds=30),
+        )
+
+    async def pairing_cancel(self) -> WhatsAppSidecarPairingStatus:
+        self.cancel_calls += 1
+        if self.registered:
+            raise AssertionError("registered auth must be logged out")
+        if self.cancel_fails:
+            raise WhatsAppSidecarUnavailableError("injected cancel failure")
+        self.stopped = True
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+
+    async def pairing_retry(self) -> WhatsAppSidecarPairingStatus:
+        self.connected = True
+        return await self.pairing_status()
+
+    async def pairing_logout(self) -> WhatsAppSidecarPairingStatus:
+        self.logout_calls += 1
+        self.connected = False
+        self.registered = False
+        self.stopped = True
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+
+    async def provider_events(self, *, limit: int = 100):
+        return []
+
+    async def acknowledge_provider_events(self, *, through_sequence: int) -> None:
+        return None
+
+    async def relay_message(self, request):
+        return request.message_id
+
+    async def send_node(self, node) -> None:
+        return None
+
+    async def query(self, node, timeout_ms):
+        return None
+
+
+def _registry(account_id: UUID, fake: FakeManagedSidecar) -> ConfiguredWhatsAppSidecarRegistry:
+    return ConfiguredWhatsAppSidecarRegistry(
+        json.dumps(
+            {
+                str(account_id): {
+                    "base_url": "http://127.0.0.1:43193",
+                    "api_token": "fake",
+                }
+            }
+        ),
+        client_factory=lambda _config: fake,
+    )
+
+
+async def _start(db_session, seed_user, registry, account_id, *, request_id=None, name="Shared"):
+    return await start_managed_whatsapp_onboarding(
+        db_session,
+        account_id=account_id,
+        user_id=seed_user.id,
+        request_id=request_id or uuid4(),
+        name=name,
+        registry=registry,
+    )
+
+
+@pytest.mark.asyncio
+async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
+    db_session, seed_user, monkeypatch
+):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        fake.connected = fake.registered = True
+
+        async def fail_bind(*_args, **_kwargs):
+            raise WhatsAppSidecarProtocolError("injected bind failure")
+
+        monkeypatch.setattr(registry, "bind_managed_account", fail_bind)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_managed_whatsapp_onboarding(
+                db_session, session_id=started.id, registry=registry
+            )
+        assert exc_info.value.status_code == 503
+        assert await db_session.get(ChannelAccount, account_id) is None
+        session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
+        assert session is not None
+        assert session.state == "error"
+        assert session.channel_account_id is None
+        assert not registry.managed_is_bound(account_id)
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_registered_disconnected_cancel_recovers_with_logout(db_session, seed_user):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        fake.registered = True
+        canceled = await cancel_managed_whatsapp_onboarding(
+            db_session, session_id=started.id, registry=registry
+        )
+        assert canceled.state == "canceled"
+        assert fake.logout_calls == 1
+        assert fake.cancel_calls == 0
+        assert await db_session.get(ChannelAccount, account_id) is None
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_retains_ownership_until_confirmed_retry(db_session, seed_user):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        fake.cancel_fails = True
+        with pytest.raises(HTTPException) as exc_info:
+            await cancel_managed_whatsapp_onboarding(
+                db_session, session_id=started.id, registry=registry
+            )
+        assert exc_info.value.status_code == 503
+        session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
+        assert session.state == "error"
+
+        fake.cancel_fails = False
+        canceled = await cancel_managed_whatsapp_onboarding(
+            db_session, session_id=started.id, registry=registry
+        )
+        assert canceled.state == "canceled"
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_expired_managed_reservation_confirms_stop(db_session, seed_user):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
+        session.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        await db_session.commit()
+        assert (
+            await expire_stale_managed_whatsapp_onboarding_sessions(db_session, registry=registry)
+            == 1
+        )
+        await db_session.refresh(session)
+        assert session.state == "expired"
+        assert fake.cancel_calls == 1
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_logout_then_archive_rollback_is_idempotent_on_retry(db_session, seed_user):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, seed_user, registry, account_id)
+        fake.connected = fake.registered = True
+        await get_managed_whatsapp_onboarding(db_session, session_id=started.id, registry=registry)
+        account = await db_session.get(ChannelAccount, account_id)
+        await require_managed_whatsapp_logout_for_archive(account=account, registry=registry)
+        assert fake.logout_calls == 1
+        await archive_channel_account(db_session, account=account)
+        await db_session.rollback()
+
+        account = await db_session.get(ChannelAccount, account_id)
+        assert account.archived_at is None
+        await require_managed_whatsapp_logout_for_archive(account=account, registry=registry)
+        assert fake.logout_calls == 1
+        assert fake.cancel_calls == 0
+        await archive_channel_account(db_session, account=account)
+        await db_session.commit()
+        assert account.archived_at is not None
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is_controlled(
+    db_session, seed_user
+):
+    account_id = uuid4()
+    request_id = uuid4()
+    now = datetime.now(UTC)
+    db_session.add(
+        ChannelWhatsAppOnboardingSession(
+            ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+            sidecar_account_id=uuid4(),
+            sidecar_config_revision="custom-revision",
+            user_id=seed_user.id,
+            request_id=request_id,
+            name="Custom",
+            state=WHATSAPP_ONBOARDING_STATE_GENERATING,
+            method="qr",
+            started_at=now,
+            expires_at=now + timedelta(minutes=5),
+        )
+    )
+    await db_session.commit()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        existing = ChannelAccount(
+            user_id=seed_user.id,
+            provider=CHANNEL_PROVIDER_WHATSAPP,
+            name="Existing",
+            status=CHANNEL_STATUS_ACTIVE,
+            visibility=CHANNEL_VISIBILITY_PUBLIC,
+            webhook_secret_hash="0" * 64,
+            config={},
+        )
+        db_session.add(existing)
+        await db_session.commit()
+        with pytest.raises(HTTPException) as start_conflict:
+            await _start(
+                db_session,
+                seed_user,
+                registry,
+                account_id,
+                request_id=uuid4(),
+                name="Existing",
+            )
+        assert start_conflict.value.status_code == 409
+        started = await _start(
+            db_session,
+            seed_user,
+            registry,
+            account_id,
+            request_id=request_id,
+            name="Duplicate",
+        )
+        db_session.add(
+            ChannelAccount(
+                user_id=seed_user.id,
+                provider=CHANNEL_PROVIDER_WHATSAPP,
+                name="Duplicate",
+                status=CHANNEL_STATUS_ACTIVE,
+                visibility=CHANNEL_VISIBILITY_PUBLIC,
+                webhook_secret_hash="0" * 64,
+                config={},
+            )
+        )
+        await db_session.commit()
+        fake.connected = fake.registered = True
+        with pytest.raises(HTTPException) as exc_info:
+            await get_managed_whatsapp_onboarding(
+                db_session, session_id=started.id, registry=registry
+            )
+        assert exc_info.value.status_code == 409
+        assert await db_session.get(ChannelAccount, account_id) is None
+        session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
+        assert session.state == "error"
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_restart_reconciliation_fails_closed_on_revision_and_physical_drift(
+    db_session, seed_user
+):
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    revision = registry.managed_account_revision(account_id)
+    account = ChannelAccount(
+        id=account_id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name="Shared",
+        status=CHANNEL_STATUS_ACTIVE,
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        webhook_secret_hash="0" * 64,
+        config={
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": "drifted",
+        },
+    )
+    db_session.add(account)
+    await db_session.commit()
+    await registry.start()
+    try:
+        fake.connected = fake.registered = True
+        await registry.reconcile_managed_ownership(db_session)
+        assert not registry.managed_is_bound(account_id)
+
+        account.config = {
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": revision,
+        }
+        await db_session.commit()
+        fake.connected = False
+        await registry.reconcile_managed_ownership(db_session)
+        assert not registry.managed_is_bound(account_id)
+
+        fake.connected = True
+        await registry.reconcile_managed_ownership(db_session)
+        assert registry.managed_is_bound(account_id)
+    finally:
+        await registry.stop()

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -125,7 +125,7 @@ def test_parse_whatsapp_sidecar_registrations_rejects_normalized_duplicate_accou
 
 
 @pytest.mark.asyncio
-async def test_configured_whatsapp_sidecar_registry_registers_and_closes_transport():
+async def test_configured_whatsapp_sidecar_registry_does_not_start_ingress_before_promotion():
     account_id = UUID("00000000-0000-0000-0000-000000000888")
     raw = json.dumps(
         {str(account_id): {"base_url": "https://sidecar.example.test", "api_token": "secret"}}
@@ -141,8 +141,7 @@ async def test_configured_whatsapp_sidecar_registry_registers_and_closes_transpo
     await registry.start()
     try:
         status = whatsapp_provider_transport_status(account_id)
-        assert status.available is True
-        assert status.mode == "sidecar"
+        assert status.available is False
         assert clients[0].config.base_url == "https://sidecar.example.test"
         assert clients[0].health_checks == 1
     finally:
@@ -153,7 +152,7 @@ async def test_configured_whatsapp_sidecar_registry_registers_and_closes_transpo
 
 
 @pytest.mark.asyncio
-async def test_configured_whatsapp_sidecar_registry_keeps_unhealthy_sidecar_visible():
+async def test_configured_whatsapp_sidecar_registry_keeps_unhealthy_sidecar_unbound():
     account_id = UUID("00000000-0000-0000-0000-000000000999")
     raw = json.dumps(
         {
@@ -175,8 +174,7 @@ async def test_configured_whatsapp_sidecar_registry_keeps_unhealthy_sidecar_visi
     try:
         status = whatsapp_provider_transport_status(account_id)
         assert status.available is False
-        assert status.mode == "sidecar"
-        assert status.reason == "provider-transport-disconnected"
+        assert status.reason == "provider-transport-unavailable"
     finally:
         await registry.stop()
 


### PR DESCRIPTION
## Summary
- Hidden X-Admin-Key-gated QR start/status/cancel Admin API for preconfigured managed WhatsApp sidecars.
- Explicit managed/custom reservation discriminator; uniqueness is scoped by ownership kind.
- Public ChannelAccount is created at the configured UUID only after connected+registered proof.
- Promotion binds transport before the final DB commit and compensates with rollback+unbind on failure.
- Managed cancel, expiry, and archive reuse the existing safe stop/logout recovery path, including registered-but-disconnected and already-stopped states.
- Managed expiry runs in the periodic reconciliation worker; GET status remains read-thin and does not write audit events.
- Managed archive is retry-safe when physical logout succeeds but DB archive later rolls back.
- Pairing responses and errors use Cache-Control: no-store, private and Pragma: no-cache.

## Safety and compatibility
- Requests cannot supply sidecar origin, bearer, token, auth, or provider material.
- Managed and Custom physical slots remain disjoint; all Custom reservation queries explicitly filter ownership_kind=custom.
- No frontend, public OpenAPI/generated client, provider adapter, message translation, generic egress, activation, runtime, or live-gate changes.
- QR-only MVP.

## Executable coverage
Focused tests cover auth, unknown/unconfigured slots, no-store success/error/validation responses, QR rotation, idempotent request replay, cancel success/failure retry, registered-disconnected cancel recovery, real expiry sweep, bind-failure rollback without a promoted phantom, start/promotion duplicate-name conflicts, managed/custom request-id isolation, restart reconciliation revision/physical drift, logout fail-closed and archive rollback retry, and Telegram/Discord deletion regressions.

## Verification
Fresh throwaway PostgreSQL migrated from empty schema to head:
- 117 relevant backend tests passed
- uv run ruff check . passed
- uv run ruff format --check . passed
- uv run python -m compileall -q app scripts tests alembic passed
- bun run typecheck passed (4/4 packages)
- Alembic single head: b4e8c1d7a2f9
- git diff --check origin/main..HEAD passed

The throwaway database was deleted. No production/provider operations were performed. Do not merge without review.