### PR TITLE
fix(discord): handle shared DM interactions

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -1617,7 +1617,7 @@ async def discord_webhook(
         return Response(status_code=status.HTTP_202_ACCEPTED)
     if command is None and payload.get("type") == 4:
         return {"type": 8, "data": {"choices": []}}
-    if command is None and payload.get("type") in {3, 5}:
+    if command is None and payload.get("type") in {2, 3, 5}:
         scope = "server" if guild_id is not None else "direct message"
         return {
             "type": 4,

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -31,7 +31,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1470,7 +1470,7 @@ async def discord_webhook(
     x_signature_ed25519: str | None = Header(default=None),
     x_signature_timestamp: str | None = Header(default=None),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, Any]:
+) -> Any:
     account = await get_active_channel_account(db, account_id=account_id)
     if account.provider != CHANNEL_PROVIDER_DISCORD:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
@@ -1495,6 +1495,16 @@ async def discord_webhook(
 
     chat = discord_chat_from_payload(payload)
     if chat is None:
+        if payload.get("type") == 4:
+            return {"type": 8, "data": {"choices": []}}
+        if payload.get("type") in {2, 3, 5}:
+            return {
+                "type": 4,
+                "data": {
+                    "content": "Discord could not route this interaction.",
+                    "flags": 64,
+                },
+            }
         return {"ok": True}
     external_chat_id, external_chat_type, external_chat_name = chat
     command = discord_control_command_from_payload(payload)
@@ -1591,8 +1601,31 @@ async def discord_webhook(
         )
         await record_inactive_bot_agent_link_event(db, account=account, binding=binding)
     await db.commit()
-    message = messages[0][0]
+    message = messages[0][0] if messages else None
     reply_text = discord_control_reply_for_command(command, binding_result, guild_id=guild_id)
+    if (
+        command is None
+        and binding_result.binding is not None
+        and payload.get("type") in {2, 3, 4, 5}
+    ):
+        # The bound Agent receives this interaction over Clawdi's synthetic
+        # Gateway and responds through the proxied interaction callback. For
+        # interactions received over HTTP, Discord requires this original
+        # request to be released with 202 and no body when that separate
+        # callback path is used.
+        # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback
+        return Response(status_code=status.HTTP_202_ACCEPTED)
+    if command is None and payload.get("type") == 4:
+        return {"type": 8, "data": {"choices": []}}
+    if command is None and payload.get("type") in {3, 5}:
+        scope = "server" if guild_id is not None else "direct message"
+        return {
+            "type": 4,
+            "data": {
+                "content": f"This {scope} is not paired.",
+                "flags": 64,
+            },
+        }
     if payload.get("type") == 2:
         if binding_result.paired and binding_result.binding is not None and guild_id is not None:
             # Discord interactions have a short acknowledgement deadline. The
@@ -1650,7 +1683,9 @@ async def discord_webhook(
         "ok": True,
         "paired": binding_result.paired,
         "unpaired": binding_result.unpaired,
-        "binding_id": str(message.binding_id) if message.binding_id else None,
+        "binding_id": (
+            str(message.binding_id) if message is not None and message.binding_id else None
+        ),
     }
 
 

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -1374,14 +1374,26 @@ def _discord_guild_command_provider_payload(command: dict[str, Any]) -> dict[str
 
 def _discord_gateway_dispatch(message: Any) -> dict[str, Any]:
     payload = message.payload if isinstance(message.payload, dict) else {}
-    data = payload.get("d") if isinstance(payload.get("d"), dict) else payload
-    dispatch_type = payload.get("t") if isinstance(payload.get("t"), str) else "MESSAGE_CREATE"
+    interaction_type = payload.get("type")
+    is_http_interaction = (
+        "t" not in payload
+        and isinstance(interaction_type, int)
+        and not isinstance(interaction_type, bool)
+        and interaction_type in {2, 3, 4, 5}
+    )
+    if is_http_interaction:
+        data = payload
+        dispatch_type = "INTERACTION_CREATE"
+    else:
+        data = payload.get("d") if isinstance(payload.get("d"), dict) else payload
+        dispatch_type = payload.get("t") if isinstance(payload.get("t"), str) else "MESSAGE_CREATE"
     if not isinstance(data, dict):
         data = {}
     data = dict(data)
-    data.setdefault("id", message.provider_message_id or str(message.id))
-    data.setdefault("channel_id", message.external_chat_id)
-    data.setdefault("content", message.text or "")
+    if not is_http_interaction:
+        data.setdefault("id", message.provider_message_id or str(message.id))
+        data.setdefault("channel_id", message.external_chat_id)
+        data.setdefault("content", message.text or "")
     return {
         "op": 0,
         "t": dispatch_type,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -18,6 +18,7 @@ import httpx
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import HTTPException, status
+from pydantic import JsonValue
 from sqlalchemy import and_, delete, exists, func, or_, select, union_all, update
 from sqlalchemy import text as sql_text
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
@@ -5329,7 +5330,10 @@ async def rearm_discord_command_reconciliation(
             changed = True
             rearmed += 1
         if changed:
-            config["discord_command_retries"] = retries
+            json_retries: dict[str, JsonValue] = {}
+            for guild_id, retry in retries.items():
+                json_retries[guild_id] = retry
+            config["discord_command_retries"] = json_retries
             link.config = config
     return rearmed
 

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -6590,7 +6590,9 @@ async def _record_discord_unpaired_message_and_maybe_instruct(
     message_type = data.get("type", 0)
     author = data.get("author")
     if (
-        message_type != 0
+        # DEFAULT and REPLY are the ordinary user-authored message types.
+        # https://discord.com/developers/docs/resources/message#message-object-message-types
+        message_type not in {0, 19}
         or not isinstance(author, dict)
         or author.get("bot") is True
         or data.get("webhook_id") is not None

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -2346,7 +2346,7 @@ def discord_guild_command_denied_reason(
     data = _discord_event_data(payload)
     member = data.get("member")
     raw_permissions = member.get("permissions") if isinstance(member, dict) else None
-    is_interaction = payload.get("type") == 2 or payload.get("t") == "INTERACTION_CREATE"
+    is_interaction = payload.get("type") == 2
     if not isinstance(raw_permissions, str) or re.fullmatch(r"[0-9]+", raw_permissions) is None:
         return DISCORD_GUILD_PERMISSION_DENIED if is_interaction else DISCORD_GUILD_USE_INTERACTION
     try:
@@ -2401,13 +2401,12 @@ def _discord_pair_install_admission(
     interaction_type = data.get("type")
     interaction_data = data.get("data")
     is_http_interaction = data is payload
-    is_gateway_interaction = payload.get("t") == "INTERACTION_CREATE" and data is not payload
     is_application_command = (
         isinstance(interaction_type, int)
         and not isinstance(interaction_type, bool)
         and interaction_type == 2
         and isinstance(interaction_data, dict)
-        and (is_http_interaction or is_gateway_interaction)
+        and is_http_interaction
     )
     expected_context = (
         DISCORD_GUILD_INTERACTION_CONTEXT
@@ -6454,6 +6453,8 @@ async def record_discord_dispatch(
     account: ChannelAccount,
     frame: dict[str, Any],
 ) -> bool:
+    if frame.get("t") == "INTERACTION_CREATE":
+        return False
     key = extract_discord_routing_key(frame)
     chat = discord_chat_from_payload(frame)
     if key is not None:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -14268,7 +14268,7 @@ async def test_discord_webhook_does_not_claim_code_for_legacy_interaction(
     )
 
     assert response.status_code == 200
-    assert response.json()["data"]["content"] == "Message received."
+    assert response.json()["data"]["content"] == "This server is not paired."
     pair_code = await db_session.get(ChannelPairCode, UUID(pair["id"]))
     assert pair_code is not None
     assert pair_code.status == PAIR_CODE_STATUS_PENDING
@@ -20279,6 +20279,7 @@ async def test_public_discord_dm_pair_handoff_unpair_and_duplicate_are_recorded_
     assert archived_binding.external_chat_name == "Renamed Public User"
 
     unbound_interactions = [
+        (2, {"name": "unbound_agent_command"}),
         (3, {"custom_id": "unbound-component", "component_type": 2}),
         (4, {"name": "unbound_autocomplete"}),
         (5, {"custom_id": "unbound-modal", "components": []}),
@@ -20300,6 +20301,10 @@ async def test_public_discord_dm_pair_handoff_unpair_and_duplicate_are_recorded_
                 "data": interaction_data,
             },
         )
+    assert unbound_responses[2].json() == {
+        "type": 4,
+        "data": {"content": "This direct message is not paired.", "flags": 64},
+    }
     assert unbound_responses[3].json() == {
         "type": 4,
         "data": {"content": "This direct message is not paired.", "flags": 64},

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -438,6 +438,44 @@ async def _create_admin_channel(
         settings.clerk_jwt_issuer = original_clerk_issuer
 
 
+async def _create_public_discord_account(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    name: str,
+    application_id: str,
+) -> dict[str, Any]:
+    async def configure_test_application(account: ChannelAccount) -> dict[str, Any]:
+        config = dict(account.config) if isinstance(account.config, dict) else {}
+        config["discord_install_config_version"] = channel_service.DISCORD_INSTALL_CONFIG_VERSION
+        config["discord_user_install_supported"] = True
+        account.config = config
+        return {
+            "id": application_id,
+            "integration_types_config": {"0": {}, "1": {}},
+        }
+
+    async def sync_test_commands(**_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(
+        admin_router,
+        "configure_discord_application",
+        configure_test_application,
+    )
+    monkeypatch.setattr(admin_router, "sync_channel_commands", sync_test_commands)
+    response = await _create_admin_channel(
+        client,
+        target_clerk_id="unused-for-public-channel",
+        provider=CHANNEL_PROVIDER_DISCORD,
+        name=name,
+        provider_token="discord-provider-token",
+        config=_discord_ready_config(application_id),
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
 async def _create_public_telegram_account_for_user(
     client: httpx.AsyncClient,
     *,
@@ -1018,8 +1056,8 @@ async def _record_discord_interaction(
     application_id: str,
     channel_id: str = "discord-chan-1",
     guild_id: str = "discord-guild-1",
-) -> None:
-    await client.post(
+) -> httpx.Response:
+    return await client.post(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
         json={
@@ -10246,13 +10284,15 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
         name="discord-interaction-ref",
         agent_id=channel_agent.id,
     )
-    await _record_discord_interaction(
+    ingress = await _record_discord_interaction(
         client,
         created=created,
         interaction_id="interaction-1",
         token="interaction-token-1",
         application_id=DISCORD_TEST_APPLICATION_ID,
     )
+    assert ingress.status_code == 202
+    assert ingress.content == b""
     other = (
         await client.post(
             "/v1/channels",
@@ -19991,6 +20031,410 @@ def test_discord_pair_install_contract_requires_matching_context_and_owner(
             trusted_interaction=True,
         )
         == expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_discord_unbound_dm_controls_ack_without_tenant_messages(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    application_id = "723456789012345678"
+    created = await _create_public_discord_account(
+        client,
+        monkeypatch,
+        name="discord-public-unbound-dm-controls",
+        application_id=application_id,
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    assert account.visibility == CHANNEL_VISIBILITY_PUBLIC
+    assert account.user_id is None
+
+    async def invoke(
+        interaction_id: str,
+        name: str,
+        *,
+        options: list[dict[str, Any]] | None = None,
+        authorizing_user_id: str = "public-unbound-user",
+    ) -> httpx.Response:
+        return await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json={
+                "type": 2,
+                "id": interaction_id,
+                "token": f"{interaction_id}-token",
+                "application_id": application_id,
+                "channel_id": "public-unbound-dm",
+                "context": 1,
+                "authorizing_integration_owners": {"1": authorizing_user_id},
+                "user": {
+                    "id": "public-unbound-user",
+                    "global_name": "Public DM User",
+                },
+                "data": {
+                    "name": name,
+                    **({"options": options} if options is not None else {}),
+                },
+            },
+        )
+
+    help_response = await invoke("public-unbound-help", "clawdi_help")
+    unpair_response = await invoke("public-unbound-unpair", "clawdi_unpair")
+    missing_pair_response = await invoke(
+        "public-unbound-missing-pair",
+        "clawdi_pair",
+        options=[],
+    )
+    invalid_pair_response = await invoke(
+        "public-unbound-invalid-pair",
+        "clawdi_pair",
+        options=[{"name": "code", "value": "BCDFGHJKLM"}],
+    )
+    denied_pair_response = await invoke(
+        "public-unbound-denied-pair",
+        "clawdi_pair",
+        options=[{"name": "code", "value": "BCDFGHJKLM"}],
+        authorizing_user_id="different-user",
+    )
+    unroutable_component = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 3,
+            "id": "public-unbound-component-without-channel",
+            "token": "public-unbound-component-without-channel-token",
+            "application_id": application_id,
+            "context": 1,
+            "authorizing_integration_owners": {"1": "public-unbound-user"},
+            "user": {"id": "public-unbound-user"},
+            "data": {"custom_id": "missing-channel", "component_type": 2},
+        },
+    )
+    unroutable_autocomplete = await client.post(
+        f"/v1/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "type": 4,
+            "id": "public-unbound-autocomplete-without-channel",
+            "token": "public-unbound-autocomplete-without-channel-token",
+            "application_id": application_id,
+            "context": 1,
+            "authorizing_integration_owners": {"1": "public-unbound-user"},
+            "user": {"id": "public-unbound-user"},
+            "data": {"name": "missing_channel"},
+        },
+    )
+
+    assert help_response.status_code == 200
+    assert help_response.json() == {
+        "type": 4,
+        "data": {
+            "content": channel_service.channel_control_help_reply(),
+            "flags": 64,
+        },
+    }
+    assert unpair_response.status_code == 200
+    assert unpair_response.json()["data"]["content"] == "This direct message is not paired."
+    assert missing_pair_response.status_code == 200
+    assert missing_pair_response.json()["data"]["content"] == "Usage: /clawdi_pair <code>"
+    assert invalid_pair_response.status_code == 200
+    assert invalid_pair_response.json()["data"]["content"] == "Pairing failed: invalid."
+    assert denied_pair_response.status_code == 200
+    assert denied_pair_response.json()["data"]["content"] == (
+        "Discord could not verify User Install for this direct-message command."
+    )
+    assert unroutable_component.json() == {
+        "type": 4,
+        "data": {"content": "Discord could not route this interaction.", "flags": 64},
+    }
+    assert unroutable_autocomplete.json() == {"type": 8, "data": {"choices": []}}
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(ChannelMessage.account_id == account.id)
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_discord_dm_pair_handoff_unpair_and_duplicate_are_recorded_correctly(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    application_id = "823456789012345678"
+    created = await _create_public_discord_account(
+        client,
+        monkeypatch,
+        name="discord-public-dm-pair-dedupe",
+        application_id=application_id,
+    )
+    linked = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(channel_agent.id)},
+    )
+    assert linked.status_code == 201, linked.text
+    pair = await client.post(
+        f"/v1/channels/{created['id']}/pair-codes",
+        json={"agent_link_id": linked.json()["id"], "ttl_seconds": 900},
+    )
+    assert pair.status_code == 201, pair.text
+    interaction = {
+        "type": 2,
+        "id": "public-dm-pair-interaction",
+        "token": "public-dm-pair-token",
+        "application_id": application_id,
+        "channel_id": "public-paired-dm",
+        "context": 1,
+        "authorizing_integration_owners": {"1": "public-pair-user"},
+        "user": {
+            "id": "public-pair-user",
+            "global_name": "Paired Public User",
+        },
+        "data": {
+            "name": "clawdi_pair",
+            "options": [{"name": "code", "value": pair.json()["code"]}],
+        },
+    }
+    webhook_url = f"/v1/channels/discord/{created['id']}/webhook"
+    headers = {"x-clawdi-channel-secret": created["webhook_secret"]}
+
+    paired = await client.post(webhook_url, headers=headers, json=interaction)
+    duplicate = await client.post(webhook_url, headers=headers, json=interaction)
+
+    assert paired.status_code == 200
+    assert paired.json()["data"]["content"].startswith("Direct message paired.")
+    assert duplicate.status_code == 200
+    assert duplicate.json()["data"]["content"] == "This interaction was already handled."
+    bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
+    assert len(bindings) == 1
+    assert bindings[0]["external_chat_id"] == "public-paired-dm"
+    assert bindings[0]["external_chat_type"] == "dm"
+    assert bindings[0]["external_chat_name"] == "Paired Public User"
+    binding_id = UUID(bindings[0]["id"])
+
+    forwarded_interactions = [
+        (2, {"name": "agent_command"}),
+        (3, {"custom_id": "agent-component", "component_type": 2}),
+        (4, {"name": "agent_autocomplete"}),
+        (5, {"custom_id": "agent-modal", "components": []}),
+    ]
+    forwarded_ids: list[str] = []
+    for interaction_type, interaction_data in forwarded_interactions:
+        interaction_id = f"public-dm-agent-interaction-{interaction_type}"
+        forwarded_ids.append(interaction_id)
+        forwarded = await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "type": interaction_type,
+                "id": interaction_id,
+                "token": f"{interaction_id}-token",
+                "application_id": application_id,
+                "channel_id": "public-paired-dm",
+                "context": 1,
+                "authorizing_integration_owners": {"1": "public-pair-user"},
+                "user": {
+                    "id": "public-pair-user",
+                    "global_name": "Paired Public User",
+                },
+                "data": interaction_data,
+            },
+        )
+        assert forwarded.status_code == 202
+        assert forwarded.content == b""
+
+    unpaired = await client.post(
+        webhook_url,
+        headers=headers,
+        json={
+            "type": 2,
+            "id": "public-dm-unpair-interaction",
+            "token": "public-dm-unpair-token",
+            "application_id": application_id,
+            "channel_id": "public-paired-dm",
+            "context": 1,
+            "authorizing_integration_owners": {"1": "public-pair-user"},
+            "user": {
+                "id": "public-pair-user",
+                "global_name": "Renamed Public User",
+            },
+            "data": {"name": "clawdi_unpair"},
+        },
+    )
+
+    assert unpaired.status_code == 200
+    assert unpaired.json()["data"]["content"].startswith("Direct message unpaired.")
+    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    archived_binding = await db_session.get(ChannelBinding, binding_id)
+    assert archived_binding is not None
+    assert archived_binding.status == BINDING_STATUS_ARCHIVED
+    assert archived_binding.external_chat_name == "Renamed Public User"
+
+    unbound_interactions = [
+        (3, {"custom_id": "unbound-component", "component_type": 2}),
+        (4, {"name": "unbound_autocomplete"}),
+        (5, {"custom_id": "unbound-modal", "components": []}),
+    ]
+    unbound_responses: dict[int, httpx.Response] = {}
+    for interaction_type, interaction_data in unbound_interactions:
+        unbound_responses[interaction_type] = await client.post(
+            webhook_url,
+            headers=headers,
+            json={
+                "type": interaction_type,
+                "id": f"public-unbound-interaction-{interaction_type}",
+                "token": f"public-unbound-interaction-{interaction_type}-token",
+                "application_id": application_id,
+                "channel_id": "public-paired-dm",
+                "context": 1,
+                "authorizing_integration_owners": {"1": "public-pair-user"},
+                "user": {"id": "public-pair-user"},
+                "data": interaction_data,
+            },
+        )
+    assert unbound_responses[3].json() == {
+        "type": 4,
+        "data": {"content": "This direct message is not paired.", "flags": 64},
+    }
+    assert unbound_responses[4].json() == {"type": 8, "data": {"choices": []}}
+    assert unbound_responses[5].json() == {
+        "type": 4,
+        "data": {"content": "This direct message is not paired.", "flags": 64},
+    }
+    messages = list(
+        (
+            await db_session.execute(
+                select(ChannelMessage).where(
+                    ChannelMessage.account_id == UUID(created["id"]),
+                    ChannelMessage.provider_message_id.in_(
+                        [
+                            "public-dm-pair-interaction",
+                            "public-dm-unpair-interaction",
+                            *forwarded_ids,
+                        ]
+                    ),
+                )
+            )
+        ).scalars()
+    )
+    assert len(messages) == 6
+    assert {message.binding_id for message in messages} == {binding_id}
+    assert {message.user_id for message in messages} == {channel_agent.user_id}
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(ChannelMessage.account_id == UUID(created["id"]))
+        )
+        == 6
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_discord_unpaired_dm_tutorial_uses_platform_marker_without_message_rows(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = await _create_public_discord_account(
+        client,
+        monkeypatch,
+        name="discord-public-unpaired-dm-tutorial",
+        application_id="923456789012345678",
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    sent: list[dict[str, Any]] = []
+
+    async def send_tutorial(**kwargs: Any) -> None:
+        sent.append(kwargs)
+
+    monkeypatch.setattr(
+        channel_service,
+        "send_platform_unbound_channel_message",
+        send_tutorial,
+    )
+
+    def frame(
+        message_id: str,
+        *,
+        message_type: int,
+        bot: bool = False,
+        webhook_id: str | None = None,
+    ) -> dict[str, Any]:
+        event = {
+            "op": 0,
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": message_id,
+                "channel_id": "public-tutorial-dm",
+                "content": "hello",
+                "type": message_type,
+                "author": {
+                    "id": "public-tutorial-user",
+                    "global_name": "Tutorial User",
+                    "bot": bot,
+                },
+            },
+        }
+        if webhook_id is not None:
+            event["d"]["webhook_id"] = webhook_id
+        return event
+
+    assert not await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame=frame("tutorial-bot-reply", message_type=19, bot=True),
+    )
+    assert not await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame=frame("tutorial-webhook-reply", message_type=19, webhook_id="webhook-1"),
+    )
+    assert not await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame=frame("tutorial-system", message_type=6),
+    )
+
+    assert await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame=frame("tutorial-reply", message_type=19),
+    )
+    await db_session.commit()
+    assert await record_discord_dispatch(
+        db_session,
+        account=account,
+        frame=frame("tutorial-default", message_type=0),
+    )
+    await db_session.commit()
+
+    assert sent == [
+        {
+            "account": account,
+            "external_chat_id": "public-tutorial-dm",
+            "text": (
+                "This Discord chat is not paired. Create a Discord pairing code in Clawdi, "
+                "then run /clawdi_pair <code>."
+            ),
+        }
+    ]
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ChannelMessage)
+            .where(ChannelMessage.account_id == account.id)
+        )
+        == 0
     )
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -17688,12 +17688,24 @@ async def test_discord_dispatch_records_bound_message(
         )
     ).scalar_one()
     assert alias.binding_id == message.binding_id
+    assert _discord_gateway_dispatch(message) == {
+        "op": 0,
+        "t": "MESSAGE_CREATE",
+        "s": message.inbox_sequence,
+        "d": {
+            "id": "msg-dispatch-1",
+            "channel_id": "chan-dispatch",
+            "guild_id": "guild-dispatch",
+            "content": "hello from discord",
+        },
+    }
 
 
 @pytest.mark.asyncio
-async def test_discord_gateway_dispatch_pair_code_creates_binding(
+async def test_discord_gateway_interaction_cannot_pair_or_create_side_effects(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     created = (
         await client.post(
@@ -17712,6 +17724,15 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
             json={"ttl_seconds": 900},
         )
     ).json()
+
+    async def membership_must_not_run(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("Gateway interaction reached pairing admission")
+
+    monkeypatch.setattr(
+        channel_service,
+        "discord_bot_guild_membership_check",
+        membership_must_not_run,
+    )
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     recorded = await record_discord_gateway_dispatch(
@@ -17742,34 +17763,19 @@ async def test_discord_gateway_dispatch_pair_code_creates_binding(
         },
     )
 
-    assert recorded is True
-    binding = (
-        await db_session.execute(
-            select(ChannelBinding).where(
-                ChannelBinding.account_id == UUID(created["id"]),
-                ChannelBinding.external_chat_id == "guild-gateway",
+    assert recorded is False
+    for model in (ChannelBinding, ChannelMessage, ChannelAgentReference, ChannelDelivery):
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(model)
+                .where(model.account_id == UUID(created["id"]))
             )
+            == 0
         )
-    ).scalar_one()
-    assert binding.status == "active"
-    message = (
-        await db_session.execute(
-            select(ChannelMessage).where(
-                ChannelMessage.provider_message_id == "interaction-gateway-pair"
-            )
-        )
-    ).scalar_one()
-    assert message.binding_id == binding.id
-    alias = (
-        await db_session.execute(
-            select(ChannelBindingAlias).where(
-                ChannelBindingAlias.account_id == UUID(created["id"]),
-                ChannelBindingAlias.alias_external_chat_id == "chan-gateway-pair",
-                ChannelBindingAlias.alias_kind == "discord_channel",
-            )
-        )
-    ).scalar_one()
-    assert alias.binding_id == binding.id
+    pair_code = await db_session.get(ChannelPairCode, UUID(pair["id"]))
+    assert pair_code is not None
+    assert pair_code.status == PAIR_CODE_STATUS_PENDING
 
 
 @pytest.mark.asyncio
@@ -20227,26 +20233,29 @@ async def test_public_discord_dm_pair_handoff_unpair_and_duplicate_are_recorded_
         (5, {"custom_id": "agent-modal", "components": []}),
     ]
     forwarded_ids: list[str] = []
+    forwarded_payloads: dict[str, dict[str, Any]] = {}
     for interaction_type, interaction_data in forwarded_interactions:
         interaction_id = f"public-dm-agent-interaction-{interaction_type}"
         forwarded_ids.append(interaction_id)
+        forwarded_payload = {
+            "type": interaction_type,
+            "id": interaction_id,
+            "token": f"{interaction_id}-token",
+            "application_id": application_id,
+            "channel_id": "public-paired-dm",
+            "context": 1,
+            "authorizing_integration_owners": {"1": "public-pair-user"},
+            "user": {
+                "id": "public-pair-user",
+                "global_name": "Paired Public User",
+            },
+            "data": interaction_data,
+        }
+        forwarded_payloads[interaction_id] = forwarded_payload
         forwarded = await client.post(
             webhook_url,
             headers=headers,
-            json={
-                "type": interaction_type,
-                "id": interaction_id,
-                "token": f"{interaction_id}-token",
-                "application_id": application_id,
-                "channel_id": "public-paired-dm",
-                "context": 1,
-                "authorizing_integration_owners": {"1": "public-pair-user"},
-                "user": {
-                    "id": "public-pair-user",
-                    "global_name": "Paired Public User",
-                },
-                "data": interaction_data,
-            },
+            json=forwarded_payload,
         )
         assert forwarded.status_code == 202
         assert forwarded.content == b""
@@ -20333,6 +20342,16 @@ async def test_public_discord_dm_pair_handoff_unpair_and_duplicate_are_recorded_
     assert len(messages) == 6
     assert {message.binding_id for message in messages} == {binding_id}
     assert {message.user_id for message in messages} == {channel_agent.user_id}
+    forwarded_messages = {
+        message.provider_message_id: message
+        for message in messages
+        if message.provider_message_id in forwarded_payloads
+    }
+    for interaction_id, payload in forwarded_payloads.items():
+        dispatch = _discord_gateway_dispatch(forwarded_messages[interaction_id])
+        assert dispatch["op"] == 0
+        assert dispatch["t"] == "INTERACTION_CREATE"
+        assert dispatch["d"] == payload
     assert (
         await db_session.scalar(
             select(func.count())
@@ -21323,7 +21342,7 @@ async def test_discord_concurrent_replayed_unpair_waits_for_event_commit_and_rep
 
 
 @pytest.mark.asyncio
-async def test_discord_gateway_replayed_unpair_cannot_archive_replacement_binding(
+async def test_discord_gateway_interaction_cannot_unpair_or_create_side_effects(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
 ) -> None:
@@ -21336,8 +21355,15 @@ async def test_discord_gateway_replayed_unpair_cannot_archive_replacement_bindin
         channel_id=channel_id,
         guild_id=guild_id,
     )
+    account_id = UUID(created["id"])
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
-    original_unpair = {
+    before_counts = {
+        model: await db_session.scalar(
+            select(func.count()).select_from(model).where(model.account_id == account_id)
+        )
+        for model in (ChannelMessage, ChannelAgentReference, ChannelDelivery)
+    }
+    gateway_unpair = {
         "op": 0,
         "t": "INTERACTION_CREATE",
         "s": 801,
@@ -21357,57 +21383,21 @@ async def test_discord_gateway_replayed_unpair_cannot_archive_replacement_bindin
             "data": {"name": "clawdi_unpair"},
         },
     }
-    assert (
-        await record_discord_gateway_dispatch(
-            sessionmaker,
-            UUID(created["id"]),
-            original_unpair,
-        )
-        is True
-    )
-    assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
-
-    pair = (
-        await client.post(
-            f"/v1/channels/{created['id']}/pair-codes",
-            json={"ttl_seconds": 900},
-        )
-    ).json()
-    replacement_pair = await client.post(
-        f"/v1/channels/discord/{created['id']}/webhook",
-        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
-        json={
-            "type": 2,
-            "id": "gateway-replacement-pair-interaction",
-            "token": "gateway-replacement-pair-token",
-            "application_id": DISCORD_TEST_APPLICATION_ID,
-            "channel_id": channel_id,
-            "guild_id": guild_id,
-            "context": 0,
-            "authorizing_integration_owners": {"0": guild_id},
-            "member": {
-                "permissions": "32",
-                "user": {"id": actor_id},
-            },
-            "data": {
-                "name": "clawdi_pair",
-                "options": [{"name": "code", "value": pair["code"]}],
-            },
-        },
-    )
-    assert replacement_pair.json()["data"]["content"].startswith("Server paired.")
-
-    assert (
-        await record_discord_gateway_dispatch(
-            sessionmaker,
-            UUID(created["id"]),
-            original_unpair,
-        )
-        is True
+    assert not await record_discord_gateway_dispatch(
+        sessionmaker,
+        account_id,
+        gateway_unpair,
     )
     bindings = (await client.get(f"/v1/channels/{created['id']}/bindings")).json()
     assert len(bindings) == 1
     assert bindings[0]["external_chat_id"] == guild_id
+    for model, before in before_counts.items():
+        assert (
+            await db_session.scalar(
+                select(func.count()).select_from(model).where(model.account_id == account_id)
+            )
+            == before
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- prevent public/shared unbound `/clawdi_help`, `/clawdi_unpair`, and failed pair/admission interactions from crashing when platform-owned traffic intentionally records no tenant `ChannelMessage`
- return HTTP 202 with an empty body for bound non-control agent interactions so the synthetic Gateway/proxied callback path retains the interaction response
- return protocol-valid unbound responses for interaction types 2/3/4/5: ephemeral not-paired replies for commands, components, and modals, plus empty autocomplete choices
- teach ordinary unpaired public DMs for both Discord DEFAULT messages (type 0) and REPLY messages (type 19), while preserving bot/webhook/system filtering
- exercise the real public application ownership and user-install context, and assert unbound platform traffic creates no fake tenant-owned message rows

## Verification

- focused public-DM Docker tests: `3 passed in 4.93s`
- broader Docker selection `discord and (dm or interaction or unpair or unpaired)`: `58 passed, 346 deselected in 16.36s`
- Ruff lint passed for the three changed backend files
- Ruff format check passed (`3 files already formatted`)
- backend `compileall` passed

## Remaining follow-ups

- Agent callbacks still need to complete within Discords three-second initial response deadline; a bounded defer/callback design remains separate follow-up work.
- Gateway `INTERACTION_CREATE` control-command handling appears dormant when HTTP interaction endpoints are configured and still uses an ordinary channel-message response path; changing that architecture safely is outside this focused fix.

## Discord protocol references

- [Interaction callback responses](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback)
- [Message types, including DEFAULT and REPLY](https://discord.com/developers/docs/resources/message#message-object-message-types)