### PR TITLE
fix(web): rename console Resources group to Library

### DIFF
--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -905,7 +905,7 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 	await page.goto("/");
 	await expectSidebarNavigationGroups(page, [
 		{ label: null, items: ["Overview", "Agents", "Sessions", "Memories"] },
-		{ label: "Resources", items: ["Connectors", "Projects", "Skills", "Vaults"] },
+		{ label: "Library", items: ["Connectors", "Projects", "Skills", "Vaults"] },
 	]);
 
 	await page.goto("/agents/agent-smoke-1");

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -30,7 +30,7 @@ function groupShape(
 
 function expectNavigationHeadings(
 	groups: ReadonlyArray<{ label: string | null; items: readonly unknown[] }>,
-	expected = ["Resources"],
+	expected = ["Library"],
 ) {
 	expect(groups.filter((group) => group.label !== null).map((group) => group.label)).toEqual(
 		expected,
@@ -55,7 +55,7 @@ describe("sidebar navigation model", () => {
 			},
 			{
 				id: "resources",
-				label: "Resources",
+				label: "Library",
 				separated: false,
 				items: [
 					{ id: "channels", label: "Channels" },

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -221,7 +221,7 @@ const CONSOLE_NAVIGATION_GROUPS = [
 	},
 	{
 		id: "resources",
-		label: "Resources",
+		label: "Library",
 		itemIds: ["channels", "ai-providers", "connectors", "projects", "skills", "vaults"],
 		separated: false,
 	},


### PR DESCRIPTION
## What

The console sidebar group was labeled "Resources" while the product copy already calls this surface the "resource library" in six places ("Manage/Open in resource library"). Renaming the group to **Library** converges the vocabulary.

"Console" itself stays: it is distinctive, matches the internal model (`consoleNavigationGroups`), and contrasts cleanly with per-Agent pages. Possible follow-up (not in this PR): split the group into Library (Projects/Skills/Vaults) and Integrations (Channels/AI Providers/Connectors).

## Verification

- `bun run typecheck`, `bun run lint`, navigation-model unit tests
- Sidebar grammar e2e (group labels) passes