### PR TITLE
fix(runtime): publish transparent egress env to the egress identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.42
+
+Package: `clawdi@0.13.42`
+
+### Fixed
+
+- Transparent egress on every tenant: the runtime now publishes
+  `transparent-egress.env` owned by root with a mode that lets the numeric
+  egress identity read it, so the mitmproxy add-on can load the tenant's
+  mTLS and copy rules instead of failing convergence.
+
 ## Clawdi CLI v0.13.41
 
 Package: `clawdi@0.13.41`

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.41",
+      "version": "0.13.42",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.41",
+	"version": "0.13.42",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2917,6 +2917,65 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(true);
 	});
 
+	test("publishes transparent egress env as a root-authored read-only handoff to the numeric egress identity", () => {
+		const numericPrivilegeToolPath = ["/usr/bin/set", "priv"].join("");
+		if (process.geteuid?.() !== 0 || !existsSync(numericPrivilegeToolPath)) return;
+		const paths = tempRuntimePaths();
+		const egressUid = 10_002;
+		const egressGid = 10_002;
+		process.env.CLAWDI_EGRESS_UID = String(egressUid);
+		process.env.CLAWDI_EGRESS_GID = String(egressGid);
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_UID = "10001";
+		process.env.CLAWDI_RUNTIME_GID = "10001";
+		const manifest = egressRuntimeManifest(paths, {
+			generation: 1,
+			engine: installCachedTestEgressEngine(paths, "12.2.3-test-egress-env-identity"),
+			profile: "enabled",
+		});
+		chmodSync(dirname(paths.serviceStateRoot), 0o777);
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "root-egress-env-handoff"),
+			paths,
+			{
+				cacheLastGood: false,
+				systemdApply: {
+					activateEgressPrerequisite: successfulPrerequisiteActivation,
+					activate: successfulPrerequisiteActivation,
+					rollback: () => {},
+				},
+				hostedRuntimeContract: {
+					expectedIdentity: {
+						home: paths.userHome,
+						user: "clawdi",
+						uid: 10_001,
+						gid: 10_001,
+					},
+					resolveUserIdentity: () => ({ uid: 10_001, gid: 10_001 }),
+				},
+			},
+		);
+		expect(result.installErrors).toEqual([]);
+
+		const envFile = paths.egressTransparentEnv;
+		const node = statSync(envFile);
+		expect([node.uid, node.gid]).toEqual([0, egressGid]);
+		expect(node.mode & 0o777).toBe(0o640);
+		expect(statSync(paths.egressRoot).mode & 0o777).toBe(0o711);
+		expect(statSync(paths.egressTransparentEnv).mode & 0o022).toBe(0);
+
+		const runAsEgressIdentity = (args: string[]) =>
+			execFileSync(
+				numericPrivilegeToolPath,
+				[`--reuid=${egressUid}`, `--regid=${egressGid}`, "--clear-groups", "--", ...args],
+				{ encoding: "utf8" },
+			);
+		expect(runAsEgressIdentity(["sh", "-c", `cat -- ${JSON.stringify(envFile)}`])).toContain(
+			`CLAWDI_EGRESS_GID="${egressGid}"`,
+		);
+		expect(() => runAsEgressIdentity(["sh", "-c", `: > ${JSON.stringify(envFile)}`])).toThrow();
+	});
+
 	test("activates transparent egress before authenticated managed-model discovery", () => {
 		const paths = tempRuntimePaths();
 		const commandPath = join(paths.userHome, ".openclaw", "bin", "openclaw");

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4485,10 +4485,11 @@ function writeTransparentEgressEnvFile(input: {
 		input.paths.egressTransparentEnv,
 		`${lines.join("\n")}\n`,
 		{
-			mode: 0o600,
+			mode: 0o640,
 			dirMode: 0o711,
 		},
 	);
+	if (runningAsRoot()) chownSync(input.paths.egressTransparentEnv, 0, input.egressGid);
 	return input.paths.egressTransparentEnv;
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -15201,13 +15201,15 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(statSync(getRuntimePaths().egressProfileBundle).mode & 0o777).toBe(0o644);
 		expect(statSync(paths.egressRoot).mode & 0o777).toBe(0o711);
 		expect(statSync(paths.egressAddon).mode & 0o777).toBe(0o640);
-		expect(statSync(paths.egressTransparentEnv).mode & 0o777).toBe(0o600);
+		expect(statSync(paths.egressTransparentEnv).mode & 0o777).toBe(0o640);
 		expect(statSync(paths.egressCaDir).mode & 0o777).toBe(0o700);
 		if (typeof process.getuid === "function" && process.getuid() === 0) {
 			expect(statSync(paths.egressCaDir).uid).toBe(10002);
 			expect(statSync(paths.egressCaDir).gid).toBe(10002);
 			expect(statSync(paths.egressAddon).uid).toBe(0);
 			expect(statSync(paths.egressAddon).gid).toBe(10002);
+			expect(statSync(paths.egressTransparentEnv).uid).toBe(0);
+			expect(statSync(paths.egressTransparentEnv).gid).toBe(10002);
 		}
 		expect(statSync(join(run, "egress-scratch")).mode & 0o777).toBe(0o700);
 		expect(openclawUnit).toContain('ExecStart="openclaw" "gateway" "run"');

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.41"', '"version": "0.13.42"'),
+					replaceOnce(cliPackage, '"version": "0.13.42"', '"version": "0.13.43"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.41"', '"version": "0.13.42"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.42"', '"version": "0.13.43"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
## The defect

The egress engine runs as uid/gid `10002` after the root sidecar drops privileges, but `writeTransparentEgressEnvFile()` published its handoff as `root:root 0600` — despite already receiving the resolved egress gid as `input.egressGid` and never applying it. The addon then failed at read time:

```
PermissionError: [Errno 13] Permission denied: /run/clawdi/egress/transparent-egress.env
```

So transparent egress could not start in a real tenant. This was not a write failure — the root CLI wrote the file successfully; the uid-10002 addon could not read it.

## The fix

Publish it exactly the way the neighbouring `writeEgressAddon()` already does: mode `0640`, chowned to `root:<egress gid>` when running as root. The file stays root-authored and unwritable by uid 10002, and `/run/clawdi` and `/run/clawdi/egress` keep their root-only `0711` modes — the narrow published-surface model is unchanged, this file simply joins it.

## How it was found

The image + exact-CLI pair release gate (clawdi-hosted#1537) installs the exact pinned CLI into a real Incus tenant image and runs `runtime init --non-interactive`. It failed closed and emitted no passing claim. `clawdi@0.13.41` is immutable on npm and currently pinned in production, so this ships as `0.13.42`.

## Coverage

The new test asserts the final file is `uid=0`, group = resolved egress gid, mode `0640`, parent dir still `0711`, and group/other have no write bit — then performs an **actual read as the numeric egress identity** via `setpriv`. A test asserting only the mode integer would not have caught the original bug, since `0600` looked plausible too.

Audited the sibling egress publications: the addon already applies the identity, and the CA path goes through a dedicated identity-aware helper. This was the only site with the defect.

## Verification

- `bun run typecheck`: 4/4 tasks
- `bun run check`: 960 files, no fixes applied
- `bun run test`: CLI 1652 passed, web 0 failed, 0 failures overall

Version bumped to `0.13.42` across `packages/cli/package.json`, `bun.lock`, and the sidecar revision probe (which simulates a CLI-only bump and must lead the current version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)