### PR TITLE
fix(web): URL-backed list pagination and sentence-case toasts

### DIFF
--- a/apps/web/src/components/connectors/connectors-surface.tsx
+++ b/apps/web/src/components/connectors/connectors-surface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronLeft, ChevronRight, Plug } from "lucide-react";
-import { createParser, parseAsString, useQueryState } from "nuqs";
+import { parseAsString, useQueryState } from "nuqs";
 import { type ReactNode, Suspense, useEffect, useMemo } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
@@ -27,6 +27,7 @@ import {
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { LIBRARY_RESOURCE_SCOPE, type ResourceNavigationScope } from "@/lib/resource-navigation";
+import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn } from "@/lib/utils";
 
@@ -34,19 +35,6 @@ import { cn } from "@/lib/utils";
 // always full at every viewport — no orphan cards on the bottom.
 const PAGE_SIZE = CONNECTOR_CATALOG_PAGE_SIZE;
 const CONNECTORS_RESOURCE = getProjectResourceDefinition("connectors");
-
-// 1-indexed page parser. Rejects non-integer / 0 / negative URL values
-// so `?page=-5` or `?page=2junk` doesn't reach the slicer. `Number()`
-// (not `parseInt`) is strict — `parseInt("2junk")` would return 2,
-// silently accepting garbage. Returning `null` from `parse` makes nuqs
-// fall back to the parser's default.
-const parseAsPositivePage = createParser({
-	parse: (raw: string) => {
-		const n = Number(raw);
-		return Number.isInteger(n) && n >= 1 ? n : null;
-	},
-	serialize: (n: number) => String(n),
-});
 
 /**
  * Wrap the nuqs-using body in a Suspense boundary so the static shell stays
@@ -118,7 +106,7 @@ function ConnectorsList({
 	);
 	const [page, setPage] = useQueryState(
 		"page",
-		parseAsPositivePage.withDefault(1).withOptions({ clearOnDefault: true }),
+		parseAsPositiveInt.withDefault(1).withOptions({ clearOnDefault: true }),
 	);
 	const debouncedQuery = useDebouncedValue(query, 250);
 

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -3,7 +3,8 @@
 import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
-import { type ReactNode, useCallback, useState } from "react";
+import { parseAsString, useQueryStates } from "nuqs";
+import { type ReactNode, Suspense, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
@@ -57,6 +58,7 @@ import {
 	memoryDetailLink,
 	type ResourceNavigationScope,
 } from "@/lib/resource-navigation";
+import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 import { cn, relativeTime } from "@/lib/utils";
@@ -81,12 +83,34 @@ export function MemoriesSurface({
 }: {
 	scope?: ResourceNavigationScope;
 }) {
+	// nuqs reads URL state under the hood, so the URL-driven body mounts
+	// inside its own Suspense boundary (mirrors connectors-surface).
+	return (
+		<Suspense fallback={<MemoriesGridSkeleton />}>
+			<MemoriesSurfaceBody scope={scope} />
+		</Suspense>
+	);
+}
+
+function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 	const api = useApi();
 	const $api = useOpenApi();
 	const queryClient = useQueryClient();
-	const [search, setSearch] = useState("");
-	const [category, setCategory] = useState<string>(ALL);
-	const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
+	// URL-backed list state (like sessions/connectors): back from a detail
+	// page restores the exact search/category/page instead of resetting.
+	const [params, setParams] = useQueryStates(
+		{
+			q: parseAsString.withDefault(""),
+			category: parseAsString.withDefault(""),
+			page: parseAsPositiveInt.withDefault(1),
+			pageSize: parseAsPositiveInt.withDefault(25),
+		},
+		{ clearOnDefault: true, history: "replace" },
+	);
+	const search = params.q;
+	const category = params.category || ALL;
+	const page = params.page;
+	const pageSize = params.pageSize;
 	const debouncedSearch = useDebouncedValue(search, 250);
 	const apiCategory = category === ALL ? "" : category;
 
@@ -119,8 +143,8 @@ export function MemoriesSurface({
 		{
 			params: {
 				query: {
-					page: pagination.pageIndex + 1,
-					page_size: pagination.pageSize,
+					page,
+					page_size: pageSize,
 					q: debouncedSearch || undefined,
 					category: apiCategory || undefined,
 				},
@@ -149,11 +173,11 @@ export function MemoriesSurface({
 			: "No memories yet. Create one above, or your Agents will create them automatically as they work.";
 	const paginationFooter = (
 		<DataTablePagination
-			page={pagination.pageIndex + 1}
-			pageSize={pagination.pageSize}
+			page={page}
+			pageSize={pageSize}
 			total={total}
-			onPageChange={(p) => setPagination((s) => ({ ...s, pageIndex: p - 1 }))}
-			onPageSizeChange={(size) => setPagination(() => ({ pageIndex: 0, pageSize: size }))}
+			onPageChange={(p) => void setParams({ page: p })}
+			onPageSizeChange={(size) => void setParams({ pageSize: size, page: 1 })}
 		/>
 	);
 	return (
@@ -175,10 +199,7 @@ export function MemoriesSurface({
 				search={
 					<SearchInput
 						value={search}
-						onChange={(v) => {
-							setSearch(v);
-							setPagination((p) => ({ ...p, pageIndex: 0 }));
-						}}
+						onChange={(v) => void setParams({ q: v, page: 1 })}
 						placeholder="Search memories…"
 					/>
 				}
@@ -188,8 +209,7 @@ export function MemoriesSurface({
 						onValueChange={(v) => {
 							const selected = v[0];
 							if (!selected) return;
-							setCategory(selected);
-							setPagination((p) => ({ ...p, pageIndex: 0 }));
+							void setParams({ category: selected === ALL ? "" : selected, page: 1 });
 						}}
 						variant="outline"
 						size="sm"
@@ -410,6 +430,22 @@ function MemoryCardSkeleton({ lineCount }: { lineCount: number }) {
 				<Skeleton className="ml-auto h-3 w-20" />
 			</div>
 		</EntityCardChassis>
+	);
+}
+
+function MemoriesGridSkeleton() {
+	return (
+		<div className="space-y-6" data-testid="memories-surface">
+			<div className="flex flex-wrap gap-2">
+				<Skeleton className="h-11 w-56 sm:h-9" />
+				<Skeleton className="h-11 w-72 sm:h-9" />
+			</div>
+			<div className={ENTITY_CARD_MASONRY_CLASS}>
+				{[4, 7, 3, 5, 6, 4].map((lineCount, index) => (
+					<MemoryCardSkeleton key={index} lineCount={lineCount} />
+				))}
+			</div>
+		</div>
 	);
 }
 

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -102,7 +102,7 @@ export function NotificationCenter() {
 		},
 		onSuccess: () => {
 			refetchMembershipDerived();
-			toast.success("Invitation Declined");
+			toast.success("Invitation declined");
 		},
 		onError: (e) => {
 			toast.error("Couldn't decline invitation", {

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -232,7 +232,7 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			revokeSucceededRef.current = true;
 			revokeExit.beginClose();
 			setRevokeOpen(false);
-			toast.success("Share Link Turned Off");
+			toast.success("Share link turned off");
 		},
 		onError: (e) => {
 			toast.error("Couldn't turn off link", {
@@ -558,7 +558,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
 			setEmail("");
-			toast.success("Invitation Sent", {
+			toast.success("Invitation sent", {
 				description:
 					"They will see it under the top-right Notification Center bell after signing in with that email.",
 			});
@@ -582,7 +582,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			cancelSucceededRef.current = true;
 			cancelExit.beginClose();
 			setCancelOpen(false);
-			toast.success("Invitation Cancelled");
+			toast.success("Invitation cancelled");
 		},
 		onError: (e) => {
 			toast.error("Couldn't cancel invitation", {
@@ -779,7 +779,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 			removeSucceededRef.current = true;
 			removeExit.beginClose();
 			setRemoveOpen(false);
-			toast.success("Member Removed");
+			toast.success("Member removed");
 		},
 		onError: (e) =>
 			toast.error("Couldn't remove member", {
@@ -797,7 +797,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 		onSuccess: (body) => {
 			setStopAllOpen(false);
 			refreshSharingState();
-			toast.success("Sharing Stopped", {
+			toast.success("Sharing stopped", {
 				description: `Turned off ${body.links_revoked} link(s) and removed ${body.members_removed} member(s).`,
 			});
 		},

--- a/apps/web/src/lib/url-search-parsers.ts
+++ b/apps/web/src/lib/url-search-parsers.ts
@@ -1,0 +1,16 @@
+import { createParser } from "nuqs";
+
+/**
+ * 1-indexed strict integer parser for URL-paginated lists. `Number()`
+ * (unlike `parseInt`) rejects mixed input like "3junk", so a malformed
+ * `?page=3junk` falls back to the parser default instead of silently
+ * landing on page 3. Shared by every nuqs-paginated list (sessions,
+ * connectors, memories, skills).
+ */
+export const parseAsPositiveInt = createParser({
+	parse: (raw: string) => {
+		const n = Number(raw);
+		return Number.isInteger(n) && n >= 1 ? n : null;
+	},
+	serialize: (n: number) => String(n),
+});

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -464,7 +464,7 @@ export default function ProjectDetailPage({
 			qc.invalidateQueries({
 				queryKey: ["get", "/v1/agents/{agent_id}/project-bindings"],
 			});
-			toast.success("Left Shared Project", { description: "Membership removed." });
+			toast.success("Left shared project", { description: "Membership removed." });
 			void router.navigate({ href: projectsTarget.href });
 		},
 		onError: (error) => {

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -3,13 +3,7 @@
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { LayoutList, Table2 } from "lucide-react";
-import {
-	createParser,
-	parseAsBoolean,
-	parseAsString,
-	parseAsStringLiteral,
-	useQueryStates,
-} from "nuqs";
+import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -30,6 +24,7 @@ import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
+import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, recencyBucketFor } from "@/lib/utils";
 
@@ -48,17 +43,6 @@ const SORT_KEYS = [
 ] as const;
 type SortKey = (typeof SORT_KEYS)[number];
 const SESSIONS_RESOURCE = getProjectResourceDefinition("sessions");
-
-// 1-indexed strict integer parser. `Number()` (unlike `parseInt`)
-// rejects mixed input like "3junk", so a malformed `?page=3junk`
-// falls back to the nuqs default instead of silently landing 3.
-const parseAsPositiveInt = createParser({
-	parse: (raw: string) => {
-		const n = Number(raw);
-		return Number.isInteger(n) && n >= 1 ? n : null;
-	},
-	serialize: (n: number) => String(n),
-});
 
 /**
  * Wrap the body in `<Suspense>` because nuqs reads URL state under the hood.

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -45,6 +45,7 @@ import type { components } from "@/lib/api-schemas";
 import { formatResourceCount, getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { isBrowserWritableSkillProject, skillCapabilities } from "@/lib/skill-authority";
+import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { cn } from "@/lib/utils";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
@@ -89,8 +90,16 @@ function SkillsPageInner() {
 		"add",
 		parseAsString.withDefault("").withOptions({ clearOnDefault: true, history: "replace" }),
 	);
-	const [search, setSearch] = useState("");
-	const [page, setPage] = useState(1);
+	// URL-backed list state (like sessions/connectors/memories): back from a
+	// Skill detail restores the exact search/page instead of resetting.
+	const [search, setSearch] = useQueryState(
+		"q",
+		parseAsString.withDefault("").withOptions({ clearOnDefault: true, history: "replace" }),
+	);
+	const [page, setPage] = useQueryState(
+		"page",
+		parseAsPositiveInt.withDefault(1).withOptions({ clearOnDefault: true, history: "replace" }),
+	);
 	const [createOpen, setCreateOpen] = useState(false);
 	const [importOpen, setImportOpen] = useState(false);
 
@@ -111,10 +120,6 @@ function SkillsPageInner() {
 	const projectError = shouldBlockQueryError(projectsQuery.error, projectsQuery.data)
 		? projectsQuery.error
 		: null;
-
-	useEffect(() => {
-		setPage(1);
-	}, [projectParam, search]);
 
 	const skillsQuery = useQuery({
 		queryKey: ["skills", "project", selectedProject?.id, search.trim(), page],
@@ -163,6 +168,7 @@ function SkillsPageInner() {
 	const selectProject = (projectId: string) => {
 		void setProjectParam(projectId);
 		void setLegacyTarget("");
+		void setPage(1);
 	};
 
 	const removeSkill = useMutation({
@@ -262,7 +268,14 @@ function SkillsPageInner() {
 				<>
 					<ListToolbar
 						search={
-							<SearchInput value={search} onChange={setSearch} placeholder="Search this Project…" />
+							<SearchInput
+								value={search}
+								onChange={(v) => {
+									void setSearch(v);
+									void setPage(1);
+								}}
+								placeholder="Search this Project…"
+							/>
 						}
 						filters={
 							<ProjectCompactPicker

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -342,7 +342,7 @@ function CopyableCommand({ command }: { command: string }) {
 					if (typeof navigator !== "undefined" && navigator.clipboard) {
 						navigator.clipboard
 							.writeText(command)
-							.then(() => toast.success("Command Copied"))
+							.then(() => toast.success("Command copied"))
 							.catch(() =>
 								toast.error("Couldn't copy", {
 									description: "Select the command and copy it manually.",


### PR DESCRIPTION
## What

**Path fluency** — the memories and skills library lists kept search/filter/page in component state, so going list → detail → back silently reset users to page 1 (sessions and connectors already keep this in the URL via nuqs). Both lists are now URL-backed (`q`/`category`/`page`/`pageSize` for memories, `q`/`page` for skills), so back/forward and deep links restore the exact view. Filter/search/project changes still reset to page 1 at the action site.

**Parser convergence** — the strict 1-indexed page parser was copy-pasted in `sessions/page.tsx` and `connectors-surface.tsx`; it now lives in `lib/url-search-parsers.ts` and all four lists share it.

**Copy case** — eight Title Case toast strings moved to the sentence-case convention (`Command copied`, `Invitation sent/cancelled/declined`, `Share link turned off`, `Member removed`, `Sharing stopped`, `Left shared project`).

## Verification

- `bun run typecheck`, `bun run lint` clean
- Full OSS Playwright suite 37/37 green