### PR TITLE
fix(web): square rail tiles at 67x68

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4338,8 +4338,8 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	expect(cloudMarkerBox.height).toBe(legacyMarkerBox.height);
 	expect(cloudIconBox.width).toBe(legacyIconBox.width);
 	expect(cloudIconBox.height).toBe(legacyIconBox.height);
-	expect(cloudMarkerBox.width).toBe(16);
-	expect(cloudIconBox.width).toBe(12);
+	expect(cloudMarkerBox.width).toBe(20);
+	expect(cloudIconBox.width).toBe(14);
 
 	const connectedTileBox = await rail
 		.getByTestId("app-sidebar-agent-tile")

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4349,7 +4349,7 @@ test("hosted mixed agent rail uses whole semantic buttons for context switching"
 	if (!connectedTileBox || !connectedButtonBox) {
 		throw new Error("Hosted rail agent tile should be a whole interactive button.");
 	}
-	expect(connectedTileBox.height).toBeCloseTo(64, 0);
+	expect(connectedTileBox.height).toBeCloseTo(68, 0);
 	expect(connectedButtonBox.x).toBeCloseTo(connectedTileBox.x, 0);
 	expect(connectedButtonBox.y).toBeCloseTo(connectedTileBox.y, 0);
 	expect(connectedButtonBox.height).toBeCloseTo(connectedTileBox.height, 0);

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -2504,7 +2504,7 @@ test("agent rail uses each whole tile for Space keyboard sorting", async ({ page
 	const firstTileBox = await firstTile.boundingBox();
 	const firstButtonBox = await firstButton.boundingBox();
 	if (!firstTileBox || !firstButtonBox) throw new Error("Agent rail tile should be interactive.");
-	expect(firstTileBox.height).toBeCloseTo(64, 0);
+	expect(firstTileBox.height).toBeCloseTo(68, 0);
 	expect(firstButtonBox.height).toBeCloseTo(firstTileBox.height, 0);
 	expect(firstButtonBox.width).toBeCloseTo(firstTileBox.width, 0);
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -730,7 +730,7 @@ function RailFocusButton({
 			aria-label={label}
 			className={cn(
 				hasCaption
-					? "h-16 w-full flex-col justify-center gap-0.5 rounded-lg px-1 py-0.5"
+					? "h-[4.25rem] w-full flex-col justify-center gap-1 rounded-lg px-1 py-1"
 					: "size-11 justify-center rounded-lg p-0",
 				className,
 			)}
@@ -754,7 +754,7 @@ function RailFocusButton({
 		<div
 			className={cn(
 				"group/rail-focus relative flex min-w-0 items-center justify-center",
-				hasCaption ? "h-16 w-full" : "size-11",
+				hasCaption ? "h-[4.25rem] w-full" : "size-11",
 			)}
 		>
 			<span
@@ -763,7 +763,7 @@ function RailFocusButton({
 					"absolute -left-1.5 w-1 rounded-r-full bg-sidebar-foreground/70 opacity-0 transition-[height,opacity] duration-200 ease-out",
 					active
 						? hasCaption
-							? "h-10 opacity-100"
+							? "h-11 opacity-100"
 							: "h-8 opacity-100"
 						: "h-2 group-hover/rail-focus:h-4 group-hover/rail-focus:opacity-50",
 				)}
@@ -817,7 +817,7 @@ function RailTileButton({
 			ref={itemRef}
 			data-testid={itemTestId}
 			style={itemStyle}
-			className={cn("relative h-16 w-full", itemClassName)}
+			className={cn("relative h-[4.25rem] w-full", itemClassName)}
 		>
 			<RailFocusButton
 				render={render}

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -175,7 +175,7 @@ export function AgentSourceBadge({
 			className={cn(
 				"shrink-0 whitespace-nowrap border font-medium leading-none shadow-sm",
 				iconOnly
-					? "size-4 justify-center rounded-full p-0"
+					? "size-5 justify-center rounded-full p-0"
 					: compact
 						? "h-5 gap-1 rounded-full px-1.5 text-2xs"
 						: "h-5 gap-1.5 rounded-full px-2 text-2xs",
@@ -185,7 +185,7 @@ export function AgentSourceBadge({
 				className,
 			)}
 		>
-			<Icon className={cn(iconOnly ? "size-2.5" : "size-3.5", iconClass)} />
+			<Icon className={cn("size-3.5", iconClass)} />
 			{iconOnly ? <span className="sr-only">{label}</span> : label}
 		</StatusBadge>
 	);
@@ -207,16 +207,14 @@ export function LegacyAgentBadge({
 			className={cn(
 				"shrink-0 whitespace-nowrap border border-warning-muted bg-warning-muted font-medium leading-none text-warning-muted-foreground shadow-sm",
 				iconOnly
-					? "size-4 justify-center rounded-full p-0"
+					? "size-5 justify-center rounded-full p-0"
 					: compact
 						? "h-5 gap-1 rounded-full px-1.5 text-2xs"
 						: "h-5 gap-1.5 rounded-full px-2 text-2xs",
 				className,
 			)}
 		>
-			<History
-				className={cn(iconOnly ? "size-2.5" : "size-3.5", "text-warning-muted-foreground")}
-			/>
+			<History className={cn("size-3.5", "text-warning-muted-foreground")} />
 			{iconOnly ? <span className="sr-only">Legacy</span> : "Legacy"}
 		</StatusBadge>
 	);


### PR DESCRIPTION
## What

Rail tile refinements:

1. **Square tiles** — after #877 tiles measured 67×64 (squat next to the 40px icon). Now 68px tall (`h-[4.25rem]`), reading as squares with normal `py-1`/`gap-1` restored; active marker scales to match. e2e height assertions updated.
2. **Readable corner badges** — the cloud/legacy source markers were a 16px circle with a ~10px glyph; the lucide Cloud was illegible. iconOnly badges are now 20px with a 14px glyph (`AgentSourceBadge`, `LegacyAgentBadge` — also used on dashboard agent cards). e2e marker assertions updated 16/12 → 20/14.

Verified: 67×68 tiles, lint/typecheck clean.