### PR TITLE
fix(web): unify search ownership, share isomorphic effect, repair e2e suite

### DIFF
--- a/apps/web/e2e/query-refresh-no-flicker.pw.ts
+++ b/apps/web/e2e/query-refresh-no-flicker.pw.ts
@@ -99,7 +99,10 @@ for (const viewport of [
 		await page.goto("/");
 
 		const link = page.getByRole("link", { name: /Open Stable Agent/ }).first();
-		await expect(link).toBeVisible();
+		// The agents query can error once during SSR (no stub server-side) and
+		// only resolve on a client retry, so the first paint allowance matches
+		// the suite-wide 15s convention instead of the 5s default.
+		await expect(link).toBeVisible({ timeout: 15_000 });
 		await expect(page.getByText("1 agent", { exact: true })).toBeVisible();
 		const card = link.locator("..");
 		const before = await card.boundingBox();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1254,37 +1254,32 @@ test("connected agent overview uses the modular hierarchy", async ({ page }, tes
 
 test("connected detail only requests overview data on Overview", async ({ page }) => {
 	const sessionRequests: string[] = [];
-	const projectBindingRequests: string[] = [];
-	const projectRequests: string[] = [];
 	const skillRequests: string[] = [];
 	await stubDashboardApi(page, [], {
 		sessionRequests,
-		projectBindingRequests,
-		projectRequests,
 		skillRequests,
 	});
 
+	// Page data stays lazy per section; the sidebar's Workspace rail owns the
+	// project-bindings/projects pair on every agent page, so only section
+	// queries prove a page over-fetches.
 	await page.goto("/agents/agent-smoke-1/settings");
 	await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
 	await page.waitForTimeout(100);
 	expect(sessionRequests).toEqual([]);
-	expect(projectBindingRequests).toEqual([]);
-	expect(projectRequests).toEqual([]);
 	expect(skillRequests).toEqual([]);
 
 	await page.goto("/agents/agent-smoke-1/sessions");
 	await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
 	await expect.poll(() => sessionRequests.length).toBe(1);
 	expect(new URL(sessionRequests[0] ?? "http://invalid").searchParams.get("page_size")).toBe("50");
-	expect(projectBindingRequests).toEqual([]);
-	expect(projectRequests).toEqual([]);
 	expect(skillRequests).toEqual([]);
 });
 
 test("connected agent settings protects an unsaved display name", async ({ page }) => {
 	await stubDashboardApi(page);
 	await page.goto("/agents/agent-smoke-1/settings");
-	const displayName = page.getByRole("textbox", { name: "Display name" });
+	const displayName = page.getByRole("textbox", { name: "Agent name" });
 	await displayName.fill("Unsaved agent name");
 
 	const sessionsLink = page.locator('a[href="/agents/agent-smoke-1/sessions"]').first();
@@ -2219,9 +2214,12 @@ test("Workspace Skills fail closed on Project binding errors without reading Ski
 	await expect(
 		main.getByText("Couldn't verify Workspace or Project access", { exact: true }),
 	).toBeVisible({ timeout: 15_000 });
-	await expect(
-		page.getByTestId("app-sidebar").getByRole("group", { name: "Workspace", exact: true }),
-	).toHaveCount(0);
+	// Fail closed: the Workspace rail keeps only its unconditional Projects
+	// entry — scoped Skills/Vaults items stay hidden while bindings error.
+	const workspaceGroup = page
+		.getByTestId("app-sidebar")
+		.getByRole("group", { name: "Workspace", exact: true });
+	await expect(workspaceGroup.getByRole("link")).toHaveText(["Projects"]);
 	expect(skillRequests).toEqual([]);
 });
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,7 +6,13 @@ const serverPort = new URL(baseURL).port || "3200";
 export default defineConfig({
 	testDir: "./e2e",
 	testMatch: "**/*.pw.ts",
-	testIgnore: ["**/hosted-smoke.pw.ts", "**/query-refresh-hosted.pw.ts"],
+	testIgnore: [
+		"**/hosted-smoke.pw.ts",
+		"**/query-refresh-hosted.pw.ts",
+		// Runs under playwright.hosted.config.ts (VITE_CLAWDI_HOSTED=true); in
+		// the OSS build the hosted channel surface cannot render.
+		"**/channel-convergence-hosted.pw.ts",
+	],
 	timeout: 30_000,
 	expect: {
 		timeout: 5_000,

--- a/apps/web/src/components/breadcrumb-title.tsx
+++ b/apps/web/src/components/breadcrumb-title.tsx
@@ -6,14 +6,13 @@ import {
 	type SetStateAction,
 	useCallback,
 	useContext,
-	useEffect,
-	useLayoutEffect,
 	useMemo,
 	useState,
 } from "react";
 import type { AgentRouteSearch } from "@/lib/agent-routes";
 import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
 import { useCommittedLocation } from "@/lib/use-committed-location";
+import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 
 /**
  * Context for "what the breadcrumb's last segment should say".
@@ -214,5 +213,3 @@ export function useCommittedBreadcrumbRoute(): CommittedBreadcrumbRoute {
 function useBreadcrumbRouteKey() {
 	return useCommittedBreadcrumbRoute().routeKey;
 }
-
-const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/lib/use-committed-location.ts
+++ b/apps/web/src/lib/use-committed-location.ts
@@ -15,9 +15,19 @@ import { useMemo } from "react";
  * committed match tree keeps every reader consistent with the visible
  * page; both flip atomically when the navigation commits.
  */
-export function useCommittedLocation() {
+/**
+ * Index-route matches interpolate to a trailing slash ("/agents/x/skills/")
+ * while `state.location.pathname` is normalized without one ("/agents/x/skills").
+ * Consumers compare and build URLs from this value, so normalize centrally.
+ */
+function normalizeCommittedPathname(pathname: string): string {
+	return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+export function useCommittedLocation(): { pathname: string; search: Record<string, unknown> } {
 	const pathname = useRouterState({
-		select: (state) => state.matches.at(-1)?.pathname ?? state.location.pathname,
+		select: (state) =>
+			normalizeCommittedPathname(state.matches.at(-1)?.pathname ?? state.location.pathname),
 	});
 	const search = useRouterState({
 		select: (state) => state.matches.at(-1)?.search ?? state.location.search,
@@ -37,6 +47,7 @@ export function useCommittedLocation() {
 export function useCommittedRouteIsLatestTarget(): boolean {
 	return useRouterState({
 		select: (state) =>
-			(state.matches.at(-1)?.pathname ?? state.location.pathname) === state.location.pathname,
+			normalizeCommittedPathname(state.matches.at(-1)?.pathname ?? state.location.pathname) ===
+			normalizeCommittedPathname(state.location.pathname),
 	});
 }

--- a/apps/web/src/lib/use-isomorphic-layout-effect.ts
+++ b/apps/web/src/lib/use-isomorphic-layout-effect.ts
@@ -1,0 +1,9 @@
+import { useEffect, useLayoutEffect } from "react";
+
+/**
+ * Layout effect on the client, passive effect during SSR — avoids the
+ * "useLayoutEffect does nothing on the server" warning while keeping
+ * pre-paint semantics where they matter (hydration-safe DOM/title sync).
+ */
+export const useIsomorphicLayoutEffect =
+	typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
 	MessageSquare,
 	Zap,
 } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline } from "@/components/dashboard/agent-label";
@@ -43,6 +43,7 @@ import {
 	SESSION_MESSAGES_STALE_MS,
 } from "@/lib/session-queries";
 import { useCommittedLocation } from "@/lib/use-committed-location";
+import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
 export default function SessionDetailPage({ sessionId }: { sessionId: string }) {
@@ -622,5 +623,3 @@ function MessagesSkeleton() {
 function EmptyContent() {
 	return <EmptyState variant="inset" description="No messages in this session." />;
 }
-
-const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -15,8 +15,7 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { parseAsString, useQueryState } from "nuqs";
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
@@ -46,7 +45,6 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import {
 	type AgentRouteSearch,
@@ -61,6 +59,7 @@ import { decodeResourceRouteParam, projectResourceHref } from "@/lib/project-res
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { RESOURCE_TINT_CLASSES } from "@/lib/resource-identity";
 import { skillCapabilities } from "@/lib/skill-authority";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 import {
 	removeDeletedSkillQueries,
@@ -78,25 +77,10 @@ function stripFrontmatter(raw: string): string {
 	return m ? (m[1] ?? "") : raw;
 }
 
-// Wrap the inner URL-state tree in Suspense. Mirrors the same pattern in
-// /skills/page.tsx and /cli-authorize.
+// nuqs used to require a Suspense boundary here; router-owned search does
+// not suspend, so the page renders directly.
 export default function SkillDetailPage({ routeKey }: { routeKey: string }) {
-	return (
-		<Suspense fallback={<SkillDetailRouteSkeleton />}>
-			<SkillDetailPageInner routeKey={routeKey} />
-		</Suspense>
-	);
-}
-
-function SkillDetailRouteSkeleton() {
-	return (
-		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<DetailBackLink href="/skills" label="Skills" mobileOnly={false} />
-			<PageHeaderSkeleton icon actions />
-			<Skeleton className="h-24 w-full rounded-lg" />
-			<Skeleton className="h-48 w-full rounded-lg" />
-		</div>
-	);
+	return <SkillDetailPageInner routeKey={routeKey} />;
 }
 
 function SkillDetailPageInner({ routeKey }: { routeKey: string }) {
@@ -121,7 +105,10 @@ export function SkillDetailContent({
 	// Library routes keep their legacy resolver fallback for backwards
 	// compatibility. Agent routes must resolve one explicit binding first and
 	// only call the endpoint for the Project selected on the Project hub.
-	const [projectIdParam] = useQueryState("project", parseAsString.withDefault(""));
+	// Router-validated search (one ownership system — not nuqs), from the
+	// committed match so the page agrees with the rendered route.
+	const { search: committedSearch } = useCommittedLocation();
+	const projectIdParam = typeof committedSearch.project === "string" ? committedSearch.project : "";
 	const isAgentScope = Boolean(agentId);
 	const selectedProjectId = (
 		isAgentScope && typeof routeSearch?.project === "string" ? routeSearch.project : projectIdParam

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -13,7 +13,6 @@ import {
 	Share2,
 	Trash2,
 } from "lucide-react";
-import { parseAsString, useQueryState } from "nuqs";
 import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -74,6 +73,7 @@ import {
 	type ResourceNavigationScope,
 	resourceCollectionTarget,
 } from "@/lib/resource-navigation";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 import { cn, errorMessage } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -102,7 +102,13 @@ export default function VaultDetailPage({
 	scope: ResourceNavigationScope;
 }) {
 	const slug = decodeResourceRouteParam(rawSlug);
-	const [vaultId] = useQueryState("vault", parseAsString);
+	// Router-validated search (one ownership system — not nuqs): committed
+	// match state keeps the id consistent with the rendered route.
+	const { search: committedSearch } = useCommittedLocation();
+	const vaultId =
+		typeof committedSearch.vault === "string" && committedSearch.vault.trim()
+			? committedSearch.vault
+			: null;
 	const api = useApi();
 	const $api = useOpenApi();
 	const qc = useQueryClient();


### PR DESCRIPTION
## What

**Consistency cleanup**
- `vault/[slug]` and `skills/[key]` detail pages no longer read URL params through nuqs — they use the router-validated, committed-match search via `useCommittedLocation()` (one ownership system; nuqs stays only where it writes URL state with history semantics). The skills detail page drops the nuqs-mandated Suspense boundary and its now-dead skeleton.
- Shared `useIsomorphicLayoutEffect` extracted to `lib/` (was duplicated in `breadcrumb-title.tsx` and `sessions/[id]/page.tsx`).

**Regression fix (from #871, caught by e2e)**
- `useCommittedRouteIsLatestTarget()` compared the leaf match pathname against `location.pathname`, but index-route matches interpolate with a trailing slash ("/agents/x/skills/" vs "/agents/x/skills"), so the guard was always false on index routes and legacy `/agents/<id>/skills|vaults` URLs stopped canonicalizing to project-access URLs. Both committed-location hooks now normalize trailing slashes centrally. Verified with the previously failing canonicalizer e2e.

**e2e suite repair (Playwright is not run in CI; several assertions were stale)**
- `Workspace Skills fail closed…`: asserted the sidebar Workspace group disappears on bindings errors — a pre-#843 design. Current design always shows the group with its unconditional Projects entry; the real fail-closed guarantee is that scoped Skills/Vaults items stay hidden and no skill requests fire. Assertion updated accordingly.
- `connected detail only requests overview data…`: asserted zero project-bindings/projects requests on settings/sessions pages — stale since #794, when the sidebar Workspace rail started resolving scope on every agent page. Now asserts only section queries (sessions/skills) stay lazy.
- `connected agent settings protects an unsaved display name`: selector used the pre-#862 label "Display name"; the field is now labeled "Agent name".
- `channel-convergence-hosted.pw.ts` added to the OSS config testIgnore — it belongs to `playwright.hosted.config.ts` (VITE_CLAWDI_HOSTED=true) and deterministically cannot render in OSS mode.
- `query-refresh-no-flicker`: first-visibility assertion bumped to the suite-wide 15s convention — the agents query can error once during SSR (no stub server-side) and only resolve on a client retry with backoff, making the 5s default flaky on cold dev servers (pre-existing flake, equally present on the baseline commit).

## Verification

- `bun run typecheck`, `bun run lint` clean
- Full OSS Playwright suite: 38/38 green locally (two additional failures observed only under full-suite cold-start load — `api-keys-settings`, `brand-icon-geometry` — pass in isolation; no product changes involved)