### PR TITLE
release(cli): 0.13.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.41
+
+Package: `clawdi@0.13.41`
+
+### Fixed
+
+- Hosted convergence now refuses to run unless the resolved runtime identity
+  matches the tenant contract, so a stray `HOME` can no longer redirect a tenant
+  into the wrong home or let installers run as root.
+- The shared `/run/clawdi` root is owned solely by the boot preparation unit,
+  and convergence can no longer recreate a missing platform root.
+- External runtime probes, installs, and uninstalls are bounded, so a wedged
+  third-party CLI fails convergence instead of hanging it.
+
 ## Clawdi CLI v0.13.40
 
 Package: `clawdi@0.13.40`

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.40",
+      "version": "0.13.41",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.40",
+	"version": "0.13.41",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.40"', '"version": "0.13.41"'),
+					replaceOnce(cliPackage, '"version": "0.13.41"', '"version": "0.13.42"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.40"', '"version": "0.13.41"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.41"', '"version": "0.13.42"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
Bumps to 0.13.41 so the published artifact contains every hosted-runtime fix merged today (#868 layout convergence, #870 shared run-root ownership, #872 hosted identity fail-closed and bounded probes).

Why skip 0.13.40: a publish run dispatched against an earlier main sha is stuck in a non-cancellable queued state during the current GitHub incident. If it ever executes it would publish an incomplete 0.13.40, and npm versions are immutable — which would block publishing the complete build. Skipping the version removes that race entirely.

Version, lockfile, and the sidecar revision probe are advanced together (the probe simulates a CLI-only bump, so it must lead the current version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)