### PR TITLE
fix: persist WhatsApp egress revision across deploy

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -297,5 +297,10 @@ jobs:
         run: |
           gem install kamal -v '2.12.0' --no-document
           test "$(kamal version)" = "2.12.0"
+          if [ "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" = true ]; then
+            export WHATSAPP_TAILSCALE_CONFIG_REVISION="$(
+              scripts/deploy-whatsapp-sidecar.sh --print-tailscale-config-revision
+            )"
+          fi
           scripts/deploy-whatsapp-sidecar.sh
           kamal deploy -P --version "${{ needs.build.outputs.image_tag }}"

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -59,7 +59,7 @@ describe("WhatsApp sidecar production deployment contract", () => {
 	});
 
 	test("prepares transparent egress before recreating the sidecar", () => {
-		const helperCall = workflow.indexOf("scripts/deploy-whatsapp-sidecar.sh");
+		const helperCall = workflow.lastIndexOf("scripts/deploy-whatsapp-sidecar.sh");
 		const appDeploy = workflow.indexOf(
 			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
 		);
@@ -69,6 +69,11 @@ describe("WhatsApp sidecar production deployment contract", () => {
 		expect(workflow).toContain("Build and push WhatsApp sidecar image");
 		expect(deployHelper).toContain("kamal accessory directories whatsapp-baileys");
 		expect(workflow).toContain("scripts/deploy-whatsapp-sidecar.sh");
+		expect(workflow).toContain(
+			"scripts/deploy-whatsapp-sidecar.sh --print-tailscale-config-revision",
+		);
+		expect(workflow.indexOf("--print-tailscale-config-revision")).toBeLessThan(helperCall);
+		expect(deployHelper).toContain("WhatsApp Tailscale config revision does not match");
 		expect(deployHelper).toContain("kamal accessory reboot whatsapp-tailscale");
 		expect(deployHelper).toContain("kamal accessory reboot whatsapp-egress-guard");
 		expect(deployHelper).toContain("kamal accessory reboot whatsapp-baileys");

--- a/scripts/deploy-whatsapp-sidecar.sh
+++ b/scripts/deploy-whatsapp-sidecar.sh
@@ -5,7 +5,6 @@ readonly sidecar_service="clawdi-whatsapp-baileys"
 readonly infra_service="clawdi-whatsapp-netns"
 readonly tailscale_service="clawdi-whatsapp-tailscale"
 readonly guard_service="clawdi-whatsapp-egress-guard"
-readonly sidecar_image="ghcr.io/clawdi-ai/clawdi-whatsapp-baileys-sidecar:${DEPLOY_IMAGE_VERSION}"
 readonly tailscale_image="tailscale/tailscale:v1.98.10@sha256:cdf5612ded5be1344f1a704b8c5e53496db97376bb533e5e15f141e48bf60cc0"
 readonly whatsapp_host_root="/home/phala/clawdi-whatsapp"
 readonly sidecar_state_dir="${whatsapp_host_root}/state"
@@ -13,6 +12,32 @@ readonly sidecar_run_dir="${whatsapp_host_root}/run"
 readonly tailscale_state_dir="${whatsapp_host_root}/tailscale-state"
 readonly guard_state_dir="${whatsapp_host_root}/egress-guard"
 readonly tailscale_resolver_file="${whatsapp_host_root}/tailscale-resolv.conf"
+
+validate_exit_node() {
+	case "$1" in
+		""|*[!A-Za-z0-9._:-]*) echo "invalid WhatsApp Tailscale exit node" >&2; exit 1 ;;
+	esac
+}
+
+tailscale_config_revision() {
+	printf '%s\n' \
+		'registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c' \
+		"${tailscale_image}" \
+		'kernel-netns-ipv4-underlay-uid-killswitch-container-shell-readiness-writable-dns' \
+		"$1" | sha256sum | cut -d ' ' -f 1
+}
+
+if [[ "${1:-}" == --print-tailscale-config-revision ]]; then
+	[[ "$#" == 1 ]] || { echo "unexpected deployment helper arguments" >&2; exit 1; }
+	validate_exit_node "${WHATSAPP_TAILSCALE_EXIT_NODE:-}"
+	tailscale_config_revision "${WHATSAPP_TAILSCALE_EXIT_NODE}"
+	exit 0
+elif [[ "$#" != 0 ]]; then
+	echo "unexpected deployment helper arguments" >&2
+	exit 1
+fi
+
+readonly sidecar_image="ghcr.io/clawdi-ai/clawdi-whatsapp-baileys-sidecar:${DEPLOY_IMAGE_VERSION}"
 
 remote_value() {
 	kamal server exec "printf 'CLAWDI_VALUE=%s\\n' \"\$($1)\"" 2>/dev/null |
@@ -65,14 +90,13 @@ ensure_container_stopped() {
 egress_enabled=false
 if [[ "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" == true ]]; then
 	egress_enabled=true
-	case "${WHATSAPP_TAILSCALE_EXIT_NODE:-}" in
-		""|*[!A-Za-z0-9._:-]*) echo "invalid WhatsApp Tailscale exit node" >&2; exit 1 ;;
-	esac
-	WHATSAPP_TAILSCALE_CONFIG_REVISION="$(printf '%s\n' \
-		'registry.k8s.io/pause:3.10.1@sha256:278fb9dbcca9518083ad1e11276933a2e96f23de604a3a08cc3c80002767d24c' \
-		"${tailscale_image}" \
-		'kernel-netns-ipv4-underlay-uid-killswitch-container-shell-readiness-writable-dns' \
-		"${WHATSAPP_TAILSCALE_EXIT_NODE}" | sha256sum | cut -d ' ' -f 1)"
+	validate_exit_node "${WHATSAPP_TAILSCALE_EXIT_NODE:-}"
+	computed_tailscale_revision="$(tailscale_config_revision "${WHATSAPP_TAILSCALE_EXIT_NODE}")"
+	if [[ -n "${WHATSAPP_TAILSCALE_CONFIG_REVISION:-}" && "${WHATSAPP_TAILSCALE_CONFIG_REVISION}" != "${computed_tailscale_revision}" ]]; then
+		echo "WhatsApp Tailscale config revision does not match the deployment contract" >&2
+		exit 1
+	fi
+	WHATSAPP_TAILSCALE_CONFIG_REVISION="${computed_tailscale_revision}"
 	export WHATSAPP_TAILSCALE_CONFIG_REVISION
 elif [[ -n "${WHATSAPP_TAILSCALE_EGRESS_ENABLED:-}" && "${WHATSAPP_TAILSCALE_EGRESS_ENABLED}" != false ]]; then
 	echo "WHATSAPP_TAILSCALE_EGRESS_ENABLED must be exactly true or false/unset" >&2

--- a/scripts/test-deploy-whatsapp-sidecar.sh
+++ b/scripts/test-deploy-whatsapp-sidecar.sh
@@ -66,6 +66,12 @@ chmod +x "${tmp}/bin/kamal"
 printf '#!/usr/bin/env bash\nexit 0\n' > "${tmp}/bin/sleep"
 chmod +x "${tmp}/bin/sleep"
 
+revision="$(
+	WHATSAPP_TAILSCALE_EXIT_NODE=exit.test \
+		"$root/scripts/deploy-whatsapp-sidecar.sh" --print-tailscale-config-revision
+)"
+[[ "${revision}" =~ ^[0-9a-f]{64}$ ]]
+
 run() {
 	local scenario="$1" enabled="$2" log="${tmp}/$1.log"
 	SCENARIO="$scenario" FAKE_LOG="$log" PATH="${tmp}/bin:$PATH" \


### PR DESCRIPTION
Keep the deterministic WhatsApp Tailscale config revision in the workflow parent shell so both the sidecar reconciler and the following Kamal app deploy render the same enabled configuration. The helper remains the single revision authority and rejects drift. Verified with the focused helper behavior test, Kamal 2.12 render contract, deploy contract tests, Biome, bash syntax, and git diff checks.