### PR TITLE
fix(settings): align API keys, Wallet, and Usage

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1726,6 +1726,7 @@ export function AppSidebar({
 			<SettingsDialog
 				open={settingsOpen}
 				section={activeSettingsSection}
+				agentTiles={agents}
 				hasExistingCloudAgents={
 					hostedAgentTiles?.some((tile) => tile.source === "on-clawdi") ?? false
 				}

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -224,7 +224,7 @@ export function AgentSettingsPanel({
 	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;
 
 	return (
-		<div className={cn("flex flex-col gap-9", className)}>
+		<div className={cn("flex flex-col gap-8", className)}>
 			{guardedBySurface ? null : (
 				<UnsavedNavigationGuard
 					dirty={nameChanged}

--- a/apps/web/src/components/hosted-route-skeleton.tsx
+++ b/apps/web/src/components/hosted-route-skeleton.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 export function HostedRouteSkeleton() {
 	return (
 		<div className="flex flex-col gap-8 px-5 sm:px-6 lg:px-8">
-			<div className="space-y-2 md:pr-12">
+			<div className="space-y-2">
 				<Skeleton className="h-6 w-36" />
 				<Skeleton className="h-4 w-64 max-w-full" />
 			</div>

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -8,9 +8,11 @@ import {
 	type LucideIcon,
 	SlidersHorizontal,
 	WalletCards,
+	XIcon,
 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
 import { IconChip } from "@/components/icon-chip";
 import { ApiKeysPanel } from "@/components/settings/api-keys-panel";
@@ -20,6 +22,7 @@ import { SettingsPanelErrorBoundary } from "@/components/settings-panel-error-bo
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogDescription,
 	DialogHeader,
@@ -108,6 +111,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
 export function SettingsDialog({
 	open,
 	section,
+	agentTiles,
 	hasExistingCloudAgents = false,
 	cloudInventoryResolved = true,
 	onSectionChange,
@@ -115,6 +119,7 @@ export function SettingsDialog({
 }: {
 	open: boolean;
 	section: SettingsSectionId;
+	agentTiles: readonly AgentTile[];
 	hasExistingCloudAgents?: boolean;
 	cloudInventoryResolved?: boolean;
 	onSectionChange: (section: SettingsSectionId) => void;
@@ -220,7 +225,7 @@ export function SettingsDialog({
 				<DialogContent
 					data-testid="settings-dialog"
 					initialFocus={activeButtonRef}
-					showCloseButton={!hasPendingSave}
+					showCloseButton={false}
 					className="h-[min(820px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-6xl gap-0 overflow-hidden p-0 sm:max-w-6xl"
 				>
 					<DialogHeader className="sr-only">
@@ -230,11 +235,12 @@ export function SettingsDialog({
 
 					<div className="grid h-full min-h-0 grid-rows-[auto_1fr] md:grid-cols-[15rem_minmax(0,1fr)] md:grid-rows-1">
 						<aside className="flex min-w-0 flex-col border-b bg-muted/30 md:border-r md:border-b-0">
-							<div className="flex h-14 shrink-0 items-center px-4 md:h-16">
+							<div className="flex h-14 shrink-0 items-center justify-between gap-3 px-4 md:h-16">
 								<div className="min-w-0">
 									<div className="truncate text-sm font-semibold">Settings</div>
 									<div className="truncate text-xs text-muted-foreground">Clawdi preferences</div>
 								</div>
+								{!hasPendingSave ? <SettingsDialogCloseButton className="md:hidden" /> : null}
 							</div>
 							<div className="relative min-w-0 md:min-h-0 md:flex-1">
 								<nav
@@ -282,25 +288,32 @@ export function SettingsDialog({
 							</div>
 						</aside>
 
-						<section className="min-h-0 overflow-y-auto py-6 md:py-8">
-							<div className="mx-auto w-full max-w-4xl">
-								{billingAccessPending ? (
-									<HostedRouteSkeleton />
-								) : billingAccessError ? (
-									<div className="px-5 sm:px-6 lg:px-8">
-										<ApiErrorPanel
-											error={hostedAccess.error}
-											normalizer={HOSTED_ACCESS_ERROR_NORMALIZER}
-											onRetry={() => void hostedAccess.refetch()}
-											title="Couldn’t verify billing access"
-										/>
-									</div>
-								) : (
-									<SettingsPanelErrorBoundary key={activeSection}>
-										<SettingsPanel section={activeSection} />
-									</SettingsPanelErrorBoundary>
-								)}
+						<section className="grid min-h-0 min-w-0 md:grid-cols-[minmax(0,1fr)_auto]">
+							<div className="min-h-0 overflow-y-auto py-6 md:py-8">
+								<div className="mx-auto w-full max-w-4xl">
+									{billingAccessPending ? (
+										<HostedRouteSkeleton />
+									) : billingAccessError ? (
+										<div className="px-5 sm:px-6 lg:px-8">
+											<ApiErrorPanel
+												error={hostedAccess.error}
+												normalizer={HOSTED_ACCESS_ERROR_NORMALIZER}
+												onRetry={() => void hostedAccess.refetch()}
+												title="Couldn’t verify billing access"
+											/>
+										</div>
+									) : (
+										<SettingsPanelErrorBoundary key={activeSection}>
+											<SettingsPanel section={activeSection} agentTiles={agentTiles} />
+										</SettingsPanelErrorBoundary>
+									)}
+								</div>
 							</div>
+							{!hasPendingSave ? (
+								<div className="hidden items-start justify-center px-2 pt-4 md:flex">
+									<SettingsDialogCloseButton />
+								</div>
+							) : null}
 						</section>
 					</div>
 				</DialogContent>
@@ -316,7 +329,25 @@ export function SettingsDialog({
 	);
 }
 
-function SettingsPanel({ section }: { section: SettingsSectionId }) {
+function SettingsDialogCloseButton({ className }: { className?: string }) {
+	return (
+		<DialogClose
+			className={className}
+			render={<Button type="button" variant="ghost" size="icon-sm" />}
+		>
+			<XIcon />
+			<span className="sr-only">Close</span>
+		</DialogClose>
+	);
+}
+
+function SettingsPanel({
+	section,
+	agentTiles,
+}: {
+	section: SettingsSectionId;
+	agentTiles: readonly AgentTile[];
+}) {
 	if (!SETTINGS_SECTION_IDS.includes(section)) return <GeneralPanel />;
 
 	switch (section) {
@@ -341,7 +372,7 @@ function SettingsPanel({ section }: { section: SettingsSectionId }) {
 		case "billing-usage":
 			return UsagePage ? (
 				<Suspense fallback={<HostedRouteSkeleton />}>
-					<UsagePage />
+					<UsagePage agentTiles={agentTiles} />
 				</Suspense>
 			) : (
 				<GeneralPanel />

--- a/apps/web/src/components/settings/settings-panel-header.tsx
+++ b/apps/web/src/components/settings/settings-panel-header.tsx
@@ -12,7 +12,7 @@ export function SettingsPanelHeader({
 	return (
 		<div
 			data-slot="settings-panel-header"
-			className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between md:pr-12"
+			className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
 		>
 			<div className="flex min-w-0 flex-col gap-1">
 				<h2 className="text-lg font-semibold tracking-tight">{title}</h2>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3188,7 +3188,7 @@ function HostedAgentSettingsTab({
 	const formatName = useCallback((name: string) => deploymentDisplayName(name, runtime), [runtime]);
 	return (
 		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
-			<div className="flex flex-col gap-10">
+			<div className="flex flex-col gap-8">
 				{projectionAvailable ? (
 					<AgentSettingsPanel environmentId={environmentId} formatName={formatName} />
 				) : (
@@ -3589,7 +3589,7 @@ function ComputeSettingsSections({
 	}
 
 	return (
-		<div className="flex flex-col gap-9">
+		<div className="flex flex-col gap-8">
 			{wallet.data ? (
 				<TopUpDialog {...walletTopUp.dialogProps} onComplete={() => setPlanChangeQuote(null)} />
 			) : null}

--- a/apps/web/src/hosted/billing/components/state-views.tsx
+++ b/apps/web/src/hosted/billing/components/state-views.tsx
@@ -56,7 +56,7 @@ export function WalletSkeleton() {
 	);
 }
 
-/** Usage: metric strip followed by peer agent and model breakdowns. */
+/** Usage: metric strip, daily trend, then peer agent and model breakdowns. */
 export function UsageSkeleton() {
 	return (
 		<div data-hosted="true" className="space-y-8">
@@ -70,6 +70,9 @@ export function UsageSkeleton() {
 					<Skeleton className="h-4 w-32" />
 				</div>
 			</div>
+			<SectionSkeleton>
+				<Skeleton className="h-44 w-full rounded-lg" />
+			</SectionSkeleton>
 			<SectionSkeleton>
 				<div className="space-y-3">
 					<Skeleton className="h-10 w-full" />

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Cpu, Zap } from "lucide-react";
 import { useMemo } from "react";
+import { SettingsSection } from "@/components/settings-section";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { Plan } from "@/hosted/billing/contracts";
@@ -75,20 +76,19 @@ export function PlanComparison({
 		basic !== undefined && performance !== undefined && !selectedTerm;
 
 	return (
-		<section data-hosted="true" className="space-y-4" aria-labelledby="plan-comparison-heading">
-			<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h3 id="plan-comparison-heading" className="text-base font-semibold">
-						Compare compute plans
-					</h3>
-					{sharedPricingUnavailable ? (
-						<p className="mt-1 text-sm text-muted-foreground">
-							A shared Basic and Performance billing term is not currently available.
-						</p>
-					) : null}
-				</div>
+		<SettingsSection
+			data-hosted="true"
+			headingLevel={3}
+			title="Compare compute plans"
+			description={
+				sharedPricingUnavailable
+					? "A shared Basic and Performance billing term is not currently available."
+					: undefined
+			}
+		>
+			<div className="space-y-4">
 				{commonOffers.length > 1 && selectedTerm !== null ? (
-					<div className="w-full shrink-0 space-y-1.5 sm:w-56">
+					<div className="ml-auto w-full space-y-1.5 sm:w-56">
 						<p className="text-xs font-medium text-muted-foreground">Billing term</p>
 						<TermSwitcher
 							offers={commonOffers}
@@ -99,8 +99,7 @@ export function PlanComparison({
 						/>
 					</div>
 				) : null}
-			</div>
-			<div className="grid gap-3 lg:grid-cols-2">
+				<div className="grid gap-3 lg:grid-cols-2">
 				{/* Basic */}
 				<Card size="sm">
 					<CardHeader className="gap-2">
@@ -173,7 +172,8 @@ export function PlanComparison({
 						</ul>
 					</CardContent>
 				</Card>
+				</div>
 			</div>
-		</section>
+		</SettingsSection>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -100,78 +100,78 @@ export function PlanComparison({
 					</div>
 				) : null}
 				<div className="grid gap-3 lg:grid-cols-2">
-				{/* Basic */}
-				<Card size="sm">
-					<CardHeader className="gap-2">
-						<CardTitle className="flex items-center gap-2">
-							<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
-						</CardTitle>
-						<CardDescription>First active Basic agent included at no charge.</CardDescription>
-						<div className="min-h-20 pt-1">
-							<p className="text-xs text-muted-foreground">Each additional Basic agent</p>
-							{basicPrice ? (
-								<>
-									<p className="text-3xl font-semibold tracking-tight tabular-nums">
-										{basicPrice.primary}
-									</p>
-									<p className="text-xs text-muted-foreground">{basicPrice.secondary}</p>
-								</>
-							) : (
-								<p className="text-sm font-medium">Pricing unavailable</p>
-							)}
-						</div>
-					</CardHeader>
-					<CardContent className="flex-1">
-						<ul className="space-y-2">
-							{basic ? (
+					{/* Basic */}
+					<Card size="sm">
+						<CardHeader className="gap-2">
+							<CardTitle className="flex items-center gap-2">
+								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
+							</CardTitle>
+							<CardDescription>First active Basic agent included at no charge.</CardDescription>
+							<div className="min-h-20 pt-1">
+								<p className="text-xs text-muted-foreground">Each additional Basic agent</p>
+								{basicPrice ? (
+									<>
+										<p className="text-3xl font-semibold tracking-tight tabular-nums">
+											{basicPrice.primary}
+										</p>
+										<p className="text-xs text-muted-foreground">{basicPrice.secondary}</p>
+									</>
+								) : (
+									<p className="text-sm font-medium">Pricing unavailable</p>
+								)}
+							</div>
+						</CardHeader>
+						<CardContent className="flex-1">
+							<ul className="space-y-2">
+								{basic ? (
+									<FeatureRow>
+										Up to {basic.vcpu} vCPU · {basic.ram_gb} GB RAM · {basic.disk_size} GB storage
+									</FeatureRow>
+								) : null}
 								<FeatureRow>
-									Up to {basic.vcpu} vCPU · {basic.ram_gb} GB RAM · {basic.disk_size} GB storage
+									Managed confidential compute · one runtime (OpenClaw or Hermes)
 								</FeatureRow>
-							) : null}
-							<FeatureRow>
-								Managed confidential compute · one runtime (OpenClaw or Hermes)
-							</FeatureRow>
-							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
-						</ul>
-					</CardContent>
-				</Card>
+								<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
+							</ul>
+						</CardContent>
+					</Card>
 
-				{/* Performance */}
-				<Card size="sm" className="border-primary/30">
-					<CardHeader className="gap-2">
-						<CardTitle className="flex items-center gap-2">
-							<Zap className="size-5 text-primary" aria-hidden /> Compute Performance
-						</CardTitle>
-						<CardDescription>Higher capacity for production workloads.</CardDescription>
-						<div className="min-h-20 pt-1">
-							<p className="text-xs text-muted-foreground">Each Performance agent</p>
-							{performancePrice ? (
-								<>
-									<p className="text-3xl font-semibold tracking-tight tabular-nums">
-										{performancePrice.primary}
-									</p>
-									<p className="text-xs text-muted-foreground">{performancePrice.secondary}</p>
-								</>
-							) : (
-								<p className="text-sm font-medium">Pricing unavailable</p>
-							)}
-						</div>
-					</CardHeader>
-					<CardContent className="flex-1">
-						<ul className="space-y-2">
-							{performance ? (
+					{/* Performance */}
+					<Card size="sm" className="border-primary/30">
+						<CardHeader className="gap-2">
+							<CardTitle className="flex items-center gap-2">
+								<Zap className="size-5 text-primary" aria-hidden /> Compute Performance
+							</CardTitle>
+							<CardDescription>Higher capacity for production workloads.</CardDescription>
+							<div className="min-h-20 pt-1">
+								<p className="text-xs text-muted-foreground">Each Performance agent</p>
+								{performancePrice ? (
+									<>
+										<p className="text-3xl font-semibold tracking-tight tabular-nums">
+											{performancePrice.primary}
+										</p>
+										<p className="text-xs text-muted-foreground">{performancePrice.secondary}</p>
+									</>
+								) : (
+									<p className="text-sm font-medium">Pricing unavailable</p>
+								)}
+							</div>
+						</CardHeader>
+						<CardContent className="flex-1">
+							<ul className="space-y-2">
+								{performance ? (
+									<FeatureRow>
+										Up to {performance.vcpu} vCPU · {performance.ram_gb} GB RAM ·{" "}
+										{performance.disk_size} GB storage
+									</FeatureRow>
+								) : null}
 								<FeatureRow>
-									Up to {performance.vcpu} vCPU · {performance.ram_gb} GB RAM ·{" "}
-									{performance.disk_size} GB storage
+									Managed confidential compute · one runtime (OpenClaw or Hermes)
 								</FeatureRow>
-							) : null}
-							<FeatureRow>
-								Managed confidential compute · one runtime (OpenClaw or Hermes)
-							</FeatureRow>
-							<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
-						</ul>
-					</CardContent>
-				</Card>
+								<FeatureRow>BYOK bypasses Clawdi AI charges</FeatureRow>
+							</ul>
+						</CardContent>
+					</Card>
 				</div>
 			</div>
 		</SettingsSection>

--- a/apps/web/src/hosted/billing/usage/usage-page.test.ts
+++ b/apps/web/src/hosted/billing/usage/usage-page.test.ts
@@ -102,7 +102,6 @@ describe("usage availability rendering", () => {
 		expect(markup).toContain("$12.50");
 		expect(markup).toContain("37");
 		expect(markup).toContain("model-read-successfully");
-		expect(markup).not.toContain("Daily usage");
 	});
 
 	test("keeps agent attribution visible when totals and model data are unavailable", () => {
@@ -127,7 +126,7 @@ describe("usage availability rendering", () => {
 		expect(markup).toContain("Usage totals unavailable");
 		expect(markup).toContain("Model breakdown unavailable");
 		expect(markup).toContain("support");
-		expect(markup).toContain("hdep_support");
+		expect(markup).not.toContain("hdep_support");
 		expect(markup).toContain("$9.25");
 		expect(markup).not.toContain("No usage yet");
 	});

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -3,10 +3,19 @@
 import { RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { AgentLabel, agentIdentity } from "@/components/dashboard/agent-label";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import { EmptyState } from "@/components/empty-state";
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
@@ -29,9 +38,23 @@ import { shouldBlockQueryError } from "@/lib/query-state";
 const DESCRIPTION = "Clawdi AI spend and requests for the current reporting window.";
 const USAGE_PAGE_CLASS = "flex flex-col gap-8 px-5 sm:px-6 lg:px-8";
 
-type VisibleUsageSection = "totals" | "by_agent" | "by_model";
+type VisibleUsageSection = "totals" | "by_agent" | "by_model" | "by_day";
 type AgentBreakdown = NonNullable<HostedUsageSummary["by_agent"]>[number];
 type ModelBreakdown = HostedUsageSummary["by_model"][number];
+type DayBreakdown = HostedUsageSummary["by_day"][number];
+type ScopedAgentBreakdown = AgentBreakdown & {
+	agent_id: string;
+	by_model: ModelBreakdown[];
+};
+
+type UsageAgentIdentity = {
+	name: string | null;
+	displayName: string | null;
+	defaultName: string | null;
+	machineName: string | null;
+	type: string | null;
+	avatarUrl: string | null;
+};
 
 function decimalUsdIsZero(value: string): boolean {
 	return /^[+-]?0+(?:\.0+)?$/.test(value.trim());
@@ -80,9 +103,57 @@ function sortModelBreakdown(left: ModelBreakdown, right: ModelBreakdown): number
 		: compareStableText(left.provider ?? "", right.provider ?? "");
 }
 
+function hasAgentModelBreakdown(agent: AgentBreakdown): agent is ScopedAgentBreakdown {
+	return typeof agent.agent_id === "string" && Array.isArray(agent.by_model);
+}
+
+function usageAgentIdentity(
+	agent: AgentBreakdown,
+	agentTiles: readonly AgentTile[],
+): UsageAgentIdentity {
+	const tile = agent.agent_id
+		? agentTiles.find((candidate) => candidate.id === agent.agent_id)
+		: null;
+	const env = tile?.env ?? null;
+	const fallbackName = agent.agent_name
+		? deploymentDisplayName(agent.agent_name, agent.agent_type ?? undefined)
+		: null;
+	return {
+		name: env?.name ?? tile?.name ?? fallbackName,
+		displayName: env?.display_name ?? null,
+		defaultName: env?.default_name ?? null,
+		machineName: env?.machine_name ?? null,
+		type: env?.agent_type ?? tile?.agentType ?? agent.agent_type ?? null,
+		avatarUrl: env?.avatar_url ?? tile?.avatarUrl ?? null,
+	};
+}
+
+function usageAgentLabel(identity: UsageAgentIdentity): string {
+	const label = agentIdentity({
+		name: identity.name,
+		display_name: identity.displayName,
+		default_name: identity.defaultName,
+		machine_name: identity.machineName,
+		agent_type: identity.type,
+	});
+	return label.secondaryLabel
+		? `${label.primaryLabel} · ${label.secondaryLabel}`
+		: label.primaryLabel;
+}
+
+export function usageModelsForAgentScope(
+	usage: HostedUsageSummary,
+	agentId: string,
+): readonly ModelBreakdown[] {
+	if (agentId === "all" || !Array.isArray(usage.by_agent)) return usage.by_model;
+	const agent = usage.by_agent.find((candidate) => candidate.agent_id === agentId);
+	return Array.isArray(agent?.by_model) ? agent.by_model : usage.by_model;
+}
+
 function unavailableUsageSections(
 	usage: HostedUsageSummary,
 	agentBreakdown: readonly AgentBreakdown[] | null,
+	dailyBreakdown: readonly DayBreakdown[] | null,
 ): Set<VisibleUsageSection> {
 	const sections = new Set<VisibleUsageSection>();
 	if (
@@ -96,10 +167,13 @@ function unavailableUsageSections(
 		sections.add("by_agent");
 	}
 	if (usage.unavailable_sections.includes("by_model")) sections.add("by_model");
+	if (usage.unavailable_sections.includes("by_day") || dailyBreakdown === null) {
+		sections.add("by_day");
+	}
 	return sections;
 }
 
-export function UsagePage() {
+export function UsagePage({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
 	const usage = useUsage();
 	const providers = useUserAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
@@ -141,6 +215,7 @@ export function UsagePage() {
 	return (
 		<UsageSummaryView
 			usage={usage.data}
+			agentTiles={agentTiles}
 			providers={providers.data ?? []}
 			managedModels={managedModelCatalog.data?.models ?? []}
 			isRetrying={manualRetrying}
@@ -153,31 +228,50 @@ export function UsagePage() {
 
 export function UsageSummaryView({
 	usage,
+	agentTiles = [],
 	providers,
 	managedModels,
 	isRetrying,
 	onRetry,
 }: {
 	usage: HostedUsageSummary;
+	agentTiles?: readonly AgentTile[];
 	providers: readonly AiProvider[];
 	managedModels: readonly ManagedModelCatalogItem[];
 	isRetrying: boolean;
 	onRetry: () => void;
 }) {
+	const [selectedAgentId, setSelectedAgentId] = useState("all");
 	const agentBreakdown = Array.isArray(usage.by_agent) ? usage.by_agent : null;
-	const missingSections = unavailableUsageSections(usage, agentBreakdown);
+	const dailyBreakdown = Array.isArray(usage.by_day) ? usage.by_day : null;
+	const missingSections = unavailableUsageSections(usage, agentBreakdown, dailyBreakdown);
 	const totals =
 		!missingSections.has("totals") && usage.total_usd !== null && usage.total_requests !== null
 			? { usd: usage.total_usd, requests: usage.total_requests }
 			: null;
 	const sortedAgents = agentBreakdown ? [...agentBreakdown].sort(sortAgentBreakdown) : [];
-	const sortedModels = [...usage.by_model].sort(sortModelBreakdown);
+	const sortedDays = dailyBreakdown
+		? [...dailyBreakdown].sort((left, right) => compareStableText(left.date, right.date))
+		: [];
+	const selectableAgents = sortedAgents.filter(hasAgentModelBreakdown);
+	const selectedAgent = selectableAgents.find((agent) => agent.agent_id === selectedAgentId);
+	const effectiveAgentId = selectedAgent?.agent_id ?? "all";
+	const scopedModels = usageModelsForAgentScope(usage, effectiveAgentId);
+	const sortedModels = [...scopedModels].sort(sortModelBreakdown);
+	const scopeItems = [
+		{ label: "All agents", value: "all" },
+		...selectableAgents.map((agent) => ({
+			label: usageAgentLabel(usageAgentIdentity(agent, agentTiles)),
+			value: agent.agent_id,
+		})),
+	];
 	const windowLabel = `${formatShortDate(usage.period_start)} – ${formatShortDate(usage.period_end)}`;
 
 	if (
 		missingSections.has("totals") &&
 		missingSections.has("by_agent") &&
-		missingSections.has("by_model")
+		missingSections.has("by_model") &&
+		missingSections.has("by_day")
 	) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
@@ -185,7 +279,7 @@ export function UsageSummaryView({
 				<EmptyState
 					variant="inset"
 					title="We can’t load your usage right now"
-					description="The usage provider is temporarily unavailable. No spend, agent, or model values are shown."
+					description="The usage provider is temporarily unavailable. No usage values are shown."
 					action={<UsageRetryButton isRetrying={isRetrying} onRetry={onRetry} />}
 					className="py-10 md:p-10"
 				/>
@@ -200,7 +294,9 @@ export function UsageSummaryView({
 		!missingSections.has("by_agent") &&
 		sortedAgents.length === 0 &&
 		!missingSections.has("by_model") &&
-		sortedModels.length === 0;
+		sortedModels.length === 0 &&
+		!missingSections.has("by_day") &&
+		sortedDays.length === 0;
 
 	if (isRealZero) {
 		return (
@@ -218,11 +314,13 @@ export function UsageSummaryView({
 
 	const retrySection: VisibleUsageSection | null = missingSections.has("totals")
 		? "totals"
-		: missingSections.has("by_agent")
-			? "by_agent"
-			: missingSections.has("by_model")
-				? "by_model"
-				: null;
+		: missingSections.has("by_day")
+			? "by_day"
+			: missingSections.has("by_agent")
+				? "by_agent"
+				: missingSections.has("by_model")
+					? "by_model"
+					: null;
 	const retryAction = (section: VisibleUsageSection) =>
 		retrySection === section ? (
 			<UsageRetryButton isRetrying={isRetrying} onRetry={onRetry} />
@@ -260,6 +358,30 @@ export function UsageSummaryView({
 					className="py-6 md:p-6"
 				/>
 			)}
+
+			<SettingsSection
+				headingLevel={3}
+				title="Daily usage"
+				description="Global Clawdi AI spend by day."
+			>
+				{missingSections.has("by_day") ? (
+					<EmptyState
+						variant="inset"
+						title="Daily usage unavailable"
+						description="The daily trend could not be read."
+						action={retryAction("by_day")}
+						className="py-4 md:p-4"
+					/>
+				) : sortedDays.length === 0 ? (
+					<EmptyState
+						variant="inset"
+						description="No daily usage in this reporting window"
+						className="py-4 md:p-4"
+					/>
+				) : (
+					<DailyUsageChart days={sortedDays} />
+				)}
+			</SettingsSection>
 
 			<SettingsSection
 				headingLevel={3}
@@ -303,23 +425,28 @@ export function UsageSummaryView({
 						</thead>
 						<tbody className="divide-y">
 							{sortedAgents.map((agent) => {
-								const displayName = agent.agent_name
-									? deploymentDisplayName(agent.agent_name)
-									: "Unattributed";
+								const identity = usageAgentIdentity(agent, agentTiles);
 								return (
 									<tr key={agent.agent_id ?? "unattributed"}>
 										<td className="min-w-0 py-3 pr-3 align-top">
-											<div className="truncate text-sm font-medium">{displayName}</div>
-											<div
-												className={
-													agent.agent_id
-														? "truncate font-mono text-[11px] text-muted-foreground"
-														: "text-xs leading-4 text-muted-foreground"
-												}
-												title={agent.agent_id ?? undefined}
-											>
-												{agent.agent_id ?? "Usage not linked to an agent"}
-											</div>
+											{agent.agent_id ? (
+												<AgentLabel
+													name={identity.name}
+													displayName={identity.displayName}
+													defaultName={identity.defaultName}
+													machineName={identity.machineName}
+													type={identity.type}
+													avatarUrl={identity.avatarUrl}
+													size="sm"
+												/>
+											) : (
+												<div className="space-y-0.5">
+													<div className="text-sm font-medium">Unattributed</div>
+													<div className="text-xs leading-4 text-muted-foreground">
+														Usage not linked to an agent
+													</div>
+												</div>
+											)}
 										</td>
 										<td className="py-3 text-right align-top text-sm tabular-nums">
 											{agent.requests.toLocaleString()}
@@ -348,66 +475,144 @@ export function UsageSummaryView({
 						action={retryAction("by_model")}
 						className="py-4 md:p-4"
 					/>
-				) : sortedModels.length === 0 ? (
-					<EmptyState
-						variant="inset"
-						description="No model usage in this reporting window"
-						className="py-4 md:p-4"
-					/>
 				) : (
-					<table className="w-full table-fixed">
-						<caption className="sr-only">Clawdi AI usage grouped by provider and model</caption>
-						<colgroup>
-							<col />
-							<col className="w-[5.5rem] sm:w-28" />
-							<col className="w-[5.5rem] sm:w-28" />
-						</colgroup>
-						<thead>
-							<tr className="border-b text-xs text-muted-foreground">
-								<th scope="col" className="pb-2 text-left font-medium">
-									Model
-								</th>
-								<th scope="col" className="pb-2 text-right font-medium">
-									Requests
-								</th>
-								<th scope="col" className="pb-2 text-right font-medium">
-									Spend
-								</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y">
-							{sortedModels.map((model) => {
-								const providerId = model.provider ?? MANAGED_PROVIDER_ID;
-								const modelName = modelDisplayName(
-									model.model,
-									modelOptionsForProvider(providerId, providers, managedModels),
-								);
-								return (
-									<tr key={`${model.provider ?? "managed"}:${model.model}`}>
-										<td className="min-w-0 py-3 pr-3 align-top">
-											<div className="flex min-w-0 items-center gap-2">
-												<ProviderIcon provider={providerId} providers={providers} size="sm" />
-												<div className="min-w-0">
-													<div className="truncate text-sm font-medium">{modelName}</div>
-													<div className="truncate text-xs text-muted-foreground">
-														{providerDisplayLabel(providerId, providers)}
-													</div>
-												</div>
-											</div>
-										</td>
-										<td className="py-3 text-right align-top text-sm tabular-nums">
-											{model.requests.toLocaleString()}
-										</td>
-										<td className="py-3 text-right align-top text-sm font-medium tabular-nums">
-											{formatUsdExact(model.amount_usd)}
-										</td>
+					<div className="space-y-4">
+						{selectableAgents.length > 0 ? (
+							<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+								<span className="text-xs font-medium text-muted-foreground">Agent scope</span>
+								<Select
+									items={scopeItems}
+									value={effectiveAgentId}
+									onValueChange={(value) => setSelectedAgentId(value ?? "all")}
+								>
+									<SelectTrigger aria-label="Agent scope" className="w-full sm:w-56">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent align="end">
+										{scopeItems.map((item) => (
+											<SelectItem key={item.value} value={item.value}>
+												{item.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						) : null}
+
+						{sortedModels.length === 0 ? (
+							<EmptyState
+								variant="inset"
+								description={
+									selectedAgent
+										? "No model usage for this agent in the reporting window"
+										: "No model usage in this reporting window"
+								}
+								className="py-4 md:p-4"
+							/>
+						) : (
+							<table className="w-full table-fixed">
+								<caption className="sr-only">Clawdi AI usage grouped by provider and model</caption>
+								<colgroup>
+									<col />
+									<col className="w-[5.5rem] sm:w-28" />
+									<col className="w-[5.5rem] sm:w-28" />
+								</colgroup>
+								<thead>
+									<tr className="border-b text-xs text-muted-foreground">
+										<th scope="col" className="pb-2 text-left font-medium">
+											Model
+										</th>
+										<th scope="col" className="pb-2 text-right font-medium">
+											Requests
+										</th>
+										<th scope="col" className="pb-2 text-right font-medium">
+											Spend
+										</th>
 									</tr>
-								);
-							})}
-						</tbody>
-					</table>
+								</thead>
+								<tbody className="divide-y">
+									{sortedModels.map((model) => {
+										const providerId = model.provider ?? MANAGED_PROVIDER_ID;
+										const modelName = modelDisplayName(
+											model.model,
+											modelOptionsForProvider(providerId, providers, managedModels),
+										);
+										return (
+											<tr key={`${model.provider ?? "managed"}:${model.model}`}>
+												<td className="min-w-0 py-3 pr-3 align-top">
+													<div className="flex min-w-0 items-center gap-2">
+														<ProviderIcon provider={providerId} providers={providers} size="sm" />
+														<div className="min-w-0">
+															<div className="truncate text-sm font-medium">{modelName}</div>
+															<div className="truncate text-xs text-muted-foreground">
+																{providerDisplayLabel(providerId, providers)}
+															</div>
+														</div>
+													</div>
+												</td>
+												<td className="py-3 text-right align-top text-sm tabular-nums">
+													{model.requests.toLocaleString()}
+												</td>
+												<td className="py-3 text-right align-top text-sm font-medium tabular-nums">
+													{formatUsdExact(model.amount_usd)}
+												</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</table>
+						)}
+					</div>
 				)}
 			</SettingsSection>
+		</div>
+	);
+}
+
+function DailyUsageChart({ days }: { days: readonly DayBreakdown[] }) {
+	const amounts = days.map((day) => Number(day.amount_usd));
+	const maxAmount = Math.max(...amounts, 0);
+	const totalAmount = amounts.reduce((total, amount) => total + amount, 0);
+	const firstDay = days[0];
+	const lastDay = days.at(-1);
+
+	return (
+		<div
+			role="img"
+			aria-label={`Daily Clawdi AI spend from ${firstDay ? formatShortDate(firstDay.date) : "the start of the window"} to ${lastDay ? formatShortDate(lastDay.date) : "the end of the window"}: ${formatUsdExact(String(totalAmount))} total.`}
+			className="rounded-lg border bg-muted/10 p-4 sm:p-5"
+		>
+			<div className="mb-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+				<span>Daily spend</span>
+				<span className="font-medium tabular-nums text-foreground">
+					Peak {formatUsdExact(String(maxAmount))}
+				</span>
+			</div>
+			<div className="flex h-36 items-end gap-1 border-b sm:h-44" aria-hidden="true">
+				{days.map((day, index) => {
+					const amount = amounts[index] ?? 0;
+					const height = maxAmount > 0 ? (amount / maxAmount) * 100 : 0;
+					const label = `${formatShortDate(day.date)} · ${formatUsdExact(day.amount_usd)}`;
+					return (
+						<div
+							key={day.date}
+							className="group flex h-full min-w-0 flex-1 items-end"
+							title={label}
+						>
+							<div
+								className="w-full rounded-t-sm bg-primary/75 group-hover:bg-primary"
+								style={{ height: `${height}%`, minHeight: amount > 0 ? "2px" : undefined }}
+							/>
+						</div>
+					);
+				})}
+			</div>
+			<div className="mt-2 flex justify-between text-xs text-muted-foreground">
+				<span>{firstDay ? formatShortDate(firstDay.date) : null}</span>
+				{lastDay && lastDay.date !== firstDay?.date ? (
+					<span>{formatShortDate(lastDay.date)}</span>
+				) : null}
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -60,7 +60,6 @@ export function AutoReloadCard({
 	const initialDraft = autoReloadDraftFromWallet(wallet);
 	const [baseline, setBaseline] = useState<AutoReloadDraft>(initialDraft);
 	const [draft, setDraft] = useState<AutoReloadDraft>(initialDraft);
-	const [editing, setEditing] = useState(false);
 	const [blurred, setBlurred] = useState<BlurredFields>(PRISTINE_FIELDS);
 	const [requestError, setRequestError] = useState<AutoReloadSaveError | null>(null);
 	const [actionClientSecret, setActionClientSecret] = useState<PaymentIntentClientSecret | null>(
@@ -76,7 +75,7 @@ export function AutoReloadCard({
 	const form = autoReloadFormState(draft);
 	const dirty = autoReloadDraftIsDirty(draft, baseline);
 	const status = autoReloadStatusSummary(wallet);
-	useSettingsEditState({ dirty: editing && dirty, busy: save.isPending });
+	useSettingsEditState({ dirty, busy: save.isPending });
 
 	useEffect(() => {
 		const next = autoReloadDraftFromWallet(wallet);
@@ -107,21 +106,11 @@ export function AutoReloadCard({
 		setBlurred((current) => ({ ...current, [field]: true }));
 	}
 
-	function beginEditing() {
-		const next = { ...autoReloadDraftFromWallet(wallet), enabled: true };
-		setBaseline(autoReloadDraftFromWallet(wallet));
-		setDraft(next);
-		setBlurred(PRISTINE_FIELDS);
-		setRequestError(null);
-		setEditing(true);
-	}
-
 	function cancelChanges() {
 		if (save.isPending) return;
 		setDraft(baseline);
 		setBlurred(PRISTINE_FIELDS);
 		setRequestError(null);
-		setEditing(false);
 	}
 
 	function acceptSavedWallet(nextWallet: WalletState) {
@@ -132,7 +121,6 @@ export function AutoReloadCard({
 		setDraft(next);
 		setBlurred(PRISTINE_FIELDS);
 		setRequestError(null);
-		setEditing(false);
 	}
 
 	function handleSaveFailure(error: unknown) {
@@ -154,20 +142,6 @@ export function AutoReloadCard({
 			const nextWallet = await save.execute(request);
 			acceptSavedWallet(nextWallet);
 			toast.success("Auto-reload settings saved");
-		} catch (error) {
-			handleSaveFailure(error);
-		}
-	}
-
-	async function turnOff() {
-		if (save.isPending) return;
-		const request = autoReloadRequest({ ...autoReloadDraftFromWallet(wallet), enabled: false });
-		if (!request) return;
-		setRequestError(null);
-		try {
-			const nextWallet = await save.execute(request);
-			acceptSavedWallet(nextWallet);
-			toast.success("Auto-reload turned off");
 		} catch (error) {
 			handleSaveFailure(error);
 		}
@@ -198,14 +172,14 @@ export function AutoReloadCard({
 					<span className="inline-flex items-center gap-2">
 						<Repeat className="size-4" aria-hidden /> Auto-reload
 					</span>
-					<StatusBadge status={editing ? "neutral" : status.tone} withDot>
-						{editing ? "Editing" : status.label}
+					<StatusBadge status={status.tone} withDot>
+						{status.label}
 					</StatusBadge>
 				</span>
 			}
-			description={editing ? "Configure when Wallet automatically adds funds." : status.description}
+			description={status.description}
 		>
-			<div className="flex max-w-3xl flex-col gap-6">
+			<div className="flex max-w-3xl flex-col gap-4">
 				<AutoReloadActionConfirm
 					wallet={wallet}
 					onTopUp={onTopUp}
@@ -228,194 +202,173 @@ export function AutoReloadCard({
 					</Alert>
 				) : null}
 
-				{editing ? (
-					<form
-						id="auto-reload-form"
-						className="space-y-6"
-						onSubmit={(event) => {
-							event.preventDefault();
-							setBlurred(ALL_FIELDS_BLURRED);
-							void runAction(saveChanges);
-						}}
-					>
-						<div className="grid gap-5 sm:grid-cols-2">
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
-								<Input
-									id="ar-threshold"
-									type="number"
-									inputMode="decimal"
-									autoComplete="off"
-									min={AUTORELOAD_THRESHOLD_MIN_USD}
-									step="0.01"
-									className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-									value={draft.threshold}
-									onChange={(event) => updateDraft("threshold", event.target.value)}
-									onBlur={() => markBlurred("threshold")}
-									disabled={save.isPending}
-									aria-invalid={thresholdInvalid || thresholdServerError}
-									aria-describedby="ar-threshold-help"
-								/>
-								<p
-									id="ar-threshold-help"
-									className={
-										thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-									}
-								>
-									Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}.
+				<form
+					id="auto-reload-form"
+					className="overflow-hidden rounded-lg border bg-muted/10"
+					onSubmit={(event) => {
+						event.preventDefault();
+						setBlurred(ALL_FIELDS_BLURRED);
+						void runAction(saveChanges);
+					}}
+				>
+					<div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-4 p-4 sm:p-5">
+						<div className="space-y-1">
+							<Label htmlFor="ar-enabled">Automatically add funds</Label>
+							<p className="text-xs leading-5 text-muted-foreground">
+								{wallet.auto_reload_enabled
+									? usage
+									: "Turn this on to reload Wallet when the balance reaches your threshold."}
+							</p>
+						</div>
+						<div className="flex items-center gap-2">
+							<span className="text-xs font-medium text-muted-foreground">
+								{draft.enabled ? "On" : "Off"}
+							</span>
+							<Switch
+								id="ar-enabled"
+								data-auto-reload-primary
+								checked={draft.enabled}
+								onCheckedChange={(checked) => updateDraft("enabled", checked)}
+								disabled={save.isPending}
+							/>
+						</div>
+					</div>
+
+					<div className="grid gap-5 border-t p-4 sm:grid-cols-2 sm:p-5">
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
+							<Input
+								id="ar-threshold"
+								type="number"
+								inputMode="decimal"
+								autoComplete="off"
+								min={AUTORELOAD_THRESHOLD_MIN_USD}
+								step="0.01"
+								className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+								value={draft.threshold}
+								onChange={(event) => updateDraft("threshold", event.target.value)}
+								onBlur={() => markBlurred("threshold")}
+								disabled={!draft.enabled || save.isPending}
+								aria-invalid={thresholdInvalid || thresholdServerError}
+								aria-describedby="ar-threshold-help"
+							/>
+							<p
+								id="ar-threshold-help"
+								className={
+									thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+							>
+								Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}.
+							</p>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="ar-amount">Amount to add (USD)</Label>
+							<Input
+								id="ar-amount"
+								type="number"
+								inputMode="decimal"
+								autoComplete="off"
+								min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+								max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
+								step="0.01"
+								className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+								value={draft.amount}
+								onChange={(event) => updateDraft("amount", event.target.value)}
+								onBlur={() => markBlurred("amount")}
+								disabled={!draft.enabled || save.isPending}
+								aria-invalid={amountInvalid || amountServerError}
+								aria-describedby="ar-amount-help"
+							/>
+							<p
+								id="ar-amount-help"
+								className={
+									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+							>
+								{AUTORELOAD_AMOUNT_RANGE_LABEL}.
+							</p>
+						</div>
+					</div>
+
+					<div className="border-t p-4 sm:p-5">
+						<div className="flex items-start justify-between gap-3">
+							<div className="space-y-0.5">
+								<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
+								<p className="text-xs text-muted-foreground">
+									{draft.monthlyLimitEnabled
+										? "Pause auto-reload after this amount is added."
+										: "No monthly limit."}
 								</p>
 							</div>
+							<Switch
+								id="ar-monthly-limit"
+								checked={draft.monthlyLimitEnabled}
+								onCheckedChange={(checked) => updateDraft("monthlyLimitEnabled", checked)}
+								disabled={!draft.enabled || save.isPending}
+							/>
+						</div>
 
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="ar-amount">Amount to add (USD)</Label>
+						{draft.monthlyLimitEnabled ? (
+							<div className="mt-4 flex flex-col gap-1.5">
+								<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
 								<Input
-									id="ar-amount"
+									id="ar-cap"
 									type="number"
 									inputMode="decimal"
 									autoComplete="off"
 									min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-									max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
 									step="0.01"
 									className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-									value={draft.amount}
-									onChange={(event) => updateDraft("amount", event.target.value)}
-									onBlur={() => markBlurred("amount")}
-									disabled={save.isPending}
-									aria-invalid={amountInvalid || amountServerError}
-									aria-describedby="ar-amount-help"
+									value={draft.cap}
+									onChange={(event) => updateDraft("cap", event.target.value)}
+									onBlur={() => markBlurred("cap")}
+									disabled={!draft.enabled || save.isPending}
+									aria-invalid={capInvalid || capServerError}
+									aria-describedby="ar-cap-help"
 								/>
 								<p
-									id="ar-amount-help"
+									id="ar-cap-help"
 									className={
-										amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+										capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
 									}
 								>
-									{AUTORELOAD_AMOUNT_RANGE_LABEL}.
+									Must cover at least one reload ({minimumCap}).
 								</p>
 							</div>
-						</div>
+						) : null}
+					</div>
 
-						<div className="grid gap-4 border-t pt-5 sm:grid-cols-2">
-							<div className="flex items-start justify-between gap-3">
-								<div className="space-y-0.5">
-									<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
-									<p className="text-xs text-muted-foreground">
-										{draft.monthlyLimitEnabled
-											? "Pause auto-reload after this amount is added."
-											: "No monthly limit."}
-									</p>
-								</div>
-								<Switch
-									id="ar-monthly-limit"
-									checked={draft.monthlyLimitEnabled}
-									onCheckedChange={(checked) => updateDraft("monthlyLimitEnabled", checked)}
-									disabled={save.isPending}
-								/>
-							</div>
-
-							{draft.monthlyLimitEnabled ? (
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
-									<Input
-										id="ar-cap"
-										type="number"
-										inputMode="decimal"
-										autoComplete="off"
-										min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-										step="0.01"
-										className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-										value={draft.cap}
-										onChange={(event) => updateDraft("cap", event.target.value)}
-										onBlur={() => markBlurred("cap")}
-										disabled={save.isPending}
-										aria-invalid={capInvalid || capServerError}
-										aria-describedby="ar-cap-help"
-									/>
-									<p
-										id="ar-cap-help"
-										className={
-											capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-										}
-									>
-										Must cover at least one reload ({minimumCap}).
-									</p>
-								</div>
-							) : null}
-						</div>
-					</form>
-				) : wallet.auto_reload_enabled ? (
-					<div className="space-y-1">
-						<p className="font-medium tabular-nums">
-							Below {formatCents(Number(wallet.auto_reload_threshold_usd) * 100)} → add{" "}
-							{formatCents(wallet.auto_reload_amount_cents)}
+					<div className="flex flex-col gap-3 border-t p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+						<p className="text-xs leading-5 text-muted-foreground">
+							Uses your saved card. A manual top-up saves a card for future reloads.
 						</p>
-						<p className="text-sm text-muted-foreground">{usage}</p>
+						<div className="flex shrink-0 justify-end gap-2">
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								onClick={cancelChanges}
+								disabled={!dirty || save.isPending}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								size="sm"
+								disabled={!dirty || !form.formValid || save.isPending}
+							>
+								{save.isPending ? (
+									<>
+										<Spinner data-icon="inline-start" /> Saving…
+									</>
+								) : (
+									"Save"
+								)}
+							</Button>
+						</div>
 					</div>
-				) : null}
-
-				<div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
-					<p className="text-xs text-muted-foreground">
-						Auto-reload uses your saved card. A manual top-up saves one.
-					</p>
-					<div className="flex flex-wrap gap-2">
-						{editing ? (
-							<div key="auto-reload-edit-actions" className="flex gap-2">
-								<Button
-									type="button"
-									size="sm"
-									variant="ghost"
-									onClick={cancelChanges}
-									disabled={save.isPending}
-								>
-									Cancel
-								</Button>
-								<Button
-									type="submit"
-									form="auto-reload-form"
-									size="sm"
-									disabled={!dirty || !form.formValid || save.isPending}
-								>
-									{save.isPending ? (
-										<>
-											<Spinner data-icon="inline-start" /> Saving…
-										</>
-									) : (
-										"Save"
-									)}
-								</Button>
-							</div>
-						) : (
-							<div key="auto-reload-summary-actions" className="flex gap-2">
-								{wallet.auto_reload_enabled ? (
-									<Button
-										type="button"
-										size="sm"
-										variant="ghost"
-										onClick={() => void runAction(turnOff)}
-										disabled={save.isPending}
-									>
-										{save.isPending ? (
-											<>
-												<Spinner data-icon="inline-start" /> Turning off…
-											</>
-										) : (
-											"Turn off"
-										)}
-									</Button>
-								) : null}
-								<Button
-									data-auto-reload-primary
-									type="button"
-									size="sm"
-									onClick={beginEditing}
-									disabled={save.isPending}
-								>
-									{wallet.auto_reload_enabled ? "Edit" : "Set up auto-reload"}
-								</Button>
-							</div>
-						)}
-					</div>
-				</div>
+				</form>
 			</div>
 		</SettingsSection>
 	);

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -136,135 +136,135 @@ export function LedgerTable({
 		<SettingsSection data-hosted="true" headingLevel={3} title="Activity">
 			<div className="flex flex-col gap-4">
 				<div className="flex justify-end">
-				<Select
-					items={LEDGER_FILTER_ITEMS}
-					value={filter}
-					onValueChange={(value) => {
-						if (value !== null) handleFilterChange(value);
-					}}
-				>
-					<SelectTrigger size="sm" className="w-40" aria-label="Filter activity">
-						<SelectValue />
-					</SelectTrigger>
-					<SelectContent>
-						{LEDGER_FILTER_ITEMS.map((item) => (
-							<SelectItem key={item.value} value={item.value}>
-								{item.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+					<Select
+						items={LEDGER_FILTER_ITEMS}
+						value={filter}
+						onValueChange={(value) => {
+							if (value !== null) handleFilterChange(value);
+						}}
+					>
+						<SelectTrigger size="sm" className="w-40" aria-label="Filter activity">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{LEDGER_FILTER_ITEMS.map((item) => (
+								<SelectItem key={item.value} value={item.value}>
+									{item.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
 
 				{isLoading ? (
-				<div className="space-y-px overflow-hidden rounded-lg border">
-					{Array.from({ length: 5 }, (_, i) => `s-${i}`).map((key) => (
-						<div key={key} className="flex items-center justify-between gap-4 px-3 py-3">
-							<Skeleton className="h-4 w-40" />
-							<Skeleton className="h-4 w-16" />
-						</div>
-					))}
-				</div>
-			) : filtered.length === 0 ? (
-				<>
-					<EmptyState
-						variant="inset"
-						icon={Receipt}
-						title={emptyState.title}
-						description={emptyState.description}
-					/>
-					{renderLoadMoreControl()}
-				</>
-			) : (
-				<>
-					{/* Mobile: a stacked list — a 4-column table would clip on narrow
+					<div className="space-y-px overflow-hidden rounded-lg border">
+						{Array.from({ length: 5 }, (_, i) => `s-${i}`).map((key) => (
+							<div key={key} className="flex items-center justify-between gap-4 px-3 py-3">
+								<Skeleton className="h-4 w-40" />
+								<Skeleton className="h-4 w-16" />
+							</div>
+						))}
+					</div>
+				) : filtered.length === 0 ? (
+					<>
+						<EmptyState
+							variant="inset"
+							icon={Receipt}
+							title={emptyState.title}
+							description={emptyState.description}
+						/>
+						{renderLoadMoreControl()}
+					</>
+				) : (
+					<>
+						{/* Mobile: a stacked list — a 4-column table would clip on narrow
 					    viewports. sm+ gets the full table. */}
-					<ul className="divide-y overflow-hidden rounded-lg border sm:hidden">
-						{filtered.map((entry) => {
-							const positive = amountIsPositive(entry);
-							return (
-								<li
-									key={ledgerEntryKey(entry)}
-									className="flex items-start justify-between gap-3 p-3"
-								>
-									<div className="min-w-0 space-y-1">
-										<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
-										<div className="truncate text-xs text-muted-foreground">
-											{entry.description}
-										</div>
-										<div className="flex items-center gap-2">
-											<StatusBadge status={statusVariant(entry.status)}>
-												{statusLabel(entry.status)}
-											</StatusBadge>
-											<span className="text-xs text-muted-foreground">
-												{relativeTime(entry.created_at)}
-											</span>
-										</div>
-										<ReceiptLink entry={entry} />
-									</div>
-									<span
-										className={cn(
-											"shrink-0 font-medium tabular-nums",
-											positive ? "text-success-muted-foreground" : "text-foreground",
-										)}
+						<ul className="divide-y overflow-hidden rounded-lg border sm:hidden">
+							{filtered.map((entry) => {
+								const positive = amountIsPositive(entry);
+								return (
+									<li
+										key={ledgerEntryKey(entry)}
+										className="flex items-start justify-between gap-3 p-3"
 									>
-										{signedAmount(entry)}
-									</span>
-								</li>
-							);
-						})}
-					</ul>
-
-					<div className="hidden overflow-hidden rounded-lg border sm:block">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>Type</TableHead>
-									<TableHead>Status</TableHead>
-									<TableHead className="text-right">Amount</TableHead>
-									<TableHead className="text-right">When</TableHead>
-									<TableHead className="text-right">Receipt</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{filtered.map((entry) => {
-									const positive = amountIsPositive(entry);
-									return (
-										<TableRow key={ledgerEntryKey(entry)}>
-											<TableCell>
-												<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
-												<div className="max-w-[18rem] truncate text-xs text-muted-foreground">
-													{entry.description}
-												</div>
-											</TableCell>
-											<TableCell>
+										<div className="min-w-0 space-y-1">
+											<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
+											<div className="truncate text-xs text-muted-foreground">
+												{entry.description}
+											</div>
+											<div className="flex items-center gap-2">
 												<StatusBadge status={statusVariant(entry.status)}>
 													{statusLabel(entry.status)}
 												</StatusBadge>
-											</TableCell>
-											<TableCell
-												className={cn(
-													"text-right font-medium tabular-nums",
-													positive ? "text-success-muted-foreground" : "text-foreground",
-												)}
-											>
-												{signedAmount(entry)}
-											</TableCell>
-											<TableCell className="whitespace-nowrap text-right text-sm text-muted-foreground">
-												{relativeTime(entry.created_at)}
-											</TableCell>
-											<TableCell className="text-right">
-												<ReceiptLink entry={entry} />
-											</TableCell>
-										</TableRow>
-									);
-								})}
-							</TableBody>
-						</Table>
-					</div>
+												<span className="text-xs text-muted-foreground">
+													{relativeTime(entry.created_at)}
+												</span>
+											</div>
+											<ReceiptLink entry={entry} />
+										</div>
+										<span
+											className={cn(
+												"shrink-0 font-medium tabular-nums",
+												positive ? "text-success-muted-foreground" : "text-foreground",
+											)}
+										>
+											{signedAmount(entry)}
+										</span>
+									</li>
+								);
+							})}
+						</ul>
 
-					{renderLoadMoreControl()}
-				</>
+						<div className="hidden overflow-hidden rounded-lg border sm:block">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Type</TableHead>
+										<TableHead>Status</TableHead>
+										<TableHead className="text-right">Amount</TableHead>
+										<TableHead className="text-right">When</TableHead>
+										<TableHead className="text-right">Receipt</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{filtered.map((entry) => {
+										const positive = amountIsPositive(entry);
+										return (
+											<TableRow key={ledgerEntryKey(entry)}>
+												<TableCell>
+													<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
+													<div className="max-w-[18rem] truncate text-xs text-muted-foreground">
+														{entry.description}
+													</div>
+												</TableCell>
+												<TableCell>
+													<StatusBadge status={statusVariant(entry.status)}>
+														{statusLabel(entry.status)}
+													</StatusBadge>
+												</TableCell>
+												<TableCell
+													className={cn(
+														"text-right font-medium tabular-nums",
+														positive ? "text-success-muted-foreground" : "text-foreground",
+													)}
+												>
+													{signedAmount(entry)}
+												</TableCell>
+												<TableCell className="whitespace-nowrap text-right text-sm text-muted-foreground">
+													{relativeTime(entry.created_at)}
+												</TableCell>
+												<TableCell className="text-right">
+													<ReceiptLink entry={entry} />
+												</TableCell>
+											</TableRow>
+										);
+									})}
+								</TableBody>
+							</Table>
+						</div>
+
+						{renderLoadMoreControl()}
+					</>
 				)}
 			</div>
 		</SettingsSection>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { ExternalLink, Receipt } from "lucide-react";
-import { useId, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { EmptyState } from "@/components/empty-state";
+import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
 import {
 	Select,
@@ -11,7 +12,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -103,7 +103,6 @@ export function LedgerTable({
 	onShowMore?: () => void;
 }) {
 	const [filter, setFilter] = useState<LedgerFilter>("all");
-	const headingId = useId();
 
 	const filtered = useMemo(() => filteredLedgerEntries(entries, filter), [entries, filter]);
 	const canLoadMore = hasMore && onShowMore != null;
@@ -134,12 +133,9 @@ export function LedgerTable({
 	}
 
 	return (
-		<section data-hosted="true" className="flex flex-col gap-4" aria-labelledby={headingId}>
-			<Separator />
-			<div className="flex items-center justify-between gap-2">
-				<h3 id={headingId} className="text-sm font-semibold">
-					Activity
-				</h3>
+		<SettingsSection data-hosted="true" headingLevel={3} title="Activity">
+			<div className="flex flex-col gap-4">
+				<div className="flex justify-end">
 				<Select
 					items={LEDGER_FILTER_ITEMS}
 					value={filter}
@@ -158,9 +154,9 @@ export function LedgerTable({
 						))}
 					</SelectContent>
 				</Select>
-			</div>
+				</div>
 
-			{isLoading ? (
+				{isLoading ? (
 				<div className="space-y-px overflow-hidden rounded-lg border">
 					{Array.from({ length: 5 }, (_, i) => `s-${i}`).map((key) => (
 						<div key={key} className="flex items-center justify-between gap-4 px-3 py-3">
@@ -269,7 +265,8 @@ export function LedgerTable({
 
 					{renderLoadMoreControl()}
 				</>
-			)}
-		</section>
+				)}
+			</div>
+		</SettingsSection>
 	);
 }

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1751,10 +1751,14 @@ export interface components {
             agent_id: string | null;
             /** Agent Name */
             agent_name: string | null;
+            /** Agent Type */
+            agent_type?: ("openclaw" | "hermes") | null;
             /** Amount Usd */
             amount_usd: string;
             /** Requests */
             requests: number;
+            /** By Model */
+            by_model?: components["schemas"]["V2HostedUsageModelBreakdown"][] | null;
         };
         /** V2HostedUsageDay */
         V2HostedUsageDay: {


### PR DESCRIPTION
## Summary
- give the shared Settings panel a coherent content/action grid with an independent close-control column, including skeletons and mobile navigation
- standardize Wallet Activity and Compute plan comparison on the shared SettingsSection primitive
- recompose Auto-reload as one bounded form unit with status, primary switch, threshold, reload amount, explicit monthly-limit switch, explanation, and actions; keep x402 separate and remove the meaningless Editing state
- restore the global Daily usage chart and preserve global Agent/model summaries
- render canonical AgentLabel/AgentIcon identity from the page inventory without exposing deployment IDs
- add an All agents / named Agent model scope selector with graceful fallback while Hosted optional fields are absent
- regenerate the deploy API client from the Hosted OpenAPI contract

## Verification
- isolated repository web suite passed: existing Web tests, TypeScript, and OSS production build
- shared typecheck and existing shared tests passed
- repository-pinned Biome 2.5.2 passed on every changed source file
- git diff --check passed
- deploy client reproduced byte-for-byte from the local Hosted OpenAPI
- manual browser review at 1280×900 and 390×844 covered API Keys, Auto-reload, and Usage: alignment/overflow, canonical Agent name + Hermes icon, global daily chart, and exact global-to-Agent model switching
- no frontend test file or scenario was added; two existing stale Usage assertions were minimally corrected to match the required chart and no-technical-ID behavior

## Dependency and rollout
Depends on Clawdi-AI/clawdi-hosted#1433. Roll out Hosted first, then this UI. Until Hosted reaches production, the live deploy-contract check is expected to reject the generated client as ahead of the production OpenAPI; do not bypass that gate with handwritten types or ignored drift.