### PR TITLE
fix(web): standardize billing settings controls

### DIFF
--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -228,68 +228,64 @@ export function SettingsDialog({
 					showCloseButton={false}
 					className="h-[min(820px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-6xl gap-0 overflow-hidden p-0 sm:max-w-6xl"
 				>
-					<DialogHeader className="sr-only">
-						<DialogTitle>Settings</DialogTitle>
-						<DialogDescription>Account, billing, and application settings.</DialogDescription>
-					</DialogHeader>
+					<div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+						<DialogHeader className="flex h-14 shrink-0 flex-row items-center justify-between gap-3 border-b px-4 text-left md:px-5">
+							<DialogTitle className="truncate text-sm font-semibold">Settings</DialogTitle>
+							<DialogDescription className="sr-only">
+								Account, billing, and application settings.
+							</DialogDescription>
+							{!hasPendingSave ? <SettingsDialogCloseButton /> : null}
+						</DialogHeader>
 
-					<div className="grid h-full min-h-0 grid-rows-[auto_1fr] md:grid-cols-[15rem_minmax(0,1fr)] md:grid-rows-1">
-						<aside className="flex min-w-0 flex-col border-b bg-muted/30 md:border-r md:border-b-0">
-							<div className="flex h-14 shrink-0 items-center justify-between gap-3 px-4 md:h-16">
-								<div className="min-w-0">
-									<div className="truncate text-sm font-semibold">Settings</div>
-									<div className="truncate text-xs text-muted-foreground">Clawdi preferences</div>
-								</div>
-								{!hasPendingSave ? <SettingsDialogCloseButton className="md:hidden" /> : null}
-							</div>
-							<div className="relative min-w-0 md:min-h-0 md:flex-1">
-								<nav
-									aria-label="Settings sections"
-									className="flex gap-1 overflow-x-auto px-3 pb-3 [scrollbar-width:thin] md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto md:px-3 md:pb-3"
-								>
-									{items.map((item) => {
-										const Icon = item.icon;
-										const active = activeSection === item.id;
-										return (
-											<Button
-												key={item.id}
-												ref={active ? activeButtonRef : undefined}
-												type="button"
-												variant="ghost"
-												aria-current={active ? "page" : undefined}
-												data-active={active}
-												onClick={() => requestSectionChange(item.id)}
-												className={cn(
-													"h-auto min-w-28 shrink-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0 md:gap-3 md:px-3",
-													"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
-												)}
-											>
-												<IconChip
-													size="sm"
-													tint={
-														active
-															? "bg-primary text-primary-foreground"
-															: "bg-background text-foreground"
-													}
+						<div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] md:grid-cols-[15rem_minmax(0,1fr)] md:grid-rows-1">
+							<aside className="flex min-w-0 flex-col border-b bg-muted/30 md:border-r md:border-b-0">
+								<div className="relative min-w-0 md:min-h-0 md:flex-1">
+									<nav
+										aria-label="Settings sections"
+										className="flex gap-1 overflow-x-auto px-3 py-3 [scrollbar-width:thin] md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto"
+									>
+										{items.map((item) => {
+											const Icon = item.icon;
+											const active = activeSection === item.id;
+											return (
+												<Button
+													key={item.id}
+													ref={active ? activeButtonRef : undefined}
+													type="button"
+													variant="ghost"
+													aria-current={active ? "page" : undefined}
+													data-active={active}
+													onClick={() => requestSectionChange(item.id)}
+													className={cn(
+														"h-auto min-w-28 shrink-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0 md:gap-3 md:px-3",
+														"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
+													)}
 												>
-													<Icon />
-												</IconChip>
-												<span className="grid min-w-0 flex-1 leading-tight">
-													<span className="truncate font-medium">{item.label}</span>
-													<span className="hidden truncate text-xs text-muted-foreground md:block">
-														{item.description}
+													<IconChip
+														size="sm"
+														tint={
+															active
+																? "bg-primary text-primary-foreground"
+																: "bg-background text-foreground"
+														}
+													>
+														<Icon />
+													</IconChip>
+													<span className="grid min-w-0 flex-1 leading-tight">
+														<span className="truncate font-medium">{item.label}</span>
+														<span className="hidden truncate text-xs text-muted-foreground md:block">
+															{item.description}
+														</span>
 													</span>
-												</span>
-											</Button>
-										);
-									})}
-								</nav>
-								<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-muted/30 to-transparent md:hidden" />
-							</div>
-						</aside>
+												</Button>
+											);
+										})}
+									</nav>
+									<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-muted/30 to-transparent md:hidden" />
+								</div>
+							</aside>
 
-						<section className="grid min-h-0 min-w-0 md:grid-cols-[minmax(0,1fr)_auto]">
-							<div className="min-h-0 overflow-y-auto py-6 md:py-8">
+							<section className="min-h-0 min-w-0 overflow-y-auto py-6 md:py-8">
 								<div className="mx-auto w-full max-w-4xl">
 									{billingAccessPending ? (
 										<HostedRouteSkeleton />
@@ -308,13 +304,8 @@ export function SettingsDialog({
 										</SettingsPanelErrorBoundary>
 									)}
 								</div>
-							</div>
-							{!hasPendingSave ? (
-								<div className="hidden items-start justify-center px-2 pt-4 md:flex">
-									<SettingsDialogCloseButton />
-								</div>
-							) : null}
-						</section>
+							</section>
+						</div>
 					</div>
 				</DialogContent>
 			</Dialog>

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -8,6 +8,7 @@ type SettingsSectionProps = Omit<
 > & {
 	title: React.ReactNode;
 	description?: React.ReactNode;
+	actions?: React.ReactNode;
 	children?: React.ReactNode;
 	variant?: "default" | "destructive";
 	headingLevel?: 2 | 3;
@@ -17,6 +18,7 @@ type SettingsSectionProps = Omit<
 export function SettingsSection({
 	title,
 	description,
+	actions,
 	children,
 	className,
 	variant = "default",
@@ -32,16 +34,19 @@ export function SettingsSection({
 			className={cn("flex flex-col gap-4", className)}
 		>
 			<Separator />
-			<div className="flex max-w-2xl flex-col gap-1.5">
-				<Heading
-					id={generatedTitleId}
-					className={cn("text-sm font-semibold", variant === "destructive" && "text-destructive")}
-				>
-					{title}
-				</Heading>
-				{description ? (
-					<div className="text-sm leading-5 text-muted-foreground">{description}</div>
-				) : null}
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div className="flex max-w-2xl min-w-0 flex-col gap-1.5">
+					<Heading
+						id={generatedTitleId}
+						className={cn("text-sm font-semibold", variant === "destructive" && "text-destructive")}
+					>
+						{title}
+					</Heading>
+					{description ? (
+						<div className="text-sm leading-5 text-muted-foreground">{description}</div>
+					) : null}
+				</div>
+				{actions ? <div className="shrink-0">{actions}</div> : null}
 			</div>
 			{children !== undefined && children !== null ? (
 				<div className="min-w-0">{children}</div>

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -463,7 +463,12 @@ export function createBillingClient(
 			unwrapDeploy(await api.POST("/v2/subscription/portal", { body })),
 		resumeSubscription: async (body: ComputeSubscriptionResumeRequest) =>
 			unwrapDeploy(await api.POST("/v2/subscription/resume", { body })),
-		getUsage: async () => unwrapDeploy(await api.GET("/v2/usage")),
+		getUsage: async (days: number | null = null) =>
+			unwrapDeploy(
+				await api.GET("/v2/usage", {
+					params: { query: { days: days ?? undefined } },
+				}),
+			),
 
 		getMe: async () => unwrapDeploy(await api.GET("/v1/me")),
 		getLegacyAgentEnvironments: async () => unwrapDeploy(await api.GET("/v1/agent-environments")),

--- a/apps/web/src/hosted/billing/components/state-views.tsx
+++ b/apps/web/src/hosted/billing/components/state-views.tsx
@@ -2,12 +2,23 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-function SectionSkeleton({ children }: { children: React.ReactNode }) {
+function SectionSkeleton({
+	children,
+	description = true,
+	actions,
+}: {
+	children?: React.ReactNode;
+	description?: boolean;
+	actions?: React.ReactNode;
+}) {
 	return (
 		<div className="space-y-4 border-t pt-4">
-			<div className="space-y-2">
-				<Skeleton className="h-4 w-28" />
-				<Skeleton className="h-4 w-52 max-w-full" />
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-2">
+					<Skeleton className="h-4 w-28" />
+					{description ? <Skeleton className="h-4 w-52 max-w-full" /> : null}
+				</div>
+				{actions}
 			</div>
 			{children}
 		</div>
@@ -27,10 +38,15 @@ export function SubscriptionSkeleton() {
 			<SectionSkeleton>
 				<Skeleton className="h-28 w-full rounded-lg" />
 			</SectionSkeleton>
-			<div className="grid gap-3 lg:grid-cols-2">
-				<Skeleton className="h-72 w-full rounded-xl" />
-				<Skeleton className="h-72 w-full rounded-xl" />
-			</div>
+			<SectionSkeleton
+				description={false}
+				actions={<Skeleton className="h-9 w-56 shrink-0 rounded-md" />}
+			>
+				<div className="grid gap-3 lg:grid-cols-2">
+					<Skeleton className="h-72 w-full rounded-xl" />
+					<Skeleton className="h-72 w-full rounded-xl" />
+				</div>
+			</SectionSkeleton>
 		</div>
 	);
 }
@@ -40,16 +56,15 @@ export function WalletSkeleton() {
 	return (
 		<div data-hosted="true" className="space-y-8">
 			<Skeleton className="h-36 w-full rounded-xl" />
-			<SectionSkeleton>
-				<div className="grid max-w-3xl gap-4 sm:grid-cols-2">
-					<Skeleton className="h-16 w-full rounded-md" />
-					<Skeleton className="h-16 w-full rounded-md" />
-				</div>
-			</SectionSkeleton>
-			<SectionSkeleton>
-				<Skeleton className="h-9 w-40" />
-			</SectionSkeleton>
-			<SectionSkeleton>
+			<SectionSkeleton
+				description={false}
+				actions={<Skeleton className="h-5 w-9 shrink-0 rounded-full" />}
+			/>
+			<SectionSkeleton />
+			<SectionSkeleton
+				description={false}
+				actions={<Skeleton className="h-8 w-40 shrink-0 rounded-md" />}
+			>
 				<Skeleton className="h-40 w-full rounded-lg" />
 			</SectionSkeleton>
 		</div>
@@ -70,17 +85,20 @@ export function UsageSkeleton() {
 					<Skeleton className="h-4 w-32" />
 				</div>
 			</div>
-			<SectionSkeleton>
+			<SectionSkeleton description={false}>
 				<Skeleton className="h-44 w-full rounded-lg" />
 			</SectionSkeleton>
-			<SectionSkeleton>
+			<SectionSkeleton description={false}>
 				<div className="space-y-3">
 					<Skeleton className="h-10 w-full" />
 					<Skeleton className="h-10 w-full" />
 					<Skeleton className="h-10 w-full" />
 				</div>
 			</SectionSkeleton>
-			<SectionSkeleton>
+			<SectionSkeleton
+				description={false}
+				actions={<Skeleton className="h-9 w-44 shrink-0 rounded-md sm:w-56" />}
+			>
 				<div className="space-y-3">
 					<Skeleton className="h-10 w-full" />
 					<Skeleton className="h-10 w-full" />

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -27,16 +27,16 @@ describe("computePricePresentation", () => {
 			savings: null,
 		});
 		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
-			primary: "$16.66/mo",
-			secondary: "Billed $200.00/yr",
+			primary: "$200.00/yr",
+			secondary: "$16.66/mo",
 			savings: "save $40.00",
 		});
 	});
 
 	test("omits savings when a monthly offer is missing", () => {
 		expect(computePricePresentation(annual, [annual])).toEqual({
-			primary: "$16.66/mo",
-			secondary: "Billed $200.00/yr",
+			primary: "$200.00/yr",
+			secondary: "$16.66/mo",
 			savings: null,
 		});
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -48,14 +48,9 @@ export function computePricePresentation(
 		comparisonIsCheaper && undiscountedTermPrice !== null
 			? undiscountedTermPrice - offer.price_cents
 			: 0;
-	const billed =
-		offer.billing_term_months === 12
-			? `Billed ${formatCents(offer.price_cents)}/yr`
-			: `Billed ${formatCents(offer.price_cents)} every ${offer.billing_term_months} months`;
-
 	return {
-		primary: monthlyPrice(offer),
-		secondary: billed,
+		primary: `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`,
+		secondary: monthlyPrice(offer),
 		savings: savingsCents > 0 ? `save ${formatCents(savingsCents)}` : null,
 	};
 }

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -309,11 +309,11 @@ export async function refreshCheckoutReturnQueries(
 
 // ── Usage ────────────────────────────────────────────────────────────────────
 
-export function useUsage() {
+export function useUsage(days: number | null) {
 	const client = useBillingClient();
 	return useBillingQuery({
-		queryKey: billingKeys.usage,
-		queryFn: () => client.getUsage(),
+		queryKey: billingKeys.usage(days),
+		queryFn: () => client.getUsage(days),
 	});
 }
 

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -1,6 +1,7 @@
 const subscriptionCreateQuotes = ["billing", "subscription-create-quote"] as const;
 const ledgerRoot = ["billing", "ledger"] as const;
 const billingHistoryRoot = ["billing", "history"] as const;
+const usageRoot = ["billing", "usage"] as const;
 
 export const billingKeys = {
 	managedModelCatalog: ["billing", "managed-model-catalog"] as const,
@@ -17,5 +18,5 @@ export const billingKeys = {
 	deployments: ["billing", "deployments"] as const,
 	legacyAgentEnvironments: ["billing", "legacy-agent-environments"] as const,
 	me: ["billing", "me"] as const,
-	usage: ["billing", "usage"] as const,
+	usage: (days: number | null) => [...usageRoot, days] as const,
 };

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -80,16 +80,9 @@ export function PlanComparison({
 			data-hosted="true"
 			headingLevel={3}
 			title="Compare compute plans"
-			description={
-				sharedPricingUnavailable
-					? "A shared Basic and Performance billing term is not currently available."
-					: undefined
-			}
-		>
-			<div className="space-y-4">
-				{commonOffers.length > 1 && selectedTerm !== null ? (
-					<div className="ml-auto w-full space-y-1.5 sm:w-56">
-						<p className="text-xs font-medium text-muted-foreground">Billing term</p>
+			actions={
+				commonOffers.length > 1 && selectedTerm !== null ? (
+					<div className="w-56">
 						<TermSwitcher
 							offers={commonOffers}
 							value={selectedTerm}
@@ -98,7 +91,15 @@ export function PlanComparison({
 							ariaLabel="Billing term for Basic and Performance"
 						/>
 					</div>
-				) : null}
+				) : null
+			}
+			description={
+				sharedPricingUnavailable
+					? "A shared Basic and Performance billing term is not currently available."
+					: undefined
+			}
+		>
+			<div>
 				<div className="grid gap-3 lg:grid-cols-2">
 					{/* Basic */}
 					<Card size="sm">

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -35,10 +35,21 @@ import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
-const DESCRIPTION = "Clawdi AI spend and requests for the current reporting window.";
+const DESCRIPTION = "Clawdi AI spend and requests.";
 const USAGE_PAGE_CLASS = "flex flex-col gap-8 px-5 sm:px-6 lg:px-8";
+const USAGE_RANGE_ITEMS = [
+	{ label: "Current period", value: "current" },
+	{ label: "Last 7 days", value: "7" },
+	{ label: "Last 30 days", value: "30" },
+	{ label: "Last 90 days", value: "90" },
+] as const;
 
 type VisibleUsageSection = "totals" | "by_agent" | "by_model" | "by_day";
+type UsageRangeDays = 7 | 30 | 90 | null;
+type UsageRangeSelection = {
+	days: UsageRangeDays;
+	onChange: (days: UsageRangeDays) => void;
+};
 type AgentBreakdown = NonNullable<HostedUsageSummary["by_agent"]>[number];
 type ModelBreakdown = HostedUsageSummary["by_model"][number];
 type DayBreakdown = HostedUsageSummary["by_day"][number];
@@ -173,8 +184,49 @@ function unavailableUsageSections(
 	return sections;
 }
 
+function usageRangeDays(value: string | null): UsageRangeDays {
+	switch (value) {
+		case "7":
+			return 7;
+		case "30":
+			return 30;
+		case "90":
+			return 90;
+		default:
+			return null;
+	}
+}
+
+function UsageRangeSelect({
+	days,
+	onChange,
+}: {
+	days: UsageRangeDays;
+	onChange: (days: UsageRangeDays) => void;
+}) {
+	return (
+		<Select
+			items={USAGE_RANGE_ITEMS}
+			value={days === null ? "current" : String(days)}
+			onValueChange={(value) => onChange(usageRangeDays(value))}
+		>
+			<SelectTrigger aria-label="Reporting range" className="w-40">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent align="end">
+				{USAGE_RANGE_ITEMS.map((item) => (
+					<SelectItem key={item.value} value={item.value}>
+						{item.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
 export function UsagePage({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
-	const usage = useUsage();
+	const [rangeDays, setRangeDays] = useState<UsageRangeDays>(null);
+	const usage = useUsage(rangeDays);
 	const providers = useUserAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
 	const [manualRetrying, setManualRetrying] = useState(false);
@@ -191,7 +243,11 @@ export function UsagePage({ agentTiles }: { agentTiles: readonly AgentTile[] }) 
 	if (usage.isLoading) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader
+					title="Usage"
+					description={DESCRIPTION}
+					actions={<UsageRangeSelect days={rangeDays} onChange={setRangeDays} />}
+				/>
 				<UsageSkeleton />
 			</div>
 		);
@@ -200,7 +256,11 @@ export function UsagePage({ agentTiles }: { agentTiles: readonly AgentTile[] }) 
 	if (shouldBlockQueryError(usage.error, usage.data) || !usage.data) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<SettingsPanelHeader title="Usage" description={DESCRIPTION} />
+				<SettingsPanelHeader
+					title="Usage"
+					description={DESCRIPTION}
+					actions={<UsageRangeSelect days={rangeDays} onChange={setRangeDays} />}
+				/>
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={usage.error}
@@ -218,6 +278,7 @@ export function UsagePage({ agentTiles }: { agentTiles: readonly AgentTile[] }) 
 			agentTiles={agentTiles}
 			providers={providers.data ?? []}
 			managedModels={managedModelCatalog.data?.models ?? []}
+			rangeSelection={{ days: rangeDays, onChange: setRangeDays }}
 			isRetrying={manualRetrying}
 			onRetry={() => {
 				void retryUsage();
@@ -231,6 +292,7 @@ export function UsageSummaryView({
 	agentTiles = [],
 	providers,
 	managedModels,
+	rangeSelection,
 	isRetrying,
 	onRetry,
 }: {
@@ -238,6 +300,7 @@ export function UsageSummaryView({
 	agentTiles?: readonly AgentTile[];
 	providers: readonly AiProvider[];
 	managedModels: readonly ManagedModelCatalogItem[];
+	rangeSelection?: UsageRangeSelection;
 	isRetrying: boolean;
 	onRetry: () => void;
 }) {
@@ -266,6 +329,9 @@ export function UsageSummaryView({
 		})),
 	];
 	const windowLabel = `${formatShortDate(usage.period_start)} – ${formatShortDate(usage.period_end)}`;
+	const rangeAction = rangeSelection ? (
+		<UsageRangeSelect days={rangeSelection.days} onChange={rangeSelection.onChange} />
+	) : null;
 
 	if (
 		missingSections.has("totals") &&
@@ -275,7 +341,7 @@ export function UsageSummaryView({
 	) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<SettingsPanelHeader title="Usage" description={`${windowLabel} reporting window.`} />
+				<SettingsPanelHeader title="Usage" description={windowLabel} actions={rangeAction} />
 				<EmptyState
 					variant="inset"
 					title="We can’t load your usage right now"
@@ -301,7 +367,7 @@ export function UsageSummaryView({
 	if (isRealZero) {
 		return (
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-				<SettingsPanelHeader title="Usage" description={`${windowLabel} reporting window.`} />
+				<SettingsPanelHeader title="Usage" description={windowLabel} actions={rangeAction} />
 				<EmptyState
 					variant="inset"
 					title="No usage yet"
@@ -328,7 +394,7 @@ export function UsageSummaryView({
 
 	return (
 		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
-			<SettingsPanelHeader title="Usage" description={`${windowLabel} reporting window.`} />
+			<SettingsPanelHeader title="Usage" description={windowLabel} actions={rangeAction} />
 
 			{totals ? (
 				<section
@@ -359,11 +425,7 @@ export function UsageSummaryView({
 				/>
 			)}
 
-			<SettingsSection
-				headingLevel={3}
-				title="Daily usage"
-				description="Global Clawdi AI spend by day."
-			>
+			<SettingsSection headingLevel={3} title="Daily usage">
 				{missingSections.has("by_day") ? (
 					<EmptyState
 						variant="inset"
@@ -383,11 +445,7 @@ export function UsageSummaryView({
 				)}
 			</SettingsSection>
 
-			<SettingsSection
-				headingLevel={3}
-				title="By agent"
-				description="Spend and requests grouped by agent."
-			>
+			<SettingsSection headingLevel={3} title="By agent">
 				{missingSections.has("by_agent") ? (
 					<EmptyState
 						variant="inset"
@@ -465,7 +523,26 @@ export function UsageSummaryView({
 			<SettingsSection
 				headingLevel={3}
 				title="By model"
-				description="Spend and requests grouped by provider and model."
+				actions={
+					!missingSections.has("by_model") && selectableAgents.length > 0 ? (
+						<Select
+							items={scopeItems}
+							value={effectiveAgentId}
+							onValueChange={(value) => setSelectedAgentId(value ?? "all")}
+						>
+							<SelectTrigger aria-label="Agent scope" className="w-44 sm:w-56">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent align="end">
+								{scopeItems.map((item) => (
+									<SelectItem key={item.value} value={item.value}>
+										{item.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					) : null
+				}
 			>
 				{missingSections.has("by_model") ? (
 					<EmptyState
@@ -476,29 +553,7 @@ export function UsageSummaryView({
 						className="py-4 md:p-4"
 					/>
 				) : (
-					<div className="space-y-4">
-						{selectableAgents.length > 0 ? (
-							<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
-								<span className="text-xs font-medium text-muted-foreground">Agent scope</span>
-								<Select
-									items={scopeItems}
-									value={effectiveAgentId}
-									onValueChange={(value) => setSelectedAgentId(value ?? "all")}
-								>
-									<SelectTrigger aria-label="Agent scope" className="w-full sm:w-56">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent align="end">
-										{scopeItems.map((item) => (
-											<SelectItem key={item.value} value={item.value}>
-												{item.label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</div>
-						) : null}
-
+					<div>
 						{sortedModels.length === 0 ? (
 							<EmptyState
 								variant="inset"

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, CreditCard, Repeat } from "lucide-react";
+import { AlertCircle, CreditCard } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSettingsEditState } from "@/components/settings-edit-state";
@@ -11,7 +11,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
-import { StatusBadge } from "@/components/ui/status-badge";
 import { Switch } from "@/components/ui/switch";
 import type { WalletState } from "@/hosted/billing/contracts";
 import { formatCents } from "@/hosted/billing/format";
@@ -162,214 +161,206 @@ export function AutoReloadCard({
 					"en-US",
 					{ month: "short", day: "numeric", timeZone: "UTC" },
 				).format(new Date(wallet.auto_reload_period_end))}`;
+	const enabledDetail = wallet.auto_reload_enabled
+		? wallet.auto_reload_status === "active"
+			? usage
+			: status.description
+		: null;
+	const hasBody = Boolean(wallet.auto_reload_action || requestError || draft.enabled || dirty);
 
 	return (
 		<SettingsSection
 			headingLevel={3}
 			data-hosted="true"
-			title={
-				<span className="flex flex-wrap items-center gap-2">
-					<span className="inline-flex items-center gap-2">
-						<Repeat className="size-4" aria-hidden /> Auto-reload
-					</span>
-					<StatusBadge status={status.tone} withDot>
-						{status.label}
-					</StatusBadge>
-				</span>
-			}
-			description={status.description}
-		>
-			<div className="flex max-w-3xl flex-col gap-4">
-				<AutoReloadActionConfirm
-					wallet={wallet}
-					onTopUp={onTopUp}
-					initialClientSecret={actionClientSecret}
-					onDiscardClientSecret={() => setActionClientSecret(null)}
+			title="Auto-reload"
+			description={draft.enabled ? enabledDetail : undefined}
+			actions={
+				<Switch
+					id="ar-enabled"
+					aria-label="Auto-reload"
+					aria-controls="auto-reload-form"
+					data-auto-reload-primary
+					checked={draft.enabled}
+					onCheckedChange={(checked) => updateDraft("enabled", checked)}
+					disabled={save.isPending}
 				/>
+			}
+		>
+			{hasBody ? (
+				<div className="flex flex-col gap-4">
+					<AutoReloadActionConfirm
+						wallet={wallet}
+						onTopUp={onTopUp}
+						initialClientSecret={actionClientSecret}
+						onDiscardClientSecret={() => setActionClientSecret(null)}
+					/>
 
-				{requestError ? (
-					<Alert variant="destructive">
-						<AlertCircle aria-hidden />
-						<AlertTitle>{requestError.title}</AlertTitle>
-						<AlertDescription id="auto-reload-save-error" className="flex flex-col gap-3">
-							<span>{requestError.description}</span>
-							{requestError.requiresPaymentMethod && onTopUp ? (
-								<Button type="button" size="sm" variant="outline" onClick={onTopUp}>
-									<CreditCard data-icon="inline-start" /> Add a card
-								</Button>
+					{requestError ? (
+						<Alert variant="destructive">
+							<AlertCircle aria-hidden />
+							<AlertTitle>{requestError.title}</AlertTitle>
+							<AlertDescription id="auto-reload-save-error" className="flex flex-col gap-3">
+								<span>{requestError.description}</span>
+								{requestError.requiresPaymentMethod && onTopUp ? (
+									<Button type="button" size="sm" variant="outline" onClick={onTopUp}>
+										<CreditCard data-icon="inline-start" /> Add a card
+									</Button>
+								) : null}
+							</AlertDescription>
+						</Alert>
+					) : null}
+
+					{draft.enabled || dirty ? (
+						<form
+							id="auto-reload-form"
+							className="flex flex-col gap-5"
+							onSubmit={(event) => {
+								event.preventDefault();
+								setBlurred(ALL_FIELDS_BLURRED);
+								void runAction(saveChanges);
+							}}
+						>
+							{draft.enabled ? (
+								<div className="flex flex-col gap-5">
+									<div className="grid gap-5 sm:grid-cols-2">
+										<div className="flex flex-col gap-1.5">
+											<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
+											<Input
+												id="ar-threshold"
+												type="number"
+												inputMode="decimal"
+												autoComplete="off"
+												min={AUTORELOAD_THRESHOLD_MIN_USD}
+												step="0.01"
+												className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+												value={draft.threshold}
+												onChange={(event) => updateDraft("threshold", event.target.value)}
+												onBlur={() => markBlurred("threshold")}
+												disabled={save.isPending}
+												aria-invalid={thresholdInvalid || thresholdServerError}
+												aria-describedby="ar-threshold-help"
+											/>
+											<p
+												id="ar-threshold-help"
+												className={
+													thresholdInvalid
+														? "text-xs text-destructive"
+														: "text-xs text-muted-foreground"
+												}
+											>
+												Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}.
+											</p>
+										</div>
+
+										<div className="flex flex-col gap-1.5">
+											<Label htmlFor="ar-amount">Amount to add (USD)</Label>
+											<Input
+												id="ar-amount"
+												type="number"
+												inputMode="decimal"
+												autoComplete="off"
+												min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+												max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
+												step="0.01"
+												className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+												value={draft.amount}
+												onChange={(event) => updateDraft("amount", event.target.value)}
+												onBlur={() => markBlurred("amount")}
+												disabled={save.isPending}
+												aria-invalid={amountInvalid || amountServerError}
+												aria-describedby="ar-amount-help"
+											/>
+											<p
+												id="ar-amount-help"
+												className={
+													amountInvalid
+														? "text-xs text-destructive"
+														: "text-xs text-muted-foreground"
+												}
+											>
+												{AUTORELOAD_AMOUNT_RANGE_LABEL}.
+											</p>
+										</div>
+									</div>
+
+									<div>
+										<div className="flex items-start justify-between gap-4">
+											<div className="space-y-0.5">
+												<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
+												<p className="text-xs text-muted-foreground">
+													{draft.monthlyLimitEnabled
+														? "Pause auto-reload after this amount is added."
+														: "No monthly limit."}
+												</p>
+											</div>
+											<Switch
+												id="ar-monthly-limit"
+												checked={draft.monthlyLimitEnabled}
+												onCheckedChange={(checked) => updateDraft("monthlyLimitEnabled", checked)}
+												disabled={save.isPending}
+											/>
+										</div>
+
+										{draft.monthlyLimitEnabled ? (
+											<div className="mt-4 flex max-w-sm flex-col gap-1.5">
+												<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
+												<Input
+													id="ar-cap"
+													type="number"
+													inputMode="decimal"
+													autoComplete="off"
+													min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+													step="0.01"
+													className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+													value={draft.cap}
+													onChange={(event) => updateDraft("cap", event.target.value)}
+													onBlur={() => markBlurred("cap")}
+													disabled={save.isPending}
+													aria-invalid={capInvalid || capServerError}
+													aria-describedby="ar-cap-help"
+												/>
+												<p
+													id="ar-cap-help"
+													className={
+														capInvalid
+															? "text-xs text-destructive"
+															: "text-xs text-muted-foreground"
+													}
+												>
+													Must cover at least one reload ({minimumCap}).
+												</p>
+											</div>
+										) : null}
+									</div>
+								</div>
 							) : null}
-						</AlertDescription>
-					</Alert>
-				) : null}
 
-				<form
-					id="auto-reload-form"
-					className="overflow-hidden rounded-lg border bg-muted/10"
-					onSubmit={(event) => {
-						event.preventDefault();
-						setBlurred(ALL_FIELDS_BLURRED);
-						void runAction(saveChanges);
-					}}
-				>
-					<div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-4 p-4 sm:p-5">
-						<div className="space-y-1">
-							<Label htmlFor="ar-enabled">Automatically add funds</Label>
-							<p className="text-xs leading-5 text-muted-foreground">
-								{wallet.auto_reload_enabled
-									? usage
-									: "Turn this on to reload Wallet when the balance reaches your threshold."}
-							</p>
-						</div>
-						<div className="flex items-center gap-2">
-							<span className="text-xs font-medium text-muted-foreground">
-								{draft.enabled ? "On" : "Off"}
-							</span>
-							<Switch
-								id="ar-enabled"
-								data-auto-reload-primary
-								checked={draft.enabled}
-								onCheckedChange={(checked) => updateDraft("enabled", checked)}
-								disabled={save.isPending}
-							/>
-						</div>
-					</div>
-
-					<div className="grid gap-5 border-t p-4 sm:grid-cols-2 sm:p-5">
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
-							<Input
-								id="ar-threshold"
-								type="number"
-								inputMode="decimal"
-								autoComplete="off"
-								min={AUTORELOAD_THRESHOLD_MIN_USD}
-								step="0.01"
-								className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-								value={draft.threshold}
-								onChange={(event) => updateDraft("threshold", event.target.value)}
-								onBlur={() => markBlurred("threshold")}
-								disabled={!draft.enabled || save.isPending}
-								aria-invalid={thresholdInvalid || thresholdServerError}
-								aria-describedby="ar-threshold-help"
-							/>
-							<p
-								id="ar-threshold-help"
-								className={
-									thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-							>
-								Minimum {formatCents(AUTORELOAD_THRESHOLD_MIN_USD * 100)}.
-							</p>
-						</div>
-
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="ar-amount">Amount to add (USD)</Label>
-							<Input
-								id="ar-amount"
-								type="number"
-								inputMode="decimal"
-								autoComplete="off"
-								min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-								max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
-								step="0.01"
-								className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-								value={draft.amount}
-								onChange={(event) => updateDraft("amount", event.target.value)}
-								onBlur={() => markBlurred("amount")}
-								disabled={!draft.enabled || save.isPending}
-								aria-invalid={amountInvalid || amountServerError}
-								aria-describedby="ar-amount-help"
-							/>
-							<p
-								id="ar-amount-help"
-								className={
-									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-							>
-								{AUTORELOAD_AMOUNT_RANGE_LABEL}.
-							</p>
-						</div>
-					</div>
-
-					<div className="border-t p-4 sm:p-5">
-						<div className="flex items-start justify-between gap-3">
-							<div className="space-y-0.5">
-								<Label htmlFor="ar-monthly-limit">Monthly limit</Label>
-								<p className="text-xs text-muted-foreground">
-									{draft.monthlyLimitEnabled
-										? "Pause auto-reload after this amount is added."
-										: "No monthly limit."}
-								</p>
-							</div>
-							<Switch
-								id="ar-monthly-limit"
-								checked={draft.monthlyLimitEnabled}
-								onCheckedChange={(checked) => updateDraft("monthlyLimitEnabled", checked)}
-								disabled={!draft.enabled || save.isPending}
-							/>
-						</div>
-
-						{draft.monthlyLimitEnabled ? (
-							<div className="mt-4 flex flex-col gap-1.5">
-								<Label htmlFor="ar-cap">Monthly limit (USD)</Label>
-								<Input
-									id="ar-cap"
-									type="number"
-									inputMode="decimal"
-									autoComplete="off"
-									min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-									step="0.01"
-									className="tabular-nums [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-									value={draft.cap}
-									onChange={(event) => updateDraft("cap", event.target.value)}
-									onBlur={() => markBlurred("cap")}
-									disabled={!draft.enabled || save.isPending}
-									aria-invalid={capInvalid || capServerError}
-									aria-describedby="ar-cap-help"
-								/>
-								<p
-									id="ar-cap-help"
-									className={
-										capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-									}
-								>
-									Must cover at least one reload ({minimumCap}).
-								</p>
-							</div>
-						) : null}
-					</div>
-
-					<div className="flex flex-col gap-3 border-t p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
-						<p className="text-xs leading-5 text-muted-foreground">
-							Uses your saved card. A manual top-up saves a card for future reloads.
-						</p>
-						<div className="flex shrink-0 justify-end gap-2">
-							<Button
-								type="button"
-								size="sm"
-								variant="outline"
-								onClick={cancelChanges}
-								disabled={!dirty || save.isPending}
-							>
-								Cancel
-							</Button>
-							<Button
-								type="submit"
-								size="sm"
-								disabled={!dirty || !form.formValid || save.isPending}
-							>
-								{save.isPending ? (
-									<>
-										<Spinner data-icon="inline-start" /> Saving…
-									</>
-								) : (
-									"Save"
-								)}
-							</Button>
-						</div>
-					</div>
-				</form>
-			</div>
+							{dirty ? (
+								<div className="flex justify-end gap-2">
+									<Button
+										type="button"
+										size="sm"
+										variant="ghost"
+										onClick={cancelChanges}
+										disabled={save.isPending}
+									>
+										Cancel
+									</Button>
+									<Button type="submit" size="sm" disabled={!form.formValid || save.isPending}>
+										{save.isPending ? (
+											<>
+												<Spinner data-icon="inline-start" /> Saving…
+											</>
+										) : (
+											"Save"
+										)}
+									</Button>
+								</div>
+							) : null}
+						</form>
+					) : null}
+				</div>
+			) : null}
 		</SettingsSection>
 	);
 }

--- a/apps/web/src/hosted/billing/wallet/x402-card.test.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.test.ts
@@ -8,7 +8,6 @@ describe("x402 wallet availability", () => {
 	test("keeps the card visible and labels the unavailable state", () => {
 		expect(pageSource).toContain("<X402Card enabled={w.x402_enabled === true} />");
 		expect(cardSource).toContain("Not available yet");
-		expect(cardSource).toContain("x402 payments are not available yet.");
 		expect(cardSource).toContain("Linked agent wallet");
 		expect(cardSource).not.toContain("deposit address");
 	});

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -23,7 +23,7 @@ export function X402Card({ enabled }: { enabled: boolean }) {
 						<Badge variant="secondary">Not available yet</Badge>
 					</span>
 				}
-				description="x402 payments are not available yet. When launched, agents will be able to add Wallet funds with USDC."
+				description="Agents will be able to add Wallet funds with USDC."
 			/>
 		);
 	}

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -3238,7 +3238,9 @@ export interface operations {
     };
     hosted_v2_usage_summary_v2_usage_get: {
         parameters: {
-            query?: never;
+            query?: {
+                days?: number | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3252,6 +3254,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["V2HostedUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
Standardizes the Settings modal header and close control; flattens Auto-reload; adds current-period and 7/30/90-day Usage ranges; aligns Usage, agent-scope, and compute-term controls with their titles; shows annual total as the primary price; keeps x402 marked Not available yet; and updates matching skeletons. Validation: Web typecheck, full lint, OSS production build, shared typecheck, existing price contract, and local desktop/mobile Chromium visual audit passed. No new frontend test cases were added. Rollout: merge and deploy Clawdi-AI/clawdi-hosted#1437 first.