### PR TITLE
fix(web): solid cloud glyph and true 14px icon in corner badges

### DIFF
--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -168,6 +168,8 @@ export function AgentSourceBadge({
 	const label = agentSourceLabel(source);
 	const title = agentSourceDescription(source);
 	const iconClass = source === "hosted" ? "text-info-muted-foreground" : "text-muted-foreground";
+	// Solid silhouette at badge sizes: the outline cloud dissolves under ~16px.
+	const iconFill = source === "hosted" ? "currentColor" : "none";
 	return (
 		<StatusBadge
 			status="neutral"
@@ -185,7 +187,7 @@ export function AgentSourceBadge({
 				className,
 			)}
 		>
-			<Icon className={cn("size-3.5", iconClass)} />
+			<Icon className={cn(iconOnly ? "!size-3.5" : "size-3.5", iconClass)} fill={iconFill} />
 			{iconOnly ? <span className="sr-only">{label}</span> : label}
 		</StatusBadge>
 	);
@@ -214,7 +216,9 @@ export function LegacyAgentBadge({
 				className,
 			)}
 		>
-			<History className={cn("size-3.5", "text-warning-muted-foreground")} />
+			<History
+				className={cn(iconOnly ? "!size-3.5" : "size-3.5", "text-warning-muted-foreground")}
+			/>
 			{iconOnly ? <span className="sr-only">Legacy</span> : "Legacy"}
 		</StatusBadge>
 	);


### PR DESCRIPTION
## What

1. **Solid cloud silhouette** — the outline lucide Cloud dissolves at badge sizes; the hosted source badge now renders it filled (`fill="currentColor"`), readable at a glance. The connected (laptop) glyph stays outline.
2. **Honor the intended icon size** — `StatusBadge` forces child svgs to 12px via `[&>svg]:size-3`, which has higher specificity than the icon's own class, so the 14px glyph from #878 never actually applied. iconOnly badges now use `!size-3.5`.

## Why a corner badge (answering the design question)

Kept deliberately: it's the standard identity-adornment pattern (Slack/Discord server badges), it carries two states (cloud vs legacy) without consuming a second text line, and the tooltip/`title` retains the full explanation. A color ring can't distinguish two non-default sources; text labels would break the single-line caption.

## Verification

- `bun run typecheck`, `bun run lint` clean
- hosted rail e2e passes with updated marker geometry (20px badge, 14px glyph)