### PR TITLE
fix: allow Tailscale runtime state and locks

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -131,6 +131,9 @@ accessories:
     options:
       cap-drop: ALL
       cap-add:
+        # Kamal creates the private bind mount as the SSH UID; container root
+        # needs the dropped DAC capability to traverse and persist state.
+        - DAC_OVERRIDE
         - NET_ADMIN
         - NET_RAW
       # iptables-legacy opens a raw control socket; dropping Docker defaults
@@ -140,7 +143,7 @@ accessories:
       security-opt: no-new-privileges:true
       tmpfs:
         - /tmp:rw,noexec,nosuid,nodev,size=16m
-        - /var/run/tailscale:rw,noexec,nosuid,nodev,size=4m
+        - /run:rw,noexec,nosuid,nodev,size=8m
     env:
       clear:
         TS_STATE_DIR: /var/lib/tailscale
@@ -187,11 +190,15 @@ accessories:
       entrypoint: /bin/sh
       cap-drop: ALL
       cap-add:
+        # Required to publish the marker inside Kamal's private bind mount.
+        - DAC_OVERRIDE
         - NET_ADMIN
         - NET_RAW
       read-only: true
       security-opt: no-new-privileges:true
-      tmpfs: /tmp:rw,noexec,nosuid,nodev,size=4m
+      tmpfs:
+        - /tmp:rw,noexec,nosuid,nodev,size=4m
+        - /run:rw,noexec,nosuid,nodev,size=4m
 <% end %>
 
   whatsapp-baileys:

--- a/docs/runbooks/whatsapp-baileys-sidecars.md
+++ b/docs/runbooks/whatsapp-baileys-sidecars.md
@@ -58,6 +58,12 @@ Baileys receives that directory read-only. Do not replace these mounts with a
 host root, Docker socket, network filesystem, or an automatically pruned
 volume.
 
+The kernel-networking containers keep a read-only root filesystem and bounded
+`/tmp` and `/run` tmpfs mounts; `/run` carries the iptables lock files. After
+dropping all default capabilities, they retain `DAC_OVERRIDE` only so their
+root process can access the two Kamal-created `0700` bind mounts, plus the
+network capabilities required for TUN and firewall setup.
+
 ## Optional Tailscale exit-node egress
 
 The checked-in configuration is inert by default. Merging it does not create a

--- a/scripts/deploy-whatsapp-sidecar.sh
+++ b/scripts/deploy-whatsapp-sidecar.sh
@@ -71,7 +71,7 @@ if [[ "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" == true ]]; then
 	WHATSAPP_TAILSCALE_CONFIG_REVISION="$(printf '%s\n' \
 		'registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c' \
 		"${tailscale_image}" \
-		'kernel-netns-uid-killswitch-v3-hardened-mounts' \
+		'kernel-netns-uid-killswitch-v4-runtime-permissions' \
 		"${WHATSAPP_TAILSCALE_EXIT_NODE}" | sha256sum | cut -d ' ' -f 1)"
 	export WHATSAPP_TAILSCALE_CONFIG_REVISION
 elif [[ -n "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" && "${WHATSAPP_TAILSCALE_EGRESS_ENABLED}" != false ]]; then

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -83,12 +83,20 @@ end
 raise "infra did not own the Kamal bridge namespace" unless option?(commands.fetch("whatsapp-netns"), "--network", "kamal")
 tailscale = commands.fetch("whatsapp-tailscale")
 raise "Tailscale did not join infra" unless option?(tailscale, "--network", "container:clawdi-whatsapp-netns")
+raise "Tailscale lost state-directory access" unless option?(tailscale, "--cap-add", "DAC_OVERRIDE")
 raise "Tailscale lost NET_ADMIN" unless option?(tailscale, "--cap-add", "NET_ADMIN")
 raise "Tailscale lost NET_RAW" unless option?(tailscale, "--cap-add", "NET_RAW")
 raise "Tailscale lost tun" unless option?(tailscale, "--device", "/dev/net/tun:/dev/net/tun")
+raise "Tailscale lost its writable runtime directory" unless option?(
+  tailscale, "--tmpfs", "/run:rw,noexec,nosuid,nodev,size=8m"
+)
 guard = commands.fetch("whatsapp-egress-guard")
 raise "guard did not join infra" unless option?(guard, "--network", "container:clawdi-whatsapp-netns")
 raise "guard entrypoint drifted" unless option?(guard, "--entrypoint", "/bin/sh")
+raise "guard lost marker-directory access" unless option?(guard, "--cap-add", "DAC_OVERRIDE")
+raise "guard lost its writable runtime directory" unless option?(
+  guard, "--tmpfs", "/run:rw,noexec,nosuid,nodev,size=4m"
+)
 guard_cmd = config.accessory("whatsapp-egress-guard").cmd
 unless guard_cmd.start_with?("-ceu '") && guard_cmd.end_with?("'") && guard_cmd.count("'") == 2
   raise "guard command quoting drifted"


### PR DESCRIPTION
## Summary

- restore `DAC_OVERRIDE` after `cap-drop: ALL` for the Tailscale and guard containers so their root processes can access the narrow Kamal-created `0700` bind mounts
- provide each read-only container with a bounded `/run` tmpfs for iptables lock files
- bump the egress configuration revision so existing accessories are recreated
- keep the root filesystem read-only and retain only the explicit DAC and network capabilities

## Root cause

The first production activation failed closed before Baileys restarted. Tailscale logs showed both `permission denied` for `/var/lib/tailscale/tailscaled.state` and `Read-only file system` for `/run/xtables.lock`. With all default capabilities dropped, root no longer had DAC override access to the SSH-UID-owned `0700` bind mount; the read-only root filesystem also lacked a writable `/run`.

The gate has been restored to `false`, Baileys is healthy on bridge, and the failed Tailscale/namespace containers were stopped.

## Verification

- official Tailscale v1.98.10 Docker probe: failure reproduced without `DAC_OVERRIDE`; state write and iptables lock succeeded with the focused capability and `/run` tmpfs
- Kamal 2.12 enabled/disabled render and Docker command contract
- deployment helper behavior test and Bash syntax
- CLI WhatsApp deployment contract: 6 tests, 63 assertions
- `git diff --check`