### PR TITLE
refactor(backend): type provider credential boundaries

### DIFF
--- a/backend/app/models/hosted_runtime.py
+++ b/backend/app/models/hosted_runtime.py
@@ -40,7 +40,7 @@ class HostedRuntimeState(Base, TimestampMixin):
     locale: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
     system: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
     egress_engine: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
-    runtimes: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
+    runtimes: Mapped[dict[str, JsonValue]] = mapped_column(JSONB(none_as_null=True), nullable=False)
     live_sync: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
     recovery: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
     egress_profiles: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))

--- a/backend/app/services/ai_provider_credentials.py
+++ b/backend/app/services/ai_provider_credentials.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 from uuid import UUID
 
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +17,10 @@ from app.services.url_security import is_public_https_url
 
 OAuthConsumerRuntime = Literal["codex", "hermes", "openclaw"]
 OAUTH_CONSUMER_RUNTIMES = frozenset({"codex", "hermes", "openclaw"})
+_RUNTIME_MAP_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
+_OAUTH_CONSUMER_RUNTIME_ADAPTER: TypeAdapter[OAuthConsumerRuntime] = TypeAdapter(
+    OAuthConsumerRuntime
+)
 
 
 class OAuthCredentialClaimConflict(ValueError):
@@ -36,12 +40,20 @@ async def lock_ai_provider_owner(db: AsyncSession, owner_user_id: UUID) -> None:
 
 
 def selected_runtime_binding(runtimes: object) -> tuple[OAuthConsumerRuntime, str | None] | None:
-    if not isinstance(runtimes, dict) or len(runtimes) != 1:
-        return None
-    runtime_name, raw_runtime = next(iter(runtimes.items()))
-    if runtime_name not in OAUTH_CONSUMER_RUNTIMES:
+    if not isinstance(runtimes, dict):
         return None
     try:
+        runtime_map = _RUNTIME_MAP_ADAPTER.validate_python(runtimes, strict=True)
+    except ValidationError:
+        return None
+    if len(runtime_map) != 1:
+        return None
+    raw_runtime_name, raw_runtime = next(iter(runtime_map.items()))
+    try:
+        runtime_name = _OAUTH_CONSUMER_RUNTIME_ADAPTER.validate_python(
+            raw_runtime_name,
+            strict=True,
+        )
         runtime = validate_hosted_runtime_desired_state(raw_runtime)
     except ValidationError:
         return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -115,6 +115,7 @@ strict = [
     "app/routes/sync.py",
     "app/services/agent_bindings.py",
     "app/services/ai_provider_connection.py",
+    "app/services/ai_provider_credentials.py",
     "app/services/channel_debug_events.py",
     "app/services/channel_webhooks.py",
     "app/services/discord_gateway_worker.py",

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -67,6 +67,7 @@ EXPECTED_CONFIG = {
         "app/routes/sync.py",
         "app/services/agent_bindings.py",
         "app/services/ai_provider_connection.py",
+        "app/services/ai_provider_credentials.py",
         "app/services/channel_debug_events.py",
         "app/services/channel_webhooks.py",
         "app/services/discord_gateway_worker.py",

--- a/backend/tests/test_ai_provider_credentials.py
+++ b/backend/tests/test_ai_provider_credentials.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.ai_provider_credentials import selected_runtime_binding
+
+
+def _configured_runtime(provider_id: str) -> dict[str, object]:
+    return {
+        "enabled": True,
+        "providerMode": "configured",
+        "provider_ids": [provider_id],
+        "primary_model": {
+            "provider_id": provider_id,
+            "model": "gpt-test",
+        },
+        "install": {"source": "official"},
+    }
+
+
+def test_selected_runtime_binding_returns_validated_provider_binding() -> None:
+    binding = selected_runtime_binding({"openclaw": _configured_runtime("openai-compatible")})
+
+    assert binding == ("openclaw", "openai-compatible")
+
+
+@pytest.mark.parametrize(
+    "runtimes",
+    (
+        None,
+        [],
+        {1: _configured_runtime("openai-compatible")},
+        {"unsupported": _configured_runtime("openai-compatible")},
+        {
+            "codex": _configured_runtime("openai-compatible"),
+            "openclaw": _configured_runtime("openai-compatible"),
+        },
+        {"openclaw": {"enabled": True}},
+    ),
+)
+def test_selected_runtime_binding_rejects_invalid_runtime_maps(runtimes: object) -> None:
+    assert selected_runtime_binding(runtimes) is None

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -9,9 +9,9 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
@@ -27,6 +27,7 @@ from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.platform_idempotency import PlatformMutationIdempotency
 from app.models.session import AgentEnvironment
+from app.models.user import User
 from app.routes import ai_providers as ai_provider_routes
 from app.schemas.ai_provider import AiProviderAcceptRequest, AiProviderResponse
 from app.services import ai_provider_oauth_attempt as oauth_attempt_service
@@ -5598,13 +5599,10 @@ async def test_oauth_import_rejects_multiple_hosted_runtime_bindings(
 @pytest.mark.asyncio
 @pytest.mark.committed_db
 async def test_auth_and_runtime_mutations_serialize_on_common_user_lock(
-    db_session,
-    engine,
-    seed_user,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from app.services import ai_provider_auth_transition, ai_provider_credentials
-
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    seed_user: User,
+) -> None:
     owner_user_id = seed_user.id
     provider_id = "common-user-lock-provider"
     provider = AiProvider(
@@ -5640,30 +5638,7 @@ async def test_auth_and_runtime_mutations_serialize_on_common_user_lock(
         }
     }
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    auth_holds_user_lock = asyncio.Event()
-    release_auth = asyncio.Event()
-    runtime_user_lock_attempted = asyncio.Event()
-    original_owner_lock = ai_provider_credentials.lock_ai_provider_owner
-
-    async def hold_auth_owner_lock(db, requested_owner_user_id):
-        await original_owner_lock(db, requested_owner_user_id)
-        auth_holds_user_lock.set()
-        await release_auth.wait()
-
-    async def observe_runtime_owner_lock(db, requested_owner_user_id):
-        runtime_user_lock_attempted.set()
-        await original_owner_lock(db, requested_owner_user_id)
-
-    monkeypatch.setattr(
-        ai_provider_auth_transition,
-        "lock_ai_provider_owner",
-        hold_auth_owner_lock,
-    )
-    monkeypatch.setattr(
-        ai_provider_credentials,
-        "lock_ai_provider_owner",
-        observe_runtime_owner_lock,
-    )
+    business_backend_pids: asyncio.Queue[int] = asyncio.Queue()
 
     async def mutate_auth() -> None:
         async with session_factory() as session:
@@ -5674,6 +5649,9 @@ async def test_auth_and_runtime_mutations_serialize_on_common_user_lock(
                 )
             )
             assert locked_provider is not None
+            backend_pid = await session.scalar(select(func.pg_backend_pid()))
+            assert isinstance(backend_pid, int)
+            business_backend_pids.put_nowait(backend_pid)
             await transition_ai_provider_auth(
                 session,
                 owner_user_id=owner_user_id,
@@ -5686,6 +5664,9 @@ async def test_auth_and_runtime_mutations_serialize_on_common_user_lock(
 
     async def mutate_runtime() -> None:
         async with session_factory() as session:
+            backend_pid = await session.scalar(select(func.pg_backend_pid()))
+            assert isinstance(backend_pid, int)
+            business_backend_pids.put_nowait(backend_pid)
             await reconcile_runtime_oauth_claims(
                 session,
                 owner_user_id=owner_user_id,
@@ -5694,22 +5675,61 @@ async def test_auth_and_runtime_mutations_serialize_on_common_user_lock(
             )
             await session.commit()
 
-    auth_task = asyncio.create_task(mutate_auth())
-    runtime_task = None
-    try:
-        await asyncio.wait_for(auth_holds_user_lock.wait(), timeout=2)
+    async with session_factory() as lock_holder:
+        await lock_holder.execute(select(User.id).where(User.id == owner_user_id).with_for_update())
+        auth_task = asyncio.create_task(mutate_auth())
         runtime_task = asyncio.create_task(mutate_runtime())
-        await asyncio.wait_for(runtime_user_lock_attempted.wait(), timeout=2)
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.shield(runtime_task), timeout=0.05)
-        release_auth.set()
-        await asyncio.wait_for(asyncio.gather(auth_task, runtime_task), timeout=2)
-    finally:
-        release_auth.set()
-        if not auth_task.done():
-            auth_task.cancel()
-        if runtime_task is not None and not runtime_task.done():
-            runtime_task.cancel()
+        tasks = (auth_task, runtime_task)
+        try:
+            backend_pids = frozenset(
+                await asyncio.wait_for(
+                    asyncio.gather(
+                        business_backend_pids.get(),
+                        business_backend_pids.get(),
+                    ),
+                    timeout=2,
+                )
+            )
+            assert len(backend_pids) == 2
+
+            async def wait_for_business_lock_waits() -> None:
+                first_pid, second_pid = backend_pids
+                async with session_factory() as observer:
+                    while True:
+                        waiting_pids = frozenset(
+                            (
+                                await observer.execute(
+                                    text(
+                                        """
+                                        SELECT pid
+                                        FROM pg_stat_activity
+                                        WHERE pid IN (:first_pid, :second_pid)
+                                          AND state = 'active'
+                                          AND wait_event_type = 'Lock'
+                                        """
+                                    ),
+                                    {
+                                        "first_pid": first_pid,
+                                        "second_pid": second_pid,
+                                    },
+                                )
+                            ).scalars()
+                        )
+                        if waiting_pids == backend_pids:
+                            return
+                        await observer.rollback()
+                        await asyncio.sleep(0.01)
+
+            await asyncio.wait_for(wait_for_business_lock_waits(), timeout=2)
+            await lock_holder.commit()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+        except BaseException:
+            await lock_holder.rollback()
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- promote the AI provider credential ownership service to BasedPyright strict
- validate persisted runtime maps through the existing Pydantic boundary and type the JSONB runtime payload
- replace private lock-function patches and timing inference with a real PostgreSQL row-lock concurrency test
- capture each business session backend PID and require independent pg_stat_activity evidence that both are active Lock waiters before releasing the owner lock

## Verification

- focused Docker PostgreSQL lock test: 1 passed
- backend type governance: 39 files, 0 diagnostics
- focused Ruff and format checks passed
- full isolated Docker suite on latest origin/main:
  - web: 909 passed
  - shared: 72 passed
  - sidecar: 43 passed
  - CLI: 1566 passed, 4 skipped
  - backend: 2048 passed, 6 skipped

No production, identity-provider, tenant, cluster, or live-data operations were performed.