### PR TITLE
fix(web): allow adding custom bots without linking

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -10197,7 +10197,7 @@ for (const firstTimeViewport of [
 	});
 }
 
-test("Add channel confirms atomic Telegram and Discord link replacement", async ({
+test("Add channel offers inventory-only creation and atomic provider replacement", async ({
 	page,
 }, testInfo) => {
 	await page.setViewportSize({ width: 320, height: 844 });
@@ -10249,12 +10249,28 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 		unlinkAgentRequests,
 		createChannelResponses: [
 			{
+				status: 503,
+				body: { detail: "Inventory creation temporarily unavailable" },
+			},
+			{
 				status: 201,
 				body: {
 					...telegramAccount,
 					id: "5a555555-5555-4555-8555-555555555555",
 					name: "Additional Telegram",
 					webhook_secret: "telegram-webhook-secret-must-not-render",
+					agent_link_id: null,
+					agent_id: null,
+					agent_token: null,
+				},
+			},
+			{
+				status: 201,
+				body: {
+					...telegramAccount,
+					id: "5a555556-5555-4555-8555-555555555556",
+					name: "Additional Telegram",
+					webhook_secret: "telegram-replacement-secret-must-not-render",
 					agent_link_id: "5a777777-7777-4777-8777-777777777777",
 					agent_id: agentId,
 					agent_token: null,
@@ -10312,11 +10328,19 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 	await expectNoHorizontalOverflow(dialog, "Telegram replacement form at 320px");
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
 	let replacementDialog = page.getByRole("alertdialog", {
-		name: "Replace this Agent’s Telegram link?",
+		name: "How should this Telegram bot be added?",
 	});
 	await expect(replacementDialog).toBeVisible();
 	await expect(replacementDialog).toContainText("one Telegram bot at a time");
 	await expect(replacementDialog).toContainText("Additional Telegram");
+	await expect(replacementDialog).toContainText("keep the current bot and its paired chats");
+	await expect(replacementDialog).toContainText("will be added to Custom bots only");
+	await expect(
+		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
+	).toBeVisible();
+	await expect(
+		replacementDialog.getByRole("button", { name: "Replace Telegram link", exact: true }),
+	).toBeVisible();
 	await expect(createChannelRequests).toHaveLength(0);
 	await expect(linkAgentRequests).toHaveLength(0);
 	await expect(unlinkAgentRequests).toHaveLength(0);
@@ -10324,7 +10348,7 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 	await expect(page.locator("html")).toHaveClass(/dark/);
 	await expectNoHorizontalOverflow(replacementDialog, "Telegram replacement confirmation at 320px");
 	await replacementDialog.screenshot({
-		path: testInfo.outputPath("replace-telegram-link-confirm-dark-320.png"),
+		path: testInfo.outputPath("add-or-replace-telegram-link-confirm-dark-320.png"),
 	});
 	await page.locator("html").evaluate((element) => element.classList.remove("dark"));
 	await replacementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
@@ -10335,13 +10359,60 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
 	replacementDialog = page.getByRole("alertdialog", {
-		name: "Replace this Agent’s Telegram link?",
+		name: "How should this Telegram bot be added?",
+	});
+	await replacementDialog.getByRole("button", { name: "Add without linking", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(1);
+	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+		provider: "telegram",
+		name: "Additional Telegram",
+		provider_token: "123456:additional-telegram-token",
+		agent_id: null,
+	});
+	await expect(replacementDialog).toBeVisible();
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Couldn't add Custom bot" }),
+	).toBeVisible();
+	await expect(
+		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
+	).toBeEnabled();
+	await expect(dialog.getByLabel("Name")).toHaveValue("Additional Telegram");
+	await expect(dialog.getByLabel("Bot token")).toHaveValue("123456:additional-telegram-token");
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
+	await replacementDialog.getByRole("button", { name: "Add without linking", exact: true }).click();
+	await expect.poll(() => createChannelRequests.length).toBe(2);
+	expect(JSON.parse(createChannelRequests[1] ?? "{}")).toEqual({
+		provider: "telegram",
+		name: "Additional Telegram",
+		provider_token: "123456:additional-telegram-token",
+		agent_id: null,
+	});
+	const inventorySuccessDialog = page.getByRole("dialog", { name: "Custom bot added" });
+	await expect(inventorySuccessDialog).toBeVisible();
+	await expect(inventorySuccessDialog).toContainText(
+		"Additional Telegram was added to Custom bots without linking to this Agent.",
+	);
+	await expectNoHorizontalOverflow(inventorySuccessDialog, "Inventory-only success at 320px");
+	await expect(page.getByRole("dialog", { name: "Pair Telegram" })).toHaveCount(0);
+	await expect(linkAgentRequests).toHaveLength(0);
+	await expect(unlinkAgentRequests).toHaveLength(0);
+	await inventorySuccessDialog.getByRole("button", { name: "Done", exact: true }).click();
+	await expect(inventorySuccessDialog).toHaveCount(0);
+
+	await addChannel.click();
+	dialog = page.getByRole("dialog", { name: "Add channel" });
+	await dialog.getByLabel("Name").fill("Additional Telegram");
+	await dialog.getByLabel("Bot token").fill("123456:additional-telegram-token");
+	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
+	replacementDialog = page.getByRole("alertdialog", {
+		name: "How should this Telegram bot be added?",
 	});
 	await replacementDialog
 		.getByRole("button", { name: "Replace Telegram link", exact: true })
 		.click();
-	await expect.poll(() => createChannelRequests.length).toBe(1);
-	expect(JSON.parse(createChannelRequests[0] ?? "{}")).toEqual({
+	await expect.poll(() => createChannelRequests.length).toBe(3);
+	expect(JSON.parse(createChannelRequests[2] ?? "{}")).toEqual({
 		provider: "telegram",
 		name: "Additional Telegram",
 		provider_token: "123456:additional-telegram-token",
@@ -10371,13 +10442,16 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 	await expectNoHorizontalOverflow(dialog, "Discord replacement form at 320px");
 	await dialog.getByRole("button", { name: "Add custom bot", exact: true }).click();
 	replacementDialog = page.getByRole("alertdialog", {
-		name: "Replace this Agent’s Discord link?",
+		name: "How should this Discord bot be added?",
 	});
-	await expect(replacementDialog).toContainText("paired chats will be removed");
+	await expect(replacementDialog).toContainText("remove the current bot's paired chats");
+	await expect(
+		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
+	).toBeVisible();
 	await replacementDialog
 		.getByRole("button", { name: "Replace Discord link", exact: true })
 		.click();
-	await expect.poll(() => createChannelRequests.length).toBe(2);
+	await expect.poll(() => createChannelRequests.length).toBe(4);
 	await expect(replacementDialog).toBeVisible();
 	await expect(
 		page.locator("[data-sonner-toast]").filter({ hasText: "Couldn't add Custom bot" }),
@@ -10386,15 +10460,15 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 		replacementDialog.getByRole("button", { name: "Cancel", exact: true }),
 	).toBeEnabled();
 	await expect(dialog.getByLabel("Name")).toHaveValue("Additional Discord");
-	expect(JSON.parse(createChannelRequests[1] ?? "{}")).toMatchObject({
+	expect(JSON.parse(createChannelRequests[3] ?? "{}")).toMatchObject({
 		agent_id: agentId,
 		replace_existing_provider_link: true,
 	});
 	await replacementDialog
 		.getByRole("button", { name: "Replace Discord link", exact: true })
 		.click();
-	await expect.poll(() => createChannelRequests.length).toBe(3);
-	expect(JSON.parse(createChannelRequests[2] ?? "{}")).toEqual({
+	await expect.poll(() => createChannelRequests.length).toBe(5);
+	expect(JSON.parse(createChannelRequests[4] ?? "{}")).toEqual({
 		provider: "discord",
 		name: "Additional Discord",
 		provider_token: "A".repeat(50),
@@ -10429,7 +10503,7 @@ test("Add channel confirms atomic Telegram and Discord link replacement", async 
 	const unexpectedErrors = errors.filter((error) => !error.includes("status of 503"));
 	expect(
 		unexpectedErrors,
-		`replacement Custom bot errors: ${unexpectedErrors.join(" | ")}`,
+		`Custom bot conflict actions errors: ${unexpectedErrors.join(" | ")}`,
 	).toEqual([]);
 });
 
@@ -10785,6 +10859,9 @@ test("Agent bot groups keep every bot visible and confirm provider replacement",
 		name: "Replace this Agent’s Telegram link?",
 	});
 	await expect(replacementDialog).toContainText("Replacement Telegram");
+	await expect(
+		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
+	).toHaveCount(0);
 	await expectNoHorizontalOverflow(replacementDialog, "Telegram Link replacement confirmation");
 	await replacementDialog.screenshot({
 		path: testInfo.outputPath("replace-existing-bot-link-confirm-desktop.png"),

--- a/apps/web/src/components/ui/confirm-action.tsx
+++ b/apps/web/src/components/ui/confirm-action.tsx
@@ -22,6 +22,7 @@ export function ConfirmAction({
 	description,
 	confirmLabel = "Confirm",
 	cancelLabel = "Cancel",
+	secondaryAction,
 	destructive = false,
 	onConfirm,
 }: {
@@ -30,6 +31,10 @@ export function ConfirmAction({
 	description: ReactNode;
 	confirmLabel?: string;
 	cancelLabel?: string;
+	secondaryAction?: {
+		label: string;
+		onAction: () => unknown;
+	};
 	destructive?: boolean;
 	/**
 	 * May be sync or async (any return). When it returns a promise the dialog
@@ -39,28 +44,29 @@ export function ConfirmAction({
 	onConfirm: () => unknown;
 }) {
 	const [open, setOpen] = useState(false);
-	const [pending, setPending] = useState(false);
+	const [pendingAction, setPendingAction] = useState<"confirm" | "secondary" | null>(null);
 	// Synchronous lock: `disabled` only takes effect on the next render, leaving
 	// a sub-frame window where a fast double-click (or Enter repeat) could fire
-	// the destructive action twice before React repaints.
+	// an action twice before React repaints.
 	const locked = useRef(false);
 	const closingAfterSuccess = useRef(false);
 
-	async function runConfirm() {
+	async function runAction(action: "confirm" | "secondary", onAction: () => unknown) {
 		if (locked.current) return;
 		locked.current = true;
-		setPending(true);
+		setPendingAction(action);
 		try {
-			await onConfirm();
+			await onAction();
 			closingAfterSuccess.current = true;
 			setOpen(false);
 		} finally {
 			if (!closingAfterSuccess.current) {
-				setPending(false);
+				setPendingAction(null);
 				locked.current = false;
 			}
 		}
 	}
+	const pending = pendingAction !== null;
 
 	return (
 		<AlertDialog
@@ -69,7 +75,7 @@ export function ConfirmAction({
 			onOpenChangeComplete={(nextOpen) => {
 				if (!nextOpen && closingAfterSuccess.current) {
 					closingAfterSuccess.current = false;
-					setPending(false);
+					setPendingAction(null);
 					locked.current = false;
 				}
 			}}
@@ -84,20 +90,37 @@ export function ConfirmAction({
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
+					{secondaryAction ? (
+						<AlertDialogAction
+							variant="outline"
+							onClick={(event) => {
+								event.preventDefault();
+								void runAction("secondary", secondaryAction.onAction).catch(() => {});
+							}}
+							disabled={pending}
+							className="min-w-0 whitespace-normal"
+						>
+							{pendingAction === "secondary" ? <Spinner /> : null}
+							{secondaryAction.label}
+						</AlertDialogAction>
+					) : null}
 					<AlertDialogAction
 						// Keep the dialog open until the caller settles; accepted background work
 						// closes here while status polling reflects its eventual outcome.
 						onClick={(event) => {
 							event.preventDefault();
-							// runConfirm rejects when onConfirm does; the dialog already stays open
+							// runAction rejects when onConfirm does; the dialog already stays open
 							// on reject and callers own their onError, so just swallow the
 							// unhandled-rejection console noise without changing behavior.
-							void runConfirm().catch(() => {});
+							void runAction("confirm", onConfirm).catch(() => {});
 						}}
 						disabled={pending}
-						className={cn(destructive && buttonVariants({ variant: "destructive" }))}
+						className={cn(
+							"min-w-0 whitespace-normal",
+							destructive && buttonVariants({ variant: "destructive" }),
+						)}
 					>
-						{pending ? <Spinner /> : null}
+						{pendingAction === "confirm" ? <Spinner /> : null}
 						{confirmLabel}
 					</AlertDialogAction>
 				</AlertDialogFooter>

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -48,10 +48,16 @@ describe("global Channels inventory", () => {
 
 	test("reuses one Add channel dialog for Console inventory and direct Agent setup", () => {
 		const connectDialog = source("./connect-bot-dialog.tsx");
+		const connectDialogLogic = source("./connect-bot-dialog.logic.ts");
+		const replacementConfirm = source("./provider-link-replacement-confirm.tsx");
 		const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 
-		expect(connectDialog).toContain("replace_existing_provider_link: true");
+		expect(connectDialogLogic).toContain("replace_existing_provider_link: true");
 		expect(connectDialog).toContain("<ProviderLinkReplacementConfirm");
+		expect(connectDialog).toContain('onAddWithoutLinking={() => submit("inventory-only")}');
+		expect(replacementConfirm).toContain('label: "Add without linking"');
+		expect(replacementConfirm).toContain("? `How should this ");
+		expect(replacementConfirm).toContain(": `Replace this Agent’s ");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(connectDialog).toContain("autoLinkAgentIdForNewCustomBot");
 		expect(agentDetail).not.toContain("<AddChannelDialog");

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -13,6 +13,8 @@ const pairingDialogUi = source("./pairing-dialog-ui.tsx");
 const pairingSuccess = source("./channel-pairing-success.ts");
 const hooks = source("./channels-hooks.ts");
 const connectDialog = source("./connect-bot-dialog.tsx");
+const connectDialogLogic = source("./connect-bot-dialog.logic.ts");
+const replacementConfirm = source("./provider-link-replacement-confirm.tsx");
 const agentCardsLogic = source("./agent-channel-cards.logic.ts");
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
 const pairedChatRow = source("./paired-chat-row.tsx");
@@ -73,8 +75,14 @@ describe("channel IA boundary", () => {
 	});
 
 	test("keeps Discord inventory in Console and Add/Pair actions on the Agent", () => {
-		expect(connectDialog).toContain("replace_existing_provider_link: true");
+		expect(connectDialogLogic).toContain("replace_existing_provider_link: true");
 		expect(connectDialog).toContain("<ProviderLinkReplacementConfirm");
+		expect(connectDialog).toContain('onAddWithoutLinking={() => submit("inventory-only")}');
+		expect(connectDialog).toContain('onConfirm={() => submit("replace")}');
+		expect(replacementConfirm).toContain('label: "Add without linking"');
+		expect(replacementConfirm).toContain("? `How should this ");
+		expect(replacementConfirm).toContain(": `Replace this Agent’s ");
+		expect(replacementConfirm).toContain("destructive");
 		expect(connectDialog).toContain("Add custom bot");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(agentDetail).toContain('linking ? "Linking…" : "Link"');
@@ -243,7 +251,7 @@ describe("channel IA boundary", () => {
 		expect(pairedChatRow).toContain("<ConfirmAction");
 		expect(pairedChatRow).toContain("binding_id: binding.id");
 		expect(pairedChatRow).toContain("unpair.isPending");
-		expect(confirmAction).toContain("void runConfirm().catch");
+		expect(confirmAction).toContain('void runAction("confirm", onConfirm).catch');
 		expect(hooks).toContain("export function useDeleteChannelBinding");
 		expect(hooks).toContain("keys.bindings(accountId)");
 		expect(hooks).toContain('toastApiError("Couldn\'t unpair chat")');

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
@@ -3,7 +3,38 @@ import {
 	discordApplicationIdError,
 	discordBotTokenError,
 	discordPublicKeyError,
+	newCustomBotAgentLinkFields,
 } from "./connect-bot-dialog.logic";
+
+describe("newCustomBotAgentLinkFields", () => {
+	test("keeps inventory-only creation detached from the Agent and replacement contract", () => {
+		const fields = newCustomBotAgentLinkFields({
+			mode: "inventory-only",
+			agentId: "agent-1",
+			autoLinkAgentId: "agent-1",
+		});
+
+		expect(fields).toEqual({ agent_id: null });
+		expect("replace_existing_provider_link" in fields).toBe(false);
+	});
+
+	test("opts into provider replacement only for the explicit replacement mode", () => {
+		expect(
+			newCustomBotAgentLinkFields({
+				mode: "replace",
+				agentId: "agent-1",
+				autoLinkAgentId: null,
+			}),
+		).toEqual({ agent_id: "agent-1", replace_existing_provider_link: true });
+		expect(
+			newCustomBotAgentLinkFields({
+				mode: "auto-link",
+				agentId: "agent-1",
+				autoLinkAgentId: "agent-1",
+			}),
+		).toEqual({ agent_id: "agent-1" });
+	});
+});
 
 describe("discordBotTokenError", () => {
 	test("allows an empty value so presence can be handled by the form gate", () => {

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
@@ -1,8 +1,28 @@
+import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
+
 const DISCORD_PUBLIC_KEY_HEX_LENGTH = 64;
 const HEX_PATTERN = /^[0-9a-fA-F]+$/;
 const DISCORD_SNOWFLAKE_PATTERN = /^\d{17,20}$/;
 const MAX_UINT64_DECIMAL = "18446744073709551615";
 const DISCORD_TOKEN_PATTERN = /^[A-Za-z0-9._-]{50,}$/;
+
+export type NewCustomBotLinkMode = "auto-link" | "inventory-only" | "replace";
+
+export function newCustomBotAgentLinkFields({
+	mode,
+	agentId,
+	autoLinkAgentId,
+}: {
+	mode: NewCustomBotLinkMode;
+	agentId?: string;
+	autoLinkAgentId: string | null;
+}): Pick<ChannelCreate, "agent_id" | "replace_existing_provider_link"> {
+	if (mode === "inventory-only") return { agent_id: null };
+	if (mode === "replace") {
+		return { agent_id: agentId, replace_existing_provider_link: true };
+	}
+	return { agent_id: autoLinkAgentId };
+}
 
 function isDiscordSnowflake(value: string): boolean {
 	return (

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -32,6 +32,8 @@ import {
 	discordApplicationIdError,
 	discordBotTokenError,
 	discordPublicKeyError,
+	type NewCustomBotLinkMode,
+	newCustomBotAgentLinkFields,
 } from "@/hosted/v2/channels/connect-bot-dialog.logic";
 import { ProviderLinkReplacementConfirm } from "@/hosted/v2/channels/provider-link-replacement-confirm";
 import { WhatsAppDeviceOnboarding } from "@/hosted/v2/channels/whatsapp-device-onboarding";
@@ -140,13 +142,12 @@ export function ConnectBotDialog({
 				!applicationIdError &&
 				!publicKeyError));
 
-	function buildBody(replaceExistingProviderLink: boolean): ChannelCreate {
+	function buildBody(linkMode: NewCustomBotLinkMode): ChannelCreate {
 		const base: ChannelCreate = {
 			provider,
 			name: name.trim(),
 			provider_token: token.trim(),
-			agent_id: replaceExistingProviderLink ? agentId : autoLinkAgentId,
-			...(replaceExistingProviderLink ? { replace_existing_provider_link: true } : {}),
+			...newCustomBotAgentLinkFields({ mode: linkMode, agentId, autoLinkAgentId }),
 		};
 		if (!discordSelected) return base;
 		return {
@@ -158,12 +159,12 @@ export function ConnectBotDialog({
 		};
 	}
 
-	async function submit(replaceExistingProviderLink = false): Promise<void> {
+	async function submit(linkMode: NewCustomBotLinkMode = "auto-link"): Promise<void> {
 		if (!canSubmit || submitLocked.current) return;
 		submitLocked.current = true;
 		setSubmitting(true);
 		const dialogSession = dialogSessionRef.current;
-		const body = buildBody(replaceExistingProviderLink);
+		const body = buildBody(linkMode);
 		try {
 			const data = await create.execute(body);
 			const result: CreatedCustomBot = {
@@ -259,7 +260,9 @@ export function ConnectBotDialog({
 	const addCustomBotButton = (
 		<Button
 			className="min-w-0 whitespace-normal"
-			onClick={providerLinkConflict ? undefined : () => void submit().catch(() => undefined)}
+			onClick={
+				providerLinkConflict ? undefined : () => void submit("auto-link").catch(() => undefined)
+			}
 			disabled={!canSubmit || isSubmitting}
 		>
 			{isSubmitting ? "Adding…" : "Add custom bot"}
@@ -476,7 +479,8 @@ export function ConnectBotDialog({
 												<ProviderLinkReplacementConfirm
 													provider={provider}
 													targetName={name.trim()}
-													onConfirm={() => submit(true)}
+													onAddWithoutLinking={() => submit("inventory-only")}
+													onConfirm={() => submit("replace")}
 												>
 													{addCustomBotButton}
 												</ProviderLinkReplacementConfirm>

--- a/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
+++ b/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
@@ -7,11 +7,13 @@ import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 export function ProviderLinkReplacementConfirm({
 	provider,
 	targetName,
+	onAddWithoutLinking,
 	onConfirm,
 	children,
 }: {
 	provider: string;
 	targetName: string;
+	onAddWithoutLinking?: () => unknown;
 	onConfirm: () => unknown;
 	children: ReactElement;
 }) {
@@ -19,17 +21,39 @@ export function ProviderLinkReplacementConfirm({
 	return (
 		<div data-hosted="true" data-v2="true" className="contents">
 			<ConfirmAction
-				title={`Replace this Agent’s ${providerLabel} link?`}
+				title={
+					onAddWithoutLinking
+						? `How should this ${providerLabel} bot be added?`
+						: `Replace this Agent’s ${providerLabel} link?`
+				}
 				description={
-					<>
-						This Agent can use one {providerLabel} bot at a time.{" "}
-						<span className="font-medium text-foreground [overflow-wrap:anywhere]">
-							{targetName}
-						</span>{" "}
-						will replace the current bot, and its paired chats will be removed from this Agent.
-					</>
+					onAddWithoutLinking ? (
+						<>
+							This Agent can use one {providerLabel} bot at a time. Choose Add without linking to
+							keep the current bot and its paired chats;{" "}
+							<span className="font-medium text-foreground [overflow-wrap:anywhere]">
+								{targetName}
+							</span>{" "}
+							will be added to Custom bots only. Choose Replace to link the new bot and remove the
+							current bot&apos;s paired chats from this Agent.
+						</>
+					) : (
+						<>
+							This Agent can use one {providerLabel} bot at a time.{" "}
+							<span className="font-medium text-foreground [overflow-wrap:anywhere]">
+								{targetName}
+							</span>{" "}
+							will replace the current bot, and its paired chats will be removed from this Agent.
+						</>
+					)
 				}
 				confirmLabel={`Replace ${providerLabel} link`}
+				secondaryAction={
+					onAddWithoutLinking
+						? { label: "Add without linking", onAction: onAddWithoutLinking }
+						: undefined
+				}
+				destructive
 				onConfirm={onConfirm}
 			>
 				{children}


### PR DESCRIPTION
## Summary

- offer Add without linking when a hosted Agent already uses that provider
- preserve the current bot and paired chats for inventory-only creation
- keep provider replacement explicit and destructive, without changing runtime cardinality
- retain Cancel and Replace only when linking an existing inventory bot

## Verification

- Docker web suite: affected tests passed; typecheck and OSS build passed
- Hosted Playwright focused coverage: 2 passed
- Biome check passed
- git diff --check passed

## Scope

Frontend only. No backend, schema, runtime, or production changes.