### PR TITLE
fix(whatsapp): keep QR reconnects in pairing state

### DIFF
--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -176,6 +176,33 @@ describe("physical Baileys runtime", () => {
 		await runtime.stop();
 	});
 
+	it("keeps unregistered QR transport transitions in the pairing lifecycle", async () => {
+		const harness = createHarness({ registered: false });
+		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);
+
+		await runtime.startQrPairing();
+		harness.events.emit("connection.update", { connection: "open" });
+		expect(runtime.pairingStatus()).toEqual({
+			status: "starting",
+			registered: false,
+			method: "qr",
+		});
+
+		harness.events.emit("connection.update", { qr: "sensitive-qr-value" });
+		harness.events.emit("connection.update", {
+			connection: "close",
+			lastDisconnect: { error: { output: { statusCode: DisconnectReason.connectionLost } } },
+		});
+		expect(runtime.pairingStatus()).toMatchObject({
+			status: "starting",
+			registered: false,
+			method: "qr",
+		});
+
+		await runtime.cancelPairing();
+		await runtime.stop();
+	});
+
 	it("confirms physical logout before clearing registered auth", async () => {
 		const harness = createHarness();
 		const runtime = new BaileysSocketRuntime(sidecarConfig(), harness.dependencies);

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -216,8 +216,13 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 			this.pairingQr !== undefined &&
 			this.pairingQrExpiresAt !== undefined &&
 			Date.now() < this.pairingQrExpiresAt;
+		const pairingTransportInFlight =
+			!registered &&
+			this.pairingMethod !== undefined &&
+			!this.fatalReason &&
+			(this.status === "connected" || this.status === "disconnected");
 		const status =
-			this.status === "connecting" || this.status === "starting"
+			this.status === "connecting" || this.status === "starting" || pairingTransportInFlight
 				? "starting"
 				: this.status === "pairing_qr" && !qrIsCurrent
 					? "starting"


### PR DESCRIPTION
## Summary

- keep an unregistered QR transport in the starting lifecycle while Baileys is connected before emitting its first QR
- keep transient QR reconnects in the same starting lifecycle instead of turning a 408 rotation gap into a terminal onboarding error
- preserve fail-closed behavior when the runtime has a fatal reason

## Production evidence

During the authorized Shared WhatsApp re-pair after #824, Baileys produced both an open-before-QR transition and a transient 408 while rotating QR. The sidecar exposed disconnected for the latter, and the backend correctly but prematurely marked the onboarding terminal. This patch normalizes those non-fatal transport transitions at the sidecar lifecycle boundary.

## Verification

- sidecar typecheck
- 8 files / 64 tests passed
- Biome passed
- git diff --check passed