### PR TITLE
test(whatsapp): remove retired cutover assertions

### DIFF
--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -44,14 +44,6 @@ describe("WhatsApp sidecar production deployment contract", () => {
 		expect(workflow).toContain("docker container inspect --format '{{.Config.Image}}'");
 	});
 
-	test("contains no retired account-sidecar deployment path", () => {
-		const runtimeSources = [deploy, workflow].join("\n");
-		expect(runtimeSources).not.toContain("cutover-whatsapp-sidecar-containers");
-		expect(runtimeSources).not.toContain("clawdi-whatsapp-sidecars");
-		expect(runtimeSources).not.toContain("CHANNEL_WHATSAPP_BAILEYS_SIDECARS_JSON");
-		expect(runtimeSources).not.toContain("WHATSAPP_BAILEYS_HOST_ROOT");
-	});
-
 	test("keeps state private and exposes only a read-only Unix socket to the app", () => {
 		expect(deploy).toContain("/home/phala/clawdi-whatsapp/run:/run/clawdi-whatsapp:ro");
 		expect(deploy).toContain('remote: /data\n        mode: "700"');


### PR DESCRIPTION
Remove the obsolete negative-string test left after the account-scoped sidecar cutover was retired. Do not replace it with another legacy-name assertion. The active singleton deployment contract tests remain.\n\nVerification: focused contracts 10 passed; workspace typecheck 4/4; Biome 916 files; zero non-archive references to the retired cutover, old sidecar root, old JSON secret, or old host-root variable.