### PR TITLE
feat(auth): project Clerk ban authority

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,15 +7,18 @@ CLERK_JWT_ISSUER=
 # Optional networkless override. Accepts a verbatim, escaped-newline, or
 # base64-encoded PEM public key; when set, no JWKS request is made.
 CLERK_PEM_PUBLIC_KEY=
-# Server-only Clerk Backend API secret. Needed for optional verified-email
-# lookup and OAuth refresh-grant revocation; never expose it to a client.
+# Server-only Clerk Backend API secret. Needed for user.updated ban authority,
+# optional verified-email lookup, and OAuth refresh-grant revocation. Direct
+# calls are pinned to Clerk API version 2026-05-12. Never expose it to a client.
 CLERK_SECRET_KEY=
 
 # Optional strict audience binding for browser session JWTs. The issuer is
 # always checked when CLERK_JWT_ISSUER is configured.
 CLERK_JWT_AUDIENCE=
 
-# Dedicated signing secret for this backend's Clerk user.deleted endpoint.
+# Dedicated signing secret for this backend's Clerk user.updated + user.deleted
+# endpoint. Subscribe only those two events; user.created is intentionally not
+# consumed because verified JWTs lazy-create users on their first Clawdi use.
 # Leave blank to keep the endpoint fail-closed (503). Do not reuse the signing
 # secret from another Clerk endpoint/bounded context.
 CLERK_WEBHOOK_SIGNING_SECRET=

--- a/backend/alembic/versions/e7b2c4d9a1f3_clerk_principal_authority.py
+++ b/backend/alembic/versions/e7b2c4d9a1f3_clerk_principal_authority.py
@@ -1,0 +1,64 @@
+"""Add the current reversible Clerk principal authority projection.
+
+Revision ID: e7b2c4d9a1f3
+Revises: d1e5f7a9b3c2
+Create Date: 2026-08-04 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e7b2c4d9a1f3"
+down_revision: str | Sequence[str] | None = "d1e5f7a9b3c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "clerk_principal_authorities",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("issuer", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=200), nullable=False),
+        sa.Column("banned", sa.Boolean(), nullable=False),
+        sa.Column("authority_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("message_id", sa.String(length=191), nullable=False),
+        sa.Column("payload_sha256", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "issuer",
+            "subject",
+            name="uq_clerk_principal_authorities_external_identity",
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.execute(
+        sa.text(
+            "SELECT count(*) FROM clerk_principal_authorities AS authority "
+            "WHERE authority.banned AND NOT EXISTS ("
+            "SELECT 1 FROM principal_lifecycles AS lifecycle "
+            "WHERE lifecycle.issuer = authority.issuer "
+            "AND lifecycle.subject = authority.subject)"
+        )
+    ).scalar_one():
+        raise RuntimeError("cannot downgrade while Clerk ban authority is active")
+    op.drop_table("clerk_principal_authorities")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -25,6 +25,7 @@ from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
+from app.services.clerk_backend import clerk_backend_headers, clerk_user_url
 from app.services.clerk_cli_oauth_settings import ClerkCliOAuthSetting
 from app.services.principal_lifecycle import (
     PrincipalIdentityConflictError,
@@ -413,14 +414,11 @@ async def _fetch_clerk_primary_email(clerk_user_id: str) -> str | None:
     primary unverified). This is identity-binding: callers use the result to
     decide which existing user row to take over, so we refuse to guess.
     """
-    url = f"https://api.clerk.com/v1/users/{clerk_user_id}"
+    url = clerk_user_url(clerk_user_id)
     # Clerk's API is fronted by Cloudflare, which serves a 403 (error 1010)
     # for requests lacking a recognizable User-Agent — including httpx's
     # default. Set an explicit one.
-    headers = {
-        "Authorization": f"Bearer {settings.clerk_secret_key}",
-        "User-Agent": "clawdi-backend/1.0",
-    }
+    headers = clerk_backend_headers()
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(url, headers=headers)

--- a/backend/app/models/principal_lifecycle.py
+++ b/backend/app/models/principal_lifecycle.py
@@ -105,3 +105,24 @@ class ClerkWebhookEventReceipt(Base, TimestampMixin):
         DateTime(timezone=True),
         nullable=False,
     )
+
+
+class ClerkPrincipalAuthority(Base, TimestampMixin):
+    """Latest authoritative reversible Clerk ban projection for one subject."""
+
+    __tablename__ = "clerk_principal_authorities"
+    __table_args__ = (
+        UniqueConstraint(
+            "issuer",
+            "subject",
+            name="uq_clerk_principal_authorities_external_identity",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    issuer: Mapped[str] = mapped_column(String(255), nullable=False)
+    subject: Mapped[str] = mapped_column(String(200), nullable=False)
+    banned: Mapped[bool] = mapped_column(nullable=False)
+    authority_updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    message_id: Mapped[str] = mapped_column(String(191), nullable=False)
+    payload_sha256: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/backend/app/routes/clerk_webhooks.py
+++ b/backend/app/routes/clerk_webhooks.py
@@ -20,19 +20,25 @@ import time
 from datetime import UTC, datetime
 from typing import Literal
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import invalidate_api_key_auth_cache, invalidate_user_api_key_auth_cache
 from app.core.config import settings
 from app.core.database import get_session
+from app.models.principal_lifecycle import PrincipalLifecycle
+from app.models.user import User
+from app.services.clerk_backend import clerk_backend_headers, clerk_user_url
 from app.services.principal_lifecycle import (
     PrincipalLifecycleConfigurationError,
     PrincipalWebhookConflictError,
     complete_principal_cleanup,
     configured_clerk_issuer,
     fence_clerk_user_deleted,
+    project_clerk_user_authority,
     record_principal_cleanup_failure,
 )
 
@@ -47,6 +53,13 @@ _TIMESTAMP_RE = re.compile(r"^[0-9]{1,20}$")
 
 class ClerkWebhookResponse(BaseModel):
     status: Literal["ok"] = "ok"
+
+
+class ClerkAuthorityResponse(BaseModel):
+    object: Literal["user"]
+    id: str
+    banned: bool
+    updated_at: int
 
 
 def _single_header(request: Request, name: str) -> str:
@@ -118,14 +131,15 @@ def verify_clerk_webhook(payload: bytes, request: Request) -> str:
     return message_id
 
 
-def _parse_user_deleted(payload: bytes) -> tuple[str, datetime]:
+def _parse_event(payload: bytes) -> tuple[str, str, datetime]:
     try:
         event = json.loads(payload)
     except (json.JSONDecodeError, UnicodeDecodeError):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid Clerk event body") from None
     if not isinstance(event, dict):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid Clerk event body")
-    if event.get("object") != "event" or event.get("type") != "user.deleted":
+    event_type = event.get("type")
+    if event.get("object") != "event" or event_type not in {"user.updated", "user.deleted"}:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Unsupported Clerk event")
     event_timestamp = event.get("timestamp")
     if (
@@ -141,12 +155,46 @@ def _parse_user_deleted(payload: bytes) -> tuple[str, datetime]:
     data = event.get("data")
     subject = data.get("id") if isinstance(data, dict) else None
     if not isinstance(subject, str) or _SUBJECT_RE.fullmatch(subject) is None:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid Clerk deletion subject")
-    return subject, event_occurred_at
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid Clerk user subject")
+    return event_type, subject, event_occurred_at
+
+
+async def _fetch_clerk_authority(subject: str) -> tuple[bool, datetime]:
+    if not settings.clerk_secret_key:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Clerk Backend API is not configured",
+        )
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                clerk_user_url(subject),
+                headers=clerk_backend_headers(),
+            )
+        if response.status_code != 200:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Clerk authority retrieval is pending retry",
+            )
+        authority = ClerkAuthorityResponse.model_validate_json(response.content)
+        if authority.id != subject or authority.updated_at < 0:
+            raise ValueError("Clerk authority subject or timestamp mismatch")
+        authority_updated_at = datetime.fromtimestamp(authority.updated_at / 1000, tz=UTC)
+    except HTTPException:
+        raise
+    except (httpx.HTTPError, ValidationError, ValueError, OverflowError, OSError):
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Clerk authority retrieval is pending retry",
+        ) from None
+    # Clerk documents `banned` as the durable cannot-sign-in control. `locked`
+    # is intentionally excluded: it can be a temporary failed-attempt lockout.
+    # https://clerk.com/docs/reference/backend-api/tag/Users/operation/GetUser
+    return authority.banned, authority_updated_at
 
 
 @router.post("/clerk", response_model=ClerkWebhookResponse)
-async def clerk_user_deleted_webhook(
+async def clerk_user_lifecycle_webhook(
     request: Request,
     db: AsyncSession = Depends(get_session),
 ) -> ClerkWebhookResponse:
@@ -154,8 +202,55 @@ async def clerk_user_deleted_webhook(
     if len(payload) > _MAX_BODY_BYTES:
         raise HTTPException(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, "Clerk event body too large")
     message_id = verify_clerk_webhook(payload, request)
-    subject, event_occurred_at = _parse_user_deleted(payload)
+    event_type, subject, event_occurred_at = _parse_event(payload)
     payload_sha256 = hashlib.sha256(payload).hexdigest()
+
+    if event_type == "user.updated":
+        try:
+            issuer = configured_clerk_issuer()
+        except PrincipalLifecycleConfigurationError:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Clerk lifecycle receiver is not configured",
+            ) from None
+        # A committed deletion is final and already contains all authority
+        # needed to ACK a stale update. Avoid a doomed Clerk GET after the
+        # provider has removed the user. The locked projection below repeats
+        # this check so a deletion committing during GET still wins.
+        if await db.scalar(
+            select(PrincipalLifecycle.id).where(
+                PrincipalLifecycle.issuer == issuer,
+                PrincipalLifecycle.subject == subject,
+            )
+        ):
+            return ClerkWebhookResponse()
+        banned, authority_updated_at = await _fetch_clerk_authority(subject)
+        try:
+            changed = await project_clerk_user_authority(
+                db,
+                issuer=issuer,
+                subject=subject,
+                banned=banned,
+                authority_updated_at=authority_updated_at,
+                message_id=message_id,
+                payload_sha256=payload_sha256,
+            )
+        except PrincipalLifecycleConfigurationError:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Clerk lifecycle receiver is not configured",
+            ) from None
+        await db.commit()
+        if changed:
+            user_id = await db.scalar(
+                select(User.id).where(
+                    User.clerk_issuer == issuer,
+                    User.clerk_id == subject,
+                )
+            )
+            if user_id is not None:
+                invalidate_user_api_key_auth_cache(user_id)
+        return ClerkWebhookResponse()
 
     try:
         receipt = await fence_clerk_user_deleted(

--- a/backend/app/routes/cli_auth.py
+++ b/backend/app/routes/cli_auth.py
@@ -52,6 +52,7 @@ from app.schemas.cli_auth import (
 from app.services.api_key import mint_api_key
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
+from app.services.clerk_backend import clerk_backend_headers, clerk_backend_url
 from app.services.clerk_cli_oauth_settings import ClerkCliOAuthSetting
 
 router = APIRouter(prefix="/cli/auth", tags=["cli-auth"])
@@ -158,11 +159,8 @@ async def revoke_oauth_refresh_grant(
         )
 
     escaped_application_id = quote(application_id, safe="")
-    url = f"https://api.clerk.com/v1/oauth_applications/{escaped_application_id}/revoke_token"
-    headers = {
-        "Authorization": f"Bearer {secret_key}",
-        "User-Agent": "clawdi-backend/1.0",
-    }
+    url = clerk_backend_url(f"oauth_applications/{escaped_application_id}/revoke_token")
+    headers = clerk_backend_headers()
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.post(

--- a/backend/app/services/clerk_backend.py
+++ b/backend/app/services/clerk_backend.py
@@ -1,0 +1,35 @@
+"""Small shared contract for direct Clerk Backend API requests."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from app.core.config import settings
+
+CLERK_BACKEND_API_ROOT = "https://api.clerk.com/v1"
+CLERK_BACKEND_API_VERSION = "2026-05-12"
+
+
+def clerk_backend_url(path: str) -> str:
+    return f"{CLERK_BACKEND_API_ROOT}/{path.lstrip('/')}"
+
+
+def clerk_user_url(subject: str) -> str:
+    return clerk_backend_url(f"users/{quote(subject, safe='')}")
+
+
+def clerk_backend_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {settings.clerk_secret_key}",
+        "Clerk-API-Version": CLERK_BACKEND_API_VERSION,
+        "User-Agent": "clawdi-backend/1.0",
+    }
+
+
+__all__ = [
+    "CLERK_BACKEND_API_ROOT",
+    "CLERK_BACKEND_API_VERSION",
+    "clerk_backend_headers",
+    "clerk_backend_url",
+    "clerk_user_url",
+]

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -29,6 +29,7 @@ from app.models.channel import (
 from app.models.device_authorization import DeviceAuthorization
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.principal_lifecycle import (
+    ClerkPrincipalAuthority,
     ClerkWebhookEventReceipt,
     PrincipalLifecycle,
 )
@@ -194,6 +195,14 @@ async def assert_clerk_principal_active(
     )
     if lifecycle_id is not None:
         raise PrincipalTerminatedError("principal has been terminated")
+    banned = await db.scalar(
+        select(ClerkPrincipalAuthority.banned).where(
+            ClerkPrincipalAuthority.issuer == resolved_issuer,
+            ClerkPrincipalAuthority.subject == subject,
+        )
+    )
+    if banned is True:
+        raise PrincipalTerminatedError("principal is suspended")
     return resolved_issuer
 
 
@@ -255,10 +264,81 @@ async def assert_user_authority_active(
         select(User.id).where(
             User.id == user_id,
             ~select(PrincipalLifecycle.id).where(PrincipalLifecycle.user_id == User.id).exists(),
+            ~select(ClerkPrincipalAuthority.id)
+            .where(
+                ClerkPrincipalAuthority.issuer == User.clerk_issuer,
+                ClerkPrincipalAuthority.subject == User.clerk_id,
+                ClerkPrincipalAuthority.banned.is_(True),
+            )
+            .exists(),
         )
     )
     if active_id is None:
         raise PrincipalTerminatedError("user authority is disabled")
+
+
+async def project_clerk_user_authority(
+    db: AsyncSession,
+    *,
+    issuer: str,
+    subject: str,
+    banned: bool,
+    authority_updated_at: datetime,
+    message_id: str,
+    payload_sha256: str,
+) -> bool:
+    """Project a current Clerk ban value; deletion is permanently dominant."""
+
+    if issuer != configured_clerk_issuer():
+        raise PrincipalIdentityConflictError("principal issuer is not accepted")
+    if authority_updated_at.tzinfo is None:
+        raise ValueError("Clerk authority timestamp must be timezone-aware")
+    await lock_clerk_principal(db, issuer=issuer, subject=subject)
+    if await db.scalar(
+        select(PrincipalLifecycle.id).where(
+            PrincipalLifecycle.issuer == issuer,
+            PrincipalLifecycle.subject == subject,
+        )
+    ):
+        return False
+
+    projection = (
+        await db.execute(
+            select(ClerkPrincipalAuthority)
+            .where(
+                ClerkPrincipalAuthority.issuer == issuer,
+                ClerkPrincipalAuthority.subject == subject,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if projection is not None and projection.authority_updated_at >= authority_updated_at:
+        return False
+    changed = projection is None or projection.banned != banned
+    if projection is None:
+        projection = ClerkPrincipalAuthority(
+            issuer=issuer,
+            subject=subject,
+            banned=banned,
+            authority_updated_at=authority_updated_at,
+            message_id=message_id,
+            payload_sha256=payload_sha256,
+        )
+        db.add(projection)
+    else:
+        projection.banned = banned
+        projection.authority_updated_at = authority_updated_at
+        projection.message_id = message_id
+        projection.payload_sha256 = payload_sha256
+    user = await load_clerk_user_for_issuer(
+        db,
+        issuer=issuer,
+        subject=subject,
+        bind_legacy=True,
+    )
+    if user is not None:
+        await db.flush()
+    return changed
 
 
 async def load_clerk_user_for_issuer(
@@ -847,6 +927,7 @@ __all__ = [
     "load_clerk_user_for_issuer",
     "lock_clerk_principal",
     "lock_user_authority",
+    "project_clerk_user_authority",
     "resolve_clerk_owner_issuer",
     "record_principal_cleanup_failure",
 ]

--- a/backend/tests/test_clerk_webhook.py
+++ b/backend/tests/test_clerk_webhook.py
@@ -8,6 +8,7 @@ import json
 import time
 import uuid
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
@@ -19,7 +20,11 @@ from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
-from app.models.principal_lifecycle import ClerkWebhookEventReceipt, PrincipalLifecycle
+from app.models.principal_lifecycle import (
+    ClerkPrincipalAuthority,
+    ClerkWebhookEventReceipt,
+    PrincipalLifecycle,
+)
 from app.models.session import AgentEnvironment
 from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
 from app.routes import clerk_webhooks
@@ -41,13 +46,18 @@ _SIGNING_SECRET = "whsec_dGVzdF9jbGVya19zaWduaW5nX3NlY3JldA=="
 _ADMIN_KEY = "direct-webhook-admin-test"
 
 
-def _payload(subject: str, *, timestamp_ms: int | None = None) -> bytes:
+def _payload(
+    subject: str,
+    *,
+    event_type: str = "user.deleted",
+    timestamp_ms: int | None = None,
+) -> bytes:
     return json.dumps(
         {
             "data": {"deleted": True, "id": subject, "object": "user"},
             "object": "event",
             "timestamp": timestamp_ms or int(time.time() * 1000),
-            "type": "user.deleted",
+            "type": event_type,
         },
         separators=(",", ":"),
     ).encode()
@@ -84,6 +94,7 @@ def _direct_webhook_settings(monkeypatch: pytest.MonkeyPatch) -> None:
         SecretStr(_SIGNING_SECRET),
     )
     monkeypatch.setattr(settings, "admin_api_key", _ADMIN_KEY)
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_direct_webhook")
     monkeypatch.setattr(settings, "platform_legacy_admin_auth_enabled", True)
 
 
@@ -94,6 +105,152 @@ async def _delete(anon_client, subject: str, *, message_id: str) -> object:
         content=payload,
         headers=_signed_headers(payload, message_id=message_id),
     )
+
+
+def _mock_clerk_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    subject: str,
+    states: list[tuple[bool, int]],
+    requests: list[httpx.Request] | None = None,
+) -> None:
+    real_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if requests is not None:
+            requests.append(request)
+        banned, updated_at = states.pop(0)
+        return httpx.Response(
+            200,
+            json={"object": "user", "id": subject, "banned": banned, "updated_at": updated_at},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(*_args: object, **_kwargs: object) -> httpx.AsyncClient:
+        return real_client(transport=transport)
+
+    monkeypatch.setattr(clerk_webhooks.httpx, "AsyncClient", client_factory)
+
+
+async def _update(anon_client, subject: str, *, message_id: str) -> object:
+    payload = _payload(subject, event_type="user.updated")
+    return await anon_client.post(
+        "/v1/webhooks/clerk",
+        content=payload,
+        headers=_signed_headers(payload, message_id=message_id),
+    )
+
+
+async def test_signed_authoritative_ban_and_unban_gate_user_and_api_key(
+    anon_client,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = await mint_api_key(db_session, user_id=seed_user.id, label="ban-gate", commit=True)
+    requests: list[httpx.Request] = []
+    _mock_clerk_authority(
+        monkeypatch,
+        subject=seed_user.clerk_id,
+        states=[(True, 2_000), (False, 3_000)],
+        requests=requests,
+    )
+
+    banned = await _update(
+        anon_client,
+        seed_user.clerk_id,
+        message_id=f"msg_{uuid.uuid4().hex}",
+    )
+    with pytest.raises(PrincipalTerminatedError):
+        await assert_user_authority_active(db_session, seed_user.id)
+    await db_session.rollback()
+    rejected = await anon_client.get(
+        "/v1/auth/me",
+        headers={"Authorization": f"Bearer {key.raw_key}"},
+    )
+
+    unbanned = await _update(
+        anon_client,
+        seed_user.clerk_id,
+        message_id=f"msg_{uuid.uuid4().hex}",
+    )
+    restored = await anon_client.get(
+        "/v1/auth/me",
+        headers={"Authorization": f"Bearer {key.raw_key}"},
+    )
+
+    assert banned.status_code == unbanned.status_code == 200
+    assert rejected.status_code == 401
+    assert restored.status_code == 200
+    assert all(request.headers["Clerk-API-Version"] == "2026-05-12" for request in requests)
+
+
+async def test_ban_before_first_login_and_stale_update_are_safe(
+    anon_client,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    subject = f"prelogin_{uuid.uuid4().hex}"
+    _mock_clerk_authority(
+        monkeypatch,
+        subject=subject,
+        states=[(True, 5_000), (False, 4_000), (True, 5_000), (True, 5_000)],
+    )
+    assert (
+        await _update(anon_client, subject, message_id=f"msg_{uuid.uuid4().hex}")
+    ).status_code == 200
+    assert (
+        await _update(anon_client, subject, message_id=f"msg_{uuid.uuid4().hex}")
+    ).status_code == 200
+    # An exact Svix replay re-fetches current authority and remains idempotent.
+    replay_id = f"msg_{uuid.uuid4().hex}"
+    replay_payload = _payload(subject, event_type="user.updated")
+    replay_headers = _signed_headers(replay_payload, message_id=replay_id)
+    for _ in range(2):
+        replay = await anon_client.post(
+            "/v1/webhooks/clerk",
+            content=replay_payload,
+            headers=replay_headers,
+        )
+        assert replay.status_code == 200
+
+    with pytest.raises(HTTPException) as error:
+        await lazy_create_user_with_personal_project(
+            db_session,
+            clerk_id=subject,
+            clerk_issuer=_ISSUER,
+            email=None,
+            name=None,
+            race_loser_status=500,
+        )
+    await db_session.rollback()
+    projection = await db_session.scalar(
+        select(ClerkPrincipalAuthority).where(ClerkPrincipalAuthority.subject == subject)
+    )
+    assert error.value.status_code == 403
+    assert projection is not None and projection.banned is True
+
+
+async def test_delete_wins_over_authoritative_unban(
+    anon_client,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    subject = f"delete_wins_{uuid.uuid4().hex}"
+    assert (
+        await _delete(anon_client, subject, message_id=f"msg_{uuid.uuid4().hex}")
+    ).status_code == 200
+
+    def fail_if_clerk_is_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("tombstoned update must not call Clerk")
+
+    monkeypatch.setattr(clerk_webhooks.httpx, "AsyncClient", fail_if_clerk_is_called)
+    assert (
+        await _update(anon_client, subject, message_id=f"msg_{uuid.uuid4().hex}")
+    ).status_code == 200
+    with pytest.raises(PrincipalTerminatedError):
+        await assert_clerk_principal_active(db_session, issuer=_ISSUER, subject=subject)
 
 
 async def test_signature_timestamp_and_body_validation_precede_persistence(

--- a/backend/tests/test_cli_oauth_auth.py
+++ b/backend/tests/test_cli_oauth_auth.py
@@ -662,6 +662,7 @@ async def test_oauth_revoke_uses_validated_oauth_identity_and_safe_proxy(
     )
     assert captured["headers"] == {
         "Authorization": f"Bearer {_SECRET_KEY}",
+        "Clerk-API-Version": "2026-05-12",
         "User-Agent": "clawdi-backend/1.0",
     }
     assert captured["json"] == {"token": refresh_token}

--- a/backend/tests/test_principal_termination_migration.py
+++ b/backend/tests/test_principal_termination_migration.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError
 
 BRIDGE_REVISION = "c9f4e2a7b1d6"
 DIRECT_REVISION = "d1e5f7a9b3c2"
+AUTHORITY_REVISION = "e7b2c4d9a1f3"
 BACKEND_DIR = Path(__file__).parents[1]
 
 
@@ -196,6 +197,65 @@ def test_direct_webhook_migration_preserves_legacy_evidence_and_is_one_way() -> 
             assert connection.scalar(text("SELECT version_num FROM alembic_version")) == (
                 DIRECT_REVISION
             )
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()
+
+
+def test_authority_migration_downgrade_allows_ban_covered_by_deletion() -> None:
+    source_url = make_url(os.environ["DATABASE_URL"])
+    database_name = f"clawdi_clerk_authority_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    database_engine = create_engine(_sync_url(source_url, database=database_name))
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    try:
+        _run_alembic(database_url, "upgrade", AUTHORITY_REVISION)
+        issuer = "https://clerk.example.test"
+        subject = "deleted-banned-user"
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO clerk_principal_authorities "
+                    "(id, issuer, subject, banned, authority_updated_at, "
+                    "message_id, payload_sha256) VALUES "
+                    "(:id, :issuer, :subject, true, now(), 'msg-ban', :hash)"
+                ),
+                {
+                    "id": uuid.uuid4(),
+                    "issuer": issuer,
+                    "subject": subject,
+                    "hash": "a" * 64,
+                },
+            )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_alembic(database_url, "downgrade", DIRECT_REVISION)
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO principal_lifecycles "
+                    "(id, issuer, subject, terminated_at, cleanup_attempts, "
+                    "next_cleanup_attempt_at) VALUES "
+                    "(:id, :issuer, :subject, now(), 0, now())"
+                ),
+                {"id": uuid.uuid4(), "issuer": issuer, "subject": subject},
+            )
+
+        _run_alembic(database_url, "downgrade", DIRECT_REVISION)
+        with database_engine.connect() as connection:
+            assert connection.scalar(text("SELECT version_num FROM alembic_version")) == (
+                DIRECT_REVISION
+            )
+            assert inspect(connection).has_table("clerk_principal_authorities") is False
     finally:
         database_engine.dispose()
         with admin_engine.connect() as connection:

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -3,6 +3,20 @@
 Guide for contributors working on `backend/`. Commands in this document assume
 you start at the repository root unless a command changes directory.
 
+## Clerk lifecycle subscription
+
+Standalone Clawdi lazy-creates a Clerk user only after a verified JWT is used;
+do not subscribe `user.created`. Configure the direct signed webhook endpoint
+`POST /v1/webhooks/clerk` for exactly `user.updated` and `user.deleted`.
+`user.updated` refreshes the current `banned` value from Clerk's Backend API
+and reversibly gates all Clawdi authentication, including API keys;
+`user.deleted` remains an irreversible tombstone followed by cleanup. Session,
+organization, messaging, and billing webhooks are intentionally unsupported.
+
+Set `CLERK_WEBHOOK_SIGNING_SECRET`, `CLERK_SECRET_KEY`, and
+`CLERK_JWT_ISSUER`. Backend API calls use the pinned Clerk API version
+`2026-05-12`.
+
 ## Local backend loop
 
 Use the canonical local-stack runbook in

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2844,8 +2844,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Clerk User Deleted Webhook */
-        post: operations["clerk_user_deleted_webhook_v1_webhooks_clerk_post"];
+        /** Clerk User Lifecycle Webhook */
+        post: operations["clerk_user_lifecycle_webhook_v1_webhooks_clerk_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -13100,7 +13100,7 @@ export interface operations {
             };
         };
     };
-    clerk_user_deleted_webhook_v1_webhooks_clerk_post: {
+    clerk_user_lifecycle_webhook_v1_webhooks_clerk_post: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Summary

- make standalone Clawdi consume signed Clerk `user.updated` and `user.deleted` lifecycle events
- project only Clerk’s reversible `banned` authority; keep verified-JWT lazy creation and irreversible deletion tombstones
- pin every direct Clerk Backend API request to `Clerk-API-Version: 2026-05-12`

## Design

Clawdi remains independent of Clawdi Hosted:

- `user.created` is intentionally not subscribed; a verified JWT lazy-creates the local user on first use
- `user.updated` re-fetches the current Clerk User and gates JWT/OAuth/API-key access when `banned=true`
- `locked` is intentionally ignored because Clerk documents it as potentially temporary failed-attempt lockout state
- `user.deleted` remains the existing irreversible principal tombstone and cleanup path
- deletion always wins over stale or concurrent updates
- no profile fields are synchronized and no second inbox, outbox, lease, worker, or event bus is added

The webhook endpoint itself has no Clerk endpoint API-version setting. Svix signs the raw event body; API version pinning applies to the authoritative Backend API GET used by `user.updated`.

## Required Clerk destination

Configure `POST /v1/webhooks/clerk` for exactly:

- `user.updated`
- `user.deleted`

Use this Clawdi endpoint’s own `CLERK_WEBHOOK_SIGNING_SECRET`. Also configure `CLERK_SECRET_KEY` and `CLERK_JWT_ISSUER`.

## Verification

- full isolated backend on final backend tree: `2101 passed, 6 skipped`
- rebased focused lifecycle/auth/migration regression: `66 passed`
- fresh PostgreSQL migration to the single Alembic head
- Ruff, format, type governance, dependency authority, compileall, and `git diff --check`
