### PR TITLE
Fix Kamal WhatsApp preflight shell transport

### DIFF
--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -250,6 +258,39 @@ describe("WhatsApp sidecar remote container preflight", () => {
 		expect(result.exitCode).not.toBe(0);
 		expect(result.stderr).toContain("Invalid container id returned by Docker");
 	});
+
+	test("fails closed without executing when base64 decoding fails or is unavailable", async () => {
+		const command = renderKamalServerExecCommand([
+			buildWhatsAppSidecarContainerPreflightCommand([]),
+		]);
+		const directory = mkdtempSync(join(tmpdir(), "clawdi-sidecar-decoder-"));
+		const marker = join(directory, "executed");
+		try {
+			writeFileSync(
+				join(directory, "base64"),
+				`#!/bin/sh\nprintf '%s\\n' 'touch "${marker}"'\nexit 23\n`,
+				{ mode: 0o700 },
+			);
+			const failedDecode = await Bun.spawn(["/bin/sh", "-c", command], {
+				env: { PATH: directory },
+				stderr: "ignore",
+				stdout: "ignore",
+			}).exited;
+			expect(failedDecode).toBe(23);
+			expect(existsSync(marker)).toBe(false);
+
+			rmSync(join(directory, "base64"));
+			const unavailableDecode = await Bun.spawn(["/bin/sh", "-c", command], {
+				env: { PATH: directory },
+				stderr: "ignore",
+				stdout: "ignore",
+			}).exited;
+			expect(unavailableDecode).not.toBe(0);
+			expect(existsSync(marker)).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("WhatsApp sidecar production deployment contract", () => {
@@ -417,7 +458,9 @@ function renderKamalServerExecCommand(commands: readonly string[]): string {
 }
 
 function decodePreflightScript(command: string): string {
-	const match = command.match(/^printf '%s' '([A-Za-z0-9+/=]+)' \| base64 --decode \| sh$/);
+	const match = command.match(
+		/^script="\$\(printf '%s' '([A-Za-z0-9+/=]+)' \| base64 -d\)" && sh -c "\$script"$/,
+	);
 	if (!match?.[1]) throw new Error("unexpected preflight command transport");
 	return Buffer.from(match[1], "base64").toString("utf8");
 }

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -159,17 +159,26 @@ describe("WhatsApp sidecar deployment materializer", () => {
 });
 
 describe("WhatsApp sidecar remote container preflight", () => {
-	test("uses an exact read-only Docker inspection contract", () => {
+	test("survives the pinned Kamal 2.12.0 server exec argument normalization", async () => {
 		const command = buildWhatsAppSidecarContainerPreflightCommand([serviceName(FIRST_ID)]);
+		const normalizedCommand = renderKamalServerExecCommand([`  ${command}\n`]);
+		const decodedScript = decodePreflightScript(normalizedCommand);
+		const oldMultilineTransport = renderKamalServerExecCommand([decodedScript]);
 
-		expect(command).toContain(
+		expect(command).not.toContain("\n");
+		expect(normalizedCommand).toBe(command);
+		expect(oldMultilineTransport).toContain("do; case");
+		expect(await shellSyntaxExitCode(oldMultilineTransport)).not.toBe(0);
+		expect(await shellSyntaxExitCode(normalizedCommand)).toBe(0);
+		expect(decodedScript).toContain(
 			"docker container ls --all --filter 'label=service' --format '{{.ID}}'",
 		);
-		expect(command).toContain(
+		expect(decodedScript).toContain(
 			'docker container inspect --format \'{{index .Config.Labels "service"}}\' "$container_id"',
 		);
-		expect(command).not.toMatch(/\bdocker\s+(?:container\s+)?(?:stop|rm|prune)\b/);
-		expect(command).not.toContain("/state");
+		expect(decodedScript).not.toMatch(/\bdocker\s+(?:container\s+)?(?:stop|rm|prune)\b/);
+		expect(decodedScript).not.toContain("/state");
+		expect((await runRemotePreflight([serviceName(FIRST_ID)], [])).exitCode).toBe(0);
 		expect(() =>
 			buildWhatsAppSidecarContainerPreflightCommand(["clawdi-whatsapp-baileys-user-input"]),
 		).toThrow("invalid WhatsApp sidecar service name");
@@ -234,6 +243,12 @@ describe("WhatsApp sidecar remote container preflight", () => {
 			expect(result.exitCode).not.toBe(0);
 			expect(result.stderr).toContain("Malformed Clawdi WhatsApp sidecar service label");
 		}
+	});
+
+	test("rejects malformed Docker container ids after Kamal normalization", async () => {
+		const result = await runRemotePreflight([], [["not-a-container-id", serviceName(FIRST_ID)]]);
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("Invalid container id returned by Docker");
 	});
 });
 
@@ -373,7 +388,9 @@ fi
 	);
 	chmodSync(fakeDocker, 0o700);
 	try {
-		const command = buildWhatsAppSidecarContainerPreflightCommand(desiredServices);
+		const command = renderKamalServerExecCommand([
+			buildWhatsAppSidecarContainerPreflightCommand(desiredServices),
+		]);
 		const processHandle = Bun.spawn(["sh", "-c", command], {
 			env: { ...process.env, PATH: `${directory}:${process.env.PATH ?? ""}` },
 			stderr: "pipe",
@@ -387,6 +404,29 @@ fi
 	} finally {
 		rmSync(directory, { recursive: true, force: true });
 	}
+}
+
+// Kamal 2.12.0 joins server exec arguments, then its pinned SSHKit 1.25.0 sanitizes lines.
+function renderKamalServerExecCommand(commands: readonly string[]): string {
+	return commands
+		.map((command) => command.trim())
+		.join(" ")
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.join("; ");
+}
+
+function decodePreflightScript(command: string): string {
+	const match = command.match(/^printf '%s' '([A-Za-z0-9+/=]+)' \| base64 --decode \| sh$/);
+	if (!match?.[1]) throw new Error("unexpected preflight command transport");
+	return Buffer.from(match[1], "base64").toString("utf8");
+}
+
+async function shellSyntaxExitCode(command: string): Promise<number> {
+	return Bun.spawn(["sh", "-n", "-c", command], {
+		stderr: "ignore",
+		stdout: "ignore",
+	}).exited;
 }
 
 function withDeploymentFiles(

--- a/scripts/whatsapp-sidecar-container-preflight.ts
+++ b/scripts/whatsapp-sidecar-container-preflight.ts
@@ -58,9 +58,9 @@ for container_id in $container_ids; do
       esac
       ;;
   esac
-done`;
+	done`;
 	const encodedScript = Buffer.from(script, "utf8").toString("base64");
-	return `printf '%s' '${encodedScript}' | base64 --decode | sh`;
+	return `script="$(printf '%s' '${encodedScript}' | base64 -d)" && sh -c "$script"`;
 }
 
 export function readDesiredWhatsAppSidecarServiceNames(manifestPath: string): string[] {

--- a/scripts/whatsapp-sidecar-container-preflight.ts
+++ b/scripts/whatsapp-sidecar-container-preflight.ts
@@ -18,7 +18,7 @@ export function buildWhatsAppSidecarContainerPreflightCommand(
 	}
 
 	const desiredCase = desired.length > 0 ? `${desired.join("|")}) ;;` : "";
-	return `set -eu
+	const script = `set -eu
 seen_services='|'
 container_ids="$(docker container ls --all --filter 'label=service' --format '{{.ID}}')"
 for container_id in $container_ids; do
@@ -59,6 +59,8 @@ for container_id in $container_ids; do
       ;;
   esac
 done`;
+	const encodedScript = Buffer.from(script, "utf8").toString("base64");
+	return `printf '%s' '${encodedScript}' | base64 --decode | sh`;
 }
 
 export function readDesiredWhatsAppSidecarServiceNames(manifestPath: string): string[] {


### PR DESCRIPTION
## Summary

- encode the generated multiline WhatsApp container preflight as a single-line Base64 payload before passing it to `kamal server exec`
- decode into a shell assignment and execute only after a successful decode, so a missing or failing decoder cannot fail open
- preserve the existing fail-closed checks for Docker IDs, malformed service labels, duplicate containers, unexpected services, and the zero-account allowlist
- execute all behavioral cases through a pinned-source-faithful Kamal/SSHKit rendering contract

## Root cause

PR #773 itself was green: automatic Clawdi Image Release run 30771404983 built the exact release SHA successfully. The first failure was deploy-vps job 91559230344, before the app deploy.

Kamal 2.12.0 `server exec` first calls `Kamal::Utils.join_commands` and sends the result through SSHKit:

- [Kamal 2.12.0 server exec](https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/cli/server.rb#L5-L32)
- [Kamal 2.12.0 join_commands](https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/utils.rb#L91-L93)
- [Kamal 2.12.0 resolves SSHKit 1.25.0](https://github.com/basecamp/kamal/blob/v2.12.0/Gemfile.lock#L174)
- [SSHKit 1.25.0 sanitizes command lines with `; `](https://github.com/capistrano/sshkit/blob/v1.25.0/lib/sshkit/command.rb#L233-L238)

The generated multiline shell was therefore rendered from:

```sh
for container_id in $container_ids; do
  case "$container_id" in
    ...
  esac
done
```

to the invalid shape observed in the job:

```sh
for container_id in $container_ids; do; case "$container_id" in; ...; esac; done
```

Reproduction before: the regression applies those exact two transformations and `sh -n` rejects the result with `do; case`.

After:

```sh
script="$(printf '%s' '<static-base64>' | base64 -d)" && sh -c "$script"
```

This stays one line through the same rendering path, passes `sh -n`, and executes the unchanged validation script. No `eval`, untrusted interpolation, lock wait, or validation relaxation is introduced. The assignment takes the decoder pipeline's final status, and `&&` prevents execution when decoding is unavailable or fails, without relying on `pipefail`.

The public deployment contract does not pin a remote distro: `DEPLOY_HOST` is self-hosted. The short `-d` form is used because it is documented by [GNU coreutils base64](https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html) and by the Linux-oriented BusyBox implementation ([fixed 1.36 source](https://github.com/mirror/busybox/blob/1_36_stable/coreutils/base64.c)); no GNU-only long-option assumption is added.

## Verification

- `bun run --cwd packages/cli test`: 1593 passed, 4 skipped, 0 failed (Docker-backed clean runner)
- `bun test --isolate --max-concurrency=1 packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts packages/cli/tests/clawdi-image-release-workflow.test.ts`: 21 passed, 0 failed
- `bun run --cwd packages/cli typecheck`
- `bunx biome check scripts/whatsapp-sidecar-container-preflight.ts packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts`
- `git diff --check`

The decoder regression covers both a decoder that emits partial executable text and then fails, and an unavailable decoder; both return non-zero and execute no decoded script.
