### PR TITLE
fix(web): stop breadcrumb flicker on back navigation

### DIFF
--- a/apps/web/src/components/app-breadcrumb.tsx
+++ b/apps/web/src/components/app-breadcrumb.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { Fragment } from "react";
 import { buildAppBreadcrumbTrail } from "@/components/app-breadcrumb-model";
-import { useBreadcrumbSegmentTitles, useBreadcrumbTitle } from "@/components/breadcrumb-title";
+import {
+	useBreadcrumbSegmentTitles,
+	useBreadcrumbTitle,
+	useCommittedBreadcrumbRoute,
+} from "@/components/breadcrumb-title";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -13,8 +17,7 @@ import {
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 export function AppBreadcrumb() {
-	const pathname = useLocation({ select: (location) => location.pathname });
-	const routeSearch = useLocation({ select: (location) => location.search });
+	const { pathname, search: routeSearch } = useCommittedBreadcrumbRoute();
 	const overrideTitle = useBreadcrumbTitle();
 	const segmentTitles = useBreadcrumbSegmentTitles();
 	const trail = buildAppBreadcrumbTrail({

--- a/apps/web/src/components/breadcrumb-title.tsx
+++ b/apps/web/src/components/breadcrumb-title.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouterState } from "@tanstack/react-router";
 import {
 	createContext,
 	type Dispatch,
@@ -14,6 +13,7 @@ import {
 } from "react";
 import type { AgentRouteSearch } from "@/lib/agent-routes";
 import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 
 /**
  * Context for "what the breadcrumb's last segment should say".
@@ -204,12 +204,7 @@ type CommittedBreadcrumbRoute = {
  * registrations to this identity; `pathname`/`search` feed trail building.
  */
 export function useCommittedBreadcrumbRoute(): CommittedBreadcrumbRoute {
-	const pathname = useRouterState({
-		select: (state) => state.matches.at(-1)?.pathname ?? state.location.pathname,
-	});
-	const search = useRouterState({
-		select: (state) => state.matches.at(-1)?.search ?? state.location.search,
-	});
+	const { pathname, search } = useCommittedLocation();
 	return useMemo(
 		() => ({ pathname, search, routeKey: `${pathname}${JSON.stringify(search)}` }),
 		[pathname, search],

--- a/apps/web/src/components/breadcrumb-title.tsx
+++ b/apps/web/src/components/breadcrumb-title.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLocation } from "@tanstack/react-router";
+import { useRouterState } from "@tanstack/react-router";
 import {
 	createContext,
 	type Dispatch,
@@ -12,6 +12,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import type { AgentRouteSearch } from "@/lib/agent-routes";
 import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
 
 /**
@@ -34,6 +35,19 @@ import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
  * the cleanup fires, and the title flickers to null between renders.
  * Splitting the contexts means the setter is stable (useState setters
  * always are), so the effect only re-runs when the *title input* changes.
+ *
+ * Second implementation note: the route identity below comes from the
+ * *committed match tree* (`state.matches`), never from `state.location`.
+ * TanStack Router swaps `state.location` the moment a navigation starts
+ * (`beforeLoad`), while the route components React renders keep coming
+ * from `state.matches` until the next route has loaded. Reading the global
+ * location during that pending window pairs the new URL with the old page:
+ * the still-mounted page re-registers its title under the new routeKey,
+ * and the breadcrumb briefly renders the old detail title against the
+ * shallower path ("Agent > Old Detail" on the way back to a list) before
+ * the real label arrives. Deriving the trail and every registration key
+ * from the committed matches keeps the breadcrumb consistent with the
+ * visible page and flips it atomically when the navigation commits.
  */
 
 export type BreadcrumbSegmentContext = "workspace";
@@ -178,10 +192,32 @@ function normalizeBreadcrumbHref(href: string | null | undefined): string | null
 	return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }
 
-function useBreadcrumbRouteKey() {
-	return useLocation({
-		select: (location) => `${location.pathname}${location.searchStr}`,
+type CommittedBreadcrumbRoute = {
+	pathname: string;
+	search: AgentRouteSearch;
+	routeKey: string;
+};
+
+/**
+ * The route the breadcrumb should describe: the committed (rendered) match
+ * tree, not the pending navigation target. `routeKey` ties title
+ * registrations to this identity; `pathname`/`search` feed trail building.
+ */
+export function useCommittedBreadcrumbRoute(): CommittedBreadcrumbRoute {
+	const pathname = useRouterState({
+		select: (state) => state.matches.at(-1)?.pathname ?? state.location.pathname,
 	});
+	const search = useRouterState({
+		select: (state) => state.matches.at(-1)?.search ?? state.location.search,
+	});
+	return useMemo(
+		() => ({ pathname, search, routeKey: `${pathname}${JSON.stringify(search)}` }),
+		[pathname, search],
+	);
+}
+
+function useBreadcrumbRouteKey() {
+	return useCommittedBreadcrumbRoute().routeKey;
 }
 
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/components/dashboard/agent-project-resource-canonicalizer.tsx
+++ b/apps/web/src/components/dashboard/agent-project-resource-canonicalizer.tsx
@@ -17,6 +17,7 @@ import {
 	agentSectionHref,
 } from "@/lib/agent-routes";
 import { shouldBlockQueryError } from "@/lib/query-state";
+import { useCommittedRouteIsLatestTarget } from "@/lib/use-committed-location";
 import { cn } from "@/lib/utils";
 
 type ProjectResourceSection = "skills" | "vaults";
@@ -81,11 +82,12 @@ function CanonicalizeProjectResource({
 			)
 		: projectsHref;
 	const canCanonicalize = bindings.data !== undefined;
+	const isLatestTarget = useCommittedRouteIsLatestTarget();
 
 	useEffect(() => {
-		if (!canCanonicalize || blockingError) return;
+		if (!canCanonicalize || blockingError || !isLatestTarget) return;
 		void router.navigate({ href: targetHref, replace: true, resetScroll: false });
-	}, [blockingError, canCanonicalize, router, targetHref]);
+	}, [blockingError, canCanonicalize, isLatestTarget, router, targetHref]);
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-4 px-4 lg:px-6")}>

--- a/apps/web/src/components/hosted-product-gate.tsx
+++ b/apps/web/src/components/hosted-product-gate.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useEffect } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { useCommittedRouteIsLatestTarget } from "@/lib/use-committed-location";
 
 export function HostedProductGate({
 	children,
@@ -15,10 +16,12 @@ export function HostedProductGate({
 }) {
 	const router = useRouter();
 	const access = useHostedProductAccess();
+	const isLatestTarget = useCommittedRouteIsLatestTarget();
 
 	useEffect(() => {
-		if (access.isDenied) void router.navigate({ href: fallbackHref, replace: true });
-	}, [access.isDenied, fallbackHref, router]);
+		if (access.isDenied && isLatestTarget)
+			void router.navigate({ href: fallbackHref, replace: true });
+	}, [access.isDenied, fallbackHref, isLatestTarget, router]);
 
 	if (access.isLoading) return <HostedRouteSkeleton />;
 	if (access.isError) {

--- a/apps/web/src/lib/resource-navigation.ts
+++ b/apps/web/src/lib/resource-navigation.ts
@@ -235,6 +235,7 @@ export function legacyAgentResourceScope(
 export type ResourceDetailSearch = Record<string, unknown> & {
 	vault?: string;
 	project?: string;
+	tab?: string;
 	useWithAgent?: string;
 	joined?: string;
 	from?: string;
@@ -251,6 +252,7 @@ export function validateResourceDetailSearch(
 	for (const key of [
 		"vault",
 		"project",
+		"tab",
 		"useWithAgent",
 		"joined",
 		"from",

--- a/apps/web/src/lib/use-committed-location.ts
+++ b/apps/web/src/lib/use-committed-location.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouterState } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+/**
+ * The location of the route tree React is *actually rendering*.
+ *
+ * TanStack Router swaps `state.location` the moment a navigation starts
+ * (`beforeLoad`), while the rendered route components keep coming from
+ * `state.matches` until the next route has loaded. A mounted page that
+ * reads the global location during that pending window pairs the new URL
+ * with the old page — links, tabs, and effect-driven redirects all derive
+ * from a route the user is navigating away from. Selecting from the
+ * committed match tree keeps every reader consistent with the visible
+ * page; both flip atomically when the navigation commits.
+ */
+export function useCommittedLocation() {
+	const pathname = useRouterState({
+		select: (state) => state.matches.at(-1)?.pathname ?? state.location.pathname,
+	});
+	const search = useRouterState({
+		select: (state) => state.matches.at(-1)?.search ?? state.location.search,
+	});
+	return useMemo(() => ({ pathname, search }), [pathname, search]);
+}
+
+/**
+ * True only while the latest navigation target still resolves to the route
+ * this component is mounted for. Effect-driven redirects (URL
+ * canonicalizers) must gate on this: async data resolving during an
+ * unrelated pending navigation would otherwise `router.navigate` over the
+ * user's in-flight destination. Compared on pathname — the committed leaf
+ * match is always this page while mounted, so equality with the latest
+ * target pathname means no navigation away is in flight.
+ */
+export function useCommittedRouteIsLatestTarget(): boolean {
+	return useRouterState({
+		select: (state) =>
+			(state.matches.at(-1)?.pathname ?? state.location.pathname) === state.location.pathname,
+	});
+}

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useLocation, useRouter } from "@tanstack/react-router";
+import { Link, useRouter } from "@tanstack/react-router";
 import {
 	ArrowRight,
 	Bot,
@@ -123,6 +123,7 @@ import {
 	resourceCollectionTarget,
 } from "@/lib/resource-navigation";
 import { isBrowserWritableSkillProject, skillCapabilities } from "@/lib/skill-authority";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 import { cn } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -161,6 +162,18 @@ function projectLocalTabHref(
 	return `${pathname}${query ? `?${query}` : ""}`;
 }
 
+function searchRecordToSearchParams(search: Record<string, unknown>): URLSearchParams {
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(search)) {
+		if (typeof value === "string") params.set(key, value);
+		else if (Array.isArray(value))
+			for (const item of value)
+				if (typeof item === "string") params.append(key, item);
+				else if (value != null) params.set(key, String(value));
+	}
+	return params;
+}
+
 const AGENT_PROJECTS_SECTION_LABEL = agentSectionLabel("projects");
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 const HostedWorkspaceSkillsPanel = IS_HOSTED_BUILD
@@ -184,9 +197,11 @@ export default function ProjectDetailPage({
 	const $api = useOpenApi();
 	const qc = useQueryClient();
 	const router = useRouter();
-	const pathname = useLocation({ select: (location) => location.pathname });
-	const searchStr = useLocation({ select: (location) => location.searchStr });
-	const searchParams = useMemo(() => new URLSearchParams(searchStr), [searchStr]);
+	// Committed-match location, not the pending target: this page stays
+	// mounted while an outgoing navigation loads, and the rendered tab must
+	// keep matching the URL the user is still looking at.
+	const { pathname, search } = useCommittedLocation();
+	const searchParams = useMemo(() => searchRecordToSearchParams(search), [search]);
 	const requestedTab = searchParams.get("tab");
 	const localTab: ProjectLocalTab = PROJECT_LOCAL_TABS.some((tab) => tab.id === requestedTab)
 		? (requestedTab as ProjectLocalTab)

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -165,11 +165,13 @@ function projectLocalTabHref(
 function searchRecordToSearchParams(search: Record<string, unknown>): URLSearchParams {
 	const params = new URLSearchParams();
 	for (const [key, value] of Object.entries(search)) {
-		if (typeof value === "string") params.set(key, value);
-		else if (Array.isArray(value))
-			for (const item of value)
-				if (typeof item === "string") params.append(key, item);
-				else if (value != null) params.set(key, String(value));
+		if (typeof value === "string") {
+			params.set(key, value);
+		} else if (Array.isArray(value)) {
+			for (const item of value) if (typeof item === "string") params.append(key, item);
+		} else if (value != null) {
+			params.set(key, String(value));
+		}
 	}
 	return params;
 }

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
 	MessageSquare,
 	Zap,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline } from "@/components/dashboard/agent-label";
@@ -111,11 +111,15 @@ export function SessionDetailContent({
 	// scroll-to-bottom on open) without requiring a scroll gesture
 	// to find the latest reply.
 	type Direction = "asc" | "desc";
-	const [direction, setDirection] = useState<Direction>(() => {
-		if (typeof window === "undefined") return "desc";
+	// SSR and hydration must agree on the first render, so the stored
+	// preference syncs in a layout effect instead of the state initializer.
+	// Layout effects run before the messages query subscribes, so a stored
+	// "asc" swaps the query key without a wasted "desc" fetch.
+	const [direction, setDirection] = useState<Direction>("desc");
+	useIsomorphicLayoutEffect(() => {
 		const stored = localStorage.getItem("clawdi.session.message-direction");
-		return stored === "asc" ? "asc" : "desc";
-	});
+		if (stored === "asc") setDirection("asc");
+	}, []);
 	const persistDirection = (d: Direction) => {
 		setDirection(d);
 		try {
@@ -618,3 +622,5 @@ function MessagesSkeleton() {
 function EmptyContent() {
 	return <EmptyState variant="inset" description="No messages in this session." />;
 }
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { useLocation } from "@tanstack/react-router";
 import {
 	ArrowDown,
 	ArrowDownNarrowWide,
@@ -43,6 +42,7 @@ import {
 	SESSION_MESSAGES_GC_MS,
 	SESSION_MESSAGES_STALE_MS,
 } from "@/lib/session-queries";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
 export default function SessionDetailPage({ sessionId }: { sessionId: string }) {
@@ -59,7 +59,10 @@ export function SessionDetailContent({
 	const api = useApi();
 	const $api = useOpenApi();
 	const { user } = useCurrentUser();
-	const routeSearch = useLocation({ select: (location) => location.search });
+	// Committed-match search, not the pending target: this page stays mounted
+	// while an outgoing navigation loads, and its links must keep pointing at
+	// the context the user is still looking at.
+	const { search: routeSearch } = useCommittedLocation();
 	const sessionsHref = agentId
 		? agentSectionHref(agentId, "sessions", agentDeploymentRouteQuery(routeSearch))
 		: "/sessions";

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/$.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/$.tsx
@@ -16,6 +16,7 @@ import {
 import { routeHeadTitle } from "@/lib/document-title";
 import { decodeResourceRouteParam } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
+import { useCommittedRouteIsLatestTarget } from "@/lib/use-committed-location";
 import { cn } from "@/lib/utils";
 import { SkillDetailContent } from "@/pages/dashboard/skills/[key]/page";
 
@@ -75,11 +76,12 @@ function LegacyAgentSkillProjectCanonicalizer({
 	const targetHref = projectId
 		? agentSkillDetailHref(agentId, skillKey, projectId, agentDeploymentRouteQuery(search))
 		: projectsHref;
+	const isLatestTarget = useCommittedRouteIsLatestTarget();
 
 	useEffect(() => {
-		if (bindings.data === undefined || blockingError) return;
+		if (bindings.data === undefined || blockingError || !isLatestTarget) return;
 		void router.navigate({ href: targetHref, replace: true, resetScroll: false });
-	}, [bindings.data, blockingError, router, targetHref]);
+	}, [bindings.data, blockingError, isLatestTarget, router, targetHref]);
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-4 px-4 lg:px-6")}>

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/vaults/$slug.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/vaults/$slug.tsx
@@ -16,6 +16,7 @@ import {
 import { routeHeadTitle } from "@/lib/document-title";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { agentResourceScope } from "@/lib/resource-navigation";
+import { useCommittedRouteIsLatestTarget } from "@/lib/use-committed-location";
 import { cn } from "@/lib/utils";
 import VaultDetailPage from "@/pages/dashboard/vault/[slug]/page";
 
@@ -77,11 +78,12 @@ function LegacyAgentVaultProjectCanonicalizer({
 				project: projectId,
 			})
 		: projectsHref;
+	const isLatestTarget = useCommittedRouteIsLatestTarget();
 
 	useEffect(() => {
-		if (bindings.data === undefined || blockingError) return;
+		if (bindings.data === undefined || blockingError || !isLatestTarget) return;
 		void router.navigate({ href: targetHref, replace: true, resetScroll: false });
-	}, [bindings.data, blockingError, router, targetHref]);
+	}, [bindings.data, blockingError, isLatestTarget, router, targetHref]);
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-4 px-4 lg:px-6")}>


### PR DESCRIPTION
## Root cause

TanStack Router swaps `state.location` the moment a navigation starts (`beforeLoad` sets it immediately), while the route components React renders keep coming from `state.matches` until the next route has loaded.

During that pending window of a back navigation (e.g. `Agent > Memories > Memory Detail` → back):

1. The still-mounted detail page's `useSetBreadcrumbTitle` sees the new global location via `useLocation()`, so its effect re-runs and **re-registers the detail title under the list page's routeKey**.
2. `AppBreadcrumb` simultaneously builds the trail from the new (shallower) path, and the poisoned registration now matches — the last crumb briefly renders the old detail title: `Agent > Memory Detail`.
3. On commit the detail page unmounts, the list page's label registers, and the trail snaps to `Agent > Memories` — the visible `1 > 3` → `1 > 2` flicker.

## Fix

Derive route identity from the **committed match tree** (`state.matches` — what React actually renders) instead of `state.location`:

- New shared hooks in `apps/web/src/lib/use-committed-location.ts`: `useCommittedLocation()` (`{ pathname, search }` from the leaf committed match, falling back to `state.location`) and `useCommittedRouteIsLatestTarget()` (false while a navigation away is in flight).
- `AppBreadcrumb` and all breadcrumb title registrations key off the committed route (`useCommittedBreadcrumbRoute`). The stale page never re-registers under the new route, so the `1 > 3` frame can no longer occur; the trail flips atomically at commit.
- Same class of bug fixed in rendered pages: `projects/[id]` (tab state used to flip to the incoming URL mid-transition; also bypassed the route's own `validateSearch` — `tab` is now validated) and `sessions/[id]` (back-link context).
- Effect-driven redirects (URL canonicalizers, hosted product gate) now gate on `useCommittedRouteIsLatestTarget()`: async data resolving during an unrelated pending navigation no longer `router.navigate`s over the user's in-flight destination. This extends the existing `ownsCurrentSection` guard pattern from `agent-home.tsx` to the three legacy canonicalizers.

## Verification

- `bun run typecheck` (apps/web)
- `bun run lint` (biome)
- `bun test` breadcrumb/agent-routes suites (25 pass)