### PR TITLE
fix(web): simplify wallet funding controls

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -8694,9 +8694,11 @@ test("auto-reload batches toggle and fields into one explicit save", async ({ pa
 	await card.getByRole("button", { name: "Set up auto-reload" }).click();
 	const threshold = card.getByLabel("When balance is below (USD)");
 	const amount = card.getByLabel("Amount to add (USD)");
+	const monthlyLimit = card.getByRole("switch", { name: "Monthly limit", exact: true });
 	const cap = card.getByLabel("Monthly limit (USD)");
 	const save = card.getByRole("button", { name: "Save", exact: true });
 	const cancel = card.getByRole("button", { name: "Cancel", exact: true });
+	await expect(monthlyLimit).toBeChecked();
 
 	await threshold.fill("7.50");
 	await amount.fill("30");

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -896,6 +896,9 @@ const walletState = {
 	auto_reload_threshold_usd: "5.00",
 	auto_reload_amount_cents: 2_500,
 	auto_reload_monthly_cap_cents: 10_000,
+	auto_reload_monthly_spent_cents: 0,
+	auto_reload_period_end: "2026-09-01T00:00:00Z",
+	auto_reload_status: "off",
 	auto_reload_action: null,
 };
 
@@ -1499,7 +1502,7 @@ type HostedApiStubOptions = {
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
-	ledgerResponseForRequest?: (limit: number) => unknown;
+	ledgerResponseForRequest?: (limit: number, cursor: string | null) => unknown;
 	ledgerRequests?: string[];
 	ledgerResponses?: unknown[];
 	legacyAgentEnvironmentIds?: readonly string[];
@@ -1717,8 +1720,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/wallet/ledger" && r.request().method() === "GET") {
 			options.ledgerRequests?.push(r.request().url());
-			const limit = Number(new URL(r.request().url()).searchParams.get("limit"));
-			const response = options.ledgerResponseForRequest?.(limit) ??
+			const url = new URL(r.request().url());
+			const limit = Number(url.searchParams.get("limit"));
+			const response = options.ledgerResponseForRequest?.(limit, url.searchParams.get("cursor")) ??
 				options.ledgerResponses?.shift() ?? { items: [], has_more: false };
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
@@ -8525,7 +8529,9 @@ test("Stripe invoice history shows both rails and a server-visible zero proratio
 	).toEqual([]);
 });
 
-test("Wallet activity caps show-more requests at the ledger API limit", async ({ page }) => {
+test("Wallet activity follows the ledger cursor without replacing loaded rows", async ({
+	page,
+}) => {
 	const ledgerRequests: string[] = [];
 	let expandedAttempts = 0;
 	const computeCharge = {
@@ -8548,14 +8554,15 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	};
 	await stubHostedApi(page, {
 		ledgerRequests,
-		ledgerResponseForRequest: (limit) => {
-			if (limit === 50) return { items: [topUp, computeCharge], has_more: true };
+		ledgerResponseForRequest: (_limit, cursor) => {
+			if (cursor === null) {
+				return { items: [topUp, computeCharge], has_more: true, next_cursor: "cursor_2" };
+			}
 			expandedAttempts += 1;
 			return expandedAttempts === 1
 				? { status: 400, body: { detail: "ledger_backend_unavailable" } }
 				: {
 						items: [
-							computeCharge,
 							{
 								...computeCharge,
 								operation: "compute_credit",
@@ -8565,7 +8572,8 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 								applied_at: "2026-07-15T00:00:01Z",
 							},
 						],
-						has_more: true,
+						has_more: false,
+						next_cursor: null,
 					};
 		},
 		plans: [basicPlan, performancePlan],
@@ -8579,7 +8587,7 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	await expect(
 		ledgerTable.locator('a[href="https://billing.stripe.test/receipt/topup"]'),
 	).toHaveText("Receipt");
-	await settingsDialog.getByRole("button", { name: "Show more" }).click();
+	await settingsDialog.getByRole("button", { name: "Load more" }).click();
 	await expect.poll(() => ledgerRequests.length).toBe(2);
 	await expect(
 		settingsDialog.getByText("Couldn’t load more activity", { exact: true }),
@@ -8588,14 +8596,13 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	await settingsDialog.getByRole("button", { name: "Retry" }).click();
 	await expect.poll(() => ledgerRequests.length).toBe(3);
 	await expect(ledgerTable.getByText("Compute reversal", { exact: true })).toBeVisible();
-	await expect(settingsDialog.getByRole("button", { name: "Show more" })).toHaveCount(0);
-	await expect(settingsDialog).toContainText(
-		"Showing your most recent activity. Older entries are archived.",
-	);
+	await expect(settingsDialog.getByRole("button", { name: "Load more" })).toHaveCount(0);
 
 	const limits = ledgerRequests.map((url) => Number(new URL(url).searchParams.get("limit")));
-	expect([...new Set(limits)]).toEqual([50, 100]);
-	expect(limits.every((limit) => limit <= 100)).toBe(true);
+	expect([...new Set(limits)]).toEqual([50]);
+	expect(new URL(ledgerRequests[1] ?? "http://invalid").searchParams.get("cursor")).toBe(
+		"cursor_2",
+	);
 	expect(
 		errors.filter((error) => !error.includes("status of 400")),
 		`wallet ledger cap: ${errors.join(" | ")}`,
@@ -8661,12 +8668,13 @@ test("Wallet formats its balance and opens billing from the balance actions", as
 test("auto-reload batches toggle and fields into one explicit save", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const autoReloadRequests: string[] = [];
-	const savedWallet = {
+	const savedWallet: typeof walletState = {
 		...walletState,
 		auto_reload_enabled: true,
 		auto_reload_threshold_usd: "7.50",
 		auto_reload_amount_cents: 3_000,
 		auto_reload_monthly_cap_cents: 12_500,
+		auto_reload_status: "active",
 	};
 	await stubHostedApi(page, {
 		autoReloadRequests,
@@ -8682,33 +8690,24 @@ test("auto-reload batches toggle and fields into one explicit save", async ({ pa
 	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
 	const card = settingsDialog.locator('[data-slot="card"]').filter({ hasText: "Auto-reload" });
-	const enabled = card.getByRole("switch", { name: "Enabled" });
+	await expect(card.getByText("Off", { exact: true })).toBeVisible();
+	await card.getByRole("button", { name: "Set up auto-reload" }).click();
 	const threshold = card.getByLabel("When balance is below (USD)");
 	const amount = card.getByLabel("Amount to add (USD)");
-	const cap = card.getByLabel("Monthly cap (USD)");
-	const save = card.getByRole("button", { name: "Save changes" });
-	const cancel = card.getByRole("button", { name: "Cancel changes" });
+	const cap = card.getByLabel("Monthly limit (USD)");
+	const save = card.getByRole("button", { name: "Save", exact: true });
+	const cancel = card.getByRole("button", { name: "Cancel", exact: true });
 
-	await expect(card.getByText("All changes saved", { exact: true })).toBeVisible();
-	await expect(save).toBeDisabled();
-	await expect(cancel).toBeDisabled();
-
-	await enabled.click();
 	await threshold.fill("7.50");
 	await amount.fill("30");
 	await cap.fill("125");
-	await expect(card.getByText("Unsaved changes", { exact: true })).toBeVisible();
 	expect(autoReloadRequests).toEqual([]);
 
 	await cancel.click();
-	await expect(enabled).not.toBeChecked();
-	await expect(threshold).toHaveValue("5");
-	await expect(amount).toHaveValue("25");
-	await expect(cap).toHaveValue("100");
-	await expect(save).toBeDisabled();
+	await expect(card.getByRole("button", { name: "Set up auto-reload" })).toBeVisible();
 	expect(autoReloadRequests).toEqual([]);
 
-	await enabled.click();
+	await card.getByRole("button", { name: "Set up auto-reload" }).click();
 	await threshold.fill("7.50");
 	await amount.fill("30");
 	await cap.fill("125");
@@ -8730,14 +8729,14 @@ test("auto-reload batches toggle and fields into one explicit save", async ({ pa
 		card.getByText("Add a card before enabling auto-reload", { exact: true }),
 	).toBeVisible();
 	await expect(card.getByRole("button", { name: "Add a card" })).toBeVisible();
-	await expect(card.getByText("Unsaved changes", { exact: true })).toBeVisible();
+	await expect(threshold).toHaveValue("7.50");
 	await card.screenshot({ path: "/tmp/auto-reload-error.png" });
 
 	await save.click();
 	await expect.poll(() => autoReloadRequests.length).toBe(2);
-	await expect(card.getByText("All changes saved", { exact: true })).toBeVisible();
-	await expect(enabled).toBeChecked();
-	await expect(save).toBeDisabled();
+	await expect(card.getByText("Active", { exact: true })).toBeVisible();
+	await expect(card.getByRole("button", { name: "Edit", exact: true })).toBeVisible();
+	await expect(card.getByText("Below $7.50 → add $30.00", { exact: true })).toBeVisible();
 	await card.screenshot({ path: "/tmp/auto-reload-saved.png" });
 
 	for (const raw of autoReloadRequests) {

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -35,6 +35,8 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 	update: "updating",
 	plan_change: "updating",
 	runtime_switch: "updating",
+	migrate_image: "updating",
+	rollback_image: "updating",
 	rename: "updating",
 	delete: "deleting",
 } satisfies Record<DeploymentOperationVerb, HostedDeploymentStatus["summary_state"]>;

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -401,10 +401,10 @@ export function createBillingClient(
 		getManagedModelCatalog: async () =>
 			unwrapDeploy(await api.GET("/v2/ai-providers/managed/models")),
 		getWallet: async () => unwrapDeploy(await api.GET("/v2/wallet")),
-		getLedger: async (limit = 50) =>
+		getLedger: async (limit = 50, cursor?: string | null) =>
 			unwrapDeploy(
 				await api.GET("/v2/wallet/ledger", {
-					params: { query: { limit } },
+					params: { query: { limit, cursor } },
 				}),
 			),
 		topUp: async (body: WalletTopupRequest, idempotencyKey: string) =>

--- a/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
@@ -10,6 +10,9 @@ function wallet(over: Partial<WalletState> = {}): WalletState {
 		auto_reload_threshold_usd: "1",
 		auto_reload_amount_cents: 2500,
 		auto_reload_monthly_cap_cents: 0,
+		auto_reload_monthly_spent_cents: 0,
+		auto_reload_period_end: "2026-09-01T00:00:00Z",
+		auto_reload_status: "off",
 		auto_reload_action: null,
 		...over,
 	};

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -147,6 +147,19 @@ export function useWalletLedger(limit = 50) {
 	});
 }
 
+export function useWalletLedgerPages(limit = 50) {
+	const client = useBillingClient();
+	return useInfiniteQuery({
+		queryKey: billingKeys.ledgerPages(limit),
+		queryFn: ({ pageParam }) => client.getLedger(limit, pageParam),
+		initialPageParam: null as string | null,
+		getNextPageParam: (lastPage) =>
+			lastPage.has_more && lastPage.next_cursor ? lastPage.next_cursor : undefined,
+		enabled: isDeployApiConfigured(),
+		retry: billingQueryRetry,
+	});
+}
+
 // ── Subscription / compute ────────────────────────────────────────────────────
 
 export function usePlans() {

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -7,6 +7,7 @@ export const billingKeys = {
 	wallet: ["billing", "wallet"] as const,
 	ledgerRoot,
 	ledger: (limit: number) => [...ledgerRoot, limit] as const,
+	ledgerPages: (limit: number) => [...ledgerRoot, "pages", limit] as const,
 	subscriptionCreateQuotes,
 	subscriptionCreateQuote: (planSlug: string, billingTermMonths: number, fundingSource: string) =>
 		[...subscriptionCreateQuotes, planSlug, billingTermMonths, fundingSource] as const,

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -27,7 +27,11 @@ describe("autoReloadFormState", () => {
 
 	test("requires a finite limit to cover one reload and supports an explicit no-limit choice", () => {
 		const tooSmall = autoReloadFormState({ ...validForm, cap: "20" });
-		const unlimited = autoReloadFormState({ ...validForm, cap: "", unlimited: true });
+		const unlimited = autoReloadFormState({
+			...validForm,
+			cap: "",
+			monthlyLimitEnabled: false,
+		});
 
 		expect(tooSmall.capValid).toBe(false);
 		expect(unlimited.capCents).toBe(0);

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -7,6 +7,7 @@ import {
 	autoReloadFormState,
 	autoReloadRequest,
 	autoReloadSaveError,
+	autoReloadStatusSummary,
 } from "./auto-reload-card.logic";
 
 const validForm = {
@@ -24,12 +25,14 @@ describe("autoReloadFormState", () => {
 		expect(state.formValid).toBe(false);
 	});
 
-	test("keeps an explicit 0 monthly cap as the no-cap value", () => {
-		const state = autoReloadFormState({ ...validForm, cap: "0" });
+	test("requires a finite limit to cover one reload and supports an explicit no-limit choice", () => {
+		const tooSmall = autoReloadFormState({ ...validForm, cap: "20" });
+		const unlimited = autoReloadFormState({ ...validForm, cap: "", unlimited: true });
 
-		expect(state.capCents).toBe(0);
-		expect(state.capValid).toBe(true);
-		expect(state.formValid).toBe(true);
+		expect(tooSmall.capValid).toBe(false);
+		expect(unlimited.capCents).toBe(0);
+		expect(unlimited.capValid).toBe(true);
+		expect(unlimited.formValid).toBe(true);
 	});
 
 	test("preserves the direct $1 threshold floor", () => {
@@ -51,6 +54,9 @@ const wallet: WalletState = {
 	auto_reload_threshold_usd: "5",
 	auto_reload_amount_cents: 2_500,
 	auto_reload_monthly_cap_cents: 10_000,
+	auto_reload_monthly_spent_cents: 2_500,
+	auto_reload_period_end: "2026-09-01T00:00:00Z",
+	auto_reload_status: "off",
 	auto_reload_action: null,
 };
 
@@ -89,6 +95,22 @@ describe("auto-reload explicit-save state", () => {
 		expect(autoReloadDraftIsDirty({ ...baseline, amount: "25.00" }, baseline)).toBe(false);
 		expect(autoReloadDraftIsDirty({ ...baseline, amount: "26" }, baseline)).toBe(true);
 		expect(autoReloadDraftIsDirty({ ...baseline, amount: "" }, baseline)).toBe(true);
+	});
+});
+
+describe("autoReloadStatusSummary", () => {
+	test("explains a monthly-limit pause without implying auto-reload was turned off", () => {
+		expect(
+			autoReloadStatusSummary({
+				...wallet,
+				auto_reload_enabled: true,
+				auto_reload_status: "paused_monthly_limit",
+			}),
+		).toEqual({
+			label: "Paused",
+			tone: "warning",
+			description: "Monthly limit reached. Auto-reload resumes Sep 1.",
+		});
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -17,14 +17,14 @@ export interface AutoReloadDraft {
 	amount: string;
 	threshold: string;
 	cap: string;
-	unlimited: boolean;
+	monthlyLimitEnabled: boolean;
 }
 
 export interface AutoReloadFormInput {
 	amount: string;
 	threshold: string;
 	cap: string;
-	unlimited?: boolean;
+	monthlyLimitEnabled?: boolean;
 }
 
 export interface AutoReloadFormState {
@@ -110,14 +110,18 @@ export function autoReloadFormState({
 	amount,
 	threshold,
 	cap,
-	unlimited = false,
+	monthlyLimitEnabled = true,
 }: AutoReloadFormInput): AutoReloadFormState {
 	const amountDollars = dollarsFromInput(amount);
 	const thresholdDollars = dollarsFromInput(threshold);
 	const capDollars = dollarsFromInput(cap);
 	const amountCents = amountDollars === null ? Number.NaN : Math.round(amountDollars * 100);
 	const thresholdUsd = thresholdDollars === null ? Number.NaN : thresholdDollars;
-	const capCents = unlimited ? 0 : capDollars === null ? Number.NaN : Math.round(capDollars * 100);
+	const capCents = monthlyLimitEnabled
+		? capDollars === null
+			? Number.NaN
+			: Math.round(capDollars * 100)
+		: 0;
 
 	const amountValid =
 		Number.isFinite(amountCents) &&
@@ -126,7 +130,8 @@ export function autoReloadFormState({
 	const thresholdValid =
 		Number.isFinite(thresholdUsd) && thresholdUsd >= AUTORELOAD_THRESHOLD_MIN_USD;
 	const capValid =
-		unlimited || (Number.isFinite(capCents) && (!amountValid || capCents >= amountCents));
+		!monthlyLimitEnabled ||
+		(Number.isFinite(capCents) && (!amountValid || capCents >= amountCents));
 	const formValid = amountValid && thresholdValid && capValid;
 
 	return {
@@ -141,15 +146,17 @@ export function autoReloadFormState({
 }
 
 export function autoReloadDraftFromWallet(wallet: WalletCacheSnapshot): AutoReloadDraft {
-	const unlimited = wallet.auto_reload_monthly_cap_cents === 0;
+	const monthlyLimitEnabled = wallet.auto_reload_monthly_cap_cents !== 0;
 	return {
 		enabled: wallet.auto_reload_enabled,
 		threshold: dollars(Number(wallet.auto_reload_threshold_usd)),
 		amount: dollars(wallet.auto_reload_amount_cents / 100),
 		cap: dollars(
-			(unlimited ? wallet.auto_reload_amount_cents : wallet.auto_reload_monthly_cap_cents) / 100,
+			(monthlyLimitEnabled
+				? wallet.auto_reload_monthly_cap_cents
+				: wallet.auto_reload_amount_cents) / 100,
 		),
-		unlimited,
+		monthlyLimitEnabled,
 	};
 }
 
@@ -158,7 +165,7 @@ export function autoReloadRequest(draft: AutoReloadDraft): WalletAutoReloadReque
 		amount: draft.amount,
 		threshold: draft.threshold,
 		cap: draft.cap,
-		unlimited: draft.unlimited,
+		monthlyLimitEnabled: draft.monthlyLimitEnabled,
 	});
 	if (!state.formValid) return null;
 

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -17,12 +17,14 @@ export interface AutoReloadDraft {
 	amount: string;
 	threshold: string;
 	cap: string;
+	unlimited: boolean;
 }
 
 export interface AutoReloadFormInput {
 	amount: string;
 	threshold: string;
 	cap: string;
+	unlimited?: boolean;
 }
 
 export interface AutoReloadFormState {
@@ -42,6 +44,12 @@ export interface AutoReloadSaveError {
 	requiresPaymentMethod: boolean;
 }
 
+export interface AutoReloadStatusSummary {
+	label: string;
+	tone: "success" | "warning" | "destructive" | "neutral";
+	description: string;
+}
+
 function dollars(value: number): string {
 	return String(Math.round(value * 100) / 100);
 }
@@ -53,17 +61,63 @@ function dollarsFromInput(value: string): number | null {
 	return Number.isFinite(parsed) ? parsed : null;
 }
 
+function periodEndLabel(value: string): string {
+	return new Intl.DateTimeFormat("en-US", {
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	}).format(new Date(value));
+}
+
+export function autoReloadStatusSummary(wallet: WalletCacheSnapshot): AutoReloadStatusSummary {
+	switch (wallet.auto_reload_status) {
+		case "active":
+			return { label: "Active", tone: "success", description: "Auto-reload is ready." };
+		case "paused_monthly_limit":
+			return {
+				label: "Paused",
+				tone: "warning",
+				description: `Monthly limit reached. Auto-reload resumes ${periodEndLabel(wallet.auto_reload_period_end)}.`,
+			};
+		case "payment_action_required":
+			return {
+				label: "Confirmation needed",
+				tone: "warning",
+				description: "Confirm the pending card payment to finish the reload.",
+			};
+		case "payment_failed":
+			return {
+				label: "Payment failed",
+				tone: "destructive",
+				description: "Update your payment method, then set up auto-reload again.",
+			};
+		case "blocked_refund":
+			return {
+				label: "Blocked",
+				tone: "destructive",
+				description: "A refunded balance must be resolved before auto-reload can run.",
+			};
+		default:
+			return {
+				label: "Off",
+				tone: "neutral",
+				description: "Automatically add funds when your balance is low.",
+			};
+	}
+}
+
 export function autoReloadFormState({
 	amount,
 	threshold,
 	cap,
+	unlimited = false,
 }: AutoReloadFormInput): AutoReloadFormState {
 	const amountDollars = dollarsFromInput(amount);
 	const thresholdDollars = dollarsFromInput(threshold);
 	const capDollars = dollarsFromInput(cap);
 	const amountCents = amountDollars === null ? Number.NaN : Math.round(amountDollars * 100);
 	const thresholdUsd = thresholdDollars === null ? Number.NaN : thresholdDollars;
-	const capCents = capDollars === null ? Number.NaN : Math.round(capDollars * 100);
+	const capCents = unlimited ? 0 : capDollars === null ? Number.NaN : Math.round(capDollars * 100);
 
 	const amountValid =
 		Number.isFinite(amountCents) &&
@@ -71,8 +125,8 @@ export function autoReloadFormState({
 		amountCents <= AUTORELOAD_AMOUNT_MAX_CENTS;
 	const thresholdValid =
 		Number.isFinite(thresholdUsd) && thresholdUsd >= AUTORELOAD_THRESHOLD_MIN_USD;
-	// 0 = no cap; any positive value is a cap. Blank / negative / non-numeric is invalid.
-	const capValid = Number.isFinite(capCents) && capCents >= 0;
+	const capValid =
+		unlimited || (Number.isFinite(capCents) && (!amountValid || capCents >= amountCents));
 	const formValid = amountValid && thresholdValid && capValid;
 
 	return {
@@ -87,11 +141,15 @@ export function autoReloadFormState({
 }
 
 export function autoReloadDraftFromWallet(wallet: WalletCacheSnapshot): AutoReloadDraft {
+	const unlimited = wallet.auto_reload_monthly_cap_cents === 0;
 	return {
 		enabled: wallet.auto_reload_enabled,
 		threshold: dollars(Number(wallet.auto_reload_threshold_usd)),
 		amount: dollars(wallet.auto_reload_amount_cents / 100),
-		cap: dollars(wallet.auto_reload_monthly_cap_cents / 100),
+		cap: dollars(
+			(unlimited ? wallet.auto_reload_amount_cents : wallet.auto_reload_monthly_cap_cents) / 100,
+		),
+		unlimited,
 	};
 }
 
@@ -100,6 +158,7 @@ export function autoReloadRequest(draft: AutoReloadDraft): WalletAutoReloadReque
 		amount: draft.amount,
 		threshold: draft.threshold,
 		cap: draft.cap,
+		unlimited: draft.unlimited,
 	});
 	if (!state.formValid) return null;
 
@@ -148,7 +207,7 @@ export function autoReloadSaveError(error: unknown): AutoReloadSaveError {
 	if (signal.includes("monthly cap") || signal.includes("monthly_cap")) {
 		return {
 			title: "Check the monthly cap",
-			description: "Enter 0 for no cap or a positive dollar amount, then save again.",
+			description: "Set a monthly limit at least as large as one reload, or choose no limit.",
 			field: "cap",
 			requiresPaymentMethod: false,
 		};

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -15,10 +15,12 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { Switch } from "@/components/ui/switch";
+import { StatusBadge } from "@/components/ui/status-badge";
+import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import { useSensitiveSetAutoReload } from "@/hosted/billing/sensitive-actions";
@@ -36,6 +38,7 @@ import {
 	autoReloadFormState,
 	autoReloadRequest,
 	autoReloadSaveError,
+	autoReloadStatusSummary,
 } from "@/hosted/billing/wallet/auto-reload-card.logic";
 import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import {
@@ -54,9 +57,13 @@ const ALL_FIELDS_BLURRED: BlurredFields = { threshold: true, amount: true, cap: 
 export function AutoReloadCard({
 	wallet,
 	onTopUp,
+	onManagePaymentMethods,
+	isManagePaymentMethodsPending = false,
 }: {
 	wallet: WalletCacheSnapshot;
 	onTopUp?: () => void;
+	onManagePaymentMethods?: () => void;
+	isManagePaymentMethodsPending?: boolean;
 }) {
 	const save = useSensitiveSetAutoReload();
 	const queryClient = useQueryClient();
@@ -64,6 +71,7 @@ export function AutoReloadCard({
 	const initialDraft = autoReloadDraftFromWallet(wallet);
 	const [baseline, setBaseline] = useState<AutoReloadDraft>(initialDraft);
 	const [draft, setDraft] = useState<AutoReloadDraft>(initialDraft);
+	const [editing, setEditing] = useState(false);
 	const [blurred, setBlurred] = useState<BlurredFields>(PRISTINE_FIELDS);
 	const [requestError, setRequestError] = useState<AutoReloadSaveError | null>(null);
 	const [actionClientSecret, setActionClientSecret] = useState<PaymentIntentClientSecret | null>(
@@ -76,13 +84,10 @@ export function AutoReloadCard({
 	baselineRef.current = baseline;
 	pendingRef.current = save.isPending;
 
-	const form = autoReloadFormState({
-		amount: draft.amount,
-		threshold: draft.threshold,
-		cap: draft.cap,
-	});
+	const form = autoReloadFormState(draft);
 	const dirty = autoReloadDraftIsDirty(draft, baseline);
-	useSettingsEditState({ dirty, busy: save.isPending });
+	const status = autoReloadStatusSummary(wallet);
+	useSettingsEditState({ dirty: editing && dirty, busy: save.isPending });
 
 	useEffect(() => {
 		const next = autoReloadDraftFromWallet(wallet);
@@ -113,11 +118,43 @@ export function AutoReloadCard({
 		setBlurred((current) => ({ ...current, [field]: true }));
 	}
 
+	function beginEditing() {
+		const next = { ...autoReloadDraftFromWallet(wallet), enabled: true };
+		setBaseline(autoReloadDraftFromWallet(wallet));
+		setDraft(next);
+		setBlurred(PRISTINE_FIELDS);
+		setRequestError(null);
+		setEditing(true);
+	}
+
 	function cancelChanges() {
 		if (save.isPending) return;
 		setDraft(baseline);
 		setBlurred(PRISTINE_FIELDS);
 		setRequestError(null);
+		setEditing(false);
+	}
+
+	function acceptSavedWallet(nextWallet: WalletState) {
+		setActionClientSecret(walletAutoReloadPaymentIntentClientSecret(nextWallet.auto_reload_action));
+		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
+		const next = autoReloadDraftFromWallet(nextWallet);
+		setBaseline(next);
+		setDraft(next);
+		setBlurred(PRISTINE_FIELDS);
+		setRequestError(null);
+		setEditing(false);
+	}
+
+	function handleSaveFailure(error: unknown) {
+		const copy = autoReloadSaveError(error);
+		setRequestError(copy);
+		const field = copy.field;
+		if (field) {
+			setBlurred((current) => ({ ...current, [field]: true }));
+			window.requestAnimationFrame(() => document.getElementById(`ar-${field}`)?.focus());
+		}
+		toast.error(copy.title, { description: copy.description });
 	}
 
 	async function saveChanges() {
@@ -126,28 +163,24 @@ export function AutoReloadCard({
 		setRequestError(null);
 		try {
 			const nextWallet = await save.execute(request);
-			setActionClientSecret(
-				walletAutoReloadPaymentIntentClientSecret(nextWallet.auto_reload_action),
-			);
-			queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
-			const next = autoReloadDraftFromWallet(nextWallet);
-			setBaseline(next);
-			setDraft(next);
-			setBlurred(PRISTINE_FIELDS);
-			toast.success("Auto-reload settings saved", {
-				description: next.enabled
-					? "Auto-reload is on with the saved threshold, amount, and monthly cap."
-					: "Auto-reload is off. Your saved parameters are ready for the next time you enable it.",
-			});
+			acceptSavedWallet(nextWallet);
+			toast.success("Auto-reload settings saved");
 		} catch (error) {
-			const copy = autoReloadSaveError(error);
-			setRequestError(copy);
-			const field = copy.field;
-			if (field) {
-				setBlurred((current) => ({ ...current, [field]: true }));
-				window.requestAnimationFrame(() => document.getElementById(`ar-${field}`)?.focus());
-			}
-			toast.error(copy.title, { description: copy.description });
+			handleSaveFailure(error);
+		}
+	}
+
+	async function turnOff() {
+		if (save.isPending) return;
+		const request = autoReloadRequest({ ...autoReloadDraftFromWallet(wallet), enabled: false });
+		if (!request) return;
+		setRequestError(null);
+		try {
+			const nextWallet = await save.execute(request);
+			acceptSavedWallet(nextWallet);
+			toast.success("Auto-reload turned off");
+		} catch (error) {
+			handleSaveFailure(error);
 		}
 	}
 
@@ -157,6 +190,15 @@ export function AutoReloadCard({
 	const thresholdServerError = requestError?.field === "threshold";
 	const amountServerError = requestError?.field === "amount";
 	const capServerError = requestError?.field === "cap";
+	const minimumCap = form.amountValid ? formatCents(form.amountCents) : "the reload amount";
+	const cap = wallet.auto_reload_monthly_cap_cents;
+	const usage =
+		cap === 0
+			? `${formatCents(wallet.auto_reload_monthly_spent_cents)} added this month · No monthly limit`
+			: `${formatCents(wallet.auto_reload_monthly_spent_cents)} of ${formatCents(cap)} used · Resets ${new Intl.DateTimeFormat(
+					"en-US",
+					{ month: "short", day: "numeric", timeZone: "UTC" },
+				).format(new Date(wallet.auto_reload_period_end))}`;
 
 	return (
 		<Card data-hosted="true">
@@ -166,26 +208,17 @@ export function AutoReloadCard({
 						<CardTitle className="flex items-center gap-2 text-base">
 							<Repeat className="size-4" aria-hidden /> Auto-reload
 						</CardTitle>
-						<CardDescription id="auto-reload-description">
-							Automatically add funds when your balance is low.
+						<CardDescription>
+							{editing ? "Choose when and how much to add." : status.description}
 						</CardDescription>
 					</div>
-					<div className="flex shrink-0 items-center gap-2">
-						<Label htmlFor="auto-reload-enabled" className="text-sm">
-							Enabled
-						</Label>
-						<Switch
-							id="auto-reload-enabled"
-							checked={draft.enabled}
-							onCheckedChange={(enabled) => updateDraft("enabled", enabled)}
-							disabled={save.isPending}
-							aria-describedby="auto-reload-description"
-						/>
-					</div>
+					<StatusBadge status={status.tone} withDot>
+						{status.label}
+					</StatusBadge>
 				</div>
 			</CardHeader>
 
-			<CardContent className="flex flex-col gap-4">
+			<CardContent className="flex flex-col gap-5">
 				<AutoReloadActionConfirm
 					wallet={wallet}
 					onTopUp={onTopUp}
@@ -208,154 +241,208 @@ export function AutoReloadCard({
 					</Alert>
 				) : null}
 
-				<form
-					id="auto-reload-form"
-					onSubmit={(event) => {
-						event.preventDefault();
-						setBlurred(ALL_FIELDS_BLURRED);
-						void runAction(saveChanges);
-					}}
-				>
-					<div className="grid gap-4 sm:grid-cols-3">
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
-							<Input
-								id="ar-threshold"
-								name="auto-reload-threshold"
-								type="number"
-								inputMode="decimal"
-								autoComplete="off"
-								min={AUTORELOAD_THRESHOLD_MIN_USD}
-								step="0.01"
-								className="tabular-nums"
-								value={draft.threshold}
-								onChange={(event) => updateDraft("threshold", event.target.value)}
-								onBlur={() => markBlurred("threshold")}
-								disabled={save.isPending}
-								aria-invalid={thresholdInvalid || thresholdServerError}
-								aria-describedby={
-									thresholdServerError
-										? "ar-threshold-help auto-reload-save-error"
-										: "ar-threshold-help"
-								}
-							/>
-							<p
-								id="ar-threshold-help"
-								className={
-									thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-								aria-live="polite"
-							>
-								Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}; up to 2 decimal places.
-							</p>
+				{editing ? (
+					<form
+						id="auto-reload-form"
+						className="max-w-2xl space-y-5"
+						onSubmit={(event) => {
+							event.preventDefault();
+							setBlurred(ALL_FIELDS_BLURRED);
+							void runAction(saveChanges);
+						}}
+					>
+						<div className="grid gap-4 sm:grid-cols-2">
+							<div className="flex flex-col gap-1.5">
+								<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
+								<Input
+									id="ar-threshold"
+									type="number"
+									inputMode="decimal"
+									autoComplete="off"
+									min={AUTORELOAD_THRESHOLD_MIN_USD}
+									step="0.01"
+									className="tabular-nums"
+									value={draft.threshold}
+									onChange={(event) => updateDraft("threshold", event.target.value)}
+									onBlur={() => markBlurred("threshold")}
+									disabled={save.isPending}
+									aria-invalid={thresholdInvalid || thresholdServerError}
+									aria-describedby="ar-threshold-help"
+								/>
+								<p
+									id="ar-threshold-help"
+									className={
+										thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+									}
+								>
+									Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}.
+								</p>
+							</div>
+
+							<div className="flex flex-col gap-1.5">
+								<Label htmlFor="ar-amount">Amount to add (USD)</Label>
+								<Input
+									id="ar-amount"
+									type="number"
+									inputMode="decimal"
+									autoComplete="off"
+									min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+									max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
+									step="0.01"
+									className="tabular-nums"
+									value={draft.amount}
+									onChange={(event) => updateDraft("amount", event.target.value)}
+									onBlur={() => markBlurred("amount")}
+									disabled={save.isPending}
+									aria-invalid={amountInvalid || amountServerError}
+									aria-describedby="ar-amount-help"
+								/>
+								<p
+									id="ar-amount-help"
+									className={
+										amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+									}
+								>
+									{AUTORELOAD_AMOUNT_RANGE_LABEL}.
+								</p>
+							</div>
 						</div>
 
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="ar-amount">Amount to add (USD)</Label>
-							<Input
-								id="ar-amount"
-								name="auto-reload-amount"
-								type="number"
-								inputMode="decimal"
-								autoComplete="off"
-								min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-								max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
-								step="0.01"
-								className="tabular-nums"
-								value={draft.amount}
-								onChange={(event) => updateDraft("amount", event.target.value)}
-								onBlur={() => markBlurred("amount")}
-								disabled={save.isPending}
-								aria-invalid={amountInvalid || amountServerError}
-								aria-describedby={
-									amountServerError ? "ar-amount-help auto-reload-save-error" : "ar-amount-help"
-								}
-							/>
-							<p
-								id="ar-amount-help"
-								className={
-									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-								aria-live="polite"
-							>
-								{AUTORELOAD_AMOUNT_RANGE_LABEL}; up to 2 decimal places.
-							</p>
-						</div>
+						<div className="space-y-3 rounded-lg border p-4">
+							<div className="flex items-start gap-3">
+								<Checkbox
+									id="ar-unlimited"
+									checked={draft.unlimited}
+									onCheckedChange={(checked) => updateDraft("unlimited", checked)}
+									disabled={save.isPending}
+								/>
+								<div className="space-y-0.5">
+									<Label htmlFor="ar-unlimited">No monthly limit</Label>
+									<p className="text-xs text-muted-foreground">
+										Reloads can continue whenever your balance is low. You can turn this off at any
+										time.
+									</p>
+								</div>
+							</div>
 
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="ar-cap">Monthly cap (USD)</Label>
-							<Input
-								id="ar-cap"
-								name="auto-reload-monthly-cap"
-								type="number"
-								inputMode="decimal"
-								autoComplete="off"
-								min={0}
-								step="0.01"
-								className="tabular-nums"
-								value={draft.cap}
-								onChange={(event) => updateDraft("cap", event.target.value)}
-								onBlur={() => markBlurred("cap")}
-								disabled={save.isPending}
-								aria-invalid={capInvalid || capServerError}
-								aria-describedby={
-									capServerError ? "ar-cap-help auto-reload-save-error" : "ar-cap-help"
-								}
-							/>
-							<p
-								id="ar-cap-help"
-								className={
-									capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-								aria-live="polite"
-							>
-								Enter 0 for no monthly cap; up to 2 decimal places.
-							</p>
+							{!draft.unlimited ? (
+								<div className="flex max-w-sm flex-col gap-1.5">
+									<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
+									<Input
+										id="ar-cap"
+										type="number"
+										inputMode="decimal"
+										autoComplete="off"
+										min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+										step="0.01"
+										className="tabular-nums"
+										value={draft.cap}
+										onChange={(event) => updateDraft("cap", event.target.value)}
+										onBlur={() => markBlurred("cap")}
+										disabled={save.isPending}
+										aria-invalid={capInvalid || capServerError}
+										aria-describedby="ar-cap-help"
+									/>
+									<p
+										id="ar-cap-help"
+										className={
+											capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+										}
+									>
+										Must cover at least one reload ({minimumCap}).
+									</p>
+								</div>
+							) : null}
 						</div>
+					</form>
+				) : wallet.auto_reload_enabled ? (
+					<div className="space-y-1">
+						<p className="font-medium tabular-nums">
+							Below {formatCents(Number(wallet.auto_reload_threshold_usd) * 100)} → add{" "}
+							{formatCents(wallet.auto_reload_amount_cents)}
+						</p>
+						<p className="text-sm text-muted-foreground">{usage}</p>
 					</div>
-				</form>
+				) : null}
 			</CardContent>
 
 			<CardFooter className="flex flex-wrap justify-between gap-3 border-t">
-				<div className="flex min-w-0 flex-col gap-1">
-					<p className="text-xs text-muted-foreground">
-						Enabling requires a saved card. Your first manual top-up saves one.
-					</p>
-					<p
-						className={
-							dirty
-								? "text-xs font-medium text-warning-muted-foreground"
-								: "text-xs text-muted-foreground"
-						}
-						aria-live="polite"
-					>
-						{dirty ? "Unsaved changes" : "All changes saved"}
-					</p>
-				</div>
-				<div className="flex gap-2">
-					<Button
-						type="button"
-						size="sm"
-						variant="ghost"
-						onClick={cancelChanges}
-						disabled={!dirty || save.isPending}
-					>
-						Cancel changes
-					</Button>
-					<Button
-						type="submit"
-						form="auto-reload-form"
-						size="sm"
-						disabled={!dirty || !form.formValid || save.isPending}
-					>
-						{save.isPending ? (
-							<>
-								<Spinner data-icon="inline-start" /> Saving…
-							</>
-						) : (
-							"Save changes"
-						)}
-					</Button>
+				<p className="text-xs text-muted-foreground">
+					Auto-reload uses your saved card. A manual top-up saves one.
+				</p>
+				<div className="flex flex-wrap gap-2">
+					{onManagePaymentMethods ? (
+						<Button
+							type="button"
+							size="sm"
+							variant="ghost"
+							onClick={onManagePaymentMethods}
+							disabled={isManagePaymentMethodsPending || save.isPending}
+						>
+							{isManagePaymentMethodsPending ? (
+								<Spinner data-icon="inline-start" />
+							) : (
+								<CreditCard data-icon="inline-start" />
+							)}
+							Payment methods
+						</Button>
+					) : null}
+					{editing ? (
+						<div key="auto-reload-edit-actions" className="flex gap-2">
+							<Button
+								type="button"
+								size="sm"
+								variant="ghost"
+								onClick={cancelChanges}
+								disabled={save.isPending}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								form="auto-reload-form"
+								size="sm"
+								disabled={!dirty || !form.formValid || save.isPending}
+							>
+								{save.isPending ? (
+									<>
+										<Spinner data-icon="inline-start" /> Saving…
+									</>
+								) : (
+									"Save"
+								)}
+							</Button>
+						</div>
+					) : (
+						<div key="auto-reload-summary-actions" className="flex gap-2">
+							{wallet.auto_reload_enabled ? (
+								<Button
+									type="button"
+									size="sm"
+									variant="ghost"
+									onClick={() => void runAction(turnOff)}
+									disabled={save.isPending}
+								>
+									{save.isPending ? (
+										<>
+											<Spinner data-icon="inline-start" /> Turning off…
+										</>
+									) : (
+										"Turn off"
+									)}
+								</Button>
+							) : null}
+							<Button
+								data-auto-reload-primary
+								type="button"
+								size="sm"
+								onClick={beginEditing}
+								disabled={save.isPending}
+							>
+								{wallet.auto_reload_enabled ? "Edit" : "Set up auto-reload"}
+							</Button>
+						</div>
+					)}
 				</div>
 			</CardFooter>
 		</Card>

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -15,11 +15,11 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBadge } from "@/components/ui/status-badge";
+import { Switch } from "@/components/ui/switch";
 import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
@@ -309,23 +309,24 @@ export function AutoReloadCard({
 						</div>
 
 						<div className="space-y-3 rounded-lg border p-4">
-							<div className="flex items-start gap-3">
-								<Checkbox
-									id="ar-unlimited"
-									checked={draft.unlimited}
-									onCheckedChange={(checked) => updateDraft("unlimited", checked)}
-									disabled={save.isPending}
-								/>
+							<div className="flex items-start justify-between gap-3">
 								<div className="space-y-0.5">
-									<Label htmlFor="ar-unlimited">No monthly limit</Label>
+									<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
 									<p className="text-xs text-muted-foreground">
-										Reloads can continue whenever your balance is low. You can turn this off at any
-										time.
+										{draft.monthlyLimitEnabled
+											? "Pause auto-reload after this amount is added."
+											: "No monthly limit."}
 									</p>
 								</div>
+								<Switch
+									id="ar-monthly-limit"
+									checked={draft.monthlyLimitEnabled}
+									onCheckedChange={(checked) => updateDraft("monthlyLimitEnabled", checked)}
+									disabled={save.isPending}
+								/>
 							</div>
 
-							{!draft.unlimited ? (
+							{draft.monthlyLimitEnabled ? (
 								<div className="flex max-w-sm flex-col gap-1.5">
 									<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
 									<Input

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -167,7 +167,7 @@ export function AutoReloadCard({
 							<Repeat className="size-4" aria-hidden /> Auto-reload
 						</CardTitle>
 						<CardDescription id="auto-reload-description">
-							Top up automatically below a balance threshold. Changes apply only after you save.
+							Automatically add funds when your balance is low.
 						</CardDescription>
 					</div>
 					<div className="flex shrink-0 items-center gap-2">

--- a/apps/web/src/hosted/billing/wallet/balance-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/balance-card.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Coins, CreditCard, Info, TriangleAlert } from "lucide-react";
+import { Coins, CreditCard, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatUsdExact } from "@/hosted/billing/format";
 import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import { isLowBalance } from "@/hosted/billing/wallet/wallet-constants";
@@ -35,22 +34,6 @@ export function BalanceCard({
 					<div className="flex items-center gap-1.5 text-sm text-muted-foreground">
 						<Coins className="size-4" aria-hidden />
 						Wallet balance
-						<Tooltip>
-							<TooltipTrigger
-								render={
-									<button
-										type="button"
-										aria-label="About this balance"
-										className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-									/>
-								}
-							>
-								<Info className="size-3.5" />
-							</TooltipTrigger>
-							<TooltipContent className="max-w-xs">
-								One USD balance shared by Clawdi AI and wallet-funded compute.
-							</TooltipContent>
-						</Tooltip>
 					</div>
 					<div>
 						<span
@@ -64,7 +47,7 @@ export function BalanceCard({
 						</span>
 					</div>
 					<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-						<span>Shared across Clawdi AI and wallet-funded compute.</span>
+						<span>Pays for Clawdi AI and wallet-funded compute.</span>
 						{low ? (
 							<span className="inline-flex items-center gap-1 font-medium text-warning-muted-foreground">
 								<TriangleAlert className="size-3.5" aria-hidden /> Low — top up before

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -39,6 +39,11 @@ describe("filteredLedgerEntries", () => {
 		).toEqual(["compute_charge"]);
 	});
 
+	test("groups automatic reloads with top-ups while keeping their label", () => {
+		expect(ledgerOperationGroup("auto_reload")).toBe("topup");
+		expect(ledgerOperationLabel("auto_reload")).toBe("Auto-reload");
+	});
+
 	test("does not expose an unknown backend operation token", () => {
 		expect(ledgerOperationLabel("bridge_internal_credit_v3")).toBe("Other activity");
 		expect(ledgerOperationGroup("invoice")).toBe("all");

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
@@ -6,6 +6,7 @@ const LEDGER_FILTERS: readonly LedgerFilter[] = ["all", "topup", "grant", "compu
 
 const LEDGER_OPERATION_LABELS: Record<string, string> = {
 	topup: "Top-up",
+	auto_reload: "Auto-reload",
 	x402: "On-chain top-up",
 	grant_signup: "Signup grant",
 	admin_adjust: "Adjustment",
@@ -30,7 +31,7 @@ export function isLedgerFilter(value: string): value is LedgerFilter {
 }
 
 export function ledgerOperationGroup(op: string): LedgerFilter {
-	if (op === "topup" || op === "x402") return "topup";
+	if (op === "topup" || op === "auto_reload" || op === "x402") return "topup";
 	if (op === "grant_signup") return "grant";
 	if (op === "compute_charge" || op === "compute_credit") return "compute";
 	if (op === "refund") return "refund";

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -91,7 +91,6 @@ export function LedgerTable({
 	entries,
 	isLoading = false,
 	hasMore = false,
-	atCap = false,
 	isFetchingMore = false,
 	onShowMore,
 }: {
@@ -99,8 +98,6 @@ export function LedgerTable({
 	isLoading?: boolean;
 	/** More entries likely exist beyond the current window. */
 	hasMore?: boolean;
-	/** The client-side row cap is reached — stop offering "Show more". */
-	atCap?: boolean;
 	isFetchingMore?: boolean;
 	onShowMore?: () => void;
 }) {
@@ -108,7 +105,7 @@ export function LedgerTable({
 	const headingId = useId();
 
 	const filtered = useMemo(() => filteredLedgerEntries(entries, filter), [entries, filter]);
-	const canLoadMore = !atCap && hasMore && onShowMore != null;
+	const canLoadMore = hasMore && onShowMore != null;
 	const emptyState = ledgerEmptyStateCopy({ entriesCount: entries.length, filter, canLoadMore });
 
 	function handleFilterChange(value: string) {
@@ -128,7 +125,7 @@ export function LedgerTable({
 							<Spinner /> Loading…
 						</>
 					) : (
-						"Show more"
+						"Load more"
 					)}
 				</Button>
 			</div>
@@ -268,13 +265,7 @@ export function LedgerTable({
 						</Table>
 					</div>
 
-					{atCap ? (
-						<p className="text-center text-xs text-muted-foreground">
-							Showing your most recent activity. Older entries are archived.
-						</p>
-					) : (
-						renderLoadMoreControl()
-					)}
+					{renderLoadMoreControl()}
 				</>
 			)}
 		</section>

--- a/apps/web/src/hosted/billing/wallet/wallet-cache.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-cache.ts
@@ -17,6 +17,9 @@ export function walletSnapshotForCache(wallet: WalletState): WalletCacheSnapshot
 		auto_reload_threshold_usd: wallet.auto_reload_threshold_usd,
 		auto_reload_amount_cents: wallet.auto_reload_amount_cents,
 		auto_reload_monthly_cap_cents: wallet.auto_reload_monthly_cap_cents,
+		auto_reload_monthly_spent_cents: wallet.auto_reload_monthly_spent_cents,
+		auto_reload_period_end: wallet.auto_reload_period_end,
+		auto_reload_status: wallet.auto_reload_status,
 	};
 	const action = wallet.auto_reload_action;
 	if (action === undefined) return snapshot;

--- a/apps/web/src/hosted/billing/wallet/wallet-constants.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-constants.ts
@@ -13,7 +13,7 @@ export const TOPUP_DEFAULT_CENTS = 2500;
 export const TOPUP_INCREMENT_CENTS = 100;
 export const TOPUP_PRESETS_CENTS = [1000, 2500, 5000, 10_000, 25_000];
 
-// Auto-reload amount bounds; threshold ≥ $1, cap ≥ 0 (0 = off).
+// Auto-reload amount bounds; threshold ≥ $1, and 0 means no monthly limit.
 export const AUTORELOAD_AMOUNT_MIN_CENTS = 500;
 export const AUTORELOAD_AMOUNT_MAX_CENTS = 50_000;
 export const AUTORELOAD_THRESHOLD_MIN_USD = 1;
@@ -31,11 +31,8 @@ export const AUTORELOAD_AMOUNT_RANGE_LABEL = amountRangeLabel(
 // Low-balance warning trips below $2.
 export const LOW_BALANCE_USD = 2;
 
-// Ledger: fetch a page at a time and cap the client-side window so a wallet
-// with thousands of entries can never render thousands of rows. "Show more"
-// steps up by a page until the cap, then the table states it's capped.
+// Ledger activity is fetched incrementally with an opaque server cursor.
 export const LEDGER_PAGE_SIZE = 50;
-export const LEDGER_MAX_ROWS = 100;
 
 export function isLowBalance(balanceUsd: string): boolean {
 	const balance = Number(balanceUsd);

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -31,7 +31,7 @@ import { env } from "@/lib/env";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "One balance for Clawdi AI, wallet-funded compute, top-ups, and auto-reload.";
+const DESCRIPTION = "Add funds and manage how your Clawdi usage is paid.";
 const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 function scrollToAutoReload() {
@@ -187,7 +187,7 @@ export function WalletPage() {
 
 				<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">
 					<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
-					{w.x402_enabled === true ? <X402Card /> : null}
+					<X402Card enabled={w.x402_enabled === true} />
 				</div>
 
 				{ledger.error && !ledgerData ? (

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
@@ -9,7 +9,7 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import { useHostedDeployments, useWalletLedger } from "@/hosted/billing/hooks";
+import { useHostedDeployments, useWalletLedgerPages } from "@/hosted/billing/hooks";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { getStripe } from "@/hosted/billing/stripe";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
@@ -24,7 +24,7 @@ import {
 	type WalletTopupReturnToast,
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
-import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
+import { LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { env } from "@/lib/env";
@@ -39,7 +39,9 @@ function scrollToAutoReload() {
 	if (!section) return;
 	const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 	section.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "center" });
-	window.requestAnimationFrame(() => document.getElementById("auto-reload-enabled")?.focus());
+	window.requestAnimationFrame(() =>
+		section.querySelector<HTMLButtonElement>("[data-auto-reload-primary]")?.focus(),
+	);
 }
 
 function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
@@ -56,11 +58,8 @@ export function WalletPage() {
 	const portal = useSensitiveBillingPortal();
 	const runAction = useActionLock();
 	const queryClient = useQueryClient();
-	const [ledgerLimit, setLedgerLimit] = useState(LEDGER_PAGE_SIZE);
-	const ledger = useWalletLedger(ledgerLimit);
-	const lastLedgerDataRef = useRef(ledger.data);
-	if (ledger.data) lastLedgerDataRef.current = ledger.data;
-	const ledgerData = ledger.data ?? lastLedgerDataRef.current;
+	const ledger = useWalletLedgerPages(LEDGER_PAGE_SIZE);
+	const ledgerEntries = ledger.data?.pages.flatMap((page) => page.items) ?? [];
 	const [topUpOpen, setTopUpOpen] = useState(false);
 
 	async function openBillingPortal() {
@@ -185,12 +184,18 @@ export function WalletPage() {
 					isManagePaymentMethodsPending={portal.isPending}
 				/>
 
-				<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">
-					<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
-					<X402Card enabled={w.x402_enabled === true} />
+				<div id="auto-reload">
+					<AutoReloadCard
+						wallet={w}
+						onTopUp={() => setTopUpOpen(true)}
+						onManagePaymentMethods={() => void runAction(openBillingPortal)}
+						isManagePaymentMethodsPending={portal.isPending}
+					/>
 				</div>
 
-				{ledger.error && !ledgerData ? (
+				<X402Card enabled={w.x402_enabled === true} />
+
+				{ledger.error && !ledger.data ? (
 					<ApiErrorPanel
 						normalizer={billingErrorNormalizer}
 						error={ledger.error}
@@ -200,23 +205,18 @@ export function WalletPage() {
 				) : (
 					<>
 						<LedgerTable
-							entries={ledgerData?.items ?? []}
+							entries={ledgerEntries}
 							isLoading={ledger.isLoading}
-							hasMore={ledgerData?.has_more ?? false}
-							atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledgerData?.has_more ?? false)}
-							isFetchingMore={ledger.isPlaceholderData && ledger.isFetching}
-							onShowMore={
-								ledger.error && ledger.data === undefined
-									? undefined
-									: () => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))
-							}
+							hasMore={ledger.hasNextPage}
+							isFetchingMore={ledger.isFetchingNextPage}
+							onShowMore={() => void ledger.fetchNextPage()}
 						/>
-						{ledger.error && ledger.data === undefined ? (
+						{ledger.isFetchNextPageError ? (
 							<ApiErrorPanel
 								normalizer={billingErrorNormalizer}
 								error={ledger.error}
 								title="Couldn’t load more activity"
-								onRetry={() => void ledger.refetch()}
+								onRetry={() => void ledger.fetchNextPage()}
 							/>
 						) : null}
 					</>

--- a/apps/web/src/hosted/billing/wallet/wallet-query.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-query.test.ts
@@ -30,6 +30,9 @@ describe("walletSnapshotQueryOptions", () => {
 			auto_reload_threshold_usd: "5.00",
 			auto_reload_amount_cents: 2_500,
 			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_monthly_spent_cents: 2_500,
+			auto_reload_period_end: "2026-09-01T00:00:00Z",
+			auto_reload_status: "active",
 			auto_reload_action: {
 				attempt_id: 7,
 				payment_intent_id: "pi_test",
@@ -63,6 +66,9 @@ describe("walletSnapshotQueryOptions", () => {
 			auto_reload_threshold_usd: "5.00",
 			auto_reload_amount_cents: 2_500,
 			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_monthly_spent_cents: 2_500,
+			auto_reload_period_end: "2026-09-01T00:00:00Z",
+			auto_reload_status: "active",
 			auto_reload_action: {
 				attempt_id: 7,
 				payment_intent_id: "pi_test",

--- a/apps/web/src/hosted/billing/wallet/x402-card.test.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 const cardSource = readFileSync(new URL("./x402-card.tsx", import.meta.url), "utf8");
+const pageSource = readFileSync(new URL("./wallet-page.tsx", import.meta.url), "utf8");
 
-describe("x402 deposit safety", () => {
-	test("hides an address when the response cannot confirm network and token", () => {
-		expect(cardSource).toContain("Contact support for deposit details");
-		expect(cardSource).toContain("wrong network");
-		expect(cardSource).toContain("wrong token");
-		expect(cardSource).toContain('href="mailto:support@clawdi.ai"');
-		expect(cardSource).not.toContain("Copy deposit address");
+describe("x402 wallet availability", () => {
+	test("keeps the card visible and labels the unavailable state", () => {
+		expect(pageSource).toContain("<X402Card enabled={w.x402_enabled === true} />");
+		expect(cardSource).toContain("Coming soon");
+		expect(cardSource).toContain("Linked agent wallet");
+		expect(cardSource).not.toContain("deposit address");
 	});
 });

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -1,33 +1,49 @@
 "use client";
 
-import { LifeBuoy, Link2, TriangleAlert } from "lucide-react";
+import { Link2 } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useHostedUser } from "@/hosted/billing/hooks";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
-/**
- * x402 self-funding block. Agents can top up their own wallet on-chain via the
- * x402 protocol; this surfaces the deposit address and a short explainer.
- * WalletPage mounts this only when the wallet snapshot reports x402 enabled.
- */
-export function X402Card() {
+export function X402Card({ enabled }: { enabled: boolean }) {
+	if (!enabled) {
+		return (
+			<Card data-hosted="true" className="self-start">
+				<CardHeader>
+					<div className="flex items-center justify-between gap-3">
+						<CardTitle className="flex items-center gap-2 text-base">
+							<Link2 className="size-4" aria-hidden /> USDC top-up
+						</CardTitle>
+						<Badge variant="secondary">Coming soon</Badge>
+					</div>
+					<CardDescription>Let your agent add funds with USDC through x402.</CardDescription>
+				</CardHeader>
+			</Card>
+		);
+	}
+
+	return <EnabledX402Card />;
+}
+
+function EnabledX402Card() {
 	const me = useHostedUser();
 	const address = me.data?.evm_wallet_address ?? null;
 
 	return (
-		<Card data-hosted="true">
+		<Card data-hosted="true" className="self-start">
 			<CardHeader>
-				<CardTitle className="flex items-center gap-2 text-base">
-					<Link2 className="size-4" aria-hidden /> On-chain top-up (x402)
-				</CardTitle>
+				<div className="flex items-center justify-between gap-3">
+					<CardTitle className="flex items-center gap-2 text-base">
+						<Link2 className="size-4" aria-hidden /> USDC top-up
+					</CardTitle>
+					<Badge variant="outline">x402</Badge>
+				</div>
 				<CardDescription>
-					Your agent can add USD value on-chain via the x402 protocol — no card needed. Deposits
-					land in the same wallet balance.
+					Your agent can add funds from its linked wallet. They appear in this balance.
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
@@ -38,31 +54,17 @@ export function X402Card() {
 						normalizer={billingErrorNormalizer}
 						error={me.error}
 						onRetry={() => me.refetch()}
-						title="Couldn’t load deposit address"
+						title="Couldn’t load linked wallet"
 					/>
 				) : address ? (
-					<Alert variant="destructive">
-						<TriangleAlert aria-hidden />
-						<AlertTitle>Contact support for deposit details</AlertTitle>
-						<AlertDescription className="flex flex-col items-start gap-3">
-							<span>
-								Your account data does not identify the required network or accepted token, so the
-								deposit address is hidden for your safety. Funds sent on the wrong network or as the
-								wrong token are unrecoverable.
-							</span>
-							<Button
-								render={<a href="mailto:support@clawdi.ai" />}
-								nativeButton={false}
-								size="sm"
-								variant="outline"
-							>
-								<LifeBuoy data-icon="inline-start" /> Contact support
-							</Button>
-						</AlertDescription>
-					</Alert>
+					<div className="space-y-1.5">
+						<p className="text-xs text-muted-foreground">Linked agent wallet</p>
+						<p className="break-all font-mono text-sm">{address}</p>
+						<p className="text-xs text-muted-foreground">Top-ups must be signed by this wallet.</p>
+					</div>
 				) : (
 					<p className="text-sm text-muted-foreground">
-						An on-chain deposit address is provisioned with your first Clawdi AI agent.
+						Connect an agent wallet before using x402.
 					</p>
 				)}
 			</CardContent>

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -135,6 +135,10 @@ export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): 
 			return "Agent deletion";
 		case "plan_change":
 			return "Plan change";
+		case "migrate_image":
+			return "Agent image migration";
+		case "rollback_image":
+			return "Agent image rollback";
 		case null:
 			return "Agent action";
 	}
@@ -257,6 +261,8 @@ export function deploymentFailurePresentation(
 		case "update":
 		case "reset_runtime_ui_access":
 		case "runtime_switch":
+		case "migrate_image":
+		case "rollback_image":
 		case "rename":
 		case null:
 			return {

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -62,6 +62,9 @@ describe("structural secret boundaries without the denylist", () => {
 			auto_reload_threshold_usd: "5",
 			auto_reload_amount_cents: 2_500,
 			auto_reload_monthly_cap_cents: 10_000,
+			auto_reload_monthly_spent_cents: 2_500,
+			auto_reload_period_end: "2026-09-01T00:00:00Z",
+			auto_reload_status: "active",
 			auto_reload_action: {
 				attempt_id: 7,
 				payment_intent_id: "pi_structural_test",

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -608,7 +608,7 @@ export interface components {
              * Verb
              * @enum {string}
              */
-            verb: "create" | "plan_change" | "start" | "stop" | "restart" | "update" | "rename" | "delete" | "reset_runtime_ui_access";
+            verb: "create" | "plan_change" | "start" | "stop" | "restart" | "update" | "rename" | "delete" | "reset_runtime_ui_access" | "migrate_image" | "rollback_image";
             /** Targetgeneration */
             targetGeneration: number;
             /** Manifestetag */
@@ -2056,6 +2056,8 @@ export interface components {
             items: components["schemas"]["V2WalletLedgerItemResponse"][];
             /** Has More */
             has_more: boolean;
+            /** Next Cursor */
+            next_cursor?: string | null;
         };
         /** V2WalletResponse */
         V2WalletResponse: {
@@ -2071,6 +2073,18 @@ export interface components {
             auto_reload_amount_cents: number;
             /** Auto Reload Monthly Cap Cents */
             auto_reload_monthly_cap_cents: number;
+            /** Auto Reload Monthly Spent Cents */
+            auto_reload_monthly_spent_cents: number;
+            /**
+             * Auto Reload Period End
+             * Format: date-time
+             */
+            auto_reload_period_end: string;
+            /**
+             * Auto Reload Status
+             * @enum {string}
+             */
+            auto_reload_status: "off" | "active" | "paused_monthly_limit" | "payment_action_required" | "payment_failed" | "blocked_refund";
             auto_reload_action?: components["schemas"]["V2WalletAutoReloadActionResponse"] | null;
         };
         /** V2WalletTopupRequest */
@@ -3282,6 +3296,7 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: number;
+                cursor?: string | null;
             };
             header?: never;
             path?: never;

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -29,6 +29,9 @@ const wallet: DeploySchemas["V2WalletResponse"] = {
 	auto_reload_threshold_usd: "5",
 	auto_reload_amount_cents: 2500,
 	auto_reload_monthly_cap_cents: 10_000,
+	auto_reload_monthly_spent_cents: 2_500,
+	auto_reload_period_end: "2026-09-01T00:00:00Z",
+	auto_reload_status: "active",
 };
 
 const usage: DeploySchemas["V2HostedUsageSummaryResponse"] = {


### PR DESCRIPTION
## Summary

- simplify Wallet copy and remove repeated explanations
- show automatic reload as a compact status summary, expanding the form only for setup or editing
- replace the implicit 0 convention with an explicit No monthly limit choice and validate finite limits against one reload
- show active, monthly-limit pause, payment action, payment failure, and refund-blocked states from the backend projection
- add a direct payment-methods action and keep automatic reload activity distinct from manual top-ups
- replace the 100-row activity window with real cursor pagination and retry the failed page
- label x402/USDC as Coming soon while disabled; when enabled, describe the address correctly as the linked agent wallet

x402 remains disabled. No second client state machine was introduced.

## Verification

- Web TypeScript: passed
- Focused Wallet tests: 18 passed
- OSS production build: passed
- Biome changed-file check: passed
- Hosted Chromium: 2 passed (auto-reload setup/save and activity cursor/retry)
- git diff --check: passed

## Dependency

Deploy Clawdi-AI/clawdi-hosted#1412 before or together with this PR. The backend change is additive; this UI consumes the new effective status and cursor fields.