### PR TITLE
refactor(backend): narrow sessions typing exception

### DIFF
--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import subprocess
 import sys
@@ -62,18 +63,46 @@ STANDARD_ONLY = frozenset(
         "app/services/memory_provider_mem0.py",
     }
 )
-FROZEN_LEGACY_ONLY = frozenset(
+RUNTIME_OBSERVATION_COMPATIBILITY_ONLY = frozenset(
     {
-        # The repository-owned byte-freeze protects this file's v1 runtime
-        # observation surface. The user explicitly deferred that legacy
-        # deployment boundary rather than permitting type-only source edits.
+        # Repository-owned byte hashes protect the pre-v2 runtime-observation
+        # and heartbeat compatibility symbols in this otherwise canonical v1
+        # API module. BasedPyright strictness is file-scoped, so the exception
+        # audit below pins every remaining diagnostic to those exact symbols.
         "app/routes/sessions.py",
     }
 )
+EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS = {
+    "app/routes/sessions.py": {
+        "_runtime_desired_provider_binding": {
+            "reportMissingTypeArgument": 1,
+            "reportUnknownArgumentType": 4,
+            "reportUnknownParameterType": 1,
+            "reportUnknownVariableType": 2,
+        },
+        "_enabled_runtime_names": {
+            "reportMissingTypeArgument": 1,
+            "reportUnknownArgumentType": 1,
+            "reportUnknownMemberType": 1,
+            "reportUnknownParameterType": 1,
+            "reportUnknownVariableType": 2,
+        },
+        "_bounded_runtime_observed": {
+            "reportUnknownVariableType": 1,
+        },
+    }
+}
 EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS = {
-    "app/routes/sessions.py": 15,
     "app/services/file_store_s3.py": 2,
     "app/services/memory_provider_mem0.py": 19,
+    **{
+        path: sum(
+            count
+            for symbol_diagnostics in symbols.values()
+            for count in symbol_diagnostics.values()
+        )
+        for path, symbols in EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS.items()
+    },
 }
 PRODUCTION_FILES = tuple(
     sorted(
@@ -82,7 +111,9 @@ PRODUCTION_FILES = tuple(
 )
 OWNED_PRODUCTION_FILES = tuple(path for path in PRODUCTION_FILES if path not in OWNED_EXCLUSIONS)
 STRICT_PRODUCTION_FILES = tuple(
-    path for path in PRODUCTION_FILES if path not in STANDARD_ONLY | FROZEN_LEGACY_ONLY
+    path
+    for path in PRODUCTION_FILES
+    if path not in STANDARD_ONLY | RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
 )
 EXPECTED_CONFIG = {
     "typeCheckingMode": "standard",
@@ -108,10 +139,26 @@ class Analysis(TypedDict):
     summary: Summary
 
 
+type SourcePosition = tuple[int, int]
+type SourceRange = tuple[SourcePosition, SourcePosition]
+
+
 def validate_config() -> None:
-    validate_exception_sets(PRODUCTION_FILES, STANDARD_ONLY, FROZEN_LEGACY_ONLY)
-    if set(EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS) != STANDARD_ONLY | FROZEN_LEGACY_ONLY:
+    validate_exception_sets(
+        PRODUCTION_FILES,
+        STANDARD_ONLY,
+        RUNTIME_OBSERVATION_COMPATIBILITY_ONLY,
+    )
+    exception_paths = STANDARD_ONLY | RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    if set(EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS) != exception_paths:
         raise ValueError("strict exception diagnostic inventory paths do not match exceptions")
+    if (
+        set(EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS)
+        != RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    ):
+        raise ValueError(
+            "runtime-observation compatibility diagnostic paths do not match exceptions"
+        )
     with CONFIG.open("rb") as handle:
         document = tomllib.load(handle)
     configured = document.get("tool", {}).get("basedpyright")
@@ -127,13 +174,13 @@ def validate_config() -> None:
 def validate_exception_sets(
     production_files: Sequence[str],
     standard_only: frozenset[str],
-    frozen_legacy_only: frozenset[str],
+    runtime_observation_compatibility_only: frozenset[str],
 ) -> None:
     production = set(production_files)
-    overlap = standard_only & frozen_legacy_only
+    overlap = standard_only & runtime_observation_compatibility_only
     if overlap:
         raise ValueError(f"typing exception sets overlap: {sorted(overlap)}")
-    stale = (standard_only | frozen_legacy_only) - production
+    stale = (standard_only | runtime_observation_compatibility_only) - production
     if stale:
         raise ValueError(f"stale typing exception paths: {sorted(stale)}")
 
@@ -269,8 +316,86 @@ def analyze(paths: Sequence[str], *, gating: bool, config: Path = CONFIG) -> Ana
     return analysis
 
 
+def _top_level_symbol_ranges(path: str) -> dict[str, SourceRange]:
+    source = (BACKEND_ROOT / path).read_bytes()
+    tree = ast.parse(source, filename=path)
+    ranges: dict[str, SourceRange] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.end_lineno is None or node.end_col_offset is None:
+            raise ValueError(f"top-level symbol has no end position: {path}:{node.name}")
+        starts = [(node.lineno - 1, node.col_offset)]
+        starts.extend(
+            (decorator.lineno - 1, max(0, decorator.col_offset - 1))
+            for decorator in node.decorator_list
+        )
+        ranges[node.name] = (min(starts), (node.end_lineno - 1, node.end_col_offset))
+    return ranges
+
+
+def _diagnostic_position(path: str, name: str, value: object) -> SourcePosition:
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"runtime-observation compatibility diagnostic has an invalid {name}: {path}"
+        )
+    line = value.get("line")
+    character = value.get("character")
+    if (
+        isinstance(line, bool)
+        or not isinstance(line, int)
+        or line < 0
+        or isinstance(character, bool)
+        or not isinstance(character, int)
+        or character < 0
+    ):
+        raise ValueError(
+            f"runtime-observation compatibility diagnostic has an invalid {name}: {path}"
+        )
+    return line, character
+
+
+def _diagnostic_range(path: str, value: object) -> SourceRange:
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"runtime-observation compatibility diagnostic has an invalid range: {path}"
+        )
+    start = _diagnostic_position(path, "range start", value.get("start"))
+    end = _diagnostic_position(path, "range end", value.get("end"))
+    if start > end:
+        raise ValueError(
+            f"runtime-observation compatibility diagnostic has a reversed range: {path}"
+        )
+    return start, end
+
+
+def _compatibility_diagnostic_location(
+    path: str,
+    diagnostic: dict[object, object],
+    symbol_ranges: dict[str, SourceRange],
+) -> tuple[str, str]:
+    rule = diagnostic.get("rule")
+    if not isinstance(rule, str):
+        raise ValueError(f"runtime-observation compatibility diagnostic omitted its rule: {path}")
+    start, end = _diagnostic_range(path, diagnostic.get("range"))
+    symbol = next(
+        (
+            name
+            for name, (symbol_start, symbol_end) in symbol_ranges.items()
+            if symbol_start <= start and end <= symbol_end
+        ),
+        None,
+    )
+    if symbol is None:
+        raise ValueError(
+            "runtime-observation compatibility diagnostic escaped its expected frozen symbol: "
+            f"{path}:{start[0]}:{start[1]}-{end[0]}:{end[1]}:{rule}"
+        )
+    return symbol, rule
+
+
 def strict_exception_audit() -> dict[str, object]:
-    paths = sorted(STANDARD_ONLY | FROZEN_LEGACY_ONLY)
+    paths = sorted(STANDARD_ONLY | RUNTIME_OBSERVATION_COMPATIBILITY_ONLY)
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -290,6 +415,16 @@ def strict_exception_audit() -> dict[str, object]:
         analysis = analyze(paths, gating=False, config=Path(handle.name))
 
     counts = dict.fromkeys(paths, 0)
+    symbol_ranges: dict[str, dict[str, SourceRange]] = {}
+    for path, expected_symbols in EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS.items():
+        ranges = _top_level_symbol_ranges(path)
+        missing = set(expected_symbols) - set(ranges)
+        if missing:
+            raise ValueError(f"runtime-observation compatibility symbols are missing: {missing}")
+        symbol_ranges[path] = {symbol: ranges[symbol] for symbol in expected_symbols}
+    compatibility_counts: dict[str, dict[str, dict[str, int]]] = {
+        path: {} for path in RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    }
     for diagnostic in analysis["generalDiagnostics"]:
         if not isinstance(diagnostic, dict):
             raise ValueError("strict exception audit returned a malformed diagnostic")
@@ -303,6 +438,14 @@ def strict_exception_audit() -> dict[str, object]:
         if path not in counts:
             raise ValueError(f"strict exception audit reported an unexpected file: {path}")
         counts[path] += 1
+        if path in RUNTIME_OBSERVATION_COMPATIBILITY_ONLY:
+            symbol, rule = _compatibility_diagnostic_location(
+                path,
+                diagnostic,
+                symbol_ranges[path],
+            )
+            rule_counts = compatibility_counts[path].setdefault(symbol, {})
+            rule_counts[rule] = rule_counts.get(rule, 0) + 1
 
     stale = [path for path, count in counts.items() if count == 0]
     if stale:
@@ -312,11 +455,17 @@ def strict_exception_audit() -> dict[str, object]:
             "strict exception diagnostic inventory mismatch: "
             f"expected={EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS} observed={counts}"
         )
+    if compatibility_counts != EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS:
+        raise ValueError(
+            "runtime-observation compatibility diagnostic inventory mismatch: "
+            f"expected={EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS} "
+            f"observed={compatibility_counts}"
+        )
     return {
         "basedpyrightVersion": EXPECTED_VERSION,
         "mode": "strict exception audit",
         "standardOnly": {path: counts[path] for path in sorted(STANDARD_ONLY)},
-        "frozenLegacyOnly": {path: counts[path] for path in sorted(FROZEN_LEGACY_ONLY)},
+        "runtimeObservationCompatibilityOnly": compatibility_counts,
         "totalDiagnostics": sum(counts.values()),
     }
 

--- a/backend/tests/test_type_governance.py
+++ b/backend/tests/test_type_governance.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import os
 import subprocess
@@ -114,11 +115,13 @@ def test_typing_exception_sets_accept_live_disjoint_paths() -> None:
             "app/services/memory_provider_mem0.py",
         }
     )
-    assert type_governance.FROZEN_LEGACY_ONLY == frozenset({"app/routes/sessions.py"})
+    assert type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY == frozenset(
+        {"app/routes/sessions.py"}
+    )
     type_governance.validate_exception_sets(
         type_governance.PRODUCTION_FILES,
         type_governance.STANDARD_ONLY,
-        type_governance.FROZEN_LEGACY_ONLY,
+        type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY,
     )
 
 
@@ -132,14 +135,14 @@ def test_typing_exception_sets_reject_overlap() -> None:
         )
 
 
-@pytest.mark.parametrize("exception_kind", ["standard", "frozen"])
+@pytest.mark.parametrize("exception_kind", ["standard", "runtime-observation"])
 def test_typing_exception_sets_reject_stale_paths(exception_kind: str) -> None:
     stale = frozenset({"app/not_owned.py"})
     with pytest.raises(ValueError, match="stale"):
         type_governance.validate_exception_sets(
             type_governance.PRODUCTION_FILES,
             stale if exception_kind == "standard" else frozenset(),
-            stale if exception_kind == "frozen" else frozenset(),
+            stale if exception_kind == "runtime-observation" else frozenset(),
         )
 
 
@@ -233,19 +236,58 @@ def test_gate_rejects_nonzero_exit_without_diagnostics(
         type_governance.analyze(["app/core/query_utils.py"], gating=True)
 
 
-def exception_diagnostics(paths: list[str]) -> list[object]:
+def exception_diagnostics(paths: list[str]) -> list[dict[str, object]]:
     return [{"file": str(type_governance.BACKEND_ROOT / path)} for path in paths]
 
 
-def test_strict_exception_audit_reports_standard_and_frozen_boundaries(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    paths = sorted(type_governance.STANDARD_ONLY | type_governance.FROZEN_LEGACY_ONLY)
+def runtime_observation_compatibility_diagnostics() -> list[dict[str, object]]:
+    diagnostics: list[dict[str, object]] = []
+    for (
+        path,
+        expected_symbols,
+    ) in type_governance.EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS.items():
+        source = (type_governance.BACKEND_ROOT / path).read_bytes()
+        tree = ast.parse(source, filename=path)
+        symbols = {
+            node.name: node
+            for node in tree.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        for symbol, rule_counts in expected_symbols.items():
+            line = symbols[symbol].lineno - 1
+            for rule, count in rule_counts.items():
+                diagnostics.extend(
+                    {
+                        "file": str(type_governance.BACKEND_ROOT / path),
+                        "range": {
+                            "start": {"line": line, "character": 0},
+                            "end": {"line": line, "character": 1},
+                        },
+                        "rule": rule,
+                    }
+                    for _ in range(count)
+                )
+    return diagnostics
+
+
+def expected_exception_diagnostics() -> list[dict[str, object]]:
     diagnostics = [
         diagnostic
-        for path, count in type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS.items()
-        for diagnostic in exception_diagnostics([path] * count)
+        for path in sorted(type_governance.STANDARD_ONLY)
+        for diagnostic in exception_diagnostics(
+            [path] * type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS[path]
+        )
     ]
+    return diagnostics + runtime_observation_compatibility_diagnostics()
+
+
+def test_strict_exception_audit_reports_standard_and_compatibility_boundaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = sorted(
+        type_governance.STANDARD_ONLY | type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    )
+    diagnostics = expected_exception_diagnostics()
     install_analyzer(
         tmp_path,
         monkeypatch,
@@ -263,41 +305,22 @@ def test_strict_exception_audit_reports_standard_and_frozen_boundaries(
         path: type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS[path]
         for path in sorted(type_governance.STANDARD_ONLY)
     }
-    assert result["frozenLegacyOnly"] == {
-        path: type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS[path]
-        for path in sorted(type_governance.FROZEN_LEGACY_ONLY)
-    }
+    assert result["runtimeObservationCompatibilityOnly"] == (
+        type_governance.EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS
+    )
 
 
 def test_strict_exception_audit_rejects_strict_clean_stale_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    paths = sorted(type_governance.STANDARD_ONLY | type_governance.FROZEN_LEGACY_ONLY)
-    install_analyzer(
-        tmp_path,
-        monkeypatch,
-        payload=analysis(
-            files=len(paths),
-            errors=len(paths) - 1,
-            diagnostics=exception_diagnostics(paths[:-1]),
-        ),
-        exit_code=1,
+    paths = sorted(
+        type_governance.STANDARD_ONLY | type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
     )
-
-    with pytest.raises(ValueError, match="strict-clean typing exceptions are stale"):
-        type_governance.strict_exception_audit()
-
-
-def test_strict_exception_audit_rejects_new_diagnostic_debt(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    paths = sorted(type_governance.STANDARD_ONLY | type_governance.FROZEN_LEGACY_ONLY)
-    observed = dict(type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS)
-    observed["app/services/memory_provider_mem0.py"] += 1
     diagnostics = [
         diagnostic
-        for path, count in observed.items()
-        for diagnostic in exception_diagnostics([path] * count)
+        for diagnostic in expected_exception_diagnostics()
+        if diagnostic["file"]
+        != str(type_governance.BACKEND_ROOT / "app/services/memory_provider_mem0.py")
     ]
     install_analyzer(
         tmp_path,
@@ -310,5 +333,193 @@ def test_strict_exception_audit_rejects_new_diagnostic_debt(
         exit_code=1,
     )
 
+    with pytest.raises(ValueError, match="strict-clean typing exceptions are stale"):
+        type_governance.strict_exception_audit()
+
+
+def test_strict_exception_audit_rejects_new_diagnostic_debt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = sorted(
+        type_governance.STANDARD_ONLY | type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    )
+    diagnostics = expected_exception_diagnostics() + exception_diagnostics(
+        ["app/services/memory_provider_mem0.py"]
+    )
+    install_analyzer(
+        tmp_path,
+        monkeypatch,
+        payload=analysis(
+            files=len(paths),
+            errors=len(diagnostics),
+            diagnostics=diagnostics,
+        ),
+        exit_code=1,
+    )
+
     with pytest.raises(ValueError, match="strict exception diagnostic inventory mismatch"):
+        type_governance.strict_exception_audit()
+
+
+def test_strict_exception_audit_rejects_diagnostic_outside_compatibility_symbols(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = sorted(
+        type_governance.STANDARD_ONLY | type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    )
+    diagnostics = expected_exception_diagnostics()
+    compatibility_diagnostic = next(
+        diagnostic for diagnostic in diagnostics if "range" in diagnostic
+    )
+    source = (type_governance.BACKEND_ROOT / "app/routes/sessions.py").read_bytes()
+    tree = ast.parse(source, filename="app/routes/sessions.py")
+    non_compatibility_symbol = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_bound_env_id"
+    )
+    line = non_compatibility_symbol.lineno - 1
+    compatibility_diagnostic["range"] = {
+        "start": {"line": line, "character": 0},
+        "end": {"line": line, "character": 1},
+    }
+    install_analyzer(
+        tmp_path,
+        monkeypatch,
+        payload=analysis(
+            files=len(paths),
+            errors=len(diagnostics),
+            diagnostics=diagnostics,
+        ),
+        exit_code=1,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="escaped its expected frozen symbol",
+    ):
+        type_governance.strict_exception_audit()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing-start",
+        "missing-end",
+        "malformed-start",
+        "malformed-end",
+        "missing-start-character",
+        "missing-end-character",
+        "bool",
+        "negative",
+        "invalid-type",
+        "reversed",
+        "cross-symbol",
+        "module-level",
+    ],
+)
+def test_compatibility_diagnostic_location_rejects_invalid_ranges(case: str) -> None:
+    path = "app/routes/sessions.py"
+    all_ranges = type_governance._top_level_symbol_ranges(path)
+    expected_symbols = type_governance.EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS[path]
+    symbol_ranges = {symbol: all_ranges[symbol] for symbol in expected_symbols}
+    binding_start = symbol_ranges["_runtime_desired_provider_binding"][0]
+    enabled_start = symbol_ranges["_enabled_runtime_names"][0]
+
+    def point(position: tuple[int, int]) -> dict[str, int]:
+        return {"line": position[0], "character": position[1]}
+
+    start = point(binding_start)
+    end = {"line": binding_start[0], "character": binding_start[1] + 1}
+    invalid_ranges: dict[str, object] = {
+        "missing-start": {"end": end},
+        "missing-end": {"start": start},
+        "malformed-start": {"start": [], "end": end},
+        "malformed-end": {"start": start, "end": []},
+        "missing-start-character": {
+            "start": {"line": binding_start[0]},
+            "end": end,
+        },
+        "missing-end-character": {
+            "start": start,
+            "end": {"line": binding_start[0]},
+        },
+        "bool": {
+            "start": {"line": True, "character": binding_start[1]},
+            "end": end,
+        },
+        "negative": {
+            "start": start,
+            "end": {"line": binding_start[0], "character": -1},
+        },
+        "invalid-type": {
+            "start": start,
+            "end": {"line": "0", "character": binding_start[1]},
+        },
+        "reversed": {
+            "start": end,
+            "end": start,
+        },
+        "cross-symbol": {
+            "start": start,
+            "end": point(enabled_start),
+        },
+        "module-level": {
+            "start": {"line": 0, "character": 0},
+            "end": {"line": 0, "character": 1},
+        },
+    }
+    expected_errors = {
+        "missing-start": "invalid range start",
+        "missing-end": "invalid range end",
+        "malformed-start": "invalid range start",
+        "malformed-end": "invalid range end",
+        "missing-start-character": "invalid range start",
+        "missing-end-character": "invalid range end",
+        "bool": "invalid range start",
+        "negative": "invalid range end",
+        "invalid-type": "invalid range end",
+        "reversed": "reversed range",
+        "cross-symbol": "escaped its expected frozen symbol",
+        "module-level": "escaped its expected frozen symbol",
+    }
+
+    with pytest.raises(ValueError, match=expected_errors[case]):
+        type_governance._compatibility_diagnostic_location(
+            path,
+            {
+                "rule": "reportUnknownParameterType",
+                "range": invalid_ranges[case],
+            },
+            symbol_ranges,
+        )
+
+
+def test_strict_exception_audit_rejects_compatibility_rule_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = sorted(
+        type_governance.STANDARD_ONLY | type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY
+    )
+    diagnostics = expected_exception_diagnostics()
+    compatibility_diagnostic = next(
+        diagnostic for diagnostic in diagnostics if "range" in diagnostic
+    )
+    compatibility_diagnostic["rule"] = "reportUnexpectedCompatibilityDebt"
+    install_analyzer(
+        tmp_path,
+        monkeypatch,
+        payload=analysis(
+            files=len(paths),
+            errors=len(diagnostics),
+            diagnostics=diagnostics,
+        ),
+        exit_code=1,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runtime-observation compatibility diagnostic inventory mismatch",
+    ):
         type_governance.strict_exception_audit()

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -113,9 +113,9 @@ different interpreter; the production `app` result is the zero-diagnostic
 invariant. Every first-party production module is clean in its owned gate.
 
 The strict-equivalent production audit reports 36 diagnostics across two
-retained standard-mode adapters and one explicitly frozen legacy module; the
-other 182 production files are strict-clean. The five reviewed SDK boundary
-owners have these exact gates:
+retained standard-mode adapters and one runtime-observation compatibility
+module with byte-frozen symbols; the other 182 production files are
+strict-clean. The five reviewed SDK boundary owners have these exact gates:
 
 | SDK boundary | Gate / diagnostics | Locked upstream and first-party normalization |
 | --- | --- | --- |
@@ -141,18 +141,33 @@ change its Bucket, Key, Body, ContentType, status, or stream contract.
 No local SDK stub or mirrored overload is used to hide diagnostics.
 `STANDARD_ONLY` contains exactly S3 and Mem0, and the owned production
 exclusion set is empty. The exception audit pins the per-file strict diagnostic
-counts (S3 2, Mem0 19, frozen legacy 15), so either added debt or a typing
-improvement fails until the exact allowlist is reviewed. The public
-`S3ObjectStoreClient` protocol is a first-party storage facade, not a substitute
-type for boto: the adapter itself retains the generated official `S3Client`.
+counts (S3 2, Mem0 19, runtime-observation compatibility 15), so either added
+debt or a typing improvement fails until the exact allowlist is reviewed. The
+public `S3ObjectStoreClient` protocol is a first-party storage facade, not a
+substitute type for boto: the adapter itself retains the generated official
+`S3Client`.
 
-`app/routes/sessions.py` is separately listed in `FROZEN_LEGACY_ONLY` with 15
-strict diagnostics. Its v1 runtime-observation symbols are protected by the
-repository byte-freeze, and this wave was explicitly authorized to defer that
-legacy deployment boundary instead of changing even type annotations inside
-the frozen symbols. This is not an SDK adapter and is not claimed as strict.
-The exception audit keeps the categories disjoint, rejects missing paths, and
-requires the exact diagnostic inventory so stale exceptions cannot linger.
+`app/routes/sessions.py` is separately listed in
+`RUNTIME_OBSERVATION_COMPATIBILITY_ONLY`. The module owns canonical Clawdi
+`/v1` APIs; it is not a legacy or Hosted v1 deployment module. Its 15 strict
+diagnostics occur only inside three repository byte-frozen pre-v2
+runtime-observation and heartbeat compatibility symbols:
+
+| Frozen symbol | Pinned strict diagnostics |
+| --- | --- |
+| `_runtime_desired_provider_binding` | 8: `reportMissingTypeArgument` 1, `reportUnknownArgumentType` 4, `reportUnknownParameterType` 1, `reportUnknownVariableType` 2 |
+| `_enabled_runtime_names` | 6: `reportMissingTypeArgument` 1, `reportUnknownArgumentType` 1, `reportUnknownMemberType` 1, `reportUnknownParameterType` 1, `reportUnknownVariableType` 2 |
+| `_bounded_runtime_observed` | 1: `reportUnknownVariableType` 1 |
+
+BasedPyright strict selection is file-scoped, so the byte freeze prevents an
+honest source-level fix for the bare `dict` annotations without changing those
+symbols. The exception audit therefore resolves every diagnostic line to its
+top-level AST symbol and requires the exact per-symbol rule counts above. A
+diagnostic outside those symbols, a rule change, added debt, or stale debt all
+fail the gate. No baseline, suppression, adapter stub, or redundant wrapper is
+used to hide the remaining compatibility boundary. Hosted v1 product and
+deployment infrastructure are outside this repository and are not part of the
+exception.
 
 Done: `owned` reports 185 files and `strict` reports 182 files, with every
 diagnostic count equal to zero; `exceptions` reports the exact 36-diagnostic


### PR DESCRIPTION
## Summary

- rename the inaccurate frozen legacy sessions exception to the Clawdi runtime-observation compatibility boundary
- pin all 15 remaining strict diagnostics to exact byte-frozen symbols and BasedPyright rules
- validate complete BasedPyright diagnostic ranges: non-negative integer start/end coordinates, ordered end-exclusive spans, and containment within one expected frozen top-level AST symbol
- document that canonical `/v1` APIs are not legacy and Hosted v1 deployment is outside this repository

No `sessions.py` or byte-freeze baseline bytes changed.

## Verification

- `uv run pytest -q tests/test_type_governance.py tests/test_v1_runtime_observation_byte_freeze.py` (42 passed)
- `uv run --extra mem0 python scripts/type_governance.py owned` (185 files, 0 diagnostics)
- `uv run --extra mem0 python scripts/type_governance.py strict` (182 files, 0 diagnostics)
- `uv run --extra mem0 python scripts/type_governance.py exceptions` (exact 36; sessions 15 only in 3 frozen symbols)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall app scripts tests alembic`