### PR TITLE
Refine Custom bot linking and deletion actions

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1473,6 +1473,9 @@ type HostedApiStubOptions = {
 	createChannelRequests?: string[];
 	createChannelResponse?: unknown;
 	createChannelResponses?: StubResponse[];
+	deleteChannelRequests?: string[];
+	deleteChannelResponses?: StubResponse[];
+	onDeleteChannel?: (accountId: string) => void;
 	deleteBindingRequests?: string[];
 	deleteBindingResponses?: StubResponse[];
 	onCreateChannel?: (response: unknown) => void;
@@ -2332,6 +2335,15 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					? links.filter((link) => isRecord(link) && link.agent_id === requestedAgentId)
 					: links,
 			);
+		}
+		if (p.match(/^\/v1\/channels\/[^/]+$/) && r.request().method() === "DELETE") {
+			const accountId = decodeURIComponent(p.slice(p.lastIndexOf("/") + 1));
+			options.deleteChannelRequests?.push(accountId);
+			const response = options.deleteChannelResponses?.shift() ?? { body: null, status: 204 };
+			if (response.delayMs) await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			if (response.status < 400) options.onDeleteChannel?.(accountId);
+			if (response.status === 204) return r.fulfill({ status: 204, body: "" });
+			return fulfillJson(r, response.body, response.status);
 		}
 		if (p.match(/^\/v1\/channels\/[^/]+$/) && r.request().method() === "GET") {
 			return fulfillJson(r, options.channelAccount ?? { detail: "Channel not found" }, 200);
@@ -9474,6 +9486,127 @@ test("Channels separates Custom and Clawdi bots with compact connect forms", asy
 	expect(errors, `Channels inventory browser errors: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("Custom bot cards delete inventory without conflating Agent unlink", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const agentId = missingProjectionEnvironmentId;
+	const firstId = "10f11111-1111-4111-8111-111111111111";
+	const secondId = "10f22222-2222-4222-8222-222222222222";
+	const publicId = "10f33333-3333-4333-8333-333333333333";
+	const firstName = "Delete from inventory";
+	const secondName = "Delete from Agent";
+	const accounts: unknown[] = [
+		{
+			id: firstId,
+			provider: "telegram",
+			name: firstName,
+			status: "active",
+			visibility: "private",
+			has_provider_token: true,
+			webhook_url: "https://cloud.example.test/channels/delete-inventory",
+			created_at: "2026-08-04T00:00:00Z",
+		},
+		{
+			id: secondId,
+			provider: "telegram",
+			name: secondName,
+			status: "active",
+			visibility: "private",
+			has_provider_token: true,
+			webhook_url: "https://cloud.example.test/channels/delete-agent",
+			created_at: "2026-08-04T00:01:00Z",
+		},
+	];
+	const publicBot = {
+		id: publicId,
+		provider: "telegram",
+		name: "Clawdi public bot",
+		status: "active",
+		visibility: "public",
+		has_provider_token: true,
+		webhook_url: "https://cloud.example.test/channels/public-delete-boundary",
+		created_at: "2026-08-04T00:02:00Z",
+		access: "public",
+		capabilities: {
+			link_agent: true,
+			pair_chat: true,
+			send_message: true,
+			manage_account: false,
+			sync_commands: false,
+		},
+		link_count: 0,
+		max_links: null,
+		available: true,
+	};
+	const deleteChannelRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		channelAccounts: accounts,
+		channelAgentLinks: [],
+		channelBotPool: { providers: { telegram: [publicBot] } },
+		deleteChannelRequests,
+		deleteChannelResponses: [
+			{ status: 503, body: { detail: "Custom bot deletion temporarily unavailable" } },
+			{ status: 204, body: null },
+			{ status: 204, body: null },
+		],
+		onDeleteChannel: (accountId) => {
+			const index = accounts.findIndex((account) => isRecord(account) && account.id === accountId);
+			if (index >= 0) accounts.splice(index, 1);
+		},
+	});
+
+	await page.goto("/channels");
+	const firstCard = page.locator(`[data-channel-account-id="${firstId}"]`);
+	const publicCard = page.locator(`[data-shared-channel-account-id="${publicId}"]`);
+	await expect(firstCard).toBeVisible();
+	await expect(publicCard.getByRole("button", { name: /Delete/ })).toHaveCount(0);
+	await firstCard.getByRole("button", { name: `Delete ${firstName}`, exact: true }).click();
+	let deleteDialog = page.getByRole("alertdialog", { name: `Delete ${firstName}?` });
+	await expect(deleteDialog).toContainText(
+		"This deletes the Custom bot, its Agent links, and its paired chats. This can't be undone.",
+	);
+	await deleteDialog.getByRole("button", { name: "Delete custom bot", exact: true }).click();
+	await expect.poll(() => deleteChannelRequests).toEqual([firstId]);
+	await expect(deleteDialog).toBeVisible();
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Couldn't delete Custom bot" }),
+	).toBeVisible();
+	await expect(
+		deleteDialog.getByRole("button", { name: "Delete custom bot", exact: true }),
+	).toBeEnabled();
+	await deleteDialog.getByRole("button", { name: "Delete custom bot", exact: true }).click();
+	await expect.poll(() => deleteChannelRequests).toEqual([firstId, firstId]);
+	await expect(firstCard).toHaveCount(0);
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Custom bot deleted" }),
+	).toBeVisible();
+
+	await page.goto(
+		`/agents/${agentId}/channel-links?source=on-clawdi&d=${runningMissingProjectionDeployment.id}`,
+	);
+	const customCard = page.locator(`[data-agent-channel-account-id="${secondId}"]`);
+	const clawdiCard = page.locator(`[data-agent-channel-account-id="${publicId}"]`);
+	await expect(customCard.getByText("Available", { exact: true })).toBeVisible();
+	await expect(customCard).not.toContainText("Replaces current link");
+	await expect(clawdiCard.getByRole("button", { name: /Delete/ })).toHaveCount(0);
+	const deleteFromAgent = customCard.getByRole("button", {
+		name: `Delete ${secondName}`,
+		exact: true,
+	});
+	expect((await deleteFromAgent.boundingBox())?.width).toBeLessThanOrEqual(96);
+	await deleteFromAgent.click();
+	deleteDialog = page.getByRole("alertdialog", { name: `Delete ${secondName}?` });
+	await deleteDialog.getByRole("button", { name: "Delete custom bot", exact: true }).click();
+	await expect.poll(() => deleteChannelRequests).toEqual([firstId, firstId, secondId]);
+	await expect(customCard).toHaveCount(0);
+
+	const unexpectedErrors = errors.filter((error) => !error.includes("status of 503"));
+	expect(
+		unexpectedErrors,
+		`Custom bot deletion browser errors: ${unexpectedErrors.join(" | ")}`,
+	).toEqual([]);
+});
+
 test("WhatsApp Custom onboarding uses a real gated linked-device lifecycle", async ({
 	page,
 }, testInfo) => {
@@ -10336,10 +10469,9 @@ test("Add channel offers inventory-only creation and atomic provider replacement
 		name: "How should this Telegram bot be added?",
 	});
 	await expect(replacementDialog).toBeVisible();
-	await expect(replacementDialog).toContainText("one Telegram bot at a time");
-	await expect(replacementDialog).toContainText("Additional Telegram");
-	await expect(replacementDialog).toContainText("keep the current bot and its paired chats");
-	await expect(replacementDialog).toContainText("will be added to Custom bots only");
+	await expect(replacementDialog).toContainText(
+		"This Agent can link only one Telegram bot. Add Additional Telegram without linking, or replace the current bot and remove its paired chats.",
+	);
 	await expect(
 		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
 	).toBeVisible();
@@ -10449,7 +10581,9 @@ test("Add channel offers inventory-only creation and atomic provider replacement
 	replacementDialog = page.getByRole("alertdialog", {
 		name: "How should this Discord bot be added?",
 	});
-	await expect(replacementDialog).toContainText("remove the current bot's paired chats");
+	await expect(replacementDialog).toContainText(
+		"This Agent can link only one Discord bot. Add Additional Discord without linking, or replace the current bot and remove its paired chats.",
+	);
 	await expect(
 		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
 	).toBeVisible();
@@ -10736,7 +10870,7 @@ test("Agent bot groups keep every bot visible and confirm provider replacement",
 	await expect(customSection.getByText("Custom bots", { exact: true })).toBeVisible();
 	await expect(linkedTelegramRow).toBeVisible();
 	await expect(replacementTelegramRow).toBeVisible();
-	await expect(replacementTelegramRow).toContainText("Replaces current link");
+	await expect(replacementTelegramRow.getByText("Available", { exact: true })).toBeVisible();
 	await expect(
 		replacementTelegramRow.getByRole("button", { name: "Link", exact: true }),
 	).toBeEnabled();
@@ -10758,8 +10892,8 @@ test("Agent bot groups keep every bot visible and confirm provider replacement",
 	await expect(unlinkedDiscordHeader.getByText("Available", { exact: true })).toBeVisible();
 	await expect(unlinkedDiscordHeader).not.toContainText("1 chat");
 	await expect(unlinkedDiscordHeader).not.toContainText("Paired");
-	await expect(unavailableTelegramHeader).toContainText("Replaces current link");
-	await expect(unavailableTelegramHeader).not.toContainText("Available");
+	await expect(unavailableTelegramHeader.getByText("Available", { exact: true })).toBeVisible();
+	await expect(unavailableTelegramHeader).not.toContainText("Replaces current link");
 	await expect(linkedTelegramChats).toHaveAccessibleName("1 paired chat");
 	const desktopPairedChatLabel = linkedTelegramChats.locator("[data-agent-paired-chats-label]");
 	await expect(desktopPairedChatLabel).toHaveText("1 paired chat");
@@ -10859,11 +10993,14 @@ test("Agent bot groups keep every bot visible and confirm provider replacement",
 		name: "Link",
 		exact: true,
 	});
+	expect((await replaceLinkButton.boundingBox())?.width).toBeLessThanOrEqual(96);
 	await replaceLinkButton.click();
 	let replacementDialog = page.getByRole("alertdialog", {
 		name: "Replace this Agent’s Telegram link?",
 	});
-	await expect(replacementDialog).toContainText("Replacement Telegram");
+	await expect(replacementDialog).toContainText(
+		"This Agent can link only one Telegram bot. Linking Replacement Telegram will replace the current bot and remove its paired chats.",
+	);
 	await expect(
 		replacementDialog.getByRole("button", { name: "Add without linking", exact: true }),
 	).toHaveCount(0);
@@ -12109,12 +12246,14 @@ test("Agent Channels uses compact task-ordered cards and the shared Telegram pai
 	expect(telegramPairColors).toEqual(discordPairColors);
 	expect(telegramPairBox?.height).toBe(discordPairBox?.height);
 	expect(telegramPairBox?.height).toBe(32);
+	expect(telegramPairBox?.width).toBeLessThanOrEqual(96);
+	expect(unlinkBox?.width).toBeLessThanOrEqual(96);
 	const readyCard = clawdiSection.locator(`[data-agent-channel-account-id="${readyId}"]`);
 	const ownedCard = customSection.locator(`[data-agent-channel-account-id="${ownedId}"]`);
 	await expect(readyCard).toBeVisible();
 	await expect(ownedCard).toBeVisible();
-	await expect(readyCard).toContainText("Replaces current link");
-	await expect(ownedCard).toContainText("Replaces current link");
+	await expect(readyCard.getByText("Available", { exact: true })).toBeVisible();
+	await expect(ownedCard.getByText("Available", { exact: true })).toBeVisible();
 	await expect(readyCard.getByRole("button", { name: "Link", exact: true })).toBeEnabled();
 	await expect(ownedCard.getByRole("button", { name: "Link", exact: true })).toBeEnabled();
 	await expect(page.getByRole("button", { name: /^Access .* Dashboard$/ })).toHaveCount(0);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -273,6 +273,7 @@ import {
 	useBotPool,
 	useChannels,
 	useCreatePairCode,
+	useDeleteChannel,
 	useUnlinkAgentChannel,
 } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
@@ -2285,8 +2286,7 @@ function ChannelsSyncState({
 	);
 }
 
-const AGENT_CHANNEL_PAIR_ACTIONS_CLASS =
-	"grid min-h-8 w-full grid-cols-[minmax(0,1fr)_7rem] items-center gap-1.5 xl:flex xl:w-auto xl:gap-2";
+const AGENT_CHANNEL_PAIR_ACTIONS_CLASS = "flex min-h-8 w-auto items-center gap-1.5 xl:gap-2";
 
 const AGENT_CHANNEL_CARD_HEADER_CLASS =
 	"h-[7.5rem] flex-none grid-rows-[2.75rem_2rem] xl:h-20 xl:grid-rows-1";
@@ -2339,6 +2339,7 @@ function ChannelsTab({
 	const linked = useAgentChannelLinks(environmentId, isCloudEnvId(environmentId), true);
 	const agentLinksQueryKey = agentChannelLinksQueryOptions(openApi, environmentId).queryKey;
 	const unlink = useUnlinkAgentChannel(environmentId);
+	const deleteChannel = useDeleteChannel();
 	const [recentLinks, setRecentLinks] = useState<ReadonlyMap<string, AgentChannelLink>>(
 		() => new Map(),
 	);
@@ -2359,6 +2360,10 @@ function ChannelsTab({
 	const [linkingAccountIds, setLinkingAccountIds] = useState<ReadonlySet<string>>(() => new Set());
 	const unlinkingLinkIdsRef = useRef<Set<string>>(new Set());
 	const [unlinkingLinkIds, setUnlinkingLinkIds] = useState<ReadonlySet<string>>(() => new Set());
+	const deletingAccountIdsRef = useRef<Set<string>>(new Set());
+	const [deletingAccountIds, setDeletingAccountIds] = useState<ReadonlySet<string>>(
+		() => new Set(),
+	);
 	useEffect(() => {
 		if (!linked.data) return;
 		setRecentLinks((current) => {
@@ -2541,6 +2546,27 @@ function ChannelsTab({
 			}
 		})();
 	}
+	async function submitDeleteChannel(accountId: string): Promise<void> {
+		if (deletingAccountIdsRef.current.has(accountId)) return;
+		deletingAccountIdsRef.current.add(accountId);
+		setDeletingAccountIds((current) => new Set(current).add(accountId));
+		try {
+			await deleteChannel.mutateAsync({ params: { path: { account_id: accountId } } });
+			setRecentLinks((current) => {
+				if (!current.has(accountId)) return current;
+				const next = new Map(current);
+				next.delete(accountId);
+				return next;
+			});
+		} finally {
+			deletingAccountIdsRef.current.delete(accountId);
+			setDeletingAccountIds((current) => {
+				const next = new Set(current);
+				next.delete(accountId);
+				return next;
+			});
+		}
+	}
 	function renderBot(bot: AgentChannelCardItem) {
 		const linkForBot = bot.link;
 		return (
@@ -2552,10 +2578,12 @@ function ChannelsTab({
 				linkedProviders={linkedProviders}
 				linking={linkingAccountIds.has(bot.id)}
 				unlinking={Boolean(linkForBot && unlinkingLinkIds.has(linkForBot.id))}
+				deleting={deletingAccountIds.has(bot.id)}
 				onLink={(replaceExistingProviderLink) => submitLink(bot.id, replaceExistingProviderLink)}
 				onUnlink={() => {
 					if (linkForBot) startUnlink(bot.id, linkForBot.id);
 				}}
+				onDelete={() => submitDeleteChannel(bot.id)}
 			/>
 		);
 	}
@@ -2750,8 +2778,10 @@ function AgentChannelBotCard({
 	linkedProviders,
 	linking,
 	unlinking,
+	deleting,
 	onLink,
 	onUnlink,
+	onDelete,
 }: {
 	bot: AgentChannelCardItem;
 	agentId: string;
@@ -2760,8 +2790,10 @@ function AgentChannelBotCard({
 	linkedProviders: ReadonlySet<string> | undefined;
 	linking: boolean;
 	unlinking: boolean;
+	deleting: boolean;
 	onLink: (replaceExistingProviderLink: boolean) => Promise<void>;
 	onUnlink: () => void;
+	onDelete: () => Promise<void>;
 }) {
 	const unavailableReason = agentChannelLinkUnavailableReason({ bot, agentType, linkedProviders });
 	const replacementRequired = agentProviderLinkReplacementRequired(
@@ -2773,7 +2805,7 @@ function AgentChannelBotCard({
 		<Button
 			type="button"
 			size="sm"
-			className="w-full min-w-0 sm:w-28"
+			className="min-w-20"
 			disabled={Boolean(unavailableReason) || linking}
 			onClick={replacementRequired ? undefined : () => void onLink(false).catch(() => undefined)}
 		>
@@ -2781,6 +2813,28 @@ function AgentChannelBotCard({
 			{linking ? "Linking…" : "Link"}
 		</Button>
 	);
+	const deleteAction =
+		bot.visibility === "private" && !bot.link ? (
+			<ConfirmAction
+				title={`Delete ${bot.name}?`}
+				description="This deletes the Custom bot, its Agent links, and its paired chats. This can't be undone."
+				confirmLabel="Delete custom bot"
+				destructive
+				onConfirm={onDelete}
+			>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					className={cn(CHANNEL_DESTRUCTIVE_ACTION_CLASS, "min-w-20")}
+					disabled={deleting}
+					aria-label={`Delete ${bot.name}`}
+				>
+					{deleting ? <Spinner className="size-3.5" /> : <Trash2 className="size-3.5" />}
+					{deleting ? "Deleting…" : "Delete"}
+				</Button>
+			</ConfirmAction>
+		) : null;
 	return (
 		<div data-agent-channel-account-id={bot.id} className="h-full min-w-0">
 			{bot.link ? (
@@ -2800,19 +2854,22 @@ function AgentChannelBotCard({
 				<AgentChannelCard
 					provider={bot.provider}
 					title={bot.name}
-					state={replacementRequired ? "Replaces current link" : (unavailableReason ?? "Available")}
+					state={unavailableReason ?? "Available"}
 					actions={
-						replacementRequired ? (
-							<ProviderLinkReplacementConfirm
-								provider={bot.provider}
-								targetName={bot.name}
-								onConfirm={() => onLink(true)}
-							>
-								{linkButton}
-							</ProviderLinkReplacementConfirm>
-						) : (
-							linkButton
-						)
+						<div className="flex min-w-0 items-center gap-2">
+							{deleteAction}
+							{replacementRequired ? (
+								<ProviderLinkReplacementConfirm
+									provider={bot.provider}
+									targetName={bot.name}
+									onConfirm={() => onLink(true)}
+								>
+									{linkButton}
+								</ProviderLinkReplacementConfirm>
+							) : (
+								linkButton
+							)}
+						</div>
 					}
 				/>
 			)}
@@ -2953,7 +3010,7 @@ function LinkedChannelRow({
 								type="button"
 								variant="outline"
 								size="sm"
-								className="w-full min-w-0 xl:w-32"
+								className="min-w-20"
 								disabled={provider !== "telegram" && creatingPairCode}
 								onClick={() => {
 									if (provider === "telegram") setTelegramPairOpen(true);
@@ -2978,7 +3035,7 @@ function LinkedChannelRow({
 								<Button
 									variant="ghost"
 									size="sm"
-									className={cn(CHANNEL_DESTRUCTIVE_ACTION_CLASS, "w-28 min-w-0")}
+									className={cn(CHANNEL_DESTRUCTIVE_ACTION_CLASS, "min-w-20")}
 									disabled={unlinking}
 									aria-label={`${unlinking ? "Unlinking" : "Unlink"} ${name} from ${agentName}`}
 								>

--- a/apps/web/src/hosted/v2/channels/channel-card.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-card.tsx
@@ -49,7 +49,10 @@ export function ChannelCard({
 					meta={state}
 				/>
 				{actions ? (
-					<div data-channel-card-actions className="flex min-w-0 items-center justify-end gap-2">
+					<div
+						data-channel-card-actions
+						className="relative z-10 flex min-w-0 items-center justify-end gap-2"
+					>
 						{actions}
 					</div>
 				) : null}

--- a/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-default-path.test.ts
@@ -24,6 +24,7 @@ describe("global Channels inventory", () => {
 		expect(channelsPage).not.toContain("data-pool-account-id");
 		expect(channelsPage).not.toContain("LinkAgentDialog");
 		expect(channelsPage).not.toContain("Link an agent");
+		expect(channelsPage).toContain("Delete custom bot");
 		expect(channelsPage).not.toContain("At capacity");
 		expect(channelsPage).toContain("providersWithBots(counts)");
 		expect(channelsPage).not.toContain("· Shared");
@@ -57,6 +58,7 @@ describe("global Channels inventory", () => {
 		expect(connectDialog).toContain('onAddWithoutLinking={() => submit("inventory-only")}');
 		expect(replacementConfirm).toContain('label: "Add without linking"');
 		expect(replacementConfirm).toContain("? `How should this ");
+		expect(replacementConfirm).toContain("This Agent can link only one");
 		expect(replacementConfirm).toContain(": `Replace this Agent’s ");
 		expect(connectDialog).toContain("onAgentConnected");
 		expect(connectDialog).toContain("autoLinkAgentIdForNewCustomBot");

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -265,13 +265,13 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				}
 				actions={
 					<ConfirmAction
-						title={`${disconnectsWhatsApp ? "Disconnect" : "Remove"} ${ch.name}?`}
+						title={`${disconnectsWhatsApp ? "Disconnect" : "Delete"} ${ch.name}?`}
 						description={
 							disconnectsWhatsApp
 								? "This logs out Clawdi as a linked device and removes the Custom bot. Linked Agents will stop sending and receiving."
-								: "Agents linked to this channel will stop sending and receiving. This can't be undone."
+								: "This deletes the Custom bot, its Agent links, and its paired chats. This can't be undone."
 						}
-						confirmLabel={disconnectsWhatsApp ? "Disconnect and remove" : "Remove channel"}
+						confirmLabel={disconnectsWhatsApp ? "Disconnect and remove" : "Delete custom bot"}
 						destructive
 						onConfirm={removeChannel}
 					>
@@ -287,7 +287,13 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 							) : (
 								<Trash2 className="size-4" />
 							)}
-							{removing ? "Removing…" : disconnectsWhatsApp ? "Disconnect" : "Remove"}
+							{removing
+								? disconnectsWhatsApp
+									? "Disconnecting…"
+									: "Deleting…"
+								: disconnectsWhatsApp
+									? "Disconnect"
+									: "Delete"}
 						</Button>
 					</ConfirmAction>
 				}
@@ -296,7 +302,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 			{providerUnavailable ? (
 				<InfoCard icon={TriangleAlert} title="Provider unavailable">
 					This provider is no longer available for new native channels. Existing channel data
-					remains visible, and you can remove the channel.
+					remains visible, and you can delete the Custom bot.
 				</InfoCard>
 			) : null}
 			{ch.provider === "discord" && !providerUnavailable ? (

--- a/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-pairing-ux.test.ts
@@ -52,6 +52,9 @@ describe("channel IA boundary", () => {
 		expect(agentDetail).not.toContain("data-agent-paired-chats");
 		expect(agentDetail).toContain("data-agent-add-custom-bot");
 		expect(agentDetail).toContain('linking ? "Linking…" : "Link"');
+		expect(agentDetail).toContain('state={unavailableReason ?? "Available"}');
+		expect(agentDetail).not.toContain("Replaces current link");
+		expect(agentDetail).toContain('confirmLabel="Delete custom bot"');
 		expect(agentDetail).toContain('creatingPairCode ? "Generating…" : "Pair"');
 		expect(agentDetail).not.toContain("Pair Telegram");
 		expect(agentDetail).not.toContain("Pair Discord");
@@ -81,6 +84,7 @@ describe("channel IA boundary", () => {
 		expect(connectDialog).toContain('onConfirm={() => submit("replace")}');
 		expect(replacementConfirm).toContain('label: "Add without linking"');
 		expect(replacementConfirm).toContain("? `How should this ");
+		expect(replacementConfirm).toContain("This Agent can link only one");
 		expect(replacementConfirm).toContain(": `Replace this Agent’s ");
 		expect(replacementConfirm).toContain("destructive");
 		expect(connectDialog).toContain("Add custom bot");

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -238,9 +238,9 @@ export function useDeleteChannel() {
 		onSuccess: async (_data, variables) => {
 			const id = variables.params.path.account_id;
 			await removeDeletedChannelQueries(qc, id);
-			toast.success("Channel removed");
+			toast.success("Custom bot deleted");
 		},
-		onError: toastApiError("Couldn't remove channel"),
+		onError: toastApiError("Couldn't delete Custom bot"),
 	});
 }
 

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { MessagesSquare, Plus } from "lucide-react";
+import { MessagesSquare, Plus, Trash2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -13,6 +13,8 @@ import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Spinner } from "@/components/ui/spinner";
 import {
 	CHANNEL_CARD_GRID_CLASS,
 	ChannelCard as SharedChannelCard,
@@ -29,7 +31,12 @@ import {
 	isNormalChannelHealth,
 	isNormalChannelStatus,
 } from "@/hosted/v2/channels/channel-ui";
-import { useBotPool, useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
+import {
+	useBotPool,
+	useChannelHealth,
+	useChannels,
+	useDeleteChannel,
+} from "@/hosted/v2/channels/channels-hooks";
 import {
 	type ChannelProviderFilter,
 	orderedChannelsForFilter,
@@ -256,6 +263,7 @@ function SharedBotCard({ bot }: { bot: ChannelBotPoolItem }) {
 }
 
 function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: ChannelHealthItem }) {
+	const del = useDeleteChannel();
 	return (
 		<div data-channel-account-id={channel.id} className="group relative z-0 h-full min-w-0">
 			<SharedChannelCard
@@ -270,6 +278,27 @@ function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: Ch
 						<ChannelStatusBadge key="status" status={channel.status} />
 					),
 				]}
+				actions={
+					<ConfirmAction
+						title={`Delete ${channel.name}?`}
+						description="This deletes the Custom bot, its Agent links, and its paired chats. This can't be undone."
+						confirmLabel="Delete custom bot"
+						destructive
+						onConfirm={() => del.mutateAsync({ params: { path: { account_id: channel.id } } })}
+					>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground hover:text-destructive"
+							disabled={del.isPending}
+							aria-label={`Delete ${channel.name}`}
+						>
+							{del.isPending ? <Spinner className="size-3.5" /> : <Trash2 className="size-3.5" />}
+							{del.isPending ? "Deleting…" : "Delete"}
+						</Button>
+					</ConfirmAction>
+				}
 			/>
 			<Link to="/channels/$id" params={{ id: channel.id }} className={ENTITY_STRETCHED_LINK_CLASS}>
 				<span className="sr-only">Open {channel.name}</span>

--- a/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
+++ b/apps/web/src/hosted/v2/channels/provider-link-replacement-confirm.tsx
@@ -27,25 +27,26 @@ export function ProviderLinkReplacementConfirm({
 						: `Replace this Agent’s ${providerLabel} link?`
 				}
 				description={
-					onAddWithoutLinking ? (
-						<>
-							This Agent can use one {providerLabel} bot at a time. Choose Add without linking to
-							keep the current bot and its paired chats;{" "}
-							<span className="font-medium text-foreground [overflow-wrap:anywhere]">
-								{targetName}
-							</span>{" "}
-							will be added to Custom bots only. Choose Replace to link the new bot and remove the
-							current bot&apos;s paired chats from this Agent.
-						</>
-					) : (
-						<>
-							This Agent can use one {providerLabel} bot at a time.{" "}
-							<span className="font-medium text-foreground [overflow-wrap:anywhere]">
-								{targetName}
-							</span>{" "}
-							will replace the current bot, and its paired chats will be removed from this Agent.
-						</>
-					)
+					<>
+						This Agent can link only one {providerLabel} bot.{" "}
+						{onAddWithoutLinking ? (
+							<>
+								Add{" "}
+								<span className="font-medium text-foreground [overflow-wrap:anywhere]">
+									{targetName}
+								</span>{" "}
+								without linking, or replace the current bot and remove its paired chats.
+							</>
+						) : (
+							<>
+								Linking{" "}
+								<span className="font-medium text-foreground [overflow-wrap:anywhere]">
+									{targetName}
+								</span>{" "}
+								will replace the current bot and remove its paired chats.
+							</>
+						)}
+					</>
 				}
 				confirmLabel={`Replace ${providerLabel} link`}
 				secondaryAction={


### PR DESCRIPTION
## Summary
- shorten both provider replacement confirmations and state the one-bot-per-provider link limit
- show replacement candidates as Available and tighten Link, Pair, Unlink, and Delete actions
- allow deleting owned Custom bots from inventory and unlinked Agent cards while preserving public bot and linked-card boundaries
- keep delete failures retryable and refresh related channel and Agent-link queries

## Verification
- Docker-isolated frontend tests: 20 tests, 365 assertions
- Typecheck and OSS build
- Biome check on all 9 changed files
- Playwright (official container): 3 focused hosted scenarios passed, including 320px layouts and action-width assertions