### PR TITLE
Pin test PostgreSQL to production PG18 image

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,6 +8,8 @@ on:
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
+      - "config/postgres-image.txt"
+      - "docker-compose.test.yml"
       - "deploy/self-host/**"
       - "apps/web/Dockerfile"
       - ".dockerignore"
@@ -16,6 +18,7 @@ on:
       - "bun.lock"
       - "scripts/openapi-typescript.sh"
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+      - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
       - ".github/actions/setup-bun-ci/**"
       - ".github/workflows/backend-ci.yml"
@@ -28,6 +31,8 @@ on:
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
+      - "config/postgres-image.txt"
+      - "docker-compose.test.yml"
       - "deploy/self-host/**"
       - "apps/web/Dockerfile"
       - ".dockerignore"
@@ -36,6 +41,7 @@ on:
       - "bun.lock"
       - "scripts/openapi-typescript.sh"
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+      - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
       - ".github/actions/setup-bun-ci/**"
       - ".github/workflows/backend-ci.yml"
@@ -83,14 +89,21 @@ jobs:
               - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
               - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+              - "scripts/check_postgres_image_parity.py"
               - "config/deploy.yml"
+              - "config/postgres-image.txt"
+              - "docker-compose.test.yml"
             test:
               - "backend/app/**"
               - "backend/tests/**"
               - "backend/alembic/**"
+              - "backend/scripts/check_postgres_runtime.py"
               - "backend/pyproject.toml"
               - "backend/uv.lock"
               - "backend/Dockerfile"
+              - "config/postgres-image.txt"
+              - "docker-compose.test.yml"
+              - "scripts/check_postgres_image_parity.py"
               - ".github/workflows/backend-ci.yml"
             sidecar:
               - "packages/whatsapp-baileys-sidecar/**"
@@ -127,6 +140,8 @@ jobs:
         with:
           bun-version: "1.3.14"
       - run: uv sync --frozen --no-install-project
+      - name: PostgreSQL image parity
+        run: uv run python ../scripts/check_postgres_image_parity.py
       - name: uv lock is current
         run: uv lock --check
       - name: Dependency authority
@@ -167,18 +182,19 @@ jobs:
         working-directory: backend
     services:
       postgres:
-        # pgvector image ships PG 16 + pgvector + pg_trgm preinstalled as extensions.
-        image: pgvector/pgvector:pg16
+        # Workflow services require a literal; the parity contract guards it.
+        image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18@sha256:a1fdff3df831a4cd165795cc4c78d5e8d99ed7d279438e59fc30d75b8d10dd67
         env:
           POSTGRES_DB: clawdi_test
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
         ports: ["5432:5432"]
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test -d clawdi_test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+          --tmpfs /var/lib/postgresql:rw,nosuid,nodev,noexec,size=1g
     env:
       DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/clawdi_test
       ENCRYPTION_KEY: test-encryption-key-32-chars-xxxx
@@ -194,11 +210,8 @@ jobs:
           prune-cache: true
           cache-dependency-glob: backend/uv.lock
       - run: uv sync --frozen --no-install-project
-      - name: Enable Postgres extensions
-        run: |
-          PGPASSWORD=test psql -h localhost -U test -d clawdi_test \
-            -c 'CREATE EXTENSION IF NOT EXISTS vector;' \
-            -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+      - name: Verify PostgreSQL runtime contract
+        run: uv run python scripts/check_postgres_runtime.py
       - name: Run migrations
         run: uv run alembic upgrade head
       - name: Project-sharing migration downgrade/upgrade round trip

--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -16,6 +16,8 @@ on:
       - "docker/**"
       - ".dockerignore"
       - "docker-compose.test.yml"
+      - "config/postgres-image.txt"
+      - "scripts/check_postgres_image_parity.py"
       - "scripts/test.sh"
       - "package.json"
       - "bun.lock"
@@ -41,6 +43,7 @@ on:
       - "backend/uv.lock"
       - "backend/tests/conftest.py"
       - "backend/tests/test_smoke.py"
+      - "backend/scripts/check_postgres_runtime.py"
       - ".github/workflows/clean-test-runner-ci.yml"
   push:
     branches: [main]
@@ -48,6 +51,8 @@ on:
       - "docker/**"
       - ".dockerignore"
       - "docker-compose.test.yml"
+      - "config/postgres-image.txt"
+      - "scripts/check_postgres_image_parity.py"
       - "scripts/test.sh"
       - "package.json"
       - "bun.lock"
@@ -73,6 +78,7 @@ on:
       - "backend/uv.lock"
       - "backend/tests/conftest.py"
       - "backend/tests/test_smoke.py"
+      - "backend/scripts/check_postgres_runtime.py"
       - ".github/workflows/clean-test-runner-ci.yml"
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -366,8 +366,9 @@ their own temporary stub binaries without touching the host. Dependency caches
 are intentionally per-run inside the container; only Docker image layers and
 build cache are reused by the Docker daemon. It does not force `CLAWDI_HOME`, so
 tests can still isolate Clawdi state through the same home/config paths as the
-product. Backend tests use a temporary `pgvector/pgvector:0.8.1-pg16` Postgres
-service and do not reuse the dev database.
+product. Backend tests use the production-pinned PostgreSQL 18.4 image from
+`config/postgres-image.txt`, verify pgvector 0.8.6 and loadable `pg_trgm`, and
+do not reuse the dev database.
 
 Clean Test Runner CI uses the first-class `ci` profile to exercise the runner
 contract in one container without repeating the full web and CLI product

--- a/backend/scripts/check_postgres_runtime.py
+++ b/backend/scripts/check_postgres_runtime.py
@@ -1,0 +1,64 @@
+"""Verify the throwaway test database matches the production PostgreSQL contract."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from urllib.parse import urlparse
+
+import asyncpg
+
+EXPECTED_SERVER_VERSION_NUM = 180004
+EXPECTED_VECTOR_VERSION = "0.8.6"
+EXPECTED_DATA_DIRECTORY = "/var/lib/postgresql/18/docker"
+
+
+async def check_runtime() -> None:
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url.startswith("postgresql+asyncpg://"):
+        raise RuntimeError("DATABASE_URL must use postgresql+asyncpg")
+    asyncpg_url = database_url.replace("+asyncpg", "", 1)
+    parsed_url = urlparse(asyncpg_url)
+    if parsed_url.hostname not in {"localhost", "127.0.0.1", "postgres"}:
+        raise RuntimeError("runtime contract requires a local throwaway PostgreSQL host")
+    if parsed_url.path != "/clawdi_test":
+        raise RuntimeError("runtime contract requires the clawdi_test database")
+
+    connection = await asyncpg.connect(asyncpg_url)
+    try:
+        server_version_num = int(await connection.fetchval("SHOW server_version_num"))
+        if server_version_num != EXPECTED_SERVER_VERSION_NUM:
+            raise RuntimeError(
+                f"expected PostgreSQL 18.4 ({EXPECTED_SERVER_VERSION_NUM}), "
+                f"got {server_version_num}"
+            )
+
+        data_directory = await connection.fetchval("SHOW data_directory")
+        if data_directory != EXPECTED_DATA_DIRECTORY:
+            raise RuntimeError(f"unexpected PostgreSQL data_directory: {data_directory}")
+
+        await connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        vector_version = await connection.fetchval(
+            "SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+        )
+        if vector_version != EXPECTED_VECTOR_VERSION:
+            raise RuntimeError(f"expected pgvector {EXPECTED_VECTOR_VERSION}, got {vector_version}")
+
+        await connection.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        pg_trgm_version = await connection.fetchval(
+            "SELECT extversion FROM pg_extension WHERE extname = 'pg_trgm'"
+        )
+        if not pg_trgm_version:
+            raise RuntimeError("pg_trgm extension was not loadable")
+    finally:
+        await connection.close()
+
+    print(
+        "PostgreSQL runtime contract passed: "
+        f"server_version_num={server_version_num}, vector={vector_version}, "
+        f"pg_trgm={pg_trgm_version}, data_directory={data_directory}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(check_runtime())

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -129,7 +129,9 @@ accessories:
         - CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN
 
   postgres:
-    image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18 # pgvector pg18 + pgBackRest (WAL archiving to R2)
+    # Immutable authority: config/postgres-image.txt. The parity contract keeps
+    # this literal copy aligned because Kamal cannot import that plain-text file.
+    image: &postgres-image ghcr.io/clawdi-ai/postgres-pgbackrest:pg18@sha256:a1fdff3df831a4cd165795cc4c78d5e8d99ed7d279438e59fc30d75b8d10dd67 # pgvector pg18 + pgBackRest (WAL archiving to R2)
     host: <%= ENV.fetch("DEPLOY_HOST") %>
     options:
       ulimit: nofile=65536:65536
@@ -170,7 +172,7 @@ accessories:
   postgres-backup:
     # Scheduled pgBackRest runs (Sunday full, daily diff) against the server's
     # shared data and socket volumes. See docs/ops/postgres-backup-restore.md.
-    image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18
+    image: *postgres-image
     host: <%= ENV.fetch("DEPLOY_HOST") %>
     cmd: gosu postgres supercronic /etc/pgbackrest/backup-cron
     volumes:

--- a/config/postgres-image.txt
+++ b/config/postgres-image.txt
@@ -1,0 +1,1 @@
+ghcr.io/clawdi-ai/postgres-pgbackrest:pg18@sha256:a1fdff3df831a4cd165795cc4c78d5e8d99ed7d279438e59fc30d75b8d10dd67

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,7 +34,9 @@ services:
         condition: service_healthy
 
   postgres:
-    image: pgvector/pgvector:0.8.1-pg16
+    # Compose cannot import config/postgres-image.txt; the parity contract
+    # keeps this required literal copy equal to that authority.
+    image: ghcr.io/clawdi-ai/postgres-pgbackrest:pg18@sha256:a1fdff3df831a4cd165795cc4c78d5e8d99ed7d279438e59fc30d75b8d10dd67
     cpus: ${CLAWDI_TEST_POSTGRES_CPUS:-2}
     mem_limit: ${CLAWDI_TEST_POSTGRES_MEMORY_LIMIT:-1g}
     memswap_limit: ${CLAWDI_TEST_POSTGRES_MEMORY_LIMIT:-1g}
@@ -45,7 +47,7 @@ services:
       POSTGRES_USER: clawdi
       POSTGRES_PASSWORD: clawdi_test
     tmpfs:
-      - /var/lib/postgresql/data:rw,nosuid,nodev,noexec,size=1g
+      - /var/lib/postgresql:rw,nosuid,nodev,noexec,size=1g
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U clawdi -d clawdi_test"]
       interval: 2s

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -47,9 +47,10 @@ cd backend && pdm test
 
 That command bind-mounts the host checkout read-only, copies it into an
 isolated container workspace, runs `uv sync` inside the container, starts a
-throwaway `pgvector/pgvector:pg16` Postgres service, applies Alembic migrations,
-and runs pytest. It also uses fake home/cache directories backed by container
-tmpfs and does not reuse the dev database.
+throwaway production-pinned PostgreSQL 18.4 service with pgvector 0.8.6, checks
+its runtime contract, applies Alembic migrations, and runs pytest. It also uses
+fake home/cache directories backed by container tmpfs and does not reuse the
+dev database.
 
 The PDM `test` command returns to the same Docker entrypoint. Raw
 `uv run pytest` remains an explicit host-local workflow only.
@@ -109,13 +110,14 @@ Long-lived shared test databases rot because other branches migrate or stamp
 them differently. The reliable pattern is a throwaway Postgres on a free port:
 
 ```bash
+POSTGRES_IMAGE="$(<config/postgres-image.txt)"
 CID=$(
   docker run --rm -d \
     -e POSTGRES_USER=clawdi \
     -e POSTGRES_PASSWORD=clawdi_test \
     -e POSTGRES_DB=clawdi_test \
     -p 127.0.0.1::5432 \
-    pgvector/pgvector:pg16
+    "$POSTGRES_IMAGE"
 )
 cleanup() {
   docker rm -f "$CID" >/dev/null
@@ -128,6 +130,7 @@ PORT=$(docker port "$CID" 5432/tcp | sed 's/.*://')
 export DATABASE_URL="postgresql+asyncpg://clawdi:clawdi_test@127.0.0.1:${PORT}/clawdi_test"
 
 cd backend
+uv run python scripts/check_postgres_runtime.py
 uv run alembic upgrade head
 uv run pytest -q
 ```

--- a/scripts/check_postgres_image_parity.py
+++ b/scripts/check_postgres_image_parity.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fail closed when PostgreSQL test or deploy image references drift."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORITY = ROOT / "config/postgres-image.txt"
+PIN_PATTERN = re.compile(r"ghcr\.io/clawdi-ai/postgres-pgbackrest:pg18@sha256:[0-9a-f]{64}")
+MAPPING_LINE = re.compile(r"^( *)([A-Za-z0-9_-]+):(?:[ \t]*(.*))?$")
+
+
+class ParityError(RuntimeError):
+    """A checked PostgreSQL image reference diverged from its authority."""
+
+
+def mapping_scalars(content: str) -> list[tuple[tuple[str, ...], str]]:
+    """Return scalar assignments with their indentation-derived YAML paths."""
+    stack: list[tuple[int, str]] = []
+    assignments: list[tuple[tuple[str, ...], str]] = []
+    for line in content.splitlines():
+        match = MAPPING_LINE.match(line)
+        if match is None:
+            continue
+        indent = len(match.group(1))
+        key = match.group(2)
+        raw_value = (match.group(3) or "").strip()
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        path = tuple(item[1] for item in stack) + (key,)
+        value = raw_value.split(" #", 1)[0].strip()
+        if value:
+            assignments.append((path, value))
+        else:
+            stack.append((indent, key))
+    return assignments
+
+
+def values_at_suffix(
+    assignments: list[tuple[tuple[str, ...], str]], suffix: tuple[str, ...]
+) -> list[str]:
+    return [value for path, value in assignments if path[-len(suffix) :] == suffix]
+
+
+def validate_image_assignments(authority: str, contents: dict[str, str] | None = None) -> None:
+    """Validate every test and production PostgreSQL image field."""
+    expected_services = {
+        ".github/workflows/backend-ci.yml": (
+            ("services", "postgres", "image"),
+            ("services", "postgres", "env", "PGDATA"),
+        ),
+        "docker-compose.test.yml": (
+            ("services", "postgres", "image"),
+            ("services", "postgres", "environment", "PGDATA"),
+        ),
+    }
+    if contents is None:
+        filenames = (*expected_services, "config/deploy.yml")
+        contents = {
+            filename: (ROOT / filename).read_text(encoding="utf-8") for filename in filenames
+        }
+
+    for filename, (image_suffix, pgdata_suffix) in expected_services.items():
+        assignments = mapping_scalars(contents[filename])
+        if values_at_suffix(assignments, image_suffix) != [authority]:
+            raise ParityError(f"{filename} PostgreSQL image must equal authority")
+        if values_at_suffix(assignments, pgdata_suffix):
+            raise ParityError(f"{filename} must exercise the pinned image's PGDATA default")
+
+    deploy_assignments = mapping_scalars(contents["config/deploy.yml"])
+    primary = values_at_suffix(deploy_assignments, ("accessories", "postgres", "image"))
+    if primary != [f"&postgres-image {authority}"]:
+        raise ParityError("config/deploy.yml postgres image anchor must equal authority")
+    backup = values_at_suffix(deploy_assignments, ("accessories", "postgres-backup", "image"))
+    if backup != ["*postgres-image"]:
+        raise ParityError("config/deploy.yml postgres-backup must reuse postgres anchor")
+
+
+def main() -> None:
+    authority = AUTHORITY.read_text(encoding="utf-8").strip()
+    if PIN_PATTERN.fullmatch(authority) is None:
+        raise SystemExit(
+            "PostgreSQL image parity failed: config/postgres-image.txt must "
+            "contain one immutable pg18 image with exactly 64 digest hex characters"
+        )
+    try:
+        validate_image_assignments(authority)
+    except ParityError as error:
+        raise SystemExit(f"PostgreSQL image parity failed: {error}") from error
+    print(f"PostgreSQL image parity passed: {authority}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -48,6 +48,7 @@ run_on_host() {
 		shift
 	fi
 	validate_suite "$suite"
+	python3 "$repo_root/scripts/check_postgres_image_parity.py"
 
 	cleanup() {
 		compose down --remove-orphans --volumes >/dev/null
@@ -164,6 +165,7 @@ backend_tests() {
 			fi
 			sleep 1
 		done
+		uv run python scripts/check_postgres_runtime.py
 		uv run alembic upgrade head
 		uv run pytest -q "$@"
 	)


### PR DESCRIPTION
## Summary

- replace Docker Hub PG16 service images in backend CI and the hermetic test runner with the immutable production PostgreSQL image
- pin Kamal primary and backup accessories to the same digest through a shared YAML anchor
- add an authoritative image ref, semantic parity check, and runtime probe for PostgreSQL 18.4, pgvector 0.8.6, pg_trgm, and the PG18 data directory
- keep persistent local and self-host PostgreSQL 16 configurations unchanged because they require a separate major-version migration

Production image provenance: Clawdi-AI/clawdi-hosted Actions run 30731504220, source commit `3a7e1e8a6b9e2ed68fead8626b9d4e1f52ad6d51`.

## Verification

- anonymous OCI manifest resolution for `sha256:a1fdff3df831a4cd165795cc4c78d5e8d99ed7d279438e59fc30d75b8d10dd67`
- isolated runtime probe: PostgreSQL 18.4, pgvector 0.8.6, pg_trgm 1.6, `/var/lib/postgresql/18/docker`
- Alembic upgrade to head
- backend smoke: 6 passed
- clean-runner contract: 8 passed
- parity contract, Compose rendering, Ruff, YAML/ERB deploy rendering, and diff checks

No production operation or persistent database migration was performed. No snapshot, source-string, or structure-locking regression test was added.