### PR TITLE
fix: align WhatsApp egress with container semantics

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -139,7 +139,8 @@ accessories:
       # iptables-legacy opens a raw control socket; dropping Docker defaults
       # therefore also requires restoring NET_RAW (verified with this image).
       device: /dev/net/tun:/dev/net/tun
-      read-only: true
+      # Tailscale's direct DNS manager updates /etc/resolv.conf and keeps its
+      # backup beside it. Leave only this disposable container layer writable.
       security-opt: no-new-privileges:true
       tmpfs:
         - /tmp:rw,noexec,nosuid,nodev,size=16m
@@ -170,11 +171,6 @@ accessories:
       iptables -C "$chain" -o tailscale0 -j ACCEPT 2>/dev/null || iptables -A "$chain" -o tailscale0 -j ACCEPT;
       iptables -C "$chain" -j REJECT 2>/dev/null || iptables -A "$chain" -j REJECT;
       iptables -C OUTPUT -m owner --uid-owner 1000 -j "$chain" 2>/dev/null || iptables -I OUTPUT 1 -m owner --uid-owner 1000 -j "$chain";
-      ip6tables -N "$chain" 2>/dev/null || true;
-      ip6tables -C "$chain" -o lo -d ::1/128 -j ACCEPT 2>/dev/null || ip6tables -A "$chain" -o lo -d ::1/128 -j ACCEPT;
-      ip6tables -C "$chain" -o tailscale0 -j ACCEPT 2>/dev/null || ip6tables -A "$chain" -o tailscale0 -j ACCEPT;
-      ip6tables -C "$chain" -j REJECT 2>/dev/null || ip6tables -A "$chain" -j REJECT;
-      ip6tables -C OUTPUT -m owner --uid-owner 1000 -j "$chain" 2>/dev/null || ip6tables -I OUTPUT 1 -m owner --uid-owner 1000 -j "$chain";
       marker="$(cat /proc/sys/kernel/random/boot_id) $(stat -Lc %i /proc/self/ns/net)";
       marker_tmp="$(mktemp /guard/.network-namespace.ready.XXXXXX)";
       { printf "%s\n" "$marker" > "$marker_tmp" &&

--- a/docs/runbooks/whatsapp-baileys-sidecars.md
+++ b/docs/runbooks/whatsapp-baileys-sidecars.md
@@ -87,18 +87,25 @@ mode. Tailscale uses the official v1.98.10 image pinned by immutable digest,
 `/dev/net/tun`, and only `NET_ADMIN` plus `NET_RAW` (required by the image's
 iptables-legacy control socket after dropping Docker's default capabilities).
 Its identity persists under `/home/phala/clawdi-whatsapp/tailscale-state`.
+Its disposable container layer remains writable because Tailscale's Linux
+direct DNS manager updates `/etc/resolv.conf` and stores its backup in `/etc`;
+the persistent state and guard mounts keep their narrower permissions.
 The exit-node argument explicitly disables LAN access.
 `TS_AUTH_ONCE=true` makes the auth key a bootstrap credential: subsequent
 container replacements reuse the persisted node identity instead of requiring
 the key to remain valid.
 
-The guard installs IPv4 and IPv6 OUTPUT chains matching only numeric UID 1000.
-That UID may use `tailscale0` and the exact local loopback address; every other
-interface is rejected. Tailscaled runs as root, so its underlay remains able to
-reach the Tailscale control plane and DERP. If `tailscale0` or its route
-disappears, Baileys traffic selects the bridge interface and is rejected rather
-than falling back. Baileys uses `100.100.100.100` through a read-only resolver
-file, so Docker's `127.0.0.11` underlay DNS is not an escape path.
+The deploy helper requires Docker's standard `kamal` underlay network to report
+`EnableIPv6=false` before it stops or replaces Baileys. The guard therefore
+installs one IPv4 OUTPUT chain matching only numeric UID 1000, covering every
+possible direct underlay route. That UID may use `tailscale0` and the exact local
+loopback address; every other interface is rejected. Tailscaled runs as root, so
+its underlay remains able to reach the Tailscale control plane and DERP.
+Tailscale still provides both IPv4 and IPv6 on `tailscale0`; the Docker-facing
+`eth0` has no IPv6 address or route. If `tailscale0` or its routes disappear,
+IPv4 bridge fallback is rejected and no IPv6 underlay exists. Baileys uses
+`100.100.100.100` through a read-only resolver file, so Docker's `127.0.0.11`
+underlay DNS is not an escape path.
 `TS_ACCEPT_DNS=true` is still required: in v1.98.10, disabled CorpDNS returns
 from `dnsConfigForNetmap` before exit-node/default resolvers are populated for
 Quad100. Enabling it makes Quad100 use the tailnet and exit-node DNS policy;
@@ -125,8 +132,9 @@ Baileys mounts the same host directory read-write and listens on
 `/run/clawdi-whatsapp/sidecar.sock`. The UDS therefore remains host-volume
 communication and is independent of Tailscale egress.
 
-Every enabled release requires the kernel Tailscale interface, matching shared
-network namespace, and IPv4/IPv6 guard rules before starting Baileys. A
+Every enabled release requires an IPv4-only Docker underlay, the kernel
+Tailscale interface, matching shared network namespace, and the IPv4 guard
+rules before starting Baileys. A
 Tailscale restart does not remove guard rules because the pause container owns
 the namespace; a pause restart forces both consumers to be recreated after the
 new guard marker.

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -48,6 +48,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 		expect(deploy).toContain("NET_ADMIN");
 		expect(deploy).toContain("NET_RAW");
 		expect(deploy).toContain("iptables -I OUTPUT 1 -m owner --uid-owner 1000");
+		expect(deploy).not.toContain("ip6tables");
+		expect(deployHelper).toContain("docker network inspect --format '{{.EnableIPv6}}' kamal");
+		expect(deployHelper).toContain("/bin/sh -ceu 'ip link show tailscale0");
 		expect(deploy).toContain("network-namespace.ready");
 		expect(deploy).toContain("TS_AUTHKEY");
 		expect(workflow).toContain('*[!A-Za-z0-9_-]*|"")');

--- a/scripts/deploy-whatsapp-sidecar.sh
+++ b/scripts/deploy-whatsapp-sidecar.sh
@@ -71,7 +71,7 @@ if [[ "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" == true ]]; then
 	WHATSAPP_TAILSCALE_CONFIG_REVISION="$(printf '%s\n' \
 		'registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c' \
 		"${tailscale_image}" \
-		'kernel-netns-uid-killswitch-v4-runtime-permissions' \
+		'kernel-netns-ipv4-underlay-uid-killswitch-container-shell-readiness-writable-dns' \
 		"${WHATSAPP_TAILSCALE_EXIT_NODE}" | sha256sum | cut -d ' ' -f 1)"
 	export WHATSAPP_TAILSCALE_CONFIG_REVISION
 elif [[ -n "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" && "${WHATSAPP_TAILSCALE_EGRESS_ENABLED}" != false ]]; then
@@ -98,6 +98,12 @@ sidecar_needs_reboot=false
 [[ "${sidecar_running}" == true ]] || sidecar_needs_reboot=true
 
 if [[ "${egress_enabled}" == true ]]; then
+	# Kamal's standard Docker network is the only underlay. Keep it IPv4-only so
+	# the UID firewall below covers every possible direct egress interface;
+	# Tailscale continues to provide both IPv4 and IPv6 on tailscale0.
+	kamal server exec \
+		"test \"\$(docker network inspect --format '{{.EnableIPv6}}' kamal)\" = false"
+
 	# A sidecar left on bridge by a previous disabled release must lose direct
 	# egress before preparing the guarded Tailscale namespace.
 	if [[ "${actual_network}" != "${desired_network}" ]]; then
@@ -143,7 +149,7 @@ if [[ "${egress_enabled}" == true ]]; then
 	tailscale_ready=false
 	for _attempt in $(seq 1 24); do
 		if kamal accessory exec whatsapp-tailscale --reuse \
-			"ip link show tailscale0 >/dev/null && tailscale status --json >/dev/null" \
+			"/bin/sh -ceu 'ip link show tailscale0 >/dev/null; tailscale status --json | grep -Eq \"\\\"BackendState\\\"[[:space:]]*:[[:space:]]*\\\"Running\\\"\"'" \
 			>/dev/null 2>&1; then
 			tailscale_ready=true
 			break
@@ -163,13 +169,12 @@ if [[ "${egress_enabled}" == true ]]; then
 	guard_ready=false
 	for _attempt in $(seq 1 12); do
 		if kamal accessory exec whatsapp-egress-guard --reuse \
-			"iptables -C OUTPUT -m owner --uid-owner 1000 -j CLAWDI_WA_EGRESS && \
-			 iptables -C CLAWDI_WA_EGRESS -o tailscale0 -j ACCEPT && \
-			 iptables -C CLAWDI_WA_EGRESS -j REJECT && \
-			 ip6tables -C OUTPUT -m owner --uid-owner 1000 -j CLAWDI_WA_EGRESS && \
-			 test -f /guard/network-namespace.ready && \
-			 test ! -L /guard/network-namespace.ready && \
-			 test \"\$(stat -c '%a' /guard/network-namespace.ready)\" = 644" \
+			"/bin/sh -ceu 'iptables -C OUTPUT -m owner --uid-owner 1000 -j CLAWDI_WA_EGRESS; \
+			 iptables -C CLAWDI_WA_EGRESS -o tailscale0 -j ACCEPT; \
+			 iptables -C CLAWDI_WA_EGRESS -j REJECT; \
+			 test -f /guard/network-namespace.ready; \
+			 test ! -L /guard/network-namespace.ready; \
+			 test \"\$(stat -c %a /guard/network-namespace.ready)\" = 644'" \
 			>/dev/null 2>&1; then
 			guard_ready=true
 			break

--- a/scripts/test-deploy-whatsapp-sidecar.sh
+++ b/scripts/test-deploy-whatsapp-sidecar.sh
@@ -8,6 +8,8 @@ cat > "${tmp}/bin/kamal" <<'FAKE'
 set -euo pipefail
 echo "$*" >> "${FAKE_LOG}"
 case "$*" in
+ *"docker network inspect --format '{{.EnableIPv6}}' kamal"*)
+   [[ "${SCENARIO}" == ipv6_underlay ]] && exit 1 || : ;;
  *"accessory stop whatsapp-baileys"*)
    [[ "${SCENARIO}" == stop_failure ]] && exit 1
    [[ "${SCENARIO}" == stop_still_running ]] || touch "${FAKE_LOG}.sidecar-stopped" ;;
@@ -96,6 +98,9 @@ test "$infra" -lt "$tailscale" && test "$tailscale" -lt "$guard"
 test "$guard" -lt "$sidecar"
 grep -q 'accessory stop whatsapp-baileys' "$transition"
 grep -q 'iptables -C OUTPUT -m owner --uid-owner 1000' "$transition"
+grep -q "docker network inspect --format '{{.EnableIPv6}}' kamal" "$transition"
+grep -q "/bin/sh -ceu 'ip link show tailscale0" "$transition"
+! grep -q 'ip6tables' "$transition"
 grep -q "stat -c '%u:%g:%a' '/home/phala/clawdi-whatsapp/tailscale-state'" "$transition"
 grep -q "stat -c '%u:%g:%a' '/home/phala/clawdi-whatsapp/egress-guard'" "$transition"
 grep -q "mktemp '/home/phala/clawdi-whatsapp/.tailscale-resolv.conf.XXXXXX'" "$transition"
@@ -113,6 +118,9 @@ stop_failure="$(run_failure stop_failure)"
 grep -q 'accessory stop whatsapp-baileys' "$stop_failure"
 stop_still_running="$(run_failure stop_still_running)"
 grep -q 'accessory stop whatsapp-baileys' "$stop_still_running"
+ipv6_underlay="$(run_failure ipv6_underlay)"
+grep -q "docker network inspect --format '{{.EnableIPv6}}' kamal" "$ipv6_underlay"
+! grep -q 'accessory stop whatsapp-baileys' "$ipv6_underlay"
 
 steady="$(run steady true)"
 ! grep -q 'accessory reboot whatsapp-baileys' "$steady"


### PR DESCRIPTION
Fixes Kamal compound-command readiness so all checks execute inside the accessory container; requires the standard Kamal underlay to remain IPv4-only; removes the invalid container ip6tables-legacy assumption; and restores the official Tailscale DNS manager writable-root contract. Verified with isolated Docker shared-netns/iptables integration, Kamal 2.12 render tests, deploy contract tests, Biome, YAML parsing, bash syntax, and production rollback health.