### PR TITLE
Converge WhatsApp authority and channel control lifecycle

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -77,6 +77,7 @@ from app.services.channels import (
     DISCORD_REF_INTERACTION_TOKEN,
     ChannelAgentContext,
     ack_discord_gateway_messages,
+    channel_control_command_event_was_handled,
     channel_runtime_account_key,
     channel_runtime_placeholder_token,
     dequeue_discord_gateway_events,
@@ -92,7 +93,6 @@ from app.services.channels import (
     get_active_channel_account,
     get_channel_agent_reference,
     lock_active_discord_binding_lease,
-    pairing_command_event_was_handled,
     record_discord_interaction_references,
     record_discord_outbound_message,
     record_inactive_bot_agent_link_event,
@@ -1493,7 +1493,7 @@ async def discord_webhook(
     command = discord_pair_command_from_payload(payload)
     channel_id, guild_id = discord_channel_scope_from_payload(payload)
     provider_event_id = discord_message_id_from_payload(payload)
-    if await pairing_command_event_was_handled(
+    if await channel_control_command_event_was_handled(
         db,
         account=account,
         external_chat_id=external_chat_id,

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -83,11 +83,11 @@ from app.services.channels import (
     dequeue_discord_gateway_events,
     discord_channel_scope_from_payload,
     discord_chat_from_payload,
+    discord_control_command_admission,
+    discord_control_command_from_payload,
+    discord_control_reply_for_command,
     discord_external_user_id_from_payload,
     discord_message_id_from_payload,
-    discord_pair_command_from_payload,
-    discord_pairing_command_admission,
-    discord_pairing_reply_for_command,
     discord_text_from_payload,
     discord_user_display_name_from_payload,
     get_active_channel_account,
@@ -100,7 +100,7 @@ from app.services.channels import (
     resolve_channel_agent_by_identity,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
-    send_pairing_command_reply,
+    send_control_command_reply,
     update_discord_binding_display_name_from_trusted_event,
     upsert_binding_alias,
     verify_discord_signature,
@@ -1490,7 +1490,7 @@ async def discord_webhook(
     if chat is None:
         return {"ok": True}
     external_chat_id, external_chat_type, external_chat_name = chat
-    command = discord_pair_command_from_payload(payload)
+    command = discord_control_command_from_payload(payload)
     channel_id, guild_id = discord_channel_scope_from_payload(payload)
     provider_event_id = discord_message_id_from_payload(payload)
     if await channel_control_command_event_was_handled(
@@ -1520,7 +1520,7 @@ async def discord_webhook(
     )
     if trusted_dm_name is not None:
         external_chat_name = trusted_dm_name
-    admission = await discord_pairing_command_admission(
+    admission = await discord_control_command_admission(
         account,
         payload,
         command=command,
@@ -1585,7 +1585,7 @@ async def discord_webhook(
         await record_inactive_bot_agent_link_event(db, account=account, binding=binding)
     await db.commit()
     message = messages[0][0]
-    reply_text = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
+    reply_text = discord_control_reply_for_command(command, binding_result, guild_id=guild_id)
     if payload.get("type") == 2:
         if binding_result.paired and binding_result.binding is not None and guild_id is not None:
             # Discord interactions have a short acknowledgement deadline. The
@@ -1628,7 +1628,7 @@ async def discord_webhook(
         guild_id=guild_id,
         paired=binding_result.paired,
     )
-    reply = await send_pairing_command_reply(
+    reply = await send_control_command_reply(
         db,
         account=account,
         external_chat_id=external_chat_id,

--- a/backend/app/routes/channel_routers/imessage_realtime.py
+++ b/backend/app/routes/channel_routers/imessage_realtime.py
@@ -38,11 +38,11 @@ from app.services.channels import (
     imessage_external_user_id_from_payload,
     imessage_message_id_from_payload,
     imessage_text_from_payload,
-    parse_pair_command,
+    parse_channel_control_command,
     record_inbound_messages_for_bindings,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
-    send_pairing_command_reply,
+    send_control_command_reply,
     verify_webhook_secret,
 )
 
@@ -135,7 +135,9 @@ async def imessage_webhook(
         return TelegramWebhookResponse(ok=True)
     external_chat_id, external_chat_type, external_chat_name = chat
     text = imessage_text_from_payload(payload)
-    command = parse_pair_command(text)
+    command = parse_channel_control_command(text)
+    if command is not None and command.kind == "help":
+        command = None
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -157,7 +159,7 @@ async def imessage_webhook(
         payload=payload,
     )
     await db.commit()
-    reply = await send_pairing_command_reply(
+    reply = await send_control_command_reply(
         db,
         account=account,
         external_chat_id=external_chat_id,

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -65,6 +65,7 @@ from app.services.channels import (
     bot_agent_link_has_provider_cardinality_capability,
     bot_agent_link_has_strict_v2_authority,
     channel_agent_reference_exists,
+    channel_control_command_event_was_handled,
     channel_runtime_account_key,
     channel_runtime_placeholder_token,
     decrypt_provider_token,
@@ -73,7 +74,6 @@ from app.services.channels import (
     find_existing_inbound_provider_event,
     get_active_channel_account,
     lock_channel_binding_identity,
-    pairing_command_event_was_handled,
     parse_pair_command,
     pending_channel_inbox_count,
     record_channel_agent_reference,
@@ -701,7 +701,7 @@ async def telegram_webhook(
     provider_event_id = telegram_event_id_from_update(payload)
     provider_event_scope = telegram_event_scope_from_update(payload)
     external_user_id = telegram_external_user_id_from_update(payload)
-    if await pairing_command_event_was_handled(
+    if await channel_control_command_event_was_handled(
         db,
         account=account,
         external_chat_id=external_chat_id,
@@ -1241,6 +1241,7 @@ def _get_telegram_commands(
     return [
         {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
         {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
     ]
 
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -59,7 +59,7 @@ from app.services.channels import (
     TELEGRAM_REF_FILE_PATH,
     TELEGRAM_REF_MESSAGE_ID,
     ChannelAgentContext,
-    ChannelPairCommand,
+    ChannelControlCommand,
     InboundBindingResult,
     binding_is_controlled_by_actor,
     bot_agent_link_has_provider_cardinality_capability,
@@ -74,7 +74,7 @@ from app.services.channels import (
     find_existing_inbound_provider_event,
     get_active_channel_account,
     lock_channel_binding_identity,
-    parse_pair_command,
+    parse_channel_control_command,
     pending_channel_inbox_count,
     record_channel_agent_reference,
     record_inactive_bot_agent_link_event,
@@ -82,7 +82,7 @@ from app.services.channels import (
     record_telegram_update_references,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
-    send_pairing_command_reply,
+    send_control_command_reply,
     send_telegram_message,
     telegram_chat_from_update,
     telegram_direct_messages_topic_id_from_update,
@@ -697,7 +697,7 @@ async def telegram_webhook(
 
     external_chat_id, external_chat_type, external_chat_name = chat
     text = telegram_text_from_update(payload)
-    command = parse_pair_command(text)
+    command = parse_channel_control_command(text)
     provider_event_id = telegram_event_id_from_update(payload)
     provider_event_scope = telegram_event_scope_from_update(payload)
     external_user_id = telegram_external_user_id_from_update(payload)
@@ -783,7 +783,7 @@ async def telegram_webhook(
             payload=payload,
         )
     await db.commit()
-    reply = await send_pairing_command_reply(
+    reply = await send_control_command_reply(
         db,
         account=account,
         external_chat_id=external_chat_id,
@@ -843,7 +843,7 @@ async def _send_telegram_unpaired_tutorial(
     external_chat_type: str | None,
     external_user_id: str | None,
     payload: dict[str, Any],
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     binding_result: InboundBindingResult,
 ) -> ChannelMessage | None:
     message = payload.get("message")

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -104,6 +104,7 @@ async def record_channel_debug_event(
         minimize_stored_diagnostics = normalized_provider in {
             CHANNEL_PROVIDER_TELEGRAM,
             CHANNEL_PROVIDER_DISCORD,
+            CHANNEL_PROVIDER_WHATSAPP,
         }
         async with db.begin_nested():
             event = ChannelDebugEvent(

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -52,6 +52,8 @@ SECRET_KEY_RE = re.compile(
 )
 _PUBLIC_SAFE_CODE_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,119}$", re.I)
 _PUBLIC_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.:@/-]{1,300}$")
+_PUBLIC_SAFE_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_PUBLIC_SAFE_SHA256_KEYS = frozenset({"clientstaticsha256"})
 _PUBLIC_SAFE_DETAIL_STRING_KEYS = frozenset(
     {
         "direction",
@@ -69,6 +71,25 @@ _PUBLIC_SAFE_DETAIL_STRING_KEYS = frozenset(
         "link_status",
     }
 )
+_PUBLIC_SAFE_DETAIL_ENUMS = {
+    "jiddescription": frozenset(
+        {
+            "invalid",
+            "missing",
+            "server=broadcast device=false",
+            "server=broadcast device=true",
+            "server=g.us device=false",
+            "server=g.us device=true",
+            "server=lid device=false",
+            "server=lid device=true",
+            "server=newsletter device=false",
+            "server=newsletter device=true",
+            "server=s.whatsapp.net device=false",
+            "server=s.whatsapp.net device=true",
+        }
+    ),
+    "runtime": frozenset({"baileys_noise", "baileys_websocket"}),
+}
 
 
 @dataclass(frozen=True)
@@ -279,6 +300,10 @@ def public_channel_debug_details(
             return "[redacted]"
         if normalized_key == "id" or normalized_key.endswith("_id"):
             return value if _PUBLIC_SAFE_ID_RE.fullmatch(value) else "[redacted]"
+        if normalized_key in _PUBLIC_SAFE_SHA256_KEYS:
+            return value if _PUBLIC_SAFE_SHA256_RE.fullmatch(value) else "[redacted]"
+        if value in _PUBLIC_SAFE_DETAIL_ENUMS.get(normalized_key, ()):
+            return value
         if normalized_key in _PUBLIC_SAFE_DETAIL_STRING_KEYS and _PUBLIC_SAFE_CODE_RE.fullmatch(
             value
         ):

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -224,7 +224,11 @@ TELEGRAM_REF_FILE_PATH = "telegram_file_path"
 TELEGRAM_REF_MESSAGE_ID = "telegram_message_id"
 DISCORD_REF_INTERACTION_ID_TOKEN = "discord_interaction_id_token"
 DISCORD_REF_INTERACTION_TOKEN = "discord_interaction_token"
-CHANNEL_RETENTION_PROVIDERS = (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD)
+CHANNEL_RETENTION_PROVIDERS = (
+    CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_WHATSAPP,
+)
 DISCORD_EPHEMERAL_REFERENCE_KINDS = (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
@@ -301,7 +305,7 @@ class DiscordPairingCommandAdmission:
 
 
 @dataclass(frozen=True)
-class ChannelPairCommand:
+class ChannelControlCommand:
     kind: str
     code: str | None = None
     command: str | None = None
@@ -1870,30 +1874,76 @@ async def lock_active_binding_authority(
     binding: ChannelBinding,
     bot_agent_link_id: UUID,
 ) -> ChannelBinding | None:
-    """Hold current binding authority through the caller's transaction."""
-    return (
+    """Lock Account -> Link -> Binding authority through the caller's transaction."""
+    locked_account = (
         await db.execute(
-            select(ChannelBinding)
-            .join(
-                ChannelBotAgentLink,
-                and_(
-                    ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
-                    ChannelBotAgentLink.account_id == ChannelBinding.account_id,
-                ),
-            )
-            .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+            select(ChannelAccount)
             .where(
-                ChannelBinding.id == binding.id,
-                ChannelBinding.account_id == account.id,
-                ChannelBinding.bot_agent_link_id == bot_agent_link_id,
-                ChannelBinding.status == BINDING_STATUS_ACTIVE,
-                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-                ChannelBotAgentLink.archived_at.is_(None),
+                ChannelAccount.id == account.id,
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
             )
             .execution_options(populate_existing=True)
+            .with_for_update(read=True, of=ChannelAccount)
+        )
+    ).scalar_one_or_none()
+    if locked_account is None:
+        return None
+    link = await lock_active_link_authority(
+        db,
+        account=locked_account,
+        bot_agent_link_id=bot_agent_link_id,
+    )
+    if link is None or binding.user_id != link.user_id:
+        return None
+    return (
+        await db.execute(
+            select(ChannelBinding)
+            .where(
+                ChannelBinding.id == binding.id,
+                ChannelBinding.account_id == locked_account.id,
+                ChannelBinding.bot_agent_link_id == link.id,
+                ChannelBinding.user_id == link.user_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+            )
+            .execution_options(populate_existing=True)
             .with_for_update(read=True, of=ChannelBinding)
+        )
+    ).scalar_one_or_none()
+
+
+async def lock_active_link_authority(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+) -> ChannelBotAgentLink | None:
+    """Hold Account -> Link authority through the caller's transaction."""
+    locked_account = (
+        await db.execute(
+            select(ChannelAccount)
+            .where(
+                ChannelAccount.id == account.id,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+            )
+            .execution_options(populate_existing=True)
+            .with_for_update(read=True, of=ChannelAccount)
+        )
+    ).scalar_one_or_none()
+    if locked_account is None:
+        return None
+    return (
+        await db.execute(
+            select(ChannelBotAgentLink)
+            .where(
+                ChannelBotAgentLink.id == bot_agent_link_id,
+                ChannelBotAgentLink.account_id == locked_account.id,
+                ChannelBotAgentLink.user_id == locked_account.user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            )
+            .with_for_update(read=True, of=ChannelBotAgentLink)
         )
     ).scalar_one_or_none()
 
@@ -1907,11 +1957,11 @@ async def resolve_inbound_binding(
     external_chat_name: str | None,
     external_user_id: str | None,
     text: str | None,
-    command: ChannelPairCommand | None = None,
+    command: ChannelControlCommand | None = None,
     command_denied_reason: str | None = None,
     command_actor_required: bool = False,
 ) -> InboundBindingResult:
-    parsed = command if command is not None else parse_pair_command(text)
+    parsed = command if command is not None else parse_channel_control_command(text)
     pairing_mutation = parsed is not None and parsed.kind in {"pair", "unpair"}
     if pairing_mutation:
         await lock_channel_binding_identity(
@@ -2067,7 +2117,7 @@ def pairing_command_requires_actor(external_chat_type: str | None) -> bool:
     return external_chat_type.lower() not in {"private", "dm"}
 
 
-def parse_pair_command(text: str | None) -> ChannelPairCommand | None:
+def parse_channel_control_command(text: str | None) -> ChannelControlCommand | None:
     if not text:
         return None
     trimmed = text.lstrip()
@@ -2078,7 +2128,7 @@ def parse_pair_command(text: str | None) -> ChannelPairCommand | None:
             return None
         code = _single_command_arg(rest)
         if code is not None and PAIR_CODE_PATTERN.fullmatch(code):
-            return ChannelPairCommand(kind="pair", code=code)
+            return ChannelControlCommand(kind="pair", code=code)
         return None
     if not trimmed.startswith("/clawdi_"):
         return None
@@ -2088,16 +2138,16 @@ def parse_pair_command(text: str | None) -> ChannelPairCommand | None:
         code = _single_command_arg(rest) if separator else ""
         if code is None:
             code = ""
-        return ChannelPairCommand(kind="pair", code=code)
+        return ChannelControlCommand(kind="pair", code=code)
     if command == UNPAIR_COMMAND:
         if separator and rest.strip():
-            return ChannelPairCommand(kind="unknown", command=command)
-        return ChannelPairCommand(kind="unpair")
+            return ChannelControlCommand(kind="unknown", command=command)
+        return ChannelControlCommand(kind="unpair")
     if command == HELP_COMMAND:
         if separator and rest.strip():
-            return ChannelPairCommand(kind="unknown", command=command)
-        return ChannelPairCommand(kind="help")
-    return ChannelPairCommand(kind="unknown", command=command)
+            return ChannelControlCommand(kind="unknown", command=command)
+        return ChannelControlCommand(kind="help")
+    return ChannelControlCommand(kind="unknown", command=command)
 
 
 def _single_command_arg(rest: str) -> str | None:
@@ -2111,7 +2161,7 @@ def _single_command_arg(rest: str) -> str | None:
 
 
 def pairing_reply_for_command(
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     result: InboundBindingResult,
     *,
     pair_command: str = PAIR_COMMAND,
@@ -2137,7 +2187,7 @@ def pairing_reply_for_command(
     if command.kind == "help":
         return channel_control_help_reply()
     if command.kind == "unknown" and command.command:
-        return f"Unknown command: {command.command}. Use {pair_command} <code> or {unpair_command}."
+        return f"Unknown command: {command.command}. Use {HELP_COMMAND} for instructions."
     return "Message received."
 
 
@@ -2150,7 +2200,7 @@ def channel_control_help_reply() -> str:
 def discord_guild_command_denied_reason(
     payload: dict[str, Any],
     *,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     guild_id: str | None,
 ) -> str | None:
     """Require Discord-computed guild permissions for pairing mutations.
@@ -2182,7 +2232,7 @@ def discord_guild_command_denied_reason(
 def discord_pair_install_denied_reason(
     payload: dict[str, Any],
     *,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     guild_id: str | None,
     external_user_id: str | None,
     trusted_interaction: bool,
@@ -2210,7 +2260,7 @@ def discord_pair_install_denied_reason(
 def _discord_pair_install_admission(
     payload: dict[str, Any],
     *,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     guild_id: str | None,
     external_user_id: str | None,
     trusted_interaction: bool,
@@ -2340,11 +2390,11 @@ async def discord_bot_guild_membership_check(
     )
 
 
-async def discord_pairing_command_admission(
+async def discord_control_command_admission(
     account: ChannelAccount,
     payload: dict[str, Any],
     *,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     guild_id: str | None,
     external_user_id: str | None,
     trusted_interaction: bool,
@@ -2382,8 +2432,8 @@ async def discord_pairing_command_admission(
     return DiscordPairingCommandAdmission()
 
 
-def discord_pairing_reply_for_command(
-    command: ChannelPairCommand | None,
+def discord_control_reply_for_command(
+    command: ChannelControlCommand | None,
     result: InboundBindingResult,
     *,
     guild_id: str | None,
@@ -2422,16 +2472,16 @@ def discord_pairing_reply_for_command(
     if command is not None and command.kind == "pair" and result.pair_failed_reason == "usage":
         return "Usage: /clawdi_pair <code>"
     if command is not None and command.kind == "unknown" and command.command:
-        return f"Unknown command: {command.command}. Use /clawdi_pair <code> or /clawdi_unpair."
+        return f"Unknown command: {command.command}. Use {HELP_COMMAND} for instructions."
     return pairing_reply_for_command(command, result)
 
 
 def extract_pair_code(text: str | None) -> str | None:
-    command = parse_pair_command(text)
+    command = parse_channel_control_command(text)
     return command.code if command is not None and command.kind == "pair" else None
 
 
-async def send_pairing_command_reply(
+async def send_control_command_reply(
     db: AsyncSession,
     *,
     account: ChannelAccount,
@@ -2439,7 +2489,7 @@ async def send_pairing_command_reply(
     send_external_chat_id: str | None = None,
     telegram_message_thread_id: int | None = None,
     telegram_direct_messages_topic_id: int | None = None,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
     binding_result: InboundBindingResult,
     reply: str | None = None,
 ) -> ChannelMessage | None:
@@ -2825,7 +2875,7 @@ async def channel_control_command_event_was_handled(
     external_chat_id: str,
     provider_event_id: str | None,
     provider_event_scope: str = PROVIDER_EVENT_SCOPE_CHAT,
-    command: ChannelPairCommand | None,
+    command: ChannelControlCommand | None,
 ) -> bool:
     """Serialize control commands and reject a previously handled provider event."""
     if (
@@ -5709,7 +5759,7 @@ async def send_whatsapp_message(
     provider_external_chat_id = (
         binding.external_chat_id if binding is not None else external_chat_id
     )
-    provider_message_id, response_payload = await _send_whatsapp_provider_payload(
+    provider_message_id, _response_payload = await _send_whatsapp_provider_payload(
         account=account,
         external_chat_id=provider_external_chat_id,
         text=text,
@@ -5721,7 +5771,11 @@ async def send_whatsapp_message(
         external_chat_id=provider_external_chat_id,
         provider_message_id=provider_message_id,
         text=text,
-        payload=response_payload,
+        payload=_safe_delivery_provider_response(
+            provider=CHANNEL_PROVIDER_WHATSAPP,
+            provider_message_id=provider_message_id,
+        ),
+        delivered_at=datetime.now(UTC),
     )
 
 
@@ -6033,13 +6087,13 @@ def discord_text_from_payload(payload: dict[str, Any]) -> str | None:
 
 
 def discord_pair_code_from_payload(payload: dict[str, Any]) -> str | None:
-    command = discord_pair_command_from_payload(payload)
+    command = discord_control_command_from_payload(payload)
     return command.code if command is not None and command.kind == "pair" else None
 
 
-def discord_pair_command_from_payload(payload: dict[str, Any]) -> ChannelPairCommand | None:
+def discord_control_command_from_payload(payload: dict[str, Any]) -> ChannelControlCommand | None:
     data = _discord_event_data(payload)
-    text_command = _parse_discord_pair_command(_read_optional_str(data.get("content")))
+    text_command = _parse_discord_control_command(_read_optional_str(data.get("content")))
     if text_command is not None:
         return text_command
     interaction_command = data.get("data")
@@ -6047,26 +6101,26 @@ def discord_pair_command_from_payload(payload: dict[str, Any]) -> ChannelPairCom
         return None
     name = interaction_command.get("name")
     if name == DISCORD_UNPAIR_COMMAND_NAME:
-        return ChannelPairCommand(kind="unpair")
+        return ChannelControlCommand(kind="unpair")
     if name == DISCORD_HELP_COMMAND_NAME:
         options = interaction_command.get("options")
         if isinstance(options, list) and options:
-            return ChannelPairCommand(kind="unknown", command=HELP_COMMAND)
-        return ChannelPairCommand(kind="help")
+            return ChannelControlCommand(kind="unknown", command=HELP_COMMAND)
+        return ChannelControlCommand(kind="help")
     if name != DISCORD_PAIR_COMMAND_NAME:
         return None
     options = interaction_command.get("options")
     if not isinstance(options, list):
-        return ChannelPairCommand(kind="pair", code="")
+        return ChannelControlCommand(kind="pair", code="")
     for option in options:
         if not isinstance(option, dict):
             continue
         if option.get("name") in {"code", "pair_code"}:
-            return ChannelPairCommand(kind="pair", code=_read_optional_str(option.get("value")))
-    return ChannelPairCommand(kind="pair", code="")
+            return ChannelControlCommand(kind="pair", code=_read_optional_str(option.get("value")))
+    return ChannelControlCommand(kind="pair", code="")
 
 
-def _parse_discord_pair_command(text: str | None) -> ChannelPairCommand | None:
+def _parse_discord_control_command(text: str | None) -> ChannelControlCommand | None:
     if not text:
         return None
     trimmed = text.lstrip()
@@ -6076,16 +6130,16 @@ def _parse_discord_pair_command(text: str | None) -> ChannelPairCommand | None:
     name = head.split("@", 1)[0].removeprefix("/")
     if name == DISCORD_UNPAIR_COMMAND_NAME:
         if separator and rest.strip():
-            return ChannelPairCommand(kind="unknown", command=f"/{name}")
-        return ChannelPairCommand(kind="unpair")
+            return ChannelControlCommand(kind="unknown", command=f"/{name}")
+        return ChannelControlCommand(kind="unpair")
     if name == DISCORD_HELP_COMMAND_NAME:
         if separator and rest.strip():
-            return ChannelPairCommand(kind="unknown", command=HELP_COMMAND)
-        return ChannelPairCommand(kind="help")
+            return ChannelControlCommand(kind="unknown", command=HELP_COMMAND)
+        return ChannelControlCommand(kind="help")
     if name != DISCORD_PAIR_COMMAND_NAME:
         return None
     code = _single_command_arg(rest) if separator else ""
-    return ChannelPairCommand(kind="pair", code=code or "")
+    return ChannelControlCommand(kind="pair", code=code or "")
 
 
 def discord_message_id_from_payload(payload: dict[str, Any]) -> str | None:
@@ -6239,7 +6293,7 @@ async def record_discord_dispatch(
         guild_id = discord_channel_scope_from_payload(frame)[1]
     else:
         return False
-    command = discord_pair_command_from_payload(frame)
+    command = discord_control_command_from_payload(frame)
     provider_event_id = discord_message_id_from_payload(frame)
     if await channel_control_command_event_was_handled(
         db,
@@ -6260,7 +6314,7 @@ async def record_discord_dispatch(
     )
     if trusted_dm_name is not None:
         external_chat_name = trusted_dm_name
-    admission = await discord_pairing_command_admission(
+    admission = await discord_control_command_admission(
         account,
         frame,
         command=command,
@@ -6336,8 +6390,8 @@ async def record_discord_dispatch(
         )
         await record_inactive_bot_agent_link_event(db, account=account, binding=binding)
     if binding_result.command_handled:
-        reply = discord_pairing_reply_for_command(command, binding_result, guild_id=guild_id)
-        await send_pairing_command_reply(
+        reply = discord_control_reply_for_command(command, binding_result, guild_id=guild_id)
+        await send_control_command_reply(
             db,
             account=account,
             external_chat_id=external_chat_id,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -92,12 +92,22 @@ log = logging.getLogger(__name__)
 
 PAIR_COMMAND = "/clawdi_pair"
 UNPAIR_COMMAND = "/clawdi_unpair"
+HELP_COMMAND = "/clawdi_help"
+CHANNEL_CONTROL_HELP_REPLY_TEMPLATE = (
+    "To connect this chat to an agent:\n"
+    "1. Open {web_origin}.\n"
+    "2. Choose your agent, open Channels, and select Pair.\n"
+    "3. Send /clawdi_pair <code> here.\n\n"
+    "To disconnect this chat, send /clawdi_unpair."
+)
 DISCORD_PAIR_COMMAND_NAME = "clawdi_pair"
 DISCORD_UNPAIR_COMMAND_NAME = "clawdi_unpair"
+DISCORD_HELP_COMMAND_NAME = "clawdi_help"
 DISCORD_RESERVED_COMMAND_NAMES = frozenset(
     {
         DISCORD_PAIR_COMMAND_NAME,
         DISCORD_UNPAIR_COMMAND_NAME,
+        DISCORD_HELP_COMMAND_NAME,
     }
 )
 DISCORD_LEGACY_RESERVED_COMMAND_NAMES = frozenset({"bot_pair", "bot_unpair"})
@@ -129,6 +139,11 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
         "description": "Disconnect this chat from Clawdi.",
         "options": [],
     },
+    {
+        "name": "clawdi_help",
+        "description": "Show safe Clawdi pairing instructions.",
+        "options": [],
+    },
 )
 DISCORD_ADMINISTRATOR_PERMISSION = 1 << 3
 DISCORD_MANAGE_GUILD_PERMISSION = 1 << 5
@@ -136,7 +151,7 @@ DISCORD_GUILD_INSTALL = 0
 DISCORD_USER_INSTALL = 1
 DISCORD_GUILD_INTERACTION_CONTEXT = 0
 DISCORD_BOT_DM_INTERACTION_CONTEXT = 1
-DISCORD_RESERVED_COMMAND_VERSION = 3
+DISCORD_RESERVED_COMMAND_VERSION = 4
 DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
 DISCORD_INSTALL_CONFIG_VERSION = 2
 DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
@@ -1220,7 +1235,12 @@ async def archive_bot_agent_link(
             "channel agent link archived",
             use_safe_diagnostics=(
                 account is not None
-                and account.provider in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}
+                and account.provider
+                in {
+                    CHANNEL_PROVIDER_TELEGRAM,
+                    CHANNEL_PROVIDER_DISCORD,
+                    CHANNEL_PROVIDER_WHATSAPP,
+                }
             ),
         )
 
@@ -1386,7 +1406,11 @@ async def archive_channel_account(db: AsyncSession, *, account: ChannelAccount) 
             delivery,
             "channel account archived",
             use_safe_diagnostics=account.provider
-            in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD},
+            in {
+                CHANNEL_PROVIDER_TELEGRAM,
+                CHANNEL_PROVIDER_DISCORD,
+                CHANNEL_PROVIDER_WHATSAPP,
+            },
         )
 
     await db.flush()
@@ -1604,6 +1628,14 @@ async def get_or_create_binding(
             binding.external_chat_name = candidate_name
         binding.paired_external_user_id = external_user_id
         binding.status = BINDING_STATUS_ACTIVE
+        await db.execute(
+            update(ChannelBindingAlias)
+            .where(ChannelBindingAlias.binding_id == binding.id)
+            .values(
+                bot_agent_link_id=bot_agent_link_id,
+                user_id=user_id,
+            )
+        )
         return binding
 
     binding = ChannelBinding(
@@ -1720,7 +1752,7 @@ async def find_binding(
         ChannelBinding.status == BINDING_STATUS_ACTIVE,
     ]
     if bot_agent_link_id is not None:
-        alias_filters.append(ChannelBindingAlias.bot_agent_link_id == bot_agent_link_id)
+        alias_filters.append(ChannelBinding.bot_agent_link_id == bot_agent_link_id)
     alias_result = await db.execute(
         select(ChannelBinding)
         .join(ChannelBindingAlias, ChannelBindingAlias.binding_id == ChannelBinding.id)
@@ -1831,6 +1863,41 @@ async def upsert_binding_alias(
     return alias
 
 
+async def lock_active_binding_authority(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    binding: ChannelBinding,
+    bot_agent_link_id: UUID,
+) -> ChannelBinding | None:
+    """Hold current binding authority through the caller's transaction."""
+    return (
+        await db.execute(
+            select(ChannelBinding)
+            .join(
+                ChannelBotAgentLink,
+                and_(
+                    ChannelBotAgentLink.id == ChannelBinding.bot_agent_link_id,
+                    ChannelBotAgentLink.account_id == ChannelBinding.account_id,
+                ),
+            )
+            .join(ChannelAccount, ChannelAccount.id == ChannelBinding.account_id)
+            .where(
+                ChannelBinding.id == binding.id,
+                ChannelBinding.account_id == account.id,
+                ChannelBinding.bot_agent_link_id == bot_agent_link_id,
+                ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+            )
+            .execution_options(populate_existing=True)
+            .with_for_update(read=True, of=ChannelBinding)
+        )
+    ).scalar_one_or_none()
+
+
 async def resolve_inbound_binding(
     db: AsyncSession,
     *,
@@ -1921,6 +1988,12 @@ async def resolve_inbound_binding(
             bindings=tuple(bindings),
             command_handled=True,
             pair_failed_reason=command_denied_reason,
+        )
+    if parsed.kind == "help":
+        return InboundBindingResult(
+            binding=binding,
+            bindings=tuple(bindings),
+            command_handled=True,
         )
     if external_user_id is None and (
         command_actor_required or pairing_command_requires_actor(external_chat_type)
@@ -2020,6 +2093,10 @@ def parse_pair_command(text: str | None) -> ChannelPairCommand | None:
         if separator and rest.strip():
             return ChannelPairCommand(kind="unknown", command=command)
         return ChannelPairCommand(kind="unpair")
+    if command == HELP_COMMAND:
+        if separator and rest.strip():
+            return ChannelPairCommand(kind="unknown", command=command)
+        return ChannelPairCommand(kind="help")
     return ChannelPairCommand(kind="unknown", command=command)
 
 
@@ -2057,9 +2134,17 @@ def pairing_reply_for_command(
         if result.pair_failed_reason == "forbidden":
             return PAIRING_REPLY_FORBIDDEN
         return PAIRING_REPLY_NOT_PAIRED
+    if command.kind == "help":
+        return channel_control_help_reply()
     if command.kind == "unknown" and command.command:
         return f"Unknown command: {command.command}. Use {pair_command} <code> or {unpair_command}."
     return "Message received."
+
+
+def channel_control_help_reply() -> str:
+    return CHANNEL_CONTROL_HELP_REPLY_TEMPLATE.format(
+        web_origin=settings.web_origin.rstrip("/"),
+    )
 
 
 def discord_guild_command_denied_reason(
@@ -2733,7 +2818,7 @@ async def find_existing_inbound_provider_event(
     return result.scalar_one_or_none()
 
 
-async def pairing_command_event_was_handled(
+async def channel_control_command_event_was_handled(
     db: AsyncSession,
     *,
     account: ChannelAccount,
@@ -2742,8 +2827,17 @@ async def pairing_command_event_was_handled(
     provider_event_scope: str = PROVIDER_EVENT_SCOPE_CHAT,
     command: ChannelPairCommand | None,
 ) -> bool:
-    """Serialize pairing mutations and reject a previously handled provider event."""
-    if provider_event_id is None or command is None or command.kind not in {"pair", "unpair"}:
+    """Serialize control commands and reject a previously handled provider event."""
+    if (
+        provider_event_id is None
+        or command is None
+        or command.kind
+        not in {
+            "pair",
+            "unpair",
+            "help",
+        }
+    ):
         return False
     # The same transaction-level scope lock is acquired again by
     # resolve_inbound_binding. Taking it before the event lookup closes the
@@ -3687,7 +3781,7 @@ async def prune_channel_debug_events(
     result = await db.execute(
         select(ChannelDebugEvent)
         .where(
-            sql_text("channel_debug_events.provider IN ('telegram', 'discord')"),
+            sql_text("channel_debug_events.provider IN ('telegram', 'discord', 'whatsapp')"),
             ChannelDebugEvent.created_at < cutoff,
         )
         .order_by(ChannelDebugEvent.created_at, ChannelDebugEvent.id)
@@ -4273,7 +4367,7 @@ async def enqueue_channel_outbound_message(
         binding_id=binding.id if binding else None,
         user_id=owner_user_id,
         direction=MESSAGE_DIRECTION_OUTBOUND,
-        external_chat_id=external_chat_id,
+        external_chat_id=binding.external_chat_id if binding is not None else external_chat_id,
         provider_message_id=None,
         text=text,
         payload={"delivery": DELIVERY_STATUS_PENDING},
@@ -4410,6 +4504,7 @@ async def deliver_channel_delivery(
         use_safe_diagnostics = delivery_provider in {
             CHANNEL_PROVIDER_TELEGRAM,
             CHANNEL_PROVIDER_DISCORD,
+            CHANNEL_PROVIDER_WHATSAPP,
         }
         if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
             _schedule_delivery_retry(
@@ -4444,7 +4539,12 @@ async def deliver_channel_delivery(
             provider=account.provider,
             provider_message_id=provider_message_id,
         )
-        if account.provider in {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}
+        if account.provider
+        in {
+            CHANNEL_PROVIDER_TELEGRAM,
+            CHANNEL_PROVIDER_DISCORD,
+            CHANNEL_PROVIDER_WHATSAPP,
+        }
         else _provider_response
     )
     message.provider_message_id = provider_message_id
@@ -5581,11 +5681,6 @@ async def send_whatsapp_message(
     bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_WHATSAPP)
-    provider_message_id, response_payload = await _send_whatsapp_provider_payload(
-        account=account,
-        external_chat_id=external_chat_id,
-        text=text,
-    )
     binding = (
         await find_binding(
             db,
@@ -5596,11 +5691,34 @@ async def send_whatsapp_message(
         if bind_to_existing
         else None
     )
+    if bot_agent_link_id is not None:
+        if (
+            binding is None
+            or await lock_active_binding_authority(
+                db,
+                account=account,
+                binding=binding,
+                bot_agent_link_id=bot_agent_link_id,
+            )
+            is None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="chat is not paired with this agent link",
+            )
+    provider_external_chat_id = (
+        binding.external_chat_id if binding is not None else external_chat_id
+    )
+    provider_message_id, response_payload = await _send_whatsapp_provider_payload(
+        account=account,
+        external_chat_id=provider_external_chat_id,
+        text=text,
+    )
     return await _record_outbound_channel_message(
         db,
         account=account,
         binding=binding,
-        external_chat_id=external_chat_id,
+        external_chat_id=provider_external_chat_id,
         provider_message_id=provider_message_id,
         text=text,
         payload=response_payload,
@@ -5930,6 +6048,11 @@ def discord_pair_command_from_payload(payload: dict[str, Any]) -> ChannelPairCom
     name = interaction_command.get("name")
     if name == DISCORD_UNPAIR_COMMAND_NAME:
         return ChannelPairCommand(kind="unpair")
+    if name == DISCORD_HELP_COMMAND_NAME:
+        options = interaction_command.get("options")
+        if isinstance(options, list) and options:
+            return ChannelPairCommand(kind="unknown", command=HELP_COMMAND)
+        return ChannelPairCommand(kind="help")
     if name != DISCORD_PAIR_COMMAND_NAME:
         return None
     options = interaction_command.get("options")
@@ -5955,6 +6078,10 @@ def _parse_discord_pair_command(text: str | None) -> ChannelPairCommand | None:
         if separator and rest.strip():
             return ChannelPairCommand(kind="unknown", command=f"/{name}")
         return ChannelPairCommand(kind="unpair")
+    if name == DISCORD_HELP_COMMAND_NAME:
+        if separator and rest.strip():
+            return ChannelPairCommand(kind="unknown", command=HELP_COMMAND)
+        return ChannelPairCommand(kind="help")
     if name != DISCORD_PAIR_COMMAND_NAME:
         return None
     code = _single_command_arg(rest) if separator else ""
@@ -6114,7 +6241,7 @@ async def record_discord_dispatch(
         return False
     command = discord_pair_command_from_payload(frame)
     provider_event_id = discord_message_id_from_payload(frame)
-    if await pairing_command_event_was_handled(
+    if await channel_control_command_event_was_handled(
         db,
         account=account,
         external_chat_id=external_chat_id,
@@ -6729,19 +6856,20 @@ def _discord_command_payload(
         # byte-for-byte unchanged. Server-side interaction checks remain the
         # authority; this only makes Discord hide the commands by default from
         # guild members without MANAGE_GUILD.
-        payload["default_member_permissions"] = str(DISCORD_MANAGE_GUILD_PERMISSION)
-        if name == DISCORD_PAIR_COMMAND_NAME:
-            payload["description"] = (
-                "Pair this server or direct message with Clawdi."
-                if discord_user_install_is_supported(account)
-                else "Pair this server with Clawdi."
-            )
-        else:
-            payload["description"] = (
-                "Disconnect this server or direct message from Clawdi."
-                if discord_user_install_is_supported(account)
-                else "Disconnect this server from Clawdi."
-            )
+        if name in {DISCORD_PAIR_COMMAND_NAME, DISCORD_UNPAIR_COMMAND_NAME}:
+            payload["default_member_permissions"] = str(DISCORD_MANAGE_GUILD_PERMISSION)
+            if name == DISCORD_PAIR_COMMAND_NAME:
+                payload["description"] = (
+                    "Pair this server or direct message with Clawdi."
+                    if discord_user_install_is_supported(account)
+                    else "Pair this server with Clawdi."
+                )
+            else:
+                payload["description"] = (
+                    "Disconnect this server or direct message from Clawdi."
+                    if discord_user_install_is_supported(account)
+                    else "Disconnect this server from Clawdi."
+                )
         if global_command:
             # Guild Install is always configured. USER_INSTALL and BOT_DM are
             # included only after /applications/@me verified that the app

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1875,21 +1875,10 @@ async def lock_active_binding_authority(
     bot_agent_link_id: UUID,
 ) -> ChannelBinding | None:
     """Lock Account -> Link -> Binding authority through the caller's transaction."""
-    locked_account = (
-        await db.execute(
-            select(ChannelAccount)
-            .where(
-                ChannelAccount.id == account.id,
-                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
-                ChannelAccount.archived_at.is_(None),
-            )
-            .execution_options(populate_existing=True)
-            .with_for_update(read=True, of=ChannelAccount)
-        )
-    ).scalar_one_or_none()
+    locked_account = await _lock_active_account_authority(db, account_id=account.id)
     if locked_account is None:
         return None
-    link = await lock_active_link_authority(
+    link = await _lock_active_link_for_account(
         db,
         account=locked_account,
         bot_agent_link_id=bot_agent_link_id,
@@ -1919,11 +1908,26 @@ async def lock_active_link_authority(
     bot_agent_link_id: UUID,
 ) -> ChannelBotAgentLink | None:
     """Hold Account -> Link authority through the caller's transaction."""
-    locked_account = (
+    locked_account = await _lock_active_account_authority(db, account_id=account.id)
+    if locked_account is None:
+        return None
+    return await _lock_active_link_for_account(
+        db,
+        account=locked_account,
+        bot_agent_link_id=bot_agent_link_id,
+    )
+
+
+async def _lock_active_account_authority(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+) -> ChannelAccount | None:
+    return (
         await db.execute(
             select(ChannelAccount)
             .where(
-                ChannelAccount.id == account.id,
+                ChannelAccount.id == account_id,
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
             )
@@ -1931,15 +1935,21 @@ async def lock_active_link_authority(
             .with_for_update(read=True, of=ChannelAccount)
         )
     ).scalar_one_or_none()
-    if locked_account is None:
-        return None
+
+
+async def _lock_active_link_for_account(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+) -> ChannelBotAgentLink | None:
     return (
         await db.execute(
             select(ChannelBotAgentLink)
             .where(
                 ChannelBotAgentLink.id == bot_agent_link_id,
-                ChannelBotAgentLink.account_id == locked_account.id,
-                ChannelBotAgentLink.user_id == locked_account.user_id,
+                ChannelBotAgentLink.account_id == account.id,
+                ChannelBotAgentLink.user_id == account.user_id,
                 ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
                 ChannelBotAgentLink.archived_at.is_(None),
             )
@@ -2878,16 +2888,7 @@ async def channel_control_command_event_was_handled(
     command: ChannelControlCommand | None,
 ) -> bool:
     """Serialize control commands and reject a previously handled provider event."""
-    if (
-        provider_event_id is None
-        or command is None
-        or command.kind
-        not in {
-            "pair",
-            "unpair",
-            "help",
-        }
-    ):
+    if provider_event_id is None or command is None:
         return False
     # The same transaction-level scope lock is acquired again by
     # resolve_inbound_binding. Taking it before the event lookup closes the
@@ -5756,6 +5757,11 @@ async def send_whatsapp_message(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="chat is not paired with this agent link",
             )
+    elif await _lock_active_account_authority(db, account_id=account.id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="channel not found",
+        )
     provider_external_chat_id = (
         binding.external_chat_id if binding is not None else external_chat_id
     )

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -33,6 +33,7 @@ from app.models.channel import (
     ChannelBotAgentLink,
     ChannelWhatsAppAuthCert,
 )
+from app.services.channels import upsert_binding_alias
 from app.services.vault_crypto import decrypt, encrypt
 
 BinaryNode = dict[str, Any]
@@ -1473,7 +1474,11 @@ async def resolve_whatsapp_binding_by_jids(
         alias = await _find_binding_alias(db, account=account, alias_external_chat_id=candidate)
         if alias is not None:
             alias_binding = await db.get(ChannelBinding, alias.binding_id)
-            if alias_binding is not None and alias_binding.status == BINDING_STATUS_ACTIVE:
+            if (
+                alias_binding is not None
+                and alias_binding.account_id == account.id
+                and alias_binding.status == BINDING_STATUS_ACTIVE
+            ):
                 matches.append(alias_binding)
     unique_matches = list({binding.id: binding for binding in matches}.values())
     if len({binding.bot_agent_link_id for binding in unique_matches}) > 1:
@@ -1500,23 +1505,12 @@ async def remember_whatsapp_binding_aliases(
         )
         if direct is not None:
             continue
-        existing = await _find_binding_alias(
+        await upsert_binding_alias(
             db,
-            account_id=binding.account_id,
+            binding=binding,
             alias_external_chat_id=candidate,
-        )
-        if existing is not None:
-            if existing.binding_id == binding.id:
-                continue
-            return
-        db.add(
-            ChannelBindingAlias(
-                account_id=binding.account_id,
-                bot_agent_link_id=binding.bot_agent_link_id,
-                binding_id=binding.id,
-                user_id=binding.user_id,
-                alias_external_chat_id=candidate,
-            )
+            alias_kind="jid_alias",
+            require_same_binding=True,
         )
 
 

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -14,13 +14,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
-    BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_ACTIVE,
     PROVIDER_EVENT_SCOPE_ACCOUNT,
     ChannelAccount,
     ChannelBinding,
-    ChannelBotAgentLink,
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
@@ -29,10 +27,11 @@ from app.services.channels import (
     find_binding,
     find_existing_inbound_provider_event,
     lock_active_binding_authority,
-    parse_pair_command,
+    lock_active_link_authority,
+    parse_channel_control_command,
     record_inbound_messages_for_bindings,
     resolve_inbound_binding,
-    send_pairing_command_reply,
+    send_control_command_reply,
 )
 from app.services.whatsapp_baileys import (
     BinaryNode,
@@ -437,7 +436,7 @@ async def persist_whatsapp_provider_event(
         external_chat_type = existing_binding.external_chat_type
         external_chat_name = existing_binding.external_chat_name
     text = whatsapp_text_from_message_proto(event.message_proto)
-    command = parse_pair_command(text)
+    command = parse_channel_control_command(text)
     if await channel_control_command_event_was_handled(
         db,
         account=account,
@@ -480,7 +479,7 @@ async def persist_whatsapp_provider_event(
                 alt_jid=alt_jid,
             )
     await db.commit()
-    reply = await send_pairing_command_reply(
+    reply = await send_control_command_reply(
         db,
         account=account,
         external_chat_id=external_chat_id,
@@ -517,16 +516,13 @@ async def _active_link_owns_account(
     account_id: UUID,
     bot_agent_link_id: UUID,
 ) -> bool:
+    account = await db.get(ChannelAccount, account_id)
     return (
-        await db.scalar(
-            select(ChannelBotAgentLink.id)
-            .where(
-                ChannelBotAgentLink.id == bot_agent_link_id,
-                ChannelBotAgentLink.account_id == account_id,
-                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-                ChannelBotAgentLink.archived_at.is_(None),
-            )
-            .with_for_update(read=True, of=ChannelBotAgentLink)
+        account is not None
+        and await lock_active_link_authority(
+            db,
+            account=account,
+            bot_agent_link_id=bot_agent_link_id,
         )
         is not None
     )
@@ -692,6 +688,7 @@ async def _build_bound_jid_resolver(
     node: BinaryNode,
     bot_agent_link_id: UUID,
 ) -> Callable[[str], str | None]:
+    candidate_bindings: dict[str, ChannelBinding | None] = {}
     bindings: dict[UUID, ChannelBinding] = {}
     candidates = _node_target_jids(node)
     for candidate in candidates:
@@ -703,6 +700,7 @@ async def _build_bound_jid_resolver(
         )
         if binding is not None:
             bindings[binding.id] = binding
+        candidate_bindings[candidate] = binding
     authorized: dict[UUID, ChannelBinding] = {}
     for binding_id in sorted(bindings, key=str):
         binding = bindings[binding_id]
@@ -715,13 +713,7 @@ async def _build_bound_jid_resolver(
         if leased is not None:
             authorized[binding_id] = leased
     resolved: dict[str, str | None] = {}
-    for candidate in candidates:
-        binding = await find_binding(
-            db,
-            account=account,
-            external_chat_id=candidate,
-            bot_agent_link_id=bot_agent_link_id,
-        )
+    for candidate, binding in candidate_bindings.items():
         resolved[candidate] = (
             authorized[binding.id].external_chat_id
             if binding is not None and binding.id in authorized

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -19,13 +19,16 @@ from app.models.channel import (
     CHANNEL_STATUS_ACTIVE,
     PROVIDER_EVENT_SCOPE_ACCOUNT,
     ChannelAccount,
+    ChannelBinding,
     ChannelBotAgentLink,
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
+    channel_control_command_event_was_handled,
     enqueue_channel_outbound_message,
     find_binding,
     find_existing_inbound_provider_event,
+    lock_active_binding_authority,
     parse_pair_command,
     record_inbound_messages_for_bindings,
     resolve_inbound_binding,
@@ -100,6 +103,10 @@ class WhatsAppProviderTransport(Protocol):
 
 
 _PROVIDER_TRANSPORTS: dict[UUID, WhatsAppProviderTransport] = {}
+
+
+class WhatsAppProviderAccountRetired(Exception):
+    """The ingress owner is no longer active; reconciliation may reattach it."""
 
 
 def register_whatsapp_provider_transport(
@@ -337,14 +344,14 @@ class WhatsAppProviderBridge:
                 targets = _node_target_jids(node)
                 if not targets or any(resolve_jid(target) is None for target in targets):
                     return None
-        transport = self._transport()
-        if transport is None or self._forward_iq_inflight >= 5:
-            return None
-        self._forward_iq_inflight += 1
-        try:
-            return await forward_iq_over(_query_iq(transport), node)
-        finally:
-            self._forward_iq_inflight -= 1
+            transport = self._transport()
+            if transport is None or self._forward_iq_inflight >= 5:
+                return None
+            self._forward_iq_inflight += 1
+            try:
+                return await forward_iq_over(_query_iq(transport), node)
+            finally:
+                self._forward_iq_inflight -= 1
 
 
 async def relay_whatsapp_provider_payload(
@@ -431,6 +438,15 @@ async def persist_whatsapp_provider_event(
         external_chat_name = existing_binding.external_chat_name
     text = whatsapp_text_from_message_proto(event.message_proto)
     command = parse_pair_command(text)
+    if await channel_control_command_event_was_handled(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        provider_event_id=event.message_id,
+        provider_event_scope=PROVIDER_EVENT_SCOPE_ACCOUNT,
+        command=command,
+    ):
+        return
     external_user_id = event.participant or event.participant_alt
     if external_user_id is None and external_chat_type == "dm":
         external_user_id = route_jid
@@ -491,7 +507,7 @@ async def _load_active_whatsapp_account(
         )
     ).scalar_one_or_none()
     if account is None:
-        raise ValueError("whatsapp provider account is unavailable")
+        raise WhatsAppProviderAccountRetired
     return account
 
 
@@ -503,12 +519,14 @@ async def _active_link_owns_account(
 ) -> bool:
     return (
         await db.scalar(
-            select(ChannelBotAgentLink.id).where(
+            select(ChannelBotAgentLink.id)
+            .where(
                 ChannelBotAgentLink.id == bot_agent_link_id,
                 ChannelBotAgentLink.account_id == account_id,
                 ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
                 ChannelBotAgentLink.archived_at.is_(None),
             )
+            .with_for_update(read=True, of=ChannelBotAgentLink)
         )
         is not None
     )
@@ -674,15 +692,41 @@ async def _build_bound_jid_resolver(
     node: BinaryNode,
     bot_agent_link_id: UUID,
 ) -> Callable[[str], str | None]:
-    resolved: dict[str, str | None] = {}
-    for candidate in _node_target_jids(node):
+    bindings: dict[UUID, ChannelBinding] = {}
+    candidates = _node_target_jids(node)
+    for candidate in candidates:
         binding = await find_binding(
             db,
             account=account,
             external_chat_id=candidate,
             bot_agent_link_id=bot_agent_link_id,
         )
-        resolved[candidate] = binding.external_chat_id if binding is not None else None
+        if binding is not None:
+            bindings[binding.id] = binding
+    authorized: dict[UUID, ChannelBinding] = {}
+    for binding_id in sorted(bindings, key=str):
+        binding = bindings[binding_id]
+        leased = await lock_active_binding_authority(
+            db,
+            account=account,
+            binding=binding,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        if leased is not None:
+            authorized[binding_id] = leased
+    resolved: dict[str, str | None] = {}
+    for candidate in candidates:
+        binding = await find_binding(
+            db,
+            account=account,
+            external_chat_id=candidate,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        resolved[candidate] = (
+            authorized[binding.id].external_chat_id
+            if binding is not None and binding.id in authorized
+            else None
+        )
     return resolved.get
 
 

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -22,13 +22,12 @@ from app.models.channel import (
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
-    _lock_active_account_authority,
-    _lock_active_link_for_account,
     channel_control_command_event_was_handled,
     enqueue_channel_outbound_message,
     find_binding,
     find_existing_inbound_provider_event,
     lock_active_binding_authority,
+    lock_active_link_authority,
     parse_channel_control_command,
     record_inbound_messages_for_bindings,
     resolve_inbound_binding,
@@ -330,7 +329,7 @@ class WhatsAppProviderBridge:
             if _is_authorized_provider_service_iq(node):
                 if not await _active_link_owns_account(
                     db,
-                    account_id=account.id,
+                    account=account,
                     bot_agent_link_id=bot_agent_link_id,
                 ):
                     return None
@@ -514,16 +513,11 @@ async def _load_active_whatsapp_account(
 async def _active_link_owns_account(
     db: AsyncSession,
     *,
-    account_id: UUID,
+    account: ChannelAccount,
     bot_agent_link_id: UUID,
 ) -> bool:
-    account = await _lock_active_account_authority(db, account_id=account_id)
-    if account is None:
-        return False
     return (
-        await _lock_active_link_for_account(
-            db, account=account, bot_agent_link_id=bot_agent_link_id
-        )
+        await lock_active_link_authority(db, account=account, bot_agent_link_id=bot_agent_link_id)
         is not None
     )
 

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -22,12 +22,13 @@ from app.models.channel import (
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
+    _lock_active_account_authority,
+    _lock_active_link_for_account,
     channel_control_command_event_was_handled,
     enqueue_channel_outbound_message,
     find_binding,
     find_existing_inbound_provider_event,
     lock_active_binding_authority,
-    lock_active_link_authority,
     parse_channel_control_command,
     record_inbound_messages_for_bindings,
     resolve_inbound_binding,
@@ -516,13 +517,12 @@ async def _active_link_owns_account(
     account_id: UUID,
     bot_agent_link_id: UUID,
 ) -> bool:
-    account = await db.get(ChannelAccount, account_id)
+    account = await _lock_active_account_authority(db, account_id=account_id)
+    if account is None:
+        return False
     return (
-        account is not None
-        and await lock_active_link_authority(
-            db,
-            account=account,
-            bot_agent_link_id=bot_agent_link_id,
+        await _lock_active_link_for_account(
+            db, account=account, bot_agent_link_id=bot_agent_link_id
         )
         is not None
     )

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import async_session_factory
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_STATUS_ACTIVE,
     CHANNEL_VISIBILITY_PUBLIC,
     WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
     WHATSAPP_ONBOARDING_STATE_ERROR,
@@ -264,6 +265,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                         ChannelAccount.id.in_(self._managed),
                         ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
                         ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                        ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                         ChannelAccount.archived_at.is_(None),
                     )
                 )
@@ -355,6 +357,21 @@ class ConfiguredWhatsAppSidecarRegistry:
             unregister_whatsapp_provider_transport(account_id)
             raise
 
+    def _release_terminal_ingress_owner(
+        self,
+        account_id: UUID,
+        task: asyncio.Task[None] | None,
+    ) -> None:
+        """Release local ownership from inside a terminal pump without awaiting itself."""
+        if self._ingress_tasks.get(account_id) is not task:
+            return
+        self._ingress_tasks.pop(account_id, None)
+        unregister_whatsapp_provider_transport(account_id)
+        self._bound_managed_accounts.discard(account_id)
+        slot_id = self._custom_account_to_slot.pop(account_id, None)
+        if slot_id is not None:
+            self._custom_slot_to_account.pop(slot_id, None)
+
     async def reconcile_custom_ownership(self) -> None:
         """Rehydrate durable account mappings and fail closed on slot drift.
 
@@ -370,6 +387,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                         await db.scalars(
                             select(ChannelAccount).where(
                                 ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+                                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                                 ChannelAccount.archived_at.is_(None),
                             )
                         )
@@ -525,6 +543,10 @@ class ConfiguredWhatsAppSidecarRegistry:
             except asyncio.CancelledError:
                 raise
             except WhatsAppProviderAccountRetired:
+                self._release_terminal_ingress_owner(
+                    account_id,
+                    asyncio.current_task(),
+                )
                 return
             except Exception:
                 log.exception("WhatsApp provider ingress pump failed for account %s", account_id)

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -34,6 +34,7 @@ from app.services.whatsapp_native_transport import (
     validate_whatsapp_sidecar_base_url,
 )
 from app.services.whatsapp_provider_bridge import (
+    WhatsAppProviderAccountRetired,
     persist_whatsapp_provider_event,
     register_whatsapp_provider_transport,
     unregister_whatsapp_provider_transport,
@@ -523,6 +524,8 @@ class ConfiguredWhatsAppSidecarRegistry:
                     await client.acknowledge_provider_events(through_sequence=event.sequence)
             except asyncio.CancelledError:
                 raise
+            except WhatsAppProviderAccountRetired:
+                return
             except Exception:
                 log.exception("WhatsApp provider ingress pump failed for account %s", account_id)
                 await asyncio.sleep(1.0)

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -18,13 +18,33 @@ from app.models.channel import (
     ChannelMessage,
 )
 from app.models.user import User
-from app.services.channel_debug_events import record_channel_debug_event
+from app.services.channel_debug_events import (
+    public_channel_debug_details,
+    record_channel_debug_event,
+)
 from app.services.whatsapp_provider_bridge import (
     register_whatsapp_provider_transport,
     unregister_whatsapp_provider_transport,
 )
 
 pytestmark = pytest.mark.usefixtures("channel_agent")
+
+
+def test_public_channel_debug_details_allows_only_known_whatsapp_runtime_enums():
+    assert public_channel_debug_details("baileys_websocket", key="runtime") == ("baileys_websocket")
+    assert public_channel_debug_details("baileys_noise", key="runtime") == "baileys_noise"
+    assert public_channel_debug_details("provider-controlled", key="runtime") == "[redacted]"
+    assert (
+        public_channel_debug_details("server=s.whatsapp.net device=true", key="jidDescription")
+        == "server=s.whatsapp.net device=true"
+    )
+    assert (
+        public_channel_debug_details("server=secret.example device=true", key="jidDescription")
+        == "[redacted]"
+    )
+    digest = "a" * 64
+    assert public_channel_debug_details(digest, key="clientStaticSha256") == digest
+    assert public_channel_debug_details("not-a-digest", key="clientStaticSha256") == "[redacted]"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channel_retention.py
+++ b/backend/tests/test_channel_retention.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_DISABLED,
     DELIVERY_STATUS_FAILED,
     DELIVERY_STATUS_SUCCEEDED,
@@ -47,6 +48,7 @@ from app.services.channels import (
     prune_channel_retention_batch,
     send_discord_message,
     send_telegram_message,
+    send_whatsapp_message,
 )
 from app.services.metrics import render_metrics
 
@@ -114,7 +116,7 @@ async def _add_message(
 
 
 @pytest.mark.asyncio
-async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
+async def test_synchronous_retained_provider_outbound_is_terminal_on_record(
     db_session: AsyncSession,
     seed_user: User,
     channel_agent: AgentEnvironment,
@@ -134,6 +136,13 @@ async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
         provider=CHANNEL_PROVIDER_DISCORD,
         chat_id="discord-sync",
     )
+    whatsapp, _whatsapp_link, _whatsapp_binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        chat_id="whatsapp-sync",
+    )
 
     async def fake_telegram_send(**_kwargs):
         return "telegram-provider-message", {"ok": True}
@@ -141,8 +150,12 @@ async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
     async def fake_discord_send(**_kwargs):
         return "discord-provider-message", {"id": "discord-provider-message"}
 
+    async def fake_whatsapp_send(**_kwargs):
+        return "whatsapp-provider-message", {"secret": "must-not-be-retained"}
+
     monkeypatch.setattr(channel_service, "_send_telegram_provider_payload", fake_telegram_send)
     monkeypatch.setattr(channel_service, "_send_discord_provider_payload", fake_discord_send)
+    monkeypatch.setattr(channel_service, "_send_whatsapp_provider_payload", fake_whatsapp_send)
 
     telegram_message = await send_telegram_message(
         db_session,
@@ -156,6 +169,13 @@ async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
         account=discord,
         external_chat_id="discord-sync",
         text="discord delivered",
+        bind_to_existing=False,
+    )
+    whatsapp_message = await send_whatsapp_message(
+        db_session,
+        account=whatsapp,
+        external_chat_id="whatsapp-sync",
+        text="whatsapp delivered",
         bind_to_existing=False,
     )
     recorded_discord_message = await channel_service.record_discord_outbound_message(
@@ -172,6 +192,12 @@ async def test_synchronous_telegram_and_discord_outbound_are_terminal_on_record(
 
     assert telegram_message.delivered_at is not None
     assert discord_message.delivered_at is not None
+    assert whatsapp_message.delivered_at is not None
+    assert whatsapp_message.payload == {
+        "provider": "whatsapp",
+        "accepted": True,
+        "provider_message_id": "whatsapp-provider-message",
+    }
     assert recorded_discord_message.delivered_at is not None
 
 
@@ -186,7 +212,7 @@ async def test_queued_success_and_terminal_failure_prune_with_delivery_cascade(
         db_session,
         user=seed_user,
         agent=channel_agent,
-        provider=CHANNEL_PROVIDER_TELEGRAM,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
         chat_id="bound-chat",
     )
     succeeded_message, succeeded_delivery = await enqueue_channel_outbound_message(

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6746,6 +6746,7 @@ async def test_telegram_bot_commands_preserve_scope_language_and_delete(
     assert get_deleted_es.json()["result"] == [
         {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
         {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
     ]
 
 
@@ -7023,6 +7024,7 @@ async def test_telegram_repair_and_unpair_clear_previous_link_commands(
     assert second_get.json()["result"] == [
         {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
         {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
     ]
 
     second_commands = [{"command": "second", "description": "Second link"}]
@@ -14110,6 +14112,9 @@ def test_parse_pair_command_matches_strict_canonical_shapes():
     assert parse_pair_command("/clawdi_unpair").kind == "unpair"
     assert parse_pair_command("/clawdi_unpair@shared_bot").kind == "unpair"
     assert parse_pair_command("/clawdi_unpair now").kind == "unknown"
+    assert parse_pair_command("/clawdi_help").kind == "help"
+    assert parse_pair_command("/clawdi_help@shared_bot").kind == "help"
+    assert parse_pair_command("/clawdi_help now").kind == "unknown"
     assert parse_pair_command("/start BCDFGHJKLM").code == "BCDFGHJKLM"
     assert parse_pair_command("/start@shared_bot BCDFGHJKLM").code == "BCDFGHJKLM"
     # Pending codes issued before the shorter-code rollout remain claimable
@@ -14124,6 +14129,24 @@ def test_parse_pair_command_matches_strict_canonical_shapes():
     assert unknown is not None
     assert unknown.kind == "unknown"
     assert unknown.command == "/clawdi_foo"
+
+
+def test_channel_control_help_reply_is_shared_safe_plain_text(monkeypatch):
+    monkeypatch.setattr(channel_service.settings, "web_origin", "https://console.example.test/")
+    expected = (
+        "To connect this chat to an agent:\n"
+        "1. Open https://console.example.test.\n"
+        "2. Choose your agent, open Channels, and select Pair.\n"
+        "3. Send /clawdi_pair <code> here.\n\n"
+        "To disconnect this chat, send /clawdi_unpair."
+    )
+    command = channel_service.ChannelPairCommand(kind="help")
+    result = channel_service.InboundBindingResult(binding=None, command_handled=True)
+
+    assert channel_service.channel_control_help_reply() == expected
+    assert channel_service.pairing_reply_for_command(command, result) == expected
+    assert discord_pairing_reply_for_command(command, result, guild_id=None) == expected
+    assert discord_pairing_reply_for_command(command, result, guild_id="guild") == expected
 
 
 @pytest.mark.parametrize(
@@ -14341,6 +14364,7 @@ async def test_pair_code_concurrent_claim_is_single_use(
     [
         ("clawdi_pair", "pair"),
         ("clawdi_unpair", "unpair"),
+        ("clawdi_help", "help"),
     ],
 )
 def test_discord_interaction_parser_accepts_current_reserved_commands(
@@ -14352,7 +14376,9 @@ def test_discord_interaction_parser_accepts_current_reserved_commands(
             "type": 2,
             "data": {
                 "name": name,
-                "options": [{"name": "code", "value": "BCDFGHJKLM"}],
+                "options": (
+                    [{"name": "code", "value": "BCDFGHJKLM"}] if expected_kind == "pair" else []
+                ),
             },
         }
     )
@@ -16982,7 +17008,7 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
         )
     ).scalar_one()
     assert stale_alias.binding_id == binding_id
-    assert stale_alias.bot_agent_link_id == link_a_id
+    assert stale_alias.bot_agent_link_id == UUID(link_b_body["id"])
 
     _reset_fake_provider_client(
         {
@@ -18988,6 +19014,7 @@ async def test_telegram_command_sync_uses_set_my_commands(
     assert _FakeProviderClient.calls[0]["json"]["commands"] == [
         {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
         {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
     ]
 
 
@@ -19054,6 +19081,7 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
             ),
             ({"id": "810000000000000004", "name": "clawdi_pair", "type": 1}, 200),
             ({"id": "810000000000000005", "name": "clawdi_unpair", "type": 1}, 200),
+            ({"id": "810000000000000006", "name": "clawdi_help", "type": 1}, 200),
             ({}, 204),
             ({}, 204),
         ]
@@ -19088,6 +19116,7 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
         "GET",
         "PATCH",
         "GET",
+        "POST",
         "POST",
         "POST",
         "DELETE",
@@ -19129,8 +19158,9 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     assert [call["json"]["name"] for call in post_calls] == [
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     ]
-    pair_command, unpair_command = [call["json"] for call in post_calls]
+    pair_command, unpair_command, help_command = [call["json"] for call in post_calls]
     assert pair_command["default_member_permissions"] == "32"
     assert unpair_command["default_member_permissions"] == "32"
     assert pair_command["integration_types"] == [0, 1]
@@ -19141,6 +19171,8 @@ async def test_discord_pair_preparation_configures_endpoint_then_global_commands
     assert unpair_command["description"] == (
         "Disconnect this server or direct message from Clawdi."
     )
+    assert "default_member_permissions" not in help_command
+    assert help_command["description"] == "Show safe Clawdi pairing instructions."
     install_url = pair.json()["discord_install_url"]
     assert install_url == (
         "https://discord.com/oauth2/authorize"
@@ -19268,9 +19300,11 @@ async def test_discord_existing_account_reconciles_reserved_commands_before_pair
         "GET",
         "POST",
         "POST",
+        "POST",
         "DELETE",
         "DELETE",
         "GET",
+        "POST",
         "POST",
         "POST",
         "DELETE",
@@ -19293,6 +19327,7 @@ async def test_discord_existing_account_reconciles_reserved_commands_before_pair
         "runtime_status",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
     assert {
         command["name"] for command in _StatefulDiscordCommandClient.commands_by_path[guild_path]
@@ -19300,6 +19335,7 @@ async def test_discord_existing_account_reconciles_reserved_commands_before_pair
         "guild_runtime",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
@@ -19314,7 +19350,7 @@ async def test_discord_existing_account_reconciles_reserved_commands_before_pair
     )
 
     assert second_pair.status_code == 201, second_pair.text
-    assert len(_StatefulDiscordCommandClient.calls) == 10
+    assert len(_StatefulDiscordCommandClient.calls) == 12
 
 
 @pytest.mark.asyncio
@@ -19467,6 +19503,7 @@ async def test_discord_reserved_delete_not_found_is_idempotent_success(
         "GET",
         "POST",
         "POST",
+        "POST",
         "DELETE",
         "DELETE",
     ]
@@ -19476,6 +19513,7 @@ async def test_discord_reserved_delete_not_found_is_idempotent_success(
         "runtime_status",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
@@ -19549,6 +19587,7 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
         "GET",
         "POST",
         "POST",
+        "POST",
         "DELETE",
     ]
     assert {
@@ -19559,6 +19598,7 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
         "bot_unpair",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
@@ -19580,8 +19620,9 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
     )
 
     assert converged_pair.status_code == 201, converged_pair.text
-    assert [call["method"] for call in _StatefulDiscordCommandClient.calls[4:]] == [
+    assert [call["method"] for call in _StatefulDiscordCommandClient.calls[5:]] == [
         "GET",
+        "POST",
         "POST",
         "POST",
         "DELETE",
@@ -19593,6 +19634,7 @@ async def test_discord_reserved_delete_failure_retries_to_convergence(
         "runtime_status",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
     await db_session.refresh(account)
     assert (
@@ -19623,6 +19665,7 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
             ),
             ({"id": "850000000000000003", "name": "clawdi_pair", "type": 1}, 200),
             ({"id": "850000000000000004", "name": "clawdi_unpair", "type": 1}, 200),
+            ({"id": "850000000000000005", "name": "clawdi_help", "type": 1}, 200),
             ({}, 204),
             ({}, 204),
             ({"message": "rate limited", "retry_after": 0}, 429),
@@ -19657,6 +19700,7 @@ async def test_discord_reserved_command_version_waits_for_global_and_guild_succe
     assert pair.headers["Retry-After"] == "0"
     assert [call["method"] for call in _DiscordPreparationProviderClient.calls] == [
         "GET",
+        "POST",
         "POST",
         "POST",
         "DELETE",
@@ -19897,6 +19941,7 @@ async def test_discord_default_command_sync_reconciles_only_reserved_commands(
         "GET",
         "POST",
         "POST",
+        "POST",
         "DELETE",
         "DELETE",
     ]
@@ -19915,7 +19960,7 @@ async def test_discord_default_command_sync_reconciles_only_reserved_commands(
     assert all("840000000000000001" not in call["url"] for call in delete_calls)
     post_calls = [call for call in _StatefulDiscordCommandClient.calls if call["method"] == "POST"]
     assert all(call["headers"]["Authorization"] == "Bot discord-token" for call in post_calls)
-    pair_command, unpair_command = [call["json"] for call in post_calls]
+    pair_command, unpair_command, help_command = [call["json"] for call in post_calls]
     assert pair_command["name"] == "clawdi_pair"
     assert pair_command["default_member_permissions"] == "32"
     assert pair_command["options"][0]["name"] == "code"
@@ -19925,12 +19970,15 @@ async def test_discord_default_command_sync_reconciles_only_reserved_commands(
     assert unpair_command["default_member_permissions"] == "32"
     assert "integration_types" not in unpair_command
     assert "contexts" not in unpair_command
+    assert help_command["name"] == "clawdi_help"
+    assert "default_member_permissions" not in help_command
     assert {
         command["name"] for command in _StatefulDiscordCommandClient.commands_by_path[guild_path]
     } == {
         "guild_runtime",
         "clawdi_pair",
         "clawdi_unpair",
+        "clawdi_help",
     }
 
 
@@ -19964,7 +20012,14 @@ async def test_discord_default_command_sync_handles_network_failure(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "name",
-    ["bot_pair", "bot_unpair", "bot_status", "clawdi_pair", "clawdi_unpair"],
+    [
+        "bot_pair",
+        "bot_unpair",
+        "bot_status",
+        "clawdi_pair",
+        "clawdi_unpair",
+        "clawdi_help",
+    ],
 )
 async def test_discord_custom_command_sync_rejects_reserved_names(
     client: httpx.AsyncClient,
@@ -21288,6 +21343,7 @@ async def test_discord_guild_only_install_capability_stays_guild_only(
             ([], 200),
             ({"id": "910000000000000001", "name": "clawdi_pair", "type": 1}, 200),
             ({"id": "910000000000000002", "name": "clawdi_unpair", "type": 1}, 200),
+            ({"id": "910000000000000003", "name": "clawdi_help", "type": 1}, 200),
         ]
     )
     monkeypatch.setattr(channel_service.httpx, "AsyncClient", _DiscordPreparationProviderClient)
@@ -21327,7 +21383,7 @@ async def test_discord_guild_only_install_capability_stays_guild_only(
     post_calls = [
         call for call in _DiscordPreparationProviderClient.calls if call["method"] == "POST"
     ]
-    assert len(post_calls) == 2
+    assert len(post_calls) == 3
     for call in post_calls:
         assert call["json"]["integration_types"] == [0]
         assert call["json"]["contexts"] == [0]

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -85,15 +85,15 @@ from app.services.channels import (
     channel_runtime_account_key,
     channel_runtime_placeholder_token,
     decrypt_agent_link_token,
-    discord_pair_command_from_payload,
-    discord_pairing_reply_for_command,
+    discord_control_command_from_payload,
+    discord_control_reply_for_command,
     encrypt_optional_token,
     extract_discord_routing_key,
     generate_agent_token,
     generate_pair_code,
     hash_token,
     normalize_telegram_bot_username,
-    parse_pair_command,
+    parse_channel_control_command,
     record_discord_dispatch,
     send_provider_outbound_payload,
     telegram_direct_messages_topic_id_from_update,
@@ -14103,29 +14103,29 @@ async def test_telegram_webhook_rejects_invalid_secret(client: httpx.AsyncClient
     assert response.status_code == 401
 
 
-def test_parse_pair_command_matches_strict_canonical_shapes():
-    assert parse_pair_command("/clawdi_pair ABCDEF1234").code == "ABCDEF1234"
-    assert parse_pair_command("/clawdi_pair@shared_bot ABC123").code == "ABC123"
-    assert parse_pair_command("/clawdi_pair ABC123 thanks").code == ""
-    assert parse_pair_command("/clawdi_pair ABC123\n•").code == ""
-    assert parse_pair_command("/clawdi_pair").code == ""
-    assert parse_pair_command("/clawdi_unpair").kind == "unpair"
-    assert parse_pair_command("/clawdi_unpair@shared_bot").kind == "unpair"
-    assert parse_pair_command("/clawdi_unpair now").kind == "unknown"
-    assert parse_pair_command("/clawdi_help").kind == "help"
-    assert parse_pair_command("/clawdi_help@shared_bot").kind == "help"
-    assert parse_pair_command("/clawdi_help now").kind == "unknown"
-    assert parse_pair_command("/start BCDFGHJKLM").code == "BCDFGHJKLM"
-    assert parse_pair_command("/start@shared_bot BCDFGHJKLM").code == "BCDFGHJKLM"
+def test_parse_channel_control_command_matches_strict_canonical_shapes():
+    assert parse_channel_control_command("/clawdi_pair ABCDEF1234").code == "ABCDEF1234"
+    assert parse_channel_control_command("/clawdi_pair@shared_bot ABC123").code == "ABC123"
+    assert parse_channel_control_command("/clawdi_pair ABC123 thanks").code == ""
+    assert parse_channel_control_command("/clawdi_pair ABC123\n•").code == ""
+    assert parse_channel_control_command("/clawdi_pair").code == ""
+    assert parse_channel_control_command("/clawdi_unpair").kind == "unpair"
+    assert parse_channel_control_command("/clawdi_unpair@shared_bot").kind == "unpair"
+    assert parse_channel_control_command("/clawdi_unpair now").kind == "unknown"
+    assert parse_channel_control_command("/clawdi_help").kind == "help"
+    assert parse_channel_control_command("/clawdi_help@shared_bot").kind == "help"
+    assert parse_channel_control_command("/clawdi_help now").kind == "unknown"
+    assert parse_channel_control_command("/start BCDFGHJKLM").code == "BCDFGHJKLM"
+    assert parse_channel_control_command("/start@shared_bot BCDFGHJKLM").code == "BCDFGHJKLM"
     # Pending codes issued before the shorter-code rollout remain claimable
     # through Telegram deep links until their stored expiry.
-    assert parse_pair_command("/start PAIRABCDEF1234").code == "PAIRABCDEF1234"
-    assert parse_pair_command("/start PAIRABCDEF1234 thanks") is None
-    assert parse_pair_command("/start OLD_PAIR_CODE") is None
-    assert parse_pair_command("/start") is None
-    assert parse_pair_command("hello world") is None
+    assert parse_channel_control_command("/start PAIRABCDEF1234").code == "PAIRABCDEF1234"
+    assert parse_channel_control_command("/start PAIRABCDEF1234 thanks") is None
+    assert parse_channel_control_command("/start OLD_PAIR_CODE") is None
+    assert parse_channel_control_command("/start") is None
+    assert parse_channel_control_command("hello world") is None
 
-    unknown = parse_pair_command("/clawdi_foo bar")
+    unknown = parse_channel_control_command("/clawdi_foo bar")
     assert unknown is not None
     assert unknown.kind == "unknown"
     assert unknown.command == "/clawdi_foo"
@@ -14140,13 +14140,13 @@ def test_channel_control_help_reply_is_shared_safe_plain_text(monkeypatch):
         "3. Send /clawdi_pair <code> here.\n\n"
         "To disconnect this chat, send /clawdi_unpair."
     )
-    command = channel_service.ChannelPairCommand(kind="help")
+    command = channel_service.ChannelControlCommand(kind="help")
     result = channel_service.InboundBindingResult(binding=None, command_handled=True)
 
     assert channel_service.channel_control_help_reply() == expected
     assert channel_service.pairing_reply_for_command(command, result) == expected
-    assert discord_pairing_reply_for_command(command, result, guild_id=None) == expected
-    assert discord_pairing_reply_for_command(command, result, guild_id="guild") == expected
+    assert discord_control_reply_for_command(command, result, guild_id=None) == expected
+    assert discord_control_reply_for_command(command, result, guild_id="guild") == expected
 
 
 @pytest.mark.parametrize(
@@ -14158,8 +14158,8 @@ def test_channel_control_help_reply_is_shared_safe_plain_text(monkeypatch):
         "/bot_unpair@shared_bot",
     ],
 )
-def test_parse_pair_command_rejects_legacy_aliases(text: str):
-    assert parse_pair_command(text) is None
+def test_parse_channel_control_command_rejects_legacy_aliases(text: str):
+    assert parse_channel_control_command(text) is None
 
 
 def test_generate_pair_code_uses_unambiguous_50_bit_shape_and_varies():
@@ -14371,7 +14371,7 @@ def test_discord_interaction_parser_accepts_current_reserved_commands(
     name: str,
     expected_kind: str,
 ):
-    command = discord_pair_command_from_payload(
+    command = discord_control_command_from_payload(
         {
             "type": 2,
             "data": {
@@ -14391,7 +14391,7 @@ def test_discord_interaction_parser_accepts_current_reserved_commands(
 @pytest.mark.parametrize("name", ["bot_pair", "bot_unpair", "pair", "unpair"])
 def test_discord_interaction_parser_rejects_legacy_and_generic_commands(name: str):
     assert (
-        discord_pair_command_from_payload(
+        discord_control_command_from_payload(
             {
                 "type": 2,
                 "data": {
@@ -14406,27 +14406,29 @@ def test_discord_interaction_parser_rejects_legacy_and_generic_commands(name: st
 
 @pytest.mark.parametrize("content", ["/bot_pair BCDFGHJKLM", "/bot_unpair"])
 def test_discord_message_parser_rejects_legacy_text_commands(content: str):
-    assert discord_pair_command_from_payload({"d": {"content": content}}) is None
+    assert discord_control_command_from_payload({"d": {"content": content}}) is None
 
 
 def test_discord_message_parser_requires_slash_for_current_commands():
-    current = discord_pair_command_from_payload({"d": {"content": "/clawdi_pair BCDFGHJKLM"}})
+    current = discord_control_command_from_payload({"d": {"content": "/clawdi_pair BCDFGHJKLM"}})
 
     assert current is not None
     assert current.kind == "pair"
     assert current.code == "BCDFGHJKLM"
-    assert discord_pair_command_from_payload({"d": {"content": "clawdi_pair BCDFGHJKLM"}}) is None
-    assert discord_pair_command_from_payload({"d": {"content": "clawdi_unpair"}}) is None
+    assert (
+        discord_control_command_from_payload({"d": {"content": "clawdi_pair BCDFGHJKLM"}}) is None
+    )
+    assert discord_control_command_from_payload({"d": {"content": "clawdi_unpair"}}) is None
 
 
 def test_discord_unknown_command_reply_uses_only_current_reserved_commands():
-    reply = discord_pairing_reply_for_command(
-        channel_service.ChannelPairCommand(kind="unknown", command="/clawdi_unpair"),
+    reply = discord_control_reply_for_command(
+        channel_service.ChannelControlCommand(kind="unknown", command="/clawdi_unpair"),
         channel_service.InboundBindingResult(binding=None, command_handled=True),
         guild_id="guild-1",
     )
 
-    assert reply == ("Unknown command: /clawdi_unpair. Use /clawdi_pair <code> or /clawdi_unpair.")
+    assert reply == "Unknown command: /clawdi_unpair. Use /clawdi_help for instructions."
     assert "/bot_" not in reply
 
 
@@ -20246,7 +20248,7 @@ def test_discord_pair_install_contract_requires_matching_context_and_owner(
     external_user_id: str,
     expected: str | None,
 ) -> None:
-    command = channel_service.ChannelPairCommand(kind="pair", code="BCDFGHJKLM")
+    command = channel_service.ChannelControlCommand(kind="pair", code="BCDFGHJKLM")
 
     assert (
         channel_service.discord_pair_install_denied_reason(

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -670,6 +670,105 @@ async def test_whatsapp_direct_outbound_holds_authority_until_provider_io_finish
 
 
 @pytest.mark.asyncio
+async def test_whatsapp_account_only_send_holds_authority_until_provider_io_finishes(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, _link, binding = await _seed_whatsapp_link_and_binding(
+        client, db_session, channel_agent, name="wa-account-only-authority-barrier"
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    io_started = asyncio.Event()
+    release_io = asyncio.Event()
+
+    async def blocked_provider(**_kwargs):
+        io_started.set()
+        await release_io.wait()
+        return "provider-message", {}
+
+    monkeypatch.setattr("app.services.channels._send_whatsapp_provider_payload", blocked_provider)
+
+    async def send() -> None:
+        async with sessionmaker() as db:
+            current_account = await db.get(ChannelAccount, account.id)
+            assert current_account is not None
+            await send_whatsapp_message(
+                db,
+                account=current_account,
+                external_chat_id=binding.external_chat_id,
+                text="control reply",
+                bind_to_existing=False,
+            )
+            await db.commit()
+
+    send_task = asyncio.create_task(send())
+    await asyncio.wait_for(io_started.wait(), timeout=1)
+    async with sessionmaker() as mutation_db:
+        mutation = asyncio.create_task(
+            mutation_db.execute(
+                select(ChannelAccount).where(ChannelAccount.id == account.id).with_for_update()
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert mutation.done() is False
+        release_io.set()
+        await send_task
+        locked_account = (await mutation).scalar_one()
+        locked_account.status = "disabled"
+        await mutation_db.commit()
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_account_retirement_wins_before_account_only_send_io(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, _link, binding = await _seed_whatsapp_link_and_binding(
+        client, db_session, channel_agent, name="wa-account-retirement-wins"
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    provider_calls = 0
+
+    async def provider(**_kwargs):
+        nonlocal provider_calls
+        provider_calls += 1
+        return "provider-message", {}
+
+    monkeypatch.setattr("app.services.channels._send_whatsapp_provider_payload", provider)
+    async with sessionmaker() as mutation_db:
+        locked_account = (
+            await mutation_db.execute(
+                select(ChannelAccount).where(ChannelAccount.id == account.id).with_for_update()
+            )
+        ).scalar_one()
+        locked_account.status = "disabled"
+
+        async def send() -> None:
+            async with sessionmaker() as send_db:
+                stale_account = await send_db.get(ChannelAccount, account.id)
+                assert stale_account is not None
+                await send_whatsapp_message(
+                    send_db,
+                    account=stale_account,
+                    external_chat_id=binding.external_chat_id,
+                    text="control reply",
+                    bind_to_existing=False,
+                )
+
+        send_task = asyncio.create_task(send())
+        await asyncio.sleep(0.05)
+        assert provider_calls == 0
+        await mutation_db.commit()
+        with pytest.raises(HTTPException, match="channel not found"):
+            await send_task
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_whatsapp_link_retirement_wins_before_direct_io_and_provider_is_not_called(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -965,15 +1064,35 @@ async def test_whatsapp_unpaired_traffic_is_silent_and_replayed_command_replies_
                     )
 
             await asyncio.gather(consume_help(), consume_help())
+
+        unknown = event(
+            6,
+            "unknown-control",
+            "15550001111@s.whatsapp.net",
+            "/clawdi_unknown",
+        )
+
+        async def consume_unknown() -> None:
+            async with sessionmaker() as db:
+                await persist_whatsapp_provider_event(
+                    db,
+                    account_id=account.id,
+                    event=unknown,
+                )
+
+        await asyncio.gather(consume_unknown(), consume_unknown())
     finally:
         unregister_whatsapp_provider_transport(account.id)
 
-    assert len(transport.outbound_messages) == 3
+    assert len(transport.outbound_messages) == 4
     assert transport.outbound_messages[0].conversation == "This chat is not paired."
-    assert [message.conversation for message in transport.outbound_messages[1:]] == [
+    assert [message.conversation for message in transport.outbound_messages[1:3]] == [
         channel_control_help_reply(),
         channel_control_help_reply(),
     ]
+    assert transport.outbound_messages[3].conversation == (
+        "Unknown command: /clawdi_unknown. Use /clawdi_help for instructions."
+    )
     await db_session.rollback()
     command_messages = list(
         (
@@ -987,6 +1106,18 @@ async def test_whatsapp_unpaired_traffic_is_silent_and_replayed_command_replies_
     )
     assert len(command_messages) == 1
     assert command_messages[0].delivered_at is not None
+    unknown_messages = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.provider_event_id == "unknown-control",
+                )
+            )
+        ).scalars()
+    )
+    assert len(unknown_messages) == 1
+    assert unknown_messages[0].delivered_at is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -26,6 +26,7 @@ from app.models.channel import (
 )
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channels import (
+    archive_bot_agent_link,
     channel_control_help_reply,
     enqueue_channel_outbound_message,
     generate_agent_token,
@@ -603,6 +604,226 @@ async def test_whatsapp_replacement_binding_refreshes_alias_authority_before_io(
         remote_jid=alias_jid,
     )
     assert drifted.binding is None
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_direct_outbound_holds_authority_until_provider_io_finishes(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, link, binding = await _seed_whatsapp_link_and_binding(
+        client, db_session, channel_agent, name="wa-direct-authority-barrier"
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    io_started = asyncio.Event()
+    release_io = asyncio.Event()
+
+    async def blocked_provider(**_kwargs):
+        io_started.set()
+        await release_io.wait()
+        return "provider-message", {}
+
+    monkeypatch.setattr(
+        "app.services.channels._send_whatsapp_provider_payload",
+        blocked_provider,
+    )
+
+    async def send() -> None:
+        async with sessionmaker() as db:
+            current_account = await db.get(ChannelAccount, account.id)
+            assert current_account is not None
+            await send_whatsapp_message(
+                db,
+                account=current_account,
+                external_chat_id=binding.external_chat_id,
+                text="leased",
+                bot_agent_link_id=link.id,
+            )
+            await db.commit()
+
+    async def archive() -> None:
+        async with sessionmaker() as db:
+            current_account = (
+                await db.execute(
+                    select(ChannelAccount).where(ChannelAccount.id == account.id).with_for_update()
+                )
+            ).scalar_one()
+            current_link = (
+                await db.execute(
+                    select(ChannelBotAgentLink)
+                    .where(ChannelBotAgentLink.id == link.id)
+                    .with_for_update()
+                )
+            ).scalar_one()
+            await archive_bot_agent_link(db, link=current_link, account=current_account)
+            await db.commit()
+
+    send_task = asyncio.create_task(send())
+    await asyncio.wait_for(io_started.wait(), timeout=1)
+    archive_task = asyncio.create_task(archive())
+    await asyncio.sleep(0.05)
+    assert archive_task.done() is False
+    release_io.set()
+    await asyncio.gather(send_task, archive_task)
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_link_retirement_wins_before_direct_io_and_provider_is_not_called(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, link, binding = await _seed_whatsapp_link_and_binding(
+        client, db_session, channel_agent, name="wa-retirement-wins-barrier"
+    )
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    provider_calls = 0
+
+    async def provider(**_kwargs):
+        nonlocal provider_calls
+        provider_calls += 1
+        return "provider-message", {}
+
+    monkeypatch.setattr("app.services.channels._send_whatsapp_provider_payload", provider)
+    async with sessionmaker() as mutation_db:
+        current_account = (
+            await mutation_db.execute(
+                select(ChannelAccount).where(ChannelAccount.id == account.id).with_for_update()
+            )
+        ).scalar_one()
+        current_link = (
+            await mutation_db.execute(
+                select(ChannelBotAgentLink)
+                .where(ChannelBotAgentLink.id == link.id)
+                .with_for_update()
+            )
+        ).scalar_one()
+        await archive_bot_agent_link(
+            mutation_db,
+            link=current_link,
+            account=current_account,
+        )
+
+        async def send() -> None:
+            async with sessionmaker() as send_db:
+                stale_account = await send_db.get(ChannelAccount, account.id)
+                assert stale_account is not None
+                await send_whatsapp_message(
+                    send_db,
+                    account=stale_account,
+                    external_chat_id=binding.external_chat_id,
+                    text="denied",
+                    bot_agent_link_id=link.id,
+                )
+
+        send_task = asyncio.create_task(send())
+        await asyncio.sleep(0.05)
+        assert provider_calls == 0
+        await mutation_db.commit()
+        with pytest.raises(HTTPException, match="not paired"):
+            await send_task
+    assert provider_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["raw", "iq", "service_iq"])
+async def test_whatsapp_protocol_io_holds_binding_authority_lease(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    operation: str,
+):
+    account, link, binding = await _seed_whatsapp_link_and_binding(
+        client, db_session, channel_agent, name=f"wa-{operation}-authority-barrier"
+    )
+    io_started = asyncio.Event()
+    release_io = asyncio.Event()
+
+    class BlockingTransport(_FakeProviderTransport):
+        async def relay_raw_node(self, node):
+            io_started.set()
+            await release_io.wait()
+            await super().relay_raw_node(node)
+
+        async def query_iq(self, node, timeout_ms):
+            io_started.set()
+            await release_io.wait()
+            return await super().query_iq(node, timeout_ms)
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    bridge = WhatsAppProviderBridge(
+        sessionmaker,
+        account_id=account.id,
+        transport=BlockingTransport(),
+    )
+
+    async def perform_io() -> None:
+        if operation == "raw":
+            result = await bridge.relay_raw_node(
+                {"tag": "presence", "attrs": {"to": binding.external_chat_id}},
+                lambda _id: None,
+                bot_agent_link_id=link.id,
+            )
+            assert result.outcome == "relayed"
+        elif operation == "iq":
+            result = await bridge.forward_iq(
+                {
+                    "tag": "iq",
+                    "attrs": {
+                        "id": "leased-iq",
+                        "xmlns": "w",
+                        "type": "get",
+                        "to": binding.external_chat_id,
+                    },
+                },
+                tenant_id=str(link.id),
+                bot_agent_link_id=link.id,
+            )
+            assert result is not None
+        else:
+            result = await bridge.forward_iq(
+                {
+                    "tag": "iq",
+                    "attrs": {
+                        "id": "leased-service-iq",
+                        "xmlns": "privacy",
+                        "type": "get",
+                        "to": "s.whatsapp.net",
+                    },
+                    "content": [{"tag": "privacy", "attrs": {}}],
+                },
+                tenant_id=str(link.id),
+                bot_agent_link_id=link.id,
+            )
+            assert result is not None
+
+    async def archive() -> None:
+        async with sessionmaker() as db:
+            current_account = (
+                await db.execute(
+                    select(ChannelAccount).where(ChannelAccount.id == account.id).with_for_update()
+                )
+            ).scalar_one()
+            current_link = (
+                await db.execute(
+                    select(ChannelBotAgentLink)
+                    .where(ChannelBotAgentLink.id == link.id)
+                    .with_for_update()
+                )
+            ).scalar_one()
+            await archive_bot_agent_link(db, link=current_link, account=current_account)
+            await db.commit()
+
+    io_task = asyncio.create_task(perform_io())
+    await asyncio.wait_for(io_started.wait(), timeout=1)
+    archive_task = asyncio.create_task(archive())
+    await asyncio.sleep(0.05)
+    assert archive_task.done() is False
+    release_io.set()
+    await asyncio.gather(io_task, archive_task)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import base64
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -11,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
+    BINDING_STATUS_ARCHIVED,
     MESSAGE_DIRECTION_INBOUND,
     MESSAGE_DIRECTION_OUTBOUND,
     ChannelAccount,
@@ -19,10 +22,22 @@ from app.models.channel import (
     ChannelBotAgentLink,
     ChannelDelivery,
     ChannelMessage,
+    ChannelPairCode,
 )
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
-from app.services.channels import generate_agent_token, store_agent_link_token
-from app.services.whatsapp_baileys import whatsapp_text_message_proto
+from app.services.channels import (
+    channel_control_help_reply,
+    enqueue_channel_outbound_message,
+    generate_agent_token,
+    hash_token,
+    send_whatsapp_message,
+    store_agent_link_token,
+)
+from app.services.whatsapp_baileys import (
+    remember_whatsapp_binding_aliases,
+    resolve_whatsapp_binding_by_jids,
+    whatsapp_text_message_proto,
+)
 from app.services.whatsapp_native_transport import WhatsAppProviderMessageEvent
 from app.services.whatsapp_noise import WhatsAppOutboundMessage
 from app.services.whatsapp_provider_bridge import (
@@ -459,6 +474,138 @@ async def test_whatsapp_provider_bridge_authorizes_raw_nodes_and_bounded_iq(
 
 
 @pytest.mark.asyncio
+async def test_whatsapp_replacement_binding_refreshes_alias_authority_before_io(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, old_link, old_binding = await _seed_whatsapp_link_and_binding(
+        client,
+        db_session,
+        channel_agent,
+        name="wa-replacement-authority",
+    )
+    alias_jid = "7826185388106@lid"
+    alias = ChannelBindingAlias(
+        account_id=account.id,
+        bot_agent_link_id=old_link.id,
+        binding_id=old_binding.id,
+        user_id=old_binding.user_id,
+        alias_external_chat_id=alias_jid,
+    )
+    db_session.add(alias)
+    old_binding.status = BINDING_STATUS_ARCHIVED
+    new_link = ChannelBotAgentLink(
+        account_id=account.id,
+        user_id=account.user_id,
+        agent_id=second_channel_agent.id,
+    )
+    store_agent_link_token(new_link, generate_agent_token("whatsapp"))
+    db_session.add(new_link)
+    await db_session.flush()
+    new_binding = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=new_link.id,
+        user_id=account.user_id,
+        external_chat_id=old_binding.external_chat_id,
+        external_chat_type="dm",
+        external_chat_name="Alice",
+    )
+    db_session.add(new_binding)
+    await db_session.flush()
+    await remember_whatsapp_binding_aliases(
+        db_session,
+        binding=new_binding,
+        remote_jid=alias_jid,
+        alt_jid=new_binding.external_chat_id,
+    )
+    await db_session.commit()
+    await db_session.refresh(alias)
+    assert alias.binding_id == new_binding.id
+    assert alias.bot_agent_link_id == new_link.id
+
+    transport = _FakeProviderTransport()
+    bridge = WhatsAppProviderBridge(
+        async_sessionmaker(db_session.bind, expire_on_commit=False),
+        account_id=account.id,
+        transport=transport,
+    )
+    raw = {"tag": "presence", "attrs": {"to": alias_jid}}
+    old_raw = await bridge.relay_raw_node(raw, lambda _id: None, bot_agent_link_id=old_link.id)
+    new_raw = await bridge.relay_raw_node(raw, lambda _id: None, bot_agent_link_id=new_link.id)
+    old_iq = await bridge.forward_iq(
+        {"tag": "iq", "attrs": {"id": "old", "xmlns": "w", "type": "get", "to": alias_jid}},
+        tenant_id=str(old_link.id),
+        bot_agent_link_id=old_link.id,
+    )
+    new_iq = await bridge.forward_iq(
+        {"tag": "iq", "attrs": {"id": "new", "xmlns": "w", "type": "get", "to": alias_jid}},
+        tenant_id=str(new_link.id),
+        bot_agent_link_id=new_link.id,
+    )
+    assert old_raw.outcome == "dropped"
+    assert new_raw.outcome == "relayed"
+    assert old_iq is None
+    assert new_iq is not None
+
+    queued, _delivery = await enqueue_channel_outbound_message(
+        db_session,
+        account=account,
+        external_chat_id=alias_jid,
+        text="queued",
+        bot_agent_link_id=new_link.id,
+    )
+    assert queued.external_chat_id == new_binding.external_chat_id
+
+    provider_calls: list[str] = []
+
+    async def fake_provider_payload(*, account, external_chat_id, text, provider_payload=None):
+        provider_calls.append(external_chat_id)
+        return "provider-message", {}
+
+    monkeypatch.setattr(
+        "app.services.channels._send_whatsapp_provider_payload",
+        fake_provider_payload,
+    )
+    with pytest.raises(HTTPException, match="not paired"):
+        await send_whatsapp_message(
+            db_session,
+            account=account,
+            external_chat_id=alias_jid,
+            text="denied",
+            bot_agent_link_id=old_link.id,
+        )
+    assert provider_calls == []
+    sent = await send_whatsapp_message(
+        db_session,
+        account=account,
+        external_chat_id=alias_jid,
+        text="allowed",
+        bot_agent_link_id=new_link.id,
+    )
+    assert provider_calls == [new_binding.external_chat_id]
+    assert sent.external_chat_id == new_binding.external_chat_id
+
+    other_response = await client.post(
+        "/v1/channels",
+        json={"provider": "whatsapp", "name": "wa-cross-account-alias-drift"},
+    )
+    assert other_response.status_code == 201
+    other_account = await db_session.get(ChannelAccount, UUID(other_response.json()["id"]))
+    assert other_account is not None
+    alias.account_id = other_account.id
+    await db_session.commit()
+    drifted = await resolve_whatsapp_binding_by_jids(
+        db_session,
+        account=other_account,
+        remote_jid=alias_jid,
+    )
+    assert drifted.binding is None
+
+
+@pytest.mark.asyncio
 async def test_whatsapp_provider_ingress_preserves_proto_aliases_and_account_dedupe(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -523,3 +670,200 @@ async def test_whatsapp_provider_ingress_preserves_proto_aliases_and_account_ded
         )
     )
     assert duplicate_count == 1
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_unpaired_traffic_is_silent_and_replayed_command_replies_once(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+):
+    account, _link, binding = await _seed_whatsapp_link_and_binding(
+        client,
+        db_session,
+        channel_agent,
+        name="wa-unpaired-command-only-replies",
+    )
+    binding.status = BINDING_STATUS_ARCHIVED
+    await db_session.commit()
+    transport = _FakeProviderTransport()
+    register_whatsapp_provider_transport(account.id, transport)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    def event(sequence: int, message_id: str, jid: str, text: str) -> WhatsAppProviderMessageEvent:
+        return WhatsAppProviderMessageEvent(
+            sequence=sequence,
+            message_id=message_id,
+            remote_jid=jid,
+            remote_jid_alt=None,
+            participant=None,
+            participant_alt=None,
+            push_name=None,
+            message_timestamp=None,
+            message_proto=whatsapp_text_message_proto(text),
+        )
+
+    try:
+        async with sessionmaker() as db:
+            await persist_whatsapp_provider_event(
+                db,
+                account_id=account.id,
+                event=event(1, "ordinary-dm", "15550001111@s.whatsapp.net", "hello"),
+            )
+            await persist_whatsapp_provider_event(
+                db,
+                account_id=account.id,
+                event=event(2, "ordinary-group", "120363000000000000@g.us", "hello group"),
+            )
+        assert transport.outbound_messages == []
+
+        command = event(
+            3,
+            "replayed-unpair",
+            "15550001111@s.whatsapp.net",
+            "/clawdi_unpair",
+        )
+
+        async def consume() -> None:
+            async with sessionmaker() as db:
+                await persist_whatsapp_provider_event(db, account_id=account.id, event=command)
+
+        await asyncio.gather(consume(), consume())
+
+        for help_event in (
+            event(4, "help-dm", "15550001111@s.whatsapp.net", "/clawdi_help"),
+            event(5, "help-group", "120363000000000000@g.us", "/clawdi_help"),
+        ):
+
+            async def consume_help() -> None:
+                async with sessionmaker() as db:
+                    await persist_whatsapp_provider_event(
+                        db,
+                        account_id=account.id,
+                        event=help_event,
+                    )
+
+            await asyncio.gather(consume_help(), consume_help())
+    finally:
+        unregister_whatsapp_provider_transport(account.id)
+
+    assert len(transport.outbound_messages) == 3
+    assert transport.outbound_messages[0].conversation == "This chat is not paired."
+    assert [message.conversation for message in transport.outbound_messages[1:]] == [
+        channel_control_help_reply(),
+        channel_control_help_reply(),
+    ]
+    await db_session.rollback()
+    command_messages = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.provider_event_id == "replayed-unpair",
+                )
+            )
+        ).scalars()
+    )
+    assert len(command_messages) == 1
+    assert command_messages[0].delivered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_concurrent_replayed_pair_mutates_and_replies_once(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+):
+    account, link, binding = await _seed_whatsapp_link_and_binding(
+        client,
+        db_session,
+        channel_agent,
+        name="wa-concurrent-pair-fence",
+    )
+    binding.status = BINDING_STATUS_ARCHIVED
+    code = "X7V9Q2M4KC"
+    db_session.add(
+        ChannelPairCode(
+            account_id=account.id,
+            bot_agent_link_id=link.id,
+            user_id=account.user_id,
+            code_hash=hash_token(code),
+            expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        )
+    )
+    await db_session.commit()
+    transport = _FakeProviderTransport()
+    register_whatsapp_provider_transport(account.id, transport)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    event = WhatsAppProviderMessageEvent(
+        sequence=4,
+        message_id="replayed-pair",
+        remote_jid=binding.external_chat_id,
+        remote_jid_alt=None,
+        participant=None,
+        participant_alt=None,
+        push_name="Alice",
+        message_timestamp=None,
+        message_proto=whatsapp_text_message_proto(f"/clawdi_pair {code}"),
+    )
+
+    async def consume() -> None:
+        async with sessionmaker() as db:
+            await persist_whatsapp_provider_event(db, account_id=account.id, event=event)
+
+    try:
+        await asyncio.gather(consume(), consume())
+        paired_help = WhatsAppProviderMessageEvent(
+            sequence=5,
+            message_id="paired-help",
+            remote_jid=binding.external_chat_id,
+            remote_jid_alt=None,
+            participant=None,
+            participant_alt=None,
+            push_name="Alice",
+            message_timestamp=None,
+            message_proto=whatsapp_text_message_proto("/clawdi_help"),
+        )
+
+        async def consume_help() -> None:
+            async with sessionmaker() as db:
+                await persist_whatsapp_provider_event(
+                    db,
+                    account_id=account.id,
+                    event=paired_help,
+                )
+
+        await asyncio.gather(consume_help(), consume_help())
+    finally:
+        unregister_whatsapp_provider_transport(account.id)
+
+    assert len(transport.outbound_messages) == 2
+    assert transport.outbound_messages[0].conversation == (
+        "Paired! This chat is now connected to your agent."
+    )
+    assert transport.outbound_messages[1].conversation == channel_control_help_reply()
+    await db_session.rollback()
+    active_bindings = list(
+        (
+            await db_session.execute(
+                select(ChannelBinding).where(
+                    ChannelBinding.account_id == account.id,
+                    ChannelBinding.external_chat_id == binding.external_chat_id,
+                    ChannelBinding.status == "active",
+                )
+            )
+        ).scalars()
+    )
+    assert len(active_bindings) == 1
+    pair_messages = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == account.id,
+                    ChannelMessage.provider_event_id == event.message_id,
+                )
+            )
+        ).scalars()
+    )
+    assert len(pair_messages) == 1
+    assert pair_messages[0].delivered_at is not None

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -5,11 +5,21 @@ import json
 from uuid import UUID
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.services.whatsapp_sidecar_registry as sidecar_registry_module
+from app.models.channel import (
+    CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_VISIBILITY_PUBLIC,
+    ChannelAccount,
+)
+from app.models.user import User
 from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarConfig,
     WhatsAppProviderMessageEvent,
+    WhatsAppSidecarCapabilities,
+    WhatsAppSidecarHealth,
+    WhatsAppSidecarPairingStatus,
 )
 from app.services.whatsapp_provider_bridge import (
     WhatsAppProviderAccountRetired,
@@ -329,10 +339,43 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ownership_kind", ["managed", "custom"])
 async def test_provider_ingress_terminal_exit_releases_owner_and_can_reattach_once(
-    monkeypatch,
-    ownership_kind,
+    monkeypatch: pytest.MonkeyPatch,
+    ownership_kind: str,
+    db_session: AsyncSession,
+    seed_user: User,
 ):
     account_id = UUID("00000000-0000-0000-0000-000000000904")
+    slot_id = (
+        account_id if ownership_kind == "managed" else UUID("00000000-0000-0000-0000-000000000944")
+    )
+    raw = json.dumps(
+        {
+            str(slot_id): {
+                "base_url": f"https://sidecar-{ownership_kind}.example.test",
+                "api_token": "secret",
+            }
+        }
+    )
+    registry = ConfiguredWhatsAppSidecarRegistry(
+        raw if ownership_kind == "managed" else "",
+        raw if ownership_kind == "custom" else "",
+    )
+    config = registry._managed.get(slot_id) or registry._custom[slot_id]
+    account = ChannelAccount(
+        id=account_id,
+        user_id=seed_user.id,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name=f"terminal-{ownership_kind}",
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        webhook_secret_hash="test-secret-hash",
+        config={
+            "connection_mode": f"baileys_{ownership_kind}",
+            "sidecar_config_revision": config.binding_revision,
+            **({"sidecar_account_id": str(slot_id)} if ownership_kind == "custom" else {}),
+        },
+    )
+    db_session.add(account)
+    await db_session.commit()
     event = WhatsAppProviderMessageEvent(
         sequence=8,
         message_id="provider-8",
@@ -350,7 +393,7 @@ async def test_provider_ingress_terminal_exit_releases_owner_and_can_reattach_on
 
     class SessionContext:
         async def __aenter__(self):
-            return object()
+            return db_session
 
         async def __aexit__(self, exc_type, exc, traceback):
             return False
@@ -370,18 +413,24 @@ async def test_provider_ingress_terminal_exit_releases_owner_and_can_reattach_on
         async def acknowledge_provider_events(self, *, through_sequence):
             acknowledgements.append(through_sequence)
 
+        async def capabilities(self):
+            return WhatsAppSidecarCapabilities(pairing=frozenset({"qr"}))
+
+        async def health(self):
+            return WhatsAppSidecarHealth(status="connected", connected=True, registered=True)
+
+        async def pairing_status(self):
+            return WhatsAppSidecarPairingStatus(status="connected", registered=True)
+
     monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
     monkeypatch.setattr(sidecar_registry_module, "persist_whatsapp_provider_event", retired)
 
-    registry = ConfiguredWhatsAppSidecarRegistry("")
     client = PumpClient()
-    registry._register_transport(account_id, client)
+    registry._clients_by_slot[slot_id] = client
     if ownership_kind == "managed":
-        registry._bound_managed_accounts.add(account_id)
+        await registry.reconcile_managed_ownership(db_session)
     else:
-        slot_id = UUID("00000000-0000-0000-0000-000000000944")
-        registry._custom_slot_to_account[slot_id] = account_id
-        registry._custom_account_to_slot[account_id] = slot_id
+        await registry.reconcile_custom_ownership()
     first_task = registry._ingress_tasks[account_id]
     await asyncio.wait_for(first_task, timeout=1)
 
@@ -391,13 +440,21 @@ async def test_provider_ingress_terminal_exit_releases_owner_and_can_reattach_on
     assert account_id not in registry._bound_managed_accounts
     assert account_id not in registry._custom_account_to_slot
 
-    registry._register_transport(account_id, client)
+    if ownership_kind == "managed":
+        await registry.reconcile_managed_ownership(db_session)
+    else:
+        await registry.reconcile_custom_ownership()
     second_task = registry._ingress_tasks[account_id]
     try:
         await asyncio.wait_for(reattached.wait(), timeout=1)
+        if ownership_kind == "managed":
+            await registry.reconcile_managed_ownership(db_session)
+        else:
+            await registry.reconcile_custom_ownership()
         assert second_task is registry._ingress_tasks[account_id]
         assert second_task is not first_task
         assert attempts == 2
+        assert len(registry._ingress_tasks) == 1
     finally:
         second_task.cancel()
         await asyncio.gather(second_task, return_exceptions=True)

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -13,6 +13,7 @@ from app.services.whatsapp_native_transport import (
 )
 from app.services.whatsapp_provider_bridge import (
     WhatsAppProviderAccountRetired,
+    unregister_whatsapp_provider_transport,
     whatsapp_provider_transport_status,
 )
 from app.services.whatsapp_sidecar_registry import (
@@ -326,7 +327,11 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_provider_ingress_stops_without_ack_when_account_is_retired(monkeypatch):
+@pytest.mark.parametrize("ownership_kind", ["managed", "custom"])
+async def test_provider_ingress_terminal_exit_releases_owner_and_can_reattach_once(
+    monkeypatch,
+    ownership_kind,
+):
     account_id = UUID("00000000-0000-0000-0000-000000000904")
     event = WhatsAppProviderMessageEvent(
         sequence=8,
@@ -340,6 +345,8 @@ async def test_provider_ingress_stops_without_ack_when_account_is_retired(monkey
         message_proto=b"\x0a\x05hello",
     )
     acknowledgements: list[int] = []
+    attempts = 0
+    reattached = asyncio.Event()
 
     class SessionContext:
         async def __aenter__(self):
@@ -349,7 +356,12 @@ async def test_provider_ingress_stops_without_ack_when_account_is_retired(monkey
             return False
 
     async def retired(_db, *, account_id, event):
-        raise WhatsAppProviderAccountRetired
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise WhatsAppProviderAccountRetired
+        reattached.set()
+        await asyncio.Future()
 
     class PumpClient:
         async def provider_events(self, *, limit=100):
@@ -361,9 +373,36 @@ async def test_provider_ingress_stops_without_ack_when_account_is_retired(monkey
     monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
     monkeypatch.setattr(sidecar_registry_module, "persist_whatsapp_provider_event", retired)
 
-    await ConfiguredWhatsAppSidecarRegistry("")._pump_provider_ingress(account_id, PumpClient())
+    registry = ConfiguredWhatsAppSidecarRegistry("")
+    client = PumpClient()
+    registry._register_transport(account_id, client)
+    if ownership_kind == "managed":
+        registry._bound_managed_accounts.add(account_id)
+    else:
+        slot_id = UUID("00000000-0000-0000-0000-000000000944")
+        registry._custom_slot_to_account[slot_id] = account_id
+        registry._custom_account_to_slot[account_id] = slot_id
+    first_task = registry._ingress_tasks[account_id]
+    await asyncio.wait_for(first_task, timeout=1)
 
     assert acknowledgements == []
+    assert account_id not in registry._ingress_tasks
+    assert whatsapp_provider_transport_status(account_id).available is False
+    assert account_id not in registry._bound_managed_accounts
+    assert account_id not in registry._custom_account_to_slot
+
+    registry._register_transport(account_id, client)
+    second_task = registry._ingress_tasks[account_id]
+    try:
+        await asyncio.wait_for(reattached.wait(), timeout=1)
+        assert second_task is registry._ingress_tasks[account_id]
+        assert second_task is not first_task
+        assert attempts == 2
+    finally:
+        second_task.cancel()
+        await asyncio.gather(second_task, return_exceptions=True)
+        registry._ingress_tasks.clear()
+        unregister_whatsapp_provider_transport(account_id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -11,7 +11,10 @@ from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarConfig,
     WhatsAppProviderMessageEvent,
 )
-from app.services.whatsapp_provider_bridge import whatsapp_provider_transport_status
+from app.services.whatsapp_provider_bridge import (
+    WhatsAppProviderAccountRetired,
+    whatsapp_provider_transport_status,
+)
 from app.services.whatsapp_sidecar_registry import (
     ConfiguredWhatsAppSidecarRegistry,
     parse_whatsapp_sidecar_registrations,
@@ -320,3 +323,100 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
     finally:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_ingress_stops_without_ack_when_account_is_retired(monkeypatch):
+    account_id = UUID("00000000-0000-0000-0000-000000000904")
+    event = WhatsAppProviderMessageEvent(
+        sequence=8,
+        message_id="provider-8",
+        remote_jid="15550001111@s.whatsapp.net",
+        remote_jid_alt=None,
+        participant=None,
+        participant_alt=None,
+        push_name=None,
+        message_timestamp=None,
+        message_proto=b"\x0a\x05hello",
+    )
+    acknowledgements: list[int] = []
+
+    class SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    async def retired(_db, *, account_id, event):
+        raise WhatsAppProviderAccountRetired
+
+    class PumpClient:
+        async def provider_events(self, *, limit=100):
+            return [event]
+
+        async def acknowledge_provider_events(self, *, through_sequence):
+            acknowledgements.append(through_sequence)
+
+    monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
+    monkeypatch.setattr(sidecar_registry_module, "persist_whatsapp_provider_event", retired)
+
+    await ConfiguredWhatsAppSidecarRegistry("")._pump_provider_ingress(account_id, PumpClient())
+
+    assert acknowledgements == []
+
+
+@pytest.mark.asyncio
+async def test_provider_ingress_retries_transient_errors(monkeypatch):
+    account_id = UUID("00000000-0000-0000-0000-000000000905")
+    calls = 0
+    persisted = asyncio.Event()
+
+    class SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    async def transient_then_wait(_db, *, account_id, event):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary database failure")
+        persisted.set()
+
+    event = WhatsAppProviderMessageEvent(
+        sequence=9,
+        message_id="provider-9",
+        remote_jid="15550001111@s.whatsapp.net",
+        remote_jid_alt=None,
+        participant=None,
+        participant_alt=None,
+        push_name=None,
+        message_timestamp=None,
+        message_proto=b"\x0a\x05hello",
+    )
+
+    class PumpClient:
+        async def provider_events(self, *, limit=100):
+            return [event]
+
+        async def acknowledge_provider_events(self, *, through_sequence):
+            await asyncio.Future()
+
+    monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
+    monkeypatch.setattr(
+        sidecar_registry_module,
+        "persist_whatsapp_provider_event",
+        transient_then_wait,
+    )
+    registry = ConfiguredWhatsAppSidecarRegistry("")
+    task = asyncio.create_task(registry._pump_provider_ingress(account_id, PumpClient()))
+    try:
+        await asyncio.wait_for(persisted.wait(), timeout=2)
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert calls == 2


### PR DESCRIPTION
## Summary
- make current `ChannelBinding` authority canonical for aliases; every synchronous WhatsApp provider I/O holds at least an active Account lease, while Link/Binding paths use deterministic Account → Link → Binding authority through I/O
- serialize all explicit WhatsApp control commands after dedupe, including pair, unpair, help, and unknown `/clawdi_*` commands, preserving persist-before-ACK and preventing duplicate mutations or replies
- stop retired managed/custom account pumps without ACK and release local transport/ownership bookkeeping; real managed/custom reconciliation paths deterministically reattach exactly once when active ownership returns, while transient failures continue retrying
- add shared `/clawdi_help` semantics across Telegram, Discord, and WhatsApp using configured `WEB_ORIGIN`; keep ordinary unpaired WhatsApp traffic silent
- normalize alias-targeted queued outbound to the binding canonical provider destination, include WhatsApp in retention, and set `delivered_at` after successful direct provider sends
- retain only safe WhatsApp diagnostics: fixed allowlisted runtime/JID-description enums and the explicitly designated SHA-256 field; all other provider, body, error, and arbitrary string details remain redacted

## Safety
- no schema or migration
- no WhatsApp linking/runtime gate changes
- no production, tenant, hosted, or live-provider operations
- iMessage changes are limited to the mechanical rename of shared private control parser/reply symbols; iMessage explicitly treats help as an ordinary message, adds no help/control behavior, and has no enablement or gate change

## Verification
- provider/registry/debug plus the prior remote failure path: 43 passed
- Telegram/Discord/shared control regression suite: 408 passed
- complete WhatsApp Noise suite: 26 passed
- focused sanitizer regression: 7 passed
- post-type-governance-fix WhatsApp provider bridge suite: 15 passed
- `uv run python scripts/type_governance.py owned`: 39 files analyzed, 0 errors, 0 warnings
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall app scripts tests alembic`
- `git diff --check`

The earlier GitHub Backend test failure was caused by safe WhatsApp diagnostics redacting fixed runtime metadata and was corrected with narrow explicit allowlists. The later `lint-and-typecheck` failure in job `91557787570` was caused by cross-module private helper imports; `_active_link_owns_account` now reuses the existing public link-authority lease with its already-loaded account, and the owned-path type governance check passes locally. Latest checks for commit `555159dd6` are still running on GitHub; this PR does not claim they are green yet.