### PR TITLE
fix(cli): separate publish provenance evidence modes

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -101,7 +101,7 @@ jobs:
               }
             : { exists: false };
           console.log(JSON.stringify({
-            schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+            schemaVersion: "clawdi.cliReleaseRecoveryInput.v2",
             mode: "plan",
             package: { name: process.env.PACKAGE_NAME, version: process.env.VERSION },
             repository: {
@@ -311,19 +311,23 @@ jobs:
           if [ "$NPM_ACTION" = "publish" ] && npm_release_visible; then
             NPM_ACTION=verify
           fi
+          publication_evidence_mode=""
           case "$NPM_ACTION" in
             publish)
               npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
+              publication_evidence_mode="fresh-publish"
               ;;
-            verify) ;;
+            verify)
+              publication_evidence_mode="existing-version"
+              ;;
             *)
               echo "unsupported npm recovery action: $NPM_ACTION" >&2
               exit 64
               ;;
           esac
-          # npm publication is immutable but registry reads are eventually
-          # consistent. Wait only for the exact version just published or found;
-          # all integrity and provenance checks below remain unchanged.
+          # Confirm the exact immutable registry artifact for both evidence modes.
+          # Only an existing-version recovery must re-read registry provenance;
+          # this job's successful --provenance publish is its provenance authority.
           registry_visible=false
           for attempt in $(seq 1 12); do
             if npm_release_visible; then
@@ -336,25 +340,30 @@ jobs:
             echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2
             exit 69
           fi
+          registry_version=$(npm view "clawdi@$VERSION" version)
+          test "$registry_version" = "$VERSION"
           published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)
-          attestations=$(npm view "clawdi@$VERSION" dist.attestations --json)
-          attestation_url=$(ATTESTATIONS="$attestations" node - <<'NODE'
+          attestations=""
+          attestation_bundle=""
+          if [ "$publication_evidence_mode" = "existing-version" ]; then
+            attestations=$(npm view "clawdi@$VERSION" dist.attestations --json)
+            attestation_url=$(ATTESTATIONS="$attestations" node - <<'NODE'
           const attestations = JSON.parse(process.env.ATTESTATIONS);
           const url = new URL(attestations.url);
           if (url.origin !== "https://registry.npmjs.org") process.exit(1);
           console.log(attestations.url);
           NODE
-          )
-          attestation_bundle=""
-          for attempt in $(seq 1 12); do
-            if attestation_bundle=$(curl --fail --silent --location "$attestation_url"); then
-              break
+            )
+            for attempt in $(seq 1 12); do
+              if attestation_bundle=$(curl --fail --silent --location "$attestation_url"); then
+                break
+              fi
+              if [ "$attempt" -lt 12 ]; then sleep 5; fi
+            done
+            if [ -z "$attestation_bundle" ]; then
+              echo "clawdi@$VERSION provenance was not visible after 60 seconds" >&2
+              exit 69
             fi
-            if [ "$attempt" -lt 12 ]; then sleep 5; fi
-          done
-          if [ -z "$attestation_bundle" ]; then
-            echo "clawdi@$VERSION provenance was not visible after 60 seconds" >&2
-            exit 69
           fi
           tag="clawdi-cli-v$VERSION"
           release_json=null
@@ -365,12 +374,27 @@ jobs:
           if resolved_tag=$(git rev-list -n 1 "$tag" 2>/dev/null); then
             tag_commit="\"$resolved_tag\""
           fi
-          recovery_input=$(PUBLISHED_INTEGRITY="$published_integrity" ATTESTATIONS="$attestations" \
+          recovery_input=$(PUBLICATION_EVIDENCE_MODE="$publication_evidence_mode" \
+            REGISTRY_VERSION="$registry_version" PUBLISHED_INTEGRITY="$published_integrity" \
+            ATTESTATIONS="$attestations" \
             ATTESTATION_BUNDLE="$attestation_bundle" LOCAL_INTEGRITY="$local_integrity" \
             LOCAL_SHA512="$local_sha512" RELEASE_JSON="$release_json" TAG_COMMIT="$tag_commit" \
             node - <<'NODE'
+          const publicationEvidence = process.env.PUBLICATION_EVIDENCE_MODE === "fresh-publish"
+            ? {
+                mode: "fresh-publish",
+                registryVersion: process.env.REGISTRY_VERSION,
+                distIntegrity: process.env.PUBLISHED_INTEGRITY,
+              }
+            : {
+                mode: "existing-version",
+                registryVersion: process.env.REGISTRY_VERSION,
+                distIntegrity: process.env.PUBLISHED_INTEGRITY,
+                attestations: JSON.parse(process.env.ATTESTATIONS),
+                attestationBundle: JSON.parse(process.env.ATTESTATION_BUNDLE),
+              };
           console.log(JSON.stringify({
-            schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+            schemaVersion: "clawdi.cliReleaseRecoveryInput.v2",
             mode: "complete",
             package: { name: "clawdi", version: process.env.VERSION },
             repository: {
@@ -392,12 +416,7 @@ jobs:
               integrity: process.env.LOCAL_INTEGRITY,
               sha512: process.env.LOCAL_SHA512,
             },
-            npm: {
-              exists: true,
-              distIntegrity: process.env.PUBLISHED_INTEGRITY,
-              attestations: JSON.parse(process.env.ATTESTATIONS),
-              attestationBundle: JSON.parse(process.env.ATTESTATION_BUNDLE),
-            },
+            publicationEvidence,
             github: {
               release: JSON.parse(process.env.RELEASE_JSON),
               tagCommit: JSON.parse(process.env.TAG_COMMIT),

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -315,7 +315,13 @@ The build/test job may use the configured fast runner, but the protected
 publish job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing
 does not support self-hosted or third-party GitHub Actions runners. The publish
 job uses Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm
-11.5.1.
+11.5.1. After a fresh `npm publish --provenance` succeeds, that command plus
+the exact registry version and matching `dist.integrity` authorizes GitHub
+Release completion; the job does not wait for the eventually consistent
+registry attestation read API. If the immutable npm version already exists,
+the workflow did not publish it and therefore requires registry provenance to
+prove the exact repository workflow, source commit, package subject, and
+artifact integrity before recovering the GitHub Release.
 
 The CLI workflow neither calls nor checks out the Hosted repository. An operator
 verifies the exact package publication, then explicitly supplies the exact
@@ -392,6 +398,9 @@ onward releases are automatic.
    one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
    from GitHub-hosted `ubuntu-latest` with
    `npm publish <tarball> --access public --provenance --ignore-scripts --tag <resolved-tag>`.
+   A successful fresh publish is completed using that command result plus the
+   exact registry version and `dist.integrity`; it does not depend on immediate
+   visibility of the registry attestation query endpoint.
    If npm already has the exact version but its GitHub Release is incomplete,
    a rerun checks out the source commit recorded by npm provenance, rebuilds the
    tarball, compares it with npm `dist.integrity`, skips the immutable npm

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -93,8 +93,13 @@ releases.
    checks out the source commit recorded by npm provenance, rebuilds the same
    artifact, verifies its npm `dist.integrity`, skips republishing the immutable
    npm version, and completes the draft release before finalization. Recovery
-   decisions come from `packages/cli/scripts/release-recovery.mjs`; the workflow
-   only gathers external facts and executes the validated action.
+   decisions come from `packages/cli/scripts/release-recovery.mjs`. Its evidence
+   modes are explicit: a fresh successful `npm publish --provenance` requires
+   the exact registry version and matching `dist.integrity` without waiting for
+   the eventually consistent attestation read API; an already-existing version
+   requires registry provenance for the exact source, workflow, package subject,
+   and artifact. The workflow only gathers those mode-specific facts and
+   executes the validated action.
    Native ownership is separate: installed native executables update only from
    the exact `clawdi-cli-v<version>` manifest and assets. npm/Bun installs use
    exact npm versions. Hosted remains a separate exact-version npm authority and

--- a/packages/cli/scripts/release-recovery.mjs
+++ b/packages/cli/scripts/release-recovery.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const INPUT_SCHEMA = "clawdi.cliReleaseRecoveryInput.v1";
-const OUTPUT_SCHEMA = "clawdi.cliReleaseRecoveryOutput.v1";
+const INPUT_SCHEMA = "clawdi.cliReleaseRecoveryInput.v2";
+const OUTPUT_SCHEMA = "clawdi.cliReleaseRecoveryOutput.v2";
 const PROVENANCE_PREDICATE = "https://slsa.dev/provenance/v1";
 const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 const SEMVER_PATTERN =
@@ -105,6 +105,43 @@ function npmInput(value) {
 		distIntegrity: string(parsed.distIntegrity, "npm.distIntegrity"),
 		attestations: object(parsed.attestations, "npm.attestations"),
 		attestationBundle: object(parsed.attestationBundle, "npm.attestationBundle"),
+	};
+}
+
+function publicationEvidenceInput(value, packageInfo) {
+	const parsed = object(value, "publicationEvidence");
+	const mode = string(parsed.mode, "publicationEvidence.mode");
+	if (mode !== "fresh-publish" && mode !== "existing-version") {
+		fail(
+			"INVALID_EVIDENCE_MODE",
+			"publicationEvidence.mode must be fresh-publish or existing-version",
+		);
+	}
+	const registryVersion = string(parsed.registryVersion, "publicationEvidence.registryVersion");
+	if (registryVersion !== packageInfo.version) {
+		fail("VERSION_MISMATCH", "registry version does not match the expected package version");
+	}
+	const allowedKeys =
+		mode === "fresh-publish"
+			? new Set(["mode", "registryVersion", "distIntegrity"])
+			: new Set(["mode", "registryVersion", "distIntegrity", "attestations", "attestationBundle"]);
+	const extraKeys = Object.keys(parsed).filter((key) => !allowedKeys.has(key));
+	if (extraKeys.length > 0) {
+		fail(
+			"INVALID_PUBLICATION_EVIDENCE",
+			`publicationEvidence contains fields forbidden in ${mode} mode: ${extraKeys.join(", ")}`,
+		);
+	}
+	const evidence = {
+		mode,
+		registryVersion,
+		distIntegrity: string(parsed.distIntegrity, "publicationEvidence.distIntegrity"),
+	};
+	if (mode === "fresh-publish") return evidence;
+	return {
+		...evidence,
+		attestations: object(parsed.attestations, "publicationEvidence.attestations"),
+		attestationBundle: object(parsed.attestationBundle, "publicationEvidence.attestationBundle"),
 	};
 }
 
@@ -249,22 +286,22 @@ function commonInput(input) {
 		packageInfo: packageInput(input.package),
 		repository: repositoryInput(input.repository),
 		requiredAssets: requiredAssetsInput(input.requiredAssets),
-		npm: npmInput(input.npm),
 		github: githubInput(input.github),
 	};
 }
 
 function plan(input, common) {
 	const currentCommit = commit(input.currentCommit, "currentCommit");
-	const provenance = common.npm.exists
-		? verifyProvenance(common.npm, common.packageInfo, common.repository)
+	const npm = npmInput(input.npm);
+	const provenance = npm.exists
+		? verifyProvenance(npm, common.packageInfo, common.repository)
 		: null;
 	const sourceCommit = provenance?.sourceCommit ?? currentCommit;
 	const state = releaseState(common.github, common.requiredAssets, sourceCommit);
-	if (!common.npm.exists && state === "published-complete") {
+	if (!npm.exists && state === "published-complete") {
 		fail("RELEASE_WITHOUT_PACKAGE", "published GitHub release exists without the npm package");
 	}
-	const shouldRelease = !(common.npm.exists && state === "published-complete");
+	const shouldRelease = !(npm.exists && state === "published-complete");
 	return {
 		schemaVersion: OUTPUT_SCHEMA,
 		mode: "plan",
@@ -274,15 +311,12 @@ function plan(input, common) {
 		tarballFilename: `clawdi-${common.packageInfo.version}.tgz`,
 		shouldRelease,
 		sourceCommit,
-		npmAction: shouldRelease ? (common.npm.exists ? "verify" : "publish") : "none",
+		npmAction: shouldRelease ? (npm.exists ? "verify" : "publish") : "none",
 		releaseState: state,
 	};
 }
 
 function complete(input, common) {
-	if (!common.npm.exists) {
-		fail("PACKAGE_NOT_PUBLISHED", "complete mode requires the published npm package");
-	}
 	const expectedSourceCommit = commit(input.expectedSourceCommit, "expectedSourceCommit");
 	const localArtifact = object(input.localArtifact, "localArtifact");
 	const localIntegrity = integrityDigest(localArtifact.integrity, "localArtifact.integrity");
@@ -290,25 +324,41 @@ function complete(input, common) {
 	if (!/^[0-9a-f]{128}$/.test(localSha512) || localSha512 !== localIntegrity.hex) {
 		fail("LOCAL_INTEGRITY_MISMATCH", "local artifact integrity and SHA-512 digest disagree");
 	}
-	const provenance = verifyProvenance(
-		common.npm,
+	const publicationEvidence = publicationEvidenceInput(
+		input.publicationEvidence,
 		common.packageInfo,
-		common.repository,
-		localSha512,
 	);
-	if (provenance.sourceCommit !== expectedSourceCommit) {
+	const published = integrityDigest(
+		publicationEvidence.distIntegrity,
+		"publicationEvidence.distIntegrity",
+	);
+	if (published.hex !== localSha512) {
+		fail("INTEGRITY_MISMATCH", "npm integrity does not match the local artifact");
+	}
+	const provenance =
+		publicationEvidence.mode === "existing-version"
+			? verifyProvenance(
+					{ exists: true, ...publicationEvidence },
+					common.packageInfo,
+					common.repository,
+					localSha512,
+				)
+			: null;
+	const sourceCommit = provenance?.sourceCommit ?? expectedSourceCommit;
+	if (sourceCommit !== expectedSourceCommit) {
 		fail(
 			"SOURCE_COMMIT_MISMATCH",
 			"published provenance does not match the expected source commit",
 		);
 	}
-	const state = releaseState(common.github, common.requiredAssets, provenance.sourceCommit);
+	const state = releaseState(common.github, common.requiredAssets, sourceCommit);
 	return {
 		schemaVersion: OUTPUT_SCHEMA,
 		mode: "complete",
+		evidenceMode: publicationEvidence.mode,
 		version: common.packageInfo.version,
 		releaseTag: `clawdi-cli-v${common.packageInfo.version}`,
-		releaseTarget: provenance.sourceCommit,
+		releaseTarget: sourceCommit,
 		releaseState: state,
 		releaseAction:
 			state === "absent" ? "create-draft" : state === "draft" ? "resume-draft" : "none",

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -138,20 +138,43 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).not.toContain("NPM_TOKEN");
 	});
 
-	test("recovers registry publication races without republishing", () => {
-		const boundaryCheck = workflow.indexOf(
+	test("separates fresh publish authority from existing-version recovery", () => {
+		const publishJob = workflow.slice(workflow.indexOf("  publish-immutable-artifact-with-oidc:"));
+		const boundaryCheck = publishJob.indexOf(
 			'if [ "$NPM_ACTION" = "publish" ] && npm_release_visible; then',
 		);
-		const publishDecision = workflow.indexOf('case "$NPM_ACTION" in');
-		const visibilityWait = workflow.indexOf("for attempt in $(seq 1 12); do", publishDecision);
-		const integrityRead = workflow.indexOf(
+		const publishDecision = publishJob.indexOf('case "$NPM_ACTION" in');
+		const publishCommand = publishJob.indexOf("npm publish ");
+		const freshEvidence = publishJob.indexOf('publication_evidence_mode="fresh-publish"');
+		const existingEvidence = publishJob.indexOf('publication_evidence_mode="existing-version"');
+		const visibilityWait = publishJob.indexOf("for attempt in $(seq 1 12); do", publishDecision);
+		const versionRead = publishJob.indexOf(
+			'registry_version=$(npm view "clawdi@$VERSION" version)',
+		);
+		const integrityRead = publishJob.indexOf(
 			'published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)',
+		);
+		const provenanceGuard = publishJob.indexOf(
+			'if [ "$publication_evidence_mode" = "existing-version" ]; then',
+		);
+		const provenanceRead = publishJob.indexOf(
+			'attestations=$(npm view "clawdi@$VERSION" dist.attestations --json)',
 		);
 
 		expect(boundaryCheck).toBeGreaterThan(-1);
 		expect(boundaryCheck).toBeLessThan(publishDecision);
+		expect(publishCommand).toBeGreaterThan(publishDecision);
+		expect(freshEvidence).toBeGreaterThan(publishCommand);
+		expect(existingEvidence).toBeGreaterThan(freshEvidence);
 		expect(visibilityWait).toBeGreaterThan(publishDecision);
-		expect(visibilityWait).toBeLessThan(integrityRead);
+		expect(visibilityWait).toBeLessThan(versionRead);
+		expect(versionRead).toBeLessThan(integrityRead);
+		expect(integrityRead).toBeLessThan(provenanceGuard);
+		expect(provenanceGuard).toBeLessThan(provenanceRead);
+		expect(publishJob).toContain('test "$registry_version" = "$VERSION"');
+		expect(publishJob).toContain("publicationEvidence,");
+		expect(publishJob).toContain('mode: "fresh-publish"');
+		expect(publishJob).toContain('mode: "existing-version"');
 		expect(workflow).toContain('if [ "$attempt" -lt 12 ]; then sleep 5; fi');
 		expect(workflow).toContain(
 			'echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2',

--- a/packages/cli/tests/release-recovery.test.ts
+++ b/packages/cli/tests/release-recovery.test.ts
@@ -64,7 +64,7 @@ function completeRelease() {
 
 function planFixture() {
 	return {
-		schemaVersion: "clawdi.cliReleaseRecoveryInput.v1",
+		schemaVersion: "clawdi.cliReleaseRecoveryInput.v2",
 		mode: "plan",
 		package: { name: "clawdi", version: "1.2.3" },
 		repository: {
@@ -79,11 +79,35 @@ function planFixture() {
 }
 
 function completeFixture() {
+	const fixture = planFixture();
 	return {
-		...planFixture(),
+		schemaVersion: fixture.schemaVersion,
 		mode: "complete",
+		package: fixture.package,
+		repository: fixture.repository,
+		requiredAssets: fixture.requiredAssets,
+		github: fixture.github,
 		expectedSourceCommit: sourceCommit,
 		localArtifact: { integrity, sha512 },
+		publicationEvidence: {
+			mode: "existing-version",
+			registryVersion: fixture.package.version,
+			distIntegrity: fixture.npm.distIntegrity,
+			attestations: fixture.npm.attestations,
+			attestationBundle: fixture.npm.attestationBundle,
+		},
+	};
+}
+
+function freshPublishFixture() {
+	const fixture = completeFixture();
+	return {
+		...fixture,
+		publicationEvidence: {
+			mode: "fresh-publish",
+			registryVersion: fixture.package.version,
+			distIntegrity: integrity,
+		},
 	};
 }
 
@@ -205,13 +229,42 @@ describe("CLI release recovery decision", () => {
 		});
 	});
 
+	test("completes a fresh provenance publish without registry attestation visibility", () => {
+		const fixture = freshPublishFixture();
+		const decision = expectDecision(fixture);
+
+		expect(fixture.publicationEvidence).toEqual({
+			mode: "fresh-publish",
+			registryVersion: "1.2.3",
+			distIntegrity: integrity,
+		});
+		expect(decision).toMatchObject({
+			evidenceMode: "fresh-publish",
+			releaseAction: "create-draft",
+			releaseTarget: sourceCommit,
+			finalize: true,
+		});
+	});
+
+	test("requires registry provenance for existing-version recovery", () => {
+		const fixture = completeFixture();
+		Reflect.deleteProperty(fixture.publicationEvidence, "attestationBundle");
+
+		const result = runRecovery(fixture);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("publicationEvidence.attestationBundle");
+	});
+
 	test("fails closed on local, published, or provenance integrity drift", () => {
 		const fixtures = [completeFixture(), completeFixture(), completeFixture()];
 		fixtures[0].localArtifact.sha512 = "cd".repeat(64);
-		fixtures[1].npm.distIntegrity = `sha512-${Buffer.from("cd".repeat(64), "hex").toString("base64")}`;
-		fixtures[2].npm.attestationBundle.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(
-			JSON.stringify({ ...provenanceStatement(), subject: [] }),
-		).toString("base64");
+		fixtures[1].publicationEvidence.distIntegrity = `sha512-${Buffer.from(
+			"cd".repeat(64),
+			"hex",
+		).toString("base64")}`;
+		fixtures[2].publicationEvidence.attestationBundle.attestations[0].bundle.dsseEnvelope.payload =
+			Buffer.from(JSON.stringify({ ...provenanceStatement(), subject: [] })).toString("base64");
 
 		for (const fixture of fixtures) {
 			const result = runRecovery(fixture);
@@ -239,9 +292,8 @@ describe("CLI release recovery decision", () => {
 			const fixture = completeFixture();
 			const statement = provenanceStatement();
 			mutate(statement);
-			fixture.npm.attestationBundle.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(
-				JSON.stringify(statement),
-			).toString("base64");
+			fixture.publicationEvidence.attestationBundle.attestations[0].bundle.dsseEnvelope.payload =
+				Buffer.from(JSON.stringify(statement)).toString("base64");
 			const result = runRecovery(fixture);
 			expect(result.exitCode).toBe(1);
 			expect(result.stderr).toMatch(/WORKFLOW_MISMATCH|SOURCE_COMMIT_MISMATCH/);


### PR DESCRIPTION
## Summary

- treat a successful `npm publish --provenance` as the fresh-publish provenance authority
- verify the exact registry version and `dist.integrity` without waiting for the eventually consistent attestation read endpoint
- keep existing-version/rerun recovery fail-closed on full registry provenance, workflow, source commit, subject, and artifact verification

## Root cause

`clawdi@0.13.36` was successfully published with npm trusted publishing and provenance, but the workflow then polled the separate registry attestation query endpoint. That eventually consistent endpoint was not visible within 60 seconds, so the job incorrectly failed after the immutable publish had already succeeded.

## Verification

- focused workflow/recovery tests: 20 passed
- CLI typecheck
- Biome
- extracted publish shell `bash -n`
- `git diff --check origin/main..HEAD`

## Release behavior

No version bump and no npm republish. This changes only future publish/recovery workflow behavior.
