### PR TITLE
Render paired chat counts as links

### DIFF
--- a/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
@@ -73,7 +73,10 @@ export function PairedChatsDialog({
 		<button
 			type="button"
 			data-agent-paired-chats-trigger={linkId}
-			className={cn(buttonVariants({ variant: "outline", size: "xs" }), "max-w-full justify-start")}
+			className={cn(
+				buttonVariants({ variant: "link", size: "xs" }),
+				"h-auto max-w-full justify-start p-0 text-sm",
+			)}
 			aria-controls={panelId}
 		>
 			<span data-agent-paired-chats-label className="whitespace-nowrap">


### PR DESCRIPTION
## Summary

- render the paired-chat count trigger with the shared link visual variant instead of an outlined chip
- remove chip sizing and padding while preserving the button semantics, Dialog/Sheet behavior, count copy, focus state, and accessible name
- apply the shared trigger consistently to Telegram, Discord, and WhatsApp Agent channel cards

## Verification

- isolated web typecheck
- existing channel card and convergence tests: 11 passed
- OSS production build
- Biome and diff checks

No regression test was added or modified.