### PR TITLE
Harden tenant service reconciliation boundaries

### DIFF
--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -251,7 +251,13 @@ interface InstallGateHarness {
 	receipt: () => unknown;
 }
 
-function officialServiceHarness(runtime: "openclaw" | "hermes" = "hermes"): InstallGateHarness {
+interface OfficialServiceInstallHarness extends InstallGateHarness {
+	addForeignDropIn: () => string;
+}
+
+function officialServiceHarness(
+	runtime: "openclaw" | "hermes" = "hermes",
+): OfficialServiceInstallHarness {
 	const paths = tempRuntimePaths();
 	const logPath = join(paths.runRoot, "official-service-receipt.log");
 	const command =
@@ -296,6 +302,16 @@ function officialServiceHarness(runtime: "openclaw" | "hermes" = "hermes"): Inst
 			0,
 		receipt: () =>
 			readRuntimeInstallReceipts(paths)?.officialServices[`${runtime}-gateway.service`],
+		addForeignDropIn: () => {
+			const path = join(
+				paths.systemdUserRoot,
+				`${runtime}-gateway.service.d`,
+				"20-user-override.conf",
+			);
+			mkdirSync(dirname(path), { recursive: true });
+			writeFileSync(path, "[Service]\nExecStart=\nExecStart=/usr/bin/false\n");
+			return path;
+		},
 	};
 }
 
@@ -534,9 +550,11 @@ describe("runtime manifest services", () => {
 		expect(runtimeWatchUnit).toContain(`ExecStart="${paths.cliManagedBin}" "runtime" "watch"`);
 		expect(runtimeWatchUnit).toContain("TasksMax=infinity");
 		expect(runtimeWatchUnit).not.toContain("ConditionPathExists=");
-		expect(runtimeWatchEnv).toContain('BYOK_RUNTIME_SECRET="runtime-byok-value"');
-		expect(runtimeWatchEnv).toContain('BYOK_SERVICE_SECRET="service-byok-value"');
+		expect(runtimeWatchEnv).not.toContain("runtime-byok-value");
+		expect(runtimeWatchEnv).not.toContain("service-byok-value");
 		expect(runtimeWatchEnv).not.toContain("stale-watcher-value");
+		expect(runtimeWatchEnv).not.toContain("BYOK_RUNTIME_SECRET");
+		expect(runtimeWatchEnv).not.toContain("BYOK_SERVICE_SECRET");
 		expect(runtimeWatchEnv).not.toContain("NON_SECRET_RUNTIME_SETTING");
 		for (const unit of [hermesUnit, dashboardUnit, openclawUnit]) {
 			expect(unit).not.toContain("clawdi run --");
@@ -733,10 +751,14 @@ describe("runtime manifest services", () => {
 		});
 		expect(gatewayEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
 		expect(gatewayEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
-		expect(watchEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="opaque-password-value"');
-		expect(watchEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="opaque-session-value"');
-		expect(watchEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
-		expect(watchEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
+		expect(watchEnv).not.toContain("opaque-password-value");
+		expect(watchEnv).not.toContain("opaque-session-value");
+		expect(watchEnv).not.toContain("runtime-source-token");
+		expect(watchEnv).not.toContain("bundle-runtime-token");
+		expect(watchEnv).not.toContain("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD");
+		expect(watchEnv).not.toContain("HERMES_DASHBOARD_BASIC_AUTH_SECRET");
+		expect(watchEnv).not.toContain("RUNTIME_TARGET_TOKEN");
+		expect(watchEnv).not.toContain("RUNTIME_BUNDLE_TOKEN");
 		expect(watchEnv).not.toContain("RUNTIME_SOURCE_TOKEN");
 		expect(watchEnv).not.toContain("must-not-be-exposed");
 		expect(watchEnv).not.toContain("UNRELATED_RUNTIME_SECRET");
@@ -802,24 +824,11 @@ describe("runtime manifest services", () => {
 		const rotatedGatewayUnit = readUserServiceConfig(paths, "hermes-gateway");
 		const rotatedWatchEnv = readFileSync(watchEnvPath, "utf8");
 		const rotatedWatchUnit = readFileSync(watchUnitPath, "utf8");
-		expect(rotatedWatchEnv).toContain(
-			'HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="rotated-dashboard-password"',
-		);
-		expect(rotatedWatchEnv).toContain(
-			'HERMES_DASHBOARD_BASIC_AUTH_SECRET="rotated-dashboard-session-secret"',
-		);
-		expect(rotatedWatchEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
-		expect(rotatedWatchEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
-		expect(rotatedWatchEnv).not.toContain(
-			'HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="dashboard-password"',
-		);
-		expect(rotatedWatchEnv).not.toContain(
-			'HERMES_DASHBOARD_BASIC_AUTH_SECRET="dashboard-session-secret"',
-		);
+		expect(rotatedWatchEnv).toBe(watchEnv);
 		expect(rotatedDashboardUnit).not.toBe(dashboardUnit);
 		expect(rotatedGatewayUnit).toBe(gatewayUnit);
-		// The root watcher consumes projected files on each tick, so its public
-		// unit need not restart solely to acquire rotated secret bytes.
+		// The root watcher reloads the apply-context file on each tick, so neither
+		// its environment nor its unit needs secret bytes.
 		expect(rotatedWatchUnit).toBe(watchUnit);
 		expect(rotatedWatchUnit).not.toContain("runtime-source-token");
 		expect(rotatedWatchUnit).not.toContain("rotated-runtime-source-token");
@@ -848,10 +857,9 @@ describe("runtime manifest services", () => {
 		expect(sourceChanged.installErrors).toEqual([]);
 		const sourceChangedWatchEnv = readFileSync(watchEnvPath, "utf8");
 		const sourceChangedWatchUnit = readFileSync(watchUnitPath, "utf8");
-		expect(sourceChangedWatchEnv).toContain('RUNTIME_TARGET_TOKEN="next-runtime-source-value"');
-		expect(sourceChangedWatchEnv).not.toContain("NEXT_RUNTIME_SOURCE_TOKEN");
-		// The public unit binds only destination names. Source and value changes
-		// stay in the root-only EnvironmentFile instead of creating a verifier.
+		expect(sourceChangedWatchEnv).toBe(rotatedWatchEnv);
+		// Secret source and value changes are resolved through the apply context
+		// and do not alter the long-lived watcher's process environment.
 		expect(sourceChangedWatchUnit).toBe(rotatedWatchUnit);
 		expect(sourceChangedWatchUnit).not.toContain("next-runtime-source-value");
 		expect(warnings.join("\n")).not.toContain("next-runtime-source-value");
@@ -1014,7 +1022,7 @@ describe("runtime manifest services", () => {
 		expect(existsSync(join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"))).toBe(false);
 	});
 
-	test("merges watcher secret environments deterministically and fails closed on conflicts", () => {
+	test("does not project colliding runtime secret destinations into the watcher environment", () => {
 		const converge = (
 			runtimeOrder: Array<"hermes" | "openclaw">,
 			secretValues: Record<string, string>,
@@ -1073,29 +1081,20 @@ describe("runtime manifest services", () => {
 			"secret://runtime/hermes": "hermes-secret",
 			"secret://runtime/openclaw": "openclaw-secret",
 		};
-		const forward = converge(["hermes", "openclaw"], conflictingValues).result;
-		const reverse = converge(["openclaw", "hermes"], conflictingValues).result;
-		const expectedError =
-			"runtime apply failed: Runtime watch secret environment SHARED_RUNTIME_SECRET conflicts between hermes-gateway and openclaw-gateway.";
-
-		expect(forward.installErrors).toEqual([expectedError]);
-		expect(reverse.installErrors).toEqual([expectedError]);
-		expect(forward.outputs.systemdSystemUnits).toEqual([]);
-		expect(reverse.outputs.systemdSystemUnits).toEqual([]);
-		expect(expectedError).not.toContain("hermes-secret");
-		expect(expectedError).not.toContain("openclaw-secret");
-
-		const deduplicated = converge(["openclaw", "hermes"], {
-			"secret://clawdi/auth-token": "test-token",
-			"secret://runtime/hermes": "shared-secret",
-			"secret://runtime/openclaw": "shared-secret",
-		});
-		expect(deduplicated.result.installErrors).toEqual([]);
-		const watchEnv = readFileSync(
-			join(deduplicated.paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
-			"utf8",
-		);
-		expect(watchEnv.match(/^SHARED_RUNTIME_SECRET="shared-secret"$/gm)).toHaveLength(1);
+		for (const runtimeOrder of [
+			["hermes", "openclaw"],
+			["openclaw", "hermes"],
+		] as const) {
+			const converged = converge([...runtimeOrder], conflictingValues);
+			expect(converged.result.installErrors).toEqual([]);
+			const watchEnv = readFileSync(
+				join(converged.paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
+				"utf8",
+			);
+			expect(watchEnv).not.toContain("SHARED_RUNTIME_SECRET");
+			expect(watchEnv).not.toContain("hermes-secret");
+			expect(watchEnv).not.toContain("openclaw-secret");
+		}
 	});
 
 	test("converges official service state before installers restart units", () => {
@@ -1879,6 +1878,30 @@ describe("runtime manifest services", () => {
 		expect(harness.converge().installErrors).toEqual([]);
 		expect(harness.installCount()).toBe(2);
 		expect(harness.receipt()).toBeDefined();
+	});
+
+	test.each([
+		["Hermes", "hermes"],
+		["OpenClaw", "openclaw"],
+	] as const)("reports foreign %s gateway drop-ins without deleting them", (_name, runtime) => {
+		const harness = officialServiceHarness(runtime);
+		expect(harness.converge().installErrors).toEqual([]);
+		const receipt = harness.receipt();
+		const foreignDropIn = harness.addForeignDropIn();
+		const foreignContents = readFileSync(foreignDropIn, "utf8");
+
+		const drifted = harness.converge();
+
+		expect(drifted.installErrors).toEqual([
+			expect.stringContaining(
+				`foreign systemd drop-in drift detected for ${runtime}-gateway.service`,
+			),
+		]);
+		expect(drifted.installErrors.join("\n")).toContain(foreignDropIn);
+		expect(drifted.outputs.systemdUserUnits).toEqual([]);
+		expect(harness.installCount()).toBe(1);
+		expect(harness.receipt()).toEqual(receipt);
+		expect(readFileSync(foreignDropIn, "utf8")).toBe(foreignContents);
 	});
 
 	test("uninstalls stale official gateway services when manifest disables them", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -5331,6 +5331,7 @@ function runtimeManagedMutationPlan(input: {
 	runtimeUserOwnershipTargets: string[];
 	staleOfficialUnits: string[];
 	systemdUserUnits: string[];
+	systemdDriftErrors: string[];
 } {
 	const rootTargets = new Set(runtimeRootLiveMutationTargets(input.manifest, input.paths));
 	rootTargets.add(runtimeInstallReceiptsPath(input.paths));
@@ -5421,6 +5422,7 @@ function runtimeManagedMutationPlan(input: {
 		runtimeUserOwnershipTargets,
 		staleOfficialUnits: systemd.staleOfficialUnits,
 		systemdUserUnits: systemd.unitNames,
+		systemdDriftErrors: systemd.driftErrors,
 	};
 }
 
@@ -5588,6 +5590,22 @@ export function convergeRuntimeManifest(
 		programs: plannedRuntimePrograms,
 		observations,
 	});
+	if (mutationPlan.systemdDriftErrors.length > 0) {
+		installErrors.push(...mutationPlan.systemdDriftErrors);
+		return runtimeConvergenceWithoutApply({
+			load,
+			paths,
+			workspaceRoot,
+			enabledRuntimes,
+			installErrors,
+			projectedProviderIds: Object.fromEntries(
+				Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
+					runtime,
+					[...providerIds],
+				]),
+			),
+		});
+	}
 	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
 	const liveSnapshot = captureRuntimeLiveSnapshot(mutationPlan.snapshot);
 	let systemdActivationApplied = false;

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -582,7 +582,6 @@ describe("hosted runtime bundle v2", () => {
 		expect(watchUnit).toContain(`EnvironmentFile=${watchEnvPath}`);
 		const gatewayTokenLine = 'OPENCLAW_GATEWAY_TOKEN="openclaw-gateway-token-golden"';
 		const watchEnv = readFileSync(watchEnvPath, "utf-8");
-		expect(watchEnv).toContain(gatewayTokenLine);
 		expect(statSync(watchEnvPath).mode & 0o777).toBe(0o600);
 		const sidecarOnlySecrets = [
 			"runtime-auth-token-golden",
@@ -590,8 +589,14 @@ describe("hosted runtime bundle v2", () => {
 			"123456789:telegram-agent-golden",
 			mcpSecret,
 		];
-		for (const secret of sidecarOnlySecrets) expect(watchEnv).not.toContain(secret);
-		expect(watchEnv).toContain("999999999:9ded1453047ec0a48ec3b735075f7448");
+		for (const secret of [
+			...sidecarOnlySecrets,
+			"openclaw-gateway-token-golden",
+			"999999999:9ded1453047ec0a48ec3b735075f7448",
+		]) {
+			expect(watchEnv).not.toContain(secret);
+		}
+		expect(watchEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 		expect(
 			readFileSync(join(paths.systemdEnvRoot, "openclaw-gateway.service.env"), "utf-8"),
 		).toContain(gatewayTokenLine);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -124,6 +124,7 @@ export interface RuntimeSystemdUserMutationPlan {
 	metadataTargets: string[];
 	unitNames: string[];
 	staleOfficialUnits: string[];
+	driftErrors: string[];
 }
 
 export interface RuntimeSystemdStaleFilePlan {
@@ -303,8 +304,14 @@ function systemdUnitFileName(name: string): string {
 	return `${systemdUnitNameSegment(name)}.service`;
 }
 
+const RUNTIME_SYSTEMD_DROP_IN_FILE = "10-clawdi-hosted.conf";
+
 function systemdDropInFilePath(paths: RuntimePaths, unitName: string): string {
-	return join(paths.systemdUserRoot, `${systemdUnitFileName(unitName)}.d`, "10-clawdi-hosted.conf");
+	return join(
+		paths.systemdUserRoot,
+		`${systemdUnitFileName(unitName)}.d`,
+		RUNTIME_SYSTEMD_DROP_IN_FILE,
+	);
 }
 
 function systemdQuote(value: string): string {
@@ -1091,6 +1098,42 @@ function systemdUnitNameFromPath(unitPath: string): string {
 	return unitPath.split("/").at(-1) ?? "";
 }
 
+function foreignRuntimeSystemdUserDropIns(paths: RuntimePaths, unitName: string): string[] {
+	const dropInRoot = join(paths.systemdUserRoot, `${unitName}.d`);
+	let rootStat: ReturnType<typeof lstatSync>;
+	try {
+		rootStat = lstatSync(dropInRoot);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return [dropInRoot];
+	// systemd merges only *.conf files from unit drop-in directories:
+	// https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html
+	return readdirSync(dropInRoot)
+		.filter((entry) => entry.endsWith(".conf") && entry !== RUNTIME_SYSTEMD_DROP_IN_FILE)
+		.map((entry) => join(dropInRoot, entry))
+		.sort();
+}
+
+function officialRuntimeSystemdUserDropInDriftErrors(
+	programs: RuntimeSystemdUserProgram[],
+	paths: RuntimePaths,
+): string[] {
+	const errors: string[] = [];
+	for (const program of officialRuntimeSystemdPrograms(programs)) {
+		const unitName = systemdUnitFileName(runtimeSystemdProgramName(program));
+		const foreignDropIns = foreignRuntimeSystemdUserDropIns(paths, unitName);
+		if (foreignDropIns.length === 0) continue;
+		errors.push(
+			`foreign systemd drop-in drift detected for ${unitName}; refusing to reconcile the platform override while these drop-ins exist: ${foreignDropIns
+				.map((path) => JSON.stringify(path))
+				.join(", ")}`,
+		);
+	}
+	return errors;
+}
+
 function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: string[]): string[] {
 	if (!existsSync(paths.systemdUserRoot)) return [];
 	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
@@ -1100,7 +1143,7 @@ function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: str
 		const unitName = entry.slice(0, -".d".length);
 		if (writtenNames.has(unitName)) continue;
 		if (!officialRuntimeServiceDescriptorForUnit(unitName)) continue;
-		const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+		const dropInPath = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
 		if (!isGeneratedSystemdFile(dropInPath)) continue;
 		const baseUnitPath = join(paths.systemdUserRoot, unitName);
 		if (!existsSync(baseUnitPath) || isGeneratedSystemdFile(baseUnitPath)) continue;
@@ -1187,7 +1230,7 @@ export function planRuntimeSystemdUserMutations(
 			}
 			if (!entry.endsWith(".service.d")) continue;
 			const unitName = entry.slice(0, -".d".length);
-			const dropInPath = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+			const dropInPath = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
 			if (!isGeneratedSystemdFile(dropInPath) || writtenNames.has(unitName)) continue;
 			targets.add(dropInPath);
 			const enablementPath = join(paths.systemdUserRoot, "default.target.wants", unitName);
@@ -1215,6 +1258,7 @@ export function planRuntimeSystemdUserMutations(
 		metadataTargets: [...metadataTargets].sort(),
 		unitNames: [...unitNames].sort(),
 		staleOfficialUnits,
+		driftErrors: officialRuntimeSystemdUserDropInDriftErrors(programs, paths),
 	};
 }
 
@@ -1261,7 +1305,7 @@ function planStaleRuntimeSystemdFiles(
 			}
 			if (!entry.endsWith(".service.d")) continue;
 			const unitName = entry.slice(0, -".d".length);
-			const dropIn = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+			const dropIn = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
 			if (desiredUser.has(unitName) || !isGeneratedSystemdFile(dropIn)) continue;
 			files.add(dropIn);
 			files.add(join(paths.systemdUserRoot, "default.target.wants", unitName));
@@ -1294,7 +1338,7 @@ export function removeStaleRuntimeSystemdFiles(
 	for (const path of plan.files) {
 		try {
 			rmSync(path, { force: true });
-			if (path.endsWith("/10-clawdi-hosted.conf") && existsSync(dirname(path))) {
+			if (path.endsWith(`/${RUNTIME_SYSTEMD_DROP_IN_FILE}`) && existsSync(dirname(path))) {
 				if (readdirSync(dirname(path)).length === 0) rmdirSync(dirname(path));
 			}
 		} catch (error) {
@@ -1336,29 +1380,6 @@ export function runtimeSystemdCommonEnvironment(paths: RuntimePaths): Record<str
 		PATH: runtimeSystemdPath(paths),
 	};
 	return environment;
-}
-
-function runtimeWatchSecretEnvironment(
-	programs: RuntimeSystemdUserProgram[],
-): Record<string, string> {
-	const retained = new Map<string, { value: string; program: string }>();
-	for (const program of [...programs].sort((a, b) =>
-		runtimeSystemdProgramName(a).localeCompare(runtimeSystemdProgramName(b)),
-	)) {
-		const programName = runtimeSystemdProgramName(program);
-		for (const [envName, value] of Object.entries(program.resolvedSecretEnv).sort(([a], [b]) =>
-			a.localeCompare(b),
-		)) {
-			const existing = retained.get(envName);
-			if (existing && existing.value !== value) {
-				throw new Error(
-					`Runtime watch secret environment ${envName} conflicts between ${existing.program} and ${programName}.`,
-				);
-			}
-			retained.set(envName, { value, program: existing?.program ?? programName });
-		}
-	}
-	return Object.fromEntries([...retained].map(([envName, entry]) => [envName, entry.value]));
 }
 
 function writeRuntimeSystemdUserProgram(input: {
@@ -1505,7 +1526,6 @@ export function writeRuntimeSystemdState(input: {
 		desiredUserUnitNames,
 	);
 	if (daemonAuthTokenFile) {
-		const watchSecretEnvironment = runtimeWatchSecretEnvironment(runtimePrograms);
 		systemUnits.push(
 			writeSystemdSystemUnit({
 				paths,
@@ -1516,16 +1536,6 @@ export function writeRuntimeSystemdState(input: {
 				cwd: workspaceRoot,
 				env: {
 					...commonEnvironment,
-					...watchSecretEnvironment,
-					CLAWDI_AUTH_TOKEN: "",
-				},
-				// Unit files are 0644. Hash only secret destination names into their
-				// revision so the unit cannot become an offline verifier for values.
-				// The watcher resolves values from the atomic apply-context file on
-				// each tick; keep secret bytes out of its public revision material.
-				revisionEnv: {
-					...commonEnvironment,
-					...Object.fromEntries(Object.keys(watchSecretEnvironment).map((name) => [name, ""])),
 					CLAWDI_AUTH_TOKEN: "",
 				},
 				extraServiceLines: ["TasksMax=infinity"],

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7516,7 +7516,8 @@ fi
 			const watchEnv = readSystemdEnvFile(paths, "clawdi-runtime-watch");
 			const daemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
 			const gatewayEnv = readSystemdEnvFile(paths, "openclaw-gateway");
-			expect(watchEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"');
+			expect(watchEnv).not.toContain("gateway-token-watch");
+			expect(watchEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 			expect(gatewayEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"');
 			expect(watchEnv).not.toContain("file-runtime-token");
 			const patchText = readFileSync(openclawPatch, "utf-8");


### PR DESCRIPTION
## Summary

- remove resolved tenant secret values and destination names from the long-lived root runtime watcher's environment; the watcher now retains only its non-secret common environment and resolves secrets from the apply-context-backed manifest bundle on each reconcile
- fail closed before filesystem snapshots, installers, systemd activation, or authority commit when an enabled official OpenClaw or Hermes gateway has a foreign systemd `*.conf` drop-in
- report foreign drop-ins through the existing convergence `installErrors` path and leave every user-owned file untouched
- centralize the platform-owned `10-clawdi-hosted.conf` filename used by rendering and garbage collection

## Verification before changing behavior

I traced the production watcher path from `runtimeWatch` through `runtimeWatchTick` to `loadRemoteRuntimeManifest`. Production does not inject an in-memory apply context, so each tick calls `readRuntimeApplyContext()` and uses that context's manifest source/auth to fetch the current bundle. The returned bundle supplies the `secretValues` consumed by convergence. No watcher code reads runtime secret destination/value pairs from `process.env`; the watcher environment copy was therefore a non-load-bearing fallback.

The official gateway base units remain vendor-owned user units. The platform-owned `10-clawdi-hosted.conf` is still rendered as before. During planning, the reconciler now enumerates each desired official gateway's `.service.d` directory and rejects foreign `*.conf` entries. systemd's documented drop-in semantics load `.conf` files from these directories in alphanumeric order: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html

## Tests

- `bun run typecheck`
- `bun run check` (passes; retains the pre-existing informational Biome diagnostic at `packages/cli/src/runtime/hosted-openclaw-skill.test.ts:77`)
- `bun run test` (CLI: 1,615 passed / 4 skipped; backend: 2,235 passed / 11 skipped; Docker test resources cleaned up)
- focused runtime manifest service suite: 36 passed
- focused strict-v2/live-watch coverage passed
- changed-file Biome check and `git diff --check`

## Coordination / overlap

`fix/daemon-control-rpc-tenant-escalation` also edits `packages/cli/src/runtime/runtime-systemd-reconciliation.ts`, specifically the adjacent `clawdi-daemon.service` environment block. This PR does not change that daemon block; its same-file edits are limited to the watcher block and drop-in planning/GC regions.

Suggested merge order: merge this boundary-hardening PR first, then rebase `fix/daemon-control-rpc-tenant-escalation` onto updated `main` and preserve the watcher changes while applying that PR's daemon environment changes. `fix/unify-privilege-drop-entry` owns different files/logic and is not touched here.
