### PR TITLE
fix(cli): simplify published release no-op

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -15,15 +15,6 @@ concurrency:
 
 env:
   CLI_ARTIFACT_NAME: clawdi-cli-release
-  CLI_RELEASE_ASSETS: >-
-    clawdi-cli-linux-x64.tar.gz
-    clawdi-cli-linux-arm64.tar.gz
-    clawdi-cli-linux-x64-musl.tar.gz
-    clawdi-cli-linux-arm64-musl.tar.gz
-    clawdi-cli-darwin-x64.tar.gz
-    clawdi-cli-darwin-arm64.tar.gz
-    clawdi-cli-manifest.txt
-    install.sh
 
 # This repository builds, verifies, and publishes one immutable artifact.
 # Prereleases publish to beta; stable releases publish to latest.
@@ -65,25 +56,8 @@ jobs:
           registry_version=$(npm view "clawdi@$version" version 2>/dev/null || true)
           if [ "$registry_version" = "$version" ]; then
             tag="clawdi-cli-v$version"
-            if release_data=$(gh release view "$tag" \
-              --json isDraft,assets \
-              --template '{{.isDraft}}{{"\n"}}{{range .assets}}{{.name}}{{"\t"}}{{.size}}{{"\n"}}{{end}}' \
-              2>/dev/null); then
-              read -r release_is_draft <<< "$release_data"
-              if [ "$release_is_draft" = "false" ]; then
-                release_complete=true
-                for asset in $CLI_RELEASE_ASSETS; do
-                  if ! awk -F '\t' -v required="$asset" \
-                    '$1 == required && $2 ~ /^[1-9][0-9]*$/ { found=1 } END { exit found ? 0 : 1 }' \
-                    <<< "$release_data"; then
-                    release_complete=false
-                    break
-                  fi
-                done
-                if [ "$release_complete" = "true" ]; then
-                  should_release=false
-                fi
-              fi
+            if [ "$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+              should_release=false
             fi
           fi
           VERSION="$version" NPM_TAG="$npm_tag" SHOULD_RELEASE="$should_release" node - <<'NODE'
@@ -287,18 +261,11 @@ jobs:
             fi
           fi
           release_action=create-draft
-          if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish,assets 2>/dev/null); then
+          if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish 2>/dev/null); then
             release_action=$(RELEASE_JSON="$existing_release" EXPECTED_COMMIT="$GITHUB_SHA" node - <<'NODE'
           const release = JSON.parse(process.env.RELEASE_JSON);
           if (release.targetCommitish !== process.env.EXPECTED_COMMIT) {
             console.error(`GitHub release targets ${release.targetCommitish} instead of this workflow commit ${process.env.EXPECTED_COMMIT}`);
-            process.exit(65);
-          }
-          const required = process.env.CLI_RELEASE_ASSETS.trim().split(/\s+/);
-          const assets = new Map(release.assets.map((asset) => [asset.name, asset.size]));
-          const incomplete = required.filter((name) => !assets.has(name) || assets.get(name) === 0);
-          if (!release.isDraft && incomplete.length > 0) {
-            console.error(`published GitHub release has incomplete assets: ${incomplete.join(", ")}`);
             process.exit(65);
           }
           console.log(release.isDraft ? "resume-draft" : "none");

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -298,8 +298,8 @@ checklist. This section covers the CLI/npm release line in detail.
 
 Publishing is automated. `.github/workflows/cli-publish.yml` watches `main`
 for changes under `packages/cli/`. If the exact npm version and its published,
-non-draft GitHub Release already exist with every required non-empty asset, the
-workflow exits before installing dependencies or building. Otherwise it builds
+non-draft GitHub Release already exist, the workflow exits before installing
+dependencies or building. Otherwise it builds
 the artifact from its own `GITHUB_SHA`. An absent exact npm version is
 published; an existing version is never republished and must have the same
 `dist.integrity` as the artifact built by this run.
@@ -324,9 +324,8 @@ version and matching `dist.integrity` authorizes GitHub Release completion; the
 job does not wait for the eventually consistent registry attestation read API.
 If release work remains and the immutable npm version already exists, the
 workflow never republishes it and only accepts an exact integrity match. The
-GitHub Release and tag must target that run's `GITHUB_SHA`. A published release
-with incomplete assets, or a release/tag for another commit while completion is
-required, fails closed.
+GitHub Release and tag must target that run's `GITHUB_SHA`; another commit while
+completion is required fails closed.
 
 The CLI workflow neither calls nor checks out the Hosted repository. An operator
 verifies the exact package publication, then explicitly supplies the exact

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -92,15 +92,15 @@ releases.
    self-hosted or third-party GitHub Actions runners. The CLI workflow does not
    call workflows in the Hosted repository or depend on Hosted repository
    settings. A lightweight preflight checks only whether the exact npm version
-   and a non-draft GitHub Release with every required non-empty asset exist; if
-   both are complete, the run skips build and publish without querying
-   provenance. Otherwise the run builds from its own `GITHUB_SHA`. An absent
+   and a non-draft GitHub Release exist; if both are complete, the run skips
+   build and publish without querying provenance. Otherwise the run builds from
+   its own `GITHUB_SHA`. An absent
    exact npm version is published with provenance; an existing version is never
    republished and must have the same `dist.integrity` as this run's artifact.
    Fresh publish completion does not wait for the eventually consistent
    attestation read API. The GitHub Release may be created or a draft may be
-   completed only for the same `GITHUB_SHA`; another target or an incomplete
-   published release fails closed. After npm succeeds, rerun the original
+   completed only for the same `GITHUB_SHA`; another target fails closed. After
+   npm succeeds, rerun the original
    workflow run to complete GitHub assets. A different commit whose artifact
    differs must bump the package version instead of recovering across commits.
    Native ownership is separate: installed native executables update only from

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -99,8 +99,6 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow.match(/test "\$\(git rev-parse HEAD\)" = "\$GITHUB_SHA"/g)).toHaveLength(2);
 		expect(workflow).not.toContain("git checkout --detach");
 		expect(workflow).not.toContain("source_commit");
-		expect(workflow).not.toContain("release-recovery");
-		expect(workflow).not.toContain("schemaVersion");
 		expect(workflow).not.toContain("Clawdi-AI/clawdi-hosted");
 		expect(workflow).not.toContain("uses: Clawdi-AI/");
 		expect(workflow).not.toContain("repository_dispatch");
@@ -173,9 +171,7 @@ describe("CLI publish workflow contract", () => {
 		expect(noOpDecision).toBeLessThan(buildJob.indexOf("bun install --frozen-lockfile"));
 		expect(buildJob).toContain("should_release=true");
 		expect(buildJob).toContain('gh release view "$tag"');
-		expect(buildJob).toContain('if [ "$release_is_draft" = "false" ]; then');
-		expect(buildJob).toContain("$2 ~ /^[1-9][0-9]*$/");
-		expect(buildJob).toContain("release_complete=false");
+		expect(buildJob).toContain("--json isDraft --jq .isDraft");
 		expect(buildJob.match(/should_release=false/g)).toHaveLength(1);
 		expect(absenceCheck).toBeGreaterThan(-1);
 		expect(absenceCheck).toBeLessThan(publishCommand);
@@ -191,8 +187,6 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain(
 			'echo "clawdi@$VERSION was not visible in the npm registry after 60 seconds" >&2',
 		);
-		expect(workflow).not.toContain("dist.attestations");
-		expect(workflow).not.toContain("attestation_bundle");
 	});
 
 	test("creates or completes only the current commit GitHub release", () => {
@@ -201,7 +195,6 @@ describe("CLI publish workflow contract", () => {
 		);
 		expect(workflow).toContain('if [ "$tag_commit" != "$GITHUB_SHA" ]; then');
 		expect(workflow).toContain("release.targetCommitish !== process.env.EXPECTED_COMMIT");
-		expect(workflow).toContain("if (!release.isDraft && incomplete.length > 0)");
 		expect(workflow).toContain('console.log(release.isDraft ? "resume-draft" : "none")');
 		expect(workflow).toContain('gh release upload "$tag"');
 		expect(workflow).toContain("--clobber");


### PR DESCRIPTION
## Summary

- treat an exact npm version plus a published, non-draft GitHub Release as a direct no-op
- remove all Release asset/size parsing and completeness state
- retain only official npm publish --provenance, exact registry integrity, and same-run draft completion

## Verification

- live public clawdi@0.13.36 + clawdi-cli-v0.13.36 preflight resolves to no-op
- workflow contract: 6 passed
- CLI typecheck
- preflight shell syntax
- git diff --check

## Diff

4 files, 13 insertions, 54 deletions. No recovery script, schema, provenance polling, asset state machine, or hardcoded desired CLI version.