### PR TITLE
fix(web): start Agent breadcrumbs at the Agent

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4667,7 +4667,6 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
 	).toHaveText([
-		"Agents",
 		"Hosted agent · Hermes",
 		"Memories",
 		"Hosted and connected agents share this memory",
@@ -4725,7 +4724,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Hosted agent · Hermes", "Connectors", "GitHub"]);
+	).toHaveText(["Hosted agent · Hermes", "Connectors", "GitHub"]);
 	await expect(main.getByText("All agents", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Open in resource library" })).toHaveCount(0);
 	const hostedConnectorsLink = page
@@ -4919,7 +4918,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Skills"]);
+	).toHaveText(["Hosted agent · Hermes", "Workspace", "Skills"]);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("hosted-workspace-skills-desktop.png") });
 	await page.screenshot({
@@ -4942,7 +4941,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Vaults"]);
+	).toHaveText(["Hosted agent · Hermes", "Workspace", "Vaults"]);
 	await expect(main.getByText("Project: Hosted Agent Project", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
@@ -4972,7 +4971,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Vaults", "Hosted Scoped Vault"]);
+	).toHaveText(["Hosted agent · Hermes", "Workspace", "Vaults", "Hosted Scoped Vault"]);
 	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
@@ -5017,13 +5016,12 @@ test("Breadcrumbs show the full trail on desktop and only the current page on na
 		await breadcrumb.evaluate((element) =>
 			Array.from(element.children).map((child) => child.tagName),
 		),
-	).toEqual(["LI", "LI", "LI", "LI", "LI"]);
+	).toEqual(["LI", "LI", "LI"]);
 	await expect(breadcrumb.locator('[data-slot="breadcrumb-item"]:visible')).toHaveText([
-		"Agents",
 		"Hosted agent · Hermes",
 		"Memories",
 	]);
-	await expect(breadcrumb.locator('[data-slot="breadcrumb-separator"]:visible')).toHaveCount(2);
+	await expect(breadcrumb.locator('[data-slot="breadcrumb-separator"]:visible')).toHaveCount(1);
 	await page.screenshot({
 		path: testInfo.outputPath("responsive-breadcrumb-desktop.png"),
 		fullPage: false,
@@ -5407,7 +5405,7 @@ test("hosted Agent Skill details retain deployment context and stay inside bound
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Hosted agent · Hermes", "Workspace", "Skills", "Hosted detail Skill"]);
+	).toHaveText(["Hosted agent · Hermes", "Workspace", "Skills", "Hosted detail Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	await expect(

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1955,7 +1955,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Skills"]);
+	).toHaveText(["Smoke Codex", "Workspace", "Skills"]);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-skills-desktop.png") });
 	await page.screenshot({
@@ -1971,7 +1971,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Vaults"]);
+	).toHaveText(["Smoke Codex", "Workspace", "Vaults"]);
 	await expect(main.getByText("Project: Smoke Project", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
@@ -2028,7 +2028,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Smoke Codex", "Projects", "Team Knowledge", "Skills"]);
+	).toHaveText(["Smoke Codex", "Projects", "Team Knowledge", "Skills"]);
 	await expect(main.getByRole("button", { name: "Back to Team Knowledge" })).toHaveCount(0);
 	await page.goto("/agents/agent-smoke-1/project-access/project-context-later");
 	await expect(main.getByRole("heading", { name: longContextProjectName, level: 1 })).toBeVisible();
@@ -2115,7 +2115,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Vaults", "Scoped Vault"]);
+	).toHaveText(["Smoke Codex", "Workspace", "Vaults", "Scoped Vault"]);
 	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
@@ -2278,7 +2278,7 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Agents", "Smoke Codex", "Workspace", "Skills", "Scoped Skill"]);
+	).toHaveText(["Smoke Codex", "Workspace", "Skills", "Scoped Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	const agentSkillsLink = main

--- a/apps/web/src/components/app-breadcrumb-model.ts
+++ b/apps/web/src/components/app-breadcrumb-model.ts
@@ -69,10 +69,7 @@ function buildAgentBreadcrumbTrail(
 	const deploymentQuery = agentDeploymentRouteQuery(search);
 	const agentHref = agentSectionHref(route.agentId, "overview", deploymentQuery);
 	const agentTitle = segmentTitle(segmentTitles, agentHref);
-	const trail: AppBreadcrumbTrailItem[] = [
-		{ key: "agents", label: "Agents", href: "/agents" },
-		{ key: "agent", label: agentTitle, href: agentHref },
-	];
+	const trail: AppBreadcrumbTrailItem[] = [{ key: "agent", label: agentTitle, href: agentHref }];
 
 	if (route.section === "overview") {
 		return finishTrail(trail, overrideTitle ?? agentTitle);

--- a/apps/web/src/components/app-breadcrumb.test.ts
+++ b/apps/web/src/components/app-breadcrumb.test.ts
@@ -41,7 +41,7 @@ describe("AppBreadcrumb semantic trail", () => {
 					},
 				},
 			}),
-		).toEqual(["Agents", "Hermes", "Workspace", "Skills"]);
+		).toEqual(["Hermes", "Workspace", "Skills"]);
 	});
 
 	test("keeps linked Projects in the Projects hierarchy", () => {
@@ -51,7 +51,7 @@ describe("AppBreadcrumb semantic trail", () => {
 					[`/agents/${agentId}/project-access/${projectId}`]: { title: "Team Knowledge" },
 				},
 			}),
-		).toEqual(["Agents", "Hermes", "Projects", "Team Knowledge", "Vaults"]);
+		).toEqual(["Hermes", "Projects", "Team Knowledge", "Vaults"]);
 	});
 
 	test("does not mistake a linked Project named Workspace for the Agent Workspace", () => {
@@ -61,7 +61,7 @@ describe("AppBreadcrumb semantic trail", () => {
 					[`/agents/${agentId}/project-access/${projectId}`]: { title: "Workspace" },
 				},
 			}),
-		).toEqual(["Agents", "Hermes", "Projects", "Workspace"]);
+		).toEqual(["Hermes", "Projects", "Workspace"]);
 	});
 
 	test("shows real Skill and Vault names in their selected Project context", () => {
@@ -77,28 +77,26 @@ describe("AppBreadcrumb semantic trail", () => {
 				title: "GitHub Issues",
 				segmentTitles,
 			}),
-		).toEqual(["Agents", "Hermes", "Workspace", "Skills", "GitHub Issues"]);
+		).toEqual(["Hermes", "Workspace", "Skills", "GitHub Issues"]);
 		expect(
 			labels(`/agents/${agentId}/vaults/production`, {
 				search: { ...deploymentSearch, project: workspaceId },
 				title: "Production Keys",
 				segmentTitles,
 			}),
-		).toEqual(["Agents", "Hermes", "Workspace", "Vaults", "Production Keys"]);
+		).toEqual(["Hermes", "Workspace", "Vaults", "Production Keys"]);
 	});
 
 	test("shows real names for Agent-level resources", () => {
 		expect(labels(`/agents/${agentId}/sessions/session-1`, { title: "Deploy the API" })).toEqual([
-			"Agents",
 			"Hermes",
 			"Sessions",
 			"Deploy the API",
 		]);
 		expect(
 			labels(`/agents/${agentId}/memories/memory-1`, { title: "Prefers concise replies" }),
-		).toEqual(["Agents", "Hermes", "Memories", "Prefers concise replies"]);
+		).toEqual(["Hermes", "Memories", "Prefers concise replies"]);
 		expect(labels(`/agents/${agentId}/connectors/github`, { title: "GitHub" })).toEqual([
-			"Agents",
 			"Hermes",
 			"Connectors",
 			"GitHub",
@@ -119,7 +117,6 @@ describe("AppBreadcrumb semantic trail", () => {
 			},
 		});
 		expect(trail.filter((item) => item.href).map((item) => item.href)).toEqual([
-			"/agents",
 			`/agents/${agentId}?source=on-clawdi&d=deployment-1`,
 			`/agents/${agentId}/project-access/${workspaceId}?source=on-clawdi&d=deployment-1`,
 			`/agents/${agentId}/project-access/${workspaceId}/skills?source=on-clawdi&d=deployment-1`,
@@ -130,6 +127,6 @@ describe("AppBreadcrumb semantic trail", () => {
 		expect(labels("/projects/550e8400-e29b-41d4-a716-446655440000")).toEqual(["Projects", null]);
 		expect(
 			labels(`/agents/${agentId}/vaults/internal-slug`, { search: { project: projectId } }),
-		).toEqual(["Agents", "Hermes", null, "Vaults", null]);
+		).toEqual(["Hermes", null, "Vaults", null]);
 	});
 });


### PR DESCRIPTION
## What changed
- remove the redundant Agents root from every Agent-scoped breadcrumb
- keep the real Agent name as the first breadcrumb and preserve Workspace, Project, resource, and Hosted deployment context
- leave the Agents page and sidebar navigation unchanged

## Verification
- focused breadcrumb tests: 7 passed
- Web TypeScript typecheck
- Biome on touched files
- git diff check