### PR TITLE
fix(cli): close hosted daemon control RPC privilege escalation

### DIFF
--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { PendingAuth } from "../lib/config";
 import { adapterForType } from "../lib/select-adapter";
-import { rejectUnsupportedOpts, runDaemonWorkers } from "./serve";
+import { rejectUnsupportedOpts, runDaemonWorkers, startDaemonControlRpc } from "./serve";
 
 /**
  * Behavior tests for daemon singleton handler behavior:
@@ -578,6 +578,44 @@ describe("full control RPC handler surface", () => {
 });
 
 describe("daemon HTTP RPC listener safety", () => {
+	it("does not create or open the control RPC listener in hosted mode", async () => {
+		const originalRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
+		const root = mkdtempSync(join(tmpdir(), "clawdi-hosted-rpc-disabled-"));
+		const controlDir = join(root, "control");
+		const abort = new AbortController();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		try {
+			const rpc = await startDaemonControlRpc({}, abort.signal, { controlDir, port: 0 });
+			expect(rpc).toBeNull();
+			expect(existsSync(join(controlDir, "control-token"))).toBe(false);
+		} finally {
+			abort.abort();
+			if (originalRuntimeMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+			else process.env.CLAWDI_RUNTIME_MODE = originalRuntimeMode;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("still opens the control RPC listener outside hosted mode", async () => {
+		const originalRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
+		const root = mkdtempSync(join(tmpdir(), "clawdi-local-rpc-enabled-"));
+		const controlDir = join(root, "control");
+		const abort = new AbortController();
+		process.env.CLAWDI_RUNTIME_MODE = "local";
+		try {
+			const rpc = await startDaemonControlRpc({}, abort.signal, { controlDir, port: 0 });
+			if (!rpc) throw new Error("expected local control RPC listener");
+			expect(rpc.http.port).toBeGreaterThan(0);
+			expect(existsSync(rpc.tokenPath)).toBe(true);
+			await rpc.close();
+		} finally {
+			abort.abort();
+			if (originalRuntimeMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
+			else process.env.CLAWDI_RUNTIME_MODE = originalRuntimeMode;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects non-loopback listen hosts unless explicitly allowed", async () => {
 		const { serve } = await import("./serve");
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -48,6 +48,7 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { evaluateHostPolicyForCommand } from "../runtime/host-policy";
 import { runRuntimeObservationProducer } from "../runtime/observation-producer";
+import { detectRuntimeMode } from "../runtime/paths";
 import {
 	createRestartCoordination,
 	type RestartCoordination,
@@ -57,6 +58,7 @@ import {
 	type ControlRpcClientConfig,
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
+	type ControlRpcServer,
 	callControlRpc,
 	DEFAULT_CONTROL_RPC_HOST,
 	DEFAULT_CONTROL_RPC_PORT,
@@ -214,7 +216,7 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		process.exit(1);
 	}
 
-	const hostedRuntime = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted";
+	const hostedRuntime = detectRuntimeMode() === "hosted";
 	const targets = legacyRun
 		? [pickLegacyDaemonRunTarget(legacyRun)]
 		: pickDaemonRunTargets({ allowEmpty: hostedRuntime });
@@ -263,16 +265,21 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		}
 	}
 
-	const rpc = await startControlRpcServer(
+	const rpc = await startDaemonControlRpc(
 		createControlRpcHandlers({ abortController: abort, restartCoordination }),
 		abort.signal,
 		rpcListen,
 	);
-	activeControlRpcHttp = { ...rpc.http, allow_remote: rpcListen.allowRemote === true };
-	log.info("serve.rpc_listening", {
-		token_path: rpc.tokenPath,
-		http: rpc.http,
-	});
+	if (rpc) {
+		activeControlRpcHttp = { ...rpc.http, allow_remote: rpcListen.allowRemote === true };
+		log.info("serve.rpc_listening", {
+			token_path: rpc.tokenPath,
+			http: rpc.http,
+		});
+	} else {
+		activeControlRpcHttp = null;
+		log.info("serve.rpc_disabled", { runtime_mode: "hosted" });
+	}
 
 	try {
 		await runDaemonWorkers({
@@ -285,7 +292,9 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		process.exitCode = 1;
 	} finally {
 		abort.abort();
-		const cleanup = await Promise.allSettled([operationManager.shutdownAll(), rpc.close()]);
+		const cleanupTasks: Promise<unknown>[] = [operationManager.shutdownAll()];
+		if (rpc) cleanupTasks.push(rpc.close());
+		const cleanup = await Promise.allSettled(cleanupTasks);
 		activeControlRpcHttp = null;
 		for (const result of cleanup) {
 			if (result.status === "fulfilled") continue;
@@ -300,6 +309,15 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 	const code = process.exitCode ?? 0;
 	log.info("serve.exit", { code });
 	process.exit(code);
+}
+
+export async function startDaemonControlRpc(
+	handlers: ControlRpcHandlers,
+	abort: AbortSignal,
+	config: ControlRpcListenConfig,
+): Promise<ControlRpcServer | null> {
+	if (detectRuntimeMode() === "hosted") return null;
+	return startControlRpcServer(handlers, abort, config);
 }
 
 type ServeInstallOpts = Record<string, unknown>;

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1556,6 +1556,7 @@ export function writeRuntimeSystemdState(input: {
 					...commonEnvironment,
 					CLAWDI_ENVIRONMENT_ID: manifest.environmentId,
 					CLAWDI_SERVE_MODE: "container",
+					CLAWDI_STATE_DIR: join(paths.serviceStateRoot, "daemon"),
 					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
 					CLAWDI_NO_AUTO_UPDATE: "1",
 					CLAWDI_NO_UPDATE_CHECK: "1",

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import {
 	chmodSync,
+	chownSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { request } from "node:http";
@@ -13,6 +15,7 @@ import { createServer as createTcpServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
+	assertControlPathOwnershipAndMode,
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
 	callControlRpc,
@@ -144,16 +147,74 @@ if (process.platform !== "win32") {
 			});
 		});
 
-		it("repairs existing token file permissions on startup", async () => {
+		for (const mode of [0o666, 0o640]) {
+			it(`rejects an existing token with mode 0${mode.toString(8)}`, async () => {
+				await withRpcFixture(async ({ controlDir, start }) => {
+					const tokenPath = join(controlDir, "control-token");
+					mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+					writeFileSync(tokenPath, "insecure-token\n", { mode });
+					chmodSync(tokenPath, mode);
+
+					await expect(start({})).rejects.toThrow(
+						`daemon control token ${tokenPath} must have mode 0600`,
+					);
+					expect(statSync(tokenPath).mode & 0o777).toBe(mode);
+				});
+			});
+		}
+
+		it("rejects a token owned by another uid", async () => {
+			const effectiveUid = process.geteuid?.() ?? 0;
+			expect(() =>
+				assertControlPathOwnershipAndMode(
+					"daemon control token",
+					"/secure/control-token",
+					effectiveUid + 1,
+					0o600,
+					effectiveUid,
+					0o600,
+				),
+			).toThrow(
+				`daemon control token /secure/control-token must be owned by effective uid ${effectiveUid}; found uid ${effectiveUid + 1}`,
+			);
+
+			if (effectiveUid !== 0) return;
 			await withRpcFixture(async ({ controlDir, start }) => {
 				const tokenPath = join(controlDir, "control-token");
-				mkdirSync(dirname(tokenPath), { recursive: true });
-				writeFileSync(tokenPath, "fixed-token\n", { mode: 0o644 });
-				chmodSync(tokenPath, 0o644);
+				mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+				writeFileSync(tokenPath, "foreign-token\n", { mode: 0o600 });
+				chownSync(tokenPath, 10001, 10001);
 
-				await start({});
+				await expect(start({})).rejects.toThrow(
+					`daemon control token ${tokenPath} must be owned by effective uid 0; found uid 10001`,
+				);
+			});
+		});
 
-				expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+		it("rejects a control directory writable by another uid", async () => {
+			await withRpcFixture(async ({ controlDir, start }) => {
+				const tokenPath = join(controlDir, "control-token");
+				mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+				writeFileSync(tokenPath, "insecure-parent-token\n", { mode: 0o600 });
+				chmodSync(controlDir, 0o770);
+
+				await expect(start({})).rejects.toThrow(
+					`daemon control directory ${controlDir} must have mode 0700`,
+				);
+			});
+		});
+
+		it("rejects a token symlink pointing outside the control directory", async () => {
+			await withRpcFixture(async ({ controlDir, start }) => {
+				const outsideToken = join(dirname(controlDir), "outside-token");
+				const tokenPath = join(controlDir, "control-token");
+				mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+				writeFileSync(outsideToken, "outside-token\n", { mode: 0o600 });
+				symlinkSync(outsideToken, tokenPath);
+
+				await expect(start({})).rejects.toThrow(
+					`daemon control token at ${tokenPath} must not be a symbolic link`,
+				);
 			});
 		});
 

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,5 +1,17 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	closeSync,
+	constants,
+	fstatSync,
+	lstatSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import {
 	type ClientRequest,
 	createServer,
@@ -9,7 +21,7 @@ import {
 	type ServerResponse,
 } from "node:http";
 import { isIP } from "node:net";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { getDaemonControlDir, getDaemonControlTokenPath } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
@@ -43,7 +55,7 @@ interface JsonRpcRequest {
 	params?: unknown;
 }
 
-interface ControlRpcServer {
+export interface ControlRpcServer {
 	tokenPath: string;
 	http: { host: string; port: number };
 	rotateToken: () => string;
@@ -211,8 +223,12 @@ function controlRpcAbortError(signal: AbortSignal | undefined): Error {
 
 function resolveControlTokenPaths(config: ControlRpcListenConfig): ControlRpcTokenPaths {
 	if (config.tokenPath) {
+		const tokenParent = dirname(config.tokenPath);
+		if (config.controlDir && resolvePath(config.controlDir) !== resolvePath(tokenParent)) {
+			throw new Error("daemon control token must be inside the configured control directory");
+		}
 		return {
-			controlDir: config.controlDir ?? dirname(config.tokenPath),
+			controlDir: tokenParent,
 			tokenPath: config.tokenPath,
 		};
 	}
@@ -230,16 +246,12 @@ function resolveControlTokenPaths(config: ControlRpcListenConfig): ControlRpcTok
 
 function ensureControlDir(controlDir: string): void {
 	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
-	try {
-		chmodSync(controlDir, 0o700);
-	} catch {
-		/* best effort */
-	}
+	assertSecureControlDirectory(controlDir, currentEffectiveUid());
 }
 
 function ensureControlToken(paths = resolveControlTokenPaths({})): string {
 	ensureControlDir(paths.controlDir);
-	if (existsSync(paths.tokenPath)) {
+	if (pathEntryExists(paths.tokenPath)) {
 		return readControlToken(paths);
 	}
 	return rotateControlToken(paths);
@@ -248,29 +260,145 @@ function ensureControlToken(paths = resolveControlTokenPaths({})): string {
 export function rotateControlToken(paths = resolveControlTokenPaths({})): string {
 	ensureControlDir(paths.controlDir);
 	const token = randomBytes(32).toString("hex");
-	writeFileSync(paths.tokenPath, `${token}\n`, { mode: 0o600 });
+	const temporaryPath = `${paths.tokenPath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
 	try {
-		chmodSync(paths.tokenPath, 0o600);
-	} catch {
-		/* best effort */
+		writeFileSync(temporaryPath, `${token}\n`, { flag: "wx", mode: 0o600 });
+		chmodSync(temporaryPath, 0o600);
+		renameSync(temporaryPath, paths.tokenPath);
+	} catch (error) {
+		try {
+			unlinkSync(temporaryPath);
+		} catch {
+			/* Preserve the original secure-write failure. */
+		}
+		throw error;
 	}
-	return token;
+	return readControlToken(paths);
 }
 
 function readControlToken(paths = resolveControlTokenPaths({})): string {
-	if (!existsSync(paths.tokenPath)) {
+	let pathStat: ReturnType<typeof lstatSync>;
+	try {
+		pathStat = lstatSync(paths.tokenPath);
+	} catch (error) {
+		if (errnoCode(error) !== "ENOENT") {
+			throw new Error(
+				`daemon control token at ${paths.tokenPath} could not be inspected: ${errorMessage(error)}`,
+			);
+		}
 		throw new Error(
 			`daemon control token not found at ${paths.tokenPath}. Start \`clawdi daemon run\` first.`,
 		);
 	}
-	try {
-		chmodSync(paths.tokenPath, 0o600);
-	} catch {
-		/* best effort */
+	if (pathStat.isSymbolicLink()) {
+		throw new Error(`daemon control token at ${paths.tokenPath} must not be a symbolic link`);
 	}
-	const token = readFileSync(paths.tokenPath, "utf-8").trim();
-	if (!token) throw new Error(`daemon control token at ${paths.tokenPath} is empty`);
-	return token;
+
+	const effectiveUid = currentEffectiveUid();
+	assertSecureControlDirectory(paths.controlDir, effectiveUid);
+
+	let fd: number;
+	try {
+		fd = openSync(paths.tokenPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+	} catch (error) {
+		const detail =
+			errnoCode(error) === "ELOOP" ? "must not be a symbolic link" : errorMessage(error);
+		throw new Error(
+			`daemon control token at ${paths.tokenPath} could not be opened safely: ${detail}`,
+		);
+	}
+	try {
+		const tokenStat = fstatSync(fd);
+		if (!tokenStat.isFile()) {
+			throw new Error(`daemon control token at ${paths.tokenPath} must be a regular file`);
+		}
+		assertControlPathOwnershipAndMode(
+			"daemon control token",
+			paths.tokenPath,
+			tokenStat.uid,
+			tokenStat.mode,
+			effectiveUid,
+			0o600,
+		);
+		const token = readFileSync(fd, "utf-8").trim();
+		if (!token) throw new Error(`daemon control token at ${paths.tokenPath} is empty`);
+		return token;
+	} finally {
+		closeSync(fd);
+	}
+}
+
+function currentEffectiveUid(): number {
+	if (typeof process.geteuid !== "function") {
+		throw new Error("daemon control RPC requires effective uid ownership checks");
+	}
+	return process.geteuid();
+}
+
+function assertSecureControlDirectory(controlDir: string, effectiveUid: number): void {
+	let directoryStat: ReturnType<typeof lstatSync>;
+	try {
+		directoryStat = lstatSync(controlDir);
+	} catch (error) {
+		throw new Error(
+			`daemon control directory ${controlDir} could not be inspected: ${errorMessage(error)}`,
+		);
+	}
+	if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
+		throw new Error(`daemon control directory ${controlDir} must be a real directory`);
+	}
+	assertControlPathOwnershipAndMode(
+		"daemon control directory",
+		controlDir,
+		directoryStat.uid,
+		directoryStat.mode,
+		effectiveUid,
+		0o700,
+	);
+}
+
+export function assertControlPathOwnershipAndMode(
+	label: string,
+	path: string,
+	actualUid: number,
+	actualMode: number,
+	effectiveUid: number,
+	requiredMode: number,
+): void {
+	if (actualUid !== effectiveUid) {
+		throw new Error(
+			`${label} ${path} must be owned by effective uid ${effectiveUid}; found uid ${actualUid}`,
+		);
+	}
+	const permissions = actualMode & 0o7777;
+	if (permissions !== requiredMode) {
+		throw new Error(
+			`${label} ${path} must have mode ${formatMode(requiredMode)}; found ${formatMode(permissions)}`,
+		);
+	}
+}
+
+function formatMode(mode: number): string {
+	return `0${mode.toString(8).padStart(3, "0")}`;
+}
+
+function pathEntryExists(path: string): boolean {
+	try {
+		lstatSync(path);
+		return true;
+	} catch (error) {
+		if (errnoCode(error) === "ENOENT") return false;
+		throw error;
+	}
+}
+
+function errnoCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+	return typeof error.code === "string" ? error.code : undefined;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 async function handleHttpRequest(

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -111,7 +111,7 @@ if (process.platform !== "win32") {
 	describe("daemon RPC process e2e", () => {
 		it("serves daemon RPC over the configured HTTP port", async () => {
 			const fixture = createFixture();
-			const daemon = startDaemon(fixture);
+			const daemon = startDaemon(fixture, "local");
 			const daemonStdout = new Response(daemon.stdout).text();
 			const [stderrReady, stderrText] = daemon.stderr.tee();
 			const daemonStderr = new Response(stderrText).text();
@@ -127,21 +127,22 @@ if (process.platform !== "win32") {
 				const noToken = await postRpcWithoutToken(rpcPort);
 				expect(noToken.status).toBe(401);
 
-				const defaultPing = await runCli(fixture, ["daemon", "ping", "--port", String(rpcPort)]);
+				const defaultPing = await runCli(
+					fixture,
+					["daemon", "ping", "--port", String(rpcPort)],
+					"local",
+				);
 				expect(defaultPing.code).toBe(0);
 				expect(defaultPing.stderr).toBe("");
 				const defaultResult = JSON.parse(defaultPing.stdout) as { pid?: number; version?: string };
 				expect(defaultResult.pid).toBe(daemon.pid);
 				expect(defaultResult.version).toBeString();
 
-				const httpPing = await runCli(fixture, [
-					"daemon",
-					"ping",
-					"--host",
-					"127.0.0.1",
-					"--port",
-					String(rpcPort),
-				]);
+				const httpPing = await runCli(
+					fixture,
+					["daemon", "ping", "--host", "127.0.0.1", "--port", String(rpcPort)],
+					"local",
+				);
 				expect(httpPing.code).toBe(0);
 				expect(httpPing.stderr).toBe("");
 				const httpResult = JSON.parse(httpPing.stdout) as { pid?: number; version?: string };
@@ -150,7 +151,11 @@ if (process.platform !== "win32") {
 
 				const tokenPath = join(fixture.stateDir, "control", "control-token");
 				const oldToken = readFileSync(tokenPath, "utf-8").trim();
-				const rotate = await runCli(fixture, ["daemon", "rotate-token", "--port", String(rpcPort)]);
+				const rotate = await runCli(
+					fixture,
+					["daemon", "rotate-token", "--port", String(rpcPort)],
+					"local",
+				);
 				expect(rotate.code).toBe(0);
 				expect(rotate.stderr).toBe("");
 				const rotateResult = JSON.parse(rotate.stdout) as { token?: string; rotated?: boolean };
@@ -166,28 +171,13 @@ if (process.platform !== "win32") {
 				expect(apiCalls.some((call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`)).toBe(
 					true,
 				);
-				expect(
-					apiCalls.some((call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`),
-				).toBe(true);
 				const heartbeat = apiCalls.find(
 					(call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`,
 				);
-				const observation = apiCalls.find(
-					(call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`,
-				);
-				if (!isRecord(heartbeat?.body) || !isRecord(observation?.body)) {
-					throw new Error("expected separate v1 heartbeat and v2 observation bodies");
-				}
-				const heartbeatBody = heartbeat.body;
-				if (!isRecord(heartbeatBody.runtime_observed)) {
-					throw new Error("expected legacy runtime observation in v1 heartbeat");
-				}
-				const legacyObserved = heartbeatBody.runtime_observed;
-				expect(legacyObserved.bootSessionId).toBeUndefined();
-				expect(legacyObserved.eventId).toBeUndefined();
-				const observationBody = observation.body;
-				expect(observationBody.bootSessionId).toBeString();
-				expect(observationBody.eventId).toBeString();
+				expect(isRecord(heartbeat?.body)).toBe(true);
+				expect(
+					apiCalls.some((call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`),
+				).toBe(false);
 				expect(existsSync(join(fixture.stateDir, "codex", "health"))).toBe(true);
 				expect(apiCalls.every((call) => call.auth === `Bearer ${API_KEY}`)).toBe(true);
 			} catch (error) {
@@ -218,7 +208,7 @@ if (process.platform !== "win32") {
 			const environmentKey = createHash("sha256").update(ENV_ID).digest("hex");
 			mkdirSync(heartbeatRoot, { recursive: true });
 			writeFileSync(join(heartbeatRoot, `${environmentKey}.json`), "{corrupt-v2-state\n");
-			const daemon = startDaemon(fixture);
+			const daemon = startDaemon(fixture, "hosted");
 			const daemonStdout = new Response(daemon.stdout).text();
 			const daemonStderr = new Response(daemon.stderr).text();
 			let failure: unknown;
@@ -310,14 +300,17 @@ function createFixture(): Fixture {
 	return { root, home, clawdiHome, stateDir, serviceStateDir, runDir, codexHome, contextPath };
 }
 
-function startDaemon(fixture: Fixture): ReturnType<typeof Bun.spawn> {
+function startDaemon(
+	fixture: Fixture,
+	runtimeMode: "local" | "hosted",
+): ReturnType<typeof Bun.spawn> {
 	return Bun.spawn(
 		[process.execPath, srcEntry, "daemon", "run", "--host", "127.0.0.1", "--port", "0"],
 		{
 			cwd: fixture.root,
 			stdout: "pipe",
 			stderr: "pipe",
-			env: cliEnv(fixture),
+			env: cliEnv(fixture, runtimeMode),
 		},
 	);
 }
@@ -325,12 +318,13 @@ function startDaemon(fixture: Fixture): ReturnType<typeof Bun.spawn> {
 async function runCli(
 	fixture: Fixture,
 	args: string[],
+	runtimeMode: "local" | "hosted",
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	const proc = Bun.spawn([process.execPath, srcEntry, ...args], {
 		cwd: fixture.root,
 		stdout: "pipe",
 		stderr: "pipe",
-		env: cliEnv(fixture),
+		env: cliEnv(fixture, runtimeMode),
 	});
 	const [stdout, stderr, code] = await Promise.all([
 		new Response(proc.stdout).text(),
@@ -340,7 +334,7 @@ async function runCli(
 	return { stdout, stderr, code };
 }
 
-function cliEnv(fixture: Fixture): Record<string, string> {
+function cliEnv(fixture: Fixture, runtimeMode: "local" | "hosted"): Record<string, string> {
 	mkdirSync(dirname(fixture.contextPath), { recursive: true });
 	writeFileSync(
 		fixture.contextPath,
@@ -369,7 +363,7 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 		CLAWDI_NO_AUTO_UPDATE: "1",
 		CLAWDI_NO_UPDATE_CHECK: "1",
 		CLAWDI_SERVE_MODE: "container",
-		CLAWDI_RUNTIME_MODE: "hosted",
+		CLAWDI_RUNTIME_MODE: runtimeMode,
 		CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
 		CLAWDI_RUNTIME_TEST_CONTEXT_FILE: fixture.contextPath,
 		CLAWDI_RUNTIME_HOME: fixture.home,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -94,6 +94,7 @@ import {
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
+import { getDaemonControlTokenPath } from "../src/serve/paths";
 import { mockFetch } from "./commands/helpers";
 
 const TEST_PROCESS_USER = String(process.getuid?.() ?? 0);
@@ -216,6 +217,7 @@ function applyRuntimeBundleChannelsToManifestLoad(
 const ENV_KEYS = [
 	"HOME",
 	"CLAWDI_HOME",
+	"CLAWDI_STATE_DIR",
 	"CLAWDI_RUNTIME_MODE",
 	"CLAWDI_HOST_POLICY_PATH",
 	"CLAWDI_SERVICE_STATE_DIR",
@@ -15812,6 +15814,13 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			);
 			expect(daemonUnit).not.toContain("ExecStart=/bin/sh -lc");
 			expect(daemonEnv).toContain('CLAWDI_SERVE_MODE="container"');
+			const daemonStateDir = join(state, "daemon");
+			expect(daemonEnv).toContain(`CLAWDI_STATE_DIR="${daemonStateDir}"`);
+			process.env.CLAWDI_STATE_DIR = daemonStateDir;
+			const controlTokenPath = getDaemonControlTokenPath();
+			expect(controlTokenPath).toBe(join(state, "daemon", "control", "control-token"));
+			expect(controlTokenPath.startsWith(home)).toBe(false);
+			delete process.env.CLAWDI_STATE_DIR;
 			expect(daemonEnv).toContain('CLAWDI_RUNTIME_REV="');
 			expect(daemonEnv).toContain("https://cloud-api.test");
 			expect(watchEnv).not.toContain("CLAWDI_RUNTIME_AUTH_ENV");


### PR DESCRIPTION
## Summary

- Disable the daemon control RPC listener entirely when `detectRuntimeMode()` reports `hosted`.
- Set hosted daemon `CLAWDI_STATE_DIR` to `${serviceStateRoot}/daemon` (normally `/var/lib/clawdi/daemon`), moving queue, health, and control state under the existing root-owned platform state tree.
- Reject insecure daemon control tokens and directories instead of attempting best-effort permission repair, and rotate tokens with an atomic same-directory replacement.

## Security impact

In an Agent v2 hosted tenant, the root daemon inherited `HOME=/home/clawdi`, so its bearer token resolved beneath the uid 10001-owned `/home/clawdi/.clawdi` tree while the control RPC listened on tenant-reachable loopback. The tenant could rename and replace the daemon directory, plant a token it controlled, authenticate to the root RPC, and reach privileged handlers including sync operations that spawn the CLI with attacker-selected project and working-directory inputs. This changes the hosted daemon so that no control listener exists, its daemon state resolves under `/var/lib/clawdi/daemon` (with the token at `/var/lib/clawdi/daemon/control/control-token` by default), and any insecure token metadata fails closed.

Each of the three defense layers independently stops the verified chain: disabling the hosted listener removes the reachable RPC endpoint; relocating daemon state beneath the root-owned platform state tree prevents uid 10001 from replacing the token directory; and strict ownership/mode validation rejects the tenant-planted directory or token before authentication.

A repository-wide search found no legitimate hosted control-RPC consumer. The only production client is the explicit local-user `clawdi daemon ...` CLI path; hosted workloads, applications, packages, and scripts do not call this RPC.

The token rule is exact: the token must be a regular, non-symlink file owned by the current effective uid with mode `0600`; its direct parent must be a real, non-symlink directory owned by the current effective uid with mode `0700`. Reads use `O_NOFOLLOW` plus descriptor-based `fstat`, and violations throw clear errors without chmod-based repair. This applies to root in hosted/system service use and to the invoking uid in local use.

The `/var/lib/clawdi/daemon` namespace follows the existing `/var/lib/clawdi/{sync,status,boot,...}` layout while keeping daemon-owned queue, health, and control state together and leaving `HOME=/home/clawdi` unchanged for user-facing behavior.

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test` (CLI: 1,619 passed, 4 expected skips; backend: 2,235 passed, 11 skipped)
- Focused control-RPC, hosted-listener gating, daemon process E2E, and systemd unit-render assertions