### PR TITLE
fix(web): omit implicit Workspace breadcrumbs

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4918,7 +4918,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Hosted agent · Hermes", "Workspace", "Skills"]);
+	).toHaveText(["Hosted agent · Hermes", "Skills"]);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("hosted-workspace-skills-desktop.png") });
 	await page.screenshot({
@@ -4941,7 +4941,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Hosted agent · Hermes", "Workspace", "Vaults"]);
+	).toHaveText(["Hosted agent · Hermes", "Vaults"]);
 	await expect(main.getByText("Project: Hosted Agent Project", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
@@ -4971,7 +4971,7 @@ test("hosted Agent keeps Memory and Connector card details nested with deploymen
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Hosted agent · Hermes", "Workspace", "Vaults", "Hosted Scoped Vault"]);
+	).toHaveText(["Hosted agent · Hermes", "Vaults", "Hosted Scoped Vault"]);
 	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
@@ -5405,7 +5405,7 @@ test("hosted Agent Skill details retain deployment context and stay inside bound
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Hosted agent · Hermes", "Workspace", "Skills", "Hosted detail Skill"]);
+	).toHaveText(["Hosted agent · Hermes", "Skills", "Hosted detail Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	await expect(

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1955,7 +1955,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Smoke Codex", "Workspace", "Skills"]);
+	).toHaveText(["Smoke Codex", "Skills"]);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-skills-desktop.png") });
 	await page.screenshot({
@@ -1971,7 +1971,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Smoke Codex", "Workspace", "Vaults"]);
+	).toHaveText(["Smoke Codex", "Vaults"]);
 	await expect(main.getByText("Project: Smoke Project", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Back to Agent Overview" })).toHaveCount(0);
 	await expect(
@@ -2115,7 +2115,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Smoke Codex", "Workspace", "Vaults", "Scoped Vault"]);
+	).toHaveText(["Smoke Codex", "Vaults", "Scoped Vault"]);
 	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
 	await expect(
 		main
@@ -2278,7 +2278,7 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 		page
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Smoke Codex", "Workspace", "Skills", "Scoped Skill"]);
+	).toHaveText(["Smoke Codex", "Skills", "Scoped Skill"]);
 	await expect(main.getByRole("button", { name: "Agent Skills" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Manage in resource library" })).toHaveCount(0);
 	const agentSkillsLink = main

--- a/apps/web/src/components/app-breadcrumb-model.ts
+++ b/apps/web/src/components/app-breadcrumb-model.ts
@@ -84,6 +84,9 @@ function buildAgentBreadcrumbTrail(
 		if (route.projectResource) {
 			return finishTrail(trail, overrideTitle ?? agentSectionLabel(route.projectResource));
 		}
+		if (context.kind !== "project") {
+			return finishTrail(trail, agentTitle);
+		}
 		return finishTrail(trail, overrideTitle ?? context.label);
 	}
 
@@ -151,13 +154,12 @@ function appendProjectContext(
 	context: ReturnType<typeof projectContext>,
 	query: ReturnType<typeof agentDeploymentRouteQuery>,
 ) {
-	if (context.kind === "project") {
-		trail.push({
-			key: "projects",
-			label: "Projects",
-			href: agentSectionHref(agentId, "projects", query),
-		});
-	}
+	if (context.kind !== "project") return;
+	trail.push({
+		key: "projects",
+		label: "Projects",
+		href: agentSectionHref(agentId, "projects", query),
+	});
 	trail.push({
 		key: `project:${context.projectId}`,
 		label: context.label,

--- a/apps/web/src/components/app-breadcrumb.test.ts
+++ b/apps/web/src/components/app-breadcrumb.test.ts
@@ -31,17 +31,21 @@ function labels(
 }
 
 describe("AppBreadcrumb semantic trail", () => {
-	test("presents the Agent Workspace outside the Projects hierarchy", () => {
+	test("omits the implicit Workspace layer from Agent breadcrumbs", () => {
+		const segmentTitles = {
+			[`/agents/${agentId}/project-access/${workspaceId}`]: {
+				title: "Workspace",
+				context: "workspace" as const,
+			},
+		};
+		expect(labels(`/agents/${agentId}/project-access/${workspaceId}`, { segmentTitles })).toEqual([
+			"Hermes",
+		]);
 		expect(
 			labels(`/agents/${agentId}/project-access/${workspaceId}/skills`, {
-				segmentTitles: {
-					[`/agents/${agentId}/project-access/${workspaceId}`]: {
-						title: "Workspace",
-						context: "workspace",
-					},
-				},
+				segmentTitles,
 			}),
-		).toEqual(["Hermes", "Workspace", "Skills"]);
+		).toEqual(["Hermes", "Skills"]);
 	});
 
 	test("keeps linked Projects in the Projects hierarchy", () => {
@@ -77,14 +81,14 @@ describe("AppBreadcrumb semantic trail", () => {
 				title: "GitHub Issues",
 				segmentTitles,
 			}),
-		).toEqual(["Hermes", "Workspace", "Skills", "GitHub Issues"]);
+		).toEqual(["Hermes", "Skills", "GitHub Issues"]);
 		expect(
 			labels(`/agents/${agentId}/vaults/production`, {
 				search: { ...deploymentSearch, project: workspaceId },
 				title: "Production Keys",
 				segmentTitles,
 			}),
-		).toEqual(["Hermes", "Workspace", "Vaults", "Production Keys"]);
+		).toEqual(["Hermes", "Vaults", "Production Keys"]);
 	});
 
 	test("shows real names for Agent-level resources", () => {
@@ -118,7 +122,6 @@ describe("AppBreadcrumb semantic trail", () => {
 		});
 		expect(trail.filter((item) => item.href).map((item) => item.href)).toEqual([
 			`/agents/${agentId}?source=on-clawdi&d=deployment-1`,
-			`/agents/${agentId}/project-access/${workspaceId}?source=on-clawdi&d=deployment-1`,
 			`/agents/${agentId}/project-access/${workspaceId}/skills?source=on-clawdi&d=deployment-1`,
 		]);
 	});
@@ -127,6 +130,6 @@ describe("AppBreadcrumb semantic trail", () => {
 		expect(labels("/projects/550e8400-e29b-41d4-a716-446655440000")).toEqual(["Projects", null]);
 		expect(
 			labels(`/agents/${agentId}/vaults/internal-slug`, { search: { project: projectId } }),
-		).toEqual(["Hermes", null, "Vaults", null]);
+		).toEqual(["Hermes", "Vaults", null]);
 	});
 });


### PR DESCRIPTION
## What changed
- omit the implicit Workspace layer from Agent-scoped breadcrumbs
- keep Skills and Vaults directly under the real Agent name
- preserve the full Projects > Project hierarchy for linked Projects
- leave Workspace sidebar grouping and page headings unchanged

## Verification
- focused breadcrumb tests: 7 passed
- Web TypeScript typecheck
- Biome on touched files
- git diff check