### PR TITLE
chore(cli): delete obsolete container runtime residue

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -111,7 +111,6 @@ export function configPaths(opts: { json?: boolean } = {}) {
 		},
 		hosted: {
 			hostPolicy: hostedPaths.hostPolicy,
-			shareRoot: hostedPaths.shareRoot,
 			serviceStateRoot: hostedPaths.serviceStateRoot,
 			managedConfig: hostedPaths.managedConfig,
 			syncState: hostedPaths.syncState,

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -3024,7 +3024,7 @@ function spawnWithNumericIdentity(
 	args: string[],
 	env: NodeJS.ProcessEnv,
 ): ChildProcess {
-	const child = buildEgressEngineSpawnCommand(commandExistsOnPath, uid, gid, command, args);
+	const child = buildEgressEngineSpawnCommand(commandExists, uid, gid, command, args);
 	return spawn(child.command, child.args, {
 		env,
 		stdio: ["ignore", "pipe", "pipe"],
@@ -3128,14 +3128,6 @@ export function publishEgressSystemCaBundle(config: TransparentEgressEnvConfig):
 
 function runningAsRootCommand(): boolean {
 	return typeof process.getuid === "function" && process.getuid() === 0;
-}
-
-function commandExistsOnPath(command: string): boolean {
-	const result = spawnSync("command", ["-v", command], {
-		shell: true,
-		stdio: "ignore",
-	});
-	return result.status === 0;
 }
 
 function waitForShutdownSignal(): Promise<void> {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1592,15 +1592,5 @@ function resolveEnvironmentId(agentType: AgentType, registeredCount: number): st
 		const fromEnv = process.env.CLAWDI_ENVIRONMENT_ID;
 		if (fromEnv) return fromEnv;
 	}
-	// Last resort: read /etc/clawdi/env-id (writable mount in
-	// the pod entrypoint). Skipped on host.
-	const podPath = "/etc/clawdi/env-id";
-	if (registeredCount === 1 && existsSync(podPath)) {
-		try {
-			return readFileSync(podPath, "utf-8").trim();
-		} catch {
-			/* fall through */
-		}
-	}
 	return null;
 }

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -14,7 +14,6 @@ export interface RuntimePaths {
 	localEnvironments: string;
 	serveState: string;
 	hostPolicy: string;
-	shareRoot: string;
 	serviceStateRoot: string;
 	oauthCredentialRoot: string;
 	managedConfig: string;
@@ -108,7 +107,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 	const clawdiHome = defaultClawdiHome(mode, userHome);
 	const serviceStateRoot = envPath("CLAWDI_SERVICE_STATE_DIR") ?? "/var/lib/clawdi";
 	const runRoot = envPath("CLAWDI_RUN_DIR") ?? "/run/clawdi";
-	const shareRoot = envPath("CLAWDI_SHARE_DIR") ?? "/usr/share/clawdi";
 	const managedCliRoot = join(serviceStateRoot, "managed-cli");
 	const npmRoot = join(serviceStateRoot, "npm");
 	const cacheRoot = join(serviceStateRoot, "cache");
@@ -125,7 +123,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		localEnvironments: join(clawdiHome, "environments"),
 		serveState: join(clawdiHome, "serve"),
 		hostPolicy: getHostPolicyPath(),
-		shareRoot,
 		serviceStateRoot,
 		oauthCredentialRoot: join(serviceStateRoot, "oauth-credentials"),
 		managedConfig: join(serviceStateRoot, "config", "clawdi.json"),

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
-import { runRuntimeUserCommand, spawnRuntimeUserCommand } from "./runtime-user-command";
+import {
+	commandExists,
+	runRuntimeUserCommand,
+	spawnRuntimeUserCommand,
+} from "./runtime-user-command";
+
+test("command existence follows shell resolution", () => {
+	expect(commandExists("command")).toBe(true);
+	expect(commandExists("clawdi-command-that-does-not-exist")).toBe(false);
+});
 
 describe("runtime user command timeout", () => {
 	test("bounds synchronous runtime-user commands", () => {

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -15,10 +15,11 @@ export function executableExists(path: string): boolean {
 }
 
 export function commandExists(name: string): boolean {
-	for (const dir of (process.env.PATH ?? "").split(":")) {
-		if (dir && executableExists(join(dir, name))) return true;
-	}
-	return false;
+	const result = spawnSync("/bin/sh", ["-c", 'command -v "$1" >/dev/null 2>&1', "sh", name], {
+		env: process.env,
+		stdio: "ignore",
+	});
+	return result.status === 0;
 }
 
 export function commandResolvable(command: string): boolean {


### PR DESCRIPTION
## Summary

- Delete the unreachable Kubernetes pod-mount fallback for `/etc/clawdi/env-id`.
- Delete the inert `shareRoot` runtime path, its `CLAWDI_SHARE_DIR` override, and its config echo.
- Consolidate the audited command-existence checks on the shared shell-semantic predicate.

## Verification before deletion

1. A repository-wide search, including tests, found `/etc/clawdi/env-id` only in `serve.ts`; there were no other readers or writers. The Incus tenant path therefore has no producer for this fallback.
2. A repository-wide search found `shareRoot`, `CLAWDI_SHARE_DIR`, and `/usr/share/clawdi` only in the `RuntimePaths` declaration/default/return value and the `config paths` echo. There was no runtime consumer, so the field was deleted instead of changing its default.
3. On current `main`, the manually walking predicate from the audit has moved from `paths.ts` to `runtime-user-command.ts`; the divergent shell-based predicate remained in `commands/runtime.ts`. This PR keeps one shared implementation and migrates that runtime caller. The retained implementation uses the shell builtin `command -v`, so it resolves builtins and follows shell PATH semantics. The command name is passed as positional parameter `$1` instead of interpolated into shell source.

## Coordination

Item 3 has a minimal unavoidable overlap with `fix/unify-privilege-drop-entry`: it updates only the shared predicate in `packages/cli/src/runtime/runtime-user-command.ts` and one predicate call in `packages/cli/src/commands/runtime.ts`. It does not alter gosu/runuser branches, `commands/run.ts`, `runtime/observed.ts`, or `runtime/manifest.ts`. The separate helper in `commands/run.ts` is intentionally left for that parallel PR as requested. Recommended sequence: merge this PR first, then rebase `fix/unify-privilege-drop-entry` and preserve/use this shared shell-semantic predicate.

The deferred `/etc/clawdi/runtime-context` layout is unchanged.

## Verification

- `bun run typecheck`
- `bun run test`
- `bun run check` (passes; reports one pre-existing info-level `useTemplate` diagnostic)
- `git diff --check`

Net diff: 16 insertions, 28 deletions (12 lines deleted net).