### PR TITLE
fix(cli): fail closed on hosted runtime identity and roots

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -225,6 +225,22 @@ systemd-owned roots instead of recursively hardening their ownership. The run
 root is searchable only for the two explicit platform-to-tenant handoff
 classes: the egress CA and per-unit tenant environment files. All other
 platform files remain private or are exposed only to dedicated system services.
+Before directory preparation, lock acquisition, or any external runtime command,
+Hosted convergence requires the explicit process contract
+`CLAWDI_RUNTIME_MODE=hosted`, a resolved HOME of exactly `/home/clawdi`, and
+`CLAWDI_RUNTIME_USER=clawdi` resolving through the host account database to the
+non-root identity `10001:10001`. Optional `CLAWDI_RUNTIME_UID` and
+`CLAWDI_RUNTIME_GID` values must match that resolved identity. The resolved HOME
+is validated regardless of whether it came from `CLAWDI_RUNTIME_HOME` or
+`HOME`; a host-policy file cannot select Hosted mode.
+
+The same precondition gate proves that all four platform roots are real
+directories before convergence starts. Convergence repeats the root proof at
+mutation-group boundaries, and platform child writers are anchored to their
+already-existing root. If a root disappears after preflight, no child writer
+recursively recreates it; convergence fails and leaves root restoration to the
+systemd/image boundary that owns it.
+
 That entrypoint reads the exact managed CLI pin from the canonical runtime
 context, installs it under a root-only versioned npm prefix, atomically activates
 `/var/lib/clawdi/maintained/clawdi/bin/clawdi`, and runs
@@ -270,6 +286,12 @@ allowlists only `error`, `message`, `hints`, and `warnings`; it never projects
 the rest of the installer response, a runtime manifest, or process environment.
 The failure still aborts Apply before authority commits and uses the existing
 filesystem/systemd rollback transaction.
+
+Runtime `--version` probes use a 10-second deadline, official service installs
+use 10 minutes, official service uninstalls use 2 minutes, and their preparatory
+user-manager maintenance uses 15 seconds. A deadline expiry is reported as a
+named convergence error rather than leaving first boot or a watch pass blocked
+indefinitely.
 
 Official service installers/uninstallers run only in the hosted systemd apply
 path. Unit tests select installer execution through an explicit in-process test
@@ -972,11 +994,14 @@ Strict-v2 workloads provide their bootstrap and apply authority through the
 single fixed file `/etc/clawdi/runtime-context.json`. The file
 is a strict `clawdi.runtimeContext.v2` object containing an `apply` tuple
 (`generation`, `manifestETag`, `applyReceiptId`, and `bootNonce`), an exact
-`cliPackageSpec`, and a typed HTTP `manifestSource` with bearer auth. Business
-secrets are not bootstrap context: the fetched bundle's `secretValues` map is
-the sole authority for exact manifest `secret://` references. API URLs that are
-already in the manifest, auth selectors, paths, mode, runtime user, and process
-environment are not duplicated in the context. A missing or malformed context
+`backend: "incus"` attestation, an exact `cliPackageSpec`, and a typed HTTP
+`manifestSource` with bearer auth. `backend` is required for every Hosted v2
+context and is validated by the common precondition gate before convergence.
+Business secrets are not bootstrap context: the fetched bundle's `secretValues`
+map is the sole authority for exact manifest `secret://` references. API URLs
+that are already in the manifest, auth selectors, paths, mode, runtime user, and
+process environment are not duplicated in the context. A missing or malformed
+context
 fails closed, and no field falls back to ambient process environment. The
 applied generation and exact CLI package must match the fetched manifest and
 are validated before CLI installation, systemd mutation, or applied-authority

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -28,6 +28,7 @@ import {
 import {
 	type RuntimeApplyContext,
 	type RuntimeApplyIdentity,
+	readRuntimeApplyContext,
 	resolveRuntimeApplyGeneration,
 	runtimeApplyIdentitiesEqual,
 } from "../runtime/apply-identity";
@@ -45,6 +46,11 @@ import {
 import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
 import { readHostPolicy } from "../runtime/host-policy";
+import {
+	assertHostedRuntimeContract,
+	type HostedRuntimeContractOptions,
+	inspectHostedRuntimeIdentity,
+} from "../runtime/hosted-runtime-contract";
 import {
 	type PreparedHostedSourcedSkill,
 	prepareHostedSourcedSkillArchives,
@@ -69,6 +75,7 @@ import {
 	runtimeUserUid,
 } from "../runtime/runtime-user-command";
 import {
+	assertRuntimePlatformRoots,
 	buildRuntimeBootStatus,
 	ensureRuntimeStateDirs,
 	hostPolicySummary,
@@ -1024,6 +1031,7 @@ interface RuntimeInitOptions {
 	nonInteractive?: boolean;
 	json?: boolean;
 	applyContext?: RuntimeApplyContext;
+	hostedRuntimeContract?: HostedRuntimeContractOptions;
 }
 
 interface RuntimeWatchOptions {
@@ -1035,6 +1043,7 @@ interface RuntimeWatchOptions {
 	notifications?: boolean;
 	notificationConsumer?: typeof consumeSse;
 	applyContext?: RuntimeApplyContext;
+	hostedRuntimeContract?: HostedRuntimeContractOptions;
 }
 
 interface RuntimeVerifyOptions {
@@ -1087,6 +1096,7 @@ interface RuntimeApplyOptions {
 	recoverFailedSystemdUnits?: boolean;
 	requireSystemdApplied?: boolean;
 	preparedHostedSourcedSkills?: ReadonlyMap<string, PreparedHostedSourcedSkill>;
+	hostedRuntimeContract?: HostedRuntimeContractOptions;
 }
 
 interface RuntimeManifestIdentity {
@@ -1944,7 +1954,7 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 				stage: "detect",
 				exitCode: 2,
 				errors: [
-					"runtime init requires hosted runtime mode (host policy or CLAWDI_RUNTIME_MODE=hosted)",
+					"runtime init requires CLAWDI_RUNTIME_MODE=hosted explicitly; host policy files do not select runtime mode",
 				],
 			},
 			paths,
@@ -1955,6 +1965,30 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 			console.log(chalk.red("runtime init is only available in hosted runtime mode."));
 		}
 		process.exitCode = 2;
+		return;
+	}
+	let applyContext: RuntimeApplyContext;
+	try {
+		applyContext = opts.applyContext ?? readRuntimeApplyContext();
+		assertHostedRuntimeContract(paths, applyContext, {
+			...opts.hostedRuntimeContract,
+			platformRoots: "deferred",
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const status = repairStatus(
+			{
+				bootId,
+				runtimeMode: mode,
+				stage: "detect",
+				exitCode: 20,
+				errors: [message],
+			},
+			paths,
+		);
+		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
+		else console.log(chalk.red(message));
+		process.exitCode = 20;
 		return;
 	}
 	try {
@@ -1979,7 +2013,9 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 		process.exitCode = 20;
 		return;
 	}
-	return withRuntimeConvergeLockAsync(paths, () => runtimeInitLocked(opts, paths, mode, bootId));
+	return withRuntimeConvergeLockAsync(paths, () =>
+		runtimeInitLocked({ ...opts, applyContext }, paths, mode, bootId),
+	);
 }
 
 async function runtimeInitLocked(
@@ -2027,13 +2063,6 @@ async function runtimeInitLocked(
 	let exitCode = 20;
 	if (!nonInteractiveOk) {
 		errors.push("runtime init requires --non-interactive in hosted mode");
-	}
-	if (!hostPolicy.exists) {
-		errors.push(`missing hosted runtime policy at ${hostPolicy.path}`);
-	} else if (!hostPolicy.valid) {
-		errors.push(
-			`invalid hosted runtime policy at ${hostPolicy.path}: ${hostPolicy.error ?? "parse failed"}`,
-		);
 	}
 	if (errors.length === 0) {
 		stage = "local";
@@ -2096,6 +2125,7 @@ async function runtimeInitLocked(
 					etag: loaded.etag ?? null,
 				},
 				requireSystemdApplied: applyIdentity !== null,
+				hostedRuntimeContract: opts.hostedRuntimeContract,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -2256,6 +2286,7 @@ async function runtimeWatchTick(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		hostedRuntimeContract?: HostedRuntimeContractOptions;
 	},
 ): Promise<Record<string, unknown>> {
 	return withRuntimeConvergeLockAsync(paths, () => runtimeWatchTickLocked(paths, opts));
@@ -2269,6 +2300,7 @@ async function runtimeWatchTickLocked(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		hostedRuntimeContract?: HostedRuntimeContractOptions;
 	},
 ): Promise<Record<string, unknown>> {
 	let reconciliation: RuntimeCliReconciliationResult;
@@ -2310,6 +2342,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 		deferCliInstallReason?: string;
 		recoverFailedSystemdUnits?: boolean;
 		applyContext?: RuntimeApplyContext;
+		hostedRuntimeContract?: HostedRuntimeContractOptions;
 	},
 ): Promise<Record<string, unknown>> {
 	const activeAppliedState = readRuntimeAppliedState(paths);
@@ -2400,6 +2433,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			manifestIdentity,
 			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
 			requireSystemdApplied: applyIdentity !== null,
+			hostedRuntimeContract: opts.hostedRuntimeContract,
 		});
 		if (applyResult.kind === "cli_handoff") {
 			const activeAppliedState = readRuntimeAppliedState(paths);
@@ -2538,6 +2572,7 @@ async function applyRuntimeDesiredState(
 	let egressPrerequisiteActivated = false;
 	const convergence = convergeRuntimeManifest(load, paths, {
 		cacheLastGood: false,
+		hostedRuntimeContract: opts.hostedRuntimeContract,
 		preparedHostedSourcedSkills,
 		commitAuthority: (committedConvergence, authority) => {
 			if (opts.requireSystemdApplied && !systemdApply.applied) {
@@ -2720,6 +2755,26 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 		process.exitCode = 2;
 		return;
 	}
+	let applyContext: RuntimeApplyContext;
+	try {
+		applyContext = opts.applyContext ?? readRuntimeApplyContext();
+		assertHostedRuntimeContract(paths, applyContext, {
+			...opts.hostedRuntimeContract,
+			platformRoots: "deferred",
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const event = {
+			schemaVersion: "clawdi.runtimeWatchEvent.v1",
+			status: "error",
+			stage: "detect",
+			error: message,
+			errors: [message],
+		};
+		emitRuntimeWatchEvent(event, opts.json);
+		process.exitCode = 20;
+		return;
+	}
 
 	try {
 		ensureRuntimeStateDirs(paths);
@@ -2759,7 +2814,8 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 			const forceRefresh = now - lastFullFetchAt >= selfHealMs || cliInstallRetryDue;
 			const event = await runtimeWatchTick(paths, {
 				forceRefresh,
-				applyContext: opts.applyContext,
+				applyContext,
+				hostedRuntimeContract: opts.hostedRuntimeContract,
 				deferCliInstall,
 				// Conditional retries run every 15 seconds. Recover failed units
 				// only on the five-minute full refresh, or once in one-shot mode.
@@ -3164,18 +3220,54 @@ export async function runtimeDoctor(opts: { json?: boolean } = {}) {
 	const paths = getRuntimePaths();
 	const policy = readHostPolicy(paths.hostPolicy);
 	const lastStatus = readRuntimeBootStatus(paths);
+	const identity = inspectHostedRuntimeIdentity(paths);
+	let runtimeContextDetail: string;
+	let runtimeContextOk = false;
+	try {
+		const context = readRuntimeApplyContext();
+		runtimeContextOk = context.backend === "incus";
+		runtimeContextDetail = context.backend;
+	} catch (error) {
+		runtimeContextDetail = error instanceof Error ? error.message : String(error);
+	}
+	let platformRootsOk = true;
+	let platformRootsDetail = "trusted";
+	try {
+		assertRuntimePlatformRoots(paths);
+	} catch (error) {
+		platformRootsOk = false;
+		platformRootsDetail = error instanceof Error ? error.message : String(error);
+	}
 	const checks: RuntimeDoctorCheck[] = [
 		{
 			name: "Runtime mode",
-			ok: paths.mode === "hosted",
-			detail: paths.mode,
-			hint: "Hosted mode requires a host policy or CLAWDI_RUNTIME_MODE=hosted.",
+			ok: identity.mode.ok,
+			detail: identity.mode.error ?? identity.mode.detail,
+			hint: "Set CLAWDI_RUNTIME_MODE=hosted explicitly; host policy files do not select runtime mode.",
 		},
 		{
-			name: "Host policy",
+			name: "Hosted policy",
 			ok: policy.exists && policy.valid,
-			detail: policy.exists ? (policy.valid ? policy.path : policy.error) : "missing",
-			hint: "Expected a readable JSON policy at the configured host policy path.",
+			detail: policy.valid ? policy.source : (policy.error ?? "missing"),
+			hint: "Hosted mode uses the built-in policy; policy files are ignored.",
+		},
+		{
+			name: "Runtime identity",
+			ok: identity.user.ok,
+			detail: identity.user.error ?? identity.user.detail,
+			hint: "The hosted tenant must run as clawdi with the expected non-root UID and GID.",
+		},
+		{
+			name: "Runtime context backend",
+			ok: runtimeContextOk,
+			detail: runtimeContextDetail,
+			hint: "Hosted v2 requires a valid runtime context attested with backend=incus.",
+		},
+		{
+			name: "Platform roots",
+			ok: platformRootsOk,
+			detail: platformRootsDetail,
+			hint: "Platform roots must remain real directories owned by the system boundary.",
 		},
 		{
 			name: "Service state",
@@ -3185,9 +3277,9 @@ export async function runtimeDoctor(opts: { json?: boolean } = {}) {
 		},
 		{
 			name: "Runtime HOME",
-			ok: existsSync(paths.userHome) && writable(paths.userHome),
-			detail: paths.userHome,
-			hint: "HOME should be the persistent runtime/user volume.",
+			ok: identity.home.ok && existsSync(paths.userHome) && writable(paths.userHome),
+			detail: identity.home.error ?? paths.userHome,
+			hint: "Hosted HOME must resolve to /home/clawdi and be a writable persistent volume.",
 		},
 		{
 			name: "Ephemeral runtime state",

--- a/packages/cli/src/lib/private-file.ts
+++ b/packages/cli/src/lib/private-file.ts
@@ -1,5 +1,6 @@
 import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { ensureDirectoryWithinTrustedRoot } from "./trusted-directory";
 
 export const PRIVATE_FILE_MODE = 0o600;
 export const PRIVATE_DIR_MODE = 0o700;
@@ -7,6 +8,7 @@ export const PRIVATE_DIR_MODE = 0o700;
 interface PrivateFileWriteOptions {
 	mode?: number;
 	dirMode?: number;
+	trustedRoot?: string;
 }
 
 export function writePrivateFileAtomic(
@@ -16,10 +18,16 @@ export function writePrivateFileAtomic(
 ): void {
 	const mode = options.mode ?? PRIVATE_FILE_MODE;
 	const dir = dirname(path);
-	mkdirSync(dir, {
-		recursive: true,
-		...(options.dirMode !== undefined ? { mode: options.dirMode } : {}),
-	});
+	if (options.trustedRoot) {
+		ensureDirectoryWithinTrustedRoot(options.trustedRoot, dir, {
+			...(options.dirMode === undefined ? {} : { mode: options.dirMode }),
+		});
+	} else {
+		mkdirSync(dir, {
+			recursive: true,
+			...(options.dirMode === undefined ? {} : { mode: options.dirMode }),
+		});
+	}
 	if (options.dirMode !== undefined) chmodBestEffort(dir, options.dirMode);
 	const tmp = join(
 		dir,

--- a/packages/cli/src/lib/trusted-directory.ts
+++ b/packages/cli/src/lib/trusted-directory.ts
@@ -1,0 +1,49 @@
+import { chmodSync, lstatSync, mkdirSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+function isMissing(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+export function assertTrustedDirectory(path: string, label = "trusted directory"): void {
+	let node: ReturnType<typeof lstatSync>;
+	try {
+		node = lstatSync(path);
+	} catch (error) {
+		if (isMissing(error)) throw new Error(`${label} is missing: ${path}`);
+		throw error;
+	}
+	if (!node.isDirectory() || node.isSymbolicLink()) {
+		throw new Error(`${label} is not a real directory: ${path}`);
+	}
+}
+
+export function ensureDirectoryWithinTrustedRoot(
+	root: string,
+	path: string,
+	options: { mode?: number } = {},
+): void {
+	const resolvedRoot = resolve(root);
+	const resolvedPath = resolve(path);
+	const childPath = relative(resolvedRoot, resolvedPath);
+	if (childPath.startsWith("..") || isAbsolute(childPath)) {
+		throw new Error(`directory is outside trusted root ${root}: ${path}`);
+	}
+	assertTrustedDirectory(resolvedRoot);
+	if (!childPath) return;
+
+	let current = resolvedRoot;
+	for (const segment of childPath.split("/")) {
+		current = join(current, segment);
+		try {
+			const node = lstatSync(current);
+			if (!node.isDirectory() || node.isSymbolicLink()) {
+				throw new Error(`trusted directory path contains a non-directory: ${current}`);
+			}
+		} catch (error) {
+			if (!isMissing(error)) throw error;
+			mkdirSync(current, options.mode === undefined ? undefined : { mode: options.mode });
+			if (options.mode !== undefined) chmodSync(current, options.mode);
+		}
+	}
+}

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, chownSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+	chmodSync,
+	chownSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -164,6 +172,7 @@ describe("runtime applied state", () => {
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.serviceStateRoot);
 		const state = {
 			...appliedStateFixture(),
 			egressSidecarSecretRevision: "e".repeat(64),

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto";
 import { chmodSync, chownSync, existsSync, readFileSync, statSync } from "node:fs";
 import { z } from "zod";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import {
 	type RuntimeApplyIdentity,
 	resolveRuntimeApplyGeneration,
 	runtimeApplyIdentitySchema,
 } from "./apply-identity";
 import type { RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 const appliedContentSourceSchema = z
 	.object({
@@ -120,10 +120,15 @@ export function writeRuntimeAppliedState(
 	paths: RuntimePaths,
 ): string {
 	const parsed = runtimeAppliedStateSchema.parse(state);
-	writePrivateFileAtomic(paths.appliedState, `${JSON.stringify(parsed, null, 2)}\n`, {
-		mode: 0o600,
-		dirMode: 0o755,
-	});
+	writeRuntimePlatformFileAtomic(
+		paths,
+		paths.appliedState,
+		`${JSON.stringify(parsed, null, 2)}\n`,
+		{
+			mode: 0o600,
+			dirMode: 0o755,
+		},
+	);
 	secureRuntimeAppliedStateFile(paths.appliedState);
 	return paths.appliedState;
 }

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -144,6 +144,17 @@ describe("runtime apply identity", () => {
 		expect(() => readRuntimeApplyContext(legacy)).toThrow(/invalid runtime context file/);
 	});
 
+	test("requires the attested Incus backend in every v2 runtime context", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-missing-runtime-backend-"));
+		roots.push(root);
+		const path = contextFile(root);
+		const parsed: Record<string, unknown> = JSON.parse(readFileSync(path, "utf-8"));
+		delete parsed.backend;
+		writeFileSync(path, JSON.stringify(parsed));
+
+		expect(() => readRuntimeApplyContext(path)).toThrow(/backend: Invalid input/);
+	});
+
 	test("rejects the removed runtimeEnv parallel secret authority", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-removed-runtime-env-"));
 		roots.push(root);

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -83,7 +83,7 @@ export type RuntimeManifestSource = z.infer<typeof runtimeManifestSourceSchema>;
 const runtimeContextFileSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeContext.v2"),
-		backend: z.literal("incus").optional(),
+		backend: z.literal("incus"),
 		apply: runtimeApplyIdentitySchema,
 		cliPackageSpec: hostedCliPackageSpecSchema.or(
 			z.literal(HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE),
@@ -96,7 +96,7 @@ type RuntimeContextFile = z.infer<typeof runtimeContextFileSchema>;
 
 export interface RuntimeApplyContext {
 	kind: "context-file";
-	backend?: "incus";
+	backend: "incus";
 	identity: RuntimeApplyIdentity;
 	cliPackageSpec: string;
 	manifestSource: RuntimeManifestSource;
@@ -114,7 +114,7 @@ export function readRuntimeApplyContext(
 	const parsed = readRuntimeContextFile(contextPath);
 	return {
 		kind: "context-file",
-		...(parsed.backend === undefined ? {} : { backend: parsed.backend }),
+		backend: parsed.backend,
 		identity: parsed.apply,
 		cliPackageSpec: parsed.cliPackageSpec,
 		manifestSource: parsed.manifestSource,

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -1,7 +1,8 @@
 import { readFileSync, rmSync } from "node:fs";
-import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE } from "../lib/private-file";
 import type { RuntimePaths } from "./paths";
 import { runtimeSecretValue } from "./secret-values";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 export const RUNTIME_AUTH_TOKEN_SECRET_REF = "secret://clawdi/auth-token";
 
@@ -18,7 +19,7 @@ export function writeRuntimeAuthToken(paths: RuntimePaths, token: string): strin
 	if (!normalized) {
 		throw new Error("runtime auth token must be non-empty and contain no control characters");
 	}
-	writePrivateFileAtomic(paths.daemonAuthToken, `${normalized}\n`, {
+	writeRuntimePlatformFileAtomic(paths, paths.daemonAuthToken, `${normalized}\n`, {
 		mode: PRIVATE_FILE_MODE,
 		dirMode: PRIVATE_DIR_MODE,
 	});

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -17,7 +17,6 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import {
 	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	hostedCliPackageSpecSchema,
@@ -25,6 +24,7 @@ import {
 	type RuntimeManifest,
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 export interface RuntimeCliUpdateResult {
 	status: "not_requested" | "current" | "installed" | "deferred" | "error";
@@ -833,7 +833,8 @@ function writeCliBootstrapStatus(
 	) {
 		throw new Error(`clawdi CLI target changed after verification: ${input.activeTarget}`);
 	}
-	writePrivateFileAtomic(
+	writeRuntimePlatformFileAtomic(
+		paths,
 		paths.cliBootstrapStatus,
 		`${JSON.stringify(
 			{
@@ -1353,7 +1354,8 @@ function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {
 }
 
 function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState): void {
-	writePrivateFileAtomic(
+	writeRuntimePlatformFileAtomic(
+		paths,
 		paths.cliUpgradeState,
 		`${JSON.stringify(normalizeCliUpgradeState(state), null, 2)}\n`,
 		{ mode: 0o600, dirMode: 0o755 },

--- a/packages/cli/src/runtime/converge-lock.test.ts
+++ b/packages/cli/src/runtime/converge-lock.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { withRuntimeConvergeLockAsync } from "./converge-lock";
@@ -21,6 +21,7 @@ describe("runtime async converge lock", () => {
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.runRoot);
 		const events: string[] = [];
 		let releaseFirst: (() => void) | undefined;
 		const firstGate = new Promise<void>((resolve) => {

--- a/packages/cli/src/runtime/converge-lock.ts
+++ b/packages/cli/src/runtime/converge-lock.ts
@@ -1,14 +1,7 @@
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	renameSync,
-	rmSync,
-	statSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { DEFAULT_RUN_ROOT, type RuntimePaths } from "./paths";
+import { ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
+import type { RuntimePaths } from "./paths";
 
 function ownerPath(lockDir: string): string {
 	return join(lockDir, "owner.json");
@@ -91,11 +84,8 @@ function sleepSync(ms: number): void {
 }
 
 function lockPath(paths: RuntimePaths): string {
-	if (paths.runRoot === DEFAULT_RUN_ROOT && !existsSync(paths.runRoot)) {
-		throw new Error(`platform directory must be created by systemd: ${paths.runRoot}`);
-	}
 	const lockRoot = dirname(paths.convergeLock);
-	mkdirSync(lockRoot, { recursive: true });
+	ensureDirectoryWithinTrustedRoot(paths.runRoot, lockRoot);
 	return paths.convergeLock;
 }
 

--- a/packages/cli/src/runtime/egress-profiles.ts
+++ b/packages/cli/src/runtime/egress-profiles.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import type { RuntimePaths } from "./paths";
 import { canonicalSecretRefSchema } from "./secret-values";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 export const secretRefSchema = canonicalSecretRefSchema;
 const profileIdSchema = z
@@ -253,9 +253,14 @@ export function hasEnabledEgressProfiles(bundle: EgressProfileBundle): boolean {
 }
 
 export function writeEgressProfileBundle(bundle: EgressProfileBundle, paths: RuntimePaths): string {
-	writePrivateFileAtomic(paths.egressProfileBundle, `${JSON.stringify(bundle, null, 2)}\n`, {
-		mode: 0o644,
-		dirMode: 0o755,
-	});
+	writeRuntimePlatformFileAtomic(
+		paths,
+		paths.egressProfileBundle,
+		`${JSON.stringify(bundle, null, 2)}\n`,
+		{
+			mode: 0o644,
+			dirMode: 0o755,
+		},
+	);
 	return paths.egressProfileBundle;
 }

--- a/packages/cli/src/runtime/file-browser-companion.ts
+++ b/packages/cli/src/runtime/file-browser-companion.ts
@@ -14,7 +14,6 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 import { stringify as stringifyYaml } from "yaml";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import { runtimeContentSha256 } from "./applied-state";
 import {
 	ensureFileBrowserServiceIsolation,
@@ -26,6 +25,7 @@ import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import type { RuntimeSystemdUserProgram } from "./runtime-systemd-reconciliation";
 import { runningAsRoot } from "./runtime-user-command";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 const FILE_BROWSER_BINARY = "filebrowser";
 const FILE_BROWSER_CANDIDATES = "candidates";
@@ -351,7 +351,10 @@ export function ensureFileBrowserCompanion(
 	cleanStaleStaging(paths);
 	if (!verifiedReceipt || before === null) {
 		installCandidate(companion, paths, asset, options);
-		writePrivateFileAtomic(paths.fileBrowserConfig, config, { mode: 0o600, dirMode: 0o700 });
+		writeRuntimePlatformFileAtomic(paths, paths.fileBrowserConfig, config, {
+			mode: 0o600,
+			dirMode: 0o700,
+		});
 	}
 	const current = () => currentRevision(companion, paths, asset.sha256, config);
 	const expected = current();

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -29,7 +29,9 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
-	return getRuntimePaths({ mode: "hosted" });
+	const paths = getRuntimePaths({ mode: "hosted" });
+	mkdirSync(paths.serviceStateRoot);
+	return paths;
 }
 
 function legacyAppliedState(generation: number): RuntimeAppliedStateV2 {

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { z } from "zod";
-import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE } from "../lib/private-file";
 import {
 	type RuntimeAppliedState,
 	readRuntimeAppliedState,
@@ -12,6 +12,7 @@ import {
 import { type RuntimeApplyIdentity, runtimeApplyIdentitySchema } from "./apply-identity";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 const positiveSafeIntegerSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
 const isoTimestampSchema = z.string().datetime({ offset: true });
@@ -219,7 +220,7 @@ export class HostedRuntimeHeartbeatSession {
 					? pending
 					: null,
 		};
-		writeState(this.statePath, candidate);
+		writeState(this.paths, this.statePath, candidate);
 		this.state = candidate;
 		this.capturedAppliedState = appliedState;
 		this.currentBootIdentity = nextBootIdentity;
@@ -266,7 +267,7 @@ export class HostedRuntimeHeartbeatSession {
 			lastCapturedAt: capturedAt,
 			pending,
 		};
-		writeState(this.statePath, candidate);
+		writeState(this.paths, this.statePath, candidate);
 		this.state = candidate;
 		return decodePendingEvent(pending);
 	}
@@ -284,7 +285,7 @@ export class HostedRuntimeHeartbeatSession {
 		const pending = decodePendingEvent(this.state.pending);
 		if (pending.event.eventId !== eventId) return false;
 		const candidate = { ...this.state, pending: null };
-		writeState(this.statePath, candidate);
+		writeState(this.paths, this.statePath, candidate);
 		this.state = candidate;
 		return true;
 	}
@@ -316,9 +317,9 @@ function readState(path: string): PersistedHeartbeatState | null {
 	}
 }
 
-function writeState(path: string, state: PersistedHeartbeatState): void {
+function writeState(paths: RuntimePaths, path: string, state: PersistedHeartbeatState): void {
 	const parsed = heartbeatStateSchema.parse(state);
-	writePrivateFileAtomic(path, `${JSON.stringify(parsed, null, 2)}\n`, {
+	writeRuntimePlatformFileAtomic(paths, path, `${JSON.stringify(parsed, null, 2)}\n`, {
 		mode: PRIVATE_FILE_MODE,
 		dirMode: PRIVATE_DIR_MODE,
 	});

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -117,6 +117,7 @@ describe("hosted bundled skill reconciliation", () => {
 	it("treats activation as committed before best-effort previous-target cleanup", () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		mkdirSync(join(root, "config"));
 		const install = (
 			activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
 		) =>

--- a/packages/cli/src/runtime/hosted-runtime-contract.test.ts
+++ b/packages/cli/src/runtime/hosted-runtime-contract.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { RuntimeApplyContext } from "./apply-identity";
+import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
+import { getRuntimePaths } from "./paths";
+
+const originalEnv = { ...process.env };
+const applyContext: RuntimeApplyContext = {
+	kind: "context-file",
+	backend: "incus",
+	identity: {
+		generation: 1,
+		manifestETag: '"test-manifest"',
+		applyReceiptId: "test-apply-receipt",
+		bootNonce: "test-boot-nonce",
+	},
+	cliPackageSpec: "clawdi@1.2.3",
+	manifestSource: {
+		type: "http",
+		url: "https://runtime.test/v1/runtime/manifest",
+		auth: { type: "bearer", token: "test-token" },
+	},
+};
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+});
+
+describe("hosted runtime convergence contract", () => {
+	test("rejects a hosted convergence whose resolved HOME is not the tenant home", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_HOME = "/root";
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_UID = "10001";
+		process.env.CLAWDI_RUNTIME_GID = "10001";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+			}),
+		).toThrow("hosted runtime HOME must resolve to /home/clawdi; resolved /root");
+	});
+
+	test("rejects a hosted convergence whose runtime user is wrong", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_USER = "root";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+			}),
+		).toThrow("hosted runtime user must be clawdi; resolved root");
+	});
+
+	test("rejects a hosted runtime account that resolves to the wrong identity", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+				resolveUserIdentity: () => ({ uid: 0, gid: 0 }),
+			}),
+		).toThrow("hosted runtime user clawdi resolved to root identity 0:0");
+	});
+
+	test("rejects convergence when hosted mode was not selected explicitly", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "local";
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+			}),
+		).toThrow("hosted convergence requires CLAWDI_RUNTIME_MODE=hosted explicitly");
+	});
+});

--- a/packages/cli/src/runtime/hosted-runtime-contract.ts
+++ b/packages/cli/src/runtime/hosted-runtime-contract.ts
@@ -1,0 +1,132 @@
+import type { RuntimeApplyContext } from "./apply-identity";
+import type { RuntimePaths } from "./paths";
+import {
+	type RuntimeUserIdentityResolver,
+	resolveRuntimeUserIdentity,
+} from "./runtime-user-command";
+import { assertRuntimePlatformRoots } from "./state";
+
+export const HOSTED_RUNTIME_HOME = "/home/clawdi";
+export const HOSTED_RUNTIME_USER = "clawdi";
+export const HOSTED_RUNTIME_UID = 10_001;
+export const HOSTED_RUNTIME_GID = 10_001;
+
+export interface HostedRuntimeIdentityExpectation {
+	home: string;
+	user: string;
+	uid: number;
+	gid: number;
+}
+
+export interface HostedRuntimeContractOptions {
+	expectedIdentity?: HostedRuntimeIdentityExpectation;
+	resolveUserIdentity?: RuntimeUserIdentityResolver;
+}
+
+export interface HostedRuntimeIdentityInspection {
+	mode: { ok: boolean; detail: string; error?: string };
+	home: { ok: boolean; detail: string; error?: string };
+	user: { ok: boolean; detail: string; error?: string };
+}
+
+export interface HostedRuntimeContract {
+	identity: HostedRuntimeIdentityExpectation;
+	assertPlatformRoots(): void;
+}
+
+const PRODUCTION_IDENTITY: HostedRuntimeIdentityExpectation = {
+	home: HOSTED_RUNTIME_HOME,
+	user: HOSTED_RUNTIME_USER,
+	uid: HOSTED_RUNTIME_UID,
+	gid: HOSTED_RUNTIME_GID,
+};
+
+function explicitRuntimeMode(): string {
+	return process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() || "missing";
+}
+
+export function inspectHostedRuntimeIdentity(
+	paths: RuntimePaths,
+	options: HostedRuntimeContractOptions = {},
+): HostedRuntimeIdentityInspection {
+	const expected = options.expectedIdentity ?? PRODUCTION_IDENTITY;
+	const mode = explicitRuntimeMode();
+	const modeError =
+		mode === "hosted" && paths.mode === "hosted"
+			? undefined
+			: `hosted convergence requires CLAWDI_RUNTIME_MODE=hosted explicitly; resolved runtime mode is ${paths.mode} (environment: ${mode})`;
+	const homeError =
+		paths.userHome === expected.home
+			? undefined
+			: `hosted runtime HOME must resolve to ${expected.home}; resolved ${paths.userHome}`;
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() ?? "";
+	let userError: string | undefined;
+	let userDetail = runtimeUser || "missing";
+	if (runtimeUser !== expected.user) {
+		userError = runtimeUser
+			? `hosted runtime user must be ${expected.user}; resolved ${runtimeUser}`
+			: `hosted runtime user must be ${expected.user}; CLAWDI_RUNTIME_USER is missing`;
+	} else {
+		try {
+			const identity = (options.resolveUserIdentity ?? resolveRuntimeUserIdentity)(runtimeUser);
+			userDetail = `${runtimeUser} (${identity.uid}:${identity.gid})`;
+			if (identity.uid === 0 || identity.gid === 0) {
+				userError = `hosted runtime user ${runtimeUser} resolved to root identity ${identity.uid}:${identity.gid}`;
+			} else if (identity.uid !== expected.uid || identity.gid !== expected.gid) {
+				userError = `hosted runtime user ${runtimeUser} must resolve to ${expected.uid}:${expected.gid}; resolved ${identity.uid}:${identity.gid}`;
+			} else {
+				for (const [name, value, resolved] of [
+					["CLAWDI_RUNTIME_UID", process.env.CLAWDI_RUNTIME_UID?.trim(), identity.uid],
+					["CLAWDI_RUNTIME_GID", process.env.CLAWDI_RUNTIME_GID?.trim(), identity.gid],
+				] as const) {
+					if (value && value !== String(resolved)) {
+						userError = `${name} must match the resolved hosted runtime identity ${resolved}; resolved ${value}`;
+						break;
+					}
+				}
+			}
+		} catch (error) {
+			userError = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	return {
+		mode: {
+			ok: modeError === undefined,
+			detail: paths.mode,
+			...(modeError ? { error: modeError } : {}),
+		},
+		home: {
+			ok: homeError === undefined,
+			detail: paths.userHome,
+			...(homeError ? { error: homeError } : {}),
+		},
+		user: {
+			ok: userError === undefined,
+			detail: userDetail,
+			...(userError ? { error: userError } : {}),
+		},
+	};
+}
+
+export function assertHostedRuntimeContract(
+	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext,
+	options: HostedRuntimeContractOptions & { platformRoots?: "required" | "deferred" } = {},
+): HostedRuntimeContract {
+	const inspection = inspectHostedRuntimeIdentity(paths, options);
+	const error = [inspection.mode, inspection.home, inspection.user].find(
+		(check) => !check.ok,
+	)?.error;
+	if (error) throw new Error(error);
+	if (applyContext.backend !== "incus") {
+		throw new Error(
+			`hosted v2 convergence requires runtime context backend incus; resolved ${String(applyContext.backend ?? "missing")}`,
+		);
+	}
+	if (options.platformRoots !== "deferred") assertRuntimePlatformRoots(paths);
+	return {
+		identity: options.expectedIdentity ?? PRODUCTION_IDENTITY,
+		assertPlatformRoots: () => assertRuntimePlatformRoots(paths),
+	};
+}

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.test.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.test.ts
@@ -69,6 +69,12 @@ function manifest(commit: string): RuntimeManifest {
 	};
 }
 
+function hostedRuntimePaths() {
+	const paths = getRuntimePaths({ mode: "hosted" });
+	mkdirSync(paths.cacheRoot, { recursive: true });
+	return paths;
+}
+
 function projectManifest(
 	contentHash: string,
 	origin = "https://cloud-api.example.test",
@@ -136,7 +142,7 @@ describe("hosted sourced Skill archives", () => {
 				headers: { "content-length": String(canonical.archive.byteLength) },
 			});
 		};
-		const paths = getRuntimePaths({ mode: "hosted" });
+		const paths = hostedRuntimePaths();
 		const first = await prepareHostedSourcedSkillArchives(desired, paths, {
 			authToken: "runtime-token",
 			fetcher,
@@ -176,7 +182,7 @@ describe("hosted sourced Skill archives", () => {
 		mkdirSync(skillDir, { recursive: true });
 		writeFileSync(join(skillDir, "SKILL.md"), "# Review PR\n");
 		const canonical = await snapshotSkillArchive(skillDir, root, "review-pr");
-		const paths = getRuntimePaths({ mode: "hosted" });
+		const paths = hostedRuntimePaths();
 
 		await expect(
 			prepareHostedSourcedSkillArchives(projectManifest("0".repeat(64)), paths, {
@@ -211,7 +217,7 @@ describe("hosted sourced Skill archives", () => {
 
 		const prepared = await prepareHostedSourcedSkillArchives(
 			projectManifest(legacyHash),
-			getRuntimePaths({ mode: "hosted" }),
+			hostedRuntimePaths(),
 			{
 				fetcher: async () =>
 					new Response(Uint8Array.from(canonical.archive), {
@@ -244,7 +250,7 @@ describe("hosted sourced Skill archives", () => {
 				headers: { "content-length": String(archive.byteLength) },
 			});
 		};
-		const paths = getRuntimePaths({ mode: "hosted" });
+		const paths = hostedRuntimePaths();
 		const first = await prepareHostedSourcedSkillArchives(manifest(commit), paths, { fetcher });
 		const prepared = first.get("review-pr");
 		expect(prepared).toMatchObject({

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
@@ -8,11 +8,11 @@ import {
 	parseCanonicalGithubRepositoryUrl,
 	readBoundedResponseBytes,
 } from "../lib/github-skill-archive";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import { extractTarGz, snapshotSkillArchive } from "../lib/tar";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { HostedSkillSource } from "./manifest-resources";
 import type { RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 // Legacy compatibility: persisted receipts keep their original schema identifier.
 const CACHE_SCHEMA = "clawdi.hostedCatalogSkillArchive.v1";
@@ -197,8 +197,12 @@ function writeCachedArchive(
 ): string {
 	const digest = sha256(tarBytes);
 	const cache = cachePaths(paths, skillId, source);
-	writePrivateFileAtomic(cache.archive, tarBytes, { mode: 0o600, dirMode: 0o700 });
-	writePrivateFileAtomic(
+	writeRuntimePlatformFileAtomic(paths, cache.archive, tarBytes, {
+		mode: 0o600,
+		dirMode: 0o700,
+	});
+	writeRuntimePlatformFileAtomic(
+		paths,
 		cache.receipt,
 		`${JSON.stringify(
 			{

--- a/packages/cli/src/runtime/install-receipts.ts
+++ b/packages/cli/src/runtime/install-receipts.ts
@@ -1,7 +1,7 @@
 import { lstatSync, readFileSync } from "node:fs";
 import { z } from "zod";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import type { RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 const revisionSchema = z.string().regex(/^[a-f0-9]{64}$/);
 
@@ -76,7 +76,8 @@ export function writeRuntimeInstallReceipts(
 ): void {
 	const parsed = runtimeInstallReceiptsSchema.parse(receipts);
 	try {
-		writePrivateFileAtomic(
+		writeRuntimePlatformFileAtomic(
+			paths,
 			runtimeInstallReceiptsPath(paths),
 			`${JSON.stringify(parsed, null, 2)}\n`,
 			{

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -78,6 +78,7 @@ describe("managed Skill reservations", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		mkdirSync(join(root, "config"));
 		const path = target();
 		reserveManagedSkill({
 			targetDir: path,
@@ -151,6 +152,7 @@ describe("managed Skill reservations", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		mkdirSync(join(root, "config"));
 		const path = target();
 		const sourceIdentity = [
 			"project",

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -15,6 +15,7 @@ import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { withRuntimeConvergeLock } from "./converge-lock";
 import { getRuntimePaths } from "./paths";
+import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./state";
 
 const LEDGER_FILE = "managed-skills.json";
 const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
@@ -139,10 +140,14 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 }
 
 function writeLedger(path: string, ledger: ManagedSkillReservationLedger): void {
-	writePrivateFileAtomic(path, `${JSON.stringify(ledger, null, 2)}\n`, {
-		mode: 0o644,
-		dirMode: 0o755,
-	});
+	const content = `${JSON.stringify(ledger, null, 2)}\n`;
+	const runtimePaths = getRuntimePaths({ mode: "hosted" });
+	const options = { mode: 0o644, dirMode: 0o755 };
+	if (runtimePlatformRootForPath(runtimePaths, path)) {
+		writeRuntimePlatformFileAtomic(runtimePaths, path, content, options);
+	} else {
+		writePrivateFileAtomic(path, content, options);
+	}
 }
 
 function withLedgerWriteLock<T>(manager: ManagedSkillReservationManager, write: () => T): T {

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -121,7 +121,7 @@ test("keeps real Hosted converge mutations inside its exact root and runtime-use
 	const home = join(root, "home", "clawdi");
 	const state = join(root, "state");
 	const run = join(root, "run");
-	const systemdSystemRoot = join(root, "systemd", "system");
+	const systemdSystemRoot = join(run, "systemd", "system");
 	const openclaw = join(home, ".openclaw", "bin", "openclaw");
 	fsOriginals.mkdirSync(dirname(openclaw), { recursive: true });
 	fsOriginals.writeFileSync(
@@ -136,7 +136,9 @@ exit 0
 	const originalEnv = { ...process.env };
 	process.env.HOME = home;
 	process.env.CLAWDI_RUNTIME_MODE = "hosted";
-	process.env.CLAWDI_RUNTIME_USER = process.env.USER ?? "root";
+	const runtimeUid = process.getuid?.() ?? 1_000;
+	const runtimeGid = process.getgid?.() ?? 1_000;
+	process.env.CLAWDI_RUNTIME_USER = String(runtimeUid);
 	process.env.CLAWDI_SERVICE_STATE_DIR = state;
 	process.env.CLAWDI_RUN_DIR = run;
 	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = systemdSystemRoot;
@@ -167,9 +169,11 @@ exit 0
 		const { normalizeHostedRuntimeBundleV2 } = await import("./manifest-source");
 		const { convergeRuntimeManifest } = await import("./manifest");
 		const { getRuntimePaths } = await import("./paths");
+		const { ensureRuntimeStateDirs } = await import("./state");
 		const load = normalizeHostedRuntimeBundleV2(fixture);
 		load.applyContext = {
 			kind: "context-file",
+			backend: "incus",
 			identity: {
 				generation: 2,
 				manifestETag: '"manifest-parity"',
@@ -184,8 +188,21 @@ exit 0
 			},
 		};
 
+		const paths = getRuntimePaths();
+		ensureRuntimeStateDirs(paths);
 		recording = true;
-		const result = convergeRuntimeManifest(load, getRuntimePaths(), { cacheLastGood: false });
+		const result = convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			hostedRuntimeContract: {
+				expectedIdentity: {
+					home,
+					user: String(runtimeUid),
+					uid: runtimeUid,
+					gid: runtimeGid,
+				},
+				resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+			},
+		});
 		recording = false;
 		expect(result.installErrors).toEqual([]);
 		expect(capturedPlan).not.toBeNull();

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -43,7 +43,7 @@ import {
 import { shouldIgnoreUserSkill } from "./managed-skill-reservation";
 import {
 	cacheRuntimeLastGoodManifest,
-	convergeRuntimeManifest,
+	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
 	type RuntimeManifest,
 	runtimeInstallerMutationTargets,
 	runtimeRecoverableSecretValues,
@@ -71,6 +71,7 @@ import {
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
+import { ensureRuntimeStateDirs } from "./state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const successfulPrerequisiteActivation = () => ({
@@ -83,6 +84,9 @@ const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
 const TEST_HOSTED_HOME = "/home/clawdi";
+const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
+const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
+const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
 const TEST_HOSTED_SECRET_VALUES = {
 	"secret://clawdi/auth-token": "test-auth-token",
 	"secret://runtime/openclaw/gateway-token": "gateway-token",
@@ -136,9 +140,31 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = TEST_RUNTIME_USER;
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 	return getRuntimePaths({ mode: "hosted" });
+}
+
+function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	opts: Parameters<typeof convergeRuntimeManifestWithContract>[2] = {},
+) {
+	ensureRuntimeStateDirs(paths);
+	return convergeRuntimeManifestWithContract(load, paths, {
+		...opts,
+		hostedRuntimeContract: opts.hostedRuntimeContract ?? {
+			expectedIdentity: {
+				home: paths.userHome,
+				user: TEST_RUNTIME_USER,
+				uid: TEST_PROCESS_UID,
+				gid: TEST_PROCESS_GID,
+			},
+			resolveUserIdentity: () => ({ uid: TEST_PROCESS_UID, gid: TEST_PROCESS_GID }),
+		},
+	});
 }
 
 function runSettings(command: string, args: string[]): RuntimeRunSettings {
@@ -158,6 +184,7 @@ function manifestLoad(
 		secretValues,
 		applyContext: {
 			kind: "context-file",
+			backend: "incus",
 			identity: {
 				generation: manifest.applyGeneration ?? manifest.generation,
 				manifestETag: `"test-${manifest.generation}"`,
@@ -4589,7 +4616,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				manifestLoad(baseManifest(symlinkPaths, {}), "inline-symlink-run-config"),
 				symlinkPaths,
 			),
-		).toThrow(`runtime managed directory is not a real directory: ${symlinkPaths.runConfigRoot}`);
+		).toThrow(`trusted directory path contains a non-directory: ${symlinkPaths.runConfigRoot}`);
 	});
 
 	test("snapshots exact installer targets only when the planned executable is missing", () => {
@@ -5500,16 +5527,10 @@ exit 42
 		);
 	});
 
-	test("requires trusted Incus context and rejects user-overridden Files contracts", () => {
+	test("rejects user-overridden Files contracts", () => {
 		const paths = tempRuntimePaths();
 		const binary = "Files gate fixture\n";
 		const manifest = fileBrowserManifest(paths, { generation: 1, binary });
-		const untrusted = manifestLoad(manifest, "files-without-incus-context");
-		expect(() => convergeRuntimeManifest(untrusted, paths)).toThrow(
-			"Files companion requires a hosted v2 bundle and trusted Incus runtime context",
-		);
-		expect(existsSync(paths.fileBrowserInstallRoot)).toBe(false);
-		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-files.service"))).toBe(false);
 		expect(() => convergeRuntimeManifest(fileBrowserManifestLoad(manifest), paths)).toThrow(
 			"Files companion requires systemd apply and readiness hooks",
 		);
@@ -5556,5 +5577,29 @@ exit 42
 		expect(() => convergeRuntimeManifest({ ...load, applyContext: undefined }, paths)).toThrow(
 			"runtime manifest convergence requires an explicit apply context",
 		);
+	});
+
+	test("fails closed when a platform root disappears before a later mutation group", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(paths, {
+			openclaw: { enabled: false, services: {} },
+			hermes: { enabled: false, services: {} },
+		});
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "missing-late-run-root"), paths, {
+			cacheLastGood: false,
+			systemdApply: {
+				activateEgressPrerequisite: successfulPrerequisiteActivation,
+				activate: () => {
+					rmSync(paths.runRoot, { recursive: true });
+					return successfulPrerequisiteActivation();
+				},
+				rollback: () => {},
+			},
+		});
+
+		expect(result.installErrors.join("\n")).toContain(
+			`platform directory is missing: ${paths.runRoot}`,
+		);
+		expect(existsSync(paths.runRoot)).toBe(false);
 	});
 });

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -33,17 +33,22 @@ import { ensureRuntimeStateDirs } from "./state";
 const originalEnv = { ...process.env };
 const originalConsoleWarn = console.warn;
 const tempRoots: string[] = [];
+const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
+const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
+const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
 
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
 	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
 ) {
+	ensureRuntimeStateDirs(paths);
 	return convergeRuntimeManifestWithContext(
 		{
 			...load,
 			applyContext: load.applyContext ?? {
 				kind: "context-file",
+				backend: "incus",
 				identity: {
 					generation: load.manifest.applyGeneration ?? load.manifest.generation,
 					manifestETag: `"test-${load.manifest.generation}"`,
@@ -59,7 +64,18 @@ function convergeRuntimeManifest(
 			},
 		},
 		paths,
-		opts,
+		{
+			...opts,
+			hostedRuntimeContract: opts?.hostedRuntimeContract ?? {
+				expectedIdentity: {
+					home: paths.userHome,
+					user: TEST_RUNTIME_USER,
+					uid: TEST_PROCESS_UID,
+					gid: TEST_PROCESS_GID,
+				},
+				resolveUserIdentity: () => ({ uid: TEST_PROCESS_UID, gid: TEST_PROCESS_GID }),
+			},
+		},
 	);
 }
 
@@ -71,6 +87,8 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = TEST_RUNTIME_USER;
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_AUTH_TOKEN = "test-token";
 	return getRuntimePaths({ mode: "hosted" });
@@ -95,6 +113,7 @@ function writeFakeGatewayCli(input: {
 	runtime: "openclaw" | "hermes";
 	unitPath: string;
 	version?: string;
+	hangVersion?: boolean;
 	failInstall?: boolean;
 	failUninstall?: boolean;
 	requiredSystemdState?: {
@@ -120,7 +139,7 @@ function writeFakeGatewayCli(input: {
 	set -euo pipefail
 	case "$*" in
 	  "--version")
-		printf '%s\\n' '${version}'
+		${input.hangVersion ? "exec sleep 60" : `printf '%s\\n' '${version}'`}
 		;;
   "gateway install --force --json"|"gateway install --force"|"gateway install")
 	${stateCheck}
@@ -254,6 +273,7 @@ interface InstallGateHarness {
 
 interface OfficialServiceInstallHarness extends InstallGateHarness {
 	addForeignDropIn: () => string;
+	hangVersionProbe: () => void;
 }
 
 function officialServiceHarness(
@@ -313,6 +333,8 @@ function officialServiceHarness(
 			writeFileSync(path, "[Service]\nExecStart=\nExecStart=/usr/bin/false\n");
 			return path;
 		},
+		hangVersionProbe: () =>
+			writeFakeGatewayCli({ path: command, logPath, runtime, unitPath, hangVersion: true }),
 	};
 }
 
@@ -672,6 +694,7 @@ describe("runtime manifest services", () => {
 		};
 		const applyContext = {
 			kind: "context-file" as const,
+			backend: "incus" as const,
 			identity: {
 				generation: 1,
 				manifestETag: '"manifest-1"',
@@ -1356,6 +1379,7 @@ describe("runtime manifest services", () => {
 
 	test("reuses a persisted Hermes dashboard receipt after process planning restarts", () => {
 		const paths = tempRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		const logPath = join(paths.runRoot, "hermes-dashboard-cold-receipt.log");
 		const npmCommand = join(paths.runRoot, "bin", "npm");
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
@@ -1920,6 +1944,19 @@ describe("runtime manifest services", () => {
 		expect(harness.receipt()).toEqual(receipt);
 		expect(readFileSync(foreignDropIn, "utf8")).toBe(foreignContents);
 	});
+
+	test("turns a hanging runtime version probe into a bounded convergence error", () => {
+		const harness = officialServiceHarness("openclaw");
+		expect(harness.converge().installErrors).toEqual([]);
+		harness.hangVersionProbe();
+		const startedAt = Date.now();
+
+		const result = harness.converge();
+
+		expect(Date.now() - startedAt).toBeLessThan(15_000);
+		expect(result.installErrors.join("\n")).toContain("runtime --version probe for");
+		expect(result.installErrors.join("\n")).toContain("timed out after 10000ms");
+	}, 15_000);
 
 	test("uninstalls stale official gateway services when manifest disables them", () => {
 		const paths = tempRuntimePaths();

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -105,6 +105,10 @@ import {
 	requiresManagedGatewayModelProbe,
 	resolveManagedGatewayModelOverrides,
 } from "./hosted-provider-resolution";
+import {
+	assertHostedRuntimeContract,
+	type HostedRuntimeContractOptions,
+} from "./hosted-runtime-contract";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	emptyRuntimeInstallReceipts,
@@ -217,6 +221,11 @@ import {
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
+import {
+	ensureRuntimePlatformDirectory,
+	runtimePlatformRootForPath,
+	writeRuntimePlatformFileAtomic,
+} from "./state";
 
 import {
 	TRANSPARENT_EGRESS_TABLE,
@@ -388,8 +397,21 @@ const openClawPluginInspectSchema = z
 	})
 	.passthrough();
 
-function writeJsonFile(path: string, payload: unknown): void {
-	writePrivateFileAtomic(path, `${JSON.stringify(payload, null, 2)}\n`);
+function writeRuntimePrivateFileAtomic(
+	paths: RuntimePaths,
+	path: string,
+	content: string | Uint8Array,
+	options: { mode?: number; dirMode?: number } = {},
+): void {
+	const trustedRoot = runtimePlatformRootForPath(paths, path);
+	if (trustedRoot) writeRuntimePlatformFileAtomic(paths, path, content, options);
+	else writePrivateFileAtomic(path, content, options);
+}
+
+function writeJsonFile(path: string, payload: unknown, paths?: RuntimePaths): void {
+	const content = `${JSON.stringify(payload, null, 2)}\n`;
+	if (paths) writeRuntimePrivateFileAtomic(paths, path, content);
+	else writePrivateFileAtomic(path, content);
 }
 
 function writeLastGoodManifest(
@@ -404,7 +426,7 @@ function writeLastGoodManifest(
 		rmSync(paths.managedSecretCacheFile, { force: true });
 		return null;
 	}
-	writeJsonFile(paths.manifestLastGood, manifest);
+	writeJsonFile(paths.manifestLastGood, manifest, paths);
 	writeLastGoodSecretValues(secretScopeManifest, secretValues, paths, excludedSecretRefs);
 	return paths.manifestLastGood;
 }
@@ -433,7 +455,8 @@ function writeLastGoodSecretValues(
 		rmSync(paths.managedSecretCacheFile, { force: true });
 		return;
 	}
-	writePrivateFileAtomic(
+	writeRuntimePrivateFileAtomic(
+		paths,
 		paths.managedSecretCacheFile,
 		`${JSON.stringify(recoverable, null, 2)}\n`,
 		{
@@ -832,7 +855,8 @@ function writeProviderHealthStatus(
 		rmSync(paths.providerHealthStatus, { force: true });
 		return null;
 	}
-	writePrivateFileAtomic(
+	writeRuntimePrivateFileAtomic(
+		paths,
 		paths.providerHealthStatus,
 		`${JSON.stringify(
 			{
@@ -1615,7 +1639,10 @@ function writeEgressSecretMaterial(
 		rmSync(path, { force: true });
 		return null;
 	}
-	writePrivateFileAtomic(path, material.content, { mode: 0o600, dirMode: 0o700 });
+	writeRuntimePrivateFileAtomic(paths, path, material.content, {
+		mode: 0o600,
+		dirMode: 0o700,
+	});
 	makeEgressIdentityOwned(path);
 	makeManagedSecretRoot(paths.managedSecretRoot);
 	try {
@@ -3520,15 +3547,19 @@ function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger
 }
 
 function writeHostedMcpManagedLedger(paths: RuntimePaths, ledger: HostedMcpManagedLedger): void {
-	writeJsonFile(hostedMcpLedgerPath(paths), {
-		schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION,
-		runtimes: Object.fromEntries(
-			HOSTED_RUNTIME_TARGETS.flatMap((runtime) => {
-				const names = ledger.runtimes[runtime];
-				return names && names.length > 0 ? [[runtime, [...names].sort()]] : [];
-			}),
-		),
-	});
+	writeJsonFile(
+		hostedMcpLedgerPath(paths),
+		{
+			schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION,
+			runtimes: Object.fromEntries(
+				HOSTED_RUNTIME_TARGETS.flatMap((runtime) => {
+					const names = ledger.runtimes[runtime];
+					return names && names.length > 0 ? [[runtime, [...names].sort()]] : [];
+				}),
+			),
+		},
+		paths,
+	);
 }
 
 function hostedBundledSkillsEnabled(): boolean {
@@ -4365,7 +4396,7 @@ function writeEgressEngineStatus(
 		rmSync(paths.egressEngineStatus, { force: true });
 		return null;
 	}
-	writeJsonFile(paths.egressEngineStatus, result);
+	writeJsonFile(paths.egressEngineStatus, result, paths);
 	return result;
 }
 
@@ -4388,7 +4419,10 @@ function requireV2EgressEngineReady(
 function writeEgressAddon(paths: RuntimePaths): { path: string; sha256: string } {
 	const source = resolvePackagedEgressAddon();
 	const content = readFileSync(source, "utf-8");
-	writePrivateFileAtomic(paths.egressAddon, content, { mode: 0o640, dirMode: 0o711 });
+	writeRuntimePrivateFileAtomic(paths, paths.egressAddon, content, {
+		mode: 0o640,
+		dirMode: 0o711,
+	});
 	if (runningAsRoot()) chownSync(paths.egressAddon, 0, runtimeEgressGid());
 	return { path: paths.egressAddon, sha256: sha256String(content) };
 }
@@ -4446,10 +4480,15 @@ function writeTransparentEgressEnvFile(input: {
 	const lines = Object.entries(env)
 		.sort(([a], [b]) => a.localeCompare(b))
 		.map(([key, value]) => `${key}=${runtimeEnvironmentFileQuote(value)}`);
-	writePrivateFileAtomic(input.paths.egressTransparentEnv, `${lines.join("\n")}\n`, {
-		mode: 0o600,
-		dirMode: 0o711,
-	});
+	writeRuntimePrivateFileAtomic(
+		input.paths,
+		input.paths.egressTransparentEnv,
+		`${lines.join("\n")}\n`,
+		{
+			mode: 0o600,
+			dirMode: 0o711,
+		},
+	);
 	return input.paths.egressTransparentEnv;
 }
 
@@ -4559,7 +4598,8 @@ function readLiveSyncEnvironmentIndex(paths: RuntimePaths): RuntimeName[] {
 }
 
 function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: RuntimePaths): void {
-	writePrivateFileAtomic(
+	writeRuntimePrivateFileAtomic(
+		paths,
 		liveSyncEnvironmentIndexPath(paths),
 		`${JSON.stringify(
 			{
@@ -5388,6 +5428,7 @@ export function convergeRuntimeManifest(
 		preparedHostedSourcedSkills?: ReadonlyMap<string, PreparedHostedSourcedSkill>;
 		hostedHermesSkillExactSourceDriver?: HostedHermesSkillExactSourceDriver;
 		hostedOpenClawSkillDriver?: HostedOpenClawSkillDriver;
+		hostedRuntimeContract?: HostedRuntimeContractOptions;
 	} = {},
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
@@ -5396,15 +5437,14 @@ export function convergeRuntimeManifest(
 	if (!applyContext) {
 		throw new Error("runtime manifest convergence requires an explicit apply context");
 	}
+	const hostedRuntimeContract = assertHostedRuntimeContract(
+		paths,
+		applyContext,
+		opts.hostedRuntimeContract,
+	);
 	if (manifest.companions?.filebrowser) {
-		if (
-			paths.mode !== "hosted" ||
-			manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2" ||
-			applyContext.backend !== "incus"
-		) {
-			throw new Error(
-				"Files companion requires a hosted v2 bundle and trusted Incus runtime context",
-			);
+		if (manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2") {
+			throw new Error("Files companion requires a hosted v2 bundle");
 		}
 		if (!opts.systemdApply) {
 			throw new Error("Files companion requires systemd apply and readiness hooks");
@@ -5561,6 +5601,7 @@ export function convergeRuntimeManifest(
 		userUnits: [],
 	};
 	try {
+		hostedRuntimeContract.assertPlatformRoots();
 		// Runtime-user targets and their ancestor metadata are already in the
 		// exact pre-image snapshot. Establish their positive ownership boundary
 		// before any official installer or CLI command drops privilege. Modes are
@@ -5607,10 +5648,7 @@ export function convergeRuntimeManifest(
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
 
-		// Installers and probes may need a private scratch/log root. This is not
-		// generation-owned live configuration and is created only after Plan and
-		// exact pre-image capture succeed.
-		mkdirSync(paths.runRoot, { recursive: true });
+		hostedRuntimeContract.assertPlatformRoots();
 		let codexCli: Record<string, string> | null = null;
 		if (
 			hostedCodexManagedProvider(manifest) ||
@@ -5675,6 +5713,7 @@ export function convergeRuntimeManifest(
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
 
+		hostedRuntimeContract.assertPlatformRoots();
 		ensureRuntimeUserHome(paths.userHome);
 		withRuntimeUserFileAccess(() => {
 			mkdirSync(workspaceRoot, { recursive: true });
@@ -5688,72 +5727,88 @@ export function convergeRuntimeManifest(
 			semRoot,
 			paths.egressProfileRoot,
 		]) {
-			mkdirSync(directory, { recursive: true, mode: 0o755 });
+			ensureRuntimePlatformDirectory(paths, directory, { mode: 0o755 });
 		}
-		mkdirSync(paths.managedSecretRoot, { recursive: true });
+		ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);
 		makeManagedSecretRoot(paths.managedSecretRoot);
-		mkdirSync(paths.egressRoot, { recursive: true, mode: 0o711 });
+		ensureRuntimePlatformDirectory(paths, paths.egressRoot, { mode: 0o711 });
 		chmodSync(paths.egressRoot, 0o711);
 		makeEgressIdentityPrivateDir(paths.egressCaDir);
-		mkdirSync(dirname(paths.egressSystemCaFile), { recursive: true, mode: 0o711 });
+		ensureRuntimePlatformDirectory(paths, dirname(paths.egressSystemCaFile), { mode: 0o711 });
 		chmodSync(dirname(paths.egressSystemCaFile), 0o711);
 		makeRuntimeUserPrivateDir(paths.egressScratchRoot, paths.userHome);
 
 		let manifestLastGood: string | null = null;
-		writeJsonFile(paths.managedConfig, {
-			schemaVersion: "clawdi.hostedManagedConfig.v1",
-			generatedAt,
-			deploymentId: manifest.deploymentId,
-			environmentId: manifest.environmentId,
-			instanceId: manifest.instanceId,
-			generation: manifest.generation,
-			locale: manifest.locale ?? null,
-			controlPlane: manifest.controlPlane,
-			egressEngine: manifest.egressEngine ?? null,
-			auth: {
-				source: "runtime-instance-data",
+		writeJsonFile(
+			paths.managedConfig,
+			{
+				schemaVersion: "clawdi.hostedManagedConfig.v1",
+				generatedAt,
+				deploymentId: manifest.deploymentId,
+				environmentId: manifest.environmentId,
+				instanceId: manifest.instanceId,
+				generation: manifest.generation,
+				locale: manifest.locale ?? null,
+				controlPlane: manifest.controlPlane,
+				egressEngine: manifest.egressEngine ?? null,
+				auth: {
+					source: "runtime-instance-data",
+					token: "<redacted>",
+				},
+				workspaceRoot,
+			},
+			paths,
+		);
+		writeJsonFile(
+			paths.syncState,
+			{
+				schemaVersion: "clawdi.runtimeSyncState.v1",
+				generatedAt,
+				deploymentId: manifest.deploymentId,
+				environmentId: manifest.environmentId,
+				instanceId: manifest.instanceId,
+				generation: manifest.generation,
+				locale: manifest.locale ?? null,
+				runtimes: Object.fromEntries(
+					Object.entries(manifest.runtimes).map(([name, runtime]) => [
+						name,
+						{
+							enabled: runtime.enabled,
+							updateChannel: runtime.updateChannel ?? null,
+							workspaceRoot,
+						},
+					]),
+				),
+			},
+			paths,
+		);
+		writeJsonFile(
+			paths.instanceData,
+			{
+				schemaVersion: "clawdi.runtimeInstanceData.v1",
+				generatedAt,
+				deploymentId: manifest.deploymentId,
+				environmentId: manifest.environmentId,
+				instanceId: manifest.instanceId,
+				generation: manifest.generation,
+				locale: manifest.locale ?? null,
+				controlPlane: manifest.controlPlane,
+				workspaceRoot,
+			},
+			paths,
+		);
+		writeJsonFile(
+			paths.sensitiveInstanceData,
+			{
+				schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
+				generatedAt,
+				tokenSource: runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
+					? "CLAWDI_AUTH_TOKEN"
+					: load.source,
 				token: "<redacted>",
 			},
-			workspaceRoot,
-		});
-		writeJsonFile(paths.syncState, {
-			schemaVersion: "clawdi.runtimeSyncState.v1",
-			generatedAt,
-			deploymentId: manifest.deploymentId,
-			environmentId: manifest.environmentId,
-			instanceId: manifest.instanceId,
-			generation: manifest.generation,
-			locale: manifest.locale ?? null,
-			runtimes: Object.fromEntries(
-				Object.entries(manifest.runtimes).map(([name, runtime]) => [
-					name,
-					{
-						enabled: runtime.enabled,
-						updateChannel: runtime.updateChannel ?? null,
-						workspaceRoot,
-					},
-				]),
-			),
-		});
-		writeJsonFile(paths.instanceData, {
-			schemaVersion: "clawdi.runtimeInstanceData.v1",
-			generatedAt,
-			deploymentId: manifest.deploymentId,
-			environmentId: manifest.environmentId,
-			instanceId: manifest.instanceId,
-			generation: manifest.generation,
-			locale: manifest.locale ?? null,
-			controlPlane: manifest.controlPlane,
-			workspaceRoot,
-		});
-		writeJsonFile(paths.sensitiveInstanceData, {
-			schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
-			generatedAt,
-			tokenSource: runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
-				? "CLAWDI_AUTH_TOKEN"
-				: load.source,
-			token: "<redacted>",
-		});
+			paths,
+		);
 
 		const egressProfileBundlePath = hasEnabledEgressProfiles(egressProfileBundle)
 			? writeEgressProfileBundle(egressProfileBundle, paths)
@@ -6025,33 +6080,37 @@ export function convergeRuntimeManifest(
 			if (!observation) throw new Error(`runtime ${name} install observation is missing`);
 
 			const inventoryPath = join(paths.installInventory, `${name}.json`);
-			writeJsonFile(inventoryPath, {
-				schemaVersion: "clawdi.runtimeInstallInventory.v1",
-				generatedAt,
-				runtime: name,
-				enabled: runtime.enabled,
-				updateChannel: runtime.updateChannel ?? null,
-				simulation: false,
-				status: observation.status,
-				executionUser: observation.executionUser,
-				install: observation.install,
-				command: runtimeInstallerCommand(name, runtime.install),
-				commandPath: observation.commandPath,
-				appRoot: observation.appRoot,
-				installerUrl: observation.installerUrl,
-				executedInstallerUrl: observation.executedInstallerUrl,
-				installStartedAt: observation.installStartedAt ?? null,
-				installFinishedAt: observation.installFinishedAt ?? null,
-				installDurationMs: observation.installDurationMs ?? null,
-				resultExitCode: observation.exitCode,
-				stdoutTail: observation.stdoutTail,
-				stderrTail: observation.stderrTail,
-				error: observation.error,
-			});
+			writeJsonFile(
+				inventoryPath,
+				{
+					schemaVersion: "clawdi.runtimeInstallInventory.v1",
+					generatedAt,
+					runtime: name,
+					enabled: runtime.enabled,
+					updateChannel: runtime.updateChannel ?? null,
+					simulation: false,
+					status: observation.status,
+					executionUser: observation.executionUser,
+					install: observation.install,
+					command: runtimeInstallerCommand(name, runtime.install),
+					commandPath: observation.commandPath,
+					appRoot: observation.appRoot,
+					installerUrl: observation.installerUrl,
+					executedInstallerUrl: observation.executedInstallerUrl,
+					installStartedAt: observation.installStartedAt ?? null,
+					installFinishedAt: observation.installFinishedAt ?? null,
+					installDurationMs: observation.installDurationMs ?? null,
+					resultExitCode: observation.exitCode,
+					stdoutTail: observation.stdoutTail,
+					stderrTail: observation.stderrTail,
+					error: observation.error,
+				},
+				paths,
+			);
 			installInventory.push(inventoryPath);
 
 			const projectionPath = join(paths.projectionRoot, `${name}.json`);
-			writeJsonFile(projectionPath, projectionPayload(name, manifest));
+			writeJsonFile(projectionPath, projectionPayload(name, manifest), paths);
 			projections.push(projectionPath);
 			if (name === "hermes" || name === "openclaw") {
 				try {
@@ -6139,18 +6198,19 @@ export function convergeRuntimeManifest(
 
 			const semaphorePath = join(semRoot, `${name}.enabled`);
 			if (runtime.enabled) {
-				writePrivateFileAtomic(semaphorePath, `${generatedAt}\n`);
+				writeRuntimePrivateFileAtomic(paths, semaphorePath, `${generatedAt}\n`);
 				instanceSemaphores.push(semaphorePath);
 			}
 		}
 
 		const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
 		if (hostedMcpProjectionDeclared(manifest) || manifest.projection?.skills !== undefined) {
-			writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
+			writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest), paths);
 			projections.push(mcpProjection);
 		} else {
 			rmSync(mcpProjection, { force: true });
 		}
+		hostedRuntimeContract.assertPlatformRoots();
 		const systemdUnits = writeRuntimeSystemdState({
 			runtimePrograms: runtimeSystemdUserPrograms,
 			egressProgram: egressSystemdProgram,
@@ -6206,6 +6266,7 @@ export function convergeRuntimeManifest(
 		}
 
 		for (const item of officialServicePlan.pending) {
+			hostedRuntimeContract.assertPlatformRoots();
 			const error = installOfficialRuntimeService(item, paths);
 			if (error) throw new Error(error);
 		}
@@ -6216,8 +6277,9 @@ export function convergeRuntimeManifest(
 		);
 		if (artifactError) throw new Error(artifactError);
 
+		hostedRuntimeContract.assertPlatformRoots();
 		const bootFinished = join(instanceRoot, "boot-finished");
-		writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);
+		writeRuntimePrivateFileAtomic(paths, bootFinished, `${generatedAt}\n`);
 		if (opts.systemdApply) {
 			const activation = opts.systemdApply.activate({
 				restartDaemon,
@@ -6280,6 +6342,7 @@ export function convergeRuntimeManifest(
 			},
 		};
 		if (installErrors.length === 0) {
+			hostedRuntimeContract.assertPlatformRoots();
 			const daemonRevisionPreviouslyCommitted =
 				desiredDaemonAuthTokenRevision !== undefined &&
 				desiredDaemonAuthTokenRevision === appliedState?.daemonAuthTokenRevision;
@@ -6331,6 +6394,7 @@ export function convergeRuntimeManifest(
 		const applyError = error instanceof Error ? error.message : String(error);
 		let filesystemRollbackSucceeded = false;
 		try {
+			hostedRuntimeContract.assertPlatformRoots();
 			restoreRuntimeLiveSnapshot(liveSnapshot);
 			if (rollbackEgressSecretOverride) {
 				writeEgressSecretMaterial(rollbackEgressSecretOverride, paths);

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -26,7 +26,9 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 	process.env.CLAWDI_ENVIRONMENT_ID = "env_producer";
-	return getRuntimePaths({ mode: "hosted" });
+	const paths = getRuntimePaths({ mode: "hosted" });
+	mkdirSync(paths.serviceStateRoot);
+	return paths;
 }
 
 function appliedState(generation: number): RuntimeAppliedStateV2 {
@@ -60,6 +62,7 @@ function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 		path,
 		JSON.stringify({
 			schemaVersion: "clawdi.runtimeContext.v2",
+			backend: "incus",
 			apply: {
 				generation,
 				manifestETag: `"manifest-${generation}"`,

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -23,6 +23,7 @@ describe("hosted runtime observed v2", () => {
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.serviceStateRoot);
 		writeRuntimeAppliedState(
 			{
 				schemaVersion: "clawdi.runtimeAppliedState.v2",

--- a/packages/cli/src/runtime/run-config.test.ts
+++ b/packages/cli/src/runtime/run-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
@@ -22,7 +22,9 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
-	return getRuntimePaths({ mode: "hosted" });
+	const paths = getRuntimePaths({ mode: "hosted" });
+	mkdirSync(paths.configurationRoot);
+	return paths;
 }
 
 function runSettings(command: string, args: string[]): RuntimeRunSettings {

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { z } from "zod";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
 import { canonicalSecretRefSchema, runtimeSecretValue } from "./secret-values";
+import { writeRuntimePlatformFileAtomic } from "./state";
 
 export const runtimeNameSchema = z
 	.string()
@@ -148,7 +148,7 @@ export function buildRuntimeRunConfig(input: {
 
 export function writeRuntimeRunConfig(config: RuntimeRunConfig, paths: RuntimePaths): string {
 	const path = runtimeRunConfigPath(config.runtime, paths, config.service);
-	writePrivateFileAtomic(path, `${JSON.stringify(config, null, 2)}\n`, {
+	writeRuntimePlatformFileAtomic(paths, path, `${JSON.stringify(config, null, 2)}\n`, {
 		mode: 0o644,
 		dirMode: 0o755,
 	});

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -27,7 +27,10 @@ import {
 	hostedManifestEgressProfiles,
 	managedMcpHeaderPlaceholder,
 } from "./hosted-egress-profiles";
-import { cacheRuntimeLastGoodManifest, convergeRuntimeManifest } from "./manifest";
+import {
+	cacheRuntimeLastGoodManifest,
+	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
+} from "./manifest";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest,
@@ -35,7 +38,8 @@ import {
 	normalizeHostedRuntimeBundleV2,
 	type RuntimeManifestLoad,
 } from "./manifest-source";
-import { getRuntimePaths } from "./paths";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+import { ensureRuntimeStateDirs } from "./state";
 
 const goldenPath = resolve(
 	import.meta.dir,
@@ -46,6 +50,31 @@ const EXPECTED_GOLDEN_SOURCE_REVISION =
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];
+const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
+const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
+const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
+
+function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	opts: Parameters<typeof convergeRuntimeManifestWithContract>[2] = {},
+) {
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = TEST_RUNTIME_USER;
+	ensureRuntimeStateDirs(paths);
+	return convergeRuntimeManifestWithContract(load, paths, {
+		...opts,
+		hostedRuntimeContract: opts.hostedRuntimeContract ?? {
+			expectedIdentity: {
+				home: paths.userHome,
+				user: TEST_RUNTIME_USER,
+				uid: TEST_PROCESS_UID,
+				gid: TEST_PROCESS_GID,
+			},
+			resolveUserIdentity: () => ({ uid: TEST_PROCESS_UID, gid: TEST_PROCESS_GID }),
+		},
+	});
+}
 
 function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): RuntimeManifestLoad {
 	const authToken = process.env.CLAWDI_BOOTSTRAP_AUTH_TOKEN ?? "test-token";
@@ -53,6 +82,7 @@ function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): Ru
 		...load,
 		applyContext: {
 			kind: "context-file",
+			backend: "incus",
 			identity: {
 				generation: load.manifest.applyGeneration ?? load.manifest.generation,
 				manifestETag: `"test-${load.manifest.generation}"`,
@@ -91,6 +121,7 @@ function setRuntimeApplyIdentityFile(
 		path,
 		JSON.stringify({
 			schemaVersion: "clawdi.runtimeContext.v2",
+			backend: "incus",
 			apply: identity,
 			cliPackageSpec,
 			manifestSource: {
@@ -527,12 +558,14 @@ describe("hosted runtime bundle v2", () => {
 		if (!projection) throw new Error("runtime bundle projection is unavailable");
 		delete projection.providers;
 		delete projection.terminalTooling;
+		projection.skills = { entries: {} };
 		const load = {
 			...projected,
 			manifest: {
 				...projected.manifest,
 				runtimes: { openclaw },
 				projection,
+				skills: { entries: {} },
 			},
 		};
 		const result = convergeRuntimeManifest(load, paths, {
@@ -1112,6 +1145,7 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.cacheRoot, { recursive: true });
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as unknown;
 		const projected = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(raw));
 
@@ -1207,6 +1241,9 @@ describe("hosted runtime bundle v2", () => {
 		const remote = await loadRemoteRuntimeManifest(paths, { applyContext });
 		if (!("manifest" in remote)) throw new Error(JSON.stringify(remote));
 		const onlineLoad = applyRuntimeBundleChannelsToManifestLoad(remote);
+		if (onlineLoad.manifest.projection) {
+			onlineLoad.manifest.projection.skills = { entries: {} };
+		}
 		const onlineConvergence = converge(onlineLoad);
 		expect(onlineConvergence.installErrors).toEqual([]);
 		const sourceRevision = onlineLoad.sourceRevision;

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -4,7 +4,6 @@ import {
 	chmodSync,
 	existsSync,
 	lstatSync,
-	mkdirSync,
 	readdirSync,
 	readFileSync,
 	readlinkSync,
@@ -15,6 +14,7 @@ import {
 import { dirname, isAbsolute, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { stripTerminalEscapes } from "../lib/sanitize";
+import { ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
 import { runtimeContentSha256 } from "./applied-state";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import { FILE_BROWSER_SERVICE_GROUP, FILE_BROWSER_SERVICE_USER } from "./file-browser-isolation";
@@ -44,6 +44,7 @@ import {
 	commandResolvable,
 	executableExists,
 	makeRuntimeUserOwned,
+	RuntimeUserCommandTimeoutError,
 	runRuntimeUserCommand,
 	runtimeEgressGid,
 	runtimeEgressUid,
@@ -459,13 +460,22 @@ function runtimeCommandCurrentRevision(command: string, home: string, cwd: strin
 	const executableRevision = runtimeFileCurrentRevision(command);
 	if (!executableRevision) return null;
 	try {
-		const result = spawnRuntimeUserCommand(command, ["--version"], home, cwd);
+		const result = spawnRuntimeUserCommand(command, ["--version"], home, cwd, {
+			timeoutMs: RUNTIME_VERSION_PROBE_TIMEOUT_MS,
+		});
+		if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
+			throw new RuntimeUserCommandTimeoutError(
+				`runtime --version probe for ${command}`,
+				RUNTIME_VERSION_PROBE_TIMEOUT_MS,
+			);
+		}
 		if (result.status !== 0) return null;
 		const stdout = Buffer.isBuffer(result.stdout) ? result.stdout.toString("utf8") : result.stdout;
 		const stderr = Buffer.isBuffer(result.stderr) ? result.stderr.toString("utf8") : result.stderr;
 		const version = [stdout, stderr].filter(Boolean).join("\n").trim();
 		return version ? runtimeContentSha256({ executableRevision, version }) : null;
-	} catch {
+	} catch (error) {
+		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
 		return null;
 	}
 }
@@ -498,7 +508,8 @@ function officialServiceCurrentRevision(
 			unitUid: unitStat.uid,
 			unitGid: unitStat.gid,
 		});
-	} catch {
+	} catch (error) {
+		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
 		return null;
 	}
 }
@@ -557,6 +568,10 @@ export function planOfficialRuntimeServices(
 const HERMES_NPM_VERSION_TIMEOUT_MS = 30_000;
 const HERMES_NPM_INSTALL_TIMEOUT_MS = 600_000;
 const HERMES_DASHBOARD_BUILD_TIMEOUT_MS = 900_000;
+const RUNTIME_VERSION_PROBE_TIMEOUT_MS = 10_000;
+const OFFICIAL_SERVICE_INSTALL_TIMEOUT_MS = 600_000;
+const OFFICIAL_SERVICE_UNINSTALL_TIMEOUT_MS = 120_000;
+const RUNTIME_SYSTEMCTL_MAINTENANCE_TIMEOUT_MS = 15_000;
 // This key deliberately reuses the existing officialServices receipt group:
 // the artifact is a prerequisite of Clawdi's compatibility dashboard service,
 // not a new install authority or receipt schema.
@@ -717,9 +732,13 @@ function writeSystemdEnvironmentFile(input: {
 	owner: "root" | "runtime-user";
 	env: Record<string, string>;
 }): string {
-	mkdirSync(input.paths.systemdRuntimeRoot, { recursive: true, mode: 0o711 });
+	ensureDirectoryWithinTrustedRoot(input.paths.runRoot, input.paths.systemdRuntimeRoot, {
+		mode: 0o711,
+	});
 	chmodSync(input.paths.systemdRuntimeRoot, 0o711);
-	mkdirSync(input.paths.systemdEnvRoot, { recursive: true, mode: 0o711 });
+	ensureDirectoryWithinTrustedRoot(input.paths.runRoot, input.paths.systemdEnvRoot, {
+		mode: 0o711,
+	});
 	// This is a deliberate handoff directory: tenant-owned 0600 environment
 	// files must be traversable without making sibling platform files readable.
 	chmodSync(input.paths.systemdEnvRoot, 0o711);
@@ -735,6 +754,7 @@ function writeSystemdEnvironmentFile(input: {
 	writePrivateFileAtomic(path, `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`, {
 		mode: 0o600,
 		dirMode: 0o711,
+		trustedRoot: input.paths.runRoot,
 	});
 	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
 	return path;
@@ -833,9 +853,13 @@ function writeSystemdUnit(input: {
 		"",
 	];
 	const writeUnitFile = (): string => {
-		mkdirSync(input.root, { recursive: true });
+		ensureDirectoryWithinTrustedRoot(input.root, input.root);
 		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, {
+			mode: 0o644,
+			dirMode: 0o755,
+			trustedRoot: input.root,
+		});
 		if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
 		return path;
 	};
@@ -907,9 +931,13 @@ function writeSystemdUserDropIn(input: {
 	];
 	return withRuntimeUserFileAccess(() => {
 		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
-		mkdirSync(dirname(path), { recursive: true });
+		ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
 		makeRuntimeUserOwned(dirname(path));
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, { mode: 0o644, dirMode: 0o755 });
+		writePrivateFileAtomic(path, `${lines.join("\n")}`, {
+			mode: 0o644,
+			dirMode: 0o755,
+			trustedRoot: input.paths.systemdUserRoot,
+		});
 		makeRuntimeUserOwned(path);
 		return join(input.paths.systemdUserRoot, unitName);
 	});
@@ -1033,7 +1061,11 @@ function installOfficialRuntimeUserService(
 		resetFailedRuntimeUserService(runtimeSystemdProgramName(program), paths, program.cwd);
 		const result = spawnRuntimeUserCommand(program.command, args, paths.userHome, program.cwd, {
 			maxBufferBytes: OFFICIAL_INSTALLER_MAX_BUFFER_BYTES,
+			timeoutMs: OFFICIAL_SERVICE_INSTALL_TIMEOUT_MS,
 		});
+		if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
+			return `official ${runtimeSystemdProgramName(program)} service install timed out after ${OFFICIAL_SERVICE_INSTALL_TIMEOUT_MS}ms`;
+		}
 		return result.status === 0 && !result.error
 			? null
 			: `official ${runtimeSystemdProgramName(program)} service install failed: ${officialInstallerFailureDetail(program, result)}`;
@@ -1072,6 +1104,7 @@ function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: s
 			"",
 			paths.userHome,
 			cwd,
+			{ timeoutMs: RUNTIME_SYSTEMCTL_MAINTENANCE_TIMEOUT_MS },
 		);
 	} catch {
 		// The unit may not exist yet; reset-failed must never block convergence.
@@ -1086,6 +1119,7 @@ function reloadRuntimeUserManager(paths: RuntimePaths, cwd: string): void {
 			"",
 			paths.userHome,
 			cwd,
+			{ timeoutMs: RUNTIME_SYSTEMCTL_MAINTENANCE_TIMEOUT_MS },
 		);
 	} catch {
 		// Best-effort: environments without a reachable user manager (unit tests,
@@ -1112,6 +1146,7 @@ function uninstallOfficialRuntimeUserService(input: {
 			"",
 			input.paths.userHome,
 			input.workspaceRoot,
+			{ timeoutMs: OFFICIAL_SERVICE_UNINSTALL_TIMEOUT_MS },
 		);
 		return null;
 	} catch (error) {

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -5,6 +5,25 @@ import { withEffectiveFilesystemIdentity } from "./effective-identity";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import { parsePositiveLinuxId } from "./transparent-egress";
 
+const RUNTIME_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
+
+export interface RuntimeUserIdentity {
+	uid: number;
+	gid: number;
+}
+
+export type RuntimeUserIdentityResolver = (runtimeUser: string) => RuntimeUserIdentity;
+
+export class RuntimeUserCommandTimeoutError extends Error {
+	constructor(
+		readonly operation: string,
+		readonly timeoutMs: number,
+	) {
+		super(`${operation} timed out after ${timeoutMs}ms`);
+		this.name = "RuntimeUserCommandTimeoutError";
+	}
+}
+
 export function executableExists(path: string): boolean {
 	try {
 		accessSync(path, constants.X_OK);
@@ -219,6 +238,35 @@ function linuxUid(value: string): number | null {
 	return Number.isInteger(uid) && uid <= 4_294_967_295 ? uid : null;
 }
 
+function strictRuntimeUserId(runtimeUser: string, kind: "uid" | "gid"): number {
+	const flag = kind === "uid" ? "-u" : "-g";
+	const resolved = spawnSync("id", [flag, runtimeUser], {
+		encoding: "utf8",
+		timeout: RUNTIME_IDENTITY_PROBE_TIMEOUT_MS,
+	});
+	if (resolved.error && "code" in resolved.error && resolved.error.code === "ETIMEDOUT") {
+		throw new RuntimeUserCommandTimeoutError(
+			`runtime user ${kind} probe for ${runtimeUser}`,
+			RUNTIME_IDENTITY_PROBE_TIMEOUT_MS,
+		);
+	}
+	if (resolved.status !== 0) {
+		throw new Error(`could not resolve ${kind} for runtime user ${runtimeUser}`);
+	}
+	const parsed = linuxUid(resolved.stdout.trim());
+	if (parsed === null) {
+		throw new Error(`runtime user ${runtimeUser} resolved an invalid ${kind}`);
+	}
+	return parsed;
+}
+
+export function resolveRuntimeUserIdentity(runtimeUser: string): RuntimeUserIdentity {
+	return {
+		uid: strictRuntimeUserId(runtimeUser, "uid"),
+		gid: strictRuntimeUserId(runtimeUser, "gid"),
+	};
+}
+
 function runtimeUserCommandEnv(
 	home: string,
 	runtimeUid: number | null,
@@ -387,11 +435,26 @@ export function runRuntimeUserCommand(
 				resolver: options.resolver,
 			})
 		: { command, args, env: {} };
-	execFileSync(child.command, child.args, {
-		input: stdin,
-		env: { ...runtimeUserCommandEnv(home, runtimeUid, options), ...child.env },
-		cwd,
-		stdio: "pipe",
-		timeout: options.timeoutMs,
-	});
+	try {
+		execFileSync(child.command, child.args, {
+			input: stdin,
+			env: { ...runtimeUserCommandEnv(home, runtimeUid, options), ...child.env },
+			cwd,
+			stdio: "pipe",
+			timeout: options.timeoutMs,
+		});
+	} catch (error) {
+		if (
+			options.timeoutMs !== undefined &&
+			error instanceof Error &&
+			"code" in error &&
+			error.code === "ETIMEDOUT"
+		) {
+			throw new RuntimeUserCommandTimeoutError(
+				`runtime command ${command} ${args.join(" ")}`.trim(),
+				options.timeoutMs,
+			);
+		}
+		throw error;
+	}
 }

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -1,5 +1,7 @@
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import { assertTrustedDirectory, ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
 import type { HostPolicyReadResult } from "./host-policy";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
 import {
@@ -173,14 +175,59 @@ export function hostPolicySummary(policy: HostPolicyReadResult): RuntimeBootStat
 	};
 }
 
-function writeJson(path: string, data: unknown, mode = 0o600): void {
-	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode });
-	try {
-		chmodSync(path, mode);
-	} catch {
-		// Best effort on filesystems without POSIX mode support.
+function writeJson(paths: RuntimePaths, path: string, data: unknown, mode = 0o600): void {
+	writeRuntimePlatformFileAtomic(paths, path, `${JSON.stringify(data, null, 2)}\n`, {
+		mode,
+		dirMode: 0o755,
+	});
+}
+
+export function runtimePlatformRoots(paths: RuntimePaths): string[] {
+	return [paths.configurationRoot, paths.serviceStateRoot, paths.cacheRoot, paths.runRoot];
+}
+
+export function runtimePlatformRootForPath(paths: RuntimePaths, path: string): string | null {
+	const resolvedPath = resolve(path);
+	return (
+		runtimePlatformRoots(paths)
+			.map((root) => resolve(root))
+			.filter((root) => {
+				const candidate = relative(root, resolvedPath);
+				return candidate === "" || (!candidate.startsWith("..") && !isAbsolute(candidate));
+			})
+			.sort((left, right) => right.length - left.length)[0] ?? null
+	);
+}
+
+export function assertRuntimePlatformRoots(paths: RuntimePaths): void {
+	for (const path of runtimePlatformRoots(paths)) {
+		assertTrustedDirectory(path, "platform directory");
 	}
+}
+
+export function ensureRuntimePlatformDirectory(
+	paths: RuntimePaths,
+	path: string,
+	options: { mode?: number } = {},
+): void {
+	const root = runtimePlatformRootForPath(paths, path);
+	if (!root) {
+		throw new Error(`runtime platform directory is outside platform roots: ${path}`);
+	}
+	ensureDirectoryWithinTrustedRoot(root, path, options);
+}
+
+export function writeRuntimePlatformFileAtomic(
+	paths: RuntimePaths,
+	path: string,
+	content: string | Uint8Array,
+	options: { mode?: number; dirMode?: number } = {},
+): void {
+	const trustedRoot = runtimePlatformRootForPath(paths, path);
+	if (!trustedRoot) {
+		throw new Error(`runtime platform file is outside platform roots: ${path}`);
+	}
+	writePrivateFileAtomic(path, content, { ...options, trustedRoot });
 }
 
 export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
@@ -199,36 +246,37 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 			}
 			mkdirSync(path, { recursive: true, mode });
 		}
-		const node = lstatSync(path);
-		if (!node.isDirectory() || node.isSymbolicLink()) {
-			throw new Error(`platform directory is not a trusted directory: ${path}`);
-		}
+		assertTrustedDirectory(path, "platform directory");
 		if (created) {
 			// mkdir modes are filtered by umask, but these platform roots have an
 			// exact access contract (including search access on the runtime root).
 			chmodSync(path, mode);
 		}
 	}
-	for (const dir of [
-		paths.statusRoot,
-		paths.instanceRoot,
-		paths.installInventory,
-		paths.projectionRoot,
-		paths.runConfigRoot,
-		paths.egressProfileRoot,
-		paths.systemdSystemRoot,
-		paths.systemdUserRoot,
-		paths.systemdEnvRoot,
-		dirname(paths.syncState),
-		paths.managedSecretRoot,
-	]) {
-		mkdirSync(dir, { recursive: true });
+	for (const [dir, mode] of [
+		[paths.statusRoot, 0o755],
+		[paths.instanceRoot, 0o755],
+		[paths.installInventory, 0o755],
+		[paths.projectionRoot, 0o755],
+		[paths.runConfigRoot, 0o755],
+		[paths.egressProfileRoot, 0o755],
+		[paths.systemdSystemRoot, 0o755],
+		[paths.systemdEnvRoot, 0o711],
+		[dirname(paths.syncState), 0o755],
+		[paths.managedSecretRoot, 0o711],
+	] as const) {
+		const platformRoot = runtimePlatformRootForPath(paths, dir);
+		if (platformRoot) ensureDirectoryWithinTrustedRoot(platformRoot, dir, { mode });
+		else assertTrustedDirectory(dir, "systemd platform directory");
 	}
+	mkdirSync(paths.systemdUserRoot, { recursive: true });
+	assertRuntimePlatformRoots(paths);
 }
 
 export function writeRuntimeBootStatus(status: RuntimeBootStatus, paths = getRuntimePaths()): void {
-	writeJson(paths.bootStatus, status, 0o644);
+	writeJson(paths, paths.bootStatus, status, 0o644);
 	writeJson(
+		paths,
 		paths.cloudStatus,
 		{
 			v1: {
@@ -244,6 +292,7 @@ export function writeRuntimeBootStatus(status: RuntimeBootStatus, paths = getRun
 		0o644,
 	);
 	writeJson(
+		paths,
 		paths.cloudResult,
 		{
 			v1: {
@@ -268,6 +317,7 @@ export function writeRuntimeWatchStatus(
 	paths = getRuntimePaths(),
 ): void {
 	writeJson(
+		paths,
 		paths.runtimeWatchStatus,
 		{
 			schemaVersion: "clawdi.runtimeWatchStatus.v1",

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -340,6 +340,7 @@ function cliEnv(fixture: Fixture, runtimeMode: "local" | "hosted"): Record<strin
 		fixture.contextPath,
 		`${JSON.stringify({
 			schemaVersion: "clawdi.runtimeContext.v2",
+			backend: "incus",
 			apply: {
 				generation: 1,
 				manifestETag: '"frozen-manifest"',

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -145,6 +145,7 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 		offline: false,
 		applyContext: {
 			kind: "context-file",
+			backend: "incus",
 			identity: {
 				generation: manifest.generation,
 				manifestETag: '"real-systemd-test"',

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -90,6 +90,7 @@ import { buildRuntimeRunConfig } from "../src/runtime/run-config";
 import { normalizeSecretValues } from "../src/runtime/secret-values";
 import {
 	buildRuntimeBootStatus,
+	ensureRuntimeStateDirs,
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
@@ -98,12 +99,31 @@ import { getDaemonControlTokenPath } from "../src/serve/paths";
 import { mockFetch } from "./commands/helpers";
 
 const TEST_PROCESS_USER = String(process.getuid?.() ?? 0);
+const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
+const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
+
+function testHostedRuntimeContract(paths: RuntimePaths) {
+	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+	const user = process.env.CLAWDI_RUNTIME_USER;
+	const uid = Number(process.env.CLAWDI_RUNTIME_UID ?? TEST_PROCESS_UID);
+	const gid = Number(process.env.CLAWDI_RUNTIME_GID ?? TEST_PROCESS_GID);
+	return {
+		expectedIdentity: {
+			home: paths.userHome,
+			user,
+			uid,
+			gid,
+		},
+		resolveUserIdentity: () => ({ uid, gid }),
+	};
+}
 
 function explicitTestApplyContext(
 	manifest: Pick<RuntimeManifest, "generation" | "applyGeneration">,
 ) {
 	return {
 		kind: "context-file" as const,
+		backend: "incus" as const,
 		identity: {
 			generation: manifest.applyGeneration ?? manifest.generation,
 			manifestETag: `"test-${manifest.generation}"`,
@@ -133,9 +153,11 @@ function normalizeHostedManifestFixture(value: unknown): {
 let currentTestApplyContext = explicitTestApplyContext({ generation: 1 });
 
 function runtimeInit(opts: Parameters<typeof runtimeInitWithContext>[0] = {}) {
+	const paths = getRuntimePaths();
 	return runtimeInitWithContext({
 		...opts,
 		applyContext: opts.applyContext ?? currentTestApplyContext,
+		hostedRuntimeContract: opts.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
 	});
 }
 
@@ -143,6 +165,9 @@ function liveTestApplyContext(): RuntimeApplyContext {
 	return {
 		get kind() {
 			return currentTestApplyContext.kind;
+		},
+		get backend() {
+			return currentTestApplyContext.backend;
 		},
 		get identity() {
 			return currentTestApplyContext.identity;
@@ -157,9 +182,11 @@ function liveTestApplyContext(): RuntimeApplyContext {
 }
 
 function runtimeWatch(opts: Parameters<typeof runtimeWatchWithContext>[0] = {}) {
+	const paths = getRuntimePaths();
 	return runtimeWatchWithContext({
 		...opts,
 		applyContext: opts.applyContext ?? liveTestApplyContext(),
+		hostedRuntimeContract: opts.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
 	});
 }
 
@@ -187,6 +214,9 @@ function convergeRuntimeManifest(
 	paths: RuntimePaths,
 	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
 ) {
+	if (!process.env.CLAWDI_RUNTIME_MODE) process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+	ensureRuntimeStateDirs(paths);
 	const requiredSecretRefs = new Set(manifestSecretRefs(load.manifest));
 	const defaultSecretValues = Object.fromEntries(
 		Object.entries(TEST_RUNTIME_SERVICE_SECRET_VALUES).filter(([ref]) =>
@@ -200,7 +230,10 @@ function convergeRuntimeManifest(
 			applyContext: load.applyContext ?? explicitTestApplyContext(load.manifest),
 		},
 		paths,
-		opts,
+		{
+			...opts,
+			hostedRuntimeContract: opts?.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
+		},
 	);
 }
 
@@ -443,6 +476,7 @@ function setRuntimeApplyContextFixture(
 	};
 	currentTestApplyContext = {
 		kind: "context-file",
+		backend: "incus",
 		identity,
 		cliPackageSpec: contextValues.cliPackageSpec,
 		manifestSource: {
@@ -2077,6 +2111,7 @@ function writeCanonicalApplyContext(
 ): void {
 	currentTestApplyContext = {
 		kind: "context-file",
+		backend: "incus",
 		identity,
 		cliPackageSpec: context.cliPackageSpec,
 		manifestSource: {
@@ -2107,6 +2142,7 @@ function writeOfflineStrictAppliedState(
 	manifest: RuntimeManifest,
 	contentSha256: string,
 ): void {
+	mkdirSync(paths.serviceStateRoot, { recursive: true });
 	writeRuntimeAppliedState(
 		{
 			schemaVersion: "clawdi.runtimeAppliedState.v2",
@@ -7979,6 +8015,7 @@ exit 42
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
 		mkdirSync(dirname(paths.managedConfig), { recursive: true });
 		mkdirSync(paths.runConfigRoot, { recursive: true });
@@ -8484,6 +8521,7 @@ esac
 		mkdirSync(getRuntimePaths().cacheRoot, { recursive: true });
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.systemdSystemRoot, { recursive: true });
 		mkdirSync(paths.systemdUserRoot, { recursive: true });
 		writeFileSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"), "[Service]\n");
@@ -8583,6 +8621,7 @@ printf 'ActiveState=inactive\\nSubState=dead\\n'
 		mkdirSync(getRuntimePaths().cacheRoot, { recursive: true });
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.systemdSystemRoot, { recursive: true });
 		writeFileSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"), "[Service]\n");
 		writeRuntimeBootStatus(
@@ -8653,6 +8692,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		mkdirSync(getRuntimePaths().cacheRoot, { recursive: true });
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.systemdSystemRoot, { recursive: true });
 		writeFileSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"), "[Service]\n");
 		writeRuntimeWatchStatus(
@@ -8706,6 +8746,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.cacheRoot, { recursive: true });
 		writeFileSync(
 			paths.manifestLastGood,
@@ -8806,6 +8847,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.cacheRoot, { recursive: true });
 		writeFileSync(
 			paths.manifestLastGood,
@@ -14267,12 +14309,10 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		const hermesSkill = join(home, ".hermes", "skills", "clawdi");
 		expect(existsSync(join(hermesSkill, ".clawdi-managed.json"))).toBe(true);
 		process.env.CLAWDI_RUNTIME_MODE = "local";
-		const localMode = convergeRuntimeManifest(
-			load(4, "hermes", updatedServers, true),
-			getRuntimePaths(),
-		);
-		expect(localMode.installErrors).toEqual([]);
-		expect(existsSync(hermesSkill)).toBe(false);
+		expect(() =>
+			convergeRuntimeManifest(load(4, "hermes", updatedServers, true), getRuntimePaths()),
+		).toThrow("hosted convergence requires CLAWDI_RUNTIME_MODE=hosted explicitly");
+		expect(existsSync(hermesSkill)).toBe(true);
 		expect(readFileSync(openclawUserSkill, "utf-8")).toBe("user-owned skill\n");
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 
@@ -15513,6 +15553,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.cacheRoot, { recursive: true });
 		const desiredPayload = hostedRuntimeWatchLocalePayload(home, 1);
 		writeRuntimeAppliedState(

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -17,6 +17,7 @@ function writeRuntimeContext(
 		path,
 		`${JSON.stringify({
 			schemaVersion: "clawdi.runtimeContext.v2",
+			backend: "incus",
 			apply: {
 				generation: 1,
 				manifestETag: '"smoke-manifest-1"',
@@ -212,7 +213,7 @@ describe("CLI smoke — src entry", () => {
 
 	it("runtime init fails closed when the canonical context is invalid", async () => {
 		const { tmpdir } = await import("node:os");
-		const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
+		const { existsSync, mkdirSync, rmSync, writeFileSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-init-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
@@ -233,8 +234,11 @@ describe("CLI smoke — src entry", () => {
 
 		writeRuntimeContext(contextPath, { authToken: null });
 		const env = {
-			HOME: home,
+			HOME: "/home/clawdi",
 			CLAWDI_RUNTIME_MODE: "hosted",
+			CLAWDI_RUNTIME_USER: "clawdi",
+			CLAWDI_RUNTIME_UID: "10001",
+			CLAWDI_RUNTIME_GID: "10001",
 			CLAWDI_HOST_POLICY_PATH: policyPath,
 			CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
 			CLAWDI_RUN_DIR: runRoot,
@@ -248,34 +252,28 @@ describe("CLI smoke — src entry", () => {
 				["runtime", "init", "--non-interactive", "--json"],
 				env,
 			);
-			expect(code).toBe(21);
+			expect(code).toBe(20);
 			const parsed = JSON.parse(stdout);
 			expect(parsed.mode).toBe("repair");
 			expect(parsed.status).toBe("error");
-			expect(parsed.stage).toBe("local");
+			expect(parsed.stage).toBe("detect");
 			expect(parsed.errors[0]).toContain(`invalid runtime context file ${contextPath}`);
 			expect(parsed.errors[0]).toContain("manifestSource.auth: Invalid input");
 			expect(parsed.datasource).toBe("RuntimeSource");
-			expect(parsed.hostPolicy.valid).toBe(true);
+			expect(parsed.hostPolicy).toMatchObject({
+				source: "builtin",
+				exists: true,
+				valid: true,
+				mode: "hosted",
+			});
 			expect(parsed.paths.serviceStateRoot).toBe(serviceStateRoot);
-			expect(existsSync(join(serviceStateRoot, "status", "boot-status.json"))).toBe(true);
-			const cloudResult = JSON.parse(
-				readFileSync(join(serviceStateRoot, "status", "cloud-result.json"), "utf-8"),
-			);
-			expect(cloudResult.v1.stage).toBe("local");
-			expect(cloudResult.v1.errors).toEqual(parsed.errors);
-
-			const status = await runCli(["runtime", "status", "--json"], env);
-			expect(status.code).toBe(1);
-			const statusParsed = JSON.parse(status.stdout);
-			expect(statusParsed.exists).toBe(true);
-			expect(statusParsed.status.mode).toBe("repair");
+			expect(existsSync(serviceStateRoot)).toBe(false);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
 
-	it("runtime init uses built-in policy when image policy is missing", async () => {
+	it("runtime init rejects a wrong hosted HOME before creating state", async () => {
 		const { tmpdir } = await import("node:os");
 		const { existsSync, mkdirSync, rmSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-no-policy-${Date.now()}`);
@@ -297,16 +295,12 @@ describe("CLI smoke — src entry", () => {
 				CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
 				CLAWDI_RUNTIME_TEST_CONTEXT_FILE: contextPath,
 			});
-			expect(code).toBe(21);
+			expect(code).toBe(20);
 			const parsed = JSON.parse(stdout);
 			expect(parsed.mode).toBe("repair");
-			expect(parsed.stage).toBe("network");
-			expect(parsed.hostPolicy.exists).toBe(true);
-			expect(parsed.hostPolicy.valid).toBe(true);
-			expect(parsed.hostPolicy.source).toBe("builtin");
-			expect(parsed.hostPolicy.path).toBeUndefined();
-			expect(parsed.errors[0]).toContain("could not fetch runtime manifest");
-			expect(existsSync(join(serviceStateRoot, "status", "boot-status.json"))).toBe(true);
+			expect(parsed.stage).toBe("detect");
+			expect(parsed.errors[0]).toContain("hosted runtime HOME must resolve to /home/clawdi");
+			expect(existsSync(serviceStateRoot)).toBe(false);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- require the explicit hosted runtime mode, resolved tenant HOME, expected non-root account identity, and Incus runtime context before any convergence mutation
- extend runtime doctor with hosted identity, context backend, and platform-root checks while correcting host-policy guidance
- bound runtime revision probes and official service install/uninstall subprocesses with named timeout errors
- anchor platform child creation and atomic writes to already-existing trusted roots, with repeated root checks across convergence mutation groups

## Design

This chooses one reusable hosted convergence contract instead of scattered identity assertions. `runtime init` and `runtime watch` run its identity and backend portion before directory preparation or lock acquisition; `convergeRuntimeManifest` runs the complete contract and retains a repeatable platform-root guard for later mutation groups.

The contract validates the resolved HOME, regardless of whether it came from `CLAWDI_RUNTIME_HOME` or ambient `HOME`. It does not require one specific environment variable to be present. It also resolves the `clawdi` account through the host account database and requires the expected non-root `10001:10001` identity; optional numeric overrides must agree.

Platform writes use an explicit trusted-root path. I rejected changing the generic atomic writer to fail on every missing parent because local and user-owned callers still rely on its existing behavior. Runtime platform writers opt into the stricter boundary, so a missing `/etc/clawdi`, `/var/lib/clawdi`, `/var/cache/clawdi`, or `/run/clawdi` root cannot be recreated through a child write. The function-level identity resolver and expected identity options exist only for hermetic tests; there is no CLI flag or production environment bypass.

I also rejected treating host-policy files as runtime-mode authority. Hosted mode must be selected explicitly, and the built-in hosted policy remains the only policy used once that mode is selected.

## Regression coverage

- wrong resolved HOME, wrong runtime user or root identity, and non-hosted mode fail before convergence mutation
- missing `backend: "incus"` fails runtime-context admission
- a hanging runtime `--version` probe returns a timeout convergence error after the 10-second bound
- deleting a platform root before a later mutation group fails closed and does not recreate the root
- runtime doctor reports identity, backend, and platform-root failures

## Local verification

GitHub is experiencing a partial outage, so these clean local results are the primary evidence:

- `bun run typecheck`: 4/4 tasks successful
- `bun run check`: 958 files checked, 0 errors, 1 pre-existing informational `useTemplate` finding
- `bun run test`: exit 0
  - web: 960 passed, 0 failed, 4,613 assertions across 155 files
  - shared: 72 passed, 0 failed, 201 assertions across 5 files
  - WhatsApp sidecar: 71 passed, 0 failed across 8 files
  - CLI: 1,651 passed, 4 skipped, 0 failed, 8,887 assertions across 124 files
  - backend: 2,241 passed, 11 skipped
  - aggregate: 4,995 passed, 15 skipped, 0 failed