### PR TITLE
fix(web): prioritize billing term totals

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -9621,8 +9621,13 @@ test("compute comparison synchronizes API prices across the shared billing term"
 		"aria-pressed",
 		"true",
 	);
-	await expect(basicCard).toContainText("$12.34/mo");
-	await expect(performanceCard).toContainText("$56.78/mo");
+	const basicMonthlyPrice = basicCard.getByText("$12.34/mo", { exact: true });
+	const performanceMonthlyPrice = performanceCard.getByText("$56.78/mo", { exact: true });
+	await expect(basicMonthlyPrice).toHaveCount(1);
+	await expect(performanceMonthlyPrice).toHaveCount(1);
+	await expect(basicMonthlyPrice).toHaveClass(/text-3xl/);
+	await expect(performanceMonthlyPrice).toHaveClass(/text-3xl/);
+	await expect(cards.getByText("Billed monthly", { exact: true })).toHaveCount(0);
 	const monthlyBoxes = await cards.evaluateAll((elements) =>
 		elements.map((element) => element.getBoundingClientRect().toJSON()),
 	);
@@ -9630,10 +9635,10 @@ test("compute comparison synchronizes API prices across the shared billing term"
 	expect(monthlyBoxes[0]?.height).toBeCloseTo(monthlyBoxes[1]?.height ?? 0, 0);
 
 	await termSwitcher.getByRole("button", { name: "Annual", exact: true }).click();
-	await expect(basicCard).toContainText("$10.29/mo");
-	await expect(basicCard).toContainText("Billed $123.48/yr");
-	await expect(performanceCard).toContainText("$45.27/mo");
-	await expect(performanceCard).toContainText("Billed $543.24/yr");
+	await expect(basicCard.getByText("$123.48/yr", { exact: true })).toHaveClass(/text-3xl/);
+	await expect(basicCard.getByText("$10.29/mo", { exact: true })).toHaveClass(/text-xs/);
+	await expect(performanceCard.getByText("$543.24/yr", { exact: true })).toHaveClass(/text-3xl/);
+	await expect(performanceCard.getByText("$45.27/mo", { exact: true })).toHaveClass(/text-xs/);
 	expect(errors, `compute plan comparison: ${errors.join(" | ")}`).toEqual([]);
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -18,25 +18,39 @@ const annual: BillingOffer = {
 	effective_monthly_price_cents: 1_666,
 	discount_percent: 17,
 };
+const quarterly: BillingOffer = {
+	billing_term_months: 3,
+	price_cents: 5_400,
+	effective_monthly_price_cents: 1_800,
+	discount_percent: 10,
+};
 
 describe("computePricePresentation", () => {
 	test("makes monthly and annual pricing visibly distinct", () => {
 		expect(computePricePresentation(monthly, [monthly, annual])).toEqual({
 			primary: "$20.00/mo",
-			secondary: "Billed monthly",
+			secondary: null,
 			savings: null,
 		});
 		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
-			primary: "$16.66/mo",
-			secondary: "Billed $200.00/yr",
+			primary: "$200.00/yr",
+			secondary: "$16.66/mo",
 			savings: "save $40.00",
+		});
+	});
+
+	test("uses the actual term total for other multi-month offers", () => {
+		expect(computePricePresentation(quarterly, [monthly, quarterly])).toEqual({
+			primary: "$54.00/qtr",
+			secondary: "$18.00/mo",
+			savings: "save $6.00",
 		});
 	});
 
 	test("omits savings when a monthly offer is missing", () => {
 		expect(computePricePresentation(annual, [annual])).toEqual({
-			primary: "$16.66/mo",
-			secondary: "Billed $200.00/yr",
+			primary: "$200.00/yr",
+			secondary: "$16.66/mo",
 			savings: null,
 		});
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -11,7 +11,7 @@ import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-su
 
 export type ComputePricePresentation = {
 	primary: string;
-	secondary: string;
+	secondary: string | null;
 	savings: string | null;
 };
 
@@ -25,14 +25,18 @@ function monthlyPrice(offer: BillingOffer): string {
 	return `${formatCents(offer.effective_monthly_price_cents)}/mo`;
 }
 
+function termPrice(offer: BillingOffer): string {
+	return `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`;
+}
+
 export function computePricePresentation(
 	offer: BillingOffer,
 	offers: readonly BillingOffer[],
 ): ComputePricePresentation {
 	if (offer.billing_term_months === 1) {
 		return {
-			primary: monthlyPrice(offer),
-			secondary: "Billed monthly",
+			primary: termPrice(offer),
+			secondary: null,
 			savings: null,
 		};
 	}
@@ -48,14 +52,9 @@ export function computePricePresentation(
 		comparisonIsCheaper && undiscountedTermPrice !== null
 			? undiscountedTermPrice - offer.price_cents
 			: 0;
-	const billed =
-		offer.billing_term_months === 12
-			? `Billed ${formatCents(offer.price_cents)}/yr`
-			: `Billed ${formatCents(offer.price_cents)} every ${offer.billing_term_months} months`;
-
 	return {
-		primary: monthlyPrice(offer),
-		secondary: billed,
+		primary: termPrice(offer),
+		secondary: monthlyPrice(offer),
 		savings: savingsCents > 0 ? `save ${formatCents(savingsCents)}` : null,
 	};
 }
@@ -63,20 +62,20 @@ export function computePricePresentation(
 export function cardDeployAmountPresentation(offer: BillingOffer): DeployAmountPresentation {
 	if (offer.billing_term_months === 1) {
 		return {
-			amount: `${formatCents(offer.price_cents)}/mo`,
+			amount: termPrice(offer),
 			caption: "Billed monthly",
 			detail: null,
 		};
 	}
 	if (offer.billing_term_months === 12) {
 		return {
-			amount: `${formatCents(offer.price_cents)}/yr`,
+			amount: termPrice(offer),
 			caption: `${monthlyPrice(offer)}, billed annually`,
 			detail: null,
 		};
 	}
 	return {
-		amount: `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`,
+		amount: termPrice(offer),
 		caption: `${monthlyPrice(offer)}, billed ${billingTermLabel(offer.billing_term_months).toLowerCase()}`,
 		detail: null,
 	};

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -252,17 +252,19 @@ function ComputePriceBlock({
 					{presentation.primary}
 				</span>
 			</div>
-			<div className="text-xs leading-4 font-normal text-muted-foreground">
-				{presentation.secondary}
-				{presentation.savings ? (
-					<>
-						{" "}
-						<span className="whitespace-nowrap" data-testid={`${testId}-savings`}>
-							· {presentation.savings}
-						</span>
-					</>
-				) : null}
-			</div>
+			{presentation.secondary ? (
+				<div className="text-xs leading-4 font-normal text-muted-foreground">
+					{presentation.secondary}
+					{presentation.savings ? (
+						<>
+							{" "}
+							<span className="whitespace-nowrap" data-testid={`${testId}-savings`}>
+								· {presentation.savings}
+							</span>
+						</>
+					) : null}
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -114,7 +114,9 @@ export function PlanComparison({
 										<p className="text-3xl font-semibold tracking-tight tabular-nums">
 											{basicPrice.primary}
 										</p>
-										<p className="text-xs text-muted-foreground">{basicPrice.secondary}</p>
+										{basicPrice.secondary ? (
+											<p className="text-xs text-muted-foreground">{basicPrice.secondary}</p>
+										) : null}
 									</>
 								) : (
 									<p className="text-sm font-medium">Pricing unavailable</p>
@@ -150,7 +152,9 @@ export function PlanComparison({
 										<p className="text-3xl font-semibold tracking-tight tabular-nums">
 											{performancePrice.primary}
 										</p>
-										<p className="text-xs text-muted-foreground">{performancePrice.secondary}</p>
+										{performancePrice.secondary ? (
+											<p className="text-xs text-muted-foreground">{performancePrice.secondary}</p>
+										) : null}
 									</>
 								) : (
 									<p className="text-sm font-medium">Pricing unavailable</p>


### PR DESCRIPTION
## Summary

- show annual and other multi-month term totals as the primary compute price
- show API-provided effective monthly pricing as secondary context
- keep monthly pricing single-line and align Compare plans with deploy selection cards

## Verification

- focused unit tests: 5 passed
- focused Chromium E2E: passed
- web typecheck and Biome check
- OSS production build
- git diff --check

No backend, x402, production, or tenant changes.