### PR TITLE
fix(whatsapp): preserve sessions and add explicit repair

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -53,6 +53,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.rev.outputs.sha }}
+      sidecar_revision: ${{ steps.sidecar-revision.outputs.revision }}
     steps:
       - name: Resolve source ref
         id: source-ref
@@ -74,6 +75,27 @@ jobs:
 
       - id: rev
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve WhatsApp sidecar deployment revision
+        id: sidecar-revision
+        run: |
+          revision="$(
+            git ls-tree -r --full-tree HEAD -- \
+              .dockerignore \
+              package.json \
+              bun.lock \
+              tsconfig.base.json \
+              apps/web/package.json \
+              packages/cli/package.json \
+              packages/shared/package.json \
+              packages/whatsapp-baileys-sidecar \
+              config/deploy.yml |
+              awk '$4 !~ /\.test\.ts$/' |
+              sha256sum |
+              cut -d ' ' -f 1
+          )"
+          test "${#revision}" = 64
+          echo "revision=${revision}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -125,6 +147,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.labels.outputs.created }}
             org.opencontainers.image.title=Clawdi WhatsApp Baileys Sidecar
             org.opencontainers.image.description=Multiplexed physical WhatsApp transport for Clawdi.
+            io.clawdi.whatsapp-sidecar.deployment-revision=${{ steps.sidecar-revision.outputs.revision }}
           provenance: false
           cache-from: type=gha,scope=clawdi-whatsapp-sidecar-image
           cache-to: type=gha,mode=max,scope=clawdi-whatsapp-sidecar-image
@@ -170,6 +193,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Backend: \`${{ env.BACKEND_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- WhatsApp sidecar: \`${{ env.SIDECAR_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- WhatsApp sidecar deployment revision: \`${{ steps.sidecar-revision.outputs.revision }}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.build_web }}" = "true" ]; then
             echo "- Web: \`${{ env.WEB_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -245,6 +269,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_PROXY_COMMAND: ${{ secrets.DEPLOY_SSH_PROXY_COMMAND }}
           DEPLOY_IMAGE_VERSION: ${{ needs.build.outputs.image_tag }}
+          SIDECAR_REVISION: ${{ needs.build.outputs.sidecar_revision }}
         run: |
           gem install kamal -v '2.12.0' --no-document
           test "$(kamal version)" = "2.12.0"
@@ -260,10 +285,27 @@ jobs:
              test \"\$(realpath -e '/home/phala/clawdi-whatsapp/run')\" = \
                '/home/phala/clawdi-whatsapp/run' && \
              test \"\$(stat -c '%u:%g:%a' '/home/phala/clawdi-whatsapp/run')\" = '1000:1000:770'"
-          kamal accessory reboot whatsapp-baileys
-          kamal server exec \
-            "test \"\$(docker container inspect --format '{{.Config.Image}}' 'clawdi-whatsapp-baileys')\" = \
-             'ghcr.io/clawdi-ai/clawdi-whatsapp-baileys-sidecar:${{ needs.build.outputs.image_tag }}'"
+          current_sidecar_inspect="$(
+            kamal server exec \
+              "docker container inspect --format '{{ index .Config.Labels \"io.clawdi.whatsapp-sidecar.deployment-revision\" }}' 'clawdi-whatsapp-baileys'"
+          )"
+          current_sidecar_revision="$(
+            printf '%s\n' "$current_sidecar_inspect" |
+              grep -Eo '[0-9a-f]{64}' |
+              tail -n 1 || true
+          )"
+          sidecar_changed=false
+          if [ "$current_sidecar_revision" != "$SIDECAR_REVISION" ]; then
+            sidecar_changed=true
+          fi
+          if [ "$sidecar_changed" = true ]; then
+            kamal accessory reboot whatsapp-baileys
+            kamal server exec \
+              "test \"\$(docker container inspect --format '{{.Config.Image}}' 'clawdi-whatsapp-baileys')\" = \
+               'ghcr.io/clawdi-ai/clawdi-whatsapp-baileys-sidecar:${{ needs.build.outputs.image_tag }}'"
+          else
+            echo "WhatsApp sidecar deployment revision is unchanged; preserving the running process."
+          fi
           ready=false
           for _attempt in $(seq 1 30); do
             if kamal accessory exec whatsapp-baileys --reuse \
@@ -277,5 +319,32 @@ jobs:
           if [ "$ready" != true ]; then
             echo "WhatsApp sidecar failed readiness" >&2
             exit 1
+          fi
+          if [ "$sidecar_changed" = true ]; then
+            postgres_output="$(
+              kamal accessory exec postgres --reuse \
+                "psql -U clawdi -d clawdi -Atqc \"SELECT id::text FROM channel_accounts WHERE provider = 'whatsapp' AND visibility = 'public' AND user_id IS NULL AND status = 'active' AND archived_at IS NULL AND config->>'connection_mode' = 'baileys_managed' AND config->>'phone_number' ~ '^[1-9][0-9]{6,14}$' ORDER BY id\""
+            )"
+            managed_session_ids="$(
+              printf '%s\n' "$postgres_output" |
+                grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}' |
+                sort -u || true
+            )"
+            for session_id in $managed_session_ids; do
+              recovered=false
+              for _attempt in $(seq 1 30); do
+                if kamal accessory exec whatsapp-baileys --reuse \
+                  "node /app/packages/whatsapp-baileys-sidecar/dist/healthcheck.js ${session_id}" \
+                  >/dev/null 2>&1; then
+                  recovered=true
+                  break
+                fi
+                sleep 2
+              done
+              if [ "$recovered" != true ]; then
+                echo "Managed WhatsApp session failed post-restart recovery: ${session_id}" >&2
+                exit 1
+              fi
+            done
           fi
           kamal deploy -P --version "${{ needs.build.outputs.image_tag }}"

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -70,6 +70,7 @@ import {
 	Dialog,
 	DialogContent,
 	DialogDescription,
+	DialogFooter,
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -280,6 +281,7 @@ import { DiscordPairDialog } from "@/hosted/v2/channels/discord-pair-dialog";
 import { PairedChatsDialog } from "@/hosted/v2/channels/paired-chats-dialog";
 import { ProviderLinkReplacementConfirm } from "@/hosted/v2/channels/provider-link-replacement-confirm";
 import { TelegramPairDialog } from "@/hosted/v2/channels/telegram-pair-dialog";
+import { WhatsAppDeviceOnboarding } from "@/hosted/v2/channels/whatsapp-device-onboarding";
 import { WhatsAppPairDialog } from "@/hosted/v2/channels/whatsapp-pair-dialog";
 import {
 	type AgentRouteSearch,
@@ -2319,6 +2321,12 @@ function ChannelsTab({
 		channelName: string;
 		open: boolean;
 	} | null>(null);
+	const [whatsappRepair, setWhatsappRepair] = useState<{
+		accountId: string;
+		channelName: string;
+		replaceExistingProviderLink: boolean;
+		started: boolean;
+	} | null>(null);
 	const [customBotDialogOpen, setCustomBotDialogOpen] = useState(false);
 	const linkingAccountIdsRef = useRef<Set<string>>(new Set());
 	const [linkingAccountIds, setLinkingAccountIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -2462,6 +2470,19 @@ function ChannelsTab({
 			});
 			return;
 		} catch (error) {
+			if (
+				error instanceof ApiError &&
+				error.status === 409 &&
+				error.detail === "whatsapp_repair_required"
+			) {
+				setWhatsappRepair({
+					accountId: channelId,
+					channelName: accountSummaries.get(channelId)?.name ?? "Custom WhatsApp",
+					replaceExistingProviderLink,
+					started: false,
+				});
+				return;
+			}
 			if (error instanceof ApiError && error.status === 409) {
 				const refreshed = await linked.refetch();
 				const existing = activeAgentLinkForAccount({
@@ -2697,6 +2718,62 @@ function ChannelsTab({
 					channelName={whatsappPair.channelName}
 					bindingCount={bindingCountForLink(whatsappPair.agentLinkId)}
 				/>
+			) : null}
+			{whatsappRepair ? (
+				<Dialog
+					open
+					onOpenChange={(open) => {
+						if (!open) setWhatsappRepair(null);
+					}}
+				>
+					<DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-md">
+						<DialogHeader>
+							<DialogTitle>Repair WhatsApp before linking</DialogTitle>
+							<DialogDescription>
+								<span className="font-medium text-foreground">{whatsappRepair.channelName}</span>{" "}
+								needs a fresh linked-device connection. The Custom bot, existing Agent Links, paired
+								chats, and history stay unchanged.
+							</DialogDescription>
+						</DialogHeader>
+						{whatsappRepair.started ? (
+							<WhatsAppDeviceOnboarding
+								repairAccountId={whatsappRepair.accountId}
+								onDone={() => {
+									const repaired = whatsappRepair;
+									setWhatsappRepair(null);
+									void submitLink(repaired.accountId, repaired.replaceExistingProviderLink).catch(
+										() => undefined,
+									);
+								}}
+							/>
+						) : (
+							<>
+								<Alert className="border-warning/30 bg-warning-muted">
+									<AlertCircle aria-hidden />
+									<AlertTitle>WhatsApp needs to be reconnected</AlertTitle>
+									<AlertDescription>
+										Repair clears only the invalid linked-device login, then asks you to scan a
+										fresh QR. It does not replace this Custom bot.
+									</AlertDescription>
+								</Alert>
+								<DialogFooter>
+									<Button variant="outline" onClick={() => setWhatsappRepair(null)}>
+										Cancel
+									</Button>
+									<Button
+										onClick={() =>
+											setWhatsappRepair((current) =>
+												current ? { ...current, started: true } : current,
+											)
+										}
+									>
+										Repair WhatsApp
+									</Button>
+								</DialogFooter>
+							</>
+						)}
+					</DialogContent>
+				</Dialog>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -134,8 +134,17 @@ export function useWhatsAppOnboardingActions() {
 			),
 		),
 	);
+	const repair = useSensitiveAction(async (accountId: string) =>
+		accept(
+			unwrap(
+				await api.POST("/v1/channels/whatsapp/onboarding/accounts/{account_id}/repair", {
+					params: { path: { account_id: accountId } },
+				}),
+			),
+		),
+	);
 
-	return { start, refresh, pairingCode, cancel, retry };
+	return { start, refresh, pairingCode, cancel, retry, repair };
 }
 
 export function useChannelAgentLinks(id: string) {

--- a/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-device-onboarding.tsx
@@ -39,9 +39,23 @@ import {
 
 type WhatsAppConnectMode = "overview" | "custom";
 
-export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
+export function WhatsAppDeviceOnboarding({
+	onDone,
+	repairAccountId,
+}: {
+	onDone: () => void;
+	repairAccountId?: string;
+}) {
 	const [mode, setMode] = useState<WhatsAppConnectMode>("overview");
-	const readiness = useWhatsAppOnboardingReadiness(true);
+	const readiness = useWhatsAppOnboardingReadiness(!repairAccountId);
+
+	if (repairAccountId) {
+		return (
+			<div data-hosted="true" data-v2="true">
+				<YourWhatsAppFlow onBack={onDone} onDone={onDone} repairAccountId={repairAccountId} />
+			</div>
+		);
+	}
 
 	if (mode === "custom") {
 		return (
@@ -91,7 +105,15 @@ export function WhatsAppDeviceOnboarding({ onDone }: { onDone: () => void }) {
 	);
 }
 
-function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () => void }) {
+function YourWhatsAppFlow({
+	onBack,
+	onDone,
+	repairAccountId,
+}: {
+	onBack: () => void;
+	onDone: () => void;
+	repairAccountId?: string;
+}) {
 	const actions = useWhatsAppOnboardingActions();
 	const [name, setName] = useState("");
 	const [phoneNumber, setPhoneNumber] = useState("");
@@ -102,8 +124,10 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 	const sessionRef = useRef<WhatsAppOnboardingSession | null>(null);
 	const startLockedRef = useRef(false);
 	const startRequestIdRef = useRef<string | null>(null);
+	const repairStartedRef = useRef(false);
 	const mountedRef = useRef(true);
 	const cancelSession = actions.cancel.execute;
+	const repairAccount = actions.repair.execute;
 
 	function setSession(next: WhatsAppOnboardingSession | null) {
 		sessionRef.current = next;
@@ -125,6 +149,22 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 			}
 		};
 	}, [cancelSession]);
+
+	useEffect(() => {
+		if (!repairAccountId || repairStartedRef.current) return;
+		repairStartedRef.current = true;
+		void repairAccount(repairAccountId)
+			.then((next) => {
+				if (mountedRef.current) {
+					setSession(next);
+				} else if (whatsappOnboardingRequiresCleanup(next.state)) {
+					void cancelSession(next.id).catch(() => undefined);
+				}
+			})
+			.catch(() => {
+				if (mountedRef.current) setRequestError(true);
+			});
+	}, [repairAccount, repairAccountId]);
 
 	useEffect(() => {
 		if (!session || !whatsappOnboardingShouldPoll(session.state)) return;
@@ -213,7 +253,58 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 		}
 	}
 
+	function retryRepairStart() {
+		if (!repairAccountId || actions.repair.isPending) return;
+		setRequestError(false);
+		void repairAccount(repairAccountId)
+			.then((next) => {
+				repairStartedRef.current = true;
+				if (mountedRef.current) {
+					setSession(next);
+				} else if (whatsappOnboardingRequiresCleanup(next.state)) {
+					void cancelSession(next.id).catch(() => undefined);
+				}
+			})
+			.catch(() => {
+				repairStartedRef.current = true;
+				if (mountedRef.current) setRequestError(true);
+			});
+	}
+
 	if (!session) {
+		if (repairAccountId) {
+			return (
+				<div className="min-w-0 space-y-4" data-whatsapp-onboarding-state="repairing">
+					{requestError ? (
+						<>
+							<PairingNotice title="Couldn't start WhatsApp repair">
+								The connection status may be temporarily unavailable. Your account and history were
+								not removed.
+							</PairingNotice>
+							<PairingDialogActions>
+								<Button type="button" variant="outline" onClick={onBack}>
+									Close
+								</Button>
+								<Button
+									type="button"
+									disabled={actions.repair.isPending}
+									onClick={retryRepairStart}
+								>
+									<RefreshCw className="size-4" />
+									Try again
+								</Button>
+							</PairingDialogActions>
+						</>
+					) : (
+						<CenteredState
+							icon={<Spinner className="size-6" />}
+							title="Preparing WhatsApp repair…"
+							description="Checking the saved device session before generating a new QR code."
+						/>
+					)}
+				</div>
+			);
+		}
 		return (
 			<div className="min-w-0 space-y-4" data-whatsapp-onboarding-state="name">
 				<button
@@ -277,6 +368,7 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 		>
 			<WhatsAppSessionState
 				session={session}
+				repairing={Boolean(repairAccountId)}
 				nowMs={nowMs}
 				phoneNumber={phoneNumber}
 				onPhoneNumberChange={setPhoneNumber}
@@ -296,7 +388,7 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 			{session.state === "connected" ? (
 				<Button type="button" className="w-full min-w-0 whitespace-normal" onClick={onDone}>
 					<Bot className="size-4 shrink-0" />
-					Review Custom bots
+					{repairAccountId ? "Done" : "Review Custom bots"}
 				</Button>
 			) : session.state === "expired" || session.state === "error" ? (
 				<PairingDialogActions>
@@ -339,6 +431,7 @@ function YourWhatsAppFlow({ onBack, onDone }: { onBack: () => void; onDone: () =
 
 export function WhatsAppSessionState({
 	session,
+	repairing = false,
 	nowMs,
 	phoneNumber,
 	onPhoneNumberChange,
@@ -346,6 +439,7 @@ export function WhatsAppSessionState({
 	pairingCodePending,
 }: {
 	session: WhatsAppOnboardingSession;
+	repairing?: boolean;
 	nowMs: number;
 	phoneNumber: string;
 	onPhoneNumberChange: (value: string) => void;
@@ -369,7 +463,11 @@ export function WhatsAppSessionState({
 			<CenteredState
 				icon={<CheckCircle2 className="size-7 text-success" />}
 				title="WhatsApp account connected"
-				description="It is now under Custom bots, but is not ready on an Agent yet. Next, Link it to an Agent, then Pair an authorized chat."
+				description={
+					repairing
+						? "The WhatsApp device is reconnected. Existing Custom bot settings, Agent Links, paired chats, and history stay unchanged."
+						: "It is now under Custom bots, but is not ready on an Agent yet. Next, Link it to an Agent, then Pair an authorized chat."
+				}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/v2/channels/whatsapp-pair-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/whatsapp-pair-dialog.tsx
@@ -27,6 +27,8 @@ import {
 	PairingNotice,
 	PairingQrCode,
 } from "@/hosted/v2/channels/pairing-dialog-ui";
+import { WhatsAppDeviceOnboarding } from "@/hosted/v2/channels/whatsapp-device-onboarding";
+import { ApiError } from "@/lib/api";
 
 const WHATSAPP_PAIR_TTL_SECONDS = 300;
 
@@ -62,6 +64,7 @@ export function WhatsAppPairDialog({
 	const [result, setResult] = useState<WhatsAppPairResult | null>(null);
 	const [requestError, setRequestError] = useState<unknown>(null);
 	const [generating, setGenerating] = useState(false);
+	const [repairing, setRepairing] = useState(false);
 	const [nowMs, setNowMs] = useState(() => Date.now());
 	const openKeyRef = useRef<string | null>(null);
 	const sessionRef = useRef(0);
@@ -151,6 +154,10 @@ export function WhatsAppPairDialog({
 				})
 			: null;
 	const accountIdentity = channelName?.trim() || "this WhatsApp account";
+	const repairRequired =
+		requestError instanceof ApiError &&
+		requestError.status === 409 &&
+		requestError.detail === "whatsapp_repair_required";
 
 	return (
 		<Dialog
@@ -159,6 +166,7 @@ export function WhatsAppPairDialog({
 			onOpenChangeComplete={(nextOpen) => {
 				if (nextOpen) return;
 				setGenerating(false);
+				setRepairing(false);
 				setRequestError(null);
 				setResult(null);
 				onCloseComplete?.();
@@ -174,6 +182,30 @@ export function WhatsAppPairDialog({
 				<PairingDialogBody data-whatsapp-pair-dialog-body>
 					{generating ? (
 						<PairingLoading>Creating a WhatsApp pair code…</PairingLoading>
+					) : repairRequired ? (
+						repairing ? (
+							<WhatsAppDeviceOnboarding
+								repairAccountId={accountId}
+								onDone={() => {
+									setRepairing(false);
+									setRequestError(null);
+									void generate();
+								}}
+							/>
+						) : (
+							<div className="space-y-4">
+								<PairingNotice title="WhatsApp needs repair before pairing">
+									Reconnect this Custom WhatsApp account first. The bot, Agent Links, paired chats,
+									and history stay unchanged.
+								</PairingNotice>
+								<PairingDialogActions>
+									<Button variant="outline" onClick={() => requestOpenChange(false)}>
+										Cancel
+									</Button>
+									<Button onClick={() => setRepairing(true)}>Repair WhatsApp</Button>
+								</PairingDialogActions>
+							</div>
+						)
 					) : requestError ? (
 						<ApiErrorPanel
 							error={requestError}

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -151,7 +151,10 @@ from app.services.whatsapp_baileys import (
     mint_whatsapp_agent_credential,
     whatsapp_agent_websocket_url,
 )
-from app.services.whatsapp_device_onboarding import require_whatsapp_logout_for_archive
+from app.services.whatsapp_device_onboarding import (
+    require_whatsapp_custom_link_ready,
+    require_whatsapp_logout_for_archive,
+)
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarError,
     whatsapp_phone_number_from_pn_jid,
@@ -882,12 +885,15 @@ async def _whatsapp_pair_deep_link(
         configured_revision, str
     ):
         return None
+    stored_phone_number = config.get("phone_number")
+    if isinstance(stored_phone_number, str):
+        trusted_phone_number = whatsapp_phone_number_from_pn_jid(
+            f"{stored_phone_number}@s.whatsapp.net"
+        )
+        if trusted_phone_number is not None:
+            return f"https://wa.me/{trusted_phone_number}?text={quote(pairing_command, safe='')}"
     registry = get_active_whatsapp_sidecar_registry()
-    if (
-        registry is None
-        or not registry.managed_is_bound(account.id)
-        or registry.managed_account_revision(account.id) != configured_revision
-    ):
+    if registry is None or registry.managed_account_revision(account.id) != configured_revision:
         return None
     client = registry.get_managed_client(account.id)
     if client is None:
@@ -896,7 +902,7 @@ async def _whatsapp_pair_deep_link(
         health = await client.health()
     except WhatsAppSidecarError:
         return None
-    if health.status != "connected" or not health.connected or not health.registered:
+    if not health.registered:
         return None
     phone_number = whatsapp_phone_number_from_pn_jid(health.account_jid)
     if phone_number is None:
@@ -912,6 +918,10 @@ async def create_channel_pair_code(
     db: AsyncSession = Depends(get_session),
 ) -> ChannelPairCodeResponse:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    await require_whatsapp_custom_link_ready(
+        account,
+        registry=get_active_whatsapp_sidecar_registry(),
+    )
     if (
         account.provider == CHANNEL_PROVIDER_TELEGRAM
         and account.encrypted_provider_token
@@ -1042,6 +1052,10 @@ async def create_channel_agent_link(
     db: AsyncSession = Depends(get_session),
 ) -> ChannelAgentLinkResponse:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    await require_whatsapp_custom_link_ready(
+        account,
+        registry=get_active_whatsapp_sidecar_registry(),
+    )
     agent_id = await _resolve_agent_id_for_link(db, auth=auth, requested_agent_id=body.agent_id)
     link, agent_token = await get_or_create_bot_agent_link(
         db,
@@ -1940,7 +1954,12 @@ def _channel_health_item(
         reasons.append("pending_inbox")
     health_status = "ok"
     if any(
-        reason in reasons for reason in ("channel_disabled", "failed_deliveries", "recent_error")
+        reason in reasons
+        for reason in (
+            "channel_disabled",
+            "failed_deliveries",
+            "recent_error",
+        )
     ):
         health_status = "error"
     elif reasons:

--- a/backend/app/routes/channel_routers/whatsapp_onboarding.py
+++ b/backend/app/routes/channel_routers/whatsapp_onboarding.py
@@ -16,6 +16,7 @@ from app.schemas.channel import (
 from app.services.whatsapp_device_onboarding import (
     cancel_whatsapp_onboarding,
     refresh_whatsapp_onboarding,
+    repair_whatsapp_account,
     request_whatsapp_pairing_code,
     retry_whatsapp_onboarding,
     start_whatsapp_onboarding,
@@ -133,5 +134,22 @@ async def retry_whatsapp_onboarding_session(
         db,
         user_id=auth.user_id,
         session_id=session_id,
+        registry=registry,
+    )
+
+
+@router.post("/accounts/{account_id}/repair")
+async def repair_whatsapp_channel_account(
+    account_id: UUID,
+    response: Response,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    _prevent_sensitive_caching(response)
+    return await repair_whatsapp_account(
+        db,
+        user_id=auth.user_id,
+        account_id=account_id,
         registry=registry,
     )

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -33,6 +33,7 @@ from app.schemas.channel import (
 from app.services.channels import (
     build_channel_account,
     generate_webhook_secret,
+    get_owned_private_channel_account,
     hash_token,
     require_channel_tenant_user_id,
 )
@@ -40,6 +41,7 @@ from app.services.principal_lifecycle import assert_user_authority_active
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarCapabilities,
     WhatsAppSidecarError,
+    WhatsAppSidecarHealth,
     WhatsAppSidecarPairingStatus,
     WhatsAppSidecarProtocolError,
     WhatsAppSidecarUnavailableError,
@@ -53,7 +55,14 @@ WHATSAPP_ONBOARDING_TTL = timedelta(minutes=5)
 _E164_DIGITS = re.compile(r"^[1-9][0-9]{6,14}$")
 _ALLOCATION_LOCK_ID = 8_071_323_912
 _LOGOUT_RECOVERY_TTL_SECONDS = 10.0
+_WhatsAppRepairReason = Literal["remote_logged_out", "unregistered"]
 _UNRELEASED_SESSION_STATES = (*WHATSAPP_ONBOARDING_ACTIVE_STATES, WHATSAPP_ONBOARDING_STATE_ERROR)
+_REPAIR_IN_PROGRESS_STATES = (
+    WHATSAPP_ONBOARDING_STATE_GENERATING,
+    WHATSAPP_ONBOARDING_STATE_READY,
+    WHATSAPP_ONBOARDING_STATE_SCANNED,
+    WHATSAPP_ONBOARDING_STATE_ERROR,
+)
 _WHATSAPP_ONBOARDING_STATES = frozenset(
     {
         WHATSAPP_ONBOARDING_STATE_GENERATING,
@@ -344,7 +353,7 @@ async def cancel_whatsapp_onboarding(
         )
     try:
         await client.health()
-        canceled = await stop_whatsapp_pairing(client)
+        canceled = await stop_whatsapp_pairing(client, allow_remote_logout_recovery=True)
     except WhatsAppSidecarError:
         await _mark_session_error(db, onboarding)
         raise HTTPException(
@@ -385,10 +394,40 @@ async def retry_whatsapp_onboarding(
         )
 
     if onboarding.channel_account_id is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="This WhatsApp connection cannot be retried",
+        account = await get_owned_private_channel_account(
+            db,
+            account_id=onboarding.channel_account_id,
+            user_id=user_id,
         )
+        try:
+            physical_session_id, config_revision = _custom_account_session(
+                account,
+                registry=registry,
+            )
+        except WhatsAppSidecarError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This WhatsApp connection cannot be retried",
+            ) from None
+        if (
+            physical_session_id != onboarding.sidecar_account_id
+            or config_revision != onboarding.sidecar_config_revision
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This WhatsApp connection cannot be retried",
+            )
+        try:
+            await registry.prepare_custom_account_repair(
+                session_id=physical_session_id,
+                account_id=account.id,
+                config_revision=config_revision,
+            )
+        except WhatsAppSidecarError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="WhatsApp account repair is temporarily unavailable",
+            ) from None
     if onboarding.state == WHATSAPP_ONBOARDING_STATE_ERROR:
         await _confirm_stopped(onboarding, registry=registry)
     await db.commit()
@@ -432,6 +471,202 @@ async def retry_whatsapp_onboarding(
     return response
 
 
+async def repair_whatsapp_account(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    account_id: UUID,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> ChannelWhatsAppOnboardingSessionResponse:
+    """Start an owner-requested re-pair without replacing the durable account."""
+
+    if registry is None or not registry.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp account repair is not configured",
+        )
+    await _lock_allocation(db)
+    account = await get_owned_private_channel_account(
+        db,
+        account_id=account_id,
+        user_id=user_id,
+    )
+    if account.provider != CHANNEL_PROVIDER_WHATSAPP:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
+    try:
+        session_id, config_revision = _custom_account_session(account, registry=registry)
+    except WhatsAppSidecarError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This WhatsApp account cannot be repaired",
+        ) from None
+    existing = await db.scalar(
+        select(ChannelWhatsAppOnboardingSession)
+        .where(
+            ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+            ChannelWhatsAppOnboardingSession.user_id == user_id,
+            ChannelWhatsAppOnboardingSession.channel_account_id == account.id,
+            ChannelWhatsAppOnboardingSession.sidecar_account_id == session_id,
+            ChannelWhatsAppOnboardingSession.state.in_(_REPAIR_IN_PROGRESS_STATES),
+        )
+        .order_by(ChannelWhatsAppOnboardingSession.created_at.desc())
+    )
+    if existing is not None:
+        await db.commit()
+        return _session_response(existing, manual_pairing_code_supported=False)
+
+    client = registry.get_custom_lifecycle_client(
+        session_id,
+        config_revision=config_revision,
+    )
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp account repair is temporarily unavailable",
+        )
+    try:
+        capabilities = await client.capabilities()
+        health = await client.health()
+        pairing = await client.pairing_status()
+    except WhatsAppSidecarError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp account repair is temporarily unavailable",
+        ) from None
+    if health.registered != pairing.registered:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WhatsApp account repair is temporarily unavailable",
+        )
+    repair_reason = _repair_reason(health)
+    if repair_reason is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This WhatsApp account does not need repair",
+        )
+
+    now = datetime.now(UTC)
+    onboarding = ChannelWhatsAppOnboardingSession(
+        ownership_kind=WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+        sidecar_account_id=session_id,
+        sidecar_config_revision=config_revision,
+        channel_account_id=account.id,
+        user_id=user_id,
+        request_id=uuid4(),
+        name=account.name,
+        state=WHATSAPP_ONBOARDING_STATE_GENERATING,
+        method="qr",
+        started_at=now,
+        expires_at=now + WHATSAPP_ONBOARDING_TTL,
+    )
+    db.add(onboarding)
+    await db.flush()
+    await db.commit()
+    onboarding = await _owned_session(db, user_id=user_id, session_id=onboarding.id)
+    try:
+        client = await registry.prepare_custom_account_repair(
+            session_id=session_id,
+            account_id=account.id,
+            config_revision=config_revision,
+        )
+        if repair_reason == "remote_logged_out":
+            recovered = await client.pairing_recover()
+            if recovered.status != "stopped" or recovered.registered:
+                raise WhatsAppSidecarProtocolError("custom Baileys recovery was not confirmed")
+        pairing = await client.pairing_qr()
+        response = await _apply_pairing_status(
+            db,
+            onboarding=onboarding,
+            pairing=pairing,
+            capabilities=capabilities,
+            registry=registry,
+        )
+    except WhatsAppSidecarError:
+        return await _mark_session_error(db, onboarding)
+    await db.commit()
+    return response
+
+
+async def require_whatsapp_custom_link_ready(
+    account: ChannelAccount,
+    *,
+    registry: ConfiguredWhatsAppSidecarRegistry | None,
+) -> None:
+    """Fail a Custom WhatsApp Link unless its physical transport is usable."""
+
+    config = account.config if isinstance(account.config, dict) else {}
+    if (
+        account.provider != CHANNEL_PROVIDER_WHATSAPP
+        or config.get("connection_mode") != "baileys_custom"
+    ):
+        return
+    if registry is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="whatsapp_connection_temporarily_unavailable",
+        )
+    try:
+        session_id, config_revision = _custom_account_session(account, registry=registry)
+    except WhatsAppSidecarError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="whatsapp_connection_temporarily_unavailable",
+        ) from None
+    client = registry.get_custom_lifecycle_client(
+        session_id,
+        config_revision=config_revision,
+    )
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="whatsapp_connection_temporarily_unavailable",
+        )
+    try:
+        health = await client.health()
+    except WhatsAppSidecarError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="whatsapp_connection_temporarily_unavailable",
+        ) from None
+    if _repair_reason(health) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="whatsapp_repair_required",
+        )
+    if not health.connected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="whatsapp_connection_temporarily_unavailable",
+        )
+
+
+def _repair_reason(health: WhatsAppSidecarHealth) -> _WhatsAppRepairReason | None:
+    if health.last_disconnect_reason == "remote_logged_out":
+        return "remote_logged_out"
+    if not health.registered:
+        return "unregistered"
+    return None
+
+
+def _custom_account_session(
+    account: ChannelAccount,
+    *,
+    registry: ConfiguredWhatsAppSidecarRegistry,
+) -> tuple[UUID, str]:
+    config = account.config if isinstance(account.config, dict) else {}
+    raw_session_id = config.get("sidecar_account_id")
+    config_revision = config.get("sidecar_config_revision")
+    if config.get("connection_mode") != "baileys_custom" or not isinstance(config_revision, str):
+        raise WhatsAppSidecarProtocolError("custom Baileys account identity is unavailable")
+    try:
+        session_id = UUID(raw_session_id) if isinstance(raw_session_id, str) else None
+    except ValueError:
+        session_id = None
+    if session_id is None or registry.custom_session_revision(session_id) != config_revision:
+        raise WhatsAppSidecarProtocolError("custom Baileys account identity is unavailable")
+    return session_id, config_revision
+
+
 async def require_whatsapp_logout_for_archive(
     db: AsyncSession,
     *,
@@ -460,7 +695,7 @@ async def require_whatsapp_logout_for_archive(
                 detail="WhatsApp disconnect could not be confirmed",
             )
         try:
-            disconnected = await stop_whatsapp_pairing(client)
+            disconnected = await stop_whatsapp_pairing(client, allow_remote_logout_recovery=True)
         except WhatsAppSidecarError:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -503,7 +738,10 @@ async def require_whatsapp_logout_for_archive(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="WhatsApp disconnect could not be confirmed",
         )
-    client = registry.get_custom_client(sidecar_account_id)
+    client = registry.get_custom_lifecycle_client(
+        sidecar_account_id,
+        config_revision=sidecar_config_revision,
+    )
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -514,14 +752,18 @@ async def require_whatsapp_logout_for_archive(
         current = await client.pairing_status()
         if health.registered != current.registered:
             raise WhatsAppSidecarProtocolError("custom sidecar registration state drifted")
-        if current.registered:
+        if current.registered and health.last_disconnect_reason != "remote_logged_out":
             await _ensure_connected_transport_for_account(
                 account_id=account.id,
                 session_id=sidecar_account_id,
                 config_revision=sidecar_config_revision,
                 registry=registry,
             )
-        disconnected = await stop_whatsapp_pairing(client, current=current)
+        disconnected = await stop_whatsapp_pairing(
+            client,
+            current=current,
+            allow_remote_logout_recovery=True,
+        )
     except WhatsAppSidecarError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -851,7 +1093,7 @@ async def _confirm_stopped(
         )
     try:
         await client.health()
-        stopped = await stop_whatsapp_pairing(client)
+        stopped = await stop_whatsapp_pairing(client, allow_remote_logout_recovery=True)
     except WhatsAppSidecarError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -868,9 +1110,14 @@ async def stop_whatsapp_pairing(
     client: WhatsAppSidecarClient,
     *,
     current: WhatsAppSidecarPairingStatus | None = None,
+    allow_remote_logout_recovery: bool = False,
 ) -> WhatsAppSidecarPairingStatus:
     observed = current if current is not None else await client.pairing_status()
     if observed.registered:
+        if allow_remote_logout_recovery:
+            health = await client.health()
+            if health.last_disconnect_reason == "remote_logged_out":
+                return await client.pairing_recover()
         return await _logout_registered_pairing(client, current=observed)
     if observed.status == "stopped":
         return observed

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -35,6 +35,7 @@ from app.services.whatsapp_device_onboarding import (
 from app.services.whatsapp_native_transport import (
     WhatsAppSidecarError,
     WhatsAppSidecarProtocolError,
+    whatsapp_phone_number_from_pn_jid,
 )
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
@@ -118,10 +119,23 @@ async def start_platform_whatsapp_pairing(
                 status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable"
             )
         if pairing.registered:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                "configured WhatsApp account is already authenticated",
-            )
+            if health.last_disconnect_reason != "remote_logged_out":
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT,
+                    "configured WhatsApp account is already authenticated",
+                )
+            try:
+                recovered = await client.pairing_recover()
+            except WhatsAppSidecarError:
+                raise HTTPException(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "WhatsApp recovery could not be confirmed",
+                ) from None
+            if recovered.status != "stopped" or recovered.registered:
+                raise HTTPException(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "WhatsApp recovery could not be confirmed",
+                )
     else:
         duplicate_name = await db.scalar(
             select(ChannelAccount.id).where(
@@ -184,7 +198,11 @@ async def cancel_platform_whatsapp_pairing(
         )
     client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
     try:
-        stopped = await stop_whatsapp_pairing(client) if client is not None else None
+        stopped = (
+            await stop_whatsapp_pairing(client, allow_remote_logout_recovery=True)
+            if client is not None
+            else None
+        )
     except WhatsAppSidecarError:
         stopped = None
     if stopped is None or stopped.status != "stopped" or stopped.registered:
@@ -248,7 +266,15 @@ async def _refresh(
     if health.registered != pairing.registered:
         return await _error(db, onboarding)
     if health.connected and pairing.status == "connected" and pairing.registered:
-        await _promote(db, onboarding=onboarding, registry=registry)
+        phone_number = whatsapp_phone_number_from_pn_jid(health.account_jid)
+        if phone_number is None:
+            return await _error(db, onboarding)
+        await _promote(
+            db,
+            onboarding=onboarding,
+            registry=registry,
+            phone_number=phone_number,
+        )
         return _response(onboarding)
     if pairing.status == "starting" and not pairing.registered:
         onboarding.state = WHATSAPP_ONBOARDING_STATE_GENERATING
@@ -285,6 +311,7 @@ async def _promote(
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
     registry: ConfiguredWhatsAppSidecarRegistry,
+    phone_number: str,
 ) -> None:
     account_id = onboarding.sidecar_account_id
     session_id = onboarding.id
@@ -302,12 +329,17 @@ async def _promote(
                 config={
                     "connection_mode": "baileys_managed",
                     "sidecar_config_revision": onboarding.sidecar_config_revision,
+                    "phone_number": phone_number,
                 },
             )
             db.add(account)
             await db.flush()
         elif not _matches(account, revision=onboarding.sidecar_config_revision):
             raise WhatsAppSidecarProtocolError("managed WhatsApp identity conflict")
+        else:
+            config = dict(account.config) if isinstance(account.config, dict) else {}
+            config["phone_number"] = phone_number
+            account.config = config
         newly_bound = await registry.bind_managed_account(
             account.id, config_revision=onboarding.sidecar_config_revision
         )

--- a/backend/app/services/whatsapp_native_transport.py
+++ b/backend/app/services/whatsapp_native_transport.py
@@ -51,8 +51,9 @@ _PAIRING_CODE_PATH = "/v1/pairing/code"
 _PAIRING_CANCEL_PATH = "/v1/pairing/cancel"
 _PAIRING_LOGOUT_PATH = "/v1/pairing/logout"
 _PAIRING_RETRY_PATH = "/v1/pairing/retry"
+_PAIRING_RECOVER_PATH = "/v1/pairing/recover"
 _MAX_PAIRING_JSON_BYTES = 128 * 1024
-_PAIRING_ACTIONS = frozenset({"qr", "code", "cancel", "logout", "retry"})
+_PAIRING_ACTIONS = frozenset({"qr", "code", "cancel", "logout", "retry", "recover"})
 _EXPECTED_BAILEYS_RELEASE = {
     "packageName": "@whiskeysockets/baileys",
     "packageVersion": "7.0.0-rc14",
@@ -94,6 +95,7 @@ class WhatsAppSidecarHealth:
     connected: bool
     registered: bool
     account_jid: str | None = field(default=None, repr=False)
+    last_disconnect_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -294,6 +296,7 @@ class WhatsAppBaileysSidecarClient:
             connected=connected,
             registered=_required_bool(payload, "registered"),
             account_jid=_sidecar_account_jid(payload.get("user")),
+            last_disconnect_reason=_sidecar_disconnect_reason(payload.get("lastDisconnectReason")),
         )
 
     async def capabilities(self) -> WhatsAppSidecarCapabilities:
@@ -347,6 +350,11 @@ class WhatsAppBaileysSidecarClient:
     async def pairing_retry(self) -> WhatsAppSidecarPairingStatus:
         return self._remember_pairing_status(
             _pairing_status(await self._request_json("POST", _PAIRING_RETRY_PATH))
+        )
+
+    async def pairing_recover(self) -> WhatsAppSidecarPairingStatus:
+        return self._remember_pairing_status(
+            _pairing_status(await self._request_json("POST", _PAIRING_RECOVER_PATH))
         )
 
     def _remember_pairing_status(
@@ -691,6 +699,14 @@ def _sidecar_account_jid(value: JsonValue | None) -> str | None:
     if not isinstance(account_jid, str) or not account_jid or len(account_jid) > 128:
         return None
     return account_jid
+
+
+def _sidecar_disconnect_reason(value: JsonValue | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or len(value) > 128:
+        raise WhatsAppSidecarProtocolError("invalid Baileys sidecar disconnect reason")
+    return value
 
 
 def whatsapp_phone_number_from_pn_jid(account_jid: str | None) -> str | None:

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -46,7 +46,6 @@ _UNRELEASED_STATES = (
     "generating",
     "ready",
     "scanned",
-    "connected",
     WHATSAPP_ONBOARDING_STATE_ERROR,
 )
 
@@ -77,6 +76,8 @@ class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
     async def pairing_logout(self) -> WhatsAppSidecarPairingStatus: ...
 
     async def pairing_retry(self) -> WhatsAppSidecarPairingStatus: ...
+
+    async def pairing_recover(self) -> WhatsAppSidecarPairingStatus: ...
 
 
 SidecarClientFactory = Callable[[WhatsAppBaileysSidecarConfig], WhatsAppSidecarClient]
@@ -130,6 +131,18 @@ class ConfiguredWhatsAppSidecarRegistry:
 
     def get_custom_client(self, session_id: UUID) -> WhatsAppSidecarClient | None:
         if session_id in self._blocked_custom_sessions:
+            return None
+        return self._client(session_id)
+
+    def get_custom_lifecycle_client(
+        self,
+        session_id: UUID,
+        *,
+        config_revision: str,
+    ) -> WhatsAppSidecarClient | None:
+        """Inspect a Custom session even when normal message transport is blocked."""
+
+        if self.custom_session_revision(session_id) != config_revision:
             return None
         return self._client(session_id)
 
@@ -311,6 +324,35 @@ class ConfiguredWhatsAppSidecarRegistry:
                 config_revision=config_revision,
             )
 
+    async def prepare_custom_account_repair(
+        self,
+        *,
+        session_id: UUID,
+        account_id: UUID,
+        config_revision: str,
+    ) -> WhatsAppSidecarClient:
+        """Detach delivery and explicitly admit one validated session for repair."""
+
+        async with self._custom_reconcile_lock:
+            if self.custom_session_revision(session_id) != config_revision:
+                raise WhatsAppSidecarProtocolError("custom Baileys session revision mismatch")
+            existing_account = self._custom_session_to_account.get(session_id)
+            existing_session = self._custom_account_to_session.get(account_id)
+            unbound = existing_account is None and existing_session is None
+            bound_to_account = existing_account == account_id and existing_session == session_id
+            if not unbound and not bound_to_account:
+                raise WhatsAppSidecarProtocolError("custom Baileys session ownership conflict")
+            if bound_to_account:
+                await self._unbind_custom_account_unlocked(
+                    session_id=session_id,
+                    account_id=account_id,
+                )
+            self._blocked_custom_sessions.discard(session_id)
+            client = self._client(session_id)
+            if client is None:
+                raise WhatsAppSidecarProtocolError("custom Baileys session is unavailable")
+            return client
+
     def _bind_custom_account_unlocked(
         self,
         *,
@@ -454,7 +496,10 @@ class ConfiguredWhatsAppSidecarRegistry:
                     log.error("WhatsApp Custom session %s failed identity validation", session_id)
                     continue
                 if owner is not None:
-                    if not pairing.registered:
+                    if (
+                        health.last_disconnect_reason == "remote_logged_out"
+                        or not pairing.registered
+                    ):
                         await self._block_custom_session_unlocked(session_id, current_account)
                         continue
                     self._blocked_custom_sessions.discard(session_id)

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -73,7 +73,7 @@ class _ManagedOnboardingSidecar:
 
     async def capabilities(self):
         return WhatsAppSidecarCapabilities(
-            pairing=frozenset({"qr", "code", "cancel", "logout", "retry"})
+            pairing=frozenset({"qr", "code", "cancel", "logout", "retry", "recover"})
         )
 
     async def health(self):
@@ -81,6 +81,7 @@ class _ManagedOnboardingSidecar:
             status="connected" if self.connected else "pairing_qr",
             connected=self.connected,
             registered=self.registered,
+            account_jid="15551234567:1@s.whatsapp.net" if self.registered else None,
         )
 
     async def pairing_qr(self):
@@ -119,6 +120,12 @@ class _ManagedOnboardingSidecar:
     async def pairing_retry(self):
         self.connected = True
         return await self.pairing_status()
+
+    async def pairing_recover(self):
+        self.connected = False
+        self.registered = False
+        self.stopped = True
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
 
     async def provider_events(self, *, limit=100):
         return []
@@ -1773,7 +1780,6 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     channel_agent,
     monkeypatch,
 ):
-
     from sqlalchemy import select
 
     from app.models.channel import ChannelAccount, ChannelSecret
@@ -2095,7 +2101,6 @@ async def test_admin_register_env_accepts_explicit_agent_id(
 async def test_admin_register_env_auto_assigns_explicit_default_names(
     admin_client, db_session, seed_user
 ):
-
     from sqlalchemy import select
 
     from app.models.session import AgentEnvironment
@@ -2171,7 +2176,6 @@ async def test_admin_register_env_auto_assigns_explicit_default_names(
 
 @pytest.mark.asyncio
 async def test_admin_register_env_rejects_default_name_request_field(admin_client, seed_user):
-
     response = await admin_client.post(
         "/v1/admin/environments",
         headers=_AUTH,
@@ -2192,7 +2196,6 @@ async def test_admin_register_env_rejects_default_name_request_field(admin_clien
 async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     admin_client, db_session, seed_user
 ):
-
     from sqlalchemy import select
 
     from app.models.hosted_runtime import HostedRuntimeSecret, HostedRuntimeState
@@ -2536,7 +2539,6 @@ async def test_admin_register_env_explicit_ids_allow_same_machine_metadata(
 async def test_admin_register_env_explicit_id_rejects_cross_tenant_id(
     admin_client, db_session, seed_user
 ):
-
     from sqlalchemy import select
 
     from app.models.session import AgentEnvironment

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11755,6 +11755,19 @@ class _WhatsAppPairLinkRegistry:
     def get_managed_client(self, account_id: UUID) -> _WhatsAppPairLinkSidecar | None:
         return self._client if account_id == self._account_id else None
 
+    def custom_session_revision(self, session_id: UUID) -> str | None:
+        return self._revision if session_id == self._account_id else None
+
+    def get_custom_lifecycle_client(
+        self,
+        session_id: UUID,
+        *,
+        config_revision: str,
+    ) -> _WhatsAppPairLinkSidecar | None:
+        if session_id != self._account_id or config_revision != self._revision:
+            return None
+        return self._client
+
 
 async def _create_whatsapp_pair_target(
     client: httpx.AsyncClient,
@@ -11819,7 +11832,7 @@ async def test_whatsapp_pair_code_returns_click_to_chat_for_bound_public_managed
 
 
 @pytest.mark.asyncio
-async def test_whatsapp_pair_code_keeps_manual_pairing_when_sidecar_is_unavailable(
+async def test_whatsapp_pair_code_uses_durable_phone_when_sidecar_is_unavailable(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     channel_agent,
@@ -11833,6 +11846,7 @@ async def test_whatsapp_pair_code_keeps_manual_pairing_when_sidecar_is_unavailab
     account.config = {
         "connection_mode": "baileys_managed",
         "sidecar_config_revision": "trusted-managed-revision",
+        "phone_number": "15551234567",
     }
     await db_session.commit()
     sidecar = _WhatsAppPairLinkSidecar(WhatsAppSidecarUnavailableError("unavailable"))
@@ -11846,9 +11860,11 @@ async def test_whatsapp_pair_code_keeps_manual_pairing_when_sidecar_is_unavailab
 
     assert response.status_code == 201, response.text
     pair = response.json()
-    assert pair["deep_link"] is None
-    assert pair["qr_payload"] is None
+    expected = f"https://wa.me/15551234567?text=%2Fclawdi_pair%20{pair['code']}"
+    assert pair["deep_link"] == expected
+    assert pair["qr_payload"] == expected
     assert pair["pairing_command"] == f"/clawdi_pair {pair['code']}"
+    assert sidecar.health_calls == 0
 
 
 @pytest.mark.asyncio
@@ -11863,7 +11879,8 @@ async def test_whatsapp_pair_code_never_links_to_a_private_custom_identity(
     assert account is not None
     account.config = {
         "connection_mode": "baileys_custom",
-        "sidecar_config_revision": "custom-revision",
+        "sidecar_account_id": str(account.id),
+        "sidecar_config_revision": "trusted-managed-revision",
     }
     await db_session.commit()
     sidecar = _WhatsAppPairLinkSidecar(
@@ -11886,7 +11903,7 @@ async def test_whatsapp_pair_code_never_links_to_a_private_custom_identity(
     pair = response.json()
     assert pair["deep_link"] is None
     assert pair["qr_payload"] is None
-    assert sidecar.health_calls == 0
+    assert sidecar.health_calls == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_custom_onboarding.py
+++ b/backend/tests/test_whatsapp_custom_onboarding.py
@@ -68,7 +68,7 @@ class FakeCustomSidecar:
             status="stopped",
             registered=False,
         )
-        self.pairing_actions = frozenset({"qr", "code", "cancel", "logout", "retry"})
+        self.pairing_actions = frozenset({"qr", "code", "cancel", "logout", "retry", "recover"})
         self.start_calls = 0
         self.cancel_calls = 0
         self.logout_calls = 0
@@ -80,6 +80,9 @@ class FakeCustomSidecar:
         self.acknowledged_sequences: list[int] = []
         self.provider_acknowledged = asyncio.Event()
         self.service_ready_result = True
+        self.health_failures_remaining = 0
+        self.last_disconnect_reason: str | None = None
+        self.pairing_recover_calls = 0
         self.health_entered: asyncio.Event | None = None
         self.health_release: asyncio.Event | None = None
 
@@ -98,10 +101,14 @@ class FakeCustomSidecar:
             self.health_entered.set()
         if self.health_release is not None:
             await self.health_release.wait()
+        if self.health_failures_remaining > 0:
+            self.health_failures_remaining -= 1
+            raise WhatsAppSidecarUnavailableError("fake health unavailable")
         return WhatsAppSidecarHealth(
             status=self.current.status,
             connected=self.current.status == "connected",
             registered=self.current.registered,
+            last_disconnect_reason=self.last_disconnect_reason,
         )
 
     async def capabilities(self) -> WhatsAppSidecarCapabilities:
@@ -145,6 +152,12 @@ class FakeCustomSidecar:
                 status="connected",
                 registered=True,
             )
+        return self.current
+
+    async def pairing_recover(self) -> WhatsAppSidecarPairingStatus:
+        self.pairing_recover_calls += 1
+        self.current = WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+        self.last_disconnect_reason = None
         return self.current
 
     async def relay_message(self, request):
@@ -237,6 +250,24 @@ async def _create_user(db: AsyncSession, label: str) -> User:
     await db.commit()
     await db.refresh(user)
     return user
+
+
+async def _connect_custom_account(
+    client: httpx.AsyncClient,
+    fake: FakeCustomSidecar,
+    *,
+    name: str,
+) -> tuple[UUID, UUID]:
+    created = await client.post(
+        "/v1/channels/whatsapp/onboarding/sessions",
+        json={"request_id": str(uuid4()), "name": name},
+    )
+    assert created.status_code == 201, created.text
+    onboarding_id = UUID(created.json()["id"])
+    fake.current = WhatsAppSidecarPairingStatus(status="connected", registered=True)
+    connected = await client.get(f"/v1/channels/whatsapp/onboarding/sessions/{onboarding_id}")
+    assert connected.status_code == 200, connected.text
+    return onboarding_id, UUID(connected.json()["channel_account_id"])
 
 
 @pytest.mark.asyncio
@@ -355,6 +386,98 @@ async def test_qr_lifecycle_is_idempotent_and_finishes_only_after_connection(
         )
         == 1
     )
+
+
+@pytest.mark.asyncio
+async def test_custom_link_prompts_owner_repair_and_preserves_the_durable_account(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    custom_sidecar: tuple[UUID, FakeCustomSidecar],
+) -> None:
+    _sidecar_account_id, fake = custom_sidecar
+    original_onboarding_id, account_id = await _connect_custom_account(
+        client,
+        fake,
+        name="Repair phone",
+    )
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    original_config = dict(account.config)
+
+    fake.current = WhatsAppSidecarPairingStatus(status="disconnected", registered=True)
+    fake.last_disconnect_reason = "remote_logged_out"
+    link_attempt = await client.post(
+        f"/v1/channels/{account_id}/agent-links",
+        json={},
+    )
+    assert link_attempt.status_code == 409, link_attempt.text
+    assert link_attempt.json() == {"detail": "whatsapp_repair_required"}
+    pair_attempt = await client.post(
+        f"/v1/channels/{account_id}/pair-codes",
+        json={"agent_link_id": str(uuid4()), "ttl_seconds": 300},
+    )
+    assert pair_attempt.status_code == 409, pair_attempt.text
+    assert pair_attempt.json() == {"detail": "whatsapp_repair_required"}
+
+    other_user = await _create_user(db_session, "whatsapp-repair-other")
+    async with _client_for_user(db_session, other_user) as other_client:
+        hidden = await other_client.post(
+            f"/v1/channels/whatsapp/onboarding/accounts/{account_id}/repair"
+        )
+    assert hidden.status_code == 404
+
+    repair = await client.post(f"/v1/channels/whatsapp/onboarding/accounts/{account_id}/repair")
+    assert repair.status_code == 200, repair.text
+    assert repair.json()["state"] == "ready"
+    assert repair.json()["channel_account_id"] == str(account_id)
+    assert fake.pairing_recover_calls == 1
+    repair_onboarding_id = UUID(repair.json()["id"])
+    assert repair_onboarding_id != original_onboarding_id
+
+    fake.current = WhatsAppSidecarPairingStatus(status="connected", registered=True)
+    repaired = await client.get(f"/v1/channels/whatsapp/onboarding/sessions/{repair_onboarding_id}")
+    assert repaired.status_code == 200, repaired.text
+    assert repaired.json()["state"] == "connected"
+    assert repaired.json()["channel_account_id"] == str(account_id)
+
+    healthy_link_attempt = await client.post(
+        f"/v1/channels/{account_id}/agent-links",
+        json={},
+    )
+    assert healthy_link_attempt.status_code == 400
+    assert healthy_link_attempt.json() == {"detail": "agent_id is required"}
+
+    await db_session.refresh(account)
+    assert account.archived_at is None
+    assert account.config == original_config
+    account_ids = (
+        await db_session.scalars(
+            select(ChannelAccount.id).where(ChannelAccount.user_id == seed_user.id)
+        )
+    ).all()
+    assert account_ids == [account_id]
+
+
+@pytest.mark.asyncio
+async def test_custom_link_does_not_offer_repair_for_a_temporary_sidecar_failure(
+    client: httpx.AsyncClient,
+    custom_sidecar: tuple[UUID, FakeCustomSidecar],
+) -> None:
+    _sidecar_account_id, fake = custom_sidecar
+    _onboarding_id, account_id = await _connect_custom_account(
+        client,
+        fake,
+        name="Temporary outage phone",
+    )
+    fake.health_failures_remaining = 1
+
+    link_attempt = await client.post(
+        f"/v1/channels/{account_id}/agent-links",
+        json={},
+    )
+    assert link_attempt.status_code == 503, link_attempt.text
+    assert link_attempt.json() == {"detail": "whatsapp_connection_temporarily_unavailable"}
 
 
 @pytest.mark.asyncio
@@ -925,6 +1048,7 @@ async def test_expiry_retry_and_confirmed_logout_before_archive(
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
 async def test_failed_physical_logout_never_archives_or_unregisters_transport(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -955,9 +1079,14 @@ async def test_failed_physical_logout_never_archives_or_unregisters_transport(
     assert registry.custom_binding(account_id) == provider_session_id
     assert get_whatsapp_provider_transport(account_id) is not None
 
-    fake.logout_result = WhatsAppSidecarPairingStatus(status="stopped", registered=False)
+    fake.current = WhatsAppSidecarPairingStatus(status="disconnected", registered=True)
+    fake.last_disconnect_reason = "remote_logged_out"
+    await registry.reconcile_custom_ownership()
+    assert registry.custom_session_is_blocked(provider_session_id) is True
+
     deleted = await client.delete(f"/v1/channels/{account_id}")
     assert deleted.status_code == 204
+    assert fake.pairing_recover_calls == 1
     await db_session.refresh(account)
     assert account.archived_at is not None
     assert registry.custom_binding(account_id) is None
@@ -1062,12 +1191,14 @@ async def test_sidecar_client_accepts_only_the_pinned_narrow_pairing_contract() 
                 200,
                 json={
                     "schemaVersion": "clawdi.whatsapp.sidecar-capabilities.v1",
-                    "pairing": ["qr", "code", "cancel", "logout", "retry"],
+                    "pairing": ["qr", "code", "cancel", "logout", "retry", "recover"],
                     "rawProviderAccess": False,
                 },
             )
         if request.url.path == f"{session_prefix}/pairing/retry":
             return httpx.Response(200, json={"status": "starting", "registered": True})
+        if request.url.path == f"{session_prefix}/pairing/recover":
+            return httpx.Response(200, json={"status": "stopped", "registered": False})
         assert request.url.path == f"{session_prefix}/pairing/code"
         assert json.loads(request.content) == {"phoneNumber": phone_number}
         return httpx.Response(
@@ -1096,6 +1227,7 @@ async def test_sidecar_client_accepts_only_the_pinned_narrow_pairing_contract() 
         assert "code" in (await sidecar.capabilities()).pairing
         pairing = await sidecar.pairing_code(phone_number)
         await sidecar.pairing_retry()
+        await sidecar.pairing_recover()
 
     assert pairing.code == "1234-5678"
     assert pairing.method == "code"
@@ -1105,6 +1237,7 @@ async def test_sidecar_client_accepts_only_the_pinned_narrow_pairing_contract() 
         "/v1/capabilities",
         f"{session_prefix}/pairing/code",
         f"{session_prefix}/pairing/retry",
+        f"{session_prefix}/pairing/recover",
     ]
 
 

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -48,6 +48,7 @@ class FakeManagedSidecar:
         self.stopped = False
         self.cancel_fails = False
         self.qr_starting = False
+        self.last_disconnect_reason: str | None = None
 
     async def refresh_health(self) -> bool:
         return self.connected
@@ -57,7 +58,7 @@ class FakeManagedSidecar:
 
     async def capabilities(self) -> WhatsAppSidecarCapabilities:
         return WhatsAppSidecarCapabilities(
-            pairing=frozenset({"qr", "code", "cancel", "logout", "retry"})
+            pairing=frozenset({"qr", "code", "cancel", "logout", "retry", "recover"})
         )
 
     async def health(self) -> WhatsAppSidecarHealth:
@@ -65,7 +66,11 @@ class FakeManagedSidecar:
             "connected" if self.connected else ("disconnected" if self.registered else "pairing_qr")
         )
         return WhatsAppSidecarHealth(
-            status=status, connected=self.connected, registered=self.registered
+            status=status,
+            connected=self.connected,
+            registered=self.registered,
+            account_jid="15551234567:1@s.whatsapp.net" if self.registered else None,
+            last_disconnect_reason=self.last_disconnect_reason,
         )
 
     async def pairing_qr(self) -> WhatsAppSidecarPairingStatus:
@@ -101,6 +106,15 @@ class FakeManagedSidecar:
     async def pairing_retry(self) -> WhatsAppSidecarPairingStatus:
         self.connected = True
         return await self.pairing_status()
+
+    async def pairing_recover(self) -> WhatsAppSidecarPairingStatus:
+        if self.last_disconnect_reason != "remote_logged_out" or not self.registered:
+            raise WhatsAppSidecarProtocolError("recovery not required")
+        self.registered = False
+        self.connected = False
+        self.stopped = True
+        self.last_disconnect_reason = None
+        return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
 
     async def pairing_logout(self) -> WhatsAppSidecarPairingStatus:
         self.logout_calls += 1
@@ -213,6 +227,8 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
         second_account = await db_session.get(ChannelAccount, second_id)
         assert first_account is not None and first_account.user_id is None
         assert second_account is not None and second_account.user_id is None
+        assert first_account.config["phone_number"] == "15551234567"
+        assert second_account.config["phone_number"] == "15551234567"
     finally:
         await registry.stop()
 
@@ -275,10 +291,48 @@ async def test_existing_shared_account_reauth_preserves_inventory_and_history(
         assert connected.state == "connected"
         assert await db_session.get(ChannelAccount, account_id) is account
         assert registry.managed_is_bound(account_id)
+        await db_session.refresh(account)
+        assert account.config["phone_number"] == "15551234567"
 
         await db_session.refresh(previous)
         assert previous.state == "connected"
         assert previous.channel_account_id == account_id
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_explicit_reauth_recovers_retained_remote_logout(db_session) -> None:
+    account_id = uuid4()
+    fake = FakeManagedSidecar()
+    registry = _registry(account_id, fake)
+    revision = registry.managed_account_revision(account_id)
+    account = ChannelAccount(
+        id=account_id,
+        user_id=None,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name="Shared",
+        status=CHANNEL_STATUS_ACTIVE,
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        webhook_secret_hash="0" * 64,
+        config={
+            "connection_mode": "baileys_managed",
+            "sidecar_config_revision": revision,
+            "phone_number": "15551234567",
+        },
+    )
+    db_session.add(account)
+    await db_session.commit()
+    await registry.start()
+    try:
+        fake.registered = True
+        fake.last_disconnect_reason = "remote_logged_out"
+
+        started = await _start(db_session, registry, account_id, name="Shared")
+
+        assert started.state == "ready"
+        assert fake.registered is False
+        assert fake.last_disconnect_reason is None
     finally:
         await registry.stop()
 

--- a/docs/runbooks/whatsapp-baileys-sidecars.md
+++ b/docs/runbooks/whatsapp-baileys-sidecars.md
@@ -25,6 +25,8 @@ Kamal declares one fixed `whatsapp-baileys` accessory in `config/deploy.yml`:
 - app mount: the run directory only, read-only;
 - root filesystem: read-only, all capabilities dropped, no new privileges;
 - network: Docker bridge for provider egress, with no published port;
+- restart policy: Kamal 2.12's `unless-stopped`, so an ordinary host reboot
+  starts the same singleton against the same durable state root;
 - identity: numeric UID/GID `1000:1000` for the Kamal SSH user, backend, and sidecar.
 
 The only sidecar deployment secret is
@@ -58,14 +60,21 @@ run directories.
 
 ## Release order
 
-Kamal 2.12 reboots the exact singleton, verifies its full-SHA image, and
-requires its authenticated UDS healthcheck. Only then does the workflow deploy
-the new backend and channels worker. The singleton uses the clean fixed
-`/home/phala/clawdi-whatsapp/state` root and stores each session directly at
-`/data/<provider-session-id>`.
+Backend- or web-only releases must not restart the WhatsApp singleton. Every
+release publishes a full-SHA sidecar image, but the workflow derives a stable
+deployment revision from the sidecar's effective Docker inputs and Kamal
+accessory configuration. It reboots the singleton only when that revision
+differs from the running container, so a failed or skipped earlier release
+cannot make a later commit miss a pending sidecar change. A real sidecar release
+verifies the full-SHA image, authenticated UDS healthcheck, and every active
+Shared session whose verified phone identity is already durable in PostgreSQL.
+Only then does the workflow deploy the new backend and channels worker. The
+singleton uses the clean fixed `/home/phala/clawdi-whatsapp/state` root and
+stores each session directly at `/data/<provider-session-id>`.
 
-Done: the release job exits 0 only after the exact singleton image and
-authenticated healthcheck pass, then starts `kamal deploy` for the backend.
+Done: an unrelated release preserves the current singleton process; a sidecar
+release exits 0 only after the exact image, global health, and per-session
+recovery gates pass.
 
 ## Rollback boundary
 
@@ -101,6 +110,20 @@ For a paired product account, retirement remains explicit:
    maintenance action.
 
 Never automatically prune unknown directories during deploy.
+
+Baileys rc14 defines `DisconnectReason.loggedOut` as status 401 and its pinned
+example deliberately does not reconnect that state. This differs from an
+ordinary process restart: with valid stored auth, `makeWASocket({ auth })`
+reconnects without a QR. Clawdi therefore quarantines a provider-reported 401,
+retains the complete SQLite auth and Signal state, and requires an authenticated
+explicit recovery action before clearing it for re-pairing. A transport event
+must never silently become credential deletion.
+
+Upstream references for the pinned source commit:
+
+- [disconnect reasons](https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/src/Types/index.ts#L28-L38)
+- [reconnect handling](https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/Example/example.ts#L70-L103)
+- [production auth-state requirements](https://github.com/WhiskeySockets/Baileys/blob/7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a/README.md#saving--restoring-sessions)
 
 ## Monitoring
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -408,6 +408,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/channels/whatsapp/onboarding/accounts/{account_id}/repair": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Repair Whatsapp Channel Account */
+        post: operations["repair_whatsapp_channel_account_v1_channels_whatsapp_onboarding_accounts__account_id__repair_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/channels/debug/events": {
         parameters: {
             query?: never;
@@ -8448,6 +8465,37 @@ export interface operations {
             header?: never;
             path: {
                 session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelWhatsAppOnboardingSessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    repair_whatsapp_channel_account_v1_channels_whatsapp_onboarding_accounts__account_id__repair_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                account_id: string;
             };
             cookie?: never;
         };

--- a/packages/whatsapp-baileys-sidecar/src/healthcheck.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/healthcheck.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { checkSidecarHealth } from "./healthcheck.js";
 
 const TOKEN = "test-sidecar-token";
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
 const servers: Server[] = [];
 const temporaryDirectories: string[] = [];
 
@@ -44,6 +45,27 @@ describe("sidecar healthcheck", () => {
 				CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN: TOKEN,
 			}),
 		).resolves.toBeUndefined();
+	});
+
+	it("requires every requested durable session to recover", async () => {
+		const recoveredPort = await startTcpHealthServer(true, true);
+		const env = {
+			CLAWDI_WA_SIDECAR_HOST: "127.0.0.1",
+			CLAWDI_WA_SIDECAR_PORT: String(recoveredPort),
+			CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN: TOKEN,
+		};
+
+		await expect(checkSidecarHealth(env, [SESSION_ID])).resolves.toBeUndefined();
+
+		const disconnectedPort = await startTcpHealthServer(true, false);
+		await expect(
+			checkSidecarHealth({ ...env, CLAWDI_WA_SIDECAR_PORT: String(disconnectedPort) }, [
+				SESSION_ID,
+			]),
+		).rejects.toThrow("session did not recover");
+		await expect(checkSidecarHealth(env, ["not-a-session"])).rejects.toThrow(
+			"invalid sidecar session id",
+		);
 	});
 
 	it("rejects mixed UDS/TCP endpoints and non-loopback TCP", async () => {
@@ -86,7 +108,7 @@ describe("sidecar healthcheck", () => {
 				CLAWDI_WA_SIDECAR_PORT: String(wrongBearerPort),
 				CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN: "wrong-token",
 			}),
-		).rejects.toThrow("identity mismatch");
+		).rejects.toThrow("request failed");
 
 		const wrongIdentityPort = await startTcpHealthServer(false);
 		await expect(
@@ -112,8 +134,11 @@ async function startUnixHealthServer(): Promise<string> {
 	return socketPath;
 }
 
-async function startTcpHealthServer(validIdentity = true): Promise<number> {
-	const server = createHealthServer(validIdentity);
+async function startTcpHealthServer(
+	validIdentity = true,
+	sessionConnected?: boolean,
+): Promise<number> {
+	const server = createHealthServer(validIdentity, sessionConnected);
 	await new Promise<void>((resolve, reject) => {
 		server.once("error", reject);
 		server.listen(0, "127.0.0.1", resolve);
@@ -121,12 +146,28 @@ async function startTcpHealthServer(validIdentity = true): Promise<number> {
 	return (server.address() as AddressInfo).port;
 }
 
-function createHealthServer(validIdentity = true): Server {
+function createHealthServer(validIdentity = true, sessionConnected?: boolean): Server {
 	const server = createServer((request, response) => {
 		response.setHeader("content-type", "application/json");
-		if (request.url !== "/v1/health" || request.headers.authorization !== `Bearer ${TOKEN}`) {
+		if (request.headers.authorization !== `Bearer ${TOKEN}`) {
 			response.statusCode = 401;
 			response.end(JSON.stringify({ error: "unauthorized" }));
+			return;
+		}
+		if (request.url === `/v1/sessions/${SESSION_ID}/health` && sessionConnected !== undefined) {
+			response.end(
+				JSON.stringify({
+					sessionId: SESSION_ID,
+					status: sessionConnected ? "connected" : "disconnected",
+					connected: sessionConnected,
+					registered: true,
+				}),
+			);
+			return;
+		}
+		if (request.url !== "/v1/health") {
+			response.statusCode = 404;
+			response.end(JSON.stringify({ error: "not_found" }));
 			return;
 		}
 		response.end(

--- a/packages/whatsapp-baileys-sidecar/src/healthcheck.ts
+++ b/packages/whatsapp-baileys-sidecar/src/healthcheck.ts
@@ -2,16 +2,44 @@ import { type RequestOptions, request } from "node:http";
 import { basename, resolve } from "node:path";
 
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+const SESSION_ID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-export async function checkSidecarHealth(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+export async function checkSidecarHealth(
+	env: NodeJS.ProcessEnv = process.env,
+	sessionIds: readonly string[] = [],
+): Promise<void> {
 	const token = required(env.CHANNEL_WHATSAPP_BAILEYS_SIDECAR_TOKEN, "sidecar token");
 	const endpoint = healthEndpoint(env);
+	const service = await requestHealth(endpoint, token, "/v1/health");
+	if (
+		!isRecord(service) ||
+		service.schemaVersion !== "clawdi.whatsapp.sidecar-health.v1" ||
+		service.ready !== true
+	) {
+		throw new Error("sidecar health identity mismatch");
+	}
+	for (const sessionId of sessionIds) {
+		if (!SESSION_ID_PATTERN.test(sessionId)) throw new Error("invalid sidecar session id");
+		const session = await requestHealth(endpoint, token, `/v1/sessions/${sessionId}/health`);
+		if (
+			!isRecord(session) ||
+			session.sessionId !== sessionId ||
+			session.status !== "connected" ||
+			session.connected !== true ||
+			session.registered !== true
+		) {
+			throw new Error("sidecar session did not recover");
+		}
+	}
+}
 
-	await new Promise<void>((resolveHealth, rejectHealth) => {
+function requestHealth(endpoint: RequestOptions, token: string, path: string): Promise<unknown> {
+	return new Promise<unknown>((resolveHealth, rejectHealth) => {
 		const healthRequest = request(
 			{
 				...endpoint,
-				path: "/v1/health",
+				path,
 				method: "GET",
 				headers: { authorization: `Bearer ${token}` },
 				timeout: 4_000,
@@ -23,18 +51,8 @@ export async function checkSidecarHealth(env: NodeJS.ProcessEnv = process.env): 
 				response.on("end", () => {
 					try {
 						const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-						if (
-							response.statusCode !== 200 ||
-							typeof body !== "object" ||
-							body === null ||
-							!("schemaVersion" in body) ||
-							body.schemaVersion !== "clawdi.whatsapp.sidecar-health.v1" ||
-							!("ready" in body) ||
-							body.ready !== true
-						) {
-							throw new Error("sidecar health identity mismatch");
-						}
-						resolveHealth();
+						if (response.statusCode !== 200) throw new Error("sidecar health request failed");
+						resolveHealth(body);
 					} catch (error: unknown) {
 						rejectHealth(error);
 					}
@@ -45,6 +63,10 @@ export async function checkSidecarHealth(env: NodeJS.ProcessEnv = process.env): 
 		healthRequest.once("error", rejectHealth);
 		healthRequest.end();
 	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function healthEndpoint(env: NodeJS.ProcessEnv): RequestOptions {
@@ -92,4 +114,4 @@ function nonEmpty(value: string | undefined): string | undefined {
 	return text ? text : undefined;
 }
 
-if (import.meta.main) await checkSidecarHealth();
+if (import.meta.main) await checkSidecarHealth(process.env, process.argv.slice(2));

--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -110,6 +110,51 @@ describe("physical Baileys runtime", () => {
 		}
 	});
 
+	it("retains quarantined rc14 auth across process restart until explicit recovery", async () => {
+		const sessionDir = mkdtempSync(join(tmpdir(), "clawdi-wa-runtime-logout-"));
+		const config = { ...sidecarConfig(), sessionDir };
+		const firstHarness = createHarness({ registered: false });
+		const first = new BaileysSocketRuntime(config, {
+			socketFactory: firstHarness.dependencies.socketFactory,
+		});
+		let second: BaileysSocketRuntime | undefined;
+		try {
+			await first.startQrPairing();
+			firstHarness.events.emit("creds.update", verifiedQrUpdate());
+			firstHarness.events.emit("connection.update", { connection: "open" });
+			firstHarness.events.emit("connection.update", {
+				connection: "close",
+				lastDisconnect: { error: { output: { statusCode: DisconnectReason.loggedOut } } },
+			});
+			expect(first.health()).toMatchObject({
+				status: "disconnected",
+				registered: true,
+				lastDisconnectReason: "remote_logged_out",
+			});
+			await first.stop();
+
+			const secondHarness = createHarness({ registered: false });
+			second = new BaileysSocketRuntime(config, {
+				socketFactory: secondHarness.dependencies.socketFactory,
+			});
+			await second.start();
+			expect(secondHarness.socketConfigurations).toHaveLength(0);
+			expect(second.health()).toMatchObject({
+				status: "disconnected",
+				registered: true,
+				lastDisconnectReason: "remote_logged_out",
+			});
+			expect(await second.recoverPairing()).toEqual({
+				status: "stopped",
+				registered: false,
+			});
+		} finally {
+			await second?.stop();
+			await first.stop();
+			rmSync(sessionDir, { recursive: true, force: true });
+		}
+	});
+
 	it("supports the pinned rc14 pairing-code method without retaining phone input", async () => {
 		const harness = createHarness({ registered: false });
 		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);
@@ -208,7 +253,7 @@ describe("physical Baileys runtime", () => {
 		await runtime.stop();
 	});
 
-	it("clears physical auth when WhatsApp unlinks the device remotely", async () => {
+	it("quarantines unexpected provider logout until explicit recovery", async () => {
 		const harness = createHarness();
 		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);
 		await runtime.start();
@@ -219,8 +264,29 @@ describe("physical Baileys runtime", () => {
 			lastDisconnect: { error: { output: { statusCode: DisconnectReason.loggedOut } } },
 		});
 
+		expect(harness.physicalAuthResets).toBe(0);
+		expect(runtime.health()).toMatchObject({
+			status: "disconnected",
+			registered: true,
+			lastDisconnectReason: "remote_logged_out",
+		});
+		await expect(runtime.retryPairing()).rejects.toThrow("physical_auth_recovery_required");
+		expect(harness.physicalAuthResets).toBe(0);
+
+		const recovered = await runtime.recoverPairing();
 		expect(harness.physicalAuthResets).toBe(1);
-		expect(runtime.pairingStatus()).toEqual({ status: "stopped", registered: false });
+		expect(recovered).toEqual({ status: "stopped", registered: false });
+		await runtime.stop();
+	});
+
+	it("rejects recovery unless a retained remote logout requires it", async () => {
+		const harness = createHarness();
+		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);
+		await runtime.start();
+		harness.events.emit("connection.update", { connection: "open" });
+
+		await expect(runtime.recoverPairing()).rejects.toThrow("physical_auth_recovery_not_required");
+		expect(harness.physicalAuthResets).toBe(0);
 		await runtime.stop();
 	});
 
@@ -459,6 +525,7 @@ function createHarness(options: HarnessOptions = {}) {
 	let cancelFailuresRemaining = options.cancelFailures ?? 0;
 	let logoutFailuresRemaining = options.logoutFailures ?? 0;
 	let physicalAuthResets = 0;
+	let physicalAuthQuarantineReason: string | undefined;
 	let stateClosed = false;
 	const creds = initAuthCreds();
 	creds.registered = options.registered ?? true;
@@ -489,6 +556,12 @@ function createHarness(options: HarnessOptions = {}) {
 			if (options.failCredsWrite) throw new Error("injected creds write failure");
 			Object.assign(creds, update);
 		},
+		physicalAuthQuarantineReason() {
+			return physicalAuthQuarantineReason;
+		},
+		quarantinePhysicalAuth(reason: string) {
+			physicalAuthQuarantineReason = reason;
+		},
 		storeRetryMessage(remoteJid: string, messageId: string, message: Uint8Array) {
 			retryMessages.push({ remoteJid, messageId, message: Buffer.from(message) });
 			options.onStoreRetryMessage?.();
@@ -508,6 +581,7 @@ function createHarness(options: HarnessOptions = {}) {
 		acknowledgeProviderEvents() {},
 		resetPhysicalAuth() {
 			physicalAuthResets += 1;
+			physicalAuthQuarantineReason = undefined;
 			for (const key of Object.keys(creds)) Reflect.deleteProperty(creds, key);
 			Object.assign(creds, initAuthCreds());
 		},

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -35,6 +35,7 @@ import {
 const RECONNECT_DELAY_MS = 3_000;
 const FIRST_QR_TTL_MS = 60_000;
 const ROTATED_QR_TTL_MS = 20_000;
+const REMOTE_LOGOUT_REASON = "remote_logged_out";
 const E164_DIGITS = /^[1-9][0-9]{6,14}$/;
 const TRANSIENT_DISCONNECT_REASONS = new Set<number>([
 	DisconnectReason.connectionClosed,
@@ -70,6 +71,8 @@ type ProviderState = {
 	};
 	retryCounterCache: CacheStore;
 	saveCreds(update?: Partial<AuthenticationCreds>): void;
+	physicalAuthQuarantineReason(): string | undefined;
+	quarantinePhysicalAuth(reason: string): void;
 	storeRetryMessage(remoteJid: string, messageId: string, message: Uint8Array): void;
 	getRetryMessage(
 		remoteJid: string | null | undefined,
@@ -113,7 +116,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		private readonly config: SidecarSessionConfig,
 		dependencies: BaileysRuntimeDependencies = {},
 	) {
-		this.logger = pino({ level: config.logLevel });
+		this.logger = pino({ level: config.logLevel }).child({ sessionId: config.sessionId });
 		// Upstream Baileys logs can contain JIDs/device metadata. The sidecar
 		// emits only its own generic lifecycle logs at the configured level.
 		this.baileysLogger = pino({ level: "silent" });
@@ -127,13 +130,24 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 				config.providerInbox,
 				(operation, error) => this.markStateFatal(operation, error),
 			);
+		const quarantineReason = this.providerState.physicalAuthQuarantineReason();
+		if (quarantineReason) {
+			this.fatalReason = quarantineReason;
+			this.lastDisconnectReason = quarantineReason;
+			this.status = "disconnected";
+			this.logger.warn(
+				{ reason: quarantineReason },
+				"WhatsApp linked-device auth quarantine restored from durable state",
+			);
+		}
 	}
 
 	async start(): Promise<void> {
-		if (this.fatalReason) {
-			throw new Error(`WhatsApp provider requires operator recovery: ${this.fatalReason}`);
-		}
 		if (this.stateClosed) throw new Error("WhatsApp provider state is closed");
+		// Keep health and explicit recovery routes reachable while quarantined.
+		// Data-plane methods still fail closed through requireSocket(), and retry
+		// applies the reason-specific recovery policy below.
+		if (this.fatalReason) return;
 		// Session-scoped status and health requests call start() before dispatch.
 		// An unregistered socket may already be generating or displaying a QR;
 		// preserve that sole physical owner instead of resetting its lifecycle.
@@ -169,10 +183,14 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 	}
 
 	health(): RuntimeHealth {
-		const user = this.socket?.user
+		// rc14 chooses login vs registration from durable creds.me. Report that
+		// same persisted identity even while the transport is reconnecting or
+		// quarantined; socket liveness must not erase account identity.
+		const durableUser = this.providerState.state.creds.me;
+		const user = durableUser
 			? {
-					id: this.socket.user.id,
-					name: this.socket.user.name,
+					id: durableUser.id,
+					name: durableUser.name,
 				}
 			: undefined;
 		return {
@@ -303,10 +321,31 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 			if (!isLinkedAuthenticationCreds(this.providerState.state.creds)) {
 				throw new PairingLifecycleError("unregistered_session_requires_pairing");
 			}
+			if (this.fatalReason === REMOTE_LOGOUT_REASON) {
+				throw new PairingLifecycleError("physical_auth_recovery_required");
+			}
 			if (!this.socket) {
 				this.fatalReason = undefined;
 				await this.openSocket();
 			}
+			return this.pairingStatus();
+		});
+	}
+
+	async recoverPairing(): Promise<PairingStatus> {
+		return await this.runLifecycle(async () => {
+			if (
+				this.fatalReason !== REMOTE_LOGOUT_REASON ||
+				!isLinkedAuthenticationCreds(this.providerState.state.creds)
+			) {
+				throw new PairingLifecycleError("physical_auth_recovery_not_required");
+			}
+			this.clearReconnectTimer();
+			this.resetPhysicalAuth();
+			this.clearPairingSecrets();
+			this.status = "stopped";
+			this.lastDisconnectReason = undefined;
+			this.fatalReason = undefined;
 			return this.pairingStatus();
 		});
 	}
@@ -441,14 +480,23 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 			this.lastDisconnectReason = reason === undefined ? "unknown_disconnect" : String(reason);
 			this.logger.warn({ reason }, "WhatsApp connection closed");
 			if (reason === DisconnectReason.loggedOut) {
+				// A provider-side loggedOut signal is not proof that the user asked
+				// Clawdi to destroy its durable auth state. Quarantine the session so
+				// ordinary retries and process restarts cannot turn a transport event
+				// into irreversible credential loss. The authenticated recovery route
+				// is the only path that may clear this retained state for re-pairing.
 				try {
-					this.resetPhysicalAuth();
+					this.providerState.quarantinePhysicalAuth(REMOTE_LOGOUT_REASON);
+					this.clearReconnectTimer();
 					this.clearPairingSecrets();
-					this.status = "stopped";
-					this.lastDisconnectReason = undefined;
-					this.fatalReason = undefined;
+					this.fatalReason = REMOTE_LOGOUT_REASON;
+					this.lastDisconnectReason = REMOTE_LOGOUT_REASON;
+					this.logger.error(
+						{ reason: REMOTE_LOGOUT_REASON },
+						"WhatsApp linked-device auth quarantined; explicit repair required",
+					);
 				} catch (error: unknown) {
-					this.markStateFatal("physical_auth_reset", asError(error));
+					this.markStateFatal("physical_auth_quarantine", asError(error));
 				}
 				return;
 			}

--- a/packages/whatsapp-baileys-sidecar/src/server.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.test.ts
@@ -40,7 +40,7 @@ class FakeRuntime implements BaileysRuntime {
 	capabilities() {
 		return {
 			schemaVersion: "clawdi.whatsapp.sidecar-capabilities.v1",
-			pairing: ["qr", "code", "cancel", "logout", "retry"],
+			pairing: ["qr", "code", "cancel", "logout", "retry", "recover"],
 			rawProviderAccess: false,
 		} as const;
 	}
@@ -73,6 +73,10 @@ class FakeRuntime implements BaileysRuntime {
 
 	async retryPairing(): Promise<PairingStatus> {
 		return this.pairingStatus();
+	}
+
+	async recoverPairing(): Promise<PairingStatus> {
+		return { status: "stopped", registered: false };
 	}
 
 	async relayMessage(request: RelayMessageRequest): Promise<string> {
@@ -173,6 +177,7 @@ describe("sidecar HTTP contract", () => {
 			[`${SESSION_PREFIX}/pairing/cancel`, { method: "POST" }],
 			[`${SESSION_PREFIX}/pairing/logout`, { method: "POST" }],
 			[`${SESSION_PREFIX}/pairing/retry`, { method: "POST" }],
+			[`${SESSION_PREFIX}/pairing/recover`, { method: "POST" }],
 		];
 
 		for (const [path, init] of requests) {
@@ -195,6 +200,7 @@ describe("sidecar HTTP contract", () => {
 			[`${SESSION_PREFIX}/pairing/cancel`, { method: "POST" }],
 			[`${SESSION_PREFIX}/pairing/logout`, { method: "POST" }],
 			[`${SESSION_PREFIX}/pairing/retry`, { method: "POST" }],
+			[`${SESSION_PREFIX}/pairing/recover`, { method: "POST" }],
 		];
 
 		for (const [path, init] of requests) {

--- a/packages/whatsapp-baileys-sidecar/src/server.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.ts
@@ -35,6 +35,7 @@ const SESSION_RUNTIME_METHODS = new Map([
 	["/v1/pairing/cancel", "POST"],
 	["/v1/pairing/logout", "POST"],
 	["/v1/pairing/retry", "POST"],
+	["/v1/pairing/recover", "POST"],
 	["/v1/relay-message", "POST"],
 	["/v1/raw-node", "POST"],
 	["/v1/query-iq", "POST"],
@@ -104,6 +105,10 @@ export function createSidecarServer(
 			}
 			if (method === "POST" && path === "/v1/pairing/retry") {
 				writeJson(response, 200, await runtime.retryPairing());
+				return;
+			}
+			if (method === "POST" && path === "/v1/pairing/recover") {
+				writeJson(response, 200, await runtime.recoverPairing());
 				return;
 			}
 			if (method === "POST" && path === "/v1/relay-message") {

--- a/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
@@ -67,6 +67,10 @@ class FakeRuntime implements BaileysRuntime {
 		throw new Error("not used");
 	}
 
+	async recoverPairing(): Promise<PairingStatus> {
+		throw new Error("not used");
+	}
+
 	async relayMessage(_request: RelayMessageRequest): Promise<string | undefined> {
 		throw new Error("not used");
 	}

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
@@ -207,12 +207,34 @@ describe("SQLite provider state", () => {
 		second.close();
 	});
 
+	it("persists physical-auth quarantine and clears it only with explicit auth reset", () => {
+		const directory = makeDirectory();
+		const first = makeState(directory);
+		first.saveCreds({ registered: true, me: REGISTERED_ME });
+		first.quarantinePhysicalAuth("remote_logged_out");
+		expect(first.physicalAuthQuarantineReason()).toBe("remote_logged_out");
+		first.close();
+
+		const second = makeState(directory);
+		expect(second.state.creds.registered).toBe(true);
+		expect(second.physicalAuthQuarantineReason()).toBe("remote_logged_out");
+		second.resetPhysicalAuth();
+		expect(second.physicalAuthQuarantineReason()).toBeUndefined();
+		second.close();
+
+		const third = makeState(directory);
+		expect(third.state.creds.registered).toBe(false);
+		expect(third.physicalAuthQuarantineReason()).toBeUndefined();
+		third.close();
+	});
+
 	it("rolls back and reports a failed physical-auth reset", async () => {
 		const failures: ProviderStateFailureOperation[] = [];
 		const state = makeState(makeDirectory(), {
 			onFailure: (operation) => failures.push(operation),
 		});
 		state.saveCreds({ registered: true, me: REGISTERED_ME });
+		state.quarantinePhysicalAuth("remote_logged_out");
 		await state.state.keys.set({ session: { sender: Buffer.from([1]) } });
 		internalDatabase(state).exec(`
 			CREATE TRIGGER fail_auth_reset BEFORE INSERT ON auth_creds
@@ -221,6 +243,7 @@ describe("SQLite provider state", () => {
 
 		expect(() => state.resetPhysicalAuth()).toThrow("injected auth reset failure");
 		expect(state.state.creds.registered).toBe(true);
+		expect(state.physicalAuthQuarantineReason()).toBe("remote_logged_out");
 		expect(await state.state.keys.get("session", ["sender"])).toEqual({
 			sender: Buffer.from([1]),
 		});

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
@@ -40,6 +40,7 @@ export type ProviderInboxConfig = {
 
 export type ProviderStateFailureOperation =
 	| "auth_creds_write"
+	| "physical_auth_quarantine"
 	| "physical_auth_reset"
 	| "signal_key_read"
 	| "signal_key_write"
@@ -175,6 +176,32 @@ export class SQLiteProviderState {
 		});
 	}
 
+	physicalAuthQuarantineReason(): string | undefined {
+		return this.withFailure("physical_auth_quarantine", () => {
+			const row = this.db
+				.query<{ reason: string }, []>(
+					"SELECT reason FROM physical_auth_quarantine WHERE singleton = 1",
+				)
+				.get();
+			return row?.reason;
+		});
+	}
+
+	quarantinePhysicalAuth(reason: string): void {
+		this.withFailure("physical_auth_quarantine", () => {
+			if (!/^[a-z][a-z0-9_]{0,63}$/.test(reason)) {
+				throw new Error("invalid physical auth quarantine reason");
+			}
+			this.transaction(() => {
+				this.db
+					.query(
+						"INSERT OR REPLACE INTO physical_auth_quarantine (singleton, reason) VALUES (1, ?)",
+					)
+					.run(reason);
+			});
+		});
+	}
+
 	appendProviderEvents(events: readonly ProviderMessageEventInput[]): void {
 		if (events.length === 0) return;
 		this.withFailure("provider_inbox_write", () => {
@@ -252,6 +279,7 @@ export class SQLiteProviderState {
 			const serialized = serializeBufferJson(fresh, "Baileys auth credentials");
 			this.transaction(() => {
 				this.db.exec(`
+					DELETE FROM physical_auth_quarantine;
 					DELETE FROM signal_keys;
 					DELETE FROM retry_cache;
 					DELETE FROM retry_messages;
@@ -596,6 +624,10 @@ function createSchema(db: Database): void {
 		CREATE TABLE IF NOT EXISTS auth_creds (
 			singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
 			value TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS physical_auth_quarantine (
+			singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+			reason TEXT NOT NULL CHECK (length(reason) BETWEEN 1 AND 64)
 		);
 		CREATE TABLE IF NOT EXISTS signal_keys (
 			category TEXT NOT NULL,

--- a/packages/whatsapp-baileys-sidecar/src/types.ts
+++ b/packages/whatsapp-baileys-sidecar/src/types.ts
@@ -40,13 +40,13 @@ export type PairingStatus = {
 
 export type SidecarCapabilities = {
 	schemaVersion: "clawdi.whatsapp.sidecar-capabilities.v1";
-	pairing: readonly ["qr", "code", "cancel", "logout", "retry"];
+	pairing: readonly ["qr", "code", "cancel", "logout", "retry", "recover"];
 	rawProviderAccess: false;
 };
 
 export const SIDECAR_CAPABILITIES: SidecarCapabilities = {
 	schemaVersion: "clawdi.whatsapp.sidecar-capabilities.v1",
-	pairing: ["qr", "code", "cancel", "logout", "retry"],
+	pairing: ["qr", "code", "cancel", "logout", "retry", "recover"],
 	rawProviderAccess: false,
 };
 
@@ -69,6 +69,7 @@ export type BaileysRuntime = {
 	cancelPairing(): Promise<PairingStatus>;
 	logoutPairing(): Promise<PairingStatus>;
 	retryPairing(): Promise<PairingStatus>;
+	recoverPairing(): Promise<PairingStatus>;
 	relayMessage(request: RelayMessageRequest): Promise<string | undefined>;
 	sendNode(node: BinaryNode): Promise<void>;
 	query(node: BinaryNode, timeoutMs: number): Promise<BinaryNode | null>;

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -71,6 +71,9 @@ config.roles.each do |role|
 end
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run
+  unless command.each_cons(2).include?([ "--restart", "unless-stopped" ])
+    raise "#{accessory.name} does not survive an ordinary host restart"
+  end
   unless command.each_cons(2).include?(expected_logging_args)
     raise "#{accessory.name} logging did not render journald"
   end


### PR DESCRIPTION
## Summary

- retain Baileys auth and Signal state when WhatsApp reports loggedOut, persist a durable quarantine, and require explicit authenticated recovery before re-pairing
- persist Shared WhatsApp phone identity so wa.me links survive sidecar downtime; avoid sidecar restarts on unrelated releases and verify session recovery after real sidecar changes
- check Custom WhatsApp health only when linking or pairing, offer owner-only repair, and preserve the existing bot, links, paired chats, and history

## Verification

- sidecar typecheck and 63 tests
- backend focused Custom, Shared, and Link tests: 36 passed
- web typecheck, 23 related tests, and OSS client/SSR/Nitro build
- Biome, Ruff check/format, generated OpenAPI client check
- 11 deployment contract tests and Kamal 2.12 render contract
- git diff --check

## Rollout note

The current production Shared session was cleared by the old image and cannot be recovered automatically. After this change is deliberately deployed, Shared WhatsApp needs one final QR scan; the durable phone identity and auth state are then preserved across ordinary deploys and host restarts.