### PR TITLE
Keep Shared WhatsApp pair links available

### DIFF
--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -883,11 +883,7 @@ async def _whatsapp_pair_deep_link(
     ):
         return None
     registry = get_active_whatsapp_sidecar_registry()
-    if (
-        registry is None
-        or not registry.managed_is_bound(account.id)
-        or registry.managed_account_revision(account.id) != configured_revision
-    ):
+    if registry is None or registry.managed_account_revision(account.id) != configured_revision:
         return None
     client = registry.get_managed_client(account.id)
     if client is None:
@@ -896,7 +892,7 @@ async def _whatsapp_pair_deep_link(
         health = await client.health()
     except WhatsAppSidecarError:
         return None
-    if health.status != "connected" or not health.connected or not health.registered:
+    if not health.registered:
         return None
     phone_number = whatsapp_phone_number_from_pn_jid(health.account_jid)
     if phone_number is None:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11776,7 +11776,7 @@ async def _create_whatsapp_pair_target(
 
 
 @pytest.mark.asyncio
-async def test_whatsapp_pair_code_returns_click_to_chat_for_bound_public_managed_pn(
+async def test_whatsapp_pair_code_returns_click_to_chat_for_registered_public_managed_pn(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     channel_agent,
@@ -11800,7 +11800,7 @@ async def test_whatsapp_pair_code_returns_click_to_chat_for_bound_public_managed
             account_jid="15551234567:17@s.whatsapp.net",
         )
     )
-    registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar)
+    registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar, bound=False)
     monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_registry", lambda: registry)
 
     response = await client.post(
@@ -11816,6 +11816,47 @@ async def test_whatsapp_pair_code_returns_click_to_chat_for_bound_public_managed
     assert pair["qr_payload"] == expected
     assert sidecar.health_calls == 1
     assert "s.whatsapp.net" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_pair_code_keeps_click_to_chat_during_registered_transport_disconnect(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created, link = await _create_whatsapp_pair_target(client, agent_id=channel_agent.id)
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
+    account.config = {
+        "connection_mode": "baileys_managed",
+        "sidecar_config_revision": "trusted-managed-revision",
+    }
+    await db_session.commit()
+    sidecar = _WhatsAppPairLinkSidecar(
+        WhatsAppSidecarHealth(
+            status="disconnected",
+            connected=False,
+            registered=True,
+            account_jid="15557654321@s.whatsapp.net",
+        )
+    )
+    registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar, bound=False)
+    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_registry", lambda: registry)
+
+    response = await client.post(
+        f"/v1/channels/{account.id}/pair-codes",
+        json={"agent_link_id": link["id"], "ttl_seconds": 900},
+    )
+
+    assert response.status_code == 201, response.text
+    pair = response.json()
+    expected = f"https://wa.me/15557654321?text=%2Fclawdi_pair%20{pair['code']}"
+    assert pair["deep_link"] == expected
+    assert pair["qr_payload"] == expected
+    assert sidecar.health_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- derive Shared WhatsApp click-to-chat links without requiring the current API process to mark the sidecar transport as bound
- retain QR and Open WhatsApp when the registered identity is temporarily disconnected
- keep strict Shared-account, revision, registration, PN JID, and canonical URL checks

## Verification
- `bun run test backend tests/test_channels.py -k whatsapp_pair_code` (4 passed)
- `uv run ruff check app/routes/channel_routers/public.py tests/test_channels.py`
- `uv run ruff format --check app/routes/channel_routers/public.py tests/test_channels.py`