### PR TITLE
fix(web): flatten wallet settings hierarchy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -8655,8 +8655,11 @@ test("Wallet formats its balance and opens billing from the balance actions", as
 	const balanceCard = settingsDialog
 		.locator('[data-slot="card"]')
 		.filter({ hasText: "Wallet balance" });
+	await expect(settingsDialog.locator('[data-slot="card"]')).toHaveCount(1);
 	await expect(balanceCard.getByText("$29.48", { exact: true })).toBeVisible();
 	await expect(balanceCard.getByRole("button", { name: "Top up", exact: true })).toBeVisible();
+	await expect(settingsDialog.getByText("Not available yet", { exact: true })).toBeVisible();
+	await expect(settingsDialog.getByText(/x402 payments are not available yet/)).toBeVisible();
 
 	await balanceCard.getByRole("button", { name: "Manage payment methods" }).click();
 
@@ -8689,7 +8692,7 @@ test("auto-reload batches toggle and fields into one explicit save", async ({ pa
 		plans: [basicPlan, performancePlan],
 	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
-	const card = settingsDialog.locator('[data-slot="card"]').filter({ hasText: "Auto-reload" });
+	const card = settingsDialog.getByTestId("auto-reload-section");
 	await expect(card.getByText("Off", { exact: true })).toBeVisible();
 	await card.getByRole("button", { name: "Set up auto-reload" }).click();
 	const threshold = card.getByLabel("When balance is below (USD)");
@@ -8779,8 +8782,9 @@ test("top-up validates the amount and blocks duplicate submission or close in fl
 	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
 	await settingsDialog.getByRole("button", { name: "Top up" }).click();
-	const topUpPanel = settingsDialog.getByRole("region", { name: "Top up Wallet" });
+	const topUpPanel = page.getByRole("dialog").filter({ hasText: "Top up Wallet" });
 	await expect(page.getByRole("dialog")).toHaveCount(1);
+	await expect(settingsDialog.getByText("Wallet balance", { exact: true })).toBeVisible();
 	const amount = topUpPanel.getByLabel("Amount (USD)");
 
 	await amount.fill("25.50");
@@ -8867,8 +8871,9 @@ test("wallet confirms a card top-up only from its exact payment reference", asyn
 	await expect(settingsDialog.getByText("No activity yet", { exact: true })).toBeVisible();
 
 	await settingsDialog.getByRole("button", { name: "Top up" }).last().click();
-	await settingsDialog
-		.getByRole("region", { name: "Top up Wallet" })
+	await page
+		.getByRole("dialog")
+		.filter({ hasText: "Top up Wallet" })
 		.getByRole("button", { name: "Continue with $25.00" })
 		.click();
 
@@ -8903,7 +8908,7 @@ test("top-up rotates its idempotency key after an explicit reuse conflict", asyn
 	await page.goto("/channels?settings=billing-wallet");
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await settingsDialog.getByRole("button", { name: "Top up" }).click();
-	const topUpPanel = settingsDialog.getByRole("region", { name: "Top up Wallet" });
+	const topUpPanel = page.getByRole("dialog").filter({ hasText: "Top up Wallet" });
 	const submit = topUpPanel.getByRole("button", { name: "Continue" });
 
 	await submit.click();

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -1,6 +1,13 @@
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
+type SettingsSectionProps = Omit<React.ComponentProps<"section">, "children" | "title"> & {
+	title: React.ReactNode;
+	description?: React.ReactNode;
+	children?: React.ReactNode;
+	variant?: "default" | "destructive";
+};
+
 /** Flat form/settings section; use SectionLabel for list-group captions and DashboardSection for bordered content containers. */
 export function SettingsSection({
 	title,
@@ -8,15 +15,10 @@ export function SettingsSection({
 	children,
 	className,
 	variant = "default",
-}: {
-	title: React.ReactNode;
-	description?: React.ReactNode;
-	children: React.ReactNode;
-	className?: string;
-	variant?: "default" | "destructive";
-}) {
+	...sectionProps
+}: SettingsSectionProps) {
 	return (
-		<section className={cn("flex flex-col gap-4", className)}>
+		<section {...sectionProps} className={cn("flex flex-col gap-4", className)}>
 			<Separator />
 			<div className="flex max-w-2xl flex-col gap-1.5">
 				<div
@@ -28,7 +30,9 @@ export function SettingsSection({
 					<div className="text-sm leading-5 text-muted-foreground">{description}</div>
 				) : null}
 			</div>
-			<div className="min-w-0">{children}</div>
+			{children !== undefined && children !== null ? (
+				<div className="min-w-0">{children}</div>
+			) : null}
 		</section>
 	);
 }

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -5,16 +5,9 @@ import { AlertCircle, CreditCard, Repeat } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSettingsEditState } from "@/components/settings-edit-state";
+import { SettingsSection } from "@/components/settings-section";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardFooter,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
@@ -57,13 +50,9 @@ const ALL_FIELDS_BLURRED: BlurredFields = { threshold: true, amount: true, cap: 
 export function AutoReloadCard({
 	wallet,
 	onTopUp,
-	onManagePaymentMethods,
-	isManagePaymentMethodsPending = false,
 }: {
 	wallet: WalletCacheSnapshot;
 	onTopUp?: () => void;
-	onManagePaymentMethods?: () => void;
-	isManagePaymentMethodsPending?: boolean;
 }) {
 	const save = useSensitiveSetAutoReload();
 	const queryClient = useQueryClient();
@@ -201,24 +190,21 @@ export function AutoReloadCard({
 				).format(new Date(wallet.auto_reload_period_end))}`;
 
 	return (
-		<Card data-hosted="true">
-			<CardHeader>
-				<div className="flex items-start justify-between gap-3">
-					<div className="min-w-0">
-						<CardTitle className="flex items-center gap-2 text-base">
-							<Repeat className="size-4" aria-hidden /> Auto-reload
-						</CardTitle>
-						<CardDescription>
-							{editing ? "Choose when and how much to add." : status.description}
-						</CardDescription>
-					</div>
+		<SettingsSection
+			data-hosted="true"
+			title={
+				<span className="flex flex-wrap items-center gap-2">
+					<span className="inline-flex items-center gap-2">
+						<Repeat className="size-4" aria-hidden /> Auto-reload
+					</span>
 					<StatusBadge status={status.tone} withDot>
 						{status.label}
 					</StatusBadge>
-				</div>
-			</CardHeader>
-
-			<CardContent className="flex flex-col gap-5">
+				</span>
+			}
+			description={editing ? "Choose when and how much to add." : status.description}
+		>
+			<div className="flex max-w-2xl flex-col gap-5">
 				<AutoReloadActionConfirm
 					wallet={wallet}
 					onTopUp={onTopUp}
@@ -308,7 +294,7 @@ export function AutoReloadCard({
 							</div>
 						</div>
 
-						<div className="space-y-3 rounded-lg border p-4">
+						<div className="space-y-3 border-t pt-5">
 							<div className="flex items-start justify-between gap-3">
 								<div className="space-y-0.5">
 									<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
@@ -365,87 +351,71 @@ export function AutoReloadCard({
 						<p className="text-sm text-muted-foreground">{usage}</p>
 					</div>
 				) : null}
-			</CardContent>
 
-			<CardFooter className="flex flex-wrap justify-between gap-3 border-t">
-				<p className="text-xs text-muted-foreground">
-					Auto-reload uses your saved card. A manual top-up saves one.
-				</p>
-				<div className="flex flex-wrap gap-2">
-					{onManagePaymentMethods ? (
-						<Button
-							type="button"
-							size="sm"
-							variant="ghost"
-							onClick={onManagePaymentMethods}
-							disabled={isManagePaymentMethodsPending || save.isPending}
-						>
-							{isManagePaymentMethodsPending ? (
-								<Spinner data-icon="inline-start" />
-							) : (
-								<CreditCard data-icon="inline-start" />
-							)}
-							Payment methods
-						</Button>
-					) : null}
-					{editing ? (
-						<div key="auto-reload-edit-actions" className="flex gap-2">
-							<Button
-								type="button"
-								size="sm"
-								variant="ghost"
-								onClick={cancelChanges}
-								disabled={save.isPending}
-							>
-								Cancel
-							</Button>
-							<Button
-								type="submit"
-								form="auto-reload-form"
-								size="sm"
-								disabled={!dirty || !form.formValid || save.isPending}
-							>
-								{save.isPending ? (
-									<>
-										<Spinner data-icon="inline-start" /> Saving…
-									</>
-								) : (
-									"Save"
-								)}
-							</Button>
-						</div>
-					) : (
-						<div key="auto-reload-summary-actions" className="flex gap-2">
-							{wallet.auto_reload_enabled ? (
+				<div className="flex flex-wrap items-center justify-between gap-3">
+					<p className="text-xs text-muted-foreground">
+						Auto-reload uses your saved card. A manual top-up saves one.
+					</p>
+					<div className="flex flex-wrap gap-2">
+						{editing ? (
+							<div key="auto-reload-edit-actions" className="flex gap-2">
 								<Button
 									type="button"
 									size="sm"
 									variant="ghost"
-									onClick={() => void runAction(turnOff)}
+									onClick={cancelChanges}
 									disabled={save.isPending}
+								>
+									Cancel
+								</Button>
+								<Button
+									type="submit"
+									form="auto-reload-form"
+									size="sm"
+									disabled={!dirty || !form.formValid || save.isPending}
 								>
 									{save.isPending ? (
 										<>
-											<Spinner data-icon="inline-start" /> Turning off…
+											<Spinner data-icon="inline-start" /> Saving…
 										</>
 									) : (
-										"Turn off"
+										"Save"
 									)}
 								</Button>
-							) : null}
-							<Button
-								data-auto-reload-primary
-								type="button"
-								size="sm"
-								onClick={beginEditing}
-								disabled={save.isPending}
-							>
-								{wallet.auto_reload_enabled ? "Edit" : "Set up auto-reload"}
-							</Button>
-						</div>
-					)}
+							</div>
+						) : (
+							<div key="auto-reload-summary-actions" className="flex gap-2">
+								{wallet.auto_reload_enabled ? (
+									<Button
+										type="button"
+										size="sm"
+										variant="ghost"
+										onClick={() => void runAction(turnOff)}
+										disabled={save.isPending}
+									>
+										{save.isPending ? (
+											<>
+												<Spinner data-icon="inline-start" /> Turning off…
+											</>
+										) : (
+											"Turn off"
+										)}
+									</Button>
+								) : null}
+								<Button
+									data-auto-reload-primary
+									type="button"
+									size="sm"
+									onClick={beginEditing}
+									disabled={save.isPending}
+								>
+									{wallet.auto_reload_enabled ? "Edit" : "Set up auto-reload"}
+								</Button>
+							</div>
+						)}
+					</div>
 				</div>
-			</CardFooter>
-		</Card>
+			</div>
+		</SettingsSection>
 	);
 }

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -11,6 +11,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -133,9 +134,10 @@ export function LedgerTable({
 	}
 
 	return (
-		<section data-hosted="true" className="space-y-3" aria-labelledby={headingId}>
+		<section data-hosted="true" className="flex flex-col gap-4" aria-labelledby={headingId}>
+			<Separator />
 			<div className="flex items-center justify-between gap-2">
-				<h2 id={headingId} className="text-base font-semibold">
+				<h2 id={headingId} className="text-sm font-semibold">
 					Activity
 				</h2>
 				<Select

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -6,6 +6,7 @@ import {
 	handleTopupStartResult,
 	topUpAmountCentsForUsdShortfall,
 	validTopUpAmountCents,
+	waitForWalletTopupCredit,
 	walletTopupCreditIsApplied,
 } from "@/hosted/billing/wallet/top-up-dialog.logic";
 
@@ -164,6 +165,16 @@ describe("walletTopupCreditIsApplied", () => {
 		expect(
 			walletTopupCreditIsApplied("pi_current", [{ ...entry, payment_reference: "pi_current" }]),
 		).toBe(true);
+	});
+
+	test("reads the paginated Activity cache used by Wallet", async () => {
+		const qc = new QueryClient();
+		qc.setQueryData(billingKeys.ledgerPages(50), {
+			pages: [{ items: [{ ...entry, payment_reference: "pi_current" }] }],
+			pageParams: [null],
+		});
+
+		expect(await waitForWalletTopupCredit(qc, "pi_current")).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import type { WalletLedgerEntry, WalletTopupResult } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import {
@@ -91,6 +91,17 @@ export function walletTopupCreditIsApplied(
 	);
 }
 
+type WalletLedgerPage = { items: WalletLedgerEntry[] };
+
+function walletTopupCreditIsCached(
+	paymentReference: string,
+	data: WalletLedgerPage | InfiniteData<WalletLedgerPage> | undefined,
+): boolean {
+	if (!data) return false;
+	const pages = "pages" in data ? data.pages : [data];
+	return pages.some((page) => walletTopupCreditIsApplied(paymentReference, page.items));
+}
+
 export async function waitForWalletTopupCredit(
 	queryClient: QueryClient,
 	paymentReference: string,
@@ -106,14 +117,14 @@ export async function waitForWalletTopupCredit(
 				{ throwOnError: true },
 			),
 		]);
-		const ledgerPages = queryClient.getQueriesData<{ items: WalletLedgerEntry[] }>({
+		const ledgerPages = queryClient.getQueriesData<
+			WalletLedgerPage | InfiniteData<WalletLedgerPage>
+		>({
 			queryKey: billingKeys.ledgerRoot,
 		});
 		if (
 			refreshes.every((refresh) => refresh.status === "fulfilled") &&
-			ledgerPages.some(([, page]) =>
-				walletTopupCreditIsApplied(paymentReference, page?.items ?? []),
-			)
+			ledgerPages.some(([, data]) => walletTopupCreditIsCached(paymentReference, data))
 		) {
 			return true;
 		}

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -1,19 +1,10 @@
 "use client";
 
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSettingsEditState } from "@/components/settings-edit-state";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardAction,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
 import {
 	Dialog,
 	DialogContent,
@@ -50,7 +41,6 @@ import {
 } from "@/hosted/billing/wallet/wallet-constants";
 
 type Step = "amount" | "pay";
-type TopUpPresentation = "dialog" | "inline";
 
 export async function confirmWalletTopup(
 	queryClient: QueryClient,
@@ -84,13 +74,11 @@ export function TopUpDialog({
 	onOpenChange,
 	onComplete,
 	initialAmountCents,
-	presentation = "dialog",
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	onComplete?: (status: "succeeded" | "processing") => void;
+	onComplete?: (status: "succeeded" | "processing", paymentReference: string | null) => void;
 	initialAmountCents?: number | null;
-	presentation?: TopUpPresentation;
 }) {
 	const topUp = useSensitiveTopUp();
 	const qc = useQueryClient();
@@ -112,10 +100,7 @@ export function TopUpDialog({
 	const valid = validTopUpAmountCents(amountCents);
 	const amountInvalid = amountTouched && !valid;
 	function finishTopup(status: PaymentOutcome) {
-		onComplete?.(status);
-		if (presentation === "inline") {
-			void confirmWalletTopup(qc, paymentReferenceRef.current);
-		}
+		onComplete?.(status, paymentReferenceRef.current);
 	}
 
 	function setAmount(next: string) {
@@ -280,31 +265,6 @@ export function TopUpDialog({
 				onSubmittingChange={setPaymentSubmitting}
 			/>
 		) : null;
-
-	if (presentation === "inline") {
-		if (!open) return null;
-		return (
-			<Card data-hosted="true" role="region" aria-labelledby="wallet-top-up-title">
-				<CardHeader>
-					<CardTitle id="wallet-top-up-title">Top up Wallet</CardTitle>
-					<CardDescription>{description}</CardDescription>
-					<CardAction>
-						<Button
-							type="button"
-							variant="ghost"
-							size="icon-sm"
-							onClick={() => close(false)}
-							disabled={topUp.isPending || paymentSubmitting}
-						>
-							<X />
-							<span className="sr-only">Close top-up</span>
-						</Button>
-					</CardAction>
-				</CardHeader>
-				<CardContent>{content}</CardContent>
-			</Card>
-		);
-	}
 
 	return (
 		<Dialog

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -32,7 +32,7 @@ import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Add funds and manage how your Clawdi usage is paid.";
-const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
+const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-8 px-4 lg:px-6");
 
 function scrollToAutoReload() {
 	const section = document.getElementById("auto-reload");
@@ -166,9 +166,15 @@ export function WalletPage() {
 		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
 			<PageHeader title="Wallet" description={DESCRIPTION} />
 
-			<TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} presentation="inline" />
+			<TopUpDialog
+				open={topUpOpen}
+				onOpenChange={setTopUpOpen}
+				onComplete={(_status, paymentReference) => {
+					void confirmWalletTopup(queryClient, paymentReference);
+				}}
+			/>
 
-			<div className={cn("space-y-6", topUpOpen && "hidden")}>
+			<div className="space-y-8">
 				<LowBalanceBanner
 					wallet={w}
 					hasWalletCompute={walletComputeCount > 0}
@@ -184,13 +190,8 @@ export function WalletPage() {
 					isManagePaymentMethodsPending={portal.isPending}
 				/>
 
-				<div id="auto-reload">
-					<AutoReloadCard
-						wallet={w}
-						onTopUp={() => setTopUpOpen(true)}
-						onManagePaymentMethods={() => void runAction(openBillingPortal)}
-						isManagePaymentMethodsPending={portal.isPending}
-					/>
+				<div id="auto-reload" data-testid="auto-reload-section">
+					<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
 				</div>
 
 				<X402Card enabled={w.x402_enabled === true} />

--- a/apps/web/src/hosted/billing/wallet/x402-card.test.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.test.ts
@@ -7,7 +7,8 @@ const pageSource = readFileSync(new URL("./wallet-page.tsx", import.meta.url), "
 describe("x402 wallet availability", () => {
 	test("keeps the card visible and labels the unavailable state", () => {
 		expect(pageSource).toContain("<X402Card enabled={w.x402_enabled === true} />");
-		expect(cardSource).toContain("Coming soon");
+		expect(cardSource).toContain("Not available yet");
+		expect(cardSource).toContain("x402 payments are not available yet.");
 		expect(cardSource).toContain("Linked agent wallet");
 		expect(cardSource).not.toContain("deposit address");
 	});

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -2,8 +2,8 @@
 
 import { Link2 } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useHostedUser } from "@/hosted/billing/hooks";
@@ -12,17 +12,18 @@ import { shouldBlockQueryError } from "@/lib/query-state";
 export function X402Card({ enabled }: { enabled: boolean }) {
 	if (!enabled) {
 		return (
-			<Card data-hosted="true" className="self-start">
-				<CardHeader>
-					<div className="flex items-center justify-between gap-3">
-						<CardTitle className="flex items-center gap-2 text-base">
-							<Link2 className="size-4" aria-hidden /> USDC top-up
-						</CardTitle>
-						<Badge variant="secondary">Coming soon</Badge>
-					</div>
-					<CardDescription>Let your agent add funds with USDC through x402.</CardDescription>
-				</CardHeader>
-			</Card>
+			<SettingsSection
+				data-hosted="true"
+				title={
+					<span className="flex flex-wrap items-center gap-2">
+						<span className="inline-flex items-center gap-2">
+							<Link2 className="size-4" aria-hidden /> USDC via x402
+						</span>
+						<Badge variant="secondary">Not available yet</Badge>
+					</span>
+				}
+				description="x402 payments are not available yet. When launched, agents will be able to add Wallet funds with USDC."
+			/>
 		);
 	}
 
@@ -34,19 +35,19 @@ function EnabledX402Card() {
 	const address = me.data?.evm_wallet_address ?? null;
 
 	return (
-		<Card data-hosted="true" className="self-start">
-			<CardHeader>
-				<div className="flex items-center justify-between gap-3">
-					<CardTitle className="flex items-center gap-2 text-base">
-						<Link2 className="size-4" aria-hidden /> USDC top-up
-					</CardTitle>
-					<Badge variant="outline">x402</Badge>
-				</div>
-				<CardDescription>
-					Your agent can add funds from its linked wallet. They appear in this balance.
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
+		<SettingsSection
+			data-hosted="true"
+			title={
+				<span className="flex flex-wrap items-center gap-2">
+					<span className="inline-flex items-center gap-2">
+						<Link2 className="size-4" aria-hidden /> USDC via x402
+					</span>
+					<Badge variant="outline">Available</Badge>
+				</span>
+			}
+			description="Your agent can add Wallet funds from its linked wallet using USDC."
+		>
+			<div className="max-w-2xl">
 				{me.isLoading ? (
 					<Skeleton className="h-9 w-full rounded-md" />
 				) : shouldBlockQueryError(me.error, me.data) ? (
@@ -67,7 +68,7 @@ function EnabledX402Card() {
 						Connect an agent wallet before using x402.
 					</p>
 				)}
-			</CardContent>
-		</Card>
+			</div>
+		</SettingsSection>
 	);
 }


### PR DESCRIPTION
## Summary

- keep Wallet visible and open Top up Wallet as the standard modal dialog
- make Balance the only card; align auto-reload, x402, and Activity with flat Settings sections
- label x402 as explicitly unavailable in both status and copy
- preserve exact top-up credit confirmation for the paginated Activity cache

## Verification

- `bun test` focused Wallet suite: 19 passed
- `bun run --cwd apps/web typecheck`
- changed-file Biome and `git diff --check`
- `bun run --cwd apps/web build:oss`
- hosted Chromium Wallet flows: 5 passed
- manual Chromium review of Wallet, auto-reload edit state, and Top up modal