### PR TITLE
fix(web): simplify agent resource copy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4534,7 +4534,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	await expect(page).toHaveTitle("Memories · Clawdi");
 	await expect(page.locator('[data-slot="breadcrumb-page"]')).toHaveText("Memories");
 	await expect(
-		main.getByText("Memories are account-wide and available across all agents.", {
+		main.getByText("Memories and provider settings belong to this account. Changes here affect all agents.", {
 			exact: true,
 		}),
 	).toHaveCount(1);
@@ -4600,7 +4600,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	await expect(main.getByRole("heading", { name: "Connectors", level: 1 })).toBeVisible();
 	await expect(page).toHaveTitle("Connectors · Clawdi");
 	await expect(
-		main.getByText("Account-wide connectors available across all agents.", {
+		main.getByText("Connections belong to this account. Connecting or disconnecting here affects all agents.", {
 			exact: true,
 		}),
 	).toBeVisible();
@@ -4669,18 +4669,18 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	});
 	const removeProjectDialog = page.getByRole("alertdialog", { name: "Unlink this Project?" });
 	await expect(removeProjectDialog).toContainText(
-		"Hosted Shared Knowledge will leave this Agent's Vault resolution order.",
+		"This Agent will no longer use Vaults through Hosted Shared Knowledge.",
 	);
 	await removeProjectDialog.getByRole("button", { name: "Cancel" }).click();
 	await expect(projectStack.getByLabel("Project to link")).toHaveCount(0);
-	await projectStack.getByRole("button", { name: "Link existing", exact: true }).click();
+	await projectStack.getByRole("button", { name: "Link project", exact: true }).click();
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
 	const compactProjectPicker = addProjectDialog.getByLabel("Project to link");
 	await compactProjectPicker.click();
 	await page.getByRole("option", { name: /Hosted Project Choice/ }).click();
 	await expect(
-		addProjectDialog.getByRole("button", { name: "Link Project", exact: true }),
+		addProjectDialog.getByRole("button", { name: "Link project", exact: true }),
 	).toBeEnabled();
 	await addProjectDialog.getByRole("button", { name: "Cancel" }).click();
 	await projectStack.screenshot({ path: testInfo.outputPath("hosted-agent-projects-desktop.png") });
@@ -4730,7 +4730,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	await expect(main.getByRole("button", { name: /Add to agent/i })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "People", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Agents", exact: true })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Attach Vault", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Attach vault", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "View all Skills", exact: true })).toHaveAttribute(
 		"href",
 		`/agents/${railHostedEnvironmentId}/project-access/project-hosted/skills${query}`,
@@ -4825,7 +4825,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	await expect(main.getByRole("heading", { name: "Vaults", level: 2 })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Skills", level: 2 })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Attach Vault", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Attach vault", exact: true })).toBeVisible();
 	await main.screenshot({ path: testInfo.outputPath("hosted-workspace-vaults-desktop.png") });
 	const hostedVaultLink = main.getByRole("link", { name: "Open vault Hosted Scoped Vault" });
 	await page.setViewportSize({ width: 390, height: 844 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1377,7 +1377,7 @@ test("connected Agent Memories keeps established UI through nested list and deta
 	await expect(page).toHaveTitle("Memories · Clawdi");
 	await expect(page.locator('[data-slot="breadcrumb-page"]')).toHaveText("Memories");
 	await expect(
-		main.getByText("Memories are account-wide and available across all agents.", {
+		main.getByText("Memories and provider settings belong to this account. Changes here affect all agents.", {
 			exact: true,
 		}),
 	).toHaveCount(1);
@@ -1418,7 +1418,7 @@ test("connected Agent Connectors keeps established UI through nested list and de
 	const main = page.locator("main");
 	await expect(main.getByRole("heading", { name: "Connectors", level: 1 })).toBeVisible();
 	await expect(
-		main.getByText("Account-wide connectors available across all agents.", {
+		main.getByText("Connections belong to this account. Connecting or disconnecting here affects all agents.", {
 			exact: true,
 		}),
 	).toBeVisible();
@@ -1652,7 +1652,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	});
 	await expect(page).toHaveTitle("Connectors · Clawdi");
 	await expect(
-		main.getByText("Account-wide connectors available across all agents.", {
+		main.getByText("Connections belong to this account. Connecting or disconnecting here affects all agents.", {
 			exact: true,
 		}),
 	).toBeVisible();
@@ -1701,15 +1701,15 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await expect(page).toHaveURL(/\/agents\/agent-smoke-1\/project-access$/);
 	const removeProjectDialog = page.getByRole("alertdialog", { name: "Unlink this Project?" });
 	await expect(removeProjectDialog).toContainText(
-		"Team Knowledge will leave this Agent's Vault resolution order.",
+		"This Agent will no longer use Vaults through Team Knowledge.",
 	);
 	await removeProjectDialog.getByRole("button", { name: "Cancel" }).click();
 	await expect(projectStack.getByLabel("Project to link")).toHaveCount(0);
 	await expect(
-		projectStack.getByRole("button", { name: "Create and link", exact: true }),
+		projectStack.getByRole("button", { name: "Create project", exact: true }),
 	).toBeVisible();
 	const addProjectTrigger = projectStack.getByRole("button", {
-		name: "Link existing",
+		name: "Link project",
 		exact: true,
 	});
 	await expect(addProjectTrigger).toBeVisible();
@@ -1717,14 +1717,14 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
 	await expect(
-		addProjectDialog.getByRole("heading", { name: "Link existing Project" }),
+		addProjectDialog.getByRole("heading", { name: "Link project" }),
 	).toBeVisible();
 	const compactProjectPicker = addProjectDialog.getByLabel("Project to link");
 	await expect(compactProjectPicker).toBeVisible();
 	await compactProjectPicker.click();
 	await page.getByRole("option", { name: /Unrelated Project/ }).click();
 	await expect(
-		addProjectDialog.getByRole("button", { name: "Link Project", exact: true }),
+		addProjectDialog.getByRole("button", { name: "Link project", exact: true }),
 	).toBeEnabled();
 	await addProjectDialog.getByRole("button", { name: "Cancel" }).click();
 	await expect(addProjectDialog).toHaveCount(0);
@@ -1789,8 +1789,8 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await expect(main.getByRole("button", { name: /Add to agent/i })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "People", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Agents", exact: true })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Install on Agent", exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Attach Vault", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Attach vault", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "View all Skills", exact: true })).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-smoke/skills",
@@ -1828,7 +1828,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await expect(main.getByRole("heading", { name: "Skills", level: 2 })).toHaveCount(0);
 	await expect(main.getByRole("heading", { name: "Vaults", level: 2 })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "View all Skills" })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Install on Agent", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: /Add to Project/i })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /Attach Vault/i })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-skills-mobile.png") });
@@ -1873,7 +1873,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await expect(main.getByRole("heading", { name: "Skills", level: 2 })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /Install skill/i })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Attach Vault", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Attach vault", exact: true })).toBeVisible();
 	const desktopWorkspace = page
 		.getByTestId("app-sidebar")
 		.getByRole("group", { name: "Workspace", exact: true });
@@ -1925,12 +1925,12 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		"href",
 		"/agents/agent-smoke-1/project-access/project-context-later/skills",
 	);
-	await expect(main.getByRole("button", { name: /Add to Project/i })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-context-later/vaults",
 	);
-	await expect(main.getByRole("button", { name: "Attach Vault", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Attach vault", exact: true })).toBeVisible();
 	const requestsBeforeInvalidScope = skillRequests.length;
 	await page.goto("/agents/agent-smoke-1/project-access/project-unrelated/skills");
 	await expect(
@@ -1990,7 +1990,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	expect(vaultRequests).toEqual([]);
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-later/skills");
 	await expect(main.getByText(`Project: ${longContextProjectName}`, { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: /Add to Project/i })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: /Attach Vault/i })).toHaveCount(0);
 
 	await page.goto("/agents/agent-smoke-1/vaults");

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1925,7 +1925,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		"href",
 		"/agents/agent-smoke-1/project-access/project-context-later/skills",
 	);
-	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Import skill", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-context-later/vaults",
@@ -1990,7 +1990,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	expect(vaultRequests).toEqual([]);
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-later/skills");
 	await expect(main.getByText(`Project: ${longContextProjectName}`, { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Import skill", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: /Attach Vault/i })).toHaveCount(0);
 
 	await page.goto("/agents/agent-smoke-1/vaults");

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -305,10 +305,10 @@ function AgentProjectsPanel({
 		},
 		onSuccess: () => {
 			onChanged();
-			toast.success("Vault resolution priority updated");
+			toast.success("Project order updated");
 		},
 		onError: (error) =>
-			toast.error("Couldn't update Vault resolution priority", {
+			toast.error("Couldn't update Project order", {
 				description: errorMessage(error),
 			}),
 	});
@@ -389,12 +389,12 @@ function AgentProjectsPanel({
 			) : contexts.length === 0 ? (
 				<EmptyState
 					variant="inset"
-					description="No Projects are linked yet. Skills stay stored in each Project; Vaults attached to linked Projects join this Agent's runtime resolution order."
+					description="No Projects are linked yet. Linking a Project makes its attached Vaults available to this Agent; Skills remain separate."
 				/>
 			) : (
 				<ol
 					className={HERO_GRID_CLASS}
-					aria-label="Linked Projects in Vault resolution order"
+					aria-label="Linked Projects in Vault priority order"
 					data-testid="agent-project-grid"
 				>
 					{contexts.map((binding, position) => {
@@ -439,7 +439,7 @@ function AgentProjectsPanel({
 												title="Unlink this Project?"
 												description={
 													<>
-														<p>{projectName} will leave this Agent's Vault resolution order.</p>
+														<p>This Agent will no longer use Vaults through {projectName}.</p>
 														<p>
 															Its Skills stay stored in the Project, and its Vault attachments are
 															unchanged.
@@ -484,7 +484,8 @@ function AgentProjectsPanel({
 					<DialogHeader>
 						<DialogTitle>Link project</DialogTitle>
 						<DialogDescription>
-							Link a Custom or shared Project. This does not install its Skills on the Agent.
+							Choose a Project to make its attached Vaults available to this Agent. Skills are
+							installed separately.
 						</DialogDescription>
 					</DialogHeader>
 					<form
@@ -504,9 +505,7 @@ function AgentProjectsPanel({
 								disabled={linkContext.isPending}
 							/>
 						) : (
-							<p className="text-sm text-muted-foreground">
-								No Custom or shared Projects are available to link.
-							</p>
+							<p className="text-sm text-muted-foreground">No Projects are available to link.</p>
 						)}
 						<DialogFooter>
 							<Button type="button" variant="ghost" onClick={() => setLinkOpen(false)}>

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -535,7 +535,7 @@ function AgentProjectsPanel({
 					<DialogHeader>
 						<DialogTitle>Create project</DialogTitle>
 						<DialogDescription>
-							Create a Project and link it to this Agent. Install Skills and attach Vaults to the
+							Create a Project and link it to this Agent. Add Skills and attach Vaults to the
 							Project separately.
 						</DialogDescription>
 					</DialogHeader>

--- a/apps/web/src/components/dashboard/workspace-skills-panel.tsx
+++ b/apps/web/src/components/dashboard/workspace-skills-panel.tsx
@@ -55,11 +55,11 @@ export function ConnectedWorkspaceSkillsPanel({
 	return (
 		<div className="space-y-4">
 			<Alert>
-				<AlertTitle>Agent filesystem is the install authority</AlertTitle>
+				<AlertTitle>Install on the Agent</AlertTitle>
 				<AlertDescription className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
 					<span>
-						This browser cannot write the connected Agent's local files. Run the CLI command on the
-						Agent machine; synced Cloud cards below remain read-only projections.
+						This connected Agent manages its own files. Run the command on the Agent machine; Skills
+						appear here after the next sync.
 					</span>
 					<Button
 						size="sm"
@@ -76,7 +76,7 @@ export function ConnectedWorkspaceSkillsPanel({
 				<ApiErrorPanel
 					error={projectionError}
 					onRetry={onRetryProjections}
-					title="Cloud Skill projections unavailable"
+					title="Couldn't load synced Skills"
 				/>
 			) : isLoading ? (
 				<div className={HERO_GRID_CLASS}>
@@ -88,7 +88,7 @@ export function ConnectedWorkspaceSkillsPanel({
 				<EmptyState
 					variant="inset"
 					icon={TerminalSquare}
-					description="No Agent-synced Skill projections yet. Install with the CLI, then sync the Agent."
+					description="No Skills have synced from this Agent yet. Install one with the CLI, then sync the Agent."
 				/>
 			) : (
 				<div className={HERO_GRID_CLASS}>
@@ -98,7 +98,7 @@ export function ConnectedWorkspaceSkillsPanel({
 							skill={skill}
 							cloudSkill={skill}
 							readOnly
-							readOnlyLabel="Agent projection · Read-only"
+							readOnlyLabel="Synced from Agent · Read-only"
 							actions={<ConnectedSkillRemoveAction skill={skill} agentType={agentType} />}
 							skillLink={(cloudSkill) =>
 								agentSkillDetailLink(agentId, cloudSkill.skill_key, projectId, routeSearch)
@@ -119,8 +119,7 @@ export function ConnectedWorkspaceSkillsPanel({
 					<DialogHeader>
 						<DialogTitle>Install skill</DialogTitle>
 						<DialogDescription>
-							Enter a GitHub Skill path, then run the generated command on the connected Agent
-							machine.
+							Enter a GitHub Skill path, then run the generated command on the Agent machine.
 						</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-3">
@@ -174,7 +173,7 @@ function ConnectedSkillRemoveAction({
 					<DialogHeader>
 						<DialogTitle>Uninstall skill</DialogTitle>
 						<DialogDescription>
-							Run this command on the connected Agent machine. This Skill is managed on the Agent.
+							Run this command on the Agent machine. The Skill is stored and managed there.
 						</DialogDescription>
 					</DialogHeader>
 					<CliCommand command={workspaceSkillRemoveCommand(skill.skill_key, agentType)} />

--- a/apps/web/src/lib/project-resource-model.ts
+++ b/apps/web/src/lib/project-resource-model.ts
@@ -67,9 +67,9 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		navLabel: "Skills",
 		description: "Reusable instructions stored and managed in a Project.",
 		managementDescription:
-			"Skills are stored in Projects. Choose a Project, then install or uninstall its Skills. Install each Skill on an Agent separately to run it.",
+			"Skills are stored in Projects. Choose a Project to import, edit, or remove Skills. Install a Project Skill on an Agent separately to run it.",
 		href: PROJECT_RESOURCE_LIST_PATHS.skills,
-		emptyCta: "Browse marketplace",
+		emptyCta: "Import skill",
 		routeGroup: "project-resources",
 		projectScope: "project-managed",
 		pathSegments: ["Projects", "Selected Project", "Skills"],

--- a/apps/web/src/lib/skill-authority.test.ts
+++ b/apps/web/src/lib/skill-authority.test.ts
@@ -22,7 +22,7 @@ describe("skillCapabilities", () => {
 			canSelect: false,
 			canSync: false,
 			readOnlyReason: "agent-sync",
-			badgeLabel: "Agent projection · Read-only",
+			badgeLabel: "Synced from Agent · Read-only",
 		});
 	});
 

--- a/apps/web/src/lib/skill-authority.ts
+++ b/apps/web/src/lib/skill-authority.ts
@@ -47,7 +47,7 @@ export function skillCapabilities(
 	project: Pick<Project, "kind" | "is_owner"> | null | undefined,
 ): SkillCapabilities {
 	if (skill.authority === "agent_sync") {
-		return readOnlyCapabilities("agent-sync", "Agent projection · Read-only");
+		return readOnlyCapabilities("agent-sync", "Synced from Agent · Read-only");
 	}
 	const projectKind = skill.project_kind ?? project?.kind;
 	if (projectKind === "environment") {

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -601,15 +601,15 @@ export default function ProjectDetailPage({
 					isAgentScope
 						? isWorkspace
 							? focus === "skills"
-								? "Skills available in this Agent's Workspace. Skills synced from the Agent are read-only."
+								? "Skills installed in this Agent's Workspace. Skills synced from the Agent are read-only."
 								: focus === "vaults"
 									? "Vaults attached to this Agent's Workspace."
-									: "This Agent's fixed Workspace for installed Skills and attached Vaults."
+									: "Skills and Vaults available directly to this Agent."
 							: focus === "skills"
 								? "Skills stored and managed in this Project. Linking it does not install them on the Agent."
 								: focus === "vaults"
-									? "Vaults this Agent can resolve through this Project."
-									: "Skills stay managed in this Project; its Vaults join the Agent's runtime resolution."
+									? "Vaults available to this Agent through this Project."
+									: "This Agent can use the Project's attached Vaults. Its Skills remain in the Project."
 						: projectDetailDescription(project, isOwner, projectType?.label ?? "Project")
 				}
 				status={
@@ -657,8 +657,8 @@ export default function ProjectDetailPage({
 					<AlertTitle>Project added</AlertTitle>
 					<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 						<span>
-							Linking makes attached Vaults available in Agent runtime resolution. Skills stay
-							stored and managed in this Project until separately installed on an Agent.
+							Linking makes attached Vaults available to an Agent. Project Skills remain separate
+							until you install them on that Agent.
 						</span>
 						<Button type="button" size="sm" onClick={() => setUseWithAgentOpen(true)}>
 							<Bot className="mr-1.5 size-3.5" />
@@ -691,10 +691,10 @@ export default function ProjectDetailPage({
 				description={
 					isAgentScope
 						? isWorkspace
-							? "Installed Skills in this Agent's fixed Workspace."
+							? "Skills installed in this Agent's Workspace."
 							: "Skills are stored and managed in this Project; linking does not install them."
 						: project.kind === "environment"
-							? "Read-only projections authored on this Agent's filesystem."
+							? "Skills synced from this Agent. Manage them on the Agent."
 							: isOwner
 								? "Reusable instructions stored in this Project."
 								: "Readable instructions shared by the owner."
@@ -813,7 +813,7 @@ export default function ProjectDetailPage({
 					isAgentScope
 						? isWorkspace
 							? "Vaults attached to this Agent's Workspace."
-							: "Vaults this Agent can use through this Project."
+							: "Vaults available to this Agent through this Project."
 						: isOwner
 							? "API keys and secrets this Project can use."
 							: "Read-only vaults shared through this Project."
@@ -956,7 +956,7 @@ export default function ProjectDetailPage({
 				<HubSection
 					id="people"
 					title="Your access"
-					description="You have viewer access to stored Skills and Vault key names. Install Skills on an Agent separately; attached Vaults can participate in runtime resolution after linking the Project."
+					description="You can view this Project's Skills and Vault key names. Link the Project to let an Agent use its attached Vaults; install Skills separately."
 				>
 					<SharedAccessPanel
 						project={project}
@@ -975,10 +975,10 @@ export default function ProjectDetailPage({
 					count={agentCount}
 					description={
 						project.kind === "environment"
-							? "Home Agent for this managed Workspace."
+							? "Agent that owns this Workspace."
 							: project.kind === "personal"
 								? "This Global Project belongs to your account and is not linked to individual Agents."
-								: "Agents linked to this Project for Vault runtime resolution."
+								: "Agents that can use this Project's attached Vaults."
 					}
 				>
 					{boundAgents.isLoading || environments.isLoading ? (
@@ -1006,7 +1006,7 @@ export default function ProjectDetailPage({
 									? "The home Agent for this Workspace is unavailable."
 									: project.kind === "personal"
 										? "Global Project belongs to your account and has no Agent links."
-										: "No Agents are linked yet. Linking adds attached Vaults to runtime resolution; it does not install Skills."
+										: "No Agents are linked yet. Linking makes attached Vaults available; Skills are installed separately."
 							}
 						/>
 					) : (
@@ -1167,10 +1167,10 @@ function projectDetailDescription(project: ProjectRow, isOwner: boolean, typeLab
 	if (project.kind === "workspace") {
 		return isOwner
 			? `${typeLabel} you own. Install Skills and attach Vaults here, share the Project, then link it to Agents when needed. Linking does not install its Skills.`
-			: `${typeLabel} shared with you. Its Skills stay stored here, while attached Vaults can join an Agent's runtime resolution after you link the Project.`;
+			: `${typeLabel} shared with you. Its Skills stay here; link the Project to let an Agent use its attached Vaults.`;
 	}
 	if (project.kind === "environment") {
-		return `${typeLabel} ${access}. This Workspace belongs to one connected Agent. It is managed for you and cannot be shared.`;
+		return `${typeLabel} ${access}. This Workspace belongs to one connected Agent and cannot be shared.`;
 	}
 	if (project.kind === "personal") {
 		return `${typeLabel} ${access}. This is your account default for resources that are not tied to one workflow or agent.`;
@@ -1237,8 +1237,8 @@ function SharedAccessPanel({
 					<h2 className="text-sm font-semibold">You Have Viewer Access</h2>
 				</div>
 				<p className="text-xs text-muted-foreground">
-					You can read this Project and link it to an Agent. Its attached Vaults then join runtime
-					resolution; its Skills stay stored here until separately installed on the Agent.
+					You can view this Project and link it to an Agent. The Agent can then use its attached
+					Vaults; install Project Skills separately.
 				</p>
 			</div>
 			<div className="rounded-md border bg-background/60 p-3">
@@ -1265,8 +1265,8 @@ function SharedAccessPanel({
 					<AlertDialogHeader>
 						<AlertDialogTitle>Leave {displayProjectName(project)}?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This removes your read-only membership. Your Agents will stop resolving attached
-							Vaults through this Project; Project Skills remain separate from Agent installs.
+							This removes your read-only membership. Your Agents will lose access to Vaults through
+							this Project; Project Skills remain separate from Agent installs.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -1344,7 +1344,7 @@ function UseProjectWithAgentDialog({
 			qc.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(selectedAgentId) });
 			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			toast.success("Project linked", {
-				description: `${projectName}'s attached Vaults now participate in ${agentName}'s runtime resolution. Skills remain stored in the Project until separately installed on the Agent.`,
+				description: `${agentName} can now use ${projectName}'s attached Vaults. Project Skills remain separate until installed on the Agent.`,
 				action: {
 					label: "Open Agent",
 					onClick: () =>
@@ -1367,8 +1367,8 @@ function UseProjectWithAgentDialog({
 				<DialogHeader>
 					<DialogTitle>Link project to Agent</DialogTitle>
 					<DialogDescription>
-						Link {projectName} as a context Project. Attached Vaults join runtime resolution; Skills
-						remain stored here and must be installed on the Agent separately.
+						Link {projectName} to make its attached Vaults available to the Agent. Project Skills
+						remain separate until you install them on the Agent.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -1461,7 +1461,7 @@ function UseProjectWithAgentDialog({
 										<div className="font-medium">Already Linked</div>
 										<p className="mt-1 text-xs text-muted-foreground">
 											Open the Agent&apos;s {AGENT_PROJECTS_SECTION_LABEL} section to review its
-											Vault resolution priority or unlink it.
+											Project order or unlink it.
 										</p>
 									</div>
 								</div>
@@ -1471,8 +1471,8 @@ function UseProjectWithAgentDialog({
 									<div>
 										<div className="font-medium">Link as Project</div>
 										<p className="mt-1 text-xs text-muted-foreground">
-											Attached Vaults join the selected Agent&apos;s runtime resolution. Skills stay
-											stored in this Project until separately installed on the Agent.
+											The selected Agent can use attached Vaults. Project Skills remain separate
+											until installed on the Agent.
 										</p>
 									</div>
 								</div>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -711,7 +711,7 @@ export default function ProjectDetailPage({
 							{canManageProjectSkills ? (
 								<Button variant="outline" size="sm" onClick={() => setInstallSkillOpen(true)}>
 									<Plus className="size-3.5" />
-									Install skill
+									Import skill
 								</Button>
 							) : null}
 						</>
@@ -956,7 +956,7 @@ export default function ProjectDetailPage({
 				<HubSection
 					id="people"
 					title="Your access"
-					description="You can view this Project's Skills and Vault key names. Link the Project to let an Agent use its attached Vaults; install Skills separately."
+					description="You can view this Project's Skills and Vault key names. Link the Project to let an Agent use its attached Vaults; install its Skills on the Agent separately."
 				>
 					<SharedAccessPanel
 						project={project}
@@ -1166,7 +1166,7 @@ function projectDetailDescription(project: ProjectRow, isOwner: boolean, typeLab
 	const access = isOwner ? "you own" : "shared with you";
 	if (project.kind === "workspace") {
 		return isOwner
-			? `${typeLabel} you own. Install Skills and attach Vaults here, share the Project, then link it to Agents when needed. Linking does not install its Skills.`
+			? `${typeLabel} you own. Add Skills and attach Vaults here, share the Project, then link it to Agents when needed. Linking does not install its Skills.`
 			: `${typeLabel} shared with you. Its Skills stay here; link the Project to let an Agent use its attached Vaults.`;
 	}
 	if (project.kind === "environment") {
@@ -1555,7 +1555,7 @@ function InstallSkillInProjectDialog({
 			setError(null);
 			onOpenChange(false);
 			onChanged();
-			toast.success("Skill installed", { description: "Saved in this Project." });
+			toast.success("Skill imported", { description: "Saved in this Project." });
 		},
 		onError: (e) => {
 			setError(errorMessage(e));
@@ -1594,8 +1594,8 @@ function InstallSkillInProjectDialog({
 		>
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>
-					<DialogTitle>Install skill</DialogTitle>
-					<DialogDescription>Install a GitHub Skill into this Project.</DialogDescription>
+					<DialogTitle>Import skill</DialogTitle>
+					<DialogDescription>Copy a GitHub Skill into this Project.</DialogDescription>
 				</DialogHeader>
 				<div className="space-y-2">
 					<Label htmlFor={`project-skill-repo-${projectId}`}>GitHub skill repository</Label>
@@ -1631,7 +1631,7 @@ function InstallSkillInProjectDialog({
 					</Button>
 					<Button onClick={submit} disabled={!repoInput.trim() || install.isPending}>
 						{install.isPending ? <Spinner /> : <Plus className="size-3.5" />}
-						Install skill
+						Import skill
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -232,7 +232,7 @@ export default function ProjectsPage() {
 					<DialogHeader>
 						<DialogTitle>Create project</DialogTitle>
 						<DialogDescription>
-							Create a Project for a team, workflow, repo, or shareable resources. Install Skills,
+							Create a Project for a team, workflow, repo, or shareable resources. Add Skills,
 							attach Vaults, and configure sharing after it is created.
 						</DialogDescription>
 					</DialogHeader>

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -377,7 +377,7 @@ export function SkillDetailContent({
 			return;
 		}
 		if (!capabilities?.canDelete) {
-			toast.error("This Skill is read-only in Cloud");
+			toast.error("This Skill is read-only here");
 			return;
 		}
 		uninstall.mutate();
@@ -389,7 +389,7 @@ export function SkillDetailContent({
 	const agentCaption = isAgentSyncProjection
 		? skillAgentLabel
 			? `synced from ${skillAgentLabel}`
-			: "synced from Agent runtime"
+			: "synced from Agent"
 		: sourceProjectName
 			? `stored in ${sourceProjectName}`
 			: null;
@@ -467,10 +467,7 @@ export function SkillDetailContent({
 							</div>
 							<div className="flex w-full shrink-0 flex-wrap gap-2 sm:w-auto sm:justify-end">
 								{!accessKnown ? null : isReadOnly ? (
-									<Badge
-										variant="secondary"
-										title="Cloud mutations are disabled for this Skill's authority or Project."
-									>
+									<Badge variant="secondary" title="This Skill is managed elsewhere.">
 										{capabilities?.badgeLabel ?? "Read-only"}
 									</Badge>
 								) : !isEditing ? (
@@ -664,7 +661,7 @@ export function SkillDetailContent({
 									</div>
 									<p className="text-xs text-muted-foreground">
 										{isAgentSyncProjection
-											? "This read-only instruction file was projected from the Agent runtime."
+											? "This instruction file was synced from the Agent and is managed there."
 											: "This instruction file is stored in the Project. Install the Skill on an Agent separately to run it."}
 									</p>
 								</div>
@@ -693,7 +690,7 @@ export function SkillDetailContent({
 									</div>
 									<p className="text-xs text-muted-foreground">
 										{isAgentSyncProjection
-											? "The Agent runtime reported this Skill, but its read-only projection does not include an instruction body yet."
+											? "This Skill was synced from the Agent, but its instructions are not available yet."
 											: "This Project Skill has no editable instruction body."}
 									</p>
 								</div>
@@ -705,7 +702,7 @@ export function SkillDetailContent({
 								variant="inset"
 								description={
 									isAgentSyncProjection
-										? "When the Agent uploads its Skill file content, the read-only preview will appear here."
+										? "The preview will appear after the Agent syncs its Skill files."
 										: "No instruction content is stored for this Skill."
 								}
 							/>

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -643,7 +643,7 @@ function SkillsPageInner() {
 					</AlertTitle>
 					<AlertDescription>
 						{targetProject.kind === "environment"
-							? "Agent Skills are authored on the Agent filesystem and sync here as read-only projections. Rename, edit, or remove them on the Agent."
+							? "Skills in this Workspace are managed on the Agent and sync here as read-only. Rename, edit, or remove them on the Agent."
 							: `You can view Skills stored in ${displayProjectName(targetProject)}, but only the owner can add or remove them.`}
 					</AlertDescription>
 				</Alert>

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -474,9 +474,9 @@ function SkillsPageInner() {
 		: isStaleTarget
 			? "This link points to an agent that no longer exists. Pick a Project above."
 			: orderedProjects.length === 0
-				? "Create a Project first, then install Skills in it."
+				? "Create a Project first, then add Skills to it."
 				: isProjectReady
-					? "No Skills are stored in this Project yet. Install one from the marketplace below."
+					? "No Skills are stored in this Project yet. Import one from GitHub below."
 					: "Pick a Project to see its skills.";
 	const canShareTargetProject =
 		targetProject && isProjectOwner(targetProject) && isCustomProject(targetProject);
@@ -883,7 +883,7 @@ function SkillsPageInner() {
 			) : canWriteTargetProject ? (
 				<section className="space-y-3">
 					<div className="flex items-center justify-between gap-2">
-						<h2 className="text-sm font-semibold">Install a skill</h2>
+						<h2 className="text-sm font-semibold">Import from GitHub</h2>
 						<a
 							href="https://skills.sh"
 							target="_blank"
@@ -923,7 +923,7 @@ function SkillsPageInner() {
 							className="sm:w-auto"
 						>
 							{installing && customRepo ? <Spinner /> : <Plus />}
-							Install skill
+							Import skill
 						</Button>
 					</div>
 					{customRepoError ? <p className="text-xs text-destructive">{customRepoError}</p> : null}
@@ -931,7 +931,7 @@ function SkillsPageInner() {
 						<ApiErrorPanel
 							error={installError}
 							onRetry={customRepo.trim() ? retryCustomInstall : undefined}
-							title="Couldn't install skill"
+							title="Couldn't import skill"
 						/>
 					) : null}
 
@@ -981,7 +981,7 @@ function SkillsPageInner() {
 											className="shrink-0"
 										>
 											{isInstalling ? <Spinner /> : <Plus />}
-											Install skill
+											Add to Project
 										</Button>
 									)}
 								</div>

--- a/apps/web/src/routes/-agent-project-resource-routes.test.ts
+++ b/apps/web/src/routes/-agent-project-resource-routes.test.ts
@@ -53,6 +53,6 @@ describe("Agent Project resource routes", () => {
 		expect(projectPage).toContain(`aria-label={\`View all \${resource}\`}`);
 		expect(projectPage).toContain("agentDeploymentRouteQuery(scope.agentQuery)");
 		expect(projectPage).toContain("!focus && projectResourceTargets");
-		expect(projectPage).toContain("Install skill");
+		expect(projectPage).toContain("Import skill");
 	});
 });


### PR DESCRIPTION
## Summary

- remove implementation terms such as projection, install authority, and runtime resolution from Agent resource UI
- clarify Workspace Skills/Vaults, linked Project, and account-wide resource boundaries
- align existing Connected and Hosted browser journeys with the canonical action labels

## Verification

- Web TypeScript typecheck
- focused Skill authority tests (6 passed)
- OSS production build
- Biome on all changed files
- Connected Agent resource Playwright journey
- Hosted Agent resource Playwright journey
- git diff --check

No resource model, API, route, or permission behavior changed.