### PR TITLE
fix(release): normalize CI certificate secrets

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -209,6 +209,16 @@ jobs:
           test "${#CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN}" -le 128
           install -d -m 700 .kamal
           printf '%s\n' "$KAMAL_SECRETS" > .kamal/secrets
+          secrets_tmp="$(mktemp)"
+          trap 'rm -f "$secrets_tmp"' EXIT
+          awk '
+            !/^CLOUDFLARE_ORIGIN_CERT=/ && !/^CLOUDFLARE_ORIGIN_KEY=/ { print }
+            END {
+              print "CLOUDFLARE_ORIGIN_CERT=$CLOUDFLARE_ORIGIN_CERT"
+              print "CLOUDFLARE_ORIGIN_KEY=$CLOUDFLARE_ORIGIN_KEY"
+            }
+          ' .kamal/secrets > "$secrets_tmp"
+          mv "$secrets_tmp" .kamal/secrets
           printf 'CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN=%s\n' \
             "$CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN" >> .kamal/secrets
           chmod 600 .kamal/secrets

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -292,6 +292,12 @@ GitHub Actions secrets; operators keep Kamal secrets in the gitignored
 `.kamal/secrets` file and export deployment parameters before running Kamal.
 Self-hosters set `DEPLOY_HOST` to their own server.
 
+The GitHub Actions deploy step rewrites the two Cloudflare certificate entries
+in `.kamal/secrets` to literal `$CLOUDFLARE_ORIGIN_CERT` and
+`$CLOUDFLARE_ORIGIN_KEY` references. This keeps an operator-local `$(cat ...)`
+path from being evaluated on an ephemeral runner; the dedicated GitHub secrets
+remain the only CI certificate source.
+
 The deployment workflow installs and verifies exactly Kamal `2.12.0`; the
 configuration keeps `minimum_version: 2.12.0` as an independent floor. The
 workflow-level GitHub concurrency queue is the scheduler layer. Kamal's

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -186,6 +186,14 @@ describe("backend image release workflow contract", () => {
 		expect(deployConfigSource).toMatch(/^minimum_version: 2\.12\.0$/m);
 	});
 
+	test("normalizes CI certificate references before Kamal reads secrets", () => {
+		const writeSecrets = imageRelease.jobs["deploy-vps"]?.steps?.find(
+			(step) => step.name === "Write Kamal secrets",
+		);
+		expect(writeSecrets?.run).toContain('print "CLOUDFLARE_ORIGIN_CERT=$CLOUDFLARE_ORIGIN_CERT"');
+		expect(writeSecrets?.run).toContain('print "CLOUDFLARE_ORIGIN_KEY=$CLOUDFLARE_ORIGIN_KEY"');
+	});
+
 	test("wires Docker health to API and channels-worker readiness", () => {
 		expect(backendDockerfile).toContain("ca-certificates curl");
 		const healthcheck = backendDockerfile.match(


### PR DESCRIPTION
Fix the production Kamal workflow so operator-local Cloudflare certificate paths cannot override the dedicated GitHub Actions secrets.

- replace any existing certificate entries with literal runner environment references
- preserve all other Kamal secrets without logging them
- add one focused release-contract assertion and document the boundary

Verification: isolated Bun 1.3.14 Docker run, 11 passed; git diff --check.