### PR TITLE
fix(web): restore linked Agent Workspace Skills

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4173,6 +4173,78 @@ test("empty accounts without deploy access only get the connected-agent path", a
 	);
 });
 
+test("connected Agent Workspace Skills stay on the connected path", async ({ page }) => {
+	const projectId = "project-connected-workspace";
+	const skillRequests: string[] = [];
+	const workspaceSkillRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [],
+		cloudAgents: [railConnectedCloudAgent],
+		agentProjectBindings: [
+			{
+				id: "binding-connected-primary",
+				agent_id: railConnectedEnvironmentId,
+				project_id: projectId,
+				binding_type: "primary",
+				priority: 0,
+				default_write_enabled: true,
+				created_at: "2026-07-15T00:00:00Z",
+			},
+		],
+		agentProjects: [
+			{
+				id: projectId,
+				name: "Connected Workspace",
+				slug: "connected-workspace",
+				kind: "environment",
+				origin_environment_id: railConnectedEnvironmentId,
+				archived_at: null,
+				created_at: "2026-07-15T00:00:00Z",
+				is_owner: true,
+				owner_display: "Hosted User",
+				owner_handle: "hosted-user",
+			},
+		],
+		skillsByProjectId: {
+			[projectId]: [
+				{
+					id: "skill-connected-review",
+					skill_key: "review-pr",
+					name: "Review pull request",
+					description: "Review changes before merging",
+					version: 1,
+					source: "agent_sync",
+					authority: "agent_sync",
+					source_repo: null,
+					agent_types: ["hermes"],
+					file_count: 1,
+					content_hash: "c".repeat(64),
+					is_active: true,
+					created_at: "2026-07-15T00:00:00Z",
+					updated_at: "2026-07-15T00:00:00Z",
+					project_id: projectId,
+					project_name: "Connected Workspace",
+					project_kind: "environment",
+				},
+			],
+		},
+		skillRequests,
+		workspaceSkillRequests,
+	});
+
+	await page.goto(`/agents/${railConnectedEnvironmentId}/project-access/${projectId}/skills`);
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
+	await expect(main.getByText("Install on the Agent", { exact: true })).toBeVisible();
+	await expect(main.getByText("Review pull request", { exact: true })).toBeVisible();
+	await expect(main.getByText("Couldn't load the Agent runtime", { exact: true })).toHaveCount(0);
+	await expect.poll(() => skillRequests.length).toBe(1);
+	expect(new URL(skillRequests[0] ?? "http://invalid").searchParams.get("project_id")).toBe(
+		projectId,
+	);
+	expect(workspaceSkillRequests).toEqual([]);
+});
+
 test("returning accounts keep hosted management but hide new deploys when denied", async ({
 	page,
 }) => {

--- a/apps/web/src/hosted/agent-identity.ts
+++ b/apps/web/src/hosted/agent-identity.ts
@@ -22,6 +22,15 @@ export function isCloudEnvId(value: string): boolean {
 	return CLOUD_ENV_ID_RE.test(value);
 }
 
+/** Preserve explicit Cloud intent while allowing UUID-backed connected Agents. */
+export function agentRouteTargetsHostedDeployment(
+	environmentId: string,
+	source: string | null | undefined,
+	deploymentSelector: string | null | undefined,
+): boolean {
+	return source === "on-clawdi" || Boolean(deploymentSelector) || !isCloudEnvId(environmentId);
+}
+
 /**
  * Keep user-given deployment names intact while preserving the existing
  * runtime-prefix cleanup for generated runtime labels.

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -21,7 +21,11 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
+import {
+	agentRouteTargetsHostedDeployment,
+	deploymentDisplayName,
+	isCloudEnvId,
+} from "@/hosted/agent-identity";
 import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -36,6 +40,7 @@ import {
 	agentDeploymentSelector,
 	agentRouteIdsEqual,
 	agentRouteOwnsSection,
+	agentRouteSource,
 	agentSectionLink,
 	bindAgentDeploymentSearch,
 	CONNECTED_AGENT_SECTION_IDS,
@@ -91,9 +96,13 @@ export function AgentHome({
 		refetch,
 	} = useAgentDeployment(environmentId, deploymentSelector);
 	const isCloudEnvironmentId = isCloudEnvId(environmentId);
-	const requestedFromCloudRedirect = routeSearch.source === "on-clawdi";
-	const requestedHostedAgent =
-		requestedFromCloudRedirect || Boolean(deploymentSelector) || !isCloudEnvironmentId;
+	const routeSource = agentRouteSource(routeSearch);
+	const requestedFromCloudRedirect = routeSource === "on-clawdi";
+	const requestedHostedAgent = agentRouteTargetsHostedDeployment(
+		environmentId,
+		routeSource,
+		deploymentSelector,
+	);
 	const unresolvedHostedAgent =
 		requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading;
 	const shouldAutoRefetchUnresolvedHostedAgent =

--- a/apps/web/src/hosted/agents/hosted-workspace-skills-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-workspace-skills-panel.tsx
@@ -10,6 +10,7 @@ import {
 	parseWorkspaceSkillGitHubInput,
 	workspaceSkillMutationsAvailable,
 } from "@/components/dashboard/workspace-skills.logic";
+import { ConnectedWorkspaceSkillsPanel } from "@/components/dashboard/workspace-skills-panel";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { SkillCard } from "@/components/skills/skill-card";
@@ -27,12 +28,14 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { agentRouteTargetsHostedDeployment } from "@/hosted/agent-identity";
 import { useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import { normalizeBillingError } from "@/hosted/billing/errors";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
 import type { AgentRouteQuery } from "@/lib/agent-routes";
-import { agentSkillDetailLink } from "@/lib/agent-routes";
+import { agentRouteSource, agentSkillDetailLink } from "@/lib/agent-routes";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
 type WorkspaceSkillMutation =
@@ -60,6 +63,8 @@ function HostedWorkspaceSkillsPanelContent({
 	routeSearch,
 	deploymentSelector,
 }: HostedWorkspaceSkillsPanelProps) {
+	const api = useApi();
+	const $api = useOpenApi();
 	const billingClient = useBillingClient();
 	const queryClient = useQueryClient();
 	const actionLockedRef = useRef(false);
@@ -69,7 +74,33 @@ function HostedWorkspaceSkillsPanelContent({
 	const deploymentResolution = useAgentDeployment(agentId, deploymentSelector);
 	const deployment = deploymentResolution.deployment;
 	const deploymentId = deployment?.resource.id ?? null;
+	const requestedHostedAgent = agentRouteTargetsHostedDeployment(
+		agentId,
+		agentRouteSource(routeSearch),
+		deploymentSelector,
+	);
+	const isConnectedAgent =
+		deploymentResolution.membershipResolved &&
+		!deployment &&
+		deploymentResolution.ambiguousMatches.length === 0 &&
+		!requestedHostedAgent;
 	const statusKey = ["hosted", "deployments", deploymentId, "skills"] as const;
+	const connectedAgent = $api.useQuery(
+		"get",
+		"/v1/agents/{agent_id}",
+		{ params: { path: { agent_id: agentId } } },
+		{ enabled: isConnectedAgent },
+	);
+	const connectedSkills = useQuery({
+		queryKey: ["skills", "connected-workspace", projectId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/skills", {
+					params: { query: { project_id: projectId, page: 1, page_size: 200 } },
+				}),
+			),
+		enabled: isConnectedAgent,
+	});
 
 	const status = useQuery({
 		queryKey: statusKey,
@@ -151,8 +182,46 @@ function HostedWorkspaceSkillsPanelContent({
 		}
 	};
 
-	if (deploymentResolution.isLoading) {
+	if (
+		deploymentResolution.isLoading ||
+		(!deploymentResolution.membershipResolved && !deployment && !deploymentResolution.error)
+	) {
 		return <WorkspaceSkillSkeleton />;
+	}
+	if (isConnectedAgent) {
+		const blockingAgentError = shouldBlockQueryError(connectedAgent.error, connectedAgent.data);
+		if (blockingAgentError) {
+			return (
+				<ApiErrorPanel
+					error={blockingAgentError}
+					onRetry={() => {
+						void connectedAgent.refetch();
+					}}
+					title="Couldn't load the Agent identity"
+				/>
+			);
+		}
+		if (!connectedAgent.data) return <WorkspaceSkillSkeleton />;
+		return (
+			<ConnectedWorkspaceSkillsPanel
+				agentId={agentId}
+				projectId={projectId}
+				routeSearch={routeSearch}
+				agentType={connectedAgent.data.agent_type}
+				projections={(connectedSkills.data?.items ?? []).filter(
+					(skill) => skill.authority === "agent_sync",
+				)}
+				isLoading={connectedSkills.isLoading}
+				projectionError={
+					shouldBlockQueryError(connectedSkills.error, connectedSkills.data)
+						? connectedSkills.error
+						: undefined
+				}
+				onRetryProjections={() => {
+					void connectedSkills.refetch();
+				}}
+			/>
+		);
 	}
 	if (deploymentResolution.error || !deployment) {
 		return (

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -245,6 +245,10 @@ export function agentDeploymentSelector(query?: AgentRouteQuery): string | null 
 	return selector || null;
 }
 
+export function agentRouteSource(query?: AgentRouteQuery): string | null {
+	return agentRouteSearchParams(query).get("source")?.trim() || null;
+}
+
 export function agentDeploymentRouteQuery(
 	query?: AgentRouteQuery,
 ): RouteSearchParamsRecord | undefined {


### PR DESCRIPTION
## Summary
- classify nested Workspace Skill routes with the same authoritative deployment inventory as Agent home
- keep connected Agents on their synced local Skill path in Hosted builds
- preserve V2 Workspace Skill APIs for actual Hosted deployments

## Verification
- Web typecheck
- focused Biome and 41 unit tests
- Hosted Playwright: connected Agent path
- Hosted Playwright: actual Hosted V2 Workspace Skill path