### PR TITLE
fix(web): align resource breadcrumbs with navigation

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4662,6 +4662,16 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 			level: 1,
 		}),
 	).toBeVisible();
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText([
+		"Agents",
+		"Hosted agent · Hermes",
+		"Memories",
+		"Hosted and connected agents share this memory",
+	]);
 	await expect(main.getByText("All agents", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Open in resource library" })).toHaveCount(0);
@@ -4711,6 +4721,11 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 			url.searchParams.get("d") === railHostedDeployment.id,
 	);
 	await expect(main.getByRole("heading", { name: "GitHub", level: 1 })).toBeVisible();
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Hosted agent · Hermes", "Connectors", "GitHub"]);
 	await expect(main.getByText("All agents", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Open in resource library" })).toHaveCount(0);
 	const hostedConnectorsLink = page
@@ -4900,6 +4915,12 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	});
 	await page.keyboard.press("Escape");
 	await page.setViewportSize({ width: 1280, height: 1200 });
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Skills"]);
+	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("hosted-workspace-skills-desktop.png") });
 	await page.screenshot({
 		path: testInfo.outputPath("hosted-workspace-sidebar-desktop.png"),
@@ -4917,11 +4938,13 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 	const focusedVaultsHeading = main.getByRole("heading", { name: "Vaults", level: 1 });
 	await expect(focusedVaultsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Vaults · Clawdi");
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Vaults"]);
 	await expect(main.getByText("Project: Hosted Agent Project", { exact: true })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveAttribute(
-		"href",
-		`/agents/${railHostedEnvironmentId}${query}`,
-	);
+	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
 		focusedVaultsHeading.locator("xpath=../../..").locator(".bg-identity-4-bg svg.lucide-key"),
 	).toBeVisible();
@@ -4945,10 +4968,12 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		);
 	});
 	await expect(main.getByRole("heading", { name: "Hosted Scoped Vault", level: 1 })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Vaults" })).toHaveAttribute(
-		"href",
-		`/agents/${railHostedEnvironmentId}/project-access/project-hosted/vaults${query}`,
-	);
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Vaults", "Hosted Scoped Vault"]);
+	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
 			.getByRole("navigation", { name: "breadcrumb" })
@@ -4957,7 +4982,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		"href",
 		`/agents/${railHostedEnvironmentId}/project-access/project-hosted/vaults${query}`,
 	);
-	await expect(main.getByRole("link", { name: "Workspace" })).toHaveAttribute(
+	await expect(main.getByRole("link", { name: "Workspace" }).last()).toHaveAttribute(
 		"href",
 		`/agents/${railHostedEnvironmentId}/project-access/project-hosted${query}`,
 	);
@@ -4995,7 +5020,7 @@ test("Breadcrumbs show the full trail on desktop and only the current page on na
 	).toEqual(["LI", "LI", "LI", "LI", "LI"]);
 	await expect(breadcrumb.locator('[data-slot="breadcrumb-item"]:visible')).toHaveText([
 		"Agents",
-		"Agent",
+		"Hosted agent · Hermes",
 		"Memories",
 	]);
 	await expect(breadcrumb.locator('[data-slot="breadcrumb-separator"]:visible')).toHaveCount(2);
@@ -5378,6 +5403,11 @@ test("hosted Agent Skill details retain deployment context and stay inside bound
 		`/agents/${railHostedEnvironmentId}/skills/hosted-detail?project=project-hosted&${deploymentQuery}`,
 	);
 	await expect(main.getByRole("heading", { name: "Hosted detail Skill", level: 1 })).toBeVisible();
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Skills", "Hosted detail Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	await expect(
@@ -5403,20 +5433,30 @@ test("hosted Agent Skill details retain deployment context and stay inside bound
 	await page.goto(
 		`/agents/${railHostedEnvironmentId}/skills/hosted-context-only?${deploymentQuery}`,
 	);
-	await expect(
-		main.getByText("Project not available to this Agent", { exact: true }),
-	).toBeVisible();
-	expect(skillDetailRequests).toHaveLength(requestsBeforeOmittedProject);
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === `/agents/${railHostedEnvironmentId}/skills/hosted-context-only` &&
+			url.searchParams.get("project") === "project-hosted" &&
+			url.searchParams.get("source") === "on-clawdi" &&
+			url.searchParams.get("d") === railHostedDeployment.id
+		);
+	});
+	await expect(main.getByText("Skill not found", { exact: true })).toBeVisible();
+	expect(skillDetailRequests).toHaveLength(requestsBeforeOmittedProject + 1);
+	expect(new URL(skillDetailRequests.at(-1) ?? "").pathname).toBe(
+		"/v1/projects/project-hosted/skills/hosted-context-only",
+	);
 
+	const requestsBeforeExplicitContext = skillDetailRequests.length;
 	await page.goto(
 		`/agents/${railHostedEnvironmentId}/skills/hosted-context-only?project=${contextProjectId}&${deploymentQuery}`,
 	);
 	await expect(
 		main.getByRole("heading", { name: "Hosted context-only Skill", level: 1 }),
 	).toBeVisible();
-	const contextProjectRequests = skillDetailRequests.filter((request) =>
-		new URL(request).pathname.endsWith("/skills/hosted-context-only"),
-	);
+	const contextProjectRequests = skillDetailRequests
+		.slice(requestsBeforeExplicitContext)
+		.filter((request) => new URL(request).pathname.endsWith("/skills/hosted-context-only"));
 	expect(contextProjectRequests.map((request) => new URL(request).pathname)).toEqual([
 		`/v1/projects/${contextProjectId}/skills/hosted-context-only`,
 	]);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1951,6 +1951,12 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	});
 	await page.keyboard.press("Escape");
 	await page.setViewportSize({ width: 1280, height: 1200 });
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Skills"]);
+	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-skills-desktop.png") });
 	await page.screenshot({
 		path: testInfo.outputPath("connected-workspace-sidebar-desktop.png"),
@@ -1961,11 +1967,13 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const focusedVaultsHeading = main.getByRole("heading", { name: "Vaults", level: 1 });
 	await expect(focusedVaultsHeading).toBeVisible();
 	await expect(page).toHaveTitle("Vaults · Clawdi");
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Vaults"]);
 	await expect(main.getByText("Project: Smoke Project", { exact: true })).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveAttribute(
-		"href",
-		"/agents/agent-smoke-1",
-	);
+	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
 		focusedVaultsHeading.locator("xpath=../../..").locator(".bg-identity-4-bg svg.lucide-key"),
 	).toBeVisible();
@@ -1988,6 +1996,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await page.setViewportSize({ width: 390, height: 844 });
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-vaults-mobile.png") });
 
+	await page.setViewportSize({ width: 1280, height: 1200 });
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-first");
 	await expect(main.getByRole("heading", { name: "Team Knowledge", level: 1 })).toBeVisible();
 	await expect(main.getByText("Team-only Skill", { exact: true })).toBeVisible();
@@ -2015,10 +2024,12 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await main.getByRole("button", { name: "View all Skills", exact: true }).click();
 	await expect(page).toHaveURL("/agents/agent-smoke-1/project-access/project-context-first/skills");
 	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Back to Team Knowledge" })).toHaveAttribute(
-		"href",
-		"/agents/agent-smoke-1/project-access/project-context-first",
-	);
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Smoke Codex", "Projects", "Team Knowledge", "Skills"]);
+	await expect(main.getByRole("button", { name: "Back to Team Knowledge" })).toHaveCount(0);
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-later");
 	await expect(main.getByRole("heading", { name: longContextProjectName, level: 1 })).toBeVisible();
 	await expect(main.getByRole("button", { name: "View all Skills" })).toHaveAttribute(
@@ -2100,10 +2111,12 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		/\/agents\/agent-smoke-1\/vaults\/scoped-vault\?project=project-smoke&vault=vault-scoped$/,
 	);
 	await expect(main.getByRole("heading", { name: "Scoped Vault", level: 1 })).toBeVisible();
-	await expect(main.getByRole("button", { name: "Vaults" })).toHaveAttribute(
-		"href",
-		"/agents/agent-smoke-1/project-access/project-smoke/vaults",
-	);
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Vaults", "Scoped Vault"]);
+	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
 			.getByRole("navigation", { name: "breadcrumb" })
@@ -2115,7 +2128,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await expect(page).toHaveURL(
 		"/agents/agent-smoke-1/vaults/scoped-vault?project=project-smoke&vault=vault-scoped",
 	);
-	await expect(main.getByRole("link", { name: "Workspace" })).toHaveAttribute(
+	await expect(main.getByRole("link", { name: "Workspace" }).last()).toHaveAttribute(
 		"href",
 		"/agents/agent-smoke-1/project-access/project-smoke",
 	);
@@ -2256,12 +2269,16 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 		`/agents/agent-smoke-1/skills/scoped-skill?project=project-smoke&${deploymentQuery}`,
 	);
 	const main = page.locator("main");
-	await expect(main.getByRole("button", { name: "Back to Projects" })).toBeVisible();
 	expect(skillDetailRequests).toEqual([]);
 	if (!releaseBindings) throw new Error("Project binding gate was not initialized");
 	releaseBindings();
 	await expect.poll(() => skillDetailRequests.length).toBe(1);
 	await expect(main.getByRole("heading", { name: "Scoped Skill", level: 1 })).toBeVisible();
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Skills", "Scoped Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	const agentSkillsLink = main
@@ -2304,10 +2321,19 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 
 	const requestsBeforeMissingProject = skillDetailRequests.length;
 	await page.goto(`/agents/agent-smoke-1/skills/context-only?${deploymentQuery}`);
-	await expect(
-		main.getByText("Project not available to this Agent", { exact: true }),
-	).toBeVisible();
-	expect(skillDetailRequests).toHaveLength(requestsBeforeMissingProject);
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === "/agents/agent-smoke-1/skills/context-only" &&
+			url.searchParams.get("project") === "project-smoke" &&
+			url.searchParams.get("source") === "on-clawdi" &&
+			url.searchParams.get("d") === "deployment-smoke"
+		);
+	});
+	await expect(main.getByText("Skill not found", { exact: true })).toBeVisible();
+	expect(skillDetailRequests).toHaveLength(requestsBeforeMissingProject + 1);
+	expect(new URL(skillDetailRequests.at(-1) ?? "").pathname).toBe(
+		"/v1/projects/project-smoke/skills/context-only",
+	);
 
 	await page.goto(
 		`/agents/agent-smoke-1/skills/missing-skill?project=${contextProjectId}&${deploymentQuery}`,
@@ -2328,7 +2354,7 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 		);
 		const errorMain = errorPage.locator("main");
 		await expect(
-			errorMain.getByText("Couldn't verify Agent Project access", { exact: true }),
+			errorMain.getByText("Couldn't verify Workspace or Project access", { exact: true }),
 		).toBeVisible({ timeout: 15_000 });
 		await expect(errorMain.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 		await expect(

--- a/apps/web/src/components/app-breadcrumb-model.ts
+++ b/apps/web/src/components/app-breadcrumb-model.ts
@@ -1,0 +1,226 @@
+import type { BreadcrumbSegmentTitles } from "@/components/breadcrumb-title";
+import {
+	type AgentRouteSearch,
+	agentDeploymentRouteQuery,
+	agentProjectDetailHref,
+	agentProjectResourceHref,
+	agentSectionHref,
+	agentSectionLabel,
+	parseAgentPathname,
+} from "@/lib/agent-routes";
+
+export type AppBreadcrumbTrailItem = {
+	key: string;
+	label: string | null;
+	href?: string;
+};
+
+type BreadcrumbTrailInput = {
+	pathname: string;
+	search: AgentRouteSearch;
+	overrideTitle: string | null;
+	segmentTitles: BreadcrumbSegmentTitles;
+};
+
+const SEGMENT_LABELS: Record<string, string> = {
+	projects: "Projects",
+	sessions: "Sessions",
+	memories: "Memories",
+	skills: "Skills",
+	vault: "Vaults",
+	vaults: "Vaults",
+	connectors: "Connectors",
+	channels: "Channels",
+	deploy: "Deploy an Agent",
+	agents: "Agents",
+	"ai-providers": "AI Providers",
+};
+
+const DETAIL_COLLECTION_SEGMENTS = new Set([
+	"projects",
+	"sessions",
+	"memories",
+	"skills",
+	"vault",
+	"vaults",
+	"connectors",
+	"channels",
+]);
+
+export function buildAppBreadcrumbTrail({
+	pathname,
+	search,
+	overrideTitle,
+	segmentTitles,
+}: BreadcrumbTrailInput): AppBreadcrumbTrailItem[] {
+	const agentRoute = parseAgentPathname(pathname);
+	if (agentRoute) {
+		return buildAgentBreadcrumbTrail(agentRoute, search, overrideTitle, segmentTitles);
+	}
+	return buildGenericBreadcrumbTrail(pathname, overrideTitle, segmentTitles);
+}
+
+function buildAgentBreadcrumbTrail(
+	route: NonNullable<ReturnType<typeof parseAgentPathname>>,
+	search: AgentRouteSearch,
+	overrideTitle: string | null,
+	segmentTitles: BreadcrumbSegmentTitles,
+): AppBreadcrumbTrailItem[] {
+	const deploymentQuery = agentDeploymentRouteQuery(search);
+	const agentHref = agentSectionHref(route.agentId, "overview", deploymentQuery);
+	const agentTitle = segmentTitle(segmentTitles, agentHref);
+	const trail: AppBreadcrumbTrailItem[] = [
+		{ key: "agents", label: "Agents", href: "/agents" },
+		{ key: "agent", label: agentTitle, href: agentHref },
+	];
+
+	if (route.section === "overview") {
+		return finishTrail(trail, overrideTitle ?? agentTitle);
+	}
+
+	if (route.section === "projects") {
+		if (!route.projectId) {
+			return finishTrail(trail, agentSectionLabel("projects"));
+		}
+		const context = projectContext(route.agentId, route.projectId, deploymentQuery, segmentTitles);
+		appendProjectContext(trail, route.agentId, context, deploymentQuery);
+		if (route.projectResource) {
+			return finishTrail(trail, overrideTitle ?? agentSectionLabel(route.projectResource));
+		}
+		return finishTrail(trail, overrideTitle ?? context.label);
+	}
+
+	if (route.section === "skills" || route.section === "vaults") {
+		const projectId = typeof search.project === "string" ? search.project.trim() : "";
+		if (projectId) {
+			const context = projectContext(route.agentId, projectId, deploymentQuery, segmentTitles);
+			appendProjectContext(trail, route.agentId, context, deploymentQuery);
+			const resourceHref = agentProjectResourceHref(
+				route.agentId,
+				projectId,
+				route.section,
+				deploymentQuery,
+			);
+			trail.push({
+				key: route.section,
+				label: agentSectionLabel(route.section),
+				href: resourceHref,
+			});
+		} else {
+			trail.push({
+				key: "projects",
+				label: agentSectionLabel("projects"),
+				href: agentSectionHref(route.agentId, "projects", deploymentQuery),
+			});
+		}
+		const hasDetail =
+			route.section === "skills" ? Boolean(route.skillKey) : Boolean(route.vaultSlug);
+		return hasDetail
+			? finishTrail(trail, overrideTitle)
+			: finishTrail(trail, agentSectionLabel(route.section));
+	}
+
+	const sectionLabel = agentSectionLabel(route.section);
+	const sectionHref = agentSectionHref(route.agentId, route.section, deploymentQuery);
+	const detailTitle =
+		route.sessionId || route.memoryId || route.connectorName ? overrideTitle : null;
+	if (route.sessionId || route.memoryId || route.connectorName) {
+		trail.push({ key: route.section, label: sectionLabel, href: sectionHref });
+		return finishTrail(trail, detailTitle);
+	}
+	return finishTrail(trail, overrideTitle ?? sectionLabel);
+}
+
+function projectContext(
+	agentId: string,
+	projectId: string,
+	query: ReturnType<typeof agentDeploymentRouteQuery>,
+	segmentTitles: BreadcrumbSegmentTitles,
+) {
+	const href = agentProjectDetailHref(agentId, projectId, query);
+	const label = segmentTitle(segmentTitles, href);
+	const registeredContext = segmentContext(segmentTitles, href);
+	return {
+		projectId,
+		href,
+		label,
+		kind: !label ? null : registeredContext === "workspace" ? "workspace" : "project",
+	};
+}
+
+function appendProjectContext(
+	trail: AppBreadcrumbTrailItem[],
+	agentId: string,
+	context: ReturnType<typeof projectContext>,
+	query: ReturnType<typeof agentDeploymentRouteQuery>,
+) {
+	if (context.kind === "project") {
+		trail.push({
+			key: "projects",
+			label: "Projects",
+			href: agentSectionHref(agentId, "projects", query),
+		});
+	}
+	trail.push({
+		key: `project:${context.projectId}`,
+		label: context.label,
+		href: context.href,
+	});
+}
+
+function buildGenericBreadcrumbTrail(
+	pathname: string,
+	overrideTitle: string | null,
+	segmentTitles: BreadcrumbSegmentTitles,
+): AppBreadcrumbTrailItem[] {
+	const segments = pathname.split("/").filter(Boolean);
+	if (segments.length === 0) return [{ key: "overview", label: "Overview" }];
+	return segments.map((segment, index) => {
+		const href = `/${segments.slice(0, index + 1).join("/")}`;
+		const isLast = index === segments.length - 1;
+		const previousSegment = segments[index - 1]?.toLowerCase();
+		const label =
+			isLast && overrideTitle
+				? overrideTitle
+				: (segmentTitle(segmentTitles, href) ??
+					(isLast && previousSegment && DETAIL_COLLECTION_SEGMENTS.has(previousSegment)
+						? null
+						: (SEGMENT_LABELS[segment.toLowerCase()] ?? safeDecodeURIComponent(segment))));
+		return {
+			key: href,
+			label,
+			...(isLast ? {} : { href }),
+		};
+	});
+}
+
+function finishTrail(
+	trail: AppBreadcrumbTrailItem[],
+	label: string | null,
+): AppBreadcrumbTrailItem[] {
+	const last = trail.at(-1);
+	if (last?.label === label) {
+		trail[trail.length - 1] = { ...last, href: undefined };
+		return trail;
+	}
+	trail.push({ key: `current:${trail.length}`, label });
+	return trail;
+}
+
+function segmentTitle(segmentTitles: BreadcrumbSegmentTitles, href: string): string | null {
+	const [path] = href.split("?");
+	return segmentTitles[path.replace(/\/+$/, "") || "/"]?.title.trim() || null;
+}
+
+function segmentContext(segmentTitles: BreadcrumbSegmentTitles, href: string) {
+	const [path] = href.split("?");
+	return segmentTitles[path.replace(/\/+$/, "") || "/"]?.context;
+}
+
+function safeDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}

--- a/apps/web/src/components/app-breadcrumb.test.ts
+++ b/apps/web/src/components/app-breadcrumb.test.ts
@@ -1,25 +1,135 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { buildAppBreadcrumbTrail } from "@/components/app-breadcrumb-model";
+import type { BreadcrumbSegmentTitles } from "@/components/breadcrumb-title";
 
-const breadcrumb = readFileSync(new URL("./app-breadcrumb.tsx", import.meta.url), "utf8");
+const agentId = "agent-1";
+const workspaceId = "workspace-1";
+const projectId = "project-1";
+const deploymentSearch = { source: "on-clawdi", d: "deployment-1" };
 
-describe("AppBreadcrumb responsive trail", () => {
-	test("keeps only the current page visible below the existing sm breakpoint", () => {
-		expect(breadcrumb).toContain(
-			'<BreadcrumbItem className={isLast ? undefined : "hidden sm:inline-flex"}>',
-		);
-		expect(breadcrumb).toContain('<BreadcrumbSeparator className="hidden sm:block" />');
-		expect(breadcrumb).not.toContain("useIsMobile");
-		expect(breadcrumb).not.toContain("matchMedia");
-		// Fragment keeps the breadcrumb <li> items and separators as direct <ol> children.
-		expect(breadcrumb).toContain("<Fragment key={href}>");
-		expect(breadcrumb).not.toContain('<span key={href} className="contents">');
+function labels(
+	pathname: string,
+	{
+		search = {},
+		title = null,
+		segmentTitles = {},
+	}: {
+		search?: Record<string, string>;
+		title?: string | null;
+		segmentTitles?: BreadcrumbSegmentTitles;
+	} = {},
+) {
+	return buildAppBreadcrumbTrail({
+		pathname,
+		search,
+		overrideTitle: title,
+		segmentTitles: {
+			[`/agents/${agentId}`]: { title: "Hermes" },
+			...segmentTitles,
+		},
+	}).map((item) => item.label);
+}
+
+describe("AppBreadcrumb semantic trail", () => {
+	test("presents the Agent Workspace outside the Projects hierarchy", () => {
+		expect(
+			labels(`/agents/${agentId}/project-access/${workspaceId}/skills`, {
+				segmentTitles: {
+					[`/agents/${agentId}/project-access/${workspaceId}`]: {
+						title: "Workspace",
+						context: "workspace",
+					},
+				},
+			}),
+		).toEqual(["Agents", "Hermes", "Workspace", "Skills"]);
 	});
 
-	test("returns Project-scoped resource crumbs to their independent collection", () => {
-		expect(breadcrumb).toContain('typeof search.project === "string"');
-		expect(breadcrumb).toContain("agentProjectResourceHref(route.agentId, projectId");
-		expect(breadcrumb).toContain("route.section,");
-		expect(breadcrumb).toContain('route.section === "projects" && route.projectId');
+	test("keeps linked Projects in the Projects hierarchy", () => {
+		expect(
+			labels(`/agents/${agentId}/project-access/${projectId}/vaults`, {
+				segmentTitles: {
+					[`/agents/${agentId}/project-access/${projectId}`]: { title: "Team Knowledge" },
+				},
+			}),
+		).toEqual(["Agents", "Hermes", "Projects", "Team Knowledge", "Vaults"]);
+	});
+
+	test("does not mistake a linked Project named Workspace for the Agent Workspace", () => {
+		expect(
+			labels(`/agents/${agentId}/project-access/${projectId}`, {
+				segmentTitles: {
+					[`/agents/${agentId}/project-access/${projectId}`]: { title: "Workspace" },
+				},
+			}),
+		).toEqual(["Agents", "Hermes", "Projects", "Workspace"]);
+	});
+
+	test("shows real Skill and Vault names in their selected Project context", () => {
+		const segmentTitles = {
+			[`/agents/${agentId}/project-access/${workspaceId}`]: {
+				title: "Workspace",
+				context: "workspace" as const,
+			},
+		};
+		expect(
+			labels(`/agents/${agentId}/skills/github%2Fissues`, {
+				search: { ...deploymentSearch, project: workspaceId },
+				title: "GitHub Issues",
+				segmentTitles,
+			}),
+		).toEqual(["Agents", "Hermes", "Workspace", "Skills", "GitHub Issues"]);
+		expect(
+			labels(`/agents/${agentId}/vaults/production`, {
+				search: { ...deploymentSearch, project: workspaceId },
+				title: "Production Keys",
+				segmentTitles,
+			}),
+		).toEqual(["Agents", "Hermes", "Workspace", "Vaults", "Production Keys"]);
+	});
+
+	test("shows real names for Agent-level resources", () => {
+		expect(labels(`/agents/${agentId}/sessions/session-1`, { title: "Deploy the API" })).toEqual([
+			"Agents",
+			"Hermes",
+			"Sessions",
+			"Deploy the API",
+		]);
+		expect(
+			labels(`/agents/${agentId}/memories/memory-1`, { title: "Prefers concise replies" }),
+		).toEqual(["Agents", "Hermes", "Memories", "Prefers concise replies"]);
+		expect(labels(`/agents/${agentId}/connectors/github`, { title: "GitHub" })).toEqual([
+			"Agents",
+			"Hermes",
+			"Connectors",
+			"GitHub",
+		]);
+	});
+
+	test("preserves Hosted deployment context in every Agent parent link", () => {
+		const trail = buildAppBreadcrumbTrail({
+			pathname: `/agents/${agentId}/skills/github%2Fissues`,
+			search: { ...deploymentSearch, project: workspaceId },
+			overrideTitle: "GitHub Issues",
+			segmentTitles: {
+				[`/agents/${agentId}`]: { title: "Hermes" },
+				[`/agents/${agentId}/project-access/${workspaceId}`]: {
+					title: "Workspace",
+					context: "workspace",
+				},
+			},
+		});
+		expect(trail.filter((item) => item.href).map((item) => item.href)).toEqual([
+			"/agents",
+			`/agents/${agentId}?source=on-clawdi&d=deployment-1`,
+			`/agents/${agentId}/project-access/${workspaceId}?source=on-clawdi&d=deployment-1`,
+			`/agents/${agentId}/project-access/${workspaceId}/skills?source=on-clawdi&d=deployment-1`,
+		]);
+	});
+
+	test("holds a stable placeholder instead of guessing or exposing an unavailable name", () => {
+		expect(labels("/projects/550e8400-e29b-41d4-a716-446655440000")).toEqual(["Projects", null]);
+		expect(
+			labels(`/agents/${agentId}/vaults/internal-slug`, { search: { project: projectId } }),
+		).toEqual(["Agents", "Hermes", null, "Vaults", null]);
 	});
 });

--- a/apps/web/src/components/app-breadcrumb.tsx
+++ b/apps/web/src/components/app-breadcrumb.tsx
@@ -2,6 +2,7 @@
 
 import { Link, useLocation } from "@tanstack/react-router";
 import { Fragment } from "react";
+import { buildAppBreadcrumbTrail } from "@/components/app-breadcrumb-model";
 import { useBreadcrumbSegmentTitles, useBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
 	Breadcrumb,
@@ -11,153 +12,56 @@ import {
 	BreadcrumbPage,
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import {
-	type AgentRouteSearch,
-	agentDeploymentRouteQuery,
-	agentProjectDetailHref,
-	agentProjectResourceHref,
-	agentSectionLabelFromSegment,
-	agentSectionLink,
-	type ParsedAgentPathname,
-	parseAgentPathname,
-} from "@/lib/agent-routes";
-
-/**
- * Route-derived header label. Top-level segments map to friendly names
- * (`sessions` → `Sessions`); the last segment of a detail page is replaced
- * by whatever `useSetBreadcrumbTitle()` has registered (session summary,
- * agent machine name, skill name, …) — falling back to a truncated URL
- * segment so loading states still render something legible instead of a
- * full UUID.
- */
-const SEGMENT_LABELS: Record<string, string> = {
-	projects: "Projects",
-	sessions: "Sessions",
-	memories: "Memories",
-	skills: "Skills",
-	vault: "Vaults",
-	vaults: "Vaults",
-	connectors: "Connectors",
-	channels: "Channels",
-	deploy: "Deploy an Agent",
-	agents: "Agents",
-	"ai-providers": "AI Providers",
-};
-
-// Looks like a UUID? Truncate it for the loading state — full UUIDs in a
-// breadcrumb just push everything off-screen and tell the user nothing.
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-function fallbackLabel(seg: string): string {
-	const decoded = decodeURIComponent(seg);
-	return UUID_RE.test(decoded) ? `${decoded.slice(0, 8)}…` : decoded;
-}
-
-function segmentLabel(
-	segments: string[],
-	index: number,
-	href: string,
-	overrideTitle: string | null,
-	segmentTitles: Record<string, string>,
-): string {
-	const seg = segments[index];
-	const isLast = index === segments.length - 1;
-	if (isLast && overrideTitle) return overrideTitle;
-	if (segmentTitles[href]) return segmentTitles[href];
-	if (segments[0]?.toLowerCase() === "agents" && index === 1) return "Agent";
-	if (segments[0]?.toLowerCase() === "agents" && index === 2) {
-		return agentSectionLabelFromSegment(seg) ?? fallbackLabel(seg);
-	}
-	return SEGMENT_LABELS[seg] ?? fallbackLabel(seg);
-}
-
-function agentBreadcrumbLink(
-	route: ParsedAgentPathname | null,
-	index: number,
-	search: AgentRouteSearch,
-) {
-	if (!route) return null;
-	const deploymentSearch = agentDeploymentRouteQuery(search);
-	if (index === 1) return agentSectionLink(route.agentId, "overview", deploymentSearch);
-	const projectId = typeof search.project === "string" ? search.project.trim() : "";
-	if (
-		index === 2 &&
-		projectId &&
-		((route.section === "skills" && route.skillKey) ||
-			(route.section === "vaults" && route.vaultSlug))
-	) {
-		return {
-			to: agentProjectResourceHref(route.agentId, projectId, route.section, deploymentSearch),
-		};
-	}
-	if (index === 2) return agentSectionLink(route.agentId, route.section, deploymentSearch);
-	if (index === 3 && route.section === "projects" && route.projectId) {
-		return { to: agentProjectDetailHref(route.agentId, route.projectId, deploymentSearch) };
-	}
-	return null;
-}
-
 export function AppBreadcrumb() {
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const routeSearch = useLocation({ select: (location) => location.search });
-	const segments = pathname.split("/").filter(Boolean);
-	const agentRoute = parseAgentPathname(pathname);
 	const overrideTitle = useBreadcrumbTitle();
 	const segmentTitles = useBreadcrumbSegmentTitles();
-
-	if (segments.length === 0) {
-		return (
-			<Breadcrumb>
-				<BreadcrumbList>
-					<BreadcrumbItem>
-						<BreadcrumbPage>Overview</BreadcrumbPage>
-					</BreadcrumbItem>
-				</BreadcrumbList>
-			</Breadcrumb>
-		);
-	}
+	const trail = buildAppBreadcrumbTrail({
+		pathname,
+		search: routeSearch,
+		overrideTitle,
+		segmentTitles,
+	});
 
 	return (
 		<Breadcrumb>
 			<BreadcrumbList>
-				{segments
-					.map((_seg, i) => i)
-					.filter(
-						(i) =>
-							!(
-								segments[0]?.toLowerCase() === "agents" &&
-								segments[2]?.toLowerCase() === "skills" &&
-								segments.length > 4 &&
-								i > 2 &&
-								i < segments.length - 1
-							),
-					)
-					.map((i) => {
-						const href = `/${segments.slice(0, i + 1).join("/")}`;
-						const isLast = i === segments.length - 1;
-						const label = segmentLabel(segments, i, href, overrideTitle, segmentTitles);
-						const agentLink = agentBreadcrumbLink(agentRoute, i, routeSearch);
-						return (
-							<Fragment key={href}>
-								<BreadcrumbItem className={isLast ? undefined : "hidden sm:inline-flex"}>
-									{isLast ? (
-										<BreadcrumbPage className="max-w-[calc(100vw-6rem)] truncate sm:max-w-[420px]">
-											{label}
-										</BreadcrumbPage>
-									) : (
-										// render lets us pass our own router-aware link while
-										// preserving shadcn's breadcrumb anchor semantics.
-										<BreadcrumbLink
-											render={agentLink ? <Link {...agentLink} /> : <Link to={href} />}
-										>
-											{label}
-										</BreadcrumbLink>
-									)}
-								</BreadcrumbItem>
-								{!isLast ? <BreadcrumbSeparator className="hidden sm:block" /> : null}
-							</Fragment>
-						);
-					})}
+				{trail.map((item, i) => {
+					const isLast = i === trail.length - 1;
+					const label = item.label ?? <BreadcrumbNamePlaceholder />;
+					return (
+						<Fragment key={item.key}>
+							<BreadcrumbItem className={isLast ? undefined : "hidden sm:inline-flex"}>
+								{isLast ? (
+									<BreadcrumbPage className="max-w-[calc(100vw-6rem)] truncate sm:max-w-[420px]">
+										{label}
+									</BreadcrumbPage>
+								) : item.href && item.label ? (
+									<BreadcrumbLink
+										className="inline-block max-w-40 truncate align-bottom lg:max-w-56"
+										render={<Link to={item.href} />}
+									>
+										{label}
+									</BreadcrumbLink>
+								) : (
+									<BreadcrumbPage>{label}</BreadcrumbPage>
+								)}
+							</BreadcrumbItem>
+							{!isLast ? <BreadcrumbSeparator className="hidden sm:block" /> : null}
+						</Fragment>
+					);
+				})}
 			</BreadcrumbList>
 		</Breadcrumb>
+	);
+}
+
+function BreadcrumbNamePlaceholder() {
+	return (
+		<span className="inline-flex items-center">
+			<span className="sr-only">Loading name</span>
+			<span aria-hidden className="h-4 w-20 rounded bg-muted" />
+		</span>
 	);
 }

--- a/apps/web/src/components/breadcrumb-title.tsx
+++ b/apps/web/src/components/breadcrumb-title.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { useLocation } from "@tanstack/react-router";
+import {
+	createContext,
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useState,
+} from "react";
 import { type AgentSectionId, agentSectionHref, agentSectionLabel } from "@/lib/agent-routes";
 import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
 
@@ -13,10 +24,10 @@ import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
  * route in `<BreadcrumbTitleProvider>`; detail pages call
  * `useSetBreadcrumbTitle(session.summary)` once they have data.
  *
- * Setting `null` (or unmounting the consumer) clears the override and
- * the breadcrumb goes back to its URL-derived label — which is correct
- * on top-level pages (`/sessions` → "Sessions") and during loading
- * states.
+ * Registrations are tied to the full route, including search params, so
+ * navigation can never reuse a name from the previous resource context.
+ * Dynamic names render a stable placeholder until their authoritative data
+ * is available; top-level pages still use their static collection label.
  *
  * Implementation note: read and write live in *separate* contexts. If
  * we put `{title, setTitle}` in one object, every render of the provider
@@ -26,30 +37,55 @@ import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
  * always are), so the effect only re-runs when the *title input* changes.
  */
 
-type SegmentTitles = Record<string, string>;
+export type BreadcrumbSegmentContext = "workspace";
+export type BreadcrumbSegmentTitle = {
+	title: string;
+	context?: BreadcrumbSegmentContext;
+};
+export type BreadcrumbSegmentTitles = Record<string, BreadcrumbSegmentTitle>;
+type BreadcrumbTitleRegistration = { routeKey: string; title: string } | null;
+type RegisteredBreadcrumbSegmentTitle = BreadcrumbSegmentTitle & { routeKey: string };
+type RegisteredBreadcrumbSegmentTitles = Record<string, RegisteredBreadcrumbSegmentTitle>;
 
-const TitleContext = createContext<string | null>(null);
-const SegmentTitlesContext = createContext<SegmentTitles>({});
-type Setter = (t: string | null) => void;
-const SetTitleContext = createContext<Setter>(() => {});
-type SegmentTitleSetter = (href: string | null | undefined, title: string | null) => void;
+const TitleContext = createContext<BreadcrumbTitleRegistration>(null);
+const SegmentTitlesContext = createContext<RegisteredBreadcrumbSegmentTitles>({});
+const SetTitleContext = createContext<Dispatch<SetStateAction<BreadcrumbTitleRegistration>>>(
+	() => {},
+);
+type SegmentTitleSetter = (
+	href: string | null | undefined,
+	title: string | null,
+	context?: BreadcrumbSegmentContext,
+	routeKey?: string,
+) => void;
 const SetSegmentTitleContext = createContext<SegmentTitleSetter>(() => {});
 
 export function BreadcrumbTitleProvider({ children }: { children: React.ReactNode }) {
-	const [title, setTitle] = useState<string | null>(null);
-	const [segmentTitles, setSegmentTitles] = useState<SegmentTitles>({});
-	const setSegmentTitle = useCallback<SegmentTitleSetter>((href, nextTitle) => {
+	const [title, setTitle] = useState<BreadcrumbTitleRegistration>(null);
+	const [segmentTitles, setSegmentTitles] = useState<RegisteredBreadcrumbSegmentTitles>({});
+	const setSegmentTitle = useCallback<SegmentTitleSetter>((href, nextTitle, context, routeKey) => {
 		const normalizedHref = normalizeBreadcrumbHref(href);
-		if (!normalizedHref) return;
+		if (!normalizedHref || !routeKey) return;
 		setSegmentTitles((current) => {
 			const trimmed = nextTitle?.trim() || null;
 			if (!trimmed) {
-				if (!(normalizedHref in current)) return current;
+				if (current[normalizedHref]?.routeKey !== routeKey) return current;
 				const { [normalizedHref]: _removed, ...rest } = current;
 				return rest;
 			}
-			if (current[normalizedHref] === trimmed) return current;
-			return { ...current, [normalizedHref]: trimmed };
+			const next: RegisteredBreadcrumbSegmentTitle = {
+				title: trimmed,
+				...(context ? { context } : {}),
+				routeKey,
+			};
+			if (
+				current[normalizedHref]?.title === next.title &&
+				current[normalizedHref]?.context === next.context &&
+				current[normalizedHref]?.routeKey === next.routeKey
+			) {
+				return current;
+			}
+			return { ...current, [normalizedHref]: next };
 		});
 	}, []);
 	return (
@@ -67,16 +103,28 @@ export function BreadcrumbTitleProvider({ children }: { children: React.ReactNod
 
 /** Read-only accessor for the breadcrumb component itself. */
 export function useBreadcrumbTitle(): string | null {
-	return useContext(TitleContext);
+	const routeKey = useBreadcrumbRouteKey();
+	const registration = useContext(TitleContext);
+	return registration?.routeKey === routeKey ? registration.title : null;
 }
 
-export function useBreadcrumbSegmentTitles(): SegmentTitles {
-	return useContext(SegmentTitlesContext);
+export function useBreadcrumbSegmentTitles(): BreadcrumbSegmentTitles {
+	const routeKey = useBreadcrumbRouteKey();
+	const registrations = useContext(SegmentTitlesContext);
+	return useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries(registrations)
+					.filter(([, registration]) => registration.routeKey === routeKey)
+					.map(([href, { title, context }]) => [href, { title, ...(context ? { context } : {}) }]),
+			),
+		[registrations, routeKey],
+	);
 }
 
 /**
  * Detail pages call this with their human-readable title. Pass `null`
- * (or wait until data is ready) to fall back to the URL segment.
+ * (or wait until data is ready) to keep the stable loading placeholder.
  *
  * Safe to call unconditionally — if `title` is null/undefined the effect
  * still runs but with no-op semantics. **Call this BEFORE any conditional
@@ -84,34 +132,43 @@ export function useBreadcrumbSegmentTitles(): SegmentTitles {
  */
 export function useSetBreadcrumbTitle(title: string | null | undefined) {
 	const setTitle = useContext(SetTitleContext);
-	useEffect(() => {
+	const routeKey = useBreadcrumbRouteKey();
+	useIsomorphicLayoutEffect(() => {
 		const trimmed = title?.trim() || null;
-		setTitle(trimmed);
+		setTitle((current) =>
+			trimmed ? { routeKey, title: trimmed } : current?.routeKey === routeKey ? null : current,
+		);
 		if (!trimmed || typeof document === "undefined") {
-			return () => setTitle(null);
+			return () => {
+				setTitle((current) => (current?.routeKey === routeKey ? null : current));
+			};
 		}
 
 		const previousTitle = document.title || APP_TITLE;
 		const nextTitle = formatDocumentTitle(trimmed);
 		document.title = nextTitle;
 		return () => {
-			setTitle(null);
+			setTitle((current) =>
+				current?.routeKey === routeKey && current.title === trimmed ? null : current,
+			);
 			if (document.title === nextTitle) {
 				document.title = previousTitle || APP_TITLE;
 			}
 		};
-	}, [setTitle, title]);
+	}, [routeKey, setTitle, title]);
 }
 
 export function useSetBreadcrumbSegmentTitle(
 	href: string | null | undefined,
 	title: string | null | undefined,
+	context?: BreadcrumbSegmentContext,
 ) {
 	const setSegmentTitle = useContext(SetSegmentTitleContext);
-	useEffect(() => {
-		setSegmentTitle(href, title?.trim() || null);
-		return () => setSegmentTitle(href, null);
-	}, [href, setSegmentTitle, title]);
+	const routeKey = useBreadcrumbRouteKey();
+	useIsomorphicLayoutEffect(() => {
+		setSegmentTitle(href, title?.trim() || null, context, routeKey);
+		return () => setSegmentTitle(href, null, undefined, routeKey);
+	}, [context, href, routeKey, setSegmentTitle, title]);
 }
 
 export function useSetAgentBreadcrumbTitle({
@@ -149,3 +206,11 @@ function normalizeBreadcrumbHref(href: string | null | undefined): string | null
 	if (!normalized || normalized === "/") return "/";
 	return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }
+
+function useBreadcrumbRouteKey() {
+	return useLocation({
+		select: (location) => `${location.pathname}${location.searchStr}`,
+	});
+}
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/components/dashboard/agent-resource-route-gate.tsx
+++ b/apps/web/src/components/dashboard/agent-resource-route-gate.tsx
@@ -1,18 +1,27 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import type { ReactNode } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { useSetBreadcrumbSegmentTitle } from "@/components/breadcrumb-title";
+import {
+	type AgentIdentityInput,
+	agentDisplayName,
+	agentIdentity,
+} from "@/components/dashboard/agent-label";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
 import { DetailNotFound } from "@/components/detail/layout";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { agentDeploymentSelector, agentRouteSource, agentSectionHref } from "@/lib/agent-routes";
 import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
+
+const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 
 /** Fail closed before a nested Agent route can read or mutate an account resource. */
 export function AgentResourceRouteGate({
@@ -28,6 +37,7 @@ export function AgentResourceRouteGate({
 	projectAccess?: { projectId: string | null | undefined };
 	children: ReactNode;
 }) {
+	const routeSearch = useLocation({ select: (location) => location.search });
 	const agent = useOpenApi().useQuery("get", "/v1/agents/{agent_id}", {
 		params: { path: { agent_id: agentId } },
 	});
@@ -35,6 +45,16 @@ export function AgentResourceRouteGate({
 		isApiNotFoundError(agent.error) || shouldBlockQueryError(agent.error, agent.data)
 			? agent.error
 			: null;
+	const hostedDeploymentRoute =
+		IS_HOSTED_BUILD &&
+		(agentRouteSource(routeSearch) === "on-clawdi" ||
+			Boolean(agentDeploymentSelector(routeSearch)));
+	const agentBreadcrumbTitle = agent.data
+		? hostedDeploymentRoute
+			? hostedAgentBreadcrumbTitle(agent.data)
+			: agentDisplayName(agent.data)
+		: null;
+	useSetBreadcrumbSegmentTitle(agentSectionHref(agentId), agentBreadcrumbTitle);
 
 	if (agent.isLoading) {
 		return (
@@ -99,6 +119,13 @@ export function AgentResourceRouteGate({
 	) : (
 		children
 	);
+}
+
+function hostedAgentBreadcrumbTitle(agent: AgentIdentityInput) {
+	const identity = agentIdentity(agent);
+	return identity.secondaryLabel
+		? `${identity.primaryLabel} · ${identity.secondaryLabel}`
+		: identity.primaryLabel;
 }
 
 /** Resolve explicit Project access only after the Agent identity gate succeeds. */

--- a/apps/web/src/components/detail/back-link.tsx
+++ b/apps/web/src/components/detail/back-link.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function DetailBackLink({
+	href,
+	label,
+	mobileOnly = true,
+}: {
+	href: string;
+	label: string;
+	mobileOnly?: boolean;
+}) {
+	return (
+		<Button
+			render={<Link to={href} />}
+			nativeButton={false}
+			variant="ghost"
+			size="sm"
+			className={cn("w-fit", mobileOnly && "sm:hidden")}
+		>
+			<ArrowLeft className="size-4" />
+			Back to {label}
+		</Button>
+	);
+}

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -10,6 +10,7 @@ import { getConnectorAuthFlow } from "@/components/connectors/auth-flow.logic";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { ConnectorCredentialsDialog } from "@/components/connectors/credentials-dialog";
 import { DashboardSection, DashboardSectionHeader } from "@/components/dashboard/section";
+import { DetailBackLink } from "@/components/detail/back-link";
 import { DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -31,7 +32,11 @@ import {
 	useDisconnect,
 } from "@/lib/connectors-data";
 import { shouldBlockQueryError } from "@/lib/query-state";
-import { LIBRARY_RESOURCE_SCOPE, type ResourceNavigationScope } from "@/lib/resource-navigation";
+import {
+	LIBRARY_RESOURCE_SCOPE,
+	type ResourceNavigationScope,
+	resourceCollectionTarget,
+} from "@/lib/resource-navigation";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, errorMessage } from "@/lib/utils";
 
@@ -71,6 +76,7 @@ function DetailSkeletonShell() {
 }
 
 function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigationScope }) {
+	const collectionTarget = resourceCollectionTarget(scope, "connectors");
 	// OAuth from hosted mode redirects directly back to this page (no
 	// intermediary callback route). Composio sometimes signals failure
 	// via `?error=…` and sometimes via `?status=error|failed` with no
@@ -257,6 +263,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 	if (isLoading) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
+				<DetailBackLink href={collectionTarget.href} label={collectionTarget.label} />
 				<DetailSkeleton />
 			</div>
 		);
@@ -269,6 +276,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 	if (isApiNotFoundError(appQ.error) || shouldBlockQueryError(appQ.error, appQ.data)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
+				<DetailBackLink href={collectionTarget.href} label={collectionTarget.label} />
 				{isApiNotFoundError(appQ.error) ? (
 					<EmptyState
 						icon={Plug}
@@ -290,6 +298,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
+			<DetailBackLink href={collectionTarget.href} label={collectionTarget.label} />
 			{scope.kind === "agent" ? (
 				<Alert>
 					<Plug />

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Brain, Laptop, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
+import { DetailBackLink } from "@/components/detail/back-link";
 import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { TimeTooltip } from "@/components/time-tooltip";
@@ -69,6 +70,7 @@ export default function MemoryDetailPage({
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<DetailBackLink href={collectionTarget.href} label={collectionTarget.label} />
 			{scope.kind === "agent" ? (
 				<Alert>
 					<Brain />

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -457,6 +457,7 @@ export default function ProjectDetailPage({
 	useSetBreadcrumbSegmentTitle(
 		scope.kind === "agent" ? agentProjectDetailHref(scope.agentId, projectId) : null,
 		isWorkspace ? "Workspace" : projectName,
+		isWorkspace ? "workspace" : undefined,
 	);
 	useSetBreadcrumbTitle(
 		projectName
@@ -624,7 +625,7 @@ export default function ProjectDetailPage({
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
-			<ProjectReturnLink target={pageReturnTarget} />
+			<ProjectReturnLink target={pageReturnTarget} mobileOnly />
 
 			<PageHeader
 				title={
@@ -1246,14 +1247,20 @@ function HubSection({
 	);
 }
 
-function ProjectReturnLink({ target }: { target: ResourceNavigationTarget }) {
+function ProjectReturnLink({
+	target,
+	mobileOnly = false,
+}: {
+	target: ResourceNavigationTarget;
+	mobileOnly?: boolean;
+}) {
 	return (
 		<Button
 			render={<Link to={target.href} />}
 			nativeButton={false}
 			variant="ghost"
 			size="sm"
-			className="w-fit"
+			className={cn("w-fit", mobileOnly && "sm:hidden")}
 		>
 			<ArrowLeft className="mr-1.5 size-4" />
 			{target.label}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useLocation } from "@tanstack/react-router";
 import {
 	ArrowDown,
 	ArrowDownNarrowWide,
@@ -14,6 +15,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline, agentDisplayName } from "@/components/dashboard/agent-label";
+import { DetailBackLink } from "@/components/detail/back-link";
 import {
 	DetailMeta,
 	DetailNotFound,
@@ -33,6 +35,7 @@ import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { agentDeploymentRouteQuery, agentSectionHref } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionMessage } from "@/lib/api-schemas";
@@ -61,6 +64,10 @@ export function SessionDetailContent({
 	const api = useApi();
 	const $api = useOpenApi();
 	const { user } = useCurrentUser();
+	const routeSearch = useLocation({ select: (location) => location.search });
+	const sessionsHref = agentId
+		? agentSectionHref(agentId, "sessions", agentDeploymentRouteQuery(routeSearch))
+		: "/sessions";
 
 	const {
 		data: session,
@@ -257,6 +264,7 @@ export function SessionDetailContent({
 	if (isSessionLoading) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+				<DetailBackLink href={sessionsHref} label="Sessions" />
 				<DetailSkeleton />
 			</div>
 		);
@@ -265,6 +273,7 @@ export function SessionDetailContent({
 	if (isApiNotFoundError(sessionError) || shouldBlockQueryError(sessionError, session)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+				<DetailBackLink href={sessionsHref} label="Sessions" />
 				{isApiNotFoundError(sessionError) ? (
 					<DetailNotFound title="Session not found" message="This session doesn't exist." />
 				) : (
@@ -283,6 +292,7 @@ export function SessionDetailContent({
 	if (!session || !summaryText) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+				<DetailBackLink href={sessionsHref} label="Sessions" />
 				<DetailNotFound title="Session not found" message="This session doesn't exist." />
 			</div>
 		);
@@ -292,6 +302,7 @@ export function SessionDetailContent({
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<DetailBackLink href={sessionsHref} label="Sessions" />
 			<div className="flex items-start justify-between gap-3">
 				<div className="min-w-0 flex-1 space-y-2">
 					<DetailTitle>{summaryText}</DetailTitle>

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import {
-	ArrowLeft,
 	BookOpen,
 	ExternalLink,
 	FileText,
@@ -32,6 +31,7 @@ import {
 	AGENT_PROJECT_SKILLS_REFRESH_POLICY,
 	agentSkillForegroundRefetchInterval,
 } from "@/components/dashboard/agent-skills-query";
+import { DetailBackLink } from "@/components/detail/back-link";
 import {
 	DetailMeta,
 	DetailNotFound,
@@ -55,6 +55,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	type AgentRouteSearch,
 	agentDeploymentRouteQuery,
+	agentProjectDetailHref,
 	agentProjectResourceHref,
 	agentSectionHref,
 } from "@/lib/agent-routes";
@@ -223,7 +224,6 @@ export function SkillDetailContent({
 			? cleanMachineName(skill.machine_name)
 			: null;
 	const breadcrumbTitle = skill?.name || (skill ? skillKey : null);
-	useSetBreadcrumbSegmentTitle(agentId ? agentSectionHref(agentId) : null, skillAgentLabel);
 	useSetBreadcrumbTitle(breadcrumbTitle);
 
 	// Browser writes require the exact Project selected by the URL. A released
@@ -243,6 +243,20 @@ export function SkillDetailContent({
 				? (projects?.find((project) => project.id === skill.project_id) ?? null)
 				: null,
 		[projects, skill?.project_id],
+	);
+	const selectedBinding = scopedBindings.data?.find(
+		(binding) => binding.project_id === selectedProjectId,
+	);
+	const breadcrumbProjectTitle =
+		selectedBinding?.binding_type === "primary"
+			? "Workspace"
+			: skillProject?.name || skill?.project_name || null;
+	useSetBreadcrumbSegmentTitle(
+		agentId && selectedProjectId
+			? agentProjectDetailHref(agentId, selectedProjectId, agentDeploymentRouteQuery(routeSearch))
+			: null,
+		breadcrumbProjectTitle,
+		selectedBinding?.binding_type === "primary" ? "workspace" : undefined,
 	);
 	const capabilities = skill
 		? skillCapabilities(skill, projects === undefined ? undefined : skillProject)
@@ -418,16 +432,11 @@ export function SkillDetailContent({
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<Button
-				render={<Link to={skillListHref} />}
-				nativeButton={false}
-				variant="ghost"
-				size="sm"
-				className="w-fit"
-			>
-				<ArrowLeft className="size-4" />
-				Back to {skillListLabel}
-			</Button>
+			<DetailBackLink
+				href={skillListHref}
+				label={skillListLabel}
+				mobileOnly={viewState === "detail"}
+			/>
 			{agentAccessError ? (
 				<ApiErrorPanel
 					error={agentAccessError}

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -18,7 +18,7 @@ import { parseAsString, useQueryState } from "nuqs";
 import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
+import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
 import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
@@ -59,6 +59,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { CopyKeysDialog } from "@/components/vault/copy-keys-dialog";
 import { prefixGroupsFor, SplitVaultDialog } from "@/components/vault/split-vault-dialog";
+import { agentDeploymentRouteQuery, agentProjectDetailHref } from "@/lib/agent-routes";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
@@ -171,6 +172,24 @@ export default function VaultDetailPage({
 	const projectById = useMemo(
 		() => new Map((projects.data ?? []).map((p) => [p.id, p])),
 		[projects.data],
+	);
+	const breadcrumbProject = requestedProjectId ? projectById.get(requestedProjectId) : null;
+	const breadcrumbProjectTitle =
+		requestedBinding?.binding_type === "primary"
+			? "Workspace"
+			: breadcrumbProject
+				? displayProjectName(breadcrumbProject)
+				: null;
+	useSetBreadcrumbSegmentTitle(
+		scope.kind === "agent" && requestedProjectId
+			? agentProjectDetailHref(
+					scope.agentId,
+					requestedProjectId,
+					agentDeploymentRouteQuery(scope.agentQuery),
+				)
+			: null,
+		breadcrumbProjectTitle,
+		requestedBinding?.binding_type === "primary" ? "workspace" : undefined,
 	);
 
 	const keys = useQuery({
@@ -518,7 +537,7 @@ export default function VaultDetailPage({
 				nativeButton={false}
 				variant="ghost"
 				size="sm"
-				className="w-fit"
+				className="w-fit sm:hidden"
 			>
 				<ArrowLeft className="mr-1.5 size-4" />
 				{backTarget.label}


### PR DESCRIPTION
## What changed
- replace URL-segment breadcrumbs with product-semantic Agent, Workspace, Project, and resource trails
- show authoritative Agent, Project, Skill, Vault, Memory, Connector, and Session names without leaking IDs or slugs
- preserve Hosted deployment context in every parent link
- remove duplicate desktop back actions while keeping clear mobile navigation
- bind async labels to the full route and use stable placeholders so stale or guessed names never flash

## Verification
- Web TypeScript typecheck
- focused breadcrumb and Agent-route unit tests
- OSS production build
- focused Connected and Hosted Playwright resource journeys
- Biome and git diff checks