### PR TITLE
fix(web): restore agent resource write paths

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4544,6 +4544,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	await projectStack.getByRole("button", { name: "Add Project", exact: true }).click();
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
+	await addProjectDialog.getByRole("tab", { name: "Existing Project" }).click();
 	const compactProjectPicker = addProjectDialog.getByLabel("Project to add");
 	await compactProjectPicker.click();
 	await page.getByRole("option", { name: /Hosted Project Choice/ }).click();
@@ -4617,7 +4618,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	const focusedSkillsHeading = main.getByRole("heading", { name: "Skills", level: 1 });
 	await expect(focusedSkillsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Skills · Clawdi");
-	await expect(main.getByText("Project: Hosted Agent Project", { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Skills Project")).toContainText("Hosted Agent Project");
 	await expect(main.getByRole("button", { name: "Back to Hosted Agent Project" })).toHaveAttribute(
 		"href",
 		`/agents/${railHostedEnvironmentId}/project-access/project-hosted${query}`,
@@ -4664,7 +4665,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	const focusedVaultsHeading = main.getByRole("heading", { name: "Vaults", level: 1 });
 	await expect(focusedVaultsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Vaults · Clawdi");
-	await expect(main.getByText("Project: Hosted Agent Project", { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Vaults Project")).toContainText("Hosted Agent Project");
 	await expect(main.getByRole("button", { name: "Back to Hosted Agent Project" })).toHaveAttribute(
 		"href",
 		`/agents/${railHostedEnvironmentId}/project-access/project-hosted${query}`,

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -513,7 +513,9 @@ type DashboardApiStubOptions = {
 	memoryDetailGate?: Promise<void>;
 	memoryDetailResponse?: { body: unknown; status: number };
 	projectBindingRequests?: string[];
+	projectBindingMutationRequests?: string[];
 	projectRequests?: string[];
+	projectCreateRequests?: string[];
 	projectBindings?: readonly unknown[];
 	projectBindingsError?: { status: number; detail: string };
 	projectBindingsGate?: Promise<void>;
@@ -534,6 +536,8 @@ async function stubDashboardApi(
 	agentOrderRequests: string[] = [],
 	options: DashboardApiStubOptions = {},
 ) {
+	const mutableProjectBindings = [...(options.projectBindings ?? projectBindings)];
+	const mutableProjects = [...(options.projects ?? projects)];
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
 		if (
@@ -575,6 +579,25 @@ async function stubDashboardApi(
 			await fulfillJson(route, agent ?? { detail: "Agent not found" }, agent ? 200 : 404);
 			return;
 		}
+		if (
+			url.pathname === "/v1/agents/agent-smoke-1/project-bindings/context" &&
+			route.request().method() === "POST"
+		) {
+			options.projectBindingMutationRequests?.push(route.request().postData() ?? "");
+			const body = route.request().postDataJSON() as { project_id: string };
+			const binding = {
+				id: `binding-${body.project_id}`,
+				agent_id: "agent-smoke-1",
+				project_id: body.project_id,
+				binding_type: "context",
+				priority: mutableProjectBindings.length,
+				default_write_enabled: false,
+				created_at: now.toISOString(),
+			};
+			mutableProjectBindings.push(binding);
+			await fulfillJson(route, binding);
+			return;
+		}
 		if (url.pathname === "/v1/agents/agent-smoke-1/project-bindings") {
 			options.projectBindingRequests?.push(route.request().url());
 			await options.projectBindingsGate;
@@ -586,11 +609,33 @@ async function stubDashboardApi(
 				);
 				return;
 			}
-			await fulfillJson(route, options.projectBindings ?? projectBindings);
+			await fulfillJson(route, mutableProjectBindings);
 			return;
 		}
 		if (url.pathname === "/v1/dashboard/stats") {
 			await fulfillJson(route, dashboardStats);
+			return;
+		}
+		if (url.pathname === "/v1/projects" && route.request().method() === "POST") {
+			options.projectCreateRequests?.push(route.request().postData() ?? "");
+			const body = route.request().postDataJSON() as { name: string };
+			const project = {
+				id: "project-created-from-agent",
+				name: body.name,
+				slug: body.name
+					.toLowerCase()
+					.replace(/[^a-z0-9]+/g, "-")
+					.replace(/(^-|-$)/g, ""),
+				kind: "workspace",
+				origin_environment_id: null,
+				archived_at: null,
+				created_at: now.toISOString(),
+				is_owner: true,
+				owner_display: "Dev User",
+				owner_handle: "dev-user",
+			};
+			mutableProjects.push(project);
+			await fulfillJson(route, project);
 			return;
 		}
 		if (url.pathname === "/v1/projects") {
@@ -600,7 +645,7 @@ async function stubDashboardApi(
 				await fulfillJson(route, options.projectsResponse.body, options.projectsResponse.status);
 				return;
 			}
-			await fulfillJson(route, options.projects ?? projects);
+			await fulfillJson(route, mutableProjects);
 			return;
 		}
 		if (url.pathname === "/v1/skills") {
@@ -1517,6 +1562,87 @@ test("connected all-agent detail loading, not-found, and error states keep Agent
 	await expect(page).toHaveURL("/agents/agent-smoke-1/connectors/error-connector");
 });
 
+test("connected Agent can create and link a writable Project before adding Skills", async ({
+	page,
+}, testInfo) => {
+	const projectCreateRequests: string[] = [];
+	const projectBindingMutationRequests: string[] = [];
+	await stubDashboardApi(page, [], {
+		projectBindings,
+		projects: projects.filter((project) => project.id === "project-smoke"),
+		projectCreateRequests,
+		projectBindingMutationRequests,
+	});
+
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.goto("/agents/agent-smoke-1/project-access/project-smoke/skills");
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible({
+		timeout: 15_000,
+	});
+	await expect(
+		main.getByText("Choose a writable Project to add skills", { exact: true }),
+	).toBeVisible();
+	await expect(main.getByRole("button", { name: "Install skill" })).toHaveCount(0);
+	await expect(main.getByLabel("Skills Project")).toContainText("Smoke Project");
+
+	await main.getByRole("button", { name: "Add Project", exact: true }).first().click();
+	const dialog = page.getByTestId("agent-project-add-dialog");
+	await expect(dialog.getByRole("tab", { name: "New Project" })).toHaveAttribute("data-active", "");
+	await dialog.screenshot({ path: testInfo.outputPath("agent-create-project-dialog.png") });
+	await dialog.getByLabel("Project name").fill("Agent Workspace");
+	await dialog.getByRole("button", { name: "Create and add" }).click();
+
+	await expect(page).toHaveURL(
+		"/agents/agent-smoke-1/project-access/project-created-from-agent/skills",
+	);
+	await expect(main.getByLabel("Skills Project")).toContainText("Agent Workspace");
+	await expect(main.getByRole("button", { name: "Install skill" })).toBeVisible();
+	await expect(
+		main.getByText("Choose a writable Project to add skills", { exact: true }),
+	).toHaveCount(0);
+	await main.screenshot({ path: testInfo.outputPath("agent-writable-skills-desktop.png") });
+	await page.setViewportSize({ width: 390, height: 844 });
+	expect(
+		await page
+			.locator("html")
+			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
+	await main.screenshot({ path: testInfo.outputPath("agent-writable-skills-mobile.png") });
+	expect(projectCreateRequests).toEqual([JSON.stringify({ name: "Agent Workspace" })]);
+	expect(projectBindingMutationRequests).toEqual([
+		JSON.stringify({ project_id: "project-created-from-agent" }),
+	]);
+});
+
+test("connected Agent can link an existing Project and manage its Skills", async ({ page }) => {
+	const projectBindingMutationRequests: string[] = [];
+	await stubDashboardApi(page, [], { projectBindingMutationRequests });
+
+	await page.goto("/agents/agent-smoke-1/project-access");
+	const main = page.locator("main");
+	const projectStack = main.getByTestId("agent-project-stack");
+	await expect(projectStack.getByTestId("agent-project-card")).toHaveCount(1, { timeout: 15_000 });
+	await projectStack.getByRole("button", { name: "Add Project", exact: true }).click();
+	const dialog = page.getByTestId("agent-project-add-dialog");
+	await dialog.getByRole("tab", { name: "Existing Project" }).click();
+	await dialog.getByLabel("Project to add").click();
+	await page.getByRole("option", { name: /Unrelated Project/ }).click();
+	await dialog.getByRole("button", { name: "Add Project", exact: true }).click();
+
+	await expect(projectStack.getByTestId("agent-project-card")).toHaveCount(2);
+	await expect(projectStack.getByText("Unrelated Project", { exact: true })).toBeVisible();
+	expect(projectBindingMutationRequests).toEqual([
+		JSON.stringify({ project_id: "project-unrelated" }),
+	]);
+
+	await projectStack.getByRole("link", { name: "Open Unrelated Project" }).click();
+	await main.getByRole("button", { name: "View all Skills", exact: true }).click();
+	await expect(page).toHaveURL("/agents/agent-smoke-1/project-access/project-unrelated/skills");
+	await expect(main.getByLabel("Skills Project")).toContainText("Unrelated Project");
+	await expect(main.getByRole("button", { name: "Install skill" })).toBeVisible();
+});
+
 test("connected agent resources select Projects before scoped Skills and Vaults", async ({
 	page,
 }, testInfo) => {
@@ -1713,6 +1839,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
 	await expect(addProjectDialog.getByRole("heading", { name: "Add Project" })).toBeVisible();
+	await addProjectDialog.getByRole("tab", { name: "Existing Project" }).click();
 	const compactProjectPicker = addProjectDialog.getByLabel("Project to add");
 	await expect(compactProjectPicker).toBeVisible();
 	await compactProjectPicker.click();
@@ -1814,7 +1941,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const focusedSkillsHeading = main.getByRole("heading", { name: "Skills", level: 1 });
 	await expect(focusedSkillsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Skills · Clawdi");
-	await expect(main.getByText("Project: Smoke Project", { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Skills Project")).toContainText("Smoke Project");
 	await expect(main.getByRole("button", { name: "Back to Smoke Project" })).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-smoke",
@@ -1857,7 +1984,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const focusedVaultsHeading = main.getByRole("heading", { name: "Vaults", level: 1 });
 	await expect(focusedVaultsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Vaults · Clawdi");
-	await expect(main.getByText("Project: Smoke Project", { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Vaults Project")).toContainText("Smoke Project");
 	await expect(main.getByRole("button", { name: "Back to Smoke Project" })).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-smoke",
@@ -1979,13 +2106,13 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await page.goto("/agents/agent-smoke-1/skills?project=project-context-first");
 	await expect(page).toHaveURL("/agents/agent-smoke-1/project-access/project-context-first/skills");
 	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
-	await expect(main.getByText("Project: Team Knowledge", { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Skills Project")).toContainText("Team Knowledge");
 	await expect(main.getByText("Team-only Skill", { exact: true })).toBeVisible();
 	await expect(main.getByText("Primary-only Skill", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /Install skill/i })).toHaveCount(0);
 	expect(vaultRequests).toEqual([]);
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-later/skills");
-	await expect(main.getByText(`Project: ${longContextProjectName}`, { exact: true })).toBeVisible();
+	await expect(main.getByLabel("Skills Project")).toContainText(longContextProjectName);
 	await expect(main.getByRole("button", { name: /Install skill/i })).toBeVisible();
 	await expect(main.getByRole("button", { name: /New vault/i })).toHaveCount(0);
 

--- a/apps/web/src/components/dashboard/agent-projects-tab.test.ts
+++ b/apps/web/src/components/dashboard/agent-projects-tab.test.ts
@@ -56,7 +56,7 @@ describe("agent Projects presentation", () => {
 		expect(tabSource).not.toContain('from: "agent-projects"');
 	});
 
-	test("keeps Project selection behind the compact toolbar dialog", () => {
+	test("keeps create and existing Project access in one compact toolbar dialog", () => {
 		const source = readFileSync(new URL("./agent-projects-tab.tsx", import.meta.url), "utf8");
 
 		expect(source).toContain("<ListToolbar");
@@ -64,7 +64,11 @@ describe("agent Projects presentation", () => {
 		expect(source).toContain('data-testid="agent-project-add-dialog"');
 		expect(source).toContain("<ProjectCompactPicker");
 		expect(source).toContain('ariaLabel="Project to add"');
-		expect(source).toContain("No Custom or shared Projects are available to add.");
+		expect(source).toContain('<TabsTrigger value="create">New Project</TabsTrigger>');
+		expect(source).toContain('<TabsTrigger value="existing">Existing Project</TabsTrigger>');
+		expect(source).toContain('api.POST("/v1/projects"');
+		expect(source).toContain("Create and add");
+		expect(source).toContain("Retry adding Project");
 		expect(source).not.toContain("<ProjectScopePicker");
 		expect(source).not.toContain('data-testid="agent-project-add"');
 	});
@@ -120,6 +124,10 @@ describe("agent Projects presentation", () => {
 		expect(projectPage).toContain("<PageHeader");
 		expect(projectPage).toContain("<SkillCardGrid");
 		expect(projectPage).toContain("<VaultCard");
+		expect(projectPage).toContain("<ProjectCompactPicker");
+		expect(projectPage).toContain("<AgentProjectAddDialog");
+		expect(projectPage).toContain("Choose a writable Project to add skills");
+		expect(projectPage).toContain("focusedProjectHref(nextProjectId)");
 		expect(projectPage).not.toContain("function VaultRow");
 		expect(vaultCards).toContain("export function VaultCard(");
 		expect(vaultCards).toContain("actions={actions}");

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -36,13 +36,17 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { AgentRouteSearch } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { agentResourceScope, type ResourceNavigationScope } from "@/lib/resource-navigation";
+import { errorMessage } from "@/lib/utils";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 
@@ -115,8 +119,8 @@ function AgentProjectsPanel({
 	onChanged: () => void;
 }) {
 	const api = useApi();
-	const [contextProjectId, setContextProjectId] = useState("");
 	const [addOpen, setAddOpen] = useState(false);
+	const [addDialogGeneration, setAddDialogGeneration] = useState(0);
 	const orderedBindings = orderedAgentProjectBindings(bindings);
 	const primary = orderedBindings.find((binding) => binding.binding_type === "primary") ?? null;
 	const contexts = orderedBindings.filter((binding) => binding.binding_type === "context");
@@ -125,29 +129,6 @@ function AgentProjectsPanel({
 		() => new Map(projects.map((project) => [project.id, project])),
 		[projects],
 	);
-	const contextChoices = projects.filter(
-		(project) =>
-			isCustomProject(project) && !bindings.some((binding) => binding.project_id === project.id),
-	);
-
-	const addContext = useMutation({
-		mutationFn: async () => {
-			await unwrap(
-				await api.POST("/v1/agents/{agent_id}/project-bindings/context", {
-					params: { path: { agent_id: agentId } },
-					body: { project_id: contextProjectId },
-				}),
-			);
-		},
-		onSuccess: () => {
-			setContextProjectId("");
-			setAddOpen(false);
-			onChanged();
-			toast.success("Project added");
-		},
-		onError: toastApiError("Couldn't add project"),
-	});
-
 	const removeBinding = useMutation({
 		mutationFn: async (bindingId: string) => {
 			await unwrap(
@@ -229,14 +210,7 @@ function AgentProjectsPanel({
 		<div className="space-y-4" data-testid="agent-project-stack">
 			<ListToolbar
 				actions={
-					<Button
-						size="sm"
-						disabled={!primary}
-						onClick={() => {
-							setContextProjectId("");
-							setAddOpen(true);
-						}}
-					>
+					<Button size="sm" disabled={!primary} onClick={() => setAddOpen(true)}>
 						<Plus className="size-3.5" />
 						Add Project
 					</Button>
@@ -331,22 +305,196 @@ function AgentProjectsPanel({
 				open={addOpen}
 				onOpenChange={setAddOpen}
 				onOpenChangeComplete={(open) => {
-					if (!open) setContextProjectId("");
+					if (!open) setAddDialogGeneration((generation) => generation + 1);
 				}}
 			>
-				<DialogContent className="sm:max-w-md" data-testid="agent-project-add-dialog">
-					<DialogHeader>
-						<DialogTitle>Add Project</DialogTitle>
-						<DialogDescription>
-							Add a Custom or shared Project to this agent's read order.
-						</DialogDescription>
-					</DialogHeader>
+				<AgentProjectAddDialog
+					key={addDialogGeneration}
+					agentId={agentId}
+					bindings={bindings}
+					projects={projects}
+					onOpenChange={setAddOpen}
+					onChanged={onChanged}
+				/>
+			</Dialog>
+		</div>
+	);
+}
+
+type AddProjectRequest = { kind: "existing"; projectId: string } | { kind: "create"; name: string };
+
+class ProjectCreatedButNotAddedError extends Error {
+	constructor(
+		readonly project: ProjectRow,
+		readonly linkError: unknown,
+	) {
+		super("Project created but could not be added to the Agent");
+		this.name = "ProjectCreatedButNotAddedError";
+	}
+}
+
+export function AgentProjectAddDialog({
+	agentId,
+	bindings,
+	projects,
+	onOpenChange,
+	onChanged,
+	onAdded,
+}: {
+	agentId: string;
+	bindings: AgentProjectBinding[];
+	projects: ProjectRow[];
+	onOpenChange: (open: boolean) => void;
+	onChanged: () => void;
+	onAdded?: (projectId: string) => void;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const [mode, setMode] = useState<"create" | "existing">("create");
+	const [projectName, setProjectName] = useState("");
+	const [contextProjectId, setContextProjectId] = useState("");
+	const [createdProjectToRetry, setCreatedProjectToRetry] = useState<ProjectRow | null>(null);
+	const contextChoices = projects.filter(
+		(project) =>
+			isCustomProject(project) && !bindings.some((binding) => binding.project_id === project.id),
+	);
+
+	const addProject = useMutation({
+		mutationFn: async (request: AddProjectRequest) => {
+			let createdProject: ProjectRow | null = null;
+			if (request.kind === "create") {
+				createdProject = await unwrap(
+					await api.POST("/v1/projects", {
+						body: { name: request.name },
+					}),
+				);
+			}
+			const projectId = request.kind === "existing" ? request.projectId : createdProject?.id;
+			if (!projectId) throw new Error("The new Project did not return an id.");
+			try {
+				await unwrap(
+					await api.POST("/v1/agents/{agent_id}/project-bindings/context", {
+						params: { path: { agent_id: agentId } },
+						body: { project_id: projectId },
+					}),
+				);
+			} catch (error) {
+				if (request.kind === "create" && createdProject) {
+					throw new ProjectCreatedButNotAddedError(createdProject, error);
+				}
+				throw error;
+			}
+			return { projectId, created: request.kind === "create" };
+		},
+		onSuccess: async ({ projectId, created }) => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) }),
+				queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] }),
+			]);
+			setProjectName("");
+			setContextProjectId("");
+			setCreatedProjectToRetry(null);
+			onOpenChange(false);
+			onChanged();
+			toast.success(created ? "Project created and added" : "Project added");
+			onAdded?.(projectId);
+		},
+		onError: (error) => {
+			if (error instanceof ProjectCreatedButNotAddedError) {
+				setCreatedProjectToRetry(error.project);
+				void queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
+				toast.error("Project created, but couldn't add it to this Agent", {
+					description: errorMessage(error.linkError),
+				});
+				return;
+			}
+			toast.error("Couldn't add project", { description: errorMessage(error) });
+		},
+	});
+	return (
+		<DialogContent className="sm:max-w-md" data-testid="agent-project-add-dialog">
+			<DialogHeader>
+				<DialogTitle>Add Project</DialogTitle>
+				<DialogDescription>
+					Create a Project for this Agent, or add a Custom or shared Project you already use.
+				</DialogDescription>
+			</DialogHeader>
+			<Tabs
+				value={mode}
+				onValueChange={(value) => {
+					if (value === "create" || value === "existing") setMode(value);
+				}}
+			>
+				<TabsList className="grid w-full grid-cols-2">
+					<TabsTrigger value="create">New Project</TabsTrigger>
+					<TabsTrigger value="existing">Existing Project</TabsTrigger>
+				</TabsList>
+				<TabsContent value="create">
 					<form
-						className="space-y-4"
+						className="space-y-4 pt-2"
 						onSubmit={(event) => {
 							event.preventDefault();
-							if (!contextProjectId || addContext.isPending) return;
-							addContext.mutate();
+							const name = projectName.trim();
+							if (!name || addProject.isPending) return;
+							addProject.mutate({ kind: "create", name });
+						}}
+					>
+						<div className="space-y-1.5">
+							<Label htmlFor="agent-project-name">Project name</Label>
+							<Input
+								id="agent-project-name"
+								value={projectName}
+								onChange={(event) => setProjectName(event.target.value)}
+								placeholder="Project name…"
+								maxLength={200}
+								autoComplete="off"
+								disabled={addProject.isPending}
+							/>
+						</div>
+						{createdProjectToRetry ? (
+							<div className="rounded-md border bg-muted/30 p-3 text-sm">
+								<p className="font-medium">
+									{displayProjectName(createdProjectToRetry)} was created.
+								</p>
+								<p className="mt-1 text-muted-foreground">
+									Adding it to this Agent failed. Retry without creating another Project.
+								</p>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									className="mt-3"
+									disabled={addProject.isPending}
+									onClick={() =>
+										addProject.mutate({ kind: "existing", projectId: createdProjectToRetry.id })
+									}
+								>
+									Retry adding Project
+								</Button>
+							</div>
+						) : null}
+						<DialogFooter>
+							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={!projectName.trim() || addProject.isPending}>
+								{addProject.isPending ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<Plus className="size-3.5" />
+								)}
+								Create and add
+							</Button>
+						</DialogFooter>
+					</form>
+				</TabsContent>
+				<TabsContent value="existing">
+					<form
+						className="space-y-4 pt-2"
+						onSubmit={(event) => {
+							event.preventDefault();
+							if (!contextProjectId || addProject.isPending) return;
+							addProject.mutate({ kind: "existing", projectId: contextProjectId });
 						}}
 					>
 						{contextChoices.length > 0 ? (
@@ -356,19 +504,19 @@ function AgentProjectsPanel({
 								onValueChange={setContextProjectId}
 								placeholder="Choose a Project…"
 								ariaLabel="Project to add"
-								disabled={addContext.isPending}
+								disabled={addProject.isPending}
 							/>
 						) : (
 							<p className="text-sm text-muted-foreground">
-								No Custom or shared Projects are available to add.
+								Every available Custom or shared Project is already linked to this Agent.
 							</p>
 						)}
 						<DialogFooter>
-							<Button type="button" variant="ghost" onClick={() => setAddOpen(false)}>
+							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button type="submit" disabled={!contextProjectId || addContext.isPending}>
-								{addContext.isPending ? (
+							<Button type="submit" disabled={!contextProjectId || addProject.isPending}>
+								{addProject.isPending ? (
 									<Spinner className="size-3.5" />
 								) : (
 									<Plus className="size-3.5" />
@@ -377,9 +525,9 @@ function AgentProjectsPanel({
 							</Button>
 						</DialogFooter>
 					</form>
-				</DialogContent>
-			</Dialog>
-		</div>
+				</TabsContent>
+			</Tabs>
+		</DialogContent>
 	);
 }
 

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
 	useAgentProjectBindings,
 } from "@/components/dashboard/agent-project-bindings-query";
 import { orderedAgentProjectBindings } from "@/components/dashboard/agent-project-scope";
+import { AgentProjectAddDialog } from "@/components/dashboard/agent-projects-tab";
 import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS } from "@/components/entity-card";
@@ -41,6 +42,7 @@ import {
 	isCustomProject,
 	isManagedProject,
 	type ProjectAgentMetadata,
+	ProjectCompactPicker,
 	ProjectIdentity,
 	ProjectKindBadge,
 	projectAgentFor,
@@ -148,6 +150,8 @@ export default function ProjectDetailPage({
 	// inputs on demand.
 	const [showInstallSkill, setShowInstallSkill] = useState(false);
 	const [showCreateVault, setShowCreateVault] = useState(false);
+	const [addProjectOpen, setAddProjectOpen] = useState(false);
+	const [addProjectDialogGeneration, setAddProjectDialogGeneration] = useState(0);
 	const joinedFromShare = !isAgentScope && searchParams.get("joined") === "share";
 
 	const projects = $api.useQuery("get", "/v1/projects", {});
@@ -197,6 +201,9 @@ export default function ProjectDetailPage({
 	);
 	const scopedBinding =
 		orderedScopedBindings.find((binding) => binding.project_id === projectId) ?? null;
+	const scopedProjects = orderedScopedBindings
+		.map((binding) => rows.find((row) => row.id === binding.project_id))
+		.filter((candidate): candidate is ProjectRow => Boolean(candidate));
 	useEffect(() => {
 		if (searchParams.get("useWithAgent") === "1") setUseWithAgentOpen(true);
 	}, [searchParams]);
@@ -470,6 +477,16 @@ export default function ProjectDetailPage({
 	const projectIdentity = identityFor(displayProjectName(project));
 	const focusedResourceIdentity = focus ? AGENT_SECTION_NAVIGATION_ITEMS[focus] : null;
 	const FocusedResourceIcon = focusedResourceIdentity?.icon ?? null;
+	const showHeaderAddProject = Boolean(focus && (focus !== "skills" || canManageSkills));
+	const focusedProjectHref = (nextProjectId: string) =>
+		scope.kind === "agent" && focus
+			? agentProjectResourceHref(
+					scope.agentId,
+					nextProjectId,
+					focus,
+					agentDeploymentRouteQuery(scope.agentQuery),
+				)
+			: projectDetailHrefForScope(scope, nextProjectId);
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
@@ -499,13 +516,19 @@ export default function ProjectDetailPage({
 						: projectDetailDescription(project, isOwner, projectType?.label ?? "Project")
 				}
 				status={
-					<span
-						className={
-							focus ? "text-xs text-muted-foreground" : "font-mono text-xs text-muted-foreground"
-						}
-					>
-						{focus ? `Project: ${displayProjectName(project)}` : project.slug}
-					</span>
+					focus && scope.kind === "agent" ? (
+						<ProjectCompactPicker
+							projects={scopedProjects}
+							value={project.id}
+							onValueChange={(nextProjectId) => {
+								void router.navigate({ href: focusedProjectHref(nextProjectId) });
+							}}
+							ariaLabel={`${focusedResourceIdentity?.label ?? "Resource"} Project`}
+							className="mt-2 w-full max-w-sm"
+						/>
+					) : (
+						<span className="font-mono text-xs text-muted-foreground">{project.slug}</span>
+					)
 				}
 				actions={
 					!isAgentScope ? (
@@ -529,9 +552,36 @@ export default function ProjectDetailPage({
 								</ShareProjectDialog>
 							) : null}
 						</>
+					) : showHeaderAddProject ? (
+						<Button variant="outline" size="sm" onClick={() => setAddProjectOpen(true)}>
+							<Plus className="size-3.5" />
+							Add Project
+						</Button>
 					) : undefined
 				}
 			/>
+
+			{isAgentScope && focus ? (
+				<Dialog
+					open={addProjectOpen}
+					onOpenChange={setAddProjectOpen}
+					onOpenChangeComplete={(open) => {
+						if (!open) setAddProjectDialogGeneration((generation) => generation + 1);
+					}}
+				>
+					<AgentProjectAddDialog
+						key={addProjectDialogGeneration}
+						agentId={scope.agentId}
+						bindings={orderedScopedBindings}
+						projects={rows}
+						onOpenChange={setAddProjectOpen}
+						onChanged={refresh}
+						onAdded={(addedProjectId) => {
+							void router.navigate({ href: focusedProjectHref(addedProjectId) });
+						}}
+					/>
+				</Dialog>
+			) : null}
 
 			{joinedFromShare ? (
 				<Alert>
@@ -545,6 +595,24 @@ export default function ProjectDetailPage({
 						<Button type="button" size="sm" onClick={() => setUseWithAgentOpen(true)}>
 							<Bot className="mr-1.5 size-3.5" />
 							Add to agent
+						</Button>
+					</AlertDescription>
+				</Alert>
+			) : null}
+
+			{isAgentScope && focus === "skills" && !canManageSkills ? (
+				<Alert>
+					<BookOpen className="size-4" />
+					<AlertTitle>Choose a writable Project to add skills</AlertTitle>
+					<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+						<span>
+							{project.kind === "environment"
+								? "This Agent Project mirrors skills from the Agent filesystem. Select an owned Custom Project, or create one here, to install skills from the dashboard."
+								: "This shared Project is read-only. Select an owned Custom Project, or create one here, to install skills."}
+						</span>
+						<Button type="button" size="sm" onClick={() => setAddProjectOpen(true)}>
+							<Plus className="size-3.5" />
+							Add Project
 						</Button>
 					</AlertDescription>
 				</Alert>


### PR DESCRIPTION
## Summary
- let users create and immediately link a writable Project from an Agent
- keep linking existing Custom/shared Projects in the same Add Project dialog
- let users switch Project context on Agent Skills and Vaults pages
- explain why the filesystem-backed Agent Project is read-only and route users to a writable Project

## Scope
- no Overview or Sidebar redesign
- preserves Project-scoped resource boundaries and hosted deployment query context
- keeps environment Project Skills read-only per the existing backend contract

## Verification
- focused dialog lifecycle/unit checks passed
- Connected create/link Project journeys passed
- Hosted Project resource journey passed
- Web typecheck, Biome, full Web suite, and OSS build passed before the final rebase