### PR TITLE
refactor(backend): make S3 adapter strict typed

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -64,10 +64,11 @@ dev = [
     # undeclared for months without CI noticing.
     "deptry>=0.20",
     # Generated from boto3/botocore service models and pinned to the runtime
-    # SDK line. The S3 service package is selected by this extra.
-    "boto3-stubs[s3]==1.43.14",
+    # SDK line. The full bundle resolves every generated client overload for
+    # strict Pyright consumers; the base stubs own boto3's public surface.
+    "boto3-stubs==1.43.14",
+    "boto3-stubs-full==1.43.14",
     "botocore-stubs==1.43.14",
-    "mypy-boto3-s3==1.43.14",
     # Public annotations for the pinned asyncpg 0.31 runtime contract.
     "asyncpg-stubs==0.31.3",
 ]
@@ -248,6 +249,7 @@ strict = [
     "app/services/discord_rate_limiter.py",
     "app/services/embedding.py",
     "app/services/file_store.py",
+    "app/services/file_store_s3.py",
     "app/services/hosted_runtime_secrets.py",
     "app/services/http_cache.py",
     "app/services/managed_ai_provider.py",

--- a/backend/scripts/outbound_api_governance.py
+++ b/backend/scripts/outbound_api_governance.py
@@ -17,8 +17,8 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 APP_ROOT = BACKEND_ROOT / "app"
 
 # SDKs with dynamic or incomplete upstream typing stay behind one reviewed
-# first-party owner. Some owners are strict-clean; S3 and Mem0 are the two
-# exact standard-mode adapter exceptions in type_governance.py.
+# first-party owner. Some owners are strict-clean; Mem0 is the sole exact
+# standard-mode adapter exception in type_governance.py.
 SDK_IMPORT_OWNERS: dict[str, str] = {
     "asyncpg": "app/services/postgres_listener.py",
     "boto3": "app/services/file_store_s3.py",

--- a/backend/scripts/type_governance.py
+++ b/backend/scripts/type_governance.py
@@ -56,10 +56,9 @@ OWNED_INCLUDE = [
 ]
 STANDARD_ONLY = frozenset(
     {
-        # Both adapters remain in the zero-diagnostic owned gate. Their strict
-        # debt is limited to pinned upstream packages that do not publish
-        # complete typed construction/import boundaries.
-        "app/services/file_store_s3.py",
+        # This adapter remains in the zero-diagnostic owned gate. Its strict
+        # debt is limited to a pinned upstream package that does not publish
+        # a complete typed import boundary.
         "app/services/memory_provider_mem0.py",
     }
 )
@@ -93,7 +92,6 @@ EXPECTED_RUNTIME_OBSERVATION_COMPATIBILITY_DIAGNOSTICS = {
     }
 }
 EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS = {
-    "app/services/file_store_s3.py": 2,
     "app/services/memory_provider_mem0.py": 19,
     **{
         path: sum(

--- a/backend/tests/test_boto_dependency_alignment.py
+++ b/backend/tests/test_boto_dependency_alignment.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import tomllib
-from importlib.metadata import version
+from importlib.metadata import packages_distributions, version
 from pathlib import Path
 
+from mypy_boto3_s3.version import __version__ as s3_stub_version
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
@@ -14,9 +15,9 @@ BOTO_DISTRIBUTIONS = frozenset(
     {
         "boto3",
         "boto3-stubs",
+        "boto3-stubs-full",
         "botocore",
         "botocore-stubs",
-        "mypy-boto3-s3",
     }
 )
 
@@ -48,6 +49,8 @@ def test_boto_runtime_stubs_lock_and_metadata_use_one_exact_patch() -> None:
         canonicalize_name(distribution): version(distribution)
         for distribution in BOTO_DISTRIBUTIONS
     } == dict.fromkeys(BOTO_DISTRIBUTIONS, BOTO_VERSION)
+    assert packages_distributions()["mypy_boto3_s3"] == ["boto3-stubs-full"]
+    assert s3_stub_version == BOTO_VERSION
 
     documentation = (REPOSITORY_ROOT / "docs/backend-development.md").read_text(encoding="utf-8")
     for distribution in BOTO_DISTRIBUTIONS:

--- a/backend/tests/test_type_governance.py
+++ b/backend/tests/test_type_governance.py
@@ -109,12 +109,7 @@ def test_config_mismatch_fails_closed(tmp_path: Path, monkeypatch: pytest.Monkey
 
 
 def test_typing_exception_sets_accept_live_disjoint_paths() -> None:
-    assert type_governance.STANDARD_ONLY == frozenset(
-        {
-            "app/services/file_store_s3.py",
-            "app/services/memory_provider_mem0.py",
-        }
-    )
+    assert type_governance.STANDARD_ONLY == frozenset({"app/services/memory_provider_mem0.py"})
     assert type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY == frozenset(
         {"app/routes/sessions.py"}
     )
@@ -123,6 +118,14 @@ def test_typing_exception_sets_accept_live_disjoint_paths() -> None:
         type_governance.STANDARD_ONLY,
         type_governance.RUNTIME_OBSERVATION_COMPATIBILITY_ONLY,
     )
+
+
+def test_s3_is_strict_and_cannot_retain_a_stale_exception() -> None:
+    path = "app/services/file_store_s3.py"
+
+    assert path in type_governance.STRICT_PRODUCTION_FILES
+    assert path not in type_governance.STANDARD_ONLY
+    assert path not in type_governance.EXPECTED_STRICT_EXCEPTION_DIAGNOSTICS
 
 
 def test_typing_exception_sets_reject_overlap() -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -180,9 +180,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/62/fbe74ff470757616468c11d735a128ae10f3743845675c1aae2d4d7d2a24/boto3_stubs-1.43.14-py3-none-any.whl", hash = "sha256:9cb47a627714aa1c4a41ddf6320be7d10b3eaae9748459cd8f71659a7d8020ca", size = 70667, upload-time = "2026-05-22T20:48:30.598Z" },
 ]
 
-[package.optional-dependencies]
-s3 = [
-    { name = "mypy-boto3-s3" },
+[[package]]
+name = "boto3-stubs-full"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/27/7dabfad6788c5a7395291d8b4c1024b35e90dd529052ce45932cecaebcb2/boto3_stubs_full-1.43.14.tar.gz", hash = "sha256:54972512d2db7bee2b87e811205f5d9f2a2a3362c13dec71fe4ff789e39cf81a", size = 8766227, upload-time = "2026-05-23T02:44:55.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/0b/5f5e72b0b66e35d28e85deb6fd082a2d72e7b670f51057b75eb37305d206/boto3_stubs_full-1.43.14-py3-none-any.whl", hash = "sha256:119c9373550c6e3287abc681eeb27ce780dfff086431725218bcc91910968b8b", size = 13290667, upload-time = "2026-05-23T02:44:51.211Z" },
 ]
 
 [[package]]
@@ -411,10 +415,10 @@ dev = [
     { name = "aiosqlite" },
     { name = "asyncpg-stubs" },
     { name = "basedpyright" },
-    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "boto3-stubs" },
+    { name = "boto3-stubs-full" },
     { name = "botocore-stubs" },
     { name = "deptry" },
-    { name = "mypy-boto3-s3" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -459,10 +463,10 @@ dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "asyncpg-stubs", specifier = "==0.31.3" },
     { name = "basedpyright", specifier = "==1.39.9" },
-    { name = "boto3-stubs", extras = ["s3"], specifier = "==1.43.14" },
+    { name = "boto3-stubs", specifier = "==1.43.14" },
+    { name = "boto3-stubs-full", specifier = "==1.43.14" },
     { name = "botocore-stubs", specifier = "==1.43.14" },
     { name = "deptry", specifier = ">=0.20" },
-    { name = "mypy-boto3-s3", specifier = "==1.43.14" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.9" },
@@ -1317,15 +1321,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
-]
-
-[[package]]
-name = "mypy-boto3-s3"
-version = "1.43.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/2c/fc409f9ff5904a02cf4c2c1518c34d20cb56f22b2368b35fd0adda2926f3/mypy_boto3_s3-1.43.14.tar.gz", hash = "sha256:73d54c1d0999c73c403dc9a9a3da4a9722715aba116595af08c0d4675f8bc670", size = 77078, upload-time = "2026-05-22T20:48:28.251Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/61/e8e74a3f4c729719efc8b1d00179bc16c302202eac32a1b56a842a997ed2/mypy_boto3_s3-1.43.14-py3-none-any.whl", hash = "sha256:ce77096d6c5f90020c45e34c83d2268ca2bb17726149ce5033751870f7fb4e97", size = 84277, upload-time = "2026-05-22T20:48:25.032Z" },
 ]
 
 [[package]]

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -78,7 +78,7 @@ uv run python -m compileall app scripts tests alembic
 ## Python type governance
 
 BasedPyright runs from the uv development environment. The owned gate covers
-all 185 production modules in standard mode and applies strict mode to 182 of
+all 185 production modules in standard mode and applies strict mode to 183 of
 them. CI also sends every changed `backend/app/**/*.py` file to the fail-closed
 exact-path gate. The gate rejects empty, missing, partial, or malformed
 analysis rather than treating it as success. Its production-file discovery is
@@ -112,16 +112,16 @@ used. Non-production counts may vary in a host-local environment with a
 different interpreter; the production `app` result is the zero-diagnostic
 invariant. Every first-party production module is clean in its owned gate.
 
-The strict-equivalent production audit reports 36 diagnostics across two
-retained standard-mode adapters and one runtime-observation compatibility
-module with byte-frozen symbols; the other 182 production files are
+The strict-equivalent production audit reports 34 diagnostics across one
+retained standard-mode adapter and one runtime-observation compatibility
+module with byte-frozen symbols; the other 183 production files are
 strict-clean. The five reviewed SDK boundary owners have these exact gates:
 
 | SDK boundary | Gate / diagnostics | Locked upstream and first-party normalization |
 | --- | --- | --- |
 | `core/sentry.py` | strict / 0 | `sentry-sdk==2.66.1`; typed `Event`/`Hint` enter one recursive object boundary, credential-shaped keys are redacted, and no SDK response enters application state. |
 | `services/composio.py` | strict / 0 | `composio==0.18.1`, `composio-client==1.43.0`, `mcp==2.0.0`; generated request types and exact first-party Pydantic wire models cover every consumed SDK/MCP result, while SDK error families map to sanitized domain failures. |
-| `services/file_store_s3.py` | standard / 2 | `boto3==1.43.14`, `botocore==1.43.14`, `boto3-stubs==1.43.14`, `botocore-stubs==1.43.14`, and `mypy-boto3-s3==1.43.14`; only the two untyped `boto3.client("s3")` construction calls remain Unknown. The adapter retains the generated `S3Client` internally and validates operation metadata, error payloads, `StreamingBody`, and bytes before returning. |
+| `services/file_store_s3.py` | strict / 0 | `boto3==1.43.14`, `botocore==1.43.14`, `boto3-stubs==1.43.14`, `boto3-stubs-full==1.43.14`, and `botocore-stubs==1.43.14`; the all-in-one generated service bundle resolves the complete public `boto3.client` overload while the S3 literal overload returns the generated `S3Client`. The runtime construction call is unchanged, and the adapter validates operation metadata, error payloads, `StreamingBody`, and bytes before returning. |
 | `services/memory_provider_mem0.py` | standard / 19 | Optional `mem0ai==2.0.14` publishes no `py.typed`; strict-mode missing-stub and Unknown diagnostics stay localized to the two official lazy import blocks and the five public operation callables. Construction uses the public `MemoryClient` path, each consumed operation is checked for existence and callability, and strict Pydantic wire models validate add/search/list/count/get/delete results before domain conversion. See the [official export](https://github.com/mem0ai/mem0/blob/v2.0.14/mem0/__init__.py) and [client source](https://github.com/mem0ai/mem0/blob/v2.0.14/mem0/client/main.py). |
 | `services/postgres_listener.py` | strict / 0 | `asyncpg==0.31.0`, `asyncpg-stubs==0.31.3`; listener callbacks accept a validated string payload only, and connection/listener failures map to `PostgresListenerError`. |
 
@@ -129,8 +129,17 @@ The five Boto distributions use their latest common public patch, 1.43.14:
 [boto3](https://pypi.org/pypi/boto3/1.43.14/json),
 [botocore](https://pypi.org/pypi/botocore/1.43.14/json),
 [boto3-stubs](https://pypi.org/pypi/boto3-stubs/1.43.14/json),
-[botocore-stubs](https://pypi.org/pypi/botocore-stubs/1.43.14/json), and
-[mypy-boto3-s3](https://pypi.org/pypi/mypy-boto3-s3/1.43.14/json).
+[boto3-stubs-full](https://pypi.org/pypi/boto3-stubs-full/1.43.14/json), and
+[botocore-stubs](https://pypi.org/pypi/botocore-stubs/1.43.14/json).
+The generated base stubs declare both public `boto3.client("s3")` and
+`Session.client("s3")` as returning `S3Client`. With only the S3 extra,
+BasedPyright also sees unresolved return types in the same overload set for
+services whose generated packages are absent, so strict mode reports the
+member as partially Unknown. The official all-in-one bundle supplies those
+generated return types, including the same 1.43.14 `mypy_boto3_s3` module
+published by the standalone
+[S3 distribution](https://pypi.org/pypi/mypy-boto3-s3/1.43.14/json), while the
+application keeps boto3's public default-session construction path unchanged.
 The official botocore 1.43.14 and formerly pinned 1.43.62 S3 models have the
 same `PutObject`, `GetObject`, `HeadObject`, and `DeleteObject` operation
 shapes used by this adapter. Their only transitive shape difference for those
@@ -139,9 +148,9 @@ adapter neither sends nor consumes it, so the common-version pin does not
 change its Bucket, Key, Body, ContentType, status, or stream contract.
 
 No local SDK stub or mirrored overload is used to hide diagnostics.
-`STANDARD_ONLY` contains exactly S3 and Mem0, and the owned production
-exclusion set is empty. The exception audit pins the per-file strict diagnostic
-counts (S3 2, Mem0 19, runtime-observation compatibility 15), so either added
+`STANDARD_ONLY` contains exactly Mem0, and the owned production exclusion set
+is empty. The exception audit pins the remaining per-file strict diagnostic
+counts (Mem0 19, runtime-observation compatibility 15), so either added
 debt or a typing improvement fails until the exact allowlist is reviewed. The
 public `S3ObjectStoreClient` protocol is a first-party storage facade, not a
 substitute type for boto: the adapter itself retains the generated official
@@ -169,8 +178,8 @@ used to hide the remaining compatibility boundary. Hosted v1 product and
 deployment infrastructure are outside this repository and are not part of the
 exception.
 
-Done: `owned` reports 185 files and `strict` reports 182 files, with every
-diagnostic count equal to zero; `exceptions` reports the exact 36-diagnostic
+Done: `owned` reports 185 files and `strict` reports 183 files, with every
+diagnostic count equal to zero; `exceptions` reports the exact 34-diagnostic
 strict debt above; `inventory` reports all four areas above.
 
 ## External API import ownership and contracts
@@ -192,16 +201,16 @@ SDK types or pinned official source, typed request construction, runtime
 validation of every consumed response, narrow sanitized exception mapping, and
 contract tests using real official clients, models, or transports.
 
-S3 and Mem0 are the only standard-mode production adapters. Their exact files
-and exact strict diagnostic counts are ratcheted by `type_governance.py`; the
-import inventory prevents their dynamic SDKs from gaining another owner. S3
-uses the generated official client/stubs and validates metadata, error bodies,
-streams, and returned bytes. Mem0 calls the pinned public `MemoryClient`, keeps
-its untyped operation results as `object`, and validates every consumed result
-with strict Pydantic wire models. Tests exercise the official S3 model/pins and
-the real Mem0 client over an official HTTPX transport. No scanner-side inferred
-type, homemade upstream protocol, suppression, or unchecked provider response
-is accepted as evidence.
+Mem0 is the only standard-mode production adapter, and its exact file and
+strict diagnostic count are ratcheted by `type_governance.py`; the import
+inventory prevents dynamic SDKs from gaining another owner. S3 uses the
+strict-clean generated official client/stubs and validates metadata, error
+bodies, streams, and returned bytes. Mem0 calls the pinned public
+`MemoryClient`, keeps its untyped operation results as `object`, and validates
+every consumed result with strict Pydantic wire models. Tests exercise the
+official S3 model/pins and the real Mem0 client over an official HTTPX
+transport. No scanner-side inferred type, homemade upstream protocol,
+suppression, or unchecked provider response is accepted as evidence.
 
 The maintained boundary contracts are:
 


### PR DESCRIPTION
## Summary

- replace the partial S3-only boto3 stubs with the official pinned all-in-one generated bundle
- promote `file_store_s3.py` from standard-only to strict without changing runtime S3 construction or business behavior
- fail closed on stale S3 exceptions and document the verified overload/type-package boundary

## Verification

- `uv lock --check`
- dependency authority and outbound API governance
- BasedPyright owned: 185 files / 0 diagnostics
- BasedPyright strict: 183 files / 0 diagnostics
- strict exception audit: 34 retained diagnostics (Mem0 19, frozen sessions symbols 15)
- focused pytest: 48 passed locally and 48 passed in the Docker clean runner
- Ruff check/format and compileall