### PR TITLE
fix(web): converge UI consistency (copy case, truncation, touch targets, guards)

### DIFF
--- a/apps/web/src/components/detail/back-link.tsx
+++ b/apps/web/src/components/detail/back-link.tsx
@@ -5,6 +5,12 @@ import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
+/**
+ * Back affordance for detail pages. Content states keep the default
+ * (mobile-only — desktop has the header breadcrumb); error, not-found,
+ * and loading states pass `mobileOnly={false}` because a dead-end page
+ * needs a visible exit on every viewport.
+ */
 export function DetailBackLink({
 	href,
 	label,

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -603,7 +603,14 @@ export function EntityChoiceCard({
 			>
 				<div className="min-w-0 flex-1">
 					<div className="flex min-w-0 items-center gap-2">
-						<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+						<span
+							className="min-w-0 flex-1 truncate text-sm font-medium"
+							title={
+								typeof title === "string" || typeof title === "number" ? String(title) : undefined
+							}
+						>
+							{title}
+						</span>
 						{badge ? <span className="shrink-0">{badge}</span> : null}
 					</div>
 					{description ? (

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -105,7 +105,7 @@ export function NotificationCenter() {
 			toast.success("Invitation Declined");
 		},
 		onError: (e) => {
-			toast.error("Couldn't Decline Invitation", {
+			toast.error("Couldn't decline invitation", {
 				description: e instanceof ApiError ? formatApiError(e.detail) : errorMessage(e),
 			});
 		},

--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -1,6 +1,7 @@
 import { Bot, FolderKanban, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { agentIdentity } from "@/components/dashboard/agent-label";
+import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import {
 	Select,
@@ -119,11 +120,11 @@ export function ProjectIdentity({
 				</div>
 				{supportingText || projectAgent ? (
 					<div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-						<span className="min-w-0 truncate">{supportingText}</span>
+						<TruncatedText className="min-w-0">{supportingText}</TruncatedText>
 						{agentLine ? (
-							<span className="min-w-0 truncate" translate="no">
+							<TruncatedText className="min-w-0" translate="no" title={`Agent: ${agentLine}`}>
 								Agent: {agentLine}
-							</span>
+							</TruncatedText>
 						) : null}
 					</div>
 				) : null}
@@ -367,9 +368,9 @@ export function ProjectCompactPicker({
 				{selectedProject ? (
 					<span className="flex min-w-0 items-center gap-2 text-left">
 						<ProjectIcon project={selectedProject} className="mt-0 size-5 rounded-md" />
-						<span className="min-w-0 truncate font-medium">
+						<TruncatedText className="min-w-0 font-medium">
 							{displayProjectName(selectedProject)}
-						</span>
+						</TruncatedText>
 						<span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
 							{projectCompactKindText(selectedProject)}
 						</span>
@@ -379,7 +380,7 @@ export function ProjectCompactPicker({
 						<span className="flex size-5 shrink-0 items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
 							<FolderKanban className="size-3" />
 						</span>
-						<span className="truncate font-medium">{allLabel}</span>
+						<TruncatedText className="font-medium">{allLabel}</TruncatedText>
 					</span>
 				) : (
 					<SelectValue placeholder={placeholder} />
@@ -397,7 +398,9 @@ export function ProjectCompactPicker({
 								<FolderKanban className="size-3.5" />
 							</span>
 							<div className="min-w-0">
-								<div className="truncate font-medium">{allLabel}</div>
+								<div className="truncate font-medium" title={allLabel}>
+									{allLabel}
+								</div>
 								<div className="truncate text-xs text-muted-foreground">{allDescription}</div>
 							</div>
 						</div>
@@ -432,12 +435,12 @@ function ProjectPickerValue({
 		<span className="flex min-w-0 flex-1 items-center gap-3 pr-1 text-left">
 			<ProjectIcon project={project} agent={agent} className="mt-0 size-7 rounded-md" />
 			<span className="grid min-w-0 flex-1 gap-0.5">
-				<span className="truncate text-sm leading-5 font-semibold">
+				<TruncatedText className="text-sm leading-5 font-semibold">
 					{displayProjectName(project)}
-				</span>
-				<span className="min-w-0 truncate text-xs leading-4 text-muted-foreground">
+				</TruncatedText>
+				<TruncatedText className="min-w-0 text-xs leading-4 text-muted-foreground">
 					{projectSupportingText(project)}
-				</span>
+				</TruncatedText>
 			</span>
 		</span>
 	);
@@ -455,19 +458,19 @@ function ProjectPickerOption({
 			<ProjectIcon project={project} agent={agent} className="mt-0 size-6 rounded-md" />
 			<div className="min-w-0 flex-1">
 				<div className="flex min-w-0 items-center gap-2">
-					<span className="truncate font-medium">{displayProjectName(project)}</span>
+					<TruncatedText className="font-medium">{displayProjectName(project)}</TruncatedText>
 					<ProjectTypeBadge project={project} />
 				</div>
 				<div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-					<span className="min-w-0 truncate">{projectSupportingText(project)}</span>
+					<TruncatedText className="min-w-0">{projectSupportingText(project)}</TruncatedText>
 					<span className="shrink-0">·</span>
 					<span className="shrink-0">{projectPickerAccessText(project)}</span>
 					{project.kind === "environment" && agent ? (
 						<>
 							<span className="shrink-0">·</span>
-							<span className="min-w-0 truncate" translate="no">
+							<TruncatedText className="min-w-0" translate="no">
 								{projectAgentLabel(agent)}
-							</span>
+							</TruncatedText>
 						</>
 					) : null}
 				</div>
@@ -496,10 +499,10 @@ function ProjectPickerAllItem({
 				<FolderKanban className={compact ? "size-3.5" : "size-3.5"} />
 			</span>
 			<span className={cn("min-w-0", compact && "grid gap-0.5")}>
-				<span className={cn("block truncate font-medium", compact && "text-sm leading-5")}>
+				<TruncatedText className={cn("block font-medium", compact && "text-sm leading-5")}>
 					{label}
-				</span>
-				<span className="block truncate text-xs text-muted-foreground">{description}</span>
+				</TruncatedText>
+				<TruncatedText className="block text-xs text-muted-foreground">{description}</TruncatedText>
 			</span>
 		</span>
 	);

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -378,10 +378,10 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 				.writeText(value)
 				.then(() => toast.success(success))
 				.catch(() =>
-					toast.error("Couldn't Copy", { description: "Select the text and copy it manually." }),
+					toast.error("Couldn't copy", { description: "Select the text and copy it manually." }),
 				);
 		} else {
-			toast.error("Couldn't Copy", { description: "Select the text and copy it manually." });
+			toast.error("Couldn't copy", { description: "Select the text and copy it manually." });
 		}
 	};
 	const agentPrompt = buildShareAgentHandoffPrompt(link);

--- a/apps/web/src/components/truncated-text.tsx
+++ b/apps/web/src/components/truncated-text.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Single-line truncation that keeps the full text one hover away. Use this
+ * for user-meaningful strings (names, titles, descriptions) that can clip;
+ * purely decorative or static labels can keep a bare `truncate` class.
+ */
+export function TruncatedText({
+	children,
+	className,
+	title,
+	...props
+}: Omit<React.ComponentProps<"span">, "title"> & {
+	children: ReactNode;
+	title?: string;
+}) {
+	const resolvedTitle =
+		title ??
+		(typeof children === "string" || typeof children === "number" ? String(children) : undefined);
+	return (
+		<span {...props} className={cn("truncate", className)} title={resolvedTitle}>
+			{children}
+		</span>
+	);
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -4,6 +4,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/* Generic label chip (kinds, counts, categories) — pill-shaped, theme colors.
+ * For success/warning/destructive/info status colors use StatusBadge instead;
+ * the two never mix so status meaning stays token-owned (see DESIGN.md). */
+
 const badgeVariants = cva(
 	"group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
 	{

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -29,7 +29,9 @@ const buttonVariants = cva(
 				"icon-xs":
 					"size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
 				"icon-sm":
-					"size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md",
+					// 32px desktop density, 44px on touch devices (iOS HIG) — one
+					// variant owns the touch-target rule instead of per-call fixes.
+					"size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md pointer-coarse:size-11",
 				"icon-lg": "size-10",
 			},
 		},

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -13,7 +13,6 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "@/components/ui/sheet";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
@@ -571,39 +570,6 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) 
 	);
 }
 
-function SidebarMenuSkeleton({
-	className,
-	showIcon = false,
-	...props
-}: React.ComponentProps<"div"> & {
-	showIcon?: boolean;
-}) {
-	// Random width between 50 to 90%.
-	const [width] = React.useState(() => {
-		return `${Math.floor(Math.random() * 40) + 50}%`;
-	});
-
-	return (
-		<div
-			data-slot="sidebar-menu-skeleton"
-			data-sidebar="menu-skeleton"
-			className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
-			{...props}
-		>
-			{showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
-			<Skeleton
-				className="h-4 max-w-(--skeleton-width) flex-1"
-				data-sidebar="menu-skeleton-text"
-				style={
-					{
-						"--skeleton-width": width,
-					} as React.CSSProperties
-				}
-			/>
-		</div>
-	);
-}
-
 function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
 	return (
 		<ul
@@ -677,7 +643,6 @@ export {
 	SidebarMenuBadge,
 	SidebarMenuButton,
 	SidebarMenuItem,
-	SidebarMenuSkeleton,
 	SidebarMenuSub,
 	SidebarMenuSubButton,
 	SidebarMenuSubItem,

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -42,6 +42,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import {
 	type CheckoutReturnNavigationTarget,
@@ -996,8 +997,18 @@ export function DeployWizard() {
 		);
 	}
 
+	const deployDirty =
+		runtime !== DEFAULT_DEPLOY_RUNTIME ||
+		agentName !== runtimeDisplayName(runtime) ||
+		compute !== "basic" ||
+		language !== "" ||
+		timezone !== "" ||
+		term !== 1 ||
+		checkoutSession !== null;
+
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
+			<UnsavedNavigationGuard dirty={deployDirty} busy={submitting} />
 			<form
 				className="flex flex-col gap-6"
 				onSubmit={(event) => {

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -46,6 +46,7 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import {
 	type AgentRouteSearch,
 	agentDeploymentRouteQuery,
@@ -429,8 +430,16 @@ export function SkillDetailContent({
 		isLoading: skillIsLoading,
 	});
 
+	const editDirty =
+		isEditing &&
+		skill != null &&
+		(draftName.trim() !== skill.name ||
+			draftDescription.trim() !== (skill.description ?? "") ||
+			draftInstructions.trim() !== stripFrontmatter(skill.content ?? "").trim());
+
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<UnsavedNavigationGuard dirty={editDirty} busy={saveEdit.isPending} />
 			<DetailBackLink
 				href={skillListHref}
 				label={skillListLabel}

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -344,12 +344,12 @@ function CopyableCommand({ command }: { command: string }) {
 							.writeText(command)
 							.then(() => toast.success("Command Copied"))
 							.catch(() =>
-								toast.error("Couldn't Copy", {
+								toast.error("Couldn't copy", {
 									description: "Select the command and copy it manually.",
 								}),
 							);
 					} else {
-						toast.error("Couldn't Copy", {
+						toast.error("Couldn't copy", {
 							description: "Select the command and copy it manually.",
 						});
 					}
@@ -399,7 +399,7 @@ function titleForError(code: ShareErrorCode): string {
 		case "already_owner":
 			return "That's Your Project";
 		default:
-			return "Couldn't Load This Share";
+			return "Couldn't load this share";
 	}
 }
 


### PR DESCRIPTION
## What

One pass over the UI consistency review, each fix converged at the highest-leverage point:

1. **Copy case** — six Title Case violations of the sentence-case convention (DESIGN.md): `Couldn't copy`, `Couldn't load this share`, `Couldn't decline invitation`.
2. **Truncation** — new `TruncatedText` component (truncate + hover title, string children resolve automatically) applied to the user-meaningful name/description surfaces in `project-metadata`; `EntityChoiceCard` title gets the same `titleAttribute` pattern its siblings already used.
3. **Touch targets** — `icon-sm` buttons now bump 32px → 44px under `pointer-coarse` (iOS HIG) in the shared button variant, replacing per-call fixes.
4. **Unsaved-change guards** — `UnsavedNavigationGuard` added to the skills/[key] editor (has real draft state) and the deploy wizard (multi-field form).
5. **Dead code** — `SidebarMenuSkeleton` (unused, random-width hydration hazard) deleted; `ui/badge` vs `StatusBadge` boundary documented on both components.
6. **Back-link policy documented, not changed** — the review initially read the `mobileOnly={false}` overrides as inconsistency; the e2e suite proved them intentional: content states are mobile-only (desktop has breadcrumbs), error/loading/not-found states keep a visible exit on every viewport. The policy is now written down in `detail/back-link.tsx`; behavior unchanged.

## Verification

- `bun run typecheck`, `bun run lint` clean
- 960 unit tests pass
- Full OSS Playwright suite 37/37 green