### PR TITLE
fix: let generic delete complete for absent deployments

### DIFF
--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -57,6 +57,7 @@ export function HostedDeploymentDeleteAction({
 			try {
 				await deleteDeployment.mutateAsync({
 					id: deployment.resource.id,
+					resourceVersion: deployment.resource.metadata.resourceVersion,
 					request: {
 						subscription_choice: offerChoice ? choice : "keep_subscription",
 					},

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -232,12 +232,14 @@ export function useDeleteDeployment() {
 	const client = useBillingClient();
 	const qc = useQueryClient();
 	return useMutation({
-		mutationFn: (vars: { id: string; request: DeploymentDeleteRequest }) =>
-			runStableDeploymentIntent("deployment-delete", { action: "delete", ...vars }, (key) =>
-				client.deleteDeployment(vars.id, vars.request, key),
+		mutationFn: (vars: { id: string; request: DeploymentDeleteRequest; resourceVersion: string }) =>
+			runStableDeploymentIntent(
+				"deployment-delete",
+				{ action: "delete", id: vars.id, request: vars.request },
+				(key) => client.deleteDeployment(vars.id, vars.request, key, vars.resourceVersion),
 			),
 		onSuccess: (accepted) => {
-			projectAcceptedDeploymentTransition(qc, accepted);
+			if (accepted.operation) projectAcceptedDeploymentTransition(qc, accepted);
 			retireRuntimeWindows(accepted.deploymentId);
 			toast.message("Agent removed", {
 				description: "Cleanup continues in the background.",

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -662,6 +662,54 @@ describe("declarative deployment mutations", () => {
 		});
 	});
 
+	it("completes deletion when the deployment is definitively absent", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			if (request.method === "GET") {
+				return jsonResponse({ detail: "Deployment not found" }, 404);
+			}
+			return jsonResponse({ deployment_id: "hdep_absent", status: "absent" });
+		});
+
+		await expect(
+			client.deleteDeployment(
+				"hdep_absent",
+				{ subscription_choice: "cancel_subscription" },
+				"intent-absent",
+				"rv-last-known",
+			),
+		).resolves.toEqual({ deploymentId: "hdep_absent", operation: null });
+		expect(requests.map((request) => request.method)).toEqual(["GET", "DELETE"]);
+		expect(requests[1]?.headers.get("Idempotency-Key")).toBe("intent-absent");
+		expect(requests[1]?.headers.get("If-Match")).toBe('"rv-last-known"');
+	});
+
+	it("keeps transient absent-deletion failures rejected", async () => {
+		const client = testClient(async (request) => {
+			if (request.method === "GET") {
+				return jsonResponse(
+					hostedDeploymentFixture({ id: "hdep_transient", resourceVersion: "rv-transient" }),
+				);
+			}
+			return jsonResponse(
+				{
+					detail: "Cloud ownership or cleanup could not be confirmed.",
+					code: "cloud_cleanup_temporarily_unavailable",
+				},
+				503,
+			);
+		});
+
+		await expect(
+			client.deleteDeployment(
+				"hdep_transient",
+				{ subscription_choice: "cancel_subscription" },
+				"intent-transient",
+			),
+		).rejects.toMatchObject({ status: 503 });
+	});
+
 	it("releases lifecycle and settings mutations as soon as their LROs are accepted", async () => {
 		const requests: Request[] = [];
 		const client = testClient(async (request) => {
@@ -715,7 +763,10 @@ describe("declarative deployment mutations", () => {
 		]);
 
 		expect(
-			accepted.every((item) => !item.operation.done && item.deploymentId === "hdep_test"),
+			accepted.every(
+				(item) =>
+					item.operation !== null && !item.operation.done && item.deploymentId === "hdep_test",
+			),
 		).toBe(true);
 		expect(
 			requests.filter((request) => new URL(request.url).pathname.startsWith("/v2/operations/")),

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -20,6 +20,7 @@ import type {
 	ComputeSubscriptionQuoteRequest,
 	ComputeSubscriptionResumeRequest,
 	DeploymentCreateRequest,
+	DeploymentDeleteConvergedResponse,
 	DeploymentDeleteRequest,
 	DeploymentDesiredLifecycle,
 	DeploymentOperation,
@@ -60,6 +61,7 @@ type BillingFetch = (request: Request) => Promise<Response>;
 type BillingAuthTokenGetter = () => Promise<string | null | undefined>;
 
 export type AcceptedOperation = { deploymentId: string; operation: DeploymentOperation };
+export type DeploymentDeleteResult = AcceptedOperation | { deploymentId: string; operation: null };
 
 export type BillingClientOptions = {
 	fetch?: BillingFetch;
@@ -164,6 +166,18 @@ function strongResourceEtag(resourceVersion: string): string {
 
 function isPreconditionConflict(error: unknown): error is BillingApiError {
 	return error instanceof BillingApiError && (error.status === 409 || error.status === 412);
+}
+
+function isNotFound(error: unknown): error is BillingApiError {
+	return error instanceof BillingApiError && error.status === 404;
+}
+
+function acceptDeploymentDelete(
+	response: DeploymentOperation | DeploymentDeleteConvergedResponse,
+): DeploymentDeleteResult {
+	return "status" in response
+		? acceptDeclarativeOperation({ deploymentId: response.deployment_id, operation: null })
+		: acceptDeclarativeOperation({ operation: response });
 }
 
 function isWorkspaceSkillResourceVersionConflict(error: unknown): error is BillingApiError {
@@ -411,6 +425,49 @@ export function createBillingClient(
 		}
 		throw new DeploymentConflictError();
 	};
+	const deleteDeployment = async (
+		id: string,
+		body: DeploymentDeleteRequest,
+		idempotencyKey: string,
+		lastKnownResourceVersion?: string,
+	): Promise<DeploymentDeleteResult> => {
+		let resourceVersion: string;
+		try {
+			resourceVersion = (await getDeployment(id)).resource.metadata.resourceVersion;
+		} catch (error) {
+			if (!isNotFound(error) || !lastKnownResourceVersion) throw error;
+			resourceVersion = lastKnownResourceVersion;
+		}
+
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const headers: MutationHeaders = {
+				"Idempotency-Key": idempotencyKey,
+				"If-Match": strongResourceEtag(resourceVersion),
+			};
+			try {
+				return acceptDeploymentDelete(
+					unwrapDeploy(
+						await api.DELETE("/v2/deployments/{deployment_id}", {
+							params: { path: { deployment_id: id }, header: headers },
+							body,
+						}),
+					),
+				);
+			} catch (error) {
+				if (!isPreconditionConflict(error)) throw error;
+				if (attempt === 0) {
+					try {
+						resourceVersion = (await getDeployment(id)).resource.metadata.resourceVersion;
+					} catch (readError) {
+						if (!isNotFound(readError)) throw readError;
+					}
+					continue;
+				}
+				throw new DeploymentConflictError({ cause: error });
+			}
+		}
+		throw new DeploymentConflictError();
+	};
 	const listWorkspaceSkills = async (
 		deploymentId: string,
 	): Promise<HostedWorkspaceSkillListResponse> =>
@@ -642,13 +699,7 @@ export function createBillingClient(
 					body,
 				}),
 			),
-		deleteDeployment: async (id: string, body: DeploymentDeleteRequest, idempotencyKey: string) =>
-			acceptDeploymentMutation(id, idempotencyKey, (headers) =>
-				api.DELETE("/v2/deployments/{deployment_id}", {
-					params: { path: { deployment_id: id }, header: headers },
-					body,
-				}),
-			),
+		deleteDeployment,
 	};
 }
 

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -26,6 +26,7 @@ export type ComputeSubscriptionQuoteRequest = Schemas["V2ComputeSubscriptionQuot
 export type ComputeSubscriptionQuoteResponse = Schemas["V2ComputeSubscriptionQuoteResponse-Output"];
 export type ComputeSubscriptionResumeRequest = Schemas["V2ComputeSubscriptionResumeRequest"];
 export type DeploymentCreateRequest = Schemas["V2HostedDeployRequest"];
+export type DeploymentDeleteConvergedResponse = Schemas["V2DeleteDeploymentConvergedResponse"];
 export type DeploymentDeleteRequest = Schemas["V2DeleteDeploymentRequest"];
 export type DeploymentUpdateRequest = Schemas["V2UpdateDeploymentRequest"];
 export type DeploymentDesiredLifecycle = "running" | "stopped";

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -100,7 +100,7 @@ describe("DeploymentStatus", () => {
 		expect(canStart(status)).toBe(false);
 		expect(canStop(status)).toBe(false);
 		expect(canRestart(status)).toBe(false);
-		expect(canDelete(status)).toBe(false);
+		expect(canDelete(status)).toBe(true);
 		expect(canQueryDeploymentProjection(status)).toBe(false);
 	});
 
@@ -221,9 +221,9 @@ describe("DeploymentStatus", () => {
 	test("disables delete once deletion is in progress or complete", () => {
 		expect(canDelete(parseDeploymentStatus("running"))).toBe(true);
 		expect(canDelete(parseDeploymentStatus("failed"))).toBe(true);
+		expect(canDelete(parseDeploymentStatus("future_status"))).toBe(true);
 		expect(canDelete(parseDeploymentStatus("deleting"))).toBe(false);
 		expect(canDelete(parseDeploymentStatus("deleted"))).toBe(false);
-		expect(canDelete(parseDeploymentStatus("future_status"))).toBe(false);
 	});
 
 	test("classifies whether any deployment is non-terminal", () => {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -348,10 +348,10 @@ export function canDelete(status: DeploymentStatus): boolean {
 		case "restarting":
 		case "updating":
 		case "failed":
+		case "unknown":
 			return true;
 		case "deleting":
 		case "deleted":
-		case "unknown":
 			return false;
 		default:
 			return exhaustive(status);

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1450,6 +1450,16 @@ export interface components {
              */
             deployment_id: string;
         };
+        /** V2DeleteDeploymentConvergedResponse */
+        V2DeleteDeploymentConvergedResponse: {
+            /** Deployment Id */
+            deployment_id: string;
+            /**
+             * Status
+             * @constant
+             */
+            status: "absent";
+        };
         /** V2DeleteDeploymentRequest */
         V2DeleteDeploymentRequest: {
             /**
@@ -2504,6 +2514,15 @@ export interface operations {
             };
         };
         responses: {
+            /** @description The deployment is definitively absent for the caller in both Hosted and Cloud. Repeating the delete returns the same response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2DeleteDeploymentConvergedResponse"];
+                };
+            };
             /** @description The declarative spec change was accepted. */
             202: {
                 headers: {
@@ -2556,6 +2575,17 @@ export interface operations {
             /** @description A strong If-Match header is required. */
             428: {
                 headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LifecycleProblemDetails"];
+                };
+            };
+            /** @description Cloud ownership or cleanup could not be confirmed; no converged absence is claimed. */
+            503: {
+                headers: {
+                    /** @description Seconds before retrying Cloud convergence. */
+                    "Retry-After"?: number;
                     [name: string]: unknown;
                 };
                 content: {


### PR DESCRIPTION
## Summary

- regenerate the hosted deploy OpenAPI client for the converged `200 { status: "absent" }` delete response and transient `503` response
- make the existing delete action available for an unknown deployment status
- let the existing generic delete flow finish normally for a converged-absent response while preserving the live `202` LRO path

## Data-flow map

- Cloud Agent projections are `AgentEnvironment` rows in `agent_environments` (`backend/app/models/session.py`); hosted runtime mapping is `HostedRuntimeState` in `hosted_runtime_states` (`backend/app/models/hosted_runtime.py`), keyed by Agent id and carrying the hosted deployment id.
- The Agents list reads Cloud projections from `GET /v1/agents`, reads hosted inventory from browser-authenticated `GET /v2/deployments` through the generated deploy client, and joins both in `useUnifiedAgentList`.
- Detail first resolves the hosted deployment from that inventory, then reads the Cloud projection from `GET /v1/agents/{agent_id}` when the deployment state permits it. Deployment status comes directly from the hosted inventory response and is normalized by `deployment-status.ts`.
- The existing delete path remains `HostedDeploymentDeleteAction -> useDeleteDeployment -> BillingClient.deleteDeployment -> DELETE /v2/deployments/{deployment_id}`.
- Hosted PR #1501 keeps Cloud cleanup in that same generic delete flow. For a locally absent deployment it resolves only caller-owned stable Cloud Agents, then invokes the existing Cloud platform runtime-state delete followed by Agent delete. On the Clawdi side, runtime-state deletion removes `HostedRuntimeState` and releases runtime OAuth claims; Agent deletion reuses `archive_agent_and_project` to archive the Agent identity and its exclusive Agent Project and revoke bound API keys. Relationships and resource rows remain intentionally untouched. Hosted returns converged `200 absent` only after that fan-out succeeds.

## Behavior and fail-closed boundary

The browser GET preflight may return 404 for an orphan. That 404 is not treated as successful deletion; it only allows the same DELETE request to be sent with the last displayed strong resource version. The flow completes only when the typed DELETE response is the authoritative `200 { deployment_id, status: "absent" }`. A `503`, timeout, unreachable service, or other error still rejects and leaves the detail page in place. Live deployments still return and project the existing `202` operation with the same headers, retry budget, and stable intent key.

## OpenAPI generation

Generated with the repository script from `Clawdi-AI/clawdi-hosted` main at merge commit `beddede9b1a9ae3c575b3557bccba22b6f83f235` (`backend/openapi.json` blob `a49853db1fd9a705cd9cbf4ca6e1ace54ee1069a`), not the possibly stale live URL:

```bash
gh api -H "Accept: application/vnd.github.raw+json" \\
  "repos/Clawdi-AI/clawdi-hosted/contents/backend/openapi.json?ref=main" \\
  | ./scripts/generate-deploy-api.sh /dev/stdin
```

No sibling generated files changed. No schema migration or new configuration is required.

## Verification

- `bun run typecheck`
- `bun run test` (Docker-backed clean runner; all Web, Shared, sidecar, CLI, and backend suites passed)
- `bun run check` (passes; one unrelated existing informational Biome suggestion in `packages/cli/src/runtime/hosted-openclaw-skill.test.ts:77`)
- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun test apps/web/src/hosted/deployment-status.test.ts apps/web/src/hosted/billing/billing-client.test.ts apps/web/src/hosted/agents/deployment-hooks.test.ts` (63 passed)
- `cd backend && uv run ruff check . && uv run ruff format --check . && uv run python -m compileall -q app scripts tests alembic`
- `bun run --cwd apps/web build:oss`
- `git diff --check origin/main..HEAD`