### PR TITLE
Fix Add Custom bot dialog and inventory-only conflicts

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -9654,6 +9654,14 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
 	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
+	let accountWarning = dialog.locator("[data-whatsapp-account-warning]");
+	await expect(accountWarning).toHaveAttribute("role", "alert");
+	await expect(
+		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
+	).toBeVisible();
+	await expect(accountWarning).toContainText("Clawdi connects as a linked device");
+	await expect(accountWarning).toContainText("replies are sent as this account");
+	await expect(accountWarning).toContainText("not your primary personal account");
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeDisabled();
 	await expect(dialog).toContainText("isn't compatible with this deployment");
 	await expect(dialog.getByLabel("Bot token")).toHaveCount(0);
@@ -9664,6 +9672,8 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
 	await dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
+	accountWarning = dialog.locator("[data-whatsapp-account-warning]");
+	await expect(accountWarning).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeEnabled();
 	await expect(dialog.getByRole("button", { name: "Choose from an Agent" })).toHaveCount(0);
 	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup desktop");
@@ -9706,6 +9716,15 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	);
 	await mobileWhatsAppProvider.click();
 	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
+	accountWarning = dialog.locator("[data-whatsapp-account-warning]");
+	await expect(accountWarning).toHaveAttribute("role", "alert");
+	await expect(
+		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
+	).toBeVisible();
+	await expect(accountWarning).toContainText(
+		"Messages to this account may be handled by the Agent",
+	);
+	await expect(accountWarning).toContainText("not your primary personal account");
 	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup at 320x568");
 	await expectNoHorizontalOverflow(page.locator("html"), "WhatsApp Custom document at 320x568");
 	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-custom-setup-320x568.png") });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -10010,6 +10010,11 @@ for (const firstTimeViewport of [
 			"href",
 			`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 		);
+		await expect(agentInterfaceHint.locator('[data-slot="alert"]')).toHaveCount(0);
+		await expect(connectDialog.locator("[data-agent-link-warning]")).toHaveCount(0);
+		await expect(connectDialog.getByRole("status")).toContainText(
+			"The new Custom bot will be linked to this Agent automatically.",
+		);
 		await connectDialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
 		await expect(connectDialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
 		await expect(connectDialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
@@ -10218,9 +10223,13 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	const discordProvider = dialog.getByRole("button", { name: /^Discord Discord$/ });
 	await expect(telegramProvider).toBeEnabled();
 	await expect(discordProvider).toBeEnabled();
-	await expect(dialog.getByRole("status")).toContainText(
+	let linkWarning = dialog.locator("[data-agent-link-warning]");
+	await expect(linkWarning).toHaveAttribute("role", "alert");
+	await expect(linkWarning.getByText("Won’t link automatically", { exact: true })).toBeVisible();
+	await expect(linkWarning).toContainText(
 		"This Agent already has a Telegram bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
 	);
+	await expect(dialog.getByRole("status")).toHaveCount(0);
 	await expect(
 		dialog.locator("[data-other-provider-hint]").getByRole("link", {
 			name: "Agent Interface",
@@ -10252,7 +10261,10 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	await addChannel.click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
 	await dialog.getByRole("button", { name: /^Discord Discord$/ }).click();
-	await expect(dialog.getByRole("status")).toContainText(
+	linkWarning = dialog.locator("[data-agent-link-warning]");
+	await expect(linkWarning).toHaveAttribute("role", "alert");
+	await expect(linkWarning.getByText("Won’t link automatically", { exact: true })).toBeVisible();
+	await expect(linkWarning).toContainText(
 		"This Agent already has a Discord bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
 	);
 	await dialog.getByLabel("Name").fill("Additional Discord");
@@ -10294,6 +10306,78 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	);
 	await expect(page.getByRole("dialog", { name: "Add channel" })).toHaveCount(0);
 	expect(errors, `inventory-only Custom bot errors: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Add channel warns and adds to inventory when Agent link status is unavailable", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 568 });
+	const agentId = missingProjectionEnvironmentId;
+	const createChannelRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: [],
+		channelAgentLinksResponse: {
+			status: 503,
+			body: { detail: "Agent link projection is temporarily unavailable" },
+		},
+		createChannelRequests,
+		createChannelResponse: {
+			status: 201,
+			body: {
+				id: "5a777777-7777-4777-8777-777777777777",
+				provider: "telegram",
+				name: "Conservative Telegram",
+				status: "active",
+				visibility: "private",
+				has_provider_token: true,
+				webhook_url: "https://cloud.example.test/channels/conservative-telegram",
+				created_at: "2026-08-03T00:03:00Z",
+				webhook_secret: "conservative-webhook-secret-must-not-render",
+				agent_link_id: null,
+				agent_id: null,
+				agent_token: null,
+			},
+		},
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await page.locator("[data-agent-add-custom-bot]").click();
+	let dialog = page.getByRole("dialog", { name: "Add channel" });
+	const linkWarning = dialog.locator("[data-agent-link-warning]");
+	await expect(linkWarning).toHaveAttribute("role", "alert");
+	await expect(
+		linkWarning.getByText("Agent link status unavailable", { exact: true }),
+	).toBeVisible();
+	await expect(linkWarning).toContainText(
+		"Clawdi can’t confirm this Agent’s existing links right now. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+	);
+	await expect(dialog.getByRole("status")).toHaveCount(0);
+	await expect(dialog.locator("[data-other-provider-hint]")).toBeVisible();
+	await expect(dialog.locator('[data-other-provider-hint] [data-slot="alert"]')).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "unavailable Agent link warning at 320px");
+	await dialog.screenshot({ path: testInfo.outputPath("agent-link-status-unavailable-320.png") });
+
+	await dialog.getByLabel("Name").fill("Conservative Telegram");
+	await dialog.getByLabel("Bot token").fill("123456:conservative-telegram-token");
+	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(1);
+	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+		provider: "telegram",
+		name: "Conservative Telegram",
+		provider_token: "123456:conservative-telegram-token",
+		agent_id: null,
+	});
+	dialog = page.getByRole("dialog", { name: "Custom bot added" });
+	await expect(dialog).toContainText(
+		"Conservative Telegram was added to Custom bots without linking to this Agent.",
+	);
+	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toHaveCount(0);
+	await expect(page.locator("body")).not.toContainText(
+		"conservative-webhook-secret-must-not-render",
+	);
 });
 
 test("Agent bot groups keep every bot visible and gate provider conflicts in place", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1469,6 +1469,7 @@ type HostedApiStubOptions = {
 	onLinkAgent?: (response: unknown) => void;
 	createChannelRequests?: string[];
 	createChannelResponse?: unknown;
+	createChannelResponses?: StubResponse[];
 	deleteBindingRequests?: string[];
 	deleteBindingResponses?: StubResponse[];
 	onCreateChannel?: (response: unknown) => void;
@@ -2295,7 +2296,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v1/channels" && r.request().method() === "POST") {
 			options.createChannelRequests?.push(r.request().postData() ?? "");
-			const configured = options.createChannelResponse ?? {};
+			const configured =
+				options.createChannelResponses?.shift() ?? options.createChannelResponse ?? {};
 			const response = isStubResponse(configured) ? configured : { body: configured, status: 201 };
 			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
 			if (response.status < 400) options.onCreateChannel?.(response.body);
@@ -9324,6 +9326,12 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	let connectDialog = page.getByRole("dialog", { name: "Add channel" });
+	await expect(
+		connectDialog.getByText("Open the relevant Agent's Agent Interface", { exact: false }),
+	).toBeVisible();
+	await expect(
+		connectDialog.getByRole("link", { name: "Agent Interface", exact: true }),
+	).toHaveCount(0);
 	await expect(connectDialog.getByRole("button", { name: /^Telegram Telegram$/ })).toHaveAttribute(
 		"aria-pressed",
 		"true",
@@ -9341,7 +9349,7 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	await connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }).click();
 	await connectDialog.getByLabel("Name").fill("Inventory Telegram");
 	await connectDialog.getByLabel("Bot token").fill("123456:console-inventory-token");
-	await connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }).click();
+	await connectDialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
 	await expect.poll(() => createChannelRequests.length).toBe(1);
 	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
 		provider: "telegram",
@@ -9349,7 +9357,7 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 		provider_token: "123456:console-inventory-token",
 		agent_id: null,
 	});
-	const successDialog = page.getByRole("dialog", { name: "Custom bot connected" });
+	const successDialog = page.getByRole("dialog", { name: "Custom bot added" });
 	await expect(successDialog).toBeVisible();
 	await expect(
 		successDialog.getByRole("button", { name: "View Custom bot", exact: true }),
@@ -9391,9 +9399,9 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	);
 	await expectContainedInOwnerAndViewport(
 		page,
-		connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }),
+		connectDialog.getByRole("button", { name: "Add custom bot", exact: true }),
 		connectDialog,
-		"Telegram credentials Connect custom bot",
+		"Telegram credentials Add custom bot",
 	);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-320.png") });
 	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
@@ -9416,9 +9424,9 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	}
 	await expectContainedInOwnerAndViewport(
 		page,
-		connectDialog.getByRole("button", { name: "Connect custom bot", exact: true }),
+		connectDialog.getByRole("button", { name: "Add custom bot", exact: true }),
 		connectDialog,
-		"Discord credentials Connect custom bot",
+		"Discord credentials Add custom bot",
 	);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-320.png") });
 	expect(errors, `Channels inventory browser errors: ${errors.join(" | ")}`).toEqual([]);
@@ -9643,9 +9651,9 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	let dialog = page.getByRole("dialog", { name: "Add channel" });
 	await dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
-	await expect(dialog.getByText("Clawdi WhatsApp", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
-	await expect(dialog.getByText("You never scan its device QR.", { exact: false })).toBeVisible();
+	await expect(dialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
+	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeDisabled();
 	await expect(dialog).toContainText("isn't compatible with this deployment");
 	await expect(dialog.getByLabel("Bot token")).toHaveCount(0);
@@ -9656,10 +9664,10 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
 	await dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
-	await expect(dialog.getByRole("button", { name: "Choose from an Agent" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeEnabled();
-	await expectNoHorizontalOverflow(dialog, "WhatsApp account choice desktop");
-	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-account-choice-desktop.png") });
+	await expect(dialog.getByRole("button", { name: "Choose from an Agent" })).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup desktop");
+	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-custom-setup-desktop.png") });
 
 	await dialog.getByRole("button", { name: "Connect your account" }).click();
 	await dialog.getByLabel("Account name").fill(longAccountName);
@@ -9697,9 +9705,10 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 		"clip",
 	);
 	await mobileWhatsAppProvider.click();
-	await expectNoHorizontalOverflow(dialog, "WhatsApp account choice at 320x568");
-	await expectNoHorizontalOverflow(page.locator("html"), "WhatsApp choice document at 320x568");
-	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-account-choice-320x568.png") });
+	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup at 320x568");
+	await expectNoHorizontalOverflow(page.locator("html"), "WhatsApp Custom document at 320x568");
+	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-custom-setup-320x568.png") });
 	await dialog.getByRole("button", { name: "Connect your account" }).click();
 	await dialog.getByLabel("Account name").fill("Phone viewport WhatsApp");
 	await dialog.getByRole("button", { name: "Generate QR" }).click();
@@ -9906,6 +9915,7 @@ for (const firstTimeViewport of [
 			agent_id: missingProjectionEnvironmentId,
 			status: "active",
 			created_at: "2026-07-27T12:00:00Z",
+			binding_count: 0,
 			account: channelAccount,
 		};
 		await stubHostedApi(page, {
@@ -9986,25 +9996,25 @@ for (const firstTimeViewport of [
 		});
 
 		await connectCustom.click();
-		let connectDialog = page.getByRole("dialog", { name: "Add channel" });
+		const connectDialog = page.getByRole("dialog", { name: "Add channel" });
 		await expect(connectDialog).toBeVisible();
 		await expect(page.getByRole("dialog")).toHaveCount(1);
 		await expect(connectDialog).toContainText(
-			"Add a Custom bot you manage, or choose a Clawdi bot for this Agent.",
+			"Add a Custom bot you manage. When possible, it will be linked to this Agent automatically.",
+		);
+		const agentInterfaceHint = connectDialog.locator("[data-other-provider-hint]");
+		await expect(agentInterfaceHint).toContainText(
+			"Need a provider that Clawdi Channels doesn't support?",
+		);
+		await expect(agentInterfaceHint.getByRole("link", { name: "Agent Interface" })).toHaveAttribute(
+			"href",
+			`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 		);
 		await connectDialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
-		await expect(connectDialog.getByText("Clawdi WhatsApp", { exact: true })).toBeVisible();
 		await expect(connectDialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
-		await expect(
-			connectDialog.getByText("You never scan its device QR.", { exact: false }),
-		).toBeVisible();
-		await connectDialog.getByRole("button", { name: "View Clawdi bots", exact: true }).click();
-		await expect(connectDialog).toHaveCount(0);
-		await expect(clawdiSection).toBeFocused();
-
-		await connectCustom.click();
-		connectDialog = page.getByRole("dialog", { name: "Add channel" });
-		await expect(connectDialog).toBeVisible();
+		await expect(connectDialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
+		await expect(connectDialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
+		await connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }).click();
 		await expect(
 			connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }),
 		).toHaveAttribute("aria-pressed", "true");
@@ -10023,7 +10033,7 @@ for (const firstTimeViewport of [
 			);
 		}
 		const submitCustomBot = connectDialog.getByRole("button", {
-			name: "Connect custom bot",
+			name: "Add custom bot",
 			exact: true,
 		});
 		await expectContainedInOwnerAndViewport(
@@ -10037,7 +10047,7 @@ for (const firstTimeViewport of [
 		});
 
 		await submitCustomBot.click();
-		const connecting = connectDialog.getByRole("button", { name: "Connecting…", exact: true });
+		const connecting = connectDialog.getByRole("button", { name: "Adding…", exact: true });
 		await expect(connecting).toBeVisible();
 		await expectContainedInOwnerAndViewport(
 			page,
@@ -10093,10 +10103,11 @@ for (const firstTimeViewport of [
 			created_at: "2026-08-01T01:00:00Z",
 			last_message_at: null,
 		});
+		channelLink.binding_count = 1;
 		await expect(pairDialog).toHaveCount(0, { timeout: 5_000 });
 		const successToast = page.locator("[data-sonner-toast]").filter({ hasText: "Chat paired" });
 		await expect(successToast).toHaveCount(1);
-		await expect(successToast).toContainText("Telegram private chat is ready.");
+		await expect(successToast).toContainText("Telegram chat is ready.");
 		await expectNoHorizontalOverflow(
 			successToast,
 			`${firstTimeViewport.label} first-time pair success toast`,
@@ -10122,6 +10133,168 @@ for (const firstTimeViewport of [
 		).toEqual([]);
 	});
 }
+
+test("Add channel keeps already-linked Telegram and Discord available as inventory-only additions", async ({
+	page,
+}, testInfo) => {
+	await page.setViewportSize({ width: 320, height: 844 });
+	const errors = collectBrowserErrors(page);
+	const agentId = missingProjectionEnvironmentId;
+	const telegramAccount = {
+		id: "5a111111-1111-4111-8111-111111111111",
+		provider: "telegram",
+		name: "Existing Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/existing-telegram",
+		created_at: "2026-08-03T00:00:00Z",
+	};
+	const discordAccount = {
+		...telegramAccount,
+		id: "5a222222-2222-4222-8222-222222222222",
+		provider: "discord",
+		name: "Existing Discord",
+		webhook_url: "https://cloud.example.test/channels/existing-discord",
+	};
+	const createChannelRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: [telegramAccount, discordAccount],
+		channelAgentLinks: [
+			{
+				id: "5a333333-3333-4333-8333-333333333333",
+				account_id: telegramAccount.id,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-08-03T00:01:00Z",
+				account: telegramAccount,
+			},
+			{
+				id: "5a444444-4444-4444-8444-444444444444",
+				account_id: discordAccount.id,
+				agent_id: agentId,
+				status: "active",
+				created_at: "2026-08-03T00:02:00Z",
+				account: discordAccount,
+			},
+		],
+		createChannelRequests,
+		createChannelResponses: [
+			{
+				status: 201,
+				body: {
+					...telegramAccount,
+					id: "5a555555-5555-4555-8555-555555555555",
+					name: "Additional Telegram",
+					webhook_secret: "telegram-webhook-secret-must-not-render",
+					agent_link_id: null,
+					agent_id: null,
+					agent_token: null,
+				},
+			},
+			{
+				status: 201,
+				body: {
+					...discordAccount,
+					id: "5a666666-6666-4666-8666-666666666666",
+					name: "Additional Discord",
+					webhook_secret: "discord-webhook-secret-must-not-render",
+					agent_link_id: null,
+					agent_id: null,
+					agent_token: null,
+				},
+			},
+		],
+	});
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const addChannel = page.locator("[data-agent-add-custom-bot]");
+	await addChannel.click();
+	let dialog = page.getByRole("dialog", { name: "Add channel" });
+	const telegramProvider = dialog.getByRole("button", { name: /^Telegram Telegram$/ });
+	const discordProvider = dialog.getByRole("button", { name: /^Discord Discord$/ });
+	await expect(telegramProvider).toBeEnabled();
+	await expect(discordProvider).toBeEnabled();
+	await expect(dialog.getByRole("status")).toContainText(
+		"This Agent already has a Telegram bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+	);
+	await expect(
+		dialog.locator("[data-other-provider-hint]").getByRole("link", {
+			name: "Agent Interface",
+		}),
+	).toHaveAttribute(
+		"href",
+		`/agents/${agentId}/console?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await dialog.getByLabel("Name").fill("Additional Telegram");
+	await dialog.getByLabel("Bot token").fill("123456:additional-telegram-token");
+	await dialog.screenshot({ path: testInfo.outputPath("already-linked-telegram-form-320.png") });
+	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(1);
+	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+		provider: "telegram",
+		name: "Additional Telegram",
+		provider_token: "123456:additional-telegram-token",
+		agent_id: null,
+	});
+	dialog = page.getByRole("dialog", { name: "Custom bot added" });
+	await expect(dialog).toContainText(
+		"Additional Telegram was added to Custom bots. It was not linked because this Agent already has a Telegram bot.",
+	);
+	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "inventory-only Telegram result at 320px");
+	await dialog.screenshot({ path: testInfo.outputPath("inventory-only-telegram-result-320.png") });
+	await dialog.getByRole("button", { name: "Done", exact: true }).click();
+
+	await addChannel.click();
+	dialog = page.getByRole("dialog", { name: "Add channel" });
+	await dialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await expect(dialog.getByRole("status")).toContainText(
+		"This Agent already has a Discord bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+	);
+	await dialog.getByLabel("Name").fill("Additional Discord");
+	await dialog.getByLabel("Bot token").fill("A".repeat(50));
+	await dialog.getByLabel("Application ID").fill("123456789012345678");
+	await dialog.getByLabel("Public key").fill("a".repeat(64));
+	await expectNoHorizontalOverflow(dialog, "inventory-only Discord form at 320px");
+	await dialog.screenshot({ path: testInfo.outputPath("already-linked-discord-form-320.png") });
+	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(2);
+	expect(JSON.parse(createChannelRequests[1] ?? "{}")).toEqual({
+		provider: "discord",
+		name: "Additional Discord",
+		provider_token: "A".repeat(50),
+		agent_id: null,
+		config: {
+			application_id: "123456789012345678",
+			public_key: "a".repeat(64),
+		},
+	});
+	dialog = page.getByRole("dialog", { name: "Custom bot added" });
+	await expect(dialog).toContainText(
+		"Additional Discord was added to Custom bots. It was not linked because this Agent already has a Discord bot.",
+	);
+	await expect(page.getByRole("dialog", { name: "Pair Discord" })).toHaveCount(0);
+	await expectNoHorizontalOverflow(dialog, "inventory-only Discord result at 320px");
+	await expect(page.locator("body")).not.toContainText("webhook-secret-must-not-render");
+	await dialog.getByRole("button", { name: "Done", exact: true }).click();
+	await addChannel.click();
+	dialog = page.getByRole("dialog", { name: "Add channel" });
+	await dialog
+		.locator("[data-other-provider-hint]")
+		.getByRole("link", {
+			name: "Agent Interface",
+		})
+		.click();
+	await expect(page).toHaveURL(
+		`/agents/${agentId}/console?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	await expect(page.getByRole("dialog", { name: "Add channel" })).toHaveCount(0);
+	expect(errors, `inventory-only Custom bot errors: ${errors.join(" | ")}`).toEqual([]);
+});
 
 test("Agent bot groups keep every bot visible and gate provider conflicts in place", async ({
 	page,

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -9659,7 +9659,10 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await expect(
 		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
 	).toBeVisible();
-	await expect(accountWarning).toContainText("Clawdi connects as a linked device");
+	await expect(accountWarning).toContainText("Clawdi connects as a linked device.");
+	await expect(accountWarning).toContainText(
+		"Once linked to an Agent, messages to this account may be handled by the Agent",
+	);
 	await expect(accountWarning).toContainText("replies are sent as this account");
 	await expect(accountWarning).toContainText("not your primary personal account");
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeDisabled();
@@ -9722,8 +9725,9 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
 	).toBeVisible();
 	await expect(accountWarning).toContainText(
-		"Messages to this account may be handled by the Agent",
+		"Once linked to an Agent, messages to this account may be handled by the Agent",
 	);
+	await expect(accountWarning).toContainText("replies are sent as this account");
 	await expect(accountWarning).toContainText("not your primary personal account");
 	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup at 320x568");
 	await expectNoHorizontalOverflow(page.locator("html"), "WhatsApp Custom document at 320x568");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -657,7 +657,12 @@ export function HostedAgentDetail({
 						!deploymentProjectionQueryable ? (
 							<StoppedAgentState deployment={deployment} />
 						) : projection.status === "resolved" ? (
-							<ChannelsTab environmentId={environmentId} agentType={runtime} agentName={name} />
+							<ChannelsTab
+								environmentId={environmentId}
+								agentType={runtime}
+								agentName={name}
+								routeSearch={routeSearch}
+							/>
 						) : (
 							<ChannelsSyncState
 								isChecking={isCheckingDeployment || isCheckingProjection}
@@ -2356,10 +2361,12 @@ function ChannelsTab({
 	environmentId,
 	agentType,
 	agentName,
+	routeSearch,
 }: {
 	environmentId: string;
 	agentType: HostedRuntime;
 	agentName: string;
+	routeSearch: AgentRouteSearch;
 }) {
 	const api = useApi();
 	const openApi = useOpenApi();
@@ -2575,12 +2582,6 @@ function ChannelsTab({
 			/>
 		);
 	}
-	function focusClawdiBots() {
-		const section = document.querySelector<HTMLElement>('[data-agent-channel-section="clawdi"]');
-		section?.scrollIntoView({ behavior: "smooth", block: "start" });
-		section?.focus({ preventScroll: true });
-	}
-
 	return (
 		<div data-agent-channels className="flex flex-col gap-8">
 			<AgentChannelBotsSection
@@ -2632,8 +2633,8 @@ function ChannelsTab({
 				onOpenChange={setCustomBotDialogOpen}
 				agentId={environmentId}
 				agentType={agentType}
-				linkedProviders={linkedProviders}
-				onChooseClawdiWhatsapp={focusClawdiBots}
+				linkedProviders={linked.data ? linkedProviders : undefined}
+				agentRouteQuery={routeSearch}
 				onAgentConnected={(bot) => {
 					setRecentLinks((current) =>
 						new Map(current).set(bot.id, {

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -50,14 +50,15 @@ describe("global Channels inventory", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
 		const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 
-		expect(connectDialog).toContain("agent_id: agentId ?? null");
+		expect(connectDialog).toContain("agent_id: autoLinkAgentId");
 		expect(connectDialog).toContain("onAgentConnected");
-		expect(connectDialog).toContain("availableBotProvidersForAgent");
+		expect(connectDialog).toContain("autoLinkAgentIdForNewCustomBot");
 		expect(agentDetail).not.toContain("<AddChannelDialog");
 		expect(agentDetail).toContain("<ConnectBotDialog");
 		expect(agentDetail).toContain("open={customBotDialogOpen}");
 		expect(agentDetail).toContain("agentId={environmentId}");
-		expect(agentDetail).toContain("linkedProviders={linkedProviders}");
+		expect(agentDetail).toContain("linkedProviders={linked.data ? linkedProviders : undefined}");
+		expect(agentDetail).toContain("agentRouteQuery={routeSearch}");
 		expect(agentDetail).toContain("Add channel");
 		expect(agentDetail).toContain('title="Clawdi bots"');
 		expect(agentDetail).toContain('title="Custom bots"');
@@ -75,6 +76,9 @@ describe("global Channels inventory", () => {
 		expect(connectDialog).not.toContain("setupSteps");
 		expect(connectDialog).toContain("whatsappSelected");
 		expect(connectDialog).toContain("<WhatsAppDeviceOnboarding");
+		expect(connectDialog).toContain("Need a provider that Clawdi Channels");
+		expect(connectDialog).toContain('agentSectionLink(agentId, "console", agentRouteQuery)');
+		expect(connectDialog).toContain("Open the relevant Agent's Agent Interface");
 		expect(connectDialog).not.toContain("Server ID");
 		expect(connectDialog).not.toContain("Guild ID");
 	});

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -79,6 +79,14 @@ describe("global Channels inventory", () => {
 		expect(connectDialog).toContain("Need a provider that Clawdi Channels");
 		expect(connectDialog).toContain('agentSectionLink(agentId, "console", agentRouteQuery)');
 		expect(connectDialog).toContain("Open the relevant Agent's Agent Interface");
+		expect(connectDialog).toContain("data-agent-link-warning");
+		expect(connectDialog).toContain('className="border-warning/30 bg-warning-muted py-2.5"');
+		expect(connectDialog).toContain("<TriangleAlert aria-hidden />");
+		expect(connectDialog).toContain('title: "Won’t link automatically"');
+		expect(connectDialog).toContain('title: "Agent link status unavailable"');
+		expect(connectDialog).toContain(
+			"The new Custom bot will be linked to this Agent automatically.",
+		);
 		expect(connectDialog).not.toContain("Server ID");
 		expect(connectDialog).not.toContain("Guild ID");
 	});

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	agentProviderHasSingleLinkLimit,
-	availableBotProvidersForAgent,
+	autoLinkAgentIdForNewCustomBot,
 	channelProviderLinkingReady,
 	pairCodeExpired,
 	pairingCommand,
@@ -90,22 +90,27 @@ describe("hosted channel instructions and gates", () => {
 		}
 	});
 
-	test("keeps WhatsApp account onboarding separate from Agent link cardinality", () => {
-		expect(availableBotProvidersForAgent("agent-1", "openclaw", new Set())).toEqual([
-			"telegram",
-			"discord",
-			"whatsapp",
-		]);
-		expect(availableBotProvidersForAgent("agent-1", "openclaw", new Set(["telegram"]))).toEqual([
-			"discord",
-			"whatsapp",
-		]);
+	test("adds conflicting Custom bots to inventory without changing the existing Agent link", () => {
+		for (const provider of ["telegram", "discord"] as const) {
+			expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", provider, new Set())).toBe(
+				"agent-1",
+			);
+			expect(
+				autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", provider, new Set([provider])),
+			).toBeNull();
+		}
+
 		expect(
-			availableBotProvidersForAgent("agent-1", "openclaw", new Set(["telegram", "discord"])),
-		).toEqual(["whatsapp"]);
+			autoLinkAgentIdForNewCustomBot("agent-1", "codex", "telegram", new Set(["telegram"])),
+		).toBe("agent-1");
 		expect(
-			availableBotProvidersForAgent(undefined, undefined, new Set(["telegram", "discord"])),
-		).toEqual(["telegram", "discord", "whatsapp"]);
+			autoLinkAgentIdForNewCustomBot(undefined, undefined, "telegram", new Set(["telegram"])),
+		).toBeNull();
+		expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", "telegram", undefined)).toBeNull();
+	});
+
+	test("keeps WhatsApp inventory onboarding separate from Agent linking", () => {
+		expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", "whatsapp", new Set())).toBeNull();
 	});
 
 	test("expires pairing actions exactly at the server deadline", () => {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -19,18 +19,25 @@ export function agentProviderHasSingleLinkLimit(
 	return Boolean(agentType && SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE[agentType]?.has(provider));
 }
 
-export function availableBotProvidersForAgent(
+/**
+ * Return the Agent id only when creating this bot can safely preserve the
+ * hosted runtime's provider cardinality. A null value is sent explicitly so
+ * the API adds the bot to inventory without selecting or linking an Agent.
+ */
+export function autoLinkAgentIdForNewCustomBot(
 	agentId: string | null | undefined,
 	agentType: string | null | undefined,
+	provider: string,
 	linkedProviders: ReadonlySet<string> | null | undefined,
-): ConnectableBotProvider[] {
-	return CONNECTABLE_BOT_PROVIDERS.filter(
-		(provider) =>
-			provider === "whatsapp" ||
-			!agentId ||
-			!agentProviderHasSingleLinkLimit(agentType, provider) ||
-			!linkedProviders?.has(provider),
-	);
+): string | null {
+	if (!agentId || !channelProviderLinkingReady(provider)) return null;
+	if (
+		agentProviderHasSingleLinkLimit(agentType, provider) &&
+		(!linkedProviders || linkedProviders.has(provider))
+	) {
+		return null;
+	}
+	return agentId;
 }
 
 export function pairingCommand(code: string): string {

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -13,15 +13,12 @@ function expectFeedbackBeforeRequest(contents: string, feedback: string, request
 }
 
 describe("channel mutation feedback", () => {
-	test("acknowledges bot connection before starting its request", () => {
+	test("acknowledges bot addition before starting its request", () => {
 		const connect = source("./connect-bot-dialog.tsx");
 
-		expectFeedbackBeforeRequest(
-			connect,
-			"setSubmitting(true)",
-			"await create.execute(buildBody())",
-		);
+		expectFeedbackBeforeRequest(connect, "setSubmitting(true)", "await create.execute(body)");
 		expect(connect).toContain('{isSubmitting ? "Close" : "Cancel"}');
+		expect(connect).toContain('{isSubmitting ? "Adding…" : "Add custom bot"}');
 		expect(connect).not.toContain("channelDialogOpenChangeAllowed");
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -75,8 +75,8 @@ describe("channel IA boundary", () => {
 	});
 
 	test("keeps Discord inventory in Console and Add/Pair actions on the Agent", () => {
-		expect(connectDialog).toContain("agent_id: agentId ?? null");
-		expect(connectDialog).toContain("Connect custom bot");
+		expect(connectDialog).toContain("agent_id: autoLinkAgentId");
+		expect(connectDialog).toContain("Add custom bot");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(agentDetail).toContain('linking ? "Linking…" : "Link"');
 		expect(agentDetail).toContain("body: { agent_id: environmentId }");

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -225,7 +225,7 @@ export function useCreateChannel() {
 				"id" | "name" | "provider" | "webhook_url" | "agent_link_id" | "agent_id"
 			>;
 		} catch (error) {
-			toastApiError("Couldn't connect Custom bot")(error);
+			toastApiError("Couldn't add Custom bot")(error);
 			throw error;
 		}
 	});

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EntityIcon } from "@/components/entity-icon";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -106,6 +107,19 @@ export function ConnectBotDialog({
 	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
 	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
 	const isSubmitting = submitting || create.isPending;
+	const agentLinkWarning =
+		!whatsappSelected && providerLinkConflict
+			? {
+					title: "Won’t link automatically",
+					description: `This Agent already has a ${meta.label} bot. The new Custom bot will be added to Custom bots without being linked to this Agent.`,
+				}
+			: !whatsappSelected && agentLinkStatusUnknown
+				? {
+						title: "Agent link status unavailable",
+						description:
+							"Clawdi can’t confirm this Agent’s existing links right now. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+					}
+				: null;
 
 	function changeProvider(next: ConnectableBotProvider) {
 		if (isSubmitting) return;
@@ -311,13 +325,20 @@ export function ConnectBotDialog({
 						<div className="flex min-w-0 flex-col gap-3">
 							{providerChoices}
 							{otherProviderHint}
-							{!whatsappSelected && agentId ? (
+							{agentLinkWarning ? (
+								<Alert
+									data-agent-link-warning
+									className="border-warning/30 bg-warning-muted py-2.5"
+								>
+									<TriangleAlert aria-hidden />
+									<AlertTitle>{agentLinkWarning.title}</AlertTitle>
+									<AlertDescription className="text-xs">
+										{agentLinkWarning.description}
+									</AlertDescription>
+								</Alert>
+							) : !whatsappSelected && agentId ? (
 								<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
-									{providerLinkConflict
-										? `This Agent already has a ${meta.label} bot. The new Custom bot will be added to Custom bots without being linked to this Agent.`
-										: agentLinkStatusUnknown
-											? "Agent link status is unavailable. The new Custom bot will be added to Custom bots without being linked to this Agent."
-											: "The new Custom bot will be linked to this Agent automatically."}
+									The new Custom bot will be linked to this Agent automatically.
 								</p>
 							) : null}
 							{whatsappSelected ? (

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -17,11 +17,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	availableBotProvidersForAgent,
+	agentProviderHasSingleLinkLimit,
+	autoLinkAgentIdForNewCustomBot,
 	CONNECTABLE_BOT_PROVIDERS,
 	type ConnectableBotProvider,
 } from "@/hosted/v2/channels/channel-linking.logic";
-import { PROVIDER_META } from "@/hosted/v2/channels/channel-providers";
+import { PROVIDER_META, providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 import {
@@ -30,6 +31,14 @@ import {
 	discordPublicKeyError,
 } from "@/hosted/v2/channels/connect-bot-dialog.logic";
 import { WhatsAppDeviceOnboarding } from "@/hosted/v2/channels/whatsapp-device-onboarding";
+import { type AgentRouteQuery, agentSectionLink } from "@/lib/agent-routes";
+
+type CreatedCustomBot = Pick<
+	ChannelCreated,
+	"id" | "name" | "provider" | "agent_link_id" | "agent_id"
+> & {
+	linkOutcome: "linked" | "inventory-only" | "inventory-only-provider-conflict";
+};
 
 export function ConnectBotDialog({
 	open,
@@ -37,21 +46,21 @@ export function ConnectBotDialog({
 	agentId,
 	agentType,
 	linkedProviders,
+	agentRouteQuery,
 	onAgentConnected,
-	onChooseClawdiWhatsapp,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	agentId?: string;
 	agentType?: string;
 	linkedProviders?: ReadonlySet<string>;
+	agentRouteQuery?: AgentRouteQuery;
 	onAgentConnected?: (bot: {
 		id: string;
 		name: string;
 		provider: string;
 		agentLinkId: string;
 	}) => void;
-	onChooseClawdiWhatsapp?: () => void;
 }) {
 	const create = useCreateChannel();
 	const [provider, setProvider] = useState<ConnectableBotProvider>("telegram");
@@ -59,41 +68,47 @@ export function ConnectBotDialog({
 	const [token, setToken] = useState("");
 	const [applicationId, setApplicationId] = useState("");
 	const [publicKey, setPublicKey] = useState("");
-	const [created, setCreated] = useState<Pick<
-		ChannelCreated,
-		"id" | "name" | "provider" | "agent_link_id" | "agent_id"
-	> | null>(null);
+	const [created, setCreated] = useState<CreatedCustomBot | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const submitLocked = useRef(false);
 	const openRef = useRef(open);
 	const dialogSessionRef = useRef(0);
 	openRef.current = open;
-	const availableProviders = availableBotProvidersForAgent(agentId, agentType, linkedProviders);
-	const unavailableProviders = CONNECTABLE_BOT_PROVIDERS.filter(
-		(item) => !availableProviders.includes(item),
-	);
 
 	useEffect(() => {
 		if (!open) return;
-		setProvider(availableProviders[0] ?? "telegram");
+		setProvider("telegram");
 		setName("");
 		setToken("");
 		setApplicationId("");
 		setPublicKey("");
 		setCreated(null);
-	}, [open, availableProviders[0]]);
+	}, [open]);
 
 	const meta = PROVIDER_META[provider];
-	const providerAlreadyLinked = !availableProviders.includes(provider);
 	const discordSelected = provider === "discord";
 	const whatsappSelected = provider === "whatsapp";
+	const providerLinkConflict = Boolean(
+		agentId &&
+			agentProviderHasSingleLinkLimit(agentType, provider) &&
+			linkedProviders?.has(provider),
+	);
+	const agentLinkStatusUnknown = Boolean(
+		agentId && agentProviderHasSingleLinkLimit(agentType, provider) && !linkedProviders,
+	);
+	const autoLinkAgentId = autoLinkAgentIdForNewCustomBot(
+		agentId,
+		agentType,
+		provider,
+		linkedProviders,
+	);
 	const tokenError = discordSelected ? discordBotTokenError(token) : null;
 	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
 	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
 	const isSubmitting = submitting || create.isPending;
 
 	function changeProvider(next: ConnectableBotProvider) {
-		if (!availableProviders.includes(next)) return;
+		if (isSubmitting) return;
 		setProvider(next);
 		setName("");
 		setToken("");
@@ -103,7 +118,6 @@ export function ConnectBotDialog({
 
 	const canSubmit =
 		!whatsappSelected &&
-		!providerAlreadyLinked &&
 		name.trim().length > 0 &&
 		token.trim().length > 0 &&
 		(!discordSelected ||
@@ -118,7 +132,7 @@ export function ConnectBotDialog({
 			provider,
 			name: name.trim(),
 			provider_token: token.trim(),
-			agent_id: agentId ?? null,
+			agent_id: autoLinkAgentId,
 		};
 		if (!discordSelected) return base;
 		return {
@@ -135,8 +149,18 @@ export function ConnectBotDialog({
 		submitLocked.current = true;
 		setSubmitting(true);
 		const dialogSession = dialogSessionRef.current;
+		const body = buildBody();
+		const skippedLinkForProviderConflict = providerLinkConflict;
 		try {
-			const data = await create.execute(buildBody());
+			const data = await create.execute(body);
+			const result: CreatedCustomBot = {
+				...data,
+				linkOutcome: data.agent_link_id
+					? "linked"
+					: skippedLinkForProviderConflict
+						? "inventory-only-provider-conflict"
+						: "inventory-only",
+			};
 			setToken("");
 			if (openRef.current && dialogSessionRef.current === dialogSession) {
 				if (agentId && data.agent_link_id && onAgentConnected) {
@@ -149,10 +173,15 @@ export function ConnectBotDialog({
 					});
 					return;
 				}
-				setCreated(data);
+				setCreated(result);
 			} else {
-				toast.success("Custom bot connected", {
-					description: `${data.name} is ready to use.`,
+				toast.success(result.linkOutcome === "linked" ? "Custom bot linked" : "Custom bot added", {
+					description:
+						result.linkOutcome === "linked"
+							? `${data.name} was added and linked to this Agent.`
+							: agentId
+								? `${data.name} was added to Custom bots without linking to this Agent.`
+								: `${data.name} was added to Custom bots.`,
 				});
 			}
 		} catch {
@@ -176,17 +205,16 @@ export function ConnectBotDialog({
 	}
 
 	const providerChoices = (
-		<fieldset className="grid grid-cols-2 gap-2 border-0 p-0 sm:grid-cols-3" aria-label="Provider">
+		<fieldset className="grid grid-cols-1 gap-2 border-0 p-0 sm:grid-cols-3" aria-label="Provider">
 			{CONNECTABLE_BOT_PROVIDERS.map((item) => {
-				const alreadyLinked = item !== "whatsapp" && !availableProviders.includes(item);
 				return (
 					<Button
 						key={item}
 						type="button"
-						variant={!alreadyLinked && provider === item ? "secondary" : "outline"}
+						variant={provider === item ? "secondary" : "outline"}
 						className="h-auto min-h-12 min-w-0 justify-start gap-1.5 px-2 sm:gap-2 sm:px-2.5"
-						disabled={alreadyLinked}
-						aria-pressed={!alreadyLinked && provider === item}
+						disabled={isSubmitting}
+						aria-pressed={provider === item}
 						onClick={() => changeProvider(item)}
 					>
 						<EntityIcon kind="channel" id={item} label={PROVIDER_META[item].label} size="sm" />
@@ -197,6 +225,29 @@ export function ConnectBotDialog({
 				);
 			})}
 		</fieldset>
+	);
+	const otherProviderHint = (
+		<p
+			data-other-provider-hint
+			className="min-w-0 text-xs text-muted-foreground [overflow-wrap:anywhere]"
+		>
+			Need a provider that Clawdi Channels doesn&apos;t support?{" "}
+			{agentId ? (
+				<>
+					Configure it in this Agent&apos;s{" "}
+					<Link
+						{...agentSectionLink(agentId, "console", agentRouteQuery)}
+						className="font-medium text-foreground underline underline-offset-4"
+						onClick={() => handleOpenChange(false)}
+					>
+						Agent Interface
+					</Link>
+					.
+				</>
+			) : (
+				"Open the relevant Agent's Agent Interface to configure it."
+			)}
+		</p>
 	);
 
 	return (
@@ -213,12 +264,20 @@ export function ConnectBotDialog({
 				{created ? (
 					<>
 						<DialogHeader>
-							<DialogTitle>Custom bot connected</DialogTitle>
+							<DialogTitle>
+								{created.linkOutcome === "linked" ? "Custom bot linked" : "Custom bot added"}
+							</DialogTitle>
 							<DialogDescription>
 								<span className="font-medium [overflow-wrap:anywhere]" title={created.name}>
 									{created.name}
 								</span>{" "}
-								is ready to use.
+								{created.linkOutcome === "linked"
+									? "was added to Custom bots and linked to this Agent."
+									: created.linkOutcome === "inventory-only-provider-conflict"
+										? `was added to Custom bots. It was not linked because this Agent already has a ${providerMeta(created.provider).label} bot.`
+										: agentId
+											? "was added to Custom bots without linking to this Agent."
+											: "was added to Custom bots. Link it from an Agent when you’re ready."}
 							</DialogDescription>
 						</DialogHeader>
 						<DialogFooter>
@@ -244,145 +303,128 @@ export function ConnectBotDialog({
 							<DialogTitle>Add channel</DialogTitle>
 							<DialogDescription>
 								{agentId
-									? "Add a Custom bot you manage, or choose a Clawdi bot for this Agent."
-									: "Connect a Custom bot you manage, or find a Clawdi bot for an Agent."}
+									? "Add a Custom bot you manage. When possible, it will be linked to this Agent automatically."
+									: "Add a Custom bot you manage to your inventory."}
 							</DialogDescription>
 						</DialogHeader>
 
-						{availableProviders.length === 0 ? (
-							<div className="space-y-3">
-								{providerChoices}
-								<p role="status" className="text-sm text-muted-foreground">
-									This Agent already has a channel from each provider. Unlink one before connecting
-									a Custom bot.
+						<div className="flex min-w-0 flex-col gap-3">
+							{providerChoices}
+							{otherProviderHint}
+							{!whatsappSelected && agentId ? (
+								<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
+									{providerLinkConflict
+										? `This Agent already has a ${meta.label} bot. The new Custom bot will be added to Custom bots without being linked to this Agent.`
+										: agentLinkStatusUnknown
+											? "Agent link status is unavailable. The new Custom bot will be added to Custom bots without being linked to this Agent."
+											: "The new Custom bot will be linked to this Agent automatically."}
 								</p>
-							</div>
-						) : (
-							<div className="flex min-w-0 flex-col gap-3">
-								{providerChoices}
-								{unavailableProviders.length === 1 ? (
-									<p className="text-xs text-muted-foreground">
-										{PROVIDER_META[unavailableProviders[0]].label} is already linked to this Agent.
-										Unlink it to connect another Custom bot from that provider.
+							) : null}
+							{whatsappSelected ? (
+								<WhatsAppDeviceOnboarding onDone={() => handleOpenChange(false)} />
+							) : (
+								<>
+									<p className="min-w-0 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
+										{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
+										<a
+											href={meta.setupUrl}
+											target="_blank"
+											rel="noreferrer"
+											className="inline-flex min-w-0 flex-wrap items-center gap-1 font-medium text-foreground underline underline-offset-4"
+										>
+											{provider === "telegram"
+												? "Create a bot with @BotFather"
+												: "Open Discord Developer Portal"}
+											<ExternalLink className="size-3" />
+										</a>
 									</p>
-								) : null}
-								{whatsappSelected ? (
-									<WhatsAppDeviceOnboarding
-										agentId={agentId}
-										onChooseClawdi={() => {
-											handleOpenChange(false);
-											onChooseClawdiWhatsapp?.();
-										}}
-										onDone={() => handleOpenChange(false)}
-									/>
-								) : (
-									<>
-										<p className="min-w-0 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
-											{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
-											<a
-												href={meta.setupUrl}
-												target="_blank"
-												rel="noreferrer"
-												className="inline-flex min-w-0 flex-wrap items-center gap-1 font-medium text-foreground underline underline-offset-4"
+
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="connect-name">Name</Label>
+										<Input
+											id="connect-name"
+											value={name}
+											onChange={(event) => setName(event.target.value)}
+											placeholder="Support Bot"
+											autoComplete="off"
+										/>
+									</div>
+
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="connect-token">Bot token</Label>
+										<Input
+											id="connect-token"
+											type="password"
+											value={token}
+											onChange={(event) => setToken(event.target.value)}
+											placeholder={meta.tokenPlaceholder}
+											autoComplete="off"
+											spellCheck={false}
+											required
+											aria-invalid={Boolean(tokenError)}
+											aria-describedby={tokenError ? "connect-token-error" : undefined}
+										/>
+										{tokenError ? (
+											<p
+												id="connect-token-error"
+												className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
 											>
-												{provider === "telegram"
-													? "Create a bot with @BotFather"
-													: "Open Discord Developer Portal"}
-												<ExternalLink className="size-3" />
-											</a>
-										</p>
-
-										<div className="flex flex-col gap-1.5">
-											<Label htmlFor="connect-name">Name</Label>
-											<Input
-												id="connect-name"
-												value={name}
-												onChange={(event) => setName(event.target.value)}
-												placeholder="Support Bot"
-												autoComplete="off"
-											/>
-										</div>
-
-										<div className="flex flex-col gap-1.5">
-											<Label htmlFor="connect-token">Bot token</Label>
-											<Input
-												id="connect-token"
-												type="password"
-												value={token}
-												onChange={(event) => setToken(event.target.value)}
-												placeholder={meta.tokenPlaceholder}
-												autoComplete="off"
-												spellCheck={false}
-												required
-												aria-invalid={Boolean(tokenError)}
-												aria-describedby={tokenError ? "connect-token-error" : undefined}
-											/>
-											{tokenError ? (
-												<p
-													id="connect-token-error"
-													className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-												>
-													{tokenError}
-												</p>
-											) : null}
-										</div>
-
-										{discordSelected ? (
-											<>
-												<div className="flex flex-col gap-1.5">
-													<Label htmlFor="connect-app-id">Application ID</Label>
-													<Input
-														id="connect-app-id"
-														value={applicationId}
-														onChange={(event) => setApplicationId(event.target.value)}
-														placeholder="Application ID"
-														autoComplete="off"
-														spellCheck={false}
-														required
-														aria-invalid={Boolean(applicationIdError)}
-														aria-describedby={
-															applicationIdError ? "connect-app-id-error" : undefined
-														}
-													/>
-													{applicationIdError ? (
-														<p
-															id="connect-app-id-error"
-															className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-														>
-															{applicationIdError}
-														</p>
-													) : null}
-												</div>
-												<div className="flex flex-col gap-1.5">
-													<Label htmlFor="connect-public-key">Public key</Label>
-													<Input
-														id="connect-public-key"
-														value={publicKey}
-														onChange={(event) => setPublicKey(event.target.value)}
-														placeholder="64-character hex public key"
-														autoComplete="off"
-														spellCheck={false}
-														required
-														aria-invalid={Boolean(publicKeyError)}
-														aria-describedby={
-															publicKeyError ? "connect-public-key-error" : undefined
-														}
-													/>
-													{publicKeyError ? (
-														<p
-															id="connect-public-key-error"
-															className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-														>
-															{publicKeyError}
-														</p>
-													) : null}
-												</div>
-											</>
+												{tokenError}
+											</p>
 										) : null}
-									</>
-								)}
-							</div>
-						)}
+									</div>
+
+									{discordSelected ? (
+										<>
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-app-id">Application ID</Label>
+												<Input
+													id="connect-app-id"
+													value={applicationId}
+													onChange={(event) => setApplicationId(event.target.value)}
+													placeholder="Application ID"
+													autoComplete="off"
+													spellCheck={false}
+													required
+													aria-invalid={Boolean(applicationIdError)}
+													aria-describedby={applicationIdError ? "connect-app-id-error" : undefined}
+												/>
+												{applicationIdError ? (
+													<p
+														id="connect-app-id-error"
+														className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+													>
+														{applicationIdError}
+													</p>
+												) : null}
+											</div>
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-public-key">Public key</Label>
+												<Input
+													id="connect-public-key"
+													value={publicKey}
+													onChange={(event) => setPublicKey(event.target.value)}
+													placeholder="64-character hex public key"
+													autoComplete="off"
+													spellCheck={false}
+													required
+													aria-invalid={Boolean(publicKeyError)}
+													aria-describedby={publicKeyError ? "connect-public-key-error" : undefined}
+												/>
+												{publicKeyError ? (
+													<p
+														id="connect-public-key-error"
+														className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+													>
+														{publicKeyError}
+													</p>
+												) : null}
+											</div>
+										</>
+									) : null}
+								</>
+							)}
+						</div>
 
 						{!whatsappSelected ? (
 							<DialogFooter>
@@ -393,15 +435,13 @@ export function ConnectBotDialog({
 								>
 									{isSubmitting ? "Close" : "Cancel"}
 								</Button>
-								{availableProviders.length > 0 ? (
-									<Button
-										className="min-w-0 whitespace-normal"
-										onClick={() => void submit()}
-										disabled={!canSubmit || isSubmitting}
-									>
-										{isSubmitting ? "Connecting…" : "Connect custom bot"}
-									</Button>
-								) : null}
+								<Button
+									className="min-w-0 whitespace-normal"
+									onClick={() => void submit()}
+									disabled={!canSubmit || isSubmitting}
+								>
+									{isSubmitting ? "Adding…" : "Add custom bot"}
+								</Button>
 							</DialogFooter>
 						) : null}
 					</>

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
@@ -9,6 +9,7 @@ process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 const { WhatsAppSessionState } = await import("./whatsapp-device-onboarding");
 
 const source = readFileSync(new URL("./whatsapp-device-onboarding.tsx", import.meta.url), "utf8");
+const normalizedSource = source.replace(/\s+/g, " ");
 const connectDialog = readFileSync(new URL("./connect-bot-dialog.tsx", import.meta.url), "utf8");
 
 function session(overrides: Partial<WhatsAppOnboardingSession> = {}): WhatsAppOnboardingSession {
@@ -52,6 +53,16 @@ describe("WhatsApp linked-device onboarding", () => {
 		expect(source).not.toContain("sm:grid-cols-2");
 		expect(source).toContain("This adds the account under Custom bots");
 		expect(source).toContain("linked-device QR");
+		expect(source).toContain("data-whatsapp-account-warning");
+		expect(source).toContain('className="border-warning/30 bg-warning-muted py-2.5"');
+		expect(normalizedSource).toContain("Use a dedicated WhatsApp account");
+		expect(normalizedSource).toContain("Clawdi connects as a linked device");
+		expect(normalizedSource).toContain("Messages to this account may be handled by the Agent");
+		expect(normalizedSource).toContain("replies are sent as this account");
+		expect(normalizedSource).toContain("not your primary personal account");
+		expect(source.indexOf("Use a dedicated WhatsApp account")).toBeLessThan(
+			source.indexOf("Connect your account"),
+		);
 		expect(connectDialog).toContain("<WhatsAppDeviceOnboarding");
 		expect(connectDialog).toContain("whitespace-normal break-words");
 		expect(connectDialog).not.toContain("min-w-0 truncate text-left");

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
@@ -43,12 +43,14 @@ function render(state: WhatsAppOnboardingSession): string {
 }
 
 describe("WhatsApp linked-device onboarding", () => {
-	test("keeps Clawdi shared accounts distinct from user-owned accounts", () => {
+	test("keeps Custom WhatsApp setup flat and separate from Clawdi-managed bots", () => {
 		expect(source).toContain('data-hosted="true"');
 		expect(source).toContain('data-v2="true"');
-		expect(source).toContain("Clawdi WhatsApp");
 		expect(source).toContain("Your WhatsApp");
-		expect(source).toContain("You never scan its device QR");
+		expect(source).not.toContain("Clawdi WhatsApp");
+		expect(source).not.toContain("WhatsAppOptionCard");
+		expect(source).not.toContain("sm:grid-cols-2");
+		expect(source).toContain("This adds the account under Custom bots");
 		expect(source).toContain("linked-device QR");
 		expect(connectDialog).toContain("<WhatsAppDeviceOnboarding");
 		expect(connectDialog).toContain("whitespace-normal break-words");

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
@@ -9,7 +9,6 @@ process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 const { WhatsAppSessionState } = await import("./whatsapp-device-onboarding");
 
 const source = readFileSync(new URL("./whatsapp-device-onboarding.tsx", import.meta.url), "utf8");
-const normalizedSource = source.replace(/\s+/g, " ");
 const connectDialog = readFileSync(new URL("./connect-bot-dialog.tsx", import.meta.url), "utf8");
 
 function session(overrides: Partial<WhatsAppOnboardingSession> = {}): WhatsAppOnboardingSession {
@@ -53,16 +52,9 @@ describe("WhatsApp linked-device onboarding", () => {
 		expect(source).not.toContain("sm:grid-cols-2");
 		expect(source).toContain("This adds the account under Custom bots");
 		expect(source).toContain("linked-device QR");
-		expect(source).toContain("data-whatsapp-account-warning");
-		expect(source).toContain('className="border-warning/30 bg-warning-muted py-2.5"');
-		expect(normalizedSource).toContain("Use a dedicated WhatsApp account");
-		expect(normalizedSource).toContain("Clawdi connects as a linked device");
-		expect(normalizedSource).toContain("Messages to this account may be handled by the Agent");
-		expect(normalizedSource).toContain("replies are sent as this account");
-		expect(normalizedSource).toContain("not your primary personal account");
-		expect(source.indexOf("Use a dedicated WhatsApp account")).toBeLessThan(
-			source.indexOf("Connect your account"),
-		);
+		expect(source).toMatch(/<Alert\s+data-whatsapp-account-warning/);
+		const warningMarkerIndex = source.indexOf("data-whatsapp-account-warning");
+		expect(warningMarkerIndex).toBeLessThan(source.indexOf("Connect your account"));
 		expect(connectDialog).toContain("<WhatsAppDeviceOnboarding");
 		expect(connectDialog).toContain("whitespace-normal break-words");
 		expect(connectDialog).not.toContain("min-w-0 truncate text-left");

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
@@ -78,9 +78,9 @@ export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
 				<TriangleAlert aria-hidden />
 				<AlertTitle>Use a dedicated WhatsApp account</AlertTitle>
 				<AlertDescription className="text-xs">
-					Clawdi connects as a linked device. Messages to this account may be handled by the Agent,
-					and replies are sent as this account. Use a separate WhatsApp account and phone number—not
-					your primary personal account.
+					Clawdi connects as a linked device. Once linked to an Agent, messages to this account may
+					be handled by the Agent, and replies are sent as this account. Use a separate WhatsApp
+					account and phone number—not your primary personal account.
 				</AlertDescription>
 			</Alert>
 			<p className="min-w-0 text-xs text-muted-foreground [overflow-wrap:anywhere]" role="status">

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
@@ -8,9 +8,11 @@ import {
 	QrCode,
 	RefreshCw,
 	Smartphone,
+	TriangleAlert,
 	Unplug,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -72,6 +74,15 @@ export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
 					</p>
 				</div>
 			</div>
+			<Alert data-whatsapp-account-warning className="border-warning/30 bg-warning-muted py-2.5">
+				<TriangleAlert aria-hidden />
+				<AlertTitle>Use a dedicated WhatsApp account</AlertTitle>
+				<AlertDescription className="text-xs">
+					Clawdi connects as a linked device. Messages to this account may be handled by the Agent,
+					and replies are sent as this account. Use a separate WhatsApp account and phone number—not
+					your primary personal account.
+				</AlertDescription>
+			</Alert>
 			<p className="min-w-0 text-xs text-muted-foreground [overflow-wrap:anywhere]" role="status">
 				{readiness.isLoading ? "Checking linked-device availability…" : readinessMessage}
 			</p>

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
 import {
 	Bot,
 	CheckCircle2,
@@ -37,26 +36,17 @@ import {
 	whatsappQrExpiryLabel,
 	whatsappReadinessMessage,
 } from "@/hosted/v2/channels/whatsapp-device-onboarding.logic";
-import { cn } from "@/lib/utils";
 
-type WhatsAppConnectMode = "choose" | "custom";
+type WhatsAppConnectMode = "overview" | "custom";
 
-export function WhatsAppDeviceOnboarding({
-	agentId,
-	onChooseClawdi,
-	onDone,
-}: {
-	agentId?: string;
-	onChooseClawdi?: () => void;
-	onDone: () => void;
-}) {
-	const [mode, setMode] = useState<WhatsAppConnectMode>("choose");
+export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
+	const [mode, setMode] = useState<WhatsAppConnectMode>("overview");
 	const readiness = useWhatsAppOnboardingReadiness(true);
 
 	if (mode === "custom") {
 		return (
 			<div data-hosted="true" data-v2="true">
-				<YourWhatsAppFlow onBack={() => setMode("choose")} onDone={onDone} />
+				<YourWhatsAppFlow onBack={() => setMode("overview")} onDone={onDone} />
 			</div>
 		);
 	}
@@ -71,101 +61,35 @@ export function WhatsAppDeviceOnboarding({
 			data-v2="true"
 			data-whatsapp-account-choice
 		>
-			<div className="grid min-w-0 gap-3 sm:grid-cols-2">
-				<WhatsAppOptionCard
-					icon={Bot}
-					title="Clawdi WhatsApp"
-					badge="Shared"
-					description="Use a Clawdi-managed WhatsApp account. You never scan its device QR."
-				>
-					{agentId ? (
-						<Button
-							type="button"
-							variant="outline"
-							className="w-full min-w-0 whitespace-normal"
-							onClick={onChooseClawdi}
-						>
-							<Bot className="size-4 shrink-0" />
-							View Clawdi bots
-						</Button>
-					) : (
-						<Button
-							render={<Link to="/agents" />}
-							nativeButton={false}
-							variant="outline"
-							className="w-full min-w-0 whitespace-normal"
-						>
-							<Bot className="size-4 shrink-0" />
-							Choose from an Agent
-						</Button>
-					)}
-				</WhatsAppOptionCard>
-
-				<WhatsAppOptionCard
-					icon={Smartphone}
-					title="Your WhatsApp"
-					badge="Custom"
-					description="Link a WhatsApp account you own by scanning a linked-device QR."
-					muted={customUnavailable}
-				>
-					<p className="min-h-8 text-xs text-muted-foreground" role="status">
-						{readiness.isLoading ? "Checking linked-device availability…" : readinessMessage}
-					</p>
-					<Button
-						type="button"
-						className="w-full min-w-0 whitespace-normal"
-						disabled={customUnavailable || readiness.isLoading}
-						onClick={() => setMode("custom")}
-					>
-						<QrCode className="size-4 shrink-0" />
-						Connect your account
-					</Button>
-				</WhatsAppOptionCard>
-			</div>
-			<p className="text-xs text-muted-foreground">
-				Linking a bot to an Agent and pairing an authorized chat are separate next steps.
-			</p>
-		</div>
-	);
-}
-
-function WhatsAppOptionCard({
-	icon: Icon,
-	title,
-	badge,
-	description,
-	muted = false,
-	children,
-}: {
-	icon: typeof Bot;
-	title: string;
-	badge: string;
-	description: string;
-	muted?: boolean;
-	children: React.ReactNode;
-}) {
-	return (
-		<section
-			className={cn("flex min-w-0 flex-col gap-3 rounded-lg border p-3", muted && "bg-muted/20")}
-		>
-			<div className="flex min-w-0 items-start gap-2.5">
+			<div className="flex min-w-0 items-start gap-3">
 				<div className="shrink-0 rounded-md bg-identity-2-bg p-2 text-identity-2-fg">
-					<Icon className="size-4" aria-hidden="true" />
+					<Smartphone className="size-4" aria-hidden="true" />
 				</div>
 				<div className="min-w-0 flex-1">
-					<div className="flex min-w-0 flex-wrap items-center gap-1.5">
-						<h3 className="font-medium [overflow-wrap:anywhere]">{title}</h3>
-						<span className="rounded-full border px-1.5 py-0.5 text-[0.65rem] text-muted-foreground">
-							{badge}
-						</span>
-					</div>
+					<h3 className="font-medium [overflow-wrap:anywhere]">Your WhatsApp</h3>
 					<p className="mt-1 text-xs text-muted-foreground [overflow-wrap:anywhere]">
-						{description}
+						Add a WhatsApp account you own by scanning a linked-device QR.
 					</p>
 				</div>
 			</div>
-			<div className="mt-auto min-w-0 space-y-2">{children}</div>
-		</section>
+			<p className="min-w-0 text-xs text-muted-foreground [overflow-wrap:anywhere]" role="status">
+				{readiness.isLoading ? "Checking linked-device availability…" : readinessMessage}
+			</p>
+			<Button
+				type="button"
+				className="w-full min-w-0 whitespace-normal sm:w-fit"
+				disabled={customUnavailable || readiness.isLoading}
+				onClick={() => setMode("custom")}
+			>
+				<QrCode className="size-4 shrink-0" />
+				Connect your account
+			</Button>
+			<p className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
+				{WHATSAPP_LINKING_READY
+					? "This adds the account under Custom bots. Agent Link and chat Pair are separate next steps."
+					: "This adds the account under Custom bots. Agent Link and chat Pair remain gated until native runtime activation is enabled."}
+			</p>
+		</div>
 	);
 }
 
@@ -300,7 +224,7 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 					onClick={onBack}
 				>
 					<ChevronLeft className="size-4" />
-					WhatsApp options
+					WhatsApp setup
 				</button>
 				<div className="space-y-1.5">
 					<Label htmlFor="whatsapp-account-name">Account name</Label>


### PR DESCRIPTION
## Summary

- flatten the Add channel Custom bot flow, removing the managed Clawdi WhatsApp choice and nested-card layout
- keep Telegram and Discord selectable when that provider is already linked; add the new bot to inventory with an explicit null Agent id instead of auto-linking
- preserve first-time automatic Agent linking and pairing, with accurate linked versus inventory-only feedback
- add responsive provider controls, long-copy wrapping, and mobile coverage for Telegram, Discord, and WhatsApp
- guide users to configure unsupported providers in the Agent Interface, using the canonical Agent route when Agent context is available

## Verification

- `bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts` — passed, 558 files checked
- `bun run --cwd apps/web typecheck` — passed
- `bun run --cwd apps/web test` — passed in the Docker-backed clean runner, including unit tests and OSS builds
- `E2E_HOSTED_PORT=3187 bunx playwright test --config=playwright.hosted.config.ts e2e/hosted-smoke.pw.ts --grep <five focused channel scenarios>` — 5 passed

## Notes

- WhatsApp Agent linking remains behind the existing native-runtime gate.
- If the Agent link projection is unavailable, creation is intentionally conservative and adds the bot to inventory without auto-linking.