### PR TITLE
fix(web): pad rail captions and corner-marker clearance

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -739,7 +739,7 @@ function RailFocusButton({
 			{caption ? (
 				<span
 					className={cn(
-						"block max-w-16 truncate text-center text-2xs font-medium",
+						"block max-w-full truncate text-center text-2xs font-medium",
 						active ? "text-sidebar-accent-foreground" : "text-muted-foreground",
 					)}
 					title={label}
@@ -896,7 +896,10 @@ function SortableAgentRailItem({
 			className={cn("touch-pan-y", agent.href && "cursor-pointer")}
 			showTooltip={showTooltip}
 		>
-			<span className="relative inline-flex rounded-md">
+			{/* The corner markers protrude -top-1/-right-1 past the icon, so the
+			    wrapper carries a small margin to keep them off the rail's
+			    overflow-hidden clip edge. */}
+			<span className="relative m-0.5 inline-flex rounded-md">
 				<AgentIcon agent={agent.agentType} size="rail" avatarUrl={agent.avatarUrl} />
 				{kind === "cloud" ? (
 					<span


### PR DESCRIPTION
## What

- Rail captions were `max-w-16` (64px) inside a 59px tile with only `px-1` — long agent names visually pressed against both tile edges and risked clipping under the rail's `overflow-x-hidden`. Captions are now `max-w-full`, so truncation happens inside the button's own padding: text gets symmetric breathing room on both sides (measured 14px insets per side).
- The cloud/legacy corner markers protrude `-top-1 -right-1` past the icon; the icon wrapper now carries `m-0.5` so the badge can't reach the rail's clip edge.

Browser-verified with a long agent name: caption truncates cleanly with symmetric padding, badge geometry confirmed via rect measurements.