### PR TITLE
fix(cli): publish only on package identity changes

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -5,9 +5,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/cli/**"
-      - "install.sh"
-      - ".github/workflows/cli-publish.yml"
+      - "packages/cli/package.json"
 
 concurrency:
   group: cli-publish
@@ -27,7 +25,6 @@ jobs:
       version: ${{ steps.check.outputs.version }}
       npm_tag: ${{ steps.check.outputs.npm_tag }}
       cli_tarball_filename: ${{ steps.check.outputs.cli_tarball_filename }}
-      should_release: ${{ steps.check.outputs.should_release }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -38,11 +35,9 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Resolve exact release identity and fast no-op
+      - name: Resolve exact release identity
         id: check
         working-directory: packages/cli
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           package_name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
@@ -52,44 +47,33 @@ jobs:
             *-*) npm_tag=beta ;;
             *) npm_tag=latest ;;
           esac
-          should_release=true
-          tag="clawdi-cli-v$version"
-          if [ "$(gh release view "$tag" --json isDraft --jq .isDraft 2>/dev/null)" = "false" ]; then
-            should_release=false
-          fi
-          VERSION="$version" NPM_TAG="$npm_tag" SHOULD_RELEASE="$should_release" node - <<'NODE'
+          VERSION="$version" NPM_TAG="$npm_tag" node - <<'NODE'
           const fs = require("node:fs");
           const outputs = {
             version: process.env.VERSION,
             npm_tag: process.env.NPM_TAG,
             cli_tarball_filename: `clawdi-${process.env.VERSION}.tgz`,
-            should_release: process.env.SHOULD_RELEASE,
           };
           fs.appendFileSync(process.env.GITHUB_OUTPUT, Object.entries(outputs)
             .map(([key, value]) => `${key}=${value}\n`).join(""));
           NODE
 
       - uses: oven-sh/setup-bun@v2
-        if: steps.check.outputs.should_release == 'true'
         with:
           bun-version: "1.3.14"
 
       - name: Install workspace dependencies
-        if: steps.check.outputs.should_release == 'true'
         run: bun install --frozen-lockfile
 
       - name: Typecheck
-        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: bun run typecheck
 
       - name: Test (ephemeral internal suite)
-        if: steps.check.outputs.should_release == 'true'
         run: bun test --isolate --max-concurrency=1 packages/cli
 
       - name: Build package and native release matrix
         id: build_native_release
-        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: |
           bun run build
@@ -98,7 +82,6 @@ jobs:
           bun run check:native-release
 
       - name: Native lifecycle (ephemeral internal suite)
-        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: |
           CLAWDI_NATIVE_BINARY=dist-native/linux-x64/clawdi \
@@ -108,7 +91,6 @@ jobs:
 
       - name: Pack and verify immutable release artifact
         id: pack_release
-        if: steps.check.outputs.should_release == 'true'
         working-directory: packages/cli
         run: |
           sh -n ../../install.sh
@@ -135,7 +117,6 @@ jobs:
           test -f "$install_dir/node_modules/clawdi/egress-addon/clawdi_egress_addon.py"
 
       - name: Upload immutable CLI release artifact
-        if: steps.check.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.CLI_ARTIFACT_NAME }}
@@ -145,7 +126,6 @@ jobs:
 
   publish-immutable-artifact-with-oidc:
     needs: build-immutable-artifact
-    if: needs['build-immutable-artifact'].outputs.should_release == 'true'
     # npm trusted publishing supports GitHub-hosted runners, not self-hosted runners.
     runs-on: ubuntu-latest
     environment: npm

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -297,10 +297,9 @@ Use `docs/runbooks/release.md` for the full app/backend/web/CLI release
 checklist. This section covers the CLI/npm release line in detail.
 
 Publishing is automated. `.github/workflows/cli-publish.yml` watches `main`
-for changes under `packages/cli/`. If the version's GitHub Release is already
-published, the workflow exits before installing dependencies or building.
-Otherwise it builds
-the artifact from its own `GITHUB_SHA`. An absent exact npm version is
+for changes to `packages/cli/package.json`, so a release run starts only when
+the package identity changes. It builds the artifact from its own `GITHUB_SHA`.
+An absent exact npm version is
 published; an existing version is never republished and must have the same
 `dist.integrity` as the artifact built by this run.
 
@@ -317,9 +316,7 @@ The build/test job may use the configured fast runner, but the protected
 publish job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing
 does not support self-hosted or third-party GitHub Actions runners. The publish
 job uses Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm
-11.5.1. The lightweight preflight reads only the GitHub Release state; it does
-not query npm or provenance. After a fresh
-`npm publish --provenance` succeeds, that command plus the exact registry
+11.5.1. After a fresh `npm publish --provenance` succeeds, that command plus the exact registry
 version and matching `dist.integrity` authorizes GitHub Release completion; the
 job does not wait for the eventually consistent registry attestation read API.
 If release work remains and the immutable npm version already exists, the
@@ -419,10 +416,8 @@ version through its Cloud manifest. The `beta` tag is publication metadata;
 production and Hosted never resolve an npm dist-tag.
 
 A manual run is available under `workflow_dispatch` if the auto-run needs a
-nudge. An unchanged version with an exact npm package and complete published
-GitHub Release is a fast no-op. If npm succeeded but GitHub Release creation
-failed, rerun that original workflow run so `GITHUB_SHA` and the artifact remain
-identical.
+nudge. If npm succeeded but GitHub Release creation failed, rerun that original
+workflow run so `GITHUB_SHA` and the artifact remain identical.
 
 ### Smoke checks before bumping the version
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -74,10 +74,9 @@ releases.
    ```
 
 6. Bump `packages/cli/package.json` using semver whenever the commit is intended
-   to produce a new CLI artifact. An unchanged version whose exact npm package
-   and complete published GitHub Release already exist is a fast no-op. Reuse
-   the version for active release work only when rerunning the original workflow
-   run after an incomplete release.
+   to produce a new CLI artifact. This package identity change is what triggers
+   the publish workflow. Rerun the original workflow run after an incomplete
+   release; do not create a new commit with the same version.
    For the managed agent-v2 release line, this repository's release workflow must
    build, typecheck, run the full CLI suite, pack one immutable npm tarball, and
    build the native matrix once. It installs the npm tarball and exercises the
@@ -91,11 +90,8 @@ releases.
    GitHub-hosted `ubuntu-latest`, because npm trusted publishing does not support
    self-hosted or third-party GitHub Actions runners. The CLI workflow does not
    call workflows in the Hosted repository or depend on Hosted repository
-   settings. A lightweight preflight checks only whether the version's GitHub
-   Release is published; if so, the run skips build and publish without querying
-   npm or provenance. Otherwise the run builds from
-   its own `GITHUB_SHA`. An absent
-   exact npm version is published with provenance; an existing version is never
+   settings. The run builds from its own `GITHUB_SHA`. An absent exact npm
+   version is published with provenance; an existing version is never
    republished and must have the same `dist.integrity` as this run's artifact.
    Fresh publish completion does not wait for the eventually consistent
    attestation read API. The GitHub Release may be created or a draft may be
@@ -158,8 +154,8 @@ releases.
    - `.github/workflows/clawdi-release.yml` is manual-only. Run `Release Clawdi`
      only after the deployed commit should get public app/backend/web release
      notes.
-   - `.github/workflows/cli-publish.yml` runs for `packages/cli/**` and the
-     CLI publish workflow file. It builds from the run's `GITHUB_SHA`, publishes
+   - `.github/workflows/cli-publish.yml` runs only when
+     `packages/cli/package.json` changes. It builds from the run's `GITHUB_SHA`, publishes
      only when the exact npm version is absent, and otherwise verifies exact
      registry integrity before completing the same-commit GitHub Release.
 

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -4,9 +4,7 @@ import { resolve } from "node:path";
 import { parse } from "yaml";
 
 interface WorkflowJob {
-	if?: string;
 	needs?: unknown;
-	outputs?: Record<string, string>;
 	permissions?: Record<string, string>;
 	steps?: Array<Record<string, unknown>>;
 }
@@ -51,9 +49,7 @@ describe("CLI publish workflow contract", () => {
 		]);
 		expect(build.permissions).toEqual({ contents: "read" });
 		expect(publish.needs).toBe("build-immutable-artifact");
-		expect(publish.if).toBe("needs['build-immutable-artifact'].outputs.should_release == 'true'");
 		expect(publish.permissions).toEqual({ contents: "write", "id-token": "write" });
-		expect(build.outputs?.should_release).toBe(`\${{ steps.check.outputs.should_release }}`);
 		expect(build.steps?.find((step) => step.id === "check")?.["working-directory"]).toBe(
 			"packages/cli",
 		);
@@ -66,9 +62,6 @@ describe("CLI publish workflow contract", () => {
 			expect(build.steps?.find((step) => step.id === stepId)?.["working-directory"]).toBe(
 				"packages/cli",
 			);
-		}
-		for (const step of build.steps?.slice(3) ?? []) {
-			expect(step.if).toBe("steps.check.outputs.should_release == 'true'");
 		}
 		expect(publish.steps?.map((step) => step.id).filter(Boolean)).toEqual([
 			"verify_release",
@@ -148,13 +141,8 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).not.toContain("NPM_TOKEN");
 	});
 
-	test("skips complete exact releases and otherwise verifies artifact integrity", () => {
-		const buildJob = workflow.slice(
-			workflow.indexOf("  build-immutable-artifact:"),
-			workflow.indexOf("  publish-immutable-artifact-with-oidc:"),
-		);
+	test("publishes only an absent exact version and verifies artifact integrity", () => {
 		const publishJob = workflow.slice(workflow.indexOf("  publish-immutable-artifact-with-oidc:"));
-		const noOpDecision = buildJob.indexOf('gh release view "$tag" --json isDraft --jq .isDraft');
 		const absenceCheck = publishJob.indexOf("if ! npm_release_visible; then");
 		const publishCommand = publishJob.indexOf("npm publish ");
 		const visibilityWait = publishJob.indexOf("for attempt in $(seq 1 12); do", publishCommand);
@@ -165,10 +153,7 @@ describe("CLI publish workflow contract", () => {
 			'published_integrity=$(npm view "clawdi@$VERSION" dist.integrity)',
 		);
 
-		expect(noOpDecision).toBeGreaterThan(-1);
-		expect(noOpDecision).toBeLessThan(buildJob.indexOf("bun install --frozen-lockfile"));
-		expect(buildJob).toContain("should_release=true");
-		expect(buildJob.match(/should_release=false/g)).toHaveLength(1);
+		expect(workflow).toContain('- "packages/cli/package.json"');
 		expect(absenceCheck).toBeGreaterThan(-1);
 		expect(absenceCheck).toBeLessThan(publishCommand);
 		expect(visibilityWait).toBeGreaterThan(publishCommand);


### PR DESCRIPTION
## Summary

- trigger the CLI publish workflow only when packages/cli/package.json changes
- remove release preflight, should-release outputs, and conditional build topology
- keep official npm provenance publication, immutable integrity verification, and original-run draft completion

## Verification

- workflow contract: 6 passed
- CLI typecheck
- git diff --check

No recovery script/schema, version floor, hardcoded desired version, provenance polling, release asset state, or cross-commit recovery.