### PR TITLE
Fence hosted runtime CLI handoff to exact package

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -679,6 +679,18 @@ journal. `badVersions` is preserved. Missing, stale, tampered, or mismatched
 bootstrap identity continues through verified rollback and otherwise fails
 closed; version ordering is not an ownership signal.
 
+When only the exact CLI package changes and the capability image remains
+compatible, the substrate may rotate the fixed runtime-context directory in
+place without replacing the workload. The running watcher first requires the
+context `cliPackageSpec` to match the fetched manifest package, installs and
+verifies that exact package, atomically activates it, and exits cleanly. The
+`Restart=always` systemd unit then starts the watcher from the absolute managed
+CLI path. The new CLI performs the complete manifest and systemd convergence;
+the old applied authority remains current until that convergence commits the
+new Apply identity. A failed first convergence rolls back to the previously
+verified CLI. This is a process handoff inside the existing workload, not a
+workload restart or replacement.
+
 ## Commands
 
 Root runtime operators can use these commands in controlled environments:
@@ -870,8 +882,10 @@ the sole authority for exact manifest `secret://` references. API URLs that are
 already in the manifest, auth selectors, paths, mode, runtime user, and process
 environment are not duplicated in the context. A missing or malformed context
 fails closed, and no field falls back to ambient process environment. The
-applied generation must match the manifest and is validated before convergence
-can mutate live state. `manifestETag` names the
+applied generation and exact CLI package must match the fetched manifest and
+are validated before CLI installation, systemd mutation, or applied-authority
+commit can occur. The paired-image local tarball exception exists only when the
+explicit test-installer gate is enabled. `manifestETag` names the
 Hosted control-plane snapshot and is persisted separately from the fetched
 bundle's HTTP ETag, which remains the strong validator derived from
 `sourceRevision`; the two values are intentionally independent. This lets one

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -18,6 +18,7 @@ import {
 	isClawdiManagedProviderProjection,
 } from "./hosted-egress-profiles";
 import {
+	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	type HostedRuntimeManifest,
 	hostedCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
@@ -393,6 +394,15 @@ function assertRuntimeApplyContextMatchesManifest(
 	) {
 		throw new Error(
 			`runtime apply identity generation ${applyContext.identity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(manifest)}`,
+		);
+	}
+	const manifestCliPackageSpec = manifest.clawdiCli?.packageSpec;
+	const pairedFixtureMatch =
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS === "1" &&
+		applyContext.cliPackageSpec === HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE;
+	if (applyContext.cliPackageSpec !== manifestCliPackageSpec && !pairedFixtureMatch) {
+		throw new Error(
+			`runtime context CLI package ${applyContext.cliPackageSpec} does not match manifest CLI package ${manifestCliPackageSpec ?? "missing"}`,
 		);
 	}
 }

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -84,6 +84,7 @@ function readFileTree(root: string): string {
 function setRuntimeApplyIdentityFile(
 	root: string,
 	identity: { generation: number; manifestETag: string; applyReceiptId: string; bootNonce: string },
+	cliPackageSpec = "clawdi@1.2.3",
 ): RuntimeApplyContext {
 	const path = join(root, "runtime-context.json");
 	writeFileSync(
@@ -91,7 +92,7 @@ function setRuntimeApplyIdentityFile(
 		JSON.stringify({
 			schemaVersion: "clawdi.runtimeContext.v2",
 			apply: identity,
-			cliPackageSpec: "clawdi@1.2.3",
+			cliPackageSpec,
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -940,12 +941,16 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
-		const applyContext = setRuntimeApplyIdentityFile(root, {
-			generation: 1,
-			manifestETag: '"bundle-golden"',
-			applyReceiptId: "apply-receipt-golden-0001",
-			bootNonce: "boot-nonce-golden-000001",
-		});
+		const applyContext = setRuntimeApplyIdentityFile(
+			root,
+			{
+				generation: 1,
+				manifestETag: '"bundle-golden"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
+			},
+			"clawdi@0.12.10-beta.57",
+		);
 		const paths = getRuntimePaths({ mode: "hosted" });
 		globalThis.fetch = Object.assign(
 			async () =>
@@ -969,12 +974,16 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
-		const applyContext = setRuntimeApplyIdentityFile(root, {
-			generation: 1,
-			manifestETag: '"bundle-golden"',
-			applyReceiptId: "apply-receipt-golden-0001",
-			bootNonce: "boot-nonce-golden-000001",
-		});
+		const applyContext = setRuntimeApplyIdentityFile(
+			root,
+			{
+				generation: 1,
+				manifestETag: '"bundle-golden"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
+			},
+			"clawdi@0.12.10-beta.57",
+		);
 		const paths = getRuntimePaths({ mode: "hosted" });
 		globalThis.fetch = Object.assign(
 			async () =>
@@ -1001,12 +1010,16 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
-		const applyContext = setRuntimeApplyIdentityFile(root, {
-			generation: 1,
-			manifestETag: '"bundle-golden"',
-			applyReceiptId: "apply-receipt-golden-0001",
-			bootNonce: "boot-nonce-golden-000001",
-		});
+		const applyContext = setRuntimeApplyIdentityFile(
+			root,
+			{
+				generation: 1,
+				manifestETag: '"bundle-golden"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
+			},
+			"clawdi@0.12.10-beta.57",
+		);
 		globalThis.fetch = Object.assign(
 			async () =>
 				new Response(readFileSync(goldenPath, "utf-8"), {
@@ -1072,12 +1085,16 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_EGRESS_UID = "10002";
 		process.env.CLAWDI_EGRESS_GID = "10002";
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
-		const applyContext = setRuntimeApplyIdentityFile(root, {
-			generation: 1,
-			manifestETag: '"bundle-golden"',
-			applyReceiptId: "apply-receipt-golden-0001",
-			bootNonce: "boot-nonce-golden-000001",
-		});
+		const applyContext = setRuntimeApplyIdentityFile(
+			root,
+			{
+				generation: 1,
+				manifestETag: '"bundle-golden"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
+			},
+			"clawdi@0.12.10-beta.57",
+		);
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const goldenRaw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
 			sourceRevision: string;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7678,6 +7678,34 @@ fi
 					applyReceiptId: "apply-receipt-generation-0031",
 					bootNonce: "boot-nonce-generation-0001",
 				},
+				{
+					...CANONICAL_TEST_CONTEXT,
+					cliPackageSpec: "clawdi@0.13.1-test",
+				},
+			);
+			const committedBeforeMismatchedCliPackage = readFileSync(paths.appliedState, "utf-8");
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
+				status: "error",
+				mode: "manifest-rejected",
+			});
+			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain(
+				"runtime context CLI package clawdi@0.13.1-test does not match manifest CLI package clawdi@0.13.0-test",
+			);
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedBeforeMismatchedCliPackage);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+
+			setRuntimeApplyContextFixture(
+				{
+					generation,
+					manifestETag: '"hosted-control-plane-generation-31"',
+					applyReceiptId: "apply-receipt-generation-0031",
+					bootNonce: "boot-nonce-generation-0001",
+				},
 				CANONICAL_TEST_CONTEXT,
 			);
 			process.exitCode = undefined;
@@ -7720,7 +7748,7 @@ fi
 				applyReceiptId: "apply-receipt-generation-0031",
 				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(watchFetch.captured).toHaveLength(10);
+			expect(watchFetch.captured).toHaveLength(12);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
@@ -8928,7 +8956,6 @@ fi
 
 	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
 		installSuccessfulSystemctlFixture();
-		setRuntimeApplyGeneration(13, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8938,6 +8965,11 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		const cliContext = {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: `clawdi@${currentVersion}`,
+		};
+		setRuntimeApplyGeneration(13, cliContext);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -9067,7 +9099,7 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
-			setRuntimeApplyGeneration(13, CANONICAL_TEST_CONTEXT);
+			setRuntimeApplyGeneration(13, cliContext);
 			await runtimeWatch({ once: true, json: true });
 
 			expect(process.exitCode ?? 0).toBe(0);
@@ -9621,7 +9653,6 @@ fi
 
 	it("runtime watch reapplies transparent egress across CLI self-upgrade", async () => {
 		installSuccessfulSystemctlFixture();
-		setRuntimeApplyGeneration(1, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9631,6 +9662,11 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		const cliContext = {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: `clawdi@${currentVersion}`,
+		};
+		setRuntimeApplyGeneration(1, cliContext);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -9825,7 +9861,7 @@ fi
 		]);
 
 		try {
-			setRuntimeApplyGeneration(2, CANONICAL_TEST_CONTEXT);
+			setRuntimeApplyGeneration(2, cliContext);
 			await runtimeWatch({ once: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
@@ -10879,7 +10915,10 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch never enters a failing projection after CLI activation", async () => {
-		setRuntimeApplyGeneration(16, CANONICAL_TEST_CONTEXT);
+		setRuntimeApplyGeneration(16, {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: "clawdi@0.13.3-beta.0",
+		});
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11027,7 +11066,6 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
-		setRuntimeApplyGeneration(18, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11038,6 +11076,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		setRuntimeApplyGeneration(18, {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: `clawdi@${currentVersion}`,
+		});
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -11218,7 +11260,6 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
-		setRuntimeApplyGeneration(17, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11227,6 +11268,10 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		setRuntimeApplyGeneration(17, {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: `clawdi@${currentVersion}`,
+		});
 		const firstAttempt = join(root, "npm-etarget-first-attempt");
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
@@ -11363,7 +11408,10 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("hands off before evaluating minimumCliVersion under old code", async () => {
-		setRuntimeApplyGeneration(19, CANONICAL_TEST_CONTEXT);
+		setRuntimeApplyGeneration(19, {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: "clawdi@0.13.10-beta.0",
+		});
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -12031,6 +12079,11 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
+		const cliContext = {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: `clawdi@${currentVersion}`,
+		};
+		setRuntimeApplyGeneration(1, cliContext);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(dirname(policyPath), { recursive: true });
@@ -12121,7 +12174,7 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
-			setRuntimeApplyGeneration(1, CANONICAL_TEST_CONTEXT);
+			setRuntimeApplyGeneration(1, cliContext);
 			await runtimeInit({ nonInteractive: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
@@ -12420,8 +12473,10 @@ exit 64
 				"utf-8",
 			),
 		) as {
+			applyGeneration: number;
 			sourceRevision: string;
 			manifest: {
+				clawdiCli: { packageSpec: string };
 				runtime: string;
 				system: Record<string, unknown>;
 				runtimes: Record<string, unknown>;
@@ -12436,6 +12491,10 @@ exit 64
 			manifest: bundle.manifest,
 			channelBindings: bundle.channelBindings,
 			secretValues: bundle.secretValues,
+		});
+		setRuntimeApplyGeneration(bundle.applyGeneration, {
+			...CANONICAL_TEST_CONTEXT,
+			cliPackageSpec: bundle.manifest.clawdiCli.packageSpec,
 		});
 
 		mkdirSync(join(run, "secrets"), { recursive: true });


### PR DESCRIPTION
## Summary

- require the authenticated hosted runtime context CLI package to match the fetched manifest exact package before installation, systemd mutation, or applied-authority commit
- preserve the existing atomic CLI install, verification, systemd handoff, rollback, and receipt/health convergence path
- retain the paired-image tarball fixture only behind CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1 and align existing fixtures with their exact manifest package

This is the in-Pod owner half of the paired declarative CLI-only update. It does not mutate Kubernetes workloads or introduce a restart path.

Companion Hosted controller PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/1373

## Verification

- bun run --cwd packages/cli test (isolated Docker runner): typecheck passed; 1583 passed, 4 skipped, 0 failed
- packages/cli/tests/runtime.test.ts focused local diagnostic: 164 passed, 0 failed
- packages/cli/src/runtime/runtime-bundle-v2.test.ts focused local diagnostic: 38 passed, 0 failed

The skipped cases are the existing opt-in native installer/daemon lifecycle tests.