### PR TITLE
fix(runtime): support runuser-only hosted images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.37
+
+Package: `clawdi@0.13.37`
+
+### Fixed
+
+- Hosted runtime convergence now uses the standard `runuser` fallback for
+  runtime-user CA checks and systemd operations when an image intentionally
+  omits `gosu`.
+
 ## Clawdi CLI v0.13.36
 
 Package: `clawdi@0.13.36`

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.36",
+      "version": "0.13.37",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.36",
+	"version": "0.13.37",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -59,7 +59,11 @@ import {
 	type RuntimeManifestLoad,
 } from "../runtime/manifest-source";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
-import { runtimeUserUid } from "../runtime/runtime-user-command";
+import {
+	buildRuntimeUserCommand,
+	commandExists,
+	runtimeUserUid,
+} from "../runtime/runtime-user-command";
 import {
 	buildRuntimeBootStatus,
 	ensureRuntimeStateDirs,
@@ -1717,14 +1721,13 @@ function runtimeUserSystemctlResult(
 	const runtimeUser = runtimeUserName();
 	if (process.getuid?.() === 0 && runtimeUser !== "root") {
 		const uid = commandOutput("id", ["-u", runtimeUser]).trim();
-		return runCommandResult("gosu", [
-			runtimeUser,
-			"env",
+		const child = buildRuntimeUserCommand(process.getuid?.(), Number(uid), runtimeUser, "env", [
 			...runtimeUserSystemdEnvArgs(paths, runtimeUser, uid),
 			"systemctl",
 			"--user",
 			...args,
 		]);
+		return runCommandResult(child.command, child.args);
 	}
 	return runCommandResult(systemctlPath(), ["--user", ...args]);
 }
@@ -1741,10 +1744,16 @@ export function buildRuntimeUserReadCommand(
 	runtimeUid: number,
 	runtimeUser: string,
 	path: string,
+	isCommandAvailable: (name: string) => boolean = commandExists,
 ): { command: string; args: string[] } {
-	return currentUid === runtimeUid
-		? { command: "test", args: ["-r", path] }
-		: { command: "gosu", args: [runtimeUser, "test", "-r", path] };
+	return buildRuntimeUserCommand(
+		currentUid,
+		runtimeUid,
+		runtimeUser,
+		"test",
+		["-r", path],
+		isCommandAvailable,
+	);
 }
 
 function commandOutput(command: string, args: string[]): string {

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -25,6 +25,29 @@ export function commandResolvable(command: string): boolean {
 	return isAbsolute(command) ? executableExists(command) : commandExists(command);
 }
 
+export function buildRuntimeUserCommand(
+	currentUid: number | undefined,
+	runtimeUid: number,
+	runtimeUser: string,
+	command: string,
+	args: string[],
+	isCommandAvailable: (name: string) => boolean = commandExists,
+): { command: string; args: string[] } {
+	if (currentUid === runtimeUid) return { command, args };
+	if (currentUid !== 0) {
+		throw new Error(
+			`cannot run command as runtime user ${runtimeUser}: current uid ${String(currentUid)} is not root`,
+		);
+	}
+	if (isCommandAvailable("gosu")) {
+		return { command: "gosu", args: [runtimeUser, command, ...args] };
+	}
+	if (isCommandAvailable("runuser")) {
+		return { command: "runuser", args: ["-u", runtimeUser, "--", command, ...args] };
+	}
+	throw new Error(`cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`);
+}
+
 export function runningAsRoot(): boolean {
 	return typeof process.geteuid === "function" && process.geteuid() === 0;
 }

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -40,9 +40,32 @@ describe("runtime sidecar egress privilege drop", () => {
 	});
 
 	it("checks the CA as the runtime user when convergence runs as root", () => {
-		expect(buildRuntimeUserReadCommand(0, 10001, "clawdi", "/run/clawdi/egress/ca.pem")).toEqual({
+		expect(
+			buildRuntimeUserReadCommand(
+				0,
+				10001,
+				"clawdi",
+				"/run/clawdi/egress/ca.pem",
+				(command) => command === "gosu",
+			),
+		).toEqual({
 			command: "gosu",
 			args: ["clawdi", "test", "-r", "/run/clawdi/egress/ca.pem"],
+		});
+	});
+
+	it("uses standard runuser when the runtime image intentionally omits gosu", () => {
+		expect(
+			buildRuntimeUserReadCommand(
+				0,
+				10001,
+				"clawdi",
+				"/run/clawdi/egress/ca.pem",
+				(command) => command === "runuser",
+			),
+		).toEqual({
+			command: "runuser",
+			args: ["-u", "clawdi", "--", "test", "-r", "/run/clawdi/egress/ca.pem"],
 		});
 	});
 


### PR DESCRIPTION
## Summary
- centralize runtime-user command selection across CA checks and systemd operations
- retain gosu preference and use standard runuser fallback for minimal Hosted images
- release as clawdi@0.13.37

## Verification
- `bash scripts/test.sh cli` (1584 pass, 4 skip)
- CLI typecheck
- Biome
- `git diff --check`