### PR TITLE
fix(web): make orphan agent deletion reachable

### DIFF
--- a/apps/web/src/hosted/agents/agent-home.test.ts
+++ b/apps/web/src/hosted/agents/agent-home.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
+
+describe("hosted agent home composition", () => {
+	test("mounts the existing delete action only in the settled unresolved-hosted branch", () => {
+		const loadingBranch = source.indexOf("if (isLoading)");
+		const errorBranch = source.indexOf("if (error && requestedHostedAgent && !deployment)");
+		const ambiguousBranch = source.indexOf("if (ambiguousMatches.length > 0)");
+		const resolvedBranch = source.indexOf("if (deployment)");
+		const unresolvedBranch = source.indexOf("if (requestedHostedAgent)");
+		const connectedBranch = source.lastIndexOf("<ConnectedAgentDetail");
+		const unresolvedComposition = source.slice(unresolvedBranch, connectedBranch);
+
+		expect(loadingBranch).toBeLessThan(unresolvedBranch);
+		expect(errorBranch).toBeLessThan(unresolvedBranch);
+		expect(ambiguousBranch).toBeLessThan(unresolvedBranch);
+		expect(resolvedBranch).toBeLessThan(unresolvedBranch);
+		expect(unresolvedComposition).toContain("<HostedDeploymentDeleteAction");
+		expect(unresolvedComposition).toContain("deploymentId={unresolvedHostedDeploymentId}");
+		expect(unresolvedComposition).toContain("<Trash2 /> Delete");
+		expect(source.slice(resolvedBranch, unresolvedBranch)).toContain("<HostedAgentDetail");
+	});
+
+	test("derives the orphan delete target from existing route identity only after lookup settles", () => {
+		expect(source).toContain(
+			"requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading",
+		);
+		expect(source).toContain(
+			"deploymentSelector ?? (!isCloudEnvironmentId ? environmentId : null)",
+		);
+		expect(source).toContain("const unresolvedHostedDeploymentId = unresolvedHostedAgent");
+	});
+});

--- a/apps/web/src/hosted/agents/agent-home.test.ts
+++ b/apps/web/src/hosted/agents/agent-home.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { agentRouteTargetsHostedDeployment } from "@/hosted/agent-identity";
 
 const source = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
 
 describe("hosted agent home composition", () => {
 	test("mounts the existing delete action only in the settled unresolved-hosted branch", () => {
-		const loadingBranch = source.indexOf("if (isLoading)");
+		const loadingBranch = source.indexOf("if (isLoading ||");
 		const errorBranch = source.indexOf("if (error && requestedHostedAgent && !deployment)");
 		const ambiguousBranch = source.indexOf("if (ambiguousMatches.length > 0)");
 		const resolvedBranch = source.indexOf("if (deployment)");
@@ -23,13 +24,15 @@ describe("hosted agent home composition", () => {
 		expect(source.slice(resolvedBranch, unresolvedBranch)).toContain("<HostedAgentDetail");
 	});
 
-	test("derives the orphan delete target from existing route identity only after lookup settles", () => {
-		expect(source).toContain(
-			"requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading",
-		);
-		expect(source).toContain(
-			"deploymentSelector ?? (!isCloudEnvironmentId ? environmentId : null)",
-		);
+	test("recovers a bare UUID route from the Cloud environment mapping after lookup settles", () => {
+		const productionEnvironmentId = "54a92911-97ca-5ba8-a25c-f413d99176d3";
+		expect(agentRouteTargetsHostedDeployment(productionEnvironmentId, null, null)).toBe(false);
+		expect(source).toContain('"/v1/environments/{environment_id}"');
+		expect(source).toContain("cloudEnvironment.data?.hosted_deployment_id?.trim()");
+		expect(source).toContain("Boolean(cloudHostedDeploymentId)");
+		expect(source).toContain("!cloudEnvironment.isLoading");
+		expect(source).toContain("!cloudEnvironment.error");
+		expect(source).toContain("deploymentSelector ??\n\t\t\tcloudHostedDeploymentId ??");
 		expect(source).toContain("const unresolvedHostedDeploymentId = unresolvedHostedAgent");
 	});
 });

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -47,6 +47,7 @@ import {
 	CONNECTED_AGENT_SECTION_IDS,
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
+import { useOpenApi } from "@/lib/api";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
@@ -84,6 +85,14 @@ export function AgentHome({
 	const router = useRouter();
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const deploymentSelector = agentDeploymentSelector(routeSearch);
+	const isCloudEnvironmentId = isCloudEnvId(environmentId);
+	const needsCloudEnvironmentMapping = isCloudEnvironmentId && !deploymentSelector;
+	const cloudEnvironment = useOpenApi().useQuery(
+		"get",
+		"/v1/environments/{environment_id}",
+		{ params: { path: { environment_id: environmentId } } },
+		{ enabled: needsCloudEnvironmentMapping },
+	);
 	const {
 		deployment,
 		environmentId: resolvedEnvId,
@@ -96,18 +105,25 @@ export function AgentHome({
 		error,
 		refetch,
 	} = useAgentDeployment(environmentId, deploymentSelector);
-	const isCloudEnvironmentId = isCloudEnvId(environmentId);
 	const routeSource = agentRouteSource(routeSearch);
 	const requestedFromCloudRedirect = routeSource === "on-clawdi";
-	const requestedHostedAgent = agentRouteTargetsHostedDeployment(
-		environmentId,
-		routeSource,
-		deploymentSelector,
-	);
+	const cloudHostedDeploymentId = needsCloudEnvironmentMapping
+		? cloudEnvironment.data?.hosted_deployment_id?.trim() || null
+		: null;
+	const requestedHostedAgent =
+		agentRouteTargetsHostedDeployment(environmentId, routeSource, deploymentSelector) ||
+		Boolean(cloudHostedDeploymentId);
 	const unresolvedHostedAgent =
-		requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading;
+		requestedHostedAgent &&
+		!deployment &&
+		ambiguousMatches.length === 0 &&
+		!error &&
+		!isLoading &&
+		(!needsCloudEnvironmentMapping || (!cloudEnvironment.isLoading && !cloudEnvironment.error));
 	const unresolvedHostedDeploymentId = unresolvedHostedAgent
-		? (deploymentSelector ?? (!isCloudEnvironmentId ? environmentId : null))
+		? (deploymentSelector ??
+			cloudHostedDeploymentId ??
+			(!isCloudEnvironmentId ? environmentId : null))
 		: null;
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
@@ -236,7 +252,7 @@ export function AgentHome({
 
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
-	if (isLoading) {
+	if (isLoading || (needsCloudEnvironmentMapping && cloudEnvironment.isLoading && !deployment)) {
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -2,7 +2,7 @@
 
 import { focusManager } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
-import { AlertCircle, ChevronRight, RefreshCw } from "lucide-react";
+import { AlertCircle, ChevronRight, RefreshCw, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -26,6 +26,7 @@ import {
 	deploymentDisplayName,
 	isCloudEnvId,
 } from "@/hosted/agent-identity";
+import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
 import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -105,6 +106,9 @@ export function AgentHome({
 	);
 	const unresolvedHostedAgent =
 		requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading;
+	const unresolvedHostedDeploymentId = unresolvedHostedAgent
+		? (deploymentSelector ?? (!isCloudEnvironmentId ? environmentId : null))
+		: null;
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
@@ -300,15 +304,27 @@ export function AgentHome({
 					title="Clawdi Cloud agent not found"
 					description="This Clawdi Cloud agent may still be starting or may have been removed."
 					action={
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							disabled={manualChecking}
-							onClick={() => void handleCheckAgain()}
-						>
-							{manualChecking ? <Spinner className="size-3.5" /> : <RefreshCw />} Check again
-						</Button>
+						<div className="flex flex-wrap justify-center gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								disabled={manualChecking}
+								onClick={() => void handleCheckAgain()}
+							>
+								{manualChecking ? <Spinner className="size-3.5" /> : <RefreshCw />} Check again
+							</Button>
+							{unresolvedHostedDeploymentId ? (
+								<HostedDeploymentDeleteAction
+									deploymentId={unresolvedHostedDeploymentId}
+									onAccepted={() => router.navigate({ href: "/agents", replace: true })}
+								>
+									<Button type="button" variant="destructive" size="sm">
+										<Trash2 /> Delete
+									</Button>
+								</HostedDeploymentDeleteAction>
+							) : null}
+						</div>
 					}
 				/>
 			</div>

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -26,15 +26,15 @@ import {
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-export function HostedDeploymentDeleteAction({
-	children,
-	deployment,
-	onAccepted,
-}: {
-	children: ReactElement;
-	deployment: HostedDeployment;
-	onAccepted?: () => Promise<void> | void;
-}) {
+export function HostedDeploymentDeleteAction(
+	props: {
+		children: ReactElement;
+		onAccepted?: () => Promise<void> | void;
+	} & ({ deployment: HostedDeployment } | { deploymentId: string }),
+) {
+	const { children, onAccepted } = props;
+	const deployment = "deployment" in props ? props.deployment : undefined;
+	const deploymentId = "deployment" in props ? props.deployment.resource.id : props.deploymentId;
 	const router = useRouter();
 	const deleteDeployment = useDeleteDeployment();
 	const [open, setOpen] = useState(false);
@@ -42,12 +42,12 @@ export function HostedDeploymentDeleteAction({
 		useState<DeploymentDeleteRequest["subscription_choice"]>("cancel_subscription");
 	const [pending, setPending] = useState(false);
 	const locked = useRef(false);
-	const subscription = deployment.commercial_display?.compute_subscription;
+	const subscription = deployment?.commercial_display?.compute_subscription;
 	const offerChoice =
-		computeFundingMode(deployment.current_plan_slug, subscription) === "subscription" &&
+		computeFundingMode(deployment?.current_plan_slug ?? null, subscription) === "subscription" &&
 		isComputeSubscriptionRenewing(subscription);
 	const periodEnd = formatShortDate(subscription?.current_period_end);
-	const name = deploymentDisplayName(deployment.resource.spec.name);
+	const name = deployment ? deploymentDisplayName(deployment.resource.spec.name) : null;
 
 	async function runDelete() {
 		if (locked.current) return;
@@ -56,8 +56,8 @@ export function HostedDeploymentDeleteAction({
 		try {
 			try {
 				await deleteDeployment.mutateAsync({
-					id: deployment.resource.id,
-					resourceVersion: deployment.resource.metadata.resourceVersion,
+					id: deploymentId,
+					resourceVersion: deployment?.resource.metadata.resourceVersion,
 					request: {
 						subscription_choice: offerChoice ? choice : "keep_subscription",
 					},
@@ -101,7 +101,7 @@ export function HostedDeploymentDeleteAction({
 			<AlertDialogTrigger render={children} />
 			<AlertDialogContent data-hosted="true">
 				<AlertDialogHeader>
-					<AlertDialogTitle>{`Delete ${name}?`}</AlertDialogTitle>
+					<AlertDialogTitle>{name ? `Delete ${name}?` : "Delete this agent?"}</AlertDialogTitle>
 					<AlertDialogDescription>
 						This permanently deletes the agent and releases its resources. This can’t be undone.
 					</AlertDialogDescription>

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -232,7 +232,11 @@ export function useDeleteDeployment() {
 	const client = useBillingClient();
 	const qc = useQueryClient();
 	return useMutation({
-		mutationFn: (vars: { id: string; request: DeploymentDeleteRequest; resourceVersion: string }) =>
+		mutationFn: (vars: {
+			id: string;
+			request: DeploymentDeleteRequest;
+			resourceVersion?: string;
+		}) =>
 			runStableDeploymentIntent(
 				"deployment-delete",
 				{ action: "delete", id: vars.id, request: vars.request },

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -685,6 +685,45 @@ describe("declarative deployment mutations", () => {
 		expect(requests[1]?.headers.get("If-Match")).toBe('"rv-last-known"');
 	});
 
+	it("deletes a definitively absent deployment without a cached resource version", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			if (request.method === "GET") {
+				return jsonResponse({ detail: "Deployment not found" }, 404);
+			}
+			return jsonResponse({ deployment_id: "hdep_orphan", status: "absent" });
+		});
+
+		await expect(
+			client.deleteDeployment(
+				"hdep_orphan",
+				{ subscription_choice: "keep_subscription" },
+				"intent-orphan",
+			),
+		).resolves.toEqual({ deploymentId: "hdep_orphan", operation: null });
+		expect(requests.map((request) => request.method)).toEqual(["GET", "DELETE"]);
+		expect(requests[1]?.headers.get("Idempotency-Key")).toBe("intent-orphan");
+		expect(requests[1]?.headers.get("If-Match")).toBe('"absent"');
+	});
+
+	it("does not delete when the deployment pre-read fails transiently", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			return jsonResponse({ detail: "Inventory temporarily unavailable" }, 503);
+		});
+
+		await expect(
+			client.deleteDeployment(
+				"hdep_pre_read_transient",
+				{ subscription_choice: "keep_subscription" },
+				"intent-pre-read-transient",
+			),
+		).rejects.toMatchObject({ status: 503 });
+		expect(requests.map((request) => request.method)).toEqual(["GET"]);
+	});
+
 	it("keeps transient absent-deletion failures rejected", async () => {
 		const client = testClient(async (request) => {
 			if (request.method === "GET") {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -172,6 +172,10 @@ function isNotFound(error: unknown): error is BillingApiError {
 	return error instanceof BillingApiError && error.status === 404;
 }
 
+// The absent-row branch in the hosted repo's backend/app/v2/routes.py requires
+// If-Match to be present but has no local resource version to compare against.
+const ABSENT_DEPLOYMENT_RESOURCE_VERSION = "absent";
+
 function acceptDeploymentDelete(
 	response: DeploymentOperation | DeploymentDeleteConvergedResponse,
 ): DeploymentDeleteResult {
@@ -435,8 +439,8 @@ export function createBillingClient(
 		try {
 			resourceVersion = (await getDeployment(id)).resource.metadata.resourceVersion;
 		} catch (error) {
-			if (!isNotFound(error) || !lastKnownResourceVersion) throw error;
-			resourceVersion = lastKnownResourceVersion;
+			if (!isNotFound(error)) throw error;
+			resourceVersion = lastKnownResourceVersion ?? ABSENT_DEPLOYMENT_RESOURCE_VERSION;
 		}
 
 		for (let attempt = 0; attempt < 2; attempt += 1) {


### PR DESCRIPTION
## Summary

- recover the hosted deployment id for a bare Cloud environment UUID from the existing generated environment-detail query
- mount the existing `HostedDeploymentDeleteAction` in the settled unresolved-hosted panel, without a deployment stub, new component, hook, or API
- send a strong `"absent"` If-Match sentinel only when the deployment pre-read definitively returns 404 without a cached resource version; transient pre-read failures still reject

## Reachability proof: `/agents/54a92911-97ca-5ba8-a25c-f413d99176d3` (no query string)

1. With no query string, `agentDeploymentSelector(routeSearch)` is null. The route id is a Cloud UUID, so `AgentHome` enables the existing generated `useOpenApi().useQuery("get", "/v1/environments/{environment_id}", ...)` query for that UUID (`apps/web/src/hosted/agents/agent-home.tsx:87-95`). `useAgentDeployment` also runs the existing hosted-inventory resolution (`apps/web/src/hosted/agents/deployment-hooks.ts:118-159`).
2. The Cloud environment detail route returns `EnvironmentResponse` (`backend/app/routes/sessions.py:743-763`). Its read joins the caller-owned `AgentEnvironment` to `HostedRuntimeState` (`backend/app/routes/sessions.py:465-505`), and the serializer copies `hosted_state.deployment_id` to `hosted_deployment_id` (`backend/app/routes/sessions.py:1226-1240`). Therefore the orphan still returns its environment record and hosted mapping even though the hosted deployment inventory no longer contains that deployment.
3. `AgentHome` trims that mapping into `cloudHostedDeploymentId`, uses it to restore hosted classification, and chooses the delete id in the order route selector, Cloud environment mapping, then the existing direct deployment-id fallback (`apps/web/src/hosted/agents/agent-home.tsx:108-127`).
4. The unresolved predicate cannot become true until hosted inventory and environment mapping have settled successfully, with no deployment and no ambiguous matches (`apps/web/src/hosted/agents/agent-home.tsx:113-127`). Mapping/inventory loading renders the existing skeleton, while inventory error, ambiguity, and a resolved deployment all return before the unresolved panel (`apps/web/src/hosted/agents/agent-home.tsx:229-310`).
5. For this orphan, inventory is settled with no deployment and the environment mapping supplies the id, so the unresolved panel mounts the existing `HostedDeploymentDeleteAction` with that id (`apps/web/src/hosted/agents/agent-home.tsx:313-347`). The resolved `HostedAgentDetail` path remains unchanged (`apps/web/src/hosted/agents/agent-home.tsx:290-310`).
6. The existing delete action submits that mapped id without inventing resource fields or a cached resource version (`apps/web/src/hosted/agents/deployment-delete-action.tsx:29-64`).
7. The billing client pre-read receives the definitive 404, selects the sentinel resource version `absent`, and `strongResourceEtag` emits the strong header `If-Match: "absent"`; other pre-read errors still throw (`apps/web/src/hosted/billing/billing-client.ts:153-177`, `apps/web/src/hosted/billing/billing-client.ts:432-459`).
8. The hosted absent-row branch requires the header but performs no resource-version comparison (`hosted/backend/app/v2/routes.py:1378-1383`). Its 200 `{"deployment_id": ..., "status": "absent"}` response is accepted as a completed deletion with no operation (`apps/web/src/hosted/billing/billing-client.ts:179-184`), and the existing action returns to Agents.

## Tests

- `bun run --cwd apps/web test:internal src/hosted/agents/agent-home.test.ts src/hosted/billing/billing-client.test.ts` — 27 passed, 111 assertions
- `bun run typecheck` — passed
- `bun run test` — passed:
  - web: 958 passed
  - shared: 72 passed
  - WhatsApp sidecar: 65 passed
  - CLI: 1,612 passed, 4 skipped
  - backend: 2,235 passed, 11 skipped
- `bun run check` — passed
