### PR TITLE
fix(web): mute paired chats link style

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-card.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-card.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ChannelCard } from "./channel-card";
 
 function source(relativePath: string): string {
@@ -116,5 +118,20 @@ describe("shared Channel card", () => {
 		expect(pairedChatsDialog).toContain("aria-controls={panelId}");
 		expect(pairedChatsDialog).not.toContain("Show more");
 		expect(pairedChatsDialog).not.toContain("Show less");
+	});
+
+	test("styles paired chats as a muted, persistently underlined shadcn link button", () => {
+		const resolvedClasses = cn(
+			buttonVariants({ variant: "link", size: "xs" }),
+			"h-auto max-w-full justify-start p-0 text-sm text-muted-foreground underline hover:text-foreground",
+		).split(" ");
+
+		expect(pairedChatsDialog).toContain(
+			'buttonVariants({ variant: "link", size: "xs" }),\n\t\t\t\t"h-auto max-w-full justify-start p-0 text-sm text-muted-foreground underline hover:text-foreground"',
+		);
+		expect(resolvedClasses).toContain("text-muted-foreground");
+		expect(resolvedClasses).toContain("underline");
+		expect(resolvedClasses).toContain("hover:text-foreground");
+		expect(resolvedClasses).not.toContain("text-primary");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/paired-chats-dialog.tsx
@@ -75,7 +75,7 @@ export function PairedChatsDialog({
 			data-agent-paired-chats-trigger={linkId}
 			className={cn(
 				buttonVariants({ variant: "link", size: "xs" }),
-				"h-auto max-w-full justify-start p-0 text-sm",
+				"h-auto max-w-full justify-start p-0 text-sm text-muted-foreground underline hover:text-foreground",
 			)}
 			aria-controls={panelId}
 		>


### PR DESCRIPTION
## Summary

- keep the paired-chat count trigger on the standard shadcn link-button variant
- replace its primary color with muted secondary text
- keep the underline visible and strengthen it to foreground on hover
- add a focused regression test for the resolved utility classes

## Verification

- web typecheck
- focused channel-card tests: 8 passed, 0 failed
- OSS production build
- Biome check on both changed files

The root review found no diff issues. A second Docker verification attempt was blocked before test execution because the host Docker address pool was exhausted; the task agent's isolated run completed successfully and cleaned its resources.