### PR TITLE
fix(web): widen rail tiles with smaller outer margin

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -730,7 +730,7 @@ function RailFocusButton({
 			aria-label={label}
 			className={cn(
 				hasCaption
-					? "h-16 w-full flex-col justify-center gap-1 rounded-lg px-1 py-1"
+					? "h-16 w-full flex-col justify-center gap-0.5 rounded-lg px-1 py-0.5"
 					: "size-11 justify-center rounded-lg p-0",
 				className,
 			)}
@@ -1068,7 +1068,7 @@ function FocusRailContent({
 						<IconChip
 							size="sm"
 							tint={RESOURCE_TINT_CLASSES.overview}
-							className="size-9 [&>svg]:size-4.5"
+							className="size-10 [&>svg]:size-5"
 						>
 							<LayoutDashboard />
 						</IconChip>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -760,7 +760,7 @@ function RailFocusButton({
 			<span
 				aria-hidden="true"
 				className={cn(
-					"absolute -left-2.5 w-1 rounded-r-full bg-sidebar-foreground/70 opacity-0 transition-[height,opacity] duration-200 ease-out",
+					"absolute -left-1.5 w-1 rounded-r-full bg-sidebar-foreground/70 opacity-0 transition-[height,opacity] duration-200 ease-out",
 					active
 						? hasCaption
 							? "h-10 opacity-100"
@@ -1056,7 +1056,7 @@ function FocusRailContent({
 
 			<SidebarSeparator className="mx-auto w-8" />
 
-			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-2.5 pt-2.5 pb-[calc(var(--header-height)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-1.5 pt-2.5 pb-[calc(var(--header-height)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				<SidebarMenu className="w-full items-center">
 					<RailTileButton
 						render={<Link to="/" onClick={onNavigate} />}

--- a/apps/web/src/components/dashboard/agent-icon.tsx
+++ b/apps/web/src/components/dashboard/agent-icon.tsx
@@ -13,7 +13,7 @@ const SIZE_CLASS: Record<AgentIconSize, string> = {
 	sm: "size-5",
 	md: "size-6",
 	lg: "size-8",
-	rail: "size-9",
+	rail: "size-10",
 	xl: "size-12",
 };
 
@@ -22,7 +22,7 @@ const SIZE_PX: Record<AgentIconSize, number> = {
 	sm: 20,
 	md: 24,
 	lg: 32,
-	rail: 36,
+	rail: 40,
 	xl: 48,
 };
 
@@ -31,7 +31,7 @@ const FALLBACK_ICON_CLASS: Record<AgentIconSize, string> = {
 	sm: "size-3",
 	md: "size-3.5",
 	lg: "size-4",
-	rail: "size-4.5",
+	rail: "size-5",
 	xl: "size-6",
 };
 

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -71,7 +71,7 @@ export function NewAgentButton({
 			className={cn(
 				"duration-200 ease-linear",
 				compact &&
-					"size-11 justify-center rounded-lg bg-sidebar-accent/70 p-0 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:size-4.5",
+					"size-11 justify-center rounded-lg bg-sidebar-accent/70 p-0 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:size-5",
 			)}
 		>
 			<CirclePlus />


### PR DESCRIPTION
## What

Follow-up to #876: captions still truncated ordinary names ("OpenClaw" → "OpenCL…") because the 10px rail content padding left only 51px of caption width, and the 36px icons read small inside the tile.

- Rail content padding `px-2.5` → `px-1.5`: tiles widen 59px → 67px, captions 51px → 59px while keeping a small outer margin.
- Rail icons 36px → 40px (`AgentIcon` rail size, avatar pixel size, fallback glyph); Console chip and New Agent button glyphs enlarged to match (`size-5`).
- Active marker offset `-left-2.5` → `-left-1.5` so it keeps landing exactly on the rail's inner edge; button gap/padding tightened (`gap-0.5`, `py-0.5`) so the 64px tile height holds with the bigger icon.

Browser-verified: "OpenClaw" renders in full, longer names truncate cleanly with symmetric insets, tile stays 67×64, marker alignment unchanged.