### PR TITLE
fix(whatsapp): preserve async QR pairing lifecycle

### DIFF
--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -226,6 +226,10 @@ async def _refresh(
     if health.connected and pairing.status == "connected" and pairing.registered:
         await _promote(db, onboarding=onboarding, registry=registry)
         return _response(onboarding)
+    if pairing.status == "starting" and not pairing.registered:
+        onboarding.state = WHATSAPP_ONBOARDING_STATE_GENERATING
+        await db.commit()
+        return _response(onboarding)
     if datetime.now(UTC) >= onboarding.expires_at:
         try:
             stopped = await stop_whatsapp_pairing(client, current=pairing)

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -47,6 +47,7 @@ class FakeManagedSidecar:
         self.logout_calls = 0
         self.stopped = False
         self.cancel_fails = False
+        self.qr_starting = False
 
     async def refresh_health(self) -> bool:
         return self.connected
@@ -69,6 +70,9 @@ class FakeManagedSidecar:
 
     async def pairing_qr(self) -> WhatsAppSidecarPairingStatus:
         self.stopped = False
+        if self.qr_starting:
+            self.qr_starting = False
+            return WhatsAppSidecarPairingStatus(status="starting", registered=False)
         return await self.pairing_status()
 
     async def pairing_status(self) -> WhatsAppSidecarPairingStatus:
@@ -137,6 +141,27 @@ async def _start(db_session, registry, account_id, *, request_id=None, name="Sha
         name=name,
         registry=registry,
     )
+
+
+@pytest.mark.asyncio
+async def test_async_qr_generation_remains_pollable(db_session) -> None:
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    fake.qr_starting = True
+    registry = _registry(account_id, fake)
+    await registry.start()
+    try:
+        started = await _start(db_session, registry, account_id)
+        assert started.state == WHATSAPP_ONBOARDING_STATE_GENERATING
+        assert started.qr is None
+
+        ready = await get_platform_whatsapp_pairing(
+            db_session, session_id=started.id, registry=registry
+        )
+        assert ready.state == "ready"
+        assert ready.qr == "ephemeral-qr"
+    finally:
+        await registry.stop()
 
 
 @pytest.mark.asyncio

--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -25,6 +25,7 @@ describe("physical Baileys runtime", () => {
 		expect(harness.socketConfigurations).toHaveLength(1);
 		const firstQrObservedAt = Date.now();
 		harness.events.emit("connection.update", { qr: "sensitive-qr-value" });
+		await runtime.start();
 		const ready = runtime.pairingStatus();
 		expect(ready).toMatchObject({
 			status: "pairing_qr",
@@ -33,6 +34,7 @@ describe("physical Baileys runtime", () => {
 			qr: "sensitive-qr-value",
 		});
 		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeWithin(59_000, 61_000);
+		expect(harness.socketConfigurations).toHaveLength(1);
 
 		const rotatedQrObservedAt = Date.now();
 		harness.events.emit("connection.update", { qr: "sensitive-qr-value-rotated" });

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -133,9 +133,10 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 			throw new Error(`WhatsApp provider requires operator recovery: ${this.fatalReason}`);
 		}
 		if (this.stateClosed) throw new Error("WhatsApp provider state is closed");
-		if (this.status === "connected" || this.status === "connecting" || this.status === "starting") {
-			return;
-		}
+		// Session-scoped status and health requests call start() before dispatch.
+		// An unregistered socket may already be generating or displaying a QR;
+		// preserve that sole physical owner instead of resetting its lifecycle.
+		if (this.socket) return;
 		if (!this.providerState.state.creds.registered) {
 			this.status = "stopped";
 			return;


### PR DESCRIPTION
## Summary
- preserve an existing unregistered pairing socket when session-scoped status requests call runtime start
- keep an asynchronous initial QR handshake in `generating` instead of marking the reservation as failed
- cover the real delayed-QR lifecycle without adding new API or architecture

## Verification
- sidecar: 59 passed
- managed onboarding: 11 passed
- workspace Biome: 916 files
- sidecar typecheck and backend Ruff: passed

## Production finding
The first live Shared pairing request exposed this async-only state transition. It produced no public account and will be canceled before retry after deployment.