### PR TITLE
fix(v2): remove assistant name from deploy client

### DIFF
--- a/backend/scripts/mock_deploy_api.py
+++ b/backend/scripts/mock_deploy_api.py
@@ -230,12 +230,22 @@ def _read_provider_auth_kind(value: Any) -> str:
 
 
 def _runtime_configuration(config: dict[str, Any], runtime: str) -> dict[str, Any]:
+    preferences = {
+        field: config[field]
+        for field in ("language", "timezone")
+        if isinstance(config.get(field), str) and config[field]
+    }
     binding = (config.get("ai_provider_bindings") or {}).get(runtime) or {}
     auth_kind = _read_provider_auth_kind(
         binding.get("auth_kind") or config.get("ai_provider_auth_kind")
     )
     if auth_kind == "unmanaged":
-        return {"primary_model": None, "providers": [], "features": []}
+        return {
+            **preferences,
+            "primary_model": None,
+            "providers": [],
+            "features": [],
+        }
 
     provider_id = binding.get("provider_id") or config.get("ai_provider_id")
     primary_model = binding.get("primary_model")
@@ -249,6 +259,7 @@ def _runtime_configuration(config: dict[str, Any], runtime: str) -> dict[str, An
             }
         )
     return {
+        **preferences,
         "primary_model": primary_model if isinstance(primary_model, dict) else None,
         "providers": providers,
         "features": [],
@@ -313,6 +324,7 @@ def _deployment_read_response(record: dict[str, Any]) -> dict[str, Any]:
     return {
         "resource": {
             "id": record["id"],
+            "name": record["name"],
             "owner_user_id": record["user_id"],
             "commercial_revision": 1,
             "deployment_target": "saas",
@@ -334,7 +346,6 @@ def _deployment_read_response(record: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "runtime": runtime,
                 "runtime_version": "dev",
-                "name": record["name"],
                 "resources": {
                     "vcpu": config.get("vcpu", 1),
                     "memory_mib": config.get("ram_gb", 2) * 1024,
@@ -430,14 +441,25 @@ async def list_deployments() -> list[dict[str, Any]]:
 
 
 def _create_deployment_record(body: dict[str, Any]) -> dict[str, Any]:
+    nested_config = body.get("config")
+    if "assistant_name" in body or (
+        isinstance(nested_config, dict) and "assistant_name" in nested_config
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="assistant_name is not part of the V2 deployment contract",
+        )
     deployment_id = f"hdep_dev_{uuid.uuid4().hex[:8]}"
-    enabled_optional = []
-    if body.get("enable_openclaw", True):
-        enabled_optional.append("openclaw")
-    if body.get("enable_hermes", False):
-        enabled_optional.append("hermes")
+    requested_runtime = body.get("runtime", "openclaw")
+    if not isinstance(requested_runtime, str) or requested_runtime not in {
+        "openclaw",
+        "hermes",
+    }:
+        raise HTTPException(status_code=422, detail="unsupported V2 runtime")
+    enabled_optional = [requested_runtime]
     agents = ["codex", *enabled_optional]
     config = _base_config()
+    config["runtime"] = requested_runtime
     config["compute_plan_slug"] = body.get("compute_plan_slug", "compute_basic")
     config["enable_openclaw"] = "openclaw" in enabled_optional
     config["enable_hermes"] = "hermes" in enabled_optional
@@ -464,9 +486,15 @@ def _create_deployment_record(body: dict[str, Any]) -> dict[str, Any]:
         }
         for runtime in agents
     }
+    requested_name = body.get("name")
+    deployment_name = (
+        requested_name.strip()
+        if isinstance(requested_name, str) and requested_name.strip()
+        else f"dev-agent-{deployment_id[-4:]}"
+    )
     created = _deployment(
         deployment_id=deployment_id,
-        name=body.get("assistant_name") or f"dev-agent-{deployment_id[-4:]}",
+        name=deployment_name,
         status="provisioning",
         config_info=config,
     )
@@ -528,9 +556,16 @@ async def update_deployment(deployment_id: str, request: Request) -> dict[str, A
     deployment = _get_deployment_record(deployment_id)
     idempotency_key = _require_mutation_headers(request, deployment)
     body = await request.json()
-    next_name = body.get("name") or body.get("assistant_name")
-    if isinstance(next_name, str) and next_name.strip():
-        deployment["name"] = next_name.strip()
+    if "name" in body or "assistant_name" in body:
+        raise HTTPException(
+            status_code=422,
+            detail="deployment names are not mutable runtime configuration",
+        )
+    config = deployment.get("config_info")
+    if isinstance(config, dict):
+        for field in ("language", "timezone"):
+            if field in body:
+                config[field] = body[field]
     return _accept_operation(
         deployment,
         verb="update",

--- a/backend/tests/test_mock_deploy_api.py
+++ b/backend/tests/test_mock_deploy_api.py
@@ -1,3 +1,5 @@
+from fastapi.testclient import TestClient
+
 from scripts import mock_deploy_api
 
 
@@ -9,6 +11,8 @@ def test_mock_deployment_read_response_is_projected_from_flat_mutation_record() 
     assert "resource" in read
     assert "id" not in read
     assert read["resource"]["id"] == mutation["id"]
+    assert read["resource"]["name"] == mutation["name"]
+    assert "name" not in read["resource"]["spec"]
     assert read["resource"]["spec"]["runtime"] == "openclaw"
     assert read["ai_provider_auth_kinds"] == {"openclaw": "api_key"}
     assert read["runtime_ui_endpoint"] == {
@@ -42,3 +46,79 @@ def test_mock_funding_revocation_projects_complete_provenance() -> None:
     assert fact["reason"] == "disputed"
     assert fact["prior_plan_slug"] == "compute_basic"
     assert fact["occurred_at"] == "2026-07-18T12:00:00Z"
+
+
+def test_mock_v2_create_projects_only_the_resource_name() -> None:
+    with TestClient(mock_deploy_api.app) as client:
+        response = client.post(
+            "/v2/subscription/checkout",
+            json={
+                "funding_source": "wallet",
+                "deploy_config": {
+                    "name": "Canonical deployment name",
+                    "runtime": "hermes",
+                    "deploy_request_id": "mock-name-contract",
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        deployment_id = response.json()["deployment_id"]
+        try:
+            resource = client.get(f"/v2/deployments/{deployment_id}").json()["resource"]
+            assert resource["name"] == "Canonical deployment name"
+            assert "name" not in resource["spec"]
+            assert "assistant_name" not in resource["spec"]["runtime_configuration"]
+        finally:
+            mock_deploy_api.DEPLOYMENTS.pop(deployment_id, None)
+
+
+def test_mock_v2_rejects_retired_names_and_updates_runtime_configuration() -> None:
+    deployment = mock_deploy_api._create_deployment_record(
+        {"name": "Stable resource name", "runtime": "hermes"}
+    )
+    deployment_id = deployment["id"]
+    resource_version = f"rv_{deployment_id}"
+    headers = {
+        "Idempotency-Key": "mock-runtime-update",
+        "If-Match": f'"{resource_version}"',
+    }
+    try:
+        with TestClient(mock_deploy_api.app) as client:
+            updated = client.patch(
+                f"/v2/deployments/{deployment_id}",
+                headers=headers,
+                json={"language": "zh-CN", "timezone": "Asia/Shanghai"},
+            )
+            assert updated.status_code == 200
+            resource = updated.json()["response"]["deployment"]
+            assert resource["name"] == "Stable resource name"
+            assert resource["spec"]["runtime_configuration"]["language"] == "zh-CN"
+            assert resource["spec"]["runtime_configuration"]["timezone"] == ("Asia/Shanghai")
+
+            next_version = resource["metadata"]["resourceVersion"]
+            for field in ("name", "assistant_name"):
+                rejected = client.patch(
+                    f"/v2/deployments/{deployment_id}",
+                    headers={
+                        "Idempotency-Key": f"mock-reject-{field}",
+                        "If-Match": f'"{next_version}"',
+                    },
+                    json={field: "Rejected name"},
+                )
+                assert rejected.status_code == 422
+    finally:
+        mock_deploy_api.DEPLOYMENTS.pop(deployment_id, None)
+
+
+def test_mock_v2_create_rejects_retired_assistant_name() -> None:
+    with TestClient(mock_deploy_api.app) as client:
+        for deploy_config in (
+            {"assistant_name": "Retired"},
+            {"config": {"assistant_name": "Retired"}},
+        ):
+            response = client.post(
+                "/v2/subscription/checkout",
+                json={"funding_source": "wallet", "deploy_config": deploy_config},
+            )
+            assert response.status_code == 422

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -967,8 +967,6 @@ export interface components {
         };
         /** RuntimeConfiguration */
         RuntimeConfiguration: {
-            /** Assistant Name */
-            assistant_name?: string | null;
             /** Language */
             language?: string | null;
             /** Timezone */
@@ -1655,8 +1653,6 @@ export interface components {
             slack_bot_token?: string | null;
             /** Slack App Token */
             slack_app_token?: string | null;
-            /** Assistant Name */
-            assistant_name?: string | null;
             /** Language */
             language?: ("en" | "es" | "fr" | "de" | "ja" | "ko" | "pt" | "zh-CN" | "zh-TW") | null;
             /** Timezone */
@@ -1693,8 +1689,6 @@ export interface components {
             model?: string | null;
             /** Name */
             name?: string | null;
-            /** Assistant Name */
-            assistant_name?: string | null;
             /** Language */
             language?: ("en" | "es" | "fr" | "de" | "ja" | "ko" | "pt" | "zh-CN" | "zh-TW") | null;
             /** Timezone */
@@ -2056,8 +2050,6 @@ export interface components {
         };
         /** V2UpdateDeploymentRequest */
         V2UpdateDeploymentRequest: {
-            /** Assistant Name */
-            assistant_name?: string | null;
             /** Runtime */
             runtime?: ("openclaw" | "hermes") | null;
             /** Language */


### PR DESCRIPTION
## Summary
- regenerate the V2 deploy client without assistant_name
- keep V1 assistant personalization unchanged
- align the local V2 mock API with the resource-name/runtime-spec boundary

## Rollout
The current Clawdi V2 wizard already sends only the top-level deployment name. Hosted PR Clawdi-AI/clawdi-hosted#1520 can therefore land first. Once its schema is live, this PRs live-contract drift check will match and the regenerated client can land.

## Validation
- shared package typecheck and 72 tests
- focused mock V2 API tests
- generated Hosted OpenAPI contract matches the #1520 schema exactly
- git diff check