### PR TITLE
fix(web): keep hosted sessions lifecycle-independent

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -198,7 +198,7 @@ describe("deployment failure status rendering", () => {
 			{ status: "restarting", copy: "Restarting", spinner: true },
 			{
 				status: "stopped",
-				copy: "Compute is stopped. Sessions, channels, and the agent interface are unavailable.",
+				copy: "Compute is stopped. Channels and the agent interface are unavailable.",
 				spinner: false,
 			},
 			{
@@ -354,7 +354,7 @@ describe("deployment transition timeout rendering", () => {
 		expect(shouldShowProjectionNotice("terminal")).toBe(false);
 		expect(shouldShowProjectionNotice("ai")).toBe(false);
 		expect(shouldShowProjectionNotice("settings")).toBe(false);
-		expect(shouldShowProjectionNotice("sessions")).toBe(true);
+		expect(shouldShowProjectionNotice("sessions")).toBe(false);
 		expect(shouldShowProjectionNotice("skills")).toBe(true);
 	});
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -46,6 +46,9 @@ describe("hosted agent detail header", () => {
 		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
 
 		expect(source).toContain(
+			"Projects, Skills, Vaults, and Channels will appear when this agent is ready.",
+		);
+		expect(source).not.toContain(
 			"Sessions, Projects, Skills, Vaults, and Channels will appear when this agent is ready.",
 		);
 		expect(source).not.toContain("Vaults, profile, and channels");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -106,7 +106,11 @@ import {
 	useResetRuntimeUiAccess,
 	useUpdateDeployment,
 } from "@/hosted/agents/deployment-hooks";
-import { HOSTED_AGENT_SESSIONS_REFRESH_POLICY } from "@/hosted/agents/hosted-agent-session-query";
+import {
+	canQueryHostedAgentSessions,
+	HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE,
+	HOSTED_AGENT_SESSIONS_REFRESH_POLICY,
+} from "@/hosted/agents/hosted-agent-session-query";
 import {
 	HostedTerminalPanel,
 	type HostedTerminalStatus,
@@ -317,9 +321,7 @@ function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgent
 
 /** Only surfaces whose primary content needs the cloud-agent projection own its notice. */
 export function shouldShowHostedProjectionNotice(section: AgentSectionId): boolean {
-	return (
-		section === "sessions" || section === "projects" || section === "skills" || section === "vaults"
-	);
+	return section === "projects" || section === "skills" || section === "vaults";
 }
 
 function LiveNote({ children }: { children: React.ReactNode }) {
@@ -439,10 +441,10 @@ export function HostedAgentDetail({
 	const $api = useOpenApi();
 	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
-	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const hasTerminalDeploymentFailure = deploymentFailurePresentation(deployment) !== null;
 	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
 	const cloudEnvironmentId = isCloudEnvId(environmentId);
+	const sessionsQueryable = canQueryHostedAgentSessions(environmentId);
 	const agentQuery = $api.useQuery(
 		"get",
 		"/v1/agents/{agent_id}",
@@ -496,7 +498,7 @@ export function HostedAgentDetail({
 
 	const sessions = useQuery({
 		...sessionListQueryOptions($api, { environment_id: environmentId, page_size: 3 }),
-		enabled: activeTab === "overview" && deploymentRunning && projection.status === "resolved",
+		enabled: activeTab === "overview" && sessionsQueryable,
 	});
 
 	const activeNavItem = AGENT_SECTION_NAVIGATION_ITEMS[activeTab];
@@ -506,7 +508,7 @@ export function HostedAgentDetail({
 		activeTab === "overview" &&
 		isStartingStatus(deploymentStatus) &&
 		!hasTerminalDeploymentFailure &&
-		projection.status !== "resolved";
+		!cloudEnvironmentId;
 	const interfaceAvailable =
 		activeTab === "overview" && !showInitialStartingPage && isRunningStatus(deploymentStatus);
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
@@ -579,8 +581,6 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							projectionStatus={projection.status}
-							canRetryProjection={deploymentProjectionQueryable}
-							onRetryProjection={() => void agentQuery.refetch()}
 							isPerformance={isPerformance}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
@@ -605,18 +605,8 @@ export function HostedAgentDetail({
 					{deploymentStatus.known && activeTab === "terminal" ? (
 						<TerminalTab deployment={deployment} />
 					) : null}
-					{deploymentStatus.known && activeTab === "sessions" ? (
-						!deploymentProjectionQueryable ? (
-							<StoppedAgentState deployment={deployment} />
-						) : projection.status === "resolved" ? (
-							<HostedAgentSessionsTab
-								environmentId={environmentId}
-								enabled={deploymentProjectionQueryable}
-								routeSearch={routeSearch}
-							/>
-						) : (
-							<ProjectionDependentUnavailable label="Sessions" />
-						)
+					{activeTab === "sessions" ? (
+						<HostedAgentSessionsTab environmentId={environmentId} routeSearch={routeSearch} />
 					) : null}
 					{activeTab === "memories" ? <MemoriesSurface /> : null}
 					{activeTab === "connectors" ? <ConnectorsSurface embedded /> : null}
@@ -709,8 +699,8 @@ function HostedProjectionNotice({
 				<AlertTitle>Some agent details are not ready</AlertTitle>
 				<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 					<span>
-						Sessions, Projects, Skills, Vaults, and Channels will appear when this agent is ready.
-						Available actions and tools still work.
+						Projects, Skills, Vaults, and Channels will appear when this agent is ready. Available
+						actions and tools still work.
 					</span>
 					<Button type="button" variant="outline" size="sm" disabled={isChecking} onClick={onRetry}>
 						{isChecking ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
@@ -770,16 +760,15 @@ function StoppedAgentState({
 
 function HostedAgentSessionsTab({
 	environmentId,
-	enabled,
 	routeSearch,
 }: {
 	environmentId: string;
-	enabled: boolean;
 	routeSearch: AgentRouteSearch;
 }) {
 	const $api = useOpenApi();
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(20);
+	const sessionsQueryable = canQueryHostedAgentSessions(environmentId);
 
 	useEffect(() => {
 		setPage(1);
@@ -787,7 +776,7 @@ function HostedAgentSessionsTab({
 
 	const sessions = useQuery({
 		...sessionListQueryOptions($api, { environment_id: environmentId, page, page_size: pageSize }),
-		enabled: enabled && isCloudEnvId(environmentId),
+		enabled: sessionsQueryable,
 		placeholderData: keepPreviousData,
 		// staleTime only controls freshness; this mounted-tab observer owns visibility refreshes.
 		...HOSTED_AGENT_SESSIONS_REFRESH_POLICY,
@@ -809,12 +798,21 @@ function HostedAgentSessionsTab({
 		);
 	}
 
+	if (!sessionsQueryable) {
+		return (
+			<EmptyState
+				title="Sessions unavailable"
+				description="Sessions will appear after this agent is created."
+			/>
+		);
+	}
+
 	return (
 		<div className="space-y-4">
 			<SessionFeed
 				sessions={sessions.data?.items ?? []}
 				isLoading={sessions.isLoading && !sessions.data}
-				emptyMessage="No sessions from this agent yet."
+				emptyMessage={HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE}
 				showAgent={false}
 				sessionLink={(session) => agentSessionDetailLink(environmentId, session.id, routeSearch)}
 			/>
@@ -884,7 +882,7 @@ export function OverviewComputeStatus({
 				</p>
 			) : status.kind === "stopped" ? (
 				<p className="text-muted-foreground" role="status">
-					Compute is stopped. Sessions, channels, and the agent interface are unavailable.
+					Compute is stopped. Channels and the agent interface are unavailable.
 				</p>
 			) : status.kind === "deleting" ? (
 				<p className="text-muted-foreground" role="status">
@@ -1064,33 +1062,12 @@ export function InitialDeploymentPage({
 	);
 }
 
-function OverviewProjectionUnavailableState({
-	canRetry,
-	onRetry,
-}: {
-	canRetry: boolean;
-	onRetry: () => void;
-}) {
-	return (
-		<div className="flex h-full min-h-40 flex-col items-start justify-center gap-3 rounded-lg border bg-muted/20 p-4">
-			<p className="text-sm text-muted-foreground">Agent details are unavailable right now.</p>
-			{canRetry ? (
-				<Button type="button" variant="outline" size="sm" onClick={onRetry}>
-					<RefreshCw /> Check again
-				</Button>
-			) : null}
-		</div>
-	);
-}
-
 function OverviewTab({
 	agentId,
 	routeSearch,
 	deployment,
 	agent,
 	projectionStatus,
-	canRetryProjection,
-	onRetryProjection,
 	isPerformance,
 	sessions,
 	sessionsLoading,
@@ -1104,8 +1081,6 @@ function OverviewTab({
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	projectionStatus: HostedProjectionResolution<unknown>["status"];
-	canRetryProjection: boolean;
-	onRetryProjection: () => void;
 	isPerformance: boolean;
 	sessions: SessionListItem[];
 	sessionsLoading: boolean;
@@ -1143,10 +1118,6 @@ function OverviewTab({
 		label: runtimeStatusPresentation.label,
 		tone: runtimeStatusPresentation.tone,
 	};
-	const deploymentRunning = isRunningStatus(deploymentStatus);
-	const sessionsEmptyMessage = deploymentRunning
-		? "No sessions from this agent yet."
-		: "Sessions appear once your agent is running.";
 	const projectBindings = useAgentProjectBindings(agentId, { enabled: Boolean(agent) });
 	const skills = useAgentProjectSkills(
 		agentId,
@@ -1190,18 +1161,13 @@ function OverviewTab({
 						</Button>
 					</div>
 					<section aria-labelledby="hosted-recent-sessions" className="min-w-0">
-						{projectionUnavailable ? (
-							<OverviewProjectionUnavailableState
-								canRetry={canRetryProjection}
-								onRetry={onRetryProjection}
-							/>
-						) : sessionsError ? (
+						{sessionsError ? (
 							<OverviewModuleError label="Sessions" onRetry={() => void onRetrySessions()} />
 						) : (
 							<OverviewSessionList
 								sessions={sessions}
-								isLoading={projectionLoading || sessionsLoading}
-								emptyMessage={sessionsEmptyMessage}
+								isLoading={sessionsLoading}
+								emptyMessage={HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE}
 								sessionLink={sessionLink}
 							/>
 						)}

--- a/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
@@ -8,6 +8,8 @@ import {
 } from "@tanstack/react-query";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
+	canQueryHostedAgentSessions,
+	HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE,
 	HOSTED_AGENT_SESSIONS_REFETCH_INTERVAL_MS,
 	HOSTED_AGENT_SESSIONS_REFRESH_POLICY,
 } from "./hosted-agent-session-query";
@@ -19,6 +21,12 @@ const sharedSessionQuerySource = readFileSync(
 );
 
 describe("hosted agent sessions refresh", () => {
+	test("uses the stable environment identity as the only backend query prerequisite", () => {
+		expect(canQueryHostedAgentSessions("4f4f8630-5a38-4d31-89ad-2e5451f6ba8f")).toBe(true);
+		expect(canQueryHostedAgentSessions("hdep_starting")).toBe(false);
+		expect(canQueryHostedAgentSessions("")).toBe(false);
+	});
+
 	test("preserves successful data and stays non-blocking after a refetch error", async () => {
 		const error = new Error("background refresh failed");
 		const cachedData = { items: [{ id: "session-1" }], total: 1 };
@@ -122,11 +130,9 @@ describe("hosted agent sessions refresh", () => {
 	});
 
 	test("mounts the polling query only in the active Sessions branch", () => {
-		const sessionsBranchStart = detailSource.indexOf(
-			'{deploymentStatus.known && activeTab === "sessions" ? (',
-		);
+		const sessionsBranchStart = detailSource.indexOf('{activeTab === "sessions" ? (');
 		const sessionsBranchEnd = detailSource.indexOf(
-			'{activeTab === "skills" ? (',
+			'{activeTab === "memories" ?',
 			sessionsBranchStart,
 		);
 		const sessionsBranch = detailSource.slice(sessionsBranchStart, sessionsBranchEnd);
@@ -134,6 +140,62 @@ describe("hosted agent sessions refresh", () => {
 		expect(sessionsBranchStart).toBeGreaterThan(-1);
 		expect(sessionsBranchEnd).toBeGreaterThan(sessionsBranchStart);
 		expect(sessionsBranch).toContain("<HostedAgentSessionsTab");
+		expect(sessionsBranch).not.toContain("deploymentStatus");
+		expect(sessionsBranch).not.toContain("deploymentProjectionQueryable");
+		expect(sessionsBranch).not.toContain("projection.status");
+		expect(sessionsBranch).not.toContain("StoppedAgentState");
+		expect(sessionsBranch).not.toContain("ProjectionDependentUnavailable");
 		expect(detailSource.match(/<HostedAgentSessionsTab/g) ?? []).toHaveLength(1);
+	});
+
+	test("keeps the Sessions tab query and copy independent of runtime lifecycle", () => {
+		const componentStart = detailSource.indexOf("function HostedAgentSessionsTab(");
+		const componentEnd = detailSource.indexOf("\nfunction ", componentStart + 1);
+		const componentSource = detailSource.slice(componentStart, componentEnd);
+
+		expect(componentSource).toContain(
+			"const sessionsQueryable = canQueryHostedAgentSessions(environmentId);",
+		);
+		expect(componentSource).toContain("enabled: sessionsQueryable");
+		expect(componentSource).not.toContain("DeploymentStatus");
+		expect(componentSource).not.toContain("projection");
+		expect(componentSource).toContain("emptyMessage={HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE}");
+		expect(componentSource).toContain("Sessions will appear after this agent is created.");
+		expect(HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE).toBe("No sessions from this agent yet.");
+	});
+
+	test("keeps Overview sessions visible during starting, updating, stopped, and failed states", () => {
+		const detailStart = detailSource.indexOf("export function HostedAgentDetail(");
+		const sessionsQueryStart = detailSource.indexOf("const sessions = useQuery({", detailStart);
+		const sessionsQueryEnd = detailSource.indexOf("\n\t});", sessionsQueryStart) + "\n\t});".length;
+		const sessionsQuerySource = detailSource.slice(sessionsQueryStart, sessionsQueryEnd);
+		const initialPageStart = detailSource.indexOf("const showInitialStartingPage", detailStart);
+		const initialPageEnd = detailSource.indexOf("const interfaceAvailable", initialPageStart);
+		const initialPageSource = detailSource.slice(initialPageStart, initialPageEnd);
+		const overviewStart = detailSource.indexOf("function OverviewTab(");
+		const recentSessionsStart = detailSource.indexOf(
+			'<h2 id="hosted-recent-sessions"',
+			overviewStart,
+		);
+		const recentSessionsEnd = detailSource.indexOf(
+			'<div className="@3xl/main:row-start-2">',
+			recentSessionsStart,
+		);
+		const recentSessionsSource = detailSource.slice(recentSessionsStart, recentSessionsEnd);
+
+		expect(sessionsQueryStart).toBeGreaterThan(detailStart);
+		expect(sessionsQueryEnd).toBeGreaterThan(sessionsQueryStart);
+		expect(sessionsQuerySource).toContain('enabled: activeTab === "overview" && sessionsQueryable');
+		expect(sessionsQuerySource).not.toContain("deploymentStatus");
+		expect(sessionsQuerySource).not.toContain("projection.status");
+		expect(initialPageSource).toContain("!cloudEnvironmentId");
+		expect(initialPageSource).not.toContain('projection.status !== "resolved"');
+		expect(recentSessionsStart).toBeGreaterThan(overviewStart);
+		expect(recentSessionsEnd).toBeGreaterThan(recentSessionsStart);
+		expect(recentSessionsSource).not.toContain("projectionUnavailable");
+		expect(recentSessionsSource).not.toContain("projectionLoading");
+		expect(recentSessionsSource).toContain("isLoading={sessionsLoading}");
+		expect(recentSessionsSource).toContain("emptyMessage={HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE}");
+		expect(detailSource).not.toContain("Sessions appear once your agent is running.");
 	});
 });

--- a/apps/web/src/hosted/agents/hosted-agent-session-query.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-session-query.ts
@@ -1,5 +1,14 @@
+import { isCloudEnvId } from "@/hosted/agent-identity";
+
 export const HOSTED_AGENT_SESSIONS_REFETCH_INTERVAL_MS = 30_000;
 export const HOSTED_AGENT_SESSIONS_REFRESH_POLICY = {
 	refetchInterval: HOSTED_AGENT_SESSIONS_REFETCH_INTERVAL_MS,
 	refetchIntervalInBackground: false,
 } as const;
+
+export const HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE = "No sessions from this agent yet.";
+
+/** `/v1/sessions` needs the stable environment identity, not a live runtime projection. */
+export function canQueryHostedAgentSessions(environmentId: string): boolean {
+	return isCloudEnvId(environmentId);
+}


### PR DESCRIPTION
## Root cause

Hosted session history is backend-owned at GET /v1/sessions, but the agent detail UI disabled its queries unless the runtime was running and the Cloud agent projection had resolved. Transitional, stopped, and failed deployments therefore showed misleading empty-state copy without querying the backend.

## Fix

- query sessions whenever the stable Cloud environment identity is valid
- remove runtime lifecycle and agent-projection gates from Overview and Sessions tab history
- keep live runtime surfaces gated separately
- correct stopped/projection/empty-state copy
- add lifecycle regression coverage

## Verification

- Docker web typecheck passed
- focused tests: 33 passed
- Docker OSS production build passed
- Biome and git diff check passed