### PR TITLE
fix(cli): use published release as completion marker

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -53,12 +53,9 @@ jobs:
             *) npm_tag=latest ;;
           esac
           should_release=true
-          registry_version=$(npm view "clawdi@$version" version 2>/dev/null || true)
-          if [ "$registry_version" = "$version" ]; then
-            tag="clawdi-cli-v$version"
-            if [ "$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
-              should_release=false
-            fi
+          tag="clawdi-cli-v$version"
+          if [ "$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
+            should_release=false
           fi
           VERSION="$version" NPM_TAG="$npm_tag" SHOULD_RELEASE="$should_release" node - <<'NODE'
           const fs = require("node:fs");

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -297,9 +297,9 @@ Use `docs/runbooks/release.md` for the full app/backend/web/CLI release
 checklist. This section covers the CLI/npm release line in detail.
 
 Publishing is automated. `.github/workflows/cli-publish.yml` watches `main`
-for changes under `packages/cli/`. If the exact npm version and its published,
-non-draft GitHub Release already exist, the workflow exits before installing
-dependencies or building. Otherwise it builds
+for changes under `packages/cli/`. If the version's GitHub Release is already
+published, the workflow exits before installing dependencies or building.
+Otherwise it builds
 the artifact from its own `GITHUB_SHA`. An absent exact npm version is
 published; an existing version is never republished and must have the same
 `dist.integrity` as the artifact built by this run.
@@ -317,8 +317,8 @@ The build/test job may use the configured fast runner, but the protected
 publish job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing
 does not support self-hosted or third-party GitHub Actions runners. The publish
 job uses Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm
-11.5.1. The lightweight preflight reads only the exact npm version and the
-corresponding GitHub Release state; it does not query provenance. After a fresh
+11.5.1. The lightweight preflight reads only the GitHub Release state; it does
+not query npm or provenance. After a fresh
 `npm publish --provenance` succeeds, that command plus the exact registry
 version and matching `dist.integrity` authorizes GitHub Release completion; the
 job does not wait for the eventually consistent registry attestation read API.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -91,9 +91,9 @@ releases.
    GitHub-hosted `ubuntu-latest`, because npm trusted publishing does not support
    self-hosted or third-party GitHub Actions runners. The CLI workflow does not
    call workflows in the Hosted repository or depend on Hosted repository
-   settings. A lightweight preflight checks only whether the exact npm version
-   and a non-draft GitHub Release exist; if both are complete, the run skips
-   build and publish without querying provenance. Otherwise the run builds from
+   settings. A lightweight preflight checks only whether the version's GitHub
+   Release is published; if so, the run skips build and publish without querying
+   npm or provenance. Otherwise the run builds from
    its own `GITHUB_SHA`. An absent
    exact npm version is published with provenance; an existing version is never
    republished and must have the same `dist.integrity` as this run's artifact.

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -154,9 +154,7 @@ describe("CLI publish workflow contract", () => {
 			workflow.indexOf("  publish-immutable-artifact-with-oidc:"),
 		);
 		const publishJob = workflow.slice(workflow.indexOf("  publish-immutable-artifact-with-oidc:"));
-		const noOpDecision = buildJob.indexOf(
-			'registry_version=$(npm view "clawdi@$version" version 2>/dev/null || true)',
-		);
+		const noOpDecision = buildJob.indexOf('gh release view "$tag" --json isDraft --jq .isDraft');
 		const absenceCheck = publishJob.indexOf("if ! npm_release_visible; then");
 		const publishCommand = publishJob.indexOf("npm publish ");
 		const visibilityWait = publishJob.indexOf("for attempt in $(seq 1 12); do", publishCommand);
@@ -170,8 +168,6 @@ describe("CLI publish workflow contract", () => {
 		expect(noOpDecision).toBeGreaterThan(-1);
 		expect(noOpDecision).toBeLessThan(buildJob.indexOf("bun install --frozen-lockfile"));
 		expect(buildJob).toContain("should_release=true");
-		expect(buildJob).toContain('gh release view "$tag"');
-		expect(buildJob).toContain("--json isDraft --jq .isDraft");
 		expect(buildJob.match(/should_release=false/g)).toHaveLength(1);
 		expect(absenceCheck).toBeGreaterThan(-1);
 		expect(absenceCheck).toBeLessThan(publishCommand);


### PR DESCRIPTION
## Summary

- use the published GitHub Release as the sole lightweight preflight completion marker
- do not query npm or provenance on already-complete releases
- retain official npm publish with provenance and exact integrity checks only on active release runs

## Verification

- live clawdi-cli-v0.13.36 preflight resolves to published/no-op
- workflow contract: 6 passed
- CLI typecheck
- preflight shell syntax
- git diff --check

No recovery script, schema, asset/size state, provenance polling, cross-commit inference, or hardcoded desired CLI version.