### PR TITLE
Keep /run/clawdi owned by boot preparation

### DIFF
--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -28,6 +28,7 @@ import {
 	planHermesDashboardArtifact,
 	prepareHermesDashboardArtifact,
 } from "./runtime-systemd-reconciliation";
+import { ensureRuntimeStateDirs } from "./state";
 
 const originalEnv = { ...process.env };
 const originalConsoleWarn = console.warn;
@@ -492,11 +493,13 @@ describe("runtime manifest services", () => {
 		const previousUmask = process.umask(0o077);
 		let result: ReturnType<typeof convergeRuntimeManifest>;
 		try {
+			ensureRuntimeStateDirs(paths);
 			result = convergeRuntimeManifest(load, paths);
 		} finally {
 			process.umask(previousUmask);
 		}
 		expect(result.installErrors).toEqual([]);
+		expect(statSync(paths.runRoot).mode & 0o777).toBe(0o711);
 		expect(statSync(paths.systemdRuntimeRoot).mode & 0o777).toBe(0o711);
 		expect(statSync(paths.systemdEnvRoot).mode & 0o777).toBe(0o711);
 		expect(result.outputs.runConfigs.map((path) => path.split("/").at(-1)).sort()).toEqual([
@@ -554,9 +557,10 @@ describe("runtime manifest services", () => {
 		expect(runtimeWatchUnit).toContain("StateDirectoryMode=0700");
 		expect(runtimeWatchUnit).toContain("CacheDirectory=clawdi");
 		expect(runtimeWatchUnit).toContain("CacheDirectoryMode=0700");
-		expect(runtimeWatchUnit).toContain("RuntimeDirectory=clawdi");
-		expect(runtimeWatchUnit).toContain("RuntimeDirectoryMode=0711");
-		expect(runtimeWatchUnit).toContain("RuntimeDirectoryPreserve=restart");
+		// The boot-level runtime root must outlive this generated watcher unit.
+		expect(runtimeWatchUnit).not.toContain("\nRuntimeDirectory=");
+		expect(runtimeWatchUnit).not.toContain("\nRuntimeDirectoryMode=");
+		expect(runtimeWatchUnit).not.toContain("\nRuntimeDirectoryPreserve=");
 		expect(runtimeWatchUnit).toContain("TasksMax=infinity");
 		expect(runtimeWatchUnit).not.toContain("ConditionPathExists=");
 		expect(runtimeWatchEnv).not.toContain("runtime-byok-value");

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -808,11 +808,9 @@ function writeSystemdUnit(input: {
 					"StateDirectoryMode=0700",
 					`CacheDirectory=${SYSTEMD_PLATFORM_DIRECTORY}`,
 					"CacheDirectoryMode=0700",
-					`RuntimeDirectory=${SYSTEMD_PLATFORM_DIRECTORY}`,
-					// The runtime root is searchable only because the tenant must read the
-					// explicitly published CA and its own 0600 environment files.
-					"RuntimeDirectoryMode=0711",
-					"RuntimeDirectoryPreserve=restart",
+					// Runtime state is prepared before convergence: the boot prep unit owns
+					// the production root for the entire boot, while ensureRuntimeStateDirs()
+					// creates non-default roots. Do not bind the shared root to this service.
 				]
 			: input.directoryKind === "file-browser"
 				? [

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -192,7 +192,8 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 		// are readable; private subtrees retain their narrower modes.
 		[paths.runRoot, DEFAULT_RUN_ROOT, 0o711],
 	] as const) {
-		if (!existsSync(path)) {
+		const created = !existsSync(path);
+		if (created) {
 			if (path === systemdPath) {
 				throw new Error(`platform directory must be created by systemd: ${path}`);
 			}
@@ -201,6 +202,11 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 		const node = lstatSync(path);
 		if (!node.isDirectory() || node.isSymbolicLink()) {
 			throw new Error(`platform directory is not a trusted directory: ${path}`);
+		}
+		if (created) {
+			// mkdir modes are filtered by umask, but these platform roots have an
+			// exact access contract (including search access on the runtime root).
+			chmodSync(path, mode);
 		}
 	}
 	for (const dir of [


### PR DESCRIPTION
## Summary

- stop generated platform services from claiming the boot-scoped `/run/clawdi` root with `RuntimeDirectory=`
- keep the tenant image's runtime preparation service as the single production owner while retaining CLI-created non-default roots
- make newly created non-default platform root modes independent of the caller's umask
- pin the generated-unit and `0711` runtime-root contracts in the existing systemd generation test

## systemd behavior and verdict

The current mixed ownership is unsafe.

The official [`systemd.exec` `RuntimeDirectory=` documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=) says runtime directories are removed when the declaring unit stops unless preservation changes that behavior. The official [`RuntimeDirectoryPreserve=` documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectoryPreserve=) narrows `restart` to automatic restarts and `systemctl restart`; an ordinary stop still removes the directory. `yes` is the value that preserves it when the service stops.

These settings are evaluated for each declaring unit. systemd does not reference-count a shared runtime directory across units: its cleanup implementation iterates the stopping unit's configured runtime directories and removes each path directly ([systemd source](https://github.com/systemd/systemd/blob/f8f2860750d9cd55c3653511d1c009b0e312b281/src/core/execute.c#L840-L870)). Therefore, a normally stopped generated unit configured with `restart` can remove `/run/clawdi` even while the boot-prep unit configured with `yes` remains active. That can remove the transparent-egress CA, tenant environment handoffs, daemon token, and managed secrets during the boot.

## Design

The generated platform watcher continues to declare its persistent configuration, state, and cache directories, but no longer declares `RuntimeDirectory=clawdi`. The image preparation unit remains the sole owner of the production default root for the boot. `ensureRuntimeStateDirs()` still fails closed when a production default root is absent and still creates non-default roots for local/test use; creation now applies the exact requested mode after validating the new path so a restrictive umask cannot turn the required `0711` root into `0700`.

The independently owned `clawdi-files` runtime directory is unchanged.

## Verification

- `bun run typecheck`: 4/4 workspace tasks successful
- `bun run check`: 955 files checked, exit 0 (one pre-existing info-level `useTemplate` diagnostic)
- `bun run test`: exit 0 in the Docker-backed clean runner
  - web: 960 passed, 0 failed
  - shared: 72 passed, 0 failed
  - WhatsApp sidecar: 71 passed, 0 failed
  - CLI: 1,644 passed, 4 skipped, 0 failed
  - backend: 2,241 passed, 11 skipped
  - total: 4,988 passed, 15 skipped, 0 failed
