### PR TITLE
fix(api): hide Clerk webhook from OpenAPI

### DIFF
--- a/backend/app/routes/clerk_webhooks.py
+++ b/backend/app/routes/clerk_webhooks.py
@@ -42,7 +42,7 @@ from app.services.principal_lifecycle import (
     record_principal_cleanup_failure,
 )
 
-router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+router = APIRouter(prefix="/webhooks", tags=["webhooks"], include_in_schema=False)
 
 _MAX_BODY_BYTES = 64 * 1024
 _MAX_SIGNATURE_HEADER_BYTES = 8 * 1024

--- a/backend/tests/test_api_version_alias.py
+++ b/backend/tests/test_api_version_alias.py
@@ -88,12 +88,16 @@ async def test_runtime_manifest_has_no_api_alias():
 
 def test_openapi_schema_advertises_only_v1_and_direct_runtime_v2():
     spec = app.openapi()
+    assert "/v1/webhooks/clerk" not in spec["paths"]
+
+    routes = _routes_by_path()
+    assert routes["/v1/webhooks/clerk"] == {"POST"}
+
     non_v1 = {path for path in spec["paths"] if not path.startswith("/v1/") and path != "/health"}
     assert non_v1
     assert all(path.startswith("/v2/runtime/") for path in non_v1)
     assert all(not path.startswith("/api/") for path in spec["paths"])
 
-    routes = _routes_by_path()
     for path in non_v1:
         assert path not in {
             f"/v1{path.removeprefix('/v2')}",

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2835,23 +2835,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/webhooks/clerk": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Clerk User Lifecycle Webhook */
-        post: operations["clerk_user_lifecycle_webhook_v1_webhooks_clerk_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/runtime/auth/keys": {
         parameters: {
             query?: never;
@@ -4628,15 +4611,6 @@ export interface components {
             expires_at: string;
             /** Completed At */
             completed_at?: string | null;
-        };
-        /** ClerkWebhookResponse */
-        ClerkWebhookResponse: {
-            /**
-             * Status
-             * @default ok
-             * @constant
-             */
-            status: "ok";
         };
         /**
          * ConnectRequest
@@ -13096,26 +13070,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    clerk_user_lifecycle_webhook_v1_webhooks_clerk_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ClerkWebhookResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- keep `POST /v1/webhooks/clerk` live while excluding it from public OpenAPI
- remove its generated TypeScript client surface
- add one contract assertion that the route exists but is absent from the schema

No webhook verification, retry, lifecycle, or runtime behavior changes.

## Verification

- isolated focused contract: `1 passed`
- generated API freshness: passed
- Ruff lint and owned-file format: passed
- `git diff --check`: passed
