### PR TITLE
fix(whatsapp): recognize verified QR registration

### DIFF
--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -2,7 +2,13 @@ import { EventEmitter } from "node:events";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type BinaryNode, DisconnectReason, initAuthCreds, proto } from "baileys";
+import {
+	type AuthenticationCreds,
+	type BinaryNode,
+	DisconnectReason,
+	initAuthCreds,
+	proto,
+} from "baileys";
 import { describe, expect, it } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
@@ -13,45 +19,95 @@ import type { ProviderMessageEventInput } from "./sqlite-state.js";
 const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 describe("physical Baileys runtime", () => {
-	it("keeps an unregistered provider session idle until authenticated pairing starts", async () => {
+	it("retains verified rc14 QR identity through restart and SQLite reopen", async () => {
+		const sessionDir = mkdtempSync(join(tmpdir(), "clawdi-wa-runtime-qr-"));
+		const config = { ...sidecarConfig(), sessionDir };
 		const harness = createHarness({ registered: false });
-		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);
-
-		await runtime.start();
-		expect(harness.socketConfigurations).toHaveLength(0);
-		expect(runtime.health()).toMatchObject({ status: "stopped", registered: false });
-
-		await runtime.startQrPairing();
-		expect(harness.socketConfigurations).toHaveLength(1);
-		const firstQrObservedAt = Date.now();
-		harness.events.emit("connection.update", { qr: "sensitive-qr-value" });
-		await runtime.start();
-		const ready = runtime.pairingStatus();
-		expect(ready).toMatchObject({
-			status: "pairing_qr",
-			registered: false,
-			method: "qr",
-			qr: "sensitive-qr-value",
+		const runtime = new BaileysSocketRuntime(config, {
+			socketFactory: harness.dependencies.socketFactory,
 		});
-		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeGreaterThanOrEqual(59_000);
-		expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeLessThanOrEqual(61_000);
-		expect(harness.socketConfigurations).toHaveLength(1);
+		let reopenedRuntime: BaileysSocketRuntime | undefined;
+		try {
+			await runtime.start();
+			expect(harness.socketConfigurations).toHaveLength(0);
+			expect(runtime.health()).toMatchObject({ status: "stopped", registered: false });
 
-		const rotatedQrObservedAt = Date.now();
-		harness.events.emit("connection.update", { qr: "sensitive-qr-value-rotated" });
-		const rotated = runtime.pairingStatus();
-		expect(rotated).toMatchObject({ qr: "sensitive-qr-value-rotated" });
-		expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeGreaterThanOrEqual(
-			19_000,
-		);
-		expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeLessThanOrEqual(21_000);
-		expect(Date.parse(rotated.qrExpiresAt ?? "")).toBeLessThan(Date.parse(ready.qrExpiresAt ?? ""));
+			await runtime.startQrPairing();
+			expect(harness.socketConfigurations).toHaveLength(1);
+			const firstQrObservedAt = Date.now();
+			harness.events.emit("connection.update", { qr: "sensitive-qr-value" });
+			const ready = runtime.pairingStatus();
+			expect(ready).toMatchObject({
+				status: "pairing_qr",
+				registered: false,
+				method: "qr",
+				qr: "sensitive-qr-value",
+			});
+			expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeGreaterThanOrEqual(
+				59_000,
+			);
+			expect(Date.parse(ready.qrExpiresAt ?? "") - firstQrObservedAt).toBeLessThanOrEqual(61_000);
+			const rotatedQrObservedAt = Date.now();
+			harness.events.emit("connection.update", { qr: "sensitive-qr-value-rotated" });
+			const rotated = runtime.pairingStatus();
+			expect(rotated).toMatchObject({ qr: "sensitive-qr-value-rotated" });
+			expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeGreaterThanOrEqual(
+				19_000,
+			);
+			expect(Date.parse(rotated.qrExpiresAt ?? "") - rotatedQrObservedAt).toBeLessThanOrEqual(
+				21_000,
+			);
+			expect(Date.parse(rotated.qrExpiresAt ?? "")).toBeLessThan(
+				Date.parse(ready.qrExpiresAt ?? ""),
+			);
 
-		harness.events.emit("creds.update", { registered: true });
-		expect(runtime.pairingStatus()).toEqual({ status: "starting", registered: true });
-		harness.events.emit("connection.update", { connection: "open" });
-		expect(runtime.pairingStatus()).toEqual({ status: "connected", registered: true });
-		await runtime.stop();
+			harness.events.emit("creds.update", verifiedQrUpdate());
+			harness.events.emit("connection.update", { isNewLogin: true, qr: undefined });
+			expect(harness.socketConfigurations[0]?.auth.creds.registered).toBe(false);
+			expect(runtime.pairingStatus()).toEqual({ status: "starting", registered: true });
+			await expect(runtime.startQrPairing()).rejects.toThrow("physical_account_already_registered");
+			await expect(runtime.cancelPairing()).rejects.toThrow("registered_session_requires_logout");
+
+			harness.events.emit("connection.update", {
+				connection: "close",
+				lastDisconnect: { error: { output: { statusCode: DisconnectReason.restartRequired } } },
+			});
+			expect(runtime.health()).toMatchObject({ status: "disconnected", registered: true });
+			await runtime.retryPairing();
+			expect(harness.socketConfigurations).toHaveLength(2);
+			harness.events.emit("connection.update", { connection: "open" });
+			expect(runtime.pairingStatus()).toEqual({ status: "connected", registered: true });
+			await runtime.stop();
+
+			const reopenedHarness = createHarness({ registered: false });
+			reopenedRuntime = new BaileysSocketRuntime(config, {
+				socketFactory: reopenedHarness.dependencies.socketFactory,
+			});
+			await reopenedRuntime.start();
+			expect(reopenedHarness.socketConfigurations).toHaveLength(1);
+			const restoredCreds = reopenedHarness.socketConfigurations[0]?.auth.creds;
+			expect(restoredCreds?.registered).toBe(false);
+			expect(restoredCreds?.me).toEqual({
+				id: "15550001111:1@s.whatsapp.net",
+				name: "Test account",
+				lid: "15550001111@lid",
+			});
+			expect(reopenedRuntime.health()).toMatchObject({ status: "connecting", registered: true });
+			reopenedHarness.events.emit("connection.update", { connection: "open" });
+			expect(reopenedRuntime.health()).toMatchObject({ status: "connected", registered: true });
+			await expect(reopenedRuntime.cancelPairing()).rejects.toThrow(
+				"registered_session_requires_logout",
+			);
+			expect(await reopenedRuntime.logoutPairing()).toEqual({
+				status: "stopped",
+				registered: false,
+			});
+			expect(reopenedHarness.logoutCalls).toBe(1);
+		} finally {
+			await reopenedRuntime?.stop();
+			await runtime.stop();
+			rmSync(sessionDir, { recursive: true, force: true });
+		}
 	});
 
 	it("supports the pinned rc14 pairing-code method without retaining phone input", async () => {
@@ -481,6 +537,9 @@ function createHarness(options: HarnessOptions = {}) {
 			},
 			async requestPairingCode(phoneNumber) {
 				pairingCodePhones.push(phoneNumber);
+				creds.me = { id: `${phoneNumber}@s.whatsapp.net`, name: "~" };
+				creds.pairingCode = "12345678";
+				events.emit("creds.update", creds);
 				return "12345678";
 			},
 			async relayMessage(jid, _message, relayOptions) {
@@ -532,5 +591,27 @@ function sidecarConfig(): SidecarSessionConfig {
 		logLevel: "silent",
 		webVersion: parseAuditedWhatsAppWebVersion("2.3000.1043857760"),
 		providerInbox: { maxEvents: 100, maxBytes: 1024 * 1024 },
+	};
+}
+
+function verifiedQrUpdate(): Partial<AuthenticationCreds> {
+	return {
+		account: {
+			details: Buffer.from([1]),
+			accountSignatureKey: Buffer.from([2]),
+			accountSignature: Buffer.from([3]),
+			deviceSignature: Buffer.from([4]),
+		},
+		me: {
+			id: "15550001111:1@s.whatsapp.net",
+			name: "Test account",
+			lid: "15550001111@lid",
+		},
+		signalIdentities: [
+			{
+				identifier: { name: "15550001111@lid", deviceId: 0 },
+				identifierKey: Buffer.from([5]),
+			},
+		],
 	};
 }

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -15,6 +15,7 @@ import pino, { type Logger } from "pino";
 import { AUDITED_PROVIDER_RELEASE } from "./audited-version.js";
 import type { SidecarSessionConfig } from "./config.js";
 import {
+	isLinkedAuthenticationCreds,
 	type ProviderMessageEvent,
 	type ProviderMessageEventInput,
 	type ProviderStateFailureOperation,
@@ -137,7 +138,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		// An unregistered socket may already be generating or displaying a QR;
 		// preserve that sole physical owner instead of resetting its lifecycle.
 		if (this.socket) return;
-		if (!this.providerState.state.creds.registered) {
+		if (!isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 			this.status = "stopped";
 			return;
 		}
@@ -177,7 +178,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		return {
 			status: this.status,
 			connected: this.status === "connected",
-			registered: this.providerState.state.creds.registered,
+			registered: isLinkedAuthenticationCreds(this.providerState.state.creds),
 			sessionId: this.config.sessionId,
 			advertisedRelease: AUDITED_PROVIDER_RELEASE,
 			uptimeSeconds: Math.floor((Date.now() - this.startedAt) / 1000),
@@ -191,7 +192,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 	}
 
 	pairingStatus(): PairingStatus {
-		const registered = this.providerState.state.creds.registered;
+		const registered = isLinkedAuthenticationCreds(this.providerState.state.creds);
 		if (registered) this.clearPairingSecrets();
 		const qrIsCurrent =
 			this.pairingQr !== undefined &&
@@ -256,7 +257,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 
 	async cancelPairing(): Promise<PairingStatus> {
 		return await this.runLifecycle(async () => {
-			if (this.providerState.state.creds.registered) {
+			if (isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 				throw new PairingLifecycleError("registered_session_requires_logout");
 			}
 			return await this.cancelPairingUnsafe();
@@ -265,7 +266,9 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 
 	async logoutPairing(): Promise<PairingStatus> {
 		return await this.runLifecycle(async () => {
-			if (!this.providerState.state.creds.registered) return await this.cancelPairingUnsafe();
+			if (!isLinkedAuthenticationCreds(this.providerState.state.creds)) {
+				return await this.cancelPairingUnsafe();
+			}
 			const socket = this.socket;
 			if (!socket || this.status !== "connected") {
 				throw new PairingLifecycleError("registered_session_not_connected");
@@ -276,7 +279,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 			} catch (error: unknown) {
 				// A failed request does not confirm companion-device removal. Keep
 				// this socket so a retry cannot create a second physical owner.
-				if (!this.providerState.state.creds.registered) {
+				if (!isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 					if (this.physicalAuthResetGeneration === resetGeneration) this.resetPhysicalAuth();
 					if (this.socket === socket) this.socket = null;
 					this.clearPairingSecrets();
@@ -297,7 +300,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 
 	async retryPairing(): Promise<PairingStatus> {
 		return await this.runLifecycle(async () => {
-			if (!this.providerState.state.creds.registered) {
+			if (!isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 				throw new PairingLifecycleError("unregistered_session_requires_pairing");
 			}
 			if (!this.socket) {
@@ -373,7 +376,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		socket.ev.on("creds.update", (update) => {
 			try {
 				this.providerState.saveCreds(update);
-				if (update.registered === true || this.providerState.state.creds.registered) {
+				if (isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 					this.clearPairingSecrets();
 				}
 			} catch (error: unknown) {
@@ -483,7 +486,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		if (this.stateClosed || this.fatalReason) {
 			throw new PairingLifecycleError("provider_state_unavailable");
 		}
-		if (this.providerState.state.creds.registered) {
+		if (isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 			throw new PairingLifecycleError("physical_account_already_registered");
 		}
 	}

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
@@ -9,12 +9,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { proto } from "baileys";
+import { type AuthenticationCreds, proto } from "baileys";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
 import { Database } from "./sqlite-database.js";
 import {
+	isLinkedAuthenticationCreds,
 	ProviderInboxCapacityError,
 	type ProviderMessageEventInput,
 	type ProviderStateFailureOperation,
@@ -40,15 +41,16 @@ afterEach(() => {
 });
 
 describe("SQLite provider state", () => {
-	it("round-trips creds, Signal keys, app-state proto, retries, and clears across restart", async () => {
+	it("round-trips verified rc14 QR creds, Signal state, and retries across restart", async () => {
 		const directory = makeDirectory();
 		const first = makeState(directory);
 		first.saveCreds({
-			registered: true,
+			...verifiedQrUpdate(),
 			registrationId: 0,
-			me: REGISTERED_ME,
 			routingInfo: Buffer.from([1, 2, 3]),
 		});
+		expect(first.state.creds.registered).toBe(false);
+		expect(isLinkedAuthenticationCreds(first.state.creds)).toBe(true);
 		const appStateKey = proto.Message.AppStateSyncKeyData.create({
 			keyData: Buffer.from([9, 8, 7]),
 			fingerprint: { rawId: 4, currentIndex: 2, deviceIndexes: [0, 1] },
@@ -67,7 +69,12 @@ describe("SQLite provider state", () => {
 
 		const second = makeState(directory);
 		expect(second.state.creds.registrationId).toBe(0);
-		expect(second.state.creds.registered).toBe(true);
+		expect(second.state.creds.registered).toBe(false);
+		expect(second.state.creds.me).toEqual({
+			...REGISTERED_ME,
+			lid: "15550001111@lid",
+		});
+		expect(isLinkedAuthenticationCreds(second.state.creds)).toBe(true);
 		expect(second.state.creds.routingInfo).toEqual(Buffer.from([1, 2, 3]));
 		expect(await second.state.keys.get("pre-key", ["one"])).toEqual({
 			one: { public: Buffer.from([1, 2]), private: Buffer.from([3, 4]) },
@@ -95,17 +102,25 @@ describe("SQLite provider state", () => {
 		second.close();
 	});
 
-	it("keeps manual phone and pairing-code input out of unregistered auth snapshots", () => {
+	it("keeps temporary pairing-code and malformed identity input unlinked and out of snapshots", () => {
 		const directory = makeDirectory();
 		const phoneJid = "14155550123@s.whatsapp.net";
 		const first = makeState(directory);
 		first.saveCreds({
 			me: { id: phoneJid, name: "~" },
 			pairingCode: "12345678",
+			account: verifiedQrUpdate().account,
+			signalIdentities: [
+				{
+					identifier: { name: "", deviceId: -1 },
+					identifierKey: Buffer.alloc(0),
+				},
+			],
 		});
 
 		expect(first.state.creds.me?.id).toBe(phoneJid);
 		expect(first.state.creds.pairingCode).toBe("12345678");
+		expect(isLinkedAuthenticationCreds(first.state.creds)).toBe(false);
 		const stored = internalDatabase(first)
 			.query<{ value: string }, []>("SELECT value FROM auth_creds WHERE singleton = 1")
 			.get();
@@ -116,6 +131,7 @@ describe("SQLite provider state", () => {
 		const second = makeState(directory);
 		expect(second.state.creds.me).toBeUndefined();
 		expect(second.state.creds.pairingCode).toBeUndefined();
+		expect(isLinkedAuthenticationCreds(second.state.creds)).toBe(false);
 		second.close();
 	});
 
@@ -436,6 +452,24 @@ function providerEvent(messageId: string): ProviderMessageEventInput {
 		messageProtoBase64: Buffer.from(
 			proto.Message.encode({ conversation: messageId }).finish(),
 		).toString("base64"),
+	};
+}
+
+function verifiedQrUpdate(): Partial<AuthenticationCreds> {
+	return {
+		account: {
+			details: Buffer.from([1]),
+			accountSignatureKey: Buffer.from([2]),
+			accountSignature: Buffer.from([3]),
+			deviceSignature: Buffer.from([4]),
+		},
+		me: { ...REGISTERED_ME, lid: "15550001111@lid" },
+		signalIdentities: [
+			{
+				identifier: { name: "15550001111@lid", deviceId: 0 },
+				identifierKey: Buffer.from([5]),
+			},
+		],
 	};
 }
 

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
@@ -6,6 +6,7 @@ import {
 	BufferJSON,
 	type CacheStore,
 	initAuthCreds,
+	jidDecode,
 	proto,
 	type SignalDataSet,
 	type SignalDataTypeMap,
@@ -770,9 +771,63 @@ function credentialsForPersistence(creds: AuthenticationCreds): AuthenticationCr
 		// survive in the physical auth database.
 		pairingCode: undefined,
 		// requestPairingCode temporarily stores the raw phone JID in `me` before
-		// authentication. A crash restarts pairing instead of retaining that input.
-		...(creds.registered ? {} : { me: undefined }),
+		// authentication. Retain it only with the complete identity evidence that
+		// rc14 produces after it verifies a successful pairing.
+		...(isLinkedAuthenticationCreds(creds) ? {} : { me: undefined }),
 	};
+}
+
+export function isLinkedAuthenticationCreds(creds: AuthenticationCreds): boolean {
+	if (creds.registered) return true;
+	return (
+		validContactIdentity(creds.me) &&
+		validSignedDeviceIdentity(creds.account) &&
+		Array.isArray(creds.signalIdentities) &&
+		creds.signalIdentities.length > 0 &&
+		creds.signalIdentities.every(validSignalIdentity)
+	);
+}
+
+function validContactIdentity(value: unknown): boolean {
+	return isRecord(value) && validIdentityJid(value.id);
+}
+
+function validSignedDeviceIdentity(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		validNonemptyBytes(value.details) &&
+		validNonemptyBytes(value.accountSignatureKey) &&
+		validNonemptyBytes(value.accountSignature) &&
+		validNonemptyBytes(value.deviceSignature)
+	);
+}
+
+function validSignalIdentity(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		isRecord(value.identifier) &&
+		validIdentityJid(value.identifier.name) &&
+		nonNegativeSafeInteger(value.identifier.deviceId) &&
+		validNonemptyBytes(value.identifierKey)
+	);
+}
+
+function validIdentityJid(value: unknown): boolean {
+	if (typeof value !== "string" || value.length === 0 || value.length > 512) return false;
+	const separator = value.indexOf("@");
+	if (separator < 1 || separator !== value.lastIndexOf("@")) return false;
+	if (!/^[^@:\s]+(?::[0-9]+)?$/.test(value.slice(0, separator))) return false;
+	const decoded = jidDecode(value);
+	return (
+		decoded !== undefined &&
+		decoded.user.length > 0 &&
+		["s.whatsapp.net", "lid", "hosted", "hosted.lid"].includes(decoded.server) &&
+		(decoded.device === undefined || nonNegativeSafeInteger(decoded.device))
+	);
+}
+
+function validNonemptyBytes(value: unknown): boolean {
+	return isByteArray(value) && value.byteLength > 0;
 }
 
 function validKeyPair(value: unknown): boolean {


### PR DESCRIPTION
## Summary

- recognize a sidecar session as linked when upstream `registered === true` or when rc14 has produced the complete verified QR identity shape (`me`, signed account identity, and nonempty valid Signal identities)
- use that single product-level predicate for persistence, auto-start, pairing-secret cleanup, lifecycle safety, and status without mutating Baileys credentials or adding durable markers
- model the rc14 QR sequence (`creds.update` without `registered:true`, `isNewLogin`, restart-required 515, reconnect/open) and prove identity survives SQLite reopen while temporary pairing-code `me` remains unlinked and unpersisted

## Upstream rc14 evidence

The pinned `v7.0.0-rc14` tag resolves to commit `7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a`.

- Pair success calls `configureSuccessfulPairing`, emits its credential update, then emits `isNewLogin`; it does not set `registered`: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Socket/socket.ts#L912-L928
- `configureSuccessfulPairing` verifies the HMAC/account/device signatures and returns `account`, `me`, `signalIdentities`, and `platform`: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Utils/validate-connection.ts#L159-L248
- The credential and Signal identity field shapes are defined here: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Types/Auth.ts#L13-L20 and https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Types/Auth.ts#L48-L70
- Pairing-code setup temporarily writes the raw phone JID to `me` before emitting credentials: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Socket/socket.ts#L764-L777
- The official example uses raw `creds.registered` only to decide whether to request a pairing code and persists every credential update: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/Example/example.ts#L78-L102
- The README likewise wires every `creds.update` to persistence: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/README.md#L285-L304
- rc14 defines restart-required as 515: https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Types/index.ts#L28-L38

## Verification

- `bun run --cwd packages/whatsapp-baileys-sidecar typecheck`
- `bun run --cwd packages/whatsapp-baileys-sidecar test:internal` (59 passed)
- focused Biome check on the four changed files
- `bun run --cwd packages/whatsapp-baileys-sidecar test` (Docker clean runner; 59 passed)
- production Node 24 image build plus local blank-state healthcheck
- `git diff --check origin/main..HEAD`

No live WhatsApp, QR, tenant, production, deployment, or merge operation was used.