### PR TITLE
fix(web): unify rail buttons and single-line rail captions

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4349,7 +4349,7 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	if (!connectedTileBox || !connectedButtonBox) {
 		throw new Error("Hosted rail agent tile should be a whole interactive button.");
 	}
-	expect(connectedTileBox.height).toBeCloseTo(72, 0);
+	expect(connectedTileBox.height).toBeCloseTo(64, 0);
 	expect(connectedButtonBox.x).toBeCloseTo(connectedTileBox.x, 0);
 	expect(connectedButtonBox.y).toBeCloseTo(connectedTileBox.y, 0);
 	expect(connectedButtonBox.height).toBeCloseTo(connectedTileBox.height, 0);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -2506,7 +2506,7 @@ test("agent rail uses each whole tile for Space keyboard sorting", async ({ page
 	const firstTileBox = await firstTile.boundingBox();
 	const firstButtonBox = await firstButton.boundingBox();
 	if (!firstTileBox || !firstButtonBox) throw new Error("Agent rail tile should be interactive.");
-	expect(firstTileBox.height).toBeCloseTo(72, 0);
+	expect(firstTileBox.height).toBeCloseTo(64, 0);
 	expect(firstButtonBox.height).toBeCloseTo(firstTileBox.height, 0);
 	expect(firstButtonBox.width).toBeCloseTo(firstTileBox.width, 0);
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -782,6 +782,57 @@ function RailFocusButton({
 	);
 }
 
+/**
+ * One rail tile for every rail entry (Console, agents): identical item
+ * geometry, so the absolute active marker lands on the same x for all of
+ * them. Sortable entries inject dnd-kit refs/props from outside.
+ */
+function RailTileButton({
+	itemRef,
+	itemStyle,
+	itemClassName,
+	itemTestId,
+	render,
+	label,
+	caption,
+	active,
+	className,
+	showTooltip = true,
+	children,
+}: {
+	itemRef?: React.Ref<HTMLLIElement>;
+	itemStyle?: React.CSSProperties;
+	itemClassName?: string;
+	itemTestId?: string;
+	render: React.ReactElement;
+	label: string;
+	caption?: string;
+	active: boolean;
+	className?: string;
+	showTooltip?: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<SidebarMenuItem
+			ref={itemRef}
+			data-testid={itemTestId}
+			style={itemStyle}
+			className={cn("relative h-16 w-full", itemClassName)}
+		>
+			<RailFocusButton
+				render={render}
+				label={label}
+				caption={caption}
+				active={active}
+				className={className}
+				showTooltip={showTooltip}
+			>
+				{children}
+			</RailFocusButton>
+		</SidebarMenuItem>
+	);
+}
+
 function SortableAgentRailItem({
 	agent,
 	active,
@@ -821,55 +872,49 @@ function SortableAgentRailItem({
 	};
 
 	return (
-		<SidebarMenuItem
-			ref={setNodeRef}
-			data-testid="app-sidebar-agent-tile"
-			style={style}
-			className={cn(
-				"group/agent-rail-item relative h-16 w-full touch-pan-y will-change-transform",
-				isDragging && "opacity-80",
-			)}
+		<RailTileButton
+			itemRef={setNodeRef}
+			itemTestId="app-sidebar-agent-tile"
+			itemStyle={style}
+			itemClassName={cn("touch-pan-y will-change-transform", isDragging && "opacity-80")}
+			render={
+				<button
+					ref={setActivatorNodeRef}
+					type="button"
+					disabled={!agent.href}
+					onClick={activateAgent}
+					{...attributes}
+					aria-disabled={agent.href ? undefined : true}
+					aria-describedby={agent.env ? attributes["aria-describedby"] : undefined}
+					aria-roledescription={agent.env ? attributes["aria-roledescription"] : undefined}
+					{...listeners}
+				/>
+			}
+			label={label}
+			caption={caption}
+			active={active}
+			className={cn("touch-pan-y", agent.href && "cursor-pointer")}
+			showTooltip={showTooltip}
 		>
-			<RailFocusButton
-				render={
-					<button
-						ref={setActivatorNodeRef}
-						type="button"
-						disabled={!agent.href}
-						onClick={activateAgent}
-						{...attributes}
-						aria-disabled={agent.href ? undefined : true}
-						aria-describedby={agent.env ? attributes["aria-describedby"] : undefined}
-						aria-roledescription={agent.env ? attributes["aria-roledescription"] : undefined}
-						{...listeners}
-					/>
-				}
-				label={label}
-				caption={caption}
-				active={active}
-				className={cn("touch-pan-y", agent.href && "cursor-pointer")}
-				showTooltip={showTooltip}
-			>
-				<span className="relative inline-flex rounded-md">
-					<AgentIcon agent={agent.agentType} size="rail" avatarUrl={agent.avatarUrl} />
-					{kind === "cloud" ? (
-						<span
-							data-agent-rail-corner-marker="cloud"
-							className="-top-1 -right-1 pointer-events-none absolute z-10"
-						>
-							<AgentSourceBadge source="hosted" iconOnly />
-						</span>
-					) : kind === "legacy" ? (
-						<span
-							data-agent-rail-corner-marker="legacy"
-							className="-top-1 -right-1 pointer-events-none absolute z-10"
-						>
-							<LegacyAgentBadge iconOnly />
-						</span>
-					) : null}
-				</span>
-			</RailFocusButton>
-		</SidebarMenuItem>
+			<span className="relative inline-flex rounded-md">
+				<AgentIcon agent={agent.agentType} size="rail" avatarUrl={agent.avatarUrl} />
+				{kind === "cloud" ? (
+					<span
+						data-agent-rail-corner-marker="cloud"
+						className="-top-1 -right-1 pointer-events-none absolute z-10"
+					>
+						<AgentSourceBadge source="hosted" iconOnly />
+					</span>
+				) : kind === "legacy" ? (
+					<span
+						data-agent-rail-corner-marker="legacy"
+						className="-top-1 -right-1 pointer-events-none absolute z-10"
+					>
+						<LegacyAgentBadge iconOnly />
+					</span>
+				) : null}
+			</span>
+		</RailTileButton>
 	);
 }
 
@@ -1009,24 +1054,22 @@ function FocusRailContent({
 			<SidebarSeparator className="mx-auto w-8" />
 
 			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-2.5 pt-2.5 pb-[calc(var(--header-height)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-				<SidebarMenu className="items-center">
-					<SidebarMenuItem>
-						<RailFocusButton
-							render={<Link to="/" onClick={onNavigate} />}
-							label="Console"
-							caption="Console"
-							active={!activeAgentId}
-							showTooltip={showTooltips}
+				<SidebarMenu className="w-full items-center">
+					<RailTileButton
+						render={<Link to="/" onClick={onNavigate} />}
+						label="Console"
+						caption="Console"
+						active={!activeAgentId}
+						showTooltip={showTooltips}
+					>
+						<IconChip
+							size="sm"
+							tint={RESOURCE_TINT_CLASSES.overview}
+							className="size-9 [&>svg]:size-4.5"
 						>
-							<IconChip
-								size="sm"
-								tint={RESOURCE_TINT_CLASSES.overview}
-								className="size-9 [&>svg]:size-4.5"
-							>
-								<LayoutDashboard />
-							</IconChip>
-						</RailFocusButton>
-					</SidebarMenuItem>
+							<LayoutDashboard />
+						</IconChip>
+					</RailTileButton>
 				</SidebarMenu>
 
 				<SidebarSeparator className="mx-auto w-8" />

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -730,7 +730,7 @@ function RailFocusButton({
 			aria-label={label}
 			className={cn(
 				hasCaption
-					? "h-[4.5rem] w-full flex-col justify-center gap-1 rounded-lg px-1 py-1"
+					? "h-16 w-full flex-col justify-center gap-1 rounded-lg px-1 py-1"
 					: "size-11 justify-center rounded-lg p-0",
 				className,
 			)}
@@ -739,7 +739,7 @@ function RailFocusButton({
 			{caption ? (
 				<span
 					className={cn(
-						"line-clamp-2 block h-[26px] max-w-16 overflow-hidden text-center text-2xs font-medium break-words",
+						"block max-w-16 truncate text-center text-2xs font-medium",
 						active ? "text-sidebar-accent-foreground" : "text-muted-foreground",
 					)}
 					title={label}
@@ -754,7 +754,7 @@ function RailFocusButton({
 		<div
 			className={cn(
 				"group/rail-focus relative flex min-w-0 items-center justify-center",
-				hasCaption ? "h-[4.5rem] w-full" : "size-11",
+				hasCaption ? "h-16 w-full" : "size-11",
 			)}
 		>
 			<span
@@ -763,7 +763,7 @@ function RailFocusButton({
 					"absolute -left-2.5 w-1 rounded-r-full bg-sidebar-foreground/70 opacity-0 transition-[height,opacity] duration-200 ease-out",
 					active
 						? hasCaption
-							? "h-11 opacity-100"
+							? "h-10 opacity-100"
 							: "h-8 opacity-100"
 						: "h-2 group-hover/rail-focus:h-4 group-hover/rail-focus:opacity-50",
 				)}
@@ -826,7 +826,7 @@ function SortableAgentRailItem({
 			data-testid="app-sidebar-agent-tile"
 			style={style}
 			className={cn(
-				"group/agent-rail-item relative h-[4.5rem] w-full touch-pan-y will-change-transform",
+				"group/agent-rail-item relative h-16 w-full touch-pan-y will-change-transform",
 				isDragging && "opacity-80",
 			)}
 		>
@@ -1018,7 +1018,11 @@ function FocusRailContent({
 							active={!activeAgentId}
 							showTooltip={showTooltips}
 						>
-							<IconChip size="sm" tint={RESOURCE_TINT_CLASSES.overview}>
+							<IconChip
+								size="sm"
+								tint={RESOURCE_TINT_CLASSES.overview}
+								className="size-9 [&>svg]:size-4.5"
+							>
 								<LayoutDashboard />
 							</IconChip>
 						</RailFocusButton>


### PR DESCRIPTION
## What

Sidebar focus rail polish:

1. **One shared rail tile component** — `RailTileButton` now renders both the Console tile and agent tiles (agents inject dnd-kit refs/props from `SortableAgentRailItem`). Previously the Console tile sat in an auto-width menu item while agent tiles were `w-full`, so the absolute active marker (`-left-2.5`) landed on a different x for Console vs agents. One component, one geometry — the marker aligns by construction.
2. **Unify Console and agent tile geometry** — the Console icon chip now matches agent rail icons exactly: `size-9 rounded-md` box with `size-4.5` glyph (was `size-8` with `size-4`).
3. **Single-line captions** — rail captions were `line-clamp-2` with a fixed `h-[26px]`, reserving a second text line even for short names. Now single-line `truncate` with the full name still available via tooltip/`title`.
4. Tile height drops 72px → 64px (`h-16`) since the second caption line is gone; the active indicator scales 44px → 40px to match.

## Verification

- `bun run typecheck`, `bun run lint` clean
- Browser-verified with stubbed API: Console-active and agent-active screenshots show the active marker at identical x/height; long agent names truncate to one line; tile height 64px
- e2e tile-geometry assertions updated (`sidebar-runtime-smoke.pw.ts`, `hosted-smoke.pw.ts`)