### PR TITLE
fix(telegram): reconcile command lifecycle projections

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -133,6 +133,7 @@ from app.services.channels import (
     get_telegram_bot_username,
     hash_token,
     mark_discord_reserved_commands_current,
+    mark_telegram_reserved_commands_current,
     normalize_telegram_bot_username,
     rearm_discord_command_reconciliation,
     require_unchanged_discord_application_identity,
@@ -1487,6 +1488,9 @@ async def admin_sync_channel_commands(
         account.config = config
         if body.guild_id is None:
             mark_discord_reserved_commands_current(account)
+        await db.commit()
+    if account.provider == CHANNEL_PROVIDER_TELEGRAM:
+        mark_telegram_reserved_commands_current(account)
         await db.commit()
     return ChannelCommandSyncResponse(provider=account.provider, commands=synced)
 

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -132,11 +132,13 @@ from app.services.channels import (
     list_strict_v2_hosted_channel_agent_ids,
     lock_channel_binding_identity,
     mark_discord_reserved_commands_current,
+    mark_telegram_reserved_commands_current,
     normalize_telegram_bot_username,
     rearm_discord_command_reconciliation,
     rotate_bot_agent_link_token,
     store_channel_secrets,
     sync_channel_commands,
+    telegram_reserved_commands_are_current,
 )
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.sync_events import queue_environment_runtime_manifest_changed
@@ -861,6 +863,14 @@ async def create_channel_pair_code(
     db: AsyncSession = Depends(get_session),
 ) -> ChannelPairCodeResponse:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    if (
+        account.provider == CHANNEL_PROVIDER_TELEGRAM
+        and account.encrypted_provider_token
+        and account.provider_token_nonce
+        and not telegram_reserved_commands_are_current(account)
+    ):
+        await sync_channel_commands(account=account)
+        mark_telegram_reserved_commands_current(account)
     if account.provider == CHANNEL_PROVIDER_DISCORD:
         await ensure_discord_application_identity_available(db, account=account)
         config_error = discord_interactions_config_error(account.config)
@@ -1385,6 +1395,9 @@ async def sync_channel_commands_route(
     )
     if account.provider == CHANNEL_PROVIDER_DISCORD and commands is None and body.guild_id is None:
         mark_discord_reserved_commands_current(account)
+        await db.commit()
+    if account.provider == CHANNEL_PROVIDER_TELEGRAM:
+        mark_telegram_reserved_commands_current(account)
         await db.commit()
     return ChannelCommandSyncResponse(provider=account.provider, commands=synced)
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -55,6 +55,7 @@ from app.routes.channel_routers.shared import (
 )
 from app.schemas.channel import TelegramWebhookResponse
 from app.services.channels import (
+    DEFAULT_CHANNEL_COMMANDS,
     TELEGRAM_REF_CALLBACK_QUERY_ID,
     TELEGRAM_REF_FILE_ID,
     TELEGRAM_REF_FILE_PATH,
@@ -281,6 +282,13 @@ _TELEGRAM_BROAD_COMMAND_SCOPE_TYPES = frozenset(
 )
 _TELEGRAM_CHAT_COMMAND_SCOPE_TYPES = frozenset({"chat", "chat_administrators", "chat_member"})
 TELEGRAM_UI_UNPAIR_REPLY = "Unpaired. This chat is no longer connected to an agent."
+_TELEGRAM_RESERVED_COMMANDS = tuple(
+    {"command": command["name"], "description": command["description"]}
+    for command in DEFAULT_CHANNEL_COMMANDS
+)
+_TELEGRAM_RESERVED_COMMAND_NAMES = frozenset(
+    command["command"] for command in _TELEGRAM_RESERVED_COMMANDS
+)
 
 
 @dataclass(frozen=True)
@@ -471,13 +479,22 @@ async def telegram_bot_api(
         )
         if command_error is not None:
             return command_error
+        commands = _telegram_json_parameter(params.get("commands"))
+        try:
+            _telegram_physical_commands(commands if isinstance(commands, list) else [])
+        except ValueError:
+            return _telegram_error_response(
+                "Bad Request: merged command list exceeds 100 commands",
+                400,
+            )
+        previous_shadow = _telegram_command_shadow(agent.link)
         _store_telegram_commands(agent.link, params=params)
-        fanout_error = await _fan_out_telegram_commands(
+        fanout_error = await _reconcile_telegram_commands_for_link(
             db,
             account=account,
-            bot_agent_link_id=agent.link.id,
-            method="setMyCommands",
-            params=params,
+            link=agent.link,
+            previous_shadow=previous_shadow,
+            provider_options=_telegram_command_provider_options(params),
         )
         if fanout_error is not None:
             return fanout_error
@@ -492,13 +509,14 @@ async def telegram_bot_api(
         )
         if command_error is not None:
             return command_error
+        previous_shadow = _telegram_command_shadow(agent.link)
         _delete_telegram_commands(agent.link, params=params)
-        fanout_error = await _fan_out_telegram_commands(
+        fanout_error = await _reconcile_telegram_commands_for_link(
             db,
             account=account,
-            bot_agent_link_id=agent.link.id,
-            method="deleteMyCommands",
-            params=params,
+            link=agent.link,
+            previous_shadow=previous_shadow,
+            provider_options=_telegram_command_provider_options(params),
         )
         if fanout_error is not None:
             return fanout_error
@@ -1272,63 +1290,258 @@ def _get_telegram_commands(
     commands = command_shadow.get(_telegram_command_shadow_key(params))
     if isinstance(commands, list):
         return [command for command in commands if isinstance(command, dict)]
-    return [
-        {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
-        {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
-        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
-    ]
+    return [dict(command) for command in _TELEGRAM_RESERVED_COMMANDS]
+
+
+def _telegram_command_shadow(
+    link: ChannelBotAgentLink,
+) -> dict[str, list[dict[str, Any]]]:
+    config = link.config if isinstance(link.config, dict) else {}
+    shadow = config.get("telegram_agent_commands")
+    if not isinstance(shadow, dict):
+        return {}
+    return {
+        key: [command for command in commands if isinstance(command, dict)]
+        for key, commands in shadow.items()
+        if isinstance(key, str) and isinstance(commands, list)
+    }
+
+
+def _telegram_physical_commands(
+    agent_commands: list[Any] | None,
+) -> list[dict[str, Any]]:
+    """Merge service and Link command ownership into one physical projection."""
+    merged = [dict(command) for command in _TELEGRAM_RESERVED_COMMANDS]
+    seen = set(_TELEGRAM_RESERVED_COMMAND_NAMES)
+    for command in agent_commands or []:
+        if not isinstance(command, dict):
+            continue
+        name = command.get("command")
+        if isinstance(name, str) and name in seen:
+            continue
+        if isinstance(name, str):
+            seen.add(name)
+        merged.append(dict(command))
+    if len(merged) > 100:
+        raise ValueError("telegram command projection exceeds provider limit")
+    return merged
 
 
 def _telegram_command_shadow_key(params: dict[str, Any]) -> str:
     return f"{_telegram_command_scope_key(params)}:{_telegram_language_code(params)}"
 
 
-async def _fan_out_telegram_commands(
+def _telegram_shadow_commands(
+    shadow: dict[str, list[dict[str, Any]]],
+    *,
+    scope_key: str,
+    language_code: str,
+) -> list[dict[str, Any]] | None:
+    return shadow.get(f"{scope_key}:{language_code}")
+
+
+def _telegram_resolve_shadow_commands(
+    shadow: dict[str, list[dict[str, Any]]],
+    candidates: list[tuple[str, str]],
+) -> list[dict[str, Any]] | None:
+    for scope_key, language_code in candidates:
+        commands = _telegram_shadow_commands(
+            shadow,
+            scope_key=scope_key,
+            language_code=language_code,
+        )
+        if commands is not None:
+            return commands
+    return None
+
+
+def _telegram_binding_command_targets(
+    shadow: dict[str, list[dict[str, Any]]],
+    binding: ChannelBinding,
+) -> list[dict[str, Any]]:
+    """Resolve Telegram's documented scope/language precedence for one chat."""
+    languages = sorted(
+        {
+            language_code
+            for key in shadow
+            for _, language_code in [_telegram_command_shadow_parts(key)]
+            if language_code
+        }
+    )
+    chat_id = binding.external_chat_id
+    chat_type = (binding.external_chat_type or "").lower()
+    is_group = chat_type in {"group", "supergroup"}
+    projections: list[dict[str, Any]] = []
+
+    def add_resolved(
+        *,
+        scope: dict[str, Any],
+        language_code: str,
+        scope_precedence: list[str],
+    ) -> None:
+        candidates: list[tuple[str, str]] = []
+        for scope_key in scope_precedence:
+            if language_code:
+                candidates.append((scope_key, language_code))
+            candidates.append((scope_key, ""))
+        commands = _telegram_resolve_shadow_commands(shadow, candidates)
+        if commands is None:
+            return
+        payload: dict[str, Any] = {"agent_commands": commands, "scope": scope}
+        if language_code:
+            payload["language_code"] = language_code
+        projections.append(payload)
+
+    language_variants = ["", *languages]
+    if is_group:
+        for language_code in language_variants:
+            add_resolved(
+                scope={"type": "chat_administrators", "chat_id": chat_id},
+                language_code=language_code,
+                scope_precedence=[
+                    f"chat_administrators:{chat_id}",
+                    f"chat:{chat_id}",
+                    "all_chat_administrators",
+                    "all_group_chats",
+                    "default",
+                ],
+            )
+            add_resolved(
+                scope={"type": "chat", "chat_id": chat_id},
+                language_code=language_code,
+                scope_precedence=[f"chat:{chat_id}", "all_group_chats", "default"],
+            )
+    else:
+        for language_code in language_variants:
+            add_resolved(
+                scope={"type": "chat", "chat_id": chat_id},
+                language_code=language_code,
+                scope_precedence=[f"chat:{chat_id}", "all_private_chats", "default"],
+            )
+
+    for key, commands in sorted(shadow.items()):
+        scope_key, language_code = _telegram_command_shadow_parts(key)
+        parts = scope_key.split(":")
+        if len(parts) != 3 or parts[0] != "chat_member" or parts[1] != chat_id:
+            continue
+        payload = {
+            "agent_commands": commands,
+            "scope": {
+                "type": "chat_member",
+                "chat_id": chat_id,
+                "user_id": parts[2],
+            },
+        }
+        if language_code:
+            payload["language_code"] = language_code
+        projections.append(payload)
+    return projections
+
+
+def _telegram_materialize_command_target(target: dict[str, Any]) -> dict[str, Any]:
+    payload = {
+        "commands": _telegram_physical_commands(target.get("agent_commands")),
+        "scope": target["scope"],
+    }
+    if language_code := target.get("language_code"):
+        payload["language_code"] = language_code
+    return payload
+
+
+def _telegram_binding_command_projections(
+    shadow: dict[str, list[dict[str, Any]]],
+    binding: ChannelBinding,
+) -> list[dict[str, Any]]:
+    return [
+        _telegram_materialize_command_target(target)
+        for target in _telegram_binding_command_targets(shadow, binding)
+    ]
+
+
+def _telegram_projection_identity(payload: dict[str, Any]) -> str:
+    return json.dumps(
+        [payload.get("scope"), payload.get("language_code", "")],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _telegram_command_provider_options(params: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _telegram_json_parameter(value)
+        for key, value in params.items()
+        if key not in {"commands", "scope", "language_code"}
+    }
+
+
+async def _reconcile_telegram_commands_for_link(
     db: AsyncSession,
     *,
     account: Any,
-    bot_agent_link_id: UUID,
-    method: str,
-    params: dict[str, Any],
+    link: ChannelBotAgentLink,
+    previous_shadow: dict[str, list[dict[str, Any]]] | None = None,
+    provider_options: dict[str, Any] | None = None,
 ) -> Response | None:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
         return None
-
-    scope = _telegram_json_parameter(params.get("scope"))
-    scope_type = _optional_str(scope.get("type")) if isinstance(scope, dict) else None
-    if isinstance(scope, dict) and scope_type not in _TELEGRAM_BROAD_COMMAND_SCOPE_TYPES:
-        response = await _post_telegram_bot_payload(
-            account=account,
-            method=method,
-            payload=_telegram_command_provider_payload(method, params, scope=scope),
-        )
-        if not _telegram_provider_call_succeeded(response):
-            return _telegram_proxy_response(response)
-        return None
-
     result = await db.execute(
         select(ChannelBinding).where(
             ChannelBinding.account_id == account.id,
-            ChannelBinding.bot_agent_link_id == bot_agent_link_id,
+            ChannelBinding.bot_agent_link_id == link.id,
             ChannelBinding.status == BINDING_STATUS_ACTIVE,
         )
     )
-    scope_key = scope_type if isinstance(scope_type, str) and scope_type != "default" else "default"
+    desired_shadow = _telegram_command_shadow(link)
+    reconciliations: list[
+        tuple[
+            dict[str, dict[str, Any]],
+            dict[str, dict[str, Any]],
+            dict[str, dict[str, Any]],
+        ]
+    ] = []
     for binding in result.scalars().all():
-        fanout_scope = _telegram_command_fanout_scope(binding, scope_key=scope_key)
-        if fanout_scope is None:
-            continue
-        response = await _post_telegram_bot_payload(
-            account=account,
-            method=method,
-            payload=_telegram_command_provider_payload(
-                method,
-                params,
-                scope=fanout_scope,
-            ),
-        )
-        if not _telegram_provider_call_succeeded(response):
-            return _telegram_proxy_response(response)
+        desired_targets = {
+            _telegram_projection_identity(target): target
+            for target in _telegram_binding_command_targets(desired_shadow, binding)
+        }
+        try:
+            desired = {
+                identity: _telegram_materialize_command_target(target)
+                for identity, target in desired_targets.items()
+            }
+        except ValueError:
+            return _telegram_error_response(
+                "Bad Request: merged command list exceeds 100 commands",
+                400,
+            )
+        previous = {
+            _telegram_projection_identity(target): target
+            for target in _telegram_binding_command_targets(previous_shadow or {}, binding)
+        }
+        reconciliations.append((desired, desired_targets, previous))
+    for desired, desired_targets, previous in reconciliations:
+        for identity in sorted(desired):
+            if desired_targets.get(identity) == previous.get(identity) and not provider_options:
+                continue
+            response = await _post_telegram_bot_payload(
+                account=account,
+                method="setMyCommands",
+                payload={**(provider_options or {}), **desired[identity]},
+            )
+            if not _telegram_provider_call_succeeded(response):
+                return _telegram_proxy_response(response)
+        for identity in sorted(previous.keys() - desired.keys()):
+            stale = previous[identity]
+            payload = {"scope": stale["scope"]}
+            if language_code := stale.get("language_code"):
+                payload["language_code"] = language_code
+            response = await _post_telegram_bot_payload(
+                account=account,
+                method="deleteMyCommands",
+                payload={**(provider_options or {}), **payload},
+            )
+            if not _telegram_provider_call_succeeded(response):
+                return _telegram_proxy_response(response)
     return None
 
 
@@ -1380,25 +1593,11 @@ async def _clear_telegram_commands_for_binding(
 ) -> bool:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
         return True
-    config = link.config if isinstance(link.config, dict) else {}
-    shadow = config.get("telegram_agent_commands")
-    if not isinstance(shadow, dict):
-        return True
-    cleared: set[str] = set()
     succeeded = True
-    for key in shadow:
-        if not isinstance(key, str):
-            continue
-        scope_key, language_code = _telegram_command_shadow_parts(key)
-        scope = _telegram_command_scope_for_binding(binding, scope_key=scope_key)
-        if scope is None:
-            continue
-        identity = json.dumps([scope, language_code], sort_keys=True, separators=(",", ":"))
-        if identity in cleared:
-            continue
-        cleared.add(identity)
-        payload: dict[str, Any] = {"scope": scope}
-        if language_code:
+    targets = _telegram_binding_command_targets(_telegram_command_shadow(link), binding)
+    for target in targets:
+        payload: dict[str, Any] = {"scope": target["scope"]}
+        if language_code := target.get("language_code"):
             payload["language_code"] = language_code
         try:
             response = await _post_telegram_bot_payload(
@@ -1430,25 +1629,20 @@ async def _replay_telegram_commands_on_pair(
     link = await db.get(ChannelBotAgentLink, binding.bot_agent_link_id)
     if link is None or link.status != BOT_AGENT_LINK_STATUS_ACTIVE:
         return
-    config = link.config if isinstance(link.config, dict) else {}
-    shadow = config.get("telegram_agent_commands")
-    if not isinstance(shadow, dict):
-        return
-    for key, commands in shadow.items():
-        if not isinstance(key, str) or not isinstance(commands, list):
+    for target in _telegram_binding_command_targets(
+        _telegram_command_shadow(link),
+        binding,
+    ):
+        try:
+            payload = _telegram_materialize_command_target(target)
+        except ValueError:
+            log.warning(
+                "telegram_pair_command_replay_skipped_oversized_projection "
+                "account_id=%s binding_id=%s",
+                account.id,
+                binding.id,
+            )
             continue
-        scope_key, language_code = _telegram_command_shadow_parts(key)
-        if scope_key not in _TELEGRAM_BROAD_COMMAND_SCOPE_TYPES:
-            continue
-        scope = _telegram_command_fanout_scope(binding, scope_key=scope_key)
-        if scope is None:
-            continue
-        payload: dict[str, Any] = {
-            "commands": [command for command in commands if isinstance(command, dict)],
-            "scope": scope,
-        }
-        if language_code:
-            payload["language_code"] = language_code
         try:
             await _post_telegram_bot_payload(
                 account=account,
@@ -1609,61 +1803,6 @@ def _telegram_command_shadow_parts(key: str) -> tuple[str, str]:
     if not separator:
         return key, ""
     return scope_key, language_code
-
-
-def _telegram_command_fanout_scope(
-    binding: ChannelBinding,
-    *,
-    scope_key: str,
-) -> dict[str, Any] | None:
-    chat_type = (binding.external_chat_type or "").lower()
-    is_group = chat_type in {"group", "supergroup"}
-    is_private = chat_type == "private" or not chat_type
-    if scope_key == "default":
-        return {
-            "type": "chat_administrators" if is_group else "chat",
-            "chat_id": binding.external_chat_id,
-        }
-    if scope_key == "all_private_chats" and is_private:
-        return {"type": "chat", "chat_id": binding.external_chat_id}
-    if scope_key == "all_group_chats" and is_group:
-        return {"type": "chat", "chat_id": binding.external_chat_id}
-    if scope_key == "all_chat_administrators" and is_group:
-        return {"type": "chat_administrators", "chat_id": binding.external_chat_id}
-    return None
-
-
-def _telegram_command_scope_for_binding(
-    binding: ChannelBinding,
-    *,
-    scope_key: str,
-) -> dict[str, Any] | None:
-    broad_scope = _telegram_command_fanout_scope(binding, scope_key=scope_key)
-    if broad_scope is not None:
-        return broad_scope
-    parts = scope_key.split(":")
-    if len(parts) == 2 and parts[0] in {"chat", "chat_administrators"}:
-        if parts[1] == binding.external_chat_id:
-            return {"type": parts[0], "chat_id": parts[1]}
-        return None
-    if len(parts) == 3 and parts[0] == "chat_member":
-        if parts[1] == binding.external_chat_id:
-            return {"type": "chat_member", "chat_id": parts[1], "user_id": parts[2]}
-    return None
-
-
-def _telegram_command_provider_payload(
-    method: str,
-    params: dict[str, Any],
-    *,
-    scope: dict[str, Any],
-) -> dict[str, Any]:
-    payload = {key: _telegram_json_parameter(value) for key, value in params.items()}
-    payload["scope"] = scope
-    if method.lower() == "setmycommands":
-        commands = _telegram_json_parameter(params.get("commands"))
-        payload["commands"] = commands if isinstance(commands, list) else []
-    return payload
 
 
 async def _post_telegram_bot_payload(

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -154,6 +154,8 @@ DISCORD_GUILD_INTERACTION_CONTEXT = 0
 DISCORD_BOT_DM_INTERACTION_CONTEXT = 1
 DISCORD_RESERVED_COMMAND_VERSION = 4
 DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY = "discord_reserved_command_version"
+TELEGRAM_RESERVED_COMMAND_VERSION = 1
+TELEGRAM_RESERVED_COMMAND_VERSION_CONFIG_KEY = "telegram_reserved_command_version"
 DISCORD_INSTALL_CONFIG_VERSION = 2
 DISCORD_INSTALL_CONFIG_VERSION_CONFIG_KEY = "discord_install_config_version"
 DISCORD_USER_INSTALL_SUPPORTED_CONFIG_KEY = "discord_user_install_supported"
@@ -4929,6 +4931,25 @@ async def send_channel_outbound_message(
     )
 
 
+def _telegram_account_command_specs(
+    commands: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    merged = [dict(command) for command in DEFAULT_CHANNEL_COMMANDS]
+    seen = {_command_name(command) for command in merged}
+    for command in commands or []:
+        name = _command_name(command)
+        if name in seen:
+            continue
+        seen.add(name)
+        merged.append(command)
+    if len(merged) > 100:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="telegram merged command list exceeds provider limit of 100",
+        )
+    return merged
+
+
 async def sync_channel_commands(
     *,
     account: ChannelAccount,
@@ -4939,7 +4960,10 @@ async def sync_channel_commands(
     using_default_commands = commands is None
     command_specs = commands or [dict(command) for command in DEFAULT_CHANNEL_COMMANDS]
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
-        return await sync_telegram_commands(account=account, commands=command_specs)
+        return await sync_telegram_commands(
+            account=account,
+            commands=_telegram_account_command_specs(commands),
+        )
     if account.provider == CHANNEL_PROVIDER_DISCORD:
         if not using_default_commands:
             for command in command_specs:
@@ -5312,6 +5336,23 @@ def discord_reserved_commands_are_current(account: ChannelAccount) -> bool:
 def mark_discord_reserved_commands_current(account: ChannelAccount) -> None:
     config = dict(account.config) if isinstance(account.config, dict) else {}
     config[DISCORD_RESERVED_COMMAND_VERSION_CONFIG_KEY] = DISCORD_RESERVED_COMMAND_VERSION
+    account.config = config
+
+
+def telegram_reserved_commands_are_current(account: ChannelAccount) -> bool:
+    if not isinstance(account.config, dict):
+        return False
+    version = account.config.get(TELEGRAM_RESERVED_COMMAND_VERSION_CONFIG_KEY)
+    return (
+        isinstance(version, int)
+        and not isinstance(version, bool)
+        and version == TELEGRAM_RESERVED_COMMAND_VERSION
+    )
+
+
+def mark_telegram_reserved_commands_current(account: ChannelAccount) -> None:
+    config = dict(account.config) if isinstance(account.config, dict) else {}
+    config[TELEGRAM_RESERVED_COMMAND_VERSION_CONFIG_KEY] = TELEGRAM_RESERVED_COMMAND_VERSION
     account.config = config
 
 

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -38,6 +38,7 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarUnavailableError,
 )
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
+from tests.test_channels import _FakeProviderClient, _reset_fake_provider_client
 
 _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # Shared header dict for the bulk of tests that exercise the happy-path
@@ -1849,6 +1850,8 @@ async def test_admin_channel_lifecycle_manages_public_bot(
         json={"agent_id": str(channel_agent.id)},
     )
     assert linked.status_code == 201, linked.text
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     pair = await client.post(
         f"/v1/channels/{body['id']}/pair-codes",
         json={"agent_link_id": linked.json()["id"], "ttl_seconds": 900},

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -38,7 +38,6 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarUnavailableError,
 )
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
-from tests.test_channels import _FakeProviderClient, _reset_fake_provider_client
 
 _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # Shared header dict for the bulk of tests that exercise the happy-path
@@ -1850,8 +1849,11 @@ async def test_admin_channel_lifecycle_manages_public_bot(
         json={"agent_id": str(channel_agent.id)},
     )
     assert linked.status_code == 201, linked.text
-    _reset_fake_provider_client({"ok": True, "result": True})
-    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+
+    async def sync_commands(**_kwargs):
+        return []
+
+    monkeypatch.setattr("app.routes.channel_routers.public.sync_channel_commands", sync_commands)
     pair = await client.post(
         f"/v1/channels/{body['id']}/pair-codes",
         json={"agent_link_id": linked.json()["id"], "ttl_seconds": 900},

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -4651,7 +4651,12 @@ async def test_telegram_bot_api_get_updates_reads_paired_inbox(client: httpx.Asy
 
 
 @pytest.mark.asyncio
-async def test_telegram_bot_api_accepts_official_bot_path_shape(client: httpx.AsyncClient):
+async def test_telegram_bot_api_accepts_official_bot_path_shape(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = await _create_paired_telegram_channel(
         client,
         name="telegram-official-path",
@@ -4690,7 +4695,10 @@ async def test_telegram_bot_api_accepts_official_bot_path_shape(client: httpx.As
 @pytest.mark.asyncio
 async def test_telegram_managed_bot_api_keeps_credential_out_of_loggable_path(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = await _create_paired_telegram_channel(
         client,
         name="telegram-managed-auth",
@@ -6771,6 +6779,143 @@ async def test_telegram_bot_commands_preserve_scope_language_and_delete(
     ]
 
 
+@pytest.mark.parametrize(
+    ("chat_type", "shadow", "expected"),
+    [
+        (
+            "private",
+            {
+                "default:": [{"command": "default", "description": "Default"}],
+                "default:es": [{"command": "default_es", "description": "Default ES"}],
+                "all_private_chats:": [{"command": "private", "description": "Private"}],
+                "all_private_chats:es": [{"command": "private_es", "description": "Private ES"}],
+                "chat:42:": [{"command": "chat", "description": "Chat"}],
+            },
+            {
+                ("chat", ""): "chat",
+                ("chat", "es"): "chat",
+            },
+        ),
+        (
+            "group",
+            {
+                "default:": [{"command": "default", "description": "Default"}],
+                "all_group_chats:": [{"command": "group", "description": "Group"}],
+                "all_chat_administrators:": [{"command": "all_admin", "description": "All admins"}],
+                "chat:42:": [{"command": "chat", "description": "Chat"}],
+                "chat_administrators:42:": [
+                    {"command": "chat_admin", "description": "Chat admins"}
+                ],
+                "chat_member:42:7:es": [{"command": "member_es", "description": "Member ES"}],
+            },
+            {
+                ("chat", ""): "chat",
+                ("chat", "es"): "chat",
+                ("chat_administrators", ""): "chat_admin",
+                ("chat_administrators", "es"): "chat_admin",
+                ("chat_member", "es"): "member_es",
+            },
+        ),
+    ],
+)
+def test_telegram_binding_command_projection_follows_provider_precedence(
+    chat_type: str,
+    shadow: dict[str, list[dict[str, Any]]],
+    expected: dict[tuple[str, str], str],
+):
+    binding = ChannelBinding(
+        external_chat_id="42",
+        external_chat_type=chat_type,
+    )
+
+    projections = telegram_router._telegram_binding_command_projections(shadow, binding)
+    projected = {
+        (payload["scope"]["type"], payload.get("language_code", "")): payload["commands"][3][
+            "command"
+        ]
+        for payload in projections
+    }
+
+    assert projected == expected
+
+
+def test_telegram_physical_commands_enforce_ownership_and_provider_limit():
+    commands = [
+        {"command": "clawdi_pair", "description": "Agent conflict"},
+        {"command": "clawdi", "description": "Agent-owned"},
+        {"command": "clawdi", "description": "Duplicate"},
+    ]
+
+    projected = telegram_router._telegram_physical_commands(commands)
+
+    assert [command["command"] for command in projected] == [
+        "clawdi_pair",
+        "clawdi_unpair",
+        "clawdi_help",
+        "clawdi",
+    ]
+    assert projected[0]["description"] == "Pair this chat with Clawdi."
+    with pytest.raises(ValueError):
+        telegram_router._telegram_physical_commands(
+            [{"command": f"agent_{index}", "description": "Agent command"} for index in range(98)]
+        )
+
+
+@pytest.mark.asyncio
+async def test_telegram_legacy_oversized_shadow_does_not_block_cleanup_or_pair_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    account = ChannelAccount(
+        id=uuid4(),
+        encrypted_provider_token=b"token",
+        provider_token_nonce=b"nonce",
+    )
+    link = ChannelBotAgentLink(
+        id=uuid4(),
+        status=BOT_AGENT_LINK_STATUS_ACTIVE,
+        config={
+            "telegram_agent_commands": {
+                "default:": [
+                    {"command": f"agent_{index}", "description": "Agent command"}
+                    for index in range(98)
+                ]
+            }
+        },
+    )
+    binding = ChannelBinding(
+        id=uuid4(),
+        bot_agent_link_id=link.id,
+        external_chat_id="42",
+        external_chat_type="private",
+    )
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def post_payload(*, account, method, payload):
+        calls.append((method, payload))
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    class FakeSession:
+        async def get(self, model, identity):
+            return link
+
+    monkeypatch.setattr(telegram_router, "_post_telegram_bot_payload", post_payload)
+
+    assert await telegram_router._clear_telegram_commands_for_binding(
+        account=account,
+        link=link,
+        binding=binding,
+    )
+    await telegram_router._replay_telegram_commands_on_pair(
+        FakeSession(),
+        account=account,
+        binding=binding,
+    )
+
+    assert calls == [("deleteMyCommands", {"scope": {"type": "chat", "chat_id": "42"}})]
+    assert "telegram_pair_command_replay_skipped_oversized_projection" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_telegram_set_my_commands_fans_out_to_bound_chats(
     client: httpx.AsyncClient,
@@ -6817,7 +6962,9 @@ async def test_telegram_set_my_commands_fans_out_to_bound_chats(
     } == {
         ("42", "chat"),
         ("-100", "chat_administrators"),
+        ("-100", "chat"),
         ("-200", "chat_administrators"),
+        ("-200", "chat"),
         ("99", "chat"),
     }
     assert all(
@@ -6830,7 +6977,7 @@ async def test_telegram_set_my_commands_fans_out_to_bound_chats(
         _telegram_bot_path(created, "setMyCommands"),
         headers=_telegram_agent_headers(created),
         json={
-            "commands": [{"command": "start", "description": "Start"}],
+            "commands": [{"command": "private", "description": "Private"}],
             "scope": {"type": "all_private_chats"},
         },
     )
@@ -6852,7 +6999,12 @@ async def test_telegram_set_my_commands_fans_out_to_bound_chats(
     assert {
         (call["json"]["scope"]["chat_id"], call["json"]["scope"]["type"])
         for call in _FakeProviderClient.calls
-    } == {("-100", "chat"), ("-200", "chat")}
+    } == {
+        ("-100", "chat"),
+        ("-100", "chat_administrators"),
+        ("-200", "chat"),
+        ("-200", "chat_administrators"),
+    }
 
     _FakeProviderClient.calls = []
     admin_scope = await client.post(
@@ -6869,6 +7021,111 @@ async def test_telegram_set_my_commands_fans_out_to_bound_chats(
         (call["json"]["scope"]["chat_id"], call["json"]["scope"]["type"])
         for call in _FakeProviderClient.calls
     } == {("-100", "chat_administrators"), ("-200", "chat_administrators")}
+
+
+@pytest.mark.asyncio
+async def test_telegram_delete_my_commands_projects_documented_fallback(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-command-delete-fallback",
+        chat_id="42",
+        chat_type="private",
+    )
+    headers = _telegram_agent_headers(created)
+    path = _telegram_bot_path(created, "setMyCommands")
+
+    async def set_commands(command: str, **params: Any) -> None:
+        response = await client.post(
+            path,
+            headers=headers,
+            json={
+                "commands": [{"command": command, "description": command}],
+                **params,
+            },
+        )
+        assert response.status_code == 200
+
+    await set_commands("default")
+    await set_commands("default_es", language_code="es")
+    await set_commands("private_es", scope={"type": "all_private_chats"}, language_code="es")
+    await set_commands("chat", scope={"type": "chat", "chat_id": "42"})
+
+    _clear_fake_provider_calls()
+    deleted_chat = await client.post(
+        _telegram_bot_path(created, "deleteMyCommands"),
+        headers=headers,
+        json={"scope": {"type": "chat", "chat_id": "42"}},
+    )
+
+    assert deleted_chat.status_code == 200
+    projections = {
+        call["json"].get("language_code", ""): call["json"]["commands"][3]["command"]
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/setMyCommands")
+    }
+    assert projections == {"": "default", "es": "private_es"}
+
+    _clear_fake_provider_calls()
+    deleted_private_es = await client.post(
+        _telegram_bot_path(created, "deleteMyCommands"),
+        headers=headers,
+        json={"scope": {"type": "all_private_chats"}, "language_code": "es"},
+    )
+    assert deleted_private_es.status_code == 200
+    es_projection = next(
+        call["json"]
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/setMyCommands") and call["json"].get("language_code") == "es"
+    )
+    assert es_projection["commands"][3]["command"] == "default_es"
+
+    _clear_fake_provider_calls()
+    deleted_default_es = await client.post(
+        _telegram_bot_path(created, "deleteMyCommands"),
+        headers=headers,
+        json={"language_code": "es"},
+    )
+    assert deleted_default_es.status_code == 200
+    assert [
+        call["json"]
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/deleteMyCommands")
+    ] == [{"scope": {"type": "chat", "chat_id": "42"}, "language_code": "es"}]
+
+
+@pytest.mark.asyncio
+async def test_telegram_set_my_commands_rejects_projection_over_provider_limit(
+    client: httpx.AsyncClient,
+):
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-command-provider-limit",
+        chat_id="42",
+        provider_token=None,
+    )
+
+    response = await client.post(
+        _telegram_bot_path(created, "setMyCommands"),
+        headers=_telegram_agent_headers(created),
+        json={
+            "commands": [
+                {"command": f"agent_{index}", "description": "Agent command"} for index in range(98)
+            ]
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["description"] == (
+        "Bad Request: merged command list exceeds 100 commands"
+    )
 
 
 @pytest.mark.asyncio
@@ -6924,11 +7181,13 @@ async def test_telegram_pairing_replays_stored_broad_scope_commands(
     assert paired.status_code == 200
     assert paired.json()["paired"] is True
     command_calls = [
-        call for call in _FakeProviderClient.calls if call["url"].endswith("/setMyCommands")
+        call
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/setMyCommands") and "scope" in call["json"]
     ]
     assert len(command_calls) == 1
     assert command_calls[0]["json"] == {
-        "commands": commands,
+        "commands": [*telegram_router._TELEGRAM_RESERVED_COMMANDS, *commands],
         "scope": {"type": "chat", "chat_id": "777"},
     }
 
@@ -7059,7 +7318,12 @@ async def test_telegram_repair_and_unpair_clear_previous_link_commands(
     ).status_code == 200
     assert [
         call["json"] for call in _FakeProviderClient.calls if call["url"].endswith("/setMyCommands")
-    ] == [{"commands": second_commands, "scope": {"type": "chat", "chat_id": "777"}}]
+    ] == [
+        {
+            "commands": [*telegram_router._TELEGRAM_RESERVED_COMMANDS, *second_commands],
+            "scope": {"type": "chat", "chat_id": "777"},
+        }
+    ]
 
     _reset_fake_provider_client({"ok": True, "result": True})
     unpaired = await client.post(
@@ -7327,7 +7591,10 @@ async def test_telegram_duplicate_authority_fields_are_rejected(
 @pytest.mark.asyncio
 async def test_telegram_multipart_reply_parameters_are_scope_checked(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = await _create_paired_telegram_channel(
         client,
         name="telegram-multipart-scope",
@@ -7509,15 +7776,8 @@ async def test_telegram_failed_outbound_response_does_not_grant_file_reference(
     monkeypatch,
     provider_status: int,
 ):
-    _reset_fake_provider_client(
-        {
-            "ok": False,
-            "error_code": 400,
-            "description": "Bad Request: upload failed",
-            "result": {"document": {"file_id": "failed-upload-file"}},
-        },
-        status_code=provider_status,
-    )
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     monkeypatch.setattr(
         "app.routes.channel_routers.telegram.httpx.AsyncClient",
         _FakeProviderClient,
@@ -7526,6 +7786,15 @@ async def test_telegram_failed_outbound_response_does_not_grant_file_reference(
         client,
         name=f"telegram-failed-upload-ref-{provider_status}",
         chat_id="42",
+    )
+    _reset_fake_provider_client(
+        {
+            "ok": False,
+            "error_code": 400,
+            "description": "Bad Request: upload failed",
+            "result": {"document": {"file_id": "failed-upload-file"}},
+        },
+        status_code=provider_status,
     )
 
     failed = await client.post(
@@ -8717,7 +8986,10 @@ async def test_telegram_materialized_shadow_methods_preserve_provider_error_and_
     provider_payload = _FakeProviderClient.calls[0]["json"]
     assert provider_payload["future_top_level_option"] == payload["future_top_level_option"]
     if method == "setMyCommands":
-        assert provider_payload["commands"][0]["future_command_field"] == "preserved"
+        future_command = next(
+            command for command in provider_payload["commands"] if command["command"] == "future"
+        )
+        assert future_command["future_command_field"] == "preserved"
     else:
         assert provider_payload["menu_button"]["future_menu_field"] == {"enabled": True}
 
@@ -12374,8 +12646,10 @@ async def test_telegram_webhook_pair_code_sends_user_reply(
 
     assert webhook.status_code == 200
     assert webhook.json()["paired"] is True
-    assert _FakeProviderClient.calls[0]["url"].endswith("/bot123456:telegram-secret/sendMessage")
-    assert _FakeProviderClient.calls[0]["json"] == {
+    send_call = next(
+        call for call in _FakeProviderClient.calls if call["url"].endswith("/sendMessage")
+    )
+    assert send_call["json"] == {
         "chat_id": "987654321",
         "message_thread_id": 321,
         "text": "Paired! This chat is now connected to your agent.",
@@ -13920,8 +14194,8 @@ async def test_telegram_webhook_pair_reply_failure_does_not_roll_back_binding(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    _FailingProviderClient.calls = []
-    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FailingProviderClient)
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = (
         await client.post(
             "/v1/channels",
@@ -13938,6 +14212,8 @@ async def test_telegram_webhook_pair_reply_failure_does_not_roll_back_binding(
             json={"ttl_seconds": 900},
         )
     ).json()
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FailingProviderClient)
 
     webhook = await client.post(
         f"/v1/channels/telegram/{created['id']}/webhook",
@@ -19017,6 +19293,7 @@ async def test_channel_delivery_link_lock_contention_does_not_exhaust_attempts(
 @pytest.mark.asyncio
 async def test_telegram_command_sync_uses_set_my_commands(
     client: httpx.AsyncClient,
+    db_session: AsyncSession,
     monkeypatch,
 ):
     _FakeProviderClient.calls = []
@@ -19043,6 +19320,96 @@ async def test_telegram_command_sync_uses_set_my_commands(
         {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
         {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
     ]
+
+    _clear_fake_provider_calls()
+    custom = await client.post(
+        f"/v1/channels/{created['id']}/commands/sync",
+        json={
+            "commands": [
+                {"name": "clawdi_help", "description": "Agent conflict"},
+                {"name": "agent_owned", "description": "Agent command"},
+            ]
+        },
+    )
+    assert custom.status_code == 200
+    assert _FakeProviderClient.calls[0]["json"]["commands"] == [
+        {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
+        {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
+        {"command": "agent_owned", "description": "Agent command"},
+    ]
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    await db_session.refresh(account)
+    assert (
+        account.config["telegram_reserved_command_version"]
+        == channel_service.TELEGRAM_RESERVED_COMMAND_VERSION
+    )
+
+    _clear_fake_provider_calls()
+    oversized = await client.post(
+        f"/v1/channels/{created['id']}/commands/sync",
+        json={
+            "commands": [
+                {"name": f"agent_{index}", "description": "Agent command"} for index in range(98)
+            ]
+        },
+    )
+    assert oversized.status_code == 400
+    assert _FakeProviderClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_pair_code_converges_reserved_default_once_before_issuance(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-reserved-command-convergence",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    _reset_fake_provider_client({"ok": False})
+
+    failed = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+
+    assert failed.status_code == 502
+    assert (
+        await db_session.execute(
+            select(func.count())
+            .select_from(ChannelPairCode)
+            .where(ChannelPairCode.account_id == UUID(created["id"]))
+        )
+    ).scalar_one() == 0
+
+    _reset_fake_provider_client({"ok": True, "result": True})
+    first = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+    assert first.status_code == 201
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["json"]["commands"] == list(
+        telegram_router._TELEGRAM_RESERVED_COMMANDS
+    )
+
+    _clear_fake_provider_calls()
+    second = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+    assert second.status_code == 201
+    assert _FakeProviderClient.calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1307,6 +1307,7 @@ async def test_channel_control_plane_actions_write_redacted_audit_events(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
+    monkeypatch,
 ):
     provider_token = "123456:telegram-secret"
     extra_secret = "channel-extra-secret"
@@ -1329,10 +1330,13 @@ async def test_channel_control_plane_actions_write_redacted_audit_events(
     assert rotated_response.status_code == 200, rotated_response.text
     rotated_agent_token = rotated_response.json()["agent_token"]
 
-    pair_response = await client.post(
-        f"/v1/channels/{created['id']}/pair-codes",
-        json={"agent_link_id": created["agent_link_id"], "ttl_seconds": 900},
-    )
+    _reset_fake_provider_client({"ok": True, "result": True})
+    with monkeypatch.context() as provider_mock:
+        provider_mock.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+        pair_response = await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": created["agent_link_id"], "ttl_seconds": 900},
+        )
     assert pair_response.status_code == 201, pair_response.text
     pair_code = pair_response.json()["code"]
 
@@ -3627,7 +3631,13 @@ async def test_public_bot_account_is_admin_managed_even_for_seed_owner(
     assert link.json()["agent_id"] == str(channel_agent.id)
     assert pair.status_code == 201
     assert pair.json()["agent_id"] == str(channel_agent.id)
-    assert _FakeProviderClient.calls == []
+    assert len(_FakeProviderClient.calls) == 1
+    assert _FakeProviderClient.calls[0]["url"].endswith("/bot123456:telegram-secret/setMyCommands")
+    assert _FakeProviderClient.calls[0]["json"]["commands"] == [
+        {"command": "clawdi_pair", "description": "Pair this chat with Clawdi."},
+        {"command": "clawdi_unpair", "description": "Disconnect this chat from Clawdi."},
+        {"command": "clawdi_help", "description": "Show safe Clawdi pairing instructions."},
+    ]
     account = (
         await db_session.execute(
             select(ChannelAccount).where(ChannelAccount.id == UUID(account_id))
@@ -4309,15 +4319,18 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
     channel = created.json()
     account_id = UUID(channel["id"])
     webhook_secret = channel["webhook_secret"]
+    _reset_fake_provider_client({"ok": True, "result": True})
 
     user_a, agent_a = await _create_user_with_channel_agent(db_session, label="pair-owner-a")
     user_b, agent_b = await _create_user_with_channel_agent(db_session, label="pair-owner-b")
 
     async with _client_for_user(db_session, user_a) as client_a:
-        pair_a = await client_a.post(
-            f"/v1/channels/{account_id}/pair-codes",
-            json={"agent_id": str(agent_a.id), "ttl_seconds": 900},
-        )
+        with monkeypatch.context() as provider_mock:
+            provider_mock.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+            pair_a = await client_a.post(
+                f"/v1/channels/{account_id}/pair-codes",
+                json={"agent_id": str(agent_a.id), "ttl_seconds": 900},
+            )
         pair_a_again = await client_a.post(
             f"/v1/channels/{account_id}/pair-codes",
             json={"agent_id": str(agent_a.id), "ttl_seconds": 900},
@@ -18334,6 +18347,7 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     channel_agent,
+    monkeypatch,
 ):
     shared_chat_id = "15550001111@s.whatsapp.net"
     channel_specs = [
@@ -18380,6 +18394,8 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
         created=created_by_provider["whatsapp"],
         agent=channel_agent,
     )
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     pair_codes = {
         provider: (
             await client.post(
@@ -18468,7 +18484,7 @@ async def test_same_external_chat_id_is_isolated_across_channel_providers(
 
 
 @pytest.mark.asyncio
-async def test_send_channel_message_uses_binding(client: httpx.AsyncClient):
+async def test_send_channel_message_uses_binding(client: httpx.AsyncClient, monkeypatch):
     created = (
         await client.post(
             "/v1/channels",
@@ -18479,6 +18495,8 @@ async def test_send_channel_message_uses_binding(client: httpx.AsyncClient):
             },
         )
     ).json()
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     pair = (
         await client.post(
             f"/v1/channels/{created['id']}/pair-codes",


### PR DESCRIPTION
## Summary

- keep Clawdi control commands in every physical Telegram projection while preserving per-Link agent command shadows
- reconcile Telegram scope and language precedence deterministically across set, delete, pair, re-pair, unpair, and unlink
- converge account-global reserved commands before pair-code issuance and preserve them during custom account command sync
- handle the 100-command provider limit and legacy oversized shadows without blocking cleanup
- audit Discord command ownership/lifecycle; no Discord changes were required

## Verification

- Docker focused lifecycle/ownership tests: 12 passed
- Agent full Telegram selection: 106 passed
- Ruff check and format check passed
- git diff --check passed

## Production

- No production operations are included in this PR
- Kingsley was recovered separately with a one-off command projection; this PR provides the durable product fix