### PR TITLE
fix(web): make Settings surfaces consistent

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -6624,19 +6624,28 @@ test("hosted locale settings submit canonical deployment PATCH", async ({ page }
 		ifMatch: string | null;
 	}> = [];
 	await stubHostedApi(page, {
-		deployments: [includedBasicDeployment],
+		deployments: [railHostedDeployment],
+		cloudAgents: [railHostedCloudAgent],
 		plans: [basicPlan],
 		updateDeploymentRequests,
 	});
-	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+	await gotoHostedAgentSettings(page, "hdep_rail_cloud", "Basic");
 
+	const displayName = page.getByRole("textbox", { name: "Display name" });
+	await displayName.fill("Unsaved Cloud name");
 	await page.locator("#hosted-agent-language").click();
 	await page.getByRole("option", { name: "Español" }).click();
+	await page.getByRole("link", { name: "Sessions", exact: true }).click();
+	const discardDialog = page.getByRole("alertdialog", { name: "Discard unsaved changes?" });
+	await expect(discardDialog).toHaveCount(1);
+	await discardDialog.getByRole("button", { name: "Keep editing" }).click();
+	await expect(displayName).toHaveValue("Unsaved Cloud name");
+	await expect(page.locator("#hosted-agent-language")).toContainText("Español");
 	await page.locator("main").getByRole("button", { name: "Save changes" }).click();
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 
 	expect(updateDeploymentRequests[0]?.idempotencyKey).toMatch(/^deployment-update-/);
-	expect(updateDeploymentRequests[0]?.ifMatch).toBe('"rv_hdep_included"');
+	expect(updateDeploymentRequests[0]?.ifMatch).toBe('"rv_hdep_rail_cloud"');
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		language: "es",
 	});
@@ -8508,6 +8517,23 @@ test("Stripe invoice history shows both rails and a server-visible zero proratio
 		],
 		plans: [basicPlan, performancePlan],
 	});
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto("/channels?settings=billing-usage");
+	await page.reload();
+	const mobileSettings = page.getByTestId("settings-dialog");
+	const usageTab = mobileSettings.getByRole("button", { name: /^Usage/ });
+	await expect
+		.poll(() =>
+			usageTab.evaluate((button) => {
+				const nav = button.closest("nav");
+				if (!nav) return false;
+				const buttonBox = button.getBoundingClientRect();
+				const navBox = nav.getBoundingClientRect();
+				return buttonBox.left >= navBox.left && buttonBox.right <= navBox.right;
+			}),
+		)
+		.toBe(true);
+	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/channels?settings=billing-plan");
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await expect(settingsDialog.getByText("Billing history", { exact: true })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1058,6 +1058,25 @@ test("connected detail only requests overview data on Overview", async ({ page }
 	expect(skillRequests).toEqual([]);
 });
 
+test("connected agent settings protects an unsaved display name", async ({ page }) => {
+	await stubDashboardApi(page);
+	await page.goto("/agents/agent-smoke-1/settings");
+	const displayName = page.getByRole("textbox", { name: "Display name" });
+	await displayName.fill("Unsaved agent name");
+
+	const sessionsLink = page.locator('a[href="/agents/agent-smoke-1/sessions"]').first();
+	await sessionsLink.click();
+	const warning = page.getByRole("alertdialog", { name: "Discard unsaved changes?" });
+	await expect(warning).toBeVisible();
+	await expect(page).toHaveURL(/\/agents\/agent-smoke-1\/settings$/);
+
+	await warning.getByRole("button", { name: "Keep editing" }).click();
+	await expect(displayName).toHaveValue("Unsaved agent name");
+	await sessionsLink.click();
+	await warning.getByRole("button", { name: "Discard changes" }).click();
+	await expect(page).toHaveURL(/\/agents\/agent-smoke-1\/sessions$/);
+});
+
 test("SessionCard stays identical across Overview, Agent Sessions, and global Sessions", async ({
 	page,
 }, testInfo) => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1647,6 +1647,7 @@ export function AppSidebar({
 				hasExistingCloudAgents={
 					hostedAgentTiles?.some((tile) => tile.source === "on-clawdi") ?? false
 				}
+				cloudInventoryResolved={agentsLoaded && !hostedInventoryFetching}
 				onSectionChange={changeSettingsSection}
 				onOpenChange={setSettingsOpen}
 			/>

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import {
 	agentDisconnectUnavailable,
 	agentOwnershipKindFromId,
@@ -216,6 +217,11 @@ export function AgentSettingsPanel({
 
 	return (
 		<div className={cn("flex flex-col gap-9", className)}>
+			<UnsavedNavigationGuard
+				dirty={nameChanged}
+				busy={updateIdentity.isPending}
+				description="Your display name will return to the last value saved on the server."
+			/>
 			<input
 				ref={fileInputRef}
 				type="file"

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -21,6 +21,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
+import { useUnsavedNavigationState } from "@/components/unsaved-navigation-state";
 import {
 	agentDisconnectUnavailable,
 	agentOwnershipKindFromId,
@@ -168,6 +169,15 @@ export function AgentSettingsPanel({
 		}
 		uploadMutation.mutate(file);
 	};
+	const normalizedDraftName = draftName.trim() || null;
+	const currentCustomName = agent?.display_name
+		? (formatName?.(agent.display_name) ?? agent.display_name)
+		: null;
+	const nameChanged = Boolean(agent) && normalizedDraftName !== currentCustomName;
+	const guardedBySurface = useUnsavedNavigationState({
+		dirty: nameChanged,
+		busy: updateIdentity.isPending,
+	});
 
 	if (isLoading) {
 		return (
@@ -186,11 +196,6 @@ export function AgentSettingsPanel({
 		);
 	}
 
-	const normalizedDraftName = draftName.trim() || null;
-	const currentCustomName = agent.display_name
-		? (formatName?.(agent.display_name) ?? agent.display_name)
-		: null;
-	const nameChanged = normalizedDraftName !== currentCustomName;
 	const hasCustomAvatar = Boolean(agent.avatar_url);
 	const ownershipKind = agentOwnershipKindFromId(agent.id, ownership);
 	// Disconnect archives the active Agent and Project, so it must wait for
@@ -217,11 +222,13 @@ export function AgentSettingsPanel({
 
 	return (
 		<div className={cn("flex flex-col gap-9", className)}>
-			<UnsavedNavigationGuard
-				dirty={nameChanged}
-				busy={updateIdentity.isPending}
-				description="Your display name will return to the last value saved on the server."
-			/>
+			{guardedBySurface ? null : (
+				<UnsavedNavigationGuard
+					dirty={nameChanged}
+					busy={updateIdentity.isPending}
+					description="Your display name will return to the last value saved on the server."
+				/>
+			)}
 			<input
 				ref={fileInputRef}
 				type="file"

--- a/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
@@ -42,6 +42,7 @@ const STATELESS_OR_CANONICAL = [
 	"components/dashboard/daemon-status.tsx",
 	"components/dashboard/new-agent-button.tsx",
 	"components/settings-dialog.tsx",
+	"components/unsaved-navigation-guard.tsx",
 	"components/ui/command.tsx",
 	"components/ui/sidebar.tsx",
 	"components/vault/copy-keys-dialog.tsx",

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ShouldBlockFn, useBlocker } from "@tanstack/react-router";
+import type { ShouldBlockFn } from "@tanstack/react-router";
 import {
 	BarChart3,
 	CreditCard,
@@ -19,16 +19,6 @@ import { GeneralPanel } from "@/components/settings/general-panel";
 import { ProfilePanel } from "@/components/settings/profile-panel";
 import { type SettingsEditState, SettingsEditStateContext } from "@/components/settings-edit-state";
 import { SettingsPanelErrorBoundary } from "@/components/settings-panel-error-boundary";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -37,12 +27,14 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import {
 	DEFAULT_SETTINGS_SECTION,
 	SETTINGS_SECTION_IDS,
 	type SettingsSectionId,
 	settingsDraftOwnerChanges,
+	shouldCanonicalizeCloudSettings,
 } from "@/lib/settings-routes";
 import { cn } from "@/lib/utils";
 
@@ -125,12 +117,14 @@ export function SettingsDialog({
 	open,
 	section,
 	hasExistingCloudAgents = false,
+	cloudInventoryResolved = true,
 	onSectionChange,
 	onOpenChange,
 }: {
 	open: boolean;
 	section: SettingsSectionId;
 	hasExistingCloudAgents?: boolean;
+	cloudInventoryResolved?: boolean;
 	onSectionChange: (section: SettingsSectionId) => void;
 	onOpenChange: (open: boolean) => void;
 }) {
@@ -148,18 +142,10 @@ export function SettingsDialog({
 	}, []);
 	const hasUnsavedChanges = [...editStates.values()].some((state) => state.dirty);
 	const hasPendingSave = [...editStates.values()].some((state) => state.busy);
-	const navigationRiskRef = useRef(false);
-	navigationRiskRef.current = hasUnsavedChanges || hasPendingSave;
 	const shouldBlockNavigation: ShouldBlockFn = useCallback(
-		({ current, next }) => navigationRiskRef.current && settingsDraftOwnerChanges(current, next),
+		({ current, next }) => settingsDraftOwnerChanges(current, next),
 		[],
 	);
-	const shouldBlockDocumentExit = useCallback(() => navigationRiskRef.current, []);
-	const blocker = useBlocker({
-		shouldBlockFn: shouldBlockNavigation,
-		enableBeforeUnload: shouldBlockDocumentExit,
-		withResolver: true,
-	});
 	useEffect(() => {
 		setMounted(true);
 	}, []);
@@ -174,7 +160,9 @@ export function SettingsDialog({
 		? section
 		: DEFAULT_SETTINGS_SECTION;
 	const billingAccessPending =
-		requestedBillingSection && IS_HOSTED_BUILD && (!mounted || hostedAccess.isLoading);
+		requestedBillingSection &&
+		IS_HOSTED_BUILD &&
+		(!mounted || hostedAccess.isLoading || !cloudInventoryResolved);
 	const billingAccessError =
 		requestedBillingSection &&
 		IS_HOSTED_BUILD &&
@@ -186,16 +174,44 @@ export function SettingsDialog({
 	useEffect(() => {
 		if (!open) return;
 		const frame = window.requestAnimationFrame(() => {
-			activeButtonRef.current?.focus({ preventScroll: true });
+			const activeButton = activeButtonRef.current;
+			if (!activeButton) return;
+			const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+			activeButton.scrollIntoView({
+				behavior: reduceMotion ? "auto" : "smooth",
+				block: "nearest",
+				inline: "nearest",
+			});
 		});
 		return () => window.cancelAnimationFrame(frame);
 	}, [open, activeSection]);
 
 	useEffect(() => {
-		if (blocker.status === "blocked" && !hasUnsavedChanges && !hasPendingSave) {
-			blocker.proceed();
+		if (
+			open &&
+			mounted &&
+			shouldCanonicalizeCloudSettings({
+				section,
+				accessLoading: hostedAccess.isLoading,
+				accessError: hostedAccess.isError,
+				canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+				inventoryResolved: cloudInventoryResolved,
+				hasExistingCloudAgents,
+			})
+		) {
+			onSectionChange(DEFAULT_SETTINGS_SECTION);
 		}
-	}, [blocker, hasPendingSave, hasUnsavedChanges]);
+	}, [
+		cloudInventoryResolved,
+		hasExistingCloudAgents,
+		hostedAccess.canCreateCloudAgents,
+		hostedAccess.isError,
+		hostedAccess.isLoading,
+		mounted,
+		onSectionChange,
+		open,
+		section,
+	]);
 
 	function requestClose(nextOpen: boolean) {
 		onOpenChange(nextOpen);
@@ -204,10 +220,6 @@ export function SettingsDialog({
 	function requestSectionChange(nextSection: SettingsSectionId) {
 		if (nextSection === activeSection) return;
 		onSectionChange(nextSection);
-	}
-
-	function discardChanges() {
-		if (blocker.status === "blocked") blocker.proceed();
 	}
 
 	return (
@@ -281,14 +293,18 @@ export function SettingsDialog({
 						<section className="min-h-0 overflow-y-auto py-6 md:py-8">
 							<div className="mx-auto w-full max-w-5xl">
 								{billingAccessPending ? (
-									<HostedRouteSkeleton />
+									<div className="px-4 lg:px-6">
+										<HostedRouteSkeleton />
+									</div>
 								) : billingAccessError ? (
-									<ApiErrorPanel
-										error={hostedAccess.error}
-										normalizer={HOSTED_ACCESS_ERROR_NORMALIZER}
-										onRetry={() => void hostedAccess.refetch()}
-										title="Couldn’t verify billing access"
-									/>
+									<div className="px-4 lg:px-6">
+										<ApiErrorPanel
+											error={hostedAccess.error}
+											normalizer={HOSTED_ACCESS_ERROR_NORMALIZER}
+											onRetry={() => void hostedAccess.refetch()}
+											title="Couldn’t verify billing access"
+										/>
+									</div>
 								) : (
 									<SettingsPanelErrorBoundary key={activeSection}>
 										<SettingsPanel section={activeSection} />
@@ -300,35 +316,12 @@ export function SettingsDialog({
 				</DialogContent>
 			</Dialog>
 
-			<AlertDialog
-				open={blocker.status === "blocked"}
-				onOpenChange={(nextOpen) => {
-					if (!nextOpen && blocker.status === "blocked") blocker.reset();
-				}}
-			>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>
-							{hasPendingSave ? "Save in progress" : "Discard unsaved changes?"}
-						</AlertDialogTitle>
-						<AlertDialogDescription>
-							{hasPendingSave
-								? "Wait for this save to finish before leaving Settings."
-								: "Your auto-reload settings will return to the last values saved on the server."}
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel>Keep editing</AlertDialogCancel>
-						<AlertDialogAction
-							variant="destructive"
-							onClick={discardChanges}
-							disabled={hasPendingSave}
-						>
-							Discard changes
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
+			<UnsavedNavigationGuard
+				dirty={hasUnsavedChanges}
+				busy={hasPendingSave}
+				shouldBlockFn={shouldBlockNavigation}
+				description="Your auto-reload settings will return to the last values saved on the server."
+			/>
 		</SettingsEditStateContext.Provider>
 	);
 }
@@ -343,7 +336,13 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			return <ApiKeysPanel />;
 		case "billing-wallet":
 			return WalletPage ? (
-				<Suspense fallback={<HostedRouteSkeleton />}>
+				<Suspense
+					fallback={
+						<div className="px-4 lg:px-6">
+							<HostedRouteSkeleton />
+						</div>
+					}
+				>
 					<WalletPage />
 				</Suspense>
 			) : (
@@ -351,7 +350,13 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			);
 		case "billing-plan":
 			return SubscriptionPage ? (
-				<Suspense fallback={<HostedRouteSkeleton />}>
+				<Suspense
+					fallback={
+						<div className="px-4 lg:px-6">
+							<HostedRouteSkeleton />
+						</div>
+					}
+				>
 					<SubscriptionPage />
 				</Suspense>
 			) : (
@@ -359,7 +364,13 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			);
 		case "billing-usage":
 			return UsagePage ? (
-				<Suspense fallback={<HostedRouteSkeleton />}>
+				<Suspense
+					fallback={
+						<div className="px-4 lg:px-6">
+							<HostedRouteSkeleton />
+						</div>
+					}
+				>
 					<UsagePage />
 				</Suspense>
 			) : (

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -293,9 +293,7 @@ export function SettingsDialog({
 						<section className="min-h-0 overflow-y-auto py-6 md:py-8">
 							<div className="mx-auto w-full max-w-5xl">
 								{billingAccessPending ? (
-									<div className="px-4 lg:px-6">
-										<HostedRouteSkeleton />
-									</div>
+									<HostedRouteSkeleton />
 								) : billingAccessError ? (
 									<div className="px-4 lg:px-6">
 										<ApiErrorPanel
@@ -336,13 +334,7 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			return <ApiKeysPanel />;
 		case "billing-wallet":
 			return WalletPage ? (
-				<Suspense
-					fallback={
-						<div className="px-4 lg:px-6">
-							<HostedRouteSkeleton />
-						</div>
-					}
-				>
+				<Suspense fallback={<HostedRouteSkeleton />}>
 					<WalletPage />
 				</Suspense>
 			) : (
@@ -350,13 +342,7 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			);
 		case "billing-plan":
 			return SubscriptionPage ? (
-				<Suspense
-					fallback={
-						<div className="px-4 lg:px-6">
-							<HostedRouteSkeleton />
-						</div>
-					}
-				>
+				<Suspense fallback={<HostedRouteSkeleton />}>
 					<SubscriptionPage />
 				</Suspense>
 			) : (
@@ -364,13 +350,7 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 			);
 		case "billing-usage":
 			return UsagePage ? (
-				<Suspense
-					fallback={
-						<div className="px-4 lg:px-6">
-							<HostedRouteSkeleton />
-						</div>
-					}
-				>
+				<Suspense fallback={<HostedRouteSkeleton />}>
 					<UsagePage />
 				</Suspense>
 			) : (

--- a/apps/web/src/components/settings-panel-error-boundary.tsx
+++ b/apps/web/src/components/settings-panel-error-boundary.tsx
@@ -19,21 +19,23 @@ export class SettingsPanelErrorBoundary extends Component<
 		if (!this.state.failed) return this.props.children;
 
 		return (
-			<Alert variant="destructive">
-				<AlertCircle aria-hidden />
-				<AlertTitle>Couldn’t load this settings section</AlertTitle>
-				<AlertDescription className="flex flex-col items-start gap-3">
-					<span>The settings code didn’t finish loading. Reload the page to try again.</span>
-					<Button
-						type="button"
-						size="sm"
-						variant="outline"
-						onClick={() => window.location.reload()}
-					>
-						<RefreshCw data-icon="inline-start" /> Reload settings
-					</Button>
-				</AlertDescription>
-			</Alert>
+			<div className="px-4 lg:px-6">
+				<Alert variant="destructive">
+					<AlertCircle aria-hidden />
+					<AlertTitle>Couldn’t load this settings section</AlertTitle>
+					<AlertDescription className="flex flex-col items-start gap-3">
+						<span>The settings code didn’t finish loading. Reload the page to try again.</span>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							onClick={() => window.location.reload()}
+						>
+							<RefreshCw data-icon="inline-start" /> Reload settings
+						</Button>
+					</AlertDescription>
+				</Alert>
+			</div>
 		);
 	}
 }

--- a/apps/web/src/components/settings-section.test.tsx
+++ b/apps/web/src/components/settings-section.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsSection } from "@/components/settings-section";
+
+describe("SettingsSection", () => {
+	test("labels the section with an accessible heading at the requested level", () => {
+		const markup = renderToStaticMarkup(
+			<SettingsSection
+				headingLevel={3}
+				title={
+					<>
+						<span aria-hidden>◆</span> Activity
+					</>
+				}
+			>
+				<p>Recent transactions</p>
+			</SettingsSection>,
+		);
+		const titleId = markup.match(/aria-labelledby="([^"]+)"/)?.[1];
+		expect(titleId).toBeTruthy();
+		expect(markup).toContain(`<h3 id="${titleId}"`);
+		expect(markup).toContain("◆");
+	});
+});

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -2,7 +2,10 @@ import { useId } from "react";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
-type SettingsSectionProps = Omit<React.ComponentProps<"section">, "children" | "title"> & {
+type SettingsSectionProps = Omit<
+	React.ComponentProps<"section">,
+	"aria-labelledby" | "children" | "title"
+> & {
 	title: React.ReactNode;
 	description?: React.ReactNode;
 	children?: React.ReactNode;
@@ -21,18 +24,17 @@ export function SettingsSection({
 	...sectionProps
 }: SettingsSectionProps) {
 	const generatedTitleId = useId();
-	const titleId = sectionProps["aria-labelledby"] ?? generatedTitleId;
 	const Heading = headingLevel === 3 ? "h3" : "h2";
 	return (
 		<section
-			aria-labelledby={titleId}
 			{...sectionProps}
+			aria-labelledby={generatedTitleId}
 			className={cn("flex flex-col gap-4", className)}
 		>
 			<Separator />
 			<div className="flex max-w-2xl flex-col gap-1.5">
 				<Heading
-					id={titleId}
+					id={generatedTitleId}
 					className={cn("text-sm font-semibold", variant === "destructive" && "text-destructive")}
 				>
 					{title}

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
@@ -6,6 +7,7 @@ type SettingsSectionProps = Omit<React.ComponentProps<"section">, "children" | "
 	description?: React.ReactNode;
 	children?: React.ReactNode;
 	variant?: "default" | "destructive";
+	headingLevel?: 2 | 3;
 };
 
 /** Flat form/settings section; use SectionLabel for list-group captions and DashboardSection for bordered content containers. */
@@ -15,17 +17,26 @@ export function SettingsSection({
 	children,
 	className,
 	variant = "default",
+	headingLevel = 2,
 	...sectionProps
 }: SettingsSectionProps) {
+	const generatedTitleId = useId();
+	const titleId = sectionProps["aria-labelledby"] ?? generatedTitleId;
+	const Heading = headingLevel === 3 ? "h3" : "h2";
 	return (
-		<section {...sectionProps} className={cn("flex flex-col gap-4", className)}>
+		<section
+			aria-labelledby={titleId}
+			{...sectionProps}
+			className={cn("flex flex-col gap-4", className)}
+		>
 			<Separator />
 			<div className="flex max-w-2xl flex-col gap-1.5">
-				<div
+				<Heading
+					id={titleId}
 					className={cn("text-sm font-semibold", variant === "destructive" && "text-destructive")}
 				>
 					{title}
-				</div>
+				</Heading>
 				{description ? (
 					<div className="text-sm leading-5 text-muted-foreground">{description}</div>
 				) : null}

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -181,12 +181,12 @@ export function ApiKeysPanel() {
 	}
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className="flex flex-col gap-8 px-4 lg:px-6">
 			<SettingsPanelHeader
 				title="API Keys"
 				description="Manage bearer tokens for servers, containers, and other headless environments."
 				actions={
-					<Button type="button" onClick={openCreateDialog} className="sm:mr-8">
+					<Button type="button" onClick={openCreateDialog}>
 						<Plus data-icon="inline-start" />
 						Create API key
 					</Button>

--- a/apps/web/src/components/settings/general-panel.tsx
+++ b/apps/web/src/components/settings/general-panel.tsx
@@ -28,7 +28,7 @@ export function GeneralPanel() {
 	const { theme, setTheme } = useTheme();
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className="flex flex-col gap-8 px-4 lg:px-6">
 			<SettingsPanelHeader title="General" description="Appearance and app-wide preferences." />
 			<div className="flex items-center justify-between gap-4 rounded-lg border p-4">
 				<div className="space-y-0.5">

--- a/apps/web/src/components/settings/profile-panel.tsx
+++ b/apps/web/src/components/settings/profile-panel.tsx
@@ -16,7 +16,7 @@ export function ProfilePanel() {
 	const initial = user?.fullName?.[0] ?? user?.primaryEmailAddress?.emailAddress?.[0] ?? "U";
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className="flex flex-col gap-8 px-4 lg:px-6">
 			<SettingsPanelHeader title="Profile" description="Your account identity." />
 			<div className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
 				<div className="flex items-center gap-4">

--- a/apps/web/src/components/unsaved-navigation-guard.tsx
+++ b/apps/web/src/components/unsaved-navigation-guard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { type ShouldBlockFn, useBlocker } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export function UnsavedNavigationGuard({
+	dirty,
+	busy,
+	description = "Your edits will return to the last values saved on the server.",
+	shouldBlockFn,
+}: {
+	dirty: boolean;
+	busy: boolean;
+	description?: string;
+	shouldBlockFn?: ShouldBlockFn;
+}) {
+	const riskRef = useRef(false);
+	riskRef.current = dirty || busy;
+	const shouldBlock: ShouldBlockFn = useCallback(
+		(args) => riskRef.current && (shouldBlockFn?.(args) ?? true),
+		[shouldBlockFn],
+	);
+	const shouldBlockDocumentExit = useCallback(() => riskRef.current, []);
+	const blocker = useBlocker({
+		shouldBlockFn: shouldBlock,
+		enableBeforeUnload: shouldBlockDocumentExit,
+		withResolver: true,
+	});
+
+	useEffect(() => {
+		if (blocker.status === "blocked" && !dirty && !busy) blocker.proceed();
+	}, [blocker, busy, dirty]);
+
+	return (
+		<AlertDialog
+			open={blocker.status === "blocked"}
+			onOpenChange={(open) => {
+				if (!open && blocker.status === "blocked") blocker.reset();
+			}}
+		>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						{busy ? "Save in progress" : "Discard unsaved changes?"}
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						{busy ? "Wait for this save to finish before leaving." : description}
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Keep editing</AlertDialogCancel>
+					<AlertDialogAction
+						variant="destructive"
+						disabled={busy}
+						onClick={() => {
+							if (blocker.status === "blocked") blocker.proceed();
+						}}
+					>
+						Discard changes
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/web/src/components/unsaved-navigation-state.tsx
+++ b/apps/web/src/components/unsaved-navigation-state.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
+
+type EditState = { dirty: boolean; busy: boolean };
+type RegisterEditState = (token: symbol, state: EditState | null) => void;
+
+const UnsavedNavigationStateContext = createContext<RegisterEditState | null>(null);
+
+export function UnsavedNavigationBoundary({
+	children,
+	description,
+}: {
+	children: ReactNode;
+	description?: string;
+}) {
+	const [states, setStates] = useState<Map<symbol, EditState>>(() => new Map());
+	const register = useCallback((token: symbol, state: EditState | null) => {
+		setStates((current) => {
+			const next = new Map(current);
+			if (state && (state.dirty || state.busy)) next.set(token, state);
+			else next.delete(token);
+			return next;
+		});
+	}, []);
+	const dirty = [...states.values()].some((state) => state.dirty);
+	const busy = [...states.values()].some((state) => state.busy);
+
+	return (
+		<UnsavedNavigationStateContext.Provider value={register}>
+			{children}
+			<UnsavedNavigationGuard dirty={dirty} busy={busy} description={description} />
+		</UnsavedNavigationStateContext.Provider>
+	);
+}
+
+export function useUnsavedNavigationState(state: EditState): boolean {
+	const register = useContext(UnsavedNavigationStateContext);
+	const tokenRef = useRef<symbol | null>(null);
+	if (tokenRef.current === null) tokenRef.current = Symbol("unsaved-navigation-state");
+	const token = tokenRef.current;
+
+	useEffect(() => {
+		if (!register) return;
+		register(token, state);
+		return () => register(token, null);
+	}, [register, state.busy, state.dirty, token]);
+
+	return register !== null;
+}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -98,6 +98,7 @@ import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -3144,6 +3145,11 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 			title="Language & timezone"
 			description="Language and time zone used by this agent."
 		>
+			<UnsavedNavigationGuard
+				dirty={dirty}
+				busy={updateDeployment.isPending}
+				description="Your language and timezone will return to the last values saved on the server."
+			/>
 			<div className="flex max-w-2xl flex-col gap-4">
 				<LiveNote>Changes apply to this agent.</LiveNote>
 				<div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -98,7 +98,10 @@ import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
-import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
+import {
+	UnsavedNavigationBoundary,
+	useUnsavedNavigationState,
+} from "@/components/unsaved-navigation-state";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
@@ -3100,15 +3103,17 @@ function HostedAgentSettingsTab({
 }) {
 	const formatName = useCallback((name: string) => deploymentDisplayName(name, runtime), [runtime]);
 	return (
-		<div className="flex flex-col gap-10">
-			{projectionAvailable ? (
-				<AgentSettingsPanel environmentId={environmentId} formatName={formatName} />
-			) : (
-				<ProjectionDependentUnavailable label="Profile settings" />
-			)}
-			<LanguageTimezoneSettingsSection deployment={deployment} />
-			<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
-		</div>
+		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
+			<div className="flex flex-col gap-10">
+				{projectionAvailable ? (
+					<AgentSettingsPanel environmentId={environmentId} formatName={formatName} />
+				) : (
+					<ProjectionDependentUnavailable label="Profile settings" />
+				)}
+				<LanguageTimezoneSettingsSection deployment={deployment} />
+				<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
+			</div>
+		</UnsavedNavigationBoundary>
 	);
 }
 
@@ -3139,17 +3144,13 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 		[configTimezone, runtimeTimezoneOptions, timezone],
 	);
 	const dirty = language !== configLanguage || timezone !== configTimezone;
+	useUnsavedNavigationState({ dirty, busy: updateDeployment.isPending });
 
 	return (
 		<SettingsSection
 			title="Language & timezone"
 			description="Language and time zone used by this agent."
 		>
-			<UnsavedNavigationGuard
-				dirty={dirty}
-				busy={updateDeployment.isPending}
-				description="Your language and timezone will return to the last values saved on the server."
-			/>
 			<div className="flex max-w-2xl flex-col gap-4">
 				<LiveNote>Changes apply to this agent.</LiveNote>
 				<div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Link, useSearch } from "@tanstack/react-router";
 import {
 	CreditCard,
 	ExternalLink,
@@ -23,7 +24,6 @@ import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
-import { settingsQueryHref } from "@/lib/settings-routes";
 import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.logic";
 
 export function ComputeDunningBanner({ deployment }: { deployment: HostedDeployment }) {
@@ -35,6 +35,10 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 		enabled: state?.ctaTarget === "top_up",
 	});
 	const [topUpOpen, setTopUpOpen] = useState(false);
+	const routeSearch = useSearch({ from: "/_protected/_dashboard" });
+	const billingHistoryLink = (
+		<Link to="." search={{ ...routeSearch, settings: "billing-plan" }} hash="billing-history" />
+	);
 
 	if (!state) return null;
 
@@ -119,12 +123,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 							<Plus data-icon="inline-start" /> Start a new subscription
 						</Button>
 					) : state.ctaTarget === "billing_history" ? (
-						<Button
-							render={<a href={settingsQueryHref("billing-plan")} />}
-							nativeButton={false}
-							size="sm"
-							variant="outline"
-						>
+						<Button render={billingHistoryLink} nativeButton={false} size="sm" variant="outline">
 							<History data-icon="inline-start" /> View billing history
 						</Button>
 					) : state.ctaTarget === "support" ? (
@@ -154,12 +153,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 						</Button>
 					) : null}
 					{state.secondaryTarget === "billing_history" ? (
-						<Button
-							render={<a href={settingsQueryHref("billing-plan")} />}
-							nativeButton={false}
-							size="sm"
-							variant="outline"
-						>
+						<Button render={billingHistoryLink} nativeButton={false} size="sm" variant="outline">
 							<History data-icon="inline-start" /> View billing history
 						</Button>
 					) : state.secondaryTarget === "support" ? (

--- a/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
@@ -3,6 +3,7 @@
 import { ExternalLink, Receipt } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
+import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -88,20 +89,13 @@ export function BillingHistorySection() {
 	const rows = history.data?.pages.flatMap((page) => page.data ?? []) ?? [];
 
 	return (
-		<section
+		<SettingsSection
+			id="billing-history"
 			data-hosted="true"
-			className="flex flex-col gap-3"
-			aria-labelledby="billing-history-title"
+			headingLevel={3}
+			title="Billing history"
+			description="Invoices for card and Wallet-funded compute subscriptions."
 		>
-			<div>
-				<h2 id="billing-history-title" className="text-base font-semibold">
-					Billing history
-				</h2>
-				<p className="text-sm text-muted-foreground">
-					Invoices for card and Wallet-funded compute subscriptions.
-				</p>
-			</div>
-
 			{history.isLoading ? (
 				<div className="flex flex-col gap-px overflow-hidden rounded-lg border">
 					{Array.from({ length: 3 }, (_, index) => `history-skeleton-${index}`).map((key) => (
@@ -207,6 +201,6 @@ export function BillingHistorySection() {
 					) : null}
 				</>
 			)}
-		</section>
+		</SettingsSection>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -15,7 +15,6 @@ import { usePlans } from "@/hosted/billing/hooks";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { BillingHistorySection } from "@/hosted/billing/subscription/billing-history-section";
 import { PlanComparison } from "@/hosted/billing/subscription/plan-comparison";
-import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { shouldBlockQueryError } from "@/lib/query-state";
@@ -71,8 +70,6 @@ export function SubscriptionPage() {
 	return (
 		<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
 			<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
-
-			<WelcomeWalletCard />
 
 			<SettingsSection
 				headingLevel={3}

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -5,10 +5,9 @@ import { CreditCard, Rocket } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { PageHeader } from "@/components/page-header";
-import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
+import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { SubscriptionSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
@@ -20,14 +19,10 @@ import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { shouldBlockQueryError } from "@/lib/query-state";
-import { cn } from "@/lib/utils";
 
 const DESCRIPTION =
 	"Plan options for new hosted agents. Existing compute is managed from each agent’s Settings.";
-const SUBSCRIPTION_PAGE_CLASS = cn(
-	CENTERED_PAGE_WIDTH_CLASS.page,
-	"flex flex-col gap-6 px-4 lg:px-6",
-);
+const SUBSCRIPTION_PAGE_CLASS = "flex flex-col gap-8 px-4 lg:px-6";
 
 export function SubscriptionPage() {
 	const plans = usePlans();
@@ -54,7 +49,7 @@ export function SubscriptionPage() {
 	if (plans.isLoading) {
 		return (
 			<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
-				<PageHeader title="Compute" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
 				<SubscriptionSkeleton />
 			</div>
 		);
@@ -63,7 +58,7 @@ export function SubscriptionPage() {
 	if (shouldBlockQueryError(plans.error, plans.data)) {
 		return (
 			<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
-				<PageHeader title="Compute" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={plans.error}
@@ -76,40 +71,34 @@ export function SubscriptionPage() {
 
 	return (
 		<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
-			<PageHeader title="Compute" description={DESCRIPTION} />
+			<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
 
 			<WelcomeWalletCard />
 
-			<Card data-hosted="true">
-				<CardHeader>
-					<CardTitle>Compute is managed per agent</CardTitle>
-					<CardDescription>Deploy new hosted agents from here.</CardDescription>
-				</CardHeader>
-				<CardContent className="space-y-4">
-					<p className="text-sm text-muted-foreground">
-						Upgrade, lifecycle, and delete controls live in that agent’s Settings page. Wallet
-						balance and Clawdi AI usage stay account-wide.
-					</p>
-					<div className="flex flex-wrap gap-2">
-						{hostedAccess.canCreateCloudAgents ? (
-							<Button render={<Link to="/deploy" />} nativeButton={false}>
-								<Rocket /> Deploy hosted agent
-							</Button>
-						) : (
-							<Button disabled>
-								<Rocket /> Deploy hosted agent
-							</Button>
-						)}
-						<Button
-							variant="outline"
-							onClick={() => runAction(openBillingPortal)}
-							disabled={portal.isPending}
-						>
-							{portal.isPending ? <Spinner /> : <CreditCard />} Open billing portal
+			<SettingsSection
+				headingLevel={3}
+				title="Manage compute"
+				description="Deploy a new hosted agent here. Manage existing plans from each agent’s Settings."
+			>
+				<div className="flex flex-wrap gap-2">
+					{hostedAccess.canCreateCloudAgents ? (
+						<Button render={<Link to="/deploy" />} nativeButton={false}>
+							<Rocket /> Deploy hosted agent
 						</Button>
-					</div>
-				</CardContent>
-			</Card>
+					) : (
+						<Button disabled>
+							<Rocket /> Deploy hosted agent
+						</Button>
+					)}
+					<Button
+						variant="outline"
+						onClick={() => runAction(openBillingPortal)}
+						disabled={portal.isPending}
+					>
+						{portal.isPending ? <Spinner /> : <CreditCard />} Open billing portal
+					</Button>
+				</div>
+			</SettingsSection>
 
 			<BillingHistorySection />
 

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -20,8 +20,7 @@ import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
-const DESCRIPTION =
-	"Plan options for new hosted agents. Existing compute is managed from each agent’s Settings.";
+const DESCRIPTION = "Plans and account billing for hosted agents.";
 const SUBSCRIPTION_PAGE_CLASS = "flex flex-col gap-8 px-4 lg:px-6";
 
 export function SubscriptionPage() {

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -4,8 +4,7 @@ import { Activity, AlertCircle, RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
-import { PageHeader } from "@/components/page-header";
-import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,10 +25,9 @@ import {
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
-import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Clawdi AI usage in USD for the current reporting window across your agents.";
-const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
+const USAGE_PAGE_CLASS = "flex flex-col gap-8 px-4 lg:px-6";
 
 type UnavailableUsageSection = HostedUsageSummary["unavailable_sections"][number];
 
@@ -78,7 +76,7 @@ export function UsagePage() {
 	if (usage.isLoading) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<PageHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
 				<UsageSkeleton />
 			</div>
 		);
@@ -87,7 +85,7 @@ export function UsagePage() {
 	if (shouldBlockQueryError(usage.error, usage.data) || !usage.data) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<PageHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={usage.error}
@@ -135,7 +133,7 @@ export function UsageSummaryView({
 	if (usage.availability === "unavailable") {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<PageHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
 				<EmptyState
 					icon={AlertCircle}
 					title="We can’t load your usage right now"
@@ -169,7 +167,7 @@ export function UsageSummaryView({
 	if (isRealZero) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<PageHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
 				<EmptyState
 					icon={Activity}
 					title="No usage yet"
@@ -181,7 +179,7 @@ export function UsageSummaryView({
 
 	return (
 		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-			<PageHeader
+			<SettingsPanelHeader
 				title="Usage"
 				description={
 					totals

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/empty-state";
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
 import type { HostedUsageSummary, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
@@ -239,7 +239,7 @@ export function UsageSummaryView({
 
 			<Card data-hosted="true">
 				<CardHeader>
-					<CardTitle className="text-base">Daily consumption</CardTitle>
+					<h3 className="text-base leading-normal font-medium">Daily consumption</h3>
 				</CardHeader>
 				<CardContent>
 					{missingSectionSet.has("by_day") ? (
@@ -297,7 +297,7 @@ export function UsageSummaryView({
 
 			<Card data-hosted="true">
 				<CardHeader>
-					<CardTitle className="text-base">By model</CardTitle>
+					<h3 className="text-base leading-normal font-medium">By model</h3>
 				</CardHeader>
 				<CardContent className="flex flex-col gap-4">
 					{missingSectionSet.has("by_model") ? (

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -191,6 +191,7 @@ export function AutoReloadCard({
 
 	return (
 		<SettingsSection
+			headingLevel={3}
 			data-hosted="true"
 			title={
 				<span className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -137,9 +137,9 @@ export function LedgerTable({
 		<section data-hosted="true" className="flex flex-col gap-4" aria-labelledby={headingId}>
 			<Separator />
 			<div className="flex items-center justify-between gap-2">
-				<h2 id={headingId} className="text-sm font-semibold">
+				<h3 id={headingId} className="text-sm font-semibold">
 					Activity
-				</h2>
+				</h3>
 				<Select
 					items={LEDGER_FILTER_ITEMS}
 					value={filter}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -4,8 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { PageHeader } from "@/components/page-header";
-import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
@@ -29,10 +28,9 @@ import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { env } from "@/lib/env";
 import { shouldBlockQueryError } from "@/lib/query-state";
-import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Add funds and manage how your Clawdi usage is paid.";
-const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-8 px-4 lg:px-6");
+const WALLET_PAGE_CLASS = "flex flex-col gap-8 px-4 lg:px-6";
 
 function scrollToAutoReload() {
 	const section = document.getElementById("auto-reload");
@@ -136,7 +134,7 @@ export function WalletPage() {
 	if (wallet.isLoading) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Wallet" description={DESCRIPTION} />
 				<WalletSkeleton />
 			</div>
 		);
@@ -145,7 +143,7 @@ export function WalletPage() {
 	if (shouldBlockQueryError(wallet.error, wallet.data) || !wallet.data) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} />
+				<SettingsPanelHeader title="Wallet" description={DESCRIPTION} />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={wallet.error}
@@ -164,7 +162,7 @@ export function WalletPage() {
 
 	return (
 		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-			<PageHeader title="Wallet" description={DESCRIPTION} />
+			<SettingsPanelHeader title="Wallet" description={DESCRIPTION} />
 
 			<TopUpDialog
 				open={topUpOpen}

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -13,6 +13,7 @@ export function X402Card({ enabled }: { enabled: boolean }) {
 	if (!enabled) {
 		return (
 			<SettingsSection
+				headingLevel={3}
 				data-hosted="true"
 				title={
 					<span className="flex flex-wrap items-center gap-2">
@@ -36,6 +37,7 @@ function EnabledX402Card() {
 
 	return (
 		<SettingsSection
+			headingLevel={3}
 			data-hosted="true"
 			title={
 				<span className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/lib/settings-routes.test.ts
+++ b/apps/web/src/lib/settings-routes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { settingsDraftOwnerChanges, validateDashboardSettingsSearch } from "@/lib/settings-routes";
+import {
+	settingsDraftOwnerChanges,
+	shouldCanonicalizeCloudSettings,
+	validateDashboardSettingsSearch,
+} from "@/lib/settings-routes";
 
 describe("dashboard Settings search", () => {
 	test("blocks only navigation that changes the Settings draft owner", () => {
@@ -34,5 +38,22 @@ describe("dashboard Settings search", () => {
 		expect(validateDashboardSettingsSearch({ settings: "unknown", keep: "yes" })).toEqual({
 			keep: "yes",
 		});
+	});
+
+	test("canonicalizes denied Cloud deep links only after access and inventory resolve", () => {
+		const denied = {
+			section: "billing-plan" as const,
+			accessLoading: false,
+			accessError: false,
+			canCreateCloudAgents: false,
+			inventoryResolved: true,
+			hasExistingCloudAgents: false,
+		};
+		expect(shouldCanonicalizeCloudSettings(denied)).toBe(true);
+		expect(shouldCanonicalizeCloudSettings({ ...denied, accessLoading: true })).toBe(false);
+		expect(shouldCanonicalizeCloudSettings({ ...denied, inventoryResolved: false })).toBe(false);
+		expect(shouldCanonicalizeCloudSettings({ ...denied, hasExistingCloudAgents: true })).toBe(
+			false,
+		);
 	});
 });

--- a/apps/web/src/lib/settings-routes.ts
+++ b/apps/web/src/lib/settings-routes.ts
@@ -51,6 +51,31 @@ export function settingsDraftOwnerChanges(
 	return current.pathname !== next.pathname || currentSection !== nextSection;
 }
 
+export function shouldCanonicalizeCloudSettings({
+	section,
+	accessLoading,
+	accessError,
+	canCreateCloudAgents,
+	inventoryResolved,
+	hasExistingCloudAgents,
+}: {
+	section: SettingsSectionId;
+	accessLoading: boolean;
+	accessError: boolean;
+	canCreateCloudAgents: boolean;
+	inventoryResolved: boolean;
+	hasExistingCloudAgents: boolean;
+}): boolean {
+	return (
+		section.startsWith("billing-") &&
+		!accessLoading &&
+		!accessError &&
+		inventoryResolved &&
+		!canCreateCloudAgents &&
+		!hasExistingCloudAgents
+	);
+}
+
 export function settingsQueryHref(
 	section: SettingsSectionId = DEFAULT_SETTINGS_SECTION,
 	params?: URLSearchParams | ReadonlyURLSearchParams,


### PR DESCRIPTION
## Summary
- preserve typed route search in billing-history links and canonicalize unavailable Cloud Settings deep links after access and inventory resolve
- align embedded Settings headings, gutters, section semantics, mobile active-nav scrolling, and simplify Compute without flattening legitimate cards
- protect connected display-name and hosted language/timezone drafts with a shared navigation guard, including pending saves

## Verification
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web build:oss`
- focused Bun tests: 22 passed
- Playwright API Keys Settings desktop/mobile: 2 passed
- Playwright connected-agent unsaved navigation: 1 passed
- `git diff --check`