### PR TITLE
fix(runtime): lift watcher task ceiling

### DIFF
--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -532,6 +532,7 @@ describe("runtime manifest services", () => {
 			"utf8",
 		);
 		expect(runtimeWatchUnit).toContain(`ExecStart="${paths.cliManagedBin}" "runtime" "watch"`);
+		expect(runtimeWatchUnit).toContain("TasksMax=infinity");
 		expect(runtimeWatchUnit).not.toContain("ConditionPathExists=");
 		expect(runtimeWatchEnv).toContain('BYOK_RUNTIME_SECRET="runtime-byok-value"');
 		expect(runtimeWatchEnv).toContain('BYOK_SERVICE_SECRET="service-byok-value"');

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1528,6 +1528,7 @@ export function writeRuntimeSystemdState(input: {
 					...Object.fromEntries(Object.keys(watchSecretEnvironment).map((name) => [name, ""])),
 					CLAWDI_AUTH_TOKEN: "",
 				},
+				extraServiceLines: ["TasksMax=infinity"],
 			}),
 		);
 	}


### PR DESCRIPTION
## Root cause\n\nThe generated runtime watcher inherited the host systemd DefaultTasksMax=76. Hermes dashboard npm/Vite builds can exceed that service-level task ceiling and fail with Cannot fork.\n\nA failed build intentionally does not commit an artifact receipt, so the next reconcile still sees the artifact as pending. That made the deployment appear to build forever. Existing receipt behavior already makes unchanged reconciles a no-op after a successful build.\n\n## Fix\n\nSet TasksMax=infinity on the generated watcher unit, matching the existing hosted user@.service convention. The pod-level pids.max=512 remains the global safety boundary.\n\nNo retry, backoff, transient build service, or live systemd mutation is introduced.\n\n## Verification\n\n- Docker focused test: 34 passed, 0 failed, 384 assertions\n- CLI typecheck: passed\n- CLI build: passed\n- Biome and pre-commit checks: passed