### PR TITLE
feat(backend): fence terminated Clerk principals

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -16,6 +16,7 @@ from app.models import (  # noqa: F401 - register models
     memory,
     platform_idempotency,
     platform_workload_auth,
+    principal_lifecycle,
     project,
     project_invitation,
     project_membership,

--- a/backend/alembic/versions/c9f4e2a7b1d6_principal_termination_fence.py
+++ b/backend/alembic/versions/c9f4e2a7b1d6_principal_termination_fence.py
@@ -1,0 +1,177 @@
+"""Add issuer-scoped principal termination fences.
+
+Revision ID: c9f4e2a7b1d6
+Revises: d7f3a1c9e5b2
+Create Date: 2026-08-02 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c9f4e2a7b1d6"
+down_revision: str | Sequence[str] | None = "d7f3a1c9e5b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_WORKLOAD_SCOPE_CHECK = (
+    "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
+    "ARRAY['platform:agents:create','platform:agents:delete',"
+    "'platform:runtime-state:write','platform:keys:mint',"
+    "'platform:keys:revoke','platform:runtime-observations:consume',"
+    "'platform:runtime-environments:retire',"
+    "'platform:principals:terminate']::varchar[]"
+)
+_PREVIOUS_WORKLOAD_SCOPE_CHECK = (
+    "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
+    "ARRAY['platform:agents:create','platform:agents:delete',"
+    "'platform:runtime-state:write','platform:keys:mint',"
+    "'platform:keys:revoke','platform:runtime-observations:consume',"
+    "'platform:runtime-environments:retire']::varchar[]"
+)
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("clerk_issuer", sa.String(length=255), nullable=True))
+    op.drop_constraint("ck_users_principal_identity", "users", type_="check")
+    op.create_check_constraint(
+        "ck_users_principal_identity",
+        "users",
+        "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+        "AND partner_tenant_ref IS NULL) OR "
+        "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+        "AND clerk_issuer IS NULL AND partner_tenant_ref IS NOT NULL)",
+    )
+
+    op.create_table(
+        "principal_lifecycles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("issuer", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=200), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("current_revision", sa.BigInteger(), nullable=False),
+        sa.Column("terminated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("cleanup_attempts", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("cleanup_completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("next_cleanup_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cleanup_claim_id", sa.String(length=64), nullable=True),
+        sa.Column("cleanup_claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint("current_revision >= 1", name="ck_principal_lifecycles_revision"),
+        sa.CheckConstraint(
+            "cleanup_attempts >= 0", name="ck_principal_lifecycles_cleanup_attempts"
+        ),
+        sa.CheckConstraint(
+            "(cleanup_completed_at IS NULL AND next_cleanup_attempt_at IS NOT NULL "
+            "AND ((cleanup_claim_id IS NULL AND cleanup_claimed_at IS NULL) OR "
+            "(cleanup_claim_id IS NOT NULL AND cleanup_claimed_at IS NOT NULL))) OR "
+            "(cleanup_completed_at IS NOT NULL AND next_cleanup_attempt_at IS NULL "
+            "AND cleanup_claim_id IS NULL AND cleanup_claimed_at IS NULL)",
+            name="ck_principal_lifecycles_cleanup",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "issuer",
+            "subject",
+            name="uq_principal_lifecycles_external_identity",
+        ),
+        sa.UniqueConstraint("user_id", name="uq_principal_lifecycles_user_id"),
+    )
+    op.create_index("ix_principal_lifecycles_user_id", "principal_lifecycles", ["user_id"])
+    op.create_index(
+        "ix_principal_lifecycles_cleanup_due",
+        "principal_lifecycles",
+        ["next_cleanup_attempt_at"],
+        postgresql_where=sa.text("cleanup_completed_at IS NULL"),
+    )
+    op.create_table(
+        "principal_lifecycle_commands",
+        sa.Column("command_id", sa.String(length=191), nullable=False),
+        sa.Column("lifecycle_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("requested_revision", sa.BigInteger(), nullable=False),
+        sa.Column("accepted_revision", sa.BigInteger(), nullable=False),
+        sa.Column("advanced", sa.Boolean(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint(
+            "requested_revision >= 1 AND accepted_revision >= requested_revision",
+            name="ck_principal_lifecycle_commands_revisions",
+        ),
+        sa.ForeignKeyConstraint(
+            ["lifecycle_id"],
+            ["principal_lifecycles.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("command_id"),
+    )
+    op.create_index(
+        "ix_principal_lifecycle_commands_lifecycle_id",
+        "principal_lifecycle_commands",
+        ["lifecycle_id"],
+    )
+
+    op.drop_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        _WORKLOAD_SCOPE_CHECK,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.execute(sa.text("SELECT count(*) FROM principal_lifecycles")).scalar_one():
+        raise RuntimeError("cannot downgrade while principal lifecycle fences exist")
+    if bind.execute(
+        sa.text(
+            "SELECT count(*) FROM platform_workload_clients "
+            "WHERE 'platform:principals:terminate' = ANY(allowed_scopes)"
+        )
+    ).scalar_one():
+        raise RuntimeError("cannot downgrade while principal-termination workload grants exist")
+
+    op.drop_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        _PREVIOUS_WORKLOAD_SCOPE_CHECK,
+    )
+    op.drop_index(
+        "ix_principal_lifecycle_commands_lifecycle_id",
+        table_name="principal_lifecycle_commands",
+    )
+    op.drop_table("principal_lifecycle_commands")
+    op.drop_index("ix_principal_lifecycles_cleanup_due", table_name="principal_lifecycles")
+    op.drop_index("ix_principal_lifecycles_user_id", table_name="principal_lifecycles")
+    op.drop_table("principal_lifecycles")
+    op.drop_constraint("ck_users_principal_identity", "users", type_="check")
+    op.create_check_constraint(
+        "ck_users_principal_identity",
+        "users",
+        "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+        "AND partner_tenant_ref IS NULL) OR "
+        "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+        "AND partner_tenant_ref IS NOT NULL)",
+    )
+    op.drop_column("users", "clerk_issuer")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -14,17 +14,25 @@ import jwt
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import canonical_clerk_issuer, settings
 from app.core.database import get_session
 from app.models.api_key import ApiKey
+from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
 from app.services.clerk_cli_oauth_settings import ClerkCliOAuthSetting
+from app.services.principal_lifecycle import (
+    PrincipalIdentityConflictError,
+    PrincipalTerminatedError,
+    assert_clerk_principal_active,
+    assert_user_authority_active,
+    load_clerk_user_for_issuer,
+)
 from app.services.user_provisioning import lazy_create_user_with_personal_project
 
 bearer_scheme = HTTPBearer()
@@ -98,6 +106,7 @@ class _CachedApiKeyAuth:
     managed: bool
     expires_at: datetime | None
     user_clerk_id: str | None
+    user_clerk_issuer: str | None
     user_principal_kind: str
     user_partner_tenant_ref: str | None
     user_email: str | None
@@ -110,6 +119,7 @@ class _CachedApiKeyAuth:
         user = User(
             id=self.user_id,
             clerk_id=self.user_clerk_id,
+            clerk_issuer=self.user_clerk_issuer,
             principal_kind=self.user_principal_kind,
             partner_tenant_ref=self.user_partner_tenant_ref,
             email=self.user_email,
@@ -183,6 +193,7 @@ def _cache_api_key_auth(
             managed=api_key.managed,
             expires_at=api_key.expires_at,
             user_clerk_id=user.clerk_id,
+            user_clerk_issuer=user.clerk_issuer,
             user_principal_kind=user.principal_kind,
             user_partner_tenant_ref=user.partner_tenant_ref,
             user_email=user.email,
@@ -198,6 +209,20 @@ def invalidate_api_key_auth_cache(api_key_id: UUID) -> None:
     for key_hash, (_, snapshot) in list(_api_key_auth_cache.items()):
         if snapshot.api_key_id == api_key_id:
             _api_key_auth_cache.pop(key_hash, None)
+
+
+def invalidate_user_api_key_auth_cache(user_id: UUID) -> None:
+    for key_hash, (_, snapshot) in list(_api_key_auth_cache.items()):
+        if snapshot.user_id == user_id:
+            _api_key_auth_cache.pop(key_hash, None)
+
+
+async def _assert_active_user_or_401(db: AsyncSession, user_id: UUID) -> None:
+    try:
+        await assert_user_authority_active(db, user_id)
+    except PrincipalTerminatedError:
+        invalidate_user_api_key_auth_cache(user_id)
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
 
 
 class AuthContext:
@@ -239,6 +264,7 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     key_hash = hashlib.sha256(token.encode()).hexdigest()
     cached = _get_cached_api_key_auth(key_hash)
     if cached is not None:
+        await _assert_active_user_or_401(db, cached.user_id)
         # Bound Agent keys are an operational authority boundary. Revalidate
         # their durable key + Agent lifecycle on every cache hit so a request
         # racing archive commit cannot re-cache authority after the caller's
@@ -275,16 +301,20 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     if api_key.expires_at and api_key.expires_at < now:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has expired")
 
+    result = await db.execute(select(User).where(User.id == api_key.user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
+    await _assert_active_user_or_401(db, user.id)
+
     # Throttle last_used_at writes: once per LAST_USED_THROTTLE per key.
     last = api_key.last_used_at
     if last is None or (now - last) > LAST_USED_THROTTLE:
         api_key.last_used_at = now
         await db.commit()
-
-    result = await db.execute(select(User).where(User.id == api_key.user_id))
-    user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
+        # Commit releases the authority lock. Reacquire and recheck before
+        # returning a credential snapshot to the route.
+        await _assert_active_user_or_401(db, user.id)
 
     api_key_project_id = None
     if api_key.environment_id is not None:
@@ -333,25 +363,44 @@ async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | No
         )
 
     clerk_id = settings.dev_auth_clerk_id
-    result = await db.execute(
-        select(User).where(
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == clerk_id,
-        )
-    )
-    user = result.scalar_one_or_none()
+    try:
+        issuer = await assert_clerk_principal_active(db, subject=clerk_id)
+    except PrincipalTerminatedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
+    if issuer is None:
+        user = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_CLERK,
+                    User.clerk_id == clerk_id,
+                )
+            )
+        ).scalar_one_or_none()
+    else:
+        try:
+            user = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=clerk_id,
+                bind_legacy=True,
+            )
+        except PrincipalIdentityConflictError:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid account identity") from None
     if user is None:
         user = await lazy_create_user_with_personal_project(
             db,
             clerk_id=clerk_id,
+            clerk_issuer=issuer,
             email=settings.dev_auth_email,
             name=settings.dev_auth_name,
             avatar_url=None,
             race_loser_status=status.HTTP_401_UNAUTHORIZED,
+            inactive_status=status.HTTP_401_UNAUTHORIZED,
         )
         await db.commit()
         await db.refresh(user)
         logger.info("dev_auth_user_created clerk_id=%s user_id=%s", clerk_id, user.id)
+    await _assert_active_user_or_401(db, user.id)
     return AuthContext(user=user)
 
 
@@ -599,14 +648,45 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
     clerk_id = payload.get("sub")
     if not isinstance(clerk_id, str) or not clerk_id:
         return None
-
-    result = await db.execute(
-        select(User).where(
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == clerk_id,
+    # OAuth access tokens are independently bound to the issuer stored in the
+    # validated Public App setting. Browser sessions use the configured Clerk
+    # JWT issuer (or, for the legacy PEM-only mode, their verified claim).
+    issuer = oauth_setting.issuer if oauth_setting is not None else settings.clerk_jwt_issuer
+    if not issuer:
+        claimed_issuer = payload.get("iss")
+        if isinstance(claimed_issuer, str):
+            try:
+                issuer = canonical_clerk_issuer(claimed_issuer)
+            except ValueError:
+                return None
+    try:
+        await assert_clerk_principal_active(
+            db,
+            subject=clerk_id,
+            issuer=issuer or None,
         )
-    )
-    user = result.scalar_one_or_none()
+        if issuer:
+            user = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=clerk_id,
+                bind_legacy=True,
+            )
+        else:
+            user = (
+                await db.execute(
+                    select(User).where(
+                        User.principal_kind == PRINCIPAL_KIND_CLERK,
+                        User.clerk_id == clerk_id,
+                    )
+                )
+            ).scalar_one_or_none()
+    except PrincipalTerminatedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
+    except PrincipalIdentityConflictError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid account identity") from None
+    if user is not None:
+        await _assert_active_user_or_401(db, user.id)
 
     raw_email = payload.get("email") or payload.get("email_address")
     email = raw_email if isinstance(raw_email, str) and raw_email else None
@@ -683,6 +763,15 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             .where(
                 User.principal_kind == PRINCIPAL_KIND_CLERK,
                 User.email == email,
+                ~select(PrincipalLifecycle.id)
+                .where(PrincipalLifecycle.user_id == User.id)
+                .exists(),
+                or_(
+                    User.clerk_issuer.is_(None),
+                    User.clerk_issuer == issuer,
+                )
+                if issuer
+                else User.clerk_issuer.is_(None),
             )
             .order_by(User.created_at)
             .limit(2)
@@ -696,6 +785,7 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             )
         if candidates:
             user = candidates[0]
+            await _assert_active_user_or_401(db, user.id)
             logger.info(
                 "snapshot rebind: user %s clerk_id %s -> %s (email match)",
                 user.id,
@@ -703,6 +793,7 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 clerk_id,
             )
             user.clerk_id = clerk_id
+            user.clerk_issuer = issuer or None
             # Concurrent rebind race: two requests carrying the
             # same Clerk JWT can both read the same candidate
             # row, both write the same `clerk_id`, and the
@@ -719,13 +810,24 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 await db.refresh(user)
             except IntegrityError:
                 await db.rollback()
-                result = await db.execute(
-                    select(User).where(
-                        User.principal_kind == PRINCIPAL_KIND_CLERK,
-                        User.clerk_id == clerk_id,
+                if issuer:
+                    try:
+                        user = await load_clerk_user_for_issuer(
+                            db,
+                            issuer=issuer,
+                            subject=clerk_id,
+                            bind_legacy=True,
+                        )
+                    except PrincipalIdentityConflictError:
+                        user = None
+                else:
+                    result = await db.execute(
+                        select(User).where(
+                            User.principal_kind == PRINCIPAL_KIND_CLERK,
+                            User.clerk_id == clerk_id,
+                        )
                     )
-                )
-                user = result.scalar_one_or_none()
+                    user = result.scalar_one_or_none()
                 if user is None:
                     # Both writers somehow lost the row — extremely
                     # unlikely (would require a concurrent delete
@@ -750,10 +852,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
         user = await lazy_create_user_with_personal_project(
             db,
             clerk_id=clerk_id,
+            clerk_issuer=issuer or None,
             email=email,
             name=name,
             avatar_url=picture,
             race_loser_status=status.HTTP_401_UNAUTHORIZED,
+            inactive_status=status.HTTP_401_UNAUTHORIZED,
         )
         # Helper leaves rows flushed-not-committed so admin callers
         # can bundle their own writes. The JWT path has nothing else
@@ -793,6 +897,15 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             # timestamps as invalid auth instead of turning them into a 500.
             return None
 
+    try:
+        await assert_clerk_principal_active(
+            db,
+            subject=clerk_id,
+            issuer=issuer or None,
+        )
+    except PrincipalTerminatedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
+    await _assert_active_user_or_401(db, user.id)
     return AuthContext(
         user=user,
         oauth_cli=oauth_cli,

--- a/backend/app/models/platform_workload_auth.py
+++ b/backend/app/models/platform_workload_auth.py
@@ -55,7 +55,8 @@ class PlatformWorkloadClient(Base, TimestampMixin):
             "ARRAY['platform:agents:create','platform:agents:delete',"
             "'platform:runtime-state:write','platform:keys:mint',"
             "'platform:keys:revoke','platform:runtime-observations:consume',"
-            "'platform:runtime-environments:retire']::varchar[]",
+            "'platform:runtime-environments:retire',"
+            "'platform:principals:terminate']::varchar[]",
             name="ck_platform_workload_clients_allowed_scopes",
         ),
     )

--- a/backend/app/models/principal_lifecycle.py
+++ b/backend/app/models/principal_lifecycle.py
@@ -1,0 +1,101 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class PrincipalLifecycle(Base, TimestampMixin):
+    """Issuer-scoped fail-closed account lifecycle fence."""
+
+    __tablename__ = "principal_lifecycles"
+    __table_args__ = (
+        UniqueConstraint(
+            "issuer",
+            "subject",
+            name="uq_principal_lifecycles_external_identity",
+        ),
+        UniqueConstraint("user_id", name="uq_principal_lifecycles_user_id"),
+        CheckConstraint(
+            "current_revision >= 1",
+            name="ck_principal_lifecycles_revision",
+        ),
+        CheckConstraint(
+            "cleanup_attempts >= 0",
+            name="ck_principal_lifecycles_cleanup_attempts",
+        ),
+        CheckConstraint(
+            "(cleanup_completed_at IS NULL AND next_cleanup_attempt_at IS NOT NULL "
+            "AND ((cleanup_claim_id IS NULL AND cleanup_claimed_at IS NULL) OR "
+            "(cleanup_claim_id IS NOT NULL AND cleanup_claimed_at IS NOT NULL))) OR "
+            "(cleanup_completed_at IS NOT NULL AND next_cleanup_attempt_at IS NULL "
+            "AND cleanup_claim_id IS NULL AND cleanup_claimed_at IS NULL)",
+            name="ck_principal_lifecycles_cleanup",
+        ),
+        Index(
+            "ix_principal_lifecycles_cleanup_due",
+            "next_cleanup_attempt_at",
+            postgresql_where=text("cleanup_completed_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    issuer: Mapped[str] = mapped_column(String(255), nullable=False)
+    subject: Mapped[str] = mapped_column(String(200), nullable=False)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        index=True,
+    )
+    current_revision: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    terminated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    cleanup_attempts: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
+    cleanup_completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    next_cleanup_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    cleanup_claim_id: Mapped[str | None] = mapped_column(String(64))
+    cleanup_claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class PrincipalLifecycleCommand(Base, TimestampMixin):
+    """Durable receipt for one externally idempotent termination command."""
+
+    __tablename__ = "principal_lifecycle_commands"
+    __table_args__ = (
+        CheckConstraint(
+            "requested_revision >= 1 AND accepted_revision >= requested_revision",
+            name="ck_principal_lifecycle_commands_revisions",
+        ),
+    )
+
+    command_id: Mapped[str] = mapped_column(String(191), primary_key=True)
+    lifecycle_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("principal_lifecycles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    requested_revision: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    accepted_revision: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    advanced: Mapped[bool] = mapped_column(Boolean, nullable=False)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -21,7 +21,7 @@ class User(Base, TimestampMixin):
             "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
             "AND partner_tenant_ref IS NULL) OR "
             "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
-            "AND partner_tenant_ref IS NOT NULL)",
+            "AND clerk_issuer IS NULL AND partner_tenant_ref IS NOT NULL)",
             name="ck_users_principal_identity",
         ),
     )
@@ -35,6 +35,12 @@ class User(Base, TimestampMixin):
         nullable=False,
     )
     partner_tenant_ref: Mapped[str | None] = mapped_column(String(255))
+    # Existing Clerk rows start with NULL and bind to the configured issuer on
+    # their next trusted JWT, create, or termination use. The released global
+    # clerk_id uniqueness remains a deliberate single-Clerk-instance compatibility
+    # constraint; clerk_issuer scopes lifecycle fences but does not enable
+    # simultaneous same-subject users from multiple Clerk instances.
+    clerk_issuer: Mapped[str | None] = mapped_column(String(255))
     email: Mapped[str | None] = mapped_column(String(320))
     name: Mapped[str | None] = mapped_column(String(200))
     # Profile picture URL captured from the Clerk JWT `picture` claim

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -162,6 +162,14 @@ from app.services.managed_ai_provider import (
     lock_deployment_managed_provider_mutation,
     upsert_clawdi_managed_provider,
 )
+from app.services.principal_lifecycle import (
+    PrincipalIdentityConflictError,
+    PrincipalLifecycleConfigurationError,
+    PrincipalTerminatedError,
+    assert_user_authority_active,
+    load_clerk_user_for_issuer,
+    resolve_clerk_owner_issuer,
+)
 from app.services.runtime_generation import (
     RuntimeApplyGenerationUpdateError,
     resolve_runtime_apply_generation_update,
@@ -305,7 +313,10 @@ async def admin_upsert_app_setting(
     return _admin_app_setting_response(setting)
 
 
-async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
+async def _resolve_or_create_user(
+    db: AsyncSession,
+    clerk_id: str,
+) -> User:
     """Resolve a user by clerk_id, lazy-creating the row + Personal
     project if needed.
 
@@ -327,20 +338,35 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     an operational anomaly worth a loud failure rather than a
     user-flow retry.
     """
-    target = (
-        await db.execute(
-            select(User).where(
-                User.principal_kind == PRINCIPAL_KIND_CLERK,
-                User.clerk_id == clerk_id,
-            )
+    try:
+        issuer = await resolve_clerk_owner_issuer(
+            db,
+            subject=clerk_id,
         )
-    ).scalar_one_or_none()
+        target = await load_clerk_user_for_issuer(
+            db,
+            issuer=issuer,
+            subject=clerk_id,
+            bind_legacy=False,
+        )
+    except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
+    except PrincipalLifecycleConfigurationError:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Clerk owner issuer is not configured",
+        ) from None
     if target is not None:
+        try:
+            await assert_user_authority_active(db, target.id)
+        except PrincipalTerminatedError:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
         return target
 
     user = await lazy_create_user_with_personal_project(
         db,
         clerk_id=clerk_id,
+        clerk_issuer=issuer,
         email=None,
         name=None,
         race_loser_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -349,25 +375,52 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     return user
 
 
-async def _find_admin_owner(db: AsyncSession, owner: PlatformOwner) -> User:
+async def _find_admin_owner(
+    db: AsyncSession,
+    owner: PlatformOwner,
+) -> User:
     if owner.kind == PRINCIPAL_KIND_CLERK:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == owner.ref,
-        )
+        try:
+            issuer = await resolve_clerk_owner_issuer(
+                db,
+                subject=owner.ref,
+            )
+            target = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=owner.ref,
+                bind_legacy=False,
+            )
+        except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
+        except PrincipalLifecycleConfigurationError:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Clerk owner issuer is not configured",
+            ) from None
     else:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
-            User.partner_tenant_ref == owner.ref,
-            User.clerk_id.is_(None),
-        )
-    target = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+        target = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                    User.partner_tenant_ref == owner.ref,
+                    User.clerk_id.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
     if target is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Owner not found")
+    try:
+        await assert_user_authority_active(db, target.id)
+    except PrincipalTerminatedError:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
     return target
 
 
-async def _resolve_or_create_admin_owner(db: AsyncSession, owner: PlatformOwner) -> User:
+async def _resolve_or_create_admin_owner(
+    db: AsyncSession,
+    owner: PlatformOwner,
+) -> User:
     if owner.kind == PRINCIPAL_KIND_CLERK:
         return await _resolve_or_create_user(db, owner.ref)
 
@@ -381,6 +434,10 @@ async def _resolve_or_create_admin_owner(db: AsyncSession, owner: PlatformOwner)
         )
     ).scalar_one_or_none()
     if target is not None:
+        try:
+            await assert_user_authority_active(db, target.id)
+        except PrincipalTerminatedError:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
         return target
     return await lazy_create_partner_user_with_personal_project(
         db,
@@ -557,14 +614,15 @@ async def _assert_admin_target_owns_environment(
     if target_clerk_id is None:
         return env.user_id
 
-    target = (
-        await db.execute(
-            select(User).where(
-                User.principal_kind == PRINCIPAL_KIND_CLERK,
-                User.clerk_id == target_clerk_id,
-            )
+    try:
+        target = await _find_admin_owner(
+            db,
+            PlatformOwner(kind=PRINCIPAL_KIND_CLERK, ref=target_clerk_id),
         )
-    ).scalar_one_or_none()
+    except HTTPException as exc:
+        if exc.status_code != status.HTTP_404_NOT_FOUND:
+            raise
+        target = None
     if target is None or env.user_id != target.id:
         logger.warning(
             "admin_environment_owner_rejected target_clerk_id=%s env_id=%s owner_user_id=%s",

--- a/backend/app/routes/cli_auth.py
+++ b/backend/app/routes/cli_auth.py
@@ -19,7 +19,6 @@ This remains additive for existing released CLI clients. New first-party CLI
 login uses Clerk's Public OAuth App Authorization Code + PKCE flow instead.
 """
 
-import hashlib
 import secrets
 import time
 from collections import deque
@@ -36,7 +35,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import AuthContext, require_oauth_cli_auth, require_web_auth
 from app.core.config import settings
 from app.core.database import get_session
-from app.models.api_key import ApiKey
 from app.models.device_authorization import DeviceAuthorization
 from app.schemas.cli_auth import (
     DeviceApproveRequest,
@@ -51,6 +49,7 @@ from app.schemas.cli_auth import (
     OAuthRevokeRequest,
     OAuthRevokeResponse,
 )
+from app.services.api_key import mint_api_key
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
 from app.services.clerk_cli_oauth_settings import ClerkCliOAuthSetting
@@ -511,21 +510,18 @@ async def approve_device_flow(
             f"Authorization is already {da.status}",
         )
 
-    raw = "clawdi_" + secrets.token_urlsafe(32)
     label = (da.client_label or "CLI device flow")[:200]
-    api_key = ApiKey(
+    minted = await mint_api_key(
+        db,
         user_id=auth.user_id,
-        key_hash=hashlib.sha256(raw.encode()).hexdigest(),
-        key_prefix=raw[:16],
         label=label,
+        commit=False,
     )
-    db.add(api_key)
-    await db.flush()  # need api_key.id for the back-reference
 
     da.status = "approved"
     da.user_id = auth.user_id
-    da.api_key_id = api_key.id
-    da.api_key_raw = raw
+    da.api_key_id = minted.api_key.id
+    da.api_key_raw = minted.raw_key
     await db.commit()
 
     return DeviceTerminalResponse(status="approved")

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import invalidate_api_key_auth_cache
+from app.core.auth import invalidate_api_key_auth_cache, invalidate_user_api_key_auth_cache
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -26,6 +26,8 @@ from app.schemas.platform import (
     PlatformApiKeyCreate,
     PlatformMutationBody,
     PlatformOwner,
+    PlatformPrincipalTermination,
+    PlatformPrincipalTerminationResponse,
     PlatformRuntimeStateResponse,
     PlatformRuntimeStateUpsert,
 )
@@ -68,6 +70,19 @@ from app.services.platform_workload_auth import (
     get_platform_workload_key_resolver,
     issue_platform_workload_token,
     require_platform_mutation_auth,
+    require_platform_workload_auth,
+)
+from app.services.principal_lifecycle import (
+    PrincipalCommandConflictError,
+    PrincipalIdentityConflictError,
+    PrincipalLifecycleConfigurationError,
+    PrincipalTerminatedError,
+    assert_user_authority_active,
+    complete_principal_cleanup,
+    fence_principal_termination,
+    load_clerk_user_for_issuer,
+    record_principal_cleanup_failure,
+    resolve_clerk_owner_issuer,
 )
 from app.services.runtime_generation import (
     RuntimeApplyGenerationUpdateError,
@@ -196,6 +211,188 @@ async def platform_workload_oauth_token(
     return JSONResponse(content=response.model_dump(), headers=_OAUTH_NO_STORE_HEADERS)
 
 
+@router.post(
+    "/principals/terminate",
+    response_model=PlatformPrincipalTerminationResponse,
+)
+async def platform_terminate_principal(
+    body: PlatformPrincipalTermination,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:principals:terminate")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> PlatformPrincipalTerminationResponse:
+    """Fence a Clerk principal before transactionally revoking local authority."""
+
+    action = "principal.terminate"
+    owner = PlatformOwner(kind=PRINCIPAL_KIND_CLERK, ref=body.principal.subject)
+    resource_id = f"{body.principal.issuer}#{body.principal.subject}"
+    if idempotency_key != body.command_id:
+        await _reject(
+            db,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Idempotency-Key must equal command_id",
+            result="invalid_command_identity",
+            owner=owner,
+            owner_user_id=None,
+            resource_type="principal_lifecycle",
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+
+    try:
+        receipt = await fence_principal_termination(
+            db,
+            issuer=body.principal.issuer,
+            subject=body.principal.subject,
+            revision=body.revision,
+            command_id=body.command_id,
+        )
+    except PrincipalLifecycleConfigurationError:
+        await _reject(
+            db,
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="principal lifecycle receiver is not configured",
+            result="receiver_unconfigured",
+            owner=owner,
+            owner_user_id=None,
+            resource_type="principal_lifecycle",
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+    except PrincipalIdentityConflictError:
+        await _reject(
+            db,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="principal issuer is not accepted",
+            result="issuer_mismatch",
+            owner=owner,
+            owner_user_id=None,
+            resource_type="principal_lifecycle",
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+    except PrincipalCommandConflictError:
+        await _reject(
+            db,
+            status_code=status.HTTP_409_CONFLICT,
+            detail="command_id was already used with a different request",
+            result="command_conflict",
+            owner=owner,
+            owner_user_id=None,
+            resource_type="principal_lifecycle",
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+
+    _record_platform_audit(
+        db,
+        owner=owner,
+        owner_user_id=receipt.user_id,
+        resource_type="principal_lifecycle",
+        resource_id=resource_id,
+        action="principal.termination.fence",
+        result="fenced" if receipt.advanced else "revision_noop",
+        request=request,
+        idempotency_key=idempotency_key,
+        details={
+            "issuer": body.principal.issuer,
+            "command_id": body.command_id,
+            "requested_revision": body.revision,
+            "accepted_revision": receipt.accepted_revision,
+            "fence_created": receipt.fence_created,
+        },
+    )
+    # This commit is deliberately before cleanup. Once it succeeds every auth
+    # and owner-creation path observes the fence even if cleanup needs repair.
+    await db.commit()
+
+    try:
+        cleanup = await complete_principal_cleanup(db, lifecycle_id=receipt.lifecycle_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        try:
+            await record_principal_cleanup_failure(
+                db,
+                lifecycle_id=receipt.lifecycle_id,
+            )
+            _record_platform_audit(
+                db,
+                owner=owner,
+                owner_user_id=receipt.user_id,
+                resource_type="principal_lifecycle",
+                resource_id=resource_id,
+                action="principal.termination.cleanup",
+                result="repair_pending",
+                request=request,
+                idempotency_key=idempotency_key,
+                details={"durable_retry": True},
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "principal termination cleanup is pending repair",
+        ) from None
+
+    if receipt.user_id is not None:
+        invalidate_user_api_key_auth_cache(receipt.user_id)
+    for key_id in cleanup.revoked_api_key_ids:
+        invalidate_api_key_auth_cache(key_id)
+
+    response = PlatformPrincipalTerminationResponse(
+        principal=body.principal,
+        command_id=body.command_id,
+        requested_revision=body.revision,
+        accepted_revision=receipt.accepted_revision,
+        advanced=receipt.advanced,
+        user_disabled=cleanup.user_disabled,
+    )
+    _record_platform_audit(
+        db,
+        owner=owner,
+        owner_user_id=receipt.user_id,
+        resource_type="principal_lifecycle",
+        resource_id=resource_id,
+        action="principal.termination.cleanup",
+        result="success",
+        request=request,
+        idempotency_key=idempotency_key,
+        details={
+            "command_id": body.command_id,
+            "requested_revision": body.revision,
+            "accepted_revision": receipt.accepted_revision,
+            "api_keys_revoked": cleanup.api_keys_revoked,
+            "agents_archived": cleanup.agents_archived,
+            "runtime_states_deleted": cleanup.runtime_states_deleted,
+            "runtime_environments_retired": cleanup.runtime_environments_retired,
+            "channel_accounts_disabled": cleanup.channel_accounts_disabled,
+            "project_access_revoked": cleanup.project_access_revoked,
+            "session_access_revoked": cleanup.session_access_revoked,
+            "ai_providers_archived": cleanup.ai_providers_archived,
+            "oauth_revoke_pending": cleanup.oauth_revoke_pending,
+        },
+    )
+    await db.commit()
+    return response
+
+
 def _audit_details(
     *,
     owner: PlatformOwner,
@@ -310,17 +507,54 @@ async def _resolve_owner(
     idempotency_key: str,
 ) -> User:
     if owner.kind == PRINCIPAL_KIND_CLERK:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == owner.ref,
-        )
+        try:
+            issuer = await resolve_clerk_owner_issuer(db, subject=owner.ref)
+            user = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=owner.ref,
+                bind_legacy=False,
+            )
+        except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+            await _reject(
+                db,
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Owner has been terminated",
+                result="owner_terminated",
+                owner=owner,
+                owner_user_id=None,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                action=action,
+                request=request,
+                idempotency_key=idempotency_key,
+            )
+            raise AssertionError("unreachable")
+        except PrincipalLifecycleConfigurationError:
+            await _reject(
+                db,
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Clerk owner issuer is not configured",
+                result="owner_issuer_unconfigured",
+                owner=owner,
+                owner_user_id=None,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                action=action,
+                request=request,
+                idempotency_key=idempotency_key,
+            )
+            raise AssertionError("unreachable")
     else:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
-            User.partner_tenant_ref == owner.ref,
-            User.clerk_id.is_(None),
-        )
-    user = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+        user = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                    User.partner_tenant_ref == owner.ref,
+                    User.clerk_id.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
     if user is None:
         await _reject(
             db,
@@ -329,6 +563,23 @@ async def _resolve_owner(
             result="owner_not_found",
             owner=owner,
             owner_user_id=None,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+    try:
+        await assert_user_authority_active(db, user.id)
+    except PrincipalTerminatedError:
+        await _reject(
+            db,
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner has been terminated",
+            result="owner_terminated",
+            owner=owner,
+            owner_user_id=user.id,
             resource_type=resource_type,
             resource_id=resource_id,
             action=action,

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -44,6 +44,14 @@ from app.services.platform_contract import (
     read_platform_replay,
     store_platform_response,
 )
+from app.services.principal_lifecycle import (
+    PrincipalIdentityConflictError,
+    PrincipalLifecycleConfigurationError,
+    PrincipalTerminatedError,
+    assert_user_authority_active,
+    load_clerk_user_for_issuer,
+    resolve_clerk_owner_issuer,
+)
 from app.services.runtime_observation import (
     RuntimeApplyIdentity,
     RuntimeObservationProtocolError,
@@ -94,6 +102,8 @@ async def require_runtime_observation_writer(
             rejection_reason = "deployment_binding_missing"
         else:
             rejection_reason = "runtime_credential_required"
+    elif api_key is None:
+        rejection_reason = "runtime_credential_required"
     elif api_key.environment_id != environment_id:
         rejection_reason = "environment_binding_mismatch"
     elif api_key.scopes is None or RUNTIME_OBSERVATION_WRITE_SCOPE not in api_key.scopes:
@@ -128,19 +138,37 @@ async def require_runtime_observation_writer(
 
 async def _resolve_owner(db: AsyncSession, owner: PlatformOwner) -> User:
     if owner.kind == PRINCIPAL_KIND_CLERK:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == owner.ref,
-        )
+        try:
+            issuer = await resolve_clerk_owner_issuer(db, subject=owner.ref)
+            resolved = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=owner.ref,
+                bind_legacy=False,
+            )
+        except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
+        except PrincipalLifecycleConfigurationError:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Clerk owner issuer is not configured",
+            ) from None
     else:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
-            User.partner_tenant_ref == owner.ref,
-            User.clerk_id.is_(None),
-        )
-    resolved = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+        resolved = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                    User.partner_tenant_ref == owner.ref,
+                    User.clerk_id.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
     if resolved is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Owner not found")
+    try:
+        await assert_user_authority_active(db, resolved.id)
+    except PrincipalTerminatedError:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Owner has been terminated") from None
     return resolved
 
 

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.core.api_scopes import RUNTIME_MCP_SCOPES
+from app.core.config import canonical_clerk_issuer
 from app.schemas.runtime import (
     HostedEgressEngine,
     HostedEgressProfiles,
@@ -29,6 +30,7 @@ PLATFORM_RUNTIME_KEY_SCOPES = RUNTIME_MCP_SCOPES
 _CLERK_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _PARTNER_TENANT_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 _SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
+_COMMAND_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 
 
 class PlatformOwner(BaseModel):
@@ -51,6 +53,52 @@ class PlatformMutationBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     owner: PlatformOwner
+
+
+class PlatformClerkPrincipal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["clerk"]
+    issuer: str = Field(min_length=1, max_length=255)
+    subject: str = Field(min_length=1, max_length=200)
+
+    @field_validator("issuer")
+    @classmethod
+    def _canonicalize_issuer(cls, value: str) -> str:
+        return canonical_clerk_issuer(value)
+
+    @field_validator("subject")
+    @classmethod
+    def _validate_subject(cls, value: str) -> str:
+        if _CLERK_REF_RE.fullmatch(value) is None:
+            raise ValueError("invalid Clerk principal subject")
+        return value
+
+
+class PlatformPrincipalTermination(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    principal: PlatformClerkPrincipal
+    revision: int = Field(ge=1, le=9_223_372_036_854_775_807)
+    command_id: str = Field(min_length=1, max_length=191)
+
+    @field_validator("command_id")
+    @classmethod
+    def _validate_command_id(cls, value: str) -> str:
+        if _COMMAND_ID_RE.fullmatch(value) is None:
+            raise ValueError("invalid principal lifecycle command ID")
+        return value
+
+
+class PlatformPrincipalTerminationResponse(BaseModel):
+    principal: PlatformClerkPrincipal
+    command_id: str
+    requested_revision: int
+    accepted_revision: int
+    advanced: bool
+    status: Literal["terminated"] = "terminated"
+    cleanup_state: Literal["complete"] = "complete"
+    user_disabled: bool
 
 
 class PlatformAgentCreate(PlatformMutationBody):

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -18,6 +18,13 @@ from app.schemas.runtime_observed import (
 )
 
 RUNTIME_OBSERVATION_WRITE_SCOPE = "runtime-observations:write"
+RuntimeObservationIngestOutcome = Literal[
+    "accepted_head_created",
+    "accepted_head_advanced",
+    "accepted_non_advance_sequence",
+    "accepted_non_advance_captured_at",
+    "duplicate_replay",
+]
 
 
 class RuntimeObservationRequestModel(BaseModel):
@@ -119,13 +126,7 @@ class RuntimeObservationReadRequest(RuntimeObservationRequestModel):
 class RuntimeObservationIngestResponse(RuntimeObservationRequestModel):
     event_id: str = Field(alias="eventId")
     stream_position: int = Field(alias="streamPosition")
-    outcome: Literal[
-        "accepted_head_created",
-        "accepted_head_advanced",
-        "accepted_non_advance_sequence",
-        "accepted_non_advance_captured_at",
-        "duplicate_replay",
-    ]
+    outcome: RuntimeObservationIngestOutcome
 
 
 class RuntimeObservationResponseModel(BaseModel):

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
 from app.services.agent_lifecycle import reactivate_agent_and_project
+from app.services.principal_lifecycle import assert_user_authority_active
 
 _AGENT_TYPE_LABELS = {
     "openclaw": "OpenClaw",
@@ -71,6 +72,8 @@ async def register_agent_environment(
 
     if environment_id is None and registration_key is None:
         raise ValueError("register_agent_environment requires environment_id or registration_key")
+
+    await assert_user_authority_active(db, user_id)
 
     if environment_id is not None:
         existing = (
@@ -179,6 +182,11 @@ async def register_agent_environment(
         return AgentEnvironmentRegistration(env=env, created=True)
     except IntegrityError:
         await db.rollback()
+        # The rollback releases transaction-scoped advisory locks. Reacquire
+        # the shared authority fence before inspecting or mutating the winner.
+        # A termination queued behind the failed create therefore fences the
+        # user before this retry can refresh or reactivate authority.
+        await assert_user_authority_active(db, user_id)
         if environment_id is not None:
             winner = (
                 await db.execute(

--- a/backend/app/services/api_key.py
+++ b/backend/app/services/api_key.py
@@ -30,6 +30,7 @@ from app.models.runtime_observation import (
     V2RuntimeEnvironmentFence,
 )
 from app.models.session import AgentEnvironment
+from app.services.principal_lifecycle import assert_user_authority_active
 
 
 @dataclass
@@ -79,6 +80,8 @@ async def mint_api_key(
     accepted only for a managed environment-bound key whose pre-provisioned
     fence matches the same owner and deployment in this transaction.
     """
+    await assert_user_authority_active(db, user_id)
+
     # Defense-in-depth: every route caller already checks env
     # ownership before calling this service, but the service
     # itself enforces it too. A future caller that forgets the

--- a/backend/app/services/platform_workload_auth.py
+++ b/backend/app/services/platform_workload_auth.py
@@ -39,6 +39,7 @@ PLATFORM_WORKLOAD_SCOPES = (
     "platform:keys:revoke",
     "platform:runtime-observations:consume",
     "platform:runtime-environments:retire",
+    "platform:principals:terminate",
 )
 
 _PRIVATE_JWK_FIELDS = frozenset({"d", "p", "q", "dp", "dq", "qi", "oth", "k"})

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -1,0 +1,855 @@
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.ai_provider import AiProvider, AiProviderAuthPayload, AiProviderOAuthAttempt
+from app.models.api_key import ApiKey
+from app.models.channel import (
+    BINDING_STATUS_ARCHIVED,
+    BOT_AGENT_LINK_STATUS_ARCHIVED,
+    CHANNEL_STATUS_DISABLED,
+    PAIR_CODE_STATUS_REVOKED,
+    WHATSAPP_ONBOARDING_ACTIVE_STATES,
+    WHATSAPP_ONBOARDING_STATE_CANCELED,
+    WHATSAPP_ONBOARDING_STATE_ERROR,
+    ChannelAccount,
+    ChannelAgentCredential,
+    ChannelBinding,
+    ChannelBotAgentLink,
+    ChannelPairCode,
+    ChannelWhatsAppOnboardingSession,
+)
+from app.models.device_authorization import DeviceAuthorization
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.principal_lifecycle import (
+    PrincipalLifecycle,
+    PrincipalLifecycleCommand,
+)
+from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
+from app.models.project_invitation import ProjectInvitation
+from app.models.project_membership import ProjectMembership
+from app.models.project_share_link import ProjectShareLink
+from app.models.runtime_observation import (
+    RUNTIME_ENVIRONMENT_ACTIVE,
+    V2RuntimeEnvironmentFence,
+)
+from app.models.session import AgentEnvironment, Session
+from app.models.session_permission import SessionPermission
+from app.models.user import PRINCIPAL_KIND_CLERK, User
+from app.services.ai_provider_auth_transition import transition_ai_provider_auth
+from app.services.ai_provider_oauth_lifecycle import terminal_oauth_attempt
+from app.services.runtime_observation import retire_runtime_environment
+
+
+class PrincipalTerminatedError(RuntimeError):
+    pass
+
+
+class PrincipalIdentityConflictError(RuntimeError):
+    pass
+
+
+class PrincipalLifecycleConfigurationError(RuntimeError):
+    pass
+
+
+class PrincipalCommandConflictError(RuntimeError):
+    pass
+
+
+class PrincipalCleanupClaimLostError(RuntimeError):
+    pass
+
+
+PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS = 60
+PRINCIPAL_CLEANUP_BACKOFF_CAP_SECONDS = 15 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class PrincipalTerminationReceipt:
+    lifecycle_id: UUID
+    accepted_revision: int
+    advanced: bool
+    user_id: UUID | None
+    fence_created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PrincipalCleanupResult:
+    user_disabled: bool
+    api_keys_revoked: int = 0
+    agents_archived: int = 0
+    runtime_states_deleted: int = 0
+    runtime_environments_retired: int = 0
+    channel_accounts_disabled: int = 0
+    project_access_revoked: int = 0
+    session_access_revoked: int = 0
+    ai_providers_archived: int = 0
+    oauth_revoke_pending: int = 0
+    revoked_api_key_ids: tuple[UUID, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimedPrincipalCleanup:
+    lifecycle_id: UUID
+    claim_id: str
+    attempt_count: int
+
+
+def configured_clerk_issuer() -> str:
+    issuer = settings.clerk_jwt_issuer
+    if not issuer:
+        raise PrincipalLifecycleConfigurationError("Clerk issuer is not configured")
+    return issuer
+
+
+def _principal_lock_name(issuer: str, subject: str) -> str:
+    return f"principal-authority:clerk:{issuer}:{subject}"
+
+
+async def _advisory_xact_lock(db: AsyncSession, name: str) -> None:
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(name, 0))))
+
+
+async def _advisory_xact_lock_shared(db: AsyncSession, name: str) -> None:
+    await db.execute(select(func.pg_advisory_xact_lock_shared(func.hashtextextended(name, 0))))
+
+
+async def lock_clerk_principal(db: AsyncSession, *, issuer: str, subject: str) -> None:
+    """Hold the exclusive principal authority lock for fence/cleanup."""
+
+    await _advisory_xact_lock(db, _principal_lock_name(issuer, subject))
+
+
+async def lock_clerk_principal_shared(
+    db: AsyncSession,
+    *,
+    issuer: str,
+    subject: str,
+) -> None:
+    """Hold the shared principal authority lock for an active request."""
+
+    await _advisory_xact_lock_shared(db, _principal_lock_name(issuer, subject))
+
+
+async def lock_user_authority(db: AsyncSession, user_id: UUID) -> None:
+    """Hold the exclusive user authority lock for fence/cleanup."""
+
+    await _advisory_xact_lock(db, f"user-authority:{user_id}")
+
+
+async def lock_user_authority_shared(db: AsyncSession, user_id: UUID) -> None:
+    """Hold the shared user authority lock for an active request."""
+
+    await _advisory_xact_lock_shared(db, f"user-authority:{user_id}")
+
+
+async def assert_clerk_principal_active(
+    db: AsyncSession,
+    *,
+    subject: str,
+    issuer: str | None = None,
+    lock: bool = True,
+) -> str | None:
+    """Lock and reject a durable Clerk tombstone before any lazy create."""
+
+    resolved_issuer = issuer or settings.clerk_jwt_issuer
+    if not resolved_issuer:
+        # Legacy PEM-only JWTs may not carry an issuer. They retain their
+        # compatibility path, but a configuration change must never hide a
+        # fence that was already persisted under a previously configured
+        # issuer.
+        lifecycle = (
+            await db.execute(
+                select(PrincipalLifecycle.issuer)
+                .where(
+                    PrincipalLifecycle.subject == subject,
+                )
+                .order_by(PrincipalLifecycle.issuer)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if lifecycle is not None:
+            if lock:
+                await lock_clerk_principal_shared(
+                    db,
+                    issuer=lifecycle,
+                    subject=subject,
+                )
+            raise PrincipalTerminatedError("principal has been terminated")
+        return None
+    if lock:
+        await lock_clerk_principal_shared(db, issuer=resolved_issuer, subject=subject)
+    lifecycle_id = await db.scalar(
+        select(PrincipalLifecycle.id).where(
+            PrincipalLifecycle.issuer == resolved_issuer,
+            PrincipalLifecycle.subject == subject,
+        )
+    )
+    if lifecycle_id is not None:
+        raise PrincipalTerminatedError("principal has been terminated")
+    return resolved_issuer
+
+
+async def resolve_clerk_owner_issuer(
+    db: AsyncSession,
+    *,
+    subject: str,
+    lock: bool = True,
+) -> str:
+    """Resolve a non-JWT Clerk owner without guessing an issuer.
+
+    The configured issuer is canonical. If configuration is temporarily
+    absent, an already-bound User supplies the only safe compatibility bridge.
+    An unbound owner fails closed, and any tombstone remains authoritative.
+    """
+
+    if settings.clerk_jwt_issuer:
+        configured_issuer = settings.clerk_jwt_issuer
+        await assert_clerk_principal_active(
+            db,
+            subject=subject,
+            issuer=configured_issuer,
+            lock=lock,
+        )
+        return configured_issuer
+
+    bound_issuer = await db.scalar(
+        select(User.clerk_issuer).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == subject,
+            User.clerk_issuer.is_not(None),
+        )
+    )
+    if bound_issuer is None:
+        await assert_clerk_principal_active(db, subject=subject, lock=lock)
+        raise PrincipalLifecycleConfigurationError(
+            "Clerk owner issuer cannot be resolved without configuration"
+        )
+    await assert_clerk_principal_active(
+        db,
+        subject=subject,
+        issuer=bound_issuer,
+        lock=lock,
+    )
+    return bound_issuer
+
+
+async def assert_user_authority_active(
+    db: AsyncSession,
+    user_id: UUID,
+    *,
+    lock: bool = True,
+) -> None:
+    """Hold the user authority lock and reject disabled/fenced identities."""
+
+    if lock:
+        await lock_user_authority_shared(db, user_id)
+    active_id = await db.scalar(
+        select(User.id).where(
+            User.id == user_id,
+            ~select(PrincipalLifecycle.id).where(PrincipalLifecycle.user_id == User.id).exists(),
+        )
+    )
+    if active_id is None:
+        raise PrincipalTerminatedError("user authority is disabled")
+
+
+async def load_clerk_user_for_issuer(
+    db: AsyncSession,
+    *,
+    issuer: str,
+    subject: str,
+    bind_legacy: bool,
+    allow_issuer_mismatch: bool = False,
+    for_update: bool = False,
+) -> User | None:
+    statement = select(User).where(
+        User.principal_kind == PRINCIPAL_KIND_CLERK,
+        User.clerk_id == subject,
+    )
+    user = (await db.execute(statement)).scalar_one_or_none()
+    if user is None:
+        return None
+    if user.clerk_issuer is not None and user.clerk_issuer != issuer:
+        if allow_issuer_mismatch:
+            return None
+        raise PrincipalIdentityConflictError("Clerk subject belongs to another issuer")
+    if for_update or (bind_legacy and user.clerk_issuer is None):
+        # Authority locks must precede User row locks. In particular, a
+        # different issuer may bind the released legacy row while termination
+        # is resolving the same globally-unique subject.
+        await lock_user_authority_shared(db, user.id)
+        user = (
+            await db.execute(
+                select(User)
+                .where(User.id == user.id)
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            )
+        ).scalar_one()
+        if user.clerk_issuer is not None and user.clerk_issuer != issuer:
+            if allow_issuer_mismatch:
+                return None
+            raise PrincipalIdentityConflictError("Clerk subject belongs to another issuer")
+    if bind_legacy and user.clerk_issuer is None:
+        user.clerk_issuer = issuer
+    return user
+
+
+async def fence_principal_termination(
+    db: AsyncSession,
+    *,
+    issuer: str,
+    subject: str,
+    revision: int,
+    command_id: str,
+    now: datetime | None = None,
+) -> PrincipalTerminationReceipt:
+    """Persist the fail-closed fence and command receipt; caller commits it."""
+
+    if issuer != configured_clerk_issuer():
+        raise PrincipalIdentityConflictError("principal issuer is not accepted")
+    await _advisory_xact_lock(db, f"principal-command:{command_id}")
+    await lock_clerk_principal(db, issuer=issuer, subject=subject)
+
+    existing_command = await db.get(PrincipalLifecycleCommand, command_id)
+    if existing_command is not None:
+        lifecycle = await db.get(PrincipalLifecycle, existing_command.lifecycle_id)
+        if (
+            lifecycle is None
+            or lifecycle.issuer != issuer
+            or lifecycle.subject != subject
+            or existing_command.requested_revision != revision
+        ):
+            raise PrincipalCommandConflictError(
+                "command ID was already used with a different request"
+            )
+        return PrincipalTerminationReceipt(
+            lifecycle_id=lifecycle.id,
+            accepted_revision=existing_command.accepted_revision,
+            advanced=existing_command.advanced,
+            user_id=lifecycle.user_id,
+            fence_created=False,
+        )
+
+    lifecycle = (
+        await db.execute(
+            select(PrincipalLifecycle)
+            .where(
+                PrincipalLifecycle.issuer == issuer,
+                PrincipalLifecycle.subject == subject,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    current_time = now or datetime.now(UTC)
+    fence_created = lifecycle is None
+    advanced = lifecycle is None or revision > lifecycle.current_revision
+    if lifecycle is None:
+        candidate = await load_clerk_user_for_issuer(
+            db,
+            issuer=issuer,
+            subject=subject,
+            bind_legacy=False,
+            allow_issuer_mismatch=True,
+        )
+        user = None
+        if candidate is not None:
+            # All authority paths take the advisory user lock before a row
+            # lock. Preserve that order here so a terminating command cannot
+            # deadlock a request that is already mutating the User row.
+            await lock_user_authority(db, candidate.id)
+            user = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=subject,
+                bind_legacy=False,
+                allow_issuer_mismatch=True,
+                for_update=True,
+            )
+        if user is not None:
+            if user.clerk_issuer is None:
+                user.clerk_issuer = issuer
+        lifecycle = PrincipalLifecycle(
+            issuer=issuer,
+            subject=subject,
+            user_id=user.id if user is not None else None,
+            current_revision=revision,
+            terminated_at=current_time,
+            next_cleanup_attempt_at=current_time,
+        )
+        db.add(lifecycle)
+        await db.flush()
+    elif advanced:
+        lifecycle.current_revision = revision
+
+    accepted_revision = lifecycle.current_revision
+    db.add(
+        PrincipalLifecycleCommand(
+            command_id=command_id,
+            lifecycle_id=lifecycle.id,
+            requested_revision=revision,
+            accepted_revision=accepted_revision,
+            advanced=advanced,
+        )
+    )
+    await db.flush()
+    return PrincipalTerminationReceipt(
+        lifecycle_id=lifecycle.id,
+        accepted_revision=accepted_revision,
+        advanced=advanced,
+        user_id=lifecycle.user_id,
+        fence_created=fence_created,
+    )
+
+
+async def complete_principal_cleanup(
+    db: AsyncSession,
+    *,
+    lifecycle_id: UUID,
+    expected_claim_id: str | None = None,
+    now: datetime | None = None,
+) -> PrincipalCleanupResult:
+    """Revoke local authority transactionally, queuing remote OAuth repair."""
+
+    identity = await db.get(PrincipalLifecycle, lifecycle_id)
+    if identity is None:
+        raise RuntimeError("principal lifecycle fence disappeared")
+    await lock_clerk_principal(db, issuer=identity.issuer, subject=identity.subject)
+    lifecycle = (
+        await db.execute(
+            select(PrincipalLifecycle)
+            .where(PrincipalLifecycle.id == lifecycle_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    if lifecycle.cleanup_completed_at is not None:
+        return PrincipalCleanupResult(user_disabled=lifecycle.user_id is not None)
+    if expected_claim_id is not None and lifecycle.cleanup_claim_id != expected_claim_id:
+        raise PrincipalCleanupClaimLostError("principal cleanup claim changed")
+
+    current_time = now or datetime.now(UTC)
+    attempt_already_recorded = lifecycle.cleanup_claim_id is not None
+    if lifecycle.user_id is None:
+        if not attempt_already_recorded:
+            lifecycle.cleanup_attempts += 1
+        _mark_principal_cleanup_complete(lifecycle, completed_at=current_time)
+        await db.flush()
+        return PrincipalCleanupResult(user_disabled=False)
+
+    await lock_user_authority(db, lifecycle.user_id)
+    user = await db.get(User, lifecycle.user_id)
+    if user is None:
+        if not attempt_already_recorded:
+            lifecycle.cleanup_attempts += 1
+        _mark_principal_cleanup_complete(lifecycle, completed_at=current_time)
+        await db.flush()
+        return PrincipalCleanupResult(user_disabled=False)
+
+    key_ids = tuple(
+        (
+            await db.scalars(
+                update(ApiKey)
+                .where(ApiKey.user_id == user.id, ApiKey.revoked_at.is_(None))
+                .values(revoked_at=current_time)
+                .returning(ApiKey.id)
+            )
+        ).all()
+    )
+    agent_ids = tuple(
+        (
+            await db.scalars(select(AgentEnvironment.id).where(AgentEnvironment.user_id == user.id))
+        ).all()
+    )
+    archived_agent_ids = tuple(
+        (
+            await db.scalars(
+                update(AgentEnvironment)
+                .where(
+                    AgentEnvironment.user_id == user.id,
+                    AgentEnvironment.archived_at.is_(None),
+                )
+                .values(archived_at=current_time)
+                .returning(AgentEnvironment.id)
+            )
+        ).all()
+    )
+    await db.execute(
+        update(Project)
+        .where(
+            Project.user_id == user.id,
+            Project.kind == PROJECT_KIND_ENVIRONMENT,
+            Project.archived_at.is_(None),
+        )
+        .values(archived_at=current_time)
+    )
+    runtime_states_deleted = 0
+    if agent_ids:
+        deleted_runtime_state_ids = tuple(
+            (
+                await db.scalars(
+                    delete(HostedRuntimeState)
+                    .where(HostedRuntimeState.environment_id.in_(agent_ids))
+                    .returning(HostedRuntimeState.environment_id)
+                )
+            ).all()
+        )
+        runtime_states_deleted = len(deleted_runtime_state_ids)
+
+    active_runtime_fences = list(
+        (
+            await db.scalars(
+                select(V2RuntimeEnvironmentFence)
+                .where(
+                    V2RuntimeEnvironmentFence.owner_id == user.id,
+                    V2RuntimeEnvironmentFence.state == RUNTIME_ENVIRONMENT_ACTIVE,
+                )
+                .order_by(V2RuntimeEnvironmentFence.environment_id)
+            )
+        ).all()
+    )
+    runtime_environments_retired = 0
+    retirement_id = f"principal-termination:{lifecycle.id}"
+    for runtime_fence in active_runtime_fences:
+        retirement = await retire_runtime_environment(
+            db,
+            environment_id=runtime_fence.environment_id,
+            expected_deployment_id=runtime_fence.deployment_id,
+            retirement_id=retirement_id,
+            owner_id=user.id,
+            retired_at=current_time,
+        )
+        runtime_environments_retired += int(retirement.transitioned)
+
+    channel_account_ids = tuple(
+        (
+            await db.scalars(
+                update(ChannelAccount)
+                .where(
+                    ChannelAccount.user_id == user.id,
+                    or_(
+                        ChannelAccount.status != CHANNEL_STATUS_DISABLED,
+                        ChannelAccount.archived_at.is_(None),
+                    ),
+                )
+                .values(status=CHANNEL_STATUS_DISABLED, archived_at=current_time)
+                .returning(ChannelAccount.id)
+            )
+        ).all()
+    )
+    await db.execute(
+        update(ChannelBotAgentLink)
+        .where(
+            ChannelBotAgentLink.user_id == user.id,
+            or_(
+                ChannelBotAgentLink.status != BOT_AGENT_LINK_STATUS_ARCHIVED,
+                ChannelBotAgentLink.archived_at.is_(None),
+            ),
+        )
+        .values(status=BOT_AGENT_LINK_STATUS_ARCHIVED, archived_at=current_time)
+    )
+    await db.execute(
+        update(ChannelBinding)
+        .where(
+            ChannelBinding.user_id == user.id,
+            ChannelBinding.status != BINDING_STATUS_ARCHIVED,
+        )
+        .values(status=BINDING_STATUS_ARCHIVED)
+    )
+    await db.execute(
+        update(ChannelPairCode)
+        .where(
+            ChannelPairCode.user_id == user.id,
+            ChannelPairCode.status != PAIR_CODE_STATUS_REVOKED,
+        )
+        .values(status=PAIR_CODE_STATUS_REVOKED)
+    )
+    await db.execute(
+        update(ChannelAgentCredential)
+        .where(
+            ChannelAgentCredential.user_id == user.id,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+        .values(revoked_at=current_time)
+    )
+    await db.execute(
+        update(ChannelWhatsAppOnboardingSession)
+        .where(
+            ChannelWhatsAppOnboardingSession.user_id == user.id,
+            ChannelWhatsAppOnboardingSession.state.in_(
+                (*WHATSAPP_ONBOARDING_ACTIVE_STATES, WHATSAPP_ONBOARDING_STATE_ERROR)
+            ),
+        )
+        .values(state=WHATSAPP_ONBOARDING_STATE_CANCELED, completed_at=current_time)
+    )
+
+    owned_project_ids = select(Project.id).where(Project.user_id == user.id)
+    deleted_membership_ids = tuple(
+        (
+            await db.scalars(
+                delete(ProjectMembership)
+                .where(
+                    or_(
+                        ProjectMembership.member_user_id == user.id,
+                        ProjectMembership.project_id.in_(owned_project_ids),
+                    )
+                )
+                .returning(ProjectMembership.id)
+            )
+        ).all()
+    )
+    deleted_invitation_ids = tuple(
+        (
+            await db.scalars(
+                delete(ProjectInvitation)
+                .where(
+                    or_(
+                        ProjectInvitation.invitee_user_id == user.id,
+                        ProjectInvitation.invited_by == user.id,
+                        ProjectInvitation.project_id.in_(owned_project_ids),
+                    )
+                )
+                .returning(ProjectInvitation.id)
+            )
+        ).all()
+    )
+    revoked_share_link_ids = tuple(
+        (
+            await db.scalars(
+                update(ProjectShareLink)
+                .where(
+                    or_(
+                        ProjectShareLink.created_by == user.id,
+                        ProjectShareLink.project_id.in_(owned_project_ids),
+                    ),
+                    ProjectShareLink.revoked_at.is_(None),
+                )
+                .values(revoked_at=current_time)
+                .returning(ProjectShareLink.id)
+            )
+        ).all()
+    )
+    owned_session_ids = select(Session.id).where(Session.user_id == user.id)
+    revoked_permission_ids = tuple(
+        (
+            await db.scalars(
+                update(SessionPermission)
+                .where(
+                    or_(
+                        SessionPermission.user_id == user.id,
+                        SessionPermission.invited_by == user.id,
+                        SessionPermission.session_id.in_(owned_session_ids),
+                    ),
+                    SessionPermission.revoked_at.is_(None),
+                )
+                .values(revoked_at=current_time)
+                .returning(SessionPermission.id)
+            )
+        ).all()
+    )
+    await db.execute(
+        update(DeviceAuthorization)
+        .where(
+            DeviceAuthorization.user_id == user.id,
+            DeviceAuthorization.status.in_(("pending", "approved")),
+        )
+        .values(status="denied", api_key_raw=None)
+    )
+
+    providers = list(
+        (
+            await db.scalars(
+                select(AiProvider)
+                .where(AiProvider.owner_user_id == user.id, AiProvider.archived_at.is_(None))
+                .order_by(AiProvider.id)
+                .with_for_update()
+            )
+        ).all()
+    )
+    oauth_revoke_pending = 0
+    for provider in providers:
+        transition = await transition_ai_provider_auth(
+            db,
+            owner_user_id=user.id,
+            provider=provider,
+            auth_type=provider.auth_type,
+            auth_ref=provider.auth_ref,
+            auth_metadata=provider.auth_metadata,
+            archive_provider=True,
+        )
+        oauth_revoke_pending += int(transition.remote_revoke_status == "pending")
+    await db.execute(
+        update(AiProviderAuthPayload)
+        .where(
+            AiProviderAuthPayload.owner_user_id == user.id,
+            AiProviderAuthPayload.archived_at.is_(None),
+        )
+        .values(
+            archived_at=current_time,
+            consumer_environment_id=None,
+            consumer_runtime=None,
+        )
+    )
+    await db.execute(
+        update(AiProviderOAuthAttempt)
+        .where(
+            AiProviderOAuthAttempt.owner_user_id == user.id,
+            AiProviderOAuthAttempt.status.in_(("pending", "polling", "exchanging")),
+        )
+        .values(**terminal_oauth_attempt("failed", completed_at=current_time).update_values())
+    )
+
+    if not attempt_already_recorded:
+        lifecycle.cleanup_attempts += 1
+    _mark_principal_cleanup_complete(lifecycle, completed_at=current_time)
+    await db.flush()
+    project_access_revoked = (
+        len(deleted_membership_ids) + len(deleted_invitation_ids) + len(revoked_share_link_ids)
+    )
+    return PrincipalCleanupResult(
+        user_disabled=True,
+        api_keys_revoked=len(key_ids),
+        agents_archived=len(archived_agent_ids),
+        runtime_states_deleted=runtime_states_deleted,
+        runtime_environments_retired=runtime_environments_retired,
+        channel_accounts_disabled=len(channel_account_ids),
+        project_access_revoked=project_access_revoked,
+        session_access_revoked=len(revoked_permission_ids),
+        ai_providers_archived=len(providers),
+        oauth_revoke_pending=oauth_revoke_pending,
+        revoked_api_key_ids=key_ids,
+    )
+
+
+def _mark_principal_cleanup_complete(
+    lifecycle: PrincipalLifecycle,
+    *,
+    completed_at: datetime,
+) -> None:
+    lifecycle.cleanup_completed_at = completed_at
+    lifecycle.next_cleanup_attempt_at = None
+    lifecycle.cleanup_claim_id = None
+    lifecycle.cleanup_claimed_at = None
+
+
+async def claim_principal_cleanup(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    lease_seconds: int = PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS,
+) -> ClaimedPrincipalCleanup | None:
+    """Claim one due cleanup without blocking another worker's row."""
+
+    claimed_at = now or datetime.now(UTC)
+    stale_before = claimed_at - timedelta(seconds=lease_seconds)
+    lifecycle = (
+        await db.execute(
+            select(PrincipalLifecycle)
+            .where(
+                PrincipalLifecycle.cleanup_completed_at.is_(None),
+                or_(
+                    and_(
+                        PrincipalLifecycle.cleanup_claim_id.is_(None),
+                        PrincipalLifecycle.next_cleanup_attempt_at <= claimed_at,
+                    ),
+                    and_(
+                        PrincipalLifecycle.cleanup_claim_id.is_not(None),
+                        PrincipalLifecycle.cleanup_claimed_at <= stale_before,
+                    ),
+                ),
+            )
+            .order_by(
+                PrincipalLifecycle.next_cleanup_attempt_at,
+                PrincipalLifecycle.created_at,
+                PrincipalLifecycle.id,
+            )
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+    ).scalar_one_or_none()
+    if lifecycle is None:
+        return None
+    claim_id = secrets.token_hex(16)
+    lifecycle.cleanup_claim_id = claim_id
+    lifecycle.cleanup_claimed_at = claimed_at
+    lifecycle.cleanup_attempts += 1
+    await db.flush()
+    return ClaimedPrincipalCleanup(
+        lifecycle_id=lifecycle.id,
+        claim_id=claim_id,
+        attempt_count=lifecycle.cleanup_attempts,
+    )
+
+
+async def record_principal_cleanup_failure(
+    db: AsyncSession,
+    *,
+    lifecycle_id: UUID,
+    expected_claim_id: str | None = None,
+    now: datetime | None = None,
+) -> bool:
+    identity = await db.get(PrincipalLifecycle, lifecycle_id)
+    if identity is None:
+        return False
+    await lock_clerk_principal(db, issuer=identity.issuer, subject=identity.subject)
+    lifecycle = (
+        await db.execute(
+            select(PrincipalLifecycle)
+            .where(PrincipalLifecycle.id == lifecycle_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one_or_none()
+    if lifecycle is None or lifecycle.cleanup_completed_at is not None:
+        return False
+    if expected_claim_id is not None and lifecycle.cleanup_claim_id != expected_claim_id:
+        return False
+    if expected_claim_id is None and lifecycle.cleanup_claim_id is not None:
+        return False
+    if lifecycle.cleanup_claim_id is None:
+        lifecycle.cleanup_attempts += 1
+    backoff_seconds = min(
+        2 ** min(max(lifecycle.cleanup_attempts - 1, 0), 10),
+        PRINCIPAL_CLEANUP_BACKOFF_CAP_SECONDS,
+    )
+    lifecycle.next_cleanup_attempt_at = (now or datetime.now(UTC)) + timedelta(
+        seconds=backoff_seconds
+    )
+    lifecycle.cleanup_claim_id = None
+    lifecycle.cleanup_claimed_at = None
+    await db.flush()
+    return True
+
+
+__all__ = [
+    "PrincipalCleanupResult",
+    "ClaimedPrincipalCleanup",
+    "PRINCIPAL_CLEANUP_BACKOFF_CAP_SECONDS",
+    "PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS",
+    "PrincipalCleanupClaimLostError",
+    "PrincipalCommandConflictError",
+    "PrincipalIdentityConflictError",
+    "PrincipalLifecycleConfigurationError",
+    "PrincipalTerminatedError",
+    "PrincipalTerminationReceipt",
+    "assert_clerk_principal_active",
+    "assert_user_authority_active",
+    "claim_principal_cleanup",
+    "complete_principal_cleanup",
+    "configured_clerk_issuer",
+    "fence_principal_termination",
+    "load_clerk_user_for_issuer",
+    "lock_clerk_principal",
+    "lock_user_authority",
+    "resolve_clerk_owner_issuer",
+    "record_principal_cleanup_failure",
+]

--- a/backend/app/services/principal_lifecycle_cleanup_worker.py
+++ b/backend/app/services/principal_lifecycle_cleanup_worker.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.services.principal_lifecycle import (
+    claim_principal_cleanup,
+    complete_principal_cleanup,
+    record_principal_cleanup_failure,
+)
+
+log = logging.getLogger(__name__)
+
+
+class PrincipalLifecycleCleanupWorker:
+    """Recover durable principal cleanup work after route/process failure."""
+
+    def __init__(
+        self,
+        sessionmaker: async_sessionmaker[AsyncSession],
+        *,
+        poll_interval_seconds: float = 1.0,
+    ) -> None:
+        self._sessionmaker = sessionmaker
+        self._poll_interval_seconds = poll_interval_seconds
+
+    async def run_once(self) -> UUID | None:
+        async with self._sessionmaker() as db:
+            claim = await claim_principal_cleanup(db)
+            await db.commit()
+        if claim is None:
+            return None
+
+        try:
+            async with self._sessionmaker() as db:
+                await complete_principal_cleanup(
+                    db,
+                    lifecycle_id=claim.lifecycle_id,
+                    expected_claim_id=claim.claim_id,
+                )
+                await db.commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - every failed cleanup remains durable retry work.
+            log.exception(
+                "principal lifecycle cleanup failed lifecycle_id=%s",
+                claim.lifecycle_id,
+            )
+            async with self._sessionmaker() as db:
+                recorded = await record_principal_cleanup_failure(
+                    db,
+                    lifecycle_id=claim.lifecycle_id,
+                    expected_claim_id=claim.claim_id,
+                )
+                await db.commit()
+            if not recorded:
+                log.info(
+                    "principal cleanup failure ignored after claim changed lifecycle_id=%s",
+                    claim.lifecycle_id,
+                )
+        return claim.lifecycle_id
+
+    async def run_forever(self, stop: asyncio.Event | None = None) -> None:
+        stop_event = stop or asyncio.Event()
+        while not stop_event.is_set():
+            try:
+                lifecycle_id = await self.run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - one row cannot stop durable recovery.
+                log.exception("principal lifecycle cleanup worker iteration failed")
+                lifecycle_id = None
+            if lifecycle_id is None:
+                try:
+                    await asyncio.wait_for(
+                        stop_event.wait(),
+                        timeout=self._poll_interval_seconds,
+                    )
+                except TimeoutError:
+                    pass
+
+
+__all__ = ["PrincipalLifecycleCleanupWorker"]

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -30,7 +30,10 @@ from app.models.runtime_observation import (
     V2RuntimeObservationInbox,
 )
 from app.models.session import AgentEnvironment
-from app.schemas.runtime_observation import RuntimeObservationEventV2
+from app.schemas.runtime_observation import (
+    RuntimeObservationEventV2,
+    RuntimeObservationIngestOutcome,
+)
 from app.services.audit import record_control_plane_audit
 
 _CURSOR_PREFIX = "clawdi-ro-v1"
@@ -57,7 +60,7 @@ class RuntimeObservationIngestResult:
     event_id: str
     stream_position: int
     duplicate: bool
-    outcome: str
+    outcome: RuntimeObservationIngestOutcome
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/user_provisioning.py
+++ b/backend/app/services/user_provisioning.py
@@ -34,6 +34,12 @@ from app.models.user import (
     PRINCIPAL_KIND_PARTNER_TENANT,
     User,
 )
+from app.services.principal_lifecycle import (
+    PrincipalIdentityConflictError,
+    PrincipalTerminatedError,
+    assert_clerk_principal_active,
+    load_clerk_user_for_issuer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +48,12 @@ async def lazy_create_user_with_personal_project(
     db: AsyncSession,
     *,
     clerk_id: str,
+    clerk_issuer: str | None = None,
     email: str | None,
     name: str | None,
     avatar_url: str | None = None,
     race_loser_status: int,
+    inactive_status: int = status.HTTP_403_FORBIDDEN,
 ) -> User:
     """Insert a User row + Personal project for `clerk_id`, race-safe.
 
@@ -80,8 +88,18 @@ async def lazy_create_user_with_personal_project(
         HTTPException 500 — Personal project insert failed. Bizarre
         states only (partial unique index, mid-flush connection drop).
     """
+    try:
+        issuer = await assert_clerk_principal_active(
+            db,
+            subject=clerk_id,
+            issuer=clerk_issuer,
+        )
+    except PrincipalTerminatedError:
+        raise HTTPException(inactive_status, "account has been terminated") from None
+
     new_user = User(
         clerk_id=clerk_id,
+        clerk_issuer=issuer,
         principal_kind=PRINCIPAL_KIND_CLERK,
         partner_tenant_ref=None,
         email=email,
@@ -98,9 +116,21 @@ async def lazy_create_user_with_personal_project(
         await db.flush()
     except IntegrityError:
         await db.rollback()
-        target = (
-            await db.execute(select(User).where(User.clerk_id == clerk_id))
-        ).scalar_one_or_none()
+        try:
+            if issuer is None:
+                target = (
+                    await db.execute(select(User).where(User.clerk_id == clerk_id))
+                ).scalar_one_or_none()
+            else:
+                await assert_clerk_principal_active(db, subject=clerk_id, issuer=issuer)
+                target = await load_clerk_user_for_issuer(
+                    db,
+                    issuer=issuer,
+                    subject=clerk_id,
+                    bind_legacy=True,
+                )
+        except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+            raise HTTPException(inactive_status, "account has been terminated") from None
         if target is None:
             raise HTTPException(
                 race_loser_status,

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -36,6 +36,7 @@ from app.services.channels import (
     hash_token,
     require_channel_tenant_user_id,
 )
+from app.services.principal_lifecycle import assert_user_authority_active
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarCapabilities,
     WhatsAppSidecarError,
@@ -477,9 +478,14 @@ async def require_whatsapp_logout_for_archive(
     owner_user_id = require_channel_tenant_user_id(account)
     raw_sidecar_account_id = config.get("sidecar_account_id")
     sidecar_config_revision = config.get("sidecar_config_revision")
+    if not isinstance(raw_sidecar_account_id, str):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp disconnect could not be confirmed",
+        )
     try:
         sidecar_account_id = UUID(raw_sidecar_account_id)
-    except (TypeError, ValueError, AttributeError):
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="WhatsApp disconnect could not be confirmed",
@@ -688,6 +694,10 @@ async def _finalize_connected_account(
     account_id: UUID | None = None
     newly_bound = False
     try:
+        owner_user_id = onboarding.user_id
+        if owner_user_id is None:
+            raise WhatsAppSidecarProtocolError("custom sidecar tenant owner is missing")
+        await assert_user_authority_active(db, owner_user_id)
         configured_revision = registry.custom_session_revision(session_id)
         if configured_revision != session_revision:
             raise WhatsAppSidecarProtocolError("custom sidecar revision mismatch")
@@ -698,10 +708,8 @@ async def _finalize_connected_account(
         )
         if existing is None and onboarding.channel_account_id is None:
             webhook_secret = generate_webhook_secret()
-            if onboarding.user_id is None:
-                raise WhatsAppSidecarProtocolError("custom sidecar tenant owner is missing")
             existing = build_channel_account(
-                owner_user_id=onboarding.user_id,
+                owner_user_id=owner_user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 name=onboarding.name,
                 visibility=CHANNEL_VISIBILITY_PRIVATE,

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -18,6 +18,7 @@ from app.services.discord_command_reconciliation_worker import (
 )
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.metrics import metrics_content_type, render_metrics
+from app.services.principal_lifecycle_cleanup_worker import PrincipalLifecycleCleanupWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 
 configure_application_logging()
@@ -136,6 +137,7 @@ def build_channel_workers() -> tuple[
     ChannelWebhookDeliveryWorker,
     DiscordCommandReconciliationWorker,
     DiscordGatewayWorker,
+    PrincipalLifecycleCleanupWorker,
     ChannelMessageRetentionWorker,
     RuntimeObservationRetentionWorker,
 ]:
@@ -150,6 +152,7 @@ def build_channel_workers() -> tuple[
         ChannelWebhookDeliveryWorker(async_session_factory),
         DiscordCommandReconciliationWorker(async_session_factory),
         DiscordGatewayWorker(async_session_factory, lock_engine=engine),
+        PrincipalLifecycleCleanupWorker(async_session_factory),
         ChannelMessageRetentionWorker(async_session_factory),
         RuntimeObservationRetentionWorker(async_session_factory),
     )

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -45,6 +45,12 @@ _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # (auth-gate regression tests) build their own dict inline so the
 # tampering stays visible at the call site.
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
+_CLERK_ISSUER = "https://admin-tests.clerk.example.test"
+
+
+@pytest.fixture(autouse=True)
+def _configured_clerk_issuer(monkeypatch):
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", _CLERK_ISSUER)
 
 
 class _ManagedOnboardingSidecar:

--- a/backend/tests/test_auth_email_rebind.py
+++ b/backend/tests/test_auth_email_rebind.py
@@ -39,7 +39,9 @@ from sqlalchemy import select
 from app.core import auth as auth_module
 from app.core.auth import _auth_via_clerk_jwt
 from app.core.config import settings
+from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.user import User
+from app.services.principal_lifecycle import fence_principal_termination
 
 
 def _rsa_keypair() -> tuple[str, str]:
@@ -73,9 +75,19 @@ def signing_key(monkeypatch):
     yield private_pem
 
 
-def _sign(private_pem: str, sub: str, email: str | None) -> str:
+def _sign(
+    private_pem: str,
+    sub: str,
+    email: str | None,
+    *,
+    issuer: str | None = None,
+) -> str:
     return jwt.encode(
-        {"sub": sub, **({"email": email} if email else {})},
+        {
+            "sub": sub,
+            **({"email": email} if email else {}),
+            **({"iss": issuer} if issuer else {}),
+        },
         private_pem,
         algorithm="RS256",
     )
@@ -88,24 +100,77 @@ def _sign(private_pem: str, sub: str, email: str | None) -> str:
 
 @pytest.mark.asyncio
 async def test_rebind_swaps_clerk_id_when_jwt_email_matches(db_session, signing_key, monkeypatch):
+    issuer = "https://snapshot-rebind.clerk.example.test"
     monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", issuer)
     email = f"rebind_{uuid.uuid4().hex[:8]}@example.test"
-    original = User(clerk_id=f"orig_{uuid.uuid4().hex[:8]}", email=email, name="Rebind")
+    original = User(
+        clerk_id=f"orig_{uuid.uuid4().hex[:8]}",
+        clerk_issuer=issuer,
+        email=email,
+        name="Rebind",
+    )
     db_session.add(original)
     await db_session.commit()
     await db_session.refresh(original)
     original_id = original.id
 
     new_sub = f"new_{uuid.uuid4().hex[:8]}"
-    token = _sign(signing_key, sub=new_sub, email=email)
+    token = _sign(signing_key, sub=new_sub, email=email, issuer=issuer)
     ctx = await _auth_via_clerk_jwt(token, db_session)
 
     assert ctx is not None
     assert ctx.user.id == original_id  # same row, snapshot data still attached
     assert ctx.user.clerk_id == new_sub  # rebound to new Clerk's sub
+    assert ctx.user.clerk_issuer == issuer
 
     await db_session.delete(ctx.user)
     await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_tombstoned_new_subject_without_mutating_snapshot_user(
+    db_session,
+    signing_key,
+    monkeypatch,
+):
+    issuer = "https://snapshot-tombstone.clerk.example.test"
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", issuer)
+    email = f"tombstone_{uuid.uuid4().hex[:8]}@example.test"
+    old_sub = f"old_{uuid.uuid4().hex[:8]}"
+    original = User(
+        clerk_id=old_sub,
+        clerk_issuer=issuer,
+        email=email,
+        name="Tombstone Rebind",
+    )
+    db_session.add(original)
+    await db_session.commit()
+
+    new_sub = f"terminated_{uuid.uuid4().hex[:8]}"
+    receipt = await fence_principal_termination(
+        db_session,
+        issuer=issuer,
+        subject=new_sub,
+        revision=1,
+        command_id=f"snapshot-tombstone-{uuid.uuid4().hex}",
+    )
+    await db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await _auth_via_clerk_jwt(
+            _sign(signing_key, sub=new_sub, email=email, issuer=issuer),
+            db_session,
+        )
+    assert exc.value.status_code == 401
+    await db_session.rollback()
+    await db_session.refresh(original)
+    lifecycle = await db_session.get(PrincipalLifecycle, receipt.lifecycle_id)
+    assert lifecycle is not None
+    assert lifecycle.cleanup_completed_at is None
+    assert original.clerk_id == old_sub
+    assert original.clerk_issuer == issuer
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -13,6 +13,7 @@ from app.services.discord_command_reconciliation_worker import (
     DiscordCommandReconciliationWorker,
 )
 from app.services.discord_gateway_worker import DiscordGatewayWorker
+from app.services.principal_lifecycle_cleanup_worker import PrincipalLifecycleCleanupWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 from app.workers.channels import ChannelWorkerHealth, _handle_health_request, build_channel_workers
 
@@ -28,6 +29,7 @@ def test_channel_worker_stack_runs_revoke_delivery_webhook_gateway_and_retention
         ChannelWebhookDeliveryWorker,
         DiscordCommandReconciliationWorker,
         DiscordGatewayWorker,
+        PrincipalLifecycleCleanupWorker,
         ChannelMessageRetentionWorker,
         RuntimeObservationRetentionWorker,
     )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -409,7 +409,9 @@ async def _create_admin_channel(
 ) -> httpx.Response:
     admin_key = f"admin-{uuid4().hex}"
     original_admin_key = settings.admin_api_key
+    original_clerk_issuer = settings.clerk_jwt_issuer
     settings.admin_api_key = admin_key
+    settings.clerk_jwt_issuer = "https://channel-tests.clerk.example.test"
     try:
         payload: dict[str, Any] = {
             "provider": provider,
@@ -429,6 +431,7 @@ async def _create_admin_channel(
         )
     finally:
         settings.admin_api_key = original_admin_key
+        settings.clerk_jwt_issuer = original_clerk_issuer
 
 
 async def _create_public_telegram_account_for_user(

--- a/backend/tests/test_cli_oauth_auth.py
+++ b/backend/tests/test_cli_oauth_auth.py
@@ -481,6 +481,34 @@ async def test_oauth_and_session_for_same_clerk_sub_resolve_same_user(
 
 
 @pytest.mark.asyncio
+async def test_oauth_and_session_issuers_cannot_rebind_the_same_clerk_sub(
+    db_session: AsyncSession,
+    clerk_oauth_signing_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clerk_sub = f"user_cross_issuer_{uuid.uuid4().hex}"
+    browser_issuer = "https://browser.clerk.example.test"
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", browser_issuer)
+    session = await _auth_via_clerk_jwt(
+        _session_token(
+            clerk_oauth_signing_key,
+            clerk_sub,
+            {"iss": browser_issuer},
+        ),
+        db_session,
+    )
+
+    assert session is not None
+    with pytest.raises(HTTPException) as rejected:
+        await _auth_via_clerk_jwt(
+            _oauth_access_token(clerk_oauth_signing_key, clerk_sub),
+            db_session,
+        )
+    assert rejected.value.status_code == 401
+    assert rejected.value.detail == "Invalid account identity"
+
+
+@pytest.mark.asyncio
 async def test_oauth_config_returns_only_public_values(
     raw_auth_client: httpx.AsyncClient, clerk_oauth_signing_key: str
 ):

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -31,6 +31,7 @@ from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import ensure_canonical_codex_tool_provider
 
 _ADMIN_KEY = "test-platform-admin-secret"
+_CLERK_ISSUER = "https://platform-tests.clerk.example.test"
 _ADMIN_AUTH = {"X-Admin-Key": _ADMIN_KEY}
 _TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.57"
 _TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC = "clawdi@0.13.2-test"
@@ -71,7 +72,9 @@ async def platform_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncCli
         yield db_session
 
     original_admin_key = settings.admin_api_key
+    original_clerk_issuer = settings.clerk_jwt_issuer
     settings.admin_api_key = _ADMIN_KEY
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
     app.dependency_overrides[get_session] = _override_get_session
     try:
         async with httpx.AsyncClient(
@@ -82,6 +85,7 @@ async def platform_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncCli
     finally:
         app.dependency_overrides.clear()
         settings.admin_api_key = original_admin_key
+        settings.clerk_jwt_issuer = original_clerk_issuer
 
 
 def _headers(key: str, *, request_id: str | None = None) -> dict[str, str]:
@@ -1283,6 +1287,7 @@ async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_cli
         "/v1/platform/auth/keys",
         "/v1/platform/auth/keys/{key_id}",
         "/v1/platform/oauth/token",
+        "/v1/platform/principals/terminate",
     }
     assert all(not path.startswith("/api/platform") for path in paths)
     assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -48,6 +48,7 @@ from app.services.platform_workload_auth import (
 from app.services.vault_crypto import encrypt
 
 _ADMIN_KEY = "test-platform-admin-secret"
+_CLERK_ISSUER = "https://platform-workload.clerk.example.test"
 _TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.57"
 _TEST_TOOLS = {
     "codex": {
@@ -119,11 +120,13 @@ async def workload_harness(db_session, seed_user) -> AsyncIterator[WorkloadHarne
         return resolver
 
     original_admin_key = settings.admin_api_key
+    original_clerk_issuer = settings.clerk_jwt_issuer
     original_legacy_flag = settings.platform_legacy_admin_auth_enabled
     original_public_api_url = settings.public_api_url
     original_token_endpoint = settings.platform_workload_token_endpoint
     original_issuer = settings.platform_workload_issuer
     settings.admin_api_key = _ADMIN_KEY
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
     settings.platform_legacy_admin_auth_enabled = True
     settings.public_api_url = "http://test"
     settings.platform_workload_token_endpoint = ""
@@ -149,6 +152,7 @@ async def workload_harness(db_session, seed_user) -> AsyncIterator[WorkloadHarne
     finally:
         app.dependency_overrides.clear()
         settings.admin_api_key = original_admin_key
+        settings.clerk_jwt_issuer = original_clerk_issuer
         settings.platform_legacy_admin_auth_enabled = original_legacy_flag
         settings.public_api_url = original_public_api_url
         settings.platform_workload_token_endpoint = original_token_endpoint

--- a/backend/tests/test_principal_lifecycle_cleanup_worker.py
+++ b/backend/tests/test_principal_lifecycle_cleanup_worker.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models.principal_lifecycle import PrincipalLifecycle
+from app.services.principal_lifecycle import (
+    PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS,
+    PrincipalCleanupClaimLostError,
+    claim_principal_cleanup,
+    complete_principal_cleanup,
+    record_principal_cleanup_failure,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.committed_db]
+
+_ISSUER = "https://cleanup-worker.clerk.example.test"
+
+
+def _pending_lifecycle(*, subject: str, due_at: datetime) -> PrincipalLifecycle:
+    return PrincipalLifecycle(
+        issuer=_ISSUER,
+        subject=subject,
+        current_revision=1,
+        terminated_at=due_at,
+        next_cleanup_attempt_at=due_at,
+    )
+
+
+async def _delete_lifecycles(session_factory, lifecycle_ids: list[uuid.UUID]) -> None:
+    async with session_factory() as db:
+        await db.execute(delete(PrincipalLifecycle).where(PrincipalLifecycle.id.in_(lifecycle_ids)))
+        await db.commit()
+
+
+async def test_cleanup_claims_use_skip_locked_across_workers(engine):
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    due_at = datetime.now(UTC) - timedelta(minutes=1)
+    first = _pending_lifecycle(subject=f"claim-a-{uuid.uuid4().hex}", due_at=due_at)
+    second = _pending_lifecycle(subject=f"claim-b-{uuid.uuid4().hex}", due_at=due_at)
+    async with session_factory() as db:
+        db.add_all([first, second])
+        await db.commit()
+    lifecycle_ids = [first.id, second.id]
+
+    first_session = session_factory()
+    second_session = session_factory()
+    try:
+        first_claim, second_claim = await asyncio.wait_for(
+            asyncio.gather(
+                claim_principal_cleanup(first_session, now=due_at + timedelta(minutes=2)),
+                claim_principal_cleanup(second_session, now=due_at + timedelta(minutes=2)),
+            ),
+            timeout=5,
+        )
+        assert first_claim is not None
+        assert second_claim is not None
+        assert {first_claim.lifecycle_id, second_claim.lifecycle_id} == set(lifecycle_ids)
+        assert first_claim.claim_id != second_claim.claim_id
+    finally:
+        await first_session.rollback()
+        await second_session.rollback()
+        await first_session.close()
+        await second_session.close()
+        await _delete_lifecycles(session_factory, lifecycle_ids)
+
+
+async def test_cleanup_claim_recovers_after_crash_and_rejects_stale_worker(engine):
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    claimed_at = datetime.now(UTC) - timedelta(minutes=5)
+    lifecycle = _pending_lifecycle(
+        subject=f"crash-{uuid.uuid4().hex}",
+        due_at=claimed_at,
+    )
+    async with session_factory() as db:
+        db.add(lifecycle)
+        await db.commit()
+
+    try:
+        async with session_factory() as db:
+            original = await claim_principal_cleanup(db, now=claimed_at)
+            assert original is not None
+            await db.commit()
+        async with session_factory() as db:
+            assert (
+                await record_principal_cleanup_failure(
+                    db,
+                    lifecycle_id=lifecycle.id,
+                    now=claimed_at,
+                )
+                is False
+            )
+            await db.rollback()
+        async with session_factory() as db:
+            not_stale = await claim_principal_cleanup(
+                db,
+                now=claimed_at + timedelta(seconds=PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS - 1),
+            )
+            assert not_stale is None
+            await db.rollback()
+        async with session_factory() as db:
+            recovered = await claim_principal_cleanup(
+                db,
+                now=claimed_at + timedelta(seconds=PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS + 1),
+            )
+            assert recovered is not None
+            assert recovered.claim_id != original.claim_id
+            assert recovered.attempt_count == 2
+            await db.commit()
+
+        async with session_factory() as db:
+            with pytest.raises(PrincipalCleanupClaimLostError):
+                await complete_principal_cleanup(
+                    db,
+                    lifecycle_id=lifecycle.id,
+                    expected_claim_id=original.claim_id,
+                )
+            await db.rollback()
+        async with session_factory() as db:
+            result = await complete_principal_cleanup(
+                db,
+                lifecycle_id=lifecycle.id,
+                expected_claim_id=recovered.claim_id,
+            )
+            assert result.user_disabled is False
+            await db.commit()
+        async with session_factory() as db:
+            persisted = await db.get(PrincipalLifecycle, lifecycle.id)
+            assert persisted is not None
+            assert persisted.cleanup_completed_at is not None
+            assert persisted.cleanup_attempts == 2
+            assert persisted.cleanup_claim_id is None
+    finally:
+        await _delete_lifecycles(session_factory, [lifecycle.id])

--- a/backend/tests/test_principal_termination.py
+++ b/backend/tests/test_principal_termination.py
@@ -1,0 +1,1309 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import ASGITransport
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core import auth as auth_module
+from app.core.config import settings
+from app.core.database import get_session
+from app.main import app
+from app.models.ai_provider import AiProvider
+from app.models.api_key import ApiKey
+from app.models.audit import ControlPlaneAuditEvent
+from app.models.channel import (
+    CHANNEL_STATUS_DISABLED,
+    WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+    ChannelAccount,
+    ChannelWhatsAppOnboardingSession,
+)
+from app.models.platform_workload_auth import (
+    PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+    PlatformWorkloadClient,
+    PlatformWorkloadSigningKey,
+)
+from app.models.principal_lifecycle import PrincipalLifecycle, PrincipalLifecycleCommand
+from app.models.project import Project
+from app.models.session import AgentEnvironment
+from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
+from app.routes import platform as platform_routes
+from app.services import agent_environments as agent_environments_service
+from app.services.agent_environments import register_agent_environment
+from app.services.api_key import mint_api_key
+from app.services.managed_ai_provider import lock_deployment_managed_provider_mutation
+from app.services.platform_workload_auth import (
+    PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE,
+    PLATFORM_WORKLOAD_SCOPES,
+    InMemoryPlatformWorkloadKeyResolver,
+    canonical_platform_workload_token_endpoint,
+    get_platform_workload_key_resolver,
+)
+from app.services.principal_lifecycle import (
+    PrincipalTerminatedError,
+    assert_clerk_principal_active,
+    assert_user_authority_active,
+    complete_principal_cleanup,
+    fence_principal_termination,
+    load_clerk_user_for_issuer,
+)
+from app.services.whatsapp_device_onboarding import _finalize_connected_account
+
+_ADMIN_KEY = "principal-termination-admin-test"
+_CLERK_ISSUER = "https://clerk.termination.example.test"
+
+
+@dataclass(frozen=True)
+class TerminationHarness:
+    client: httpx.AsyncClient
+    client_id: str
+    client_kid: str
+    client_private_key: Any
+
+
+class _GatedWhatsAppRegistry:
+    """Minimal registry seam for deterministic promotion transaction tests."""
+
+    def __init__(self, revision: str) -> None:
+        self.revision = revision
+        self.bind_entered = asyncio.Event()
+        self.release_bind = asyncio.Event()
+        self.custom_bindings: dict[uuid.UUID, uuid.UUID] = {}
+
+    def custom_session_revision(self, _session_id: uuid.UUID) -> str:
+        return self.revision
+
+    async def bind_custom_account(
+        self,
+        *,
+        session_id: uuid.UUID,
+        account_id: uuid.UUID,
+        config_revision: str,
+    ) -> bool:
+        assert config_revision == self.revision
+        self.bind_entered.set()
+        await asyncio.wait_for(self.release_bind.wait(), timeout=5)
+        self.custom_bindings[account_id] = session_id
+        return True
+
+    def custom_binding(self, account_id: uuid.UUID) -> uuid.UUID | None:
+        return self.custom_bindings.get(account_id)
+
+    async def unbind_custom_account(
+        self,
+        *,
+        session_id: uuid.UUID,
+        account_id: uuid.UUID,
+    ) -> bool:
+        if self.custom_bindings.get(account_id) != session_id:
+            return False
+        del self.custom_bindings[account_id]
+        return True
+
+
+async def _wait_for_advisory_waiter(session_factory, pid: int) -> None:
+    async with session_factory() as observer:
+        waiting = False
+        for _ in range(100):
+            waiting = bool(
+                await observer.scalar(
+                    text(
+                        "SELECT EXISTS (SELECT 1 FROM pg_locks "
+                        "WHERE pid = :pid AND locktype = 'advisory' AND NOT granted)"
+                    ),
+                    {"pid": pid},
+                )
+            )
+            if waiting:
+                break
+            await asyncio.sleep(0.01)
+    assert waiting is True
+
+
+async def _delete_lifecycle(session_factory, lifecycle_id: uuid.UUID | None) -> None:
+    if lifecycle_id is None:
+        return
+    async with session_factory() as session:
+        await session.execute(
+            delete(PrincipalLifecycleCommand).where(
+                PrincipalLifecycleCommand.lifecycle_id == lifecycle_id
+            )
+        )
+        await session.execute(
+            delete(PrincipalLifecycle).where(PrincipalLifecycle.id == lifecycle_id)
+        )
+        await session.commit()
+
+
+def _public_jwk(private_key: Any, *, kid: str) -> dict[str, Any]:
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+    jwk.update({"kid": kid, "alg": "RS256", "use": "sig", "key_ops": ["verify"]})
+    return jwk
+
+
+@pytest_asyncio.fixture
+async def termination_harness(db_session) -> AsyncIterator[TerminationHarness]:
+    client_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    signing_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    client_id = f"principal-termination-{uuid.uuid4().hex}"
+    client_kid = f"client-{uuid.uuid4().hex}"
+    signing_kid = f"issuer-{uuid.uuid4().hex}"
+    private_key_ref = f"memory://{signing_kid}"
+    now = datetime.now(UTC)
+    db_session.add_all(
+        [
+            PlatformWorkloadClient(
+                client_id=client_id,
+                assertion_kid=client_kid,
+                assertion_algorithm="RS256",
+                public_jwk=_public_jwk(client_private_key, kid=client_kid),
+                status=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+                allowed_scopes=list(PLATFORM_WORKLOAD_SCOPES),
+                token_version=1,
+            ),
+            PlatformWorkloadSigningKey(
+                kid=signing_kid,
+                algorithm="RS256",
+                private_key_ref=private_key_ref,
+                status="active",
+                not_before=now - timedelta(minutes=1),
+                expires_at=now + timedelta(hours=1),
+            ),
+        ]
+    )
+    await db_session.commit()
+    resolver = InMemoryPlatformWorkloadKeyResolver({private_key_ref: signing_private_key})
+
+    async def _override_get_session():
+        yield db_session
+
+    def _override_resolver():
+        return resolver
+
+    previous = {
+        "admin_api_key": settings.admin_api_key,
+        "clerk_jwt_issuer": settings.clerk_jwt_issuer,
+        "platform_legacy_admin_auth_enabled": settings.platform_legacy_admin_auth_enabled,
+        "platform_workload_issuer": settings.platform_workload_issuer,
+        "platform_workload_token_endpoint": settings.platform_workload_token_endpoint,
+        "public_api_url": settings.public_api_url,
+    }
+    settings.admin_api_key = _ADMIN_KEY
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+    settings.platform_legacy_admin_auth_enabled = True
+    settings.platform_workload_issuer = "principal-termination-platform-test"
+    settings.platform_workload_token_endpoint = ""
+    settings.public_api_url = "http://test"
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_platform_workload_key_resolver] = _override_resolver
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            yield TerminationHarness(
+                client=client,
+                client_id=client_id,
+                client_kid=client_kid,
+                client_private_key=client_private_key,
+            )
+    finally:
+        app.dependency_overrides.clear()
+        for name, value in previous.items():
+            setattr(settings, name, value)
+
+
+def _client_assertion(harness: TerminationHarness) -> str:
+    now = int(datetime.now(UTC).timestamp())
+    return jwt.encode(
+        {
+            "iss": harness.client_id,
+            "sub": harness.client_id,
+            "aud": canonical_platform_workload_token_endpoint(),
+            "iat": now,
+            "exp": now + 120,
+            "jti": str(uuid.uuid4()),
+        },
+        harness.client_private_key,
+        algorithm="RS256",
+        headers={"kid": harness.client_kid, "typ": "JWT"},
+    )
+
+
+async def _access_token(harness: TerminationHarness, *scopes: str) -> str:
+    response = await harness.client.post(
+        "/v1/platform/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": harness.client_id,
+            "scope": " ".join(scopes),
+            "client_assertion_type": PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE,
+            "client_assertion": _client_assertion(harness),
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _termination_body(subject: str, revision: int, command_id: str) -> dict[str, Any]:
+    return {
+        "principal": {"kind": "clerk", "issuer": _CLERK_ISSUER, "subject": subject},
+        "revision": revision,
+        "command_id": command_id,
+    }
+
+
+async def _terminate(
+    harness: TerminationHarness,
+    token: str,
+    *,
+    subject: str,
+    revision: int,
+    command_id: str,
+) -> httpx.Response:
+    return await harness.client.post(
+        "/v1/platform/principals/terminate",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Idempotency-Key": command_id,
+        },
+        json=_termination_body(subject, revision, command_id),
+    )
+
+
+async def _create_agent(
+    harness: TerminationHarness,
+    token: str,
+    *,
+    owner_kind: str,
+    owner_ref: str,
+    label: str,
+) -> tuple[httpx.Response, uuid.UUID]:
+    agent_id = uuid.uuid4()
+    response = await harness.client.post(
+        "/v1/platform/agents",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Idempotency-Key": f"{label}-{uuid.uuid4().hex}",
+        },
+        json={
+            "owner": {"kind": owner_kind, "ref": owner_ref},
+            "agent_id": str(agent_id),
+            "machine_id": label,
+            "machine_name": label,
+            "agent_type": "openclaw",
+            "os_name": "linux",
+        },
+    )
+    return response, agent_id
+
+
+@pytest.mark.asyncio
+async def test_delete_before_create_fences_admin_platform_and_missing_user(
+    termination_harness,
+    db_session,
+):
+    subject = f"missing_{uuid.uuid4().hex}"
+    command_id = f"terminate-{uuid.uuid4().hex}"
+    create_only_token = await _access_token(termination_harness, "platform:agents:create")
+    missing_scope = await _terminate(
+        termination_harness,
+        create_only_token,
+        subject=subject,
+        revision=1,
+        command_id=command_id,
+    )
+    legacy_admin = await termination_harness.client.post(
+        "/v1/platform/principals/terminate",
+        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": command_id},
+        json=_termination_body(subject, 1, command_id),
+    )
+    assert missing_scope.status_code == 403, missing_scope.text
+    assert legacy_admin.status_code == 401, legacy_admin.text
+
+    token = await _access_token(
+        termination_harness,
+        "platform:principals:terminate",
+        "platform:agents:create",
+    )
+    terminated = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=1,
+        command_id=command_id,
+    )
+    assert terminated.status_code == 200, terminated.text
+    assert terminated.json() == {
+        "principal": {"kind": "clerk", "issuer": _CLERK_ISSUER, "subject": subject},
+        "command_id": command_id,
+        "requested_revision": 1,
+        "accepted_revision": 1,
+        "advanced": True,
+        "status": "terminated",
+        "cleanup_state": "complete",
+        "user_disabled": False,
+    }
+
+    stale_platform, _ = await _create_agent(
+        termination_harness,
+        token,
+        owner_kind="clerk",
+        owner_ref=subject,
+        label="stale-platform",
+    )
+    stale_admin = await termination_harness.client.post(
+        "/v1/admin/auth/keys",
+        headers={"X-Admin-Key": _ADMIN_KEY},
+        json={"target_clerk_id": subject, "label": "stale-admin"},
+    )
+    assert stale_platform.status_code == 403, stale_platform.text
+    assert stale_admin.status_code == 403, stale_admin.text
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None
+    lifecycle = (
+        await db_session.execute(
+            select(PrincipalLifecycle).where(PrincipalLifecycle.subject == subject)
+        )
+    ).scalar_one()
+    assert lifecycle.user_id is None
+    assert lifecycle.cleanup_completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_missing_issuer_configuration_cannot_revive_terminated_owner(
+    termination_harness,
+    db_session,
+):
+    subject = f"config_removed_{uuid.uuid4().hex}"
+    token = await _access_token(
+        termination_harness,
+        "platform:principals:terminate",
+        "platform:agents:create",
+    )
+    response = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=1,
+        command_id=f"config-removed-{uuid.uuid4().hex}",
+    )
+    assert response.status_code == 200, response.text
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = ""
+    try:
+        stale_admin = await termination_harness.client.post(
+            "/v1/admin/auth/keys",
+            headers={"X-Admin-Key": _ADMIN_KEY},
+            json={"target_clerk_id": subject, "label": "config-removed"},
+        )
+        stale_platform, _ = await _create_agent(
+            termination_harness,
+            token,
+            owner_kind="clerk",
+            owner_ref=subject,
+            label="config-removed",
+        )
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+
+    assert stale_admin.status_code == 403, stale_admin.text
+    assert stale_platform.status_code == 403, stale_platform.text
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None
+
+
+@pytest.mark.asyncio
+async def test_non_jwt_owner_requires_configured_or_bound_issuer(
+    termination_harness,
+    db_session,
+    seed_user,
+):
+    token = await _access_token(termination_harness, "platform:agents:create")
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = ""
+    try:
+        unbound, _ = await _create_agent(
+            termination_harness,
+            token,
+            owner_kind="clerk",
+            owner_ref=seed_user.clerk_id,
+            label="unbound-owner",
+        )
+        assert unbound.status_code == 503, unbound.text
+
+        seed_user.clerk_issuer = _CLERK_ISSUER
+        await db_session.commit()
+        bound, agent_id = await _create_agent(
+            termination_harness,
+            token,
+            owner_kind="clerk",
+            owner_ref=seed_user.clerk_id,
+            label="bound-owner",
+        )
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+    assert bound.status_code == 200, bound.text
+    assert await db_session.get(AgentEnvironment, agent_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_termination_denies_stale_jwt_and_cached_api_key(
+    termination_harness,
+    db_session,
+    seed_user,
+    monkeypatch,
+):
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="termination-cache-test",
+        commit=True,
+    )
+
+    api_headers = {"Authorization": f"Bearer {minted.raw_key}"}
+    before_api_key = await termination_harness.client.get("/v1/auth/me", headers=api_headers)
+    assert before_api_key.status_code == 200, before_api_key.text
+
+    clerk_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = int(datetime.now(UTC).timestamp())
+    clerk_jwt = jwt.encode(
+        {
+            "sub": seed_user.clerk_id,
+            "iss": _CLERK_ISSUER,
+            "iat": now,
+            "exp": now + 600,
+            "email": seed_user.email,
+        },
+        clerk_private_key,
+        algorithm="RS256",
+    )
+
+    async def _resolve_test_clerk_key(_token: str):
+        return clerk_private_key.public_key()
+
+    monkeypatch.setattr(auth_module, "_resolve_clerk_signing_key", _resolve_test_clerk_key)
+    jwt_headers = {"Authorization": f"Bearer {clerk_jwt}"}
+    before_jwt = await termination_harness.client.get("/v1/auth/me", headers=jwt_headers)
+    assert before_jwt.status_code == 200, before_jwt.text
+
+    # Simulate another worker retaining its positive cache. Cache hits must
+    # still consult the durable user/fence state after termination commits.
+    monkeypatch.setattr(platform_routes, "invalidate_user_api_key_auth_cache", lambda _id: None)
+    monkeypatch.setattr(platform_routes, "invalidate_api_key_auth_cache", lambda _id: None)
+    token = await _access_token(termination_harness, "platform:principals:terminate")
+    command_id = f"terminate-{uuid.uuid4().hex}"
+    response = await _terminate(
+        termination_harness,
+        token,
+        subject=seed_user.clerk_id,
+        revision=4,
+        command_id=command_id,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["user_disabled"] is True
+
+    after_api_key = await termination_harness.client.get("/v1/auth/me", headers=api_headers)
+    after_jwt = await termination_harness.client.get("/v1/auth/me", headers=jwt_headers)
+    assert after_api_key.status_code == 401, after_api_key.text
+    assert after_jwt.status_code == 401, after_jwt.text
+
+    await db_session.refresh(seed_user)
+    await db_session.refresh(minted.api_key)
+    assert seed_user.clerk_issuer == _CLERK_ISSUER
+    assert minted.api_key.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_revision_ordering_and_command_idempotency(termination_harness, db_session):
+    subject = f"revision_{uuid.uuid4().hex}"
+    token = await _access_token(termination_harness, "platform:principals:terminate")
+    command_5 = f"revision-5-{uuid.uuid4().hex}"
+    first = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=5,
+        command_id=command_5,
+    )
+    duplicate = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=5,
+        command_id=command_5,
+    )
+    lower = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=4,
+        command_id=f"revision-4-{uuid.uuid4().hex}",
+    )
+    equal = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=5,
+        command_id=f"revision-5-equal-{uuid.uuid4().hex}",
+    )
+    higher = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=6,
+        command_id=f"revision-6-{uuid.uuid4().hex}",
+    )
+    assert first.status_code == duplicate.status_code == 200
+    assert duplicate.json() == first.json()
+    assert lower.status_code == equal.status_code == higher.status_code == 200
+    assert lower.json()["advanced"] is False
+    assert lower.json()["accepted_revision"] == 5
+    assert equal.json()["advanced"] is False
+    assert higher.json()["advanced"] is True
+    assert higher.json()["accepted_revision"] == 6
+    lifecycle = (
+        await db_session.execute(
+            select(PrincipalLifecycle).where(PrincipalLifecycle.subject == subject)
+        )
+    ).scalar_one()
+    assert lifecycle.current_revision == 6
+    assert lifecycle.cleanup_completed_at is not None
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(PrincipalLifecycleCommand)
+            .where(PrincipalLifecycleCommand.lifecycle_id == lifecycle.id)
+        )
+        == 4
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_keeps_fence_and_retry_repairs(
+    termination_harness,
+    db_session,
+    seed_user,
+    monkeypatch,
+):
+    subject = seed_user.clerk_id
+    assert subject is not None
+    command_id = f"repair-{uuid.uuid4().hex}"
+    token = await _access_token(termination_harness, "platform:principals:terminate")
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="termination-repair-cache-test",
+        commit=True,
+    )
+    api_headers = {"Authorization": f"Bearer {minted.raw_key}"}
+    assert (
+        await termination_harness.client.get("/v1/auth/me", headers=api_headers)
+    ).status_code == 200
+
+    async def _fail_cleanup(*args, **kwargs):
+        raise RuntimeError("injected cleanup failure")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(platform_routes, "complete_principal_cleanup", _fail_cleanup)
+        failed = await _terminate(
+            termination_harness,
+            token,
+            subject=subject,
+            revision=1,
+            command_id=command_id,
+        )
+    assert failed.status_code == 503, failed.text
+    lifecycle = (
+        await db_session.execute(
+            select(PrincipalLifecycle).where(PrincipalLifecycle.subject == subject)
+        )
+    ).scalar_one()
+    assert lifecycle.cleanup_completed_at is None
+    assert lifecycle.next_cleanup_attempt_at is not None
+    assert lifecycle.cleanup_claim_id is None
+    await db_session.refresh(seed_user)
+    await db_session.refresh(minted.api_key)
+    assert minted.api_key.revoked_at is None
+    fenced_api_key = await termination_harness.client.get("/v1/auth/me", headers=api_headers)
+    assert fenced_api_key.status_code == 401, fenced_api_key.text
+
+    repaired = await _terminate(
+        termination_harness,
+        token,
+        subject=subject,
+        revision=1,
+        command_id=command_id,
+    )
+    assert repaired.status_code == 200, repaired.text
+    await db_session.refresh(lifecycle)
+    await db_session.refresh(seed_user)
+    await db_session.refresh(minted.api_key)
+    assert lifecycle.cleanup_completed_at is not None
+    assert minted.api_key.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_partner_tenant_owner_is_not_fenced_by_clerk_lifecycle(
+    termination_harness,
+    db_session,
+):
+    partner_ref = f"partner:{uuid.uuid4().hex}"
+    partner = User(
+        clerk_id=None,
+        clerk_issuer=None,
+        principal_kind=PRINCIPAL_KIND_PARTNER_TENANT,
+        partner_tenant_ref=partner_ref,
+    )
+    db_session.add(partner)
+    await db_session.flush()
+    personal = Project(
+        user_id=partner.id,
+        name="Personal",
+        slug="personal",
+        kind="personal",
+    )
+    db_session.add(personal)
+    await db_session.commit()
+    token = await _access_token(
+        termination_harness,
+        "platform:principals:terminate",
+        "platform:agents:create",
+    )
+    await _terminate(
+        termination_harness,
+        token,
+        subject=f"unrelated_{uuid.uuid4().hex}",
+        revision=1,
+        command_id=f"unrelated-{uuid.uuid4().hex}",
+    )
+    created, agent_id = await _create_agent(
+        termination_harness,
+        token,
+        owner_kind="partner_tenant",
+        owner_ref=partner_ref,
+        label="partner-agent",
+    )
+    assert created.status_code == 200, created.text
+    assert await db_session.get(AgentEnvironment, agent_id) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_active_requests_share_locks_and_termination_waits_then_revokes(
+    engine,
+    db_session,
+    seed_user,
+):
+    subject = seed_user.clerk_id
+    assert subject is not None
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    await db_session.commit()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    release_active = asyncio.Event()
+    active_ready = [asyncio.Event(), asyncio.Event()]
+    created_key_ids: list[uuid.UUID] = []
+    termination_started = asyncio.Event()
+    termination_pid: int | None = None
+    command_id = f"shared-lock-{uuid.uuid4().hex}"
+    lifecycle_id: uuid.UUID | None = None
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+
+    async def _active_request(index: int) -> None:
+        async with session_factory() as session:
+            await assert_clerk_principal_active(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+            )
+            await assert_user_authority_active(session, seed_user.id)
+            minted = await mint_api_key(
+                session,
+                user_id=seed_user.id,
+                label=f"shared-active-{index}",
+                commit=False,
+            )
+            created_key_ids.append(minted.api_key.id)
+            active_ready[index].set()
+            await asyncio.wait_for(release_active.wait(), timeout=5)
+            await session.commit()
+
+    async def _terminate_after_active_requests() -> uuid.UUID:
+        nonlocal termination_pid
+        async with session_factory() as session:
+            termination_pid = await session.scalar(select(func.pg_backend_pid()))
+            termination_started.set()
+            receipt = await fence_principal_termination(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+                revision=1,
+                command_id=command_id,
+            )
+            await session.commit()
+            await complete_principal_cleanup(session, lifecycle_id=receipt.lifecycle_id)
+            await session.commit()
+            return receipt.lifecycle_id
+
+    active_tasks = [asyncio.create_task(_active_request(index)) for index in range(2)]
+    termination_task: asyncio.Task[uuid.UUID] | None = None
+    try:
+        # Both requests reach the mutation while the other transaction is
+        # still open; exclusive active-request locks would time out here.
+        await asyncio.wait_for(
+            asyncio.gather(*(event.wait() for event in active_ready)),
+            timeout=5,
+        )
+        termination_task = asyncio.create_task(_terminate_after_active_requests())
+        await asyncio.wait_for(termination_started.wait(), timeout=5)
+        assert termination_pid is not None
+
+        await _wait_for_advisory_waiter(session_factory, termination_pid)
+
+        release_active.set()
+        await asyncio.wait_for(asyncio.gather(*active_tasks), timeout=5)
+        lifecycle_id = await asyncio.wait_for(termination_task, timeout=10)
+
+        async with session_factory() as session:
+            revoked_count = await session.scalar(
+                select(func.count())
+                .select_from(ApiKey)
+                .where(
+                    ApiKey.id.in_(created_key_ids),
+                    ApiKey.revoked_at.is_not(None),
+                )
+            )
+            assert revoked_count == 2
+            with pytest.raises(PrincipalTerminatedError):
+                await assert_user_authority_active(session, seed_user.id)
+            await session.rollback()
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+        release_active.set()
+        for task in active_tasks:
+            if not task.done():
+                task.cancel()
+        if termination_task is not None and not termination_task.done():
+            termination_task.cancel()
+        await asyncio.gather(*active_tasks, return_exceptions=True)
+        if termination_task is not None:
+            await asyncio.gather(termination_task, return_exceptions=True)
+        await _delete_lifecycle(session_factory, lifecycle_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_cross_issuer_legacy_binding_keeps_authority_before_user_row_lock(
+    engine,
+    db_session,
+    seed_user,
+):
+    subject = seed_user.clerk_id
+    assert subject is not None
+    seed_user.clerk_issuer = None
+    await db_session.commit()
+
+    binding_issuer = "https://binding.clerk.example.test"
+    command_id = f"cross-issuer-lock-{uuid.uuid4().hex}"
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    binding_holds_row = asyncio.Event()
+    release_binding = asyncio.Event()
+    termination_started = asyncio.Event()
+    termination_pid: int | None = None
+    lifecycle_id: uuid.UUID | None = None
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+
+    async def _bind_legacy_user() -> None:
+        async with session_factory() as session:
+            await assert_clerk_principal_active(
+                session,
+                issuer=binding_issuer,
+                subject=subject,
+            )
+            user = await load_clerk_user_for_issuer(
+                session,
+                issuer=binding_issuer,
+                subject=subject,
+                bind_legacy=True,
+            )
+            assert user is not None
+            binding_holds_row.set()
+            await asyncio.wait_for(release_binding.wait(), timeout=5)
+            # Mirrors JWT auth after its legacy issuer binding. This shared
+            # lock is reentrant only when the helper acquired authority before
+            # the User row; the old row-then-authority order deadlocked here.
+            await assert_user_authority_active(session, user.id)
+            await session.commit()
+
+    async def _terminate_other_issuer() -> uuid.UUID:
+        nonlocal termination_pid
+        await asyncio.wait_for(binding_holds_row.wait(), timeout=5)
+        async with session_factory() as session:
+            termination_pid = await session.scalar(select(func.pg_backend_pid()))
+            termination_started.set()
+            receipt = await fence_principal_termination(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+                revision=1,
+                command_id=command_id,
+            )
+            assert receipt.user_id is None
+            await session.commit()
+            await complete_principal_cleanup(session, lifecycle_id=receipt.lifecycle_id)
+            await session.commit()
+            return receipt.lifecycle_id
+
+    binding_task = asyncio.create_task(_bind_legacy_user())
+    termination_task = asyncio.create_task(_terminate_other_issuer())
+    try:
+        await asyncio.wait_for(termination_started.wait(), timeout=5)
+        assert termination_pid is not None
+        await _wait_for_advisory_waiter(session_factory, termination_pid)
+        release_binding.set()
+        _, lifecycle_id = await asyncio.wait_for(
+            asyncio.gather(binding_task, termination_task),
+            timeout=10,
+        )
+
+        async with session_factory() as session:
+            user = await session.get(User, seed_user.id)
+            lifecycle = await session.get(PrincipalLifecycle, lifecycle_id)
+            assert user is not None
+            assert user.clerk_issuer == binding_issuer
+            assert lifecycle is not None
+            assert lifecycle.issuer == _CLERK_ISSUER
+            assert lifecycle.user_id is None
+            assert lifecycle.cleanup_completed_at is not None
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+        release_binding.set()
+        for task in (binding_task, termination_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(binding_task, termination_task, return_exceptions=True)
+        await _delete_lifecycle(session_factory, lifecycle_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_registration_rollback_rechecks_fence_before_refreshing_winner(
+    engine,
+    db_session,
+    seed_user,
+    monkeypatch,
+):
+    subject = seed_user.clerk_id
+    assert subject is not None
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    await db_session.commit()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    environment_id = uuid.uuid4()
+    loser_reached_create = asyncio.Event()
+    release_loser = asyncio.Event()
+    termination_started = asyncio.Event()
+    termination_pid: int | None = None
+    lifecycle_id: uuid.UUID | None = None
+    original_next_name = agent_environments_service._next_explicit_default_name
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+
+    async def _gated_next_name(db, user_id, agent_type):
+        loser_reached_create.set()
+        await asyncio.wait_for(release_loser.wait(), timeout=5)
+        return await original_next_name(db, user_id, agent_type)
+
+    async def _losing_registration():
+        async with session_factory() as session:
+            return await register_agent_environment(
+                session,
+                user_id=seed_user.id,
+                environment_id=environment_id,
+                machine_id="loser-machine",
+                machine_name="Losing Registration",
+                agent_type="codex",
+                agent_version="loser",
+                os_name="linux",
+                sort_order=1,
+                registration_key=None,
+            )
+
+    async def _terminate() -> uuid.UUID:
+        nonlocal termination_pid
+        async with session_factory() as session:
+            termination_pid = await session.scalar(select(func.pg_backend_pid()))
+            termination_started.set()
+            command_id = f"registration-rollback-{uuid.uuid4().hex}"
+            receipt = await fence_principal_termination(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+                revision=1,
+                command_id=command_id,
+            )
+            await session.commit()
+            await complete_principal_cleanup(session, lifecycle_id=receipt.lifecycle_id)
+            await session.commit()
+            return receipt.lifecycle_id
+
+    monkeypatch.setattr(
+        agent_environments_service,
+        "_next_explicit_default_name",
+        _gated_next_name,
+    )
+    loser_task = asyncio.create_task(_losing_registration())
+    termination_task: asyncio.Task[uuid.UUID] | None = None
+    try:
+        await asyncio.wait_for(loser_reached_create.wait(), timeout=5)
+        async with session_factory() as session:
+            winner = await register_agent_environment(
+                session,
+                user_id=seed_user.id,
+                environment_id=environment_id,
+                machine_id="winner-machine",
+                machine_name="Winning Registration",
+                agent_type="codex",
+                agent_version="winner",
+                os_name="linux",
+                sort_order=2,
+                registration_key=f"winner:{uuid.uuid4().hex}",
+            )
+            assert winner.created is True
+
+        termination_task = asyncio.create_task(_terminate())
+        await asyncio.wait_for(termination_started.wait(), timeout=5)
+        assert termination_pid is not None
+        await _wait_for_advisory_waiter(session_factory, termination_pid)
+
+        release_loser.set()
+        loser_result = (await asyncio.gather(loser_task, return_exceptions=True))[0]
+        assert isinstance(loser_result, PrincipalTerminatedError)
+        lifecycle_id = await asyncio.wait_for(termination_task, timeout=10)
+
+        async with session_factory() as session:
+            registered = await session.get(AgentEnvironment, environment_id)
+            assert registered is not None
+            assert registered.machine_id == "winner-machine"
+            assert registered.agent_version == "winner"
+            assert registered.archived_at is not None
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+        release_loser.set()
+        if not loser_task.done():
+            loser_task.cancel()
+        if termination_task is not None and not termination_task.done():
+            termination_task.cancel()
+        await asyncio.gather(loser_task, return_exceptions=True)
+        if termination_task is not None:
+            await asyncio.gather(termination_task, return_exceptions=True)
+        await _delete_lifecycle(session_factory, lifecycle_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_whatsapp_promotion_is_ordered_before_cleanup_and_stale_retry_is_fenced(
+    engine,
+    db_session,
+    seed_user,
+):
+    subject = seed_user.clerk_id
+    assert subject is not None
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    revision = f"promotion-{uuid.uuid4().hex}"
+    now = datetime.now(UTC)
+    first = ChannelWhatsAppOnboardingSession(
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+        sidecar_account_id=uuid.uuid4(),
+        sidecar_config_revision=revision,
+        user_id=seed_user.id,
+        request_id=uuid.uuid4(),
+        name="Concurrent custom",
+        state="ready",
+        method="qr",
+        started_at=now,
+        expires_at=now + timedelta(minutes=5),
+    )
+    stale = ChannelWhatsAppOnboardingSession(
+        ownership_kind=first.ownership_kind,
+        sidecar_account_id=uuid.uuid4(),
+        sidecar_config_revision=revision,
+        user_id=seed_user.id,
+        request_id=uuid.uuid4(),
+        name="Stale custom",
+        state="ready",
+        method="qr",
+        started_at=now,
+        expires_at=now + timedelta(minutes=5),
+    )
+    db_session.add_all([first, stale])
+    await db_session.commit()
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    registry = _GatedWhatsAppRegistry(revision)
+    termination_started = asyncio.Event()
+    termination_pid: int | None = None
+    lifecycle_id: uuid.UUID | None = None
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+
+    async def _run_promotion(onboarding_id: uuid.UUID) -> None:
+        async with session_factory() as session:
+            onboarding = await session.get(ChannelWhatsAppOnboardingSession, onboarding_id)
+            assert onboarding is not None
+            await _finalize_connected_account(
+                session,
+                onboarding=onboarding,
+                registry=registry,
+            )
+
+    async def _terminate() -> uuid.UUID:
+        nonlocal termination_pid
+        async with session_factory() as session:
+            termination_pid = await session.scalar(select(func.pg_backend_pid()))
+            termination_started.set()
+            command_id = f"whatsapp-custom-{uuid.uuid4().hex}"
+            receipt = await fence_principal_termination(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+                revision=1,
+                command_id=command_id,
+            )
+            await session.commit()
+            await complete_principal_cleanup(session, lifecycle_id=receipt.lifecycle_id)
+            await session.commit()
+            return receipt.lifecycle_id
+
+    promotion_task = asyncio.create_task(_run_promotion(first.id))
+    termination_task: asyncio.Task[uuid.UUID] | None = None
+    try:
+        await asyncio.wait_for(registry.bind_entered.wait(), timeout=5)
+        termination_task = asyncio.create_task(_terminate())
+        await asyncio.wait_for(termination_started.wait(), timeout=5)
+        assert termination_pid is not None
+        await _wait_for_advisory_waiter(session_factory, termination_pid)
+
+        registry.release_bind.set()
+        await asyncio.wait_for(promotion_task, timeout=5)
+        lifecycle_id = await asyncio.wait_for(termination_task, timeout=10)
+
+        async with session_factory() as session:
+            lifecycle = await session.get(PrincipalLifecycle, lifecycle_id)
+            assert lifecycle is not None
+            assert lifecycle.cleanup_completed_at is not None
+            promoted = await session.get(ChannelWhatsAppOnboardingSession, first.id)
+            assert promoted is not None
+            assert promoted.channel_account_id is not None
+            account = await session.get(ChannelAccount, promoted.channel_account_id)
+            assert account is not None
+            assert account.status == CHANNEL_STATUS_DISABLED
+            assert account.archived_at is not None
+
+        with pytest.raises(PrincipalTerminatedError):
+            await _run_promotion(stale.id)
+
+        async with session_factory() as session:
+            stale_after = await session.get(ChannelWhatsAppOnboardingSession, stale.id)
+            assert stale_after is not None
+            assert stale_after.channel_account_id is None
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+        registry.release_bind.set()
+        if not promotion_task.done():
+            promotion_task.cancel()
+        if termination_task is not None and not termination_task.done():
+            termination_task.cancel()
+        await asyncio.gather(promotion_task, return_exceptions=True)
+        if termination_task is not None:
+            await asyncio.gather(termination_task, return_exceptions=True)
+        await _delete_lifecycle(session_factory, lifecycle_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_concurrent_endpoint_replay_uses_durable_command_receipt(
+    termination_harness,
+    engine,
+):
+    """Concurrent HTTP retries converge through the durable command receipt."""
+
+    subject = f"endpoint_concurrent_{uuid.uuid4().hex}"
+    command_id = f"endpoint-concurrent-{uuid.uuid4().hex}"
+    token = await _access_token(termination_harness, "platform:principals:terminate")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _fresh_session() -> AsyncIterator[Any]:
+        async with session_factory() as session:
+            yield session
+
+    previous_session_override = app.dependency_overrides[get_session]
+    app.dependency_overrides[get_session] = _fresh_session
+    higher_command_id = f"endpoint-concurrent-higher-{uuid.uuid4().hex}"
+    tasks = [
+        asyncio.create_task(
+            _terminate(
+                termination_harness,
+                token,
+                subject=subject,
+                revision=revision,
+                command_id=current_command_id,
+            )
+        )
+        for revision, current_command_id in (
+            (7, command_id),
+            (7, command_id),
+            (8, higher_command_id),
+        )
+    ]
+    try:
+        first, duplicate, higher = await asyncio.wait_for(
+            asyncio.gather(*tasks),
+            timeout=10,
+        )
+        assert first.status_code == duplicate.status_code == higher.status_code == 200
+        assert duplicate.json() == first.json()
+        assert higher.json()["accepted_revision"] == 8
+        assert higher.json()["advanced"] is True
+    finally:
+        app.dependency_overrides[get_session] = previous_session_override
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async with session_factory() as session:
+        lifecycle = (
+            await session.execute(
+                select(PrincipalLifecycle).where(PrincipalLifecycle.subject == subject)
+            )
+        ).scalar_one()
+        assert lifecycle.current_revision == 8
+        assert lifecycle.cleanup_completed_at is not None
+        assert (
+            await session.scalar(
+                select(func.count())
+                .select_from(PrincipalLifecycleCommand)
+                .where(PrincipalLifecycleCommand.lifecycle_id == lifecycle.id)
+            )
+            == 2
+        )
+        await session.execute(
+            delete(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.resource_id == f"{_CLERK_ISSUER}#{subject}"
+            )
+        )
+        await session.execute(
+            delete(PrincipalLifecycleCommand).where(
+                PrincipalLifecycleCommand.lifecycle_id == lifecycle.id
+            )
+        )
+        await session.delete(lifecycle)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_provider_mutation_holds_principal_authority_before_owner_lock(
+    engine,
+    db_session,
+    seed_user,
+):
+    """The established provider owner lock remains below principal authority."""
+
+    subject = seed_user.clerk_id
+    assert subject is not None
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    provider_id = f"clawdi-v2-deployment-{uuid.uuid4().int}"
+    provider = AiProvider(
+        owner_user_id=seed_user.id,
+        provider_id=provider_id,
+        type="openai_compatible",
+        label="Termination Lock Ordering",
+        base_url="https://provider-lock.example.test/v1",
+        auth_type="none",
+        managed_by="clawdi",
+    )
+    db_session.add(provider)
+    await db_session.commit()
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    provider_mutation_ready = asyncio.Event()
+    release_provider_mutation = asyncio.Event()
+    termination_started = asyncio.Event()
+    termination_pid: int | None = None
+    lifecycle_id: uuid.UUID | None = None
+    previous_issuer = settings.clerk_jwt_issuer
+    settings.clerk_jwt_issuer = _CLERK_ISSUER
+
+    async def _paused_provider_mutation() -> None:
+        async with session_factory() as session:
+            await assert_clerk_principal_active(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+            )
+            await assert_user_authority_active(session, seed_user.id)
+            await lock_deployment_managed_provider_mutation(
+                session,
+                owner_user_id=seed_user.id,
+                provider_id=provider_id,
+            )
+            provider_mutation_ready.set()
+            await asyncio.wait_for(release_provider_mutation.wait(), timeout=5)
+            await session.commit()
+
+    async def _terminate_while_provider_is_paused() -> None:
+        nonlocal lifecycle_id, termination_pid
+        await asyncio.wait_for(provider_mutation_ready.wait(), timeout=5)
+        command_id = f"provider-race-{uuid.uuid4().hex}"
+        async with session_factory() as session:
+            termination_pid = await session.scalar(select(func.pg_backend_pid()))
+            termination_started.set()
+            receipt = await fence_principal_termination(
+                session,
+                issuer=_CLERK_ISSUER,
+                subject=subject,
+                revision=1,
+                command_id=command_id,
+            )
+            lifecycle_id = receipt.lifecycle_id
+            await session.commit()
+            await complete_principal_cleanup(session, lifecycle_id=receipt.lifecycle_id)
+            await session.commit()
+
+    tasks = [
+        asyncio.create_task(_paused_provider_mutation()),
+        asyncio.create_task(_terminate_while_provider_is_paused()),
+    ]
+    try:
+        await asyncio.wait_for(termination_started.wait(), timeout=5)
+        assert termination_pid is not None
+        await _wait_for_advisory_waiter(session_factory, termination_pid)
+        release_provider_mutation.set()
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+    finally:
+        settings.clerk_jwt_issuer = previous_issuer
+        release_provider_mutation.set()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    await db_session.refresh(seed_user)
+    await db_session.refresh(provider)
+    assert provider.archived_at is not None
+
+    await _delete_lifecycle(session_factory, lifecycle_id)

--- a/backend/tests/test_principal_termination_migration.py
+++ b/backend/tests/test_principal_termination_migration.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL, make_url
+
+BASE_REVISION = "d7f3a1c9e5b2"
+TERMINATION_REVISION = "c9f4e2a7b1d6"
+BACKEND_DIR = Path(__file__).parents[1]
+
+
+def _sync_url(url: URL, *, database: str) -> URL:
+    return url.set(drivername="postgresql+psycopg2", database=database)
+
+
+def _run_alembic(database_url: URL, *args: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url.render_as_string(hide_password=False)
+    subprocess.run(
+        [str(Path(sys.executable).with_name("alembic")), *args],
+        cwd=BACKEND_DIR,
+        env=env,
+        check=True,
+    )
+
+
+def test_principal_termination_migration_downgrade_guards_authority_state():
+    source_url = make_url(os.environ["DATABASE_URL"])
+    database_name = f"clawdi_principal_termination_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    database_engine = create_engine(_sync_url(source_url, database=database_name))
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    try:
+        _run_alembic(database_url, "upgrade", BASE_REVISION)
+        _run_alembic(database_url, "upgrade", TERMINATION_REVISION)
+
+        lifecycle_id = uuid.uuid4()
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO principal_lifecycles "
+                    "(id, issuer, subject, current_revision, terminated_at, "
+                    "cleanup_attempts, next_cleanup_attempt_at) "
+                    "VALUES (:id, 'https://clerk.example.test', "
+                    "'terminated-user', 1, now(), 0, now())"
+                ),
+                {"id": lifecycle_id},
+            )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_alembic(database_url, "downgrade", BASE_REVISION)
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text("DELETE FROM principal_lifecycles WHERE id = :id"),
+                {"id": lifecycle_id},
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO platform_workload_clients "
+                    "(id, client_id, assertion_kid, assertion_algorithm, public_jwk, "
+                    "status, allowed_scopes, token_version) VALUES "
+                    "(:id, 'termination-client', 'termination-kid', 'RS256', "
+                    "CAST(:jwk AS jsonb), 'active', "
+                    "ARRAY['platform:principals:terminate']::varchar[], 1)"
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "jwk": '{"kid":"termination-kid","alg":"RS256","kty":"RSA"}',
+                },
+            )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_alembic(database_url, "downgrade", BASE_REVISION)
+
+        with database_engine.connect() as connection:
+            assert connection.scalar(text("SELECT version_num FROM alembic_version")) == (
+                TERMINATION_REVISION
+            )
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -291,7 +291,9 @@ async def admin_client(db_session) -> AsyncIterator[httpx.AsyncClient]:
         yield db_session
 
     original_admin_key = settings.admin_api_key
+    original_clerk_issuer = settings.clerk_jwt_issuer
     settings.admin_api_key = _ADMIN_KEY
+    settings.clerk_jwt_issuer = "https://runtime-manifest.clerk.example.test"
     app.dependency_overrides[get_session] = _override_get_session
     try:
         transport = ASGITransport(app=app)
@@ -300,6 +302,7 @@ async def admin_client(db_session) -> AsyncIterator[httpx.AsyncClient]:
     finally:
         app.dependency_overrides.clear()
         settings.admin_api_key = original_admin_key
+        settings.clerk_jwt_issuer = original_clerk_issuer
 
 
 async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2009,6 +2009,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/platform/principals/terminate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Platform Terminate Principal
+         * @description Fence a Clerk principal before transactionally revoking local authority.
+         */
+        post: operations["platform_terminate_principal_v1_platform_principals_terminate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/platform/agents": {
         parameters: {
             query?: never;
@@ -5956,6 +5976,18 @@ export interface components {
             /** Scopes */
             scopes?: string[];
         };
+        /** PlatformClerkPrincipal */
+        PlatformClerkPrincipal: {
+            /**
+             * Kind
+             * @constant
+             */
+            kind: "clerk";
+            /** Issuer */
+            issuer: string;
+            /** Subject */
+            subject: string;
+        };
         /** PlatformMutationBody */
         PlatformMutationBody: {
             owner: components["schemas"]["PlatformOwner"];
@@ -5991,6 +6023,40 @@ export interface components {
             kind: "clerk" | "partner_tenant";
             /** Ref */
             ref: string;
+        };
+        /** PlatformPrincipalTermination */
+        PlatformPrincipalTermination: {
+            principal: components["schemas"]["PlatformClerkPrincipal"];
+            /** Revision */
+            revision: number;
+            /** Command Id */
+            command_id: string;
+        };
+        /** PlatformPrincipalTerminationResponse */
+        PlatformPrincipalTerminationResponse: {
+            principal: components["schemas"]["PlatformClerkPrincipal"];
+            /** Command Id */
+            command_id: string;
+            /** Requested Revision */
+            requested_revision: number;
+            /** Accepted Revision */
+            accepted_revision: number;
+            /** Advanced */
+            advanced: boolean;
+            /**
+             * Status
+             * @default terminated
+             * @constant
+             */
+            status: "terminated";
+            /**
+             * Cleanup State
+             * @default complete
+             * @constant
+             */
+            cleanup_state: "complete";
+            /** User Disabled */
+            user_disabled: boolean;
         };
         /** PlatformRuntimeStateResponse */
         PlatformRuntimeStateResponse: {
@@ -11460,6 +11526,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlatformOAuthErrorResponse"];
+                };
+            };
+        };
+    };
+    platform_terminate_principal_v1_platform_principals_terminate_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformPrincipalTermination"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformPrincipalTerminationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Add the workload-only `POST /v1/platform/principals/terminate` receiver with the explicit `platform:principals:terminate` OAuth scope and the request/ACK contract used by Clawdi-AI/clawdi-hosted#1393.
- Persist one issuer+subject tombstone before cleanup. The dedicated command receipt is the sole idempotency authority; monotonic revisions and immutable command identity make replay deterministic without a second platform-idempotency record.
- Keep `users.clerk_id` globally unique as the existing single-Clerk-instance compatibility bridge. `clerk_issuer` records provenance/lifecycle namespace; this PR does not claim arbitrary same-subject multi-issuer coexistence.
- Revoke local authority transactionally after the fence: User access, API keys, Agents/runtime state, channels, project/session sharing, device grants, and AI-provider authority. Existing OAuth revocation repair remains durable.
- Recover cleanup through one leased `FOR UPDATE SKIP LOCKED` worker with persistent capped backoff. A cleanup failure can delay resource disposal but can never remove or bypass the tombstone.
- Apply one lock order—principal authority, user authority, then User row—to auth, lazy creation, key mint, Agent registration/reactivation, owner mutation, rollback recovery, and WhatsApp promotion. Real PostgreSQL coverage includes termination races and cross-issuer legacy binding without deadlock.
- Remove redundant lifecycle/cleanup/user states, database triggers, and generic platform-idempotency double writes.

## Rollout

1. Deploy this migration and receiver.
2. Grant the Hosted workload `platform:principals:terminate`.
3. Enable the termination sender in Clawdi-AI/clawdi-hosted#1393.
4. Monitor pending cleanup leases/retries and sender acknowledgements.

This receiver terminates authority; it is not a Hosted PII/GDPR erasure implementation.

## PostgreSQL semantics

- [Transaction-level advisory locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
- [Advisory-lock functions](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS)
- [`FOR UPDATE SKIP LOCKED`](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

## Verification

All validation used isolated Docker/PostgreSQL environments.

- Focused PostgreSQL termination/cleanup suite after pruning: `21 passed`
- Test additions reduced from 2,126 to 1,664 lines (21.7%) by removing duplicate resource matrices, mock-only backoff cases, and schema-field mirrors
- BasedPyright changed paths: 19 files, 0 diagnostics
- Ruff lint/format, compileall, Alembic single head, generated API, and `git diff --check`: passed
- Cross-issuer and lock-order tests use independent database sessions and real PostgreSQL advisory/row locks.

No production, provider, cluster, secret, or tenant operation was performed.