### PR TITLE
fix(whatsapp): run Baileys sidecar on Node

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -257,7 +257,7 @@ jobs:
           ready=false
           for _attempt in $(seq 1 30); do
             if kamal accessory exec whatsapp-baileys --reuse \
-              "bun run /app/packages/whatsapp-baileys-sidecar/src/healthcheck.ts" \
+              "node /app/packages/whatsapp-baileys-sidecar/dist/healthcheck.js" \
               >/dev/null 2>&1; then
               ready=true
               break

--- a/bun.lock
+++ b/bun.lock
@@ -107,17 +107,14 @@
     "packages/whatsapp-baileys-sidecar": {
       "name": "@clawdi/whatsapp-baileys-sidecar",
       "version": "0.1.0",
-      "bin": {
-        "clawdi-whatsapp-baileys-sidecar": "src/index.ts",
-      },
       "dependencies": {
         "baileys": "npm:@whiskeysockets/baileys@7.0.0-rc14",
         "pino": "^10.3.1",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.13",
         "@types/node": "^22.20.0",
         "typescript": "catalog:",
+        "vitest": "4.1.10",
       },
     },
   },
@@ -857,7 +854,11 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -939,6 +940,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
@@ -979,6 +994,8 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "assign-symbols": ["assign-symbols@1.0.0", "", {}, "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
@@ -1009,6 +1026,8 @@
 
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
 
+    "better-sqlite3": ["better-sqlite3@13.0.2", "", { "dependencies": { "node-addon-api": "^8.0.0" } }, "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g=="],
+
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
@@ -1036,6 +1055,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1234,6 +1255,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -1749,6 +1772,8 @@
 
     "nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
+    "node-addon-api": ["node-addon-api@8.9.1", "", {}, "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
@@ -1768,6 +1793,8 @@
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "ocache": ["ocache@0.1.5", "", { "dependencies": { "ohash": "^2.0.11" } }, "sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w=="],
 
@@ -2085,6 +2112,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -2107,11 +2136,13 @@
 
     "srvx": ["srvx@0.11.17", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -2159,7 +2190,13 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -2263,6 +2300,8 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "web": ["web@workspace:apps/web"],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
@@ -2278,6 +2317,8 @@
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
@@ -2457,6 +2498,10 @@
 
     "@tanstack/start-plugin-core/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "@vitest/expect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "baileys/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
@@ -2576,6 +2621,8 @@
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@clerk/themes/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "@clerk/themes/@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -126,7 +126,7 @@ describe("clean runner suite contract", () => {
 		});
 		expect(sidecarScripts).toMatchObject({
 			test: "../../scripts/test.sh sidecar",
-			"test:internal": "bun test",
+			"test:internal": "vitest run",
 		});
 		expect(cliScripts["test:native-linux-lifecycle:internal"]).toContain(
 			"native-installer.e2e.test.ts",

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -28,7 +28,7 @@ describe("WhatsApp sidecar production deployment contract", () => {
 
 	test("health-checks the singleton before deploying the backend", () => {
 		const reboot = workflow.indexOf("kamal accessory reboot whatsapp-baileys");
-		const health = workflow.indexOf("src/healthcheck.ts", reboot);
+		const health = workflow.indexOf("dist/healthcheck.js", reboot);
 		const appDeploy = workflow.indexOf(
 			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
 		);
@@ -57,10 +57,14 @@ describe("WhatsApp sidecar production deployment contract", () => {
 		expect(deploy).toContain("security-opt: no-new-privileges:true");
 	});
 
-	test("builds a non-root bounded image from the repository Bun toolchain", () => {
+	test("builds with the repository toolchain and runs on non-root Node", () => {
 		expect(dockerfile).toContain("FROM oven/bun:1.3.14-alpine");
 		expect(dockerfile).toContain("bun install --frozen-lockfile --production");
-		expect(dockerfile).toContain("USER bun:bun");
+		expect(dockerfile).toContain("FROM node:24.18.0-alpine AS runtime");
+		expect(dockerfile).toContain("USER node:node");
+		expect(dockerfile).toContain(
+			'CMD ["node", "/app/packages/whatsapp-baileys-sidecar/dist/index.js"]',
+		);
 		expect(dockerfile).toContain("HEALTHCHECK");
 		expect(dockerfile).not.toContain("latest");
 	});

--- a/packages/whatsapp-baileys-sidecar/Dockerfile
+++ b/packages/whatsapp-baileys-sidecar/Dockerfile
@@ -10,23 +10,37 @@ COPY packages/shared/package.json packages/shared/package.json
 COPY packages/whatsapp-baileys-sidecar/package.json packages/whatsapp-baileys-sidecar/package.json
 RUN bun install --frozen-lockfile --production --filter @clawdi/whatsapp-baileys-sidecar
 
-FROM oven/bun:1.3.14-alpine AS runtime
+FROM oven/bun:1.3.14-alpine AS build
+
+WORKDIR /app
+COPY package.json bun.lock tsconfig.base.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/whatsapp-baileys-sidecar/package.json packages/whatsapp-baileys-sidecar/package.json
+RUN bun install --frozen-lockfile --filter @clawdi/whatsapp-baileys-sidecar
+COPY packages/whatsapp-baileys-sidecar/tsconfig.json packages/whatsapp-baileys-sidecar/tsconfig.json
+COPY packages/whatsapp-baileys-sidecar/tsconfig.build.json packages/whatsapp-baileys-sidecar/tsconfig.build.json
+COPY packages/whatsapp-baileys-sidecar/src packages/whatsapp-baileys-sidecar/src
+RUN bun run --cwd packages/whatsapp-baileys-sidecar build
+
+FROM node:24.18.0-alpine AS runtime
 
 RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
-COPY --from=dependencies --chown=bun:bun /app/node_modules ./node_modules
-COPY --from=dependencies --chown=bun:bun /app/packages/whatsapp-baileys-sidecar/node_modules ./packages/whatsapp-baileys-sidecar/node_modules
-COPY --chown=bun:bun packages/whatsapp-baileys-sidecar/package.json packages/whatsapp-baileys-sidecar/package.json
-COPY --chown=bun:bun packages/whatsapp-baileys-sidecar/src packages/whatsapp-baileys-sidecar/src
+COPY --from=dependencies --chown=node:node /app/node_modules ./node_modules
+COPY --from=dependencies --chown=node:node /app/packages/whatsapp-baileys-sidecar/node_modules ./packages/whatsapp-baileys-sidecar/node_modules
+COPY --chown=node:node packages/whatsapp-baileys-sidecar/package.json packages/whatsapp-baileys-sidecar/package.json
+COPY --from=build --chown=node:node /app/packages/whatsapp-baileys-sidecar/dist packages/whatsapp-baileys-sidecar/dist
 
 RUN chmod -R a-w /app
 
-USER bun:bun
+USER node:node
 
 LABEL service="clawdi-whatsapp-baileys-sidecar"
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 \
-  CMD ["bun", "run", "/app/packages/whatsapp-baileys-sidecar/src/healthcheck.ts"]
+	CMD ["node", "/app/packages/whatsapp-baileys-sidecar/dist/healthcheck.js"]
 
-CMD ["bun", "run", "/app/packages/whatsapp-baileys-sidecar/src/index.ts"]
+CMD ["node", "/app/packages/whatsapp-baileys-sidecar/dist/index.js"]

--- a/packages/whatsapp-baileys-sidecar/package.json
+++ b/packages/whatsapp-baileys-sidecar/package.json
@@ -3,23 +3,20 @@
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",
-	"bin": {
-		"clawdi-whatsapp-baileys-sidecar": "src/index.ts"
-	},
 	"scripts": {
-		"dev": "bun run src/index.ts",
-		"start": "bun run src/index.ts",
+		"build": "tsc -p tsconfig.build.json",
+		"start": "node dist/index.js",
 		"typecheck": "tsc --noEmit",
 		"test": "../../scripts/test.sh sidecar",
-		"test:internal": "bun test"
+		"test:internal": "vitest run"
 	},
 	"dependencies": {
 		"baileys": "npm:@whiskeysockets/baileys@7.0.0-rc14",
 		"pino": "^10.3.1"
 	},
 	"devDependencies": {
-		"@types/bun": "^1.3.13",
 		"@types/node": "^22.20.0",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"vitest": "4.1.10"
 	}
 }

--- a/packages/whatsapp-baileys-sidecar/src/config.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/config.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 
 import { loadConfigFromEnv } from "./config.js";
 

--- a/packages/whatsapp-baileys-sidecar/src/graceful-shutdown.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/graceful-shutdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 
 import { createSharedShutdown } from "./graceful-shutdown.js";
 

--- a/packages/whatsapp-baileys-sidecar/src/healthcheck.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/healthcheck.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { checkSidecarHealth } from "./healthcheck.js";
 

--- a/packages/whatsapp-baileys-sidecar/src/json-bytes.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/json-bytes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 
 import { decodeJsonBytes, encodeJsonBytes, parseBinaryNode } from "./json-bytes.js";
 

--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "bun:test";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type BinaryNode, DisconnectReason, initAuthCreds, proto } from "baileys";
+import { describe, expect, it } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
 import type { SidecarSessionConfig } from "./config.js";
@@ -33,14 +33,18 @@ describe("physical Baileys runtime", () => {
 			method: "qr",
 			qr: "sensitive-qr-value",
 		});
-		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeWithin(59_000, 61_000);
+		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeGreaterThanOrEqual(59_000);
+		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeLessThanOrEqual(61_000);
 		expect(harness.socketConfigurations).toHaveLength(1);
 
 		const rotatedQrObservedAt = Date.now();
 		harness.events.emit("connection.update", { qr: "sensitive-qr-value-rotated" });
 		const rotated = runtime.pairingStatus();
 		expect(rotated).toMatchObject({ qr: "sensitive-qr-value-rotated" });
-		expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeWithin(19_000, 21_000);
+		expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeGreaterThanOrEqual(
+			19_000,
+		);
+		expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeLessThanOrEqual(21_000);
 		expect(Date.parse(rotated.qrExpiresAt ?? "")).toBeLessThan(Date.parse(ready.qrExpiresAt ?? ""));
 
 		harness.events.emit("creds.update", { registered: true });

--- a/packages/whatsapp-baileys-sidecar/src/server.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from "bun:test";
 import type { AddressInfo } from "node:net";
 import type { BinaryNode } from "baileys";
+import { afterEach, describe, expect, it } from "vitest";
 import { AUDITED_PROVIDER_RELEASE } from "./audited-version.js";
 import { createSidecarServer, type SidecarSessionService } from "./server.js";
 import type { ProviderMessageEvent } from "./sqlite-state.js";

--- a/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
 import type { SidecarSessionConfig } from "./config.js";

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-database.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-database.ts
@@ -1,0 +1,58 @@
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+
+type Statement<TRow, TParams extends SQLInputValue[]> = {
+	all: (...params: TParams) => TRow[];
+	get: (...params: TParams) => TRow | null;
+	run: (...params: TParams) => void;
+};
+
+export class Database {
+	private readonly database: DatabaseSync;
+
+	constructor(path: string) {
+		this.database = new DatabaseSync(path, {
+			allowExtension: false,
+			enableDoubleQuotedStringLiterals: false,
+			timeout: 0,
+		});
+	}
+
+	query<TRow = Record<string, unknown>, TParams extends SQLInputValue[] = SQLInputValue[]>(
+		sql: string,
+	): Statement<TRow, TParams> {
+		const statement = this.database.prepare(sql);
+		return {
+			all: (...params) => statement.all(...params) as TRow[],
+			get: (...params) => (statement.get(...params) as TRow | undefined) ?? null,
+			run: (...params) => {
+				statement.run(...params);
+			},
+		};
+	}
+
+	run(sql: string, params: readonly SQLInputValue[] = []): void {
+		this.database.prepare(sql).run(...params);
+	}
+
+	exec(sql: string): void {
+		this.database.exec(sql);
+	}
+
+	transaction<T>(operation: () => T): () => T {
+		return () => {
+			this.database.exec("BEGIN");
+			try {
+				const result = operation();
+				this.database.exec("COMMIT");
+				return result;
+			} catch (error: unknown) {
+				this.database.exec("ROLLBACK");
+				throw error;
+			}
+		};
+	}
+
+	close(): void {
+		this.database.close();
+	}
+}

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
@@ -1,5 +1,3 @@
-import { Database } from "bun:sqlite";
-import { afterEach, describe, expect, it } from "bun:test";
 import {
 	chmodSync,
 	mkdtempSync,
@@ -12,8 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { proto } from "baileys";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
+import { Database } from "./sqlite-database.js";
 import {
 	ProviderInboxCapacityError,
 	type ProviderMessageEventInput,
@@ -30,7 +30,7 @@ const temporaryDirectories: string[] = [];
 afterEach(() => {
 	for (const directory of temporaryDirectories.splice(0)) {
 		try {
-			const database = new Database(join(directory, "provider-state.sqlite"), { strict: true });
+			const database = new Database(join(directory, "provider-state.sqlite"));
 			database.close();
 		} catch {
 			// The database may not exist or may intentionally be corrupt.
@@ -180,7 +180,7 @@ describe("SQLite provider state", () => {
 		expect(first.providerEvents(100)).toEqual([]);
 		first.close();
 		first = undefined;
-		Bun.gc(true);
+		globalThis.gc?.();
 
 		const second = makeState(directory);
 		expect(second.state.creds.registered).toBe(false);
@@ -446,7 +446,7 @@ function internalDatabase(state: SQLiteProviderState): Database {
 }
 
 function mutateDatabase(directory: string, action: (database: Database) => void): void {
-	const database = new Database(join(directory, "provider-state.sqlite"), { strict: true });
+	const database = new Database(join(directory, "provider-state.sqlite"));
 	try {
 		action(database);
 	} finally {

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
@@ -1,4 +1,3 @@
-import { Database } from "bun:sqlite";
 import { chmodSync, existsSync, lstatSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
@@ -15,6 +14,7 @@ import {
 
 import { AUDITED_BAILEYS_RELEASE, AUDITED_WHATSAPP_WEB_VERSION_TEXT } from "./audited-version.js";
 import { assertOwnedDirectory } from "./filesystem-security.js";
+import { Database } from "./sqlite-database.js";
 
 export type ProviderMessageEvent = {
 	sequence: number;
@@ -115,7 +115,7 @@ export class SQLiteProviderState {
 		secureStateFiles(sessionDir);
 		this.databasePath = join(sessionDir, STATE_DATABASE_FILE);
 		const databaseExisted = existsSync(this.databasePath);
-		const db = new Database(this.databasePath, { create: true, strict: true });
+		const db = new Database(this.databasePath);
 		try {
 			chmodSync(this.databasePath, 0o600);
 			configureDatabase(db);
@@ -641,11 +641,9 @@ function validateOrBindMetadata(
 	const currentProvenance = [AUDITED_BAILEYS_RELEASE, input.webVersion.join(".")] as const;
 	if (!input.databaseExisted) {
 		const insert = db.query("INSERT INTO provider_metadata (key, value) VALUES (?, ?)");
-		db.transaction(() => {
-			for (const [key, value] of expectedIdentity) insert.run(key, value);
-			insert.run("baileys_release", currentProvenance[0]);
-			insert.run("whatsapp_web_version", currentProvenance[1]);
-		})();
+		for (const [key, value] of expectedIdentity) insert.run(key, value);
+		insert.run("baileys_release", currentProvenance[0]);
+		insert.run("whatsapp_web_version", currentProvenance[1]);
 		return;
 	}
 	const rows = db

--- a/packages/whatsapp-baileys-sidecar/tsconfig.build.json
+++ b/packages/whatsapp-baileys-sidecar/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"allowImportingTsExtensions": false,
+		"declaration": false,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"noEmit": false,
+		"sourceMap": false,
+		"types": ["node"]
+	},
+	"exclude": ["src/**/*.test.ts"]
+}

--- a/packages/whatsapp-baileys-sidecar/tsconfig.json
+++ b/packages/whatsapp-baileys-sidecar/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "dist",
 		"rootDir": "src",
-		"types": ["bun", "node"]
+		"types": ["node"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
## Summary

- run the production Baileys sidecar on Node 24, matching Baileys supported runtime and complete ws event contract
- replace Bun SQLite with the Node standard library node:sqlite while preserving the existing schema, WAL/exclusive locking, durability, and singleton multi-session API
- compile the sidecar for the runtime image and use Node for container and Kamal health checks
- move the existing sidecar tests to a Node-compatible runner without adding new test cases

## Root cause

Production Bun logs reported that ws WebSocket upgrade and unexpected-response events are not implemented. Baileys rc14 explicitly subscribes to both events and declares Node >=20. QR generation succeeded, but two independent phones could not complete linked-device registration.

## Verification

- sidecar typecheck
- 59/59 existing sidecar tests under Node-compatible Vitest
- repository Biome check
- isolated scripts/test.sh sidecar
- deployment contract 4/4
- production image build
- read-only non-root 1000:1000 container smoke
- authenticated UDS health check
- node:sqlite runtime load
- no Bun WebSocket warnings

No frontend, API, schema, session layout, account ownership, or activation-gate changes.