### PR TITLE
fix(whatsapp): support shared account reauthentication

### DIFF
--- a/backend/alembic/versions/d7f3a1c9e5b2_finish_whatsapp_pairing_sessions.py
+++ b/backend/alembic/versions/d7f3a1c9e5b2_finish_whatsapp_pairing_sessions.py
@@ -1,0 +1,102 @@
+"""Treat connected WhatsApp pairing sessions as completed history.
+
+Revision ID: d7f3a1c9e5b2
+Revises: c2f8a4d6e9b1
+Create Date: 2026-08-03 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d7f3a1c9e5b2"
+down_revision: str | Sequence[str] | None = "c2f8a4d6e9b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PAIRING_STATES = "'generating', 'ready', 'scanned', 'error'"
+_LEGACY_ACTIVE_STATES = "'generating', 'ready', 'scanned', 'connected', 'error'"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("LOCK TABLE channel_whatsapp_onboarding_sessions IN ACCESS EXCLUSIVE MODE")
+    )
+    _replace_indexes(_PAIRING_STATES)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("LOCK TABLE channel_whatsapp_onboarding_sessions IN ACCESS EXCLUSIVE MODE")
+    )
+    duplicate = bind.execute(
+        sa.text(
+            """
+            SELECT 1
+            FROM channel_whatsapp_onboarding_sessions
+            WHERE state IN ('generating', 'ready', 'scanned', 'connected', 'error')
+            GROUP BY sidecar_account_id
+            HAVING count(*) > 1
+            UNION ALL
+            SELECT 1
+            FROM channel_whatsapp_onboarding_sessions
+            WHERE ownership_kind = 'custom'
+              AND state IN ('generating', 'ready', 'scanned', 'connected', 'error')
+            GROUP BY user_id, name
+            HAVING count(*) > 1
+            UNION ALL
+            SELECT 1
+            FROM channel_whatsapp_onboarding_sessions
+            WHERE ownership_kind = 'platform'
+              AND state IN ('generating', 'ready', 'scanned', 'connected', 'error')
+            GROUP BY name
+            HAVING count(*) > 1
+            LIMIT 1
+            """
+        )
+    ).first()
+    if duplicate is not None:
+        raise RuntimeError(
+            "cannot restore legacy WhatsApp pairing indexes while completed sessions overlap"
+        )
+    _replace_indexes(_LEGACY_ACTIVE_STATES)
+
+
+def _replace_indexes(states: str) -> None:
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_sidecar_account",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_custom_user_name",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.drop_index(
+        "uq_channel_whatsapp_onboarding_active_platform_name",
+        table_name="channel_whatsapp_onboarding_sessions",
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_sidecar_account",
+        "channel_whatsapp_onboarding_sessions",
+        ["sidecar_account_id"],
+        unique=True,
+        postgresql_where=sa.text(f"state IN ({states})"),
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_custom_user_name",
+        "channel_whatsapp_onboarding_sessions",
+        ["user_id", "name"],
+        unique=True,
+        postgresql_where=sa.text(f"ownership_kind = 'custom' AND state IN ({states})"),
+    )
+    op.create_index(
+        "uq_channel_whatsapp_onboarding_active_platform_name",
+        "channel_whatsapp_onboarding_sessions",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text(f"ownership_kind = 'platform' AND state IN ({states})"),
+    )

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -226,9 +226,7 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
             "uq_channel_whatsapp_onboarding_active_sidecar_account",
             "sidecar_account_id",
             unique=True,
-            postgresql_where=sql_text(
-                "state IN ('generating', 'ready', 'scanned', 'connected', 'error')"
-            ),
+            postgresql_where=sql_text("state IN ('generating', 'ready', 'scanned', 'error')"),
         ),
         Index(
             "uq_channel_whatsapp_onboarding_active_custom_user_name",
@@ -236,8 +234,7 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
             "name",
             unique=True,
             postgresql_where=sql_text(
-                "ownership_kind = 'custom' AND "
-                "state IN ('generating', 'ready', 'scanned', 'connected', 'error')"
+                "ownership_kind = 'custom' AND state IN ('generating', 'ready', 'scanned', 'error')"
             ),
         ),
         Index(
@@ -246,7 +243,7 @@ class ChannelWhatsAppOnboardingSession(Base, TimestampMixin):
             unique=True,
             postgresql_where=sql_text(
                 "ownership_kind = 'platform' AND "
-                "state IN ('generating', 'ready', 'scanned', 'connected', 'error')"
+                "state IN ('generating', 'ready', 'scanned', 'error')"
             ),
         ),
     )

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -39,7 +39,7 @@ from app.services.whatsapp_native_transport import (
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
 _LOCK_ID = 8_071_323_913
-_OWNING_STATES = ("generating", "ready", "scanned", "connected", "error")
+_OWNING_STATES = ("generating", "ready", "scanned", "error")
 _EXPIRABLE_STATES = ("generating", "ready", "scanned", "error")
 
 
@@ -97,25 +97,49 @@ async def start_platform_whatsapp_pairing(
             raise HTTPException(
                 status.HTTP_409_CONFLICT, "configured WhatsApp account identity conflicts"
             )
-        raise HTTPException(
-            status.HTTP_409_CONFLICT, "configured WhatsApp account is already onboarded"
+        if account.name != name:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "configured WhatsApp account name conflicts"
+            )
+        client = registry.get_managed_client(account_id)
+        if client is None:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable"
+            )
+        try:
+            health = await client.health()
+            pairing = await client.pairing_status()
+        except WhatsAppSidecarError:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable"
+            ) from None
+        if health.registered != pairing.registered:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable"
+            )
+        if pairing.registered:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "configured WhatsApp account is already authenticated",
+            )
+    else:
+        duplicate_name = await db.scalar(
+            select(ChannelAccount.id).where(
+                ChannelAccount.user_id.is_(None),
+                ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+                ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+                ChannelAccount.name == name,
+                ChannelAccount.archived_at.is_(None),
+            )
         )
-    duplicate_name = await db.scalar(
-        select(ChannelAccount.id).where(
-            ChannelAccount.user_id.is_(None),
-            ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
-            ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
-            ChannelAccount.name == name,
-            ChannelAccount.archived_at.is_(None),
-        )
-    )
-    if duplicate_name is not None:
-        raise HTTPException(status.HTTP_409_CONFLICT, "WhatsApp account name already exists")
+        if duplicate_name is not None:
+            raise HTTPException(status.HTTP_409_CONFLICT, "WhatsApp account name already exists")
     now = datetime.now(UTC)
     onboarding = ChannelWhatsAppOnboardingSession(
         ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
         sidecar_account_id=account_id,
         sidecar_config_revision=revision,
+        channel_account_id=account.id if account is not None else None,
         user_id=None,
         request_id=request_id,
         name=name,

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -110,6 +110,7 @@ class ConfiguredWhatsAppSidecarRegistry:
         self._service_client: WhatsAppSidecarClient | None = None
         self._clients_by_session: dict[UUID, WhatsAppSidecarClient] = {}
         self._bound_managed_accounts: set[UUID] = set()
+        self._managed_attach_failures: dict[UUID, str] = {}
         self._custom_session_to_account: dict[UUID, UUID] = {}
         self._custom_account_to_session: dict[UUID, UUID] = {}
         self._blocked_custom_sessions: set[UUID] = set()
@@ -178,6 +179,7 @@ class ConfiguredWhatsAppSidecarRegistry:
         for account_id in (*self._bound_managed_accounts, *self._custom_account_to_session):
             unregister_whatsapp_provider_transport(account_id)
         self._bound_managed_accounts.clear()
+        self._managed_attach_failures.clear()
         self._custom_session_to_account.clear()
         self._custom_account_to_session.clear()
         self._blocked_custom_sessions.clear()
@@ -234,15 +236,18 @@ class ConfiguredWhatsAppSidecarRegistry:
         else:
             accounts = await self._managed_accounts(db)
         desired: dict[UUID, str] = {}
+        account_ids = {account.id for account in accounts}
         for account in accounts:
             config = account.config if isinstance(account.config, dict) else {}
             revision = config.get("sidecar_config_revision")
             if config.get("connection_mode") != "baileys_managed" or not isinstance(revision, str):
-                log.error("WhatsApp managed account %s has invalid physical identity", account.id)
+                self._record_managed_attach_failure(account.id, "invalid_physical_identity")
                 continue
             desired[account.id] = revision
         for account_id in tuple(self._bound_managed_accounts - desired.keys()):
             await self.unbind_managed_account(account_id)
+        for account_id in tuple(self._managed_attach_failures.keys() - account_ids):
+            self._managed_attach_failures.pop(account_id, None)
         for account_id, revision in desired.items():
             try:
                 client = self._client(account_id)
@@ -260,10 +265,22 @@ class ConfiguredWhatsAppSidecarRegistry:
                         "managed Baileys physical auth is unavailable"
                     )
                 await self.bind_managed_account(account_id, config_revision=revision)
+                if self._managed_attach_failures.pop(account_id, None) is not None:
+                    log.info("WhatsApp managed account %s attachment recovered", account_id)
             except WhatsAppSidecarError:
                 if account_id in self._bound_managed_accounts:
                     await self.unbind_managed_account(account_id)
-                log.error("WhatsApp managed account %s is not safe to attach", account_id)
+                self._record_managed_attach_failure(account_id, "physical_auth_unavailable")
+
+    def _record_managed_attach_failure(self, account_id: UUID, reason: str) -> None:
+        if self._managed_attach_failures.get(account_id) == reason:
+            return
+        self._managed_attach_failures[account_id] = reason
+        log.error(
+            "WhatsApp managed account %s is not safe to attach: %s",
+            account_id,
+            reason,
+        )
 
     async def _managed_accounts(self, db: AsyncSession) -> list[ChannelAccount]:
         return list(

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -218,6 +218,72 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
 
 
 @pytest.mark.asyncio
+async def test_existing_shared_account_reauth_preserves_inventory_and_history(
+    db_session,
+) -> None:
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    revision = registry.managed_account_revision(account_id)
+    account = ChannelAccount(
+        id=account_id,
+        user_id=None,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name="Shared",
+        status=CHANNEL_STATUS_ACTIVE,
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        webhook_secret_hash="0" * 64,
+        config={
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": revision,
+        },
+    )
+    previous = ChannelWhatsAppOnboardingSession(
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_PLATFORM,
+        sidecar_account_id=account_id,
+        sidecar_config_revision=revision,
+        channel_account_id=account_id,
+        user_id=None,
+        request_id=uuid4(),
+        name="Shared",
+        state="connected",
+        method="qr",
+        started_at=datetime.now(UTC) - timedelta(hours=1),
+        expires_at=datetime.now(UTC) - timedelta(minutes=55),
+        completed_at=datetime.now(UTC) - timedelta(minutes=59),
+    )
+    db_session.add_all((account, previous))
+    await db_session.commit()
+    await registry.start()
+    try:
+        fake.connected = fake.registered = True
+        with pytest.raises(HTTPException) as exc_info:
+            await _start(db_session, registry, account_id, name="Shared")
+        assert exc_info.value.status_code == 409
+        assert "already authenticated" in exc_info.value.detail
+
+        fake.connected = fake.registered = False
+        started = await _start(db_session, registry, account_id, name="Shared")
+        assert started.state == "ready"
+        assert started.channel_account_id == account_id
+        assert started.id != previous.id
+
+        fake.connected = fake.registered = True
+        connected = await get_platform_whatsapp_pairing(
+            db_session, session_id=started.id, registry=registry
+        )
+        assert connected.state == "connected"
+        assert await db_session.get(ChannelAccount, account_id) is account
+        assert registry.managed_is_bound(account_id)
+
+        await db_session.refresh(previous)
+        assert previous.state == "connected"
+        assert previous.channel_account_id == account_id
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
 async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
     db_session, monkeypatch
 ):
@@ -505,6 +571,62 @@ async def test_restart_reconciliation_fails_closed_on_revision_and_physical_drif
         await db_session.commit()
         await registry.reconcile_managed_ownership(db_session)
         assert not registry.managed_is_bound(account_id)
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_managed_attach_failure_logs_only_on_transition(db_session, caplog) -> None:
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    revision = registry.managed_account_revision(account_id)
+    db_session.add(
+        ChannelAccount(
+            id=account_id,
+            user_id=None,
+            provider=CHANNEL_PROVIDER_WHATSAPP,
+            name="Shared",
+            status=CHANNEL_STATUS_ACTIVE,
+            visibility=CHANNEL_VISIBILITY_PUBLIC,
+            webhook_secret_hash="0" * 64,
+            config={},
+        )
+    )
+    await db_session.commit()
+    await registry.start()
+    try:
+        await registry.reconcile_managed_ownership(db_session)
+        await registry.reconcile_managed_ownership(db_session)
+        invalid = [
+            record
+            for record in caplog.records
+            if record.message.endswith("invalid_physical_identity")
+        ]
+        assert len(invalid) == 1
+
+        account = await db_session.get(ChannelAccount, account_id)
+        assert account is not None
+        account.config = {
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": revision,
+        }
+        await db_session.commit()
+        await registry.reconcile_managed_ownership(db_session)
+        await registry.reconcile_managed_ownership(db_session)
+        failures = [
+            record
+            for record in caplog.records
+            if record.message.endswith("physical_auth_unavailable")
+        ]
+        assert len(failures) == 1
+
+        fake.connected = fake.registered = True
+        await registry.reconcile_managed_ownership(db_session)
+        recoveries = [
+            record for record in caplog.records if record.message.endswith("attachment recovered")
+        ]
+        assert len(recoveries) == 1
     finally:
         await registry.stop()
 


### PR DESCRIPTION
## Summary

- treat `connected` WhatsApp onboarding sessions as completed history rather than live pairing reservations
- allow the existing hidden Admin pairing-session API to reauthenticate an exact matching Shared WhatsApp account under the same account/session UUID when physical auth is absent
- preserve the existing `ChannelAccount`, Agent Links, chat Pairs/Bindings, messages, and sidecar state path
- reject reauthentication while physical auth is still registered or account identity/name/revision drifts
- emit managed attach failures only when the bounded failure state changes, and one recovery event after attachment succeeds

No new API, UI, consumer adapter, socket, provider protocol, or credential storage is introduced.

## Production incident evidence

The affected account is active in product inventory but its rc14 sidecar session is `stopped`, `connected=false`, `registered=false`. The service-level sidecar is healthy. The old completed onboarding row currently prevents a second pairing session because `connected` is included in the partial unique-index predicates. Production preflight found zero duplicates under the corrected in-progress predicates.

## Verification

- clean throwaway PostgreSQL upgraded from empty schema through the new Alembic head
- focused isolated Docker suite: `6 passed, 86 deselected`
- changed production type governance: 3 files, 0 errors, 0 warnings
- Ruff check and format: passed
- Alembic single head: `d7f3a1c9e5b2`
- `git diff --check`: passed

The focused tests prove fail-closed refusal for an already authenticated account, same-UUID reauthentication after auth loss, preservation of the existing inventory row and completed history, successful rebind, and transition-only failure/recovery logging.
