### PR TITLE
Refine Add channel dialog hierarchy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -10195,7 +10195,7 @@ for (const firstTimeViewport of [
 	});
 }
 
-test("Add channel keeps already-linked Telegram and Discord available as inventory-only additions", async ({
+test("Add channel confirms atomic Telegram and Discord link replacement", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 320, height: 844 });
@@ -10219,6 +10219,8 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 		webhook_url: "https://cloud.example.test/channels/existing-discord",
 	};
 	const createChannelRequests: string[] = [];
+	const linkAgentRequests: Array<{ accountId: string; body: string }> = [];
+	const unlinkAgentRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [runningMissingProjectionDeployment],
 		channelAccounts: [telegramAccount, discordAccount],
@@ -10241,6 +10243,8 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 			},
 		],
 		createChannelRequests,
+		linkAgentRequests,
+		unlinkAgentRequests,
 		createChannelResponses: [
 			{
 				status: 201,
@@ -10249,10 +10253,14 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 					id: "5a555555-5555-4555-8555-555555555555",
 					name: "Additional Telegram",
 					webhook_secret: "telegram-webhook-secret-must-not-render",
-					agent_link_id: null,
-					agent_id: null,
+					agent_link_id: "5a777777-7777-4777-8777-777777777777",
+					agent_id: agentId,
 					agent_token: null,
 				},
+			},
+			{
+				status: 503,
+				body: { detail: "Replacement transaction temporarily unavailable" },
 			},
 			{
 				status: 201,
@@ -10261,8 +10269,8 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 					id: "5a666666-6666-4666-8666-666666666666",
 					name: "Additional Discord",
 					webhook_secret: "discord-webhook-secret-must-not-render",
-					agent_link_id: null,
-					agent_id: null,
+					agent_link_id: "5a888888-8888-4888-8888-888888888888",
+					agent_id: agentId,
 					agent_token: null,
 				},
 			},
@@ -10285,13 +10293,10 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	await expect(telegramProvider).toBeEnabled();
 	await expect(discordProvider).toBeEnabled();
 	await expect(providerConfiguration).toHaveAccessibleName("Configure Telegram");
-	let linkWarning = providerConfiguration.locator("[data-agent-link-warning]");
-	await expect(linkWarning).toHaveAttribute("role", "alert");
-	await expect(linkWarning.getByText("Telegram is already linked", { exact: true })).toBeVisible();
-	await expect(linkWarning).toContainText(
-		"This Agent already has a Telegram link. The new bot will be added to Custom bots without linking to this Agent.",
-	);
-	await expect(dialog.getByRole("status")).toHaveCount(0);
+	await expect(providerConfiguration.locator("[data-agent-link-warning]")).toHaveCount(0);
+	await expect(
+		providerConfiguration.getByRole("status").getByText(/replace.*existing Telegram link/i),
+	).toBeVisible();
 	await expect(
 		providerChooser.locator("[data-other-provider-hint]").getByRole("link", {
 			name: "Agent Interface",
@@ -10302,29 +10307,50 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	);
 	await dialog.getByLabel("Name").fill("Additional Telegram");
 	await dialog.getByLabel("Bot token").fill("123456:additional-telegram-token");
-	await expectNoHorizontalOverflow(dialog, "inventory-only Telegram form at 320px");
+	await expectNoHorizontalOverflow(dialog, "Telegram replacement form at 320px");
+	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	let replacementDialog = page.getByRole("alertdialog", {
+		name: "Replace this Agent’s Telegram link?",
+	});
+	await expect(replacementDialog).toBeVisible();
+	await expect(replacementDialog).toContainText("one Telegram bot at a time");
+	await expect(replacementDialog).toContainText("Additional Telegram");
+	await expect(createChannelRequests).toHaveLength(0);
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
 	await page.locator("html").evaluate((element) => element.classList.add("dark"));
 	await expect(page.locator("html")).toHaveClass(/dark/);
-	await dialog.screenshot({
-		path: testInfo.outputPath("already-linked-telegram-form-dark-320.png"),
+	await expectNoHorizontalOverflow(replacementDialog, "Telegram replacement confirmation at 320px");
+	await replacementDialog.screenshot({
+		path: testInfo.outputPath("replace-telegram-link-confirm-dark-320.png"),
 	});
 	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	await replacementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(replacementDialog).toHaveCount(0);
+	await expect(createChannelRequests).toHaveLength(0);
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
+
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	replacementDialog = page.getByRole("alertdialog", {
+		name: "Replace this Agent’s Telegram link?",
+	});
+	await replacementDialog
+		.getByRole("button", { name: "Replace Telegram link", exact: true })
+		.click();
 	await expect.poll(() => createChannelRequests.length).toBe(1);
 	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
 		provider: "telegram",
 		name: "Additional Telegram",
 		provider_token: "123456:additional-telegram-token",
-		agent_id: null,
+		agent_id: agentId,
+		replace_existing_provider_link: true,
 	});
-	dialog = page.getByRole("dialog", { name: "Custom bot added" });
-	await expect(dialog).toContainText(
-		"Additional Telegram was added to Custom bots. It was not linked because Telegram is already linked to this Agent.",
-	);
-	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toHaveCount(0);
-	await expectNoHorizontalOverflow(dialog, "inventory-only Telegram result at 320px");
-	await dialog.screenshot({ path: testInfo.outputPath("inventory-only-telegram-result-320.png") });
-	await dialog.getByRole("button", { name: "Done", exact: true }).click();
+	const telegramPairDialog = page.getByRole("dialog", { name: "Pair Telegram" });
+	await expect(telegramPairDialog).toBeVisible();
+	await expect(page.getByRole("dialog", { name: "Add channel" })).toHaveCount(0);
+	await telegramPairDialog.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(telegramPairDialog).toHaveCount(0);
 
 	await addChannel.click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
@@ -10332,38 +10358,60 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	await expect(dialog.locator("[data-provider-configuration]")).toHaveAccessibleName(
 		"Configure Discord",
 	);
-	linkWarning = dialog.locator("[data-provider-configuration] [data-agent-link-warning]");
-	await expect(linkWarning).toHaveAttribute("role", "alert");
-	await expect(linkWarning.getByText("Discord is already linked", { exact: true })).toBeVisible();
-	await expect(linkWarning).toContainText(
-		"This Agent already has a Discord link. The new bot will be added to Custom bots without linking to this Agent.",
-	);
+	await expect(dialog.locator("[data-agent-link-warning]")).toHaveCount(0);
+	await expect(
+		dialog.getByRole("status").getByText(/replace.*existing Discord link/i),
+	).toBeVisible();
 	await dialog.getByLabel("Name").fill("Additional Discord");
 	await dialog.getByLabel("Bot token").fill("A".repeat(50));
 	await dialog.getByLabel("Application ID").fill("123456789012345678");
 	await dialog.getByLabel("Public key").fill("a".repeat(64));
-	await expectNoHorizontalOverflow(dialog, "inventory-only Discord form at 320px");
-	await dialog.screenshot({ path: testInfo.outputPath("already-linked-discord-form-320.png") });
+	await expectNoHorizontalOverflow(dialog, "Discord replacement form at 320px");
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	replacementDialog = page.getByRole("alertdialog", {
+		name: "Replace this Agent’s Discord link?",
+	});
+	await expect(replacementDialog).toContainText("paired chats will be removed");
+	await replacementDialog
+		.getByRole("button", { name: "Replace Discord link", exact: true })
+		.click();
 	await expect.poll(() => createChannelRequests.length).toBe(2);
-	expect(JSON.parse(createChannelRequests[1] ?? "{}")).toEqual({
+	await expect(replacementDialog).toBeVisible();
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Couldn't add Custom bot" }),
+	).toBeVisible();
+	await expect(
+		replacementDialog.getByRole("button", { name: "Cancel", exact: true }),
+	).toBeEnabled();
+	await expect(dialog.getByLabel("Name")).toHaveValue("Additional Discord");
+	expect(JSON.parse(createChannelRequests[1] ?? "{}")).toMatchObject({
+		agent_id: agentId,
+		replace_existing_provider_link: true,
+	});
+	await replacementDialog
+		.getByRole("button", { name: "Replace Discord link", exact: true })
+		.click();
+	await expect.poll(() => createChannelRequests.length).toBe(3);
+	expect(JSON.parse(createChannelRequests[2] ?? "{}")).toEqual({
 		provider: "discord",
 		name: "Additional Discord",
 		provider_token: "A".repeat(50),
-		agent_id: null,
+		agent_id: agentId,
+		replace_existing_provider_link: true,
 		config: {
 			application_id: "123456789012345678",
 			public_key: "a".repeat(64),
 		},
 	});
-	dialog = page.getByRole("dialog", { name: "Custom bot added" });
-	await expect(dialog).toContainText(
-		"Additional Discord was added to Custom bots. It was not linked because Discord is already linked to this Agent.",
-	);
-	await expect(page.getByRole("dialog", { name: "Pair Discord" })).toHaveCount(0);
-	await expectNoHorizontalOverflow(dialog, "inventory-only Discord result at 320px");
+	const discordPairDialog = page.getByRole("dialog", { name: "Pair Discord" });
+	await expect(discordPairDialog).toBeVisible();
+	await expect(page.getByRole("alertdialog")).toHaveCount(0);
+	await discordPairDialog.getByRole("button", { name: "Close", exact: true }).click();
+	await expect(discordPairDialog).toHaveCount(0);
 	await expect(page.locator("body")).not.toContainText("webhook-secret-must-not-render");
-	await dialog.getByRole("button", { name: "Done", exact: true }).click();
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
+
 	await addChannel.click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
 	await dialog
@@ -10376,7 +10424,11 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 		`/agents/${agentId}/console?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 	);
 	await expect(page.getByRole("dialog", { name: "Add channel" })).toHaveCount(0);
-	expect(errors, `inventory-only Custom bot errors: ${errors.join(" | ")}`).toEqual([]);
+	const unexpectedErrors = errors.filter((error) => !error.includes("status of 503"));
+	expect(
+		unexpectedErrors,
+		`replacement Custom bot errors: ${unexpectedErrors.join(" | ")}`,
+	).toEqual([]);
 });
 
 test("Add channel warns and adds to inventory when Agent link status is unavailable", async ({
@@ -10385,14 +10437,26 @@ test("Add channel warns and adds to inventory when Agent link status is unavaila
 	await page.setViewportSize({ width: 320, height: 568 });
 	const agentId = missingProjectionEnvironmentId;
 	const createChannelRequests: string[] = [];
+	const linkAgentRequests: Array<{ accountId: string; body: string }> = [];
+	const unknownTelegramAccount = {
+		id: "5a999999-9999-4999-8999-999999999999",
+		provider: "telegram",
+		name: "Unknown-status Telegram",
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/unknown-status-telegram",
+		created_at: "2026-08-03T00:02:00Z",
+	};
 	await stubHostedApi(page, {
 		deployments: [runningMissingProjectionDeployment],
-		channelAccounts: [],
+		channelAccounts: [unknownTelegramAccount],
 		channelAgentLinksResponse: {
 			status: 503,
 			body: { detail: "Agent link projection is temporarily unavailable" },
 		},
 		createChannelRequests,
+		linkAgentRequests,
 		createChannelResponse: {
 			status: 201,
 			body: {
@@ -10415,6 +10479,12 @@ test("Add channel warns and adds to inventory when Agent link status is unavaila
 	await page.goto(
 		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
 	);
+	const unknownStatusCard = page.locator(
+		`[data-agent-channel-account-id="${unknownTelegramAccount.id}"]`,
+	);
+	await expect(unknownStatusCard).toContainText("Agent link status unavailable");
+	await expect(unknownStatusCard.getByRole("button", { name: "Link", exact: true })).toBeDisabled();
+	await expect(linkAgentRequests).toHaveLength(0);
 	await page.locator("[data-agent-add-custom-bot]").click();
 	let dialog = page.getByRole("dialog", { name: "Add channel" });
 	const linkWarning = dialog.locator("[data-agent-link-warning]");
@@ -10449,9 +10519,10 @@ test("Add channel warns and adds to inventory when Agent link status is unavaila
 	await expect(page.locator("body")).not.toContainText(
 		"conservative-webhook-secret-must-not-render",
 	);
+	await expect(linkAgentRequests).toHaveLength(0);
 });
 
-test("Agent bot groups keep every bot visible and gate provider conflicts in place", async ({
+test("Agent bot groups keep every bot visible and confirm provider replacement", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
@@ -10462,6 +10533,9 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	const replacementTelegramId = "6ccccccc-cccc-4ccc-8ccc-cccccccccccc";
 	const discordId = "6ddddddd-dddd-4ddd-8ddd-dddddddddddd";
 	const clawdiDiscordId = "6eeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+	const replacementTelegramLinkId = "6a111111-1111-4111-8111-111111111111";
+	const linkAgentRequests: Array<{ accountId: string; body: string }> = [];
+	const unlinkAgentRequests: string[] = [];
 	const telegramAccount = {
 		id: telegramId,
 		provider: "telegram",
@@ -10523,10 +10597,27 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 				agent_id: agentId,
 				status: "active",
 				created_at: "2026-07-31T00:01:00Z",
+				binding_count: 1,
 				account: telegramAccount,
 			},
 		],
 		channelBotPool: { providers: { discord: [clawdiDiscord] } },
+		linkAgentRequests,
+		unlinkAgentRequests,
+		linkAgentResponses: [
+			{ status: 503, body: { detail: "Atomic replacement temporarily unavailable" } },
+			{
+				status: 201,
+				body: {
+					id: replacementTelegramLinkId,
+					account_id: replacementTelegramId,
+					agent_id: agentId,
+					status: "active",
+					created_at: "2026-08-03T00:04:00Z",
+					agent_token: null,
+				},
+			},
+		],
 		channelHealthItems: [
 			{
 				account_id: telegramId,
@@ -10564,12 +10655,10 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await expect(customSection.getByText("Custom bots", { exact: true })).toBeVisible();
 	await expect(linkedTelegramRow).toBeVisible();
 	await expect(replacementTelegramRow).toBeVisible();
-	await expect(replacementTelegramRow).toContainText(
-		"Another bot from this provider is already linked",
-	);
+	await expect(replacementTelegramRow).toContainText("Replaces current link");
 	await expect(
 		replacementTelegramRow.getByRole("button", { name: "Link", exact: true }),
-	).toBeDisabled();
+	).toBeEnabled();
 	await expect(discordRow).toBeVisible();
 	await expect(clawdiDiscordRow).toBeVisible();
 	await expect(discordRow.locator(`[title="${discordAccount.name}"]`)).toBeVisible();
@@ -10588,9 +10677,7 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 	await expect(unlinkedDiscordHeader.getByText("Available", { exact: true })).toBeVisible();
 	await expect(unlinkedDiscordHeader).not.toContainText("1 chat");
 	await expect(unlinkedDiscordHeader).not.toContainText("Paired");
-	await expect(unavailableTelegramHeader).toContainText(
-		"Another bot from this provider is already linked",
-	);
+	await expect(unavailableTelegramHeader).toContainText("Replaces current link");
 	await expect(unavailableTelegramHeader).not.toContainText("Available");
 	await expect(linkedTelegramChats).toHaveAccessibleName("1 paired chat");
 	const desktopPairedChatLabel = linkedTelegramChats.locator("[data-agent-paired-chats-label]");
@@ -10684,7 +10771,61 @@ test("Agent bot groups keep every bot visible and gate provider conflicts in pla
 		path: testInfo.outputPath("agent-bot-groups-provider-limits-320x568.png"),
 		fullPage: false,
 	});
-	expect(errors, `Agent bot group provider limit errors: ${errors.join(" | ")}`).toEqual([]);
+
+	await page.setViewportSize({ width: 1440, height: 900 });
+	await replacementTelegramRow.evaluate((element) => element.scrollIntoView({ block: "center" }));
+	const replaceLinkButton = replacementTelegramRow.getByRole("button", {
+		name: "Link",
+		exact: true,
+	});
+	await replaceLinkButton.click();
+	let replacementDialog = page.getByRole("alertdialog", {
+		name: "Replace this Agent’s Telegram link?",
+	});
+	await expect(replacementDialog).toContainText("Replacement Telegram");
+	await expectNoHorizontalOverflow(replacementDialog, "Telegram Link replacement confirmation");
+	await replacementDialog.screenshot({
+		path: testInfo.outputPath("replace-existing-bot-link-confirm-desktop.png"),
+	});
+	await replacementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
+
+	await replaceLinkButton.click();
+	replacementDialog = page.getByRole("alertdialog", {
+		name: "Replace this Agent’s Telegram link?",
+	});
+	await replacementDialog
+		.getByRole("button", { name: "Replace Telegram link", exact: true })
+		.click();
+	await expect.poll(() => linkAgentRequests.length).toBe(1);
+	await expect(replacementDialog).toBeVisible();
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Couldn't link bot" }),
+	).toBeVisible();
+	await expect(
+		replacementDialog.getByRole("button", { name: "Replace Telegram link", exact: true }),
+	).toBeEnabled();
+	await replacementDialog
+		.getByRole("button", { name: "Replace Telegram link", exact: true })
+		.click();
+	await expect.poll(() => linkAgentRequests.length).toBe(2);
+	for (const request of linkAgentRequests) {
+		expect(request).toEqual({
+			accountId: replacementTelegramId,
+			body: JSON.stringify({
+				agent_id: agentId,
+				replace_existing_provider_link: true,
+			}),
+		});
+	}
+	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toBeVisible();
+	await expect(unlinkAgentRequests).toHaveLength(0);
+	const unexpectedErrors = errors.filter((error) => !error.includes("status of 503"));
+	expect(
+		unexpectedErrors,
+		`Agent bot group provider limit errors: ${unexpectedErrors.join(" | ")}`,
+	).toEqual([]);
 });
 
 test("Agent bot card deduplicates records and reconciles a repeated conflict in place", async ({
@@ -11429,6 +11570,24 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		webhook_url: "https://cloud.example.test/channels/my-telegram",
 		created_at: "2026-07-27T12:10:00Z",
 	};
+	const telegramAgentLink = {
+		id: telegramLinkId,
+		account_id: telegramId,
+		agent_id: agentId,
+		status: "active",
+		created_at: "2026-07-27T12:15:00Z",
+		binding_count: 1,
+		account: telegramAccount,
+	};
+	const discordAgentLink = {
+		id: discordLinkId,
+		account_id: discordId,
+		agent_id: agentId,
+		status: "active",
+		created_at: "2026-07-27T12:20:00Z",
+		binding_count: 12,
+		account: discordAccount,
+	};
 	const pairCodeRequests: string[] = [];
 	const deleteBindingRequests: string[] = [];
 	const unlinkAgentRequests: string[] = [];
@@ -11556,14 +11715,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		channelAccounts: [telegramAccount, discordAccount, ownedAccount],
 		channelBindings,
 		channelAgentLinks: [
-			{
-				id: telegramLinkId,
-				account_id: telegramId,
-				agent_id: agentId,
-				status: "active",
-				created_at: "2026-07-27T12:15:00Z",
-				account: telegramAccount,
-			},
+			telegramAgentLink,
 			{
 				id: otherTelegramLinkId,
 				account_id: telegramId,
@@ -11572,14 +11724,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 				created_at: "2026-07-27T12:17:00Z",
 				account: telegramAccount,
 			},
-			{
-				id: discordLinkId,
-				account_id: discordId,
-				agent_id: agentId,
-				status: "active",
-				created_at: "2026-07-27T12:20:00Z",
-				account: discordAccount,
-			},
+			discordAgentLink,
 		],
 		channelBotPool: {
 			providers: {
@@ -11884,10 +12029,10 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	const ownedCard = customSection.locator(`[data-agent-channel-account-id="${ownedId}"]`);
 	await expect(readyCard).toBeVisible();
 	await expect(ownedCard).toBeVisible();
-	await expect(readyCard).toContainText("Another bot from this provider is already linked");
-	await expect(ownedCard).toContainText("Another bot from this provider is already linked");
-	await expect(readyCard.getByRole("button", { name: "Link", exact: true })).toBeDisabled();
-	await expect(ownedCard.getByRole("button", { name: "Link", exact: true })).toBeDisabled();
+	await expect(readyCard).toContainText("Replaces current link");
+	await expect(ownedCard).toContainText("Replaces current link");
+	await expect(readyCard.getByRole("button", { name: "Link", exact: true })).toBeEnabled();
+	await expect(ownedCard.getByRole("button", { name: "Link", exact: true })).toBeEnabled();
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);
 	const currentBindingRow = page.locator(`[data-channel-binding-id="${currentBindingId}"]`);
 	const telegramChatsTrigger = telegramGroup.locator(
@@ -12252,6 +12397,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		status: "active",
 		created_at: "2026-07-30T10:10:00Z",
 	});
+	telegramAgentLink.binding_count = 2;
 	await expect(telegramChatsTrigger).toHaveAccessibleName("2 paired chats", {
 		timeout: 5_000,
 	});
@@ -12762,6 +12908,7 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 		`/v1/channels/${discordId}/bindings/${discordServerBindingId}`,
 	);
 	await discordUnpairClick;
+	discordAgentLink.binding_count = 11;
 	await expect(discordServerRow).toHaveCount(0);
 	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
 	await pairedChatsPanel.getByRole("button", { name: "Close", exact: true }).click();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -9332,21 +9332,49 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	await expect(
 		connectDialog.getByRole("link", { name: "Agent Interface", exact: true }),
 	).toHaveCount(0);
-	await expect(connectDialog.getByRole("button", { name: /^Telegram Telegram$/ })).toHaveAttribute(
-		"aria-pressed",
-		"true",
+	const providerChooser = connectDialog.getByRole("group", { name: "Choose provider" });
+	const providerConfiguration = connectDialog.locator("[data-provider-configuration]");
+	const telegramProvider = providerChooser.getByRole("button", { name: "Telegram", exact: true });
+	const discordProvider = providerChooser.getByRole("button", { name: "Discord", exact: true });
+	await expect(providerChooser).toBeVisible();
+	await expect(providerConfiguration).toHaveAccessibleName("Configure Telegram");
+	await expect(providerConfiguration).toHaveClass(/border-t/);
+	await expect(providerChooser.locator("[data-other-provider-hint]")).toBeVisible();
+	await expect(telegramProvider).toHaveAttribute("aria-pressed", "true");
+	await expect(telegramProvider).toHaveClass(/border-primary/);
+	await expect(telegramProvider).toHaveClass(/bg-primary\/5/);
+	await expect(telegramProvider).toHaveClass(/ring-1/);
+	await expect(telegramProvider).toHaveClass(/ring-primary\/30/);
+	await expect(telegramProvider.locator("svg.lucide-check")).toBeVisible();
+	await expect(discordProvider.locator("svg.lucide-check")).toHaveCount(0);
+	const [providerChooserBox, providerConfigurationBox] = await Promise.all([
+		providerChooser.boundingBox(),
+		providerConfiguration.boundingBox(),
+	]);
+	expect(providerConfigurationBox?.y ?? 0).toBeGreaterThan(
+		(providerChooserBox?.y ?? 0) + (providerChooserBox?.height ?? 0),
 	);
 	await expect(connectDialog.getByLabel("Application ID")).toHaveCount(0);
 	await expect(
 		connectDialog.getByText("Create a bot with @BotFather", { exact: true }),
 	).toBeVisible();
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-desktop.png") });
-	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await expect(page.locator("html")).toHaveClass(/dark/);
+	await connectDialog.screenshot({
+		path: testInfo.outputPath("connect-bot-telegram-dark-desktop.png"),
+	});
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
+	await discordProvider.click();
+	await expect(discordProvider).toHaveAttribute("aria-pressed", "true");
+	await expect(discordProvider.locator("svg.lucide-check")).toBeVisible();
+	await expect(telegramProvider.locator("svg.lucide-check")).toHaveCount(0);
+	await expect(providerConfiguration).toHaveAccessibleName("Configure Discord");
 	await expect(connectDialog.getByLabel("Application ID")).toBeVisible();
 	await expect(connectDialog.getByLabel("Public key")).toBeVisible();
 	await expect(connectDialog.getByText(/Server ID/i)).toHaveCount(0);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-discord-desktop.png") });
-	await connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }).click();
+	await telegramProvider.click();
 	await connectDialog.getByLabel("Name").fill("Inventory Telegram");
 	await connectDialog.getByLabel("Bot token").fill("123456:console-inventory-token");
 	await connectDialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
@@ -9390,6 +9418,10 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	});
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	connectDialog = page.getByRole("dialog", { name: "Add channel" });
+	await expect(connectDialog.getByRole("group", { name: "Choose provider" })).toBeVisible();
+	await expect(connectDialog.locator("[data-provider-configuration]")).toHaveAccessibleName(
+		"Configure Telegram",
+	);
 	await expectNoHorizontalOverflow(connectDialog, "Telegram credentials dialog at 320px");
 	await expectContainedInOwnerAndViewport(
 		page,
@@ -9404,7 +9436,10 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 		"Telegram credentials Add custom bot",
 	);
 	await connectDialog.screenshot({ path: testInfo.outputPath("connect-bot-telegram-320.png") });
-	await connectDialog.getByRole("button", { name: /^Discord Discord$/ }).click();
+	await connectDialog.getByRole("button", { name: "Discord", exact: true }).click();
+	await expect(connectDialog.locator("[data-provider-configuration]")).toHaveAccessibleName(
+		"Configure Discord",
+	);
 	await connectDialog.getByLabel("Bot token").fill("!".repeat(300));
 	await connectDialog.getByLabel("Application ID").fill("9".repeat(300));
 	await connectDialog.getByLabel("Public key").fill("z".repeat(300));
@@ -9650,21 +9685,18 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.goto("/channels");
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	let dialog = page.getByRole("dialog", { name: "Add channel" });
-	await dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
-	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
+	await dialog.getByRole("button", { name: "WhatsApp", exact: true }).click();
+	await expect(dialog.getByRole("heading", { name: "Configure WhatsApp" })).toBeVisible();
+	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toHaveCount(0);
 	await expect(dialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
 	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
 	let accountWarning = dialog.locator("[data-whatsapp-account-warning]");
 	await expect(accountWarning).toHaveAttribute("role", "alert");
-	await expect(
-		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
-	).toBeVisible();
-	await expect(accountWarning).toContainText("Clawdi connects as a linked device.");
+	await expect(accountWarning.getByText("Use a dedicated number", { exact: true })).toBeVisible();
 	await expect(accountWarning).toContainText(
-		"Once linked to an Agent, messages to this account may be handled by the Agent",
+		"Clawdi uses WhatsApp’s linked-device feature. When linked to an Agent, replies are sent from this account—use a separate number, not your primary personal one.",
 	);
-	await expect(accountWarning).toContainText("replies are sent as this account");
-	await expect(accountWarning).toContainText("not your primary personal account");
+	await expect(accountWarning).not.toContainText("messages to this account may be handled");
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeDisabled();
 	await expect(dialog).toContainText("isn't compatible with this deployment");
 	await expect(dialog.getByLabel("Bot token")).toHaveCount(0);
@@ -9674,7 +9706,7 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.reload();
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
-	await dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
+	await dialog.getByRole("button", { name: "WhatsApp", exact: true }).click();
 	accountWarning = dialog.locator("[data-whatsapp-account-warning]");
 	await expect(accountWarning).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Connect your account" })).toBeEnabled();
@@ -9711,24 +9743,19 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await page.setViewportSize({ width: 320, height: 568 });
 	await page.getByRole("button", { name: "Add channel", exact: true }).click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
-	const mobileWhatsAppProvider = dialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ });
+	const mobileWhatsAppProvider = dialog.getByRole("button", { name: "WhatsApp", exact: true });
 	await expect(mobileWhatsAppProvider).toContainText("WhatsApp");
-	await expect(mobileWhatsAppProvider.locator("span").filter({ hasText: /^WhatsApp$/ })).toHaveCSS(
-		"text-overflow",
-		"clip",
-	);
 	await mobileWhatsAppProvider.click();
+	await expect(mobileWhatsAppProvider).toHaveAttribute("aria-pressed", "true");
+	await expect(mobileWhatsAppProvider.locator("svg.lucide-check")).toBeVisible();
+	await expect(dialog.getByRole("heading", { name: "Configure WhatsApp" })).toBeVisible();
 	await expect(dialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
 	accountWarning = dialog.locator("[data-whatsapp-account-warning]");
 	await expect(accountWarning).toHaveAttribute("role", "alert");
-	await expect(
-		accountWarning.getByText("Use a dedicated WhatsApp account", { exact: true }),
-	).toBeVisible();
+	await expect(accountWarning.getByText("Use a dedicated number", { exact: true })).toBeVisible();
 	await expect(accountWarning).toContainText(
-		"Once linked to an Agent, messages to this account may be handled by the Agent",
+		"Clawdi uses WhatsApp’s linked-device feature. When linked to an Agent, replies are sent from this account—use a separate number, not your primary personal one.",
 	);
-	await expect(accountWarning).toContainText("replies are sent as this account");
-	await expect(accountWarning).toContainText("not your primary personal account");
 	await expectNoHorizontalOverflow(dialog, "WhatsApp Custom setup at 320x568");
 	await expectNoHorizontalOverflow(page.locator("html"), "WhatsApp Custom document at 320x568");
 	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-custom-setup-320x568.png") });
@@ -9779,7 +9806,7 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await expect(dialog.getByText("Couldn't connect WhatsApp", { exact: true })).toBeVisible();
 	await dialog.screenshot({ path: testInfo.outputPath("whatsapp-error-320x568.png") });
 	await dialog.getByRole("button", { name: "Back", exact: true }).click();
-	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("heading", { name: "Configure WhatsApp" })).toBeVisible();
 	expect(cancelCalls).toBe(1);
 
 	await dialog.getByRole("button", { name: "Connect your account" }).click();
@@ -9787,7 +9814,7 @@ test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", asy
 	await dialog.getByRole("button", { name: "Generate QR" }).click();
 	await expect(dialog.getByRole("button", { name: "Cancel connection" })).toBeVisible();
 	await dialog.getByRole("button", { name: "Cancel connection" }).click();
-	await expect(dialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("heading", { name: "Configure WhatsApp" })).toBeVisible();
 	expect(cancelCalls).toBe(2);
 	await expectNoHorizontalOverflow(dialog, "WhatsApp canceled flow at 320x568");
 	const unexpectedErrors = errors.filter(
@@ -10038,13 +10065,13 @@ for (const firstTimeViewport of [
 		await expect(connectDialog.getByRole("status")).toContainText(
 			"The new Custom bot will be linked to this Agent automatically.",
 		);
-		await connectDialog.getByRole("button", { name: /^WhatsApp WhatsApp$/ }).click();
-		await expect(connectDialog.getByText("Your WhatsApp", { exact: true })).toBeVisible();
+		await connectDialog.getByRole("button", { name: "WhatsApp", exact: true }).click();
+		await expect(connectDialog.getByRole("heading", { name: "Configure WhatsApp" })).toBeVisible();
 		await expect(connectDialog.getByText("Clawdi WhatsApp", { exact: true })).toHaveCount(0);
 		await expect(connectDialog.locator("[data-whatsapp-account-choice] section")).toHaveCount(0);
-		await connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }).click();
+		await connectDialog.getByRole("button", { name: "Telegram", exact: true }).click();
 		await expect(
-			connectDialog.getByRole("button", { name: /^Telegram Telegram$/ }),
+			connectDialog.getByRole("button", { name: "Telegram", exact: true }),
 		).toHaveAttribute("aria-pressed", "true");
 		await connectDialog.getByLabel("Name").fill("Browser Telegram");
 		await connectDialog.getByLabel("Bot token").fill("123456:browser-test-token");
@@ -10077,6 +10104,12 @@ for (const firstTimeViewport of [
 		await submitCustomBot.click();
 		const connecting = connectDialog.getByRole("button", { name: "Adding…", exact: true });
 		await expect(connecting).toBeVisible();
+		for (const providerChoice of await connectDialog
+			.getByRole("group", { name: "Choose provider" })
+			.getByRole("button")
+			.all()) {
+			await expect(providerChoice).toBeDisabled();
+		}
 		await expectContainedInOwnerAndViewport(
 			page,
 			connecting,
@@ -10242,19 +10275,25 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	const addChannel = page.locator("[data-agent-add-custom-bot]");
 	await addChannel.click();
 	let dialog = page.getByRole("dialog", { name: "Add channel" });
-	const telegramProvider = dialog.getByRole("button", { name: /^Telegram Telegram$/ });
-	const discordProvider = dialog.getByRole("button", { name: /^Discord Discord$/ });
+	const providerChooser = dialog.getByRole("group", { name: "Choose provider" });
+	const providerConfiguration = dialog.locator("[data-provider-configuration]");
+	const telegramProvider = providerChooser.getByRole("button", {
+		name: "Telegram",
+		exact: true,
+	});
+	const discordProvider = providerChooser.getByRole("button", { name: "Discord", exact: true });
 	await expect(telegramProvider).toBeEnabled();
 	await expect(discordProvider).toBeEnabled();
-	let linkWarning = dialog.locator("[data-agent-link-warning]");
+	await expect(providerConfiguration).toHaveAccessibleName("Configure Telegram");
+	let linkWarning = providerConfiguration.locator("[data-agent-link-warning]");
 	await expect(linkWarning).toHaveAttribute("role", "alert");
-	await expect(linkWarning.getByText("Won’t link automatically", { exact: true })).toBeVisible();
+	await expect(linkWarning.getByText("Telegram is already linked", { exact: true })).toBeVisible();
 	await expect(linkWarning).toContainText(
-		"This Agent already has a Telegram bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+		"This Agent already has a Telegram link. The new bot will be added to Custom bots without linking to this Agent.",
 	);
 	await expect(dialog.getByRole("status")).toHaveCount(0);
 	await expect(
-		dialog.locator("[data-other-provider-hint]").getByRole("link", {
+		providerChooser.locator("[data-other-provider-hint]").getByRole("link", {
 			name: "Agent Interface",
 		}),
 	).toHaveAttribute(
@@ -10263,7 +10302,13 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	);
 	await dialog.getByLabel("Name").fill("Additional Telegram");
 	await dialog.getByLabel("Bot token").fill("123456:additional-telegram-token");
-	await dialog.screenshot({ path: testInfo.outputPath("already-linked-telegram-form-320.png") });
+	await expectNoHorizontalOverflow(dialog, "inventory-only Telegram form at 320px");
+	await page.locator("html").evaluate((element) => element.classList.add("dark"));
+	await expect(page.locator("html")).toHaveClass(/dark/);
+	await dialog.screenshot({
+		path: testInfo.outputPath("already-linked-telegram-form-dark-320.png"),
+	});
+	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
 	await expect.poll(() => createChannelRequests.length).toBe(1);
 	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
@@ -10274,7 +10319,7 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	});
 	dialog = page.getByRole("dialog", { name: "Custom bot added" });
 	await expect(dialog).toContainText(
-		"Additional Telegram was added to Custom bots. It was not linked because this Agent already has a Telegram bot.",
+		"Additional Telegram was added to Custom bots. It was not linked because Telegram is already linked to this Agent.",
 	);
 	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toHaveCount(0);
 	await expectNoHorizontalOverflow(dialog, "inventory-only Telegram result at 320px");
@@ -10283,12 +10328,15 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 
 	await addChannel.click();
 	dialog = page.getByRole("dialog", { name: "Add channel" });
-	await dialog.getByRole("button", { name: /^Discord Discord$/ }).click();
-	linkWarning = dialog.locator("[data-agent-link-warning]");
+	await dialog.getByRole("button", { name: "Discord", exact: true }).click();
+	await expect(dialog.locator("[data-provider-configuration]")).toHaveAccessibleName(
+		"Configure Discord",
+	);
+	linkWarning = dialog.locator("[data-provider-configuration] [data-agent-link-warning]");
 	await expect(linkWarning).toHaveAttribute("role", "alert");
-	await expect(linkWarning.getByText("Won’t link automatically", { exact: true })).toBeVisible();
+	await expect(linkWarning.getByText("Discord is already linked", { exact: true })).toBeVisible();
 	await expect(linkWarning).toContainText(
-		"This Agent already has a Discord bot. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+		"This Agent already has a Discord link. The new bot will be added to Custom bots without linking to this Agent.",
 	);
 	await dialog.getByLabel("Name").fill("Additional Discord");
 	await dialog.getByLabel("Bot token").fill("A".repeat(50));
@@ -10310,7 +10358,7 @@ test("Add channel keeps already-linked Telegram and Discord available as invento
 	});
 	dialog = page.getByRole("dialog", { name: "Custom bot added" });
 	await expect(dialog).toContainText(
-		"Additional Discord was added to Custom bots. It was not linked because this Agent already has a Discord bot.",
+		"Additional Discord was added to Custom bots. It was not linked because Discord is already linked to this Agent.",
 	);
 	await expect(page.getByRole("dialog", { name: "Pair Discord" })).toHaveCount(0);
 	await expectNoHorizontalOverflow(dialog, "inventory-only Discord result at 320px");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -257,7 +257,8 @@ import { CHANNEL_CARD_GRID_CLASS, ChannelCard } from "@/hosted/v2/channels/chann
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client.logic";
 import {
-	agentProviderHasSingleLinkLimit,
+	agentProviderLinkReplacementRequired,
+	agentProviderLinkStatusUnknown,
 	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/channel-linking.logic";
 import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
@@ -278,6 +279,7 @@ import {
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { DiscordPairDialog } from "@/hosted/v2/channels/discord-pair-dialog";
 import { PairedChatsDialog } from "@/hosted/v2/channels/paired-chats-dialog";
+import { ProviderLinkReplacementConfirm } from "@/hosted/v2/channels/provider-link-replacement-confirm";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
 import {
 	type AgentRouteSearch,
@@ -2308,17 +2310,14 @@ function agentChannelLinkUnavailableReason({
 }: {
 	bot: AgentChannelCardItem;
 	agentType: HostedRuntime;
-	linkedProviders: ReadonlySet<string>;
+	linkedProviders: ReadonlySet<string> | undefined;
 }): string | null {
 	if (!channelProviderLinkingReady(bot.provider)) return "Coming soon";
 	if (!bot.available || !bot.canLink || bot.status.toLowerCase() !== "active") {
 		return bot.maxLinks !== null ? "At capacity" : "Unavailable";
 	}
-	if (
-		agentProviderHasSingleLinkLimit(agentType, bot.provider) &&
-		linkedProviders.has(bot.provider)
-	) {
-		return "Another bot from this provider is already linked";
+	if (agentProviderLinkStatusUnknown(agentType, bot.provider, linkedProviders)) {
+		return "Agent link status unavailable";
 	}
 	return null;
 }
@@ -2410,7 +2409,8 @@ function ChannelsTab({
 	}, [cardGroups]);
 	const bindingCountForLink = (linkId: string) =>
 		visibleActiveLinks.find((link) => link.id === linkId)?.binding_count ?? 0;
-	const linkedProviders = useMemo(() => {
+	const linkedProviders = useMemo<ReadonlySet<string> | undefined>(() => {
+		if (!linked.data) return undefined;
 		const providers = new Set<string>();
 		for (const link of visibleActiveLinks) {
 			const provider = link.account?.provider ?? accountSummaries.get(link.account_id)?.provider;
@@ -2418,13 +2418,23 @@ function ChannelsTab({
 		}
 		return providers;
 	}, [accountSummaries, visibleActiveLinks]);
-	const link = useSensitiveAction(async (channelId: string) =>
-		unwrap(
-			await api.POST("/v1/channels/{account_id}/agent-links", {
-				params: { path: { account_id: channelId } },
-				body: { agent_id: environmentId },
-			}),
-		),
+	const link = useSensitiveAction(
+		async ({
+			channelId,
+			replaceExistingProviderLink,
+		}: {
+			channelId: string;
+			replaceExistingProviderLink: boolean;
+		}) =>
+			unwrap(
+				await api.POST("/v1/channels/{account_id}/agent-links", {
+					params: { path: { account_id: channelId } },
+					body: {
+						agent_id: environmentId,
+						...(replaceExistingProviderLink ? { replace_existing_provider_link: true } : {}),
+					},
+				}),
+			),
 	);
 
 	function showPairingForLink(nextLink: AgentChannelLink) {
@@ -2459,12 +2469,15 @@ function ChannelsTab({
 		showPairingForLink(nextLink);
 	}
 
-	async function submitLink(channelId: string): Promise<boolean> {
-		if (!channelId || linkingAccountIdsRef.current.has(channelId)) return false;
+	async function submitLink(
+		channelId: string,
+		replaceExistingProviderLink: boolean,
+	): Promise<void> {
+		if (!channelId || linkingAccountIdsRef.current.has(channelId)) return;
 		linkingAccountIdsRef.current.add(channelId);
 		setLinkingAccountIds((current) => new Set(current).add(channelId));
 		try {
-			const data = await link.execute(channelId);
+			const data = await link.execute({ channelId, replaceExistingProviderLink });
 			acceptLinkedChannel({
 				id: data.id,
 				account_id: data.account_id,
@@ -2473,7 +2486,7 @@ function ChannelsTab({
 				created_at: data.created_at,
 				binding_count: 0,
 			});
-			return true;
+			return;
 		} catch (error) {
 			if (error instanceof ApiError && error.status === 409) {
 				const refreshed = await linked.refetch();
@@ -2488,11 +2501,11 @@ function ChannelsTab({
 					toast.info("Bot already linked", {
 						description: "Using the existing link for this Agent.",
 					});
-					return true;
+					return;
 				}
 			}
 			toastApiError("Couldn't link bot")(error);
-			return false;
+			throw error;
 		} finally {
 			linkingAccountIdsRef.current.delete(channelId);
 			setLinkingAccountIds((current) => {
@@ -2541,7 +2554,7 @@ function ChannelsTab({
 				linkedProviders={linkedProviders}
 				linking={linkingAccountIds.has(bot.id)}
 				unlinking={Boolean(linkForBot && unlinkingLinkIds.has(linkForBot.id))}
-				onLink={() => void submitLink(bot.id)}
+				onLink={(replaceExistingProviderLink) => submitLink(bot.id, replaceExistingProviderLink)}
 				onUnlink={() => {
 					if (linkForBot) startUnlink(bot.id, linkForBot.id);
 				}}
@@ -2746,14 +2759,31 @@ function AgentChannelBotCard({
 	agentId: string;
 	agentName: string;
 	agentType: HostedRuntime;
-	linkedProviders: ReadonlySet<string>;
+	linkedProviders: ReadonlySet<string> | undefined;
 	linking: boolean;
 	unlinking: boolean;
-	onLink: () => void;
+	onLink: (replaceExistingProviderLink: boolean) => Promise<void>;
 	onUnlink: () => void;
 }) {
 	const unavailableReason = agentChannelLinkUnavailableReason({ bot, agentType, linkedProviders });
 	const activationGated = unavailableReason === "Coming soon";
+	const replacementRequired = agentProviderLinkReplacementRequired(
+		agentType,
+		bot.provider,
+		linkedProviders,
+	);
+	const linkButton = (
+		<Button
+			type="button"
+			size="sm"
+			className="w-full min-w-0 sm:w-28"
+			disabled={Boolean(unavailableReason) || linking}
+			onClick={replacementRequired ? undefined : () => void onLink(false).catch(() => undefined)}
+		>
+			{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
+			{linking ? "Linking…" : "Link"}
+		</Button>
+	);
 	return (
 		<div data-agent-channel-account-id={bot.id} className="h-full min-w-0">
 			{bot.link ? (
@@ -2773,24 +2803,23 @@ function AgentChannelBotCard({
 				<AgentChannelCard
 					provider={bot.provider}
 					title={bot.name}
-					state={unavailableReason ?? "Available"}
+					state={replacementRequired ? "Replaces current link" : (unavailableReason ?? "Available")}
 					actions={
 						activationGated ? (
 							<p className="flex min-w-0 items-center justify-center gap-1.5 text-xs text-muted-foreground [overflow-wrap:anywhere] sm:w-28">
 								<Info className="size-3.5 shrink-0" />
 								Agent Link gated
 							</p>
-						) : (
-							<Button
-								type="button"
-								size="sm"
-								className="w-full min-w-0 sm:w-28"
-								disabled={Boolean(unavailableReason) || linking}
-								onClick={onLink}
+						) : replacementRequired ? (
+							<ProviderLinkReplacementConfirm
+								provider={bot.provider}
+								targetName={bot.name}
+								onConfirm={() => onLink(true)}
 							>
-								{linking ? <Spinner className="size-3.5" /> : <Link2 className="size-3.5" />}
-								{linking ? "Linking…" : "Link"}
-							</Button>
+								{linkButton}
+							</ProviderLinkReplacementConfirm>
+						) : (
+							linkButton
 						)
 					}
 				/>

--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -95,7 +95,6 @@ describe("shared Channel card", () => {
 		expect(card).not.toContain("data-channel-card-footer");
 		expect(agentChannels).toContain("h-[7.5rem] flex-none grid-rows-[2.75rem_2rem]");
 		expect(agentChannels).toContain("xl:h-20 xl:grid-rows-1");
-		expect(agentChannels).toContain('state={unavailableReason ?? "Available"}');
 		expect(agentChannels).toContain("pairedChatsControl");
 		expect(agentChannels).not.toContain('isNormalChannelStatus(link.status) ? (\n\t\t\t"Linked"');
 		expect(consoleChannels).not.toContain('state="Available"');

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -82,7 +82,6 @@ describe("global Channels inventory", () => {
 		expect(connectDialog).toContain("data-agent-link-warning");
 		expect(connectDialog).toContain('className="border-warning/30 bg-warning-muted py-2.5"');
 		expect(connectDialog).toContain("<TriangleAlert aria-hidden />");
-		expect(connectDialog).toContain('title: "Won’t link automatically"');
 		expect(connectDialog).toContain('title: "Agent link status unavailable"');
 		expect(connectDialog).toContain(
 			"The new Custom bot will be linked to this Agent automatically.",

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -50,7 +50,8 @@ describe("global Channels inventory", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
 		const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 
-		expect(connectDialog).toContain("agent_id: autoLinkAgentId");
+		expect(connectDialog).toContain("replace_existing_provider_link: true");
+		expect(connectDialog).toContain("<ProviderLinkReplacementConfirm");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(connectDialog).toContain("autoLinkAgentIdForNewCustomBot");
 		expect(agentDetail).not.toContain("<AddChannelDialog");
@@ -62,7 +63,6 @@ describe("global Channels inventory", () => {
 		expect(agentDetail).toContain("Add channel");
 		expect(agentDetail).toContain('title="Clawdi bots"');
 		expect(agentDetail).toContain('title="Custom bots"');
-		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setTelegramPair({");
 	});
 

--- a/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-finish-line.test.ts
@@ -30,7 +30,6 @@ describe("hosted-agent channel finish line", () => {
 		expect(channelsTab).toContain('<ChannelStatusBadge key="status" status={link.status} />');
 		expect(channelsTab).not.toContain("HealthBadge");
 		expect(channelsTab).not.toContain("channel health");
-		expect(channelsTab).toContain('state={unavailableReason ?? "Available"}');
 		expect(channelsTab).toContain("!isNormalChannelStatus(link.status)");
 		expect(channelsTab).toContain("pairedChatsControl");
 		expect(channelsTab).not.toContain("Link to start pairing chats");

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	agentProviderHasSingleLinkLimit,
+	agentProviderLinkReplacementRequired,
+	agentProviderLinkStatusUnknown,
 	autoLinkAgentIdForNewCustomBot,
 	channelProviderLinkingReady,
 	pairCodeExpired,
@@ -90,10 +92,13 @@ describe("hosted channel instructions and gates", () => {
 		}
 	});
 
-	test("adds conflicting Custom bots to inventory without changing the existing Agent link", () => {
+	test("requires replacement confirmation for known single-provider conflicts", () => {
 		for (const provider of ["telegram", "discord"] as const) {
 			expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", provider, new Set())).toBe(
 				"agent-1",
+			);
+			expect(agentProviderLinkReplacementRequired("openclaw", provider, new Set([provider]))).toBe(
+				true,
 			);
 			expect(
 				autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", provider, new Set([provider])),
@@ -107,10 +112,19 @@ describe("hosted channel instructions and gates", () => {
 			autoLinkAgentIdForNewCustomBot(undefined, undefined, "telegram", new Set(["telegram"])),
 		).toBeNull();
 		expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", "telegram", undefined)).toBeNull();
+		expect(agentProviderLinkStatusUnknown("openclaw", "telegram", undefined)).toBe(true);
 	});
 
-	test("keeps WhatsApp inventory onboarding separate from Agent linking", () => {
+	test("keeps WhatsApp gated now and applies replacement semantics when linking is ready", () => {
 		expect(autoLinkAgentIdForNewCustomBot("agent-1", "openclaw", "whatsapp", new Set())).toBeNull();
+		expect(
+			agentProviderLinkReplacementRequired("openclaw", "whatsapp", new Set(["whatsapp"])),
+		).toBe(false);
+		expect(agentProviderLinkStatusUnknown("openclaw", "whatsapp", undefined)).toBe(false);
+		expect(
+			agentProviderLinkReplacementRequired("openclaw", "whatsapp", new Set(["whatsapp"]), true),
+		).toBe(true);
+		expect(agentProviderLinkStatusUnknown("openclaw", "whatsapp", undefined, true)).toBe(true);
 	});
 
 	test("expires pairing actions exactly at the server deadline", () => {

--- a/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-linking.logic.ts
@@ -19,6 +19,30 @@ export function agentProviderHasSingleLinkLimit(
 	return Boolean(agentType && SINGLE_LINK_PROVIDERS_BY_AGENT_TYPE[agentType]?.has(provider));
 }
 
+export function agentProviderLinkReplacementRequired(
+	agentType: string | null | undefined,
+	provider: string,
+	linkedProviders: ReadonlySet<string> | null | undefined,
+	linkingReady = channelProviderLinkingReady(provider),
+): boolean {
+	return Boolean(
+		linkingReady &&
+			agentProviderHasSingleLinkLimit(agentType, provider) &&
+			linkedProviders?.has(provider),
+	);
+}
+
+export function agentProviderLinkStatusUnknown(
+	agentType: string | null | undefined,
+	provider: string,
+	linkedProviders: ReadonlySet<string> | null | undefined,
+	linkingReady = channelProviderLinkingReady(provider),
+): boolean {
+	return Boolean(
+		linkingReady && agentProviderHasSingleLinkLimit(agentType, provider) && !linkedProviders,
+	);
+}
+
 /**
  * Return the Agent id only when creating this bot can safely preserve the
  * hosted runtime's provider cardinality. A null value is sent explicitly so

--- a/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-mutation-feedback.test.ts
@@ -33,7 +33,7 @@ describe("channel mutation feedback", () => {
 		expectFeedbackBeforeRequest(
 			detail,
 			"setLinkingAccountIds((current) => new Set(current).add(channelId))",
-			"await link.execute(channelId)",
+			"await link.execute({ channelId, replaceExistingProviderLink })",
 		);
 		expectFeedbackBeforeRequest(
 			detail,

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -59,8 +59,6 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).toContain("<PairedChatsDialog");
 		expect(pairedChatsDialog).toContain("<PairedChatRow");
 		expect(pairedChatRow).toContain("Unpair");
-		expect(agentDetail).toContain("body: { agent_id: environmentId }");
-		expect(agentDetail).toContain("agentProviderHasSingleLinkLimit");
 		expect(agentDetail).toContain('title="Clawdi bots"');
 		expect(agentDetail).toContain('title="Custom bots"');
 		expect(agentDetail).toContain("No Clawdi bots available");
@@ -75,11 +73,11 @@ describe("channel IA boundary", () => {
 	});
 
 	test("keeps Discord inventory in Console and Add/Pair actions on the Agent", () => {
-		expect(connectDialog).toContain("agent_id: autoLinkAgentId");
+		expect(connectDialog).toContain("replace_existing_provider_link: true");
+		expect(connectDialog).toContain("<ProviderLinkReplacementConfirm");
 		expect(connectDialog).toContain("Add custom bot");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(agentDetail).toContain('linking ? "Linking…" : "Link"');
-		expect(agentDetail).toContain("body: { agent_id: environmentId }");
 		expect(agentDetail).toContain("setDiscordPairOpen(true)");
 		expect(agentDetail).toContain("setDiscordPair({");
 		expect(agentDetail).toContain("<DiscordPairDialog");
@@ -149,7 +147,9 @@ describe("channel IA boundary", () => {
 	test("opens the shared fixed-TTL Telegram flow immediately after a new link", () => {
 		expect(agentDetail).toContain("const [telegramPair, setTelegramPair]");
 		expect(agentDetail).toContain('account?.provider === "telegram"');
-		expect(agentDetail).toContain("onLink={() => void submitLink(bot.id)}");
+		expect(agentDetail).toContain(
+			"onLink={(replaceExistingProviderLink) => submitLink(bot.id, replaceExistingProviderLink)}",
+		);
 		expect(agentDetail).toContain("<TelegramPairDialog");
 		expect(pairDialog).toContain("const TELEGRAM_PAIR_TTL_SECONDS = 300");
 		expect(discordPairDialog).toContain("const DISCORD_PAIR_TTL_SECONDS = 300");

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -19,12 +19,14 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	agentProviderHasSingleLinkLimit,
+	agentProviderLinkReplacementRequired,
+	agentProviderLinkStatusUnknown,
 	autoLinkAgentIdForNewCustomBot,
 	CONNECTABLE_BOT_PROVIDERS,
 	type ConnectableBotProvider,
+	channelProviderLinkingReady,
 } from "@/hosted/v2/channels/channel-linking.logic";
-import { PROVIDER_META, providerMeta } from "@/hosted/v2/channels/channel-providers";
+import { PROVIDER_META } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 import {
@@ -32,6 +34,7 @@ import {
 	discordBotTokenError,
 	discordPublicKeyError,
 } from "@/hosted/v2/channels/connect-bot-dialog.logic";
+import { ProviderLinkReplacementConfirm } from "@/hosted/v2/channels/provider-link-replacement-confirm";
 import { WhatsAppDeviceOnboarding } from "@/hosted/v2/channels/whatsapp-device-onboarding";
 import { type AgentRouteQuery, agentSectionLink } from "@/lib/agent-routes";
 
@@ -39,7 +42,7 @@ type CreatedCustomBot = Pick<
 	ChannelCreated,
 	"id" | "name" | "provider" | "agent_link_id" | "agent_id"
 > & {
-	linkOutcome: "linked" | "inventory-only" | "inventory-only-provider-conflict";
+	linkOutcome: "linked" | "inventory-only";
 };
 
 export function ConnectBotDialog({
@@ -90,13 +93,12 @@ export function ConnectBotDialog({
 	const meta = PROVIDER_META[provider];
 	const discordSelected = provider === "discord";
 	const whatsappSelected = provider === "whatsapp";
+	const providerLinkingReady = channelProviderLinkingReady(provider);
 	const providerLinkConflict = Boolean(
-		agentId &&
-			agentProviderHasSingleLinkLimit(agentType, provider) &&
-			linkedProviders?.has(provider),
+		agentId && agentProviderLinkReplacementRequired(agentType, provider, linkedProviders),
 	);
 	const agentLinkStatusUnknown = Boolean(
-		agentId && agentProviderHasSingleLinkLimit(agentType, provider) && !linkedProviders,
+		agentId && agentProviderLinkStatusUnknown(agentType, provider, linkedProviders),
 	);
 	const autoLinkAgentId = autoLinkAgentIdForNewCustomBot(
 		agentId,
@@ -108,19 +110,13 @@ export function ConnectBotDialog({
 	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
 	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
 	const isSubmitting = submitting || create.isPending;
-	const agentLinkWarning =
-		!whatsappSelected && providerLinkConflict
-			? {
-					title: `${meta.label} is already linked`,
-					description: `This Agent already has a ${meta.label} link. The new bot will be added to Custom bots without linking to this Agent.`,
-				}
-			: !whatsappSelected && agentLinkStatusUnknown
-				? {
-						title: "Agent link status unavailable",
-						description:
-							"Clawdi can’t confirm this Agent’s existing links right now. The new Custom bot will be added to Custom bots without being linked to this Agent.",
-					}
-				: null;
+	const agentLinkWarning = agentLinkStatusUnknown
+		? {
+				title: "Agent link status unavailable",
+				description:
+					"Clawdi can’t confirm this Agent’s existing links right now. The new Custom bot will be added to Custom bots without being linked to this Agent.",
+			}
+		: null;
 
 	function changeProvider(next: ConnectableBotProvider) {
 		if (isSubmitting) return;
@@ -142,12 +138,13 @@ export function ConnectBotDialog({
 				!applicationIdError &&
 				!publicKeyError));
 
-	function buildBody(): ChannelCreate {
-		const base = {
+	function buildBody(replaceExistingProviderLink: boolean): ChannelCreate {
+		const base: ChannelCreate = {
 			provider,
 			name: name.trim(),
 			provider_token: token.trim(),
-			agent_id: autoLinkAgentId,
+			agent_id: replaceExistingProviderLink ? agentId : autoLinkAgentId,
+			...(replaceExistingProviderLink ? { replace_existing_provider_link: true } : {}),
 		};
 		if (!discordSelected) return base;
 		return {
@@ -159,22 +156,17 @@ export function ConnectBotDialog({
 		};
 	}
 
-	async function submit() {
+	async function submit(replaceExistingProviderLink = false): Promise<void> {
 		if (!canSubmit || submitLocked.current) return;
 		submitLocked.current = true;
 		setSubmitting(true);
 		const dialogSession = dialogSessionRef.current;
-		const body = buildBody();
-		const skippedLinkForProviderConflict = providerLinkConflict;
+		const body = buildBody(replaceExistingProviderLink);
 		try {
 			const data = await create.execute(body);
 			const result: CreatedCustomBot = {
 				...data,
-				linkOutcome: data.agent_link_id
-					? "linked"
-					: skippedLinkForProviderConflict
-						? "inventory-only-provider-conflict"
-						: "inventory-only",
+				linkOutcome: data.agent_link_id ? "linked" : "inventory-only",
 			};
 			setToken("");
 			if (openRef.current && dialogSessionRef.current === dialogSession) {
@@ -199,8 +191,6 @@ export function ConnectBotDialog({
 								: `${data.name} was added to Custom bots.`,
 				});
 			}
-		} catch {
-			// useCreateChannel surfaces the API error; retain inputs for retry.
 		} finally {
 			submitLocked.current = false;
 			setSubmitting(false);
@@ -264,6 +254,15 @@ export function ConnectBotDialog({
 			{otherProviderHint}
 		</fieldset>
 	);
+	const addCustomBotButton = (
+		<Button
+			className="min-w-0 whitespace-normal"
+			onClick={providerLinkConflict ? undefined : () => void submit().catch(() => undefined)}
+			disabled={!canSubmit || isSubmitting}
+		>
+			{isSubmitting ? "Adding…" : "Add custom bot"}
+		</Button>
+	);
 
 	return (
 		<Dialog
@@ -288,11 +287,9 @@ export function ConnectBotDialog({
 								</span>{" "}
 								{created.linkOutcome === "linked"
 									? "was added to Custom bots and linked to this Agent."
-									: created.linkOutcome === "inventory-only-provider-conflict"
-										? `was added to Custom bots. It was not linked because ${providerMeta(created.provider).label} is already linked to this Agent.`
-										: agentId
-											? "was added to Custom bots without linking to this Agent."
-											: "was added to Custom bots. Link it from an Agent when you’re ready."}
+									: agentId
+										? "was added to Custom bots without linking to this Agent."
+										: "was added to Custom bots. Link it from an Agent when you’re ready."}
 							</DialogDescription>
 						</DialogHeader>
 						<DialogFooter>
@@ -345,7 +342,12 @@ export function ConnectBotDialog({
 												{agentLinkWarning.description}
 											</AlertDescription>
 										</Alert>
-									) : !whatsappSelected && agentId ? (
+									) : providerLinkConflict ? (
+										<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
+											Adding this bot will ask you to replace this Agent&apos;s existing{" "}
+											{meta.label} link.
+										</p>
+									) : providerLinkingReady && agentId ? (
 										<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
 											The new Custom bot will be linked to this Agent automatically.
 										</p>
@@ -468,13 +470,17 @@ export function ConnectBotDialog({
 											>
 												{isSubmitting ? "Close" : "Cancel"}
 											</Button>
-											<Button
-												className="min-w-0 whitespace-normal"
-												onClick={() => void submit()}
-												disabled={!canSubmit || isSubmitting}
-											>
-												{isSubmitting ? "Adding…" : "Add custom bot"}
-											</Button>
+											{providerLinkConflict ? (
+												<ProviderLinkReplacementConfirm
+													provider={provider}
+													targetName={name.trim()}
+													onConfirm={() => submit(true)}
+												>
+													{addCustomBotButton}
+												</ProviderLinkReplacementConfirm>
+											) : (
+												addCustomBotButton
+											)}
 										</DialogFooter>
 									) : null}
 								</div>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { ExternalLink, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -110,8 +111,8 @@ export function ConnectBotDialog({
 	const agentLinkWarning =
 		!whatsappSelected && providerLinkConflict
 			? {
-					title: "Won’t link automatically",
-					description: `This Agent already has a ${meta.label} bot. The new Custom bot will be added to Custom bots without being linked to this Agent.`,
+					title: `${meta.label} is already linked`,
+					description: `This Agent already has a ${meta.label} link. The new bot will be added to Custom bots without linking to this Agent.`,
 				}
 			: !whatsappSelected && agentLinkStatusUnknown
 				? {
@@ -218,28 +219,6 @@ export function ConnectBotDialog({
 		if (!nextOpen) setCreated(null);
 	}
 
-	const providerChoices = (
-		<fieldset className="grid grid-cols-1 gap-2 border-0 p-0 sm:grid-cols-3" aria-label="Provider">
-			{CONNECTABLE_BOT_PROVIDERS.map((item) => {
-				return (
-					<Button
-						key={item}
-						type="button"
-						variant={provider === item ? "secondary" : "outline"}
-						className="h-auto min-h-12 min-w-0 justify-start gap-1.5 px-2 sm:gap-2 sm:px-2.5"
-						disabled={isSubmitting}
-						aria-pressed={provider === item}
-						onClick={() => changeProvider(item)}
-					>
-						<EntityIcon kind="channel" id={item} label={PROVIDER_META[item].label} size="sm" />
-						<span className="min-w-0 whitespace-normal break-words text-left text-xs leading-tight [overflow-wrap:anywhere] sm:text-sm">
-							{PROVIDER_META[item].label}
-						</span>
-					</Button>
-				);
-			})}
-		</fieldset>
-	);
 	const otherProviderHint = (
 		<p
 			data-other-provider-hint
@@ -263,6 +242,28 @@ export function ConnectBotDialog({
 			)}
 		</p>
 	);
+	const providerChoices = (
+		<fieldset className="min-w-0 space-y-2 border-0 p-0" data-provider-chooser>
+			<legend className="mb-2 text-sm font-medium">Choose provider</legend>
+			<div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+				{CONNECTABLE_BOT_PROVIDERS.map((item) => (
+					<EntityChoiceCard
+						key={item}
+						variant="compact"
+						className="gap-2 p-2"
+						icon={
+							<EntityIcon kind="channel" id={item} label={PROVIDER_META[item].label} size="sm" />
+						}
+						title={PROVIDER_META[item].label}
+						selected={provider === item}
+						disabled={isSubmitting}
+						onClick={() => changeProvider(item)}
+					/>
+				))}
+			</div>
+			{otherProviderHint}
+		</fieldset>
+	);
 
 	return (
 		<Dialog
@@ -273,7 +274,7 @@ export function ConnectBotDialog({
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="max-h-[calc(100dvh-2rem)] min-w-0 overflow-x-hidden overflow-y-auto sm:max-w-md [&>*]:min-w-0"
+				className="max-h-[calc(100dvh-2rem)] min-w-0 overflow-x-hidden overflow-y-auto sm:max-w-lg [&>*]:min-w-0"
 			>
 				{created ? (
 					<>
@@ -288,7 +289,7 @@ export function ConnectBotDialog({
 								{created.linkOutcome === "linked"
 									? "was added to Custom bots and linked to this Agent."
 									: created.linkOutcome === "inventory-only-provider-conflict"
-										? `was added to Custom bots. It was not linked because this Agent already has a ${providerMeta(created.provider).label} bot.`
+										? `was added to Custom bots. It was not linked because ${providerMeta(created.provider).label} is already linked to this Agent.`
 										: agentId
 											? "was added to Custom bots without linking to this Agent."
 											: "was added to Custom bots. Link it from an Agent when you’re ready."}
@@ -322,149 +323,163 @@ export function ConnectBotDialog({
 							</DialogDescription>
 						</DialogHeader>
 
-						<div className="flex min-w-0 flex-col gap-3">
+						<div className="flex min-w-0 flex-col gap-4">
 							{providerChoices}
-							{otherProviderHint}
-							{agentLinkWarning ? (
-								<Alert
-									data-agent-link-warning
-									className="border-warning/30 bg-warning-muted py-2.5"
-								>
-									<TriangleAlert aria-hidden />
-									<AlertTitle>{agentLinkWarning.title}</AlertTitle>
-									<AlertDescription className="text-xs">
-										{agentLinkWarning.description}
-									</AlertDescription>
-								</Alert>
-							) : !whatsappSelected && agentId ? (
-								<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
-									The new Custom bot will be linked to this Agent automatically.
-								</p>
-							) : null}
-							{whatsappSelected ? (
-								<WhatsAppDeviceOnboarding onDone={() => handleOpenChange(false)} />
-							) : (
-								<>
-									<p className="min-w-0 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
-										{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
-										<a
-											href={meta.setupUrl}
-											target="_blank"
-											rel="noreferrer"
-											className="inline-flex min-w-0 flex-wrap items-center gap-1 font-medium text-foreground underline underline-offset-4"
+							<section
+								className="min-w-0 border-t pt-4"
+								aria-labelledby="provider-configuration-title"
+								data-provider-configuration
+							>
+								<h3 id="provider-configuration-title" className="mb-3 text-sm font-medium">
+									Configure {meta.label}
+								</h3>
+								<div className="flex min-w-0 flex-col gap-3">
+									{agentLinkWarning ? (
+										<Alert
+											data-agent-link-warning
+											className="border-warning/30 bg-warning-muted py-2.5"
 										>
-											{provider === "telegram"
-												? "Create a bot with @BotFather"
-												: "Open Discord Developer Portal"}
-											<ExternalLink className="size-3" />
-										</a>
-									</p>
-
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-name">Name</Label>
-										<Input
-											id="connect-name"
-											value={name}
-											onChange={(event) => setName(event.target.value)}
-											placeholder="Support Bot"
-											autoComplete="off"
-										/>
-									</div>
-
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-token">Bot token</Label>
-										<Input
-											id="connect-token"
-											type="password"
-											value={token}
-											onChange={(event) => setToken(event.target.value)}
-											placeholder={meta.tokenPlaceholder}
-											autoComplete="off"
-											spellCheck={false}
-											required
-											aria-invalid={Boolean(tokenError)}
-											aria-describedby={tokenError ? "connect-token-error" : undefined}
-										/>
-										{tokenError ? (
-											<p
-												id="connect-token-error"
-												className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-											>
-												{tokenError}
-											</p>
-										) : null}
-									</div>
-
-									{discordSelected ? (
-										<>
-											<div className="flex flex-col gap-1.5">
-												<Label htmlFor="connect-app-id">Application ID</Label>
-												<Input
-													id="connect-app-id"
-													value={applicationId}
-													onChange={(event) => setApplicationId(event.target.value)}
-													placeholder="Application ID"
-													autoComplete="off"
-													spellCheck={false}
-													required
-													aria-invalid={Boolean(applicationIdError)}
-													aria-describedby={applicationIdError ? "connect-app-id-error" : undefined}
-												/>
-												{applicationIdError ? (
-													<p
-														id="connect-app-id-error"
-														className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-													>
-														{applicationIdError}
-													</p>
-												) : null}
-											</div>
-											<div className="flex flex-col gap-1.5">
-												<Label htmlFor="connect-public-key">Public key</Label>
-												<Input
-													id="connect-public-key"
-													value={publicKey}
-													onChange={(event) => setPublicKey(event.target.value)}
-													placeholder="64-character hex public key"
-													autoComplete="off"
-													spellCheck={false}
-													required
-													aria-invalid={Boolean(publicKeyError)}
-													aria-describedby={publicKeyError ? "connect-public-key-error" : undefined}
-												/>
-												{publicKeyError ? (
-													<p
-														id="connect-public-key-error"
-														className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
-													>
-														{publicKeyError}
-													</p>
-												) : null}
-											</div>
-										</>
+											<TriangleAlert aria-hidden />
+											<AlertTitle>{agentLinkWarning.title}</AlertTitle>
+											<AlertDescription className="text-xs">
+												{agentLinkWarning.description}
+											</AlertDescription>
+										</Alert>
+									) : !whatsappSelected && agentId ? (
+										<p role="status" className="text-xs text-muted-foreground" aria-live="polite">
+											The new Custom bot will be linked to this Agent automatically.
+										</p>
 									) : null}
-								</>
-							)}
-						</div>
+									{whatsappSelected ? (
+										<WhatsAppDeviceOnboarding onDone={() => handleOpenChange(false)} />
+									) : (
+										<>
+											<p className="min-w-0 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
+												{provider === "telegram" ? "Need a bot token? " : "Need app credentials? "}
+												<a
+													href={meta.setupUrl}
+													target="_blank"
+													rel="noreferrer"
+													className="inline-flex min-w-0 flex-wrap items-center gap-1 font-medium text-foreground underline underline-offset-4"
+												>
+													{provider === "telegram"
+														? "Create a bot with @BotFather"
+														: "Open Discord Developer Portal"}
+													<ExternalLink className="size-3" />
+												</a>
+											</p>
 
-						{!whatsappSelected ? (
-							<DialogFooter>
-								<Button
-									variant="outline"
-									className="min-w-0 whitespace-normal"
-									onClick={() => handleOpenChange(false)}
-								>
-									{isSubmitting ? "Close" : "Cancel"}
-								</Button>
-								<Button
-									className="min-w-0 whitespace-normal"
-									onClick={() => void submit()}
-									disabled={!canSubmit || isSubmitting}
-								>
-									{isSubmitting ? "Adding…" : "Add custom bot"}
-								</Button>
-							</DialogFooter>
-						) : null}
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-name">Name</Label>
+												<Input
+													id="connect-name"
+													value={name}
+													onChange={(event) => setName(event.target.value)}
+													placeholder="Support Bot"
+													autoComplete="off"
+												/>
+											</div>
+
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="connect-token">Bot token</Label>
+												<Input
+													id="connect-token"
+													type="password"
+													value={token}
+													onChange={(event) => setToken(event.target.value)}
+													placeholder={meta.tokenPlaceholder}
+													autoComplete="off"
+													spellCheck={false}
+													required
+													aria-invalid={Boolean(tokenError)}
+													aria-describedby={tokenError ? "connect-token-error" : undefined}
+												/>
+												{tokenError ? (
+													<p
+														id="connect-token-error"
+														className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+													>
+														{tokenError}
+													</p>
+												) : null}
+											</div>
+
+											{discordSelected ? (
+												<>
+													<div className="flex flex-col gap-1.5">
+														<Label htmlFor="connect-app-id">Application ID</Label>
+														<Input
+															id="connect-app-id"
+															value={applicationId}
+															onChange={(event) => setApplicationId(event.target.value)}
+															placeholder="Application ID"
+															autoComplete="off"
+															spellCheck={false}
+															required
+															aria-invalid={Boolean(applicationIdError)}
+															aria-describedby={
+																applicationIdError ? "connect-app-id-error" : undefined
+															}
+														/>
+														{applicationIdError ? (
+															<p
+																id="connect-app-id-error"
+																className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+															>
+																{applicationIdError}
+															</p>
+														) : null}
+													</div>
+													<div className="flex flex-col gap-1.5">
+														<Label htmlFor="connect-public-key">Public key</Label>
+														<Input
+															id="connect-public-key"
+															value={publicKey}
+															onChange={(event) => setPublicKey(event.target.value)}
+															placeholder="64-character hex public key"
+															autoComplete="off"
+															spellCheck={false}
+															required
+															aria-invalid={Boolean(publicKeyError)}
+															aria-describedby={
+																publicKeyError ? "connect-public-key-error" : undefined
+															}
+														/>
+														{publicKeyError ? (
+															<p
+																id="connect-public-key-error"
+																className="break-words text-xs text-destructive [overflow-wrap:anywhere]"
+															>
+																{publicKeyError}
+															</p>
+														) : null}
+													</div>
+												</>
+											) : null}
+										</>
+									)}
+
+									{!whatsappSelected ? (
+										<DialogFooter>
+											<Button
+												variant="outline"
+												className="min-w-0 whitespace-normal"
+												onClick={() => handleOpenChange(false)}
+											>
+												{isSubmitting ? "Close" : "Cancel"}
+											</Button>
+											<Button
+												className="min-w-0 whitespace-normal"
+												onClick={() => void submit()}
+												disabled={!canSubmit || isSubmitting}
+											>
+												{isSubmitting ? "Adding…" : "Add custom bot"}
+											</Button>
+										</DialogFooter>
+									) : null}
+								</div>
+							</section>
+						</div>
 					</>
 				)}
 			</DialogContent>

--- a/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
+++ b/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { providerMeta } from "@/hosted/v2/channels/channel-providers";
+
+export function ProviderLinkReplacementConfirm({
+	provider,
+	targetName,
+	onConfirm,
+	children,
+}: {
+	provider: string;
+	targetName: string;
+	onConfirm: () => unknown;
+	children: ReactElement;
+}) {
+	const providerLabel = providerMeta(provider).label;
+	return (
+		<ConfirmAction
+			title={`Replace this Agent’s ${providerLabel} link?`}
+			description={
+				<>
+					This Agent can use one {providerLabel} bot at a time.{" "}
+					<span className="font-medium text-foreground [overflow-wrap:anywhere]">{targetName}</span>{" "}
+					will replace the current bot, and its paired chats will be removed from this Agent.
+				</>
+			}
+			confirmLabel={`Replace ${providerLabel} link`}
+			onConfirm={onConfirm}
+		>
+			{children}
+		</ConfirmAction>
+	);
+}

--- a/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
+++ b/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
@@ -17,19 +17,23 @@ export function ProviderLinkReplacementConfirm({
 }) {
 	const providerLabel = providerMeta(provider).label;
 	return (
-		<ConfirmAction
-			title={`Replace this Agent’s ${providerLabel} link?`}
-			description={
-				<>
-					This Agent can use one {providerLabel} bot at a time.{" "}
-					<span className="font-medium text-foreground [overflow-wrap:anywhere]">{targetName}</span>{" "}
-					will replace the current bot, and its paired chats will be removed from this Agent.
-				</>
-			}
-			confirmLabel={`Replace ${providerLabel} link`}
-			onConfirm={onConfirm}
-		>
-			{children}
-		</ConfirmAction>
+		<div data-hosted="true" data-v2="true" className="contents">
+			<ConfirmAction
+				title={`Replace this Agent’s ${providerLabel} link?`}
+				description={
+					<>
+						This Agent can use one {providerLabel} bot at a time.{" "}
+						<span className="font-medium text-foreground [overflow-wrap:anywhere]">
+							{targetName}
+						</span>{" "}
+						will replace the current bot, and its paired chats will be removed from this Agent.
+					</>
+				}
+				confirmLabel={`Replace ${providerLabel} link`}
+				onConfirm={onConfirm}
+			>
+				{children}
+			</ConfirmAction>
+		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.test.ts
@@ -46,7 +46,6 @@ describe("WhatsApp linked-device onboarding", () => {
 	test("keeps Custom WhatsApp setup flat and separate from Clawdi-managed bots", () => {
 		expect(source).toContain('data-hosted="true"');
 		expect(source).toContain('data-v2="true"');
-		expect(source).toContain("Your WhatsApp");
 		expect(source).not.toContain("Clawdi WhatsApp");
 		expect(source).not.toContain("WhatsAppOptionCard");
 		expect(source).not.toContain("sm:grid-cols-2");
@@ -56,8 +55,6 @@ describe("WhatsApp linked-device onboarding", () => {
 		const warningMarkerIndex = source.indexOf("data-whatsapp-account-warning");
 		expect(warningMarkerIndex).toBeLessThan(source.indexOf("Connect your account"));
 		expect(connectDialog).toContain("<WhatsAppDeviceOnboarding");
-		expect(connectDialog).toContain("whitespace-normal break-words");
-		expect(connectDialog).not.toContain("min-w-0 truncate text-left");
 		expect(connectDialog).not.toContain("phone-number ID");
 		expect(connectDialog).not.toContain("Graph API");
 	});

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
@@ -7,7 +7,6 @@ import {
 	CircleAlert,
 	QrCode,
 	RefreshCw,
-	Smartphone,
 	TriangleAlert,
 	Unplug,
 } from "lucide-react";
@@ -63,24 +62,15 @@ export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
 			data-v2="true"
 			data-whatsapp-account-choice
 		>
-			<div className="flex min-w-0 items-start gap-3">
-				<div className="shrink-0 rounded-md bg-identity-2-bg p-2 text-identity-2-fg">
-					<Smartphone className="size-4" aria-hidden="true" />
-				</div>
-				<div className="min-w-0 flex-1">
-					<h3 className="font-medium [overflow-wrap:anywhere]">Your WhatsApp</h3>
-					<p className="mt-1 text-xs text-muted-foreground [overflow-wrap:anywhere]">
-						Add a WhatsApp account you own by scanning a linked-device QR.
-					</p>
-				</div>
-			</div>
+			<p className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
+				Add a WhatsApp account you own by scanning a linked-device QR.
+			</p>
 			<Alert data-whatsapp-account-warning className="border-warning/30 bg-warning-muted py-2.5">
 				<TriangleAlert aria-hidden />
-				<AlertTitle>Use a dedicated WhatsApp account</AlertTitle>
+				<AlertTitle>Use a dedicated number</AlertTitle>
 				<AlertDescription className="text-xs">
-					Clawdi connects as a linked device. Once linked to an Agent, messages to this account may
-					be handled by the Agent, and replies are sent as this account. Use a separate WhatsApp
-					account and phone number—not your primary personal account.
+					Clawdi uses WhatsApp’s linked-device feature. When linked to an Agent, replies are sent
+					from this account—use a separate number, not your primary personal one.
 				</AlertDescription>
 			</Alert>
 			<p className="min-w-0 text-xs text-muted-foreground [overflow-wrap:anywhere]" role="status">

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -664,6 +664,7 @@ async def create_channel(
             account=account,
             agent_id=initial_agent_id,
             user_id=auth.user_id,
+            replace_existing_provider_link=body.replace_existing_provider_link,
         )
     db.add(account)
     try:
@@ -688,6 +689,7 @@ async def create_channel(
                 agent_id=initial_agent_id,
                 user_id=auth.user_id,
                 agent_token=link_agent_token,
+                replace_existing_provider_link=body.replace_existing_provider_link,
             )
             link_agent_token = created_token or link_agent_token
             await _queue_agent_link_runtime_changed(db, account=account, link=link)
@@ -707,6 +709,7 @@ async def create_channel(
                 "provider": account.provider,
                 "visibility": account.visibility,
                 "initial_agent_id": str(initial_agent_id) if initial_agent_id else None,
+                "replace_existing_provider_link": body.replace_existing_provider_link,
                 "has_provider_credential": body.provider_token is not None,
                 "secret_names": sorted((body.secrets or {}).keys()),
             },
@@ -999,6 +1002,7 @@ async def create_channel_agent_link(
         account=account,
         agent_id=agent_id,
         user_id=auth.user_id,
+        replace_existing_provider_link=body.replace_existing_provider_link,
     )
     if agent_token is not None:
         await _queue_agent_link_runtime_changed(db, account=account, link=link)
@@ -1017,6 +1021,7 @@ async def create_channel_agent_link(
             "provider": account.provider,
             "agent_id": str(agent_id),
             "created": agent_token is not None,
+            "replace_existing_provider_link": body.replace_existing_provider_link,
         },
     )
     await db.commit()

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 ChannelProvider = Literal["telegram", "discord", "whatsapp"]
 ChannelVisibility = Literal["private", "public"]
@@ -31,6 +31,10 @@ class ChannelAccountCreate(BaseModel):
     provider: ChannelProvider
     name: str = Field(min_length=1, max_length=120)
     agent_id: UUID | None = None
+    replace_existing_provider_link: bool = Field(
+        default_factory=bool,
+        description="Explicit opt-in to replace this Agent's active link for the same provider.",
+    )
     provider_token: str | None = Field(default=None, min_length=1, max_length=2000)
     config: dict[str, Any] | None = None
     secrets: dict[str, str] | None = None
@@ -57,6 +61,12 @@ class ChannelAccountCreate(BaseModel):
                 raise ValueError("secret values cannot be blank")
             cleaned[name] = secret
         return cleaned
+
+    @model_validator(mode="after")
+    def _validate_provider_link_replacement(self) -> ChannelAccountCreate:
+        if self.replace_existing_provider_link and self.agent_id is None:
+            raise ValueError("agent_id is required to replace an existing provider link")
+        return self
 
 
 class ChannelAccountResponse(BaseModel):
@@ -164,6 +174,16 @@ class ChannelWhatsAppOnboardingSessionResponse(BaseModel):
 
 class ChannelAgentLinkCreate(BaseModel):
     agent_id: UUID | None = None
+    replace_existing_provider_link: bool = Field(
+        default_factory=bool,
+        description="Explicit opt-in to replace this Agent's active link for the same provider.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_provider_link_replacement(self) -> ChannelAgentLinkCreate:
+        if self.replace_existing_provider_link and self.agent_id is None:
+            raise ValueError("agent_id is required to replace an existing provider link")
+        return self
 
 
 class ChannelAgentLinkResponse(BaseModel):

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -194,7 +194,7 @@ HERMES_AGENT_TYPE = "hermes"
 OPENCLAW_AGENT_TYPE = "openclaw"
 HOSTED_RUNTIME_AGENT_TYPES = frozenset({HERMES_AGENT_TYPE, OPENCLAW_AGENT_TYPE})
 HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS = frozenset(
-    {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD}
+    {CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD, CHANNEL_PROVIDER_WHATSAPP}
 )
 STRICT_V2_AGENT_LINK_DETAIL = "Only Cloud Agents can be linked or paired with channels."
 WHATSAPP_COMING_SOON_DETAIL = (
@@ -646,6 +646,7 @@ async def get_or_create_bot_agent_link(
     agent_id: UUID,
     user_id: UUID | None = None,
     agent_token: str | None = None,
+    replace_existing_provider_link: bool = False,
 ) -> tuple[ChannelBotAgentLink, str | None]:
     link_user_id = require_channel_tenant_user_id(account, tenant_user_id=user_id)
     # Serialize against both Link creation and runtime retirement. The fence is
@@ -712,8 +713,16 @@ async def get_or_create_bot_agent_link(
         account=account,
         agent_id=agent_id,
         user_id=link_user_id,
+        replace_existing_provider_link=replace_existing_provider_link,
     )
     await ensure_bot_agent_link_capacity(db, account=account)
+    if replace_existing_provider_link:
+        await archive_existing_hosted_agent_provider_links(
+            db,
+            account=account,
+            agent_id=agent_id,
+            user_id=link_user_id,
+        )
     raw_token = agent_token or generate_agent_token(account.provider)
     link = ChannelBotAgentLink(
         account_id=account.id,
@@ -993,6 +1002,7 @@ async def ensure_hosted_agent_provider_link_available(
     account: ChannelAccount,
     agent_id: UUID,
     user_id: UUID,
+    replace_existing_provider_link: bool = False,
 ) -> None:
     agent = (
         await db.execute(
@@ -1030,10 +1040,67 @@ async def ensure_hosted_agent_provider_link_available(
     )
     if not existing_link_ids:
         return
+    if replace_existing_provider_link:
+        return
     raise HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail=hosted_agent_provider_link_limit_detail(account.provider),
     )
+
+
+async def archive_existing_hosted_agent_provider_links(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    agent_id: UUID,
+    user_id: UUID,
+) -> None:
+    """Archive other active single-provider Links before creating a replacement.
+
+    The caller holds the Agent and runtime-fence locks acquired by
+    ``get_or_create_bot_agent_link``. Link row locks and binding identity locks
+    serialize this archive with unlink, pairing, and delivery mutations. All
+    changes remain in the caller's transaction, so a later failure restores
+    the previous Link and its scoped runtime state.
+    """
+    if account.provider not in HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS:
+        return
+    rows = (
+        await db.execute(
+            select(ChannelBotAgentLink, ChannelAccount)
+            .join(ChannelAccount, ChannelAccount.id == ChannelBotAgentLink.account_id)
+            .where(
+                ChannelBotAgentLink.agent_id == agent_id,
+                ChannelBotAgentLink.user_id == user_id,
+                ChannelBotAgentLink.account_id != account.id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+                ChannelAccount.provider == account.provider,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+            )
+            .order_by(ChannelBotAgentLink.id)
+            .with_for_update(of=ChannelBotAgentLink)
+        )
+    ).all()
+    for existing_link, existing_account in rows:
+        bindings = list(
+            (
+                await db.execute(
+                    select(ChannelBinding).where(
+                        ChannelBinding.bot_agent_link_id == existing_link.id,
+                        ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                    )
+                )
+            ).scalars()
+        )
+        for binding in sorted(bindings, key=lambda item: item.external_chat_id):
+            await lock_channel_binding_identity(
+                db,
+                account_id=existing_account.id,
+                external_chat_id=binding.external_chat_id,
+            )
+        await archive_bot_agent_link(db, link=existing_link, account=existing_account)
 
 
 def channel_bot_link_limit(account: ChannelAccount) -> int | None:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -17,6 +17,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -74,6 +75,7 @@ from app.routes.channel_routers.discord import (
     cleanup_discord_guild_commands_after_authority_revoked,
 )
 from app.routes.channel_routers.shared import _discord_gateway_dispatch
+from app.schemas.channel import ChannelAccountCreate, ChannelAgentLinkCreate
 from app.services import channel_config as channel_config_service
 from app.services import channels as channel_service
 from app.services.channel_debug_events import record_channel_debug_event
@@ -1017,6 +1019,27 @@ async def test_create_channel_masks_provider_token(client: httpx.AsyncClient):
     assert TELEGRAM_AGENT_TOKEN_RE.fullmatch(created["agent_token"])
     assert created["webhook_secret"]
     assert "telegram-secret" not in response.text
+
+
+def test_provider_link_replace_opt_in_is_non_nullable_and_defaults_false():
+    account = ChannelAccountCreate(provider=CHANNEL_PROVIDER_TELEGRAM, name="Schema test")
+    link = ChannelAgentLinkCreate()
+
+    assert account.replace_existing_provider_link is False
+    assert link.replace_existing_provider_link is False
+
+    with pytest.raises(ValidationError):
+        ChannelAccountCreate.model_validate(
+            {
+                "provider": CHANNEL_PROVIDER_TELEGRAM,
+                "name": "Schema test",
+                "replace_existing_provider_link": None,
+            }
+        )
+    with pytest.raises(ValidationError):
+        ChannelAgentLinkCreate.model_validate({"replace_existing_provider_link": None})
+    with pytest.raises(ValidationError, match="agent_id is required"):
+        ChannelAgentLinkCreate(replace_existing_provider_link=True)
 
 
 @pytest.mark.asyncio
@@ -2166,6 +2189,278 @@ async def test_hosted_agent_rejects_second_provider_account_but_keeps_existing_l
     assert agent.id not in eligible_agent_ids
     assert runtime_channels.status_code == 200, runtime_channels.text
     assert [item["id"] for item in runtime_channels.json()] == [first_account.json()["id"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_type", "provider"),
+    [
+        ("hermes", CHANNEL_PROVIDER_TELEGRAM),
+        ("hermes", CHANNEL_PROVIDER_DISCORD),
+        ("openclaw", CHANNEL_PROVIDER_TELEGRAM),
+        ("openclaw", CHANNEL_PROVIDER_DISCORD),
+    ],
+)
+async def test_agent_link_replace_opt_in_atomically_archives_the_existing_provider_link(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+    agent_type: str,
+    provider: str,
+):
+    if provider == CHANNEL_PROVIDER_DISCORD:
+
+        async def fake_configure_discord_application(account: ChannelAccount):
+            return {"id": DISCORD_TEST_APPLICATION_ID}
+
+        async def fake_sync_channel_commands(**kwargs):
+            return []
+
+        monkeypatch.setattr(
+            "app.routes.admin.configure_discord_application",
+            fake_configure_discord_application,
+        )
+        monkeypatch.setattr(
+            "app.routes.admin.sync_channel_commands",
+            fake_sync_channel_commands,
+        )
+    discord_credentials = (
+        {
+            "provider_token": f"discord-replacement-token-{uuid4().hex}",
+            "config": _discord_ready_config(),
+        }
+        if provider == CHANNEL_PROVIDER_DISCORD
+        else {}
+    )
+    first_account_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"{agent_type}-{provider}-replace-first-{uuid4().hex}",
+        **discord_credentials,
+    )
+    second_account_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"{agent_type}-{provider}-replace-second-{uuid4().hex}",
+        **discord_credentials,
+    )
+    assert first_account_response.status_code == 201, first_account_response.text
+    assert second_account_response.status_code == 201, second_account_response.text
+    first_account_id = UUID(first_account_response.json()["id"])
+    second_account_id = UUID(second_account_response.json()["id"])
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label=f"{agent_type}-{provider}-replace",
+        agent_type=agent_type,
+    )
+
+    async with _client_for_user(db_session, user) as user_client:
+        first_response = await user_client.post(
+            f"/v1/channels/{first_account_id}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+    assert first_response.status_code == 201, first_response.text
+    first_link = await db_session.get(ChannelBotAgentLink, UUID(first_response.json()["id"]))
+    assert first_link is not None
+    binding = ChannelBinding(
+        account_id=first_account_id,
+        bot_agent_link_id=first_link.id,
+        user_id=user.id,
+        external_chat_id=f"replacement-chat-{uuid4().hex}",
+        external_chat_type="private",
+        external_chat_name="Replacement cleanup",
+    )
+    pair_code = ChannelPairCode(
+        account_id=first_account_id,
+        bot_agent_link_id=first_link.id,
+        user_id=user.id,
+        code_hash=hash_token(f"replacement-{uuid4()}"),
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+    credential = ChannelAgentCredential(
+        account_id=first_account_id,
+        bot_agent_link_id=first_link.id,
+        user_id=user.id,
+        provider=provider,
+        identity_pub_key_hash=hash_token(f"replacement-credential-{uuid4()}"),
+        identity_public_key=b"replacement-public-key",
+        synthetic_jid=f"replacement-{uuid4().hex}@example.test",
+        encrypted_credentials=b"replacement-encrypted-credentials",
+        credential_nonce=b"replacement-credential-nonce",
+    )
+    db_session.add_all((binding, pair_code, credential))
+    await db_session.commit()
+
+    async with _client_for_user(db_session, user) as user_client:
+        replacement = await user_client.post(
+            f"/v1/channels/{second_account_id}/agent-links",
+            json={
+                "agent_id": str(agent.id),
+                "replace_existing_provider_link": True,
+            },
+        )
+        idempotent = await user_client.post(
+            f"/v1/channels/{second_account_id}/agent-links",
+            json={
+                "agent_id": str(agent.id),
+                "replace_existing_provider_link": True,
+            },
+        )
+        active_links = await user_client.get(
+            "/v1/channels/agent-links",
+            params={"agent_id": str(agent.id)},
+        )
+
+    assert replacement.status_code == 201, replacement.text
+    assert replacement.json()["account_id"] == str(second_account_id)
+    assert replacement.json()["agent_token"] is not None
+    assert idempotent.status_code == 201, idempotent.text
+    assert idempotent.json()["id"] == replacement.json()["id"]
+    assert idempotent.json()["agent_token"] is None
+    assert active_links.status_code == 200, active_links.text
+    assert [item["account_id"] for item in active_links.json()] == [str(second_account_id)]
+
+    for row in (first_link, binding, pair_code, credential):
+        await db_session.refresh(row)
+    assert first_link.status == BOT_AGENT_LINK_STATUS_ARCHIVED
+    assert first_link.archived_at is not None
+    assert first_link.agent_token_hash is None
+    assert first_link.encrypted_agent_token is None
+    assert first_link.agent_token_nonce is None
+    assert binding.status == BINDING_STATUS_ARCHIVED
+    assert pair_code.status == PAIR_CODE_STATUS_REVOKED
+    assert credential.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_create_channel_replace_opt_in_links_the_new_custom_bot(
+    db_session: AsyncSession,
+):
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label="create-channel-provider-replace",
+        agent_type="openclaw",
+    )
+    async with _client_for_user(db_session, user) as user_client:
+        first = await user_client.post(
+            "/v1/channels",
+            json={
+                "provider": CHANNEL_PROVIDER_TELEGRAM,
+                "name": f"create-replace-first-{uuid4().hex}",
+                "agent_id": str(agent.id),
+            },
+        )
+        replacement = await user_client.post(
+            "/v1/channels",
+            json={
+                "provider": CHANNEL_PROVIDER_TELEGRAM,
+                "name": f"create-replace-second-{uuid4().hex}",
+                "agent_id": str(agent.id),
+                "replace_existing_provider_link": True,
+            },
+        )
+
+    assert first.status_code == 201, first.text
+    assert replacement.status_code == 201, replacement.text
+    assert replacement.json()["agent_id"] == str(agent.id)
+    assert replacement.json()["agent_link_id"] is not None
+    first_link = await db_session.get(ChannelBotAgentLink, UUID(first.json()["agent_link_id"]))
+    replacement_link = await db_session.get(
+        ChannelBotAgentLink,
+        UUID(replacement.json()["agent_link_id"]),
+    )
+    assert first_link is not None
+    assert first_link.status == BOT_AGENT_LINK_STATUS_ARCHIVED
+    assert first_link.archived_at is not None
+    assert replacement_link is not None
+    assert replacement_link.status == BOT_AGENT_LINK_STATUS_ACTIVE
+    assert replacement_link.archived_at is None
+
+
+@pytest.mark.asyncio
+async def test_provider_link_replacement_rolls_back_when_a_downstream_step_fails(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    first_account_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        name=f"rollback-replace-first-{uuid4().hex}",
+    )
+    second_account_response = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        name=f"rollback-replace-second-{uuid4().hex}",
+    )
+    assert first_account_response.status_code == 201, first_account_response.text
+    assert second_account_response.status_code == 201, second_account_response.text
+    first_account_id = UUID(first_account_response.json()["id"])
+    second_account_id = UUID(second_account_response.json()["id"])
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label="rollback-provider-replace",
+        agent_type="openclaw",
+    )
+    first_link, first_token = await _seed_existing_channel_link(
+        db_session,
+        account_id=str(first_account_id),
+        agent=agent,
+    )
+    binding = ChannelBinding(
+        account_id=first_account_id,
+        bot_agent_link_id=first_link.id,
+        user_id=user.id,
+        external_chat_id=f"rollback-chat-{uuid4().hex}",
+        external_chat_type="private",
+    )
+    db_session.add(binding)
+    await db_session.commit()
+    session_factory = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    with pytest.raises(RuntimeError, match="downstream replacement failure"):
+        async with session_factory() as replacement_session:
+            async with replacement_session.begin():
+                replacement_account = await replacement_session.get(
+                    ChannelAccount,
+                    second_account_id,
+                )
+                assert replacement_account is not None
+                await channel_service.get_or_create_bot_agent_link(
+                    replacement_session,
+                    account=replacement_account,
+                    agent_id=agent.id,
+                    user_id=user.id,
+                    replace_existing_provider_link=True,
+                )
+                raise RuntimeError("downstream replacement failure")
+
+    async with session_factory() as verification_session:
+        restored_link = await verification_session.get(ChannelBotAgentLink, first_link.id)
+        restored_binding = await verification_session.get(ChannelBinding, binding.id)
+        replacement_links = list(
+            (
+                await verification_session.execute(
+                    select(ChannelBotAgentLink).where(
+                        ChannelBotAgentLink.account_id == second_account_id,
+                        ChannelBotAgentLink.agent_id == agent.id,
+                        ChannelBotAgentLink.archived_at.is_(None),
+                    )
+                )
+            ).scalars()
+        )
+    assert restored_link is not None
+    assert restored_link.status == BOT_AGENT_LINK_STATUS_ACTIVE
+    assert restored_link.archived_at is None
+    assert decrypt_agent_link_token(restored_link) == first_token
+    assert restored_binding is not None
+    assert restored_binding.status == BINDING_STATUS_ACTIVE
+    assert replacement_links == []
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3922,6 +3922,11 @@ export interface components {
             name: string;
             /** Agent Id */
             agent_id?: string | null;
+            /**
+             * Replace Existing Provider Link
+             * @description Explicit opt-in to replace this Agent's active link for the same provider.
+             */
+            replace_existing_provider_link?: boolean;
             /** Provider Token */
             provider_token?: string | null;
             /** Config */
@@ -4072,6 +4077,11 @@ export interface components {
         ChannelAgentLinkCreate: {
             /** Agent Id */
             agent_id?: string | null;
+            /**
+             * Replace Existing Provider Link
+             * @description Explicit opt-in to replace this Agent's active link for the same provider.
+             */
+            replace_existing_provider_link?: boolean;
         };
         /** ChannelAgentLinkResponse */
         ChannelAgentLinkResponse: {


### PR DESCRIPTION
## Summary
- reuse the shared compact EntityChoiceCard selected state for provider choices
- separate provider choice and provider configuration without nested cards
- clarify Telegram/Discord link-conflict semantics and tighten WhatsApp linked-device safety copy
- preserve inventory-only conflict handling, conservative unknown-status behavior, auto-linking, and the WhatsApp feature gate

## Verification
- `bunx biome check` on the five changed Web files
- isolated Web runner: TypeScript, 31 focused tests, and OSS production build
- Playwright: 6 focused hosted scenarios covering selected border/ring/check, chooser/config separation, Telegram/Discord conflict copy and inventory-only requests, unknown status, pending disabled state, WhatsApp copy/lifecycle, desktop, 320px, and horizontal overflow
- visually inspected dark desktop, dark 320px, WhatsApp desktop, and WhatsApp 320px screenshots
