### PR TITLE
fix(channels): make Shared bots platform-owned

### DIFF
--- a/backend/alembic/versions/c2f8a4d6e9b1_platform_shared_channel_ownership.py
+++ b/backend/alembic/versions/c2f8a4d6e9b1_platform_shared_channel_ownership.py
@@ -1,0 +1,400 @@
+"""Make shared channel accounts explicit platform inventory.
+
+Revision ID: c2f8a4d6e9b1
+Revises: b4e8c1d7a2f9
+Create Date: 2026-08-03 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c2f8a4d6e9b1"
+down_revision: str | Sequence[str] | None = "b4e8c1d7a2f9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ACTIVE_ONBOARDING_STATES = "'generating', 'ready', 'scanned', 'connected', 'error'"
+
+
+def upgrade() -> None:
+    # Lock the ownership roots while the fake tenant owners are removed. Child
+    # Link/Binding/Message/Credential rows remain untouched and tenant-scoped.
+    bind = op.get_bind()
+    bind.execute(sa.text("LOCK TABLE channel_accounts IN ACCESS EXCLUSIVE MODE"))
+    bind.execute(
+        sa.text("LOCK TABLE channel_whatsapp_onboarding_sessions IN ACCESS EXCLUSIVE MODE")
+    )
+
+    op.drop_index(
+        "uq_channel_accounts_user_provider_name_active",
+        table_name="channel_accounts",
+    )
+    op.alter_column(
+        "channel_accounts",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+    op.alter_column(
+        "channel_secrets",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+    op.alter_column(
+        "channel_whatsapp_auth_certs",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+    op.alter_column(
+        "channel_whatsapp_onboarding_sessions",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+    op.drop_constraint(
+        "ck_channel_whatsapp_onboarding_ownership_kind",
+        "channel_whatsapp_onboarding_sessions",
+        type_="check",
+    )
+    op.drop_constraint(
+        "uq_channel_whatsapp_onboarding_kind_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        type_="unique",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_user_name",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+
+    # Public provider credentials stay attached to the same account. Only the
+    # bookkeeping owner is removed so deleting that former User cannot cascade
+    # platform inventory or account-level secrets/certificates.
+    bind.execute(
+        sa.text(
+            """
+            UPDATE channel_secrets AS secret
+            SET user_id = NULL
+            FROM channel_accounts AS account
+            WHERE secret.account_id = account.id
+              AND account.visibility = 'public'
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE channel_whatsapp_auth_certs AS cert
+            SET user_id = NULL
+            FROM channel_accounts AS account
+            WHERE cert.account_id = account.id
+              AND account.visibility = 'public'
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE channel_accounts
+            SET user_id = NULL
+            WHERE visibility = 'public'
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE channel_whatsapp_onboarding_sessions
+            SET ownership_kind = 'platform', user_id = NULL
+            WHERE ownership_kind = 'managed'
+            """
+        )
+    )
+
+    # The old per-tenant uniqueness allowed the same public inventory name or
+    # managed request id under different fake owners. Preserve every row and
+    # credential, renaming only later collisions before platform-wide indexes.
+    _deduplicate_platform_account_names(bind)
+    _deduplicate_platform_session_names(bind)
+    _deduplicate_platform_request_ids(bind)
+
+    op.create_check_constraint(
+        "ck_channel_accounts_visibility_owner",
+        "channel_accounts",
+        "(visibility = 'private' AND user_id IS NOT NULL) OR "
+        "(visibility = 'public' AND user_id IS NULL)",
+    )
+    op.create_index(
+        "uq_channel_accounts_user_provider_name_active",
+        "channel_accounts",
+        ["user_id", "provider", "name"],
+        unique=True,
+        postgresql_where=sa.text("visibility = 'private' AND archived_at IS NULL"),
+    )
+    op.create_index(
+        "uq_channel_accounts_platform_provider_name_active",
+        "channel_accounts",
+        ["provider", "name"],
+        unique=True,
+        postgresql_where=sa.text(
+            "visibility = 'public' AND user_id IS NULL AND archived_at IS NULL"
+        ),
+    )
+    op.create_table(
+        "channel_account_runtime_markers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("account_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("scope", sa.String(length=400), nullable=False),
+        sa.Column("outcome", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["channel_accounts.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "account_id",
+            "kind",
+            "scope",
+            name="uq_channel_account_runtime_markers_account_kind_scope",
+        ),
+    )
+
+    op.create_check_constraint(
+        "ck_channel_whatsapp_onboarding_owner",
+        "channel_whatsapp_onboarding_sessions",
+        "(ownership_kind = 'custom' AND user_id IS NOT NULL) OR "
+        "(ownership_kind = 'platform' AND user_id IS NULL)",
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_custom_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        ["user_id", "request_id"],
+        unique=True,
+        postgresql_where=sa.text("ownership_kind = 'custom'"),
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_platform_request",
+        "channel_whatsapp_onboarding_sessions",
+        ["request_id"],
+        unique=True,
+        postgresql_where=sa.text("ownership_kind = 'platform'"),
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_custom_user_name",
+        "channel_whatsapp_onboarding_sessions",
+        ["user_id", "name"],
+        unique=True,
+        postgresql_where=sa.text(
+            f"ownership_kind = 'custom' AND state IN ({_ACTIVE_ONBOARDING_STATES})"
+        ),
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_platform_name",
+        "channel_whatsapp_onboarding_sessions",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text(
+            f"ownership_kind = 'platform' AND state IN ({_ACTIVE_ONBOARDING_STATES})"
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("LOCK TABLE channel_accounts IN ACCESS EXCLUSIVE MODE"))
+    bind.execute(
+        sa.text("LOCK TABLE channel_whatsapp_onboarding_sessions IN ACCESS EXCLUSIVE MODE")
+    )
+    has_platform_inventory = bind.scalar(
+        sa.text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM channel_accounts
+                WHERE visibility = 'public' OR user_id IS NULL
+                UNION ALL
+                SELECT 1 FROM channel_whatsapp_onboarding_sessions
+                WHERE ownership_kind = 'platform' OR user_id IS NULL
+                UNION ALL
+                SELECT 1 FROM channel_secrets WHERE user_id IS NULL
+                UNION ALL
+                SELECT 1 FROM channel_whatsapp_auth_certs WHERE user_id IS NULL
+            )
+            """
+        )
+    )
+    if has_platform_inventory:
+        raise RuntimeError(
+            "Cannot downgrade migration c2f8a4d6e9b1 while platform channel inventory exists; "
+            "the previous schema requires an arbitrary tenant owner"
+        )
+
+    op.drop_table("channel_account_runtime_markers")
+
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_platform_name",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_custom_user_name",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_platform_request",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_custom_user_request",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_constraint(
+        "ck_channel_whatsapp_onboarding_owner",
+        "channel_whatsapp_onboarding_sessions",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_channel_whatsapp_onboarding_ownership_kind",
+        "channel_whatsapp_onboarding_sessions",
+        "ownership_kind IN ('custom', 'managed')",
+    )
+    op.create_unique_constraint(
+        "uq_channel_whatsapp_onboarding_kind_user_request",
+        "channel_whatsapp_onboarding_sessions",
+        ["ownership_kind", "user_id", "request_id"],
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_user_name",
+        "channel_whatsapp_onboarding_sessions",
+        ["user_id", "name"],
+        unique=True,
+        postgresql_where=sa.text(f"state IN ({_ACTIVE_ONBOARDING_STATES})"),
+    )
+
+    op.drop_index(
+        "uq_channel_accounts_platform_provider_name_active",
+        table_name="channel_accounts",
+    )
+    op.drop_index(
+        "uq_channel_accounts_user_provider_name_active",
+        table_name="channel_accounts",
+    )
+    op.drop_constraint(
+        "ck_channel_accounts_visibility_owner",
+        "channel_accounts",
+        type_="check",
+    )
+    op.create_index(
+        "uq_channel_accounts_user_provider_name_active",
+        "channel_accounts",
+        ["user_id", "provider", "name"],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+    )
+
+    op.alter_column(
+        "channel_whatsapp_onboarding_sessions",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.alter_column(
+        "channel_whatsapp_auth_certs",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.alter_column(
+        "channel_secrets",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.alter_column(
+        "channel_accounts",
+        "user_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+
+
+def _deduplicate_platform_account_names(bind: sa.Connection) -> None:
+    bind.execute(
+        sa.text(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY provider, name
+                           ORDER BY created_at, id
+                       ) AS duplicate_number
+                FROM channel_accounts
+                WHERE visibility = 'public' AND archived_at IS NULL
+            )
+            UPDATE channel_accounts AS account
+            SET name = left(account.name, 73) || '-platform-' || account.id::text
+            FROM ranked
+            WHERE account.id = ranked.id
+              AND ranked.duplicate_number > 1
+            """
+        )
+    )
+
+
+def _deduplicate_platform_session_names(bind: sa.Connection) -> None:
+    bind.execute(
+        sa.text(
+            f"""
+            WITH ranked AS (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY name
+                           ORDER BY created_at, id
+                       ) AS duplicate_number
+                FROM channel_whatsapp_onboarding_sessions
+                WHERE ownership_kind = 'platform'
+                  AND state IN ({_ACTIVE_ONBOARDING_STATES})
+            )
+            UPDATE channel_whatsapp_onboarding_sessions AS session
+            SET name = left(session.name, 73) || '-platform-' || session.id::text
+            FROM ranked
+            WHERE session.id = ranked.id
+              AND ranked.duplicate_number > 1
+            """
+        )
+    )
+
+
+def _deduplicate_platform_request_ids(bind: sa.Connection) -> None:
+    bind.execute(
+        sa.text(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY request_id
+                           ORDER BY created_at, id
+                       ) AS duplicate_number
+                FROM channel_whatsapp_onboarding_sessions
+                WHERE ownership_kind = 'platform'
+            )
+            UPDATE channel_whatsapp_onboarding_sessions AS session
+            SET request_id = md5('platform-pairing:' || session.id::text)::uuid
+            FROM ranked
+            WHERE session.id = ranked.id
+              AND ranked.duplicate_number > 1
+            """
+        )
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.middleware.request_timing import RequestTimingMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.middleware.skill_upload_preflight import SkillUploadPreflightMiddleware
 from app.routes.admin import router as admin_router
+from app.routes.admin import whatsapp_pairing_router as admin_whatsapp_pairing_router
 from app.routes.agent_project_bindings import router as agent_project_bindings_router
 from app.routes.ai_providers import router as ai_providers_router
 from app.routes.audit import router as audit_router
@@ -68,7 +69,7 @@ from app.services.embedding import LocalEmbedder
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_device_onboarding import expire_stale_whatsapp_onboarding_sessions
 from app.services.whatsapp_managed_onboarding import (
-    expire_stale_managed_whatsapp_onboarding_sessions,
+    expire_stale_platform_whatsapp_pairing_sessions,
 )
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
@@ -138,7 +139,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
                             db,
                             registry=whatsapp_sidecars,
                         )
-                        await expire_stale_managed_whatsapp_onboarding_sessions(
+                        await expire_stale_platform_whatsapp_pairing_sessions(
                             db,
                             registry=whatsapp_sidecars,
                         )
@@ -374,6 +375,8 @@ for _router in _VERSIONED_ROUTERS:
     app.include_router(_router, prefix="/v1")
     if _router not in (runtime_router, platform_router):
         app.include_router(_router, prefix="/api", include_in_schema=False)
+
+app.include_router(admin_whatsapp_pairing_router, prefix="/v1")
 # The declarative runtime observation companion is a clean-v2 contract. It is
 # mounted directly and intentionally has neither a /v1 nor a hidden /api alias.
 app.include_router(runtime_observation_v2_router)
@@ -441,8 +444,7 @@ def _is_whatsapp_onboarding_request(request: Request) -> bool:
         (
             "/api/channels/whatsapp/onboarding/",
             "/v1/channels/whatsapp/onboarding/",
-            "/api/admin/channels/whatsapp/onboarding",
-            "/v1/admin/channels/whatsapp/onboarding",
+            "/v1/admin/channels/whatsapp/pairing-sessions",
         )
     )
 

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sqlalchemy import (
     BigInteger,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Index,
@@ -44,7 +45,7 @@ WHATSAPP_ONBOARDING_STATE_EXPIRED = "expired"
 WHATSAPP_ONBOARDING_STATE_CANCELED = "canceled"
 WHATSAPP_ONBOARDING_STATE_ERROR = "error"
 WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM = "custom"
-WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED = "managed"
+WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM = "platform"
 WHATSAPP_ONBOARDING_ACTIVE_STATES = (
     WHATSAPP_ONBOARDING_STATE_GENERATING,
     WHATSAPP_ONBOARDING_STATE_READY,
@@ -80,10 +81,10 @@ class ChannelAccount(Base, TimestampMixin):
     __tablename__ = "channel_accounts"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     provider: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
@@ -109,25 +110,65 @@ class ChannelAccount(Base, TimestampMixin):
     archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     __table_args__ = (
+        CheckConstraint(
+            "(visibility = 'private' AND user_id IS NOT NULL) OR "
+            "(visibility = 'public' AND user_id IS NULL)",
+            name="ck_channel_accounts_visibility_owner",
+        ),
         Index(
             "uq_channel_accounts_user_provider_name_active",
             "user_id",
             "provider",
             "name",
             unique=True,
-            postgresql_where=sql_text("archived_at IS NULL"),
+            postgresql_where=sql_text("visibility = 'private' AND archived_at IS NULL"),
+        ),
+        Index(
+            "uq_channel_accounts_platform_provider_name_active",
+            "provider",
+            "name",
+            unique=True,
+            postgresql_where=sql_text(
+                "visibility = 'public' AND user_id IS NULL AND archived_at IS NULL"
+            ),
+        ),
+    )
+
+
+class ChannelAccountRuntimeMarker(Base, TimestampMixin):
+    """Account-scoped provider runtime state that carries no tenant authority."""
+
+    __tablename__ = "channel_account_runtime_markers"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    account_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("channel_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    scope: Mapped[str] = mapped_column(String(400), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id",
+            "kind",
+            "scope",
+            name="uq_channel_account_runtime_markers_account_kind_scope",
         ),
     )
 
 
 class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
-    """Non-secret ownership and lifecycle metadata for a Custom device login.
+    """Non-secret ownership and lifecycle metadata for a physical device login.
 
     ``sidecar_account_id`` is the legacy column name for an opaque provider
     session UUID. A separate ChannelAccount is created only after Baileys reports
     an authenticated socket, so pending/failed device sessions never appear in
     bot inventory. Session UUIDs are not reused. QR values, pairing codes, phone
-    numbers, and provider auth state never enter this row.
+    numbers, and provider auth state never enter this row. Custom sessions belong
+    to a tenant; platform sessions have no tenant owner.
     """
 
     __tablename__ = "channel_whatsapp_onboarding_sessions"
@@ -148,10 +189,10 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
         ForeignKey("channel_accounts.id", ondelete="SET NULL"),
         index=True,
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     request_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
@@ -165,11 +206,23 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     __table_args__ = (
-        UniqueConstraint(
-            "ownership_kind",
+        CheckConstraint(
+            "(ownership_kind = 'custom' AND user_id IS NOT NULL) OR "
+            "(ownership_kind = 'platform' AND user_id IS NULL)",
+            name="ck_channel_whatsapp_onboarding_owner",
+        ),
+        Index(
+            "uq_channel_whatsapp_onboarding_custom_user_request",
             "user_id",
             "request_id",
-            name="uq_channel_whatsapp_onboarding_kind_user_request",
+            unique=True,
+            postgresql_where=sql_text("ownership_kind = 'custom'"),
+        ),
+        Index(
+            "uq_channel_whatsapp_onboarding_platform_request",
+            "request_id",
+            unique=True,
+            postgresql_where=sql_text("ownership_kind = 'platform'"),
         ),
         Index(
             "uq_channel_whatsapp_onboarding_active_sidecar_account",
@@ -180,11 +233,21 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
             ),
         ),
         Index(
-            "uq_channel_whatsapp_onboarding_active_user_name",
+            "uq_channel_whatsapp_onboarding_active_custom_user_name",
             "user_id",
             "name",
             unique=True,
             postgresql_where=sql_text(
+                "ownership_kind = 'custom' AND "
+                "state IN ('generating', 'ready', 'scanned', 'connected', 'error')"
+            ),
+        ),
+        Index(
+            "uq_channel_whatsapp_onboarding_active_platform_name",
+            "name",
+            unique=True,
+            postgresql_where=sql_text(
+                "ownership_kind = 'platform' AND "
                 "state IN ('generating', 'ready', 'scanned', 'connected', 'error')"
             ),
         ),
@@ -251,10 +314,10 @@ class ChannelSecret(Base, TimestampMixin):
         nullable=False,
         index=True,
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     name: Mapped[str] = mapped_column(String(80), nullable=False)
@@ -808,10 +871,10 @@ class ChannelWhatsAppAuthCert(Base, TimestampMixin):
         unique=True,
         index=True,
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     root_public_key: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -27,6 +27,7 @@ can land in this file under the same auth dep.
 """
 
 import logging
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Annotated, Any, Never, cast
 from uuid import UUID
@@ -2086,7 +2087,7 @@ def _admin_channel_response(account: ChannelAccount, owner: User | None) -> Admi
     )
 
 
-def _enabled_runtime_names(runtimes: dict[str, object]) -> list[str]:
+def _enabled_runtime_names(runtimes: Mapping[str, object]) -> list[str]:
     return sorted(
         name
         for name, value in runtimes.items()

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -46,6 +46,7 @@ from app.models.channel import (
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_PROVIDERS,
     CHANNEL_VISIBILITY_PUBLIC,
     ChannelAccount,
@@ -75,7 +76,7 @@ from app.schemas.admin import (
     AdminEnvironmentCreate,
     AdminManagedAiProviderResponse,
     AdminManagedAiProviderUpsert,
-    AdminManagedWhatsAppOnboardingCreate,
+    AdminPlatformWhatsAppPairingSessionCreate,
     AdminRuntimeStateResponse,
     AdminRuntimeStateUpsert,
 )
@@ -119,6 +120,7 @@ from app.services.channel_config import (
 )
 from app.services.channels import (
     archive_channel_account,
+    build_channel_account,
     channel_webhook_url,
     configure_discord_application,
     configure_telegram_provider_webhook,
@@ -174,12 +176,11 @@ from app.services.user_provisioning import (
     lazy_create_partner_user_with_personal_project,
     lazy_create_user_with_personal_project,
 )
-from app.services.whatsapp_device_onboarding import require_whatsapp_custom_logout_for_archive
+from app.services.whatsapp_device_onboarding import require_whatsapp_logout_for_archive
 from app.services.whatsapp_managed_onboarding import (
-    cancel_managed_whatsapp_onboarding,
-    get_managed_whatsapp_onboarding,
-    require_managed_whatsapp_logout_for_archive,
-    start_managed_whatsapp_onboarding,
+    cancel_platform_whatsapp_pairing,
+    get_platform_whatsapp_pairing,
+    start_platform_whatsapp_pairing,
 )
 from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
 
@@ -192,6 +193,11 @@ logger = logging.getLogger(__name__)
 # tell admin endpoints exist let alone what header they expect. The
 # routes themselves stay live — gating is `require_admin_api_key`.
 router = APIRouter(prefix="/admin", tags=["admin"], include_in_schema=False)
+whatsapp_pairing_router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    include_in_schema=False,
+)
 
 
 def _no_store(response: Response) -> None:
@@ -1066,7 +1072,7 @@ async def admin_list_channels(
 
     result = await db.execute(
         select(ChannelAccount, User)
-        .join(User, User.id == ChannelAccount.user_id)
+        .outerjoin(User, User.id == ChannelAccount.user_id)
         .where(*filters)
         .order_by(ChannelAccount.provider, ChannelAccount.visibility, ChannelAccount.name)
     )
@@ -1084,6 +1090,11 @@ async def admin_create_channel(
     db: AsyncSession = Depends(get_session),
 ) -> AdminChannelCreatedResponse:
     await validate_channel_account_config_urls(provider=body.provider, config=body.config)
+    if body.provider == CHANNEL_PROVIDER_WHATSAPP and body.visibility == CHANNEL_VISIBILITY_PUBLIC:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Public WhatsApp accounts require a physical pairing session.",
+        )
     if body.provider == CHANNEL_PROVIDER_DISCORD:
         if body.provider_token is None:
             raise HTTPException(
@@ -1091,7 +1102,11 @@ async def admin_create_channel(
                 detail="Discord channels require a bot token.",
             )
         validate_required_discord_interactions_config(body.config)
-    target = await _resolve_or_create_user(db, body.target_clerk_id)
+    target = (
+        await _resolve_or_create_user(db, body.target_clerk_id)
+        if body.target_clerk_id is not None
+        else None
+    )
     ciphertext, nonce = encrypt_optional_token(body.provider_token)
     webhook_secret = generate_webhook_secret()
     account_config = (
@@ -1099,8 +1114,8 @@ async def admin_create_channel(
         if body.provider == CHANNEL_PROVIDER_DISCORD
         else body.config
     )
-    account = ChannelAccount(
-        user_id=target.id,
+    account = build_channel_account(
+        owner_user_id=target.id if target is not None else None,
         provider=body.provider,
         name=body.name,
         visibility=body.visibility,
@@ -1135,7 +1150,7 @@ async def admin_create_channel(
             resource_type="channel_account",
             resource_id=str(account.id),
             channel_account_id=account.id,
-            target_user_id=target.id,
+            target_user_id=target.id if target is not None else None,
             source="api.admin",
             details={
                 "provider": account.provider,
@@ -1172,11 +1187,11 @@ async def admin_create_channel(
         await db.commit()
     await db.refresh(account)
     logger.info(
-        "admin_channel_created target_clerk_id=%s channel_id=%s provider=%s visibility=%s",
-        body.target_clerk_id,
+        "admin_channel_created channel_id=%s provider=%s visibility=%s owner_user_id=%s",
         account.id,
         account.provider,
         account.visibility,
+        account.user_id,
     )
     return AdminChannelCreatedResponse(
         **_admin_channel_response(account, target).model_dump(),
@@ -1184,22 +1199,21 @@ async def admin_create_channel(
     )
 
 
-@router.post(
-    "/channels/whatsapp/onboarding",
+@whatsapp_pairing_router.post(
+    "/channels/whatsapp/pairing-sessions",
     response_model=ChannelWhatsAppOnboardingSessionResponse,
+    status_code=status.HTTP_201_CREATED,
 )
-async def admin_start_managed_whatsapp_onboarding(
-    body: AdminManagedWhatsAppOnboardingCreate,
+async def admin_start_platform_whatsapp_pairing(
+    body: AdminPlatformWhatsAppPairingSessionCreate,
     response: Response,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _no_store(response)
-    target = await _resolve_or_create_user(db, body.target_clerk_id)
-    result = await start_managed_whatsapp_onboarding(
+    result = await start_platform_whatsapp_pairing(
         db,
         account_id=body.account_id,
-        user_id=target.id,
         request_id=body.request_id,
         name=body.name,
         registry=get_active_whatsapp_sidecar_registry(),
@@ -1207,11 +1221,10 @@ async def admin_start_managed_whatsapp_onboarding(
     record_control_plane_audit(
         db,
         actor_type="admin",
-        action="channel.whatsapp.onboarding.start",
-        resource_type="channel_whatsapp_onboarding",
+        action="channel.whatsapp.pairing.start",
+        resource_type="channel_whatsapp_pairing_session",
         resource_id=str(result.id),
         channel_account_id=result.channel_account_id,
-        target_user_id=target.id,
         source="api.admin",
         details={"account_id": str(body.account_id), "state": result.state},
     )
@@ -1219,42 +1232,42 @@ async def admin_start_managed_whatsapp_onboarding(
     return result
 
 
-@router.get(
-    "/channels/whatsapp/onboarding/{session_id}",
+@whatsapp_pairing_router.get(
+    "/channels/whatsapp/pairing-sessions/{session_id}",
     response_model=ChannelWhatsAppOnboardingSessionResponse,
 )
-async def admin_get_managed_whatsapp_onboarding(
+async def admin_get_platform_whatsapp_pairing(
     session_id: UUID,
     response: Response,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _no_store(response)
-    result = await get_managed_whatsapp_onboarding(
+    result = await get_platform_whatsapp_pairing(
         db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
     )
     return result
 
 
-@router.delete(
-    "/channels/whatsapp/onboarding/{session_id}",
+@whatsapp_pairing_router.delete(
+    "/channels/whatsapp/pairing-sessions/{session_id}",
     response_model=ChannelWhatsAppOnboardingSessionResponse,
 )
-async def admin_cancel_managed_whatsapp_onboarding(
+async def admin_cancel_platform_whatsapp_pairing(
     session_id: UUID,
     response: Response,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _no_store(response)
-    result = await cancel_managed_whatsapp_onboarding(
+    result = await cancel_platform_whatsapp_pairing(
         db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
     )
     record_control_plane_audit(
         db,
         actor_type="admin",
-        action="channel.whatsapp.onboarding.cancel",
-        resource_type="channel_whatsapp_onboarding",
+        action="channel.whatsapp.pairing.cancel",
+        resource_type="channel_whatsapp_pairing_session",
         resource_id=str(result.id),
         channel_account_id=result.channel_account_id,
         source="api.admin",
@@ -1282,13 +1295,18 @@ async def admin_update_channel(
     db: AsyncSession = Depends(get_session),
 ) -> AdminChannelResponse:
     account, owner = await _admin_get_channel_row(db, account_id=account_id)
-    updates = body.model_fields_set
+    updates = set(body.model_fields_set)
     if "name" in updates:
         account.name = body.name or account.name
     if "status" in updates and body.status is not None:
         account.status = body.status
-    if "visibility" in updates and body.visibility is not None:
-        account.visibility = body.visibility
+    if "visibility" in updates:
+        if body.visibility != account.visibility:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Channel visibility cannot be changed in place; recreate the channel.",
+            )
+        updates.remove("visibility")
     current_telegram_bot_username = (
         normalize_telegram_bot_username(
             account.config.get("bot_username") if isinstance(account.config, dict) else None
@@ -1490,12 +1508,8 @@ async def admin_delete_channel(
             )
         ).scalars()
     )
-    await require_whatsapp_custom_logout_for_archive(
+    await require_whatsapp_logout_for_archive(
         db,
-        account=account,
-        registry=get_active_whatsapp_sidecar_registry(),
-    )
-    await require_managed_whatsapp_logout_for_archive(
         account=account,
         registry=get_active_whatsapp_sidecar_registry(),
     )
@@ -2038,12 +2052,14 @@ async def _admin_get_channel_row(
     *,
     account_id: UUID,
     include_archived: bool = False,
-) -> tuple[ChannelAccount, User]:
+) -> tuple[ChannelAccount, User | None]:
     filters = [ChannelAccount.id == account_id]
     if not include_archived:
         filters.append(ChannelAccount.archived_at.is_(None))
     result = await db.execute(
-        select(ChannelAccount, User).join(User, User.id == ChannelAccount.user_id).where(*filters)
+        select(ChannelAccount, User)
+        .outerjoin(User, User.id == ChannelAccount.user_id)
+        .where(*filters)
     )
     row = result.one_or_none()
     if row is None:
@@ -2052,11 +2068,11 @@ async def _admin_get_channel_row(
     return account, owner
 
 
-def _admin_channel_response(account: ChannelAccount, owner: User) -> AdminChannelResponse:
+def _admin_channel_response(account: ChannelAccount, owner: User | None) -> AdminChannelResponse:
     return AdminChannelResponse(
         id=account.id,
         owner_user_id=account.user_id,
-        owner_clerk_id=owner.clerk_id,
+        owner_clerk_id=owner.clerk_id if owner is not None else None,
         provider=account.provider,
         name=account.name,
         status=account.status,

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -100,6 +100,7 @@ from app.services.channels import (
     archive_bot_agent_link,
     archive_channel_account,
     bot_agent_link_has_strict_v2_authority,
+    build_channel_account,
     channel_bot_link_limit,
     channel_webhook_url,
     configure_discord_application,
@@ -148,7 +149,7 @@ from app.services.whatsapp_baileys import (
     mint_whatsapp_agent_credential,
     whatsapp_agent_websocket_url,
 )
-from app.services.whatsapp_device_onboarding import require_whatsapp_custom_logout_for_archive
+from app.services.whatsapp_device_onboarding import require_whatsapp_logout_for_archive
 from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
 
 router = APIRouter(prefix="/channels", tags=["channels"])
@@ -546,8 +547,14 @@ async def list_channel_bot_pool(
             ChannelAccount.archived_at.is_(None),
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             or_(
-                ChannelAccount.user_id == auth.user_id,
-                ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                and_(
+                    ChannelAccount.user_id == auth.user_id,
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
+                ),
+                and_(
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                    ChannelAccount.user_id.is_(None),
+                ),
             ),
         )
         .order_by(ChannelAccount.provider, ChannelAccount.visibility.desc(), ChannelAccount.name)
@@ -631,10 +638,11 @@ async def create_channel(
         if body.provider == CHANNEL_PROVIDER_DISCORD
         else body.config
     )
-    account = ChannelAccount(
-        user_id=auth.user_id,
+    account = build_channel_account(
+        owner_user_id=auth.user_id,
         provider=body.provider,
         name=body.name,
+        visibility=CHANNEL_VISIBILITY_PRIVATE,
         encrypted_provider_token=ciphertext,
         provider_token_nonce=nonce,
         webhook_secret_hash=hash_token(webhook_secret),
@@ -822,7 +830,7 @@ async def delete_channel(
             )
         ).scalars()
     )
-    await require_whatsapp_custom_logout_for_archive(
+    await require_whatsapp_logout_for_archive(
         db,
         account=account,
         registry=get_active_whatsapp_sidecar_registry(),
@@ -1597,6 +1605,15 @@ async def _health_accounts(
     result = await db.execute(
         select(ChannelAccount)
         .outerjoin(
+            ChannelBotAgentLink,
+            and_(
+                ChannelBotAgentLink.account_id == ChannelAccount.id,
+                ChannelBotAgentLink.user_id == user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            ),
+        )
+        .outerjoin(
             ChannelBinding,
             and_(
                 ChannelBinding.account_id == ChannelAccount.id,
@@ -1607,11 +1624,18 @@ async def _health_accounts(
         .where(
             ChannelAccount.archived_at.is_(None),
             or_(
-                ChannelAccount.user_id == user_id,
+                and_(
+                    ChannelAccount.user_id == user_id,
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
+                ),
                 and_(
                     ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                    ChannelAccount.user_id.is_(None),
                     ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
-                    ChannelBinding.id.is_not(None),
+                    or_(
+                        ChannelBotAgentLink.id.is_not(None),
+                        ChannelBinding.id.is_not(None),
+                    ),
                 ),
             ),
         )

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -33,6 +33,7 @@ from app.models.channel import (
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PUBLIC,
     MESSAGE_DIRECTION_OUTBOUND,
     ChannelAccount,
     ChannelBinding,
@@ -72,6 +73,7 @@ from app.services.channels import (
     drop_pending_telegram_updates,
     find_binding,
     find_existing_inbound_provider_event,
+    find_platform_channel_runtime_marker,
     get_active_channel_account,
     lock_channel_binding_identity,
     parse_channel_control_command,
@@ -79,10 +81,12 @@ from app.services.channels import (
     record_channel_agent_reference,
     record_inactive_bot_agent_link_event,
     record_inbound_messages_for_bindings,
+    record_platform_channel_runtime_marker,
     record_telegram_update_references,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
     send_control_command_reply,
+    send_platform_unbound_channel_message,
     send_telegram_message,
     telegram_chat_from_update,
     telegram_direct_messages_topic_id_from_update,
@@ -769,11 +773,9 @@ async def telegram_webhook(
             provider_event_id=provider_event_id,
             provider_event_scope=provider_event_scope,
         )
-        return TelegramWebhookResponse(
-            ok=True,
-            binding_id=existing.binding_id if existing is not None else None,
-        )
-    message = messages[0][0]
+        if existing is not None:
+            return TelegramWebhookResponse(ok=True, binding_id=existing.binding_id)
+    message = messages[0][0] if messages else None
     for routed_message, binding in messages:
         await record_telegram_update_references(
             db,
@@ -815,7 +817,7 @@ async def telegram_webhook(
             unpaired=binding_result.unpaired,
         )
         await db.commit()
-    if messages and message.binding_id and not binding_result.command_handled:
+    if message is not None and message.binding_id and not binding_result.command_handled:
         delivered_at = datetime.now(UTC)
         for routed_message, binding in messages:
             delivered = await _deliver_telegram_agent_webhook_for_binding(
@@ -831,7 +833,7 @@ async def telegram_webhook(
         ok=True,
         paired=binding_result.paired,
         unpaired=binding_result.unpaired,
-        binding_id=message.binding_id,
+        binding_id=message.binding_id if message is not None else None,
     )
 
 
@@ -845,7 +847,7 @@ async def _send_telegram_unpaired_tutorial(
     payload: dict[str, Any],
     command: ChannelControlCommand | None,
     binding_result: InboundBindingResult,
-) -> ChannelMessage | None:
+) -> bool:
     message = payload.get("message")
     if (
         not isinstance(message, dict)
@@ -853,10 +855,10 @@ async def _send_telegram_unpaired_tutorial(
         or binding_result.binding is not None
         or binding_result.bindings
     ):
-        return None
+        return False
     sender = message.get("from")
     if isinstance(sender, dict) and sender.get("is_bot") is True:
-        return None
+        return False
 
     direct_messages_topic_id = telegram_direct_messages_topic_id_from_update(payload)
     if external_chat_type == "private":
@@ -864,7 +866,7 @@ async def _send_telegram_unpaired_tutorial(
     elif external_chat_type == "direct_messages" and direct_messages_topic_id is not None:
         cooldown_scope = f"direct_messages:{external_chat_id}:{direct_messages_topic_id}"
     else:
-        return None
+        return False
 
     marker = {
         "kind": _TELEGRAM_UNPAIRED_TUTORIAL_KIND,
@@ -889,7 +891,39 @@ async def _send_telegram_unpaired_tutorial(
                     external_user_id=external_user_id,
                 )
             ):
-                return None
+                return False
+            if account.visibility == CHANNEL_VISIBILITY_PUBLIC and account.user_id is None:
+                now = datetime.now(UTC)
+                runtime_marker = await find_platform_channel_runtime_marker(
+                    db,
+                    account=account,
+                    kind=_TELEGRAM_UNPAIRED_TUTORIAL_KIND,
+                    scope=cooldown_scope,
+                )
+                if (
+                    runtime_marker is not None
+                    and runtime_marker.outcome == "sent"
+                    and runtime_marker.updated_at + TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN > now
+                ):
+                    return False
+                await send_platform_unbound_channel_message(
+                    account=account,
+                    external_chat_id=external_chat_id,
+                    text=TELEGRAM_UNPAIRED_TUTORIAL,
+                    telegram_message_thread_id=telegram_message_thread_id_from_update(payload),
+                    telegram_direct_messages_topic_id=direct_messages_topic_id,
+                )
+                record_platform_channel_runtime_marker(
+                    db,
+                    account=account,
+                    marker=runtime_marker,
+                    kind=_TELEGRAM_UNPAIRED_TUTORIAL_KIND,
+                    scope=cooldown_scope,
+                    outcome="sent",
+                    occurred_at=datetime.now(UTC),
+                )
+                await db.flush()
+                return True
             recent_tutorial = await db.scalar(
                 select(ChannelMessage.id)
                 .where(
@@ -903,7 +937,7 @@ async def _send_telegram_unpaired_tutorial(
                 .limit(1)
             )
             if recent_tutorial is not None:
-                return None
+                return False
             tutorial = await send_telegram_message(
                 db,
                 account=account,
@@ -917,7 +951,7 @@ async def _send_telegram_unpaired_tutorial(
             tutorial_payload["clawdi_system"] = marker
             tutorial.payload = tutorial_payload
             await db.flush()
-            return tutorial
+            return True
     except HTTPException as exc:
         log.warning(
             "telegram_unpaired_tutorial_failed account_id=%s chat_id=%s status=%s",
@@ -931,7 +965,7 @@ async def _send_telegram_unpaired_tutorial(
             account.id,
             external_chat_id,
         )
-    return None
+    return False
 
 
 def _telegram_error_response(description: str, error_code: int) -> JSONResponse:

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -98,16 +98,23 @@ async def _run_whatsapp_baileys_websocket(
 ) -> None:
     async with async_session_factory() as db:
         try:
-            account = await get_active_channel_account(db, account_id=account_id)
+            agent = await resolve_channel_agent_by_identity(
+                db,
+                provider=CHANNEL_PROVIDER_WHATSAPP,
+                account_id=account_id,
+                link_id=bot_agent_link_id,
+                agent_token_hash=agent_token_hash,
+            )
         except HTTPException:
             await websocket.close(code=1008)
             return
+        account = agent.account
         if account.provider != CHANNEL_PROVIDER_WHATSAPP:
             await websocket.close(code=1008)
             return
         auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
         await db.commit()
-        account_user_id = account.user_id
+        tenant_user_id = agent.link.user_id
 
     session_revoked = asyncio.Event()
     session_revocation_lock = asyncio.Lock()
@@ -218,7 +225,7 @@ async def _run_whatsapp_baileys_websocket(
             await record_channel_debug_event(
                 db,
                 account=account,
-                user_id=account_user_id,
+                user_id=tenant_user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 direction="agent",
                 stage=event.stage,
@@ -279,6 +286,7 @@ async def _run_whatsapp_baileys_websocket(
             _run_whatsapp_websocket_inbox_pump(
                 account_id=account_id,
                 bot_agent_link_id=bot_agent_link_id,
+                tenant_user_id=tenant_user_id,
                 tenant_id=tenant.tenant_id,
                 session=session,
                 websocket=websocket,
@@ -373,6 +381,7 @@ async def _run_whatsapp_websocket_inbox_pump(
     *,
     account_id: UUID,
     bot_agent_link_id: UUID,
+    tenant_user_id: UUID,
     tenant_id: str,
     session: WhatsAppNoiseEmulatorSession,
     websocket: WebSocket,
@@ -428,6 +437,7 @@ async def _run_whatsapp_websocket_inbox_pump(
         deliver=deliver,
         debug_events=_WhatsAppWebsocketInboxDebugEvents(
             account_id,
+            user_id=tenant_user_id,
             require_session_authority=require_session_authority,
         ),
     )
@@ -439,9 +449,11 @@ class _WhatsAppWebsocketInboxDebugEvents:
         self,
         account_id: UUID,
         *,
+        user_id: UUID,
         require_session_authority: Callable[[], Awaitable[None]],
     ) -> None:
         self._account_id = account_id
+        self._user_id = user_id
         self._require_session_authority = require_session_authority
 
     async def record(self, payload: dict[str, Any]) -> None:
@@ -451,7 +463,7 @@ class _WhatsAppWebsocketInboxDebugEvents:
             await record_channel_debug_event(
                 db,
                 account=account,
-                user_id=account.user_id,
+                user_id=self._user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 direction=_optional_str(payload.get("direction")) or "agent",
                 stage=_optional_str(payload.get("stage")) or "inbox_delivery",

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -20,6 +20,7 @@ from pydantic import (
     JsonValue,
     SecretStr,
     field_validator,
+    model_validator,
 )
 
 from app.schemas.ai_provider import AiProviderAuth, AiProviderModel
@@ -249,14 +250,13 @@ class AdminDeploymentManagedAiProviderResponse(BaseModel):
 class AdminChannelCreate(BaseModel):
     """Create a provider bot account through the admin control plane.
 
-    `target_clerk_id` supplies the backing user row for bookkeeping and
-    private managed bots. Public bots remain admin-managed shared
-    infrastructure: authenticated users can create their own links and pair
-    codes, but cannot mutate provider credentials or destructive bot-level
-    state through user APIs.
+    Private accounts require a target tenant owner. Public accounts are
+    platform inventory and reject a target tenant owner.
     """
 
-    target_clerk_id: str
+    model_config = ConfigDict(extra="forbid")
+
+    target_clerk_id: AdminClerkId | None = None
     provider: AdminChannelProvider
     name: str = Field(min_length=1, max_length=120)
     visibility: AdminChannelVisibility = "public"
@@ -277,10 +277,19 @@ class AdminChannelCreate(BaseModel):
     def _validate_secrets(cls, value: dict[str, str] | None) -> dict[str, str] | None:
         return _clean_channel_secret_values(value)
 
+    @model_validator(mode="after")
+    def _validate_ownership(self) -> AdminChannelCreate:
+        if self.visibility == "private" and self.target_clerk_id is None:
+            raise ValueError("private channels require target_clerk_id")
+        if self.visibility == "public" and self.target_clerk_id is not None:
+            raise ValueError("public channels must not specify target_clerk_id")
+        return self
 
-class AdminManagedWhatsAppOnboardingCreate(BaseModel):
+
+class AdminPlatformWhatsAppPairingSessionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     account_id: UUID
-    target_clerk_id: str = Field(min_length=1, max_length=255)
     request_id: UUID
     name: str = Field(min_length=1, max_length=120)
 
@@ -325,7 +334,7 @@ class AdminChannelUpdate(BaseModel):
 
 class AdminChannelResponse(BaseModel):
     id: UUID
-    owner_user_id: UUID
+    owner_user_id: UUID | None
     owner_clerk_id: str | None
     provider: str
     name: str

--- a/backend/app/services/bluebubbles_compat.py
+++ b/backend/app/services/bluebubbles_compat.py
@@ -17,6 +17,7 @@ from app.models.channel import (
     ChannelMessage,
     ChannelScheduledMessage,
 )
+from app.services.channels import require_channel_tenant_user_id
 from app.services.file_store import FileStore
 
 BLUEBUBBLES_ATTACHMENT_MAX_BYTES = 100 * 1024 * 1024
@@ -417,7 +418,7 @@ async def stage_attachment_upload(
     await file_store.put(file_key, data)
     upload = ChannelAttachmentUpload(
         account_id=account.id,
-        user_id=user_id or account.user_id,
+        user_id=require_channel_tenant_user_id(account, tenant_user_id=user_id),
         upload_path=upload_path,
         file_key=file_key,
         file_name=safe_name,

--- a/backend/app/services/channel_debug_events.py
+++ b/backend/app/services/channel_debug_events.py
@@ -18,6 +18,8 @@ from app.models.channel import (
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PRIVATE,
+    CHANNEL_VISIBILITY_PUBLIC,
     MESSAGE_DIRECTION_INBOUND,
     ChannelAccount,
     ChannelBinding,
@@ -193,10 +195,42 @@ async def channel_debug_health(
         (
             await db.execute(
                 select(ChannelAccount)
-                .where(
-                    ChannelAccount.user_id == user_id,
-                    ChannelAccount.archived_at.is_(None),
+                .outerjoin(
+                    ChannelBotAgentLink,
+                    and_(
+                        ChannelBotAgentLink.account_id == ChannelAccount.id,
+                        ChannelBotAgentLink.user_id == user_id,
+                        ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                        ChannelBotAgentLink.archived_at.is_(None),
+                    ),
                 )
+                .outerjoin(
+                    ChannelBinding,
+                    and_(
+                        ChannelBinding.account_id == ChannelAccount.id,
+                        ChannelBinding.user_id == user_id,
+                        ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    ),
+                )
+                .where(
+                    ChannelAccount.archived_at.is_(None),
+                    or_(
+                        and_(
+                            ChannelAccount.user_id == user_id,
+                            ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
+                        ),
+                        and_(
+                            ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                            ChannelAccount.user_id.is_(None),
+                            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                            or_(
+                                ChannelBotAgentLink.id.is_not(None),
+                                ChannelBinding.id.is_not(None),
+                            ),
+                        ),
+                    ),
+                )
+                .distinct()
                 .order_by(ChannelAccount.provider, ChannelAccount.name)
             )
         )

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -50,6 +50,7 @@ from app.models.channel import (
     PROVIDER_EVENT_SCOPE_ACCOUNT,
     PROVIDER_EVENT_SCOPE_CHAT,
     ChannelAccount,
+    ChannelAccountRuntimeMarker,
     ChannelAgentCredential,
     ChannelAgentReference,
     ChannelBinding,
@@ -502,6 +503,74 @@ def normalize_telegram_bot_username(value: Any) -> str | None:
     return username if TELEGRAM_BOT_USERNAME_PATTERN.fullmatch(username) else None
 
 
+def build_channel_account(
+    *,
+    owner_user_id: UUID | None,
+    provider: str,
+    name: str,
+    visibility: str,
+    webhook_secret_hash: str,
+    account_id: UUID | None = None,
+    status_value: str = CHANNEL_STATUS_ACTIVE,
+    encrypted_provider_token: bytes | None = None,
+    provider_token_nonce: bytes | None = None,
+    config: dict[str, Any] | None = None,
+) -> ChannelAccount:
+    """Build an account while enforcing the inventory ownership boundary."""
+
+    if visibility == CHANNEL_VISIBILITY_PRIVATE:
+        if owner_user_id is None:
+            raise ValueError("private channel accounts require a tenant owner")
+    elif visibility == CHANNEL_VISIBILITY_PUBLIC:
+        if owner_user_id is not None:
+            raise ValueError("public channel accounts are platform-owned")
+    else:
+        raise ValueError("unsupported channel visibility")
+    values: dict[str, Any] = {
+        "user_id": owner_user_id,
+        "provider": provider,
+        "name": name,
+        "status": status_value,
+        "visibility": visibility,
+        "encrypted_provider_token": encrypted_provider_token,
+        "provider_token_nonce": provider_token_nonce,
+        "webhook_secret_hash": webhook_secret_hash,
+        "config": config,
+    }
+    if account_id is not None:
+        values["id"] = account_id
+    return ChannelAccount(**values)
+
+
+def require_channel_tenant_user_id(
+    account: ChannelAccount,
+    *,
+    tenant_user_id: UUID | None = None,
+) -> UUID:
+    """Resolve tenant-scoped child ownership without borrowing platform inventory ownership."""
+
+    if account.visibility == CHANNEL_VISIBILITY_PRIVATE:
+        if account.user_id is None or (
+            tenant_user_id is not None and tenant_user_id != account.user_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="channel tenant authority does not match",
+            )
+        return account.user_id
+    if account.visibility == CHANNEL_VISIBILITY_PUBLIC:
+        if account.user_id is not None or tenant_user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="channel tenant authority is required",
+            )
+        return tenant_user_id
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="channel ownership state is invalid",
+    )
+
+
 async def store_channel_secrets(
     db: AsyncSession,
     *,
@@ -583,7 +652,7 @@ async def get_or_create_bot_agent_link(
     user_id: UUID | None = None,
     agent_token: str | None = None,
 ) -> tuple[ChannelBotAgentLink, str | None]:
-    link_user_id = user_id or account.user_id
+    link_user_id = require_channel_tenant_user_id(account, tenant_user_id=user_id)
     # Serialize against both Link creation and runtime retirement. The fence is
     # the retirement authority; locking only AgentEnvironment leaves a window
     # where retirement can commit before this transaction creates a Link.
@@ -1259,9 +1328,8 @@ async def get_owned_private_channel_account(
 ) -> ChannelAccount:
     """Resolve a user-owned mutable channel account.
 
-    Public channel accounts are Clawdi-managed infrastructure even when their
-    database owner is a target user row. User-facing mutable operations must
-    only apply to private accounts created by that user.
+    Public channel accounts are platform-owned infrastructure. User-facing
+    mutable operations apply only to private accounts created by that user.
     """
     result = await db.execute(
         select(ChannelAccount).where(
@@ -1288,9 +1356,13 @@ async def get_accessible_channel_account(
             ChannelAccount.id == account_id,
             ChannelAccount.archived_at.is_(None),
             or_(
-                ChannelAccount.user_id == user_id,
+                and_(
+                    ChannelAccount.user_id == user_id,
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
+                ),
                 and_(
                     ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                    ChannelAccount.user_id.is_(None),
                     ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ),
             ),
@@ -1314,8 +1386,14 @@ async def get_usable_channel_account(
             ChannelAccount.archived_at.is_(None),
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             or_(
-                ChannelAccount.user_id == user_id,
-                ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                and_(
+                    ChannelAccount.user_id == user_id,
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
+                ),
+                and_(
+                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                    ChannelAccount.user_id.is_(None),
+                ),
             ),
         )
     )
@@ -1943,16 +2021,28 @@ async def _lock_active_link_for_account(
     account: ChannelAccount,
     bot_agent_link_id: UUID,
 ) -> ChannelBotAgentLink | None:
+    link_owner_filter = None
+    if account.visibility == CHANNEL_VISIBILITY_PRIVATE:
+        if account.user_id is None:
+            return None
+        link_owner_filter = ChannelBotAgentLink.user_id == account.user_id
+    elif account.visibility == CHANNEL_VISIBILITY_PUBLIC:
+        if account.user_id is not None:
+            return None
+    else:
+        return None
+    filters = [
+        ChannelBotAgentLink.id == bot_agent_link_id,
+        ChannelBotAgentLink.account_id == account.id,
+        ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+        ChannelBotAgentLink.archived_at.is_(None),
+    ]
+    if link_owner_filter is not None:
+        filters.append(link_owner_filter)
     return (
         await db.execute(
             select(ChannelBotAgentLink)
-            .where(
-                ChannelBotAgentLink.id == bot_agent_link_id,
-                ChannelBotAgentLink.account_id == account.id,
-                ChannelBotAgentLink.user_id == account.user_id,
-                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-                ChannelBotAgentLink.archived_at.is_(None),
-            )
+            .where(*filters)
             .with_for_update(read=True, of=ChannelBotAgentLink)
         )
     ).scalar_one_or_none()
@@ -2516,6 +2606,19 @@ async def send_control_command_reply(
     )
     bind_reply_to_existing = reply_link_id is not None
     try:
+        if (
+            reply_link_id is None
+            and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+            and account.user_id is None
+        ):
+            await send_platform_unbound_channel_message(
+                account=account,
+                external_chat_id=send_external_chat_id or external_chat_id,
+                text=reply_text,
+                telegram_message_thread_id=telegram_message_thread_id,
+                telegram_direct_messages_topic_id=telegram_direct_messages_topic_id,
+            )
+            return None
         return await send_channel_outbound_message(
             db,
             account=account,
@@ -2543,6 +2646,82 @@ async def send_control_command_reply(
             external_chat_id,
         )
     return None
+
+
+async def send_platform_unbound_channel_message(
+    *,
+    account: ChannelAccount,
+    external_chat_id: str,
+    text: str,
+    telegram_message_thread_id: int | None = None,
+    telegram_direct_messages_topic_id: int | None = None,
+) -> None:
+    """Send an account-level provider reply without inventing tenant Message state."""
+
+    if account.visibility != CHANNEL_VISIBILITY_PUBLIC or account.user_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="platform channel ownership is required",
+        )
+    if account.provider == CHANNEL_PROVIDER_TELEGRAM:
+        await _send_telegram_provider_payload(
+            account=account,
+            external_chat_id=external_chat_id,
+            text=text,
+            message_thread_id=telegram_message_thread_id,
+            direct_messages_topic_id=telegram_direct_messages_topic_id,
+        )
+        return
+    await send_provider_outbound_payload(
+        account=account,
+        external_chat_id=external_chat_id,
+        text=text,
+    )
+
+
+async def find_platform_channel_runtime_marker(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    kind: str,
+    scope: str,
+) -> ChannelAccountRuntimeMarker | None:
+    if account.visibility != CHANNEL_VISIBILITY_PUBLIC or account.user_id is not None:
+        raise ValueError("platform channel ownership is required")
+    return await db.scalar(
+        select(ChannelAccountRuntimeMarker).where(
+            ChannelAccountRuntimeMarker.account_id == account.id,
+            ChannelAccountRuntimeMarker.kind == kind,
+            ChannelAccountRuntimeMarker.scope == scope,
+        )
+    )
+
+
+def record_platform_channel_runtime_marker(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    marker: ChannelAccountRuntimeMarker | None,
+    kind: str,
+    scope: str,
+    outcome: str,
+    occurred_at: datetime,
+) -> ChannelAccountRuntimeMarker:
+    if account.visibility != CHANNEL_VISIBILITY_PUBLIC or account.user_id is not None:
+        raise ValueError("platform channel ownership is required")
+    if marker is None:
+        marker = ChannelAccountRuntimeMarker(
+            account_id=account.id,
+            kind=kind,
+            scope=scope,
+            outcome=outcome,
+            updated_at=occurred_at,
+        )
+        db.add(marker)
+    else:
+        marker.outcome = outcome
+        marker.updated_at = occurred_at
+    return marker
 
 
 def telegram_chat_from_update(payload: dict[str, Any]) -> tuple[str, str | None, str | None] | None:
@@ -2791,7 +2970,10 @@ async def _record_inbound_message_with_status(
         )
         if existing is not None:
             return existing, False
-    owner_user_id = binding.user_id if binding is not None else account.user_id
+    owner_user_id = require_channel_tenant_user_id(
+        account,
+        tenant_user_id=binding.user_id if binding is not None else None,
+    )
     message = ChannelMessage(
         account_id=account.id,
         bot_agent_link_id=binding.bot_agent_link_id if binding else None,
@@ -2956,6 +3138,15 @@ async def record_inbound_messages_for_bindings(
         target_bindings = (binding_result.binding,)
     else:
         target_bindings = (None,)
+
+    if (
+        target_bindings == (None,)
+        and account.visibility == CHANNEL_VISIBILITY_PUBLIC
+        and account.user_id is None
+    ):
+        # Unbound provider traffic has no tenant authority. Keep platform
+        # inventory free of fake tenant-owned Message rows.
+        return []
 
     if require_active_authority:
         bound_targets = tuple(binding for binding in target_bindings if binding is not None)
@@ -3139,7 +3330,7 @@ async def record_channel_agent_reference(
     }
     if len(owner_user_ids) > 1:
         raise ValueError("channel reference owner context does not match")
-    owner_user_id = next(iter(owner_user_ids), account.user_id)
+    owner_user_id = next(iter(owner_user_ids), None)
 
     if bot_agent_link_id is not None:
         link_user_id = (
@@ -3156,6 +3347,11 @@ async def record_channel_agent_reference(
             raise ValueError("channel reference owner context does not match")
         if not owner_user_ids:
             owner_user_id = link_user_id
+
+    owner_user_id = require_channel_tenant_user_id(
+        account,
+        tenant_user_id=owner_user_id,
+    )
 
     if scoped_link_id is None:
         # PostgreSQL NULLs do not conflict under the Link-scoped constraint.
@@ -4411,7 +4607,10 @@ async def enqueue_channel_outbound_message(
         external_chat_id=external_chat_id,
         bot_agent_link_id=bot_agent_link_id,
     )
-    owner_user_id = binding.user_id if binding is not None else account.user_id
+    owner_user_id = require_channel_tenant_user_id(
+        account,
+        tenant_user_id=binding.user_id if binding is not None else None,
+    )
     message = ChannelMessage(
         account_id=account.id,
         bot_agent_link_id=binding.bot_agent_link_id if binding else None,
@@ -5863,7 +6062,10 @@ async def _record_outbound_channel_message(
     payload: dict[str, Any] | None,
     delivered_at: datetime | None = None,
 ) -> ChannelMessage:
-    owner_user_id = binding.user_id if binding is not None else account.user_id
+    owner_user_id = require_channel_tenant_user_id(
+        account,
+        tenant_user_id=binding.user_id if binding is not None else None,
+    )
     message = ChannelMessage(
         account_id=account.id,
         bot_agent_link_id=binding.bot_agent_link_id if binding else None,
@@ -6453,6 +6655,79 @@ async def _record_discord_unpaired_message_and_maybe_instruct(
     if await find_binding(db, account=account, external_chat_id=authority_chat_id) is not None:
         return False
 
+    tutorial = (
+        "This Discord server is not paired. Create a Discord pairing code in Clawdi, "
+        "then run /clawdi_pair <code>."
+        if guild_id is not None
+        else "This Discord chat is not paired. Create a Discord pairing code in Clawdi, "
+        "then run /clawdi_pair <code>."
+    )
+    if account.visibility == CHANNEL_VISIBILITY_PUBLIC and account.user_id is None:
+        now = datetime.now(UTC)
+        runtime_marker = await find_platform_channel_runtime_marker(
+            db,
+            account=account,
+            kind=_DISCORD_UNPAIRED_TUTORIAL_KIND,
+            scope=channel_id,
+        )
+        if runtime_marker is not None:
+            cooldown = (
+                _DISCORD_UNPAIRED_TUTORIAL_SUCCESS_COOLDOWN
+                if runtime_marker.outcome == "sent"
+                else _DISCORD_UNPAIRED_TUTORIAL_FAILURE_BACKOFF
+            )
+            if runtime_marker.updated_at + cooldown > now:
+                return True
+        try:
+            await send_platform_unbound_channel_message(
+                account=account,
+                external_chat_id=channel_id,
+                text=tutorial,
+            )
+        except HTTPException as exc:
+            record_platform_channel_runtime_marker(
+                db,
+                account=account,
+                marker=runtime_marker,
+                kind=_DISCORD_UNPAIRED_TUTORIAL_KIND,
+                scope=channel_id,
+                outcome="failed",
+                occurred_at=now,
+            )
+            log.warning(
+                "discord_unpaired_tutorial_failed account_id=%s channel_id=%s status=%s",
+                account.id,
+                channel_id,
+                exc.status_code,
+            )
+        except Exception:
+            record_platform_channel_runtime_marker(
+                db,
+                account=account,
+                marker=runtime_marker,
+                kind=_DISCORD_UNPAIRED_TUTORIAL_KIND,
+                scope=channel_id,
+                outcome="failed",
+                occurred_at=now,
+            )
+            log.exception(
+                "discord_unpaired_tutorial_failed account_id=%s channel_id=%s",
+                account.id,
+                channel_id,
+            )
+        else:
+            record_platform_channel_runtime_marker(
+                db,
+                account=account,
+                marker=runtime_marker,
+                kind=_DISCORD_UNPAIRED_TUTORIAL_KIND,
+                scope=channel_id,
+                outcome="sent",
+                occurred_at=now,
+            )
+        await db.flush()
+        return True
+
     now = datetime.now(UTC)
     marker_result = InboundBindingResult(binding=None, bindings=())
     messages = await record_inbound_messages_for_bindings(
@@ -6498,13 +6773,6 @@ async def _record_discord_unpaired_message_and_maybe_instruct(
             marker.payload = {"kind": _DISCORD_UNPAIRED_TUTORIAL_KIND, "outcome": "suppressed"}
             return True
 
-    tutorial = (
-        "This Discord server is not paired. Create a Discord pairing code in Clawdi, "
-        "then run /clawdi_pair <code>."
-        if guild_id is not None
-        else "This Discord chat is not paired. Create a Discord pairing code in Clawdi, "
-        "then run /clawdi_pair <code>."
-    )
     try:
         await send_discord_message(
             db,

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -33,7 +33,7 @@ from app.models.channel import (
     ChannelBotAgentLink,
     ChannelWhatsAppAuthCert,
 )
-from app.services.channels import upsert_binding_alias
+from app.services.channels import require_channel_tenant_user_id, upsert_binding_alias
 from app.services.vault_crypto import decrypt, encrypt
 
 BinaryNode = dict[str, Any]
@@ -1604,7 +1604,7 @@ async def mint_whatsapp_agent_credential(
     credential = ChannelAgentCredential(
         account_id=account.id,
         bot_agent_link_id=bot_agent_link_id,
-        user_id=user_id or account.user_id,
+        user_id=require_channel_tenant_user_id(account, tenant_user_id=user_id),
         provider=CHANNEL_PROVIDER_WHATSAPP,
         identity_pub_key_hash=hashlib.sha256(minted.identity_pub_key).hexdigest(),
         identity_public_key=minted.identity_pub_key,
@@ -1679,7 +1679,6 @@ async def resolve_whatsapp_credential_by_identity(
             ChannelBotAgentLink.user_id == ChannelAgentCredential.user_id,
             ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
             ChannelBotAgentLink.archived_at.is_(None),
-            ChannelAccount.user_id == ChannelAgentCredential.user_id,
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             ChannelAccount.archived_at.is_(None),
         )

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
-    CHANNEL_STATUS_ACTIVE,
     CHANNEL_VISIBILITY_PRIVATE,
     WHATSAPP_ONBOARDING_ACTIVE_STATES,
     WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
@@ -31,7 +30,12 @@ from app.schemas.channel import (
     ChannelWhatsAppOnboardingSessionResponse,
     WhatsAppOnboardingState,
 )
-from app.services.channels import generate_webhook_secret, hash_token
+from app.services.channels import (
+    build_channel_account,
+    generate_webhook_secret,
+    hash_token,
+    require_channel_tenant_user_id,
+)
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarCapabilities,
     WhatsAppSidecarError,
@@ -135,6 +139,7 @@ async def start_whatsapp_onboarding(
         select(ChannelAccount.id).where(
             ChannelAccount.user_id == user_id,
             ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
             ChannelAccount.name == name,
             ChannelAccount.archived_at.is_(None),
         )
@@ -426,7 +431,7 @@ async def retry_whatsapp_onboarding(
     return response
 
 
-async def require_whatsapp_custom_logout_for_archive(
+async def require_whatsapp_logout_for_archive(
     db: AsyncSession,
     *,
     account: ChannelAccount,
@@ -435,8 +440,41 @@ async def require_whatsapp_custom_logout_for_archive(
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         return
     config = account.config if isinstance(account.config, dict) else {}
-    if config.get("connection_mode") != "baileys_custom":
+    connection_mode = config.get("connection_mode")
+    if connection_mode == "baileys_managed":
+        if registry is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="WhatsApp disconnect could not be confirmed",
+            )
+        revision = config.get("sidecar_config_revision")
+        client = registry.get_managed_client(account.id)
+        if (
+            client is None
+            or not isinstance(revision, str)
+            or registry.managed_account_revision(account.id) != revision
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="WhatsApp disconnect could not be confirmed",
+            )
+        try:
+            disconnected = await stop_whatsapp_pairing(client)
+        except WhatsAppSidecarError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="WhatsApp disconnect could not be confirmed",
+            ) from None
+        if disconnected.status != "stopped" or disconnected.registered:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="WhatsApp disconnect could not be confirmed",
+            )
+        await registry.unbind_managed_account(account.id)
         return
+    if connection_mode != "baileys_custom":
+        return
+    owner_user_id = require_channel_tenant_user_id(account)
     raw_sidecar_account_id = config.get("sidecar_account_id")
     sidecar_config_revision = config.get("sidecar_config_revision")
     try:
@@ -497,7 +535,7 @@ async def require_whatsapp_custom_logout_for_archive(
         select(ChannelWhatsAppOnboardingSession).where(
             ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
             ChannelWhatsAppOnboardingSession.channel_account_id == account.id,
-            ChannelWhatsAppOnboardingSession.user_id == account.user_id,
+            ChannelWhatsAppOnboardingSession.user_id == owner_user_id,
             ChannelWhatsAppOnboardingSession.state == WHATSAPP_ONBOARDING_STATE_CONNECTED,
         )
     )
@@ -660,11 +698,12 @@ async def _finalize_connected_account(
         )
         if existing is None and onboarding.channel_account_id is None:
             webhook_secret = generate_webhook_secret()
-            existing = ChannelAccount(
-                user_id=onboarding.user_id,
+            if onboarding.user_id is None:
+                raise WhatsAppSidecarProtocolError("custom sidecar tenant owner is missing")
+            existing = build_channel_account(
+                owner_user_id=onboarding.user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 name=onboarding.name,
-                status=CHANNEL_STATUS_ACTIVE,
                 visibility=CHANNEL_VISIBILITY_PRIVATE,
                 webhook_secret_hash=hash_token(webhook_secret),
                 config={
@@ -866,6 +905,8 @@ async def _mark_session_error(
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     session_id = onboarding.id
     user_id = onboarding.user_id
+    if user_id is None:
+        raise WhatsAppSidecarProtocolError("custom sidecar tenant owner is missing")
     await db.rollback()
     current = await _owned_session(db, user_id=user_id, session_id=session_id)
     if current.state in {

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -11,9 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
-    CHANNEL_STATUS_ACTIVE,
     CHANNEL_VISIBILITY_PUBLIC,
-    WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+    WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
     WHATSAPP_ONBOARDING_STATE_CANCELED,
     WHATSAPP_ONBOARDING_STATE_CONNECTED,
     WHATSAPP_ONBOARDING_STATE_ERROR,
@@ -28,7 +27,7 @@ from app.schemas.channel import (
     ChannelWhatsAppOnboardingSessionResponse,
     WhatsAppOnboardingState,
 )
-from app.services.channels import generate_webhook_secret, hash_token
+from app.services.channels import build_channel_account, generate_webhook_secret, hash_token
 from app.services.whatsapp_device_onboarding import (
     WHATSAPP_ONBOARDING_TTL,
     stop_whatsapp_pairing,
@@ -44,11 +43,10 @@ _OWNING_STATES = ("generating", "ready", "scanned", "connected", "error")
 _EXPIRABLE_STATES = ("generating", "ready", "scanned", "error")
 
 
-async def start_managed_whatsapp_onboarding(
+async def start_platform_whatsapp_pairing(
     db: AsyncSession,
     *,
     account_id: UUID,
-    user_id: UUID,
     request_id: UUID,
     name: str,
     registry: ConfiguredWhatsAppSidecarRegistry | None,
@@ -62,8 +60,7 @@ async def start_managed_whatsapp_onboarding(
     existing = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
             ChannelWhatsAppOnboardingSession.ownership_kind
-            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
-            ChannelWhatsAppOnboardingSession.user_id == user_id,
+            == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
             ChannelWhatsAppOnboardingSession.request_id == request_id,
         )
     )
@@ -71,11 +68,11 @@ async def start_managed_whatsapp_onboarding(
         if existing.sidecar_account_id != account_id:
             raise HTTPException(status.HTTP_409_CONFLICT, "request already owns another account")
         await db.commit()
-        return await get_managed_whatsapp_onboarding(db, session_id=existing.id, registry=registry)
+        return await get_platform_whatsapp_pairing(db, session_id=existing.id, registry=registry)
     occupied = await db.scalar(
         select(ChannelWhatsAppOnboardingSession.id).where(
             ChannelWhatsAppOnboardingSession.ownership_kind
-            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+            == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
             ChannelWhatsAppOnboardingSession.sidecar_account_id == account_id,
             ChannelWhatsAppOnboardingSession.state.in_(_OWNING_STATES),
         )
@@ -84,9 +81,19 @@ async def start_managed_whatsapp_onboarding(
         raise HTTPException(
             status.HTTP_409_CONFLICT, "configured WhatsApp account is already owned"
         )
+    duplicate_session_name = await db.scalar(
+        select(ChannelWhatsAppOnboardingSession.id).where(
+            ChannelWhatsAppOnboardingSession.ownership_kind
+            == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
+            ChannelWhatsAppOnboardingSession.name == name,
+            ChannelWhatsAppOnboardingSession.state.in_(_OWNING_STATES),
+        )
+    )
+    if duplicate_session_name is not None:
+        raise HTTPException(status.HTTP_409_CONFLICT, "WhatsApp account name already exists")
     account = await db.get(ChannelAccount, account_id)
     if account is not None:
-        if not _matches(account, user_id=user_id, revision=revision):
+        if not _matches(account, revision=revision):
             raise HTTPException(
                 status.HTTP_409_CONFLICT, "configured WhatsApp account identity conflicts"
             )
@@ -95,8 +102,9 @@ async def start_managed_whatsapp_onboarding(
         )
     duplicate_name = await db.scalar(
         select(ChannelAccount.id).where(
-            ChannelAccount.user_id == user_id,
+            ChannelAccount.user_id.is_(None),
             ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
             ChannelAccount.name == name,
             ChannelAccount.archived_at.is_(None),
         )
@@ -105,10 +113,10 @@ async def start_managed_whatsapp_onboarding(
         raise HTTPException(status.HTTP_409_CONFLICT, "WhatsApp account name already exists")
     now = datetime.now(UTC)
     onboarding = ChannelWhatsAppOnboardingSession(
-        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
         sidecar_account_id=account_id,
         sidecar_config_revision=revision,
-        user_id=user_id,
+        user_id=None,
         request_id=request_id,
         name=name,
         state=WHATSAPP_ONBOARDING_STATE_GENERATING,
@@ -121,7 +129,7 @@ async def start_managed_whatsapp_onboarding(
     return await _refresh(db, onboarding=onboarding, registry=registry, start_qr=True)
 
 
-async def get_managed_whatsapp_onboarding(
+async def get_platform_whatsapp_pairing(
     db: AsyncSession,
     *,
     session_id: UUID,
@@ -137,7 +145,7 @@ async def get_managed_whatsapp_onboarding(
     return await _refresh(db, onboarding=onboarding, registry=registry, start_qr=False)
 
 
-async def cancel_managed_whatsapp_onboarding(
+async def cancel_platform_whatsapp_pairing(
     db: AsyncSession,
     *,
     session_id: UUID,
@@ -167,45 +175,7 @@ async def cancel_managed_whatsapp_onboarding(
     return _response(onboarding)
 
 
-async def require_managed_whatsapp_logout_for_archive(
-    *,
-    account: ChannelAccount,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
-) -> None:
-    config = account.config if isinstance(account.config, dict) else {}
-    if (
-        account.provider != CHANNEL_PROVIDER_WHATSAPP
-        or config.get("connection_mode") != "baileys_managed"
-    ):
-        return
-    if registry is None:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
-        )
-    client = registry.get_managed_client(account.id)
-    revision = config.get("sidecar_config_revision")
-    if (
-        client is None
-        or not isinstance(revision, str)
-        or registry.managed_account_revision(account.id) != revision
-    ):
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
-        )
-    try:
-        result = await stop_whatsapp_pairing(client)
-    except WhatsAppSidecarError:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
-        ) from None
-    if result.status != "stopped" or result.registered:
-        raise HTTPException(
-            status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp disconnect could not be confirmed"
-        )
-    await registry.unbind_managed_account(account.id)
-
-
-async def expire_stale_managed_whatsapp_onboarding_sessions(
+async def expire_stale_platform_whatsapp_pairing_sessions(
     db: AsyncSession,
     *,
     registry: ConfiguredWhatsAppSidecarRegistry,
@@ -215,7 +185,7 @@ async def expire_stale_managed_whatsapp_onboarding_sessions(
             await db.scalars(
                 select(ChannelWhatsAppOnboardingSession.id).where(
                     ChannelWhatsAppOnboardingSession.ownership_kind
-                    == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+                    == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
                     ChannelWhatsAppOnboardingSession.state.in_(_EXPIRABLE_STATES),
                     ChannelWhatsAppOnboardingSession.expires_at <= datetime.now(UTC),
                 )
@@ -224,7 +194,7 @@ async def expire_stale_managed_whatsapp_onboarding_sessions(
     )
     expired = 0
     for session_id in session_ids:
-        result = await get_managed_whatsapp_onboarding(db, session_id=session_id, registry=registry)
+        result = await get_platform_whatsapp_pairing(db, session_id=session_id, registry=registry)
         if result.state == WHATSAPP_ONBOARDING_STATE_EXPIRED:
             expired += 1
     return expired
@@ -294,12 +264,11 @@ async def _promote(
     account = await db.get(ChannelAccount, onboarding.sidecar_account_id)
     try:
         if account is None:
-            account = ChannelAccount(
-                id=account_id,
-                user_id=onboarding.user_id,
+            account = build_channel_account(
+                account_id=account_id,
+                owner_user_id=None,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 name=onboarding.name,
-                status=CHANNEL_STATUS_ACTIVE,
                 visibility=CHANNEL_VISIBILITY_PUBLIC,
                 webhook_secret_hash=hash_token(generate_webhook_secret()),
                 config={
@@ -309,9 +278,7 @@ async def _promote(
             )
             db.add(account)
             await db.flush()
-        elif not _matches(
-            account, user_id=onboarding.user_id, revision=onboarding.sidecar_config_revision
-        ):
+        elif not _matches(account, revision=onboarding.sidecar_config_revision):
             raise WhatsAppSidecarProtocolError("managed WhatsApp identity conflict")
         newly_bound = await registry.bind_managed_account(
             account.id, config_revision=onboarding.sidecar_config_revision
@@ -340,10 +307,10 @@ async def _promote(
         raise
 
 
-def _matches(account: ChannelAccount, *, user_id: UUID, revision: str) -> bool:
+def _matches(account: ChannelAccount, *, revision: str) -> bool:
     config = account.config if isinstance(account.config, dict) else {}
     return (
-        account.user_id == user_id
+        account.user_id is None
         and account.provider == CHANNEL_PROVIDER_WHATSAPP
         and account.visibility == CHANNEL_VISIBILITY_PUBLIC
         and account.archived_at is None
@@ -358,7 +325,7 @@ async def _session(db: AsyncSession, session_id: UUID) -> ChannelWhatsAppOnboard
         .where(
             ChannelWhatsAppOnboardingSession.id == session_id,
             ChannelWhatsAppOnboardingSession.ownership_kind
-            == WHATSAPP_ONBOARDING_OWNERSHIP_MANAGED,
+            == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
         )
         .with_for_update()
     )

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PRIVATE,
     PROVIDER_EVENT_SCOPE_ACCOUNT,
     ChannelAccount,
     ChannelBinding,
@@ -30,6 +31,7 @@ from app.services.channels import (
     lock_active_link_authority,
     parse_channel_control_command,
     record_inbound_messages_for_bindings,
+    require_channel_tenant_user_id,
     resolve_inbound_binding,
     send_control_command_reply,
 )
@@ -189,7 +191,7 @@ class WhatsAppProviderBridge:
             await record_channel_debug_event(
                 db,
                 account=account,
-                user_id=account.user_id,
+                user_id=queued.user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 direction="agent",
                 stage="outbound_delivery",
@@ -222,6 +224,19 @@ class WhatsAppProviderBridge:
         external_chat_id = attrs.get("to") or attrs.get("recipient")
         async with self._sessionmaker() as db:
             account = await _load_active_whatsapp_account(db, account_id=self._account_id)
+            link = await lock_active_link_authority(
+                db,
+                account=account,
+                bot_agent_link_id=bot_agent_link_id,
+            )
+            if link is None:
+                return WhatsAppProviderNodeRelayResult(
+                    outcome="dropped",
+                    tag=tag,
+                    external_chat_id=external_chat_id,
+                    reason="link-authority-missing",
+                )
+            tenant_user_id = link.user_id
             resolve_jid = await _build_bound_jid_resolver(
                 db,
                 account=account,
@@ -238,7 +253,7 @@ class WhatsAppProviderBridge:
                 await record_channel_debug_event(
                     db,
                     account=account,
-                    user_id=account.user_id,
+                    user_id=tenant_user_id,
                     provider=CHANNEL_PROVIDER_WHATSAPP,
                     direction="agent",
                     stage="outbound_relay",
@@ -259,7 +274,7 @@ class WhatsAppProviderBridge:
                 await record_channel_debug_event(
                     db,
                     account=account,
-                    user_id=account.user_id,
+                    user_id=tenant_user_id,
                     provider=CHANNEL_PROVIDER_WHATSAPP,
                     direction="agent",
                     stage="outbound_relay",
@@ -281,7 +296,7 @@ class WhatsAppProviderBridge:
                 await record_channel_debug_event(
                     db,
                     account=account,
-                    user_id=account.user_id,
+                    user_id=tenant_user_id,
                     provider=CHANNEL_PROVIDER_WHATSAPP,
                     direction="agent",
                     stage="outbound_relay",
@@ -300,7 +315,7 @@ class WhatsAppProviderBridge:
             await record_channel_debug_event(
                 db,
                 account=account,
-                user_id=account.user_id,
+                user_id=tenant_user_id,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 direction="agent",
                 stage="outbound_relay",
@@ -417,17 +432,18 @@ async def persist_whatsapp_provider_event(
         alt_jid=alt_jid,
     )
     if binding_lookup.conflict:
-        await record_channel_debug_event(
-            db,
-            account=account,
-            user_id=account.user_id,
-            provider=CHANNEL_PROVIDER_WHATSAPP,
-            direction="inbound",
-            stage="provider_ingress",
-            outcome="dropped",
-            external_chat_id=route_jid,
-            details={"reason": "binding-alias-conflict", "messageId": event.message_id},
-        )
+        if account.visibility == CHANNEL_VISIBILITY_PRIVATE:
+            await record_channel_debug_event(
+                db,
+                account=account,
+                user_id=require_channel_tenant_user_id(account),
+                provider=CHANNEL_PROVIDER_WHATSAPP,
+                direction="inbound",
+                stage="provider_ingress",
+                outcome="dropped",
+                external_chat_id=route_jid,
+                details={"reason": "binding-alias-conflict", "messageId": event.message_id},
+            )
         await db.commit()
         return
     existing_binding = binding_lookup.binding

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -272,6 +272,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                     select(ChannelAccount).where(
                         ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
                         ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                        ChannelAccount.user_id.is_(None),
                         ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                         ChannelAccount.archived_at.is_(None),
                     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,6 +27,7 @@ import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.auth import AuthContext, get_auth, get_auth_short_session, optional_web_auth
@@ -293,7 +294,30 @@ async def seed_user(
     fallback target. Without this, write paths that resolve project
     server-side would 500 on a fresh test user.
     """
+    from app.models.channel import (
+        WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
+        ChannelAccount,
+        ChannelWhatsAppOnboardingSession,
+    )
     from app.models.project import PROJECT_KIND_PERSONAL, Project
+
+    uses_committed_db = request.node.get_closest_marker("committed_db") is not None
+    platform_account_ids_before: set[uuid.UUID] = set()
+    platform_session_ids_before: set[uuid.UUID] = set()
+    if uses_committed_db:
+        platform_account_ids_before = set(
+            await db_session.scalars(
+                select(ChannelAccount.id).where(ChannelAccount.user_id.is_(None))
+            )
+        )
+        platform_session_ids_before = set(
+            await db_session.scalars(
+                select(ChannelWhatsAppOnboardingSession.id).where(
+                    ChannelWhatsAppOnboardingSession.ownership_kind
+                    == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM
+                )
+            )
+        )
 
     user = User(
         clerk_id=f"test_{test_identity}",
@@ -312,11 +336,43 @@ async def seed_user(
     db_session.add(personal)
     await db_session.commit()
     await db_session.refresh(user)
+    seed_user_id = user.id
     try:
         yield user
     finally:
-        if request.node.get_closest_marker("committed_db"):
-            await db_session.delete(user)
+        if uses_committed_db:
+            # A failed flush leaves the committed lane unusable until rollback.
+            # Public channel inventory is platform-owned, so deleting the test
+            # tenant no longer cascades through accounts created by the test.
+            await db_session.rollback()
+            platform_account_ids_after = set(
+                await db_session.scalars(
+                    select(ChannelAccount.id).where(ChannelAccount.user_id.is_(None))
+                )
+            )
+            platform_session_ids_after = set(
+                await db_session.scalars(
+                    select(ChannelWhatsAppOnboardingSession.id).where(
+                        ChannelWhatsAppOnboardingSession.ownership_kind
+                        == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM
+                    )
+                )
+            )
+            created_platform_session_ids = platform_session_ids_after - platform_session_ids_before
+            created_platform_account_ids = platform_account_ids_after - platform_account_ids_before
+            if created_platform_session_ids:
+                await db_session.execute(
+                    delete(ChannelWhatsAppOnboardingSession).where(
+                        ChannelWhatsAppOnboardingSession.id.in_(created_platform_session_ids)
+                    )
+                )
+            if created_platform_account_ids:
+                await db_session.execute(
+                    delete(ChannelAccount).where(
+                        ChannelAccount.id.in_(created_platform_account_ids)
+                    )
+                )
+            await db_session.execute(delete(User).where(User.id == seed_user_id))
             await db_session.commit()
 
 

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1949,23 +1949,7 @@ async def test_admin_channel_create_requires_admin_key(admin_client, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_admin_channel_create_enforces_visibility_ownership(
-    admin_client, db_session, seed_user
-):
-    from app.models.channel import ChannelAccount
-
-    public_with_owner = await admin_client.post(
-        "/v1/admin/channels",
-        headers=_AUTH,
-        json={
-            "target_clerk_id": seed_user.clerk_id,
-            "provider": "telegram",
-            "name": f"invalid-public-owner-{uuid.uuid4().hex}",
-            "visibility": "public",
-        },
-    )
-    assert public_with_owner.status_code == 422
-
+async def test_admin_private_channel_requires_owner(admin_client, seed_user):
     private_without_owner = await admin_client.post(
         "/v1/admin/channels",
         headers=_AUTH,
@@ -1990,29 +1974,6 @@ async def test_admin_channel_create_enforces_visibility_ownership(
     assert private.status_code == 201, private.text
     assert private.json()["owner_user_id"] == str(seed_user.id)
     assert private.json()["owner_clerk_id"] == seed_user.clerk_id
-    private_account = await db_session.get(ChannelAccount, uuid.UUID(private.json()["id"]))
-    assert private_account is not None and private_account.user_id == seed_user.id
-
-    private_flip = await admin_client.patch(
-        f"/v1/admin/channels/{private.json()['id']}",
-        headers=_AUTH,
-        json={"visibility": "public"},
-    )
-    assert private_flip.status_code == 409
-
-    public_whatsapp = await admin_client.post(
-        "/v1/admin/channels",
-        headers=_AUTH,
-        json={
-            "provider": "whatsapp",
-            "name": f"physical-only-{uuid.uuid4().hex}",
-            "visibility": "public",
-        },
-    )
-    assert public_whatsapp.status_code == 400
-    assert public_whatsapp.json()["detail"] == (
-        "Public WhatsApp accounts require a physical pairing session."
-    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1770,7 +1770,7 @@ async def test_admin_channel_lifecycle_manages_public_bot(
 
     from sqlalchemy import select
 
-    from app.models.channel import ChannelAccount
+    from app.models.channel import ChannelAccount, ChannelSecret
     from app.services.channels import (
         decrypt_provider_token,
         get_channel_secret,
@@ -1798,7 +1798,6 @@ async def test_admin_channel_lifecycle_manages_public_bot(
         "/v1/admin/channels",
         headers=_AUTH,
         json={
-            "target_clerk_id": seed_user.clerk_id,
             "provider": "telegram",
             "name": f"admin-public-{uuid.uuid4().hex}",
             "visibility": "public",
@@ -1809,7 +1808,8 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     )
     assert created.status_code == 201, created.text
     body = created.json()
-    assert body["owner_clerk_id"] == seed_user.clerk_id
+    assert body["owner_user_id"] is None
+    assert body["owner_clerk_id"] is None
     assert body["visibility"] == "public"
     assert body["has_provider_token"] is True
     assert body["webhook_secret"]
@@ -1819,11 +1819,30 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     account = (
         await db_session.execute(select(ChannelAccount).where(ChannelAccount.id == body["id"]))
     ).scalar_one()
-    assert account.user_id == seed_user.id
+    assert account.user_id is None
     assert account.visibility == "public"
     assert decrypt_provider_token(account) == "123456:admin-token"
     assert account.config == {"commands": "managed", "bot_username": "ClawdiPublicBot"}
     assert await get_channel_secret(db_session, account=account, name="app_secret") == "secret-v1"
+    secret = (
+        await db_session.execute(
+            select(ChannelSecret).where(
+                ChannelSecret.account_id == account.id,
+                ChannelSecret.name == "app_secret",
+            )
+        )
+    ).scalar_one()
+    assert secret.user_id is None
+
+    visibility_flip = await admin_client.patch(
+        f"/v1/admin/channels/{body['id']}",
+        headers=_AUTH,
+        json={"visibility": "private"},
+    )
+    assert visibility_flip.status_code == 409
+    assert visibility_flip.json()["detail"] == (
+        "Channel visibility cannot be changed in place; recreate the channel."
+    )
 
     linked = await client.post(
         f"/v1/channels/{body['id']}/agent-links",
@@ -1927,6 +1946,73 @@ async def test_admin_channel_create_requires_admin_key(admin_client, seed_user):
         },
     )
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_admin_channel_create_enforces_visibility_ownership(
+    admin_client, db_session, seed_user
+):
+    from app.models.channel import ChannelAccount
+
+    public_with_owner = await admin_client.post(
+        "/v1/admin/channels",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "provider": "telegram",
+            "name": f"invalid-public-owner-{uuid.uuid4().hex}",
+            "visibility": "public",
+        },
+    )
+    assert public_with_owner.status_code == 422
+
+    private_without_owner = await admin_client.post(
+        "/v1/admin/channels",
+        headers=_AUTH,
+        json={
+            "provider": "telegram",
+            "name": f"missing-private-owner-{uuid.uuid4().hex}",
+            "visibility": "private",
+        },
+    )
+    assert private_without_owner.status_code == 422
+
+    private = await admin_client.post(
+        "/v1/admin/channels",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "provider": "telegram",
+            "name": f"private-owner-{uuid.uuid4().hex}",
+            "visibility": "private",
+        },
+    )
+    assert private.status_code == 201, private.text
+    assert private.json()["owner_user_id"] == str(seed_user.id)
+    assert private.json()["owner_clerk_id"] == seed_user.clerk_id
+    private_account = await db_session.get(ChannelAccount, uuid.UUID(private.json()["id"]))
+    assert private_account is not None and private_account.user_id == seed_user.id
+
+    private_flip = await admin_client.patch(
+        f"/v1/admin/channels/{private.json()['id']}",
+        headers=_AUTH,
+        json={"visibility": "public"},
+    )
+    assert private_flip.status_code == 409
+
+    public_whatsapp = await admin_client.post(
+        "/v1/admin/channels",
+        headers=_AUTH,
+        json={
+            "provider": "whatsapp",
+            "name": f"physical-only-{uuid.uuid4().hex}",
+            "visibility": "public",
+        },
+    )
+    assert public_whatsapp.status_code == 400
+    assert public_whatsapp.json()["detail"] == (
+        "Public WhatsApp accounts require a physical pairing session."
+    )
 
 
 @pytest.mark.asyncio
@@ -2879,8 +2965,8 @@ async def test_admin_endpoints_excluded_from_openapi_schema(admin_client, seed_u
 
 
 @pytest.mark.asyncio
-async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logout_is_fail_closed(
-    admin_client, db_session, seed_user, monkeypatch
+async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logout_is_fail_closed(
+    admin_client, db_session, monkeypatch
 ):
     import app.routes.admin as admin_routes
     from app.models.channel import ChannelAccount, ChannelWhatsAppOnboardingSession
@@ -2896,41 +2982,35 @@ async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logou
     monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
     payload = {
         "account_id": str(account_id),
-        "target_clerk_id": seed_user.clerk_id,
         "request_id": str(uuid.uuid4()),
         "name": "Shared WhatsApp",
     }
+    pairing_url = "/v1/admin/channels/whatsapp/pairing-sessions"
     try:
-        assert (
-            await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json=payload)
-        ).status_code == 401
-        started = await admin_client.post(
-            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
-        )
-        assert started.status_code == 200, started.text
+        assert (await admin_client.post(pairing_url, json=payload)).status_code == 401
+        started = await admin_client.post(pairing_url, json=payload, headers=_AUTH)
+        assert started.status_code == 201, started.text
         assert started.headers["cache-control"] == "no-store, private"
         assert started.json()["qr"] == fake.qr
         assert await db_session.get(ChannelAccount, account_id) is None
         fake.qr = "sensitive-rotated-qr"
-        repeated = await admin_client.post(
-            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
-        )
+        repeated = await admin_client.post(pairing_url, json=payload, headers=_AUTH)
         assert repeated.json()["id"] == started.json()["id"]
         assert repeated.json()["qr"] == fake.qr
         fake.connected = fake.registered = True
-        promoted = await admin_client.get(
-            f"/v1/admin/channels/whatsapp/onboarding/{started.json()['id']}", headers=_AUTH
-        )
+        promoted = await admin_client.get(f"{pairing_url}/{started.json()['id']}", headers=_AUTH)
         assert promoted.status_code == 200, promoted.text
         assert promoted.headers["cache-control"] == "no-store, private"
         assert promoted.json()["channel_account_id"] == str(account_id)
         account = await db_session.get(ChannelAccount, account_id)
         assert account is not None and account.visibility == "public"
+        assert account.user_id is None
         assert account.config["connection_mode"] == "baileys_managed"
         session = await db_session.get(
             ChannelWhatsAppOnboardingSession, uuid.UUID(started.json()["id"])
         )
-        assert session.ownership_kind == "managed"
+        assert session.ownership_kind == "platform"
+        assert session.user_id is None
         await registry.stop()
         registry = ConfiguredWhatsAppSidecarRegistry(
             "fake",
@@ -2956,30 +3036,24 @@ async def test_admin_managed_whatsapp_qr_promotes_only_after_connected_and_logou
 
 
 @pytest.mark.asyncio
-async def test_admin_managed_whatsapp_errors_are_authenticated_configured_only_and_no_store(
-    admin_client, seed_user, monkeypatch
+async def test_admin_platform_whatsapp_errors_are_authenticated_configured_only_and_no_store(
+    admin_client, monkeypatch
 ):
     import app.routes.admin as admin_routes
 
     monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: None)
     payload = {
         "account_id": str(uuid.uuid4()),
-        "target_clerk_id": seed_user.clerk_id,
         "request_id": str(uuid.uuid4()),
         "name": "Shared WhatsApp",
     }
+    pairing_url = "/v1/admin/channels/whatsapp/pairing-sessions"
     responses = [
-        await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json=payload),
-        await admin_client.post("/v1/admin/channels/whatsapp/onboarding", json={}, headers=_AUTH),
-        await admin_client.post(
-            "/v1/admin/channels/whatsapp/onboarding", json=payload, headers=_AUTH
-        ),
-        await admin_client.get(
-            f"/v1/admin/channels/whatsapp/onboarding/{uuid.uuid4()}", headers=_AUTH
-        ),
-        await admin_client.delete(
-            f"/v1/admin/channels/whatsapp/onboarding/{uuid.uuid4()}", headers=_AUTH
-        ),
+        await admin_client.post(pairing_url, json=payload),
+        await admin_client.post(pairing_url, json={}, headers=_AUTH),
+        await admin_client.post(pairing_url, json=payload, headers=_AUTH),
+        await admin_client.get(f"{pairing_url}/{uuid.uuid4()}", headers=_AUTH),
+        await admin_client.delete(f"{pairing_url}/{uuid.uuid4()}", headers=_AUTH),
     ]
     assert [response.status_code for response in responses] == [401, 422, 404, 404, 404]
     for response in responses:
@@ -2988,9 +3062,7 @@ async def test_admin_managed_whatsapp_errors_are_authenticated_configured_only_a
 
 
 @pytest.mark.asyncio
-async def test_admin_managed_whatsapp_cancel_success_is_no_store(
-    admin_client, seed_user, monkeypatch
-):
+async def test_admin_platform_whatsapp_cancel_success_is_no_store(admin_client, monkeypatch):
     import app.routes.admin as admin_routes
 
     account_id = uuid.uuid4()
@@ -3002,20 +3074,18 @@ async def test_admin_managed_whatsapp_cancel_success_is_no_store(
     )
     await registry.start()
     monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    pairing_url = "/v1/admin/channels/whatsapp/pairing-sessions"
     try:
         started = await admin_client.post(
-            "/v1/admin/channels/whatsapp/onboarding",
+            pairing_url,
             headers=_AUTH,
             json={
                 "account_id": str(account_id),
-                "target_clerk_id": seed_user.clerk_id,
                 "request_id": str(uuid.uuid4()),
                 "name": "Cancelable Shared WhatsApp",
             },
         )
-        canceled = await admin_client.delete(
-            f"/v1/admin/channels/whatsapp/onboarding/{started.json()['id']}", headers=_AUTH
-        )
+        canceled = await admin_client.delete(f"{pairing_url}/{started.json()['id']}", headers=_AUTH)
         assert canceled.status_code == 200
         assert canceled.json()["state"] == "canceled"
         assert canceled.headers["cache-control"] == "no-store, private"
@@ -3032,7 +3102,7 @@ async def test_admin_delete_non_whatsapp_provider_regression(
     from app.models.channel import ChannelAccount
 
     account = ChannelAccount(
-        user_id=seed_user.id,
+        user_id=None,
         provider=provider,
         name=f"delete-{provider}-{uuid.uuid4()}",
         status="active",

--- a/backend/tests/test_api_version_alias.py
+++ b/backend/tests/test_api_version_alias.py
@@ -14,6 +14,11 @@ from httpx import ASGITransport
 
 from app.main import app
 
+_CANONICAL_ONLY_V1_PREFIXES = (
+    "/v1/platform/",
+    "/v1/admin/channels/whatsapp/pairing-sessions",
+)
+
 
 def _routes_by_path() -> dict[str, set[str]]:
     routes: dict[str, set[str]] = {}
@@ -31,7 +36,7 @@ def test_every_legacy_v1_route_has_api_alias():
         for path in routes
         if path.startswith("/v1/")
         and path != "/v1/runtime/manifest"
-        and not path.startswith("/v1/platform/")
+        and not path.startswith(_CANONICAL_ONLY_V1_PREFIXES)
     ]
     assert v1_paths, "expected /v1 routes to be mounted"
     missing = [

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -48,6 +48,7 @@ from app.models.channel import (
     PAIR_CODE_STATUS_PENDING,
     PAIR_CODE_STATUS_REVOKED,
     ChannelAccount,
+    ChannelAccountRuntimeMarker,
     ChannelAgentCredential,
     ChannelAgentReference,
     ChannelBinding,
@@ -384,11 +385,12 @@ async def _create_admin_channel(
     settings.admin_api_key = admin_key
     try:
         payload: dict[str, Any] = {
-            "target_clerk_id": target_clerk_id,
             "provider": provider,
             "name": name,
             "visibility": visibility,
         }
+        if visibility == "private":
+            payload["target_clerk_id"] = target_clerk_id
         if provider_token is not None:
             payload["provider_token"] = provider_token
         if config is not None:
@@ -1465,12 +1467,15 @@ async def test_public_channel_activity_is_scoped_to_event_owner(
     ).json()
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
+    tenant_user_id = account.user_id
+    assert tenant_user_id is not None
     account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
     db_session.add(
         ChannelMessage(
             account_id=account.id,
             bot_agent_link_id=UUID(created["agent_link_id"]),
-            user_id=account.user_id,
+            user_id=tenant_user_id,
             direction=MESSAGE_DIRECTION_OUTBOUND,
             external_chat_id="owner-chat",
             provider_message_id=None,
@@ -1662,6 +1667,7 @@ async def test_channel_health_includes_public_bound_channels_without_cross_user_
     ).json()
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
+    account.user_id = None
     account.visibility = CHANNEL_VISIBILITY_PUBLIC
     owner_message = ChannelMessage(
         account_id=account.id,
@@ -1686,13 +1692,19 @@ async def test_channel_health_includes_public_bound_channels_without_cross_user_
             last_error="owner-only failure",
         )
     )
-    other_user, _other_agent = await _create_user_with_channel_agent(
+    other_user, other_agent = await _create_user_with_channel_agent(
         db_session,
         label="health-other",
     )
+    async with _client_for_user(db_session, other_user) as other_client:
+        other_link_response = await other_client.post(
+            f"/v1/channels/{account.id}/agent-links",
+            json={"agent_id": str(other_agent.id)},
+        )
+    assert other_link_response.status_code == 201, other_link_response.text
     other_binding = ChannelBinding(
         account_id=account.id,
-        bot_agent_link_id=UUID(created["agent_link_id"]),
+        bot_agent_link_id=UUID(other_link_response.json()["id"]),
         user_id=other_user.id,
         external_chat_id="other-health-chat",
         external_chat_type="private",
@@ -1703,7 +1715,7 @@ async def test_channel_health_includes_public_bound_channels_without_cross_user_
     db_session.add(
         ChannelMessage(
             account_id=account.id,
-            bot_agent_link_id=UUID(created["agent_link_id"]),
+            bot_agent_link_id=UUID(other_link_response.json()["id"]),
             binding_id=other_binding.id,
             user_id=other_user.id,
             direction=MESSAGE_DIRECTION_INBOUND,
@@ -3637,7 +3649,7 @@ async def test_explicit_link_channel_reference_uses_public_link_owner(
     link_id = UUID(linked.json()["id"])
     account = await db_session.get(ChannelAccount, account_id)
     assert account is not None
-    assert account.user_id != link_user.id
+    assert account.user_id is None
 
     reference = await channel_service.record_channel_agent_reference(
         db_session,
@@ -3651,7 +3663,7 @@ async def test_explicit_link_channel_reference_uses_public_link_owner(
     assert reference.user_id == link_user.id
     assert reference.bot_agent_link_id == link_id
 
-    reference.user_id = account.user_id
+    reference.user_id = seed_user.id
     await db_session.commit()
     repaired_reference = await channel_service.record_channel_agent_reference(
         db_session,
@@ -8837,10 +8849,11 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
     link_b = await db_session.get(ChannelBotAgentLink, UUID(second["id"]))
     assert account is not None and link_a is not None and link_b is not None
     account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
     binding_a = ChannelBinding(
         account_id=account.id,
         bot_agent_link_id=link_a.id,
-        user_id=account.user_id,
+        user_id=link_a.user_id,
         external_chat_id="shared-gateway-channel-a",
         external_chat_type="guild_text",
         external_chat_name="shared-gateway-guild-a",
@@ -8848,7 +8861,7 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
     binding_b = ChannelBinding(
         account_id=account.id,
         bot_agent_link_id=link_b.id,
-        user_id=account.user_id,
+        user_id=link_b.user_id,
         external_chat_id="shared-gateway-channel-b",
         external_chat_type="guild_text",
         external_chat_name="shared-gateway-guild-b",
@@ -8860,7 +8873,7 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
             ChannelBindingAlias(
                 account_id=account.id,
                 bot_agent_link_id=link_a.id,
-                user_id=account.user_id,
+                user_id=link_a.user_id,
                 binding_id=binding_a.id,
                 alias_kind="discord_channel",
                 alias_external_chat_id="shared-gateway-channel-a",
@@ -8868,7 +8881,7 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
             ChannelBindingAlias(
                 account_id=account.id,
                 bot_agent_link_id=link_b.id,
-                user_id=account.user_id,
+                user_id=link_b.user_id,
                 binding_id=binding_b.id,
                 alias_kind="discord_channel",
                 alias_external_chat_id="shared-gateway-channel-b",
@@ -9466,13 +9479,16 @@ async def test_shared_discord_account_command_shadows_and_fanout_are_link_scoped
     link_b = link_b_response.json()
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
+    tenant_user_id = account.user_id
+    assert tenant_user_id is not None
     account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
     db_session.add_all(
         [
             ChannelBinding(
                 account_id=account.id,
                 bot_agent_link_id=UUID(created["agent_link_id"]),
-                user_id=account.user_id,
+                user_id=tenant_user_id,
                 external_chat_id="shared-link-channel-a",
                 external_chat_type="guild_text",
                 external_chat_name="shared-link-guild-a",
@@ -9480,7 +9496,7 @@ async def test_shared_discord_account_command_shadows_and_fanout_are_link_scoped
             ChannelBinding(
                 account_id=account.id,
                 bot_agent_link_id=UUID(link_b["id"]),
-                user_id=account.user_id,
+                user_id=tenant_user_id,
                 external_chat_id="shared-link-channel-b",
                 external_chat_type="guild_text",
                 external_chat_name="shared-link-guild-b",
@@ -13150,6 +13166,84 @@ async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_
 
 
 @pytest.mark.asyncio
+async def test_public_telegram_unpaired_tutorial_keeps_cooldown_without_tenant_messages(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    _reset_fake_provider_client({"ok": True, "result": {"username": "platform_test_bot"}})
+    created_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        name=f"telegram-platform-unpaired-{uuid4().hex}",
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    account_id = UUID(created["id"])
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    account.encrypted_provider_token, account.provider_token_nonce = encrypt_optional_token(
+        "123456:telegram-platform-secret"
+    )
+    await db_session.commit()
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 107}})
+
+    webhook_url = f"/v1/channels/telegram/{account_id}/webhook"
+    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
+
+    def update(update_id: int) -> dict[str, Any]:
+        return {
+            "update_id": update_id,
+            "message": {
+                "message_id": update_id,
+                "text": "help me pair",
+                "chat": {"id": 987654411, "type": "private"},
+                "from": {"id": 987654411, "is_bot": False},
+            },
+        }
+
+    assert (await client.post(webhook_url, headers=headers, json=update(7_611))).status_code == 200
+    assert (await client.post(webhook_url, headers=headers, json=update(7_612))).status_code == 200
+    assert (
+        len([call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")])
+        == 1
+    )
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(ChannelMessage.account_id == account_id)
+        )
+        == 0
+    )
+    marker = (
+        await db_session.execute(
+            select(ChannelAccountRuntimeMarker).where(
+                ChannelAccountRuntimeMarker.account_id == account_id,
+                ChannelAccountRuntimeMarker.kind == "telegram_unpaired_tutorial",
+            )
+        )
+    ).scalar_one()
+    assert marker.scope == "private:987654411"
+    assert marker.outcome == "sent"
+
+    marker.updated_at = (
+        datetime.now(UTC)
+        - telegram_router.TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN
+        - timedelta(seconds=1)
+    )
+    await db_session.commit()
+    assert (await client.post(webhook_url, headers=headers, json=update(7_613))).status_code == 200
+    assert (
+        len([call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")])
+        == 2
+    )
+
+
+@pytest.mark.asyncio
 async def test_telegram_unpaired_tutorial_failure_does_not_expose_internal_error(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -16009,6 +16103,89 @@ async def test_discord_unpaired_tutorial_failure_has_short_retry_then_success_co
         assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
         await db_session.commit()
     assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_public_discord_unpaired_tutorial_keeps_backoff_without_tenant_messages(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def configure_discord_application(account: ChannelAccount) -> dict[str, Any]:
+        return {"id": DISCORD_TEST_APPLICATION_ID}
+
+    async def sync_channel_commands(**kwargs) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(
+        admin_router, "configure_discord_application", configure_discord_application
+    )
+    monkeypatch.setattr(admin_router, "sync_channel_commands", sync_channel_commands)
+    created_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_DISCORD,
+        name=f"discord-platform-unpaired-{uuid4().hex}",
+        provider_token="discord-platform-token",
+        config=_discord_ready_config(),
+    )
+    assert created_response.status_code == 201, created_response.text
+    account = await db_session.get(ChannelAccount, UUID(created_response.json()["id"]))
+    assert account is not None
+    assert account.user_id is None
+    attempts = 0
+
+    async def send_tutorial(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise HTTPException(status_code=502, detail="private provider failure")
+        return "tutorial-message", {"id": "tutorial-message", "channel_id": "dm-channel"}
+
+    monkeypatch.setattr(channel_service, "_send_discord_provider_payload", send_tutorial)
+
+    def frame(message_id: str) -> dict[str, Any]:
+        return {
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": message_id,
+                "channel_id": "dm-channel",
+                "content": "hello",
+                "author": {"id": "discord-user", "bot": False},
+            },
+        }
+
+    for message_id in ("platform-failed", "platform-backoff"):
+        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
+        await db_session.commit()
+    assert attempts == 1
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(ChannelMessage.account_id == account.id)
+        )
+        == 0
+    )
+    marker = (
+        await db_session.execute(
+            select(ChannelAccountRuntimeMarker).where(
+                ChannelAccountRuntimeMarker.account_id == account.id,
+                ChannelAccountRuntimeMarker.kind == "discord_unpaired_tutorial",
+            )
+        )
+    ).scalar_one()
+    assert marker.scope == "dm-channel"
+    assert marker.outcome == "failed"
+
+    marker.updated_at = datetime.now(UTC) - timedelta(seconds=31)
+    await db_session.commit()
+    for message_id in ("platform-retry", "platform-success-cooldown"):
+        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
+        await db_session.commit()
+    assert attempts == 2
+    assert marker.outcome == "sent"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -37,6 +37,7 @@ from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_IMESSAGE,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_DISABLED,
     CHANNEL_VISIBILITY_PUBLIC,
     DELIVERY_STATUS_FAILED,
@@ -48,7 +49,6 @@ from app.models.channel import (
     PAIR_CODE_STATUS_PENDING,
     PAIR_CODE_STATUS_REVOKED,
     ChannelAccount,
-    ChannelAccountRuntimeMarker,
     ChannelAgentCredential,
     ChannelAgentReference,
     ChannelBinding,
@@ -418,6 +418,26 @@ async def _create_public_telegram_account_for_user(
     )
     assert response.status_code == 201, response.text
     return response.json()
+
+
+async def _seed_historical_platform_whatsapp_account(
+    db_session: AsyncSession,
+    *,
+    name: str,
+) -> ChannelAccount:
+    """Seed the retired generic-create shape for historical-state projections."""
+
+    account = channel_service.build_channel_account(
+        owner_user_id=None,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name=name,
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        webhook_secret_hash=hash_token(uuid4().hex),
+    )
+    db_session.add(account)
+    await db_session.commit()
+    await db_session.refresh(account)
+    return account
 
 
 async def _seed_existing_channel_link(
@@ -3059,9 +3079,8 @@ async def test_historical_local_link_remains_listable_and_cleanable_but_cannot_p
                 ChannelMessage.provider_event_id == "update:9001",
             )
         )
-    ).scalar_one()
-    assert inbound_message.binding_id is None
-    assert inbound_message.bot_agent_link_id is None
+    ).scalar_one_or_none()
+    assert inbound_message is None
     assert unpair.status_code == 200, unpair.text
     assert unpair.json()["unpaired"] is True
     assert unlink.status_code == 204
@@ -3138,17 +3157,13 @@ async def test_historical_pending_pair_code_cannot_create_new_chat_binding(
 async def test_whatsapp_managed_link_admission_remains_gated(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
-    seed_user,
     agent_type: str,
 ):
-    created = await _create_admin_channel(
-        client,
-        target_clerk_id=seed_user.clerk_id,
-        provider="whatsapp",
+    account = await _seed_historical_platform_whatsapp_account(
+        db_session,
         name=f"{agent_type}-whatsapp-gated-{uuid4().hex}",
     )
-    assert created.status_code == 201, created.text
-    account_id = created.json()["id"]
+    account_id = str(account.id)
     user, agent = await _create_user_with_channel_agent(
         db_session,
         label=f"{agent_type}-whatsapp-gated",
@@ -4096,16 +4111,12 @@ async def test_public_preset_channel_links_and_bindings_are_user_scoped(
 async def test_env_bound_list_channels_hides_historical_local_whatsapp_credentials(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
-    seed_user,
 ):
-    created = await _create_admin_channel(
-        client,
-        target_clerk_id=seed_user.clerk_id,
-        provider="whatsapp",
+    seeded_account = await _seed_historical_platform_whatsapp_account(
+        db_session,
         name=f"runtime-whatsapp-{uuid4().hex}",
     )
-    assert created.status_code == 201, created.text
-    account_id = created.json()["id"]
+    account_id = str(seeded_account.id)
     user, agent = await _create_user_with_channel_agent(
         db_session,
         label="runtime-wa-creds",
@@ -4376,9 +4387,8 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
             .order_by(ChannelMessage.created_at.desc())
             .limit(1)
         )
-    ).scalar_one()
-    assert bob_unpair_reply.binding_id is None
-    assert bob_unpair_reply.bot_agent_link_id is None
+    ).scalar_one_or_none()
+    assert bob_unpair_reply is None
 
     bob_takeover = await client.post(
         f"/v1/channels/telegram/{account_id}/webhook",
@@ -4401,9 +4411,8 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
             .order_by(ChannelMessage.created_at.desc())
             .limit(1)
         )
-    ).scalar_one()
-    assert bob_takeover_reply.binding_id is None
-    assert bob_takeover_reply.bot_agent_link_id is None
+    ).scalar_one_or_none()
+    assert bob_takeover_reply is None
 
     pair_code_b = (
         await db_session.execute(
@@ -13166,84 +13175,6 @@ async def test_telegram_unpaired_private_tutorial_is_idempotent_cooled_down_and_
 
 
 @pytest.mark.asyncio
-async def test_public_telegram_unpaired_tutorial_keeps_cooldown_without_tenant_messages(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
-    _reset_fake_provider_client({"ok": True, "result": {"username": "platform_test_bot"}})
-    created_response = await _create_admin_channel(
-        client,
-        target_clerk_id=seed_user.clerk_id,
-        provider=CHANNEL_PROVIDER_TELEGRAM,
-        name=f"telegram-platform-unpaired-{uuid4().hex}",
-    )
-    assert created_response.status_code == 201, created_response.text
-    created = created_response.json()
-    account_id = UUID(created["id"])
-    account = await db_session.get(ChannelAccount, account_id)
-    assert account is not None
-    account.encrypted_provider_token, account.provider_token_nonce = encrypt_optional_token(
-        "123456:telegram-platform-secret"
-    )
-    await db_session.commit()
-    _reset_fake_provider_client({"ok": True, "result": {"message_id": 107}})
-
-    webhook_url = f"/v1/channels/telegram/{account_id}/webhook"
-    headers = {"x-telegram-bot-api-secret-token": created["webhook_secret"]}
-
-    def update(update_id: int) -> dict[str, Any]:
-        return {
-            "update_id": update_id,
-            "message": {
-                "message_id": update_id,
-                "text": "help me pair",
-                "chat": {"id": 987654411, "type": "private"},
-                "from": {"id": 987654411, "is_bot": False},
-            },
-        }
-
-    assert (await client.post(webhook_url, headers=headers, json=update(7_611))).status_code == 200
-    assert (await client.post(webhook_url, headers=headers, json=update(7_612))).status_code == 200
-    assert (
-        len([call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")])
-        == 1
-    )
-    assert (
-        await db_session.scalar(
-            select(func.count())
-            .select_from(ChannelMessage)
-            .where(ChannelMessage.account_id == account_id)
-        )
-        == 0
-    )
-    marker = (
-        await db_session.execute(
-            select(ChannelAccountRuntimeMarker).where(
-                ChannelAccountRuntimeMarker.account_id == account_id,
-                ChannelAccountRuntimeMarker.kind == "telegram_unpaired_tutorial",
-            )
-        )
-    ).scalar_one()
-    assert marker.scope == "private:987654411"
-    assert marker.outcome == "sent"
-
-    marker.updated_at = (
-        datetime.now(UTC)
-        - telegram_router.TELEGRAM_UNPAIRED_TUTORIAL_COOLDOWN
-        - timedelta(seconds=1)
-    )
-    await db_session.commit()
-    assert (await client.post(webhook_url, headers=headers, json=update(7_613))).status_code == 200
-    assert (
-        len([call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")])
-        == 2
-    )
-
-
-@pytest.mark.asyncio
 async def test_telegram_unpaired_tutorial_failure_does_not_expose_internal_error(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -16103,89 +16034,6 @@ async def test_discord_unpaired_tutorial_failure_has_short_retry_then_success_co
         assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
         await db_session.commit()
     assert attempts == 2
-
-
-@pytest.mark.asyncio
-async def test_public_discord_unpaired_tutorial_keeps_backoff_without_tenant_messages(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def configure_discord_application(account: ChannelAccount) -> dict[str, Any]:
-        return {"id": DISCORD_TEST_APPLICATION_ID}
-
-    async def sync_channel_commands(**kwargs) -> list[dict[str, Any]]:
-        return []
-
-    monkeypatch.setattr(
-        admin_router, "configure_discord_application", configure_discord_application
-    )
-    monkeypatch.setattr(admin_router, "sync_channel_commands", sync_channel_commands)
-    created_response = await _create_admin_channel(
-        client,
-        target_clerk_id=seed_user.clerk_id,
-        provider=CHANNEL_PROVIDER_DISCORD,
-        name=f"discord-platform-unpaired-{uuid4().hex}",
-        provider_token="discord-platform-token",
-        config=_discord_ready_config(),
-    )
-    assert created_response.status_code == 201, created_response.text
-    account = await db_session.get(ChannelAccount, UUID(created_response.json()["id"]))
-    assert account is not None
-    assert account.user_id is None
-    attempts = 0
-
-    async def send_tutorial(**kwargs):
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise HTTPException(status_code=502, detail="private provider failure")
-        return "tutorial-message", {"id": "tutorial-message", "channel_id": "dm-channel"}
-
-    monkeypatch.setattr(channel_service, "_send_discord_provider_payload", send_tutorial)
-
-    def frame(message_id: str) -> dict[str, Any]:
-        return {
-            "t": "MESSAGE_CREATE",
-            "d": {
-                "id": message_id,
-                "channel_id": "dm-channel",
-                "content": "hello",
-                "author": {"id": "discord-user", "bot": False},
-            },
-        }
-
-    for message_id in ("platform-failed", "platform-backoff"):
-        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
-        await db_session.commit()
-    assert attempts == 1
-    assert (
-        await db_session.scalar(
-            select(func.count())
-            .select_from(ChannelMessage)
-            .where(ChannelMessage.account_id == account.id)
-        )
-        == 0
-    )
-    marker = (
-        await db_session.execute(
-            select(ChannelAccountRuntimeMarker).where(
-                ChannelAccountRuntimeMarker.account_id == account.id,
-                ChannelAccountRuntimeMarker.kind == "discord_unpaired_tutorial",
-            )
-        )
-    ).scalar_one()
-    assert marker.scope == "dm-channel"
-    assert marker.outcome == "failed"
-
-    marker.updated_at = datetime.now(UTC) - timedelta(seconds=31)
-    await db_session.commit()
-    for message_id in ("platform-retry", "platform-success-cooldown"):
-        assert await record_discord_dispatch(db_session, account=account, frame=frame(message_id))
-        await db_session.commit()
-    assert attempts == 2
-    assert marker.outcome == "sent"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_platform_shared_channel_ownership_migration.py
+++ b/backend/tests/test_platform_shared_channel_ownership_migration.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+MIGRATION_FILENAME = "c2f8a4d6e9b1_platform_shared_channel_ownership.py"
+
+
+def _load_migration():
+    path = Path(__file__).parents[1] / "alembic" / "versions" / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location("platform_shared_channel_ownership", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def _create_previous_schema(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            """
+            CREATE TABLE users (
+                id uuid PRIMARY KEY
+            );
+            CREATE TABLE channel_accounts (
+                id uuid PRIMARY KEY,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                provider varchar(32) NOT NULL,
+                name varchar(120) NOT NULL,
+                status varchar(32) NOT NULL DEFAULT 'active',
+                visibility varchar(32) NOT NULL DEFAULT 'private',
+                encrypted_provider_token bytea,
+                provider_token_nonce bytea,
+                webhook_secret_hash varchar(64) NOT NULL,
+                config jsonb,
+                archived_at timestamptz,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now()
+            );
+            CREATE UNIQUE INDEX uq_channel_accounts_user_provider_name_active
+                ON channel_accounts (user_id, provider, name)
+                WHERE archived_at IS NULL;
+            CREATE TABLE channel_secrets (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                name varchar(80) NOT NULL,
+                encrypted_value bytea NOT NULL,
+                value_nonce bytea NOT NULL
+            );
+            CREATE TABLE channel_whatsapp_auth_certs (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE
+            );
+            CREATE TABLE channel_whatsapp_onboarding_sessions (
+                id uuid PRIMARY KEY,
+                ownership_kind varchar(16) NOT NULL DEFAULT 'custom',
+                sidecar_account_id uuid NOT NULL,
+                sidecar_config_revision varchar(64) NOT NULL,
+                channel_account_id uuid REFERENCES channel_accounts(id) ON DELETE SET NULL,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                request_id uuid NOT NULL,
+                name varchar(120) NOT NULL,
+                state varchar(32) NOT NULL,
+                method varchar(16) NOT NULL,
+                started_at timestamptz NOT NULL,
+                expires_at timestamptz NOT NULL,
+                completed_at timestamptz,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT ck_channel_whatsapp_onboarding_ownership_kind
+                    CHECK (ownership_kind IN ('custom', 'managed')),
+                CONSTRAINT uq_channel_whatsapp_onboarding_kind_user_request
+                    UNIQUE (ownership_kind, user_id, request_id)
+            );
+            CREATE UNIQUE INDEX uq_channel_whatsapp_onboarding_active_user_name
+                ON channel_whatsapp_onboarding_sessions (user_id, name)
+                WHERE state IN ('generating', 'ready', 'scanned', 'connected', 'error');
+            CREATE TABLE channel_bot_agent_links (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE
+            );
+            CREATE TABLE channel_bindings (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                bot_agent_link_id uuid NOT NULL REFERENCES channel_bot_agent_links(id)
+                    ON DELETE CASCADE,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE
+            );
+            CREATE TABLE channel_messages (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                bot_agent_link_id uuid REFERENCES channel_bot_agent_links(id) ON DELETE SET NULL,
+                binding_id uuid REFERENCES channel_bindings(id) ON DELETE SET NULL,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE
+            );
+            CREATE TABLE channel_agent_credentials (
+                id uuid PRIMARY KEY,
+                account_id uuid NOT NULL REFERENCES channel_accounts(id) ON DELETE CASCADE,
+                bot_agent_link_id uuid NOT NULL REFERENCES channel_bot_agent_links(id)
+                    ON DELETE CASCADE,
+                user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                encrypted_credentials bytea NOT NULL
+            )
+            """
+        )
+    )
+
+
+def test_platform_shared_channel_migration_preserves_inventory_and_tenant_children(
+    engine: AsyncEngine,
+) -> None:
+    migration = _load_migration()
+    assert migration.down_revision == "b4e8c1d7a2f9"
+    schema = f"platform_shared_channel_{uuid.uuid4().hex}"
+    sync_engine = create_engine(engine.url.set(drivername="postgresql+psycopg2"))
+    old_op = migration.op
+    ids = {name: uuid.uuid4() for name in _ID_NAMES}
+    try:
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET search_path TO "{schema}"'))
+            _create_previous_schema(connection)
+            _seed_previous_rows(connection, ids)
+            migration.op = Operations(MigrationContext.configure(connection))
+
+            migration.upgrade()
+
+            public_rows = connection.execute(
+                sa.text(
+                    """
+                    SELECT id, user_id, encrypted_provider_token
+                    FROM channel_accounts
+                    WHERE visibility = 'public'
+                    ORDER BY id
+                    """
+                )
+            ).all()
+            assert len(public_rows) == 3
+            assert all(row.user_id is None for row in public_rows)
+            telegram = next(row for row in public_rows if row.id == ids["telegram_account"])
+            assert bytes(telegram.encrypted_provider_token) == b"telegram-provider-token"
+            assert (
+                connection.scalar(
+                    sa.text("SELECT user_id FROM channel_accounts WHERE id = :id"),
+                    {"id": ids["private_account"]},
+                )
+                == ids["tenant_user"]
+            )
+
+            secret = connection.execute(
+                sa.text("SELECT user_id, encrypted_value FROM channel_secrets WHERE id = :id"),
+                {"id": ids["public_secret"]},
+            ).one()
+            assert secret.user_id is None
+            assert bytes(secret.encrypted_value) == b"public-provider-secret"
+            assert (
+                connection.scalar(
+                    sa.text("SELECT user_id FROM channel_whatsapp_auth_certs WHERE id = :id"),
+                    {"id": ids["auth_cert"]},
+                )
+                is None
+            )
+
+            child_owners = connection.execute(
+                sa.text(
+                    """
+                    SELECT user_id FROM channel_bot_agent_links WHERE id = :link_id
+                    UNION ALL
+                    SELECT user_id FROM channel_bindings WHERE id = :binding_id
+                    UNION ALL
+                    SELECT user_id FROM channel_messages WHERE id = :message_id
+                    UNION ALL
+                    SELECT user_id FROM channel_agent_credentials WHERE id = :credential_id
+                    """
+                ),
+                {
+                    "link_id": ids["link"],
+                    "binding_id": ids["binding"],
+                    "message_id": ids["message"],
+                    "credential_id": ids["credential"],
+                },
+            ).scalars()
+            assert list(child_owners) == [ids["tenant_user"]] * 4
+            assert (
+                bytes(
+                    connection.scalar(
+                        sa.text(
+                            "SELECT encrypted_credentials "
+                            "FROM channel_agent_credentials WHERE id = :id"
+                        ),
+                        {"id": ids["credential"]},
+                    )
+                )
+                == b"tenant-credential"
+            )
+
+            custom = connection.execute(
+                sa.text(
+                    """
+                    SELECT ownership_kind, user_id, request_id, name
+                    FROM channel_whatsapp_onboarding_sessions
+                    WHERE id = :id
+                    """
+                ),
+                {"id": ids["custom_session"]},
+            ).one()
+            assert tuple(custom) == (
+                "custom",
+                ids["tenant_user"],
+                ids["shared_request"],
+                "Custom Device",
+            )
+            platform_sessions = connection.execute(
+                sa.text(
+                    """
+                    SELECT user_id, request_id, name
+                    FROM channel_whatsapp_onboarding_sessions
+                    WHERE ownership_kind = 'platform'
+                    ORDER BY id
+                    """
+                )
+            ).all()
+            assert len(platform_sessions) == 2
+            assert all(row.user_id is None for row in platform_sessions)
+            assert len({row.request_id for row in platform_sessions}) == 2
+            assert len({row.name for row in platform_sessions}) == 2
+
+            with pytest.raises(sa.exc.IntegrityError):
+                with connection.begin_nested():
+                    connection.execute(
+                        sa.text(
+                            """
+                            INSERT INTO channel_accounts (
+                                id, user_id, provider, name, visibility, webhook_secret_hash
+                            ) VALUES (:id, :tenant_user, 'telegram', :name, 'public', :hash)
+                            """
+                        ),
+                        {
+                            "id": uuid.uuid4(),
+                            "tenant_user": ids["tenant_user"],
+                            "name": f"invalid-owned-public-{uuid.uuid4()}",
+                            "hash": "1" * 64,
+                        },
+                    )
+            with pytest.raises(sa.exc.IntegrityError):
+                with connection.begin_nested():
+                    connection.execute(
+                        sa.text(
+                            """
+                            INSERT INTO channel_whatsapp_onboarding_sessions (
+                                id, ownership_kind, sidecar_account_id, sidecar_config_revision,
+                                user_id, request_id, name, state, method, started_at, expires_at
+                            ) VALUES (
+                                :id, 'platform', :sidecar, 'duplicate-request', NULL,
+                                :request_id, :name, 'canceled', 'qr', now(), now()
+                            )
+                            """
+                        ),
+                        {
+                            "id": uuid.uuid4(),
+                            "sidecar": uuid.uuid4(),
+                            "request_id": platform_sessions[0].request_id,
+                            "name": f"duplicate-request-{uuid.uuid4()}",
+                        },
+                    )
+
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO channel_account_runtime_markers (
+                        id, account_id, kind, scope, outcome
+                    ) VALUES (
+                        :id, :account_id, 'telegram_unpaired_tutorial',
+                        'private:123', 'sent'
+                    )
+                    """
+                ),
+                {
+                    "id": ids["runtime_marker"],
+                    "account_id": ids["telegram_account"],
+                },
+            )
+
+            connection.execute(
+                sa.text("DELETE FROM users WHERE id = :id"),
+                {"id": ids["fake_platform_owner"]},
+            )
+            assert (
+                connection.scalar(
+                    sa.text("SELECT count(*) FROM channel_accounts WHERE visibility = 'public'")
+                )
+                == 3
+            )
+            assert connection.scalar(sa.text("SELECT count(*) FROM channel_secrets")) == 1
+            assert (
+                connection.scalar(sa.text("SELECT count(*) FROM channel_whatsapp_auth_certs")) == 1
+            )
+            assert (
+                connection.scalar(
+                    sa.text(
+                        "SELECT count(*) FROM channel_whatsapp_onboarding_sessions "
+                        "WHERE ownership_kind = 'platform'"
+                    )
+                )
+                == 2
+            )
+            assert connection.scalar(sa.text("SELECT count(*) FROM channel_messages")) == 1
+            assert (
+                connection.scalar(sa.text("SELECT count(*) FROM channel_account_runtime_markers"))
+                == 1
+            )
+
+            with pytest.raises(RuntimeError, match="previous schema requires an arbitrary tenant"):
+                migration.downgrade()
+    finally:
+        migration.op = old_op
+        with sync_engine.begin() as connection:
+            connection.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        sync_engine.dispose()
+
+
+_ID_NAMES = (
+    "fake_platform_owner",
+    "tenant_user",
+    "telegram_account",
+    "discord_account",
+    "whatsapp_account",
+    "private_account",
+    "public_secret",
+    "auth_cert",
+    "link",
+    "binding",
+    "message",
+    "credential",
+    "runtime_marker",
+    "custom_session",
+    "platform_session_one",
+    "platform_session_two",
+    "shared_request",
+)
+
+
+def _seed_previous_rows(connection: sa.Connection, ids: dict[str, uuid.UUID]) -> None:
+    connection.execute(
+        sa.text("INSERT INTO users (id) VALUES (:fake_owner), (:tenant_user)"),
+        {
+            "fake_owner": ids["fake_platform_owner"],
+            "tenant_user": ids["tenant_user"],
+        },
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO channel_accounts (
+                id, user_id, provider, name, visibility, encrypted_provider_token,
+                provider_token_nonce, webhook_secret_hash, config
+            ) VALUES
+                (
+                    :telegram, :fake_owner, 'telegram', 'Shared Bot', 'public',
+                    :telegram_token, :nonce, :hash, '{}'::jsonb
+                ),
+                (
+                    :discord, :fake_owner, 'discord', 'Shared Bot', 'public',
+                    :discord_token, :nonce, :hash, '{}'::jsonb
+                ),
+                (
+                    :whatsapp, :fake_owner, 'whatsapp', 'Shared WhatsApp', 'public',
+                    NULL, NULL, :hash,
+                    '{"connection_mode":"baileys_managed"}'::jsonb
+                ),
+                (
+                    :private, :tenant_user, 'telegram', 'Private Bot', 'private',
+                    :private_token, :nonce, :hash, '{}'::jsonb
+                )
+            """
+        ),
+        {
+            "telegram": ids["telegram_account"],
+            "discord": ids["discord_account"],
+            "whatsapp": ids["whatsapp_account"],
+            "private": ids["private_account"],
+            "fake_owner": ids["fake_platform_owner"],
+            "tenant_user": ids["tenant_user"],
+            "telegram_token": b"telegram-provider-token",
+            "discord_token": b"discord-provider-token",
+            "private_token": b"private-provider-token",
+            "nonce": b"nonce",
+            "hash": "0" * 64,
+        },
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO channel_secrets (
+                id, account_id, user_id, name, encrypted_value, value_nonce
+            ) VALUES (
+                :id, :account_id, :fake_owner, 'provider_secret', :value, :nonce
+            );
+            INSERT INTO channel_whatsapp_auth_certs (id, account_id, user_id)
+            VALUES (:cert_id, :whatsapp_account, :fake_owner)
+            """
+        ),
+        {
+            "id": ids["public_secret"],
+            "account_id": ids["telegram_account"],
+            "fake_owner": ids["fake_platform_owner"],
+            "value": b"public-provider-secret",
+            "nonce": b"secret-nonce",
+            "cert_id": ids["auth_cert"],
+            "whatsapp_account": ids["whatsapp_account"],
+        },
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO channel_bot_agent_links (id, account_id, user_id)
+            VALUES (:link, :account, :tenant_user);
+            INSERT INTO channel_bindings (id, account_id, bot_agent_link_id, user_id)
+            VALUES (:binding, :account, :link, :tenant_user);
+            INSERT INTO channel_messages (
+                id, account_id, bot_agent_link_id, binding_id, user_id
+            ) VALUES (:message, :account, :link, :binding, :tenant_user);
+            INSERT INTO channel_agent_credentials (
+                id, account_id, bot_agent_link_id, user_id, encrypted_credentials
+            ) VALUES (:credential, :account, :link, :tenant_user, :credential_value)
+            """
+        ),
+        {
+            "link": ids["link"],
+            "binding": ids["binding"],
+            "message": ids["message"],
+            "credential": ids["credential"],
+            "account": ids["telegram_account"],
+            "tenant_user": ids["tenant_user"],
+            "credential_value": b"tenant-credential",
+        },
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO channel_whatsapp_onboarding_sessions (
+                id, ownership_kind, sidecar_account_id, sidecar_config_revision,
+                channel_account_id, user_id, request_id, name, state, method,
+                started_at, expires_at
+            ) VALUES
+                (
+                    :custom, 'custom', :custom_sidecar, 'custom-revision', NULL,
+                    :tenant_user, :request_id, 'Custom Device', 'ready', 'qr', now(),
+                    now() + interval '5 minutes'
+                ),
+                (
+                    :platform_one, 'managed', :whatsapp_account, 'managed-revision',
+                    :whatsapp_account, :fake_owner, :request_id, 'Shared Device',
+                    'connected', 'qr', now(), now() + interval '5 minutes'
+                ),
+                (
+                    :platform_two, 'managed', :platform_sidecar, 'managed-revision-two',
+                    NULL, :tenant_user, :request_id, 'Shared Device', 'ready', 'qr', now(),
+                    now() + interval '5 minutes'
+                )
+            """
+        ),
+        {
+            "custom": ids["custom_session"],
+            "custom_sidecar": uuid.uuid4(),
+            "platform_one": ids["platform_session_one"],
+            "platform_two": ids["platform_session_two"],
+            "platform_sidecar": uuid.uuid4(),
+            "whatsapp_account": ids["whatsapp_account"],
+            "fake_owner": ids["fake_platform_owner"],
+            "tenant_user": ids["tenant_user"],
+            "request_id": ids["shared_request"],
+        },
+    )

--- a/backend/tests/test_platform_shared_channel_ownership_migration.py
+++ b/backend/tests/test_platform_shared_channel_ownership_migration.py
@@ -4,7 +4,6 @@ import importlib.util
 import uuid
 from pathlib import Path
 
-import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -27,9 +26,7 @@ def _create_previous_schema(connection: sa.Connection) -> None:
     connection.execute(
         sa.text(
             """
-            CREATE TABLE users (
-                id uuid PRIMARY KEY
-            );
+            CREATE TABLE users (id uuid PRIMARY KEY);
             CREATE TABLE channel_accounts (
                 id uuid PRIMARY KEY,
                 user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -117,15 +114,12 @@ def _create_previous_schema(connection: sa.Connection) -> None:
     )
 
 
-def test_platform_shared_channel_migration_preserves_inventory_and_tenant_children(
-    engine: AsyncEngine,
-) -> None:
+def test_migration_preserves_public_credentials_and_tenant_children(engine: AsyncEngine) -> None:
     migration = _load_migration()
-    assert migration.down_revision == "b4e8c1d7a2f9"
     schema = f"platform_shared_channel_{uuid.uuid4().hex}"
+    ids = {name: uuid.uuid4() for name in _ID_NAMES}
     sync_engine = create_engine(engine.url.set(drivername="postgresql+psycopg2"))
     old_op = migration.op
-    ids = {name: uuid.uuid4() for name in _ID_NAMES}
     try:
         with sync_engine.begin() as connection:
             connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
@@ -136,193 +130,42 @@ def test_platform_shared_channel_migration_preserves_inventory_and_tenant_childr
 
             migration.upgrade()
 
-            public_rows = connection.execute(
+            account = connection.execute(
                 sa.text(
-                    """
-                    SELECT id, user_id, encrypted_provider_token
-                    FROM channel_accounts
-                    WHERE visibility = 'public'
-                    ORDER BY id
-                    """
-                )
-            ).all()
-            assert len(public_rows) == 3
-            assert all(row.user_id is None for row in public_rows)
-            telegram = next(row for row in public_rows if row.id == ids["telegram_account"])
-            assert bytes(telegram.encrypted_provider_token) == b"telegram-provider-token"
-            assert (
-                connection.scalar(
-                    sa.text("SELECT user_id FROM channel_accounts WHERE id = :id"),
-                    {"id": ids["private_account"]},
-                )
-                == ids["tenant_user"]
-            )
-
+                    "SELECT user_id, encrypted_provider_token FROM channel_accounts WHERE id = :id"
+                ),
+                {"id": ids["account"]},
+            ).one()
             secret = connection.execute(
                 sa.text("SELECT user_id, encrypted_value FROM channel_secrets WHERE id = :id"),
-                {"id": ids["public_secret"]},
+                {"id": ids["secret"]},
             ).one()
-            assert secret.user_id is None
-            assert bytes(secret.encrypted_value) == b"public-provider-secret"
-            assert (
-                connection.scalar(
-                    sa.text("SELECT user_id FROM channel_whatsapp_auth_certs WHERE id = :id"),
-                    {"id": ids["auth_cert"]},
-                )
-                is None
-            )
-
             child_owners = connection.execute(
                 sa.text(
                     """
-                    SELECT user_id FROM channel_bot_agent_links WHERE id = :link_id
-                    UNION ALL
-                    SELECT user_id FROM channel_bindings WHERE id = :binding_id
-                    UNION ALL
-                    SELECT user_id FROM channel_messages WHERE id = :message_id
-                    UNION ALL
-                    SELECT user_id FROM channel_agent_credentials WHERE id = :credential_id
+                    SELECT user_id FROM channel_bot_agent_links WHERE id = :link
+                    UNION ALL SELECT user_id FROM channel_bindings WHERE id = :binding
+                    UNION ALL SELECT user_id FROM channel_messages WHERE id = :message
+                    UNION ALL SELECT user_id FROM channel_agent_credentials WHERE id = :credential
                     """
                 ),
-                {
-                    "link_id": ids["link"],
-                    "binding_id": ids["binding"],
-                    "message_id": ids["message"],
-                    "credential_id": ids["credential"],
-                },
+                ids,
             ).scalars()
-            assert list(child_owners) == [ids["tenant_user"]] * 4
-            assert (
-                bytes(
-                    connection.scalar(
-                        sa.text(
-                            "SELECT encrypted_credentials "
-                            "FROM channel_agent_credentials WHERE id = :id"
-                        ),
-                        {"id": ids["credential"]},
-                    )
-                )
-                == b"tenant-credential"
-            )
 
-            custom = connection.execute(
-                sa.text(
-                    """
-                    SELECT ownership_kind, user_id, request_id, name
-                    FROM channel_whatsapp_onboarding_sessions
-                    WHERE id = :id
-                    """
-                ),
-                {"id": ids["custom_session"]},
-            ).one()
-            assert tuple(custom) == (
-                "custom",
-                ids["tenant_user"],
-                ids["shared_request"],
-                "Custom Device",
-            )
-            platform_sessions = connection.execute(
-                sa.text(
-                    """
-                    SELECT user_id, request_id, name
-                    FROM channel_whatsapp_onboarding_sessions
-                    WHERE ownership_kind = 'platform'
-                    ORDER BY id
-                    """
-                )
-            ).all()
-            assert len(platform_sessions) == 2
-            assert all(row.user_id is None for row in platform_sessions)
-            assert len({row.request_id for row in platform_sessions}) == 2
-            assert len({row.name for row in platform_sessions}) == 2
-
-            with pytest.raises(sa.exc.IntegrityError):
-                with connection.begin_nested():
-                    connection.execute(
-                        sa.text(
-                            """
-                            INSERT INTO channel_accounts (
-                                id, user_id, provider, name, visibility, webhook_secret_hash
-                            ) VALUES (:id, :tenant_user, 'telegram', :name, 'public', :hash)
-                            """
-                        ),
-                        {
-                            "id": uuid.uuid4(),
-                            "tenant_user": ids["tenant_user"],
-                            "name": f"invalid-owned-public-{uuid.uuid4()}",
-                            "hash": "1" * 64,
-                        },
-                    )
-            with pytest.raises(sa.exc.IntegrityError):
-                with connection.begin_nested():
-                    connection.execute(
-                        sa.text(
-                            """
-                            INSERT INTO channel_whatsapp_onboarding_sessions (
-                                id, ownership_kind, sidecar_account_id, sidecar_config_revision,
-                                user_id, request_id, name, state, method, started_at, expires_at
-                            ) VALUES (
-                                :id, 'platform', :sidecar, 'duplicate-request', NULL,
-                                :request_id, :name, 'canceled', 'qr', now(), now()
-                            )
-                            """
-                        ),
-                        {
-                            "id": uuid.uuid4(),
-                            "sidecar": uuid.uuid4(),
-                            "request_id": platform_sessions[0].request_id,
-                            "name": f"duplicate-request-{uuid.uuid4()}",
-                        },
-                    )
+            assert account.user_id is None
+            assert bytes(account.encrypted_provider_token) == b"provider-token"
+            assert secret.user_id is None
+            assert bytes(secret.encrypted_value) == b"provider-secret"
+            assert list(child_owners) == [ids["tenant"]] * 4
 
             connection.execute(
-                sa.text(
-                    """
-                    INSERT INTO channel_account_runtime_markers (
-                        id, account_id, kind, scope, outcome
-                    ) VALUES (
-                        :id, :account_id, 'telegram_unpaired_tutorial',
-                        'private:123', 'sent'
-                    )
-                    """
-                ),
-                {
-                    "id": ids["runtime_marker"],
-                    "account_id": ids["telegram_account"],
-                },
+                sa.text("DELETE FROM users WHERE id = :fake_owner"),
+                ids,
             )
-
-            connection.execute(
-                sa.text("DELETE FROM users WHERE id = :id"),
-                {"id": ids["fake_platform_owner"]},
-            )
-            assert (
-                connection.scalar(
-                    sa.text("SELECT count(*) FROM channel_accounts WHERE visibility = 'public'")
-                )
-                == 3
-            )
+            assert connection.scalar(sa.text("SELECT count(*) FROM channel_accounts")) == 1
             assert connection.scalar(sa.text("SELECT count(*) FROM channel_secrets")) == 1
-            assert (
-                connection.scalar(sa.text("SELECT count(*) FROM channel_whatsapp_auth_certs")) == 1
-            )
-            assert (
-                connection.scalar(
-                    sa.text(
-                        "SELECT count(*) FROM channel_whatsapp_onboarding_sessions "
-                        "WHERE ownership_kind = 'platform'"
-                    )
-                )
-                == 2
-            )
             assert connection.scalar(sa.text("SELECT count(*) FROM channel_messages")) == 1
-            assert (
-                connection.scalar(sa.text("SELECT count(*) FROM channel_account_runtime_markers"))
-                == 1
-            )
-
-            with pytest.raises(RuntimeError, match="previous schema requires an arbitrary tenant"):
-                migration.downgrade()
+            assert connection.scalar(sa.text("SELECT count(*) FROM channel_agent_credentials")) == 1
     finally:
         migration.op = old_op
         with sync_engine.begin() as connection:
@@ -331,33 +174,21 @@ def test_platform_shared_channel_migration_preserves_inventory_and_tenant_childr
 
 
 _ID_NAMES = (
-    "fake_platform_owner",
-    "tenant_user",
-    "telegram_account",
-    "discord_account",
-    "whatsapp_account",
-    "private_account",
-    "public_secret",
-    "auth_cert",
+    "fake_owner",
+    "tenant",
+    "account",
+    "secret",
     "link",
     "binding",
     "message",
     "credential",
-    "runtime_marker",
-    "custom_session",
-    "platform_session_one",
-    "platform_session_two",
-    "shared_request",
 )
 
 
 def _seed_previous_rows(connection: sa.Connection, ids: dict[str, uuid.UUID]) -> None:
     connection.execute(
-        sa.text("INSERT INTO users (id) VALUES (:fake_owner), (:tenant_user)"),
-        {
-            "fake_owner": ids["fake_platform_owner"],
-            "tenant_user": ids["tenant_user"],
-        },
+        sa.text("INSERT INTO users (id) VALUES (:fake_owner), (:tenant)"),
+        ids,
     )
     connection.execute(
         sa.text(
@@ -365,121 +196,32 @@ def _seed_previous_rows(connection: sa.Connection, ids: dict[str, uuid.UUID]) ->
             INSERT INTO channel_accounts (
                 id, user_id, provider, name, visibility, encrypted_provider_token,
                 provider_token_nonce, webhook_secret_hash, config
-            ) VALUES
-                (
-                    :telegram, :fake_owner, 'telegram', 'Shared Bot', 'public',
-                    :telegram_token, :nonce, :hash, '{}'::jsonb
-                ),
-                (
-                    :discord, :fake_owner, 'discord', 'Shared Bot', 'public',
-                    :discord_token, :nonce, :hash, '{}'::jsonb
-                ),
-                (
-                    :whatsapp, :fake_owner, 'whatsapp', 'Shared WhatsApp', 'public',
-                    NULL, NULL, :hash,
-                    '{"connection_mode":"baileys_managed"}'::jsonb
-                ),
-                (
-                    :private, :tenant_user, 'telegram', 'Private Bot', 'private',
-                    :private_token, :nonce, :hash, '{}'::jsonb
-                )
-            """
-        ),
-        {
-            "telegram": ids["telegram_account"],
-            "discord": ids["discord_account"],
-            "whatsapp": ids["whatsapp_account"],
-            "private": ids["private_account"],
-            "fake_owner": ids["fake_platform_owner"],
-            "tenant_user": ids["tenant_user"],
-            "telegram_token": b"telegram-provider-token",
-            "discord_token": b"discord-provider-token",
-            "private_token": b"private-provider-token",
-            "nonce": b"nonce",
-            "hash": "0" * 64,
-        },
-    )
-    connection.execute(
-        sa.text(
-            """
+            ) VALUES (
+                :account, :fake_owner, 'telegram', 'Shared Bot', 'public',
+                :token, :nonce, :hash, '{}'::jsonb
+            );
             INSERT INTO channel_secrets (
                 id, account_id, user_id, name, encrypted_value, value_nonce
             ) VALUES (
-                :id, :account_id, :fake_owner, 'provider_secret', :value, :nonce
+                :secret, :account, :fake_owner, 'provider_secret', :secret_value, :nonce
             );
-            INSERT INTO channel_whatsapp_auth_certs (id, account_id, user_id)
-            VALUES (:cert_id, :whatsapp_account, :fake_owner)
-            """
-        ),
-        {
-            "id": ids["public_secret"],
-            "account_id": ids["telegram_account"],
-            "fake_owner": ids["fake_platform_owner"],
-            "value": b"public-provider-secret",
-            "nonce": b"secret-nonce",
-            "cert_id": ids["auth_cert"],
-            "whatsapp_account": ids["whatsapp_account"],
-        },
-    )
-    connection.execute(
-        sa.text(
-            """
             INSERT INTO channel_bot_agent_links (id, account_id, user_id)
-            VALUES (:link, :account, :tenant_user);
+            VALUES (:link, :account, :tenant);
             INSERT INTO channel_bindings (id, account_id, bot_agent_link_id, user_id)
-            VALUES (:binding, :account, :link, :tenant_user);
-            INSERT INTO channel_messages (
-                id, account_id, bot_agent_link_id, binding_id, user_id
-            ) VALUES (:message, :account, :link, :binding, :tenant_user);
+            VALUES (:binding, :account, :link, :tenant);
+            INSERT INTO channel_messages (id, account_id, bot_agent_link_id, binding_id, user_id)
+            VALUES (:message, :account, :link, :binding, :tenant);
             INSERT INTO channel_agent_credentials (
                 id, account_id, bot_agent_link_id, user_id, encrypted_credentials
-            ) VALUES (:credential, :account, :link, :tenant_user, :credential_value)
+            ) VALUES (:credential, :account, :link, :tenant, :credential_value)
             """
         ),
         {
-            "link": ids["link"],
-            "binding": ids["binding"],
-            "message": ids["message"],
-            "credential": ids["credential"],
-            "account": ids["telegram_account"],
-            "tenant_user": ids["tenant_user"],
+            **ids,
+            "token": b"provider-token",
+            "secret_value": b"provider-secret",
             "credential_value": b"tenant-credential",
-        },
-    )
-    connection.execute(
-        sa.text(
-            """
-            INSERT INTO channel_whatsapp_onboarding_sessions (
-                id, ownership_kind, sidecar_account_id, sidecar_config_revision,
-                channel_account_id, user_id, request_id, name, state, method,
-                started_at, expires_at
-            ) VALUES
-                (
-                    :custom, 'custom', :custom_sidecar, 'custom-revision', NULL,
-                    :tenant_user, :request_id, 'Custom Device', 'ready', 'qr', now(),
-                    now() + interval '5 minutes'
-                ),
-                (
-                    :platform_one, 'managed', :whatsapp_account, 'managed-revision',
-                    :whatsapp_account, :fake_owner, :request_id, 'Shared Device',
-                    'connected', 'qr', now(), now() + interval '5 minutes'
-                ),
-                (
-                    :platform_two, 'managed', :platform_sidecar, 'managed-revision-two',
-                    NULL, :tenant_user, :request_id, 'Shared Device', 'ready', 'qr', now(),
-                    now() + interval '5 minutes'
-                )
-            """
-        ),
-        {
-            "custom": ids["custom_session"],
-            "custom_sidecar": uuid.uuid4(),
-            "platform_one": ids["platform_session_one"],
-            "platform_two": ids["platform_session_two"],
-            "platform_sidecar": uuid.uuid4(),
-            "whatsapp_account": ids["whatsapp_account"],
-            "fake_owner": ids["fake_platform_owner"],
-            "tenant_user": ids["tenant_user"],
-            "request_id": ids["shared_request"],
+            "nonce": b"nonce",
+            "hash": "0" * 64,
         },
     )

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -11,18 +11,21 @@ from app.models.channel import (
     CHANNEL_STATUS_ACTIVE,
     CHANNEL_VISIBILITY_PUBLIC,
     WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+    WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
     WHATSAPP_ONBOARDING_STATE_GENERATING,
     ChannelAccount,
     ChannelWhatsAppOnboardingSession,
 )
 from app.services.channels import archive_channel_account
-from app.services.whatsapp_device_onboarding import stop_whatsapp_pairing
+from app.services.whatsapp_device_onboarding import (
+    require_whatsapp_logout_for_archive,
+    stop_whatsapp_pairing,
+)
 from app.services.whatsapp_managed_onboarding import (
-    cancel_managed_whatsapp_onboarding,
-    expire_stale_managed_whatsapp_onboarding_sessions,
-    get_managed_whatsapp_onboarding,
-    require_managed_whatsapp_logout_for_archive,
-    start_managed_whatsapp_onboarding,
+    cancel_platform_whatsapp_pairing,
+    expire_stale_platform_whatsapp_pairing_sessions,
+    get_platform_whatsapp_pairing,
+    start_platform_whatsapp_pairing,
 )
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarCapabilities,
@@ -126,11 +129,10 @@ def _registry(account_id: UUID, fake: FakeManagedSidecar) -> ConfiguredWhatsAppS
     )
 
 
-async def _start(db_session, seed_user, registry, account_id, *, request_id=None, name="Shared"):
-    return await start_managed_whatsapp_onboarding(
+async def _start(db_session, registry, account_id, *, request_id=None, name="Shared"):
+    return await start_platform_whatsapp_pairing(
         db_session,
         account_id=account_id,
-        user_id=seed_user.id,
         request_id=request_id or uuid4(),
         name=name,
         registry=registry,
@@ -140,7 +142,6 @@ async def _start(db_session, seed_user, registry, account_id, *, request_id=None
 @pytest.mark.asyncio
 async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
     db_session,
-    seed_user,
 ) -> None:
     first_id = uuid4()
     second_id = uuid4()
@@ -160,19 +161,22 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
     )
     await registry.start()
     try:
-        first = await _start(db_session, seed_user, registry, first_id, name="Shared Alpha")
-        second = await _start(db_session, seed_user, registry, second_id, name="Shared Beta")
+        first = await _start(db_session, registry, first_id, name="Shared Alpha")
+        second = await _start(db_session, registry, second_id, name="Shared Beta")
         assert set(clients) == {first_id, second_id}
         assert clients[first_id] is not clients[second_id]
+        first_session = await db_session.get(ChannelWhatsAppOnboardingSession, first.id)
+        assert first_session.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM
+        assert first_session.user_id is None
 
         clients[first_id].connected = clients[first_id].registered = True
         clients[second_id].connected = clients[second_id].registered = True
-        await get_managed_whatsapp_onboarding(
+        await get_platform_whatsapp_pairing(
             db_session,
             session_id=first.id,
             registry=registry,
         )
-        await get_managed_whatsapp_onboarding(
+        await get_platform_whatsapp_pairing(
             db_session,
             session_id=second.id,
             registry=registry,
@@ -180,22 +184,24 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
 
         assert registry.managed_is_bound(first_id)
         assert registry.managed_is_bound(second_id)
-        assert await db_session.get(ChannelAccount, first_id) is not None
-        assert await db_session.get(ChannelAccount, second_id) is not None
+        first_account = await db_session.get(ChannelAccount, first_id)
+        second_account = await db_session.get(ChannelAccount, second_id)
+        assert first_account is not None and first_account.user_id is None
+        assert second_account is not None and second_account.user_id is None
     finally:
         await registry.stop()
 
 
 @pytest.mark.asyncio
 async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
-    db_session, seed_user, monkeypatch
+    db_session, monkeypatch
 ):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         fake.connected = fake.registered = True
 
         async def fail_bind(*_args, **_kwargs):
@@ -203,7 +209,7 @@ async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
 
         monkeypatch.setattr(registry, "bind_managed_account", fail_bind)
         with pytest.raises(HTTPException) as exc_info:
-            await get_managed_whatsapp_onboarding(
+            await get_platform_whatsapp_pairing(
                 db_session, session_id=started.id, registry=registry
             )
         assert exc_info.value.status_code == 503
@@ -218,15 +224,15 @@ async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
 
 
 @pytest.mark.asyncio
-async def test_registered_disconnected_cancel_recovers_with_logout(db_session, seed_user):
+async def test_registered_disconnected_cancel_recovers_with_logout(db_session):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         fake.registered = True
-        canceled = await cancel_managed_whatsapp_onboarding(
+        canceled = await cancel_platform_whatsapp_pairing(
             db_session, session_id=started.id, registry=registry
         )
         assert canceled.state == "canceled"
@@ -238,16 +244,16 @@ async def test_registered_disconnected_cancel_recovers_with_logout(db_session, s
 
 
 @pytest.mark.asyncio
-async def test_cancel_failure_retains_ownership_until_confirmed_retry(db_session, seed_user):
+async def test_cancel_failure_retains_ownership_until_confirmed_retry(db_session):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         fake.cancel_fails = True
         with pytest.raises(HTTPException) as exc_info:
-            await cancel_managed_whatsapp_onboarding(
+            await cancel_platform_whatsapp_pairing(
                 db_session, session_id=started.id, registry=registry
             )
         assert exc_info.value.status_code == 503
@@ -255,7 +261,7 @@ async def test_cancel_failure_retains_ownership_until_confirmed_retry(db_session
         assert session.state == "error"
 
         fake.cancel_fails = False
-        canceled = await cancel_managed_whatsapp_onboarding(
+        canceled = await cancel_platform_whatsapp_pairing(
             db_session, session_id=started.id, registry=registry
         )
         assert canceled.state == "canceled"
@@ -264,18 +270,18 @@ async def test_cancel_failure_retains_ownership_until_confirmed_retry(db_session
 
 
 @pytest.mark.asyncio
-async def test_expired_managed_reservation_confirms_stop(db_session, seed_user):
+async def test_expired_platform_reservation_confirms_stop(db_session):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
         session.expires_at = datetime.now(UTC) - timedelta(seconds=1)
         await db_session.commit()
         assert (
-            await expire_stale_managed_whatsapp_onboarding_sessions(db_session, registry=registry)
+            await expire_stale_platform_whatsapp_pairing_sessions(db_session, registry=registry)
             == 1
         )
         await db_session.refresh(session)
@@ -286,20 +292,20 @@ async def test_expired_managed_reservation_confirms_stop(db_session, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_expired_reservation_promotes_connected_registered_sidecar(db_session, seed_user):
+async def test_expired_reservation_promotes_connected_registered_sidecar(db_session):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
         session.expires_at = datetime.now(UTC) - timedelta(seconds=1)
         await db_session.commit()
         fake.connected = fake.registered = True
 
         assert (
-            await expire_stale_managed_whatsapp_onboarding_sessions(db_session, registry=registry)
+            await expire_stale_platform_whatsapp_pairing_sessions(db_session, registry=registry)
             == 0
         )
         account = await db_session.get(ChannelAccount, account_id)
@@ -313,24 +319,24 @@ async def test_expired_reservation_promotes_connected_registered_sidecar(db_sess
 
 
 @pytest.mark.asyncio
-async def test_logout_then_archive_rollback_is_idempotent_on_retry(db_session, seed_user):
+async def test_logout_then_archive_rollback_is_idempotent_on_retry(db_session):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
     await registry.start()
     try:
-        started = await _start(db_session, seed_user, registry, account_id)
+        started = await _start(db_session, registry, account_id)
         fake.connected = fake.registered = True
-        await get_managed_whatsapp_onboarding(db_session, session_id=started.id, registry=registry)
+        await get_platform_whatsapp_pairing(db_session, session_id=started.id, registry=registry)
         account = await db_session.get(ChannelAccount, account_id)
-        await require_managed_whatsapp_logout_for_archive(account=account, registry=registry)
+        await require_whatsapp_logout_for_archive(db_session, account=account, registry=registry)
         assert fake.logout_calls == 1
         await archive_channel_account(db_session, account=account)
         await db_session.rollback()
 
         account = await db_session.get(ChannelAccount, account_id)
         assert account.archived_at is None
-        await require_managed_whatsapp_logout_for_archive(account=account, registry=registry)
+        await require_whatsapp_logout_for_archive(db_session, account=account, registry=registry)
         assert fake.logout_calls == 1
         assert fake.cancel_calls == 0
         await archive_channel_account(db_session, account=account)
@@ -341,7 +347,7 @@ async def test_logout_then_archive_rollback_is_idempotent_on_retry(db_session, s
 
 
 @pytest.mark.asyncio
-async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is_controlled(
+async def test_custom_and_platform_request_ids_are_isolated_and_duplicate_name_is_controlled(
     db_session, seed_user
 ):
     account_id = uuid4()
@@ -367,7 +373,7 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
     await registry.start()
     try:
         existing = ChannelAccount(
-            user_id=seed_user.id,
+            user_id=None,
             provider=CHANNEL_PROVIDER_WHATSAPP,
             name="Existing",
             status=CHANNEL_STATUS_ACTIVE,
@@ -380,7 +386,6 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
         with pytest.raises(HTTPException) as start_conflict:
             await _start(
                 db_session,
-                seed_user,
                 registry,
                 account_id,
                 request_id=uuid4(),
@@ -389,7 +394,6 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
         assert start_conflict.value.status_code == 409
         started = await _start(
             db_session,
-            seed_user,
             registry,
             account_id,
             request_id=request_id,
@@ -397,7 +401,7 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
         )
         db_session.add(
             ChannelAccount(
-                user_id=seed_user.id,
+                user_id=None,
                 provider=CHANNEL_PROVIDER_WHATSAPP,
                 name="Duplicate",
                 status=CHANNEL_STATUS_ACTIVE,
@@ -409,7 +413,7 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
         await db_session.commit()
         fake.connected = fake.registered = True
         with pytest.raises(HTTPException) as exc_info:
-            await get_managed_whatsapp_onboarding(
+            await get_platform_whatsapp_pairing(
                 db_session, session_id=started.id, registry=registry
             )
         assert exc_info.value.status_code == 409
@@ -422,7 +426,7 @@ async def test_custom_and_managed_request_ids_are_isolated_and_duplicate_name_is
 
 @pytest.mark.asyncio
 async def test_restart_reconciliation_fails_closed_on_revision_and_physical_drift(
-    db_session, seed_user
+    db_session,
 ):
     account_id = uuid4()
     fake = FakeManagedSidecar()
@@ -430,7 +434,7 @@ async def test_restart_reconciliation_fails_closed_on_revision_and_physical_drif
     revision = registry.managed_account_revision(account_id)
     account = ChannelAccount(
         id=account_id,
-        user_id=seed_user.id,
+        user_id=None,
         provider=CHANNEL_PROVIDER_WHATSAPP,
         name="Shared",
         status=CHANNEL_STATUS_ACTIVE,

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -31,7 +31,7 @@ provider transport, not an Agent-facing connector.
 | Agent | A Clawdi runtime endpoint that can receive channel messages and send replies through an SDK-compatible surface. Channels bind to `AgentEnvironment`, not Projects. | `agent_environments` |
 | Provider | The external network family: Telegram, Discord, WhatsApp, or iMessage/BlueBubbles. | `ChannelAccount.provider` |
 | External bot | A concrete external bot identity or provider endpoint, such as one Telegram bot token, one Discord application, one WhatsApp phone identity, or one BlueBubbles server. | `channel_accounts` |
-| Visibility | Whether an external bot is private to its owner or available as a Clawdi-managed public bot. | `ChannelAccount.visibility` |
+| Visibility | Whether an external bot is private to its owner or available as a Clawdi-managed public bot. Private rows have a tenant `user_id`; public rows have `user_id = NULL`. | `ChannelAccount.visibility`, `ChannelAccount.user_id` |
 | Bot access | The caller's effective relationship to a selectable bot account: `owner` for caller-owned private bots, `public` for Clawdi-managed public bots. | `/v1/channels/bot-pool` response |
 | Bot capabilities | The caller's allowed actions for a selectable bot account, such as link, pair, send, manage account, or sync commands. | `/v1/channels/bot-pool` response |
 | Bot pool | The authenticated user's selectable bot candidates: owned private bots and active Clawdi-managed public bots. This is a read-only view, not a separate state table. | `/v1/channels/bot-pool` |
@@ -57,6 +57,7 @@ User
 
 ChannelAccount (external bot)
   has one provider and one visibility
+  belongs to one User when private; is ownerless platform inventory when public
   has many ChannelBotAgentLink rows
   has many ChannelBinding rows
   has many ChannelMessage and ChannelDelivery rows
@@ -131,11 +132,13 @@ Private bots:
 Public bots:
 
 - Created and managed only through `/v1/admin/channels`.
-- Stored as `visibility = public`.
+- Stored as `visibility = public` with `user_id = NULL`; they do not cascade
+  with any tenant `User`.
 - Visible to authenticated users for linking and pairing.
 - Provider credentials, webhook secret rotation, archive, and provider-wide
-  command sync remain admin operations. The backing `user_id` is not product
-  ownership and does not grant mutable user API access.
+  command sync remain admin operations. Account-level encrypted secrets and
+  WhatsApp auth certificates are platform-owned and likewise have no tenant
+  `user_id`.
 - User-created child state is still owned by the requesting user:
   `channel_bot_agent_links`, `channel_pair_codes`, `channel_bindings`,
   `channel_messages`, `channel_deliveries`, attachments, scheduled messages,
@@ -611,12 +614,15 @@ Admin control plane:
 | API | Scope |
 | --- | --- |
 | `GET /v1/admin/channels` | Lists managed channel accounts. |
-| `POST /v1/admin/channels` | Creates private or public managed channel accounts. |
+| `POST /v1/admin/channels` | Creates Telegram/Discord accounts. Private creation requires `target_clerk_id`; public creation rejects it. Public WhatsApp uses physical pairing below. |
 | `GET /v1/admin/channels/{id}` | Reads a managed channel account. |
-| `PATCH /v1/admin/channels/{id}` | Updates account metadata, provider token, config, and encrypted secrets. |
+| `PATCH /v1/admin/channels/{id}` | Updates account metadata, provider token, config, and encrypted secrets. Visibility cannot change in place; recreate the account instead. |
 | `POST /v1/admin/channels/{id}/webhook-secret/rotate` | Rotates provider ingress secret. |
 | `POST /v1/admin/channels/{id}/commands/sync` | Syncs provider-wide pair/unpair commands. |
 | `DELETE /v1/admin/channels/{id}` | Archives the account and active child state. |
+| `POST /v1/admin/channels/whatsapp/pairing-sessions` | Starts an ownerless platform WhatsApp physical QR session for `{account_id, request_id, name}`. |
+| `GET /v1/admin/channels/whatsapp/pairing-sessions/{id}` | Reads QR/pairing status and promotes a connected session into the same public `ChannelAccount` inventory. |
+| `DELETE /v1/admin/channels/whatsapp/pairing-sessions/{id}` | Cancels an unconnected physical session after confirmed logout. Connected accounts use the ordinary admin archive route. |
 
 Provider ingress:
 


### PR DESCRIPTION
## Summary

PR #769 added managed WhatsApp QR onboarding beside the mature admin channel CRUD, but duplicated tenant resolution, ChannelAccount construction, audit, and archive/logout behavior and assigned Public WhatsApp inventory to an arbitrary Clerk user. This change makes Public Telegram, Discord, and WhatsApp accounts explicit ownerless platform inventory while keeping Link, PairCode, Binding, message, delivery, token, and synthetic credential state tenant-scoped.

- Public `ChannelAccount.user_id = NULL`; Private accounts require an owner. Service validation, a DB check, and visibility-specific partial unique indexes enforce the boundary.
- Public account `ChannelSecret` and WhatsApp auth-certificate rows are ownerless. Runtime tenant authority comes from Link/Binding/message/credential state and fails closed when absent.
- Generic admin Telegram/Discord CRUD remains canonical. Public create has no `target_clerk_id`; Private create requires it; visibility changes require recreation.
- Public WhatsApp retains only the async physical transport lifecycle:
  - `POST /v1/admin/channels/whatsapp/pairing-sessions` with `{account_id, request_id, name}`
  - `GET /v1/admin/channels/whatsapp/pairing-sessions/{id}`
  - `DELETE /v1/admin/channels/whatsapp/pairing-sessions/{id}`
- Connected sessions promote into the same ownerless Public `ChannelAccount` inventory. The pairing router is intentionally mounted only under `/v1`; there is no `/api` alias or legacy onboarding stub.
- Managed and Custom physical archive paths share fail-closed logout. Singleton sidecar transport, Custom onboarding, reconciliation, and existing runtime gates remain unchanged.

## Migration

The migration removes fake owners from existing Public accounts, Public secrets, WhatsApp auth certificates, and old managed sessions without changing provider credentials or tenant-scoped children. Managed sessions become ownerless platform sessions; Custom sessions remain tenant-owned. Historical active name/request collisions are deterministically resolved before NULL-safe partial unique indexes are installed. Downgrade refuses while platform inventory exists rather than inventing a tenant owner.

## Tests and size

The committed-DB fixture now snapshots platform account/session IDs, rolls back failed transactions, and deletes only platform inventory created by that test before deleting its seed tenant. This fixes the test-isolation cascade without weakening production uniqueness.

Focused ownership/alias/migration coverage: 24 passed. A fresh migrated PostgreSQL full run passed: **2,092 passed, 6 skipped**. Post-suite checks found zero leaked platform accounts, platform sessions, or pair codes.

Diff versus `origin/main`:

- production and migration: +1,110 / -222 (net +888)
- tests: +476 / -128 (net +348)
- docs: +12 / -6 (net +6)

The only new test file is the 227-line isolated migration test. It creates the minimum prior schema needed to run the real migration without mutating the shared pytest schema, then proves provider credentials and tenant Link/Binding/message/credential children survive fake-owner deletion. Other coverage modifies existing canonical admin, channel isolation, WhatsApp QR/Custom, and route-alias tests. Redundant provider tutorial scenarios and a redundant standalone alias test were removed.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
- `bun run typecheck`
- `bun run check`
- changed-production BasedPyright: 15 files, zero diagnostics
- generated API diff check passed; hidden admin routes require no client regeneration
- Alembic single head: `c2f8a4d6e9b1`
- `git diff --check`

`alembic check` still reports the repository baseline metadata drift across unrelated existing tables, indexes, removed columns, and timestamp nullability; it reports no new ownership/runtime-marker drift. No hosted, UI, provider protocol, generic egress, runtime gate, production, tenant, secret, or real-provider changes are included.
