### PR TITLE
Fix agent list loading and ownership edge cases

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -54,4 +54,12 @@ describe("hosted agent detail header", () => {
 		);
 		expect(source).not.toContain("Vaults, profile, and channels");
 	});
+
+	test("uses the shared billing query contract for overview workspace skills", () => {
+		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
+
+		expect(source).toContain("queryKey: billingKeys.workspaceSkills(deployment.resource.id)");
+		expect(source).toContain("enabled: isRunningStatus(deploymentStatus)");
+		expect(source).toContain("retry: billingQueryRetry");
+	});
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -151,12 +151,14 @@ import {
 } from "@/hosted/billing/deploy/language-timezone-controls";
 import {
 	billingErrorNormalizer,
+	billingQueryRetry,
 	normalizeBillingError,
 	PlanChangePendingError,
 	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
 import {
+	billingKeys,
 	useCancelSubscription,
 	useChangePlan,
 	useCheckPlanChange,
@@ -1131,8 +1133,10 @@ function OverviewTab({
 				? "unavailable"
 				: "ready";
 	const runtimeSkills = useQuery({
-		queryKey: ["hosted", "deployments", deployment.resource.id, "skills"],
+		queryKey: billingKeys.workspaceSkills(deployment.resource.id),
 		queryFn: () => billingClient.listWorkspaceSkills(deployment.resource.id),
+		enabled: isRunningStatus(deploymentStatus),
+		retry: billingQueryRetry,
 	});
 	const skillsModule = runtimeSkills.isLoading
 		? { description: <OverviewDescriptionSkeleton label="skills" /> }

--- a/apps/web/src/hosted/agents/ownership-sensor.ts
+++ b/apps/web/src/hosted/agents/ownership-sensor.ts
@@ -24,7 +24,23 @@ function envIdSet(ids: readonly string[] | undefined): ReadonlySet<string> {
 	return set;
 }
 
-export function useLegacyEnvIds(): ReadonlySet<string> | null {
+export function resolveLegacyEnvIds(
+	enabled: boolean,
+	environmentIds: readonly string[] | undefined,
+	error: Error | null,
+): {
+	envIds: ReadonlySet<string> | null;
+	error: Error | null;
+	isLoading: boolean;
+} {
+	if (!enabled) return { envIds: EMPTY_ENV_IDS, error: null, isLoading: false };
+	if (environmentIds !== undefined) {
+		return { envIds: envIdSet(environmentIds), error: null, isLoading: false };
+	}
+	return { envIds: null, error, isLoading: error === null };
+}
+
+export function useLegacyEnvIds() {
 	const access = useHostedProductAccess();
 	const client = useBillingClient();
 	const enabled = access.canUseLegacyHostedDashboard && isDeployApiConfigured();
@@ -39,17 +55,16 @@ export function useLegacyEnvIds(): ReadonlySet<string> | null {
 		staleTime: 30_000,
 	});
 
-	return useMemo(() => {
-		if (!enabled) return EMPTY_ENV_IDS;
+	const resolution = useMemo(() => {
 		// Only data (fresh or stale cache) resolves the set. The endpoint has
 		// no 404 in its success contract — users without live v1 deployments
 		// get an empty list — so a 404 can only mean "route not deployed
 		// yet" (rollout skew) and, like every other error, stays UNRESOLVED:
 		// destructive consumers fail closed instead of treating live legacy
 		// agents as connected.
-		if (query.data) return envIdSet(query.data.environment_ids);
-		return null;
-	}, [enabled, query.data, query.error, query.isPending]);
+		return resolveLegacyEnvIds(enabled, query.data?.environment_ids, query.error);
+	}, [enabled, query.data, query.error]);
+	return { ...resolution, refetch: query.refetch };
 }
 
 /**
@@ -67,7 +82,7 @@ export function HostedAgentOwnershipSensor({
 	onChange: (ownership: AgentOwnership | null) => void;
 }) {
 	const cloudInventory = useHostedDeploymentInventory();
-	const legacyEnvIds = useLegacyEnvIds();
+	const legacy = useLegacyEnvIds();
 
 	const cloudEnvIds = useMemo(
 		() => claimedEnvIdsFromDeployments(cloudInventory.deployments ?? []),
@@ -77,10 +92,10 @@ export function HostedAgentOwnershipSensor({
 	const ownership = useMemo<AgentOwnership>(
 		() => ({
 			cloudEnvIds,
-			legacyEnvIds: legacyEnvIds ?? EMPTY_ENV_IDS,
-			isResolved: cloudInventory.status === "resolved" && legacyEnvIds !== null,
+			legacyEnvIds: legacy.envIds ?? EMPTY_ENV_IDS,
+			isResolved: cloudInventory.status === "resolved" && legacy.envIds !== null,
 		}),
-		[cloudEnvIds, cloudInventory.status, legacyEnvIds],
+		[cloudEnvIds, cloudInventory.status, legacy.envIds],
 	);
 
 	useEffect(() => {

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -16,6 +16,8 @@ export const billingKeys = {
 	billingHistory: (limit: number) => [...billingHistoryRoot, limit] as const,
 	plans: ["billing", "plans"] as const,
 	deployments: ["billing", "deployments"] as const,
+	workspaceSkills: (deploymentId: string) =>
+		["hosted", "deployments", deploymentId, "skills"] as const,
 	legacyAgentEnvironments: ["billing", "legacy-agent-environments"] as const,
 	me: ["billing", "me"] as const,
 	usage: (days: number | null, agentId: string | null = null) =>

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -14,7 +14,8 @@ export type HostedInventoryStatus = "resolved" | "loading" | "error" | "unavaila
 export type HostedInventoryResolution = {
 	status: HostedInventoryStatus;
 	/**
-	 * The last successful membership snapshot, with deleted deployments removed.
+	 * The last successful membership snapshot. Deleted deployments retain any
+	 * projected agent claim until the projection is cleaned up.
 	 * `null` means membership has never resolved; an empty array is authoritative.
 	 */
 	deployments: HostedDeployment[] | null;
@@ -37,9 +38,12 @@ export class HostedInventoryUnavailableError extends Error {
 	}
 }
 
-/** Deleted deployments stop owning an agent as soon as the deploy API says so. */
+/** Deleted deployments retain a projected agent claim during asynchronous cleanup. */
 export function isHostedDeploymentMember(deployment: HostedDeployment): boolean {
-	return deploymentStatusFromResource(deployment.resource.status).kind !== "deleted";
+	return (
+		deploymentStatusFromResource(deployment.resource.status).kind !== "deleted" ||
+		runtimeEnvironmentId(deployment) !== undefined
+	);
 }
 
 /** Pending or authoritatively accepted deletion dismisses the agent during cleanup. */

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -280,6 +280,15 @@ describe("deploymentToTiles", () => {
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
 
+	test("does not flash pending sync while the environment join is unresolved", () => {
+		const [tile] = hostedDeploymentToTiles(
+			deployment({ status: "running", environmentId: "env-lagging-join" }),
+		);
+
+		expect(tile?.env).toBeNull();
+		expect(tile?.cardStatus?.labels).toEqual(["Running"]);
+	});
+
 	test("keeps a failed plan change on a summary-only tile", () => {
 		const environmentId = "env-failed-plan-change";
 		const reason = "Top up your Wallet and retry the plan change.";

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -199,7 +199,7 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 	};
 	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
 	const failure = deploymentFailurePresentation(d);
-	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv ?? null, failure);
+	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv, failure);
 	const cardStatus: AgentCardStatusProjection = {
 		visual: {
 			label: runtimeStatus.primary.label,

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -3,12 +3,21 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import type { AgentTile } from "@/components/dashboard/agents-card";
+import {
+	claimedEnvIdsFromDeployments,
+	hostedDeploymentMembers,
+} from "@/hosted/hosted-agent-resolution";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 type Env = components["schemas"]["AgentResponse"];
 type SelectUnifiedAgentList =
 	typeof import("@/hosted/use-unified-agent-list").selectUnifiedAgentList;
+type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
+type ResolveLegacyEnvIds = typeof import("@/hosted/agents/ownership-sensor").resolveLegacyEnvIds;
 
 let getUnifiedAgentList: SelectUnifiedAgentList | null = null;
+let getDeploymentToTiles: DeploymentToTiles | null = null;
+let getLegacyEnvIdsResolution: ResolveLegacyEnvIds | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -16,11 +25,25 @@ beforeAll(async () => {
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/use-unified-agent-list");
 	getUnifiedAgentList = module.selectUnifiedAgentList;
+	const tilesModule = await import("@/hosted/use-hosted-agent-tiles");
+	getDeploymentToTiles = tilesModule.deploymentToTiles;
+	const ownershipModule = await import("@/hosted/agents/ownership-sensor");
+	getLegacyEnvIdsResolution = ownershipModule.resolveLegacyEnvIds;
 });
 
 function selectUnifiedAgentList(args: Parameters<SelectUnifiedAgentList>[0]) {
 	if (!getUnifiedAgentList) throw new Error("selectUnifiedAgentList was not loaded");
 	return getUnifiedAgentList(args);
+}
+
+function deploymentToTiles(...args: Parameters<DeploymentToTiles>) {
+	if (!getDeploymentToTiles) throw new Error("deploymentToTiles was not loaded");
+	return getDeploymentToTiles(...args);
+}
+
+function resolveLegacyEnvIds(...args: Parameters<ResolveLegacyEnvIds>) {
+	if (!getLegacyEnvIdsResolution) throw new Error("resolveLegacyEnvIds was not loaded");
+	return getLegacyEnvIdsResolution(...args);
 }
 
 function env(id: string, name: string): Env {
@@ -163,6 +186,55 @@ describe("selectUnifiedAgentList", () => {
 			[connected.id, "self-managed"],
 		]);
 		expect(selection.membershipResolved).toBe(true);
+	});
+
+	test("hides a deleted deployment without resurfacing its lagging environment as connected", () => {
+		const projected = env("44444444-4444-4444-8444-444444444444", "deleted-hosted-env");
+		const deleted = hostedDeploymentFixture({
+			id: "dep_deleted",
+			status: "deleted",
+			cloudEnvironments: { openclaw: projected.id },
+		});
+		const deployments = hostedDeploymentMembers([deleted]);
+		const hostedTiles = deploymentToTiles(deleted, new Map([[projected.id, projected]]));
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [projected],
+			hostedTiles,
+			claimedEnvIds: claimedEnvIdsFromDeployments(deployments),
+			legacyEnvIds: new Set(),
+			hostedInventoryStatus: "resolved",
+			showLegacyAgents: false,
+		});
+
+		expect(deployments).toEqual([deleted]);
+		expect(selection.hostedTiles).toEqual([]);
+		expect(selection.connectedTiles).toEqual([]);
+		expect(selection.tiles).toEqual([]);
+	});
+});
+
+describe("legacy membership resolution", () => {
+	test("surfaces an initial endpoint failure instead of remaining in loading state", () => {
+		const error = new Error("legacy endpoint unavailable");
+		const unifiedSource = readFileSync(
+			new URL("./use-unified-agent-list.ts", import.meta.url),
+			"utf8",
+		);
+		const sectionSource = readFileSync(
+			new URL("./hosted-agents-section.tsx", import.meta.url),
+			"utf8",
+		);
+
+		expect(resolveLegacyEnvIds(true, undefined, error)).toEqual({
+			envIds: null,
+			error,
+			isLoading: false,
+		});
+		expect(unifiedSource).toContain(
+			"error: hosted.error ?? (showLegacyAgents ? legacy.error : null)",
+		);
+		expect(sectionSource).toContain("{unified.error ? (");
+		expect(sectionSource).toContain("<HostedUnavailableBanner");
 	});
 });
 

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -97,8 +97,8 @@ export function useUnifiedAgentList({
 		cloudEnvs,
 		includeDeployments: showCloudDeployments,
 	});
-	const resolvedLegacyEnvIds = useLegacyEnvIds();
-	const legacyEnvIds = showLegacyAgents ? resolvedLegacyEnvIds : EMPTY_ENV_IDS;
+	const legacy = useLegacyEnvIds();
+	const legacyEnvIds = showLegacyAgents ? legacy.envIds : EMPTY_ENV_IDS;
 	const selection = useMemo(
 		() =>
 			selectUnifiedAgentList({
@@ -125,11 +125,13 @@ export function useUnifiedAgentList({
 		deletionFailures: hosted.deletionFailures,
 		inventoryStatus: hosted.inventoryStatus,
 		isFetching: hosted.isFetching,
-		isLoading:
-			(showCloudDeployments && hosted.isLoading) ||
-			(showLegacyAgents && resolvedLegacyEnvIds === null),
-		error: hosted.error,
-		refetch: hosted.refetch,
+		isLoading: (showCloudDeployments && hosted.isLoading) || (showLegacyAgents && legacy.isLoading),
+		error: hosted.error ?? (showLegacyAgents ? legacy.error : null),
+		refetch: () =>
+			Promise.all([
+				...(showCloudDeployments ? [hosted.refetch()] : []),
+				...(showLegacyAgents ? [legacy.refetch()] : []),
+			]),
 	};
 }
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -369,7 +369,7 @@ async def _list_agent_identities(
     envs = result.scalars().all()
     states_by_env: dict[UUID, HostedRuntimeState] = {}
     env_ids = [env.id for env in envs]
-    if env_ids:
+    if not agent_response and env_ids:
         states = (
             (
                 await db.execute(


### PR DESCRIPTION
## Summary

- avoid loading full HostedRuntimeState rows for /v1/agents while preserving legacy environment responses
- retain deleted deployment environment claims through asynchronous cleanup without rendering a hosted or connected tile
- surface initial legacy ownership failures through the unified list error and retry path while keeping classification fail-closed
- preserve an unresolved environment join for hosted tile status and align overview workspace-skills reads with shared query keys, retry policy, and running-state gating

## Query impact

Before, GET /v1/agents selected AgentEnvironment rows and then selected complete HostedRuntimeState rows, including the JSONB runtime, MCP, skills, tools, live-sync, and recovery payloads, before discarding them. After, the canonical agent list performs only the AgentEnvironment query. The legacy /v1/environments list still performs both queries because its response uses runtime-state fields. Response shapes and ETag behavior are unchanged.

## Verification

- bun test apps/web/src/hosted/use-unified-agent-list.test.ts apps/web/src/hosted/use-hosted-agent-tiles.test.ts apps/web/src/hosted/agents/hosted-agent-detail.test.ts
- bun run typecheck
- bun run check
- bun run test