### PR TITLE
release(cli): 0.13.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Clawdi CLI v0.13.37
+## Clawdi CLI v0.13.38
 
-Package: `clawdi@0.13.37`
+Package: `clawdi@0.13.38`
 
 ### Fixed
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.37",
+	"version": "0.13.38",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Bumps the CLI to 0.13.38 to publish the unified privilege-drop fix (#858), which merged after `clawdi@0.13.37` was already published. Also moves the corresponding changelog entry from the 0.13.37 heading to 0.13.38, since the published 0.13.37 artifact does not contain the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)